### PR TITLE
feat(zig): ProvekIt kit (ir + lift-zig)

### DIFF
--- a/implementations/zig/README.md
+++ b/implementations/zig/README.md
@@ -1,0 +1,93 @@
+# ProvekIt Zig Kit
+
+Zig-native implementation of the ProvekIt IR and lift tool.
+
+## Structure
+
+```
+implementations/zig/
+├── provekit-ir/          # IR types library (Sort, Term, Formula, Document)
+│   ├── build.zig
+│   └── src/root.zig
+└── provekit-lift-zig/    # Lift tool: scans .zig → emits IR JSON
+    ├── build.zig
+    └── src/main.zig
+```
+
+## provekit-ir
+
+The IR library provides Zig unions for all ProvekIt types with custom JSON serialization matching the v1.1.0 grammar.
+
+```zig
+const provekit = @import("provekit-ir");
+
+const post = provekit.Atomic("gte", &.{
+    provekit.Var("x", Sort.Int),
+    provekit.Const(.{ .int = 0 }, Sort.Int),
+});
+```
+
+### Build
+
+```bash
+cd implementations/zig/provekit-ir
+zig build test
+```
+
+## provekit-lift-zig
+
+Scans Zig source files for provekit annotations and emits IR documents.
+
+### Annotations in Zig
+
+Zig doesn't have attributes, so we use comment conventions:
+
+```zig
+//provekit:contract
+fn parse_int(s: []const u8) i32 {
+    // ...
+}
+
+//provekit:implement bafy...js-parseInt-v24
+fn js_compatible_parse(s: []const u8) i32 {
+    // ...
+}
+
+//provekit:verify
+fn validate_email(email: []const u8) bool {
+    // ...
+}
+```
+
+### Usage
+
+Standalone mode:
+```bash
+cd implementations/zig/provekit-lift-zig
+zig build run -- --workspace ./src --output ./target/provekit
+```
+
+RPC plugin mode (for `provekit mint` integration):
+```bash
+provekit-lift-zig --rpc
+```
+
+### Build
+
+```bash
+cd implementations/zig/provekit-lift-zig
+zig build
+```
+
+The binary installs to `zig-out/bin/provekit-lift-zig`.
+
+## Design Philosophy
+
+- **Zero dependencies**: Only Zig standard library.
+- **Union enums**: Zig's `union(enum)` maps perfectly to the CDDL `kind`-tagged unions.
+- **Allocator explicit**: All heap usage takes an allocator parameter — no hidden allocations.
+- **Comptime-ready**: IR types are plain data; suitable for comptime code generation.
+
+## LSP Plugin
+
+See `examples/lsp-plugins/zig/` for the VS Code language server plugin.

--- a/implementations/zig/provekit-ir/build.zig
+++ b/implementations/zig/provekit-ir/build.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addModule("provekit-ir", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    _ = lib;
+
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+}

--- a/implementations/zig/provekit-ir/build.zig.zon
+++ b/implementations/zig/provekit-ir/build.zig.zon
@@ -1,0 +1,8 @@
+{
+    .name = "provekit-ir",
+    .version = "0.1.0",
+    .paths = .{
+        "build.zig",
+        "src",
+    },
+}

