### PR TITLE
feat: letter-envelope TS_CID + CSHARP_CID (retire last self-reference pins)

### DIFF
--- a/.provekit/self-contracts-attestations/csharp.json
+++ b/.provekit/self-contracts-attestations/csharp.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1",
+  "kind": "self-contracts-attestation",
+  "lang": "csharp",
+  "cid": "blake3-512:cec85197e5bc394cb97fa3b96c076eca5ace3eeda819f8a2b8b7001f85336dbfadc7e28be3a38676f81387f908b327f0fffeae7d6d04fe76a8c754e5db38c61e",
+  "declaredAt": "2026-05-02T17:00:00Z",
+  "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+  "signature": "ed25519:B63Kg4EGWkIO4DjFTUnlg1smPRi0o+AH5+S15M2AMc+pzNPyDRpT/gIH2rH1REd2jUX9/ceqBYwMK5po9XmIDw=="
+}

--- a/.provekit/self-contracts-attestations/ts.json
+++ b/.provekit/self-contracts-attestations/ts.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1",
+  "kind": "self-contracts-attestation",
+  "lang": "ts",
+  "cid": "blake3-512:449339930add6457bf25542f2117a025daada4a4bd1de704737750ad6d1c1be814c284d31bb97159ca0b2d2c52f8c043a64533d3432195f5a0f338c5d4904d44",
+  "declaredAt": "2026-05-02T17:00:00Z",
+  "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+  "signature": "ed25519:k0yBkqDNbRBEr3gQou4BAeFFKgz38BUSnXz3/ePfsHehg0Jae6bmleLbUvMNN+g0FU59hoBIUBfKz0iNzjwoCg=="
+}

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,12 @@
 # --- Pinned CIDs ------------------------------------------------------------
 #
 # Bumping a self-contracts CID is now an explicit attestation event, NOT a
-# Makefile string edit:
+# Makefile string edit. The dance is identical for every peer kit
+# (rust, go, cpp, ts, csharp):
 #
 #   1. Make your code change in `implementations/<lang>/provekit-self-contracts`
-#      (or the Go / C++ analog).
-#   2. `make build-rust && make mint-rust`   (or mint-go / mint-cpp)
+#      (or the language's analog).
+#   2. `make mint-<lang>`
 #      -> the mint target FAILS and prints the new CID.
 #   3. `cargo run --release --manifest-path tools/foundation-keygen/Cargo.toml \
 #         --bin sign-self-contracts -- <lang> <new-cid>`
@@ -40,20 +41,17 @@
 #
 # The bundle (letter) does not know its own CID. The on-disk attestation
 # (envelope) names the CID and is signed externally. See
+# `protocol/specs/2026-05-02-bundle-attestation-protocol.md` for the
+# generic letter-envelope framing and
 # `protocol/specs/2026-05-02-binary-attestation-protocol.md` for the
-# letter-envelope framing and `protocol/specs/2026-05-02-provekit-migrate-protocol.md`
-# for the documented bump dance.
+# binary-specific elaboration. The source tree no longer carries
+# machine-local truth about its own bytes for any of the five peer kits.
 #
 # `CATALOG_CID` is bumped to v1.3.1 here; the constant remains because
 # `make help` echoes it. Follow-up: retire it the same way the
 # self-contracts CIDs are retired (read from the embedded catalog
 # signature attestation).
 CATALOG_CID := blake3-512:dab2eca97eaea7cc107b1ff3f2326094d804a5e91749bf8e9caa36cd049dc0ae1cb65afb353af8fcd271f87e9e0fc7e7710ec6a68666da6a11f802bc304ff799
-
-# `TS_CID` and `CSHARP_CID` retain the old self-reference pattern for now;
-# follow-up: extend the letter-envelope refactor to those two peers.
-TS_CID      := blake3-512:449339930add6457bf25542f2117a025daada4a4bd1de704737750ad6d1c1be814c284d31bb97159ca0b2d2c52f8c043a64533d3432195f5a0f338c5d4904d44
-CSHARP_CID  := blake3-512:cec85197e5bc394cb97fa3b96c076eca5ace3eeda819f8a2b8b7001f85336dbfadc7e28be3a38676f81387f908b327f0fffeae7d6d04fe76a8c754e5db38c61e
 
 PROVEKIT := implementations/rust/target/release/provekit
 VERIFY_SELF_CONTRACTS := tools/foundation-keygen/target/release/verify-self-contracts
@@ -90,8 +88,8 @@ help:
 	@echo "  rust:    (envelope) $(SELF_CONTRACTS_ATTEST_DIR)/rust.json"
 	@echo "  go:      (envelope) $(SELF_CONTRACTS_ATTEST_DIR)/go.json"
 	@echo "  cpp:     (envelope) $(SELF_CONTRACTS_ATTEST_DIR)/cpp.json"
