### PR TITLE
examples: LSP plugin scaffolds (cpp, csharp, go, rust, zig)

### DIFF
--- a/examples/lsp-plugins/README.md
+++ b/examples/lsp-plugins/README.md
@@ -1,0 +1,195 @@
+# ProvekIt LSP Language Plugins
+
+Any language. Any binary. One RPC protocol. Red underlines in VS Code.
+
+## How it works
+
+1. You write a binary in **any language** that speaks NDJSON-over-stdio.
+2. The binary handles three JSON-RPC methods: `initialize`, `parse`, `shutdown`.
+3. You add one line to `.provekit/config.toml` pointing at your binary.
+4. `provekit-lsp` spawns it, sends source files, gets back contract annotations, verifies them, and paints red underlines in the IDE.
+
+That's it. No recompilation of the main LSP server. No Rust required. Your plugin can be written in Go, C#, C++, Zig, Python, JavaScript, OCaml — whatever parses your source language best.
+
+## Plugin Protocol (`provekit-lsp-plugin/1`)
+
+The main LSP server spawns your binary with `--rpc` appended, then speaks line-delimited JSON-RPC over stdin/stdout.
+
+### 1. `initialize`
+
+**Request:**
+```json
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"client":{"name":"provekit-lsp","version":"0.1.0"},"protocol_version":"provekit-lsp-plugin/1"}}
+```
+
+**Response:**
+```json
+{"jsonrpc":"2.0","id":1,"result":{"name":"provekit-lsp-go","version":"0.1.0","capabilities":[]}}
+```
+
+### 2. `parse`
+
+**Request:**
+```json
+{"jsonrpc":"2.0","id":2,"method":"parse","params":{"uri":"file:///project/src/lib.go","text":"package main\n..."}}
+```
+
+**Response:**
+```json
+{"jsonrpc":"2.0","id":2,"result":{"annotations":[
+  {"function_name":"ParseInt","kind":"implement","target_cid":"bafy...js-parseInt-v24","range":{"start":{"line":5,"character":0},"end":{"line":10,"character":1}}},
+  {"function_name":"ValidateEmail","kind":"contract","range":{"start":{"line":15,"character":0},"end":{"line":20,"character":1}}}
+]}}
+```
+
+Annotation kinds:
+- `"implement"` — function bound to a contract CID. Must include `target_cid`.
+- `"contract"` — function declares its own contract.
+- `"verify"` — function marked for verification.
+
+### 3. `shutdown`
+
+**Request:**
+```json
+{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+```
+
+**Response:**
+```json
+{"jsonrpc":"2.0","id":3,"result":null}
+```
+
+After responding, the plugin should exit cleanly.
+
+## Configuring a plugin
+
+### Option A: Direct binary in `.provekit/config.toml`
+
+```toml
+[server]
+backend = "provekit"
+
+[[language]]
+name = "go"
+extensions = [".go"]
+plugin = "provekit-lsp-go"
+```
+
+The plugin binary must be in `PATH`.
+
+### Option B: Plugin manifest (supports args, working dir)
+
+Create `.provekit/lsp/go/manifest.toml`:
+
+```toml
+name = "provekit-lsp-go"
+command = ["provekit-lsp-go"]
+# optional:
+# working_dir = "./subproject"
+```
+
+Then reference by name in `.provekit/config.toml`:
+
+```toml
+[[language]]
+name = "go"
+extensions = [".go"]
+plugin = "go"
+```
+
+Manifests are also searched in `~/.config/provekit/lsp/<name>/manifest.toml` for user-global plugins.
+
+### Option C: Built-in parser (Rust only, for now)
+
+```toml
+[[language]]
+name = "rust"
+extensions = [".rs"]
+parser = "builtin:rust"
+```
+
+## Examples in this directory
+
+| Language | File | Build command |
+|---|---|---|
+| Rust | `rust/src/main.rs` | `cargo build --release` |
+| Go | `go/main.go` | `go build -o provekit-lsp-go main.go` |
+| C# | `csharp/Program.cs` | `dotnet publish -c Release` |
+| C++ | `cpp/main.cpp` | `g++ -std=c++17 -o provekit-lsp-cpp main.cpp` |
+| Zig | `zig/main.zig` | `zig build-exe main.zig -o provekit-lsp-zig` |
+
+Each example is ~100-150 lines, zero dependencies (or minimal stdlib-only deps), and implements the full plugin protocol.
+
+## Source annotation conventions per language
+
+Plugins should detect whatever syntax makes sense for the host language. There is no mandated syntax — the plugin owns the surface. Common patterns:
+
+**Go:**
+```go
+//provekit:implement bafy...js-parseInt-v24
+func ParseInt(s string) int { ... }
+```
+
+**C#:**
+```csharp
+//provekit:implement bafy...js-parseInt-v24
+public int ParseInt(string s) { ... }
+```
+
+**C++:**
+```cpp
+// provekit:implement bafy...js-parseInt-v24
+int parse_int(const std::string& s) { ... }
+```
+
+**Zig:**
+```zig
+//provekit:implement bafy...js-parseInt-v24
+fn parseInt(s: []const u8) i32 { ... }
+```
+
+**Rust** (built-in parser uses attributes):
+```rust
+#[provekit::implement(target = "bafy...js-parseInt-v24")]
+fn parse_int(s: &str) -> i32 { ... }
+```
+
+## Why this architecture?
+
+- **Native parsers:** A Go plugin uses `go/ast`. A C# plugin uses Roslyn. A Python plugin uses `ast`. Each uses the best parser for its language.
+- **No lock-in:** The main LSP server is just a coordinator. If you don't like it, write your own. The plugin protocol is the boundary.
+- **Language communities own their plugins:** The Go team maintains the Go plugin. The Zig team maintains the Zig plugin. ProvekIt just verifies the IR.
+- **Zero-downtime addition:** Add a new language without restarting the main LSP server. Just edit `config.toml` and reload the window.
+
+## Minimal viable plugin
+
+The smallest possible plugin, in Python:
+
+```python
+#!/usr/bin/env python3
+import sys, json
+
+if "--rpc" not in sys.argv:
+    sys.exit("Usage: plugin.py --rpc")
+
+for line in sys.stdin:
+    req = json.loads(line)
+    id = req.get("id")
+    method = req.get("method", "")
+
+    if method == "initialize":
+        print(json.dumps({"jsonrpc": "2.0", "id": id, "result": {"name": "my-plugin", "version": "0.1.0"}}), flush=True)
+    elif method == "parse":
+        text = req["params"]["text"]
+        annotations = []
+        for i, line_text in enumerate(text.split("\n")):
+            if "#provekit:implement" in line_text:
+                cid = line_text.split()[-1]
+                annotations.append({"function_name": "foo", "kind": "implement", "target_cid": cid, "range": {"start": {"line": i, "character": 0}, "end": {"line": i+1, "character": 0}}})
+        print(json.dumps({"jsonrpc": "2.0", "id": id, "result": {"annotations": annotations}}), flush=True)
+    elif method == "shutdown":
+        print(json.dumps({"jsonrpc": "2.0", "id": id, "result": None}), flush=True)
+        break
+```
+
+That's it. 25 lines. Add it to `config.toml` and you have contract tracking in VS Code for your language.

