### PR TITLE
Cut v1.3.0 catalog (additive over v1.2.0; signed)

### DIFF
--- a/.provekit/catalog-signatures/v1.3.0.json
+++ b/.provekit/catalog-signatures/v1.3.0.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1",
+  "protocolName": "provekit-protocol",
+  "protocolVersion": "v1.3.0",
+  "catalogCid": "blake3-512:5a3129f49276fef3239796d7dfdae3d8ddf92f92201adddd1ebce59a5f455b91d3b50168765136c740984e325fb002d2bf44f7233438c7e40285d87b205d24c7",
+  "declaredAt": "2026-05-02T15:00:00Z",
+  "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+  "signature": "ed25519:uSykn8u/35nSLyxd/5ZWZmyJQ01jEDjvUBuJNfeUooma3LqGLSOQZY1qd5LS95I2AEmLWWa5kk1lsalwdGWXAg=="
+}

--- a/docs/launch/bluepaper.md
+++ b/docs/launch/bluepaper.md
@@ -11,8 +11,8 @@ The reader verifies this document's authority by computing the BLAKE3-512 hash o
 ## §0. Pinned authority
 
 ```
-protocol catalog (v1.2.0)
-  blake3-512:1e5cfee6043d485d276c26a8da17830fe828c5b7b395a5fb1f042e7442407a37c39c59c0e002ca18857b12d3efb0d86687b9a3a0e3f6e3e933856f0717d0579f
+protocol catalog (v1.3.0)
+  blake3-512:5a3129f49276fef3239796d7dfdae3d8ddf92f92201adddd1ebce59a5f455b91d3b50168765136c740984e325fb002d2bf44f7233438c7e40285d87b205d24c7
 ```
 
 This is `BLAKE3-512(JCS(catalog-json))`, not `BLAKE3-512(catalog-file-bytes)`. The catalog is canonicalized first per RFC 8785 (sorted keys, no whitespace, deterministic number form), then hashed. Anything else gets a different number.
@@ -317,7 +317,7 @@ lattice tractability theorem   blake3-512:b6d7c2772c2929294d7f516f79559bd292e44f
 memento envelope grammar       blake3-512:58bba3e1a9f6439eac5cb0c681faf65d38de9e6b8ad539854acda451ca67562a9d238eb95a5d7df2c0776657015fa026c51059dff61e1ba9aa2438b57425d6a5
 proof substrate                blake3-512:ad53d6c59ee08270a48715376cc211f964ff44a55b3318d68a402e9c915ff593d5a5bbbd424f7777e2bcfe89d6c5bd2b49efcb5aae7de24752f3bcabb90484ae
 proof file format              blake3-512:7bb4589af25c6c3992520494869bbbe4cfbcf7a77b91ebd61d6327e78699ef16cd5bc34afbe4cdf88a717c055c16536b5106bc4dca2d9d6b5cfcc1eede68e1b3
