### PR TITLE
fix(conformance): three harness bugs surfaced by local run

### DIFF
--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -36,6 +36,18 @@ run_quiet() {
     "$@" >/dev/null 2>&1
 }
 
+# Skip a kit when its toolchain is absent. Reports SKIP and returns 1
+# so the caller can early-out before trying to run the kit. Distinguishes
+# missing-tool from real conformance failure.
+need_tool() {
+    local tool="$1" lang="$2"
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        report "$lang" "SKIP" "$tool not on PATH"
+        return 1
+    fi
+    return 0
+}
+
 echo ""
 echo "=========================================="
 echo " Cross-Language Conformance Suite"
@@ -44,58 +56,70 @@ echo ""
 
 # --- Rust (canonical reference) ---
 echo "[Rust] cargo test -p provekit-ir-symbolic"
-if (cd implementations/rust && run_quiet cargo test -p provekit-ir-symbolic --lib); then
-    report "rust" "PASS" "canonical reference matches pinned fixtures"
-else
-    report "rust" "FAIL" "cargo test failed"
+if need_tool cargo rust; then
+    if (cd implementations/rust && run_quiet cargo test -p provekit-ir-symbolic --lib); then
+        report "rust" "PASS" "canonical reference matches pinned fixtures"
+    else
+        report "rust" "FAIL" "cargo test failed"
+    fi
 fi
 
 # --- Go ---
 echo "[Go] go test"
-if (cd implementations/go && run_quiet go test -count=1 ./...); then
-    report "go" "PASS" "matches canonical JCS bytes"
-else
-    report "go" "FAIL" "go test failed"
+if need_tool go go; then
+    if (cd implementations/go && run_quiet go test -count=1 ./...); then
+        report "go" "PASS" "matches canonical JCS bytes"
+    else
+        report "go" "FAIL" "go test failed"
+    fi
 fi
 
 # --- Java ---
 echo "[Java] mvn test"
-if (cd implementations/java && run_quiet mvn test); then
-    report "java" "PASS" "13 modules, integration tests prove equivalence"
-else
-    report "java" "FAIL" "mvn test failed"
+if need_tool mvn java; then
+    if (cd implementations/java && run_quiet mvn test); then
+        report "java" "PASS" "13 modules, integration tests prove equivalence"
+    else
+        report "java" "FAIL" "mvn test failed"
+    fi
 fi
 
 # --- Python ---
 echo "[Python] pytest"
-if (cd implementations/python/provekit-lift-py-tests && run_quiet python3 -m pytest tests/); then
-    report "python" "PASS" "55 tests, byte-identical to Rust"
-else
-    report "python" "FAIL" "pytest failed"
+if need_tool python3 python; then
+    if (cd implementations/python/provekit-lift-py-tests && run_quiet python3 -m pytest tests/); then
+        report "python" "PASS" "55 tests, byte-identical to Rust"
+    else
+        report "python" "FAIL" "pytest failed"
+    fi
 fi
 
 # --- C++ ---
 echo "[C++] compile + run parseInt.invariant.cpp"
-local cpp_example="implementations/cpp/provekit-ir-symbolic/example/parseInt.invariant.cpp"
-local cpp_include="implementations/cpp/provekit-ir-symbolic/include"
-local cpp_bin="/tmp/provekit-cpp-conformance"
-if run_quiet c++ -std=c++17 -I "$cpp_include" "$cpp_example" -o "$cpp_bin" && "$cpp_bin" >/dev/null 2>&1; then
-    report "cpp" "PASS" "matches deterministic JCS output"
-else
-    report "cpp" "FAIL" "parseInt.invariant.cpp failed"
+if need_tool c++ cpp; then
+    cpp_example="implementations/cpp/provekit-ir-symbolic/example/parseInt.invariant.cpp"
+    cpp_include="implementations/cpp/provekit-ir-symbolic/include"
+    cpp_bin="/tmp/provekit-cpp-conformance"
+    if run_quiet c++ -std=c++17 -I "$cpp_include" "$cpp_example" -o "$cpp_bin" && "$cpp_bin" >/dev/null 2>&1; then
+        report "cpp" "PASS" "matches deterministic JCS output"
+    else
+        report "cpp" "FAIL" "parseInt.invariant.cpp failed"
+    fi
 fi
 
 # --- C ---
 echo "[C] make test"
-if (cd implementations/c/provekit-ir && run_quiet make test); then
-    report "c" "PASS" "5 tests match Rust JCS + hashes"
-else
-    report "c" "FAIL" "make test failed"
+if need_tool make c; then
+    if (cd implementations/c/provekit-ir && run_quiet make test); then
+        report "c" "PASS" "5 tests match Rust JCS + hashes"
+    else
+        report "c" "FAIL" "make test failed"
+    fi
 fi
 
 # --- Zig ---
 echo "[Zig] zig build test"
-local zig="${PWD}/zig-toolchain/zig"
+zig="${PWD}/zig-toolchain/zig"
 if [ -x "$zig" ]; then
     if (cd implementations/zig/provekit-ir && run_quiet "$zig" build test); then
         report "zig" "PASS" "5 tests match Rust JCS + BLAKE3-512"
@@ -108,16 +132,18 @@ fi
 
 # --- TypeScript ---
 echo "[TypeScript] bun test"
-if (cd implementations/typescript && run_quiet bun test src/lift/*.test.ts); then
-    report "typescript" "PASS" "29 tests, adapters prove equivalence"
-else
-    report "typescript" "FAIL" "bun test failed"
+if need_tool bun typescript; then
+    if (cd implementations/typescript && run_quiet bun test src/lift/*.test.ts); then
+        report "typescript" "PASS" "29 tests, adapters prove equivalence"
+    else
+        report "typescript" "FAIL" "bun test failed"
+    fi
 fi
 
 # --- Summary ---
 echo ""
 echo "=========================================="
-echo " Results: ${GREEN}${PASSES} pass${NC}, ${RED}${FAILS} fail${NC}"
+printf " Results: ${GREEN}%d pass${NC}, ${RED}%d fail${NC}\n" "$PASSES" "$FAILS"
 echo "=========================================="
 
 if [ "$FAILS" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Ran \`./conformance/run.sh\` (PR #56) on a developer machine and surfaced three harness bugs that landed alongside the suite. Fixed all three.

1. **\`local\`-keyword at top-level scope** (lines 79-81, 98). Bash with \`set -u\` aborted at first reference to the unbound variable. Replaced with plain assignments.
2. **Final summary line uses \`echo\`** so \`\\\\033\` escapes printed as literal text. Replaced with \`printf\`.
3. **No missing-toolchain detection.** When cargo / mvn / bun / etc. were absent, the harness reported FAIL instead of SKIP, conflating broken-locally with broken-conformance. Added \`need_tool\` helper that emits SKIP and short-circuits.

## Empirical post-fix run

6 PASS (rust, java, python, cpp, c, typescript), 1 FAIL (go — real bug, separate follow-up), 1 SKIP (zig — toolchain not at expected path; pending PR for the \`@\"and\"\` fix).

## Test plan
- [ ] CI conformance-gate runs the harness and reports same shape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Conformance tests now gracefully skip when language toolchains (Rust, Go, Java, Python, C++, C, TypeScript) are unavailable, reporting SKIP status instead of failing.
  * Improved test summary output with enhanced formatting and better status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->