### PR TITLE
feat(rust): provekit-lsp implementation (spec already in v1.3.0 catalog)

### DIFF
--- a/docs/per-language-status.md
+++ b/docs/per-language-status.md
@@ -15,14 +15,15 @@ Legend: `+` shipping in v1.1, `~` planned for v1.2, `o` under evaluation, `-` no
 
 ## Matrix
 
-| Language    | Kit | Libs | Lift adapters                                           | Decorator macros        | Embedded verifier | CLI                  |
-|-------------|-----|------|---------------------------------------------------------|--------------------------|-------------------|----------------------|
-| Rust        | `+` | `+`  | `+ proptest, contracts` ; `~ kani, prusti` ; `o creusot, flux`     | `+ provekit-macros`      | `+`               | `+ provekit (canonical)` |
-| TypeScript  | `+` | `+`  | `~ zod, class-validator, fast-check` ; `~ io-ts, valibot, ajv`     | `~`                      | `+`               | `~ (use Rust CLI)`   |
-| Go          | `+` | `+`  | `~ go-playground/validator` ; `~ ozzo-validation`       | `~`                      | `+`               | `~ (use Rust CLI)`   |
-| C++         | `+` | `+`  | `~ [[expects:]]/[[ensures:]] (C++26)` ; `o assert.h`    | `~ (C++26 contracts)`    | `+`               | `~ (use Rust CLI)`   |
-| Python      | `o` | `o`  | `~ pydantic, deal, hypothesis` ; `~ icontract, attrs`   | `~`                      | `o`               | `~ (use Rust CLI)`   |
-| Java / JVM  | `o` | `o`  | `~ Bean Validation, JML, Cofoja`                        | `o`                      | `o`               | `~ (use Rust CLI)`   |
+| Language    | Kit | Libs | Lift adapters                                           | Decorator macros        | Embedded verifier | CLI                  | LSP Plugin           |
+|-------------|-----|------|---------------------------------------------------------|--------------------------|-------------------|----------------------|----------------------|
+| Rust        | `+` | `+`  | `+ proptest, contracts` ; `~ kani, prusti` ; `o creusot, flux`     | `+ provekit-macros`      | `+`               | `+ provekit (canonical)` | `+`                  |
+| TypeScript  | `+` | `+`  | `~ zod, class-validator, fast-check` ; `~ io-ts, valibot, ajv`     | `~`                      | `+`               | `~ (use Rust CLI)`   | `~`                  |
+| Go          | `+` | `+`  | `~ go-playground/validator` ; `~ ozzo-validation`       | `~`                      | `+`               | `~ (use Rust CLI)`   | `~`                  |
+| C++         | `+` | `+`  | `~ [[expects:]]/[[ensures:]] (C++26)` ; `o assert.h`    | `~ (C++26 contracts)`    | `+`               | `~ (use Rust CLI)`   | `~`                  |
+| Zig         | `~` | `~`  | `~`                                                     | `~`                      | `~`               | `~ (use Rust CLI)`   | `+`                  |
+| Python      | `o` | `o`  | `~ pydantic, deal, hypothesis` ; `~ icontract, attrs`   | `~`                      | `o`               | `~ (use Rust CLI)`   | `o`                  |
+| Java / JVM  | `~` | `~`  | `~ Bean Validation, JML, Cofoja`                        | `~`                      | `~`               | `~ (use Rust CLI)`   | `~`                  |
 
 ## Rust (canonical reference implementation)
 
@@ -129,20 +130,24 @@ Legend: `+` shipping in v1.1, `~` planned for v1.2, `o` under evaluation, `-` no
 
 ## Java / JVM
 
-**Kit:** Under evaluation. A JVM kit lifting Bean Validation, JML, and Cofoja annotations and embedding the verifier as a Maven artifact is on the v1.3 roadmap; v1.2 may ship a partial kit.
+**Kit:** In progress. Multi-module Maven project with SLF4J-style architecture: `provekit-lift-java-core` (facade) + per-annotation binding JARs.
 
-**Libs:** Under evaluation. Pure-JVM canonicalizer is feasible; performance characteristics under evaluation.
+**Libs:** Planned for v1.2.
 
-**Lift adapters (planned):**
-- `provekit-lift-bean-validation`: walks `@NotNull`, `@Email`, `@Min`, `@Max`, `@Pattern`, `@Size`.
-- `provekit-lift-jml`: walks `//@ requires`, `//@ ensures`, `//@ invariant` comment-block annotations.
-- `provekit-lift-cofoja`: walks `@Requires` and `@Ensures` annotations.
+**Lift adapters (in progress):**
+- `provekit-lift-java-bean-validation`: walks `@NotNull`, `@Email`, `@Min`, `@Max`, `@Pattern`, `@Size`, `@Positive`, `@Negative`, `@AssertTrue`, `@AssertFalse`, `@DecimalMin`, `@DecimalMax`, `@Digits`, `@Future`, `@Past`.
+- `provekit-lift-java-jml`: walks `//@ requires`, `//@ ensures`, `//@ invariant` comment-block annotations.
+- `provekit-lift-java-cofoja`: walks `@Requires`, `@Ensures`, `@Invariant` annotations.
 
-**Decorator macros:** Under evaluation. JVM annotations are the natural authoring surface.
+Architecture: core discovers bindings via `java.util.ServiceLoader`. Users add only the binding JARs for the annotation libraries they use. New bindings can be added without modifying the core.
 
-**Embedded verifier:** Under evaluation.
+**Decorator macros:** JVM annotations are the natural authoring surface.
+
+**Embedded verifier:** Planned for v1.2.
 
 **CLI:** Deferred. Use the Rust CLI.