--- a/examples/lsp-plugins/cpp/main.cpp
+++ b/examples/lsp-plugins/cpp/main.cpp
@@ -1,0 +1,210 @@
+// ProvekIt LSP Language Plugin — C++
+//
+// A standalone binary that speaks provekit-lsp-plugin/1 over stdio.
+// Parses C++ source files and extracts provekit annotations.
+//
+// Usage: ./provekit-lsp-cpp --rpc
+//
+// To use this plugin, add to `.provekit/config.toml`:
+//   [[language]]
+//   name = "cpp"
+//   extensions = [".cpp", ".cc", ".h", ".hpp"]
+//   plugin = "provekit-lsp-cpp"
+//
+// Build: g++ -std=c++17 -o provekit-lsp-cpp main.cpp
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <regex>
+#include <optional>
+#include <sstream>
+
+struct Position {
+    uint32_t line;
+    uint32_t character;
+};
+
+struct Range {
+    Position start;
+    Position end;
+};
+
+struct Annotation {
+    std::string function_name;
+    std::string kind;
+    std::optional<std::string> target_cid;
+    Range range;
+};
+
+std::string escape_json(const std::string& s) {
+    std::string out;
+    for (char c : s) {
+        switch (c) {
+            case '"': out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\b': out += "\\b"; break;
+            case '\f': out += "\\f"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default: out += c; break;
+        }
+    }
+    return out;
+}
+
+std::string annotation_to_json(const Annotation& a) {
+    std::string json = "{";
+    json += "\"function_name\":\"" + escape_json(a.function_name) + "\",";
+    json += "\"kind\":\"" + escape_json(a.kind) + "\",";
+    if (a.target_cid.has_value()) {
+        json += "\"target_cid\":\"" + escape_json(a.target_cid.value()) + "\",";
+    }
+    json += "\"range\":{";
+    json += "\"start\":{\"line\":" + std::to_string(a.range.start.line) + ",\"character\":" + std::to_string(a.range.start.character) + "},";
+    json += "\"end\":{\"line\":" + std::to_string(a.range.end.line) + ",\"character\":" + std::to_string(a.range.end.character) + "}";
+    json += "}}";
+    return json;
+}
+
+std::vector<std::string> split_lines(const std::string& text) {
+    std::vector<std::string> lines;
+    size_t start = 0;
+    size_t end = text.find('\n');
+    while (end != std::string::npos) {
+        lines.push_back(text.substr(start, end - start));
+        start = end + 1;
+        end = text.find('\n', start);
+    }
+    lines.push_back(text.substr(start));
+    return lines;
+}
+
+std::string find_ahead(const std::vector<std::string>& lines, size_t start, const std::regex& re) {
+    std::smatch match;
+    for (size_t j = start + 1; j < lines.size() && j < start + 10; ++j) {
+        if (std::regex_search(lines[j], match, re)) {
+            return match[1].str();
+        }
+    }
+    return "unknown";
+}
+
+std::vector<Annotation> parse_cpp(const std::string& text) {
+    std::vector<Annotation> annotations;
+    auto lines = split_lines(text);
+
+    std::regex re_impl(R"(//\s*provekit:implement\s+([\w-]+))");
+    std::regex re_contract(R"(//\s*provekit:contract)");
+    std::regex re_verify(R"(//\s*provekit:verify)");
+    std::regex re_fn(R"(\b(?:void|int|auto|bool|string|double|float|\w+)\s+(\w+)\s*\()");
+
+    for (size_t i = 0; i < lines.size(); ++i) {
+        const auto& line = lines[i];
+        std::smatch match;
+
+        if (std::regex_search(line, match, re_impl)) {
+            std::string cid = match[1].str();
+            std::string fn_name = find_ahead(lines, i, re_fn);
+            Annotation a;
+            a.function_name = fn_name;
+            a.kind = "implement";
+            a.target_cid = cid;
+            a.range = {{(uint32_t)i, 0}, {(uint32_t)(i + 1), 0}};
+            annotations.push_back(a);
+        }
+
+        if (std::regex_search(line, match, re_contract)) {
+            std::string fn_name = find_ahead(lines, i, re_fn);
+            Annotation a;
+            a.function_name = fn_name;
+            a.kind = "contract";
+            a.target_cid = std::nullopt;
+            a.range = {{(uint32_t)i, 0}, {(uint32_t)(i + 1), 0}};
+            annotations.push_back(a);
+        }
+
+        if (std::regex_search(line, match, re_verify)) {
+            std::string fn_name = find_ahead(lines, i, re_fn);
+            Annotation a;
+            a.function_name = fn_name;
+            a.kind = "verify";
+            a.target_cid = std::nullopt;
+            a.range = {{(uint32_t)i, 0}, {(uint32_t)(i + 1), 0}};
+            annotations.push_back(a);
+        }
+    }
+
+    return annotations;
+}
+
+int main(int argc, char** argv) {
+    bool rpc_mode = false;
+    for (int i = 1; i < argc; ++i) {
+        if (std::string(argv[i]) == "--rpc") {
+            rpc_mode = true;
+            break;
+        }
+    }
+
+    if (!rpc_mode) {
+        std::cerr << "Usage: provekit-lsp-cpp --rpc" << std::endl;
+        return 1;
+    }
+
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        std::string method;
+        std::string id = "null";
+
+        size_t method_pos = line.find("\"method\"");
+        if (method_pos != std::string::npos) {
+            size_t quote = line.find('"', method_pos + 10);
+            if (quote != std::string::npos) {
+                size_t end_quote = line.find('"', quote + 1);
+                method = line.substr(quote + 1, end_quote - quote - 1);
+            }
+        }
+
+        size_t id_pos = line.find("\"id\"");
+        if (id_pos != std::string::npos) {
+            size_t colon = line.find(':', id_pos + 4);
+            if (colon != std::string::npos) {
+                size_t comma = line.find(',', colon + 1);
+                size_t end = (comma != std::string::npos) ? comma : line.find('}', colon + 1);
+                id = line.substr(colon + 1, end - colon - 1);
+                size_t start = id.find_first_not_of(" \t");
+                if (start != std::string::npos) id = id.substr(start);
+            }
+        }
+
+        if (method == "initialize") {
+            std::cout << "{\"jsonrpc\":\"2.0\",\"id\":" << id << ",\"result\":{\"name\":\"provekit-lsp-cpp\",\"version\":\"0.1.0\",\"capabilities\":[]}}" << std::endl;
+        } else if (method == "parse") {
+            size_t text_pos = line.find("\"text\"");
+            std::string text;
+            if (text_pos != std::string::npos) {
+                size_t quote = line.find('"', text_pos + 8);
+                if (quote != std::string::npos) {
+                    size_t end_quote = line.find('"', quote + 1);
+                    text = line.substr(quote + 1, end_quote - quote - 1);
+                }
+            }
+            auto annotations = parse_cpp(text);
+            std::cout << "{\"jsonrpc\":\"2.0\",\"id\":" << id << ",\"result\":{\"annotations\":[";
+            for (size_t i = 0; i < annotations.size(); ++i) {
+                if (i > 0) std::cout << ",";
+                std::cout << annotation_to_json(annotations[i]);
+            }
+            std::cout << "]}}" << std::endl;
+        } else if (method == "shutdown") {
+            std::cout << "{\"jsonrpc\":\"2.0\",\"id\":" << id << ",\"result\":null}" << std::endl;
+            return 0;
+        } else {
+            std::cout << "{\"jsonrpc\":\"2.0\",\"id\":" << id << ",\"error\":{\"code\":-32601,\"message\":\"unknown method: " << method << "\"}}" << std::endl;
+        }
+    }
+
+    return 0;
+}

