### PR TITLE
feat(go): enforce ConsequentBundlePinned via targetProofCid lookup

### DIFF
--- a/implementations/go/provekit-ir-symbolic/verifier/load_all_proofs.go
+++ b/implementations/go/provekit-ir-symbolic/verifier/load_all_proofs.go
@@ -68,6 +68,15 @@ func (s *LoadAllProofsStage) loadOne(proofPath string, pool *MementoPool) error 
 		return fmt.Errorf("read: %w", err)
 	}
 
+	// Compute the bundle CID once, up front. This is BOTH the rule-1
+	// trust root anchor AND the BundleMembers key the forward pin
+	// (BridgeDeclaration.ConsequentBundlePinned, NORMATIVE) is keyed
+	// on; mirrors Rust's `derived_full = blake3_512_of(&bytes)` at the
+	// top of load_one. Computing it inside the V11-filename branch
+	// would silently drop bundle tracking for legacy-named .proof
+	// files and let the shim-poisoning vector slip through that path.
+	bundleCID := canonicalizer.ComputeCID(bytes)
+
 	// Rule 1: filename CID matches content (trust root).
 	// v1.1.0 prefers `blake3-512:<128 hex>.proof`. We also tolerate
 	// bare `<hex>.proof` (legacy path; the hash-tag check below catches
@@ -77,10 +86,9 @@ func (s *LoadAllProofsStage) loadOne(proofPath string, pool *MementoPool) error 
 	filename := filepath.Base(proofPath)
 	if m := proofFilenameV11RE.FindStringSubmatch(filename); m != nil {
 		filenameCID := m[1]
-		derived := canonicalizer.ComputeCID(bytes)
-		if derived != filenameCID {
+		if bundleCID != filenameCID {
 			return fmt.Errorf("rule 1 (trust root): filename CID %s != content hash %s",
-				filenameCID, derived)
+				filenameCID, bundleCID)
 		}
 	} else if m := proofFilenameAnyTagRE.FindStringSubmatch(filename); m != nil {
 		// Self-identifying tag we do not recognize. Reject loud.
@@ -147,6 +155,19 @@ func (s *LoadAllProofsStage) loadOne(proofPath string, pool *MementoPool) error 
 			continue
 		}
 		pool.Insert(cid, env)
