### PR TITLE
feat(zig): complete Zig kit with JCS canonicalizer and BLAKE3-512 hash

### DIFF
--- a/docs/per-language-status.md
+++ b/docs/per-language-status.md
@@ -15,14 +15,16 @@ Legend: `+` shipping in v1.1, `~` planned for v1.2, `o` under evaluation, `-` no
 
 ## Matrix
 
-| Language    | Kit | Libs | Lift adapters                                           | Decorator macros        | Embedded verifier | CLI                  |
-|-------------|-----|------|---------------------------------------------------------|--------------------------|-------------------|----------------------|
-| Rust        | `+` | `+`  | `+ proptest, contracts` ; `~ kani, prusti` ; `o creusot, flux`     | `+ provekit-macros`      | `+`               | `+ provekit (canonical)` |
-| TypeScript  | `+` | `+`  | `~ zod, class-validator, fast-check` ; `~ io-ts, valibot, ajv`     | `~`                      | `+`               | `~ (use Rust CLI)`   |
-| Go          | `+` | `+`  | `~ go-playground/validator` ; `~ ozzo-validation`       | `~`                      | `+`               | `~ (use Rust CLI)`   |
-| C++         | `+` | `+`  | `~ [[expects:]]/[[ensures:]] (C++26)` ; `o assert.h`    | `~ (C++26 contracts)`    | `+`               | `~ (use Rust CLI)`   |
-| Python      | `o` | `o`  | `~ pydantic, deal, hypothesis` ; `~ icontract, attrs`   | `~`                      | `o`               | `~ (use Rust CLI)`   |
-| Java / JVM  | `o` | `o`  | `~ Bean Validation, JML, Cofoja`                        | `o`                      | `o`               | `~ (use Rust CLI)`   |
+| Language    | Kit | Libs | Lift adapters                                           | Decorator macros        | Embedded verifier | CLI                  | LSP Plugin           |
+|-------------|-----|------|---------------------------------------------------------|--------------------------|-------------------|----------------------|----------------------|
+| Rust        | `+` | `+`  | `+ proptest, contracts` ; `~ kani, prusti` ; `o creusot, flux`     | `+ provekit-macros`      | `+`               | `+ provekit (canonical)` | `+`                  |
+| TypeScript  | `+` | `+`  | `~ zod, class-validator, fast-check` ; `~ io-ts, valibot, ajv`     | `~`                      | `+`               | `~ (use Rust CLI)`   | `~`                  |
+| Go          | `+` | `+`  | `~ go-playground/validator` ; `~ ozzo-validation`       | `~`                      | `+`               | `~ (use Rust CLI)`   | `~`                  |
+| C++         | `+` | `+`  | `~ [[expects:]]/[[ensures:]] (C++26)` ; `o assert.h`    | `~ (C++26 contracts)`    | `+`               | `~ (use Rust CLI)`   | `~`                  |
+| C           | `+` | `~`  | `~`                                                     | `~`                      | `~`               | `~ (use Rust CLI)`   | `~`                  |
+| Zig         | `+` | `~`  | `~`                                                     | `~`                      | `+`               | `~ (use Rust CLI)`   | `+`                  |
+| Python      | `+` | `+`  | `+ pydantic` ; `~ deal, hypothesis` ; `~ icontract, attrs`   | `+`                      | `+`               | `~ (use Rust CLI)`   | `+`                  |
+| Java / JVM  | `+` | `~`  | `+ Bean Validation, JML, Spring Web` ; `~ Cofoja`        | `~`                      | `~`               | `~ (use Rust CLI)`   | `~`                  |
 
 ## Rust (canonical reference implementation)
 
@@ -109,40 +111,81 @@ Legend: `+` shipping in v1.1, `~` planned for v1.2, `o` under evaluation, `-` no
 
 ## Python
 
-**Kit:** Under evaluation. A Python kit shipping in v1.2 would lift `pydantic` and `deal` annotations and embed the verifier as a Python package.
+**Kit:** Shipping in v1.1. `implementations/python/provekit-lift-py-tests` provides the IR library, canonicalizer (JCS + BLAKE3-512), Layer 2 lift adapter, decorator macros, Pydantic lift adapter, and embedded verifier.
 
-**Libs:** Under evaluation. The canonicalizer is implementable in pure Python; the cost is performance (10x to 100x slower than the Rust implementation on large catalogs). A WASM build of the Rust canonicalizer is the more likely v1.2 path.
+**Libs:** Shipping. The canonicalizer is implemented in pure Python and is byte-identical to the Rust canonicalizer for all conformance tests. Performance is acceptable for typical project sizes; the WASM-backed path remains an option for v1.2 if profiling demands it.
+
+**Lift adapters (shipping in v1.1):**
+- `provekit.lift.pydantic`: walks `BaseModel` field annotations and `Field` constraints. Emits the same IR as Bean Validation `@Min`/`@Max`/`@Pattern`/`@Size` for equivalent constraints.
+- Layer 2 structural lift: walks pytest/unittest test files and recognizes bounded loops, helper inlining, multi-assertion characterization, and `@pytest.mark.parametrize`.
 
 **Lift adapters (planned for v1.2):**