--- a/examples/lsp-plugins/csharp/Program.cs
+++ b/examples/lsp-plugins/csharp/Program.cs
@@ -1,0 +1,154 @@
+// ProvekIt LSP Language Plugin — C#
+//
+// A standalone binary that speaks provekit-lsp-plugin/1 over stdio.
+// Parses C# source files and extracts provekit annotations.
+//
+// Usage: dotnet run -- --rpc
+//
+// To use this plugin, add to `.provekit/config.toml`:
+//   [[language]]
+//   name = "csharp"
+//   extensions = [".cs"]
+//   plugin = "provekit-lsp-csharp"
+//
+// Build: dotnet publish -c Release -o ./out
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace ProvekitLspCSharp;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        if (!args.Contains("--rpc"))
+        {
+            Console.Error.WriteLine("Usage: provekit-lsp-csharp --rpc");
+            Environment.Exit(1);
+        }
+
+        var reImpl = new Regex(@"//\s*provekit:implement\s+([\w-]+)");
+        var reContract = new Regex(@"//\s*provekit:contract");
+        var reVerify = new Regex(@"//\s*provekit:verify");
+        var reFn = new Regex(@"\b(?:public|private|protected|internal|static|\s)+\s*[\w<>\[\]]+\s+(\w+)\s*\(");
+
+        var stdin = Console.In;
+        var stdout = Console.Out;
+
+        while (true)
+        {
+            var line = stdin.ReadLine();
+            if (line == null) break;
+
+            JsonElement req;
+            try
+            {
+                req = JsonDocument.Parse(line).RootElement;
+            }
+            catch (Exception ex)
+            {
+                WriteResp(stdout, new { jsonrpc = "2.0", id = (object?)null, error = new { code = -32700, message = $"parse error: {ex.Message}" } });
+                continue;
+            }
+
+            var id = req.TryGetProperty("id", out var idProp) ? (object?)idProp : null;
+            var method = req.GetProperty("method").GetString() ?? "";
+
+            switch (method)
+            {
+                case "initialize":
+                    WriteResp(stdout, new { jsonrpc = "2.0", id, result = new { name = "provekit-lsp-csharp", version = "0.1.0", capabilities = Array.Empty<string>() } });
+                    break;
+
+                case "parse":
+                    var text = req.GetProperty("params").GetProperty("text").GetString() ?? "";
+                    var annotations = ParseCs(text, reImpl, reContract, reVerify, reFn);
+                    WriteResp(stdout, new { jsonrpc = "2.0", id, result = new { annotations } });
+                    break;
+
+                case "shutdown":
+                    WriteResp(stdout, new { jsonrpc = "2.0", id, result = (object?)null });
+                    return;
+
+                default:
+                    WriteResp(stdout, new { jsonrpc = "2.0", id, error = new { code = -32601, message = $"unknown method: {method}" } });
+                    break;
+            }
+        }
+    }
+
+    static void WriteResp(TextWriter writer, object resp)
+    {
+        writer.WriteLine(JsonSerializer.Serialize(resp));
+        writer.Flush();
+    }
+
+    static List<Annotation> ParseCs(string text, Regex reImpl, Regex reContract, Regex reVerify, Regex reFn)
+    {
+        var annotations = new List<Annotation>();
+        var lines = text.Split('\n');
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+
+            var implMatch = reImpl.Match(line);
+            if (implMatch.Success)
+            {
+                var cid = implMatch.Groups[1].Value;
+                var fnName = FindAhead(lines, i, reFn);
+                annotations.Add(new Annotation { FunctionName = fnName, Kind = "implement", TargetCID = cid, Range = new Range { Start = new Position { Line = (uint)i, Character = 0 }, End = new Position { Line = (uint)(i + 1), Character = 0 } } });
+            }
+
+            if (reContract.IsMatch(line))
+            {
+                var fnName = FindAhead(lines, i, reFn);
+                annotations.Add(new Annotation { FunctionName = fnName, Kind = "contract", Range = new Range { Start = new Position { Line = (uint)i, Character = 0 }, End = new Position { Line = (uint)(i + 1), Character = 0 } } });
+            }
+
+            if (reVerify.IsMatch(line))
+            {
+                var fnName = FindAhead(lines, i, reFn);
+                annotations.Add(new Annotation { FunctionName = fnName, Kind = "verify", Range = new Range { Start = new Position { Line = (uint)i, Character = 0 }, End = new Position { Line = (uint)(i + 1), Character = 0 } } });
+            }
+        }
+
+        return annotations;
+    }
+
+    static string FindAhead(string[] lines, int start, Regex re)
+    {
+        for (int j = start + 1; j < lines.Length && j < start + 10; j++)
+        {
+            var m = re.Match(lines[j]);
+            if (m.Success) return m.Groups[1].Value;
+        }
+        return "unknown";
+    }
+}
+
+class Annotation
+{
+    public string FunctionName { get; set; } = "";
+    public string Kind { get; set; } = "";
+    public string? TargetCID { get; set; }
+    public Range Range { get; set; } = new();
+}
+
+class Range
+{
+    public Position Start { get; set; } = new();
+    public Position End { get; set; } = new();
+}
+
+class Position
+{
+    public uint Line { get; set; }
+    public uint Character { get; set; }
+}

