### PR TITLE
fix(test): smt-lib emitter test asserts is_err (consistency with PR #39)

### DIFF
--- a/implementations/rust/provekit-ir-compiler-smt-lib/tests/emitter.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/tests/emitter.rs
@@ -414,8 +414,11 @@ fn var_with_empty_name_returns_err() {
              "sort": {"kind": "primitive", "name": "Int"}}
         ]
     });
-    // Spec allows empty string names; serde deserializes them fine.
-    assert!(emit(&f).is_ok());
+    // PR #39 added structural validation: empty var names are malformed
+    // IR (SMT-LIB rejects empty symbols, every host-language lifter
+    // refuses empty identifiers). The function name was correct; the
+    // prior assertion documented the bug instead of catching it.
+    assert!(emit(&f).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The smt-lib crate had a test \`var_with_empty_name_returns_err\` whose function name claimed one outcome but asserted the opposite (\`is_ok()\` with a comment justifying it as spec-compliant). PR #39 added structural validation that rejects empty var names; this PR brings the test's assertion in line with that semantics. The contradictory siblings on PR #39 are resolved.

## Test plan

- [ ] CI \`make test-all\` passes (only remaining test failure across the rust workspace)
- [ ] Conformance gate finally goes green