### PR TITLE
fix(c): native BLAKE3 + test ownership fixes (retire python shell-out)

### DIFF
--- a/implementations/c/provekit-ir/Makefile
+++ b/implementations/c/provekit-ir/Makefile
@@ -1,12 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
+#
+# C kit build. BLAKE3 is vendored at <repo>/tools/blake3-vendored and
+# compiled with all SIMD paths disabled, so there is no host BLAKE3
+# install requirement and the build is hermetic on any C11 toolchain.
 
 CC = cc
-CFLAGS = -Wall -Wextra -std=c11 -Iinclude -g
+B3_DIR = ../../../tools/blake3-vendored
+B3_FLAGS = -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512 -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_USE_NEON=0
+CFLAGS = -Wall -Wextra -std=c11 -Iinclude -I$(B3_DIR) $(B3_FLAGS) -g
 LDFLAGS =
 
-SRC = src/ir.c src/jcs.c src/hash.c
+KIT_SRC = src/ir.c src/jcs.c src/hash.c
+B3_SRC = $(B3_DIR)/blake3.c $(B3_DIR)/blake3_dispatch.c $(B3_DIR)/blake3_portable.c
 TEST_SRC = tests/test_runner.c
-OBJS = $(SRC:.c=.o)
+
+KIT_OBJS = $(KIT_SRC:.c=.o)
+B3_OBJS = $(B3_SRC:.c=.o)
+OBJS = $(KIT_OBJS) $(B3_OBJS)
 
 .PHONY: all test clean
 
@@ -22,4 +32,4 @@ tests/test_runner: $(OBJS) $(TEST_SRC)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OBJS) tests/test_runner
+	rm -f $(KIT_OBJS) $(B3_OBJS) tests/test_runner

--- a/implementations/c/provekit-ir/src/hash.c
+++ b/implementations/c/provekit-ir/src/hash.c
@@ -1,54 +1,48 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Hash delegation: shells out to Python blake3 module.
- * Native C BLAKE3 planned for v1.2.
+ * Native BLAKE3-512 over a UTF-8 JCS string.
+ *
+ * Links against the BLAKE3 reference C source vendored at
+ * tools/blake3-vendored/. The C kit's Makefile compiles those sources
+ * with all SIMD paths disabled (-DBLAKE3_NO_AVX2 etc.); no system
+ * BLAKE3 install or Python interpreter is required.
+ *
+ * Output: malloc'd NUL-terminated string of the form
+ *   "blake3-512:" + 128 lowercase hex chars
+ * Caller is responsible for free().
  */
 
 #include "provekit/ir.h"
