### PR TITLE
feat(cpp): port binaryCid + targetProofCid + sourceContractCid + EvidenceTerm to C++ kit

### DIFF
--- a/implementations/cpp/provekit-ir-symbolic/example/evidence_term_test.cpp
+++ b/implementations/cpp/provekit-ir-symbolic/example/evidence_term_test.cpp
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cross-impl JCS conformance test for the v1.3.0 protocol additions:
+//   1. `EvidenceTerm` IR-JSON shape , locked byte fixture from the
+//      Rust peer's write_evidence/marshal_declarations in
+//      implementations/rust/provekit-ir-symbolic/src/serialize.rs.
+//   2. `binaryCid` field on the catalog memento , determinism +
+//      shape check; absent vs present must be byte-distinct.
+//
+// THIS IS A GOLDEN TEST: the expected byte strings below are derived
+// from the spec + Rust reference, not from the C++ impl. Any drift
+// here is either a C++ bug or a Rust bug; both are reportable.
+//
+// Spec sources:
+//   protocol/specs/2026-04-30-ir-formal-grammar.md (BridgeDeclaration)
+//   protocol/specs/2026-04-30-proof-file-format.md §binaryCid
+//   protocol/specs/2026-05-02-binary-attestation-protocol.md
+//   implementations/rust/provekit-ir-symbolic/src/serialize.rs (peer)
+//   implementations/rust/provekit-proof-envelope/src/proof.rs   (peer)
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "provekit/ir.hpp"
+#include "provekit/proof-envelope/proof_envelope.hpp"
+
+using namespace provekit::ir;
+using ::provekit::proof_envelope::Ed25519Seed;
+using ::provekit::proof_envelope::ProofEnvelopeInput;
+using ::provekit::proof_envelope::build_proof_envelope;
+
+namespace {
+
+bool check_eq_str(const char* label, const std::string& got, const std::string& want) {
+    if (got == want) {
+        std::printf("  [PASS] %s\n", label);
+        return true;
+    }
+    std::printf("  [FAIL] %s\n", label);
+    std::printf("         got:  %s\n", got.c_str());
+    std::printf("         want: %s\n", want.c_str());
+    return false;
+}
+
+}  // namespace
+
+int main() {
+    int failures = 0;
+    std::printf("v1.3.0 cross-impl conformance smoke test:\n\n");
+
+    // --- 1. EvidenceTerm: locked IR-JSON shape ------------------------------
+    //
+    // Rust reference (serialize.rs `write_evidence`):
+    //   {"kind":"evidence","proofType":"<x>","certificate":{"tool":"<x>",
+    //    "version":"<x>","formulaHash":"<x>","proofData":"<x>"}}
+    //
+    // Wrapped inside a contract declaration via marshal_declarations, the
+    // field appears AFTER `inv?` and BEFORE the closing `}` (insertion
+    // order from the kit; canonicalizer's JCS pass re-sorts before hashing).
+
+    reset_collector();
+    begin_collecting();
+    contract(
+        "evidence-bearing-contract",
+        /*pre=*/nullptr,
+        /*post=*/nullptr,
+        // A trivial inv: forall n. n > 0. Uses the same fresh-name counter
+        // as parseInt-requires-positive for stability.
+        /*inv=*/forall(Int(), [](std::shared_ptr<Term> n) {
+            return gt(n, num(0));
+        }),
+        /*outBinding=*/"out",
+        /*evidence=*/evidence(
+            "smt-lib",
+            EvidenceCertificate{
+                /*tool=*/"z3",
+                /*version=*/"4.13.0",
+                /*formula_hash=*/"blake3-512:deadbeef",
+                /*proof_data=*/"(unsat)"}));
+    auto decls = finish();
+
+    const std::string got = marshal_declarations(decls);
+    const std::string want =
+        "[{\"kind\":\"contract\","
+        "\"name\":\"evidence-bearing-contract\","
+        "\"outBinding\":\"out\","
+        "\"inv\":{\"kind\":\"forall\","
+        "\"name\":\"_x0\","
+        "\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},"
+        "\"body\":{\"kind\":\"atomic\","
+        "\"name\":\">\","
+        "\"args\":[{\"kind\":\"var\",\"name\":\"_x0\"},"
+        "{\"kind\":\"const\",\"value\":0,\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}]}},"
+        "\"evidence\":{\"kind\":\"evidence\","
+        "\"proofType\":\"smt-lib\","
+        "\"certificate\":{\"tool\":\"z3\","
+        "\"version\":\"4.13.0\","
+        "\"formulaHash\":\"blake3-512:deadbeef\","
+        "\"proofData\":\"(unsat)\"}}}]";
+
+    if (!check_eq_str("EvidenceTerm IR-JSON shape", got, want)) {
+        failures++;
+    }
+
+    // --- 2. EvidenceTerm absent: marshal_declarations omits the field -------
+    //
+    // The "omit absent" JCS rule means a contract with evidence == nullptr
+    // produces identical bytes to the v1.2.0 shape. This guarantees the
+    // pinned C++ self-contracts CID does not drift on this branch.
+
+    reset_collector();
+    begin_collecting();
+    contract(
+        "no-evidence-contract",
+        /*pre=*/nullptr,
+        /*post=*/nullptr,
+        /*inv=*/forall(Int(), [](std::shared_ptr<Term> n) {
+            return gt(n, num(0));
+        }),
+        /*outBinding=*/"out");  // evidence defaults to nullptr
+    auto bare_decls = finish();
+
+    const std::string bare_got = marshal_declarations(bare_decls);
+    const std::string bare_want =
+        "[{\"kind\":\"contract\","
+        "\"name\":\"no-evidence-contract\","
+        "\"outBinding\":\"out\","
+        "\"inv\":{\"kind\":\"forall\","
+        "\"name\":\"_x0\","
+        "\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},"
+        "\"body\":{\"kind\":\"atomic\","
+        "\"name\":\">\","
+        "\"args\":[{\"kind\":\"var\",\"name\":\"_x0\"},"
+        "{\"kind\":\"const\",\"value\":0,\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}]}}}]";
+
+    if (!check_eq_str("EvidenceTerm absent (omit-when-null)",
+                      bare_got, bare_want)) {
+        failures++;
+    }
+
+    // --- 3. PrimitiveBridgeDeclaration: v1.3.0 fields exist & default empty -
+    //
+    // The kit-default parseInt registration leaves source_contract_cid and
+    // target_proof_cid empty. Concrete kits set them when minting a real
+    // bridge envelope. This pass just confirms the slots are addressable
+    // (compile-time check via .source_contract_cid / .target_proof_cid).
+
+    reset_registry();
+    ensure_kit_bridges_registered();
+    auto bridges = list_bridges();
+    if (bridges.size() != 1) {
+        std::printf("  [FAIL] expected 1 default bridge, got %zu\n",
+                    bridges.size());
+        failures++;
+    } else {
+        const auto& b = bridges[0];
+        if (b.ir_name != "parseInt") {
+            std::printf("  [FAIL] bridge ir_name = %s, want parseInt\n",
+                        b.ir_name.c_str());
+            failures++;
+        } else if (!b.source_contract_cid.empty()) {
+            std::printf("  [FAIL] default bridge source_contract_cid not empty: %s\n",
+                        b.source_contract_cid.c_str());
+            failures++;
+        } else if (!b.target_proof_cid.empty()) {
+            std::printf("  [FAIL] default bridge target_proof_cid not empty: %s\n",
+                        b.target_proof_cid.c_str());
+            failures++;
+        } else {
+            std::printf("  [PASS] PrimitiveBridgeDeclaration v1.3.0 slots present\n");
+        }
+    }
+
+    // --- 4. binaryCid: present vs absent yields byte-distinct envelopes -----
+    //
+    // The Rust peer (provekit-proof-envelope/src/proof.rs) emits the
+    // CBOR pair only when `binary_cid` is Some(_). The C++ peer mirrors
+    // by sentinel: empty string = absent. We assert two things:
+    //   (a) Two builds with the SAME absent input produce identical bytes.
+    //   (b) A build with binary_cid set produces DIFFERENT bytes than
+    //       the absent build (proves the field actually changes the
+    //       canonical output, vs. being silently dropped).
+
+    Ed25519Seed seed{};
+    seed.fill(0x42);
+
+    const std::string signer_cid_v1 =
+        "blake3-512:"
+        "00000000000000000000000000000000000000000000000000000000000000ab"
+        "cd000000000000000000000000000000000000000000000000000000000000ab";
+
+    ProofEnvelopeInput absent_input{
+        .name = "test-binary-cid",
+        .version = "1.0.0",
+        .members = std::map<std::string, std::vector<uint8_t>>{},
+        .signer_cid = signer_cid_v1,
+        .signer_seed = seed,
+        .declared_at = "2026-05-02T00:00:00.000Z",
+    };
+    // binary_cid omitted (default = empty string).
+
+    ProofEnvelopeInput present_input = absent_input;
+    present_input.binary_cid =
+        "blake3-512:"
+        "1111111111111111111111111111111111111111111111111111111111111111"
+        "1111111111111111111111111111111111111111111111111111111111111111";
+
+    auto absent_a = build_proof_envelope(absent_input);
+    auto absent_b = build_proof_envelope(absent_input);
+    auto present  = build_proof_envelope(present_input);
+
+    if (absent_a.bytes != absent_b.bytes) {
+        std::printf("  [FAIL] binaryCid absent: build is non-deterministic\n");
+        failures++;
+    } else {
+        std::printf("  [PASS] binaryCid absent: deterministic\n");
+    }
+
+    if (absent_a.bytes == present.bytes) {
+        std::printf("  [FAIL] binaryCid present produced identical bytes "
+                    "to absent , field was silently dropped\n");
+        failures++;
+    } else {
+        std::printf("  [PASS] binaryCid present: byte-distinct from absent\n");
+    }
+
+    // The first byte of the catalog map is the CBOR map head. Adding one
+    // optional pair shifts the map count by 1: 7 entries (without
+    // binaryCid) → 0xa7; 8 entries → 0xa8. This is the cheap structural
+    // check that the pair landed where the Rust peer puts it.
+    if (absent_a.bytes.empty() || absent_a.bytes[0] != 0xa7) {
+        std::printf("  [FAIL] absent catalog map head: got 0x%02x, want 0xa7\n",
+                    absent_a.bytes.empty() ? 0 : absent_a.bytes[0]);
+        failures++;
+    } else {
+        std::printf("  [PASS] absent catalog map head: 0xa7 (7 keys)\n");
+    }
+    if (present.bytes.empty() || present.bytes[0] != 0xa8) {
+        std::printf("  [FAIL] present catalog map head: got 0x%02x, want 0xa8\n",
+                    present.bytes.empty() ? 0 : present.bytes[0]);
+        failures++;
+    } else {
+        std::printf("  [PASS] present catalog map head: 0xa8 (8 keys)\n");
+    }
+
+    std::printf("\n");
+    if (failures == 0) {
+        std::printf("v1.3.0 CONFORMANCE SMOKE TEST OK.\n");
+        return 0;
+    }
+    std::printf("v1.3.0 CONFORMANCE SMOKE TEST FAILED: %d divergence(s).\n",
+                failures);
+    return 1;
+}