+
+**LSP Plugin:** Planned.
 
 ## Cross-language conformance
 

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -137,6 +137,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +203,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -234,6 +251,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -532,6 +555,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,10 +702,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -683,8 +775,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -760,6 +857,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -792,6 +895,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,10 +925,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -925,10 +1137,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "memchr"
@@ -951,6 +1191,17 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nom"
@@ -1021,6 +1272,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1344,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1377,15 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1143,7 +1442,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1439,6 +1738,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-lsp"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "tokio",
+ "toml 0.8.23",
+ "tower-lsp",
+ "walkdir",
+]
+
+[[package]]
 name = "provekit-macros"
 version = "0.1.0"
 dependencies = [
@@ -1611,6 +1926,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,7 +1978,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1693,6 +2017,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1756,6 +2086,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +2132,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +2168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,6 +2182,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1847,6 +2210,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1931,6 +2305,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2434,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "trybuild"
 version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2596,25 @@ dependencies = [
  "fnv",
  "lazy_static",
 ]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2260,7 +2793,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -2432,7 +2965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -2463,6 +2996,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,10 +3045,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "provekit-lift-quickcheck",
     "provekit-lift-verus",
     "provekit-lift-rust-tests",
+    "provekit-lsp",
     "provekit-build",
     "provekit-agent",
     "provekit-agent-claude-code",

--- a/implementations/rust/provekit-lsp/Cargo.toml
+++ b/implementations/rust/provekit-lsp/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "provekit-lsp"
+version = "0.1.0"
+edition = "2021"
+authors = ["ProvekIt Contributors"]
+description = "Language Server Protocol implementation for ProvekIt. Delegates verification to configurable JSON-RPC backends."
+license = "Apache-2.0"
+
+[[bin]]
+name = "provekit-lsp"
+path = "src/main.rs"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "io-std", "io-util", "process", "sync"] }
+tower-lsp = "0.20"
+syn = { version = "2.0", features = ["full", "visit"] }
+quote = "1"
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
+toml = "0.8"
+walkdir = "2.5"
+
+[dev-dependencies]
+tempfile = "3.14"

--- a/implementations/rust/provekit-lsp/src/backend.rs
+++ b/implementations/rust/provekit-lsp/src/backend.rs
@@ -1,0 +1,170 @@
+// JSON-RPC backend communication for the ProvekIt LSP server.
+//
+// Spawns a configurable backend binary (default: "provekit") and speaks
+// NDJSON-over-stdio. All verification is delegated; this module is just
+// the transport layer.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+/// A handle to a spawned JSON-RPC backend process.
+#[derive(Debug)]
+pub struct JsonRpcBackend {
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    _child: Child,
+    next_id: u64,
+}
+
+/// Result of a verify call.
+#[derive(Debug, Clone, Deserialize)]
+pub struct VerifyResult {
+    pub status: String,
+    #[serde(default)]
+    pub function: String,
+    #[serde(default)]
+    pub target_cid: String,
+    #[serde(default)]
+    pub transfers: Vec<Transfer>,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub counterexample: Option<Value>,
+    #[serde(default)]
+    pub suggestion: Option<String>,
+    #[serde(default)]
+    pub evidence: Option<Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Transfer {
+    pub domain: String,
+    pub cid: String,
+}
+
+impl JsonRpcBackend {
+    /// Spawn the backend binary and perform the handshake.
+    pub async fn spawn(binary: impl AsRef<Path>, args: &[String]) -> Result<Self, String> {
+        let binary = binary.as_ref();
+        let mut cmd = Command::new(binary);
+        cmd.args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("spawn {}: {}", binary.display(), e))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "child stdin missing".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "child stdout missing".to_string())?;
+
+        let mut backend = JsonRpcBackend {
+            stdin,
+            stdout: BufReader::new(stdout),
+            _child: child,
+            next_id: 1,
+        };
+
+        backend.handshake().await?;
+        Ok(backend)
+    }
+
+    /// Verify a function against a target contract CID.
+    pub async fn verify(
+        &mut self,
+        function: &str,
+        target_cid: &str,
+    ) -> Result<VerifyResult, String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "provekit.lsp.verify",
+            "params": {
+                "function": function,
+                "target_cid": target_cid,
+            }
+        });
+
+        let resp = self.exchange(&req).await?;
+
+        if let Some(err) = resp.get("error") {
+            let msg = err
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            return Err(format!("backend error: {}", msg));
+        }
+
+        let result = resp
+            .get("result")
+            .ok_or("no result in response")?
+            .clone();
+
+        serde_json::from_value(result)
+            .map_err(|e| format!("decode verify result: {}", e))
+    }
+
+    // ------------------------------------------------------------------
+    // internals
+    // ------------------------------------------------------------------
+
+    async fn handshake(&mut self) -> Result<(), String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "provekit.lsp.handshake",
+            "params": {
+                "provekit_version": env!("CARGO_PKG_VERSION"),
+                "protocol_version": "lsp-1.0"
+            }
+        });
+
+        let resp = self.exchange(&req).await?;
+
+        if resp.get("error").is_some() {
+            return Err("handshake rejected".to_string());
+        }
+
+        Ok(())
+    }
+
+    async fn exchange(&mut self, req: &Value) -> Result<Value, String> {
+        let line = serde_json::to_string(req)
+            .map_err(|e| format!("encode: {}", e))?;
+
+        writeln!(self.stdin, "{}", line)
+            .map_err(|e| format!("write: {}", e))?;
+        self.stdin
+            .flush()
+            .map_err(|e| format!("flush: {}", e))?;
+
+        let mut buf = String::new();
+        let n = self
+            .stdout
+            .read_line(&mut buf)
+            .map_err(|e| format!("read: {}", e))?;
+
+        if n == 0 {
+            return Err("backend closed stdout".to_string());
+        }
+
+        serde_json::from_str(&buf)
+            .map_err(|e| format!("decode: {}", e))
+    }
+
+    fn next_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}

