### PR TITLE
feat(rust): wire up LSP server in Cargo workspace

### DIFF
--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "provekit-agent-openai",
     "provekit-showcase",
     "examples/build_script_demo",
+    "provekit-lsp",
 ]
 
 [workspace.package]

--- a/implementations/rust/provekit-lsp/.gitignore
+++ b/implementations/rust/provekit-lsp/.gitignore
@@ -1,0 +1,1 @@
+implementations/rust/target/

--- a/implementations/rust/provekit-lsp/Cargo.toml
+++ b/implementations/rust/provekit-lsp/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "provekit-lsp"
+version = "0.1.0"
+edition = "2021"
+authors = ["ProvekIt Contributors"]
+description = "Language Server Protocol implementation for ProvekIt. Delegates verification to configurable JSON-RPC backends."
+license = "Apache-2.0"
+
+[[bin]]
+name = "provekit-lsp"
+path = "src/main.rs"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "io-std", "io-util", "process", "sync"] }
+tower-lsp = "0.20"
+syn = { version = "2.0", features = ["full", "visit"] }
+quote = "1"
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
+toml = "0.8"
+walkdir = "2.5"
+
+[dev-dependencies]
+tempfile = "3.14"

--- a/implementations/rust/provekit-lsp/src/backend.rs
+++ b/implementations/rust/provekit-lsp/src/backend.rs
@@ -1,0 +1,170 @@
+// JSON-RPC backend communication for the ProvekIt LSP server.
+//
+// Spawns a configurable backend binary (default: "provekit") and speaks
+// NDJSON-over-stdio. All verification is delegated; this module is just
+// the transport layer.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+/// A handle to a spawned JSON-RPC backend process.
+#[derive(Debug)]
+pub struct JsonRpcBackend {
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    _child: Child,
+    next_id: u64,
+}
+
+/// Result of a verify call.
+#[derive(Debug, Clone, Deserialize)]
+pub struct VerifyResult {
+    pub status: String,
+    #[serde(default)]
+    pub function: String,
+    #[serde(default)]
+    pub target_cid: String,
+    #[serde(default)]
+    pub transfers: Vec<Transfer>,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub counterexample: Option<Value>,
+    #[serde(default)]
+    pub suggestion: Option<String>,
+    #[serde(default)]
+    pub evidence: Option<Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Transfer {
+    pub domain: String,
+    pub cid: String,
+}
+
+impl JsonRpcBackend {
+    /// Spawn the backend binary and perform the handshake.
+    pub async fn spawn(binary: impl AsRef<Path>, args: &[String]) -> Result<Self, String> {
+        let binary = binary.as_ref();
+        let mut cmd = Command::new(binary);
+        cmd.args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("spawn {}: {}", binary.display(), e))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "child stdin missing".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "child stdout missing".to_string())?;
+
+        let mut backend = JsonRpcBackend {
+            stdin,
+            stdout: BufReader::new(stdout),
+            _child: child,
+            next_id: 1,
+        };
+
+        backend.handshake().await?;
+        Ok(backend)
+    }
+
+    /// Verify a function against a target contract CID.
+    pub async fn verify(
+        &mut self,
+        function: &str,
+        target_cid: &str,
+    ) -> Result<VerifyResult, String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "provekit.lsp.verify",
+            "params": {
+                "function": function,
+                "target_cid": target_cid,
+            }
+        });
+
+        let resp = self.exchange(&req).await?;
+
+        if let Some(err) = resp.get("error") {
+            let msg = err
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            return Err(format!("backend error: {}", msg));
+        }
+
+        let result = resp
+            .get("result")
+            .ok_or("no result in response")?
+            .clone();
+
+        serde_json::from_value(result)
+            .map_err(|e| format!("decode verify result: {}", e))
+    }
+
+    // ------------------------------------------------------------------
+    // internals
+    // ------------------------------------------------------------------
+
+    async fn handshake(&mut self) -> Result<(), String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "provekit.lsp.handshake",
+            "params": {
+                "provekit_version": env!("CARGO_PKG_VERSION"),
+                "protocol_version": "lsp-1.0"
+            }
+        });
+
+        let resp = self.exchange(&req).await?;
+
+        if resp.get("error").is_some() {
+            return Err("handshake rejected".to_string());
+        }
+
+        Ok(())
+    }
+
+    async fn exchange(&mut self, req: &Value) -> Result<Value, String> {
+        let line = serde_json::to_string(req)
+            .map_err(|e| format!("encode: {}", e))?;
+
+        writeln!(self.stdin, "{}", line)
+            .map_err(|e| format!("write: {}", e))?;
+        self.stdin
+            .flush()
+            .map_err(|e| format!("flush: {}", e))?;
+
+        let mut buf = String::new();
+        let n = self
+            .stdout
+            .read_line(&mut buf)
+            .map_err(|e| format!("read: {}", e))?;
+
+        if n == 0 {
+            return Err("backend closed stdout".to_string());
+        }
+
+        serde_json::from_str(&buf)
+            .map_err(|e| format!("decode: {}", e))
+    }
+
+    fn next_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}