--- a/implementations/cpp/provekit-ir-symbolic/include/provekit/ir.hpp
+++ b/implementations/cpp/provekit-ir-symbolic/include/provekit/ir.hpp
@@ -1,4 +1,4 @@
-// provekit-ir-symbolic — C++ kit (header-only).
+// provekit-ir-symbolic , C++ kit (header-only).
 //
 // Maximal-uniformity IR per protocol/specs/2026-04-30-ir-formal-grammar.md
 // (v1.1.0 catalog). Every node has `kind`, then `name` (when applicable),
@@ -43,7 +43,7 @@ inline Sort String() { return Sort{"String"}; }
 inline Sort Bool() { return Sort{"Bool"}; }
 
 // ---------------------------------------------------------------------------
-// Term — VarTerm (no sort), ConstTerm (sort kept), CtorTerm (no sort).
+// Term , VarTerm (no sort), ConstTerm (sort kept), CtorTerm (no sort).
 // ---------------------------------------------------------------------------
 
 struct Term;
@@ -101,7 +101,19 @@ struct PrimitiveBridgeDeclaration {
   std::vector<std::string> ir_arg_sorts;
   std::string ir_return_sort;
   std::string source_layer;
+  // Optional CID of the source-layer contract this bridge originates from.
+  // Empty string == absent. Mirrors v1.3.0 BridgeDeclaration.sourceContractCid
+  // per protocol/specs/2026-04-30-ir-formal-grammar.md §BridgeDeclaration;
+  // bridges that pin both the source-side and target-side contracts make the
+  // implication chain hash-bounded across bundles.
+  std::string source_contract_cid;
   std::string target_contract_cid;
+  // Optional CID of the .proof bundle that contains the target contract.
+  // Empty string == absent. Mirrors v1.3.0 BridgeDeclaration.targetProofCid
+  // (the forward pin from a bridge to a specific consequent proof bundle).
+  // Without this, verifiers must scan all available .proof files; with it,
+  // lookup is O(1) by CID and the bundle reference is tamper-evident.
+  std::string target_proof_cid;
   std::string target_layer;
   std::string notes;
 };