-	@echo "  ts:      $(TS_CID)"
-	@echo "  csharp:  $(CSHARP_CID)"
+	@echo "  ts:      (envelope) $(SELF_CONTRACTS_ATTEST_DIR)/ts.json"
+	@echo "  csharp:  (envelope) $(SELF_CONTRACTS_ATTEST_DIR)/csharp.json"
 
 # --- Per-language builds -----------------------------------------------------
 
@@ -156,8 +154,15 @@ mint-cpp: build-rust build-cpp
 
 .PHONY: mint-ts
 mint-ts: build-ts
-	@echo ">> minting ts self-contracts (vitest path)"
-	pnpm vitest run implementations/typescript/src/bin/mint-ts-self-contracts.test.ts
+	@echo ">> minting ts self-contracts"
+	@out=$$(pnpm -s vitest run --reporter=verbose \
+		implementations/typescript/src/bin/mint-ts-self-contracts.test.ts 2>&1 \
+		| grep -F 'catalog CID:' | awk '{print $$NF}' | head -1); \
+	echo "  cid: $$out"; \
+	$(VERIFY_SELF_CONTRACTS) $(SELF_CONTRACTS_ATTEST_DIR)/ts.json "$$out" || \
+		(echo "FAIL: ts self-contracts attestation rejected; bump dance:" && \
+		 echo "      cargo run --release --manifest-path tools/foundation-keygen/Cargo.toml \\\\" && \
+		 echo "        --bin sign-self-contracts -- ts $$out" && exit 1)
 
 .PHONY: mint-csharp
 mint-csharp:
@@ -166,8 +171,10 @@ mint-csharp:
 		dotnet run -c Release 2>/dev/null \
 		| grep -F 'catalog CID:' | awk '{print $$NF}' | head -1); \
 	echo "  cid: $$out"; \
-	test "$$out" = "$(CSHARP_CID)" || \
-		(echo "FAIL: csharp CID mismatch (expected $(CSHARP_CID))" && exit 1)
+	$(VERIFY_SELF_CONTRACTS) $(SELF_CONTRACTS_ATTEST_DIR)/csharp.json "$$out" || \
+		(echo "FAIL: csharp self-contracts attestation rejected; bump dance:" && \
+		 echo "      cargo run --release --manifest-path tools/foundation-keygen/Cargo.toml \\\\" && \
+		 echo "        --bin sign-self-contracts -- csharp $$out" && exit 1)
 
 .PHONY: all-mint
 all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp
@@ -176,8 +183,8 @@ all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp
 	@printf "  %-8s  %s\n" "rust"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/rust.json)"
 	@printf "  %-8s  %s\n" "go"     "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/go.json)"
 	@printf "  %-8s  %s\n" "cpp"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/cpp.json)"
-	@printf "  %-8s  %s\n" "ts"     "$(TS_CID)"
-	@printf "  %-8s  %s\n" "csharp" "$(CSHARP_CID)"
+	@printf "  %-8s  %s\n" "ts"     "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/ts.json)"
+	@printf "  %-8s  %s\n" "csharp" "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/csharp.json)"
 
 # --- Conformance gate --------------------------------------------------------
 

--- a/tools/foundation-keygen/src/bin/sign_self_contracts.rs
+++ b/tools/foundation-keygen/src/bin/sign_self_contracts.rs
@@ -4,7 +4,8 @@
 //
 // Letter-envelope attestation signer for per-language self-contracts
 // bundles. Mirrors `sign_catalog_v1_3_1.rs` but parameterized by `lang`
-// (one of `rust`, `go`, `cpp`) and a freshly-observed bundle CID.
+// (one of `rust`, `go`, `cpp`, `ts`, `csharp`) and a freshly-observed
+// bundle CID.
 //
 // Usage:
 //