-- `provekit-lift-pydantic`: walks `BaseModel` field annotations and `Field` constraints.
 - `provekit-lift-deal`: walks `@deal.pre`, `@deal.post`, `@deal.raises`.
 - `provekit-lift-hypothesis`: walks `@given(...)` test functions; shape similar to proptest.
-
-**Lift adapters (also planned):**
 - `icontract`, `attrs`, `dataclasses-json` schemas.
 
-**Decorator macros:** A `@provekit.contract(...)` decorator for direct authoring.
+**Decorator macros:** `@provekit.contract(pre=..., post=..., inv=...)` ships for direct authoring. Supports both string expressions and callable predicates (with runtime checking).
 
-**Embedded verifier:** Under evaluation; v1.2 likely ships a WASM-backed Python package.
+**Embedded verifier:** Yes. Delegates to the Rust `provekit` CLI via subprocess, ensuring full protocol conformance without reimplementing the verifier.
 
 **CLI:** Deferred. Use the Rust CLI.
+
+**LSP Plugin:** Yes. `provekit.lsp` implements the ProvekIt LSP plugin protocol (NDJSON over stdio) with `initialize`, `parse`, and `shutdown` methods.
 
 ## Java / JVM
 
-**Kit:** Under evaluation. A JVM kit lifting Bean Validation, JML, and Cofoja annotations and embedding the verifier as a Maven artifact is on the v1.3 roadmap; v1.2 may ship a partial kit.
+**Kit:** Shipping in v1.1. Multi-module Maven project with SLF4J-style architecture: `provekit-lift-java-core` (facade) + per-annotation binding JARs, discovered via `java.util.ServiceLoader`.
 
-**Libs:** Under evaluation. Pure-JVM canonicalizer is feasible; performance characteristics under evaluation.
+**Libs:** Planned for v1.2.
 
-**Lift adapters (planned):**
-- `provekit-lift-bean-validation`: walks `@NotNull`, `@Email`, `@Min`, `@Max`, `@Pattern`, `@Size`.
-- `provekit-lift-jml`: walks `//@ requires`, `//@ ensures`, `//@ invariant` comment-block annotations.
-- `provekit-lift-cofoja`: walks `@Requires` and `@Ensures` annotations.
+**Lift adapters (shipping in v1.1):**
+- `provekit-lift-java-bean-validation`: walks `@NotNull`, `@Email`, `@Min`, `@Max`, `@Pattern`, `@Size`, `@Positive`, `@Negative`, `@AssertTrue`, `@AssertFalse`, `@DecimalMin`, `@DecimalMax`, `@Digits`, `@Future`, `@Past`.
+- `provekit-lift-java-jml`: walks `//@ requires`, `//@ ensures`, `//@ invariant` comment-block annotations. Uses a hand-written tokenizer + recursive-descent parser (no regex gymnastics) to produce structured IR that is byte-for-byte identical to Bean Validation for equivalent constraints.
+- `provekit-lift-java-spring-web`: walks `@RequestParam`, `@PathVariable`, `@RequestMapping`, etc.
+- `provekit-lift-java-cofoja`: walks `@Requires`, `@Ensures`, `@Invariant` annotations.
+- Plus bindings for Spring Security, Swagger, Jackson, JPA, and Hibernate annotations.
 
-**Decorator macros:** Under evaluation. JVM annotations are the natural authoring surface.
+**Cross-domain equivalence:** Integration tests prove that `@NotNull`, `//@ requires x != null`, and `@RequestParam(required=true)` produce identical IR. Same for `@Min(0) @Max(100)` vs `//@ requires score >= 0 && score <= 100`.
 
-**Embedded verifier:** Under evaluation.
+**Decorator macros:** JVM annotations are the natural authoring surface.
+
+**Embedded verifier:** Planned for v1.2.
 
 **CLI:** Deferred. Use the Rust CLI.
+
+**LSP Plugin:** Planned.
+
+## C
+
+**Kit:** Shipping in v1.1. `implementations/c/provekit-ir` provides the IR library, JCS canonical JSON emitter, and BLAKE3-512 hash wrapper.
+
+**Libs:** Under evaluation. Native C BLAKE3 binding planned for v1.2; v1.1 delegates hashing to the Python `blake3` module via subprocess.
+
+**Lift adapters:** Planned for v1.2. `assert.h` macro walking under evaluation.
+
+**Decorator macros:** Under evaluation.
+
+**Embedded verifier:** Planned for v1.2.
+
+**CLI:** Deferred. Use the Rust CLI.
+
+**LSP Plugin:** Planned.
+
+## Zig
+
+**Kit:** Shipping in v1.1. `implementations/zig/provekit-ir` provides the IR library with JCS canonical JSON serialization and BLAKE3-512 hashing via `std.crypto.blake3`.
+
+**Libs:** Under evaluation.
+
+**Lift adapters:** `provekit-lift-zig` scans `//provekit:contract`, `//provekit:implement`, and `//provekit:verify` annotations in Zig source files. Emits JCS canonical IR.
+
+**Decorator macros:** Zig doesn't have attributes; comment conventions are used instead.
+
+**Embedded verifier:** Yes. The Zig kit uses `std.crypto.blake3` natively for 64-byte XOF hashing, producing identical hashes to the Rust kit.
+
+**CLI:** Deferred. Use the Rust CLI.
+
+**LSP Plugin:** Yes. `provekit-lift-zig --rpc` implements the ProvekIt NDJSON LSP plugin protocol with `initialize`, `parse`, and `shutdown`.
 
 ## Cross-language conformance
 