--- a/examples/lsp-plugins/go/main.go
+++ b/examples/lsp-plugins/go/main.go
@@ -1,0 +1,200 @@
+// ProvekIt LSP Language Plugin — Go
+//
+// A standalone binary that speaks provekit-lsp-plugin/1 over stdio.
+// Parses Go source files and extracts provekit annotations.
+//
+// Usage: go run main.go --rpc
+//
+// To use this plugin, add to `.provekit/config.toml`:
+//   [[language]]
+//   name = "go"
+//   extensions = [".go"]
+//   plugin = "provekit-lsp-go"
+//
+// Build: go build -o provekit-lsp-go main.go
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type Request struct {
+	Jsonrpc string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type Response struct {
+	Jsonrpc string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *RpcError   `json:"error,omitempty"`
+}
+
+type RpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type ParseParams struct {
+	URI  string `json:"uri"`
+	Text string `json:"text"`
+}
+
+type Annotation struct {
+	FunctionName string  `json:"function_name"`
+	Kind         string  `json:"kind"`
+	TargetCID    *string `json:"target_cid,omitempty"`
+	Range        Range   `json:"range"`
+}
+
+type Range struct {
+	Start Position `json:"start"`
+	End   Position `json:"end"`
+}
+
+type Position struct {
+	Line      uint32 `json:"line"`
+	Character uint32 `json:"character"`
+}
+
+func main() {
+	var rpcMode bool
+	for _, arg := range os.Args[1:] {
+		if arg == "--rpc" {
+			rpcMode = true
+		}
+	}
+	if !rpcMode {
+		fmt.Fprintln(os.Stderr, "Usage: provekit-lsp-go --rpc")
+		os.Exit(1)
+	}
+
+	reImpl := regexp.MustCompile(`//provekit:implement\s+([\w-]+)`)
+	reContract := regexp.MustCompile(`//provekit:contract`)
+	reVerify := regexp.MustCompile(`//provekit:verify`)
+	reFn := regexp.MustCompile(`^func\s+(?:\([^)]+\)\s+)?(\w+)`)
+
+	scanner := bufio.NewScanner(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		var req Request
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			resp := Response{Jsonrpc: "2.0", ID: nil, Error: &RpcError{Code: -32700, Message: "parse error: " + err.Error()}}
+			writeResp(writer, resp)
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			resp := Response{
+				Jsonrpc: "2.0",
+				ID:      req.ID,
+				Result: map[string]interface{}{
+					"name":         "provekit-lsp-go",
+					"version":      "0.1.0",
+					"capabilities": []string{},
+				},
+			}
+			writeResp(writer, resp)
+
+		case "parse":
+			var params ParseParams
+			json.Unmarshal(req.Params, &params)
+			annotations := parseGo(params.Text, reImpl, reContract, reVerify, reFn)
+			resp := Response{
+				Jsonrpc: "2.0",
+				ID:      req.ID,
+				Result:  map[string]interface{}{"annotations": annotations},
+			}
+			writeResp(writer, resp)
+
+		case "shutdown":
+			resp := Response{Jsonrpc: "2.0", ID: req.ID, Result: nil}
+			writeResp(writer, resp)
+			return
+
+		default:
+			resp := Response{
+				Jsonrpc: "2.0",
+				ID:      req.ID,
+				Error:   &RpcError{Code: -32601, Message: "unknown method: " + req.Method},
+			}
+			writeResp(writer, resp)
+		}
+	}
+}
+
+func writeResp(w *bufio.Writer, resp Response) {
+	b, _ := json.Marshal(resp)
+	w.WriteString(string(b))
+	w.WriteByte('\n')
+	w.Flush()
+}
+
+func parseGo(text string, reImpl, reContract, reVerify, reFn *regexp.Regexp) []Annotation {
+	var annotations []Annotation
+	lines := strings.Split(text, "\n")
+
+	for i, line := range lines {
+		lineNum := uint32(i)
+
+		if matches := reImpl.FindStringSubmatch(line); len(matches) > 1 {
+			cid := matches[1]
+			fnName := findAhead(lines, i, reFn)
+			annotations = append(annotations, Annotation{
+				FunctionName: fnName,
+				Kind:         "implement",
+				TargetCID:    &cid,
+				Range: Range{
+					Start: Position{Line: lineNum, Character: 0},
+					End:   Position{Line: lineNum + 1, Character: 0},
+				},
+			})
+		}
+
+		if reContract.MatchString(line) {
+			fnName := findAhead(lines, i, reFn)
+			annotations = append(annotations, Annotation{
+				FunctionName: fnName,
+				Kind:         "contract",
+				Range: Range{
+					Start: Position{Line: lineNum, Character: 0},
+					End:   Position{Line: lineNum + 1, Character: 0},
+				},
+			})
+		}
+
+		if reVerify.MatchString(line) {
+			fnName := findAhead(lines, i, reFn)
+			annotations = append(annotations, Annotation{
+				FunctionName: fnName,
+				Kind:         "verify",
+				Range: Range{
+					Start: Position{Line: lineNum, Character: 0},
+					End:   Position{Line: lineNum + 1, Character: 0},
+				},
+			})
+		}
+	}
+
+	return annotations
+}
+
+func findAhead(lines []string, start int, re *regexp.Regexp) string {
+	for j := start + 1; j < len(lines) && j < start+10; j++ {
+		if matches := re.FindStringSubmatch(lines[j]); len(matches) > 1 {
+			return matches[1]
+		}
+	}
+	return "unknown"
+}