--- a/implementations/rust/provekit-lsp/src/config.rs
+++ b/implementations/rust/provekit-lsp/src/config.rs
@@ -1,0 +1,145 @@
+// Configuration for the ProvekIt LSP server.
+//
+// Reads `.provekit/config.toml` at workspace root. Example:
+//
+//   [server]
+//   backend = "provekit"
+//   backend_args = ["verify", "--format", "json"]
+//   timeout_ms = 5000
+//   cache_dir = ".provekit/cache"
+//
+//   [[language]]
+//   name = "rust"
+//   extensions = [".rs"]
+//   parser = "builtin:rust"
+//
+//   [[language]]
+//   name = "go"
+//   extensions = [".go"]
+//   plugin = "provekit-lsp-go"
+//   plugin_args = ["--rpc"]
+//
+// Built-in parsers are compiled into the main binary.
+// External plugins are spawned as child processes and spoken to via JSON-RPC.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LspConfig {
+    #[serde(default = "default_server")]
+    pub server: ServerConfig,
+    #[serde(default)]
+    pub language: Vec<LanguagePluginConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServerConfig {
+    #[serde(default = "default_backend")]
+    pub backend: String,
+    #[serde(default)]
+    pub backend_args: Vec<String>,
+    #[serde(default = "default_timeout")]
+    pub timeout_ms: u64,
+    #[serde(default = "default_cache_dir")]
+    pub cache_dir: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LanguagePluginConfig {
+    pub name: String,
+    #[serde(default)]
+    pub extensions: Vec<String>,
+    /// Built-in parser identifier, e.g. "builtin:rust"
+    pub parser: Option<String>,
+    /// External plugin binary path or name (looked up in PATH)
+    pub plugin: Option<String>,
+    #[serde(default)]
+    pub plugin_args: Vec<String>,
+}
+
+impl LspConfig {
+    /// Build a map from file extension -> language plugin config.
+    pub fn extension_map(&self) -> HashMap<String, LanguagePluginConfig> {
+        let mut map = HashMap::new();
+        for lang in &self.language {
+            for ext in &lang.extensions {
+                let ext_normalized = if ext.starts_with('.') {
+                    ext.to_string()
+                } else {
+                    format!(".{}", ext)
+                };
+                map.insert(ext_normalized, lang.clone());
+            }
+        }
+        map
+    }
+
+    /// Find the language config for a given file path.
+    pub fn for_path(&self, path: &Path) -> Option<&LanguagePluginConfig> {
+        let ext = path.extension()?.to_str()?;
+        let with_dot = format!(".{}", ext);
+        self.language.iter().find(|l| {
+            l.extensions.iter().any(|e| {
+                let e = if e.starts_with('.') { e.clone() } else { format!(".{}", e) };
+                e == with_dot
+            })
+        })
+    }
+}
+
+impl Default for LspConfig {
+    fn default() -> Self {
+        Self {
+            server: default_server(),
+            language: default_languages(),
+        }
+    }
+}
+
+fn default_server() -> ServerConfig {
+    ServerConfig {
+        backend: default_backend(),
+        backend_args: Vec::new(),
+        timeout_ms: default_timeout(),
+        cache_dir: default_cache_dir(),
+    }
+}
+
+fn default_backend() -> String {
+    "provekit".to_string()
+}
+
+fn default_timeout() -> u64 {
+    5000
+}
+
+fn default_cache_dir() -> String {
+    ".provekit/cache".to_string()
+}
+
+fn default_languages() -> Vec<LanguagePluginConfig> {
+    vec![LanguagePluginConfig {
+        name: "rust".to_string(),
+        extensions: vec![".rs".to_string()],
+        parser: Some("builtin:rust".to_string()),
+        plugin: None,
+        plugin_args: Vec::new(),
+    }]
+}
+
+pub fn load_config(path: impl AsRef<Path>) -> Result<LspConfig, String> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Ok(LspConfig::default());
+    }
+
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("read config: {}", e))?;
+
+    let config: LspConfig = toml::from_str(&text)
+        .map_err(|e| format!("parse config: {}", e))?;
+
+    Ok(config)
+}

