### PR TITLE
fix(ci): relative paths in lift plugin manifests

### DIFF
--- a/implementations/cpp/.provekit/lift/cpp/manifest.toml
+++ b/implementations/cpp/.provekit/lift/cpp/manifest.toml
@@ -1,2 +1,3 @@
 name = "cpp-lift"
-command = ["/Users/tsavo/provekit/implementations/cpp/target/mint_cpp_self_contracts", "--rpc"]
+command = ["./target/mint_cpp_self_contracts", "--rpc"]
+working_dir = "."

--- a/implementations/go/.provekit/lift/go/manifest.toml
+++ b/implementations/go/.provekit/lift/go/manifest.toml
@@ -1,2 +1,3 @@
 name = "go-lift"
-command = ["/Users/tsavo/provekit/implementations/go/provekit-lift-go-tests/provekit-lift-go", "--rpc"]
+command = ["./provekit-lift-go-tests/provekit-lift-go", "--rpc"]
+working_dir = "."


### PR DESCRIPTION
## Summary

\`go-lift\` and \`cpp-lift\` manifest.toml had \`/Users/tsavo/provekit/\` as absolute commands. CI has no such path; spawn fails with ENOENT. Six other lift manifests use \`./...\` + \`working_dir = \".\"\` correctly. Brought go-lift and cpp-lift in line.

## Why this matters beyond unblocking CI

Same pathology as the Makefile \`*_CID :=\` pins Sir flagged: source tree carries machine-local truth, breaks the moment the source moves. The bundle-attestation-protocol spec (#207) names the CID half of this; this PR fixes the absolute-path half. Both express the same discipline — **don't pin maintainer-machine state in tracked files**.

## Test plan

- [ ] CI \`mint-go\` spawns the binary at the relative path successfully
- [ ] CI \`mint-cpp\` likewise
- [ ] GO_CID still mismatches (separate, expected — letter-envelope refactor in #206 will retire the constant)