### PR TITLE
spec: promote targetProofCid attack-and-mitigation to normative example

### DIFF
--- a/protocol/specs/2026-04-30-ir-formal-grammar.md
+++ b/protocol/specs/2026-04-30-ir-formal-grammar.md
@@ -415,6 +415,126 @@ address alone. If `@types/node` publishes a new version, `P1` changes, the
 `targetProofCid` in your bridge no longer resolves, and your build **fails**
 at compile time until you re-verify against the new proof.
 
+---
+
+### Bridge target pinning: the shim-poisoning vector
+
+The previous subsection explains why bridges pin proofs in the normal case.
+This subsection names the **attack** that the pin defeats, so that conformant
+implementations cannot omit the check on the grounds that "the bridge already
+points at a contract."
+
+#### Statement of the attack
+
+A bridge declaration carries two outbound CIDs into the target side:
+
+1. `targetContractCid`: the antecedent. The contract whose `pre`/`post` the
+   source claims to satisfy.
+2. `targetProofCid`: the consequent. The specific `.proof` bundle whose
+   discharge mementos witness that satisfaction.
+
+Without the second pin, a bridge commits **only to the antecedent shape**.
+Any `.proof` bundle that happens to contain a contract memento with the
+matching `targetContractCid` is treated as a valid witness, regardless of
+which binary that bundle was minted for. The verifier accepts the
+substitution because, syntactically, the obligation is discharged: the
+named contract is present, its discharge memento is present, the bundle
+signature is valid for some signer.
+
+The semantic guarantee is broken. The verifier has no way to refuse a
+discharge that came from a **different binary's** proof bundle, even though
+the source contract's claim was made against a specific consequent.
+
+This is **shim poisoning**: an attacker mints a `.proof` bundle whose
+contract memento matches the bridge's `targetContractCid` by content but
+whose witnessed proof memento was discharged against a poisoned shim
+binary. The bridge's antecedent matches by hash. The consequent does not,
+but the bridge had no way to say which consequent it meant.
+
+The forward pin closes this hole at the protocol layer, before any
+discharge logic runs.
+
+#### Worked example
+
+A Rust function `my_parse_int` claims to satisfy `ref-parseInt-v1` by way
+of a bridge through `js-parseInt-v24`. The honest chain pins both ends:
+
+```json
+{
+  "kind": "bridge",
+  "name": "myParseInt-implements-node24",
+  "sourceContractCid": "blake3-512:source...",
+  "targetContractCid": "blake3-512:js-parseInt-v24...",
+  "targetProofCid":   "blake3-512:node-v24-proof-honest...",
+  "sourceLayer": "rust",
+  "targetLayer": "javascript"
+}
+```
+
+**Scenario A (shim poisoning, no forward pin).** Suppose `targetProofCid`
+were absent or unenforced. The attacker publishes a separate `.proof`
+bundle, `node-v24-proof-poisoned`, whose contract member is byte-equal to
+`js-parseInt-v24` (same `targetContractCid`) but whose discharge memento
+was minted against a poisoned shim binary that returns attacker-controlled
+output for chosen inputs. The verifier loads either bundle by name. It
+finds a contract memento with the expected CID. It finds a discharge that
+references that contract. The bridge's antecedent obligation is met. The
+verifier ships **green**, with the poisoned discharge silently
+substituted.
+
+**Scenario B (forward pin enforced).** With `targetProofCid` enforced, the
+verifier first resolves the bridge's `targetProofCid` to a specific bundle
+CID and refuses to consume any other bundle as the consequent, regardless
+of name overlap. The poisoned bundle's CID does not match
+`node-v24-proof-honest`. Substitution is rejected at protocol layer,
+before any contract-membership or discharge-validity check runs.
+
+The two scenarios differ by **one CID equality check**. That check is the
+entire mitigation.
+
+#### Mitigation: status of the forward pin
+
+`targetProofCid` is REQUIRED in the BridgeDeclaration grammar (see EBNF
+above) and is enforced by `INVARIANT BridgeDeclaration.RequiredFields`
+and `INVARIANT BridgeDeclaration.ValidTargetProofCid`. The field MUST be
+present and MUST be a syntactically valid CID; producers MUST NOT emit
+bridges without it.
+
+The grammar-level requirement is necessary but not sufficient. Conformant
+verifiers MUST also use the field at resolve time:
+
+**INVARIANT BridgeDeclaration.ConsequentBundlePinned (NORMATIVE):**
+```
+∀b: BridgeDeclaration, P: ProofBundle →
+  AcceptedAsConsequentFor(P, b) ⇒ Cid(P) = b.targetProofCid
+```
+A verifier MUST NOT accept any `.proof` bundle as the consequent for a
+bridge unless that bundle's CID is bit-equal to the bridge's
+`targetProofCid`. Bundles whose contract members happen to share the
+bridge's `targetContractCid` MUST NOT be substituted for the pinned
+bundle.
+
+#### Two-pin closure with `binaryCid`
+
+The forward pin (bridge → bundle) closes only half the loop. The bundle
+itself can still be a wrapper around an unrelated binary unless the bundle
+back-pins the binary it attests to. That back pin is `binaryCid`, defined
+in `2026-05-02-binary-attestation-protocol.md` §2 and §5. Together:
+
+| Pin | Direction | Field | Specified in |
+|---|---|---|---|
+| Forward | bridge → bundle | `targetProofCid` | this spec, §BridgeDeclaration |
+| Back | bundle → binary | `binaryCid` | binary-attestation §2 |
+
+A verifier that enforces both pins refuses (a) substitution of a poisoned
+bundle for the bridge's intended consequent, and (b) substitution of a
+poisoned binary under an honestly-pinned bundle. Either pin alone leaves
+the other half of the substitution surface open. See
+`2026-05-02-binary-attestation-protocol.md` §5 for the back-pin half of
+this argument.
+
+---
+
 ### The supply chain security model
 
 A `.proof` bundle is a **signed bill of materials**. The developer signs it