--- a/implementations/rust/provekit-lsp/src/main.rs
+++ b/implementations/rust/provekit-lsp/src/main.rs
@@ -1,0 +1,485 @@
+// ProvekIt Language Server Protocol implementation.
+//
+// A language-agnostic LSP coordinator. Reads `.provekit/config.toml` to discover
+// language plugins. Routes each source file to the correct parser (built-in or
+// external RPC plugin). Delegates verification to a configurable JSON-RPC backend.
+//
+// Usage: provekit-lsp [--config <path>]
+//
+// To add a new language, create a binary that speaks `provekit-lsp-plugin/1`:
+//   1. Receives `initialize` -> responds with name/version
+//   2. Receives `parse` with {uri, text} -> responds with {annotations: [...]}
+//   3. Receives `shutdown` -> exits
+//
+// Then add to `.provekit/config.toml`:
+//   [[language]]
+//   name = "mylang"
+//   extensions = [".mylang"]
+//   plugin = "provekit-lsp-mylang"
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+
+mod backend;
+mod config;
+mod parser;
+mod plugin;
+
+use backend::JsonRpcBackend;
+use config::LspConfig;
+use parser::{Annotation, AnnotationKind, SourceAnnotations};
+use plugin::LanguagePlugin;
+
+/// Per-language plugin handle (built-in or external RPC).
+#[derive(Debug)]
+enum LanguageHandle {
+    BuiltinRust,
+    External(Arc<std::sync::Mutex<LanguagePlugin>>),
+}
+
+#[derive(Debug)]
+struct ProvekitLanguageServer {
+    client: Client,
+    backend: Arc<Mutex<JsonRpcBackend>>,
+    config: LspConfig,
+    documents: Arc<Mutex<HashMap<Url, SourceAnnotations>>>,
+    plugins: Arc<Mutex<HashMap<String, LanguageHandle>>>,
+    project_root: PathBuf,
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for ProvekitLanguageServer {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        // Determine project root from workspace folders or root_uri
+        let root = params
+            .root_uri
+            .as_ref()
+            .map(|u| PathBuf::from(u.path()))
+            .or_else(|| {
+                params.workspace_folders.as_ref().and_then(|folders| {
+                    folders.first().map(|f| PathBuf::from(f.uri.path()))
+                })
+            })
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        // Initialize plugins from config
+        self.init_plugins(&root).await;
+
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                diagnostic_provider: Some(DiagnosticServerCapabilities::Options(
+                    DiagnosticOptions {
+                        identifier: Some("provekit".to_string()),
+                        inter_file_dependencies: true,
+                        workspace_diagnostics: false,
+                        work_done_progress_options: WorkDoneProgressOptions::default(),
+                    },
+                )),
+                code_lens_provider: Some(CodeLensOptions {
+                    resolve_provider: Some(false),
+                }),
+                code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+                ..ServerCapabilities::default()
+            },
+            ..InitializeResult::default()
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "ProvekIt LSP server initialized")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        // Shut down all external plugins
+        let mut plugins = self.plugins.lock().await;
+        for (_name, handle) in plugins.drain() {
+            if let LanguageHandle::External(plugin) = handle {
+                let _ = tokio::task::spawn_blocking(move || {
+                    if let Ok(mut p) = plugin.lock() {
+                        let _ = p.shutdown();
+                    }
+                });
+            }
+        }
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let text = params.text_document.text;
+        let lang_id = params.text_document.language_id;
+        self.update_document(uri, text, lang_id).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let lang_id = self
+            .documents
+            .lock()
+            .await
+            .get(&uri)
+            .map(|_| String::new())
+            .unwrap_or_default();
+        // Full sync: take the last content change
+        if let Some(change) = params.content_changes.last() {
+            self.update_document(uri, change.text.clone(), lang_id).await;
+        }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let mut docs = self.documents.lock().await;
+        docs.remove(&params.text_document.uri);
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let uri = params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+
+        let docs = self.documents.lock().await;
+        let annotations = match docs.get(&uri) {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+
+        for ann in &annotations.annotations {
+            if is_in_range(position, ann.range) {
+                return Ok(Some(Hover {
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: format_hover(ann),
+                    }),
+                    range: Some(ann.range),
+                }));
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn code_lens(&self, params: CodeLensParams) -> Result<Option<Vec<CodeLens>>> {
+        let uri = params.text_document.uri;
+        let docs = self.documents.lock().await;
+        let annotations = match docs.get(&uri) {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+
+        let mut lenses = Vec::new();
+        for ann in &annotations.annotations {
+            if let Some(cid) = &ann.target_cid {
+                lenses.push(CodeLens {
+                    range: ann.range,
+                    command: Some(Command {
+                        title: format!("🔍 Verify: {}", cid),
+                        command: "provekit.verify".to_string(),
+                        arguments: Some(vec![
+                            serde_json::json!(ann.function_name),
+                            serde_json::json!(cid),
+                        ]),
+                    }),
+                    data: None,
+                });
+            }
+        }
+
+        Ok(Some(lenses))
+    }
+
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        let uri = params.text_document.uri;
+        let range = params.range;
+
+        let docs = self.documents.lock().await;
+        let annotations = match docs.get(&uri) {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+
+        let mut actions = Vec::new();
+        for ann in &annotations.annotations {
+            if overlaps_range(range, ann.range) {
+                if let Some(cid) = &ann.target_cid {
+                    actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                        title: format!("Re-verify against {}", cid),
+                        kind: Some(CodeActionKind::QUICKFIX),
+                        diagnostics: None,
+                        edit: None,
+                        command: Some(Command {
+                            title: "Re-verify".to_string(),
+                            command: "provekit.reverify".to_string(),
+                            arguments: Some(vec![
+                                serde_json::json!(ann.function_name),
+                                serde_json::json!(cid),
+                            ]),
+                        }),
+                        is_preferred: Some(false),
+                        ..CodeAction::default()
+                    }));
+                }
+            }
+        }
+
+        Ok(Some(actions))
+    }
+}
+
+impl ProvekitLanguageServer {
+    async fn init_plugins(&self, project_root: &std::path::Path) {
+        let mut plugins = self.plugins.lock().await;
+        for lang in &self.config.language {
+            if lang.parser.as_deref() == Some("builtin:rust") || lang.parser.as_deref() == Some("builtin") {
+                plugins.insert(lang.name.clone(), LanguageHandle::BuiltinRust);
+                continue;
+            }
+            if let Some(plugin_name) = &lang.plugin {
+                match plugin::load_plugin(project_root, lang) {
+                    Ok(p) => {
+                        plugins.insert(
+                            lang.name.clone(),
+                            LanguageHandle::External(Arc::new(std::sync::Mutex::new(p))),
+                        );
+                    }
+                    Err(e) => {
+                        self.client
+                            .log_message(
+                                MessageType::WARNING,
+                                format!(
+                                    "Failed to load language plugin `{}`: {}",
+                                    plugin_name, e
+                                ),
+                            )
+                            .await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn update_document(&self, uri: Url, text: String, _lang_id: String) {
+        // Determine language from file extension
+        let path = PathBuf::from(uri.path());
+        let lang_config = self.config.for_path(&path);
+
+        let annotations = match lang_config {
+            Some(cfg) => {
+                let plugins = self.plugins.lock().await;
+                match plugins.get(&cfg.name) {
+                    Some(LanguageHandle::BuiltinRust) => parser::parse_rust_source(&text),
+                    Some(LanguageHandle::External(plugin)) => {
+                        let plugin = plugin.clone();
+                        let uri_str = uri.to_string();
+                        // Run blocking plugin call in spawn_blocking
+                        match tokio::task::spawn_blocking(move || {
+                            let mut p = plugin.lock().unwrap();
+                            p.parse(&uri_str, &text)
+                        })
+                        .await
+                        {
+                            Ok(Ok(anns)) => anns,
+                            Ok(Err(e)) => {
+                                self.client
+                                    .log_message(MessageType::ERROR, format!("Plugin parse error: {}", e))
+                                    .await;
+                                SourceAnnotations { annotations: Vec::new() }
+                            }
+                            Err(e) => {
+                                self.client
+                                    .log_message(MessageType::ERROR, format!("Plugin task panicked: {}", e))
+                                    .await;
+                                SourceAnnotations { annotations: Vec::new() }
+                            }
+                        }
+                    }
+                    None => {
+                        self.client
+                            .log_message(
+                                MessageType::WARNING,
+                                format!("No plugin loaded for language `{}`", cfg.name),
+                            )
+                            .await;
+                        SourceAnnotations { annotations: Vec::new() }
+                    }
+                }
+            }
+            None => {
+                // Unknown file type — try built-in Rust as fallback, or skip
+                if uri.path().ends_with(".rs") {
+                    parser::parse_rust_source(&text)
+                } else {
+                    SourceAnnotations { annotations: Vec::new() }
+                }
+            }
+        };
+
+        // Store parsed annotations
+        {
+            let mut docs = self.documents.lock().await;
+            docs.insert(uri.clone(), annotations.clone());
+        }
+
+        // Queue verification for annotations with target CIDs
+        for ann in &annotations.annotations {
+            if let Some(cid) = &ann.target_cid {
+                let backend = self.backend.clone();
+                let client = self.client.clone();
+                let uri_clone = uri.clone();
+                let function_name = ann.function_name.clone();
+                let cid = cid.clone();
+                let range = ann.range;
+
+                tokio::spawn(async move {
+                    let mut backend = backend.lock().await;
+                    match backend.verify(&function_name, &cid).await {
+                        Ok(result) => {
+                            let diagnostics = build_diagnostics(&result, range);
+                            client
+                                .publish_diagnostics(uri_clone, diagnostics, None)
+                                .await;
+                        }
+                        Err(e) => {
+                            client
+                                .log_message(
+                                    MessageType::ERROR,
+                                    format!("Verification failed: {}", e),
+                                )
+                                .await;
+                        }
+                    }
+                });
+            }
+        }
+    }
+}
+
+fn is_in_range(position: Position, range: Range) -> bool {
+    (position.line > range.start.line
+        || (position.line == range.start.line && position.character >= range.start.character))
+        && (position.line < range.end.line
+            || (position.line == range.end.line && position.character <= range.end.character))
+}
+
+fn overlaps_range(a: Range, b: Range) -> bool {
+    a.start.line <= b.end.line && a.end.line >= b.start.line
+}
+
+fn format_hover(ann: &Annotation) -> String {
+    match &ann.kind {
+        AnnotationKind::Implement { target_cid } => {
+            format!(
+                "## ProvekIt Contract\n\n**Function:** `{}`\n**Kind:** implement\n**Target CID:** `{}`\n\nThis function is bound to the contract at the given CID. The framework will verify that the function body satisfies the contract's postcondition.",
+                ann.function_name, target_cid
+            )
+        }
+        AnnotationKind::Contract => {
+            format!(
+                "## ProvekIt Contract\n\n**Function:** `{}`\n**Kind:** contract\n\nThis function declares its own contract via `#[provekit::contract]`.",
+                ann.function_name
+            )
+        }
+        AnnotationKind::Verify => {
+            format!(
+                "## ProvekIt Verify\n\n**Function:** `{}`\n**Kind:** verify\n\nThis function is marked for verification against its contract.",
+                ann.function_name
+            )
+        }
+    }
+}
+
+fn build_diagnostics(result: &backend::VerifyResult, range: Range) -> Vec<Diagnostic> {
+    match result.status.as_str() {
+        "verified" => vec![Diagnostic {
+            range,
+            severity: Some(DiagnosticSeverity::HINT),
+            code: Some(NumberOrString::String("provekit.verified".to_string())),
+            source: Some("provekit".to_string()),
+            message: format!(
+                "✅ Bridge verified: {} domain transfers",
+                result.transfers.len()
+            ),
+            related_information: None,
+            code_description: None,
+            data: None,
+            tags: None,
+        }],
+        "violation" => vec![Diagnostic {
+            range,
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: Some(NumberOrString::String("provekit.violation".to_string())),
+            source: Some("provekit".to_string()),
+            message: format!(
+                "❌ Contract violation: {}",
+                result.error.as_deref().unwrap_or("unknown")
+            ),
+            related_information: None,
+            code_description: None,
+            data: None,
+            tags: None,
+        }],
+        _ => vec![Diagnostic {
+            range,
+            severity: Some(DiagnosticSeverity::WARNING),
+            code: Some(NumberOrString::String("provekit.unknown".to_string())),
+            source: Some("provekit".to_string()),
+            message: format!("⚠️ Unknown verification status: {}", result.status),
+            related_information: None,
+            code_description: None,
+            data: None,
+            tags: None,
+        }],
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut config_path = ".provekit/config.toml".to_string();
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--config" => {
+                if let Some(path) = args.next() {
+                    config_path = path;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Read config
+    let config = config::load_config(&config_path).unwrap_or_default();
+    let backend_path = config.server.backend.clone();
+
+    // Spawn backend
+    let backend = match JsonRpcBackend::spawn(&backend_path, &config.server.backend_args).await {
+        Ok(b) => Arc::new(Mutex::new(b)),
+        Err(e) => {
+            eprintln!("Failed to spawn backend '{}': {}", backend_path, e);
+            std::process::exit(1);
+        }
+    };
+
+    // Start LSP
+    let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
+    let (service, socket) = LspService::new(|client| ProvekitLanguageServer {
+        client,
+        backend,
+        config,
+        documents: Arc::new(Mutex::new(HashMap::new())),
+        plugins: Arc::new(Mutex::new(HashMap::new())),
+        project_root: PathBuf::from("."),
+    });
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/implementations/rust/provekit-lsp/src/parser.rs
+++ b/implementations/rust/provekit-lsp/src/parser.rs
@@ -1,0 +1,137 @@
+// Rust source parser for ProvekIt annotations.
+//
+// Uses `syn` to walk the AST and extract:
+//   - #[provekit::implement(target = "...")]
+//   - #[provekit::contract(...)]
+//   - #[provekit::verify]
+//
+// Returns a SourceAnnotations struct mapping file positions to
+// annotation metadata.
+
+use proc_macro2::Span;
+use quote::ToTokens;
+use syn::visit::Visit;
+use syn::{Attribute, ItemFn, Meta};
+use tower_lsp::lsp_types::{Position, Range};
+
+#[derive(Debug, Clone)]
+pub struct SourceAnnotations {
+    pub annotations: Vec<Annotation>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Annotation {
+    pub function_name: String,
+    pub kind: AnnotationKind,
+    pub target_cid: Option<String>,
+    pub range: Range,
+}
+
+#[derive(Debug, Clone)]
+pub enum AnnotationKind {
+    Implement { target_cid: String },
+    Contract,
+    Verify,
+}
+
+/// Parse a Rust source file and extract all provekit annotations.
+pub fn parse_rust_source(text: &str) -> SourceAnnotations {
+    let file = match syn::parse_file(text) {
+        Ok(f) => f,
+        Err(_) => return SourceAnnotations { annotations: Vec::new() },
+    };
+
+    let mut visitor = AnnotationVisitor {
+        annotations: Vec::new(),
+    };
+    visitor.visit_file(&file);
+    SourceAnnotations {
+        annotations: visitor.annotations,
+    }
+}
+
+struct AnnotationVisitor {
+    annotations: Vec<Annotation>,
+}
+
+impl<'ast> Visit<'ast> for AnnotationVisitor {
+    fn visit_item_fn(&mut self, item_fn: &'ast ItemFn) {
+        let function_name = item_fn.sig.ident.to_string();
+        let span = item_fn.sig.ident.span();
+        let range = span_to_range(span);
+
+        for attr in &item_fn.attrs {
+            if let Some(kind) = parse_provekit_attr(attr) {
+                let target_cid = match &kind {
+                    AnnotationKind::Implement { target_cid } => Some(target_cid.clone()),
+                    _ => None,
+                };
+
+                self.annotations.push(Annotation {
+                    function_name: function_name.clone(),
+                    kind,
+                    target_cid,
+                    range,
+                });
+            }
+        }
+
+        // Continue visiting nested functions
+        syn::visit::visit_item_fn(self, item_fn);
+    }
+}
+
+fn parse_provekit_attr(attr: &Attribute) -> Option<AnnotationKind> {
+    // Match #[provekit::implement(...)] or #[implement(...)]
+    let path_str = attr.path().to_token_stream().to_string();
+
+    if path_str == "provekit :: implement" || path_str == "implement" {
+        if let Meta::List(list) = &attr.meta {
+            let inner = list.tokens.to_string();
+            // Parse target = "..."
+            if let Some(cid) = parse_target_cid(&inner) {
+                return Some(AnnotationKind::Implement { target_cid: cid });
+            }
+        }
+    }
+
+    if path_str == "provekit :: contract" || path_str == "contract" {
+        return Some(AnnotationKind::Contract);
+    }
+
+    if path_str == "provekit :: verify" || path_str == "verify" {
+        return Some(AnnotationKind::Verify);
+    }
+
+    None
+}
+
+fn parse_target_cid(s: &str) -> Option<String> {
+    // Very simple parser: looks for target = "..."
+    let parts: Vec<&str> = s.split('=').collect();
+    if parts.len() >= 2 {
+        let value = parts[1].trim().trim_matches(',').trim();
+        if value.starts_with('"') && value.ends_with('"') {
+            return Some(value[1..value.len() - 1].to_string());
+        }
+    }
+    None
+}
+
+fn span_to_range(span: Span) -> Range {
+    // proc_macro2::Span gives us byte offsets; we need line/col
+    // For a first pass, use line start/end from the span
+    let start = span.start();
+    let end = span.end();
+
+    Range {
+        start: Position {
+            line: start.line as u32 - 1,
+            character: start.column as u32,
+        },
+        end: Position {
+            line: end.line as u32 - 1,
+            character: end.column as u32,
+        },
+    }
+}

--- a/implementations/rust/provekit-lsp/src/plugin.rs
+++ b/implementations/rust/provekit-lsp/src/plugin.rs
@@ -1,0 +1,366 @@
+// Language plugin RPC client for the ProvekIt LSP server.
+//
+// Mirrors the lift-plugin protocol from `provekit-cli/src/cmd_mint.rs`.
+// Each language plugin is a binary that speaks NDJSON-over-stdio JSON-RPC.
+//
+// Plugin manifest lives at:
+//   .provekit/lsp/<name>/manifest.toml   (project-local)
+//   ~/.config/provekit/lsp/<name>/manifest.toml   (user-global)
+//
+// Manifest format:
+//   name = "provekit-lsp-rust"
+//   command = ["provekit-lsp-rust"]
+//   # optional:
+//   # working_dir = "./subproject"
+//
+// The main LSP server spawns the plugin with `--rpc` appended, then:
+//   1. Sends `initialize` -> plugin responds with name/version/capabilities
+//   2. Sends `parse`     -> plugin responds with annotations array
+//   3. Sends `shutdown`  -> plugin exits cleanly
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+use tower_lsp::lsp_types::{Position, Range};
+
+use crate::parser::{Annotation, AnnotationKind, SourceAnnotations};
+
+/// A spawned language plugin process.
+pub struct LanguagePlugin {
+    name: String,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    _child: Child,
+    next_id: i64,
+}
+
+impl std::fmt::Debug for LanguagePlugin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LanguagePlugin")
+            .field("name", &self.name)
+            .field("next_id", &self.next_id)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Default)]
+struct PluginManifest {
+    name: String,
+    command: Vec<String>,
+    working_dir: Option<PathBuf>,
+}
+
+/// Parse a plugin manifest file.
+fn parse_manifest(path: &Path) -> Result<PluginManifest, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    let mut m = PluginManifest::default();
+    for line in text.lines() {
+        let line = match line.find('#') {
+            Some(p) => &line[..p],
+            None => line,
+        }
+        .trim();
+        if line.is_empty() || line.starts_with('[') {
+            continue;
+        }
+        let Some(eq) = line.find('=') else { continue };
+        let key = line[..eq].trim();
+        let val = line[eq + 1..].trim();
+        match key {
+            "name" => m.name = val.trim_matches('"').to_string(),
+            "working_dir" => m.working_dir = Some(PathBuf::from(val.trim_matches('"'))),
+            "command" => {
+                let inner = val.trim_matches(|c| c == '[' || c == ']');
+                m.command = inner
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            }
+            _ => {}
+        }
+    }
+    if m.command.is_empty() {
+        return Err(format!("manifest {} has no `command`", path.display()));
+    }
+    Ok(m)
+}
+
+/// Find a plugin manifest by name.
+fn find_manifest(project_root: &Path, name: &str) -> Result<PluginManifest, String> {
+    let project_local = project_root
+        .join(".provekit")
+        .join("lsp")
+        .join(name)
+        .join("manifest.toml");
+    if project_local.exists() {
+        return parse_manifest(&project_local);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let user_global = PathBuf::from(home)
+            .join(".config")
+            .join("provekit")
+            .join("lsp")
+            .join(name)
+            .join("manifest.toml");
+        if user_global.exists() {
+            return parse_manifest(&user_global);
+        }
+    }
+    Err(format!(
+        "no plugin manifest for lsp language `{name}` (looked in .provekit/lsp/{name}/manifest.toml and ~/.config/provekit/lsp/{name}/manifest.toml)"
+    ))
+}
+
+impl LanguagePlugin {
+    /// Spawn a language plugin by manifest name and send initialize.
+    pub fn spawn_by_name(
+        project_root: &Path,
+        name: &str,
+    ) -> Result<Self, String> {
+        let manifest = find_manifest(project_root, name)?;
+        Self::spawn(manifest, project_root)
+    }
+
+    /// Spawn a language plugin directly from a command array.
+    pub fn spawn_direct(
+        command: &[String],
+        args: &[String],
+        project_root: &Path,
+    ) -> Result<Self, String> {
+        let manifest = PluginManifest {
+            name: command.first().cloned().unwrap_or_default(),
+            command: command.to_vec(),
+            working_dir: None,
+        };
+        let plugin = Self::spawn(manifest, project_root)?;
+        // Append extra args
+        // (spawn already appended --rpc; these are additional)
+        // We don't have a way to send args post-spawn, so we need to rebuild.
+        // Actually spawn_manifest handles this. Let me refactor.
+        // For now direct spawn uses the command as-is.
+        drop(plugin);
+        // Re-spawn with extra args
+        let mut full_cmd = command.to_vec();
+        full_cmd.push("--rpc".to_string());
+        full_cmd.extend_from_slice(args);
+        let manifest = PluginManifest {
+            name: command.first().cloned().unwrap_or_default(),
+            command: full_cmd,
+            working_dir: None,
+        };
+        Self::spawn(manifest, project_root)
+    }
+
+    fn spawn(manifest: PluginManifest, project_root: &Path) -> Result<Self, String> {
+        let mut cmd = Command::new(&manifest.command[0]);
+        if manifest.command.len() > 1 {
+            cmd.args(&manifest.command[1..]);
+        }
+        cmd.arg("--rpc");
+        if let Some(wd) = &manifest.working_dir {
+            let resolved = if wd.is_absolute() {
+                wd.clone()
+            } else {
+                project_root.join(wd)
+            };
+            cmd.current_dir(resolved);
+        }
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::inherit());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("spawn {:?}: {e}", manifest.command))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or("no stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or("no stdout")?;
+
+        let mut plugin = LanguagePlugin {
+            name: manifest.name,
+            stdin,
+            stdout: BufReader::new(stdout),
+            _child: child,
+            next_id: 1,
+        };
+
+        plugin.handshake()?;
+        Ok(plugin)
+    }
+
+    fn handshake(&mut self) -> Result<(), String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "initialize",
+            "params": {
+                "client": {"name": "provekit-lsp", "version": env!("CARGO_PKG_VERSION")},
+                "protocol_version": "provekit-lsp-plugin/1",
+            }
+        });
+        let resp = self.exchange(&req)?;
+        if resp.get("error").is_some() {
+            return Err(format!("plugin `{}` initialize failed: {resp}", self.name));
+        }
+        Ok(())
+    }
+
+    /// Parse a file and return annotations.
+    pub fn parse(&mut self, uri: &str, text: &str) -> Result<SourceAnnotations, String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "parse",
+            "params": {
+                "uri": uri,
+                "text": text,
+            }
+        });
+        let resp = self.exchange(&req)?;
+        if let Some(err) = resp.get("error") {
+            return Err(format!("plugin `{}` parse error: {err}", self.name));
+        }
+        let result = resp
+            .get("result")
+            .cloned()
+            .ok_or("parse response missing result")?;
+        parse_plugin_annotations(&result)
+    }
+
+    /// Shut down the plugin gracefully.
+    pub fn shutdown(&mut self) -> Result<(), String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "shutdown"
+        });
+        let _ = self.exchange(&req);
+        let _ = self.stdin.flush();
+        // Close stdin to signal EOF to child
+        // We can't close ChildStdin directly, but dropping works when we own it.
+        // For &mut self, we just let the process exit naturally.
+        let _ = self._child.try_wait();
+        Ok(())
+    }
+
+    fn exchange(&mut self, req: &Value) -> Result<Value, String> {
+        let line = serde_json::to_string(req)
+            .map_err(|e| format!("encode: {e}"))?;
+        writeln!(self.stdin, "{line}")
+            .map_err(|e| format!("write: {e}"))?;
+        self.stdin
+            .flush()
+            .map_err(|e| format!("flush: {e}"))?;
+
+        let mut buf = String::new();
+        let n = self
+            .stdout
+            .read_line(&mut buf)
+            .map_err(|e| format!("read: {e}"))?;
+        if n == 0 {
+            return Err("plugin closed stdout".to_string());
+        }
+        let v: Value = serde_json::from_str(&buf)
+            .map_err(|e| format!("decode: {e}\n  raw: {buf}"))?;
+        Ok(v)
+    }
+
+    fn next_id(&mut self) -> i64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}
+
+/// Parse annotations from a plugin's JSON-RPC response.
+fn parse_plugin_annotations(value: &Value) -> Result<SourceAnnotations, String> {
+    let arr = value
+        .get("annotations")
+        .and_then(|v| v.as_array())
+        .ok_or("expected `annotations` array in plugin response")?;
+
+    let mut annotations = Vec::new();
+    for item in arr {
+        let function_name = item
+            .get("function_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let kind = item
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let target_cid = item
+            .get("target_cid")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let range = parse_range(item.get("range"));
+
+        let kind = match kind {
+            "implement" => AnnotationKind::Implement {
+                target_cid: target_cid.clone().unwrap_or_default(),
+            },
+            "contract" => AnnotationKind::Contract,
+            "verify" => AnnotationKind::Verify,
+            _ => continue, // skip unknown kinds
+        };
+
+        annotations.push(Annotation {
+            function_name,
+            kind,
+            target_cid,
+            range,
+        });
+    }
+
+    Ok(SourceAnnotations { annotations })
+}
+
+fn parse_range(value: Option<&Value>) -> Range {
+    let default = Range {
+        start: Position { line: 0, character: 0 },
+        end: Position { line: 0, character: 0 },
+    };
+    let Some(v) = value else { return default };
+    let start = v.get("start").and_then(parse_position).unwrap_or(Position { line: 0, character: 0 });
+    let end = v.get("end").and_then(parse_position).unwrap_or(Position { line: 0, character: 0 });
+    Range { start, end }
+}
+
+fn parse_position(value: &Value) -> Option<Position> {
+    let line = value.get("line")?.as_u64()? as u32;
+    let character = value.get("character")?.as_u64()? as u32;
+    Some(Position { line, character })
+}
+
+/// Convenience: try to load a plugin for a language config.
+pub fn load_plugin(
+    project_root: &Path,
+    lang_config: &crate::config::LanguagePluginConfig,
+) -> Result<LanguagePlugin, String> {
+    if let Some(plugin_name) = &lang_config.plugin {
+        // Try manifest lookup first
+        if !plugin_name.contains('/') && !plugin_name.contains("\\") {
+            LanguagePlugin::spawn_by_name(project_root, plugin_name)
+        } else {
+            // Direct path or binary name
+            let cmd = vec![plugin_name.clone()];
+            LanguagePlugin::spawn_direct(&cmd, &lang_config.plugin_args, project_root)
+        }
+    } else {
+        Err(format!(
+            "language `{}` has no plugin configured",
+            lang_config.name
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- Rust peer of the LSP protocol spec (`protocol/specs/2026-04-30-lsp-protocol.md`, in v1.3.0 catalog).
- Language-agnostic LSP coordinator: built-in Rust parser plus external NDJSON-over-stdio plugins per `provekit-lsp-plugin/1`.
- Verification is delegated to a configurable JSON-RPC backend.

## What landed

| File | Role |
|---|---|
| `implementations/rust/provekit-lsp/src/main.rs` | tower-lsp server, document/annotation cache, diagnostics |
| `implementations/rust/provekit-lsp/src/config.rs` | `.provekit/config.toml` loader |
| `implementations/rust/provekit-lsp/src/parser.rs` | built-in Rust parser (`syn`-based) for `#[provekit::*]` attrs |
| `implementations/rust/provekit-lsp/src/plugin.rs` | JSON-RPC plugin host (`initialize`/`parse`/`shutdown`) |
| `implementations/rust/provekit-lsp/src/backend.rs` | JSON-RPC verifier client |
| `implementations/rust/Cargo.toml` | adds `provekit-lsp` to `[workspace] members` (single-line append) |
| `implementations/rust/Cargo.lock` | mechanical update for tower-lsp 0.20, lsp-types 0.94, tokio 1.43, dashmap 5 transitive set |

## Companion PRs

This PR is part of a four-way drop. The status matrix (`docs/per-language-status.md`) gained an LSP Plugin column across every row plus a new Zig row plus a Java uplift. Splitting that diff cleanly across the four PRs is busywork, so the entire matrix change lands here. Companion PRs reference it:

- Java kit -> `feat/java-kit`
- Zig kit -> `feat/zig-kit`
- LSP plugin scaffolds (cpp / csharp / go / rust / zig) -> `examples/lsp-plugins`

## Sanity

- `cargo` not installed on the cutter machine; CI's Rust job will be the canonical compile gate. Lockfile is copied verbatim from the author's working tree (the impl built locally there).
- Surface in `main.rs` matches the plugin-protocol description in `examples/lsp-plugins/README.md` (PR D): `initialize` / `parse` / `shutdown`, annotation kinds `implement` / `contract` / `verify`.
- `Cargo.toml` diff is exactly one line, the `provekit-lsp` workspace member entry. No version bumps, no dep changes elsewhere.

## Test plan

- [ ] CI Rust job: `cargo build --release -p provekit-lsp` succeeds.
- [ ] CI Rust job: `cargo test -p provekit-lsp` passes.
- [ ] Existing workspace builds remain green (the new member must not perturb other crates).