-protocol catalog (v1.2.0)      blake3-512:1e5cfee6043d485d276c26a8da17830fe828c5b7b395a5fb1f042e7442407a37c39c59c0e002ca18857b12d3efb0d86687b9a3a0e3f6e3e933856f0717d0579f
+protocol catalog (v1.3.0)      blake3-512:5a3129f49276fef3239796d7dfdae3d8ddf92f92201adddd1ebce59a5f455b91d3b50168765136c740984e325fb002d2bf44f7233438c7e40285d87b205d24c7
 self-contracts (stable; v1.1.0+)        blake3-512:b692f43a151f88aa31b998adaa091b2ac7ebad231c3c2b63426d93a8090de688bc8f12e02fe6ef901a513c4bf89dbffc884cd1164fa566fd1a757cf478434dfe
 signatures and non-repudiation blake3-512:8b71229fcb7413f18a93a9b260012298311c1ce754850ee717780c181f1fda39a6600b2e5069e775cd7dd15e8c81e40b47bf7585aa0b23ab76c112c85116365c
 ```
@@ -382,6 +382,8 @@ The constant-size and constant-time claims are theorems. Their empirical confirm
 v1.1.0 (2026-04-30): protocol freeze. BLAKE3-512 widening from earlier truncated forms. Every CID now carries the full 128-hex string. Per-language kit-standard finalized; conformance suite passing on Rust, C++, TypeScript reference peers. Catalog CID `5b770182...19f05cd4`.
 
 v1.2.0 (2026-04-30): additive bump over v1.1.0. Adds four pluggability protocols: agent-plugin-protocol (LSP-shape JSON-RPC seam for coding agents), ir-compiler-protocol (per-solver IR translators), multi-solver-protocol (single/chain/portfolio dispatch), lift-plugin-protocol (one Rust CLI dispatching to per-language plugins via stdio JSON-RPC). Reference CLI plugins ship for Rust + Go + C++; TypeScript is consumed via toolchain (vitest), not as a peer CLI. Any v1.1.0 memento or `.proof` remains valid under v1.2.0 — the bump is purely additive. Catalog CID `1e5cfee6...17d0579f`. Signed under the same foundation key as v1.1.0.
+
+v1.3.0 (2026-05-02): additive bump over v1.2.0. Adds four protocol enrichments and two new specs. (1) BridgeDeclaration gains `sourceContractCid` + `targetProofCid` for hash-bounded cross-bundle witness pinning. (2) ProofEnvelope catalog memento gains optional `binaryCid` for supply-chain anchoring (rule 5 is MAY in v1.3.0; promotion to MUST awaits a reference verifier in v1.4.0). (3) ProofEnvelope catalog memento gains optional `metadata` map for non-normative tooling/diagnostics. (4) `EvidenceTerm` proof-certificate carrier for `smt-lib`/`coq`/`custom` proof types. New specs: `correctness-is-a-hash` (the memcmp theorem) and `lsp-protocol` (real-time IDE integration with pluggable JSON-RPC backend). All v1.2.0 mementos and `.proof` bundles remain valid; v1.2.0's CID `1e5cfee6...17d0579f` stays attestable for anyone pinned. Catalog CID `5a3129f4...205d24c7`. Signed under the same foundation key.
 
 ---
 

--- a/implementations/rust/provekit-cli/assets/catalog-signature-v1.3.0.json
+++ b/implementations/rust/provekit-cli/assets/catalog-signature-v1.3.0.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1",
+  "protocolName": "provekit-protocol",
+  "protocolVersion": "v1.3.0",
+  "catalogCid": "blake3-512:5a3129f49276fef3239796d7dfdae3d8ddf92f92201adddd1ebce59a5f455b91d3b50168765136c740984e325fb002d2bf44f7233438c7e40285d87b205d24c7",
+  "declaredAt": "2026-05-02T15:00:00Z",
+  "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+  "signature": "ed25519:uSykn8u/35nSLyxd/5ZWZmyJQ01jEDjvUBuJNfeUooma3LqGLSOQZY1qd5LS95I2AEmLWWa5kk1lsalwdGWXAg=="
+}

--- a/implementations/rust/provekit-cli/assets/protocol-catalog.json
+++ b/implementations/rust/provekit-cli/assets/protocol-catalog.json
@@ -1,7 +1,7 @@
 {
   "kind": "catalog",
   "name": "provekit-protocol",
-  "version": "v1.2.0-2026-04-30",
+  "version": "v1.3.0-2026-05-02",
   "algorithms": {
     "hash": [
       "blake3-512"
@@ -14,27 +14,30 @@
     ]
   },
   "properties": {
-    "ir-formal-grammar": "blake3-512:6c0127e0d24946d7be75861db20507ccdcfdf968d3333f8aa34083e849d8238d73b3acfaa31880648995a024112182ed6b6002cd489548b4b18f5d4c3768dd96",
+    "ir-formal-grammar": "blake3-512:99f091633181eda7ad1798c15316c49c829899f8622146fae5de698dfbe36bd6038d45da334514c87b8e978739b538ab61f96c44093624c60d7a242ae37cc4bb",
     "canonicalization-grammar": "blake3-512:4d8c2940c53a59c678c8fb65e33dc2cb0ae8ae8a283b97b9c69fd678565653d15e6ee9dc3ffc6a32dc1ff035821b0c1a006f0455498d2ea91faef845d7b39830",
     "memento-envelope-grammar": "blake3-512:58bba3e1a9f6439eac5cb0c681faf65d38de9e6b8ad539854acda451ca67562a9d238eb95a5d7df2c0776657015fa026c51059dff61e1ba9aa2438b57425d6a5",
     "signatures-and-non-repudiation": "blake3-512:8b71229fcb7413f18a93a9b260012298311c1ce754850ee717780c181f1fda39a6600b2e5069e775cd7dd15e8c81e40b47bf7585aa0b23ab76c112c85116365c",
     "chain-validity-and-fail-closed": "blake3-512:dd905e8660d855c0c8140ceaafb0e189391234ff981422e714644b23642b24d7ca0253c76d09b46e58c5f8d8362cc8efca436baf2be927ab63a7bacf356e7673",
     "ir-extension-protocol": "blake3-512:cff64b923879548fd54efb63c5ea116ba184adadec126e956387f1ee9d0f7907edbdb1a05866d62442a6fb2142948654464e63830a061efdaed8af9403bb0c13",
-    "proof-file-format": "blake3-512:7bb4589af25c6c3992520494869bbbe4cfbcf7a77b91ebd61d6327e78699ef16cd5bc34afbe4cdf88a717c055c16536b5106bc4dca2d9d6b5cfcc1eede68e1b3",
+    "proof-file-format": "blake3-512:18bde34e6a93b470f17f030040d9d5448aff660f12bd3fa22267cc50564dc7d499dd28ab0f2ad58d17531e897214a35ac2eddd45f2d3238c0fe7e31a1fd66de1",
     "semantic-envelope": "blake3-512:6b14a0c4a36877ea77a609f5262257fb4c65940e8e5eefc03647746525d052216761b1707384bffec5fb3c021ac0e07e45d390efefa2c7f5c67c045d93352b56",
     "supply-chain-via-semantic-envelope": "blake3-512:b924576310bf2defcc2e346e01bdaff6dbdb2a33b2554178e3786e484cb4a4da136443f17675a6cd939fcbcff8afb27396222b5b6649a6eaa31672f5446b15d0",
     "handshake-algorithm": "blake3-512:acbf67dda9373c648e591d8ad74b8f8d56f4c92ba9c82bdc6690dc521e6f17012dd195e98a96b099090eeeb5a424312d90ff441c882d0e317a190561aa1a6925",
     "per-language-kit-standard": "blake3-512:7d3e72d58c87864eea2b7b330096d2cc4591292c1905baa447d4f74b8d80327521e284fc37f874fae80ba8f170a2456aed27c37215ee8752f8fd57e2d60b0f88",
     "lattice-tractability-theorem": "blake3-512:b6d7c2772c2929294d7f516f79559bd292e44f51805a6bd6ea0ca7fe365b82ec96b86c434f53dfb003f5acd306533831dc0257e46ead4c7d71081f9f56ec6d07",
-    "contract-merge-semantics": "blake3-512:aeb9e2c56603f56372c29cdcbbb11ec3ae6fada0b2004d9fb99955e21230b03a72d02fc7051eea09ed24b7271b758909011948b531b668bb5c20e8ab8a268bee",
+    "contract-merge-semantics": "blake3-512:040118310ca0df13518c8da4b1b2698d712f8e9d7a3ff1ee4f601c8870b221ec696549710715b173b0dc2cf2f20140be646c40d8f62cb06b6a1171d645daafa6",
     "protocol-catalog-format": "blake3-512:6d610d405cdd41a50425ec45cc5c3599ec372dfed17e41e89cb2f5cca03937989881ac34b1e8f039c9766934307ac42618100818fa8ae2ccf86bd8623eb2243c",
     "agent-plugin-protocol": "blake3-512:ff1dface88c0ba11cc8b4d7d05e002b240108fb4dc0b7447551f20994cd74086c66839071f14d15835b6d3992047a7e80db2038f57b0c96fb85e866eb60c2e30",
     "ir-compiler-protocol": "blake3-512:27d3b0affccd0f814d79f2adfce08ca8898a40ceeeb9703cf611edc58d0b0dd13869be1aeaff13d74fb4bc2401f72757a96e16807ce490c70f80b4348abbbb18",
     "multi-solver-protocol": "blake3-512:71fc7ac22997938629d835f87e4e8a322026d77c1e1f834c9fbe0f79cca4e903792c628e96d3004c88d29706f4d87bc042ff837fef571c0cb3012495a03003d3",
-    "lift-plugin-protocol": "blake3-512:8f6597f8d85fc1940ce093626d046bec85af0cdb2e44544a32ae91012a1abd2d5107eaaac787f7bb2727191cb2938a9d6d121d1335e410cd382e4579c52d03d1"
+    "lift-plugin-protocol": "blake3-512:fa5e47b0650b07a3d7d37e3efc0ec006d079224b23c601464a69fd91f6cbdb3e9adf4f2f1d54eb73c0f553c73750d4ca9349eeeba2ec9d47d081c52f6de263b6",
+    "correctness-is-a-hash": "blake3-512:5a41e9ad8b0e63df400b93b77a0106468160fb2b92db4099fa5b757c3c5596176c5891365dbc6a8263a57ea8a42866eaa9e1a41fa3a43a5aadef4b21f851a845",
+    "lsp-protocol": "blake3-512:75cac55f568b7363c3ae839ffdd11dc26d1a54d84d26ba43fca770b3fe2f7eca6305f77dad22b6b9f5f0bdb1cf10dc6fadd815ee3bf1507bb1eba6f106ee22bc"
   },
-  "declaredAt": "2026-04-30T15:00:00Z",
-  "_unsigned": "v1.2.0 minor bump (additive over v1.1.0): adds four pluggability protocols — agent-plugin-protocol (LSP-shape JSON-RPC seam for coding agents), ir-compiler-protocol (per-solver IR translators), multi-solver-protocol (single/chain/portfolio dispatch), lift-plugin-protocol (one Rust CLI + per-language plugins via stdio JSON-RPC). All four are additive: any v1.1.0 memento or .proof remains valid under v1.2.0. The reference CLI plugins ship for Rust + Go + C++; TypeScript is consumed via toolchain (vitest), not as a CLI peer. v1.1.0's own catalog CID (5b770182...19f05cd4) remains the version anyone pinned to it. v1.2.0's catalog is signed under the same foundation key.",
+  "declaredAt": "2026-05-02T15:00:00Z",
+  "_unsigned": "v1.3.0 minor bump (additive over v1.2.0): four protocol-additive enrichments + two new specs. (1) BridgeDeclaration gains `sourceContractCid` + `targetProofCid` fields for hash-bounded cross-bundle witness pinning. (2) Catalog memento gains optional `binaryCid` for supply-chain anchoring (rule 5 is MAY in v1.3.0; promotion to MUST awaits a reference verifier in v1.4.0). (3) Catalog memento gains optional `metadata` map for non-normative tooling/diagnostics. (4) `EvidenceTerm` proof-certificate carrier for `smt-lib`/`coq`/`custom` proof types. New specs: `correctness-is-a-hash` (the memcmp theorem) and `lsp-protocol` (real-time IDE integration with pluggable JSON-RPC backend). All v1.2.0 mementos and .proof bundles remain valid; the bump is purely additive. Catalog signed under the same foundation v0 key. v1.2.0 attestation (1e5cfee6...17d0579f) remains valid for anyone pinned.",
+  "_v1_2_0_unsigned": "v1.2.0 minor bump (additive over v1.1.0): adds four pluggability protocols — agent-plugin-protocol (LSP-shape JSON-RPC seam for coding agents), ir-compiler-protocol (per-solver IR translators), multi-solver-protocol (single/chain/portfolio dispatch), lift-plugin-protocol (one Rust CLI + per-language plugins via stdio JSON-RPC). All four are additive: any v1.1.0 memento or .proof remains valid under v1.2.0. The reference CLI plugins ship for Rust + Go + C++; TypeScript is consumed via toolchain (vitest), not as a CLI peer. v1.1.0's own catalog CID (5b770182...19f05cd4) remains the version anyone pinned to it. v1.2.0's catalog is signed under the same foundation key.",
   "_breakingChanges": [],
   "_v1_1_0_breakingChanges": [
     "Property memento role removed; contract memento role added with body fields {pre?, post?, inv?, outBinding, preHash?, postHash?, invHash?, authoring}",
@@ -49,5 +52,16 @@
     "ir-compiler-protocol: per-solver IR translators (SMT-LIB v2.6 reference; TPTP / Lean / Coq pluggable)",
     "multi-solver-protocol: single / chain / portfolio-first-wins / portfolio-consensus / per-fragment-dispatch modes",
     "lift-plugin-protocol: one Rust CLI dispatches to per-language lift plugins via stdio JSON-RPC. Reference CLI plugins ship for Rust + Go + C++; TypeScript is consumed via its own toolchain (vitest), not as a peer CLI"
+  ],
+  "_v1_3_0_additiveChanges": [
+    "BridgeDeclaration: sourceContractCid + targetProofCid for hash-bounded cross-bundle witness pinning (no implicit lookup)",
+    "ProofEnvelope catalog memento: optional binaryCid for supply-chain anchoring (rule 5 is MAY pending reference verifier in v1.4.0)",
+    "ProofEnvelope catalog memento: optional metadata map for non-normative tooling/diagnostics (verifiers MUST NOT use metadata for verification logic)",
+    "EvidenceTerm: proof-certificate carrier with proofType in {smt-lib, coq, custom} and certificate carrying tool/version/formulaHash/proofData",
+    "correctness-is-a-hash: new spec promoting the memcmp theorem (petabytes verified by 64 bytes is content-addressing's load-bearing claim)",
+    "lsp-protocol: new spec for real-time IDE contract verification with pluggable JSON-RPC backend (same shape as lift-plugin-protocol)",
+    "ir-formal-grammar enrichment: 27 named formal invariants documented in FOL across Terms / Formulas / Declarations / Sorts / Reference Parser / Test sections",
+    "contract-merge-semantics enrichment: cross-bundle merge clarifications",
+    "lift-plugin-protocol enrichment: minor clarifications"
   ]
 }

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -204,7 +204,7 @@ pub struct VerifyProtocolArgs {
     /// Also verify the signed catalog attestation (Ed25519 signature
     /// over the catalog's CID by the ProvekIt Foundation Root Key).
     /// Default uses the embedded `foundation-v0.pub` and embedded
-    /// `catalog-signature-v1.2.0.json`; override via `--pubkey-file`
+    /// `catalog-signature-v1.3.0.json`; override via `--pubkey-file`
     /// and `--signature-file`.
     #[arg(long)]
     pub signed: bool,

--- a/implementations/rust/provekit-cli/src/protocol.rs
+++ b/implementations/rust/provekit-cli/src/protocol.rs
@@ -19,9 +19,9 @@ use serde_json::Value as Json;
 /// The protocol catalog CID this CLI declares conformance to. Kept in
 /// sync with `protocol/specs/2026-04-30-protocol-versioning.md`. If
 /// the catalog changes, bump this string AND ship a new CLI.
-/// Currently: v1.2.0 (additive bump over v1.1.0).
+/// Currently: v1.3.0 (additive bump over v1.2.0).
 pub const EXPECTED_CATALOG_CID: &str =
-    "blake3-512:1e5cfee6043d485d276c26a8da17830fe828c5b7b395a5fb1f042e7442407a37c39c59c0e002ca18857b12d3efb0d86687b9a3a0e3f6e3e933856f0717d0579f";
+    "blake3-512:5a3129f49276fef3239796d7dfdae3d8ddf92f92201adddd1ebce59a5f455b91d3b50168765136c740984e325fb002d2bf44f7233438c7e40285d87b205d24c7";
 
 /// Catalog JSON bytes embedded at compile time. The CLI never reads
 /// the on-disk spec file at runtime; `verify-protocol` recomputes from
@@ -39,12 +39,12 @@ pub const EMBEDDED_FOUNDATION_PUBKEY: &[u8] =
 
 /// Signed attestation bytes (the JSON object) embedded at compile
 /// time. Mirrors the committed
-/// `.provekit/catalog-signatures/v1.2.0.json` (current). The v1.1.0
-/// attestation remains at `.provekit/catalog-signatures/v1.1.0.json`
-/// for callers pinning to the older version; pass `--signature-file`
-/// + `--catalog` to verify against it explicitly.
+/// `.provekit/catalog-signatures/v1.3.0.json` (current). The v1.2.0
+/// and v1.1.0 attestations remain on-disk and as embedded asset
+/// siblings for callers pinning to those versions; pass
+/// `--signature-file` + `--catalog` to verify against them explicitly.
 pub const EMBEDDED_CATALOG_SIGNATURE: &[u8] =
-    include_bytes!("../assets/catalog-signature-v1.2.0.json");
+    include_bytes!("../assets/catalog-signature-v1.3.0.json");
 
 /// Recompute the embedded catalog's CID using the same routine
 /// `tools/recompute-spec-cids` uses: parse JSON, JCS-encode, BLAKE3-512.

--- a/protocol/specs/2026-04-30-proof-file-format.md
+++ b/protocol/specs/2026-04-30-proof-file-format.md
@@ -142,12 +142,20 @@ A `.proof` file passes integrity verification iff:
    signing per the memento envelope grammar.
 
 5. **Binary CID matches running artifact (when present).** If the
-   catalog includes `binaryCid`, the verifier MUST check that the
-   hash of the currently executing binary equals `binaryCid`. This is
-   the supply chain anchor: a `.proof` bundle is only valid for the
-   exact binary it was minted against. Recompilation, runtime patches,
-   or supply-chain injections change the binary CID and cause the
-   proof to be rejected.
+   catalog includes `binaryCid`, the verifier MAY check that the
+   hash of the currently executing binary equals `binaryCid`. This
+   is the supply chain anchor: a `.proof` bundle whose `binaryCid`
+   matches the running binary attests to "this proof was produced
+   by THIS binary, not a tampered fork." Recompilation, runtime
+   patches, or supply-chain injections change the binary CID; a
+   verifier that performs this check rejects mismatches.
+
+   v1.3.0 status: this rule is MAY (not MUST). The protocol defines
+   the field and the check; no v1.3.0 verifier implements
+   `hash(running_binary)` yet. Producers may emit `binaryCid` (Rust
+   does, defaulting to `None`); consumers may verify. A future v1.4.0
+   minor bump considers promoting to MUST once a reference verifier
+   ships the running-binary hash routine end-to-end.
 
 Fail-closed by default. Any rule violation produces a structured
 rejection with the failing rule's ID; verifiers MUST NOT accept

--- a/protocol/specs/2026-04-30-protocol-catalog.json
+++ b/protocol/specs/2026-04-30-protocol-catalog.json
@@ -1,7 +1,7 @@
 {
   "kind": "catalog",
   "name": "provekit-protocol",
-  "version": "v1.2.0-2026-04-30",
+  "version": "v1.3.0-2026-05-02",
   "algorithms": {
     "hash": [
       "blake3-512"
@@ -14,27 +14,30 @@
     ]
   },
   "properties": {
-    "ir-formal-grammar": "blake3-512:6c0127e0d24946d7be75861db20507ccdcfdf968d3333f8aa34083e849d8238d73b3acfaa31880648995a024112182ed6b6002cd489548b4b18f5d4c3768dd96",
+    "ir-formal-grammar": "blake3-512:99f091633181eda7ad1798c15316c49c829899f8622146fae5de698dfbe36bd6038d45da334514c87b8e978739b538ab61f96c44093624c60d7a242ae37cc4bb",
     "canonicalization-grammar": "blake3-512:4d8c2940c53a59c678c8fb65e33dc2cb0ae8ae8a283b97b9c69fd678565653d15e6ee9dc3ffc6a32dc1ff035821b0c1a006f0455498d2ea91faef845d7b39830",
     "memento-envelope-grammar": "blake3-512:58bba3e1a9f6439eac5cb0c681faf65d38de9e6b8ad539854acda451ca67562a9d238eb95a5d7df2c0776657015fa026c51059dff61e1ba9aa2438b57425d6a5",
     "signatures-and-non-repudiation": "blake3-512:8b71229fcb7413f18a93a9b260012298311c1ce754850ee717780c181f1fda39a6600b2e5069e775cd7dd15e8c81e40b47bf7585aa0b23ab76c112c85116365c",
     "chain-validity-and-fail-closed": "blake3-512:dd905e8660d855c0c8140ceaafb0e189391234ff981422e714644b23642b24d7ca0253c76d09b46e58c5f8d8362cc8efca436baf2be927ab63a7bacf356e7673",
     "ir-extension-protocol": "blake3-512:cff64b923879548fd54efb63c5ea116ba184adadec126e956387f1ee9d0f7907edbdb1a05866d62442a6fb2142948654464e63830a061efdaed8af9403bb0c13",
-    "proof-file-format": "blake3-512:7bb4589af25c6c3992520494869bbbe4cfbcf7a77b91ebd61d6327e78699ef16cd5bc34afbe4cdf88a717c055c16536b5106bc4dca2d9d6b5cfcc1eede68e1b3",
+    "proof-file-format": "blake3-512:18bde34e6a93b470f17f030040d9d5448aff660f12bd3fa22267cc50564dc7d499dd28ab0f2ad58d17531e897214a35ac2eddd45f2d3238c0fe7e31a1fd66de1",
     "semantic-envelope": "blake3-512:6b14a0c4a36877ea77a609f5262257fb4c65940e8e5eefc03647746525d052216761b1707384bffec5fb3c021ac0e07e45d390efefa2c7f5c67c045d93352b56",
     "supply-chain-via-semantic-envelope": "blake3-512:b924576310bf2defcc2e346e01bdaff6dbdb2a33b2554178e3786e484cb4a4da136443f17675a6cd939fcbcff8afb27396222b5b6649a6eaa31672f5446b15d0",
     "handshake-algorithm": "blake3-512:acbf67dda9373c648e591d8ad74b8f8d56f4c92ba9c82bdc6690dc521e6f17012dd195e98a96b099090eeeb5a424312d90ff441c882d0e317a190561aa1a6925",
     "per-language-kit-standard": "blake3-512:7d3e72d58c87864eea2b7b330096d2cc4591292c1905baa447d4f74b8d80327521e284fc37f874fae80ba8f170a2456aed27c37215ee8752f8fd57e2d60b0f88",
     "lattice-tractability-theorem": "blake3-512:b6d7c2772c2929294d7f516f79559bd292e44f51805a6bd6ea0ca7fe365b82ec96b86c434f53dfb003f5acd306533831dc0257e46ead4c7d71081f9f56ec6d07",
-    "contract-merge-semantics": "blake3-512:aeb9e2c56603f56372c29cdcbbb11ec3ae6fada0b2004d9fb99955e21230b03a72d02fc7051eea09ed24b7271b758909011948b531b668bb5c20e8ab8a268bee",
+    "contract-merge-semantics": "blake3-512:040118310ca0df13518c8da4b1b2698d712f8e9d7a3ff1ee4f601c8870b221ec696549710715b173b0dc2cf2f20140be646c40d8f62cb06b6a1171d645daafa6",
     "protocol-catalog-format": "blake3-512:6d610d405cdd41a50425ec45cc5c3599ec372dfed17e41e89cb2f5cca03937989881ac34b1e8f039c9766934307ac42618100818fa8ae2ccf86bd8623eb2243c",
     "agent-plugin-protocol": "blake3-512:ff1dface88c0ba11cc8b4d7d05e002b240108fb4dc0b7447551f20994cd74086c66839071f14d15835b6d3992047a7e80db2038f57b0c96fb85e866eb60c2e30",
     "ir-compiler-protocol": "blake3-512:27d3b0affccd0f814d79f2adfce08ca8898a40ceeeb9703cf611edc58d0b0dd13869be1aeaff13d74fb4bc2401f72757a96e16807ce490c70f80b4348abbbb18",
     "multi-solver-protocol": "blake3-512:71fc7ac22997938629d835f87e4e8a322026d77c1e1f834c9fbe0f79cca4e903792c628e96d3004c88d29706f4d87bc042ff837fef571c0cb3012495a03003d3",
-    "lift-plugin-protocol": "blake3-512:8f6597f8d85fc1940ce093626d046bec85af0cdb2e44544a32ae91012a1abd2d5107eaaac787f7bb2727191cb2938a9d6d121d1335e410cd382e4579c52d03d1"
+    "lift-plugin-protocol": "blake3-512:fa5e47b0650b07a3d7d37e3efc0ec006d079224b23c601464a69fd91f6cbdb3e9adf4f2f1d54eb73c0f553c73750d4ca9349eeeba2ec9d47d081c52f6de263b6",
+    "correctness-is-a-hash": "blake3-512:5a41e9ad8b0e63df400b93b77a0106468160fb2b92db4099fa5b757c3c5596176c5891365dbc6a8263a57ea8a42866eaa9e1a41fa3a43a5aadef4b21f851a845",
+    "lsp-protocol": "blake3-512:75cac55f568b7363c3ae839ffdd11dc26d1a54d84d26ba43fca770b3fe2f7eca6305f77dad22b6b9f5f0bdb1cf10dc6fadd815ee3bf1507bb1eba6f106ee22bc"
   },
-  "declaredAt": "2026-04-30T15:00:00Z",
-  "_unsigned": "v1.2.0 minor bump (additive over v1.1.0): adds four pluggability protocols — agent-plugin-protocol (LSP-shape JSON-RPC seam for coding agents), ir-compiler-protocol (per-solver IR translators), multi-solver-protocol (single/chain/portfolio dispatch), lift-plugin-protocol (one Rust CLI + per-language plugins via stdio JSON-RPC). All four are additive: any v1.1.0 memento or .proof remains valid under v1.2.0. The reference CLI plugins ship for Rust + Go + C++; TypeScript is consumed via toolchain (vitest), not as a CLI peer. v1.1.0's own catalog CID (5b770182...19f05cd4) remains the version anyone pinned to it. v1.2.0's catalog is signed under the same foundation key.",
+  "declaredAt": "2026-05-02T15:00:00Z",
+  "_unsigned": "v1.3.0 minor bump (additive over v1.2.0): four protocol-additive enrichments + two new specs. (1) BridgeDeclaration gains `sourceContractCid` + `targetProofCid` fields for hash-bounded cross-bundle witness pinning. (2) Catalog memento gains optional `binaryCid` for supply-chain anchoring (rule 5 is MAY in v1.3.0; promotion to MUST awaits a reference verifier in v1.4.0). (3) Catalog memento gains optional `metadata` map for non-normative tooling/diagnostics. (4) `EvidenceTerm` proof-certificate carrier for `smt-lib`/`coq`/`custom` proof types. New specs: `correctness-is-a-hash` (the memcmp theorem) and `lsp-protocol` (real-time IDE integration with pluggable JSON-RPC backend). All v1.2.0 mementos and .proof bundles remain valid; the bump is purely additive. Catalog signed under the same foundation v0 key. v1.2.0 attestation (1e5cfee6...17d0579f) remains valid for anyone pinned.",
+  "_v1_2_0_unsigned": "v1.2.0 minor bump (additive over v1.1.0): adds four pluggability protocols — agent-plugin-protocol (LSP-shape JSON-RPC seam for coding agents), ir-compiler-protocol (per-solver IR translators), multi-solver-protocol (single/chain/portfolio dispatch), lift-plugin-protocol (one Rust CLI + per-language plugins via stdio JSON-RPC). All four are additive: any v1.1.0 memento or .proof remains valid under v1.2.0. The reference CLI plugins ship for Rust + Go + C++; TypeScript is consumed via toolchain (vitest), not as a CLI peer. v1.1.0's own catalog CID (5b770182...19f05cd4) remains the version anyone pinned to it. v1.2.0's catalog is signed under the same foundation key.",
   "_breakingChanges": [],
   "_v1_1_0_breakingChanges": [
     "Property memento role removed; contract memento role added with body fields {pre?, post?, inv?, outBinding, preHash?, postHash?, invHash?, authoring}",
@@ -49,5 +52,16 @@
     "ir-compiler-protocol: per-solver IR translators (SMT-LIB v2.6 reference; TPTP / Lean / Coq pluggable)",
     "multi-solver-protocol: single / chain / portfolio-first-wins / portfolio-consensus / per-fragment-dispatch modes",
     "lift-plugin-protocol: one Rust CLI dispatches to per-language lift plugins via stdio JSON-RPC. Reference CLI plugins ship for Rust + Go + C++; TypeScript is consumed via its own toolchain (vitest), not as a peer CLI"
+  ],
+  "_v1_3_0_additiveChanges": [
+    "BridgeDeclaration: sourceContractCid + targetProofCid for hash-bounded cross-bundle witness pinning (no implicit lookup)",
+    "ProofEnvelope catalog memento: optional binaryCid for supply-chain anchoring (rule 5 is MAY pending reference verifier in v1.4.0)",
+    "ProofEnvelope catalog memento: optional metadata map for non-normative tooling/diagnostics (verifiers MUST NOT use metadata for verification logic)",
+    "EvidenceTerm: proof-certificate carrier with proofType in {smt-lib, coq, custom} and certificate carrying tool/version/formulaHash/proofData",
+    "correctness-is-a-hash: new spec promoting the memcmp theorem (petabytes verified by 64 bytes is content-addressing's load-bearing claim)",
+    "lsp-protocol: new spec for real-time IDE contract verification with pluggable JSON-RPC backend (same shape as lift-plugin-protocol)",
+    "ir-formal-grammar enrichment: 27 named formal invariants documented in FOL across Terms / Formulas / Declarations / Sorts / Reference Parser / Test sections",
+    "contract-merge-semantics enrichment: cross-bundle merge clarifications",
+    "lift-plugin-protocol enrichment: minor clarifications"
   ]
 }

--- a/tools/foundation-keygen/Cargo.toml
+++ b/tools/foundation-keygen/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/bin/sign_catalog.rs"
 name = "sign-catalog-v1-2-0"
 path = "src/bin/sign_catalog_v1_2_0.rs"
 
+[[bin]]
+name = "sign-catalog-v1-3-0"
+path = "src/bin/sign_catalog_v1_3_0.rs"
+
 [lib]
 path = "src/lib.rs"
 

--- a/tools/foundation-keygen/src/bin/sign_catalog_v1_3_0.rs
+++ b/tools/foundation-keygen/src/bin/sign_catalog_v1_3_0.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// sign-catalog-v1-3-0
+//
+// Compute the protocol catalog's CID, build the canonical attestation
+// JSON for protocolVersion `v1.3.0`, sign it under the v0 foundation
+// seed, and write the signed attestation to
+// `.provekit/catalog-signatures/v1.3.0.json`.
+//
+// Mirrors `sign_catalog_v1_2_0.rs` but parameterized for v1.3.0. Same
+// key, additive bump (no breaking changes from v1.2.0).
+
+use std::fs;
+use std::process::ExitCode;
+
+use foundation_keygen::{
+    build_signed_attestation_for, catalog_path, compute_catalog_cid_from_path,
+    signature_path_for, FOUNDATION_V0_SEED, V1_3_0_DECLARED_AT,
+};
+
+const PROTOCOL_VERSION: &str = "v1.3.0";
+
+fn run() -> Result<(), String> {
+    let catalog = catalog_path();
+    let cid = compute_catalog_cid_from_path(&catalog)?;
+    let attestation = build_signed_attestation_for(
+        PROTOCOL_VERSION,
+        &FOUNDATION_V0_SEED,
+        &cid,
+        V1_3_0_DECLARED_AT,
+    )?;
+
+    let out_path = signature_path_for(PROTOCOL_VERSION);
+    if let Some(dir) = out_path.parent() {
+        fs::create_dir_all(dir).map_err(|e| format!("mkdir {}: {}", dir.display(), e))?;
+    }
+    let mut out = serde_json::to_string_pretty(&attestation)
+        .map_err(|e| format!("serialize attestation: {}", e))?;
+    out.push('\n');
+    fs::write(&out_path, out).map_err(|e| format!("write {}: {}", out_path.display(), e))?;
+
+    println!("# ProvekIt v1.3.0 catalog attestation");
+    println!();
+    println!("catalog file:    {}", catalog.display());
+    println!("catalog CID:     {}", cid);
+    println!("signer:          {}", attestation["signer"]);
+    println!("signature:       {}", attestation["signature"]);
+    println!();
+    println!("wrote signed attestation: {}", out_path.display());
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("sign-catalog-v1-3-0: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/tools/foundation-keygen/src/lib.rs
+++ b/tools/foundation-keygen/src/lib.rs
@@ -52,6 +52,11 @@ pub const V1_1_0_DECLARED_AT: &str = "2026-04-30T15:00:00Z";
 /// catalog's declaredAt field carries forward.
 pub const V1_2_0_DECLARED_AT: &str = "2026-04-30T15:00:00Z";
 
+/// Pinned `declaredAt` for v1.3.0. Bumped to 2026-05-02; v1.3.0 is
+/// additive over v1.2.0 (no breaking changes); attestation is signed
+/// against the new catalog CID under the same foundation key.
+pub const V1_3_0_DECLARED_AT: &str = "2026-05-02T15:00:00Z";
+
 /// Catalog file path, resolved relative to this crate's manifest dir.
 pub fn catalog_path() -> PathBuf {
     repo_root().join("protocol/specs/2026-04-30-protocol-catalog.json")

--- a/tools/recompute-spec-cids/src/main.rs
+++ b/tools/recompute-spec-cids/src/main.rs
@@ -2,7 +2,7 @@
 //
 // recompute-spec-cids
 //
-// Catalog freeze tool (current target: v1.2.0). Computes BLAKE3-512 CIDs for every protocol
+// Catalog freeze tool (current target: v1.3.0). Computes BLAKE3-512 CIDs for every protocol
 // spec file listed in `protocol/specs/2026-04-30-protocol-catalog.json`,
 // substitutes them into the catalog (replacing `RECOMPUTE-AFTER-*`
 // placeholders), then computes the catalog's own CID as
@@ -76,6 +76,14 @@ const SPEC_MAP: &[(&str, &str)] = &[
     (
         "lift-plugin-protocol",
         "2026-04-30-lift-plugin-protocol.md",
+    ),
+    (
+        "correctness-is-a-hash",
+        "2026-04-29-correctness-is-a-hash.md",
+    ),
+    (
+        "lsp-protocol",
+        "2026-04-30-lsp-protocol.md",
     ),
 ];
 
@@ -246,7 +254,7 @@ fn run(verify: bool) -> Result<(), String> {
     }
 
     // 7. Report.
-    println!("# Protocol catalog freeze (v1.2.0)");
+    println!("# Protocol catalog freeze (v1.3.0)");
     println!();
     println!("Catalog file:    {}", catalog_path.display());
     println!("Catalog CID:     {}", catalog_cid);


### PR DESCRIPTION
## Summary

Re-bakes the catalog as **v1.3.0** following the 32 commits since the v1.2.0 cut at `87d552a`. 4 spec CIDs re-minted, 2 new specs added as catalog properties, signed under the same foundation v0 key.

**v1.3.0 catalog CID:**
```
blake3-512:5a3129f49276fef3239796d7dfdae3d8ddf92f92201adddd1ebce59a5f455b91d3b50168765136c740984e325fb002d2bf44f7233438c7e40285d87b205d24c7
```

## What changed

**Re-minted properties** (specs that drifted since v1.2.0):
| Property | New CID prefix | Why |
|---|---|---|
| `ir-formal-grammar` | `99f09163...` | 27 formal invariants added |
| `contract-merge-semantics` | `040118310c...` | cross-bundle merge clarifications |
| `proof-file-format` | `18bde34e...` | binaryCid + metadata + rule 5 softened to MAY |
| `lift-plugin-protocol` | `fa5e47b0...` | minor clarifications |

**New properties:**
| Property | CID prefix | Spec |
|---|---|---|
| `correctness-is-a-hash` | `5a41e9ad...` | the memcmp theorem |
| `lsp-protocol` | `75cac55f...` | real-time IDE integration |

**Other v1.3.0 protocol enrichments** (already in spec text):
- `BridgeDeclaration.sourceContractCid` + `targetProofCid` for hash-bounded cross-bundle witness pinning
- `ProofEnvelope.binaryCid` for supply-chain anchoring (rule 5 is MAY in v1.3.0)
- `ProofEnvelope.metadata` for non-normative tooling/diagnostics
- `EvidenceTerm` proof-certificate carrier

## Backward compatibility

**v1.2.0 keeps working.** Any v1.2.0 memento or `.proof` remains valid. The bump is purely additive. v1.2.0's CID `1e5cfee6...17d0579f` stays attestable via `.provekit/catalog-signatures/v1.2.0.json` for anyone pinned to it.

## Consumer surfaces migrated

- `EXPECTED_CATALOG_CID` in `protocol.rs:23` → v1.3.0 CID
- `EMBEDDED_CATALOG_SIGNATURE` → `catalog-signature-v1.3.0.json`
- CLI `assets/` refreshed with v1.3.0 catalog + signature
- `.provekit/catalog-signatures/v1.3.0.json` written by `sign-catalog-v1-3-0` binary
- `recompute-spec-cids` SPEC_MAP gains 2 new entries
- bluepaper §0 + Appendix A + version log updated

## Test plan

- [ ] `cargo run --release --manifest-path tools/recompute-spec-cids/Cargo.toml -- --verify` exits 0 ✓
- [ ] `provekit verify-protocol --signed` returns `status: match` against the new CID ✓
- [ ] v1.2.0 attestation still validates via `--catalog 1e5cfee6...17d0579f --signature-file .provekit/catalog-signatures/v1.2.0.json` (back-compat)
- [ ] CI passes (cross-language conformance gate inherits from main)

## Known follow-ups (v1.4.0)

- Cross-impl ports: EvidenceTerm to C++/C#; binaryCid + targetProofCid + sourceContractCid to Go/TS/C++/C#. CDDL codegen pipeline makes mechanical
- Promote 15 remaining spec invariants (27 total in spec; 12 kit-encoded) to mintable contracts
- Coq three-way consensus: wire Coq as a workflow producer
- `binaryCid` integrity rule 5 promotion to MUST awaits reference verifier
- `provekit migrate` verb (#178) to automate this cut next time
- `recompute-spec-cids` footgun (#180): default-write should be `--write`, not implicit
- Opacity-coverage consensus (`multi-solver-protocol/2`) (#181)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new protocol specifications to the catalog.

* **Updates**
  * Bumped protocol catalog to version 1.3.0 (2026-05-02) with enhanced specification definitions and compatibility enhancements.
  * Relaxed verification requirements for optional binary integrity checks in proof file handling.
  * Updated protocol documentation with changelog for additive protocol enrichments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->