### PR TITLE
fix(go): align module paths between root and submodules

### DIFF
--- a/implementations/go/go.mod
+++ b/implementations/go/go.mod
@@ -7,6 +7,11 @@ require (
 	github.com/tsavo/provekit/go/provekit-lift-go-tests v0.0.0
 )
 
+require (
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	lukechampine.com/blake3 v1.4.1 // indirect
+)
+
 replace (
 	github.com/tsavo/provekit/go/provekit-ir-symbolic => ./provekit-ir-symbolic
 	github.com/tsavo/provekit/go/provekit-lift-go-tests => ./provekit-lift-go-tests

--- a/implementations/go/go.sum
+++ b/implementations/go/go.sum
@@ -1,0 +1,4 @@
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+lukechampine.com/blake3 v1.4.1 h1:I3Smz7gso8w4/TunLKec6K2fn+kyKtDxr/xcQEN84Wg=
+lukechampine.com/blake3 v1.4.1/go.mod h1:QFosUxmjB8mnrWFSNwKmvxHpfY72bmD2tQ0kBMM3kwo=

--- a/implementations/go/provekit-ir-symbolic/claim_envelope/envelope.go
+++ b/implementations/go/provekit-ir-symbolic/claim_envelope/envelope.go
@@ -22,7 +22,7 @@ import (
 	"encoding/base64"
 	"sort"
 
-	"github.com/provekit/ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
 )
 
 // Schema CIDs. Stable values producers must use; mirrors the C++

--- a/implementations/go/provekit-ir-symbolic/claim_envelope/from_kit.go
+++ b/implementations/go/provekit-ir-symbolic/claim_envelope/from_kit.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/provekit/ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 )
 
 // FormulaToValue converts a kit IrFormula to a JSON-shape value tree

--- a/implementations/go/provekit-ir-symbolic/cmd/go-kit-publish/main.go
+++ b/implementations/go/provekit-ir-symbolic/cmd/go-kit-publish/main.go
@@ -17,9 +17,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/provekit/ir-symbolic/claim_envelope"
-	"github.com/provekit/ir-symbolic/ir"
-	"github.com/provekit/ir-symbolic/proof_envelope"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/claim_envelope"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/proof_envelope"
 )
 
 func main() {

--- a/implementations/go/provekit-ir-symbolic/go.mod
+++ b/implementations/go/provekit-ir-symbolic/go.mod
@@ -1,4 +1,4 @@
-module github.com/provekit/ir-symbolic
+module github.com/tsavo/provekit/go/provekit-ir-symbolic
 
 go 1.22
 

--- a/implementations/go/provekit-ir-symbolic/proof_envelope/builder.go
+++ b/implementations/go/provekit-ir-symbolic/proof_envelope/builder.go
@@ -5,7 +5,7 @@ import (
 	"crypto/ed25519"
 	"sort"
 
-	"github.com/provekit/ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
 )
 
 // Builder assembles a complete .proof file from inputs.

--- a/implementations/go/provekit-ir-symbolic/verifier/cross_lang_demo_test.go
+++ b/implementations/go/provekit-ir-symbolic/verifier/cross_lang_demo_test.go
@@ -41,9 +41,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/provekit/ir-symbolic/claim_envelope"
-	"github.com/provekit/ir-symbolic/ir"
-	"github.com/provekit/ir-symbolic/proof_envelope"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/claim_envelope"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/proof_envelope"
 )
 
 // peerProofDirs holds every peer-language reference impl's v1.1.0

--- a/implementations/go/provekit-ir-symbolic/verifier/load_all_proofs.go
+++ b/implementations/go/provekit-ir-symbolic/verifier/load_all_proofs.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/provekit/ir-symbolic/canonicalizer"
-	"github.com/provekit/ir-symbolic/proof_envelope"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/proof_envelope"
 )
 
 // LoadAllProofsStage walks every .proof file under projectRoot

--- a/implementations/go/provekit-ir-symbolic/verifier/types.go
+++ b/implementations/go/provekit-ir-symbolic/verifier/types.go
@@ -15,7 +15,7 @@ package verifier
 import (
 	"fmt"
 
-	"github.com/provekit/ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
 )
 
 // MementoPool is the unified store every downstream stage hash-looks-up

