### PR TITLE
v1.4.0 spec drafts: opacity-coverage consensus + binary-attestation

### DIFF
--- a/protocol/specs/2026-05-02-binary-attestation-protocol.md
+++ b/protocol/specs/2026-05-02-binary-attestation-protocol.md
@@ -1,0 +1,196 @@
+# Binary Attestation Protocol
+
+**Status:** v1.4.0 normative draft
+**Date:** 2026-05-02
+**Catalog property:** Listed in the v1.4.0 catalog as `binary-attestation-protocol`; CID is computed from this file's bytes per `2026-04-30-protocol-catalog-format.md` §2.1 (raw-byte BLAKE3-512). No CID line appears in this header by design: a self-referencing CID would invalidate on every edit.
+**Owner:** verifier crate + producers minting `.proof` bundles.
+**Related:**
+- `2026-04-30-proof-file-format.md` (the `.proof` envelope grammar this spec governs the lifecycle of)
+- `2026-04-30-memento-envelope-grammar.md` (memento shape; discharges nest as members)
+- `2026-05-02-multi-solver-protocol-v2.md` (consumer of discharges from `coverage_required` consensus)
+- `2026-04-30-ir-formal-grammar.md` (BridgeDeclaration `targetProofCid`, the forward pin)
+
+## §0. Letter-envelope framing
+
+A binary attestation is a *letter* and an *envelope*.
+
+- **LETTER** = the binary, immutable, content-addressed by `bcid = hash(binary_bytes)`.
+- **ENVELOPE** = the `.proof` bundle, minted AFTER the binary is built, contains `binaryCid: bcid`, contains discharge mementos, signed externally.
+
+The binary doesn't know its envelope. The envelope knows the binary's hash. One-way reference. No circularity.
+
+This shape is the resolution of the chicken-and-egg problem: "how does a binary attest to its own hash without containing its own hash?" It doesn't. The envelope does. The same pattern appears in Sigstore/cosign (the bundle references the artifact digest), Apple notarization (the ticket attests to a signed binary's hash), Authenticode (the catalog signs hashes of files), TLS server certs (the cert binds a public key to a name, not the bytes of the server), and JWT (the signature attests to a payload it does not contain). Prior art is uniform: the attestation names the artifact; the artifact never names the attestation.
+
+This spec is the protocol surface for that pattern in ProvekIt.
+
+## §1. Why this matters
+
+`2026-04-30-proof-file-format.md` integrity rule 5 ("Binary CID matches running artifact (when present)") was softened to MAY in the v1.3.0 catalog cut, with explicit rationale: no reference verifier had yet shipped the `hash(running_binary)` routine end-to-end, so producers could emit `binaryCid` without consumers being able to enforce it.
+
+**v1.4.0 promotes the verifier-side hash check to MUST given a reference verifier ships alongside this spec.** Rule 5 in the proof-file-format spec remains the consumer-side check; this spec defines the producer-side lifecycle and the verifier procedure that closes the loop.
+
+The supply-chain anchor is only an anchor when both ends are pinned. v1.3.0 had the field; v1.4.0 has the protocol.
+
+## §2. Build-mint-sign pipeline
+
+The producer-side lifecycle is five steps. Each step's output is the next step's input. No step references its own output; the references run only in the build direction.
+
+1. **Build** binary `B`. `B` contains contract CIDs `[c1, c2, ...]` it CLAIMS to satisfy. The contract list is hash-stable, derived from the source IR; recompiling the same source produces byte-identical contract CIDs.
+2. **Hash** `B` → `bcid = blake3-512(binary_bytes)`. The hash is computed once, after the build is final.
+3. **Discharge.** Run the prover against (`B`'s source IR, `c1..cn`) → discharge mementos `[d1, d2, ...]`. Each `d_i` is a `coverage_required` consensus discharge (per `2026-05-02-multi-solver-protocol-v2.md`) or another memento kind admissible under `2026-04-30-memento-envelope-grammar.md`.
+4. **Mint** a bundle:
+   ```
+   {
+     "binaryCid": bcid,
+     "discharges": [d1, d2, ...],
+     "signer": <signer-pubkey-memento-cid>,
+     "signature": <Ed25519 signature over canonical bytes with signature field omitted>
+   }
+   ```
+   The bundle's other required fields (`formatVersion`, `members`, etc.) carry forward from `2026-04-30-proof-file-format.md` unchanged; this spec governs the `binaryCid`, `discharges`, `signer`, `signature` fields' lifecycle.
+5. **Sign externally** with a foundation key, a producer key, or any third party's key (see §6 on permissionless attestation).
+6. **Distribute** `(B, bundle.proof)` as a pair, OR detached with content-addressable lookup (§3).
+
+**INVARIANT (build order):** `bcid` MUST be computed from the final binary bytes. A producer that hashes a pre-strip, pre-sign, or pre-compress artifact and ships a different artifact ships a mismatched bundle; verifiers MUST reject (§10).
+
+**INVARIANT (no self-reference in the binary):** `B` MUST NOT contain `bcid` as a hardcoded constant. Self-reference is not a build technique; see §9.
+
+## §3. Distribution: detached + content-addressable
+
+A `.proof` bundle is a separate file at `<bcid>.proof` (the existing convention from `2026-04-30-proof-file-format.md`). The bundle's filename is its content-address; the file's bytes hash to a CID equal to the filename.
+
+**Manifest hint is advisory.** A package manifest (`package.json.provekit.proofHash`, `Cargo.toml`'s equivalent, `go.mod`'s equivalent) MAY carry a hint pointing at the bundle. The hint accelerates discovery; it does NOT establish trust. The verifier validates by content (§4), not by manifest claim.
+
+**Alternative considered: stapled bundles.** Stapling the bundle into the binary (Authenticode-style, OCSP-stapling-style) was considered and rejected. Two reasons:
+1. It complicates binary builds: the binary must be re-linked after the bundle is minted, which changes `bcid`, which invalidates the bundle, requiring fixed-point iteration.
+2. It conflicts with content-addressability: a stapled binary's hash includes the bundle's bytes, so the bundle cannot reference its own container without circularity.
+
+Detached + content-addressable preserves the letter-envelope shape: `B`'s bytes are fixed; `bundle.proof` references `B`'s hash one-way.
+
+## §4. Verifier procedure
+
+Given binary `B` presented at runtime (a `.dylib`, `.so`, `.exe`, Wasm module, JS bundle, or other content-addressable artifact):
+
+1. **Hash** `B` → `bcid_observed`.
+2. **Look up** the bundle by `bcid_observed`. Sources, in priority order: a manifest hint (advisory), a content-addressed cache, a side-channel (e.g., a signature server, an attached `.proof` file at the binary's path).
+3. **Verify** the bundle's signature against the bundle's `signer` pubkey memento. Per `2026-04-30-proof-file-format.md` §3 rule 3.
+4. **Confirm** `bundle.binaryCid == bcid_observed`. The bundle's claim about the binary must match the binary actually presented.
+5. **Treat** the bundle's `discharges` as authoritative for `B`, subject to the consumer's key-trust policy (§8 on multi-source attestation).
+
+**INVARIANT (signature-alone is insufficient):** A bundle whose `binaryCid` does NOT match the running binary's hash MUST be rejected, EVEN IF the signature is valid and the signer is trusted. Signature attests to bundle integrity, not to binary identity. See §9 on this forbidden pattern.
+
+**INVARIANT (verifier procedure is total order):** Steps 1-4 are gating. Step 5 is consumption. A bundle that fails any gate MUST NOT contribute to the verifier's verdict for `B`.
+
+## §5. Two-pin closure
+
+The binary-attestation protocol works alongside the bridge-side pin established by `targetProofCid` in `2026-04-30-ir-formal-grammar.md` §BridgeDeclaration. Together they close a two-pin loop:
+
+- **Forward pin (call site → bundle):** A bridge declaration's `targetProofCid` pins the bundle that attests to the bridge's target. This is a CID-to-bundle reference written at IR-mint time.
+- **Back pin (bundle → binary):** A bundle's `binaryCid` pins the binary the bundle attests to. This is a hash-to-binary reference written at mint-time per §2.
+
+**The verifier checks both pins.** A call-site bridge points at a bundle (forward pin). The bundle's `binaryCid` matches the running binary's hash (back pin). Either pin alone leaves a hole:
+- Forward pin alone: the bundle is identified, but a substituted binary at runtime goes undetected.
+- Back pin alone: the running binary's bundle is found, but a substituted call-site bridge points at a *different* bundle, and the consumer doesn't notice.
+
+Both together = closed. The call site names the bundle; the bundle names the binary; the verifier confirms both.
+
+**INVARIANT (two-pin closure):** A consumer that performs only the forward pin OR only the back pin has NOT verified supply-chain integrity. The protocol REQUIRES both checks.
+
+## §6. Monotonic envelope accretion (the cosmic property)
+
+The binary is closed. The contract surface is open.
+
+Once published at `bcid`, the binary never changes. New bundles can be minted indefinitely, by anyone, each attesting to the same `bcid` with new discharges.
+
+**Worked example.** `parseInt-v1.0.0` at `bcid = blake3-512:abc...`:
+
+- 2026-Q1: foundation publishes initial bundle attesting `[parseInt_correct]`. Signer = foundation key.
+- 2026-Q3: a security researcher mints a new bundle. Same `bcid`. Discharges = `[memory_safe]`. Signer = researcher key. The binary is unchanged; the contract surface gained a claim.
+- 2027-Q1: a regulator mints another bundle. Same `bcid`. Discharges = `[FDA_21CFR_Part_11_compliance]`. Signer = regulator key.
+- 2030: someone discovers a new contract class (a property nobody had named in 2026), mints another bundle attesting `bcid` against that property.
+
+Three architectural consequences:
+
+1. **Permissionless attestation.** Third parties mint bundles for binaries they didn't author. The producer's role at build-time and the attester's role at mint-time are separable; the latter requires only the binary bytes and a key.
+2. **Monotonic verification surface.** Pinning a `bcid` is forward-compatible: a 2026 pin gains 2030 contracts by fetching new bundles, no binary upgrade required. The set of contracts a binary is known to satisfy grows over time without altering the binary.
+3. **Trust decisions stay at the key layer.** A binary's attestation set is a multi-source DAG of claims, each anchored to a specific signer. Consumers select bundles by which signers they trust; the protocol does not centralize trust.
+
+**INVARIANT (monotonicity):** A bundle minted at time `t` attesting to `bcid` REMAINS valid at time `t' > t` as long as its signature verifies. Future bundles do NOT invalidate past bundles. The verification surface accretes; it does not replace.
+
+## §7. Connection to `provekit witness`
+
+The `provekit witness` command (added at commit `2c27c6b`, "permissionless proof lattice extension") is the operational realization of monotonic envelope accretion. Given a binary at `bcid` and a set of discharge mementos under a chosen signer's key, `provekit witness` produces a new bundle attesting to that `bcid`.
+
+This spec normatively documents what that command produces. The command's input contract:
+- A binary file path (or `bcid` directly, if the consumer already has it).
+- A set of discharges to include (per §2 step 3).
+- A signer key (foundation, producer, third party, etc.).
+
+Output: a `.proof` file at `<bcid>.proof` (or a name suffixed by signer if the consumer keeps multiple bundles per binary).
+
+**INVARIANT (witness command shape):** `provekit witness` MUST NOT alter the binary. It MUST NOT mutate any existing bundle. Each invocation produces ONE new bundle; existing bundles remain bit-for-bit unchanged.
+
+## §8. Re-signing semantics
+
+Multiple bundles can attest to the same `binaryCid`. The verifier picks bundle(s) based on which discharges the consumer needs.
+
+- Old bundles stay valid. New bundles add coverage.
+- A consumer wanting to verify `parseInt_correct` fetches the foundation bundle. A consumer wanting `memory_safe` fetches the researcher bundle. A consumer wanting both fetches both.
+
+**Conflict policy: protocol surfaces, consumers resolve.** If two bundles claim contradictory discharges (one says "B satisfies C," another says "B does NOT satisfy C"), the verifier surfaces the conflict in its diagnostic output. The protocol does NOT mandate the resolution. Consumers choose:
+- Prefer the foundation key (centralized trust).
+- Fail closed (any conflict invalidates the verdict).
+- Prefer the most recent bundle by signature timestamp (recency policy).
+- Other consumer-defined policies.
+
+**INVARIANT (conflict surfacing):** A verifier presented with bundles claiming contradictory discharges for the same `bcid` MUST report the conflict to the consumer, with both bundles' CIDs and signers. The verdict is consumer-policy-determined.
+
+## §9. Forbidden patterns
+
+Three patterns are forbidden by this spec's design.
+
+1. **Binary embedding `hash(binary)` as a hardcoded constant.** Self-reference is impossible to compute: changing the constant changes the hash, which changes the constant. A fixed-point iteration is required, and even if found, it pins the binary to one specific hash that any modification breaks. The letter-envelope pattern exists precisely to avoid this.
+
+2. **Bundle without a `binaryCid` field claiming to attest to a binary.** A bundle's authority comes from naming what it attests to. A bundle that does not name its target attests to nothing; it is not interpretable as a binary attestation.
+
+3. **Verifier accepting a bundle whose `binaryCid` does NOT match the running binary's hash, even if the bundle is signed by a trusted key.** Signature verifies bundle integrity; `binaryCid` match verifies binary identity. Both are required. A trusted signer mis-attesting a binary is still mis-attesting; the protocol catches this regardless of trust.
+
+## §10. Conformance
+
+| Producer state | Consumer obligation |
+|---|---|
+| Ships a binary WITHOUT an accompanying bundle | The binary is UNATTESTED. Consumers MAY choose to run it; they get no protocol-level integrity guarantees. |
+| Ships a binary WITH a bundle whose signature is invalid | The bundle is CORRUPTED. Verifiers MUST reject. |
+| Ships a binary at hash `X` with a bundle whose `binaryCid = Y`, where `Y ≠ X` | The bundle is MISMATCHED. Verifiers MUST reject (per §4 step 4 and §9 pattern 3). |
+| Ships a binary at hash `X` with a bundle whose `binaryCid = X` and valid signature | The bundle is CONFORMANT. Verifiers proceed to consume `discharges` per consumer policy. |
+
+**INVARIANT (no partial acceptance):** A verifier MUST NOT accept a bundle whose signature verifies but whose `binaryCid` mismatches, NOR a bundle whose `binaryCid` matches but whose signature is invalid. Both gates are required (§4).
+
+## §11. Acceptance
+
+This spec is satisfied by:
+
+- A reference verifier implementation that performs steps 1-5 of §4 end-to-end on the host platforms ProvekIt targets.
+- `provekit witness` produces bundles whose shape conforms to §2 and whose lifecycle conforms to §8.
+- Integration tests cover:
+  - The §4 happy path: a binary at `bcid`, a bundle at `<bcid>.proof`, a successful verdict.
+  - The §9 pattern 3 negative path: a bundle whose `binaryCid` is altered post-signing; verifier rejects despite valid signature.
+  - The §6 monotonic accretion: a binary with two bundles from different signers; verifier surfaces both attestation sets.
+  - The §8 conflict path: two bundles with contradictory discharges; verifier surfaces the conflict to consumer-policy resolution.
+  - The §5 two-pin closure: a bridge with `targetProofCid` pointing at one bundle, runtime binary matching another `bcid`; verifier rejects.
+
+## §12. Open follow-ups
+
+- **Bundle revocation.** §6 states that bundles are monotonically accrued and never invalidated by future bundles. A separate revocation mechanism (e.g., a signed revocation memento naming a bundle CID as withdrawn by its signer) is deferred. The protocol as specified has no revocation; consumers wanting revocation define it at the trust layer.
+- **Signer rotation.** The bundle's `signer` field references a public-key memento. Key rotation is the public-key memento spec's concern, not this spec's.
+- **Cross-platform `bcid` semantics.** A single source can produce multiple binaries (one per platform). Each binary has its own `bcid`; each requires its own bundle. A future spec may define a "binary group" memento that names a set of `bcid`s as variants of the same source. Out of scope for v1.4.0.
+
+## §13. Related specs
+
+- `2026-04-30-proof-file-format.md` — the bundle envelope's grammar; this spec governs the lifecycle.
+- `2026-04-30-memento-envelope-grammar.md` — the memento shape; discharges are mementos.
+- `2026-05-02-multi-solver-protocol-v2.md` — produces the discharges this spec packages.
+- `2026-05-02-opacity-manifest-grammar.md` — manifests carried inside discharges via SolveResult envelopes.
+- `2026-04-30-ir-formal-grammar.md` — `BridgeDeclaration.targetProofCid`, the forward pin in §5's two-pin closure.
+- `2026-04-30-protocol-catalog-format.md` — the rule by which this spec's CID is computed.
+- `2026-04-30-canonicalization-grammar.md` — JCS canonicalization, normative for bundle bytes prior to signing.

--- a/protocol/specs/2026-05-02-ir-compiler-protocol-v2.md
+++ b/protocol/specs/2026-05-02-ir-compiler-protocol-v2.md
@@ -1,0 +1,197 @@
+# IR Compiler Protocol (`provekit-ir-compiler/2`)
+
+**Status:** v1.4.0 normative draft
+**Date:** 2026-05-02
+**Catalog property:** Listed in the v1.4.0 catalog as `ir-compiler-protocol-v2`; CID is computed from this file's bytes per `2026-04-30-protocol-catalog-format.md` §2.1 (raw-byte BLAKE3-512).
+**Owner:** verifier crate + every conformant IR compiler.
+**Supersedes:** `2026-04-30-ir-compiler-protocol.md` (v1, listed in the v1.3.0 catalog at `ir-compiler-protocol`). The v1 spec remains valid for any v1.3.0-or-earlier verifier; v1.4.0 verifiers running in `coverage_required` consensus mode require v2 conformance.
+
+## §0. The protocol is the bytes
+
+A v2 compiler's wire output is a pair of byte strings: the compiled solver script, and the OpacityManifest. Both are part of the protocol. Two conformant compilers in two languages translating the same IR document with the same dialect produce byte-identical scripts AND byte-identical manifests. The English in this document describes those bytes; if the bytes disagree with the English, the bytes win and the English is updated.
+
+## §1. Why v2 exists
+
+The v1 spec (`2026-04-30-ir-compiler-protocol.md`) gave each compiler a hard binary choice when faced with an IR position it could not soundly translate: refuse the whole compile (`compile_error.unsupported_*`) or silently elide the position. The first cuts off composition; the second is unsound.
+
+ProvekIt v1.4.0 introduces a multi-solver consensus mode that wants to compose partial competence: an SMT solver that handles arithmetic but not predicate quantification; a Coq solver that handles induction but is slow on bitvectors; a Lean solver that handles dependent types but not strings. Each compiler is the authority on what its theory can soundly handle. The verifier's job is to compose them.
+
+The v2 contract closes the gap with a third option: **a compiler emits a tractable script for everything it can soundly translate, marks every untranslatable position with a theory-equivalent of "trust me," and records each marked position in an OpacityManifest.** The verifier reads every solver's manifest; consensus succeeds when, for every opaque position any solver reported, some *other* solver in the pool both handled that position AND returned `Discharged`.
+
+The IR is unchanged. **The IR knows nothing about Coq, opacity, or solver capabilities.** The IR knows about `Lambda`, `Atomic`, `Forall`, kit predicates. Each compiler decides what its theory can soundly translate. Opacity is a compiler-side concept; the IR's only role is to be the universal language whose subterms get content-addressed by `positionCid`.
+
+This spec defines:
+
+1. The new `OpacityManifest` emission requirement (§3).
+2. The compiler opacity-emission rule: emit a tractable placeholder for each opaque position, AND record it in the manifest (§4).
+3. Position content-addressing: `positionCid` is the BLAKE3-512 of the JCS-canonical bytes of the opaque IR subterm (§5).
+4. The closed-enum reason codes shipped in v1.4.0 plus the extension procedure (§6).
+5. The updated JSON-RPC method shapes that carry the manifest (§7).
+6. Backward-compatibility positioning relative to v1 (§8).
+
+The manifest's grammar, byte-for-byte canonicalization rules, and worked example live in the standalone spec `2026-05-02-opacity-manifest-grammar.md`. This spec defines the *requirement* to emit one; that spec defines the manifest's *shape*.
+
+## §2. Inheritance from v1
+
+Everything in `2026-04-30-ir-compiler-protocol.md` carries forward unchanged unless this spec says otherwise:
+
+- Plugin discovery via `~/.config/provekit/ir-compilers/<name>/manifest.toml`.
+- Manifest schema (`name`, `version`, `protocol_version`, `binary`, `dialects`).
+- JSON-RPC over stdio framing.
+- The `provekit.ir.handshake`, `provekit.ir.compile`, `provekit.ir.shutdown` methods (with the v2 amendments below).
+- The dialect registry: `smt-lib-v2.6`, `smt-lib-v2.6-bv`, `smt-lib-v2.6-delta`, `tptp-fof`, `tptp-thf`, `lean-tactic-mode`, `gallina`, `isabelle-hol`. New dialects continue to be added by amending the relevant spec.
+- The error model (`-32700`, `-32600`, …, `2000`–`2004`).
+- Capability negotiation at handshake time.
+- The bootstrapping shape: in-process trait + standalone subprocess binary, sharing one emit implementation.
+
+The single substantive change v2 introduces is the OpacityManifest emission requirement. The single contract change is that `provekit.ir.compile` now returns the manifest as a sibling field of `preamble` and `body`.
+
+## §3. The emission requirement
+
+**INVARIANT (v2 emission):** A v2-conformant compiler MUST, on every successful `provekit.ir.compile` call, emit an `OpacityManifest` per `2026-05-02-opacity-manifest-grammar.md`. The manifest's `protocolVersion` field MUST be the literal `"ir-compiler-protocol/2"`. The manifest's `compiler` field MUST equal the dialect identifier this compiler serves. Empty `opacities: []` is the byte-shape for "this compiler translated every position soundly."
+
+**INVARIANT (manifest is non-optional):** A compiler that returns a successful `compile` response without an `opacityManifest` field is non-conformant with v2. A v1.4.0 verifier consuming such a response MUST NOT treat it as v2 input; the verifier MUST either (a) treat the compiler as v1-only (excluded from `coverage_required` consensus) or (b) reject the response.
+
+**INVARIANT (sound emission required for opacity):** A compiler that marks a position opaque MUST emit a syntactically valid theory-side placeholder for that position. The placeholder MUST be the theory-equivalent of "trust me" (vacuous, tautological, or admitted) such that the resulting solver script remains syntactically valid AND tractable for the solver. The opaque parts are MARKED, not omitted.
+
+The required placeholders by dialect:
+
+| Dialect | Placeholder for an opaque position |
+|---|---|
+| `smt-lib-v2.6`, `smt-lib-v2.6-bv`, `smt-lib-v2.6-delta` | `(assert true)` substituted at the syntactic position of the opaque subterm. If the position is sub-formula-level (inside a Boolean structure), the entire smallest-enclosing-assertion is replaced with `(assert true)` — the compiler MUST NOT splice `true` into a partial expression. |
+| `gallina` | `Admitted.` for the lemma corresponding to the opaque position. |
+| `lean-tactic-mode` | `sorry` at the tactic position of the opaque position. |
+| `isabelle-hol` | `oops` (or `sorry`, per Isabelle's conventions) at the proof position of the opaque position. |
+| `tptp-fof`, `tptp-thf` | The tautological axiom `fof(opaque_<positionCid>, axiom, $true).` (or its `thf` analog), substituted at the position. |
+
+For dialects not enumerated above, the compiler MUST document its placeholder convention in the dialect's spec; the convention MUST satisfy the soundness rule: the resulting script remains syntactically valid for the solver, and the solver's verdict on the script is sound *modulo* the positions marked opaque.
+
+**INVARIANT (placeholder + manifest atomicity):** Every position the compiler emitted a placeholder for MUST appear as an `Opacity` entry in the manifest. Conversely, every `Opacity` entry in the manifest MUST correspond to a placeholder in the emitted script. The placeholder-only-no-manifest case is unsound; the manifest-only-no-placeholder case is malformed.
+
+## §4. Position content-addressing
+
+`Opacity.positionCid` is defined and normatively specified in `2026-05-02-opacity-manifest-grammar.md` §3. Restated for this spec:
+
+```
+positionCid = "blake3-512:" || hex(BLAKE3-512(JCS(opaque_subterm)))
+```
+
+The "opaque subterm" is the IR-JSON node the compiler chose to mark opaque. The compiler's choice of granularity is the compiler's authority; the verifier compares positions by `positionCid` only.
+
+**INVARIANT (positional content-addressing):** Two compilers that mark the same syntactic IR subterm opaque produce the same `positionCid`. The verifier matches opacities across solvers exclusively by `positionCid` equality.
+
+## §5. Reason codes (closed enum + extension procedure)
+
+The v1.4.0 reason codes:
+
+| Reason code | Meaning |
+|---|---|
+| `kit_predicate_no_semantics` | The opaque subterm is an `Atomic` predicate application whose name is registered as a kit predicate, but the compiler has no theory semantics for it. |
+| `nested_lambda` | The opaque subterm is a `Lambda` whose body contains another `Lambda`. The compiler's lambda fragment is first-order; nested-lambda bodies are out of range. |
+| `predicate_quantification` | The opaque subterm is a `Lambda` whose `paramSort` is `Bool` or a function sort. The compiler can quantify over individual values but not over predicates. |
+| `dependent_type` | The opaque subterm references a value-dependent type. The compiler's type system is non-dependent. |
+| `other:<freeform>` | Anything else. The freeform suffix documents the reason for human auditors and participates in byte-level manifest equality. |
+
+**Closed-enum justification:** the verifier's coverage rule needs to know "this opacity reason is the same class of opacity another solver claimed to handle." A closed enum gives stable comparison. `other:<freeform>` is the open-bucket extension for novel opacity classes; v1.4.0 ships with the four codes above. Future minor versions of `ir-compiler-protocol/2` MAY add codes additively. The full extension procedure and its forward-compatibility guarantee is in `2026-05-02-opacity-manifest-grammar.md` §4.
+
+**INVARIANT (closed-enum stability):** The four base reason codes are stable across the lifetime of `ir-compiler-protocol/2`. Conformant compilers MUST emit one of the base codes whenever their reason matches one of the four meanings, rather than falling through to `other:`.
+
+## §6. Updated JSON-RPC method shapes
+
+### §6.1 `provekit.ir.handshake`
+
+The handshake response gains one optional field:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "name": "smt-lib-reference",
+    "version": "0.2.0",
+    "protocol_version": "ir-compiler-protocol/2",
+    "dialects": ["smt-lib-v2.6"],
+    "supported_sorts": ["Int", "Bool", "Real", "String"],
+    "supported_predicates": [ "=", "<", "<=", ">", ">=", "and", "or", "not", "implies", "forall", "exists" ],
+    "opacity_reason_codes": [
+      "kit_predicate_no_semantics",
+      "nested_lambda",
+      "predicate_quantification",
+      "dependent_type"
+    ]
+  }
+}
+```
+
+`protocol_version` MUST be `"ir-compiler-protocol/2"`. `opacity_reason_codes` SHOULD enumerate the closed-enum codes the compiler will actually emit; verifiers use this for diagnostic display only. Compilers MAY also emit `other:<...>` codes at runtime even if `opacity_reason_codes` doesn't list them.
+
+A verifier that performs handshake MUST reject any compiler whose `protocol_version` is not in `{ "ir-compiler-protocol/1", "ir-compiler-protocol/2" }`. A compiler claiming v1 is excluded from `coverage_required` consensus per `2026-05-02-multi-solver-protocol-v2.md`.
+
+### §6.2 `provekit.ir.compile`
+
+The response gains a required `opacityManifest` field:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "preamble": "(set-logic ALL)\n(declare-const x Int)\n",
+    "body": "(assert (not (> x 0)))\n(check-sat)\n",
+    "free_vars": [ { "name": "x", "sort": "Int" } ],
+    "opacityManifest": {
+      "compiler": "smt-lib-v2.6",
+      "compilerVersion": "0.2.0",
+      "opacities": [],
+      "protocolVersion": "ir-compiler-protocol/2"
+    }
+  }
+}
+```
+
+**INVARIANT:** Every successful `compile` response from a v2 compiler carries `opacityManifest` as a sibling of `preamble`, `body`, and `free_vars`. The manifest's bytes are the JCS-canonical form per `2026-05-02-opacity-manifest-grammar.md` §6.
+
+When `opacities` is non-empty, the `body` MUST contain the placeholder substitutions specified in §3. The verifier MAY parse the script to confirm the placeholders are present; it is not required to. The trust anchor is the catalog-signed compiler implementation.
+
+### §6.3 `provekit.ir.shutdown`
+
+Unchanged from v1.
+
+## §7. Capability negotiation, error model, plugin discovery
+
+Unchanged from v1 except:
+
+- The `protocol_version` value `"ir-compiler-protocol/2"` is now also valid (in addition to `"ir-compiler-protocol/1"`).
+- The `2001 compile_error.unsupported_sort` and `2002 compile_error.unsupported_predicate` codes are still valid escape hatches when a compiler decides a position is so badly malformed it cannot even mark it opaque (e.g., an unrecognized sort referenced from a free variable). v2 compilers SHOULD prefer marking the position opaque over erroring out, so that the consensus mechanism has a chance to compose around it; erroring out remains valid for genuinely malformed input.
+- A new error code `2005 compile_error.opacity_emission_failed` is added for the rare case where a compiler successfully decides a position is opaque but cannot emit a syntactically valid placeholder for it. This is a compiler bug; the verifier reports it and stops.
+
+## §8. Backward-compatibility
+
+**v1 compilers participate in v1 modes.** A v1 compiler (returning `protocol_version: "ir-compiler-protocol/1"`, no `opacityManifest`) continues to work in any v1 multi-solver mode (`Single`, `Chain`, `Portfolio { first-wins }`, `Portfolio { consensus, coverage_required: false }`). The verifier passes its compiled output to the named solver as before; no manifest is consulted, no coverage rule applies.
+
+**v1 compilers do NOT participate in `coverage_required` consensus.** The v2 multi-solver spec (`2026-05-02-multi-solver-protocol-v2.md`) requires every solver in a `coverage_required = true` portfolio to emit a v2 manifest. A pool that includes any v1 compiler is rejected at consensus time with `compile_error.opacity_manifest_missing`-equivalent telemetry. This is **scorched earth, no back-compat**, by design: composing partial competence requires every compiler in the pool to declare what it cannot soundly handle.
+
+**v2 compilers participate in v1 modes.** A v2 compiler is forward-compatible. When invoked in a v1 multi-solver mode, the verifier MAY ignore the `opacityManifest` field. The placeholders in `body` may surface as vacuous discharges; the operator who configured a v1-only solver pool with v2 compilers has accepted this.
+
+**Catalog migration.** The v1.4.0 catalog cut (separate spec work) decides whether `ir-compiler-protocol-v2` enters the catalog as a sibling of `ir-compiler-protocol` (this spec's draft assumption) or replaces it. Either way, the v1 spec's CID remains valid in any older catalog that referenced it.
+
+The v1 spec CID, for cross-reference: `blake3-512:71fc7ac22997938629d835f87e4e8a322026d77c1e1f834c9fbe0f79cca4e903792c628e96d3004c88d29706f4d87bc042ff837fef571c0cb3012495a03003d3` (per the v1.3.0 catalog).
+
+## §9. Acceptance
+
+This spec is satisfied by:
+
+- The reference Rust implementation at `implementations/rust/provekit-ir-compiler-smt-lib/` updated to emit OpacityManifests on every `compile` call.
+- The byte-fixture suite at `tests/opacity-manifest-fixtures/` (specified in `2026-05-02-opacity-manifest-grammar.md` §10).
+- A v2 conformance test asserting that the worked example in `2026-05-02-opacity-manifest-grammar.md` §8 round-trips byte-identically through the SMT-LIB v2.6 compiler.
+- A v1 backward-compatibility test asserting that an existing v1 multi-solver demo continues to work when its compiler is upgraded to v2 (the manifest is emitted but ignored).
+- The `provekit ir-compiler list` command surfacing each plugin's `protocol_version` so operators can audit pool composition before enabling `coverage_required` consensus.
+
+## §10. Related specs
+
+- `2026-05-02-opacity-manifest-grammar.md` — the manifest's byte-level shape, canonicalization, position content-addressing, worked example. This spec REQUIRES the manifest; that spec DEFINES it.
+- `2026-05-02-multi-solver-protocol-v2.md` — the verifier's consumption rule that uses manifests to compose consensus verdicts.
+- `2026-04-30-ir-compiler-protocol.md` — the v1 spec this v2 supersedes. CID `blake3-512:71fc7ac22997938629d835f87e4e8a322026d77c1e1f834c9fbe0f79cca4e903792c628e96d3004c88d29706f4d87bc042ff837fef571c0cb3012495a03003d3` per the v1.3.0 catalog.
+- `2026-04-30-ir-formal-grammar.md` — the IR-JSON grammar whose subterms are content-addressed by `positionCid`. Unchanged in v1.4.0; the IR is opacity-agnostic.
+- `2026-04-30-protocol-catalog-format.md` — the rule by which this spec's CID is computed.
+- `2026-04-30-canonicalization-grammar.md` — JCS canonicalization, normative for the manifest bytes.

--- a/protocol/specs/2026-05-02-multi-solver-protocol-v2.md
+++ b/protocol/specs/2026-05-02-multi-solver-protocol-v2.md
@@ -75,6 +75,8 @@ The defining mode of v1.4.0. Sibling to v1's `Portfolio { consensus }`; activate
 
 **INVARIANT (mode admission):** When `coverage_required = true`, every solver in the pool MUST be backed by an IR compiler reporting `protocol_version = "ir-compiler-protocol/2"` at handshake time. The verifier MUST reject the pool configuration before any solve attempt if any compiler in the pool is v1-only. Rejection surfaces as a configuration error (`config_error.coverage_requires_v2_compilers`), not as a runtime verdict.
 
+The verifier MUST complete the `initialize` handshake with each compiler before pool admission. Any compiler that fails handshake or returns a `protocol_version` other than `ir-compiler-protocol/2` is refused at startup, NOT runtime.
+
 This is **scorched earth, no back-compat**, by design: composing partial competence requires every compiler in the pool to declare what it cannot soundly handle. A v1.3.0-or-earlier solver cannot make that declaration; admitting it to a `coverage_required` pool would defeat the soundness rule the mode exists to enforce.
 
 The execution rule:
@@ -163,6 +165,8 @@ SolverTag   ::= "\"" SolverName "@" SolverVersion "\""    // e.g., "z3@4.13.0"
 **INVARIANT:** Every SolveResult MUST carry `opacityManifest`, `solver`, `verdict`, and `wallClockMs`. Additional fields MAY appear; v2 verifiers ignore unknown fields. The keys appear in JCS-sorted order (`opacityManifest`, `solver`, `verdict`, `wallClockMs`) when canonicalized.
 
 **INVARIANT (manifest nesting):** The `opacityManifest` field's bytes inside the SolveResult envelope are byte-identical to the same manifest's bytes when canonicalized in isolation. JCS canonicalization is structural; already-canonical sub-objects survive an outer canonicalization pass unchanged. See `2026-05-02-opacity-manifest-grammar.md` §7.
+
+**INVARIANT (SolverTag authority):** When a `SolverTag` (`name@version`) appears in both a SolveResult envelope and a memento minted from that result, the envelope's tag is authoritative; mementos copy the tag verbatim, never derive their own.
 
 The verdict provenance for a `Portfolio { consensus, coverage_required: true }` discharge is the array of SolveResult envelopes for every solver in the pool, plus the `coverage_union` and `coverage_assignments` fields produced by step 7 of §5. This array becomes part of the implication memento minted for the call site (the v1 per-solver memento rule generalizes; one consensus memento now references every contributing SolveResult).
 

--- a/protocol/specs/2026-05-02-multi-solver-protocol-v2.md
+++ b/protocol/specs/2026-05-02-multi-solver-protocol-v2.md
@@ -1,0 +1,270 @@
+# Multi-Solver Protocol (v2)
+
+**Status:** v1.4.0 normative draft
+**Date:** 2026-05-02
+**Catalog property:** Listed in the v1.4.0 catalog as `multi-solver-protocol-v2`; CID is computed from this file's bytes per `2026-04-30-protocol-catalog-format.md` §2.1 (raw-byte BLAKE3-512).
+**Owner:** verifier crate.
+**Supersedes:** `2026-04-30-multi-solver-protocol.md` (v1, listed in the v1.3.0 catalog at `multi-solver-protocol`, CID `blake3-512:71fc7ac22997938629d835f87e4e8a322026d77c1e1f834c9fbe0f79cca4e903792c628e96d3004c88d29706f4d87bc042ff837fef571c0cb3012495a03003d3`). The v1 spec remains valid for any v1.3.0-or-earlier verifier; v1.4.0 verifiers running in `coverage_required` consensus mode require v2 conformance.
+
+## §0. The protocol is the bytes
+
+The multi-solver verdict is composed from a pool of SolveResult envelopes. Each envelope is structured data with a defined byte form. The composition rules in this spec operate on those bytes; two conformant verifiers in two languages, given the same pool of SolveResult envelopes, produce the same composed verdict and the same provenance record.
+
+If this English text says one thing and a conformant verifier's bytes say another, the bytes win and the English is updated.
+
+## §1. Why v2 exists
+
+The v1 multi-solver protocol composed solver verdicts under four execution modes: `Single`, `Chain`, `Portfolio { first-wins }`, `Portfolio { consensus }`, `Dispatch`. Consensus mode required all definitive verdicts to agree on the FOL fragment. It had no concept of *partial competence*: a solver that returned `Discharged` after silently skipping a position it could not soundly translate looked indistinguishable from a solver that handled the whole formula.
+
+The IR-compiler-protocol/2 spec (`2026-05-02-ir-compiler-protocol-v2.md`) closes that gap on the compiler side: every v2 compiler emits an `OpacityManifest` declaring which IR positions it could not soundly translate. This v2 multi-solver spec closes the gap on the verifier side: a new plan mode, `Portfolio { consensus, coverage_required: true }`, refuses to compose a verdict unless every opaque position any solver reported is *covered* by some other solver in the pool that did NOT need to mark it opaque AND returned `Discharged`.
+
+The IR is unchanged. The IR knows nothing about Coq, opacity, or solver capabilities. **Each compiler is the authority on what its theory can soundly handle.** The verifier's authority is composition, not translation.
+
+This spec defines:
+
+1. The new `Portfolio { consensus, coverage_required: true }` execution mode (§4).
+2. The verdict-composition rule that consumes OpacityManifests (§5).
+3. The SolveResult envelope grammar including the manifest field (§6).
+4. The configuration shape extending v1's `[solvers]` block with `coverage_required` (§7).
+5. The backward-compatibility positioning relative to v1 modes (§8).
+
+The OpacityManifest's grammar, canonicalization, position content-addressing, and worked example live in `2026-05-02-opacity-manifest-grammar.md`. The compiler's emission requirement lives in `2026-05-02-ir-compiler-protocol-v2.md`. This spec consumes both.
+
+## §2. Inheritance from v1
+
+Everything in `2026-04-30-multi-solver-protocol.md` carries forward unchanged unless this spec says otherwise:
+
+- The `[solvers]` configuration grammar in `.provekit/config.toml`, extended in §7 with one new field.
+- The execution modes `Single`, `Chain`, `Portfolio { first-wins }`, `Portfolio { consensus }` (now equivalent to `Portfolio { consensus, coverage_required: false }`), `Dispatch`.
+- Stub solver shorthands.
+- Per-fragment dispatch heuristics.
+- Per-solver IR-compiler dispatch via the `ir_compiler` tag.
+- Per-solver implication-memento provenance.
+- The `min_solver_witnesses` trust knob.
+- The `TierStats` report schema.
+
+The single substantive change is the introduction of `coverage_required` and the new verdict-composition rule that activates when it is set to `true`.
+
+## §3. Terminology
+
+- **Solver pool.** The ordered list of solvers configured under `[solvers] portfolio = [...]`.
+- **SolveResult.** The envelope a single solver returns: a verdict plus the OpacityManifest emitted by that solver's IR compiler.
+- **Verdict.** One of `Discharged`, `Unsatisfied`, `Undecidable`, `Disagreement` (the v1 enum). v1.4.0 adds no verdict cases; coverage failures surface as `Undecidable` with a structured reason.
+- **OpacityManifest.** The structure defined in `2026-05-02-opacity-manifest-grammar.md`. Each entry has a `positionCid` and a `reasonCode`.
+- **Coverage union.** Across a pool's SolveResults, the set of distinct `positionCid`s that appear in any solver's manifest.
+- **Coverage.** A `positionCid` is *covered* by solver S iff S's manifest contains NO entry with that `positionCid` AND S's verdict is `Discharged`.
+- **`coverage_required`.** A boolean knob on `Portfolio { consensus }` mode that, when `true`, requires every position in the coverage union to be covered by at least one solver in the pool.
+
+## §4. Execution modes (v2)
+
+### §4.1 Modes inherited unchanged from v1
+
+| Mode | v2 semantics |
+|---|---|
+| `Single` | Invoke one solver; its verdict is the call site's verdict. No coverage check. |
+| `Chain` | Sequential fall-through; first definitive verdict wins. No coverage check. |
+| `Portfolio { first-wins }` | Parallel; first definitive verdict wins. No coverage check. |
+| `Portfolio { consensus }` | Equivalent to `Portfolio { consensus, coverage_required: false }`. Parallel; ALL definitive verdicts must agree on the FOL fragment. No coverage check. |
+| `Dispatch` | Inspect formula theory; pick matching solver. Single-solver dispatch. No coverage check. |
+
+In all of the above, OpacityManifests in SolveResult envelopes are recorded for telemetry and provenance but do NOT participate in verdict composition. v1 and v2 compilers can be mixed freely.
+
+### §4.2 New mode: `Portfolio { consensus, coverage_required: true }`
+
+The defining mode of v1.4.0. Sibling to v1's `Portfolio { consensus }`; activated by setting `coverage_required = true` in the `[solvers]` block.
+
+**INVARIANT (mode admission):** When `coverage_required = true`, every solver in the pool MUST be backed by an IR compiler reporting `protocol_version = "ir-compiler-protocol/2"` at handshake time. The verifier MUST reject the pool configuration before any solve attempt if any compiler in the pool is v1-only. Rejection surfaces as a configuration error (`config_error.coverage_requires_v2_compilers`), not as a runtime verdict.
+
+This is **scorched earth, no back-compat**, by design: composing partial competence requires every compiler in the pool to declare what it cannot soundly handle. A v1.3.0-or-earlier solver cannot make that declaration; admitting it to a `coverage_required` pool would defeat the soundness rule the mode exists to enforce.
+
+The execution rule:
+
+1. Spawn every solver in the pool against the formula in parallel (per the v1 portfolio shape; cancellation semantics inherit from v1's open follow-up).
+2. Collect each solver's SolveResult envelope `(verdict_i, manifest_i)`.
+3. Apply the verdict-composition rule (§5).
+
+## §5. Verdict-composition rule
+
+Given a pool `S = { s_1, ..., s_n }` with SolveResults `(verdict_i, manifest_i)`:
+
+```
+ConsensusCoverage(formula, S) :=
+  // Step 1: reject any pool member with a missing or v1-shaped manifest.
+  if ∃ i : manifest_i is absent or not ir-compiler-protocol/2
+    then Undecidable("coverage_required: solver s_i lacks v2 manifest")
+
+  // Step 2: any concrete refutation kills the consensus.
+  if ∃ i : verdict_i = Unsatisfied
+    then Unsatisfied  // formula is concretely refuted; no coverage check needed
+
+  // Step 3: existing v1 disagreement check, applied per-position.
+  if ∃ i, j : verdict_i ∈ {Discharged, Unsatisfied} ∧
+              verdict_j ∈ {Discharged, Unsatisfied} ∧
+              verdict_i ≠ verdict_j
+    then Disagreement(by_solver = ...)
+
+  // Step 4: compute the coverage union.
+  let opacityUnion = ⋃_{i=1..n} { entry.positionCid | entry ∈ manifest_i.opacities }
+
+  // Step 5: every opaque position must be covered.
+  if ∃ p ∈ opacityUnion :
+       ¬∃ i ∈ {1..n} :
+            verdict_i = Discharged ∧
+            ¬∃ entry ∈ manifest_i.opacities : entry.positionCid = p
+    then Undecidable("coverage_required: position <p> uncovered by any solver in pool")
+
+  // Step 6: at least one solver must have returned Discharged.
+  if ¬∃ i : verdict_i = Discharged
+    then Undecidable("coverage_required: no solver discharged")
+
+  // Step 7: consensus succeeds.
+  return Discharged with provenance:
+    - per_solver_results: { (s_i, verdict_i, manifest_i) }
+    - coverage_union: opacityUnion
+    - coverage_assignments: { p ↦ s_i  |  for each p, the lexicographically-first solver
+                                          in the pool that covered p }
+```
+
+**INVARIANT (composition soundness):** When `ConsensusCoverage(formula, S) = Discharged`, every position in the coverage union was reasoned about by at least one solver in the pool that did not need to mark it opaque AND that solver returned `Discharged`. The composition is sound: every part of the formula was soundly discharged by some pool member.
+
+**INVARIANT (per-position disagreement orthogonality):** The disagreement check in step 3 applies to the *whole formula* between any two solvers that both returned definitive verdicts. The coverage rule in step 5 applies *per-position*. The two are orthogonal: a coverage gap fails as `Undecidable`, a disagreement fails as `Disagreement`. A pool can fail both checks; the v2 verifier reports both signals to telemetry, and the call-site verdict is the one that fails first in step order (Step 2 > Step 3 > Step 5 > Step 6).
+
+**INVARIANT (coverage-assignment determinism):** The `coverage_assignments` map records, for each position in the coverage union, the *first* solver in the pool's configured order that covered the position. Two verifiers consuming the same SolveResult pool with the same configured order produce byte-identical `coverage_assignments` records.
+
+### §5.1 Why step 1 rejects rather than skips
+
+A v1.3.0-or-earlier solver in a `coverage_required` pool is a misconfiguration, not a runtime ambiguity. The verifier MUST refuse to run rather than silently proceed (e.g., by treating the missing manifest as `opacities: []`). Treating absence as emptiness would let an unsound v1 compiler claim sound coverage of a position it never reasoned about.
+
+### §5.2 Why step 2 rejects on Unsatisfied
+
+If any solver returns `Unsatisfied`, the formula is concretely refuted (the solver found a counterexample). Continuing to a coverage check would only confirm the refutation. The verdict is `Unsatisfied` with provenance; the disagreement check of step 3 still flags the case where another solver returned `Discharged` for the same formula (a SOLVER DISAGREEMENT in v1's sense).
+
+### §5.3 Why empty `opacities` is sound
+
+If every solver in the pool returns `(Discharged, opacities: [])`, the coverage union is empty, step 5 is vacuously satisfied, step 6 finds at least one `Discharged`, and the verdict is `Discharged`. This is the "every solver translated everything soundly and discharged the formula" case; v2 reduces to v1 consensus when no opacity is reported by any solver.
+
+## §6. SolveResult envelope grammar
+
+Every solver invocation under any v2 mode produces a SolveResult envelope, JCS-canonicalized for inclusion in the verdict provenance record:
+
+```ebnf
+SolveResult ::= "{"
+                  "\"opacityManifest\"" ":" OpacityManifest ","
+                  "\"solver\"" ":" SolverTag ","
+                  "\"verdict\"" ":" Verdict ","
+                  "\"wallClockMs\"" ":" Number
+                "}"
+
+Verdict     ::= "\"Discharged\"" | "\"Unsatisfied\"" | "\"Undecidable\"" | "\"Disagreement\""
+
+SolverTag   ::= "\"" SolverName "@" SolverVersion "\""    // e.g., "z3@4.13.0"
+```
+
+**INVARIANT:** Every SolveResult MUST carry `opacityManifest`, `solver`, `verdict`, and `wallClockMs`. Additional fields MAY appear; v2 verifiers ignore unknown fields. The keys appear in JCS-sorted order (`opacityManifest`, `solver`, `verdict`, `wallClockMs`) when canonicalized.
+
+**INVARIANT (manifest nesting):** The `opacityManifest` field's bytes inside the SolveResult envelope are byte-identical to the same manifest's bytes when canonicalized in isolation. JCS canonicalization is structural; already-canonical sub-objects survive an outer canonicalization pass unchanged. See `2026-05-02-opacity-manifest-grammar.md` §7.
+
+The verdict provenance for a `Portfolio { consensus, coverage_required: true }` discharge is the array of SolveResult envelopes for every solver in the pool, plus the `coverage_union` and `coverage_assignments` fields produced by step 7 of §5. This array becomes part of the implication memento minted for the call site (the v1 per-solver memento rule generalizes; one consensus memento now references every contributing SolveResult).
+
+## §7. Configuration shape
+
+Extends v1's `[solvers]` block with one new field, `coverage_required`:
+
+```toml
+[solvers]
+mode = "consensus"
+coverage_required = true                 # opt-in to v2 coverage check; default false
+portfolio = ["z3", "cvc5", "coq"]
+
+[solvers.z3]
+ir_compiler = "smt-lib-v2.6"
+binary = "z3"
+
+[solvers.cvc5]
+ir_compiler = "smt-lib-v2.6"
+binary = "cvc5"
+
+[solvers.coq]
+ir_compiler = "gallina"
+binary = "coqtop"
+```
+
+`coverage_required` is OPTIONAL. Default value is `false`. When unset or `false`, the verifier uses v1 consensus semantics (all definitive verdicts must agree on the FOL fragment; no coverage check). When `true`, the verifier applies the §5 ConsensusCoverage rule.
+
+**INVARIANT (default is v1):** Within v1.4.0, the default behavior of `Portfolio { consensus }` is byte-for-byte the v1 behavior. Operators opt in to v2 coverage by setting `coverage_required = true` explicitly.
+
+`coverage_required = true` requires `mode = "consensus"`. Any other combination (`coverage_required = true` with `mode = "first-wins"`, etc.) is a configuration error. The verifier refuses to start with `config_error.coverage_required_requires_consensus_mode`.
+
+## §8. Backward-compatibility
+
+**v1 modes unchanged.** `Single`, `Chain`, `Portfolio { first-wins }`, `Portfolio { consensus, coverage_required: false }`, and `Dispatch` continue to work exactly as in v1, with v1 or v2 compilers freely mixable. The OpacityManifest, when emitted by a v2 compiler, is recorded for telemetry but does not affect the verdict.
+
+**v1 compilers excluded from `coverage_required` pools.** Per §4.2 admission rule, a `coverage_required = true` pool rejects v1 compilers at startup. The opt-out is to drop `coverage_required` and run v1 consensus, in which case the v1 compiler participates normally.
+
+**v2 verifiers consuming v1 pools.** A v2 verifier configured with `coverage_required = false` (or unset) is operationally identical to a v1 verifier on the same configuration. Operators may upgrade verifiers without upgrading any solver until they explicitly opt in to v2 coverage.
+
+**v1 verifiers consuming v2 SolveResults.** A v1 verifier consuming a SolveResult emitted by a v2 compiler ignores the `opacityManifest` field. The verdict and provenance the v1 verifier records are identical to what it would record for a v1 SolveResult; the manifest's bytes are dead weight in the envelope. This is forward-compatible by design.
+
+**Catalog migration.** The v1.4.0 catalog cut (separate spec work) decides whether `multi-solver-protocol-v2` enters the catalog as a sibling of `multi-solver-protocol` (this spec's draft assumption) or replaces it. Either way, the v1 spec's CID remains valid in any older catalog that referenced it.
+
+## §9. Telemetry and reporting
+
+`TierStats` extends v1's schema with a coverage section. The new fields are additive:
+
+```rust
+pub struct TierStats {
+    // v1 fields (unchanged)
+    pub discharged_by_hash: usize,
+    pub discharged_by_cache: usize,
+    pub vacuous_discharge: usize,
+    pub solved_and_minted: usize,
+    pub residue: usize,
+    pub violations: usize,
+    pub disagreements: usize,
+    pub solver_invocations: usize,
+    pub per_solver: BTreeMap<String, SolverStats>,
+
+    // v2 additions
+    pub coverage_required_runs: usize,           // calls under coverage_required = true
+    pub coverage_holds: usize,                    // ... that produced a Discharged verdict
+    pub coverage_gaps: usize,                     // ... that failed step 5
+    pub coverage_v1_compiler_rejections: usize,   // pools rejected at admission per §4.2
+    pub opacity_positions_seen: usize,            // size of coverage_union, summed
+    pub opacity_positions_covered: usize,         // positions covered, summed
+}
+```
+
+The v1 `disagreements` counter continues to count step-3 disagreements (unchanged). v2 introduces `coverage_gaps` for step-5 failures and `coverage_v1_compiler_rejections` for §4.2 admission failures. The counters are independent: a single call site can register a disagreement, a coverage gap, or both, and the call-site verdict reports the first failure in step order.
+
+The verifier's report includes a per-call-site coverage breakdown when `coverage_required = true`: the coverage union, the coverage assignment, and (on failure) the uncovered positions with the reason codes any solver attached to them. Operators use this to decide which solver to add to the pool to close the gap.
+
+## §10. Acceptance
+
+This spec is satisfied by:
+
+- `cargo build --release -p provekit-verifier` succeeds with the v2 modes.
+- `cargo test --release -p provekit-verifier` passes (v1 tests green plus new tests for `coverage_required` admission, the §5 composition rule, and the §7 configuration error paths).
+- Integration test `tests/multi_solver_modes_v2.rs` exercises:
+  - The §8 worked example: SMT marks two opacity positions; Coq marks none; Coq returns `Discharged`; consensus holds.
+  - The "coverage gap" case: SMT marks one position; no other solver in the pool covers it; consensus fails as `Undecidable("coverage_required: position <p> uncovered")`.
+  - The "v1 compiler in v2 pool" case: a stub v1 compiler in a `coverage_required` pool causes startup rejection.
+  - The "Unsatisfied short-circuits coverage" case: one solver returns `Unsatisfied`; the coverage union is computed for telemetry but the verdict is `Unsatisfied`.
+- The v1.4.0 demo at `examples/multi-solver-coverage-demo/` runs end-to-end with stub v2 compilers and produces a `Discharged` verdict via coverage.
+- The v1 multi-solver demo at `examples/multi-solver-demo/` continues to pass byte-for-byte (v1 modes unchanged).
+
+## §11. Open follow-ups
+
+- **Disagreement memento role.** Inherited from v1 §9. The `verdict-disagreement` memento envelope shape is still TBD. v2 adds a peer concern: a `coverage-gap` memento envelope that signs a position-uncovered failure for downstream auditors. New schema CID, new memento `kind = "coverage-gap"`. Deferred to a later spec.
+- **Subprocess cancellation.** Inherited from v1 §9. `coverage_required` mode benefits from cancellation slightly less than `first-wins` (every solver's verdict is needed for the coverage union), but a solver returning `Unsatisfied` could short-circuit the rest per §5.2.
+- **Coverage-aware pool sizing heuristics.** Once we have empirical data on which compilers cover which opacity-reason classes, the verifier could suggest pool augmentations ("your pool has 3 unhandled `dependent_type` positions; consider adding a Lean solver"). Future telemetry-driven feature; not normative.
+- **Transitive coverage.** If solver A covers position p_1 but marks p_2 opaque, and solver B covers p_2 but is unable to compile to handle p_1 in the same call, the pool has no joint solution. v2 does not attempt to split the formula across solvers; future "formula-fragmentation" mode could.
+
+## §12. Related specs
+
+- `2026-05-02-opacity-manifest-grammar.md` — the manifest's byte-level shape and position content-addressing.
+- `2026-05-02-ir-compiler-protocol-v2.md` — the compiler-side emission requirement that produces the manifests this spec consumes.
+- `2026-04-30-multi-solver-protocol.md` — the v1 spec this v2 supersedes. CID `blake3-512:71fc7ac22997938629d835f87e4e8a322026d77c1e1f834c9fbe0f79cca4e903792c628e96d3004c88d29706f4d87bc042ff837fef571c0cb3012495a03003d3` per the v1.3.0 catalog.
+- `2026-04-30-handshake-algorithm.md` — the three-tier discharge model. v2's per-solver mementos (inherited from v1 §5) flow into the same Tier-2 cache.
+- `2026-04-30-memento-envelope-grammar.md` — implication memento shape; per-solver provenance is unchanged in v2.
+- `2026-04-30-protocol-catalog-format.md` — the rule by which this spec's CID is computed.
+- `2026-04-30-canonicalization-grammar.md` — JCS canonicalization, normative for SolveResult envelopes.

--- a/protocol/specs/2026-05-02-opacity-manifest-grammar.md
+++ b/protocol/specs/2026-05-02-opacity-manifest-grammar.md
@@ -1,0 +1,263 @@
+# Opacity Manifest Grammar
+
+**Status:** v1.4.0 normative draft
+**Date:** 2026-05-02
+**Catalog property:** Listed in the v1.4.0 catalog as `opacity-manifest-grammar`; CID is computed from this file's bytes per the catalog format (`2026-04-30-protocol-catalog-format.md` §2.1, raw-byte BLAKE3-512).
+**Owner:** verifier crate + every conformant IR compiler.
+**Related:**
+- `2026-05-02-ir-compiler-protocol-v2.md` (the emission requirement)
+- `2026-05-02-multi-solver-protocol-v2.md` (the consensus rule that consumes manifests)
+- `2026-04-30-canonicalization-grammar.md` (JCS canonicalization)
+- `2026-04-30-proof-file-format.md` (envelope grammar style)
+
+## §0. The protocol is the bytes
+
+An OpacityManifest is structured data. Two compilers in two languages translating the same opaque IR positions in the same way MUST produce byte-identical manifests. The bytes are the protocol; the grammar in this document is the description of the bytes.
+
+A reader who hashes the manifest a different way, or compares manifests by parsing them into language-native objects rather than comparing JCS-canonical bytes, is hashing or comparing something other than the protocol-defined manifest. The verifier's coverage rule is defined in terms of `positionCid` strings, which are themselves byte-derived; everything composes back to the bytes.
+
+## §1. Why opacity manifests exist
+
+The verifier composes verdicts from multiple solvers. A solver that translates IR-JSON into its native theory may encounter positions in the formula it cannot soundly translate (a `kit_predicate` with no theory semantics, a `Lambda` whose body is itself a `Lambda`, a quantifier over predicates, a value-dependent type). The IR is not at fault: the IR is the universal language; *each compiler is the authority on what its theory can soundly handle*.
+
+A v1.3.0 compiler, faced with such a position, has two options:
+1. Refuse to emit anything (`compile_error.unsupported_*`).
+2. Emit a body that silently elides the offending position.
+
+Option 1 cuts off composition: a position one solver cannot handle removes the entire formula from that solver's contribution to a portfolio. Option 2 is unsound: the solver returns `Discharged` for a formula it never fully reasoned about.
+
+The v1.4.0 design takes a third option. **A compiler emits a tractable script for everything it can soundly translate, marks every untranslated position with a theory-equivalent of "trust me" (SMT `(assert true)`, Coq `Admitted.`, Lean `sorry`, Isabelle `oops`), and records each marked position in an OpacityManifest.** The compiled output remains syntactically valid for the solver. The opaque parts are MARKED, not omitted.
+
+The verifier reads every solver's manifest. If solver A marked position X opaque and solver B (whose manifest does NOT contain X) returned `Discharged` for the same formula, position X is *covered* by B. A consensus that covers every opacity position across the union of manifests is a sound joint discharge: each opaque position was reasoned about by *some* solver in the pool that did not need to mark it opaque.
+
+The OpacityManifest is the data structure that makes this rule decidable and content-addressed.
+
+## §2. Grammar
+
+The OpacityManifest is a JSON object with exactly four required top-level properties.
+
+```ebnf
+OpacityManifest ::= "{"
+                      "\"protocolVersion\"" ":" "\"ir-compiler-protocol/2\"" ","
+                      "\"compiler\"" ":" String ","
+                      "\"compilerVersion\"" ":" String ","
+                      "\"opacities\"" ":" "[" Opacity ( "," Opacity )* "]"
+                    "}"
+
+Opacity ::= "{"
+              "\"positionCid\"" ":" PositionCid ","
+              "\"reasonCode\"" ":" ReasonCode
+            "}"
+
+PositionCid ::= "\"blake3-512:\"" HexDigest
+HexDigest   ::= 128 lower-case hex characters
+
+ReasonCode ::= "\"kit_predicate_no_semantics\""
+             | "\"nested_lambda\""
+             | "\"predicate_quantification\""
+             | "\"dependent_type\""
+             | "\"other:\"" FreeformReason
+
+FreeformReason ::= String   // arbitrary; documents the reason for tooling
+```
+
+### §2.1 Field semantics
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `protocolVersion` | string | yes | MUST be the literal `"ir-compiler-protocol/2"`. Tags the manifest with the contract that produced it. A v1.5.0 manifest will use a different tag. |
+| `compiler` | string | yes | The compiler's dialect identifier from the IR-compiler dialect registry, e.g. `"smt-lib-v2.6"`, `"gallina"`, `"lean-tactic-mode"`. Identifies which compiler emitted the manifest, not which solver consumes it. |
+| `compilerVersion` | string | yes | The compiler implementation's version, surfaced in mementos and reports for provenance. SHOULD match the `version` field returned by `provekit.ir.handshake`. |
+| `opacities` | array | yes | Possibly-empty list of `Opacity` records. Empty `opacities: []` is the byte-shape for "this compiler translated every position soundly." |
+
+`Opacity.positionCid` is the BLAKE3-512 of the JCS-canonical bytes of the opaque IR subterm; see §3. `Opacity.reasonCode` is one of the closed-enum strings in §4 or an `other:<freeform>` extension code.
+
+### §2.2 Empty manifest
+
+An empty-opacities manifest is **not optional**; a compiler that handled every position soundly MUST still emit the envelope with `opacities: []`. The presence of the envelope is what tells the verifier this compiler conforms to ir-compiler-protocol/2 at all. Absence of an envelope means the solver is pre-v1.4.0 and is excluded from `coverage_required` consensus by the rule in `2026-05-02-multi-solver-protocol-v2.md`.
+
+**INVARIANT:** A compiler that returns a SolveResult for `coverage_required = true` consensus MUST emit an OpacityManifest envelope, even when `opacities` is empty.
+
+### §2.3 Ordering of `opacities`
+
+The `opacities` array MUST be sorted by `positionCid` ascending (lexicographic over the `blake3-512:<hex>` string). When two entries share a `positionCid` (which can happen if a compiler decides the same syntactic subterm is opaque for two distinct reasons), they are sorted by `reasonCode` ascending as a secondary key. After JCS canonicalization the array form is determined byte-for-byte by these two ordering rules.
+
+**INVARIANT:** Two conformant compilers, given the same set of `(positionCid, reasonCode)` pairs to emit, MUST produce byte-identical `opacities` arrays.
+
+## §3. Position content-addressing
+
+`Opacity.positionCid` is the BLAKE3-512 of the JCS-canonical bytes of the opaque IR subterm:
+
+```
+positionCid = "blake3-512:" || hex(BLAKE3-512(JCS(opaque_subterm)))
+```
+
+The "opaque subterm" is the IR-JSON node the compiler chose to mark opaque. It may be a single `Lambda` node, a single `Atomic` predicate application, or a sort declaration. The compiler's choice of granularity is the compiler's authority; the verifier compares positions by `positionCid` only and never reasons about the node's internal structure.
+
+**INVARIANT (positional content-addressing):** Two compilers that mark the same syntactic IR subterm opaque produce the same `positionCid`. Two compilers that mark different subterms opaque (even if the difference is a child node nested inside the other) produce different `positionCid`s.
+
+Rationale: this is precisely the "formula equality is hash equality" rule from `2026-04-30-handshake-algorithm.md` applied to opaque subterm comparison. The verifier needs to ask "did some other solver in the pool *not* need to mark this exact position opaque?" Position equality is hash equality of the canonical-bytes representation.
+
+### §3.1 Why JCS over the IR subterm
+
+The canonical IR-JSON grammar (`2026-04-30-ir-formal-grammar.md`) already produces canonical IR bytes. Hashing a node *inside* a canonical document is the same as JCS-canonicalizing the node in isolation, since JCS canonicalization is structural and key-local: the canonical form of a sub-object is the sub-object's canonical form, regardless of its parent context.
+
+Implementations MAY skip a redundant JCS pass if they extract the subterm's bytes directly from a canonical IR document. The bytes hashed are what matter; the route is at the implementer's discretion.
+
+## §4. Reason codes (closed enum + extension procedure)
+
+The four base reason codes shipped in v1.4.0 and the open-bucket extension shape:
+
+| Reason code | Meaning |
+|---|---|
+| `kit_predicate_no_semantics` | The opaque subterm is an `Atomic` predicate application whose name is registered as a kit predicate, but the compiler has no theory semantics for it. The kit predicate exists in the IR, but the compiler cannot translate its meaning into its target theory. |
+| `nested_lambda` | The opaque subterm is a `Lambda` whose body contains another `Lambda`. The compiler's lambda fragment is first-order; a nested-lambda body is outside its sound translation range. |
+| `predicate_quantification` | The opaque subterm is a `Lambda` whose `paramSort` is `Bool` or a function sort. The compiler can quantify over individual values but not over predicates. |
+| `dependent_type` | The opaque subterm references a value-dependent type (a sort whose definition mentions a value-level variable). The compiler's type system is non-dependent. |
+| `other:<freeform>` | Anything else. The freeform suffix after the colon is compiler-specific; it documents the reason for human auditors but participates in the byte-level equality of the manifest. |
+
+**INVARIANT (closed-enum stability):** The four base reason codes (`kit_predicate_no_semantics`, `nested_lambda`, `predicate_quantification`, `dependent_type`) are stable across the lifetime of `ir-compiler-protocol/2`. Conformant compilers MUST emit one of these four codes whenever their reason matches one of these four meanings, rather than falling through to `other:`.
+
+**Extension procedure.** A future minor version of `ir-compiler-protocol/2` (say, `ir-compiler-protocol/2.1`) MAY add additional base codes by amending this spec. New codes are added additively; no existing code is renamed or removed. A v2 verifier consuming a v2.1 manifest treats unrecognized base codes as if they were `other:<code>` for coverage-comparison purposes: the manifest is still valid, but the verifier cannot collapse the new code's semantics into a known equivalence class. This is graceful: a future opacity class that the verifier does not yet understand is treated conservatively.
+
+**INVARIANT (forward compatibility):** A v1.4.0 verifier consuming an OpacityManifest that contains a reason code outside the v1.4.0 set MUST NOT reject the manifest. It MUST treat the unrecognized code identically to `other:<code>`: include the position in the coverage union, require some other solver in the pool to discharge it.
+
+## §5. Coverage-comparison algorithm
+
+The same algorithm is restated normatively in `2026-05-02-multi-solver-protocol-v2.md` §verdict-composition; this spec gives the byte-level form.
+
+Given a set of solvers `S = { s_1, ..., s_n }` each returning a SolveResult `(verdict_i, manifest_i)`:
+
+```
+coverage_union = ⋃_{i=1..n} { entry.positionCid | entry ∈ manifest_i.opacities }
+
+is_covered(position_cid) :=
+  ∃ i ∈ {1..n} :
+    verdict_i = Discharged ∧
+    ¬∃ entry ∈ manifest_i.opacities : entry.positionCid = position_cid
+
+consensus_holds := ∀ p ∈ coverage_union : is_covered(p)
+```
+
+**INVARIANT (coverage soundness):** If `consensus_holds = true` and every solver's verdict is in `{Discharged}` (no `Unsatisfied`, no missing manifest), then for every position in the coverage union there exists at least one solver in the pool that reasoned about that position soundly and concluded the formula is `Discharged`. Composing those per-position discharges gives a joint discharge of the whole formula.
+
+The full consensus rule (which also requires no solver to have returned `Unsatisfied`, no FOL-fragment disagreement, etc.) lives in the multi-solver-protocol/2 spec; this section defines only the position-level coverage primitive.
+
+## §6. Cross-language byte conformance
+
+A conformant OpacityManifest emitter in any language (Rust, C++, Python, OCaml, ...) MUST produce byte-identical manifests for byte-identical opacity sets. The recipe:
+
+1. Compute each `positionCid` via JCS-canonicalize-then-BLAKE3-512 of the opaque subterm bytes (§3).
+2. Build the in-memory `opacities` list, deduplicating by `(positionCid, reasonCode)` if the compiler accidentally records the same opacity twice.
+3. Sort the list per §2.3 (positionCid ascending, reasonCode tiebreak).
+4. Construct the JSON object with the four required keys.
+5. JCS-canonicalize the object per `2026-04-30-canonicalization-grammar.md`.
+6. The byte string from step 5 is the manifest's wire form. The manifest's CID, when needed (e.g., for inclusion-by-reference in proof envelopes), is `blake3-512:<hex(BLAKE3-512(jcs_bytes))>`.
+
+A reference test suite at `tests/opacity-manifest-fixtures/` (v1.4.0) provides input/output pairs: given a fixed IR document and a fixed opacity-marking strategy, the expected manifest bytes are checked in. New language ports MUST pass every fixture byte-for-byte.
+
+**INVARIANT (cross-language determinism):** Two conformant OpacityManifest emitters in any two languages produce byte-identical manifest output for the same logical opacity set.
+
+## §7. Inclusion in SolveResult envelopes
+
+Per `2026-05-02-multi-solver-protocol-v2.md` §SolveResult-envelope, every SolveResult emitted by a v1.4.0 solver carries its OpacityManifest as a sibling field of the verdict:
+
+```json
+{
+  "verdict": "Discharged",
+  "opacityManifest": { ... },
+  "solver": "z3@4.13.0",
+  "wallClockMs": 142
+}
+```
+
+The `opacityManifest` field's bytes are the JCS-canonical form per §6. The SolveResult envelope itself is JCS-canonicalized once when the verifier wraps it for memento provenance; the manifest's nested JCS form survives the outer JCS pass because JCS canonicalization is structural and idempotent on already-canonical sub-objects.
+
+**INVARIANT:** A SolveResult's `opacityManifest` field, extracted and re-canonicalized in isolation, hashes to the same `blake3-512:<hex>` value as it does inside the SolveResult envelope. JCS does not re-order or alter already-canonical sub-objects.
+
+## §8. Worked example
+
+Consider the formula:
+
+```
+forall P. ∀x. P(x) ∧ proves_by_induction(P)
+```
+
+In the IR this is two nested `Lambda` nodes (the outer one binding `P` of sort `Bool -> Bool`, the inner binding `x`), with an `And` whose right branch is an `Atomic` application of the kit predicate `proves_by_induction` to the bound predicate variable `P`.
+
+### §8.1 SMT-LIB v2.6 compiler
+
+The SMT compiler:
+
+- Walks the outer `Lambda`. Its `paramSort` is a function sort (`Bool -> Bool`). The compiler marks this `Lambda` opaque with `reasonCode = "predicate_quantification"`. It emits `(assert true)` for that position and continues.
+- The inner `Lambda` (`x : Int`) is fine. The compiler translates it as a universally quantified Int variable.
+- The `Atomic` application of `proves_by_induction(P)` is a kit predicate the compiler has no semantics for. Marked opaque with `reasonCode = "kit_predicate_no_semantics"`.
+
+Resulting SMT manifest (after JCS):
+
+```json
+{
+  "compiler": "smt-lib-v2.6",
+  "compilerVersion": "0.2.0",
+  "opacities": [
+    { "positionCid": "blake3-512:5a...", "reasonCode": "kit_predicate_no_semantics" },
+    { "positionCid": "blake3-512:c1...", "reasonCode": "predicate_quantification" }
+  ],
+  "protocolVersion": "ir-compiler-protocol/2"
+}
+```
+
+(Keys appear sorted by JCS rule. `opacities` entries appear sorted by `positionCid` ascending.)
+
+### §8.2 Coq compiler
+
+The Coq compiler has a higher-order type system and a tactic library that includes `proves_by_induction`. It translates both `Lambda`s natively as `forall` quantifiers (inner: over `nat`, outer: over `(nat -> Prop)`). The kit predicate is registered with a Coq tactic mapping. Nothing is opaque.
+
+Resulting Coq manifest:
+
+```json
+{
+  "compiler": "gallina",
+  "compilerVersion": "0.1.0",
+  "opacities": [],
+  "protocolVersion": "ir-compiler-protocol/2"
+}
+```
+
+### §8.3 Coverage check
+
+Both solvers return `Discharged` (the SMT solver because `(assert true)` makes the obligation vacuous; the Coq solver via the actual induction tactic). The verifier:
+
+1. Computes `coverage_union = { 5a..., c1... }`.
+2. Checks each position:
+   - `5a...` (the kit predicate position): SMT marks it opaque; Coq does not. Coq returned `Discharged`. **Covered.**
+   - `c1...` (the outer Lambda position): SMT marks it opaque; Coq does not. Coq returned `Discharged`. **Covered.**
+3. Consensus holds. The verifier records the joint verdict as `Discharged`, with provenance: position `5a...` covered by Coq, position `c1...` covered by Coq. The SMT solver's contribution is recorded but is not load-bearing for those two positions.
+
+If only the SMT solver had been in the pool, the coverage check would have failed (no other solver in the pool returned `Discharged` while not also marking those positions opaque). The verdict would be `Undecidable` rather than the unsound `Discharged` an SMT-only run would have produced.
+
+## §9. Failure modes the manifest does NOT prevent
+
+The manifest is a soundness mechanism for *position-level* opacity. It does not prevent:
+
+- **Two solvers disagreeing on the FOL fragment they both reasoned about.** The multi-solver-protocol/2 disagreement check (inherited from v1) handles this orthogonally; if SMT says `Discharged` and Coq says `Unsatisfied` for the same formula's transparent fragment, that is a SOLVER DISAGREEMENT regardless of opacity.
+- **A compiler maliciously claiming opacity for positions it could have translated.** The verifier trusts each compiler's manifest; a buggy or adversarial compiler that over-reports opacity will simply require the pool to include another solver that handles those positions, or the formula will be `Undecidable`. Under-reporting opacity (claiming a position is sound when it isn't) IS a soundness bug; the catalog-signed compiler implementation is the trust anchor.
+- **A subterm that two compilers disagree on the granularity of.** Compiler A may mark a whole `And` opaque while compiler B marks only the right branch opaque. The two manifest entries have different `positionCid`s and the verifier treats them as distinct positions; covering both requires some solver to handle each. This is conservative: the verifier never assumes A's coarser opacity covers B's finer opacity.
+
+## §10. Acceptance
+
+This spec is satisfied by:
+
+- A reference Rust implementation in `implementations/rust/provekit-opacity-manifest/` (v1.4.0).
+- The byte-fixture suite at `tests/opacity-manifest-fixtures/`.
+- A conformance test that the SMT-LIB v2.6 compiler emits the manifest expected by §8.1 byte-for-byte on the §8 input.
+- Cross-language conformance (when a second-language port lands): both languages produce identical manifest bytes for every fixture.
+
+## §11. Related specs
+
+- `2026-05-02-ir-compiler-protocol-v2.md` — defines the *requirement* that compilers emit this manifest; this spec defines the manifest's *shape*.
+- `2026-05-02-multi-solver-protocol-v2.md` — defines the *consumption* rule that uses manifests to compose verdicts.
+- `2026-04-30-canonicalization-grammar.md` — JCS canonicalization, normative.
+- `2026-04-30-ir-formal-grammar.md` — the IR-JSON grammar whose subterms are content-addressed by `positionCid`.
+- `2026-04-30-handshake-algorithm.md` — the "formula equality is hash equality" composition principle this spec extends to position equality.
+- `2026-04-30-multi-solver-protocol.md` (v1, superseded) — predecessor without opacity awareness; CID `blake3-512:71fc7ac22997938629d835f87e4e8a322026d77c1e1f834c9fbe0f79cca4e903792c628e96d3004c88d29706f4d87bc042ff837fef571c0cb3012495a03003d3` per the v1.3.0 catalog.

--- a/protocol/specs/2026-05-02-opacity-manifest-grammar.md
+++ b/protocol/specs/2026-05-02-opacity-manifest-grammar.md
@@ -84,6 +84,10 @@ The `opacities` array MUST be sorted by `positionCid` ascending (lexicographic o
 
 **INVARIANT:** Two conformant compilers, given the same set of `(positionCid, reasonCode)` pairs to emit, MUST produce byte-identical `opacities` arrays.
 
+### §2.4 SolverTag authority
+
+**INVARIANT (SolverTag authority):** When a `SolverTag` (`name@version`) appears in both a SolveResult envelope and a memento minted from that result, the envelope's tag is authoritative; mementos copy the tag verbatim, never derive their own.
+
 ## §3. Position content-addressing
 
 `Opacity.positionCid` is the BLAKE3-512 of the JCS-canonical bytes of the opaque IR subterm:


### PR DESCRIPTION
## Summary

Four new specs for protocol v1.4.0:

- **`2026-05-02-multi-solver-protocol-v2.md`** — `Portfolio { consensus, coverage_required: true }` mode, ConsensusCoverage 7-step rule, scorched-earth admission (no back-compat), §4.2 handshake-before-admission, §6 SolverTag authority
- **`2026-05-02-ir-compiler-protocol-v2.md`** — opacity manifest emission requirement, INVARIANT trio (non-optional / sound emission / atomic placeholder-manifest pairing), per-dialect placeholder table, error code 2005
- **`2026-05-02-opacity-manifest-grammar.md`** — EBNF, sort order (positionCid asc, reasonCode tiebreak), 4 closed reason codes (`kit_predicate_no_semantics`, `nested_lambda`, `predicate_quantification`, `dependent_type`) + `other:<freeform>`, content-hash positions
- **`2026-05-02-binary-attestation-protocol.md`** — letter-envelope framing, build-mint-sign pipeline, two-pin closure (`targetProofCid` forward + `binaryCid` back), monotonic envelope accretion, connection to `provekit witness`

## Architectural anchors

- **Subjective state, objective correctness** — substrate enforces shape of state transitions (four invariants), normatively opaque to semantics
- **Letter-envelope binary signing** — binary doesn't embed its own hash; envelope (proof bundle) knows binary's hash; one-way reference, no circularity
- **Coq is a real producer, not a workflow detail** — opacity-coverage admission lets Coq cover what z3+cvc5 leave opaque (lambdas, predicate quantification, dependent types) without IR becoming Coq-specific

## Notes

- These are spec drafts only. No code yet; that's task #181.
- Catalog re-bake to v1.4.0 happens after spec text settles.
- Substrate-not-blockchain manifesto is being written separately (sibling to `why-plugin-lifters.md`).

## Test plan
- [ ] Specs compile to clean BLAKE3-512 (no internal contradictions)
- [ ] No coherence drift between multi-solver-v2, ir-compiler-v2, and opacity-manifest-grammar
- [ ] binary-attestation-protocol references `provekit witness` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)