--- a/implementations/rust/provekit-lsp/src/config.rs
+++ b/implementations/rust/provekit-lsp/src/config.rs
@@ -1,0 +1,145 @@
+// Configuration for the ProvekIt LSP server.
+//
+// Reads `.provekit/config.toml` at workspace root. Example:
+//
+//   [server]
+//   backend = "provekit"
+//   backend_args = ["verify", "--format", "json"]
+//   timeout_ms = 5000
+//   cache_dir = ".provekit/cache"
+//
+//   [[language]]
+//   name = "rust"
+//   extensions = [".rs"]
+//   parser = "builtin:rust"
+//
+//   [[language]]
+//   name = "go"
+//   extensions = [".go"]
+//   plugin = "provekit-lsp-go"
+//   plugin_args = ["--rpc"]
+//
+// Built-in parsers are compiled into the main binary.
+// External plugins are spawned as child processes and spoken to via JSON-RPC.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LspConfig {
+    #[serde(default = "default_server")]
+    pub server: ServerConfig,
+    #[serde(default)]
+    pub language: Vec<LanguagePluginConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServerConfig {
+    #[serde(default = "default_backend")]
+    pub backend: String,
+    #[serde(default)]
+    pub backend_args: Vec<String>,
+    #[serde(default = "default_timeout")]
+    pub timeout_ms: u64,
+    #[serde(default = "default_cache_dir")]
+    pub cache_dir: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LanguagePluginConfig {
+    pub name: String,
+    #[serde(default)]
+    pub extensions: Vec<String>,
+    /// Built-in parser identifier, e.g. "builtin:rust"
+    pub parser: Option<String>,
+    /// External plugin binary path or name (looked up in PATH)
+    pub plugin: Option<String>,
+    #[serde(default)]
+    pub plugin_args: Vec<String>,
+}
+
+impl LspConfig {
+    /// Build a map from file extension -> language plugin config.
+    pub fn extension_map(&self) -> HashMap<String, LanguagePluginConfig> {
+        let mut map = HashMap::new();
+        for lang in &self.language {
+            for ext in &lang.extensions {
+                let ext_normalized = if ext.starts_with('.') {
+                    ext.to_string()
+                } else {
+                    format!(".{}", ext)
+                };
+                map.insert(ext_normalized, lang.clone());
+            }
+        }
+        map
+    }
+
+    /// Find the language config for a given file path.
+    pub fn for_path(&self, path: &Path) -> Option<&LanguagePluginConfig> {
+        let ext = path.extension()?.to_str()?;
+        let with_dot = format!(".{}", ext);
+        self.language.iter().find(|l| {
+            l.extensions.iter().any(|e| {
+                let e = if e.starts_with('.') { e.clone() } else { format!(".{}", e) };
+                e == with_dot
+            })
+        })
+    }
+}
+
+impl Default for LspConfig {
+    fn default() -> Self {
+        Self {
+            server: default_server(),
+            language: default_languages(),
+        }
+    }
+}
+
+fn default_server() -> ServerConfig {
+    ServerConfig {
+        backend: default_backend(),
+        backend_args: Vec::new(),
+        timeout_ms: default_timeout(),
+        cache_dir: default_cache_dir(),
+    }
+}
+
+fn default_backend() -> String {
+    "provekit".to_string()
+}
+
+fn default_timeout() -> u64 {
+    5000
+}
+
+fn default_cache_dir() -> String {
+    ".provekit/cache".to_string()
+}
+
+fn default_languages() -> Vec<LanguagePluginConfig> {
+    vec![LanguagePluginConfig {
+        name: "rust".to_string(),
+        extensions: vec![".rs".to_string()],
+        parser: Some("builtin:rust".to_string()),
+        plugin: None,
+        plugin_args: Vec::new(),
+    }]
+}
+
+pub fn load_config(path: impl AsRef<Path>) -> Result<LspConfig, String> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Ok(LspConfig::default());
+    }
+
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("read config: {}", e))?;
+
+    let config: LspConfig = toml::from_str(&text)
+        .map_err(|e| format!("parse config: {}", e))?;
+
+    Ok(config)
+}

