### PR TITLE
fix(ci): mint-go must depend on build-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ mint-rust: build-rust
 		(echo "FAIL: rust CID mismatch (expected $(RUST_CID))" && exit 1)
 
 .PHONY: mint-go
-mint-go: build-rust
+mint-go: build-rust build-go
 	@echo ">> minting go self-contracts"
 	@out=$$($(PROVEKIT) mint --project implementations/go --quiet); \
 	echo "  cid: $$out"; \


### PR DESCRIPTION
## Summary

\`mint-go\` had \`build-rust\` as its only dependency, so CI never compiled the Go binary at \`implementations/go/provekit-lift-go-tests/provekit-lift-go\` before invoking it. PR #12 mint-rust agent flagged this; it's why the post-everything CI run still fails.

## Test plan

- [ ] CI build-go runs before mint-go
- [ ] Whatever CID mint-go produces is visible in the log (next PR will bump GO_CID to match)

## Architectural note

GO_CID has the same self-reference pathology Sir flagged for RUST_CID (PR #22 commentary). The proper fix is letter-envelope: external signed attestation. Tracked as task #206 follow-up.