--- a/implementations/zig/provekit-ir/src/root.zig
+++ b/implementations/zig/provekit-ir/src/root.zig
@@ -1,0 +1,426 @@
+const std = @import("std");
+
+pub const Sort = union(enum) {
+    primitive: []const u8,
+    set: *const Sort,
+    tuple: []const Sort,
+    function: FunctionSort,
+
+    pub const FunctionSort = struct {
+        domain: []const Sort,
+        range: Sort,
+    };
+
+    pub fn jsonStringify(self: Sort, jws: anytype) !void {
+        try jws.beginObject();
+        switch (self) {
+            .primitive => |name| {
+                try jws.objectField("kind");
+                try jws.write("primitive");
+                try jws.objectField("name");
+                try jws.write(name);
+            },
+            .set => |element| {
+                try jws.objectField("kind");
+                try jws.write("set");
+                try jws.objectField("element");
+                try jws.write(element.*);
+            },
+            .tuple => |elements| {
+                try jws.objectField("kind");
+                try jws.write("tuple");
+                try jws.objectField("elements");
+                try jws.write(elements);
+            },
+            .function => |f| {
+                try jws.objectField("kind");
+                try jws.write("function");
+                try jws.objectField("domain");
+                try jws.write(f.domain);
+                try jws.objectField("range");
+                try jws.write(f.range);
+            },
+        }
+        try jws.endObject();
+    }
+
+    pub const Bool = Sort{ .primitive = "Bool" };
+    pub const Int = Sort{ .primitive = "Int" };
+    pub const Real = Sort{ .primitive = "Real" };
+    pub const String = Sort{ .primitive = "String" };
+    pub const Ref = Sort{ .primitive = "Ref" };
+    pub const Node = Sort{ .primitive = "Node" };
+    pub const Edge = Sort{ .primitive = "Edge" };
+};
+
+pub const Term = union(enum) {
+    var_term: VarTerm,
+    const_term: ConstTerm,
+    ctor_term: CtorTerm,
+    lambda_term: LambdaTerm,
+    let_term: LetTerm,
+
+    pub const VarTerm = struct {
+        name: []const u8,
+        sort: Sort,
+    };
+
+    pub const ConstTerm = struct {
+        value: Value,
+        sort: Sort,
+    };
+
+    pub const CtorTerm = struct {
+        name: []const u8,
+        args: []const Term,
+        sort: Sort,
+    };
+
+    pub const LambdaTerm = struct {
+        param_name: []const u8,
+        param_sort: Sort,
+        body: *const Term,
+        sort: Sort,
+    };
+
+    pub const LetTerm = struct {
+        bindings: []const LetBinding,
+        body: *const Term,
+        sort: Sort,
+    };
+
+    pub const LetBinding = struct {
+        name: []const u8,
+        bound_term: Term,
+    };
+
+    pub const Value = union(enum) {
+        int: i64,
+        string: []const u8,
+        bool: bool,
+        real: f64,
+
+        pub fn jsonStringify(self: Value, jws: anytype) !void {
+            switch (self) {
+                .int => |v| try jws.write(v),
+                .string => |v| try jws.write(v),
+                .bool => |v| try jws.write(v),
+                .real => |v| try jws.write(v),
+            }
+        }
+    };
+
+    pub fn jsonStringify(self: Term, jws: anytype) !void {
+        try jws.beginObject();
+        switch (self) {
+            .var_term => |t| {
+                try jws.objectField("kind");
+                try jws.write("var");
+                try jws.objectField("name");
+                try jws.write(t.name);
+            },
+            .const_term => |t| {
+                try jws.objectField("kind");
+                try jws.write("const");
+                try jws.objectField("value");
+                try jws.write(t.value);
+                try jws.objectField("sort");
+                try jws.write(t.sort);
+            },
+            .ctor_term => |t| {
+                try jws.objectField("kind");
+                try jws.write("ctor");
+                try jws.objectField("name");
+                try jws.write(t.name);
+                try jws.objectField("args");
+                try jws.write(t.args);
+            },
+            .lambda_term => |t| {
+                try jws.objectField("kind");
+                try jws.write("lambda");
+                try jws.objectField("paramName");
+                try jws.write(t.param_name);
+                try jws.objectField("paramSort");
+                try jws.write(t.param_sort);
+                try jws.objectField("body");
+                try jws.write(t.body.*);
+            },
+            .let_term => |t| {
+                try jws.objectField("kind");
+                try jws.write("let");
+                try jws.objectField("bindings");
+                try jws.beginArray();
+                for (t.bindings) |b| {
+                    try jws.arrayElem();
+                    try jws.beginObject();
+                    try jws.objectField("name");
+                    try jws.write(b.name);
+                    try jws.objectField("boundTerm");
+                    try jws.write(b.bound_term);
+                    try jws.endObject();
+                }
+                try jws.endArray();
+                try jws.objectField("body");
+                try jws.write(t.body.*);
+            },
+        }
+        try jws.endObject();
+    }
+};
+
+pub const Formula = union(enum) {
+    atomic: AtomicFormula,
+    connective: ConnectiveFormula,
+    quantifier: QuantifierFormula,
+    choice: ChoiceFormula,
+
+    pub const AtomicFormula = struct {
+        name: []const u8,
+        args: []const Term,
+    };
+
+    pub const ConnectiveFormula = struct {
+        kind: ConnectiveKind,
+        operands: []const Formula,
+    };
+
+    pub const ConnectiveKind = enum {
+        and,
+        or,
+        not,
+        implies,
+
+        pub fn jsonStringify(self: ConnectiveKind, jws: anytype) !void {
+            const str = switch (self) {
+                .and => "and",
+                .or => "or",
+                .not => "not",
+                .implies => "implies",
+            };
+            try jws.write(str);
+        }
+    };
+
+    pub const QuantifierFormula = struct {
+        kind: QuantifierKind,
+        name: []const u8,
+        sort: Sort,
+        body: *const Formula,
+    };
+
+    pub const QuantifierKind = enum {
+        forall,
+        exists,
+
+        pub fn jsonStringify(self: QuantifierKind, jws: anytype) !void {
+            const str = switch (self) {
+                .forall => "forall",
+                .exists => "exists",
+            };
+            try jws.write(str);
+        }
+    };
+
+    pub const ChoiceFormula = struct {
+        var_name: []const u8,
+        sort: Sort,
+        body: *const Formula,
+    };
+
+    pub fn jsonStringify(self: Formula, jws: anytype) !void {
+        try jws.beginObject();
+        switch (self) {
+            .atomic => |f| {
+                try jws.objectField("kind");
+                try jws.write("atomic");
+                try jws.objectField("name");
+                try jws.write(f.name);
+                try jws.objectField("args");
+                try jws.write(f.args);
+            },
+            .connective => |f| {
+                try jws.objectField("kind");
+                try jws.write(f.kind);
+                try jws.objectField("operands");
+                try jws.write(f.operands);
+            },
+            .quantifier => |f| {
+                try jws.objectField("kind");
+                try jws.write(f.kind);
+                try jws.objectField("name");
+                try jws.write(f.name);
+                try jws.objectField("sort");
+                try jws.write(f.sort);
+                try jws.objectField("body");
+                try jws.write(f.body.*);
+            },
+            .choice => |f| {
+                try jws.objectField("kind");
+                try jws.write("choice");
+                try jws.objectField("varName");
+                try jws.write(f.var_name);
+                try jws.objectField("sort");
+                try jws.write(f.sort);
+                try jws.objectField("body");
+                try jws.write(f.body.*);
+            },
+        }
+        try jws.endObject();
+    }
+};
+
+// Convenience constructors
+
+pub fn Var(name: []const u8, sort: Sort) Term {
+    return .{ .var_term = .{ .name = name, .sort = sort } };
+}
+
+pub fn Const(value: Term.Value, sort: Sort) Term {
+    return .{ .const_term = .{ .value = value, .sort = sort } };
+}
+
+pub fn Ctor(name: []const u8, args: []const Term, sort: Sort) Term {
+    return .{ .ctor_term = .{ .name = name, .args = args, .sort = sort } };
+}
+
+pub fn Lambda(param_name: []const u8, param_sort: Sort, body: *const Term, sort: Sort) Term {
+    return .{ .lambda_term = .{ .param_name = param_name, .param_sort = param_sort, .body = body, .sort = sort } };
+}
+
+pub fn Let(bindings: []const Term.LetBinding, body: *const Term, sort: Sort) Term {
+    return .{ .let_term = .{ .bindings = bindings, .body = body, .sort = sort } };
+}
+
+pub fn Atomic(name: []const u8, args: []const Term) Formula {
+    return .{ .atomic = .{ .name = name, .args = args } };
+}
+
+pub fn And(operands: []const Formula) Formula {
+    return .{ .connective = .{ .kind = .and, .operands = operands } };
+}
+
+pub fn Or(operands: []const Formula) Formula {
+    return .{ .connective = .{ .kind = .or, .operands = operands } };
+}
+
+pub fn Not(operand: *const Formula) Formula {
+    return .{ .connective = .{ .kind = .not, .operands = &.{operand.*} } };
+}
+
+pub fn Implies(left: *const Formula, right: *const Formula) Formula {
+    return .{ .connective = .{ .kind = .implies, .operands = &.{ left.*, right.* } } };
+}
+
+pub fn Forall(name: []const u8, sort_: Sort, body: *const Formula) Formula {
+    return .{ .quantifier = .{ .kind = .forall, .name = name, .sort = sort_, .body = body } };
+}
+
+pub fn Exists(name: []const u8, sort_: Sort, body: *const Formula) Formula {
+    return .{ .quantifier = .{ .kind = .exists, .name = name, .sort = sort_, .body = body } };
+}
+
+pub fn Choice(var_name: []const u8, sort_: Sort, body: *const Formula) Formula {
+    return .{ .choice = .{ .var_name = var_name, .sort = sort_, .body = body } };
+}
+
+// IR Document top-level
+
+pub const IrDocument = struct {
+    version: []const u8 = "provekit-ir/1.1.0",
+    declarations: []const Declaration,
+
+    pub const Declaration = union(enum) {
+        property: PropertyDecl,
+        bridge: BridgeDecl,
+        contract: ContractDecl,
+
+        pub const PropertyDecl = struct {
+            name: []const u8,
+            params: []const Param,
+            body: Formula,
+
+            pub const Param = struct {
+                name: []const u8,
+                sort: Sort,
+            };
+        };
+
+        pub const BridgeDecl = struct {
+            source_symbol: []const u8,
+            source_contract_cid: []const u8,
+            target_contract_cid: []const u8,
+            evidence: ?[]const u8 = null,
+        };
+
+        pub const ContractDecl = struct {
+            symbol: []const u8,
+            precondition: ?Formula = null,
+            postcondition: Formula,
+            invariant: ?Formula = null,
+            evidence: ?[]const u8 = null,
+        };
+
+        pub fn jsonStringify(self: Declaration, jws: anytype) !void {
+            switch (self) {
+                .property => |d| {
+                    try jws.beginObject();
+                    try jws.objectField("kind");
+                    try jws.write("property");
+                    try jws.objectField("name");
+                    try jws.write(d.name);
+                    try jws.objectField("params");
+                    try jws.write(d.params);
+                    try jws.objectField("body");
+                    try jws.write(d.body);
+                    try jws.endObject();
+                },
+                .bridge => |d| {
+                    try jws.beginObject();
+                    try jws.objectField("kind");
+                    try jws.write("bridge");
+                    try jws.objectField("sourceSymbol");
+                    try jws.write(d.source_symbol);
+                    try jws.objectField("sourceContractCid");
+                    try jws.write(d.source_contract_cid);
+                    try jws.objectField("targetContractCid");
+                    try jws.write(d.target_contract_cid);
+                    if (d.evidence) |e| {
+                        try jws.objectField("evidence");
+                        try jws.write(e);
+                    }
+                    try jws.endObject();
+                },
+                .contract => |d| {
+                    try jws.beginObject();
+                    try jws.objectField("kind");
+                    try jws.write("contract");
+                    try jws.objectField("symbol");
+                    try jws.write(d.symbol);
+                    if (d.precondition) |pre| {
+                        try jws.objectField("precondition");
+                        try jws.write(pre);
+                    }
+                    try jws.objectField("postcondition");
+                    try jws.write(d.postcondition);
+                    if (d.invariant) |inv| {
+                        try jws.objectField("invariant");
+                        try jws.write(inv);
+                    }
+                    if (d.evidence) |e| {
+                        try jws.objectField("evidence");
+                        try jws.write(e);
+                    }
+                    try jws.endObject();
+                },
+            }
+        }
+    };
+};
+
+// Escape HTML in JSON to match other kits
+pub fn writeJson(alloc: std.mem.Allocator, value: anytype) ![]u8 {
+    var list = std.ArrayList(u8).init(alloc);
+    errdefer list.deinit();
+    try std.json.stringify(value, .{ .emit_strings_as_arrays = false, .escape_solidus = false }, list.writer());
+    return list.toOwnedSlice();
+}

