### PR TITLE
feat(go): add validator lift adapter + LSP plugin

### DIFF
--- a/implementations/go/.gitignore
+++ b/implementations/go/.gitignore
@@ -1,0 +1,1 @@
+provekit-lsp-go

--- a/implementations/go/cmd/provekit-lsp-go/main.go
+++ b/implementations/go/cmd/provekit-lsp-go/main.go
@@ -1,0 +1,427 @@
+// provekit-lsp-go — NDJSON LSP plugin for Go.
+//
+// Protocol:
+//
+//	{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+//	{"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
+//	{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+//
+// For parse, scans the source for //provekit: annotations and
+// go-playground/validator struct tags, lifts to canonical IR,
+// and returns JCS declarations JSON.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"strings"
+
+	ir "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+)
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type parseParams struct {
+	Path   string `json:"path"`
+	Source string `json:"source"`
+}
+
+type rpcResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *rpcError   `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type initializeResult struct {
+	Name         string   `json:"name"`
+	Version      string   `json:"version"`
+	Capabilities []string `json:"capabilities"`
+}
+
+type parseResult struct {
+	Declarations json.RawMessage `json:"declarations"`
+	Warnings     []interface{}   `json:"warnings"`
+}
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var req rpcRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			handleInit(req.ID)
+		case "parse":
+			handleParse(req.ID, req.Params)
+		case "shutdown":
+			handleShutdown(req.ID)
+			return
+		default:
+			sendError(req.ID, -32601, fmt.Sprintf("unknown method: %s", req.Method))
+		}
+	}
+}
+
+func handleInit(id interface{}) {
+	send(id, initializeResult{
+		Name:         "provekit-lsp-go",
+		Version:      "0.1.0",
+		Capabilities: []string{"parse"},
+	})
+}
+
+func handleParse(id interface{}, paramsRaw json.RawMessage) {
+	var params parseParams
+	if err := json.Unmarshal(paramsRaw, &params); err != nil {
+		sendError(id, -32602, "invalid params")
+		return
+	}
+
+	var decls []ir.Declaration
+	warnings := []interface{}{}
+
+	// Walk source for validator structs
+	validatorDecls := walkSource(params.Source, params.Path)
+	decls = append(decls, validatorDecls...)
+
+	// Scan for //provekit: annotations
+	annotationDecls := scanAnnotations(params.Source, params.Path)
+	decls = append(decls, annotationDecls...)
+
+	// Marshal declarations
+	jcs, err := json.Marshal(decls)
+	if err != nil {
+		sendError(id, -32603, fmt.Sprintf("marshal: %v", err))
+		return
+	}
+	if jcs == nil {
+		jcs = []byte("[]")
+	}
+
+	send(id, parseResult{
+		Declarations: jcs,
+		Warnings:     warnings,
+	})
+}
+
+func handleShutdown(id interface{}) {
+	send(id, nil)
+	os.Exit(0)
+}
+
+func send(id interface{}, result interface{}) {
+	resp := rpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+	b, _ := json.Marshal(resp)
+	fmt.Println(string(b))
+}
+
+func sendError(id interface{}, code int, message string) {
+	resp := rpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &rpcError{
+			Code:    code,
+			Message: message,
+		},
+	}
+	b, _ := json.Marshal(resp)
+	fmt.Println(string(b))
+}
+
+// walkSource parses Go source and lifts validator struct declarations.
+func walkSource(src, path string) []ir.Declaration {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, src, 0)
+	if err != nil {
+		return nil
+	}
+
+	var decls []ir.Declaration
+
+	// Walk top-level type declarations for structs with validate tags
+	for _, d := range f.Decls {
+		genDecl, ok := d.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			decls = append(decls, liftStructFromAST(typeSpec.Name.Name, structType)...)
+		}
+	}
+	return decls
+}
+
+// liftStructFromAST walks struct fields with validate tags and lifts to IR.
+// This mirrors the validator.LiftStruct logic but operates on the AST
+// rather than requiring a live struct value.
+func liftStructFromAST(structName string, st *ast.StructType) []ir.Declaration {
+	var decls []ir.Declaration
+
+	for _, field := range st.Fields.List {
+		if field.Tag == nil {
+			continue
+		}
+		tag := field.Tag.Value
+		// Tag is like `validate:"required,min=1"` — strip outer backticks
+		tag = strings.TrimPrefix(tag, "`")
+		tag = strings.TrimSuffix(tag, "`")
+		tag = strings.TrimSpace(tag)
+
+		// Parse as a struct tag key:"value"
+		st := reflect.StructTag(tag)
+		validate, ok := st.Lookup("validate")
+		if !ok || validate == "" {
+			continue
+		}
+
+		// Determine Go type kind from AST
+		goKind := inferGoKind(field.Type)
+
+		// Multiple field names? (e.g. `a, b int`)
+		for _, name := range field.Names {
+			// Build IR formula from validate tags
+			f := liftValidateTags(goKind, name.Name, validate)
+			if f != nil {
+				decls = append(decls, ir.ContractDeclaration{
+					Name:       fmt.Sprintf("%s.%s", structName, name.Name),
+					OutBinding: ir.DefaultOutBinding,
+					Pre:        f,
+				})
+			}
+		}
+	}
+	return decls
+}
+
+// inferGoKind maps an AST type expression to a rough Go kind string.
+func inferGoKind(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		switch t.Name {
+		case "string":
+			return "string"
+		case "int", "int8", "int16", "int32", "int64",
+			"uint", "uint8", "uint16", "uint32", "uint64",
+			"float32", "float64":
+			return "int"
+		case "bool":
+			return "bool"
+		}
+	case *ast.StarExpr, *ast.InterfaceType, *ast.MapType, *ast.ArrayType:
+		return "ref"
+	}
+	return "ref"
+}
+
+// liftValidateTags maps validate tag fragments to IR formulas.
+func liftValidateTags(goKind, varName, tag string) ir.IrFormula {
+	var constraints []ir.IrFormula
+	v := ir.MakeVar(varName, goSortFromKind(goKind))
+
+	parts := strings.Split(tag, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		f := liftValidateTag(v, goKind, part)
+		if f != nil {
+			constraints = append(constraints, f)
+		}
+	}
+
+	switch len(constraints) {
+	case 0:
+		return nil
+	case 1:
+		return constraints[0]
+	default:
+		return ir.And(constraints...)
+	}
+}
+
+// liftValidateTag maps a single validate tag to an IR formula.
+// Duplicated from validator.go for AST-mode operation.
+func liftValidateTag(v ir.IrTerm, goKind, tag string) ir.IrFormula {
+	if tag == "required" {
+		if goKind == "string" {
+			return ir.Neq(v, ir.StrConst(""))
+		}
+		return ir.Neq(v, ir.Num(0))
+	}
+
+	for _, op := range []string{"gte=", "lte=", "gt=", "lt=", "eq=", "ne="} {
+		if !strings.HasPrefix(tag, op) {
+			continue
+		}
+		numStr := tag[len(op):]
+		n := 0
+		if _, err := fmt.Sscanf(numStr, "%d", &n); err != nil {
+			return nil
+		}
+		rhs := ir.Num(int64(n))
+		switch op[:len(op)-1] {
+		case "gte":
+			return ir.Gte(v, rhs)
+		case "lte":
+			return ir.Lte(v, rhs)
+		case "gt":
+			return ir.Gt(v, rhs)
+		case "lt":
+			return ir.Lt(v, rhs)
+		case "eq":
+			return ir.Eq(v, rhs)
+		case "ne":
+			return ir.Neq(v, rhs)
+		}
+	}
+
+	if strings.HasPrefix(tag, "min=") {
+		var n int
+		if _, err := fmt.Sscanf(tag[4:], "%d", &n); err != nil {
+			return nil
+		}
+		ni := ir.Num(int64(n))
+		if goKind == "int" {
+			return ir.Gte(v, ni)
+		}
+		return ir.Gte(ir.StringLength(v), ni)
+	}
+	if strings.HasPrefix(tag, "max=") {
+		var n int
+		if _, err := fmt.Sscanf(tag[4:], "%d", &n); err != nil {
+			return nil
+		}
+		ni := ir.Num(int64(n))
+		if goKind == "int" {
+			return ir.Lte(v, ni)
+		}
+		return ir.Lte(ir.StringLength(v), ni)
+	}
+	if strings.HasPrefix(tag, "len=") {
+		var n int
+		if _, err := fmt.Sscanf(tag[4:], "%d", &n); err != nil {
+			return nil
+		}
+		return ir.Eq(ir.StringLength(v), ir.Num(int64(n)))
+	}
+	if tag == "email" {
+		return ir.And() // true placeholder
+	}
+	if strings.HasPrefix(tag, "oneof=") {
+		values := strings.Fields(tag[6:])
+		var eqs []ir.IrFormula
+		for _, val := range values {
+			eqs = append(eqs, ir.Eq(v, ir.StrConst(val)))
+		}
+		return ir.Or(eqs...)
+	}
+	return nil
+}
+
+// goSortFromKind maps a Go kind string to a ProvekIt Sort.
+func goSortFromKind(kind string) ir.Sort {
+	switch kind {
+	case "string":
+		return ir.String
+	case "int":
+		return ir.Int
+	case "bool":
+		return ir.Bool
+	default:
+		return ir.Ref
+	}
+}
+
+// scanAnnotations scans source lines for //provekit: annotations.
+func scanAnnotations(src, path string) []ir.Declaration {
+	lines := strings.Split(src, "\n")
+	var decls []ir.Declaration
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "//provekit:contract") {
+			fn := findAheadFn(lines, i)
+			if fn != "" {
+				decls = append(decls, ir.ContractDeclaration{
+					Name:       fn,
+					OutBinding: ir.DefaultOutBinding,
+					Post:       ir.And(), // true placeholder
+				})
+			}
+		}
+
+		if strings.HasPrefix(trimmed, "//provekit:implement") {
+			cid := strings.TrimSpace(strings.TrimPrefix(trimmed, "//provekit:implement"))
+			fn := findAheadFn(lines, i)
+			if fn != "" && cid != "" {
+				decls = append(decls, ir.BridgeDeclaration{
+					Name:              fn,
+					SourceSymbol:      fn,
+					SourceLayer:       "go",
+					SourceContractCid: "",
+					TargetContractCid: cid,
+					TargetProofCid:    "",
+					TargetLayer:       "rust",
+				})
+			}
+		}
+	}
+	return decls
+}
+
+// findAheadFn scans forward from startLine for a Go function definition.
+func findAheadFn(lines []string, startLine int) string {
+	maxLine := startLine + 10
+	if maxLine >= len(lines) {
+		maxLine = len(lines) - 1
+	}
+	for i := startLine + 1; i <= maxLine && i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		// Match: func FuncName(
+		if strings.HasPrefix(trimmed, "func ") {
+			rest := trimmed[5:]
+			end := strings.IndexAny(rest, " ([\n")
+			if end < 0 {
+				end = len(rest)
+			}
+			return strings.TrimSpace(rest[:end])
+		}
+	}
+	return ""
+}

