### PR TITLE
fix(ci): use `provekit verify` not `provekit invariants verify` in workflows

### DIFF
--- a/.github/actions/provekit-verify/README.md
+++ b/.github/actions/provekit-verify/README.md
@@ -24,7 +24,7 @@ jobs:
       - uses: provekit/provekit/.github/actions/provekit-verify@main
 ```
 
-The action wraps `npx provekit invariants verify --ci`. Exit code 1 (a
+The action wraps `npx provekit verify --ci`. Exit code 1 (a
 violation) fails the workflow. Exit code 2 (decay) fails by default and can be
 demoted to a warning by setting `fail-on-decay: false`. Exit code 3 (internal
 error) always fails.
@@ -33,7 +33,7 @@ error) always fails.
 
 | Name                | Default | Description |
 | ------------------- | ------- | ----------- |
-| `working-directory` | `.`     | Directory to `cd` into before running `provekit invariants verify`. |
+| `working-directory` | `.`     | Directory to `cd` into before running `provekit verify`. |
 | `fail-on-decay`     | `true`  | When `false`, exit code 2 (decay) is treated as success — useful while the constraint corpus is still settling. |
 | `verbose`           | `false` | Pass `--verbose` to `provekit`. |
 | `provekit-version`  | `latest` | npm version spec passed to `npx -y "provekit@<version>"`. Pin a known-good version in production. |

--- a/.github/actions/provekit-verify/action.yml
+++ b/.github/actions/provekit-verify/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   working-directory:
-    description: 'Directory in which to run `provekit invariants verify`. Defaults to the repository root.'
+    description: 'Directory in which to run `provekit verify`. Defaults to the repository root.'
     required: false
     default: '.'
   fail-on-decay:
@@ -35,7 +35,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Run provekit invariants verify
+    - name: Run provekit verify
       id: verify
       shell: bash
       working-directory: ${{ inputs.working-directory }}
@@ -52,12 +52,12 @@ runs:
         # Capture the JSON report. We run twice: once with --json to capture
         # the machine-readable verdict, once without for human-friendly logs.
         # The duplicate run is cheap because the cache is warm on the second
-        # call. Both go through `provekit invariants verify` — the standing-
+        # call. Both go through `provekit verify` — the standing-
         # runtime gate, no LLM, no network.
-        npx -y "provekit@${PROVEKIT_VERSION}" invariants verify --json $verbose_flag > provekit-report.json 2> provekit-report.err
+        npx -y "provekit@${PROVEKIT_VERSION}" verify --json $verbose_flag > provekit-report.json 2> provekit-report.err
         json_exit=$?
 
-        npx -y "provekit@${PROVEKIT_VERSION}" invariants verify $verbose_flag
+        npx -y "provekit@${PROVEKIT_VERSION}" verify $verbose_flag
         verify_exit=$?
 
         # Build a markdown summary from the JSON report. Falls back to

--- a/.github/workflows/provekit.yml
+++ b/.github/workflows/provekit.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run tests
         run: pnpm test
       - name: ProvekIt verify
-        run: npx provekit invariants verify --ci
+        run: npx provekit verify --ci

--- a/docs/templates/provekit-example-workflow.yml
+++ b/docs/templates/provekit-example-workflow.yml
@@ -5,7 +5,7 @@
 # copy it into their own repository and have a working CI gate immediately.
 #
 # Drop this verbatim into `.github/workflows/provekit.yml` in your repo.
-# The job runs `npx provekit invariants verify --ci`, which is the standing-
+# The job runs `npx provekit verify --ci`, which is the standing-
 # invariant gate (Z3 only, no LLM, no network). Exit code 1 (violation) fails
 # the workflow.
 
@@ -27,4 +27,4 @@ jobs:
         # `npm install` works without one.
         run: npm ci || npm install
       - name: ProvekIt verify
-        run: npx provekit invariants verify --ci
+        run: npx provekit verify --ci


### PR DESCRIPTION
## Root cause

The CLI was unified to a single `prove`/`verify` verb (see [`implementations/rust/provekit-cli/src/main.rs`](../blob/main/implementations/rust/provekit-cli/src/main.rs) — `Cmd::Prove(_) | Cmd::Verify(_) => cmd_prove::run(a)`), but the workflow files, composite action, and example template still called `provekit invariants verify`. CI logs surface the failure as:

```
Unknown command: invariants
provekit v0.4.0 — protocol-first verifier
Usage:
  provekit verify [--ci]              Discharge bridge call-site obligations
  ...
```

## Files touched

- `.github/workflows/provekit.yml` — `run:` line
- `.github/actions/provekit-verify/action.yml` — 2 `npx` invocations, step name, input description, inline comment
- `.github/actions/provekit-verify/README.md` — Quick start prose + Inputs table
- `docs/templates/provekit-example-workflow.yml` — header comment + `run:` line

Flags preserved (`--ci`, `--json`, `--verbose`). Generic prose about "invariants hold" (action.yml line 111, exit-code legend) left untouched — that's plural-noun usage, not a CLI verb.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` clean on all three YAMLs
- [x] `rg "invariants verify" .github/ docs/` returns nothing
- [x] `rg "provekit invariants" .github/ docs/` returns nothing
- [x] CLI source confirms only `Prove`/`Verify` subcommands, no `invariants`
- [ ] Actions workflow run on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)