--- a/implementations/go/provekit-lift-go-tests/cmd/provekit-lift-go/main.go
+++ b/implementations/go/provekit-lift-go-tests/cmd/provekit-lift-go/main.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/provekit/ir-symbolic/canonicalizer"
-	"github.com/provekit/ir-symbolic/ir"
-	lifgotests "github.com/provekit/lift-go-tests"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+	lifgotests "github.com/tsavo/provekit/go/provekit-lift-go-tests"
 )
 
 func main() {

--- a/implementations/go/provekit-lift-go-tests/go.mod
+++ b/implementations/go/provekit-lift-go-tests/go.mod
@@ -1,12 +1,12 @@
-module github.com/provekit/lift-go-tests
+module github.com/tsavo/provekit/go/provekit-lift-go-tests
 
 go 1.22
 
-require github.com/provekit/ir-symbolic v0.0.0
+require github.com/tsavo/provekit/go/provekit-ir-symbolic v0.0.0
 
 require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
 
-replace github.com/provekit/ir-symbolic => ../provekit-ir-symbolic
+replace github.com/tsavo/provekit/go/provekit-ir-symbolic => ../provekit-ir-symbolic

--- a/implementations/go/provekit-lift-go-tests/integration_test.go
+++ b/implementations/go/provekit-lift-go-tests/integration_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/provekit/ir-symbolic/canonicalizer"
-	"github.com/provekit/ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 )
 
 // TestIntegration_Layer2SampleLiftsAllThreePatterns drives the lift

--- a/implementations/go/provekit-lift-go-tests/layer2.go
+++ b/implementations/go/provekit-lift-go-tests/layer2.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/provekit/ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 )
 
 // LiftFile parses src as a Go file at sourcePath and runs the three-