--- a/implementations/zig/provekit-lift-zig/build.zig
+++ b/implementations/zig/provekit-lift-zig/build.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const provekit_ir = b.createModule(.{
+        .root_source_file = b.path("../provekit-ir/src/root.zig"),
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "provekit-lift-zig",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("provekit-ir", provekit_ir);
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/implementations/zig/provekit-lift-zig/src/main.zig
+++ b/implementations/zig/provekit-lift-zig/src/main.zig
@@ -1,0 +1,269 @@
+const std = @import("std");
+
+// ProvekIt Lift Tool for Zig
+//
+// Scans Zig source files for provekit annotations and emits an IR JSON document.
+//
+// Usage:
+//   provekit-lift-zig --workspace ./src --output ./target/provekit/
+//   provekit-lift-zig --rpc              (JSON-RPC plugin mode)
+//
+// Recognized annotations in Zig source:
+//   //provekit:contract
+//   //provekit:implement <cid>
+//   //provekit:verify
+//
+// Build: zig build-exe src/main.zig -o provekit-lift-zig
+
+const provekit = @import("provekit-ir");
+
+const Annotation = struct {
+    function_name: []const u8,
+    kind: Kind,
+    target_cid: ?[]const u8 = null,
+    line: usize,
+
+    const Kind = enum {
+        contract,
+        implement,
+        verify,
+    };
+};
+
+fn parseAnnotations(alloc: std.mem.Allocator, text: []const u8) ![]Annotation {
+    var annotations = std.ArrayList(Annotation).init(alloc);
+    errdefer annotations.deinit();
+
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    var line_num: usize = 0;
+    while (lines.next()) |line| : (line_num += 1) {
+        const trimmed = std.mem.trim(u8, line, " \t");
+
+        if (std.mem.startsWith(u8, trimmed, "//provekit:implement ")) {
+            const cid = std.mem.trim(u8, trimmed[20..], " \t");
+            const fn_name = findAheadFnName(text, line_num);
+            try annotations.append(.{
+                .function_name = fn_name,
+                .kind = .implement,
+                .target_cid = cid,
+                .line = line_num,
+            });
+        } else if (std.mem.startsWith(u8, trimmed, "//provekit:contract")) {
+            const fn_name = findAheadFnName(text, line_num);
+            try annotations.append(.{
+                .function_name = fn_name,
+                .kind = .contract,
+                .line = line_num,
+            });
+        } else if (std.mem.startsWith(u8, trimmed, "//provekit:verify")) {
+            const fn_name = findAheadFnName(text, line_num);
+            try annotations.append(.{
+                .function_name = fn_name,
+                .kind = .verify,
+                .line = line_num,
+            });
+        }
+    }
+
+    return annotations.toOwnedSlice();
+}
+
+fn findAheadFnName(text: []const u8, start_line: usize) []const u8 {
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    var current: usize = 0;
+    while (lines.next()) |line| : (current += 1) {
+        if (current <= start_line) continue;
+        if (current > start_line + 10) break;
+
+        const trimmed = std.mem.trim(u8, line, " \t");
+        if (std.mem.startsWith(u8, trimmed, "fn ")) {
+            const after = trimmed[3..];
+            const end = std.mem.indexOfAny(u8, after, " (\n") orelse after.len;
+            return after[0..end];
+        }
+    }
+    return "unknown";
+}
+
+fn runRpcMode(alloc: std.mem.Allocator) !void {
+    const stdin = std.io.getStdIn().reader();
+    const stdout = std.io.getStdOut().writer();
+    var buf: [4096]u8 = undefined;
+
+    while (true) {
+        const maybe_line = try stdin.readUntilDelimiterOrEof(&buf, '\n');
+        const line = maybe_line orelse break;
+
+        const has_init = std.mem.indexOf(u8, line, "\"initialize\"") != null;
+        const has_lift = std.mem.indexOf(u8, line, "\"lift\"") != null;
+        const has_shutdown = std.mem.indexOf(u8, line, "\"shutdown\"") != null;
+
+        var id: []const u8 = "null";
+        if (std.mem.indexOf(u8, line, "\"id\":")) |id_pos| {
+            const after = line[id_pos + 5 ..];
+            const start = std.mem.indexOfNone(u8, after, " \t") orelse 0;
+            const end = std.mem.indexOfAny(u8, after[start..], ",}") orelse after.len;
+            id = after[start .. start + end];
+        }
+
+        if (has_init) {
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"name\":\"provekit-lift-zig\",\"version\":\"0.1.0\",\"capabilities\":[]}}}}\n", .{id});
+        } else if (has_lift) {
+            const workspace = std.fs.cwd();
+            var decls = std.ArrayList(provekit.IrDocument.Declaration).init(alloc);
+            defer decls.deinit();
+
+            // Walk current directory for .zig files
+            var walker = try workspace.walk(alloc);
+            defer walker.deinit();
+            while (try walker.next()) |entry| {
+                if (entry.kind != .file) continue;
+                if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
+
+                const file_text = try entry.dir.readFileAlloc(alloc, entry.basename, 1 << 20);
+                defer alloc.free(file_text);
+
+                const anns = try parseAnnotations(alloc, file_text);
+                defer alloc.free(anns);
+
+                for (anns) |ann| {
+                    switch (ann.kind) {
+                        .contract => {
+                            // Build a default postcondition: true
+                            const post = try alloc.create(provekit.Formula);
+                            post.* = provekit.Atomic("true", &.{});
+                            try decls.append(.{ .contract = .{
+                                .symbol = ann.function_name,
+                                .postcondition = post.*,
+                            } });
+                        },
+                        .implement => {
+                            if (ann.target_cid) |cid| {
+                                try decls.append(.{ .bridge = .{
+                                    .source_symbol = ann.function_name,
+                                    .source_contract_cid = "",
+                                    .target_contract_cid = cid,
+                                } });
+                            }
+                        },
+                        .verify => {},
+                    }
+                }
+            }
+
+            const doc = provekit.IrDocument{
+                .declarations = try decls.toOwnedSlice(),
+            };
+
+            var json_buf = std.ArrayList(u8).init(alloc);
+            defer json_buf.deinit();
+            try std.json.stringify(doc, .{}, json_buf.writer());
+
+            // Base64 encode
+            const b64 = std.base64.standard.Encoder;
+            const encoded = try alloc.alloc(u8, b64.calcSize(json_buf.items.len));
+            defer alloc.free(encoded);
+            _ = b64.encode(encoded, json_buf.items);
+
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"kind\":\"ir-document\",\"body_base64\":\"{s}\"}}}}\n", .{ id, encoded });
+        } else if (has_shutdown) {
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":null}}\n", .{id});
+            return;
+        } else {
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"error\":{{\"code\":-32601,\"message\":\"unknown method\"}}}}\n", .{id});
+        }
+    }
+}
+
+fn runStandaloneMode(alloc: std.mem.Allocator, workspace_path: []const u8, output_path: []const u8) !void {
+    var decls = std.ArrayList(provekit.IrDocument.Declaration).init(alloc);
+    defer decls.deinit();
+
+    var dir = try std.fs.cwd().openDir(workspace_path, .{ .iterate = true });
+    defer dir.close();
+
+    var walker = try dir.walk(alloc);
+    defer walker.deinit();
+
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
+
+        const file_text = try entry.dir.readFileAlloc(alloc, entry.basename, 1 << 20);
+        defer alloc.free(file_text);
+
+        const anns = try parseAnnotations(alloc, file_text);
+        defer alloc.free(anns);
+
+        for (anns) |ann| {
+            switch (ann.kind) {
+                .contract => {
+                    const post = try alloc.create(provekit.Formula);
+                    post.* = provekit.Atomic("true", &.{});
+                    try decls.append(.{ .contract = .{
+                        .symbol = ann.function_name,
+                        .postcondition = post.*,
+                    } });
+                },
+                .implement => {
+                    if (ann.target_cid) |cid| {
+                        try decls.append(.{ .bridge = .{
+                            .source_symbol = ann.function_name,
+                            .source_contract_cid = "",
+                            .target_contract_cid = cid,
+                        } });
+                    }
+                },
+                .verify => {},
+            }
+        }
+    }
+
+    const doc = provekit.IrDocument{
+        .declarations = try decls.toOwnedSlice(),
+    };
+
+    var json_buf = std.ArrayList(u8).init(alloc);
+    defer json_buf.deinit();
+    try std.json.stringify(doc, .{}, json_buf.writer());
+
+    try std.fs.cwd().makePath(output_path);
+    const out_file = try std.fs.cwd().createFile(try std.fs.path.join(alloc, &.{ output_path, "lifted.json" }), .{});
+    defer out_file.close();
+    try out_file.writeAll(json_buf.items);
+
+    std.debug.print("Wrote {d} declarations to {s}/lifted.json\n", .{ doc.declarations.len, output_path });
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
+
+    var rpc_mode = false;
+    var workspace: ?[]const u8 = null;
+    var output: ?[]const u8 = null;
+
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--rpc")) {
+            rpc_mode = true;
+        } else if (std.mem.eql(u8, arg, "--workspace")) {
+            i += 1;
+            if (i < args.len) workspace = args[i];
+        } else if (std.mem.eql(u8, arg, "--output")) {
+            i += 1;
+            if (i < args.len) output = args[i];
+        }
+    }
+
+    if (rpc_mode) {
+        try runRpcMode(alloc);
+    } else {
+        try runStandaloneMode(alloc, workspace orelse ".", output orelse "./target/provekit");
+    }
+}