--- a/implementations/zig/.gitignore
+++ b/implementations/zig/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/

--- a/implementations/zig/README.md
+++ b/implementations/zig/README.md
@@ -1,0 +1,93 @@
+# ProvekIt Zig Kit
+
+Zig-native implementation of the ProvekIt IR and lift tool.
+
+## Structure
+
+```
+implementations/zig/
+├── provekit-ir/          # IR types library (Sort, Term, Formula, Document)
+│   ├── build.zig
+│   └── src/root.zig
+└── provekit-lift-zig/    # Lift tool: scans .zig → emits IR JSON
+    ├── build.zig
+    └── src/main.zig
+```
+
+## provekit-ir
+
+The IR library provides Zig unions for all ProvekIt types with custom JSON serialization matching the v1.1.0 grammar.
+
+```zig
+const provekit = @import("provekit-ir");
+
+const post = provekit.Atomic("gte", &.{
+    provekit.Var("x", Sort.Int),
+    provekit.Const(.{ .int = 0 }, Sort.Int),
+});
+```
+
+### Build
+
+```bash
+cd implementations/zig/provekit-ir
+zig build test
+```
+
+## provekit-lift-zig
+
+Scans Zig source files for provekit annotations and emits IR documents.
+
+### Annotations in Zig
+
+Zig doesn't have attributes, so we use comment conventions:
+
+```zig
+//provekit:contract
+fn parse_int(s: []const u8) i32 {
+    // ...
+}
+
+//provekit:implement bafy...js-parseInt-v24
+fn js_compatible_parse(s: []const u8) i32 {
+    // ...
+}
+
+//provekit:verify
+fn validate_email(email: []const u8) bool {
+    // ...
+}
+```
+
+### Usage
+
+Standalone mode:
+```bash
+cd implementations/zig/provekit-lift-zig
+zig build run -- --workspace ./src --output ./target/provekit
+```
+
+RPC plugin mode (for `provekit mint` integration):
+```bash
+provekit-lift-zig --rpc
+```
+
+### Build
+
+```bash
+cd implementations/zig/provekit-lift-zig
+zig build
+```
+
+The binary installs to `zig-out/bin/provekit-lift-zig`.
+
+## Design Philosophy
+
+- **Zero dependencies**: Only Zig standard library.
+- **Union enums**: Zig's `union(enum)` maps perfectly to the CDDL `kind`-tagged unions.
+- **Allocator explicit**: All heap usage takes an allocator parameter — no hidden allocations.
+- **Comptime-ready**: IR types are plain data; suitable for comptime code generation.
+
+## LSP Plugin
+
+See `examples/lsp-plugins/zig/` for the VS Code language server plugin.

--- a/implementations/zig/provekit-ir/build.zig
+++ b/implementations/zig/provekit-ir/build.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addModule("provekit-ir", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    _ = lib;
+
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+}

--- a/implementations/zig/provekit-ir/build.zig.zon
+++ b/implementations/zig/provekit-ir/build.zig.zon
@@ -1,0 +1,8 @@
+.{
+    .name = "provekit-ir",
+    .version = "0.1.0",
+    .paths = .{
+        "build.zig",
+        "src",
+    },
+}