### PR DESCRIPTION
## Why this matters

Closes the v1.3.0 audit residual on `BridgeDeclaration.targetProofCid`. The field has been REQUIRED in the IR grammar since the v1.3.0 cut, but the spec text never named the attack it defends against. That left conformant implementations free to treat the field as optional metadata at verify time, which collapses the security property into a syntactic check.

The defended attack, in Sir's framing from the prior session:

> we added targetCid to bridge to pin the witness... Without it, one program call satisfies ANY random contracts by pin. With it, it satisfies a specific contract for a specific binary.

The bridge's `targetContractCid` pins the **antecedent** (which contract shape the source claims to satisfy). Without `targetProofCid`, ANY `.proof` bundle whose contract member matches that antecedent shape can be substituted as the **consequent**, including a poisoned bundle minted against an attacker-controlled shim binary. This PR names that vector as **shim poisoning** and adds:

- A side-by-side worked example (Scenario A: substitution succeeds without the pin; Scenario B: substitution rejected with the pin enforced).
- `INVARIANT BridgeDeclaration.ConsequentBundlePinned` (NORMATIVE) requiring verifiers to refuse any bundle whose CID is not bit-equal to the bridge's `targetProofCid`.
- Two-pin closure framing tying forward pin (`targetProofCid`) to back pin (`binaryCid`, defined in `2026-05-02-binary-attestation-protocol.md` §2 and §5).

The forward pin and back pin together form the closure that prevents both proof-bundle substitution and shim binary substitution under an honest bundle.

## What changed

One file, one section added (~120 lines of markdown):

- `protocol/specs/2026-04-30-ir-formal-grammar.md`: new subsection "Bridge target pinning: the shim-poisoning vector" inserted between the existing "Why bridges pin proofs..." rationale and "The supply chain security model".

The new subsection is structured as:

1. Statement of the attack (named as shim poisoning).
2. Worked example with Scenarios A and B.
3. Mitigation status (the field is already MUST in the grammar invariants; PR adds the verifier-side normative invariant).
4. Two-pin closure with `binaryCid`, with cross-reference to the binary-attestation spec.

`targetProofCid` was already MUST at the grammar level (`INVARIANT BridgeDeclaration.RequiredFields`, `INVARIANT BridgeDeclaration.ValidTargetProofCid`). The new `ConsequentBundlePinned` invariant promotes the **verifier-side** consumption of the field from implicit to normative.

## Catalog drift consequence

This spec edit changes the content hash of `2026-04-30-ir-formal-grammar.md`, which drifts the protocol catalog CID. The catalog CID is currently pinned in `implementations/rust/provekit-cli/src/protocol.rs` as `EXPECTED_CATALOG_CID`.

This PR does NOT re-bake the catalog. A v1.3.1 cut is deferred:

- Run `cargo run --release --manifest-path tools/recompute-spec-cids/Cargo.toml -- --write`
- Add and run a `sign-catalog-v1-3-1` bin entry mirroring `sign-catalog-v1-3-0`
- Update `EXPECTED_CATALOG_CID` and ship as v1.3.1

Until that lands, `provekit verify-protocol` against this spec text on a v1.3.0 catalog will report drift. That is the intended state pending the re-bake.

## Cross-impl enforcement status

Spot-checked `implementations/rust/provekit-verifier/`. Finding:

- `src/enumerate_callsites.rs` reads the bridge body and extracts `targetContractCid`, `sourceLayer`, and `targetLayer` into the `CallSite` struct, but **does not extract `targetProofCid`**.
- `src/types.rs` `CallSite` struct has no `bridge_target_proof_cid` field.
- `src/resolve_target.rs` looks up the consequent in `pool.mementos` keyed by `bridge_target_cid` (the contract CID, not the proof CID). Any pool member with the matching contract CID resolves; there is no constraint that it have come from the bridge's pinned `.proof` bundle.

**Status:** the new `ConsequentBundlePinned` invariant is normative in the spec but **not yet enforced** by the Rust verifier. The grammar-level `RequiredFields` invariant (which gates that `targetProofCid` is present and well-formed at IR-load time) is enforced via `provekit-ir-types` deserialization (`#[serde(rename = "targetProofCid")]` in `lib.rs`). Verify-time enforcement is the open follow-up. Filing the impl gap as a separate issue is appropriate; this PR is spec-only.

## Self-review

- [x] New subsection stands alone for someone without prior context (names the attack, gives a concrete substitution scenario, states the mitigation invariant).
- [x] Worked example is concrete: Scenario A shows the poisoned `node-v24-proof-poisoned` bundle substituting for `node-v24-proof-honest` with byte-equal contract member but poisoned discharge memento, not a generic "wrong bundle".
- [x] Two-pin closure with `binaryCid` references `2026-05-02-binary-attestation-protocol.md` §2 and §5 by file and section anchor; does not duplicate that spec's content.
- [x] No em-dashes, no en-dashes (grepped diff for `[—–]`, clean).
- [x] One commit, exact title from the task spec.
- [x] PR opened against `TSavo/provekit:main`.