-#include <stdio.h>
+#include "blake3.h"
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+
+#define PK_BLAKE3_OUT_LEN 64
+#define PK_HEX_PREFIX "blake3-512:"
+#define PK_HEX_PREFIX_LEN 11
+#define PK_HEX_BODY_LEN (PK_BLAKE3_OUT_LEN * 2)
+#define PK_HEX_TOTAL_LEN (PK_HEX_PREFIX_LEN + PK_HEX_BODY_LEN)
 
 char *pk_hash_jcs(const char *jcs_string) {
     if (!jcs_string) return NULL;
 
-    /* Write JCS bytes to a named temp file. */
-    char path[] = "/tmp/pk_hash_XXXXXX";
-    int fd = mkstemp(path);
-    if (fd < 0) return NULL;
+    blake3_hasher h;
+    blake3_hasher_init(&h);
+    blake3_hasher_update(&h, jcs_string, strlen(jcs_string));
 
-    size_t len = strlen(jcs_string);
-    if (write(fd, jcs_string, len) != (ssize_t)len) {
-        close(fd);
-        unlink(path);
-        return NULL;
+    uint8_t out[PK_BLAKE3_OUT_LEN];
+    blake3_hasher_finalize(&h, out, PK_BLAKE3_OUT_LEN);
+
+    char *result = (char *)malloc(PK_HEX_TOTAL_LEN + 1);
+    if (!result) return NULL;
+    memcpy(result, PK_HEX_PREFIX, PK_HEX_PREFIX_LEN);
+
+    static const char hex[] = "0123456789abcdef";
+    for (size_t i = 0; i < PK_BLAKE3_OUT_LEN; i++) {
+        result[PK_HEX_PREFIX_LEN + 2 * i] = hex[(out[i] >> 4) & 0xf];
+        result[PK_HEX_PREFIX_LEN + 2 * i + 1] = hex[out[i] & 0xf];
     }
-    close(fd);
-
-    char cmd[1024];
-    snprintf(cmd, sizeof(cmd),
-        "python3 -c \"import blake3; data=open('%s','rb').read(); print('blake3-512:' + blake3.blake3(data).digest(length=64).hex())\"",
-        path);
-
-    FILE *pipe = popen(cmd, "r");
-    if (!pipe) {
-        unlink(path);
-        return NULL;
-    }
-
-    char result[256];
-    if (fgets(result, sizeof(result), pipe) == NULL) {
-        pclose(pipe);
-        unlink(path);
-        return NULL;
-    }
-    pclose(pipe);
-    unlink(path);
-
-    /* Strip trailing newline. */
-    size_t rlen = strlen(result);
-    if (rlen > 0 && result[rlen - 1] == '\n') result[rlen - 1] = '\0';
-
-    return strdup(result);
+    result[PK_HEX_TOTAL_LEN] = '\0';
+    return result;
 }

--- a/implementations/c/provekit-ir/tests/test_runner.c
+++ b/implementations/c/provekit-ir/tests/test_runner.c
@@ -57,27 +57,32 @@ static void test_eq_atomic_jcs(void) {
 /* ----------------------------------------------------------------------- */
 
 static void test_pattern1_bounded_loop_jcs(void) {
-    pk_sort *int_sort = pk_sort_primitive("Int");
-    pk_term *x = pk_term_var_new("x");
-    pk_term *zero = pk_term_const_int(0, int_sort);
-    pk_term *hundred = pk_term_const_int(100, int_sort);
-
-    pk_term *gte_args[] = { x, zero };
+    /* The C kit takes ownership of every term/sort handed to a constructor;
+     * there is no ref-counting. Construct fresh terms per atomic so the
+     * single ownership chain rooted at `q` does not double-free shared
+     * leaves when `pk_formula_free(q)` walks the tree. */
+    pk_term *x1 = pk_term_var_new("x");
+    pk_term *zero1 = pk_term_const_int(0, pk_sort_primitive("Int"));
+    pk_term *gte_args[] = { x1, zero1 };
     pk_formula *lower = pk_formula_atomic_new("≥", gte_args, 2);
 
-    pk_term *lt_args[] = { x, hundred };
+    pk_term *x2 = pk_term_var_new("x");
+    pk_term *hundred = pk_term_const_int(100, pk_sort_primitive("Int"));
+    pk_term *lt_args[] = { x2, hundred };
     pk_formula *upper = pk_formula_atomic_new("<", lt_args, 2);
 
     pk_formula *conj_ops[] = { lower, upper };
     pk_formula *antecedent = pk_formula_connective_new("and", conj_ops, 2);
 
-    pk_term *gte2_args[] = { x, zero };
+    pk_term *x3 = pk_term_var_new("x");
+    pk_term *zero2 = pk_term_const_int(0, pk_sort_primitive("Int"));
+    pk_term *gte2_args[] = { x3, zero2 };
     pk_formula *inner = pk_formula_atomic_new("≥", gte2_args, 2);
 
     pk_formula *impl_ops[] = { antecedent, inner };
     pk_formula *body = pk_formula_connective_new("implies", impl_ops, 2);
 
-    pk_formula *q = pk_formula_quantifier_new("forall", "x", int_sort, body);
+    pk_formula *q = pk_formula_quantifier_new("forall", "x", pk_sort_primitive("Int"), body);
 
     char *got = emit_formula(q);
 
@@ -137,10 +142,14 @@ static void test_bridge_decl_jcs(void) {
     char *got = pk_buffer_steal(buf);
     pk_buffer_free(buf);
 
+    /* JCS sorts keys by code point, so `notes` (n-o) lands between `name`
+     * (n-a) and `sourceContractCid` (s). This expected string mirrors the
+     * canonical-on-disk emit order, not any spec-listing order. */
     const char *expected =
-        "{\"kind\":\"bridge\",\"name\":\"myBridge\",\"sourceContractCid\":\"bafySource\","
-        "\"sourceLayer\":\"c-kit\",\"sourceSymbol\":\"source\",\"targetContractCid\":\"bafyTarget\","
-        "\"targetLayer\":\"coq\",\"targetProofCid\":\"bafyProof\",\"notes\":\"some notes\"}";
+        "{\"kind\":\"bridge\",\"name\":\"myBridge\",\"notes\":\"some notes\","
+        "\"sourceContractCid\":\"bafySource\",\"sourceLayer\":\"c-kit\","
+        "\"sourceSymbol\":\"source\",\"targetContractCid\":\"bafyTarget\","
+        "\"targetLayer\":\"coq\",\"targetProofCid\":\"bafyProof\"}";
 
     assert_eq_str(got, expected, "bridge decl JCS");
 


### PR DESCRIPTION
## Summary

Closes task #210 and folds in two test fixes that raced with PR #32's commit timing.

### Native BLAKE3
- \`src/hash.c\`: replaced \`popen(\"python3 -c 'import blake3; ...'\")\` with direct calls to the BLAKE3 reference C implementation at \`tools/blake3-vendored/\` (already vendored, same source the C++ kit uses).
- \`Makefile\`: compiles \`blake3.c\`, \`blake3_dispatch.c\`, \`blake3_portable.c\` with SIMD paths disabled (\`BLAKE3_NO_AVX2 / NO_AVX512 / NO_SSE2 / NO_SSE41 / USE_NEON=0\`). No host Python or blake3 module required; build is hermetic on any C11 toolchain.

### Test fixes (race-recovery from PR #32)
- \`test_pattern1_bounded_loop_jcs\`: was sharing \`x\`/\`zero\`/\`int_sort\` across multiple atomic formulas. The kit takes ownership without ref-counting, so \`pk_formula_free(q)\` double-freed shared leaves and aborted. Now constructs fresh terms per atomic.
- \`test_bridge_decl_jcs\`: expected string had \`notes\` at end, but JCS sorts keys by code point so \`notes\` (n-o) goes between \`name\` (n-a) and \`sourceContractCid\` (s). Kit's emit was already JCS-correct; test fixture was hand-written wrong.

## Test plan

- [x] \`make clean && make test\` locally on macOS — 5/5 pass
- [x] \`test_eq_atomic_hash\` produces \`blake3-512:5eade72c...\` matching the Rust-pinned value (cross-impl JCS+BLAKE3 byte equality)

## Note on the broader pattern

This is the same letter-envelope discipline applied at a different seam: the kit no longer carries machine-local truth about which Python interpreter to invoke. The vendored BLAKE3 source IS the source of truth for hashing; the kit consumes it via a relative path. Pairs structurally with PR #24 (manifest paths) and PR #30 (self-contracts attestation envelopes).