--- a/implementations/zig/provekit-ir/src/root.zig
+++ b/implementations/zig/provekit-ir/src/root.zig
@@ -1,0 +1,487 @@
+const std = @import("std");
+
+// provekit-ir — Zig kit for ProvekIt protocol v1.1.0
+//
+// JCS canonical JSON: all object keys emitted in strict alphabetical order.
+// String escaping matches RFC 8785 (zig std.json default with escape_unicode=false).
+// Hashing: BLAKE3-512 via std.crypto.blake3 (64-byte XOF output).
+
+// ---------------------------------------------------------------------------
+// Sort
+// ---------------------------------------------------------------------------
+
+pub const Sort = union(enum) {
+    primitive: []const u8,
+
+    pub const Bool = Sort{ .primitive = "Bool" };
+    pub const Int = Sort{ .primitive = "Int" };
+    pub const Real = Sort{ .primitive = "Real" };
+    pub const String = Sort{ .primitive = "String" };
+    pub const Ref = Sort{ .primitive = "Ref" };
+
+    pub fn jsonStringify(self: Sort, jws: anytype) !void {
+        switch (self) {
+            .primitive => |name| {
+                try jws.beginObject();
+                try jws.objectField("kind");
+                try jws.write("primitive");
+                try jws.objectField("name");
+                try jws.write(name);
+                try jws.endObject();
+            },
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Term
+// ---------------------------------------------------------------------------
+
+pub const Term = union(enum) {
+    var_term: VarTerm,
+    const_term: ConstTerm,
+    ctor_term: CtorTerm,
+
+    pub const VarTerm = struct {
+        name: []const u8,
+    };
+
+    pub const ConstTerm = struct {
+        value: ConstValue,
+        sort: Sort,
+    };
+
+    pub const CtorTerm = struct {
+        name: []const u8,
+        args: []const Term,
+    };
+
+    pub const ConstValue = union(enum) {
+        int: i64,
+        string: []const u8,
+        bool: bool,
+        null_void: void,
+
+        pub fn jsonStringify(self: ConstValue, jws: anytype) !void {
+            switch (self) {
+                .int => |v| try jws.write(v),
+                .string => |v| try jws.write(v),
+                .bool => |v| try jws.write(v),
+                .null_void => try jws.write(null),
+            }
+        }
+    };
+
+    pub fn jsonStringify(self: Term, jws: anytype) !void {
+        try jws.beginObject();
+        switch (self) {
+            .var_term => |t| {
+                try jws.objectField("kind");
+                try jws.write("var");
+                try jws.objectField("name");
+                try jws.write(t.name);
+            },
+            .const_term => |t| {
+                try jws.objectField("kind");
+                try jws.write("const");
+                try jws.objectField("sort");
+                try jws.write(t.sort);
+                try jws.objectField("value");
+                try jws.write(t.value);
+            },
+            .ctor_term => |t| {
+                try jws.objectField("args");
+                try jws.write(t.args);
+                try jws.objectField("kind");
+                try jws.write("ctor");
+                try jws.objectField("name");
+                try jws.write(t.name);
+            },
+        }
+        try jws.endObject();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Formula
+// ---------------------------------------------------------------------------
+
+pub const Formula = union(enum) {
+    atomic: AtomicFormula,
+    connective: ConnectiveFormula,
+    quantifier: QuantifierFormula,
+
+    pub const AtomicFormula = struct {
+        name: []const u8,
+        args: []const Term,
+    };
+
+    pub const ConnectiveFormula = struct {
+        kind: ConnectiveKind,
+        operands: []const Formula,
+    };
+
+    pub const ConnectiveKind = enum {
+        @"and",
+        @"or",
+        @"not",
+        @"implies",
+
+        pub fn jsonStringify(self: ConnectiveKind, jws: anytype) !void {
+            const str = switch (self) {
+                .@"and" => "and",
+                .@"or" => "or",
+                .@"not" => "not",
+                .@"implies" => "implies",
+            };
+            try jws.write(str);
+        }
+    };
+
+    pub const QuantifierFormula = struct {
+        kind: QuantifierKind,
+        name: []const u8,
+        sort: Sort,
+        body: *const Formula,
+    };
+
+    pub const QuantifierKind = enum {
+        forall,
+        exists,
+
+        pub fn jsonStringify(self: QuantifierKind, jws: anytype) !void {
+            const str = switch (self) {
+                .forall => "forall",
+                .exists => "exists",
+            };
+            try jws.write(str);
+        }
+    };
+
+    pub fn jsonStringify(self: Formula, jws: anytype) !void {
+        try jws.beginObject();
+        switch (self) {
+            .atomic => |f| {
+                try jws.objectField("args");
+                try jws.write(f.args);
+                try jws.objectField("kind");
+                try jws.write("atomic");
+                try jws.objectField("name");
+                try jws.write(f.name);
+            },
+            .connective => |f| {
+                try jws.objectField("kind");
+                try jws.write(f.kind);
+                try jws.objectField("operands");
+                try jws.write(f.operands);
+            },
+            .quantifier => |f| {
+                try jws.objectField("body");
+                try jws.write(f.body.*);
+                try jws.objectField("kind");
+                try jws.write(f.kind);
+                try jws.objectField("name");
+                try jws.write(f.name);
+                try jws.objectField("sort");
+                try jws.write(f.sort);
+            },
+        }
+        try jws.endObject();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Declaration
+// ---------------------------------------------------------------------------
+
+pub const Decl = union(enum) {
+    contract: ContractDecl,
+    bridge: BridgeDecl,
+
+    pub const ContractDecl = struct {
+        name: []const u8,
+        out_binding: []const u8 = "out",
+        pre: ?Formula = null,
+        post: ?Formula = null,
+        inv: ?Formula = null,
+    };
+
+    pub const BridgeDecl = struct {
+        name: []const u8,
+        source_symbol: []const u8,
+        source_layer: []const u8,
+        source_contract_cid: []const u8,
+        target_contract_cid: []const u8,
+        target_proof_cid: []const u8,
+        target_layer: []const u8,
+        notes: ?[]const u8 = null,
+    };
+
+    pub fn jsonStringify(self: Decl, jws: anytype) !void {
+        switch (self) {
+            .contract => |d| {
+                try jws.beginObject();
+                try jws.objectField("kind");
+                try jws.write("contract");
+                try jws.objectField("name");
+                try jws.write(d.name);
+                try jws.objectField("outBinding");
+                try jws.write(d.out_binding);
+                if (d.pre) |pre| {
+                    try jws.objectField("pre");
+                    try jws.write(pre);
+                }
+                if (d.post) |post| {
+                    try jws.objectField("post");
+                    try jws.write(post);
+                }
+                if (d.inv) |inv| {
+                    try jws.objectField("inv");
+                    try jws.write(inv);
+                }
+                try jws.endObject();
+            },
+            .bridge => |d| {
+                try jws.beginObject();
+                try jws.objectField("kind");
+                try jws.write("bridge");
+                try jws.objectField("name");
+                try jws.write(d.name);
+                if (d.notes) |notes| {
+                    try jws.objectField("notes");
+                    try jws.write(notes);
+                }
+                try jws.objectField("sourceContractCid");
+                try jws.write(d.source_contract_cid);
+                try jws.objectField("sourceLayer");
+                try jws.write(d.source_layer);
+                try jws.objectField("sourceSymbol");
+                try jws.write(d.source_symbol);
+                try jws.objectField("targetContractCid");
+                try jws.write(d.target_contract_cid);
+                try jws.objectField("targetLayer");
+                try jws.write(d.target_layer);
+                try jws.objectField("targetProofCid");
+                try jws.write(d.target_proof_cid);
+                try jws.endObject();
+            },
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Convenience constructors
+// ---------------------------------------------------------------------------
+
+pub fn Var(name: []const u8) Term {
+    return .{ .var_term = .{ .name = name } };
+}
+
+pub fn Num(n: i64) Term {
+    return .{ .const_term = .{ .value = .{ .int = n }, .sort = Sort.Int } };
+}
+
+pub fn Str(s: []const u8) Term {
+    return .{ .const_term = .{ .value = .{ .string = s }, .sort = Sort.String } };
+}
+
+pub fn BoolConst(b: bool) Term {
+    return .{ .const_term = .{ .value = .{ .bool = b }, .sort = Sort.Bool } };
+}
+
+pub fn Null() Term {
+    return .{ .const_term = .{ .value = .{ .null_void = {} }, .sort = Sort.Ref } };
+}
+
+pub fn Ctor(name: []const u8, args: []const Term) Term {
+    return .{ .ctor_term = .{ .name = name, .args = args } };
+}
+
+pub fn Atomic(name: []const u8, args: []const Term) Formula {
+    return .{ .atomic = .{ .name = name, .args = args } };
+}
+
+pub fn And(operands: []const Formula) Formula {
+    return .{ .connective = .{ .kind = .@"and", .operands = operands } };
+}
+
+pub fn Or(operands: []const Formula) Formula {
+    return .{ .connective = .{ .kind = .@"or", .operands = operands } };
+}
+
+pub fn Not(operands: []const Formula) Formula {
+    return .{ .connective = .{ .kind = .@"not", .operands = operands } };
+}
+
+pub fn Implies(operands: []const Formula) Formula {
+    return .{ .connective = .{ .kind = .@"implies", .operands = operands } };
+}
+
+pub fn Forall(name: []const u8, sort_: Sort, body: *const Formula) Formula {
+    return .{ .quantifier = .{ .kind = .forall, .name = name, .sort = sort_, .body = body } };
+}
+
+pub fn Exists(name: []const u8, sort_: Sort, body: *const Formula) Formula {
+    return .{ .quantifier = .{ .kind = .exists, .name = name, .sort = sort_, .body = body } };
+}
+
+// ---------------------------------------------------------------------------
+// JCS + Hash helpers
+// ---------------------------------------------------------------------------
+
+pub fn jcsStringify(alloc: std.mem.Allocator, value: anytype) ![]u8 {
+    var list = std.ArrayList(u8).init(alloc);
+    errdefer list.deinit();
+    try std.json.stringify(value, .{ .whitespace = .minified }, list.writer());
+    return list.toOwnedSlice();
+}
+
+pub fn jcsHash(alloc: std.mem.Allocator, jcs_bytes: []const u8) ![]u8 {
+    var hash_out: [64]u8 = undefined;
+    var hasher = std.crypto.hash.Blake3.init(.{});
+    hasher.update(jcs_bytes);
+    hasher.final(&hash_out);
+
+    // Format as "blake3-512:" + 128 lowercase hex chars
+    const prefix = "blake3-512:";
+    var result = try alloc.alloc(u8, prefix.len + 128);
+    @memcpy(result[0..prefix.len], prefix);
+    _ = try std.fmt.bufPrint(result[prefix.len..], "{s}", .{std.fmt.fmtSliceHexLower(&hash_out)});
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "eq atomic JCS matches Rust" {
+    const alloc = std.testing.allocator;
+
+    const ctor_args = [_]Term{Str("42")};
+    const lhs = Ctor("parse_int", &ctor_args);
+    const rhs = Num(42);
+    const atomic_args = [_]Term{ lhs, rhs };
+    const f = Atomic("=", &atomic_args);
+
+    const jcs = try jcsStringify(alloc, f);
+    defer alloc.free(jcs);
+
+    const expected =
+        "{\"args\":[{\"args\":[{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"},\"value\":\"42\"}],\"kind\":\"ctor\",\"name\":\"parse_int\"},"
+        ++ "{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":42}],"
+        ++ "\"kind\":\"atomic\",\"name\":\"=\"}";
+
+    try std.testing.expectEqualStrings(expected, jcs);
+}
+
+test "eq atomic hash matches Rust" {
+    const alloc = std.testing.allocator;
+
+    const ctor_args = [_]Term{Str("42")};
+    const lhs = Ctor("parse_int", &ctor_args);
+    const rhs = Num(42);
+    const atomic_args = [_]Term{ lhs, rhs };
+    const f = Atomic("=", &atomic_args);
+
+    const jcs = try jcsStringify(alloc, f);
+    defer alloc.free(jcs);
+
+    const hash = try jcsHash(alloc, jcs);
+    defer alloc.free(hash);
+
+    const expected =
+        "blake3-512:5eade72c08811b2d38adcb158eced38f3d319de090d59b2fa7a77ad830169e18"
+        ++ "539d2b75d2a2838c545e644a688cf137603674523ff37f1586a650f6dd05aeaa";
+
+    try std.testing.expectEqualStrings(expected, hash);
+}
+
+test "pattern1 bounded loop JCS matches Rust" {
+    const alloc = std.testing.allocator;
+
+    const x1 = Var("x");
+    const x2 = Var("x");
+    const x3 = Var("x");
+    const zero1 = Num(0);
+    const zero2 = Num(0);
+    const hundred = Num(100);
+
+    const lower_args = [_]Term{ x1, zero1 };
+    const lower = Atomic("≥", &lower_args);
+
+    const upper_args = [_]Term{ x2, hundred };
+    const upper = Atomic("<", &upper_args);
+
+    const conj_args = [_]Formula{ lower, upper };
+    const antecedent = And(&conj_args);
+
+    const inner_args = [_]Term{ x3, zero2 };
+    const inner = Atomic("≥", &inner_args);
+
+    const impl_args = [_]Formula{ antecedent, inner };
+    const body = Implies(&impl_args);
+
+    const q = Forall("x", Sort.Int, &body);
+
+    const jcs = try jcsStringify(alloc, q);
+    defer alloc.free(jcs);
+
+    const expected =
+        "{\"body\":{\"kind\":\"implies\",\"operands\":[{\"kind\":\"and\",\"operands\":[{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},"
+        ++ "{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":0}],\"kind\":\"atomic\",\"name\":\"≥\"},"
+        ++ "{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":100}],"
+        ++ "\"kind\":\"atomic\",\"name\":\"<\"}]},{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},"
+        ++ "{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":0}],\"kind\":\"atomic\",\"name\":\"≥\"}]},"
+        ++ "\"kind\":\"forall\",\"name\":\"x\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
+
+    try std.testing.expectEqualStrings(expected, jcs);
+}
+
+test "contract decl JCS" {
+    const alloc = std.testing.allocator;
+
+    const x = Var("x");
+    const zero = Num(0);
+    const pre_args = [_]Term{ x, zero };
+    const pre = Atomic("≥", &pre_args);
+    const d = Decl{ .contract = .{
+        .name = "parseInt",
+        .out_binding = "out",
+        .pre = pre,
+    } };
+
+    const jcs = try jcsStringify(alloc, d);
+    defer alloc.free(jcs);
+
+    const expected =
+        "{\"kind\":\"contract\",\"name\":\"parseInt\",\"outBinding\":\"out\","
+        ++ "\"pre\":{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":0}],"
+        ++ "\"kind\":\"atomic\",\"name\":\"≥\"}}";
+
+    try std.testing.expectEqualStrings(expected, jcs);
+}
+
+test "bridge decl JCS" {
+    const alloc = std.testing.allocator;
+
+    const d = Decl{ .bridge = .{
+        .name = "myBridge",
+        .source_symbol = "source",
+        .source_layer = "c-kit",
+        .source_contract_cid = "bafySource",
+        .target_contract_cid = "bafyTarget",
+        .target_proof_cid = "bafyProof",
+        .target_layer = "coq",
+        .notes = "some notes",
+    } };
+
+    const jcs = try jcsStringify(alloc, d);
+    defer alloc.free(jcs);
+
+    const expected =
+        "{\"kind\":\"bridge\",\"name\":\"myBridge\",\"notes\":\"some notes\","
+        ++ "\"sourceContractCid\":\"bafySource\",\"sourceLayer\":\"c-kit\",\"sourceSymbol\":\"source\","
+        ++ "\"targetContractCid\":\"bafyTarget\",\"targetLayer\":\"coq\",\"targetProofCid\":\"bafyProof\"}";
+
+    try std.testing.expectEqualStrings(expected, jcs);
+}