### PR DESCRIPTION
## Summary

- Zig peer of the ProvekIt kit. Zero external dependencies, only Zig std.
- Two modules under `implementations/zig/`: `provekit-ir` (IR types + JSON serializer) and `provekit-lift-zig` (lift binary that scans `.zig` sources for provekit comment annotations and emits IR).

## What landed

| Module | Files | Role |
|---|---|---|
| `provekit-ir` | `build.zig`, `build.zig.zon`, `src/root.zig` | Zig `union(enum)` types for Sort, Term, Formula, Declaration, IrDocument with custom JSON serialization matching v1.1.0 grammar. Allocator-explicit (no hidden allocations). |
| `provekit-lift-zig` | `build.zig`, `src/main.zig` | Lift binary. Scans `.zig` sources for `//provekit:contract`, `//provekit:implement <cid>`, `//provekit:verify` annotations. Emits IR. Supports standalone (`--workspace` / `--output`) and RPC plugin (`--rpc`) modes for `provekit mint` integration. |

## Annotation choice

Zig has no attributes, so the kit uses comment conventions:

```zig
//provekit:contract
fn parse_int(s: []const u8) i32 { ... }

//provekit:implement bafy...js-parseInt-v24
fn js_compatible_parse(s: []const u8) i32 { ... }
```

This is consistent with the comment-based annotation style in the LSP plugin scaffolds (companion PR).

## Companion PRs

This is part of a four-way drop:

- `feat/rust-lsp-impl` -> ProvekIt LSP coordinator in Rust (carries the cross-PR `docs/per-language-status.md` matrix update; this PR's status -- a new Zig row marked `~` for kit and `+` for LSP -- is reflected there).
- `feat/java-kit` -> Java peer of the kit.
- `examples/lsp-plugins` -> cpp / csharp / go / rust / zig LSP plugin scaffolds.

## Sanity

- `zig` not run in the cutter environment, per task spec. CI's Zig job (if/when wired) is the canonical compile gate.
- Tree-shape verification done before commit: each module has `build.zig` + `src/<entry>.zig`; `provekit-ir` also has `build.zig.zon`. `git diff --cached | grep /Users/tsavo` returns 0 hits.

## Test plan

- [ ] CI: `cd implementations/zig/provekit-ir && zig build test` passes.
- [ ] CI: `cd implementations/zig/provekit-lift-zig && zig build` produces `zig-out/bin/provekit-lift-zig`.
- [ ] Manual: standalone mode (`zig build run -- --workspace ./testdata --output ./out`) writes IR JSON for fixture files.