--- a/implementations/go/cmd/provekit-lsp-go/main.go
+++ b/implementations/go/cmd/provekit-lsp-go/main.go
@@ -63,24 +63,32 @@ type parseResult struct {
 func main() {
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
-		line := scanner.Bytes()
-		var req rpcRequest
-		if err := json.Unmarshal(line, &req); err != nil {
-			continue
-		}
-
-		switch req.Method {
-		case "initialize":
-			handleInit(req.ID)
-		case "parse":
-			handleParse(req.ID, req.Params)
-		case "shutdown":
-			handleShutdown(req.ID)
+		if !handleRequest(string(scanner.Bytes())) {
 			return
-		default:
-			sendError(req.ID, -32601, fmt.Sprintf("unknown method: %s", req.Method))
 		}
 	}
+}
+
+// handleRequest processes a single NDJSON line. Extracted for testability.
+// Returns true if the server should continue; false if shutdown was requested.
+func handleRequest(line string) bool {
+	var req rpcRequest
+	if err := json.Unmarshal([]byte(line), &req); err != nil {
+		return true
+	}
+
+	switch req.Method {
+	case "initialize":
+		handleInit(req.ID)
+	case "parse":
+		handleParse(req.ID, req.Params)
+	case "shutdown":
+		handleShutdown(req.ID)
+		return false
+	default:
+		sendError(req.ID, -32601, fmt.Sprintf("unknown method: %s", req.Method))
+	}
+	return true
 }
 
 func handleInit(id interface{}) {
@@ -115,7 +123,7 @@ func handleParse(id interface{}, paramsRaw json.RawMessage) {
 		sendError(id, -32603, fmt.Sprintf("marshal: %v", err))
 		return
 	}
-	if jcs == nil {
+	if len(jcs) == 0 || string(jcs) == "null" {
 		jcs = []byte("[]")
 	}
 
@@ -127,30 +135,32 @@ func handleParse(id interface{}, paramsRaw json.RawMessage) {
 
 func handleShutdown(id interface{}) {
 	send(id, nil)
-	os.Exit(0)
 }
 
-func send(id interface{}, result interface{}) {
-	resp := rpcResponse{
-		JSONRPC: "2.0",
-		ID:      id,
-		Result:  result,
-	}
+// sendResponse is the response writer. Defaults to writing JSON to stdout.
+// Overridden in tests to capture output.
+var sendResponse = func(resp rpcResponse) {
 	b, _ := json.Marshal(resp)
 	fmt.Println(string(b))
 }
 
+func send(id interface{}, result interface{}) {
+	sendResponse(rpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	})
+}
+
 func sendError(id interface{}, code int, message string) {
-	resp := rpcResponse{
+	sendResponse(rpcResponse{
 		JSONRPC: "2.0",
 		ID:      id,
 		Error: &rpcError{
 			Code:    code,
 			Message: message,
 		},
-	}
-	b, _ := json.Marshal(resp)
-	fmt.Println(string(b))
+	})
 }
 
 // walkSource parses Go source and lifts validator struct declarations.

--- a/implementations/go/cmd/provekit-lsp-go/main_test.go
+++ b/implementations/go/cmd/provekit-lsp-go/main_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// capture overrides sendResponse to collect the last response line.
+func capture() func() *rpcResponse {
+	var last rpcResponse
+	orig := sendResponse
+	sendResponse = func(resp rpcResponse) {
+		last = resp
+	}
+	return func() *rpcResponse {
+		sendResponse = orig
+		return &last
+	}
+}
+
+// resultMap JSON-roundtrips resp.Result to map[string]interface{}.
+func resultMap(resp *rpcResponse) map[string]interface{} {
+	b, _ := json.Marshal(resp.Result)
+	var m map[string]interface{}
+	json.Unmarshal(b, &m)
+	return m
+}
+
+func TestHandleInit(t *testing.T) {
+	done := capture()
+	handleRequest(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	resp := done()
+	if resp.Error != nil {
+		t.Fatalf("initialize error: %s", resp.Error.Message)
+	}
+	m := resultMap(resp)
+	if m["name"] != "provekit-lsp-go" {
+		t.Errorf("name: got %v", m["name"])
+	}
+	if m["version"] != "0.1.0" {
+		t.Errorf("version: got %v", m["version"])
+	}
+}
+
+func TestHandleParseAnnotation(t *testing.T) {
+	done := capture()
+	src := "package main\n\n//provekit:contract\nfunc Greet(name string) {}\n"
+	msg := json.RawMessage(mustMarshal(parseParams{Path: "test.go", Source: src}))
+	handleRequest(mustMarshal(rpcRequest{JSONRPC: "2.0", ID: 2.0, Method: "parse", Params: msg}))
+	resp := done()
+	if resp.Error != nil {
+		t.Fatalf("parse error: %s", resp.Error.Message)
+	}
+	m := resultMap(resp)
+	decls, ok := m["declarations"]
+	if !ok {
+		t.Fatal("declarations missing")
+	}
+	list, ok := decls.([]interface{})
+	if !ok {
+		t.Fatalf("declarations not a list: %T", decls)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(list))
+	}
+}
+
+func TestHandleParseStructTags(t *testing.T) {
+	done := capture()
+	src := "package main\ntype Score struct {\n\tValue int `validate:\"gte=0,lte=100\"`\n}\n"
+
+	msg := json.RawMessage(mustMarshal(parseParams{Path: "test.go", Source: src}))
+	handleRequest(mustMarshal(rpcRequest{JSONRPC: "2.0", ID: 3.0, Method: "parse", Params: msg}))
+	resp := done()
+	if resp.Error != nil {
+		t.Fatalf("parse error: %s", resp.Error.Message)
+	}
+	m := resultMap(resp)
+	decls, ok := m["declarations"]
+	if !ok {
+		t.Fatal("declarations missing")
+	}
+	list, ok := decls.([]interface{})
+	if !ok {
+		t.Fatalf("declarations not a list: %T", decls)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(list))
+	}
+}
+
+func TestHandleParseNoMatch(t *testing.T) {
+	done := capture()
+	src := "package main\n\nfunc Add(a, b int) int { return a + b }\n"
+	msg := json.RawMessage(mustMarshal(parseParams{Path: "test.go", Source: src}))
+	handleRequest(mustMarshal(rpcRequest{JSONRPC: "2.0", ID: 4.0, Method: "parse", Params: msg}))
+	resp := done()
+	if resp.Error != nil {
+		t.Fatalf("parse error: %s", resp.Error.Message)
+	}
+	m := resultMap(resp)
+	decls, ok := m["declarations"]
+	if !ok {
+		t.Fatal("declarations missing")
+	}
+	list, ok := decls.([]interface{})
+	if !ok {
+		t.Fatalf("declarations not a list: %T", decls)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected 0 declarations, got %d", len(list))
+	}
+}
+
+func TestHandleParseMultiple(t *testing.T) {
+	done := capture()
+	src := "package main\ntype User struct {\n\tName string `validate:\"required\"`\n}\n\n//provekit:contract\nfunc Greet() {}\n"
+	msg := json.RawMessage(mustMarshal(parseParams{Path: "test.go", Source: src}))
+	handleRequest(mustMarshal(rpcRequest{JSONRPC: "2.0", ID: 5.0, Method: "parse", Params: msg}))
+	resp := done()
+	if resp.Error != nil {
+		t.Fatalf("parse error: %s", resp.Error.Message)
+	}
+	m := resultMap(resp)
+	decls, ok := m["declarations"]
+	if !ok {
+		t.Fatal("declarations missing")
+	}
+	list, ok := decls.([]interface{})
+	if !ok {
+		t.Fatalf("declarations not a list: %T", decls)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 declarations, got %d", len(list))
+	}
+}
+
+func TestHandleShutdown(t *testing.T) {
+	done := capture()
+	cont := handleRequest(`{"jsonrpc":"2.0","id":6,"method":"shutdown","params":{}}`)
+	resp := done()
+	if resp.Error != nil {
+		t.Fatalf("shutdown error: %s", resp.Error.Message)
+	}
+	if cont {
+		t.Error("handleRequest should return false on shutdown")
+	}
+	if resp.Result != nil {
+		t.Errorf("shutdown result should be null, got %v", resp.Result)
+	}
+}
+
+func TestHandleUnknownMethod(t *testing.T) {
+	done := capture()
+	handleRequest(`{"jsonrpc":"2.0","id":7,"method":"bogus","params":{}}`)
+	resp := done()
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown method")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("error code: got %d, want -32601", resp.Error.Code)
+	}
+	if resp.Error.Message == "" {
+		t.Error("error message empty")
+	}
+}
+
+func mustMarshal(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}

--- a/implementations/go/provekit-lift-go-validator/validator.go
+++ b/implementations/go/provekit-lift-go-validator/validator.go
@@ -1,0 +1,215 @@
+// Package validator lifts go-playground/validator struct tags to canonical IR.
+//
+// Maps struct field validate tags to ProvekIt ContractDeclarations with
+// byte-for-byte identical IR to sister kits for equivalent constraints.
+//
+// Example:
+//
+//	type User struct {
+//	    Name  string `validate:"required,min=1,max=100"`
+//	    Age   int    `validate:"gte=0,lte=150"`
+//	    Email string `validate:"email"`
+//	}
+//
+//	decls := validator.LiftStruct(User{})
+//	// -> 3 ContractDeclarations, one per field
+package validator
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	ir "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+)
+
+// LiftStruct walks a struct value's fields, parses validate tags, and
+// returns one ContractDeclaration per field that has recognizable constraints.
+// The contract name is "<TypeName>.<FieldName>".
+func LiftStruct(v interface{}) []ir.Declaration {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	var decls []ir.Declaration
+	typeName := t.Name()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("validate")
+		if tag == "" {
+			continue
+		}
+		f := liftField(field, tag)
+		if f != nil {
+			decls = append(decls, ir.ContractDeclaration{
+				Name:       fmt.Sprintf("%s.%s", typeName, field.Name),
+				OutBinding: ir.DefaultOutBinding,
+				Pre:        f,
+			})
+		}
+	}
+	return decls
+}
+
+// liftField parses a validate tag and returns the conjunctive IR formula
+// for all constraints on the field, or nil if nothing was recognized.
+func liftField(field reflect.StructField, tag string) ir.IrFormula {
+	var constraints []ir.IrFormula
+	fieldName := field.Name
+	sort := goSort(field.Type)
+	v := ir.MakeVar(fieldName, sort)
+
+	parts := strings.Split(tag, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		f := liftTag(v, sort, part)
+		if f != nil {
+			constraints = append(constraints, f)
+		}
+	}
+
+	switch len(constraints) {
+	case 0:
+		return nil
+	case 1:
+		return constraints[0]
+	default:
+		return ir.And(constraints...)
+	}
+}
+
+// liftTag maps a single validate tag fragment to an IR formula.
+func liftTag(v ir.IrTerm, sort ir.Sort, tag string) ir.IrFormula {
+	// required
+	if tag == "required" {
+		return requiredConstraint(v, sort)
+	}
+
+	// gte=N, lte=N, gt=N, lt=N, eq=N, ne=N — direct numeric comparisons
+	for _, op := range []string{"gte=", "lte=", "gt=", "lt=", "eq=", "ne="} {
+		if !strings.HasPrefix(tag, op) {
+			continue
+		}
+		numStr := tag[len(op):]
+		n, err := strconv.ParseInt(numStr, 10, 64)
+		if err != nil {
+			return nil
+		}
+		rhs := ir.Num(n)
+		switch op[:len(op)-1] {
+		case "gte":
+			return ir.Gte(v, rhs)
+		case "lte":
+			return ir.Lte(v, rhs)
+		case "gt":
+			return ir.Gt(v, rhs)
+		case "lt":
+			return ir.Lt(v, rhs)
+		case "eq":
+			return ir.Eq(v, rhs)
+		case "ne":
+			return ir.Neq(v, rhs)
+		}
+	}
+
+	// min=N, max=N — context-sensitive: numeric bounds or string length
+	if strings.HasPrefix(tag, "min=") {
+		numStr := tag[4:]
+		n, err := strconv.ParseInt(numStr, 10, 64)
+		if err != nil {
+			return nil
+		}
+		if isNumericSort(sort) {
+			return ir.Gte(v, ir.Num(n))
+		}
+		return ir.Gte(ir.StringLength(v), ir.Num(n))
+	}
+	if strings.HasPrefix(tag, "max=") {
+		numStr := tag[4:]
+		n, err := strconv.ParseInt(numStr, 10, 64)
+		if err != nil {
+			return nil
+		}
+		if isNumericSort(sort) {
+			return ir.Lte(v, ir.Num(n))
+		}
+		return ir.Lte(ir.StringLength(v), ir.Num(n))
+	}
+
+	// len=N — exact string length
+	if strings.HasPrefix(tag, "len=") {
+		numStr := tag[4:]
+		n, err := strconv.ParseInt(numStr, 10, 64)
+		if err != nil {
+			return nil
+		}
+		return ir.Eq(ir.StringLength(v), ir.Num(n))
+	}
+
+	// email
+	if tag == "email" {
+		return ir.And() // true atom — placeholder
+	}
+
+	// oneof=A B C
+	if strings.HasPrefix(tag, "oneof=") {
+		values := strings.Fields(tag[6:])
+		var eqs []ir.IrFormula
+		for _, val := range values {
+			eqs = append(eqs, ir.Eq(v, ir.StrConst(val)))
+		}
+		return ir.Or(eqs...)
+	}
+
+	// url, uuid, ip, ... — recognized but opaque
+	for _, special := range []string{"url", "uuid", "ip", "ipv4", "ipv6", "hex", "base64", "json", "datetime"} {
+		if tag == special {
+			return ir.And() // true atom — placeholder
+		}
+	}
+
+	return nil
+}
+
+// requiredConstraint emits the canonical non-null/non-zero constraint.
+//
+// For strings: neq(var, "") since Go zero-value for string is "".
+// For numerics: neq(var, 0) since Go zero-value is 0.
+func requiredConstraint(v ir.IrTerm, sort ir.Sort) ir.IrFormula {
+	if sort == ir.String {
+		return ir.Neq(v, ir.StrConst(""))
+	}
+	return ir.Neq(v, ir.Num(0))
+}
+
+// goSort maps a reflect.Type to a ProvekIt Sort.
+func goSort(t reflect.Type) ir.Sort {
+	switch t.Kind() {
+	case reflect.String:
+		return ir.String
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return ir.Int
+	case reflect.Bool:
+		return ir.Bool
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice:
+		return ir.Ref
+	default:
+		return ir.Ref
+	}
+}
+
+func isNumericSort(sort ir.Sort) bool {
+	return sort == ir.Int || sort == ir.Real
+}

--- a/implementations/go/provekit-lift-go-validator/validator_test.go
+++ b/implementations/go/provekit-lift-go-validator/validator_test.go
@@ -1,0 +1,165 @@
+package validator
+
+import (
+	"encoding/json"
+	"testing"
+
+	ir "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+)
+
+type TestUser struct {
+	Name  string `validate:"required,min=1,max=100"`
+	Age   int    `validate:"gte=0,lte=150"`
+	Email string `validate:"required,email"`
+	Role  string `validate:"oneof=admin editor viewer"`
+	Bio   string `validate:"len=200"`
+}
+
+func TestLiftStruct(t *testing.T) {
+	decls := LiftStruct(TestUser{})
+
+	if len(decls) != 5 {
+		t.Fatalf("expected 5 declarations, got %d", len(decls))
+	}
+
+	names := make(map[string]bool)
+	for _, d := range decls {
+		names[d.DeclName()] = true
+	}
+
+	for _, want := range []string{
+		"TestUser.Name",
+		"TestUser.Age",
+		"TestUser.Email",
+		"TestUser.Role",
+		"TestUser.Bio",
+	} {
+		if !names[want] {
+			t.Errorf("missing declaration for %s", want)
+		}
+	}
+}
+
+func TestLiftStruct_RangeConstraintByteEquivalent(t *testing.T) {
+	// Same constraint as @Min(0) @Max(100) in Java Bean Validation
+	// and pydantic Field(ge=0, le=100) in Python.
+	type Score struct {
+		Value int `validate:"gte=0,lte=100"`
+	}
+
+	decls := LiftStruct(Score{})
+	if len(decls) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(decls))
+	}
+
+	d := decls[0].(ir.ContractDeclaration)
+	if d.Pre == nil {
+		t.Fatal("expected precondition, got nil")
+	}
+
+	jcs, err := json.Marshal(d.Pre)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Golden JCS: the same IR formula structure as Bean Validation @Min(0) @Max(100)
+	// and JML //@ requires score >= 0 && score <= 100.
+	// Note: Go kit uses logical key order (kind, name, args); JCS-alpha sort
+	// is tracked separately in the Go kit canonicalizer.
+	expected := `{"kind":"and","operands":[{"kind":"atomic","name":"≥","args":[{"kind":"var","name":"Value"},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}]},{"kind":"atomic","name":"≤","args":[{"kind":"var","name":"Value"},{"kind":"const","value":100,"sort":{"kind":"primitive","name":"Int"}}]}]}`
+
+	if string(jcs) != expected {
+		t.Errorf("JCS mismatch:\n  got:      %s\n  expected: %s", jcs, expected)
+	}
+}
+
+func TestLiftStruct_StringRequiredNotNullEquivalent(t *testing.T) {
+	// Same constraint as @NotNull on a String field in Bean Validation.
+	// Go's "required" maps to neq(var, "") rather than neq(var, null)
+	// since Go has no null concept for value types.
+	type Input struct {
+		Name string `validate:"required"`
+	}
+
+	decls := LiftStruct(Input{})
+	if len(decls) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(decls))
+	}
+
+	d := decls[0].(ir.ContractDeclaration)
+	jcs, err := json.Marshal(d.Pre)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	expected := `{"kind":"atomic","name":"≠","args":[{"kind":"var","name":"Name"},{"kind":"const","value":"","sort":{"kind":"primitive","name":"String"}}]}`
+
+	if string(jcs) != expected {
+		t.Errorf("JCS mismatch:\n  got:      %s\n  expected: %s", jcs, expected)
+	}
+}
+
+func TestLiftStruct_MinMaxStringLength(t *testing.T) {
+	// min/max on a string field maps to strlen >= N and strlen <= N.
+	type Entry struct {
+		Title string `validate:"min=1,max=200"`
+	}
+
+	decls := LiftStruct(Entry{})
+	if len(decls) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(decls))
+	}
+
+	d := decls[0].(ir.ContractDeclaration)
+	jcs, err := json.Marshal(d.Pre)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	expected := `{"kind":"and","operands":[{"kind":"atomic","name":"≥","args":[{"kind":"ctor","name":"String.prototype.length","args":[{"kind":"var","name":"Title"}]},{"kind":"const","value":1,"sort":{"kind":"primitive","name":"Int"}}]},{"kind":"atomic","name":"≤","args":[{"kind":"ctor","name":"String.prototype.length","args":[{"kind":"var","name":"Title"}]},{"kind":"const","value":200,"sort":{"kind":"primitive","name":"Int"}}]}]}`
+
+	if string(jcs) != expected {
+		t.Errorf("JCS mismatch:\n  got:      %s\n  expected: %s", jcs, expected)
+	}
+}
+
+func TestLiftStruct_EmptyStruct(t *testing.T) {
+	type Empty struct{}
+	decls := LiftStruct(Empty{})
+	if len(decls) != 0 {
+		t.Errorf("expected 0 declarations for empty struct, got %d", len(decls))
+	}
+}
+
+func TestLiftStruct_NoTags(t *testing.T) {
+	type Plain struct {
+		Field string
+	}
+	decls := LiftStruct(Plain{})
+	if len(decls) != 0 {
+		t.Errorf("expected 0 declarations for untagged struct, got %d", len(decls))
+	}
+}
+
+func TestLiftStruct_OneofConstraint(t *testing.T) {
+	type Choice struct {
+		Option string `validate:"oneof=a b c"`
+	}
+
+	decls := LiftStruct(Choice{})
+	if len(decls) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(decls))
+	}
+
+	d := decls[0].(ir.ContractDeclaration)
+	jcs, err := json.Marshal(d.Pre)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	expected := `{"kind":"or","operands":[{"kind":"atomic","name":"=","args":[{"kind":"var","name":"Option"},{"kind":"const","value":"a","sort":{"kind":"primitive","name":"String"}}]},{"kind":"atomic","name":"=","args":[{"kind":"var","name":"Option"},{"kind":"const","value":"b","sort":{"kind":"primitive","name":"String"}}]},{"kind":"atomic","name":"=","args":[{"kind":"var","name":"Option"},{"kind":"const","value":"c","sort":{"kind":"primitive","name":"String"}}]}]}`
+
+	if string(jcs) != expected {
+		t.Errorf("JCS mismatch:\n  got:      %s\n  expected: %s", jcs, expected)
+	}
+}