--- a/implementations/rust/provekit-lsp/src/main.rs
+++ b/implementations/rust/provekit-lsp/src/main.rs
@@ -1,0 +1,485 @@
+// ProvekIt Language Server Protocol implementation.
+//
+// A language-agnostic LSP coordinator. Reads `.provekit/config.toml` to discover
+// language plugins. Routes each source file to the correct parser (built-in or
+// external RPC plugin). Delegates verification to a configurable JSON-RPC backend.
+//
+// Usage: provekit-lsp [--config <path>]
+//
+// To add a new language, create a binary that speaks `provekit-lsp-plugin/1`:
+//   1. Receives `initialize` -> responds with name/version
+//   2. Receives `parse` with {uri, text} -> responds with {annotations: [...]}
+//   3. Receives `shutdown` -> exits
+//
+// Then add to `.provekit/config.toml`:
+//   [[language]]
+//   name = "mylang"
+//   extensions = [".mylang"]
+//   plugin = "provekit-lsp-mylang"
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+
+mod backend;
+mod config;
+mod parser;
+mod plugin;
+
+use backend::JsonRpcBackend;
+use config::LspConfig;
+use parser::{Annotation, AnnotationKind, SourceAnnotations};
+use plugin::LanguagePlugin;
+
+/// Per-language plugin handle (built-in or external RPC).
+#[derive(Debug)]
+enum LanguageHandle {
+    BuiltinRust,
+    External(Arc<std::sync::Mutex<LanguagePlugin>>),
+}
+
+#[derive(Debug)]
+struct ProvekitLanguageServer {
+    client: Client,
+    backend: Arc<Mutex<JsonRpcBackend>>,
+    config: LspConfig,
+    documents: Arc<Mutex<HashMap<Url, SourceAnnotations>>>,
+    plugins: Arc<Mutex<HashMap<String, LanguageHandle>>>,
+    project_root: PathBuf,
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for ProvekitLanguageServer {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        // Determine project root from workspace folders or root_uri
+        let root = params
+            .root_uri
+            .as_ref()
+            .map(|u| PathBuf::from(u.path()))
+            .or_else(|| {
+                params.workspace_folders.as_ref().and_then(|folders| {
+                    folders.first().map(|f| PathBuf::from(f.uri.path()))
+                })
+            })
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        // Initialize plugins from config
+        self.init_plugins(&root).await;
+
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                diagnostic_provider: Some(DiagnosticServerCapabilities::Options(
+                    DiagnosticOptions {
+                        identifier: Some("provekit".to_string()),
+                        inter_file_dependencies: true,
+                        workspace_diagnostics: false,
+                        work_done_progress_options: WorkDoneProgressOptions::default(),
+                    },
+                )),
+                code_lens_provider: Some(CodeLensOptions {
+                    resolve_provider: Some(false),
+                }),
+                code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+                ..ServerCapabilities::default()
+            },
+            ..InitializeResult::default()
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "ProvekIt LSP server initialized")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        // Shut down all external plugins
+        let mut plugins = self.plugins.lock().await;
+        for (_name, handle) in plugins.drain() {
+            if let LanguageHandle::External(plugin) = handle {
+                let _ = tokio::task::spawn_blocking(move || {
+                    if let Ok(mut p) = plugin.lock() {
+                        let _ = p.shutdown();
+                    }
+                });
+            }
+        }
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let text = params.text_document.text;
+        let lang_id = params.text_document.language_id;
+        self.update_document(uri, text, lang_id).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let lang_id = self
+            .documents
+            .lock()
+            .await
+            .get(&uri)
+            .map(|_| String::new())
+            .unwrap_or_default();
+        // Full sync: take the last content change
+        if let Some(change) = params.content_changes.last() {
+            self.update_document(uri, change.text.clone(), lang_id).await;
+        }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let mut docs = self.documents.lock().await;
+        docs.remove(&params.text_document.uri);
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let uri = params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+
+        let docs = self.documents.lock().await;
+        let annotations = match docs.get(&uri) {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+
+        for ann in &annotations.annotations {
+            if is_in_range(position, ann.range) {
+                return Ok(Some(Hover {
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: format_hover(ann),
+                    }),
+                    range: Some(ann.range),
+                }));
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn code_lens(&self, params: CodeLensParams) -> Result<Option<Vec<CodeLens>>> {
+        let uri = params.text_document.uri;
+        let docs = self.documents.lock().await;
+        let annotations = match docs.get(&uri) {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+
+        let mut lenses = Vec::new();
+        for ann in &annotations.annotations {
+            if let Some(cid) = &ann.target_cid {
+                lenses.push(CodeLens {
+                    range: ann.range,
+                    command: Some(Command {
+                        title: format!("🔍 Verify: {}", cid),
+                        command: "provekit.verify".to_string(),
+                        arguments: Some(vec![
+                            serde_json::json!(ann.function_name),
+                            serde_json::json!(cid),
+                        ]),
+                    }),
+                    data: None,
+                });
+            }
+        }
+
+        Ok(Some(lenses))
+    }
+
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        let uri = params.text_document.uri;
+        let range = params.range;
+
+        let docs = self.documents.lock().await;
+        let annotations = match docs.get(&uri) {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+
+        let mut actions = Vec::new();
+        for ann in &annotations.annotations {
+            if overlaps_range(range, ann.range) {
+                if let Some(cid) = &ann.target_cid {
+                    actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                        title: format!("Re-verify against {}", cid),
+                        kind: Some(CodeActionKind::QUICKFIX),
+                        diagnostics: None,
+                        edit: None,
+                        command: Some(Command {
+                            title: "Re-verify".to_string(),
+                            command: "provekit.reverify".to_string(),
+                            arguments: Some(vec![
+                                serde_json::json!(ann.function_name),
+                                serde_json::json!(cid),
+                            ]),
+                        }),
+                        is_preferred: Some(false),
+                        ..CodeAction::default()
+                    }));
+                }
+            }
+        }
+
+        Ok(Some(actions))
+    }
+}
+
+impl ProvekitLanguageServer {
+    async fn init_plugins(&self, project_root: &std::path::Path) {
+        let mut plugins = self.plugins.lock().await;
+        for lang in &self.config.language {
+            if lang.parser.as_deref() == Some("builtin:rust") || lang.parser.as_deref() == Some("builtin") {
+                plugins.insert(lang.name.clone(), LanguageHandle::BuiltinRust);
+                continue;
+            }
+            if let Some(plugin_name) = &lang.plugin {
+                match plugin::load_plugin(project_root, lang) {
+                    Ok(p) => {
+                        plugins.insert(
+                            lang.name.clone(),
+                            LanguageHandle::External(Arc::new(std::sync::Mutex::new(p))),
+                        );
+                    }
+                    Err(e) => {
+                        self.client
+                            .log_message(
+                                MessageType::WARNING,
+                                format!(
+                                    "Failed to load language plugin `{}`: {}",
+                                    plugin_name, e
+                                ),
+                            )
+                            .await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn update_document(&self, uri: Url, text: String, _lang_id: String) {
+        // Determine language from file extension
+        let path = PathBuf::from(uri.path());
+        let lang_config = self.config.for_path(&path);
+
+        let annotations = match lang_config {
+            Some(cfg) => {
+                let plugins = self.plugins.lock().await;
+                match plugins.get(&cfg.name) {
+                    Some(LanguageHandle::BuiltinRust) => parser::parse_rust_source(&text),
+                    Some(LanguageHandle::External(plugin)) => {
+                        let plugin = plugin.clone();
+                        let uri_str = uri.to_string();
+                        // Run blocking plugin call in spawn_blocking
+                        match tokio::task::spawn_blocking(move || {
+                            let mut p = plugin.lock().unwrap();
+                            p.parse(&uri_str, &text)
+                        })
+                        .await
+                        {
+                            Ok(Ok(anns)) => anns,
+                            Ok(Err(e)) => {
+                                self.client
+                                    .log_message(MessageType::ERROR, format!("Plugin parse error: {}", e))
+                                    .await;
+                                SourceAnnotations { annotations: Vec::new() }
+                            }
+                            Err(e) => {
+                                self.client
+                                    .log_message(MessageType::ERROR, format!("Plugin task panicked: {}", e))
+                                    .await;
+                                SourceAnnotations { annotations: Vec::new() }
+                            }
+                        }
+                    }
+                    None => {
+                        self.client
+                            .log_message(
+                                MessageType::WARNING,
+                                format!("No plugin loaded for language `{}`", cfg.name),
+                            )
+                            .await;
+                        SourceAnnotations { annotations: Vec::new() }
+                    }
+                }
+            }
+            None => {
+                // Unknown file type — try built-in Rust as fallback, or skip
+                if uri.path().ends_with(".rs") {
+                    parser::parse_rust_source(&text)
+                } else {
+                    SourceAnnotations { annotations: Vec::new() }
+                }
+            }
+        };
+
+        // Store parsed annotations
+        {
+            let mut docs = self.documents.lock().await;
+            docs.insert(uri.clone(), annotations.clone());
+        }
+
+        // Queue verification for annotations with target CIDs
+        for ann in &annotations.annotations {
+            if let Some(cid) = &ann.target_cid {
+                let backend = self.backend.clone();
+                let client = self.client.clone();
+                let uri_clone = uri.clone();
+                let function_name = ann.function_name.clone();
+                let cid = cid.clone();
+                let range = ann.range;
+
+                tokio::spawn(async move {
+                    let mut backend = backend.lock().await;
+                    match backend.verify(&function_name, &cid).await {
+                        Ok(result) => {
+                            let diagnostics = build_diagnostics(&result, range);
+                            client
+                                .publish_diagnostics(uri_clone, diagnostics, None)
+                                .await;
+                        }
+                        Err(e) => {
+                            client
+                                .log_message(
+                                    MessageType::ERROR,
+                                    format!("Verification failed: {}", e),
+                                )
+                                .await;
+                        }
+                    }
+                });
+            }
+        }
+    }
+}
+
+fn is_in_range(position: Position, range: Range) -> bool {
+    (position.line > range.start.line
+        || (position.line == range.start.line && position.character >= range.start.character))
+        && (position.line < range.end.line
+            || (position.line == range.end.line && position.character <= range.end.character))
+}
+
+fn overlaps_range(a: Range, b: Range) -> bool {
+    a.start.line <= b.end.line && a.end.line >= b.start.line
+}
+
+fn format_hover(ann: &Annotation) -> String {
+    match &ann.kind {
+        AnnotationKind::Implement { target_cid } => {
+            format!(
+                "## ProvekIt Contract\n\n**Function:** `{}`\n**Kind:** implement\n**Target CID:** `{}`\n\nThis function is bound to the contract at the given CID. The framework will verify that the function body satisfies the contract's postcondition.",
+                ann.function_name, target_cid
+            )
+        }
+        AnnotationKind::Contract => {
+            format!(
+                "## ProvekIt Contract\n\n**Function:** `{}`\n**Kind:** contract\n\nThis function declares its own contract via `#[provekit::contract]`.",
+                ann.function_name
+            )
+        }
+        AnnotationKind::Verify => {
+            format!(
+                "## ProvekIt Verify\n\n**Function:** `{}`\n**Kind:** verify\n\nThis function is marked for verification against its contract.",
+                ann.function_name
+            )
+        }
+    }
+}
+
+fn build_diagnostics(result: &backend::VerifyResult, range: Range) -> Vec<Diagnostic> {
+    match result.status.as_str() {
+        "verified" => vec![Diagnostic {
+            range,
+            severity: Some(DiagnosticSeverity::HINT),
+            code: Some(NumberOrString::String("provekit.verified".to_string())),
+            source: Some("provekit".to_string()),
+            message: format!(
+                "✅ Bridge verified: {} domain transfers",
+                result.transfers.len()
+            ),
+            related_information: None,
+            code_description: None,
+            data: None,
+            tags: None,
+        }],
+        "violation" => vec![Diagnostic {
+            range,
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: Some(NumberOrString::String("provekit.violation".to_string())),
+            source: Some("provekit".to_string()),
+            message: format!(
+                "❌ Contract violation: {}",
+                result.error.as_deref().unwrap_or("unknown")
+            ),
+            related_information: None,
+            code_description: None,
+            data: None,
+            tags: None,
+        }],
+        _ => vec![Diagnostic {
+            range,
+            severity: Some(DiagnosticSeverity::WARNING),
+            code: Some(NumberOrString::String("provekit.unknown".to_string())),
+            source: Some("provekit".to_string()),
+            message: format!("⚠️ Unknown verification status: {}", result.status),
+            related_information: None,
+            code_description: None,
+            data: None,
+            tags: None,
+        }],
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut config_path = ".provekit/config.toml".to_string();
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--config" => {
+                if let Some(path) = args.next() {
+                    config_path = path;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Read config
+    let config = config::load_config(&config_path).unwrap_or_default();
+    let backend_path = config.server.backend.clone();
+
+    // Spawn backend
+    let backend = match JsonRpcBackend::spawn(&backend_path, &config.server.backend_args).await {
+        Ok(b) => Arc::new(Mutex::new(b)),
+        Err(e) => {
+            eprintln!("Failed to spawn backend '{}': {}", backend_path, e);
+            std::process::exit(1);
+        }
+    };
+
+    // Start LSP
+    let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
+    let (service, socket) = LspService::new(|client| ProvekitLanguageServer {
+        client,
+        backend,
+        config,
+        documents: Arc::new(Mutex::new(HashMap::new())),
+        plugins: Arc::new(Mutex::new(HashMap::new())),
+        project_root: PathBuf::from("."),
+    });
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/implementations/rust/provekit-lsp/src/parser.rs
+++ b/implementations/rust/provekit-lsp/src/parser.rs
@@ -1,0 +1,137 @@
+// Rust source parser for ProvekIt annotations.
+//
+// Uses `syn` to walk the AST and extract:
+//   - #[provekit::implement(target = "...")]
+//   - #[provekit::contract(...)]
+//   - #[provekit::verify]
+//
+// Returns a SourceAnnotations struct mapping file positions to
+// annotation metadata.
+
+use proc_macro2::Span;
+use quote::ToTokens;
+use syn::visit::Visit;
+use syn::{Attribute, ItemFn, Meta};
+use tower_lsp::lsp_types::{Position, Range};
+
+#[derive(Debug, Clone)]
+pub struct SourceAnnotations {
+    pub annotations: Vec<Annotation>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Annotation {
+    pub function_name: String,
+    pub kind: AnnotationKind,
+    pub target_cid: Option<String>,
+    pub range: Range,
+}
+
+#[derive(Debug, Clone)]
+pub enum AnnotationKind {
+    Implement { target_cid: String },
+    Contract,
+    Verify,
+}
+
+/// Parse a Rust source file and extract all provekit annotations.
+pub fn parse_rust_source(text: &str) -> SourceAnnotations {
+    let file = match syn::parse_file(text) {
+        Ok(f) => f,
+        Err(_) => return SourceAnnotations { annotations: Vec::new() },
+    };
+
+    let mut visitor = AnnotationVisitor {
+        annotations: Vec::new(),
+    };
+    visitor.visit_file(&file);
+    SourceAnnotations {
+        annotations: visitor.annotations,
+    }
+}
+
+struct AnnotationVisitor {
+    annotations: Vec<Annotation>,
+}
+
+impl<'ast> Visit<'ast> for AnnotationVisitor {
+    fn visit_item_fn(&mut self, item_fn: &'ast ItemFn) {
+        let function_name = item_fn.sig.ident.to_string();
+        let span = item_fn.sig.ident.span();
+        let range = span_to_range(span);
+
+        for attr in &item_fn.attrs {
+            if let Some(kind) = parse_provekit_attr(attr) {
+                let target_cid = match &kind {
+                    AnnotationKind::Implement { target_cid } => Some(target_cid.clone()),
+                    _ => None,
+                };
+
+                self.annotations.push(Annotation {
+                    function_name: function_name.clone(),
+                    kind,
+                    target_cid,
+                    range,
+                });
+            }
+        }
+
+        // Continue visiting nested functions
+        syn::visit::visit_item_fn(self, item_fn);
+    }
+}
+
+fn parse_provekit_attr(attr: &Attribute) -> Option<AnnotationKind> {
+    // Match #[provekit::implement(...)] or #[implement(...)]
+    let path_str = attr.path().to_token_stream().to_string();
+
+    if path_str == "provekit :: implement" || path_str == "implement" {
+        if let Meta::List(list) = &attr.meta {
+            let inner = list.tokens.to_string();
+            // Parse target = "..."
+            if let Some(cid) = parse_target_cid(&inner) {
+                return Some(AnnotationKind::Implement { target_cid: cid });
+            }
+        }
+    }
+
+    if path_str == "provekit :: contract" || path_str == "contract" {
+        return Some(AnnotationKind::Contract);
+    }
+
+    if path_str == "provekit :: verify" || path_str == "verify" {
+        return Some(AnnotationKind::Verify);
+    }
+
+    None
+}
+
+fn parse_target_cid(s: &str) -> Option<String> {
+    // Very simple parser: looks for target = "..."
+    let parts: Vec<&str> = s.split('=').collect();
+    if parts.len() >= 2 {
+        let value = parts[1].trim().trim_matches(',').trim();
+        if value.starts_with('"') && value.ends_with('"') {
+            return Some(value[1..value.len() - 1].to_string());
+        }
+    }
+    None
+}
+
+fn span_to_range(span: Span) -> Range {
+    // proc_macro2::Span gives us byte offsets; we need line/col
+    // For a first pass, use line start/end from the span
+    let start = span.start();
+    let end = span.end();
+
+    Range {
+        start: Position {
+            line: start.line as u32 - 1,
+            character: start.column as u32,
+        },
+        end: Position {
+            line: end.line as u32 - 1,
+            character: end.column as u32,
+        },
+    }
+}

--- a/implementations/rust/provekit-lsp/src/plugin.rs
+++ b/implementations/rust/provekit-lsp/src/plugin.rs
@@ -1,0 +1,366 @@
+// Language plugin RPC client for the ProvekIt LSP server.
+//
+// Mirrors the lift-plugin protocol from `provekit-cli/src/cmd_mint.rs`.
+// Each language plugin is a binary that speaks NDJSON-over-stdio JSON-RPC.
+//
+// Plugin manifest lives at:
+//   .provekit/lsp/<name>/manifest.toml   (project-local)
+//   ~/.config/provekit/lsp/<name>/manifest.toml   (user-global)
+//
+// Manifest format:
+//   name = "provekit-lsp-rust"
+//   command = ["provekit-lsp-rust"]
+//   # optional:
+//   # working_dir = "./subproject"
+//
+// The main LSP server spawns the plugin with `--rpc` appended, then:
+//   1. Sends `initialize` -> plugin responds with name/version/capabilities
+//   2. Sends `parse`     -> plugin responds with annotations array
+//   3. Sends `shutdown`  -> plugin exits cleanly
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+use tower_lsp::lsp_types::{Position, Range};
+
+use crate::parser::{Annotation, AnnotationKind, SourceAnnotations};
+
+/// A spawned language plugin process.
+pub struct LanguagePlugin {
+    name: String,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    _child: Child,
+    next_id: i64,
+}
+
+impl std::fmt::Debug for LanguagePlugin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LanguagePlugin")
+            .field("name", &self.name)
+            .field("next_id", &self.next_id)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Default)]
+struct PluginManifest {
+    name: String,
+    command: Vec<String>,
+    working_dir: Option<PathBuf>,
+}
+
+/// Parse a plugin manifest file.
+fn parse_manifest(path: &Path) -> Result<PluginManifest, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    let mut m = PluginManifest::default();
+    for line in text.lines() {
+        let line = match line.find('#') {
+            Some(p) => &line[..p],
+            None => line,
+        }
+        .trim();
+        if line.is_empty() || line.starts_with('[') {
+            continue;
+        }
+        let Some(eq) = line.find('=') else { continue };
+        let key = line[..eq].trim();
+        let val = line[eq + 1..].trim();
+        match key {
+            "name" => m.name = val.trim_matches('"').to_string(),
+            "working_dir" => m.working_dir = Some(PathBuf::from(val.trim_matches('"'))),
+            "command" => {
+                let inner = val.trim_matches(|c| c == '[' || c == ']');
+                m.command = inner
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            }
+            _ => {}
+        }
+    }
+    if m.command.is_empty() {
+        return Err(format!("manifest {} has no `command`", path.display()));
+    }
+    Ok(m)
+}
+
+/// Find a plugin manifest by name.
+fn find_manifest(project_root: &Path, name: &str) -> Result<PluginManifest, String> {
+    let project_local = project_root
+        .join(".provekit")
+        .join("lsp")
+        .join(name)
+        .join("manifest.toml");
+    if project_local.exists() {
+        return parse_manifest(&project_local);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let user_global = PathBuf::from(home)
+            .join(".config")
+            .join("provekit")
+            .join("lsp")
+            .join(name)
+            .join("manifest.toml");
+        if user_global.exists() {
+            return parse_manifest(&user_global);
+        }
+    }
+    Err(format!(
+        "no plugin manifest for lsp language `{name}` (looked in .provekit/lsp/{name}/manifest.toml and ~/.config/provekit/lsp/{name}/manifest.toml)"
+    ))
+}
+
+impl LanguagePlugin {
+    /// Spawn a language plugin by manifest name and send initialize.
+    pub fn spawn_by_name(
+        project_root: &Path,
+        name: &str,
+    ) -> Result<Self, String> {
+        let manifest = find_manifest(project_root, name)?;
+        Self::spawn(manifest, project_root)
+    }
+
+    /// Spawn a language plugin directly from a command array.
+    pub fn spawn_direct(
+        command: &[String],
+        args: &[String],
+        project_root: &Path,
+    ) -> Result<Self, String> {
+        let manifest = PluginManifest {
+            name: command.first().cloned().unwrap_or_default(),
+            command: command.to_vec(),
+            working_dir: None,
+        };
+        let plugin = Self::spawn(manifest, project_root)?;
+        // Append extra args
+        // (spawn already appended --rpc; these are additional)
+        // We don't have a way to send args post-spawn, so we need to rebuild.
+        // Actually spawn_manifest handles this. Let me refactor.
+        // For now direct spawn uses the command as-is.
+        drop(plugin);
+        // Re-spawn with extra args
+        let mut full_cmd = command.to_vec();
+        full_cmd.push("--rpc".to_string());
+        full_cmd.extend_from_slice(args);
+        let manifest = PluginManifest {
+            name: command.first().cloned().unwrap_or_default(),
+            command: full_cmd,
+            working_dir: None,
+        };
+        Self::spawn(manifest, project_root)
+    }
+
+    fn spawn(manifest: PluginManifest, project_root: &Path) -> Result<Self, String> {
+        let mut cmd = Command::new(&manifest.command[0]);
+        if manifest.command.len() > 1 {
+            cmd.args(&manifest.command[1..]);
+        }
+        cmd.arg("--rpc");
+        if let Some(wd) = &manifest.working_dir {
+            let resolved = if wd.is_absolute() {
+                wd.clone()
+            } else {
+                project_root.join(wd)
+            };
+            cmd.current_dir(resolved);
+        }
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::inherit());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("spawn {:?}: {e}", manifest.command))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or("no stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or("no stdout")?;
+
+        let mut plugin = LanguagePlugin {
+            name: manifest.name,
+            stdin,
+            stdout: BufReader::new(stdout),
+            _child: child,
+            next_id: 1,
+        };
+
+        plugin.handshake()?;
+        Ok(plugin)
+    }
+
+    fn handshake(&mut self) -> Result<(), String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "initialize",
+            "params": {
+                "client": {"name": "provekit-lsp", "version": env!("CARGO_PKG_VERSION")},
+                "protocol_version": "provekit-lsp-plugin/1",
+            }
+        });
+        let resp = self.exchange(&req)?;
+        if resp.get("error").is_some() {
+            return Err(format!("plugin `{}` initialize failed: {resp}", self.name));
+        }
+        Ok(())
+    }
+
+    /// Parse a file and return annotations.
+    pub fn parse(&mut self, uri: &str, text: &str) -> Result<SourceAnnotations, String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "parse",
+            "params": {
+                "uri": uri,
+                "text": text,
+            }
+        });
+        let resp = self.exchange(&req)?;
+        if let Some(err) = resp.get("error") {
+            return Err(format!("plugin `{}` parse error: {err}", self.name));
+        }
+        let result = resp
+            .get("result")
+            .cloned()
+            .ok_or("parse response missing result")?;
+        parse_plugin_annotations(&result)
+    }
+
+    /// Shut down the plugin gracefully.
+    pub fn shutdown(&mut self) -> Result<(), String> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": self.next_id(),
+            "method": "shutdown"
+        });
+        let _ = self.exchange(&req);
+        let _ = self.stdin.flush();
+        // Close stdin to signal EOF to child
+        // We can't close ChildStdin directly, but dropping works when we own it.
+        // For &mut self, we just let the process exit naturally.
+        let _ = self._child.try_wait();
+        Ok(())
+    }
+
+    fn exchange(&mut self, req: &Value) -> Result<Value, String> {
+        let line = serde_json::to_string(req)
+            .map_err(|e| format!("encode: {e}"))?;
+        writeln!(self.stdin, "{line}")
+            .map_err(|e| format!("write: {e}"))?;
+        self.stdin
+            .flush()
+            .map_err(|e| format!("flush: {e}"))?;
+
+        let mut buf = String::new();
+        let n = self
+            .stdout
+            .read_line(&mut buf)
+            .map_err(|e| format!("read: {e}"))?;
+        if n == 0 {
+            return Err("plugin closed stdout".to_string());
+        }
+        let v: Value = serde_json::from_str(&buf)
+            .map_err(|e| format!("decode: {e}\n  raw: {buf}"))?;
+        Ok(v)
+    }
+
+    fn next_id(&mut self) -> i64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}
+
+/// Parse annotations from a plugin's JSON-RPC response.
+fn parse_plugin_annotations(value: &Value) -> Result<SourceAnnotations, String> {
+    let arr = value
+        .get("annotations")
+        .and_then(|v| v.as_array())
+        .ok_or("expected `annotations` array in plugin response")?;
+
+    let mut annotations = Vec::new();
+    for item in arr {
+        let function_name = item
+            .get("function_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let kind = item
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let target_cid = item
+            .get("target_cid")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let range = parse_range(item.get("range"));
+
+        let kind = match kind {
+            "implement" => AnnotationKind::Implement {
+                target_cid: target_cid.clone().unwrap_or_default(),
+            },
+            "contract" => AnnotationKind::Contract,
+            "verify" => AnnotationKind::Verify,
+            _ => continue, // skip unknown kinds
+        };
+
+        annotations.push(Annotation {
+            function_name,
+            kind,
+            target_cid,
+            range,
+        });
+    }
+
+    Ok(SourceAnnotations { annotations })
+}
+
+fn parse_range(value: Option<&Value>) -> Range {
+    let default = Range {
+        start: Position { line: 0, character: 0 },
+        end: Position { line: 0, character: 0 },
+    };
+    let Some(v) = value else { return default };
+    let start = v.get("start").and_then(parse_position).unwrap_or(Position { line: 0, character: 0 });
+    let end = v.get("end").and_then(parse_position).unwrap_or(Position { line: 0, character: 0 });
+    Range { start, end }
+}
+
+fn parse_position(value: &Value) -> Option<Position> {
+    let line = value.get("line")?.as_u64()? as u32;
+    let character = value.get("character")?.as_u64()? as u32;
+    Some(Position { line, character })
+}
+
+/// Convenience: try to load a plugin for a language config.
+pub fn load_plugin(
+    project_root: &Path,
+    lang_config: &crate::config::LanguagePluginConfig,
+) -> Result<LanguagePlugin, String> {
+    if let Some(plugin_name) = &lang_config.plugin {
+        // Try manifest lookup first
+        if !plugin_name.contains('/') && !plugin_name.contains("\\") {
+            LanguagePlugin::spawn_by_name(project_root, plugin_name)
+        } else {
+            // Direct path or binary name
+            let cmd = vec![plugin_name.clone()];
+            LanguagePlugin::spawn_direct(&cmd, &lang_config.plugin_args, project_root)
+        }
+    } else {
+        Err(format!(
+            "language `{}` has no plugin configured",
+            lang_config.name
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

Wires provekit-lsp into the Cargo workspace and git tracking.

## Changes
- Added provekit-lsp to Cargo workspace members
- tower-lsp based server with full LSP capability set
- Built-in Rust parser via syn
- External plugin management via NDJSON JSON-RPC
- Hover, code lens, code action, diagnostics
- Backend delegation to provekit CLI