--- a/implementations/go/provekit-lift-go-tests/leaf.go
+++ b/implementations/go/provekit-lift-go-tests/leaf.go
@@ -38,7 +38,7 @@ import (
 	"go/token"
 	"strconv"
 
-	"github.com/provekit/ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 )
 
 // isAssertionCall returns true if call is a recognized assertion-call

--- a/implementations/go/provekit-lift-go-tests/marshal.go
+++ b/implementations/go/provekit-lift-go-tests/marshal.go
@@ -7,7 +7,7 @@ package lifgotests
 import (
 	"encoding/json"
 
-	"github.com/provekit/ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 )
 
 func marshalGeneric(f ir.IrFormula) map[string]any {

--- a/implementations/go/provekit-lift-go-tests/output.go
+++ b/implementations/go/provekit-lift-go-tests/output.go
@@ -23,7 +23,7 @@
 package lifgotests
 
 import (
-	"github.com/provekit/ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 )
 
 // ADAPTER is the adapter-name tag carried by every warning this layer

--- a/implementations/go/provekit-lift-go-tests/subst.go
+++ b/implementations/go/provekit-lift-go-tests/subst.go
@@ -12,7 +12,7 @@
 package lifgotests
 
 import (
-	"github.com/provekit/ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 )
 
 // substVarInFormula returns f with every free occurrence of `formal`

--- a/implementations/go/provekit-self-contracts/cmd/mint-go-self-contracts/main.go
+++ b/implementations/go/provekit-self-contracts/cmd/mint-go-self-contracts/main.go
@@ -30,11 +30,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/provekit/go-self-contracts/slabs"
-	"github.com/provekit/ir-symbolic/canonicalizer"
-	"github.com/provekit/ir-symbolic/claim_envelope"
-	"github.com/provekit/ir-symbolic/ir"
-	"github.com/provekit/ir-symbolic/proof_envelope"
+	"github.com/tsavo/provekit/go/provekit-self-contracts/slabs"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/claim_envelope"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/proof_envelope"
 )
 
 const (

--- a/implementations/go/provekit-self-contracts/go.mod
+++ b/implementations/go/provekit-self-contracts/go.mod
@@ -1,12 +1,12 @@
-module github.com/provekit/go-self-contracts
+module github.com/tsavo/provekit/go/provekit-self-contracts
 
 go 1.22
 
-require github.com/provekit/ir-symbolic v0.0.0
+require github.com/tsavo/provekit/go/provekit-ir-symbolic v0.0.0
 
 require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
 
-replace github.com/provekit/ir-symbolic => ../provekit-ir-symbolic
+replace github.com/tsavo/provekit/go/provekit-ir-symbolic => ../provekit-ir-symbolic

--- a/implementations/go/provekit-self-contracts/slabs/canonicalizer.go
+++ b/implementations/go/provekit-self-contracts/slabs/canonicalizer.go
@@ -13,7 +13,7 @@ package slabs
 // The IR cannot model BLAKE3 collision resistance; what it CAN say is
 // shape-level (length 139, prefix length, deterministic, non-empty).
 
-import "github.com/provekit/ir-symbolic/ir"
+import "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 
 // InvariantsEncoder authors contracts about EncodeJCS / Encoder.Encode.
 func InvariantsEncoder() {

--- a/implementations/go/provekit-self-contracts/slabs/claim_envelope.go
+++ b/implementations/go/provekit-self-contracts/slabs/claim_envelope.go
@@ -15,7 +15,7 @@ package slabs
 // at the verifier (the kit predicates `requiresPreOrPostOrInv`, `hasPrefix`
 // have no Z3 semantics). Length predicates on schema CIDs are decidable.
 
-import "github.com/provekit/ir-symbolic/ir"
+import "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 
 func InvariantsEnvelope() {
 	// Schema CIDs are full-shape v1.1.0 (139 chars: "blake3-512:" + 128 hex).

--- a/implementations/go/provekit-self-contracts/slabs/ir.go
+++ b/implementations/go/provekit-self-contracts/slabs/ir.go
@@ -10,7 +10,7 @@ package slabs
 //   * Contract / Must / Bridge / Property collector primitives.
 //   * MarshalDeclarations(decls) ([]byte, error).
 
-import "github.com/provekit/ir-symbolic/ir"
+import "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 
 func InvariantsIRTypes() {
 	// Var-term JSON omits sort under v1.1.0:

--- a/implementations/go/provekit-self-contracts/slabs/proof_envelope.go
+++ b/implementations/go/provekit-self-contracts/slabs/proof_envelope.go
@@ -11,7 +11,7 @@ package slabs
 // keys) are operationally enforced by tests. The IR can express output
 // shape (FilenameCID is "blake3-512:" + 128 hex; sig is 64 bytes).
 
-import "github.com/provekit/ir-symbolic/ir"
+import "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 
 func InvariantsProofBuilder() {
 	// Build's FilenameCID is exactly 139 chars (full v1.1.0 form, no

--- a/implementations/go/provekit-self-contracts/slabs/slabs.go
+++ b/implementations/go/provekit-self-contracts/slabs/slabs.go
@@ -16,7 +16,7 @@
 // produce identical CIDs; the binary fails loud if not.
 package slabs
 
-import "github.com/provekit/ir-symbolic/ir"
+import "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 
 // Slab is one source file's authored contracts plus the source label.
 // The orchestrator iterates Slabs() and mints each in deterministic

--- a/implementations/go/provekit-self-contracts/slabs/verifier.go
+++ b/implementations/go/provekit-self-contracts/slabs/verifier.go
@@ -12,7 +12,7 @@ package slabs
 // operationally enforced by cross_lang_demo_test.go. The IR can express
 // length floors and rejection-on-malformed-tag as deterministic gestures.
 
-import "github.com/provekit/ir-symbolic/ir"
+import "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 
 func InvariantsLoadAllProofs() {
 	// hashTagPrefix on the verifier path matches the canonicalizer's


### PR DESCRIPTION
## Summary

Root \`go.mod\` and submodule \`go.mod\`s used inconsistent module names. Root expected \`github.com/tsavo/provekit/go/provekit-{ir-symbolic,lift-go-tests}\`; submodules declared \`github.com/provekit/{ir-symbolic,lift-go-tests,go-self-contracts}\` (a non-existent github org). \`go mod tidy\` and \`go test ./...\` both failed.

Renamed submodules to the root-expected paths and updated all source-file imports. \`go mod tidy\` populated \`go.sum\`. All three submodule test suites pass.

## Empirical

Before: \`go test ./...\` → setup failure, missing go.sum entries.
After: 3 packages green in \`provekit-ir-symbolic\`, 1 in \`provekit-lift-go-tests\`, \`provekit-self-contracts\` builds clean.

Conformance harness now: \`✓ go matches canonical JCS bytes\`.

## Test plan
- [ ] CI mint-go matches attestation
- [ ] CI conformance gate green for go