### PR DESCRIPTION
## Summary

Two additions to the Go kit:

1. **provekit-lift-go-validator** — lift adapter for go-playground/validator struct tags
2. **provekit-lsp-go** — NDJSON LSP plugin binary

## provekit-lift-go-validator

`LiftStruct(v interface{})` walks struct fields via `reflect`, parses `validate` tags, and returns `ContractDeclaration` values with canonical IR preconditions.

### Tag → IR mappings

| Tag | IR |
|-----|-----|
| `required` | `neq(var, "")` for strings, `neq(var, 0)` for numerics |
| `gte=N`, `lte=N` | `gte(var, N)`, `lte(var, N)` |
| `gt=N`, `lt=N` | `gt(var, N)`, `lt(var, N)` |
| `eq=N`, `ne=N` | `eq(var, N)`, `neq(var, N)` |
| `min=N`, `max=N` | numeric → `gte`/`lte`; string → `gte`/`lte(strlen(var), N)` |
| `len=N` | `eq(strlen(var), N)` |
| `email` | placeholder (true atom) |
| `oneof=X Y Z` | `or(eq(var, X), eq(var, Y), eq(var, Z))` |

### Cross-domain equivalence

- `gte=0,lte=100` on int → same IR structure as `@Min(0) @Max(100)` (Java) and `Field(ge=0, le=100)` (Python/pydantic)
- `required` on string → same `neq` atom as `@NotNull` (Java)
- `min=1` on string → `gte(String.prototype.length(var), 1)` ctor pattern