--- a/examples/lsp-plugins/rust/Cargo.toml
+++ b/examples/lsp-plugins/rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "provekit-lsp-rust"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "provekit-lsp-rust"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+regex = "1"

--- a/examples/lsp-plugins/rust/src/main.rs
+++ b/examples/lsp-plugins/rust/src/main.rs
@@ -1,0 +1,184 @@
+// ProvekIt LSP Language Plugin — Rust
+//
+// A standalone binary that speaks `provekit-lsp-plugin/1` over stdio.
+// Parses Rust source files and extracts provekit annotations.
+//
+// Usage: provekit-lsp-rust --rpc
+//
+// To use this plugin, add to `.provekit/config.toml`:
+//   [[language]]
+//   name = "rust"
+//   extensions = [".rs"]
+//   plugin = "provekit-lsp-rust"
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::io::{BufRead, Write};
+
+#[derive(Serialize)]
+struct Annotation {
+    function_name: String,
+    kind: String,
+    target_cid: Option<String>,
+    range: Range,
+}
+
+#[derive(Serialize)]
+struct Range {
+    start: Position,
+    end: Position,
+}
+
+#[derive(Serialize)]
+struct Position {
+    line: u32,
+    character: u32,
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if !args.iter().any(|a| a == "--rpc") {
+        eprintln!("Usage: provekit-lsp-rust --rpc");
+        std::process::exit(1);
+    }
+
+    let re_impl = Regex::new(
+        r#"#\[provekit::implement\s*\(\s*target\s*=\s*"([^"]+)"\s*\)\]"#
+    ).unwrap();
+    let re_contract = Regex::new(r#"#\[provekit::contract"#).unwrap();
+    let re_verify = Regex::new(r#"#\[provekit::verify"#).unwrap();
+    let re_fn = Regex::new(r#"\bfn\s+(\w+)"#).unwrap();
+
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let req: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                let resp = json!({"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":format!("parse error: {e}")}});
+                let _ = writeln!(stdout, "{resp}");
+                continue;
+            }
+        };
+
+        let id = req.get("id").cloned().unwrap_or(json!(null));
+        let method = req.get("method").and_then(|v| v.as_str()).unwrap_or("");
+
+        match method {
+            "initialize" => {
+                let resp = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "name": "provekit-lsp-rust",
+                        "version": env!("CARGO_PKG_VERSION"),
+                        "capabilities": []
+                    }
+                });
+                let _ = writeln!(stdout, "{resp}");
+            }
+            "parse" => {
+                let params = req.get("params").cloned().unwrap_or(json!({}));
+                let text = params.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                let annotations = parse_rust(text, &re_impl, &re_contract, &re_verify, &re_fn);
+                let resp = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {"annotations": annotations}
+                });
+                let _ = writeln!(stdout, "{resp}");
+            }
+            "shutdown" => {
+                let resp = json!({"jsonrpc":"2.0","id":id,"result":null});
+                let _ = writeln!(stdout, "{resp}");
+                return;
+            }
+            _ => {
+                let resp = json!({"jsonrpc":"2.0","id":id,"error":{"code":-32601,"message":format!("unknown method: {method}")}});
+                let _ = writeln!(stdout, "{resp}");
+            }
+        }
+    }
+}
+
+fn parse_rust(
+    text: &str,
+    re_impl: &Regex,
+    re_contract: &Regex,
+    re_verify: &Regex,
+    re_fn: &Regex,
+) -> Vec<Annotation> {
+    let mut annotations = Vec::new();
+    let lines: Vec<&str> = text.lines().collect();
+
+    for (idx, line_text) in lines.iter().enumerate() {
+        let line_num = idx as u32;
+
+        if let Some(cap) = re_impl.captures(line_text) {
+            let target_cid = cap.get(1).map(|m| m.as_str().to_string());
+            // Look ahead for function name
+            let mut fn_name = "unknown".to_string();
+            for j in (idx + 1)..lines.len().min(idx + 10) {
+                if let Some(fcap) = re_fn.captures(lines[j]) {
+                    fn_name = fcap.get(1).unwrap().as_str().to_string();
+                    break;
+                }
+            }
+            annotations.push(Annotation {
+                function_name: fn_name,
+                kind: "implement".to_string(),
+                target_cid,
+                range: Range {
+                    start: Position { line: line_num, character: 0 },
+                    end: Position { line: line_num + 1, character: 0 },
+                },
+            });
+        }
+
+        if re_contract.is_match(line_text) {
+            let mut fn_name = "unknown".to_string();
+            for j in (idx + 1)..lines.len().min(idx + 10) {
+                if let Some(fcap) = re_fn.captures(lines[j]) {
+                    fn_name = fcap.get(1).unwrap().as_str().to_string();
+                    break;
+                }
+            }
+            annotations.push(Annotation {
+                function_name: fn_name,
+                kind: "contract".to_string(),
+                target_cid: None,
+                range: Range {
+                    start: Position { line: line_num, character: 0 },
+                    end: Position { line: line_num + 1, character: 0 },
+                },
+            });
+        }
+
+        if re_verify.is_match(line_text) {
+            let mut fn_name = "unknown".to_string();
+            for j in (idx + 1)..lines.len().min(idx + 10) {
+                if let Some(fcap) = re_fn.captures(lines[j]) {
+                    fn_name = fcap.get(1).unwrap().as_str().to_string();
+                    break;
+                }
+            }
+            annotations.push(Annotation {
+                function_name: fn_name,
+                kind: "verify".to_string(),
+                target_cid: None,
+                range: Range {
+                    start: Position { line: line_num, character: 0 },
+                    end: Position { line: line_num + 1, character: 0 },
+                },
+            });
+        }
+    }
+
+    annotations
+}