@@ -37,7 +38,7 @@ fn run() -> Result<(), String> {
     let mut args = std::env::args().skip(1);
     let lang = args
         .next()
-        .ok_or_else(|| "missing <lang> argument (rust|go|cpp)".to_string())?;
+        .ok_or_else(|| "missing <lang> argument (rust|go|cpp|ts|csharp)".to_string())?;
     let cid = args
         .next()
         .ok_or_else(|| "missing <cid> argument (blake3-512:<128 hex>)".to_string())?;

--- a/tools/foundation-keygen/src/lib.rs
+++ b/tools/foundation-keygen/src/lib.rs
@@ -94,7 +94,7 @@ pub fn signature_path_for(protocol_version: &str) -> PathBuf {
 /// `.provekit/self-contracts-attestations/<lang>.json` (committed).
 /// Letter-envelope attestation file for a peer's self-contracts bundle.
 /// `lang` ranges over the per-language peer identifiers (`rust`, `go`,
-/// `cpp` initially; `ts` and `csharp` are deferred to a follow-up).
+/// `cpp`, `ts`, `csharp`); the full set is the five-peer kit suite.
 pub fn self_contracts_attestation_path_for(lang: &str) -> PathBuf {
     repo_root()
         .join(".provekit/self-contracts-attestations")
@@ -111,10 +111,11 @@ pub fn self_contracts_attestation_path_for(lang: &str) -> PathBuf {
 pub const SELF_CONTRACTS_DECLARED_AT_V1_3_1: &str = "2026-05-02T17:00:00Z";
 
 /// Recognized peer identifiers for self-contracts attestations.
-/// Kept in sync with the Makefile's `mint-{rust,go,cpp}` targets.
-/// `ts` and `csharp` use distinct minting paths today and are not yet
-/// covered by the letter-envelope attestation refactor (see PR body).
-pub const SELF_CONTRACTS_LANGS: &[&str] = &["rust", "go", "cpp"];
+/// Kept in sync with the Makefile's `mint-{rust,go,cpp,ts,csharp}` targets.
+/// All five peer kits use the same letter-envelope attestation shape;
+/// the source tree no longer carries machine-local truth about its own
+/// bytes for any kit.
+pub const SELF_CONTRACTS_LANGS: &[&str] = &["rust", "go", "cpp", "ts", "csharp"];
 
 /// Build the six-field self-contracts attestation message body
 /// (no `signature` field). JCS-canonical bytes of this object are what
@@ -490,5 +491,59 @@ mod tests {
         let err = verify_signed_self_contracts_attestation(&bytes, "ed25519:fake", "blake3-512:beef")
             .unwrap_err();
         assert!(err.contains("kind"));
+    }
+
+    #[test]
+    fn self_contracts_ts_round_trip_verifies() {
+        // ts joined the letter-envelope refactor in the second pass;
+        // exercise the round-trip explicitly so the lang-set extension
+        // does not regress silently.
+        let cid = "blake3-512:beef";
+        let pk = ed25519_pubkey_string(&FOUNDATION_V0_SEED);
+        let attestation = build_signed_self_contracts_attestation(
+            &FOUNDATION_V0_SEED,
+            "ts",
+            cid,
+            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+        )
+        .unwrap();
+        let bytes = serde_json::to_vec(&attestation).unwrap();
+        let verdict = verify_signed_self_contracts_attestation(&bytes, &pk, cid).unwrap();
+        assert!(verdict.signer_matches);
+        assert!(verdict.signature_ok);
+        assert!(verdict.cid_matches);
+        assert!(verdict.ok());
+    }
+
+    #[test]
+    fn self_contracts_csharp_round_trip_verifies() {
+        // csharp joined the letter-envelope refactor in the second pass;
+        // exercise the round-trip explicitly so the lang-set extension
+        // does not regress silently.
+        let cid = "blake3-512:beef";
+        let pk = ed25519_pubkey_string(&FOUNDATION_V0_SEED);
+        let attestation = build_signed_self_contracts_attestation(
+            &FOUNDATION_V0_SEED,
+            "csharp",
+            cid,
+            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+        )
+        .unwrap();
+        let bytes = serde_json::to_vec(&attestation).unwrap();
+        let verdict = verify_signed_self_contracts_attestation(&bytes, &pk, cid).unwrap();
+        assert!(verdict.signer_matches);
+        assert!(verdict.signature_ok);
+        assert!(verdict.cid_matches);
+        assert!(verdict.ok());
+    }
+
+    #[test]
+    fn self_contracts_lang_set_is_five_peers() {
+        // Guard the canonical kit suite. Adding or removing a peer is
+        // a deliberate act; this test forces an explicit edit.
+        assert_eq!(
+            SELF_CONTRACTS_LANGS,
+            &["rust", "go", "cpp", "ts", "csharp"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Extends PR #30's letter-envelope refactor to the last two peer kits that still carried machine-local truth about their own bytes inside the source tree (`TS_CID` / `CSHARP_CID`). Closes task #212.

After this change, all five peer kits (rust, go, cpp, ts, csharp) verify their self-contracts bundles against externally signed attestation envelopes. The source tree carries no `_CID :=` pin for any peer.

## New attestation envelopes

Both signed under foundation-v0 (`ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=`), pinned `declaredAt: 2026-05-02T17:00:00Z`:

- `.provekit/self-contracts-attestations/ts.json` -> `blake3-512:449339930add6457bf25542f2117a025daada4a4bd1de704737750ad6d1c1be814c284d31bb97159ca0b2d2c52f8c043a64533d3432195f5a0f338c5d4904d44` (no drift from prior `TS_CID`)
- `.provekit/self-contracts-attestations/csharp.json` -> `blake3-512:cec85197e5bc394cb97fa3b96c076eca5ace3eeda819f8a2b8b7001f85336dbfadc7e28be3a38676f81387f908b327f0fffeae7d6d04fe76a8c754e5db38c61e` (matches CI value from PR #36)

Both files were generated by `sign-self-contracts` and re-verified end-to-end via `verify-self-contracts` and `make conformance`.

## sign-self-contracts now accepts ts / csharp

The binary previously hard-rejected anything outside `[rust, go, cpp]`. Two changes in `tools/foundation-keygen`:

- `src/lib.rs`: `SELF_CONTRACTS_LANGS` extended to `["rust", "go", "cpp", "ts", "csharp"]`. Doc comment for `self_contracts_attestation_path_for` updated to drop the "deferred to a follow-up" note.
- `src/bin/sign_self_contracts.rs`: usage strings extended; gating logic unchanged (it consults `SELF_CONTRACTS_LANGS`).

Tests added in `src/lib.rs`:
- `self_contracts_ts_round_trip_verifies`
- `self_contracts_csharp_round_trip_verifies`
- `self_contracts_lang_set_is_five_peers` (guards the canonical kit suite)

`cargo test --release --manifest-path tools/foundation-keygen/Cargo.toml`: 10/10 passing.

## Makefile diff summary

- Deleted: `TS_CID := blake3-512:...` and `CSHARP_CID := blake3-512:...` (two lines plus their explanatory comment block).
- `mint-ts`: now captures the CID from `pnpm vitest run --reporter=verbose ...` stdout and runs `verify-self-contracts <ts.json> "$out"`. Default vitest reporter swallowed the `console.log("catalog CID: ...")` line; verbose preserves it.
- `mint-csharp`: same shape as `mint-rust` -- captures the CID from `dotnet run` stdout and runs `verify-self-contracts <csharp.json> "$out"`. Bump-dance error message follows the rust/go/cpp pattern.
- `make help` footer: `ts` and `csharp` now print as `(envelope) .provekit/self-contracts-attestations/<lang>.json` instead of literal CIDs.
- `all-mint` footer: same envelope format for consistency.
- Bump-dance comment block at the top of the Makefile generalized over all five peers.

`grep -E '(TS|CSHARP)_CID :=' Makefile` returns no matches; `CATALOG_CID :=` is the only remaining `_CID :=` constant (preserved per scope; documented as separate follow-up).

## Spec note

`protocol/specs/2026-05-02-bundle-attestation-protocol.md` already describes the per-language `artifactName` set generically (`"rust", "go", "cpp", etc.` -- the §6.3 wording explicitly anticipates additions). `2026-05-02-provekit-migrate-protocol.md` covers catalog-version mechanics, not self-contracts. **No spec edits were required.**

## Smoke test

`make conformance` passes locally:

```
==== all 5 self-contract CIDs match pinned values ====
  rust      (envelope: .provekit/self-contracts-attestations/rust.json)
  go        (envelope: .provekit/self-contracts-attestations/go.json)
  cpp       (envelope: .provekit/self-contracts-attestations/cpp.json)
  ts        (envelope: .provekit/self-contracts-attestations/ts.json)
  csharp    (envelope: .provekit/self-contracts-attestations/csharp.json)

==== conformance: PASS ====
```

## References

- PR #30 (rust / go / cpp letter-envelope cut)
- `protocol/specs/2026-05-02-bundle-attestation-protocol.md`
- `protocol/specs/2026-05-02-binary-attestation-protocol.md`

## What this closes

The structural pattern Sir flagged in the PR #30 body: the source tree no longer carries machine-local truth about its own bytes for any peer kit. Bumping any of the five self-contracts CIDs is now a single explicit `sign-self-contracts <lang> <new-cid>` event, gated by the foundation key.

## Test plan

- [x] `cargo test --release --manifest-path tools/foundation-keygen/Cargo.toml` (10/10 passing including 3 new self-contracts tests)
- [x] `make mint-ts` verifies `ts.json` envelope
- [x] `make mint-csharp` verifies `csharp.json` envelope
- [x] `make conformance` passes end-to-end with all 5 envelope verifications
- [x] No em-dashes / en-dashes; no stale `TS_CID` / `CSHARP_CID` references anywhere in the repo

Generated with [Claude Code](https://claude.com/claude-code)