### PR TITLE
fix(cpp): init binary_cid in mint_cpp_self_contracts (Werror)

### DIFF
--- a/implementations/cpp/provekit-self-contracts/mint_cpp_self_contracts.cpp
+++ b/implementations/cpp/provekit-self-contracts/mint_cpp_self_contracts.cpp
@@ -130,6 +130,8 @@ static std::string mint_one_run(const std::string& out_dir, bool verbose) {
         .signer_cid = signer_cid,
         .signer_seed = signer_seed,
         .declared_at = declared_at,
+        // Self-contracts bundle does not back-pin a binary; emit absent.
+        .binary_cid = "",
     };
     auto built = build_proof_envelope(proof_input);
 


### PR DESCRIPTION
## Summary

PR #21 added \`binary_cid\` to C++ \`ProofEnvelopeInput\` but missed \`mint_cpp_self_contracts.cpp\` consumer. CI's \`-Werror -Wmissing-field-initializers\` correctly flagged it. Initializing as empty string (absent), matching the omit-when-empty CBOR rule.

## Test plan

- [ ] CI \`mint-cpp\` compiles cleanly
- [ ] cpp self-contracts bundle CID continues to match attestation