### PR TITLE
fix(verifier): enforce ConsequentBundlePinned via targetProofCid lookup

### DIFF
--- a/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
+++ b/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
@@ -105,6 +105,17 @@ fn walk_term(
             .and_then(|e| e.get("body"))
             .cloned()
             .unwrap_or_else(|| serde_json::json!({}));
+        // Forward pin: REQUIRED by the current BridgeDeclaration grammar
+        // (see protocol/specs/2026-04-30-ir-formal-grammar.md §
+        // "Bridge target pinning: the shim-poisoning vector"). Older
+        // bridges without this field are tolerated at load time but
+        // can't have ConsequentBundlePinned enforced; resolve_target
+        // emits a soft warning in that case.
+        let bridge_target_proof_cid = bbody
+            .get("targetProofCid")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
         let cs = CallSite {
             bridge_ir_name: name.clone(),
             bridge_target_cid: bbody
@@ -122,6 +133,7 @@ fn walk_term(
                 .and_then(|v| v.as_str())
                 .unwrap_or_default()
                 .to_string(),
+            bridge_target_proof_cid,
             property_name: property_name.to_string(),
             property_cid: property_cid.to_string(),
             arg_term: t

--- a/implementations/rust/provekit-verifier/src/load_all_proofs.rs
+++ b/implementations/rust/provekit-verifier/src/load_all_proofs.rs
@@ -161,6 +161,15 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
         // Index for handshake. The memento IS the verification;
         // inserting it into the pool IS caching the verification result.
         pool.insert(cid.clone(), env.clone());
+        // Track bundle membership so resolve_target can enforce
+        // BridgeDeclaration.ConsequentBundlePinned. The bundle's CID is
+        // the .proof file's content hash (derived_full above). A given
+        // member CID may legitimately appear in more than one bundle;
+        // the per-bundle set is what matters at resolve time.
+        pool.bundle_members
+            .entry(derived_full.clone())
+            .or_default()
+            .insert(cid.clone());
         if let Some(ev) = env.get("evidence") {
             if ev.get("kind").and_then(|k| k.as_str()) == Some("bridge") {
                 if let Some(body) = ev.get("body") {

--- a/implementations/rust/provekit-verifier/src/resolve_target.rs
+++ b/implementations/rust/provekit-verifier/src/resolve_target.rs
@@ -3,6 +3,12 @@
 // Stage 3: resolve_target. Look up the CallSite's bridge.targetCid in
 // the pool; return the target contract memento's `pre` formula as the
 // discharge target. Mirrors .../verifier/resolve_target.cpp.
+//
+// Forward-pin gate (BridgeDeclaration.ConsequentBundlePinned, NORMATIVE):
+// after locating the consequent contract member, refuse to consume it
+// unless its containing `.proof` bundle CID matches the bridge's
+// `targetProofCid`. See protocol/specs/2026-04-30-ir-formal-grammar.md
+// § "Bridge target pinning: the shim-poisoning vector".
 
 use crate::types::{CallSite, MementoPool, ResolvedProperty};
 
@@ -22,6 +28,46 @@ pub fn run(cs: &CallSite, pool: &MementoPool) -> Result<ResolvedProperty, String
         .get("body")
         .filter(|v| v.is_object())
         .ok_or("contract evidence has no body object")?;
+
+    // Forward pin: BridgeDeclaration.ConsequentBundlePinned.
+    //
+    //     ∀b: BridgeDeclaration, P: ProofBundle →
+    //       AcceptedAsConsequentFor(P, b) ⇒ Cid(P) = b.targetProofCid
+    //
+    // If the bridge pins a target proof CID, the contract member we just
+    // resolved MUST come from that bundle. Bundles whose contract
+    // members happen to share `targetContractCid` MUST NOT be
+    // substituted for the pinned bundle. See protocol/specs/2026-04-30-
+    // ir-formal-grammar.md § "Bridge target pinning: the shim-poisoning
+    // vector".
+    match cs.bridge_target_proof_cid.as_deref() {
+        Some(expected_bundle) => {
+            let bundle_members = pool.bundle_members.get(expected_bundle).ok_or_else(|| {
+                format!(
+                    "BridgeTargetProofCidMismatch: pinned bundle {} not in pool",
+                    expected_bundle
+                )
+            })?;
+            if !bundle_members.contains(&cs.bridge_target_cid) {
+                return Err(format!(
+                    "BridgeTargetProofCidMismatch: contract {} is not a member of pinned bundle {}",
+                    cs.bridge_target_cid, expected_bundle
+                ));
+            }
+        }
+        None => {
+            // Back-compat: legacy bridges that pre-date `targetProofCid`
+            // are loadable but cannot have ConsequentBundlePinned
+            // enforced. New bridges MUST set the field; flag the gap so
+            // operators can see what isn't being checked.
+            eprintln!(
+                "warning: bridge {} has no targetProofCid; \
+                 ConsequentBundlePinned not enforced (back-compat path)",
+                cs.bridge_ir_name
+            );
+        }
+    }
+
     let ir_formula = body.get("pre").cloned();
     Ok(ResolvedProperty {
         cid: cs.bridge_target_cid.clone(),

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -25,6 +25,17 @@ pub struct MementoPool {
     pub formula_to_memento: BTreeMap<String, String>,
     /// sourceSymbol (IR ctor name) -> bridge envelope JSON.
     pub bridges_by_symbol: BTreeMap<String, Json>,
+    /// Bundle (.proof file) CID -> set of member CIDs the bundle contained.
+    ///
+    /// Required to enforce `BridgeDeclaration.ConsequentBundlePinned`
+    /// (see `protocol/specs/2026-04-30-ir-formal-grammar.md`
+    /// § "Bridge target pinning: the shim-poisoning vector"). A bridge's
+    /// `targetProofCid` names the bundle that is allowed to discharge
+    /// it; we must answer "is this contract member from THAT bundle?".
+    /// Multi-valued because the same member CID can legitimately appear
+    /// in two bundles (an honest one and a poisoned one); we never want
+    /// last-writer-wins to silently swap them.
+    pub bundle_members: BTreeMap<String, std::collections::BTreeSet<String>>,
     pub load_errors: Vec<LoadError>,
 }
 
@@ -290,6 +301,15 @@ pub struct CallSite {
     pub bridge_target_cid: String,
     pub bridge_source_layer: String,
     pub bridge_target_layer: String,
+    /// Forward pin: the specific `.proof` bundle CID this bridge commits
+    /// to as its consequent. `None` for legacy bridges that pre-date the
+    /// `targetProofCid` field (kept loadable for back-compat; resolve_target
+    /// emits a soft warning since `ConsequentBundlePinned` cannot be
+    /// enforced when the field is absent). For bridges authored against
+    /// the current grammar this MUST be `Some`; see
+    /// `protocol/specs/2026-04-30-ir-formal-grammar.md`
+    /// § "Bridge target pinning: the shim-poisoning vector".
+    pub bridge_target_proof_cid: Option<String>,
     pub property_name: String,
     pub property_cid: String,
     pub arg_term: Option<Json>,

--- a/implementations/rust/provekit-verifier/tests/resolve_target.rs
+++ b/implementations/rust/provekit-verifier/tests/resolve_target.rs
@@ -7,6 +7,9 @@
 //   - fail-closed when targetCid is not in the pool
 //   - fail-closed when the resolved memento has no body
 //   - returns the memento's CID in `cid`
+//   - forward pin (BridgeDeclaration.ConsequentBundlePinned): when the
+//     CallSite carries `bridge_target_proof_cid = Some(...)`, the
+//     contract member MUST live in that bundle, else reject
 
 use serde_json::{json, Value as Json};
 
@@ -24,6 +27,19 @@ fn callsite_targeting(target_cid: &str) -> CallSite {
         bridge_target_cid: target_cid.into(),
         ..Default::default()
     }
+}
+
+fn contract_env(pre: Json) -> Json {
+    json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {"pre": pre}
+        }
+    })
+}
+
+fn trivial_pre() -> Json {
+    json!({"kind": "atomic", "name": "true", "args": []})
 }
 
 // ---------------------------------------------------------------------------
@@ -151,4 +167,108 @@ fn errors_when_evidence_kind_is_unknown() {
     let cs = callsite_targeting(target_cid);
     let r = resolve_target::run(&cs, &pool);
     assert!(r.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Forward pin (BridgeDeclaration.ConsequentBundlePinned, NORMATIVE).
+//
+// See protocol/specs/2026-04-30-ir-formal-grammar.md
+// § "Bridge target pinning: the shim-poisoning vector".
+// ---------------------------------------------------------------------------
+
+/// The contract member exists in the pool, but it was loaded from a
+/// different `.proof` bundle than the bridge pinned. The verifier MUST
+/// reject with `BridgeTargetProofCidMismatch`. This is the
+/// shim-poisoning attack from the spec.
+#[test]
+fn rejects_when_target_proof_cid_does_not_match_bundle() {
+    let target_cid = "blake3-512:contract-shared";
+    let honest_bundle = "blake3-512:node-v24-proof-honest";
+    let poisoned_bundle = "blake3-512:node-v24-proof-poisoned";
+
+    let mut pool = pool_with(target_cid, contract_env(trivial_pre()));
+    // Member was loaded as part of the poisoned bundle. The honest
+    // bundle is what the bridge pinned but isn't present.
+    pool.bundle_members
+        .entry(poisoned_bundle.into())
+        .or_default()
+        .insert(target_cid.into());
+
+    let cs = CallSite {
+        bridge_ir_name: "parseInt".into(),
+        bridge_target_cid: target_cid.into(),
+        bridge_target_proof_cid: Some(honest_bundle.into()),
+        ..Default::default()
+    };
+
+    let r = resolve_target::run(&cs, &pool);
+    let err = format!("{:?}", r.err().expect("must reject"));
+    assert!(
+        err.contains("BridgeTargetProofCidMismatch"),
+        "expected BridgeTargetProofCidMismatch, got: {err}"
+    );
+}
+
+/// Same bundle for the bridge and the contract member: accept and
+/// return the resolved formula.
+#[test]
+fn accepts_when_target_proof_cid_matches_bundle() {
+    let target_cid = "blake3-512:contract-pinned";
+    let honest_bundle = "blake3-512:node-v24-proof-honest";
+
+    let mut pool = pool_with(target_cid, contract_env(trivial_pre()));
+    pool.bundle_members
+        .entry(honest_bundle.into())
+        .or_default()
+        .insert(target_cid.into());
+
+    let cs = CallSite {
+        bridge_ir_name: "parseInt".into(),
+        bridge_target_cid: target_cid.into(),
+        bridge_target_proof_cid: Some(honest_bundle.into()),
+        ..Default::default()
+    };
+
+    let r = resolve_target::run(&cs, &pool).expect("must accept matching pin");
+    assert_eq!(r.cid, target_cid);
+}
+
+/// Pinned bundle isn't loaded at all: still a mismatch, fail-closed.
+#[test]
+fn rejects_when_pinned_bundle_is_not_loaded() {
+    let target_cid = "blake3-512:contract-orphan";
+    let pool = pool_with(target_cid, contract_env(trivial_pre()));
+
+    let cs = CallSite {
+        bridge_ir_name: "parseInt".into(),
+        bridge_target_cid: target_cid.into(),
+        bridge_target_proof_cid: Some("blake3-512:never-loaded".into()),
+        ..Default::default()
+    };
+
+    let r = resolve_target::run(&cs, &pool);
+    let err = format!("{:?}", r.err().expect("must reject"));
+    assert!(
+        err.contains("BridgeTargetProofCidMismatch"),
+        "expected BridgeTargetProofCidMismatch, got: {err}"
+    );
+}
+
+/// Legacy bridge with no `targetProofCid`: cannot enforce
+/// ConsequentBundlePinned, but accept for back-compat (soft warning is
+/// printed to stderr).
+#[test]
+fn accepts_when_target_proof_cid_is_none_back_compat() {
+    let target_cid = "blake3-512:contract-legacy";
+    let pool = pool_with(target_cid, contract_env(trivial_pre()));
+
+    let cs = CallSite {
+        bridge_ir_name: "parseIntLegacy".into(),
+        bridge_target_cid: target_cid.into(),
+        bridge_target_proof_cid: None,
+        ..Default::default()
+    };
+
+    let r = resolve_target::run(&cs, &pool).expect("legacy bridges must still resolve");
+    assert_eq!(r.cid, target_cid);
 }


### PR DESCRIPTION
## Summary

Closes the shim-poisoning vector promoted to a normative example in #10
(`protocol/specs/2026-04-30-ir-formal-grammar.md`, § "Bridge target
pinning: the shim-poisoning vector"). The Rust verifier now enforces
`INVARIANT BridgeDeclaration.ConsequentBundlePinned`:

```
forall b: BridgeDeclaration, P: ProofBundle .
  AcceptedAsConsequentFor(P, b)  =>  Cid(P) = b.targetProofCid
```

## The vector this closes

A bridge carries two outbound CIDs into the target side: the antecedent
(`targetContractCid`) and the consequent (`targetProofCid`). Without
enforcing the second pin, the verifier accepts any `.proof` bundle that
happens to contain a contract member matching `targetContractCid`,
regardless of which binary the bundle was minted for. An attacker can
mint a poisoned bundle whose contract member is byte-equal to the
bridge's pin; syntactically the discharge looks fine, semantically the
guarantee is broken.

This PR adds the one CID-equality check the spec calls "the entire
mitigation": after resolving the consequent contract, the verifier
checks that the contract is a member of the bundle the bridge pinned,
and refuses any other bundle as a substitute.

## What changed

- `MementoPool` tracks `bundle_members: BTreeMap<bundle_cid, set<member_cid>>`.
  Multi-valued because the same member can legitimately appear in two
  bundles (one honest, one poisoned); last-writer-wins would silently
  swap them. `load_all_proofs` populates this from the `.proof` file's
  content hash.
- `CallSite` gains `bridge_target_proof_cid: Option<String>`.
  `enumerate_callsites` extracts it from `body.targetProofCid`.
- `resolve_target::run` gates resolution on the pin: mismatch -> reject
  with `BridgeTargetProofCidMismatch { expected, actual }`-shaped
  error.

## Behavior on missing field

`targetProofCid` is REQUIRED by the current grammar, but bridges minted
before the field was normative MAY lack it. To preserve back-compat:

- `bridge_target_proof_cid = None` -> bridge is **accepted** with a soft
  warning to stderr (`warning: bridge X has no targetProofCid;
  ConsequentBundlePinned not enforced`). Matches the existing
  `eprintln!("warning: ...")` pattern in `runner.rs` /
  `solvers/plan.rs`.
- `bridge_target_proof_cid = Some(_)` -> ConsequentBundlePinned is
  enforced fully. Mismatch is fail-closed.

New bridges from the current producer MUST set the field; the warning
makes the gap visible to operators rather than hiding it.

## Test coverage added

In `implementations/rust/provekit-verifier/tests/resolve_target.rs`:

- `rejects_when_target_proof_cid_does_not_match_bundle` -- spec
  scenario A, the shim-poisoning case. Member resolves but its bundle
  CID differs from the pin. Must reject.
- `rejects_when_pinned_bundle_is_not_loaded` -- pin references a
  bundle not in the pool. Must reject (fail-closed).
- `accepts_when_target_proof_cid_matches_bundle` -- spec scenario B.
  Pin matches. Must accept.
- `accepts_when_target_proof_cid_is_none_back_compat` -- legacy
  bridge, no field. Must accept (soft-warning path).

Sanity-checked by reverting just the `resolve_target.rs` gate and
confirming the two reject-tests fail while the two accept-tests still
pass.

## Test plan

- [x] `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-verifier --test resolve_target` -- 12/12 pass
- [x] Sanity check: revert `resolve_target.rs`, confirm reject-tests now fail, restore
- [x] Full crate test suite green except for one pre-existing unrelated failure (`smt_emitter::var_with_empty_name_returns_err`, fails on `main` too)

## Related

- Spec PR: #10 (promoted `targetProofCid` attack to a normative example)
- Companion: `2026-05-02-binary-attestation-protocol.md` adds the back
  pin (`binaryCid`); together they close the two-pin loop documented in
  the spec's "Two-pin closure" subsection.