+		// Track bundle membership so resolve_target can enforce
+		// BridgeDeclaration.ConsequentBundlePinned. The bundle CID is
+		// the .proof file's content hash (bundleCID computed above). A
+		// given member CID may legitimately appear in more than one
+		// bundle (one honest, one poisoned); the per-bundle set is
+		// what matters at resolve time. Mirrors Rust load_all_proofs.rs
+		// pool.bundle_members entry insertion.
+		members, ok := pool.BundleMembers[bundleCID]
+		if !ok {
+			members = map[string]struct{}{}
+			pool.BundleMembers[bundleCID] = members
+		}
+		members[cid] = struct{}{}
 		// If it's a bridge envelope, index by sourceSymbol.
 		if ev, ok := env["evidence"].(map[string]interface{}); ok {
 			if ev["kind"] == "bridge" {

--- a/implementations/go/provekit-ir-symbolic/verifier/resolve_target.go
+++ b/implementations/go/provekit-ir-symbolic/verifier/resolve_target.go
@@ -1,5 +1,10 @@
 package verifier
 
+import (
+	"fmt"
+	"os"
+)
+
 // ResolveTargetStage hash-looks-up a bridge's targetContractCid in the
 // pool and returns the resolved contract memento's `pre` formula. O(1):
 // no file IO; pool was built once at LoadAllProofsStage.
@@ -8,6 +13,13 @@ package verifier
 // discharge targets the contract's `pre` slot (the precondition the
 // caller must establish at the call site). post/inv participate in the
 // handshake algorithm via their own slots.
+//
+// Forward-pin gate (BridgeDeclaration.ConsequentBundlePinned, NORMATIVE):
+// after locating the consequent contract member, refuse to consume it
+// unless its containing `.proof` bundle CID matches the bridge's
+// `targetProofCid`. See protocol/specs/2026-04-30-ir-formal-grammar.md
+// § "Bridge target pinning: the shim-poisoning vector". Mirrors Rust
+// PR #13 (provekit-verifier/src/resolve_target.rs lines 32-69).
 type ResolveTargetStage struct{}
 
 // Run resolves a single CallSite's bridge target.
@@ -27,6 +39,43 @@ func (s *ResolveTargetStage) Run(cs CallSite, pool *MementoPool) (*ResolvedPrope
 	if body == nil {
 		return nil, "body-missing"
 	}
+
+	// Forward pin: BridgeDeclaration.ConsequentBundlePinned.
+	//
+	//     ∀b: BridgeDeclaration, P: ProofBundle →
+	//       AcceptedAsConsequentFor(P, b) ⇒ Cid(P) = b.targetProofCid
+	//
+	// If the bridge pins a target proof CID, the contract member we
+	// just resolved MUST come from that bundle. Bundles whose contract
+	// members happen to share `targetContractCid` MUST NOT be
+	// substituted for the pinned bundle. Mirrors Rust resolve_target.rs
+	// lines 43-69.
+	if expectedBundle := cs.BridgeTargetProofCID; expectedBundle != "" {
+		members, ok := pool.BundleMembers[expectedBundle]
+		if !ok {
+			return nil, fmt.Sprintf(
+				"BridgeTargetProofCidMismatch: pinned bundle %s not in pool",
+				expectedBundle,
+			)
+		}
+		if _, ok := members[cs.BridgeTargetCID]; !ok {
+			return nil, fmt.Sprintf(
+				"BridgeTargetProofCidMismatch: contract %s is not a member of pinned bundle %s",
+				cs.BridgeTargetCID, expectedBundle,
+			)
+		}
+	} else {
+		// Back-compat: legacy bridges that pre-date `targetProofCid`
+		// are loadable but cannot have ConsequentBundlePinned
+		// enforced. New bridges MUST set the field; flag the gap so
+		// operators can see what isn't being checked. Mirrors Rust's
+		// `eprintln!("warning: ...")` path.
+		fmt.Fprintf(os.Stderr,
+			"warning: bridge %s has no targetProofCid; "+
+				"ConsequentBundlePinned not enforced (back-compat path)\n",
+			cs.BridgeIRName)
+	}
+
 	pre, ok := body["pre"]
 	if !ok {
 		return nil, "no-pre-slot"

--- a/implementations/go/provekit-ir-symbolic/verifier/resolve_target_test.go
+++ b/implementations/go/provekit-ir-symbolic/verifier/resolve_target_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Stage 3 (resolve_target) tests for the forward pin
+// BridgeDeclaration.ConsequentBundlePinned (NORMATIVE).
+//
+// Mirrors implementations/rust/provekit-verifier/tests/resolve_target.rs
+// (PR #13). Same fixtures, same verdicts: cross-impl conformance is
+// the contract.
+//
+// Spec: protocol/specs/2026-04-30-ir-formal-grammar.md
+//   § "Bridge target pinning: the shim-poisoning vector"
+//
+//     ∀b: BridgeDeclaration, P: ProofBundle →
+//       AcceptedAsConsequentFor(P, b) ⇒ Cid(P) = b.targetProofCid
+
+package verifier
+
+import (
+	"strings"
+	"testing"
+)
+
+// trivialPre returns a minimal `pre` formula so the resolver can
+// produce a ResolvedProperty when the pin check passes.
+func trivialPre() map[string]interface{} {
+	return map[string]interface{}{
+		"kind": "atomic",
+		"name": "true",
+		"args": []interface{}{},
+	}
+}
+
+// contractEnv builds a minimal contract envelope around `pre`.
+func contractEnv(pre map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"evidence": map[string]interface{}{
+			"kind": "contract",
+			"body": map[string]interface{}{"pre": pre},
+		},
+	}
+}
+
+// poolWith returns a fresh pool seeded with one memento at cid.
+func poolWith(cid string, env map[string]interface{}) *MementoPool {
+	pool := NewMementoPool()
+	pool.Mementos[cid] = env
+	return pool
+}
+
+// rejects_when_target_proof_cid_does_not_match_bundle (Rust analog).
+//
+// The contract member exists in the pool, but it was loaded from a
+// different `.proof` bundle than the bridge pinned. The verifier MUST
+// reject with `BridgeTargetProofCidMismatch`. This is the
+// shim-poisoning attack the spec section closes.
+func TestResolveTarget_RejectsWhenTargetProofCidDoesNotMatchBundle(t *testing.T) {
+	targetCID := "blake3-512:contract-shared"
+	honestBundle := "blake3-512:node-v24-proof-honest"
+	poisonedBundle := "blake3-512:node-v24-proof-poisoned"
+
+	pool := poolWith(targetCID, contractEnv(trivialPre()))
+	// Member was loaded as part of the poisoned bundle. The honest
+	// bundle is what the bridge pinned but isn't present.
+	pool.BundleMembers[poisonedBundle] = map[string]struct{}{
+		targetCID: {},
+	}
+
+	cs := CallSite{
+		BridgeIRName:         "parseInt",
+		BridgeTargetCID:      targetCID,
+		BridgeTargetProofCID: honestBundle,
+	}
+
+	stage := &ResolveTargetStage{}
+	resolved, reason := stage.Run(cs, pool)
+	if resolved != nil {
+		t.Fatalf("must reject, got resolved=%+v reason=%q", resolved, reason)
+	}
+	if !strings.Contains(reason, "BridgeTargetProofCidMismatch") {
+		t.Fatalf("expected BridgeTargetProofCidMismatch, got: %q", reason)
+	}
+}
+
+// rejects_when_pinned_bundle_is_not_loaded (Rust analog).
+//
+// Pinned bundle isn't loaded at all — BundleMembers has no entry for
+// it. Still a mismatch, fail-closed. The contract member IS present in
+// the pool (this is what makes it the right test rather than a
+// "target not in pool" test).
+func TestResolveTarget_RejectsWhenPinnedBundleIsNotLoaded(t *testing.T) {
+	targetCID := "blake3-512:contract-orphan"
+	pool := poolWith(targetCID, contractEnv(trivialPre()))
+	// Note: deliberately do NOT seed BundleMembers — the contract is
+	// in the pool, but no bundle is registered for it.
+
+	cs := CallSite{
+		BridgeIRName:         "parseInt",
+		BridgeTargetCID:      targetCID,
+		BridgeTargetProofCID: "blake3-512:never-loaded",
+	}
+
+	stage := &ResolveTargetStage{}
+	resolved, reason := stage.Run(cs, pool)
+	if resolved != nil {
+		t.Fatalf("must reject, got resolved=%+v reason=%q", resolved, reason)
+	}
+	if !strings.Contains(reason, "BridgeTargetProofCidMismatch") {
+		t.Fatalf("expected BridgeTargetProofCidMismatch, got: %q", reason)
+	}
+}
+
+// accepts_when_target_proof_cid_matches_bundle (Rust analog).
+//
+// Same bundle for the bridge and the contract member: accept and
+// return the resolved formula.
+func TestResolveTarget_AcceptsWhenTargetProofCidMatchesBundle(t *testing.T) {
+	targetCID := "blake3-512:contract-pinned"
+	honestBundle := "blake3-512:node-v24-proof-honest"
+
+	pool := poolWith(targetCID, contractEnv(trivialPre()))
+	pool.BundleMembers[honestBundle] = map[string]struct{}{
+		targetCID: {},
+	}
+
+	cs := CallSite{
+		BridgeIRName:         "parseInt",
+		BridgeTargetCID:      targetCID,
+		BridgeTargetProofCID: honestBundle,
+	}
+
+	stage := &ResolveTargetStage{}
+	resolved, reason := stage.Run(cs, pool)
+	if resolved == nil {
+		t.Fatalf("must accept matching pin, got reason=%q", reason)
+	}
+	if resolved.CID != targetCID {
+		t.Fatalf("resolved CID = %q, want %q", resolved.CID, targetCID)
+	}
+}
+
+// accepts_when_target_proof_cid_is_none_back_compat (Rust analog).
+//
+// Legacy bridge with no `targetProofCid` (empty string is the Go
+// analog of Rust's `None`): cannot enforce ConsequentBundlePinned,
+// but accept for back-compat. resolve_target writes a soft warning to
+// stderr; the test does not assert on stderr (matches Rust's pattern).
+func TestResolveTarget_AcceptsWhenTargetProofCidIsAbsentBackCompat(t *testing.T) {
+	targetCID := "blake3-512:contract-legacy"
+	pool := poolWith(targetCID, contractEnv(trivialPre()))
+
+	cs := CallSite{
+		BridgeIRName:         "parseIntLegacy",
+		BridgeTargetCID:      targetCID,
+		BridgeTargetProofCID: "", // back-compat: no pin
+	}
+
+	stage := &ResolveTargetStage{}
+	resolved, reason := stage.Run(cs, pool)
+	if resolved == nil {
+		t.Fatalf("legacy bridges must still resolve, got reason=%q", reason)
+	}
+	if resolved.CID != targetCID {
+		t.Fatalf("resolved CID = %q, want %q", resolved.CID, targetCID)
+	}
+}

--- a/implementations/go/provekit-ir-symbolic/verifier/types.go
+++ b/implementations/go/provekit-ir-symbolic/verifier/types.go
@@ -26,10 +26,20 @@ import (
 // bridge envelopes by their evidence.body.sourceSymbol for the
 // callsite-enumeration stage.
 // formulaToMemento indexes formula CIDs → memento CIDs for O(1) verification.
+//
+// BundleMembers tracks bundle CID → set of member CIDs for the forward
+// pin (BridgeDeclaration.ConsequentBundlePinned, NORMATIVE — see
+// protocol/specs/2026-04-30-ir-formal-grammar.md § "Bridge target
+// pinning: the shim-poisoning vector"). Multi-valued because the same
+// member CID can legitimately appear in more than one bundle (one
+// honest, one poisoned); last-writer-wins would silently swap them.
+// Populated by load_all_proofs from the .proof file's content hash;
+// consumed by resolve_target.
 type MementoPool struct {
 	Mementos         map[string]map[string]interface{} // CID → parsed envelope
 	FormulaToMemento map[string]string                 // formula CID → memento CID
 	BridgesBySymbol  map[string]map[string]interface{} // sourceSymbol → bridge envelope
+	BundleMembers    map[string]map[string]struct{}    // bundle CID → set of member CIDs
 	LoadErrors       []LoadError
 }
 
@@ -39,6 +49,7 @@ func NewMementoPool() *MementoPool {
 		Mementos:         map[string]map[string]interface{}{},
 		FormulaToMemento: map[string]string{},
 		BridgesBySymbol:  map[string]map[string]interface{}{},
+		BundleMembers:    map[string]map[string]struct{}{},
 	}
 }
 
@@ -253,10 +264,16 @@ type LoadError struct {
 // per-call-site obligation downstream stages discharge.
 //
 // BridgeSourceContractCID and BridgeTargetProofCID mirror the
-// BridgeDeclaration fields in the IR formal grammar (PR #10). They are
-// stored for downstream verifier stages (e.g. cross-bundle proof
-// resolution); the load-all-proofs stage does not enforce them today,
-// matching the Rust CallSite shape.
+// BridgeDeclaration fields in the IR formal grammar (PR #10).
+// BridgeTargetProofCID is the bridge's pinned consequent .proof bundle
+// CID; resolve_target enforces ConsequentBundlePinned against it
+// (mirrors Rust PR #13, protocol/specs/2026-04-30-ir-formal-grammar.md
+// § "Bridge target pinning: the shim-poisoning vector"). Empty string
+// is the back-compat shape: legacy bridges that pre-date the field
+// load and resolve, but ConsequentBundlePinned cannot be enforced and
+// resolve_target emits a soft warning. BridgeSourceContractCID is
+// stored only; reverse-pin enforcement (LiftedFromContract) is owned
+// by future verifier work.
 type CallSite struct {
 	BridgeIRName            string
 	BridgeTargetCID         string


### PR DESCRIPTION
## Summary

Closes the shim-poisoning vector promoted to a normative example in #10 (`protocol/specs/2026-04-30-ir-formal-grammar.md`, section "Bridge target pinning: the shim-poisoning vector"). The Go verifier now enforces `INVARIANT BridgeDeclaration.ConsequentBundlePinned`:

```
forall b: BridgeDeclaration, P: ProofBundle .
  AcceptedAsConsequentFor(P, b)  =>  Cid(P) = b.targetProofCid
```

Cross-impl conformance with Rust: same fixtures, same verdicts. Mirrors PR #13 byte-for-byte at the verdict layer.

## The vector this closes

A bridge carries two outbound CIDs into the target side: the antecedent (`targetContractCid`) and the bundle (`targetProofCid`). Without the bundle pin, an attacker substitutes a poisoned `.proof` whose contract member happens to byte-match the bridge's antecedent and the poisoned member's `pre`/`post` is consumed as if signed by the honest producer. With the pin, the bridge requires a SPECIFIC proof bundle by CID; substitution fails fail-closed.

PR #18 plumbed the three pin fields (`binaryCid`, `targetProofCid`, `sourceContractCid`) into the Go kit STORED-only. This PR turns `targetProofCid` into ENFORCED. `binaryCid` and `sourceContractCid` remain stored only, matching Rust today.

## What changed

- `MementoPool` gains `BundleMembers: map[string]map[string]struct{}`. Multi-valued (forward direction, bundle CID to set of member CIDs) because the same member CID can legitimately appear in more than one bundle (one honest, one poisoned); last-writer-wins would silently swap them. Mirrors Rust's `BTreeMap<String, BTreeSet<String>>` shape.
- `LoadAllProofsStage.loadOne` computes the bundle CID once at the top (mirrors Rust `derived_full` at `load_all_proofs.rs:69`), reuses it for the rule-1 trust-root check, and uses it as the `BundleMembers` key. Computing it only inside the V11-filename branch would silently drop bundle tracking for legacy-named `.proof` files.
- `ResolveTargetStage.Run` gates resolution on the pin: when `CallSite.BridgeTargetProofCID` is set, the resolved consequent's bundle CID must be in `BundleMembers[expected]`; mismatch returns fail-closed with reason `"BridgeTargetProofCidMismatch: ..."`. Empty string is the back-compat shape: legacy bridges that pre-date the field still resolve, with a soft warning to stderr (mirrors Rust's `eprintln!`).

## Behavior on missing field

`targetProofCid` is REQUIRED by the current grammar, but bridges minted before the field was normative MAY lack it. To preserve back-compat:

- `BridgeTargetProofCID == ""` accepted with a soft warning to stderr (`warning: bridge X has no targetProofCid; ConsequentBundlePinned not enforced (back-compat path)`). Text matches Rust byte-for-byte.
- `BridgeTargetProofCID != ""` ConsequentBundlePinned enforced fully. Mismatch is fail-closed; the resolver returns `nil` and a reason string containing `BridgeTargetProofCidMismatch`.

New bridges from the current Go producer MUST set the field; the warning makes the gap visible to operators rather than hiding it.

## Test coverage added

`implementations/go/provekit-ir-symbolic/verifier/resolve_target_test.go`, fixtures transcribed from `implementations/rust/provekit-verifier/tests/resolve_target.rs`:

- `TestResolveTarget_RejectsWhenTargetProofCidDoesNotMatchBundle` the shim-poisoning case. Member resolves but lives in a bundle the bridge did not pin, reject.
- `TestResolveTarget_RejectsWhenPinnedBundleIsNotLoaded` contract is in the pool but the pinned bundle was never loaded, reject. Distinct from the "target not in pool" case (the contract IS resolved; the bundle is not).
- `TestResolveTarget_AcceptsWhenTargetProofCidMatchesBundle` pin matches loaded bundle, accept and return the formula.
- `TestResolveTarget_AcceptsWhenTargetProofCidIsAbsentBackCompat` legacy bridge with empty `targetProofCid`, accept with warning.

Self-check: stashing only the gate change in `resolve_target.go` and re-running the new tests fails the two reject cases as expected (the resolver happily returns a `ResolvedProperty`). Re-applying the gate makes them pass. The framework's safety guard is empirical.

## Files touched

- `implementations/go/provekit-ir-symbolic/verifier/types.go`
- `implementations/go/provekit-ir-symbolic/verifier/load_all_proofs.go`
- `implementations/go/provekit-ir-symbolic/verifier/resolve_target.go`
- `implementations/go/provekit-ir-symbolic/verifier/resolve_target_test.go`

## Test plan

- [x] `go build ./...` clean across `provekit-ir-symbolic`, `provekit-lift-go-tests`, `provekit-self-contracts`
- [x] `go test ./...` clean across same
- [x] New `TestResolveTarget_*` cases all pass
- [x] Two reject cases fail without the gate (verified by stash/restore)

## Refs

- Rust analog: #13
- Normative spec: #10

Generated with [Claude Code](https://claude.com/claude-code)