### PR TITLE
Triangle oracle: test-suite execution via per-framework adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 .neurallog/judge-cache/
 .neurallog/lessons/
 .neurallog/witnesses/
+.neurallog/test-cache/
 .neurallog/graph.json
 .neurallog/report.json
 .neurallog/derivation.json

--- a/src/checkers/PropertyTestChecker.ts
+++ b/src/checkers/PropertyTestChecker.ts
@@ -12,7 +12,7 @@ import { JudgeCache } from "../judgeCache";
 import { loadModuleWithPrivates, collectTransitiveSource } from "../moduleLoader";
 import { LessonStore } from "../lessons";
 import { readObservations } from "../runtime";
-import { findTestsForFunction, formatForPrompt as formatTestOracleForPrompt } from "../testOracle";
+import { findTestsForFunction, formatForPrompt as formatTestOracleForPrompt, detectTestFramework, runTestsForReferences, summarizeTriangle } from "../testOracle";
 
 interface ExtractedFn {
   fn: (...args: any[]) => any;
@@ -736,7 +736,32 @@ export class PropertyTestChecker implements Checker {
         outcome = { kind: "harness-error", message: String(e?.message || e).slice(0, 200), harnessCode: harness };
       }
 
-      this.harnessResults.push(this.harnessOutcomeToCheckResult(cand, outcome));
+      const result = this.harnessOutcomeToCheckResult(cand, outcome);
+
+      if (process.env.NEURALLOG_RUN_ORACLE_TESTS === "1") {
+        const framework = detectTestFramework(this.projectRoot);
+        if (framework) {
+          const refs = findTestsForFunction(this.projectRoot, cand.contract.function);
+          if (refs.length > 0) {
+            const oracleResults = await runTestsForReferences(
+              this.projectRoot,
+              framework,
+              refs,
+              absPath,
+              { maxTests: 3, timeoutMsEach: 30000 }
+            );
+            const triangle = summarizeTriangle(outcome.kind, oracleResults);
+            if (triangle.note) {
+              result.error = result.error ? `${result.error}; ${triangle.note}` : triangle.note;
+              if (triangle.hasDisagreement) {
+                result.error = `triangle-disagreement: ${result.error}`;
+              }
+            }
+          }
+        }
+      }
+
+      this.harnessResults.push(result);
 
       if (outcome.kind === "pass") stats.pass++;
       else if (outcome.kind === "encoding-gap") stats.encodingGap++;

--- a/src/checkers/PropertyTestChecker.ts
+++ b/src/checkers/PropertyTestChecker.ts
@@ -73,6 +73,15 @@ export class PropertyTestChecker implements Checker {
     skipReason: string;
   }> = [];
   harnessResults: CheckResult[] = [];
+  private oracleRefCache = new Map<string, ReturnType<typeof findTestsForFunction>>();
+
+  private getOracleRefsCached(fnName: string): ReturnType<typeof findTestsForFunction> {
+    const hit = this.oracleRefCache.get(fnName);
+    if (hit) return hit;
+    const refs = findTestsForFunction(this.projectRoot, fnName);
+    this.oracleRefCache.set(fnName, refs);
+    return refs;
+  }
 
   constructor(private projectRoot: string = process.cwd()) {
     const raw = process.env.NEURALLOG_PROPERTY_TEST_LIMIT;
@@ -629,6 +638,15 @@ export class PropertyTestChecker implements Checker {
     const store = new ContractStore(this.projectRoot);
     const touched = new Set<string>();
 
+    // Oracle-test discovery, hoisted so framework detection + the per-function test
+    // lookup happen at most once per run. "unknown" frameworks have no adapter and
+    // would only produce adapter-error outcomes, so we short-circuit by treating
+    // them as no-oracle.
+    const oracleEnabled = process.env.NEURALLOG_RUN_ORACLE_TESTS === "1";
+    const detectedFramework = oracleEnabled ? detectTestFramework(this.projectRoot) : null;
+    const oracleFramework = detectedFramework && detectedFramework !== "unknown" ? detectedFramework : null;
+    this.oracleRefCache.clear();
+
     const candidates = this.harnessCandidates.slice(0, limit);
     const concurrency = Math.max(1, parseInt(process.env.NEURALLOG_HARNESS_CONCURRENCY || "3", 10) || 3);
     console.log(`[harness] ${candidates.length} candidate contracts (of ${this.harnessCandidates.length}); synthesizing with ${synthModel} at concurrency ${concurrency}`);
@@ -738,24 +756,21 @@ export class PropertyTestChecker implements Checker {
 
       const result = this.harnessOutcomeToCheckResult(cand, outcome);
 
-      if (process.env.NEURALLOG_RUN_ORACLE_TESTS === "1") {
-        const framework = detectTestFramework(this.projectRoot);
-        if (framework) {
-          const refs = findTestsForFunction(this.projectRoot, cand.contract.function);
-          if (refs.length > 0) {
-            const oracleResults = await runTestsForReferences(
-              this.projectRoot,
-              framework,
-              refs,
-              absPath,
-              { maxTests: 3, timeoutMsEach: 30000 }
-            );
-            const triangle = summarizeTriangle(outcome.kind, oracleResults);
-            if (triangle.note) {
-              result.error = result.error ? `${result.error}; ${triangle.note}` : triangle.note;
-              if (triangle.hasDisagreement) {
-                result.error = `triangle-disagreement: ${result.error}`;
-              }
+      if (oracleFramework) {
+        const refs = this.getOracleRefsCached(cand.contract.function);
+        if (refs.length > 0) {
+          const oracleResults = await runTestsForReferences(
+            this.projectRoot,
+            oracleFramework,
+            refs,
+            absPath,
+            { maxTests: 3, timeoutMsEach: 30000 }
+          );
+          const triangle = summarizeTriangle(outcome.kind, oracleResults);
+          if (triangle.note) {
+            result.error = result.error ? `${result.error}; ${triangle.note}` : triangle.note;
+            if (triangle.hasDisagreement) {
+              result.error = `triangle-disagreement: ${result.error}`;
             }
           }
         }

--- a/src/testAdapters/Adapter.ts
+++ b/src/testAdapters/Adapter.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared interface for test-framework adapters.
+ *
+ * Each adapter knows how to invoke one test runner (vitest, jest, mocha,
+ * etc.) against a specific test file / test name and return a structured
+ * outcome. Adapters are small, independent, and framework-specific —
+ * they do not share state and they do not parse each other's output.
+ *
+ * The pipeline uses adapters via lookup in the registry (./index.ts).
+ * Adding a new framework is a single new file implementing TestAdapter,
+ * plus one registration line in the registry.
+ */
+
+export type TestOutcomeKind =
+  | "pass"           // test ran and its assertions held
+  | "fail"           // test ran and an assertion failed
+  | "error"          // test threw an uncaught error (not an assertion failure)
+  | "skipped"        // test was skipped by the framework (e.g., .skip, .only exclusion)
+  | "timeout"        // adapter killed the process after exceeding timeoutMs
+  | "adapter-error"; // adapter itself failed (couldn't spawn, couldn't parse output, etc.)
+
+export interface TestInvocation {
+  /** Absolute or project-relative path to the test file. */
+  testFile: string;
+
+  /**
+   * Optional test-name filter. When provided, the adapter runs only the
+   * test whose block name matches this string. Matching semantics are
+   * framework-specific (vitest uses -t substring, jest uses -t regex,
+   * mocha uses --grep). When omitted, the adapter runs every test in
+   * the file.
+   */
+  testName?: string;
+
+  /** Project root — used to resolve relative paths and spawn the runner. */
+  projectRoot: string;
+
+  /** Hard deadline for the entire invocation. Adapters must kill the child process on timeout. */
+  timeoutMs: number;
+}
+
+export interface TestOutcome {
+  kind: TestOutcomeKind;
+
+  /**
+   * One-sentence or short-paragraph description of the outcome suitable
+   * for logging. On pass, usually "ok — <duration>ms." On fail/error,
+   * includes the framework's failure message (assertion text, stack top).
+   * On adapter-error, describes what went wrong inside the adapter
+   * (spawn failure, unparseable output).
+   */
+  message: string;
+
+  /** Wall-clock milliseconds from adapter invocation to outcome determination. */
+  durationMs: number;
+
+  /**
+   * Raw stdout captured from the test runner. Truncated to some
+   * reasonable size (typically 8KB) to keep reports manageable.
+   * Optional: adapters that can't capture stdout (rare) may omit this.
+   */
+  rawOutput?: string;
+}
+
+export interface TestAdapter {
+  /** Canonical framework identifier — must match the value returned by detectTestFramework. */
+  readonly framework: string;
+
+  /** Human-readable adapter name, e.g. "vitest JSON reporter". */
+  readonly name: string;
+
+  /** Execute one invocation. Never throws — errors are returned as TestOutcome with kind "adapter-error". */
+  runTest(invocation: TestInvocation): Promise<TestOutcome>;
+}

--- a/src/testAdapters/index.ts
+++ b/src/testAdapters/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Test-adapter registry. Framework detection happens in ../testOracle.ts;
+ * this module maps a detected framework identifier to the adapter that
+ * implements it. Adapters import Adapter interface types from ./Adapter.
+ */
+
+import type { TestAdapter } from "./Adapter";
+import { VitestAdapter } from "./vitest";
+import { JestAdapter } from "./jest";
+import { MochaAdapter } from "./mocha";
+import { NodeTestAdapter } from "./nodeTest";
+
+export type { TestAdapter, TestInvocation, TestOutcome, TestOutcomeKind } from "./Adapter";
+
+const ADAPTERS: Record<string, TestAdapter> = {};
+
+function register(adapter: TestAdapter): void {
+  ADAPTERS[adapter.framework] = adapter;
+}
+
+register(new VitestAdapter());
+register(new JestAdapter());
+register(new MochaAdapter());
+register(new NodeTestAdapter());
+
+export function getAdapter(framework: string): TestAdapter | null {
+  return ADAPTERS[framework] || null;
+}
+
+export function listAdapters(): TestAdapter[] {
+  return Object.values(ADAPTERS);
+}

--- a/src/testAdapters/jest.ts
+++ b/src/testAdapters/jest.ts
@@ -1,5 +1,5 @@
 import type { TestAdapter, TestInvocation, TestOutcome } from "./Adapter";
-import { runCommand } from "./vitest";
+import { runCommand, extractLastJsonBlock } from "./vitest";
 
 /**
  * Jest adapter. Invokes `npx jest <file> [-t name] --json --silent` and
@@ -21,13 +21,13 @@ export class JestAdapter implements TestAdapter {
     }
 
     return runCommand("npx", args, inv.projectRoot, inv.timeoutMs, start, (stdout) => {
-      const jsonMatch = stdout.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) {
+      const jsonBlock = extractLastJsonBlock(stdout);
+      if (!jsonBlock) {
         return { kind: "adapter-error" as const, message: "no JSON block in jest output" };
       }
       let report: any;
       try {
-        report = JSON.parse(jsonMatch[0]);
+        report = JSON.parse(jsonBlock);
       } catch (e: any) {
         return { kind: "adapter-error" as const, message: `could not parse jest JSON: ${e?.message?.slice(0, 80)}` };
       }

--- a/src/testAdapters/jest.ts
+++ b/src/testAdapters/jest.ts
@@ -1,0 +1,63 @@
+import type { TestAdapter, TestInvocation, TestOutcome } from "./Adapter";
+import { runCommand } from "./vitest";
+
+/**
+ * Jest adapter. Invokes `npx jest <file> [-t name] --json --silent` and
+ * parses the JSON output (testResults/assertionResults). Jest's -t flag
+ * is a regex, so we escape the testName to make substring matching
+ * predictable; callers who want regex semantics can pass pre-escaped
+ * patterns.
+ */
+export class JestAdapter implements TestAdapter {
+  readonly framework = "jest";
+  readonly name = "jest JSON output";
+
+  async runTest(inv: TestInvocation): Promise<TestOutcome> {
+    const start = Date.now();
+    const args = ["jest", inv.testFile, "--json", "--silent"];
+    if (inv.testName) {
+      const escaped = inv.testName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      args.push("-t", escaped);
+    }
+
+    return runCommand("npx", args, inv.projectRoot, inv.timeoutMs, start, (stdout) => {
+      const jsonMatch = stdout.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        return { kind: "adapter-error" as const, message: "no JSON block in jest output" };
+      }
+      let report: any;
+      try {
+        report = JSON.parse(jsonMatch[0]);
+      } catch (e: any) {
+        return { kind: "adapter-error" as const, message: `could not parse jest JSON: ${e?.message?.slice(0, 80)}` };
+      }
+
+      const assertions: Array<{ status: string; title: string; failureMessages?: string[] }> = [];
+      for (const tr of report.testResults || []) {
+        for (const ar of tr.assertionResults || []) {
+          assertions.push(ar);
+        }
+      }
+
+      if (assertions.length === 0) {
+        return { kind: "adapter-error" as const, message: inv.testName ? `no test matched "${inv.testName}"` : "no assertions reported" };
+      }
+
+      const failures = assertions.filter((a) => a.status === "failed");
+      const skipped = assertions.filter((a) => a.status === "skipped" || a.status === "pending" || a.status === "todo");
+      const passed = assertions.filter((a) => a.status === "passed");
+
+      if (failures.length > 0) {
+        const msg = failures[0]!.failureMessages?.[0] || "assertion failed";
+        return { kind: "fail" as const, message: msg.split("\n")[0]!.slice(0, 200) };
+      }
+      if (passed.length === 0 && skipped.length > 0) {
+        return { kind: "skipped" as const, message: "all matching tests skipped" };
+      }
+      if (passed.length === 0) {
+        return { kind: "adapter-error" as const, message: "no tests passed or failed — runtime anomaly" };
+      }
+      return { kind: "pass" as const, message: `${passed.length} assertion(s) passed` };
+    });
+  }
+}

--- a/src/testAdapters/mocha.ts
+++ b/src/testAdapters/mocha.ts
@@ -1,0 +1,61 @@
+import type { TestAdapter, TestInvocation, TestOutcome } from "./Adapter";
+import { runCommand } from "./vitest";
+
+/**
+ * Mocha adapter. Invokes `npx mocha <file> [--grep name] --reporter json`.
+ * Mocha's JSON reporter emits a single report object to stdout; we parse
+ * stats.passes/failures/pending plus the failures[] array for failure
+ * detail.
+ *
+ * Note: mocha's --grep uses regex. Like the jest adapter, we escape the
+ * testName for predictable substring matching.
+ */
+export class MochaAdapter implements TestAdapter {
+  readonly framework = "mocha";
+  readonly name = "mocha JSON reporter";
+
+  async runTest(inv: TestInvocation): Promise<TestOutcome> {
+    const start = Date.now();
+    const args = ["mocha", inv.testFile, "--reporter", "json"];
+    if (inv.testName) {
+      const escaped = inv.testName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      args.push("--grep", escaped);
+    }
+
+    return runCommand("npx", args, inv.projectRoot, inv.timeoutMs, start, (stdout) => {
+      const jsonMatch = stdout.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        return { kind: "adapter-error" as const, message: "no JSON block in mocha output" };
+      }
+      let report: any;
+      try {
+        report = JSON.parse(jsonMatch[0]);
+      } catch (e: any) {
+        return { kind: "adapter-error" as const, message: `could not parse mocha JSON: ${e?.message?.slice(0, 80)}` };
+      }
+
+      const stats = report.stats || {};
+      const passes = stats.passes || 0;
+      const failures = stats.failures || 0;
+      const pending = stats.pending || 0;
+      const tests = stats.tests || 0;
+
+      if (tests === 0) {
+        return { kind: "adapter-error" as const, message: inv.testName ? `no test matched "${inv.testName}"` : "no tests ran" };
+      }
+
+      if (failures > 0) {
+        const firstFail = (report.failures || [])[0];
+        const msg = firstFail?.err?.message || firstFail?.err?.stack?.split("\n")[0] || "assertion failed";
+        return { kind: "fail" as const, message: msg.split("\n")[0].slice(0, 200) };
+      }
+      if (passes === 0 && pending === tests) {
+        return { kind: "skipped" as const, message: "all matching tests pending/skipped" };
+      }
+      if (passes === 0) {
+        return { kind: "adapter-error" as const, message: "no tests passed or failed — runtime anomaly" };
+      }
+      return { kind: "pass" as const, message: `${passes} test(s) passed` };
+    });
+  }
+}

--- a/src/testAdapters/mocha.ts
+++ b/src/testAdapters/mocha.ts
@@ -1,5 +1,5 @@
 import type { TestAdapter, TestInvocation, TestOutcome } from "./Adapter";
-import { runCommand } from "./vitest";
+import { runCommand, extractLastJsonBlock } from "./vitest";
 
 /**
  * Mocha adapter. Invokes `npx mocha <file> [--grep name] --reporter json`.
@@ -23,13 +23,13 @@ export class MochaAdapter implements TestAdapter {
     }
 
     return runCommand("npx", args, inv.projectRoot, inv.timeoutMs, start, (stdout) => {
-      const jsonMatch = stdout.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) {
+      const jsonBlock = extractLastJsonBlock(stdout);
+      if (!jsonBlock) {
         return { kind: "adapter-error" as const, message: "no JSON block in mocha output" };
       }
       let report: any;
       try {
-        report = JSON.parse(jsonMatch[0]);
+        report = JSON.parse(jsonBlock);
       } catch (e: any) {
         return { kind: "adapter-error" as const, message: `could not parse mocha JSON: ${e?.message?.slice(0, 80)}` };
       }

--- a/src/testAdapters/nodeTest.ts
+++ b/src/testAdapters/nodeTest.ts
@@ -1,0 +1,61 @@
+import type { TestAdapter, TestInvocation, TestOutcome } from "./Adapter";
+import { runCommand } from "./vitest";
+
+/**
+ * Node built-in test runner adapter. Invokes `node --test <file>` and
+ * parses the TAP output. Node's test runner doesn't have a name-filter
+ * CLI flag equivalent to -t/--grep, so when testName is provided we
+ * run the whole file and filter the results by test name afterwards.
+ *
+ * Detects the TAP summary (# tests, # pass, # fail) for an overall
+ * verdict and scans individual test lines for name-specific outcomes.
+ */
+export class NodeTestAdapter implements TestAdapter {
+  readonly framework = "node-test";
+  readonly name = "node --test TAP output";
+
+  async runTest(inv: TestInvocation): Promise<TestOutcome> {
+    const start = Date.now();
+    const args = ["--test", inv.testFile];
+
+    return runCommand("node", args, inv.projectRoot, inv.timeoutMs, start, (stdout, _stderr, exitCode) => {
+      const lines = stdout.split("\n");
+
+      // TAP lines: "ok 42 - <name>" or "not ok 42 - <name>"
+      const testLineRe = /^(ok|not ok)\s+\d+\s*(?:-\s*)?(.*?)(?:\s+#\s*(.+))?$/;
+
+      let passed = 0, failed = 0, skipped = 0;
+      const nameFilter = inv.testName;
+      const matchingLines: string[] = [];
+
+      for (const line of lines) {
+        const m = line.match(testLineRe);
+        if (!m) continue;
+        const [, status, name, directive] = m;
+        if (nameFilter && !name!.includes(nameFilter)) continue;
+
+        matchingLines.push(line);
+        if (directive && /SKIP|TODO/i.test(directive)) skipped++;
+        else if (status === "ok") passed++;
+        else failed++;
+      }
+
+      const total = passed + failed + skipped;
+      if (total === 0) {
+        return { kind: "adapter-error" as const, message: nameFilter ? `no test matched "${nameFilter}"` : "no TAP test lines parsed" };
+      }
+
+      if (failed > 0) {
+        const failureLine = matchingLines.find((l) => l.startsWith("not ok")) || "";
+        return { kind: "fail" as const, message: failureLine.slice(0, 200) || "assertion failed" };
+      }
+      if (passed === 0 && skipped > 0) {
+        return { kind: "skipped" as const, message: "all matching tests skipped" };
+      }
+      if (passed === 0) {
+        return { kind: "adapter-error" as const, message: `node --test returned exit ${exitCode} with no passing tests` };
+      }
+      return { kind: "pass" as const, message: `${passed} test(s) passed` };
+    });
+  }
+}

--- a/src/testAdapters/nodeTest.ts
+++ b/src/testAdapters/nodeTest.ts
@@ -2,13 +2,17 @@ import type { TestAdapter, TestInvocation, TestOutcome } from "./Adapter";
 import { runCommand } from "./vitest";
 
 /**
- * Node built-in test runner adapter. Invokes `node --test <file>` and
- * parses the TAP output. Node's test runner doesn't have a name-filter
- * CLI flag equivalent to -t/--grep, so when testName is provided we
- * run the whole file and filter the results by test name afterwards.
+ * Node built-in test runner adapter. Invokes
+ *   node --test --test-reporter=tap [--test-name-pattern=...] <file>
  *
- * Detects the TAP summary (# tests, # pass, # fail) for an overall
- * verdict and scans individual test lines for name-specific outcomes.
+ * Two notes:
+ *   1. Node 23+ changed the default reporter to `spec`; TAP is no
+ *      longer the default, so we request it explicitly.
+ *   2. Node's runner supports --test-name-pattern (added in 18.17 /
+ *      20.0) with regex semantics. We escape the caller's testName
+ *      to get substring behaviour predictable across versions; the
+ *      fallback post-hoc TAP-line filter still runs for older Node
+ *      versions that ignore the flag.
  */
 export class NodeTestAdapter implements TestAdapter {
   readonly framework = "node-test";
@@ -16,7 +20,12 @@ export class NodeTestAdapter implements TestAdapter {
 
   async runTest(inv: TestInvocation): Promise<TestOutcome> {
     const start = Date.now();
-    const args = ["--test", inv.testFile];
+    const args = ["--test", "--test-reporter=tap"];
+    if (inv.testName) {
+      const escaped = inv.testName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      args.push(`--test-name-pattern=${escaped}`);
+    }
+    args.push(inv.testFile);
 
     return runCommand("node", args, inv.projectRoot, inv.timeoutMs, start, (stdout, _stderr, exitCode) => {
       const lines = stdout.split("\n");

--- a/src/testAdapters/vitest.ts
+++ b/src/testAdapters/vitest.ts
@@ -1,0 +1,117 @@
+import { spawn } from "child_process";
+import type { TestAdapter, TestInvocation, TestOutcome, TestOutcomeKind } from "./Adapter";
+
+/**
+ * Vitest adapter. Invokes `vitest run <file> [-t name] --reporter=json`
+ * and parses the JSON reporter's `testResults[].assertionResults[]` to
+ * determine per-test outcomes. Filters by testName via vitest's
+ * substring match semantics.
+ */
+export class VitestAdapter implements TestAdapter {
+  readonly framework = "vitest";
+  readonly name = "vitest JSON reporter";
+
+  async runTest(inv: TestInvocation): Promise<TestOutcome> {
+    const start = Date.now();
+    const args = ["vitest", "run", inv.testFile, "--reporter=json"];
+    if (inv.testName) {
+      args.push("-t", inv.testName);
+    }
+
+    return runCommand("npx", args, inv.projectRoot, inv.timeoutMs, start, (stdout) => {
+      const jsonMatch = stdout.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        return { kind: "adapter-error" as const, message: "no JSON block in vitest output" };
+      }
+      let report: any;
+      try {
+        report = JSON.parse(jsonMatch[0]);
+      } catch (e: any) {
+        return { kind: "adapter-error" as const, message: `could not parse vitest JSON: ${e?.message?.slice(0, 80)}` };
+      }
+
+      const assertions: Array<{ status: string; title: string; failureMessages?: string[] }> = [];
+      for (const tr of report.testResults || []) {
+        for (const ar of tr.assertionResults || []) {
+          if (!inv.testName || (ar.title || "").includes(inv.testName) || (ar.fullName || "").includes(inv.testName)) {
+            assertions.push(ar);
+          }
+        }
+      }
+
+      if (assertions.length === 0) {
+        return { kind: "adapter-error" as const, message: inv.testName ? `no test matched "${inv.testName}"` : "no assertions reported" };
+      }
+
+      const failures = assertions.filter((a) => a.status === "failed");
+      const errors = assertions.filter((a) => a.status === "error" || a.status === "unknown");
+      const skipped = assertions.filter((a) => a.status === "skipped" || a.status === "pending" || a.status === "todo");
+
+      if (failures.length > 0) {
+        const msg = failures[0]!.failureMessages?.[0] || "assertion failed";
+        return { kind: "fail" as const, message: msg.split("\n")[0]!.slice(0, 200) };
+      }
+      if (errors.length > 0) {
+        return { kind: "error" as const, message: "test runtime error" };
+      }
+      if (skipped.length === assertions.length) {
+        return { kind: "skipped" as const, message: "all matching tests skipped" };
+      }
+      return { kind: "pass" as const, message: `${assertions.length} assertion(s) passed` };
+    });
+  }
+}
+
+export async function runCommand(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+  start: number,
+  parse: (stdout: string, stderr: string, exitCode: number | null) => { kind: TestOutcomeKind; message: string }
+): Promise<TestOutcome> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const child = spawn(cmd, args, { cwd, env: process.env });
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { child.kill("SIGKILL"); } catch {}
+      resolve({
+        kind: "timeout",
+        message: `adapter killed process after ${timeoutMs}ms`,
+        durationMs: Date.now() - start,
+        rawOutput: stdout.slice(0, 8192),
+      });
+    }, timeoutMs);
+
+    child.stdout?.on("data", (buf) => { stdout += buf.toString(); });
+    child.stderr?.on("data", (buf) => { stderr += buf.toString(); });
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        kind: "adapter-error",
+        message: `spawn failed: ${err.message?.slice(0, 120) || "unknown"}`,
+        durationMs: Date.now() - start,
+      });
+    });
+
+    child.on("close", (exitCode) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const parsed = parse(stdout, stderr, exitCode);
+      resolve({
+        ...parsed,
+        durationMs: Date.now() - start,
+        rawOutput: stdout.slice(0, 8192),
+      });
+    });
+  });
+}

--- a/src/testAdapters/vitest.ts
+++ b/src/testAdapters/vitest.ts
@@ -2,10 +2,11 @@ import { spawn } from "child_process";
 import type { TestAdapter, TestInvocation, TestOutcome, TestOutcomeKind } from "./Adapter";
 
 /**
- * Vitest adapter. Invokes `vitest run <file> [-t name] --reporter=json`
+ * Vitest adapter. Invokes `vitest run <file> [-t regex] --reporter=json`
  * and parses the JSON reporter's `testResults[].assertionResults[]` to
- * determine per-test outcomes. Filters by testName via vitest's
- * substring match semantics.
+ * determine per-test outcomes. Note: vitest's -t (--testNamePattern) is
+ * interpreted as a regex, so we escape the caller's testName before
+ * passing it to get predictable substring-style matching.
  */
 export class VitestAdapter implements TestAdapter {
   readonly framework = "vitest";
@@ -15,17 +16,18 @@ export class VitestAdapter implements TestAdapter {
     const start = Date.now();
     const args = ["vitest", "run", inv.testFile, "--reporter=json"];
     if (inv.testName) {
-      args.push("-t", inv.testName);
+      const escaped = inv.testName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      args.push("-t", escaped);
     }
 
     return runCommand("npx", args, inv.projectRoot, inv.timeoutMs, start, (stdout) => {
-      const jsonMatch = stdout.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) {
+      const jsonBlock = extractLastJsonBlock(stdout);
+      if (!jsonBlock) {
         return { kind: "adapter-error" as const, message: "no JSON block in vitest output" };
       }
       let report: any;
       try {
-        report = JSON.parse(jsonMatch[0]);
+        report = JSON.parse(jsonBlock);
       } catch (e: any) {
         return { kind: "adapter-error" as const, message: `could not parse vitest JSON: ${e?.message?.slice(0, 80)}` };
       }
@@ -62,6 +64,28 @@ export class VitestAdapter implements TestAdapter {
   }
 }
 
+/**
+ * Extracts the last balanced-braces JSON object from a stdout stream.
+ * Test frameworks can log objects to stdout before or after the reporter's
+ * JSON output, so matching the first brace greedily is fragile. This
+ * scans from the end backwards for the matching open-brace that contains
+ * a complete object, tolerating pre- and post-reporter log noise.
+ */
+export function extractLastJsonBlock(stdout: string): string | null {
+  const lastBrace = stdout.lastIndexOf("}");
+  if (lastBrace < 0) return null;
+  let depth = 0;
+  for (let i = lastBrace; i >= 0; i--) {
+    const ch = stdout[i];
+    if (ch === "}") depth++;
+    else if (ch === "{") {
+      depth--;
+      if (depth === 0) return stdout.slice(i, lastBrace + 1);
+    }
+  }
+  return null;
+}
+
 export async function runCommand(
   cmd: string,
   args: string[],
@@ -75,11 +99,34 @@ export async function runCommand(
     let stderr = "";
     let settled = false;
 
-    const child = spawn(cmd, args, { cwd, env: process.env });
+    // detached: true on POSIX puts the child in its own process group, so
+    // we can SIGKILL the whole group (including npx's grandchild vitest
+    // process) via a negative PID. On Windows we can't do this; fall back
+    // to the single-process kill.
+    const isPosix = process.platform !== "win32";
+    let child;
+    try {
+      child = spawn(cmd, args, { cwd, env: process.env, detached: isPosix });
+    } catch (err: any) {
+      resolve({
+        kind: "adapter-error",
+        message: `spawn synchronously failed: ${err?.message?.slice(0, 120) || "unknown"}`,
+        durationMs: Date.now() - start,
+      });
+      return;
+    }
+
+    const killTree = () => {
+      try {
+        if (isPosix && child.pid) process.kill(-child.pid, "SIGKILL");
+        else child.kill("SIGKILL");
+      } catch {}
+    };
+
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
-      try { child.kill("SIGKILL"); } catch {}
+      killTree();
       resolve({
         kind: "timeout",
         message: `adapter killed process after ${timeoutMs}ms`,
@@ -106,7 +153,17 @@ export async function runCommand(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      const parsed = parse(stdout, stderr, exitCode);
+
+      let parsed: { kind: TestOutcomeKind; message: string };
+      try {
+        parsed = parse(stdout, stderr, exitCode);
+      } catch (e: any) {
+        parsed = {
+          kind: "adapter-error",
+          message: `parse threw: ${e?.message?.slice(0, 160) || "unknown"}`,
+        };
+      }
+
       resolve({
         ...parsed,
         durationMs: Date.now() - start,

--- a/src/testCache.ts
+++ b/src/testCache.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from "fs";
-import { join } from "path";
+import { join, isAbsolute, resolve as resolvePath } from "path";
 import { createHash } from "crypto";
 import type { TestOutcome } from "./testAdapters/Adapter";
 
@@ -20,31 +20,41 @@ import type { TestOutcome } from "./testAdapters/Adapter";
 
 export class TestCache {
   private dir: string;
+  private projectRoot: string;
 
   constructor(projectRoot: string) {
+    this.projectRoot = projectRoot;
     this.dir = join(projectRoot, ".neurallog", "test-cache");
   }
 
-  private key(testFile: string, testName: string, sourceFile: string): string {
+  private resolve(p: string): string {
+    return isAbsolute(p) ? p : resolvePath(this.projectRoot, p);
+  }
+
+  private key(framework: string, testFile: string, testName: string, sourceFile: string): string {
     const h = createHash("sha256");
+    const testAbs = this.resolve(testFile);
+    const sourceAbs = this.resolve(sourceFile);
     let testMtime = "0";
-    try { testMtime = String(statSync(testFile).mtimeMs); } catch {}
+    try { testMtime = String(statSync(testAbs).mtimeMs); } catch {}
     let sourceMtime = "0";
-    try { sourceMtime = String(statSync(sourceFile).mtimeMs); } catch {}
-    h.update(testFile);
+    try { sourceMtime = String(statSync(sourceAbs).mtimeMs); } catch {}
+    h.update(framework);
+    h.update("\n");
+    h.update(testAbs);
     h.update("\n");
     h.update(testMtime);
     h.update("\n");
     h.update(testName);
     h.update("\n");
-    h.update(sourceFile);
+    h.update(sourceAbs);
     h.update("\n");
     h.update(sourceMtime);
     return h.digest("hex").slice(0, 16);
   }
 
-  get(testFile: string, testName: string, sourceFile: string): TestOutcome | null {
-    const k = this.key(testFile, testName, sourceFile);
+  get(framework: string, testFile: string, testName: string, sourceFile: string): TestOutcome | null {
+    const k = this.key(framework, testFile, testName, sourceFile);
     const path = join(this.dir, `${k}.json`);
     if (!existsSync(path)) return null;
     try {
@@ -54,8 +64,8 @@ export class TestCache {
     }
   }
 
-  put(testFile: string, testName: string, sourceFile: string, outcome: TestOutcome): void {
-    const k = this.key(testFile, testName, sourceFile);
+  put(framework: string, testFile: string, testName: string, sourceFile: string, outcome: TestOutcome): void {
+    const k = this.key(framework, testFile, testName, sourceFile);
     mkdirSync(this.dir, { recursive: true });
     const path = join(this.dir, `${k}.json`);
     try {

--- a/src/testCache.ts
+++ b/src/testCache.ts
@@ -1,0 +1,59 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from "fs";
+import { join } from "path";
+import { createHash } from "crypto";
+import type { TestOutcome } from "./testAdapters/Adapter";
+
+/**
+ * Cache for test-adapter outcomes. Keyed by (test file mtime-ns,
+ * test name, source file hash) so that unchanged code + unchanged
+ * tests skips re-invocation. Source file hash is included because
+ * the outcome depends on the implementation the test is exercising.
+ */
+
+export class TestCache {
+  private dir: string;
+
+  constructor(projectRoot: string) {
+    this.dir = join(projectRoot, ".neurallog", "test-cache");
+  }
+
+  private key(testFile: string, testName: string, sourceFile: string): string {
+    const h = createHash("sha256");
+    let testMtime = "0";
+    try { testMtime = String(statSync(testFile).mtimeMs); } catch {}
+    let sourceMtime = "0";
+    try { sourceMtime = String(statSync(sourceFile).mtimeMs); } catch {}
+    h.update(testFile);
+    h.update("\n");
+    h.update(testMtime);
+    h.update("\n");
+    h.update(testName);
+    h.update("\n");
+    h.update(sourceFile);
+    h.update("\n");
+    h.update(sourceMtime);
+    return h.digest("hex").slice(0, 16);
+  }
+
+  get(testFile: string, testName: string, sourceFile: string): TestOutcome | null {
+    const k = this.key(testFile, testName, sourceFile);
+    const path = join(this.dir, `${k}.json`);
+    if (!existsSync(path)) return null;
+    try {
+      return JSON.parse(readFileSync(path, "utf-8"));
+    } catch {
+      return null;
+    }
+  }
+
+  put(testFile: string, testName: string, sourceFile: string, outcome: TestOutcome): void {
+    const k = this.key(testFile, testName, sourceFile);
+    mkdirSync(this.dir, { recursive: true });
+    const path = join(this.dir, `${k}.json`);
+    try {
+      writeFileSync(path, JSON.stringify(outcome, null, 2));
+    } catch (e: any) {
+      console.log(`[test-cache] put failed: ${e?.message?.slice(0, 60) || "unknown"}`);
+    }
+  }
+}

--- a/src/testCache.ts
+++ b/src/testCache.ts
@@ -4,10 +4,18 @@ import { createHash } from "crypto";
 import type { TestOutcome } from "./testAdapters/Adapter";
 
 /**
- * Cache for test-adapter outcomes. Keyed by (test file mtime-ns,
- * test name, source file hash) so that unchanged code + unchanged
- * tests skips re-invocation. Source file hash is included because
- * the outcome depends on the implementation the test is exercising.
+ * Cache for test-adapter outcomes. Keyed by (test file path + mtimeMs,
+ * test name, source file path + mtimeMs) so that unchanged code +
+ * unchanged tests skip re-invocation. Source mtime is included because
+ * the outcome depends on the implementation the test is exercising;
+ * if the source file is touched, the cached outcome is invalidated.
+ *
+ * Uses mtimeMs (millisecond resolution) rather than content hashing
+ * because mtimes are fast to read and practically identical to content
+ * hashes for the "has this file changed since cached" question. If
+ * content-addressing becomes required later (e.g. to handle git
+ * checkouts that preserve content but reset mtime), switch to sha256
+ * of file contents here.
  */
 
 export class TestCache {

--- a/src/testOracle.triangle.test.ts
+++ b/src/testOracle.triangle.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { summarizeTriangle } from "./testOracle";
+import { TestCache } from "./testCache";
+import { getAdapter, listAdapters } from "./testAdapters";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const tmpRoot = join(tmpdir(), `neurallog-triangle-test-${Date.now()}`);
+
+beforeAll(() => {
+  mkdirSync(tmpRoot, { recursive: true });
+});
+
+afterAll(() => {
+  try { rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+});
+
+describe("summarizeTriangle", () => {
+  const passResult = { reference: any("ref-pass"), outcome: { kind: "pass" as const, message: "ok", durationMs: 10 }, cached: false };
+  const failResult = { reference: any("ref-fail"), outcome: { kind: "fail" as const, message: "expected 1 got 2", durationMs: 12 }, cached: false };
+  const errorResult = { reference: any("ref-err"), outcome: { kind: "adapter-error" as const, message: "spawn failed", durationMs: 0 }, cached: false };
+
+  function any(testName: string) {
+    return { file: "t.test.ts", lineStart: 1, lineEnd: 5, snippet: "", testName };
+  }
+
+  it("returns empty note for empty oracle results", () => {
+    const r = summarizeTriangle("pass", []);
+    expect(r.note).toBe("");
+    expect(r.hasAgreement).toBe(false);
+    expect(r.hasDisagreement).toBe(false);
+  });
+
+  it("harness=pass + all tests pass → agreement", () => {
+    const r = summarizeTriangle("pass", [passResult, passResult]);
+    expect(r.hasAgreement).toBe(true);
+    expect(r.hasDisagreement).toBe(false);
+    expect(r.note).toContain("2 test(s) pass");
+  });
+
+  it("harness=pass + tests fail → disagreement", () => {
+    const r = summarizeTriangle("pass", [passResult, failResult]);
+    expect(r.hasDisagreement).toBe(true);
+    expect(r.note).toContain("1 test(s) fail");
+  });
+
+  it("harness=encoding-gap + tests fail → agreement (both signal problem)", () => {
+    const r = summarizeTriangle("encoding-gap", [failResult]);
+    expect(r.hasAgreement).toBe(true);
+    expect(r.hasDisagreement).toBe(false);
+  });
+
+  it("harness=encoding-gap + tests pass → disagreement (harness may be wrong)", () => {
+    const r = summarizeTriangle("encoding-gap", [passResult, passResult]);
+    expect(r.hasDisagreement).toBe(true);
+    expect(r.hasAgreement).toBe(false);
+  });
+
+  it("adapter-errors don't count as pass or fail for agreement purposes", () => {
+    const r = summarizeTriangle("pass", [errorResult, errorResult]);
+    expect(r.hasAgreement).toBe(false);
+    expect(r.hasDisagreement).toBe(false);
+    expect(r.note).toContain("2 test(s) could not run");
+  });
+});
+
+describe("TestCache", () => {
+  it("returns null on miss", () => {
+    const cache = new TestCache(tmpRoot);
+    expect(cache.get("nonexistent.ts", "some test", "src/foo.ts")).toBeNull();
+  });
+
+  it("round-trips an outcome", () => {
+    const testFile = join(tmpRoot, "a.test.ts");
+    const sourceFile = join(tmpRoot, "a.ts");
+    writeFileSync(testFile, "// test");
+    writeFileSync(sourceFile, "// source");
+    const cache = new TestCache(tmpRoot);
+    cache.put(testFile, "my test", sourceFile, { kind: "pass", message: "ok", durationMs: 50 });
+    const got = cache.get(testFile, "my test", sourceFile);
+    expect(got).not.toBeNull();
+    expect(got!.kind).toBe("pass");
+    expect(got!.durationMs).toBe(50);
+  });
+
+  it("invalidates on source file mtime change", async () => {
+    const testFile = join(tmpRoot, "b.test.ts");
+    const sourceFile = join(tmpRoot, "b.ts");
+    writeFileSync(testFile, "// test");
+    writeFileSync(sourceFile, "// v1");
+    const cache = new TestCache(tmpRoot);
+    cache.put(testFile, "t", sourceFile, { kind: "pass", message: "ok", durationMs: 1 });
+    expect(cache.get(testFile, "t", sourceFile)).not.toBeNull();
+
+    // Bump source mtime
+    await new Promise((r) => setTimeout(r, 10));
+    writeFileSync(sourceFile, "// v2");
+    expect(cache.get(testFile, "t", sourceFile)).toBeNull();
+  });
+});
+
+describe("testAdapters registry", () => {
+  it("exposes adapters for all four frameworks", () => {
+    expect(getAdapter("vitest")).not.toBeNull();
+    expect(getAdapter("jest")).not.toBeNull();
+    expect(getAdapter("mocha")).not.toBeNull();
+    expect(getAdapter("node-test")).not.toBeNull();
+  });
+
+  it("returns null for unknown framework", () => {
+    expect(getAdapter("pytest")).toBeNull();
+    expect(getAdapter("ava")).toBeNull();
+  });
+
+  it("listAdapters returns all registered", () => {
+    const all = listAdapters();
+    expect(all.length).toBeGreaterThanOrEqual(4);
+    const frameworks = all.map((a) => a.framework);
+    expect(frameworks).toContain("vitest");
+    expect(frameworks).toContain("jest");
+    expect(frameworks).toContain("mocha");
+    expect(frameworks).toContain("node-test");
+  });
+
+  it("each adapter has a canonical framework and a human name", () => {
+    for (const a of listAdapters()) {
+      expect(typeof a.framework).toBe("string");
+      expect(a.framework.length).toBeGreaterThan(0);
+      expect(typeof a.name).toBe("string");
+      expect(a.name.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/testOracle.triangle.test.ts
+++ b/src/testOracle.triangle.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { summarizeTriangle } from "./testOracle";
 import { TestCache } from "./testCache";
 import { getAdapter, listAdapters } from "./testAdapters";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, utimesSync, statSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -39,9 +39,18 @@ describe("summarizeTriangle", () => {
     expect(r.note).toContain("2 test(s) pass");
   });
 
-  it("harness=pass + tests fail → disagreement", () => {
-    const r = summarizeTriangle("pass", [passResult, failResult]);
+  it("harness=pass + uniformly failing tests → disagreement", () => {
+    const r = summarizeTriangle("pass", [failResult, failResult]);
     expect(r.hasDisagreement).toBe(true);
+    expect(r.hasAgreement).toBe(false);
+    expect(r.note).toContain("2 test(s) fail");
+  });
+
+  it("harness=pass + mixed pass/fail oracles → neither agreement nor disagreement (ambiguous)", () => {
+    const r = summarizeTriangle("pass", [passResult, failResult]);
+    expect(r.hasAgreement).toBe(false);
+    expect(r.hasDisagreement).toBe(false);
+    expect(r.note).toContain("1 test(s) pass");
     expect(r.note).toContain("1 test(s) fail");
   });
 
@@ -81,7 +90,7 @@ describe("summarizeTriangle", () => {
 describe("TestCache", () => {
   it("returns null on miss", () => {
     const cache = new TestCache(tmpRoot);
-    expect(cache.get("nonexistent.ts", "some test", "src/foo.ts")).toBeNull();
+    expect(cache.get("vitest", "nonexistent.ts", "some test", "src/foo.ts")).toBeNull();
   });
 
   it("round-trips an outcome", () => {
@@ -90,26 +99,39 @@ describe("TestCache", () => {
     writeFileSync(testFile, "// test");
     writeFileSync(sourceFile, "// source");
     const cache = new TestCache(tmpRoot);
-    cache.put(testFile, "my test", sourceFile, { kind: "pass", message: "ok", durationMs: 50 });
-    const got = cache.get(testFile, "my test", sourceFile);
+    cache.put("vitest", testFile, "my test", sourceFile, { kind: "pass", message: "ok", durationMs: 50 });
+    const got = cache.get("vitest", testFile, "my test", sourceFile);
     expect(got).not.toBeNull();
     expect(got!.kind).toBe("pass");
     expect(got!.durationMs).toBe(50);
   });
 
-  it("invalidates on source file mtime change", async () => {
+  it("invalidates on source file mtime change (via utimes — deterministic)", () => {
     const testFile = join(tmpRoot, "b.test.ts");
     const sourceFile = join(tmpRoot, "b.ts");
     writeFileSync(testFile, "// test");
     writeFileSync(sourceFile, "// v1");
     const cache = new TestCache(tmpRoot);
-    cache.put(testFile, "t", sourceFile, { kind: "pass", message: "ok", durationMs: 1 });
-    expect(cache.get(testFile, "t", sourceFile)).not.toBeNull();
+    cache.put("vitest", testFile, "t", sourceFile, { kind: "pass", message: "ok", durationMs: 1 });
+    expect(cache.get("vitest", testFile, "t", sourceFile)).not.toBeNull();
 
-    // Bump source mtime
-    await new Promise((r) => setTimeout(r, 10));
-    writeFileSync(sourceFile, "// v2");
-    expect(cache.get(testFile, "t", sourceFile)).toBeNull();
+    // Force mtime forward by 10 seconds regardless of filesystem granularity.
+    const now = statSync(sourceFile).mtime;
+    const future = new Date(now.getTime() + 10_000);
+    utimesSync(sourceFile, future, future);
+    expect(cache.get("vitest", testFile, "t", sourceFile)).toBeNull();
+  });
+
+  it("different frameworks are cached independently", () => {
+    const testFile = join(tmpRoot, "c.test.ts");
+    const sourceFile = join(tmpRoot, "c.ts");
+    writeFileSync(testFile, "// test");
+    writeFileSync(sourceFile, "// source");
+    const cache = new TestCache(tmpRoot);
+    cache.put("vitest", testFile, "t", sourceFile, { kind: "pass", message: "via vitest", durationMs: 1 });
+    expect(cache.get("vitest", testFile, "t", sourceFile)!.message).toBe("via vitest");
+    // Same file/test/source under a different framework: should be a miss
+    expect(cache.get("jest", testFile, "t", sourceFile)).toBeNull();
   });
 });
 

--- a/src/testOracle.triangle.test.ts
+++ b/src/testOracle.triangle.test.ts
@@ -61,7 +61,20 @@ describe("summarizeTriangle", () => {
     const r = summarizeTriangle("pass", [errorResult, errorResult]);
     expect(r.hasAgreement).toBe(false);
     expect(r.hasDisagreement).toBe(false);
-    expect(r.note).toContain("2 test(s) could not run");
+    expect(r.note).toContain("2 could not run");
+  });
+
+  it("neutral harness kinds (harness-error, timeout) produce no agreement/disagreement", () => {
+    expect(summarizeTriangle("harness-error", [passResult])).toMatchObject({ hasAgreement: false, hasDisagreement: false });
+    expect(summarizeTriangle("timeout", [failResult])).toMatchObject({ hasAgreement: false, hasDisagreement: false });
+    expect(summarizeTriangle("synthesis-failed", [passResult, failResult])).toMatchObject({ hasAgreement: false, hasDisagreement: false });
+  });
+
+  it("note does not end with a trailing comma when only skipped/errored outcomes are present", () => {
+    const skippedResult = { reference: any("s"), outcome: { kind: "skipped" as const, message: "over cap", durationMs: 0 }, cached: false };
+    const r = summarizeTriangle("pass", [skippedResult, errorResult]);
+    expect(r.note).not.toMatch(/,\s*$/);
+    expect(r.note).toContain("no actionable oracle verdicts");
   });
 });
 

--- a/src/testOracle.ts
+++ b/src/testOracle.ts
@@ -204,8 +204,10 @@ export async function runTest(
 }
 
 /**
- * Run every test reference for a function. Bounded by maxTests to keep
- * total runtime predictable — excess references are skipped with a note.
+ * Run every test reference for a function, bounded by maxTests to keep
+ * total runtime predictable. Excess references (beyond maxTests) are
+ * returned with outcome { kind: "skipped", message: "... (over cap) ..." }
+ * so the caller sees that references existed but weren't executed.
  */
 export async function runTestsForReferences(
   projectRoot: string,
@@ -219,6 +221,17 @@ export async function runTestsForReferences(
   const results: ExecutedOracleResult[] = [];
   for (const ref of references.slice(0, maxTests)) {
     results.push(await runTest(projectRoot, framework, ref, sourceFile, timeoutMsEach));
+  }
+  for (const ref of references.slice(maxTests)) {
+    results.push({
+      reference: ref,
+      outcome: {
+        kind: "skipped",
+        message: `reference skipped — exceeds maxTests=${maxTests} cap (${references.length} total references)`,
+        durationMs: 0,
+      },
+      cached: false,
+    });
   }
   return results;
 }
@@ -238,21 +251,47 @@ export function summarizeTriangle(
 
   const passes = oracleResults.filter((r) => r.outcome.kind === "pass");
   const fails = oracleResults.filter((r) => r.outcome.kind === "fail" || r.outcome.kind === "error");
+  const skipped = oracleResults.filter((r) => r.outcome.kind === "skipped");
   const errors = oracleResults.filter((r) => r.outcome.kind === "adapter-error" || r.outcome.kind === "timeout");
+
+  // harnessKind classification:
+  //   suggests-problem:  encoding-gap, fail, violation
+  //   suggests-ok:       pass
+  //   neutral:           harness-error, timeout, synthesis-failed, untestable — the harness
+  //                      itself didn't provide a verdict about the claim, so we don't
+  //                      infer agreement or disagreement from the tests.
   const harnessSuggestsProblem = harnessKind === "encoding-gap" || harnessKind === "fail" || harnessKind === "violation";
+  const harnessSuggestsOk = harnessKind === "pass";
+  const harnessNeutral = !harnessSuggestsProblem && !harnessSuggestsOk;
 
-  const agreementFragments: string[] = [];
-  if (passes.length > 0) agreementFragments.push(`${passes.length} test(s) pass`);
-  if (fails.length > 0) agreementFragments.push(`${fails.length} test(s) fail`);
-  if (errors.length > 0) agreementFragments.push(`${errors.length} test(s) could not run`);
+  const fragments: string[] = [];
+  if (passes.length > 0) fragments.push(`${passes.length} test(s) pass`);
+  if (fails.length > 0) fragments.push(`${fails.length} test(s) fail`);
+  if (skipped.length > 0) fragments.push(`${skipped.length} skipped`);
+  if (errors.length > 0) fragments.push(`${errors.length} could not run`);
 
-  const note = `triangle: harness=${harnessKind}, ${agreementFragments.join(", ")}`;
+  // If no test actually produced a verdict (everything skipped/errored), there's nothing
+  // to agree or disagree with.
+  const actionableOutcomes = passes.length + fails.length;
+  if (actionableOutcomes === 0) {
+    return {
+      note: `triangle: harness=${harnessKind}, ${fragments.join(", ")} (no actionable oracle verdicts)`,
+      hasAgreement: false,
+      hasDisagreement: false,
+    };
+  }
+
+  const note = `triangle: harness=${harnessKind}, ${fragments.join(", ")}`;
+  if (harnessNeutral) {
+    return { note, hasAgreement: false, hasDisagreement: false };
+  }
+
   const hasAgreement =
     (harnessSuggestsProblem && fails.length > 0) ||
-    (!harnessSuggestsProblem && passes.length > 0 && fails.length === 0);
+    (harnessSuggestsOk && passes.length > 0 && fails.length === 0);
   const hasDisagreement =
     (harnessSuggestsProblem && passes.length > 0 && fails.length === 0) ||
-    (!harnessSuggestsProblem && fails.length > 0);
+    (harnessSuggestsOk && fails.length > 0);
 
   return { note, hasAgreement, hasDisagreement };
 }

--- a/src/testOracle.ts
+++ b/src/testOracle.ts
@@ -177,7 +177,7 @@ export async function runTest(
   const testFile = isAbsolute(reference.file) ? reference.file : resolvePath(projectRoot, reference.file);
   const sourceAbs = isAbsolute(sourceFile) ? sourceFile : resolvePath(projectRoot, sourceFile);
 
-  const cached = cache.get(testFile, reference.testName, sourceAbs);
+  const cached = cache.get(framework, testFile, reference.testName, sourceAbs);
   if (cached) return { reference, outcome: cached, cached: true };
 
   const adapter = getAdapter(framework);
@@ -189,15 +189,32 @@ export async function runTest(
     };
   }
 
-  const outcome = await adapter.runTest({
-    projectRoot,
-    testFile,
-    testName: reference.testName,
-    timeoutMs,
-  });
+  let outcome;
+  try {
+    outcome = await adapter.runTest({
+      projectRoot,
+      testFile,
+      testName: reference.testName,
+      timeoutMs,
+    });
+  } catch (e: any) {
+    // Adapters are documented to never throw — they should convert
+    // errors into adapter-error outcomes themselves. If one escapes
+    // anyway, we must normalize here so the checker never sees a
+    // rejected promise from a call it assumed was safe.
+    return {
+      reference,
+      outcome: {
+        kind: "adapter-error",
+        message: `adapter threw (contract violation): ${String(e?.message || e).slice(0, 160)}`,
+        durationMs: 0,
+      },
+      cached: false,
+    };
+  }
 
   if (outcome.kind !== "adapter-error" && outcome.kind !== "timeout") {
-    cache.put(testFile, reference.testName, sourceAbs, outcome);
+    cache.put(framework, testFile, reference.testName, sourceAbs, outcome);
   }
 
   return { reference, outcome, cached: false };
@@ -216,7 +233,7 @@ export async function runTestsForReferences(
   sourceFile: string,
   opts: { maxTests?: number; timeoutMsEach?: number } = {}
 ): Promise<ExecutedOracleResult[]> {
-  const maxTests = opts.maxTests ?? 5;
+  const maxTests = opts.maxTests ?? 3;
   const timeoutMsEach = opts.timeoutMsEach ?? 30000;
   const results: ExecutedOracleResult[] = [];
   for (const ref of references.slice(0, maxTests)) {
@@ -286,12 +303,20 @@ export function summarizeTriangle(
     return { note, hasAgreement: false, hasDisagreement: false };
   }
 
+  // Only declare agreement when the oracle outcomes are uniform and point
+  // the same direction as the harness. Mixed pass+fail is intrinsically
+  // ambiguous — some tests exercise the claim's input region and agree,
+  // others exercise different regions and disagree — neither "agree" nor
+  // "disagree" cleanly applies, so we return both false and let callers
+  // surface the mixed state via the note string.
+  const uniformPass = passes.length > 0 && fails.length === 0;
+  const uniformFail = fails.length > 0 && passes.length === 0;
   const hasAgreement =
-    (harnessSuggestsProblem && fails.length > 0) ||
-    (harnessSuggestsOk && passes.length > 0 && fails.length === 0);
+    (harnessSuggestsProblem && uniformFail) ||
+    (harnessSuggestsOk && uniformPass);
   const hasDisagreement =
-    (harnessSuggestsProblem && passes.length > 0 && fails.length === 0) ||
-    (harnessSuggestsOk && fails.length > 0);
+    (harnessSuggestsProblem && uniformPass) ||
+    (harnessSuggestsOk && uniformFail);
 
   return { note, hasAgreement, hasDisagreement };
 }

--- a/src/testOracle.ts
+++ b/src/testOracle.ts
@@ -1,20 +1,21 @@
 /**
  * Triangle oracle: user's existing test suite as a third verification oracle.
  *
- * Clover's architecture insight: when the project has unit tests, those tests
- * are an independent source of truth alongside the Z3 proof and the runtime
- * harness. This module detects the test framework, finds tests referencing
- * a target function, and exposes their source so harness synthesis can use
- * them as reference.
- *
- * v1 scope: detection + source extraction for prompt injection. Actual test
- * *execution* as a runtime oracle (invoking the test runner with specific
- * inputs and cross-referencing outcomes) is a larger architectural step and
- * left as followup.
+ * Two modes:
+ *   1. Advisory: detect the framework, find tests referencing the target
+ *      function, and expose their source for prompt injection so harness
+ *      synthesis can align with existing test conventions.
+ *   2. Executing: actually invoke the test runner (via a framework-specific
+ *      adapter in ./testAdapters/) against those tests and return
+ *      structured outcomes. Enables cross-referencing test pass/fail with
+ *      harness pass/encoding-gap for a true three-oracle triangulation.
  */
 
 import { readFileSync, existsSync, readdirSync, statSync } from "fs";
-import { join, relative } from "path";
+import { join, relative, isAbsolute, resolve as resolvePath } from "path";
+import { getAdapter } from "./testAdapters";
+import { TestCache } from "./testCache";
+import type { TestOutcome } from "./testAdapters/Adapter";
 
 export type TestFramework = "vitest" | "jest" | "mocha" | "ava" | "tap" | "node-test" | "unknown";
 
@@ -151,4 +152,107 @@ export function formatForPrompt(refs: TestReference[]): string {
     lines.push("");
   }
   return lines.join("\n");
+}
+
+export interface ExecutedOracleResult {
+  reference: TestReference;
+  outcome: TestOutcome;
+  cached: boolean;
+}
+
+/**
+ * Run a single test reference via the framework-appropriate adapter.
+ * Consults the TestCache first; on miss, spawns the runner, stores the
+ * outcome. Returns adapter-error if no adapter is registered for the
+ * detected framework.
+ */
+export async function runTest(
+  projectRoot: string,
+  framework: TestFramework,
+  reference: TestReference,
+  sourceFile: string,
+  timeoutMs: number = 30000
+): Promise<ExecutedOracleResult> {
+  const cache = new TestCache(projectRoot);
+  const testFile = isAbsolute(reference.file) ? reference.file : resolvePath(projectRoot, reference.file);
+  const sourceAbs = isAbsolute(sourceFile) ? sourceFile : resolvePath(projectRoot, sourceFile);
+
+  const cached = cache.get(testFile, reference.testName, sourceAbs);
+  if (cached) return { reference, outcome: cached, cached: true };
+
+  const adapter = getAdapter(framework);
+  if (!adapter) {
+    return {
+      reference,
+      outcome: { kind: "adapter-error", message: `no adapter registered for framework "${framework}"`, durationMs: 0 },
+      cached: false,
+    };
+  }
+
+  const outcome = await adapter.runTest({
+    projectRoot,
+    testFile,
+    testName: reference.testName,
+    timeoutMs,
+  });
+
+  if (outcome.kind !== "adapter-error" && outcome.kind !== "timeout") {
+    cache.put(testFile, reference.testName, sourceAbs, outcome);
+  }
+
+  return { reference, outcome, cached: false };
+}
+
+/**
+ * Run every test reference for a function. Bounded by maxTests to keep
+ * total runtime predictable — excess references are skipped with a note.
+ */
+export async function runTestsForReferences(
+  projectRoot: string,
+  framework: TestFramework,
+  references: TestReference[],
+  sourceFile: string,
+  opts: { maxTests?: number; timeoutMsEach?: number } = {}
+): Promise<ExecutedOracleResult[]> {
+  const maxTests = opts.maxTests ?? 5;
+  const timeoutMsEach = opts.timeoutMsEach ?? 30000;
+  const results: ExecutedOracleResult[] = [];
+  for (const ref of references.slice(0, maxTests)) {
+    results.push(await runTest(projectRoot, framework, ref, sourceFile, timeoutMsEach));
+  }
+  return results;
+}
+
+/**
+ * Summarise a triangle (harness outcome vs test-oracle outcomes) into a
+ * single diagnostic string suitable for the CheckResult.error field.
+ * The caller still decides the verdict; this just renders the signal.
+ */
+export function summarizeTriangle(
+  harnessKind: string,
+  oracleResults: ExecutedOracleResult[]
+): { note: string; hasAgreement: boolean; hasDisagreement: boolean } {
+  if (oracleResults.length === 0) {
+    return { note: "", hasAgreement: false, hasDisagreement: false };
+  }
+
+  const passes = oracleResults.filter((r) => r.outcome.kind === "pass");
+  const fails = oracleResults.filter((r) => r.outcome.kind === "fail" || r.outcome.kind === "error");
+  const errors = oracleResults.filter((r) => r.outcome.kind === "adapter-error" || r.outcome.kind === "timeout");
+  const harnessSuggestsProblem = harnessKind === "encoding-gap" || harnessKind === "fail" || harnessKind === "violation";
+
+  const agreementFragments: string[] = [];
+  if (passes.length > 0) agreementFragments.push(`${passes.length} test(s) pass`);
+  if (fails.length > 0) agreementFragments.push(`${fails.length} test(s) fail`);
+  if (errors.length > 0) agreementFragments.push(`${errors.length} test(s) could not run`);
+
+  const note = `triangle: harness=${harnessKind}, ${agreementFragments.join(", ")}`;
+  const hasAgreement =
+    (harnessSuggestsProblem && fails.length > 0) ||
+    (!harnessSuggestsProblem && passes.length > 0 && fails.length === 0);
+  const hasDisagreement =
+    (harnessSuggestsProblem && passes.length > 0 && fails.length === 0) ||
+    (!harnessSuggestsProblem && fails.length > 0);
+
+  return { note, hasAgreement, hasDisagreement };
 }


### PR DESCRIPTION
## Summary

Adds the execution half of the triangle-oracle design sketched in PR #1. When \`NEURALLOG_RUN_ORACLE_TESTS=1\`, the property-test checker invokes the user's existing test runner against tests referencing the function under examination, and cross-references those outcomes with the harness verdict to produce a stronger verification signal.

**Stacked on \`refinements\` — please merge #1 first.**

## Architecture

Per the ask, adapters are properly broken out — one file per framework, shared interface:

\`\`\`
src/testAdapters/
  Adapter.ts      TestAdapter interface + TestInvocation/TestOutcome types
  index.ts        registry (getAdapter / listAdapters)
  vitest.ts       VitestAdapter
  jest.ts         JestAdapter
  mocha.ts        MochaAdapter
  nodeTest.ts     NodeTestAdapter
\`\`\`

Adding a new framework is one file implementing \`TestAdapter\` + one \`register\` line in the registry.

## Signal semantics

| harness | tests | interpretation |
|---------|-------|---------------|
| pass    | pass  | triangle agreement — strongest corroboration |
| pass    | fail  | disagreement — tests assert something harness didn't exercise |
| gap     | fail  | agreement — multiple oracles refute the claim |
| gap     | pass  | disagreement — harness may have wrong abstraction, or tests don't cover the witness region |

Annotated in \`CheckResult.error\` via \`summarizeTriangle\`. Judgment stays with downstream tooling — the checker just surfaces the signal.

## Env gates

- \`NEURALLOG_RUN_ORACLE_TESTS=1\` — enable execution (off by default)
- Per-test timeout hardcoded to 30s; max 3 tests per contract

## Intentionally not included

Runtime input mutation (take Z3 witness, modify test fixture, re-run) requires per-framework fixture introspection — out of scope for v1. Advisory context in the synthesis prompt (already in #1) plus execution cross-reference (this PR) is the minimum useful triangle.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 83 tests pass (13 new: triangle summarization, cache invalidation, registry lookup)
- [ ] Integration: run \`NEURALLOG_PROPERTY_TEST=1 NEURALLOG_HARNESS_SYNTHESIS=1 NEURALLOG_RUN_ORACLE_TESTS=1\` against a project with existing tests; observe triangle annotations in report
- [ ] Reviewer smoke: confirm adapter dispatch works for each framework locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated oracle-based test execution during harness synthesis to validate generated code
  * Added support for multiple test frameworks (Jest, Mocha, Vitest, Node.js test runner)
  * Implemented test result caching to improve synthesis performance
  * Added test outcome summarization with agreement/disagreement detection

* **Chores**
  * Updated `.gitignore` to exclude test cache directory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->