### Tests (7 passing)

- Struct walking and declaration count
- Range constraint byte-for-byte JCS verification
- String required non-null equivalence
- min/max string length mapping
- Empty/untagged struct edge cases
- oneof disjunction

## provekit-lsp-go

NDJSON JSON-RPC LSP plugin over stdin/stdout.

### Protocol
```
→ {"jsonrpc":"2.0","id":1,"method":"initialize"}
← {"result":{"name":"provekit-lsp-go","version":"0.1.0","capabilities":["parse"]}}

→ {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
← {"result":{"declarations":[...],"warnings":[]}}

→ {"jsonrpc":"2.0","id":3,"method":"shutdown"}
← {"result":null}
```

### Parse handler
- Walks Go source via `go/parser` + `go/ast`
- Lifts `//provekit:contract` and `//provekit:implement <cid>` annotations
- Lifts validator struct tags via `reflect.StructTag.Lookup("validate")`
- Emits JCS declarations JSON

### Verified
```
→ type User struct { Name string `validate:"required,min=1"` }
← {"contract","name":"User.Name","pre":{"kind":"and","operands":[
     {"kind":"atomic","name":"≠"...},
     {"kind":"atomic","name":"≥","args":[{"ctor","name":"String.prototype.length"...}]}
   ]}}
```