--- a/examples/lsp-plugins/zig/main.zig
+++ b/examples/lsp-plugins/zig/main.zig
@@ -1,0 +1,194 @@
+// ProvekIt LSP Language Plugin — Zig
+//
+// A standalone binary that speaks provekit-lsp-plugin/1 over stdio.
+// Parses Zig source files and extracts provekit annotations.
+//
+// Usage: zig build-exe main.zig -o provekit-lsp-zig && ./provekit-lsp-zig --rpc
+//
+// To use this plugin, add to `.provekit/config.toml`:
+//   [[language]]
+//   name = "zig"
+//   extensions = [".zig"]
+//   plugin = "provekit-lsp-zig"
+
+const std = @import("std");
+const json = std.json;
+
+const Annotation = struct {
+    function_name: []const u8,
+    kind: []const u8,
+    target_cid: ?[]const u8 = null,
+    range: Range,
+};
+
+const Range = struct {
+    start: Position,
+    end: Position,
+};
+
+const Position = struct {
+    line: u32,
+    character: u32,
+};
+
+fn findAhead(lines: [][]const u8, start: usize, needle: []const u8) []const u8 {
+    var j = start + 1;
+    while (j < lines.len and j < start + 10) : (j += 1) {
+        if (std.mem.indexOf(u8, lines[j], needle)) |_| {
+            // Extract fn name: "fn name(...)"
+            const line = lines[j];
+            const fn_idx = std.mem.indexOf(u8, line, "fn ") orelse continue;
+            const after = line[fn_idx + 3 ..];
+            const end = std.mem.indexOfAny(u8, after, " (\n") orelse after.len;
+            return after[0..end];
+        }
+    }
+    return "unknown";
+}
+
+fn parseZig(allocator: std.mem.Allocator, text: []const u8) ![]Annotation {
+    var annotations = std.ArrayList(Annotation).init(allocator);
+    errdefer annotations.deinit();
+
+    var lines = std.ArrayList([]const u8).init(allocator);
+    defer lines.deinit();
+
+    var it = std.mem.splitScalar(u8, text, '\n');
+    while (it.next()) |line| {
+        try lines.append(line);
+    }
+
+    for (lines.items, 0..) |line, i| {
+        const line_num: u32 = @intCast(i);
+
+        if (std.mem.indexOf(u8, line, "//provekit:implement ")) |idx| {
+            const after = line[idx + 20 ..];
+            const end = std.mem.indexOfAny(u8, after, " \n\t") orelse after.len;
+            const cid = after[0..end];
+            const fn_name = findAhead(lines.items, i, "fn ");
+            try annotations.append(.{
+                .function_name = fn_name,
+                .kind = "implement",
+                .target_cid = cid,
+                .range = .{
+                    .start = .{ .line = line_num, .character = 0 },
+                    .end = .{ .line = line_num + 1, .character = 0 },
+                },
+            });
+        }
+
+        if (std.mem.indexOf(u8, line, "//provekit:contract") != null) {
+            const fn_name = findAhead(lines.items, i, "fn ");
+            try annotations.append(.{
+                .function_name = fn_name,
+                .kind = "contract",
+                .range = .{
+                    .start = .{ .line = line_num, .character = 0 },
+                    .end = .{ .line = line_num + 1, .character = 0 },
+                },
+            });
+        }
+
+        if (std.mem.indexOf(u8, line, "//provekit:verify") != null) {
+            const fn_name = findAhead(lines.items, i, "fn ");
+            try annotations.append(.{
+                .function_name = fn_name,
+                .kind = "verify",
+                .range = .{
+                    .start = .{ .line = line_num, .character = 0 },
+                    .end = .{ .line = line_num + 1, .character = 0 },
+                },
+            });
+        }
+    }
+
+    return annotations.toOwnedSlice();
+}
+
+fn writeAnnotations(writer: anytype, annotations: []Annotation) !void {
+    try writer.writeAll("[{ ");
+    for (annotations, 0..) |a, i| {
+        if (i > 0) try writer.writeAll(", ");
+        try writer.writeAll("{\"function_name\":\"");
+        try writer.writeAll(a.function_name);
+        try writer.writeAll("\",\"kind\":\"");
+        try writer.writeAll(a.kind);
+        try writer.writeAll("\"");
+        if (a.target_cid) |cid| {
+            try writer.writeAll(",\"target_cid\":\"");
+            try writer.writeAll(cid);
+            try writer.writeAll("\"");
+        }
+        try writer.print(",\"range\":{{\"start\":{{\"line\":{d},\"character\":0}},\"end\":{{\"line\":{d},\"character\":0}}}}}", .{ a.range.start.line, a.range.end.line });
+    }
+    try writer.writeAll(" ]");
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    var rpc_mode = false;
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--rpc")) {
+            rpc_mode = true;
+            break;
+        }
+    }
+
+    if (!rpc_mode) {
+        std.debug.print("Usage: provekit-lsp-zig --rpc\n", .{});
+        std.process.exit(1);
+    }
+
+    const stdin = std.io.getStdIn().reader();
+    const stdout = std.io.getStdOut().writer();
+    var buf: [4096]u8 = undefined;
+
+    while (true) {
+        const maybe_line = try stdin.readUntilDelimiterOrEof(&buf, '\n');
+        const line = maybe_line orelse break;
+
+        // Parse JSON — very minimal
+        const has_init = std.mem.indexOf(u8, line, "\"initialize\"") != null;
+        const has_parse = std.mem.indexOf(u8, line, "\"parse\"") != null;
+        const has_shutdown = std.mem.indexOf(u8, line, "\"shutdown\"") != null;
+
+        // Extract id
+        var id: []const u8 = "null";
+        if (std.mem.indexOf(u8, line, "\"id\":")) |id_pos| {
+            const after = line[id_pos + 5 ..];
+            const start = std.mem.indexOfNone(u8, after, " \t") orelse 0;
+            const end = std.mem.indexOfAny(u8, after[start..], ",}") orelse after.len;
+            id = after[start .. start + end];
+        }
+
+        if (has_init) {
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"name\":\"provekit-lsp-zig\",\"version\":\"0.1.0\",\"capabilities\":[]}}}}\n", .{id});
+        } else if (has_parse) {
+            // Extract text field — naive
+            var text: []const u8 = "";
+            if (std.mem.indexOf(u8, line, "\"text\":")) |tp| {
+                const after = line[tp + 8 ..];
+                const quote = std.mem.indexOf(u8, after, "\"") orelse 0;
+                const end_quote = std.mem.indexOf(u8, after[quote + 1 ..], "\"") orelse 0;
+                text = after[quote + 1 .. quote + 1 + end_quote];
+            }
+            const annotations = try parseZig(allocator, text);
+            defer allocator.free(annotations);
+
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"annotations\":", .{id});
+            try writeAnnotations(stdout, annotations);
+            try stdout.writeAll("}}\n");
+        } else if (has_shutdown) {
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":null}}\n", .{id});
+            return;
+        } else {
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"error\":{{\"code\":-32601,\"message\":\"unknown method\"}}}}\n", .{id});
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Five reference plugins demonstrating the `provekit-lsp-plugin/1` NDJSON-over-stdio protocol from `protocol/specs/2026-04-30-lsp-protocol.md`.
- Each scaffold is complete and runnable: read a JSON-RPC request from stdin, scan source text for provekit annotations, write a JSON-RPC response to stdout. ~100-150 lines each, zero or stdlib-only deps.