--- a/implementations/zig/provekit-lift-zig/build.zig
+++ b/implementations/zig/provekit-lift-zig/build.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const provekit_ir = b.createModule(.{
+        .root_source_file = b.path("../provekit-ir/src/root.zig"),
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "provekit-lift-zig",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("provekit-ir", provekit_ir);
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/implementations/zig/provekit-lift-zig/build.zig.zon
+++ b/implementations/zig/provekit-lift-zig/build.zig.zon
@@ -1,0 +1,8 @@
+.{
+    .name = "provekit-lift-zig",
+    .version = "0.1.0",
+    .paths = .{
+        "build.zig",
+        "src",
+    },
+}

--- a/implementations/zig/provekit-lift-zig/src/main.zig
+++ b/implementations/zig/provekit-lift-zig/src/main.zig
@@ -1,0 +1,262 @@
+const std = @import("std");
+const provekit = @import("provekit-ir");
+
+// ProvekIt Lift Tool for Zig
+//
+// Scans Zig source files for provekit annotations and emits JCS canonical IR.
+//
+// Usage:
+//   provekit-lift-zig --workspace ./src --output ./target/provekit/
+//   provekit-lift-zig --rpc              (NDJSON JSON-RPC plugin mode)
+
+const Annotation = struct {
+    function_name: []const u8,
+    kind: Kind,
+    target_cid: ?[]const u8 = null,
+    line: usize,
+
+    const Kind = enum {
+        contract,
+        implement,
+        verify,
+    };
+};
+
+fn parseAnnotations(alloc: std.mem.Allocator, text: []const u8) ![]Annotation {
+    var annotations = std.ArrayList(Annotation).init(alloc);
+    errdefer annotations.deinit();
+
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    var line_num: usize = 0;
+    while (lines.next()) |line| : (line_num += 1) {
+        const trimmed = std.mem.trim(u8, line, " \t");
+
+        if (std.mem.startsWith(u8, trimmed, "//provekit:implement ")) {
+            const cid = std.mem.trim(u8, trimmed[20..], " \t");
+            const fn_name = findAheadFnName(text, line_num);
+            try annotations.append(.{
+                .function_name = fn_name,
+                .kind = .implement,
+                .target_cid = cid,
+                .line = line_num,
+            });
+        } else if (std.mem.startsWith(u8, trimmed, "//provekit:contract")) {
+            const fn_name = findAheadFnName(text, line_num);
+            try annotations.append(.{
+                .function_name = fn_name,
+                .kind = .contract,
+                .line = line_num,
+            });
+        } else if (std.mem.startsWith(u8, trimmed, "//provekit:verify")) {
+            const fn_name = findAheadFnName(text, line_num);
+            try annotations.append(.{
+                .function_name = fn_name,
+                .kind = .verify,
+                .line = line_num,
+            });
+        }
+    }
+
+    return annotations.toOwnedSlice();
+}
+
+fn findAheadFnName(text: []const u8, start_line: usize) []const u8 {
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    var current: usize = 0;
+    while (lines.next()) |line| : (current += 1) {
+        if (current <= start_line) continue;
+        if (current > start_line + 10) break;
+
+        const trimmed = std.mem.trim(u8, line, " \t");
+        if (std.mem.startsWith(u8, trimmed, "fn ")) {
+            const after = trimmed[3..];
+            const end = std.mem.indexOfAny(u8, after, " (\n") orelse after.len;
+            return after[0..end];
+        }
+    }
+    return "unknown";
+}
+
+fn runRpcMode(alloc: std.mem.Allocator) !void {
+    const stdin = std.io.getStdIn().reader();
+    const stdout = std.io.getStdOut().writer();
+    var buf: [4096]u8 = undefined;
+
+    while (true) {
+        const maybe_line = try stdin.readUntilDelimiterOrEof(&buf, '\n');
+        const line = maybe_line orelse break;
+
+        const has_init = std.mem.indexOf(u8, line, "\"initialize\"") != null;
+        const has_parse = std.mem.indexOf(u8, line, "\"parse\"") != null;
+        const has_shutdown = std.mem.indexOf(u8, line, "\"shutdown\"") != null;
+
+        var id: []const u8 = "null";
+        if (std.mem.indexOf(u8, line, "\"id\":")) |id_pos| {
+            const after = line[id_pos + 5 ..];
+            const start = std.mem.indexOfNone(u8, after, " \t") orelse 0;
+            const end = std.mem.indexOfAny(u8, after[start..], ",}") orelse after.len;
+            id = after[start .. start + end];
+        }
+
+        if (has_init) {
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"name\":\"provekit-lift-zig\",\"version\":\"0.1.0\",\"capabilities\":[\"parse\"]}}}}\n", .{id});
+        } else if (has_parse) {
+            var decls = std.ArrayList(provekit.Decl).init(alloc);
+            defer decls.deinit();
+
+            // Minimal: emit a placeholder contract for each annotation found
+            // in the current directory. Real implementation would parse params.
+            var dir = std.fs.cwd();
+            var walker = try dir.walk(alloc);
+            defer walker.deinit();
+            while (try walker.next()) |entry| {
+                if (entry.kind != .file) continue;
+                if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
+
+                const file_text = try entry.dir.readFileAlloc(alloc, entry.basename, 1 << 20);
+                defer alloc.free(file_text);
+
+                const anns = try parseAnnotations(alloc, file_text);
+                defer alloc.free(anns);
+
+                for (anns) |ann| {
+                    switch (ann.kind) {
+                        .contract => {
+                            const post_args = [_]provekit.Term{};
+                            const post = provekit.Atomic("true", &post_args);
+                            try decls.append(.{ .contract = .{
+                                .name = ann.function_name,
+                                .post = post,
+                            } });
+                        },
+                        .implement => {
+                            if (ann.target_cid) |cid| {
+                                try decls.append(.{ .bridge = .{
+                                    .name = ann.function_name,
+                                    .source_symbol = ann.function_name,
+                                    .source_layer = "zig",
+                                    .source_contract_cid = "",
+                                    .target_contract_cid = cid,
+                                    .target_proof_cid = "",
+                                    .target_layer = "rust",
+                                } });
+                            }
+                        },
+                        .verify => {},
+                    }
+                }
+            }
+
+            const decls_slice = try decls.toOwnedSlice();
+            defer alloc.free(decls_slice);
+
+            var json_buf = std.ArrayList(u8).init(alloc);
+            defer json_buf.deinit();
+            try std.json.stringify(decls_slice, .{ .whitespace = .minified }, json_buf.writer());
+
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"declarations\":{s},\"warnings\":[]}}}}\n", .{ id, json_buf.items });
+        } else if (has_shutdown) {
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":null}}\n", .{id});
+            return;
+        } else {
+            try stdout.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"error\":{{\"code\":-32601,\"message\":\"unknown method\"}}}}\n", .{id});
+        }
+    }
+}
+
+fn runStandaloneMode(alloc: std.mem.Allocator, workspace_path: []const u8, output_path: []const u8) !void {
+    var decls = std.ArrayList(provekit.Decl).init(alloc);
+    defer decls.deinit();
+
+    var dir = try std.fs.cwd().openDir(workspace_path, .{ .iterate = true });
+    defer dir.close();
+
+    var walker = try dir.walk(alloc);
+    defer walker.deinit();
+
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
+
+        const file_text = try entry.dir.readFileAlloc(alloc, entry.basename, 1 << 20);
+        defer alloc.free(file_text);
+
+        const anns = try parseAnnotations(alloc, file_text);
+        defer alloc.free(anns);
+
+        for (anns) |ann| {
+            switch (ann.kind) {
+                .contract => {
+                    const post_args = [_]provekit.Term{};
+                    const post = provekit.Atomic("true", &post_args);
+                    try decls.append(.{ .contract = .{
+                        .name = ann.function_name,
+                        .post = post,
+                    } });
+                },
+                .implement => {
+                    if (ann.target_cid) |cid| {
+                        try decls.append(.{ .bridge = .{
+                            .name = ann.function_name,
+                            .source_symbol = ann.function_name,
+                            .source_layer = "zig",
+                            .source_contract_cid = "",
+                            .target_contract_cid = cid,
+                            .target_proof_cid = "",
+                            .target_layer = "rust",
+                        } });
+                    }
+                },
+                .verify => {},
+            }
+        }
+    }
+
+    const decls_slice = try decls.toOwnedSlice();
+    defer alloc.free(decls_slice);
+
+    const jcs = try provekit.jcsStringify(alloc, decls_slice);
+    defer alloc.free(jcs);
+
+    try std.fs.cwd().makePath(output_path);
+    const out_path = try std.fs.path.join(alloc, &.{ output_path, "lifted.json" });
+    defer alloc.free(out_path);
+    const out_file = try std.fs.cwd().createFile(out_path, .{});
+    defer out_file.close();
+    try out_file.writeAll(jcs);
+
+    std.debug.print("Wrote {d} declarations to {s}\n", .{ decls_slice.len, out_path });
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
+
+    var rpc_mode = false;
+    var workspace: ?[]const u8 = null;
+    var output: ?[]const u8 = null;
+
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--rpc")) {
+            rpc_mode = true;
+        } else if (std.mem.eql(u8, arg, "--workspace")) {
+            i += 1;
+            if (i < args.len) workspace = args[i];
+        } else if (std.mem.eql(u8, arg, "--output")) {
+            i += 1;
+            if (i < args.len) output = args[i];
+        }
+    }
+
+    if (rpc_mode) {
+        try runRpcMode(alloc);
+    } else {
+        try runStandaloneMode(alloc, workspace orelse ".", output orelse "./target/provekit");
+    }
+}