@@ -130,8 +142,16 @@ inline void ensure_kit_bridges_registered() {
   static bool done = false;
   if (done) return;
   done = true;
+  // Field order matches PrimitiveBridgeDeclaration: ir_name, ir_arg_sorts,
+  // ir_return_sort, source_layer, source_contract_cid (v1.3.0 add),
+  // target_contract_cid, target_proof_cid (v1.3.0 add), target_layer, notes.
+  // The two v1.3.0 CID slots are empty placeholders here; concrete kits set
+  // them when minting a real bridge envelope. The Rust peer's BridgeDecl in
+  // implementations/rust/provekit-ir-symbolic/src/lib.rs follows the same
+  // optional-empty pattern.
   register_primitive_bridge({"parseInt", {"String"}, "Int", "cpp-kit",
-                             "bafy_CPP_PARSEINT_PLACEHOLDER", "libcxx", ""});
+                             "", "bafy_CPP_PARSEINT_PLACEHOLDER", "",
+                             "libcxx", ""});
 }
 
 inline std::shared_ptr<Term> parse_int(std::shared_ptr<Term> s) {
@@ -139,7 +159,7 @@ inline std::shared_ptr<Term> parse_int(std::shared_ptr<Term> s) {
   return std::make_shared<Term>(Term{CtorTerm{"parseInt", {std::move(s)}}});
 }
 
-// out() — references the return value within a post formula. Compiles to
+// out() , references the return value within a post formula. Compiles to
 // a VarTerm whose `name` matches the enclosing contract's outBinding
 // (default "out"). The kit's contract() primitive enforces outBinding=out;
 // custom outBindings can use make_var(name) directly.
@@ -148,7 +168,7 @@ inline std::shared_ptr<Term> out() {
 }
 
 // ---------------------------------------------------------------------------
-// Formula — three kinds: AtomicFormula, ConnectiveFormula, QuantifierFormula.
+// Formula , three kinds: AtomicFormula, ConnectiveFormula, QuantifierFormula.
 // ---------------------------------------------------------------------------
 
 struct Formula;
@@ -181,7 +201,7 @@ struct Formula {
 };
 
 // ---------------------------------------------------------------------------
-// Quantifier counter — fresh names for bound variables.
+// Quantifier counter , fresh names for bound variables.
 // ---------------------------------------------------------------------------
 
 inline std::atomic<int>& quantifier_counter() {
@@ -227,7 +247,7 @@ inline std::shared_ptr<Formula> ne(std::shared_ptr<Term> a, std::shared_ptr<Term
 }
 
 // ---------------------------------------------------------------------------
-// Connectives — unified shape with `operands` array.
+// Connectives , unified shape with `operands` array.
 // ---------------------------------------------------------------------------
 
 inline std::shared_ptr<Formula> connective_(std::string kind,
@@ -249,7 +269,7 @@ inline std::shared_ptr<Formula> or_(std::vector<std::shared_ptr<Formula>> operan
 }
 
 // ---------------------------------------------------------------------------
-// Quantifiers — flat shape, no Lambda wrapper.
+// Quantifiers , flat shape, no Lambda wrapper.
 // ---------------------------------------------------------------------------
 
 template <typename Body>
@@ -299,6 +319,46 @@ std::shared_ptr<Formula> choice(std::string varName, Sort sort, Body body) {
 }
 
 // ---------------------------------------------------------------------------
+// EvidenceTerm , proof-certificate carrier per v1.3.0 catalog.
+// ---------------------------------------------------------------------------
+//
+// Mirrors implementations/rust/provekit-ir-symbolic/src/lib.rs `EvidenceTerm`
+// + `EvidenceCertificate`. Locked IR-JSON shape per the spec is:
+//
+//   {"kind":"evidence",
+//    "proofType":"smt-lib"|"coq"|"custom",
+//    "certificate":{"tool":"...","version":"...",
+//                   "formulaHash":"...","proofData":"..."}}
+//
+// All fields are required strings. The kit emits insertion order; the
+// canonicalizer's JCS pass re-sorts before hashing.
+//
+// `proofType` values are open-set strings; the protocol catalog lists
+// "smt-lib", "coq", and "custom" as the three known values for v1.3.0.
+//
+// Cross-impl JCS conformance: the byte-identical fixture lives at
+// implementations/cpp/provekit-ir-symbolic/example/evidence_term_test.cpp;
+// any change to write_evidence below MUST keep that fixture passing.
+
+struct EvidenceCertificate {
+  std::string tool;
+  std::string version;
+  std::string formula_hash;
+  std::string proof_data;
+};
+
+struct EvidenceTerm {
+  std::string proof_type;
+  EvidenceCertificate certificate;
+};
+
+inline std::shared_ptr<EvidenceTerm> evidence(std::string proof_type,
+                                               EvidenceCertificate cert) {
+  return std::make_shared<EvidenceTerm>(
+      EvidenceTerm{std::move(proof_type), std::move(cert)});
+}
+
+// ---------------------------------------------------------------------------
 // Contract collector
 // ---------------------------------------------------------------------------
 
@@ -308,6 +368,9 @@ struct ContractDecl {
   std::shared_ptr<Formula> post;  // nullable
   std::shared_ptr<Formula> inv;   // nullable
   std::string outBinding;         // conventionally "out"
+  // Optional v1.3.0 evidence certificate carrier. nullptr == absent
+  // (matches the "omit absent" JCS rule and Rust's `Option<EvidenceTerm>`).
+  std::shared_ptr<EvidenceTerm> evidence;
 };
 
 inline std::vector<ContractDecl>& collector() {
@@ -321,11 +384,15 @@ inline void begin_collecting() {
 
 // contract() is the full authoring primitive; pre/post/inv each optional but
 // at least one must be non-null (kit-side check below fails fast).
+//
+// The `evidence` parameter is the v1.3.0 EvidenceTerm slot; nullptr (default)
+// means absent and is omitted from marshal_declarations output.
 inline void contract(std::string name,
                      std::shared_ptr<Formula> pre = nullptr,
                      std::shared_ptr<Formula> post = nullptr,
                      std::shared_ptr<Formula> inv = nullptr,
-                     std::string outBinding = "out") {
+                     std::string outBinding = "out",
+                     std::shared_ptr<EvidenceTerm> evidence = nullptr) {
   if (!pre && !post && !inv) {
     std::fprintf(stderr,
                  "ERROR: contract(\"%s\"): at least one of pre/post/inv must be non-null\n",
@@ -334,7 +401,7 @@ inline void contract(std::string name,
   }
   collector().push_back(ContractDecl{
       std::move(name), std::move(pre), std::move(post), std::move(inv),
-      std::move(outBinding)});
+      std::move(outBinding), std::move(evidence)});
 }
 
 // must() is the precondition-only convenience alias.
@@ -382,7 +449,7 @@ inline void reset_bridge_collector() {
 }
 
 // ---------------------------------------------------------------------------
-// JSON serialization — emits the protocol-locked uniform IR shape.
+// JSON serialization , emits the protocol-locked uniform IR shape.
 // ---------------------------------------------------------------------------
 
 inline void write_string(std::ostringstream& out, const std::string& s) {
@@ -547,10 +614,31 @@ inline void write_formula(std::ostringstream& out, const Formula& f) {
   }, f.v);
 }
 
+// Emit an EvidenceTerm in locked IR-JSON shape per the v1.3.0 catalog.
+// Byte-pinned with the Rust peer's write_evidence in
+// implementations/rust/provekit-ir-symbolic/src/serialize.rs:
+//   {"kind":"evidence","proofType":"<x>","certificate":{"tool":"<x>",
+//    "version":"<x>","formulaHash":"<x>","proofData":"<x>"}}
+inline void write_evidence(std::ostringstream& out, const EvidenceTerm& e) {
+  out << "{\"kind\":\"evidence\",\"proofType\":";
+  write_string(out, e.proof_type);
+  out << ",\"certificate\":{\"tool\":";
+  write_string(out, e.certificate.tool);
+  out << ",\"version\":";
+  write_string(out, e.certificate.version);
+  out << ",\"formulaHash\":";
+  write_string(out, e.certificate.formula_hash);
+  out << ",\"proofData\":";
+  write_string(out, e.certificate.proof_data);
+  out << "}}";
+}
+
 // Marshal an array of ContractDecl into the IR-JSON Document shape:
-//   [{"kind":"contract","name":"...","outBinding":"out","pre":..,"post":..,"inv":..}, ...]
-// pre/post/inv are omitted when null (matches JCS canonicalization "omit absent" rule).
-// Locked key order per ContractDeclaration: kind, name, outBinding, pre?, post?, inv?.
+//   [{"kind":"contract","name":"...","outBinding":"out","pre":..,"post":..,"inv":..,"evidence":..}, ...]
+// pre/post/inv/evidence are omitted when null (matches JCS canonicalization "omit absent" rule).
+// Locked key order per ContractDeclaration: kind, name, outBinding, pre?, post?, inv?, evidence?.
+// The evidence slot is appended after inv, matching the Rust peer's
+// marshal_declarations in provekit-ir-symbolic/src/serialize.rs.
 inline std::string marshal_declarations(const std::vector<ContractDecl>& decls) {
   std::ostringstream out;
   out << "[";
@@ -571,6 +659,10 @@ inline std::string marshal_declarations(const std::vector<ContractDecl>& decls) 
     if (decls[i].inv) {
       out << ",\"inv\":";
       write_formula(out, *decls[i].inv);
+    }
+    if (decls[i].evidence) {
+      out << ",\"evidence\":";
+      write_evidence(out, *decls[i].evidence);
     }
     out << "}";
   }

--- a/implementations/cpp/provekit/proof-envelope/proof_envelope.cpp
+++ b/implementations/cpp/provekit/proof-envelope/proof_envelope.cpp
@@ -90,6 +90,20 @@ std::vector<CborPair> body_pairs_unsigned(const ProofEnvelopeInput& in) {
     pairs.push_back(make_members_pair("members", in.members));
     pairs.push_back(make_string_pair("signer", in.signer_cid));
     pairs.push_back(make_string_pair("declaredAt", in.declared_at));
+    // Optional `binaryCid` , only emitted when present (sentinel: empty
+    // string means absent). Mirrors the Rust peer's `Option<String>` branch
+    // at implementations/rust/provekit-proof-envelope/src/proof.rs:
+    //
+    //     if let Some(ref bcid) = input.binary_cid {
+    //         pairs.push(make_string_pair("binaryCid", bcid));
+    //     }
+    //
+    // emit_sorted_map then re-sorts by bytewise CBOR-encoded-key form per
+    // RFC 8949 §4.2.1, so absent vs present yields byte-identical output
+    // for legacy callers that leave binary_cid empty.
+    if (!in.binary_cid.empty()) {
+        pairs.push_back(make_string_pair("binaryCid", in.binary_cid));
+    }
     return pairs;
 }
 

--- a/implementations/cpp/provekit/proof-envelope/proof_envelope.hpp
+++ b/implementations/cpp/provekit/proof-envelope/proof_envelope.hpp
@@ -34,6 +34,17 @@ struct ProofEnvelopeInput {
     std::string signer_cid;
     Ed25519Seed signer_seed;
     std::string declared_at;  // RFC 3339, e.g. "2026-04-30T12:00:00.000Z"
+
+    // Optional CID of the compiled binary this proof bundle covers. When
+    // non-empty, the framework checks that the running binary's hash matches
+    // before trusting any claims in this bundle (proof-file-format rule 5;
+    // MAY in v1.3.0, promoted to MUST under the v1.4.0 binary-attestation-
+    // protocol spec).
+    //
+    // Sentinel: empty string means "absent" , the CBOR pair is not emitted,
+    // matching the Rust peer's `Option<String>` `None` branch in
+    // implementations/rust/provekit-proof-envelope/src/proof.rs.
+    std::string binary_cid;
 };
 
 struct ProofEnvelopeOutput {

--- a/tools/run-cpp-v1-3-0-conformance.sh
+++ b/tools/run-cpp-v1-3-0-conformance.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Build + run the C++ v1.3.0 cross-impl conformance smoke test.
+#
+# Asserts byte-identicality with the Rust peer for the three v1.3.0
+# protocol-additive enrichments newly ported to the C++ kit:
+#
+#   1. EvidenceTerm IR-JSON shape (locked byte fixture)
+#   2. PrimitiveBridgeDeclaration v1.3.0 slots
+#      (source_contract_cid + target_proof_cid)
+#   3. binaryCid optional field on the catalog memento
+#      (present-vs-absent byte distinctness + map-head structure)
+#
+# Spec sources:
+#   protocol/specs/2026-04-30-ir-formal-grammar.md (BridgeDeclaration)
+#   protocol/specs/2026-04-30-proof-file-format.md (binaryCid)
+#   protocol/specs/2026-05-02-binary-attestation-protocol.md
+#
+# Mirrors tools/build-cpp-self-contracts.sh: vendored-blake3, openssl@3
+# from brew or system, header-only nlohmann/json. No Bazel; clang++
+# direct invocation is the conformance-gate path until rules_foreign_cc
+# ships.
+#
+# Usage:
+#   tools/run-cpp-v1-3-0-conformance.sh
+
+set -e
+
+WORKSPACE="$(cd "$(dirname "$0")/.." && pwd)"
+CPP="$WORKSPACE/implementations/cpp/provekit"
+KIT_INC="$WORKSPACE/implementations/cpp/provekit-ir-symbolic/include"
+B3_DIR="$WORKSPACE/tools/blake3-vendored"
+
+# --- Resolve OpenSSL prefix --------------------------------------------------
+detect_openssl_prefix() {
+    if [ -n "${OPENSSL_PREFIX:-}" ] && [ -d "$OPENSSL_PREFIX/include/openssl" ]; then
+        echo "$OPENSSL_PREFIX"
+        return
+    fi
+    for cand in /usr/local/opt/openssl@3 /opt/homebrew/opt/openssl@3 /usr/local /usr; do
+        if [ -d "$cand/include/openssl" ]; then
+            echo "$cand"
+            return
+        fi
+    done
+    echo ""
+}
+OPENSSL_PREFIX="$(detect_openssl_prefix)"
+if [ -z "$OPENSSL_PREFIX" ]; then
+    echo "error: openssl headers not found." >&2
+    exit 1
+fi
+
+# --- Compile vendored BLAKE3 to objects --------------------------------------
+B3_FLAGS="-DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512 -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_USE_NEON=0"
+B3_OBJ_DIR="$(mktemp -d -t b3-obj.XXXXXX)"
+OUT_BIN="$(mktemp -t v1_3_0_conformance.XXXXXX)"
+trap 'rm -rf "$B3_OBJ_DIR" "$OUT_BIN"' EXIT INT TERM
+
+CC="${CC:-clang}"
+CXX="${CXX:-clang++}"
+
+for src in blake3.c blake3_dispatch.c blake3_portable.c; do
+    "$CC" -O2 -Wall $B3_FLAGS -c "$B3_DIR/$src" \
+        -o "$B3_OBJ_DIR/${src%.c}.o"
+done
+
+# --- Compile + link the conformance test -------------------------------------
+"$CXX" -std=c++17 -O2 -Wall -Wextra -Werror \
+    -I"$OPENSSL_PREFIX/include" \
+    -I"$B3_DIR" \
+    -I"$KIT_INC" \
+    -I"$WORKSPACE/implementations/cpp" \
+    -L"$OPENSSL_PREFIX/lib" \
+    "$B3_OBJ_DIR/blake3.o" \
+    "$B3_OBJ_DIR/blake3_dispatch.o" \
+    "$B3_OBJ_DIR/blake3_portable.o" \
+    "$CPP/canonicalizer/hash.cpp" \
+    "$CPP/canonicalizer/jcs.cpp" \
+    "$CPP/canonicalizer/property_hash.cpp" \
+    "$CPP/proof-envelope/cbor.cpp" \
+    "$CPP/proof-envelope/sign_ed25519.cpp" \
+    "$CPP/proof-envelope/proof_envelope.cpp" \
+    "$WORKSPACE/implementations/cpp/provekit-ir-symbolic/example/evidence_term_test.cpp" \
+    -lcrypto \
+    -o "$OUT_BIN"
+
+"$OUT_BIN"


### PR DESCRIPTION
## Summary

Closes the cross-impl conformance gap on the C++ peer for the four v1.3.0 protocol-additive enrichments (newly normative after PR #10):

- `binaryCid` (proof envelope back-pin to the binary)
- `targetProofCid` (bridge forward-pin to a consequent proof bundle)
- `sourceContractCid` (bridge source-layer contract identification)
- `EvidenceTerm` IR variant (proof-certificate carrier)

The C++ kit was previously the lone hold-out: existing Rust + audit notes flagged "EvidenceTerm to C++/C#" as the explicit gap, and the just-merged spec PR promoted `targetProofCid` to normative.

## Per-field landing site

| Field | C++ landing site | Rust peer reference |
|---|---|---|
| `binaryCid` | `ProofEnvelopeInput::binary_cid` in `proof_envelope.hpp`; emitted by `body_pairs_unsigned` in `proof_envelope.cpp` only when non-empty (sentinel = empty string). | `provekit-proof-envelope/src/proof.rs::ProofEnvelopeInput::binary_cid: Option<String>` |
| `sourceContractCid` | `PrimitiveBridgeDeclaration::source_contract_cid` in `ir.hpp`. | `provekit-ir-symbolic/src/lib.rs::BridgeDecl` (forward-looking; same gap on Rust side) |
| `targetProofCid` | `PrimitiveBridgeDeclaration::target_proof_cid` in `ir.hpp`. | same as above |
| `EvidenceTerm` | New `EvidenceTerm` + `EvidenceCertificate` structs in `ir.hpp`; optional `evidence` slot on `ContractDecl` + `contract()`; `write_evidence` helper; `marshal_declarations` appends `"evidence":{...}` after `inv?`. | `provekit-ir-symbolic/src/serialize.rs::write_evidence` |

## What was / wasn't portable given current C++ kit shape

**Ported:**
- All four field additions (struct slots + optional emission paths).
- `EvidenceTerm` IR-JSON serializer matches Rust byte-for-byte under a locked golden fixture.
- `binaryCid` CBOR pair emission mirrors Rust's `Option<String>` `None` branch by sentinel.
- New `tools/run-cpp-v1-3-0-conformance.sh` exercises all four additions; 7/7 PASS.

**Deliberately NOT ported (out of scope; same gap exists on Rust):**
- `sourceContractCid` / `targetProofCid` are NOT added to `MintBridgeArgs` body emission. The bridge MEMENTO body in Rust's `mint_bridge` does not yet carry these fields; adding them only on C++ would break byte-identicality. They live on the DECLARATION (kit-side IR-JSON) until both peers wire them through `mint_bridge` together.
- A Bridge `IR-JSON` serializer was not scaffolded. Rust's `parse.rs` explicitly notes "Bridge declarations as inline JSON are not yet handled (bridges live in `BridgeDecl` minted via `mint_bridge`)". The C++ kit mirrors that.

## Golden test status

```
$ tools/run-cpp-v1-3-0-conformance.sh
v1.3.0 cross-impl conformance smoke test:
  [PASS] EvidenceTerm IR-JSON shape
  [PASS] EvidenceTerm absent (omit-when-null)
  [PASS] PrimitiveBridgeDeclaration v1.3.0 slots present
  [PASS] binaryCid absent: deterministic
  [PASS] binaryCid present: byte-distinct from absent
  [PASS] absent catalog map head: 0xa7 (7 keys)
  [PASS] present catalog map head: 0xa8 (8 keys)
v1.3.0 CONFORMANCE SMOKE TEST OK.
```

## CID drift check

`make build-cpp` and the orchestrator round-trip both produce the unchanged pinned `CPP_CID = blake3-512:9335e6376d776819cfd3b2458da29bc258e7c2ebaad542a8613dd84f50c51c31d6e1a4346cea3903b8ad12294d96aef445d0ed838aa630835b9be0bc17e62842` (Makefile). Optional-field-absent default produces byte-identical output to the v1.2.0 shape, so the conformance gate stays green.

## Test plan

- [x] `tools/build-cpp-self-contracts.sh --build-only` succeeds clean
- [x] `tools/build-cpp-self-contracts.sh /tmp/out` produces unchanged CID `9335e63...`
- [x] `tools/run-cpp-v1-3-0-conformance.sh` 7/7 PASS
- [x] Existing `proof_envelope_test.cpp` smoke still passes (legacy `binary_cid` empty case unchanged: map head 0xa7)
- [x] No em/en-dashes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)