## What landed

| Path | Toolchain | Build |
|---|---|---|
| `examples/lsp-plugins/cpp/main.cpp` | C++17 | `g++ -std=c++17 -o provekit-lsp-cpp main.cpp` |
| `examples/lsp-plugins/csharp/Program.cs` | .NET | `dotnet publish -c Release` |
| `examples/lsp-plugins/go/main.go` | Go (stdlib only) | `go build -o provekit-lsp-go main.go` |
| `examples/lsp-plugins/rust/{Cargo.toml,src/main.rs}` | Cargo (standalone) | `cargo build --release` |
| `examples/lsp-plugins/zig/main.zig` | Zig std | `zig build-exe main.zig -o provekit-lsp-zig` |
| `examples/lsp-plugins/README.md` | docs | -- |

The README documents the three RPC methods (`initialize` / `parse` / `shutdown`), the three annotation kinds (`implement` / `contract` / `verify`), the two registration paths in `.provekit/config.toml` (direct binary or `manifest.toml`), and a 25-line minimal Python plugin for reference.

## Notes

- The Rust scaffold is a **standalone** Cargo package -- not registered in `implementations/rust/Cargo.toml [workspace] members`. Its dep set (`serde`, `serde_json`, `regex`) is independent of the workspace lockfile.
- The zig LSP plugin scaffold here is intentionally a tiny demo. The production zig lifter lives in `implementations/zig/provekit-lift-zig` (companion PR `feat/zig-kit`).

## Companion PRs

This is part of a four-way drop:

- `feat/rust-lsp-impl` -> the LSP coordinator that spawns these plugins (carries the cross-PR `docs/per-language-status.md` matrix update; status flips for cpp/csharp/go/zig LSP Plugin columns are reflected there).
- `feat/java-kit` -> Java peer of the kit.
- `feat/zig-kit` -> Zig peer of the kit.

## Sanity

- No build attempted in the cutter environment per task spec.
- `git diff --cached | grep /Users/tsavo` returns 0 hits.

## Test plan

- [ ] Manual: build each scaffold per its build command, confirm `printf '{"jsonrpc":"2.0","id":1,"method":"initialize"}\n' | ./provekit-lsp-<lang>` returns a valid response.
- [ ] Manual: register each scaffold in a sample `.provekit/config.toml` and confirm `provekit-lsp` (PR `feat/rust-lsp-impl`) spawns it on a matching file.