### PR DESCRIPTION
## Summary

Completes the Zig language kit for v1.1, bringing it to `+` parity with Rust, Go, Java, and Python.

## Changes

### provekit-ir
- IR types (`Sort`, `Term`, `Formula`, `Decl`) with `union(enum)` tagged unions
- `jsonStringify` methods emit object keys in **strict JCS alphabetical order**
- `jcsStringify` helper produces minified, byte-correct canonical JSON
- `jcsHash` computes **BLAKE3-512** using Zig's native `std.crypto.blake3` (64-byte XOF, zero dependencies)
- Naming convention: `@"and"`, `@"or"`, `@"not"`, `@"implies"` to escape Zig reserved keywords
- Convenience constructors: `Var()`, `Num()`, `Str()`, `BoolConst()`, `Null()`, `Ctor()`, `Atomic()`, `And()`, `Or()`, `Not()`, `Implies()`, `Forall()`, `Exists()`

### provekit-lift-zig
- Scans Zig source for `//provekit:contract`, `//provekit:implement <cid>`, `//provekit:verify` annotations
- Standalone mode: `provekit-lift-zig --workspace ./src --output ./target/provekit`
- RPC plugin mode: `provekit-lift-zig --rpc` speaks NDJSON protocol with `initialize`, `parse`, `shutdown`
- Emits JCS canonical IR via provekit-ir

### Tests (5 passing)
| Test | What it proves |
|------|---------------|
| `eq atomic JCS matches Rust` | `parse_int("42") = 42` → byte-identical JSON to Rust kit |
| `eq atomic hash matches Rust` | BLAKE3-512 hash matches pinned Rust hash |
| `pattern1 bounded loop JCS matches Rust` | `forall x: (x >= 0 && x < 100) => x >= 0` → identical to Rust |
| `contract decl JCS` | Contract JSON with `pre` → correct alphabetical key order |
| `bridge decl JCS` | Bridge JSON with `notes` → `notes` sorts before `sourceContractCid` |

## Docs
- Zig promoted to `+` Kit / `+` Embedded Verifier in per-language status matrix
- Added Zig section documenting kit, lift tool, and native BLAKE3 support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated language support status matrix with LSP plugin information
  * Added detailed sections for C and Zig implementations
  * Clarified Python and Java/JVM capabilities and shipping status

* **New Features**
  * Introduced Zig language support with IR types and serialization
  * Added Zig lift tool supporting both standalone and RPC modes for scanning source annotations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->