### PR TITLE
fix(zig): zig 0.14 zon format + harness fallback to system zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ implementations/*/blake3-512:*.proof
 # and serves as the durable record of what the auto-lifter reaches on
 # real source. Rebuild with `make self-lift-<crate>`.
 !.provekit/self-lifts/**/*.proof
+
+# Zig build artifacts
+implementations/zig/**/.zig-cache/
+implementations/zig/**/zig-out/

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -119,15 +119,23 @@ fi
 
 # --- Zig ---
 echo "[Zig] zig build test"
-zig="${PWD}/zig-toolchain/zig"
-if [ -x "$zig" ]; then
+# Prefer pinned toolchain for hermetic CI; fall back to system zig.
+zig_pinned="${PWD}/zig-toolchain/zig"
+if [ -x "$zig_pinned" ]; then
+    zig="$zig_pinned"
+elif command -v zig >/dev/null 2>&1; then
+    zig="$(command -v zig)"
+else
+    zig=""
+fi
+if [ -n "$zig" ]; then
     if (cd implementations/zig/provekit-ir && run_quiet "$zig" build test); then
         report "zig" "PASS" "5 tests match Rust JCS + BLAKE3-512"
     else
         report "zig" "FAIL" "zig build test failed"
     fi
 else
-    report "zig" "SKIP" "zig toolchain not found at $zig"
+    report "zig" "SKIP" "zig toolchain not at $zig_pinned and not on PATH"
 fi
 
 # --- TypeScript ---

--- a/implementations/zig/provekit-ir/build.zig.zon
+++ b/implementations/zig/provekit-ir/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "provekit-ir",
+    .name = .provekit_ir,
+    .fingerprint = 0x28ea7787609d6565,
     .version = "0.1.0",
     .paths = .{
         "build.zig",

--- a/implementations/zig/provekit-lift-zig/build.zig.zon
+++ b/implementations/zig/provekit-lift-zig/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "provekit-lift-zig",
+    .name = .provekit_lift_zig,
+    .fingerprint = 0x243eb567a3bcd8ec,
     .version = "0.1.0",
     .paths = .{
         "build.zig",


### PR DESCRIPTION
## Summary

Closes the conformance harness's last red kit.

**build.zig.zon** (both modules):
- Zig 0.14+ rejects \`.name = \"string\"\` — needs enum literal \`.name = .provekit_ir\`
- Zig 0.14+ requires \`.fingerprint\`; used zig-suggested per-package value

**conformance/run.sh**:
- Zig block now falls back to system zig via \`command -v\` when pinned \`zig-toolchain/zig\` absent. SKIP only when neither exists.

**.gitignore**:
- Cover zig build artifacts (.zig-cache/, zig-out/)

## Empirical

Local run with zig 0.14.0 on PATH:

\`\`\`
✓ rust         canonical reference matches pinned fixtures
✓ go           matches canonical JCS bytes
✓ java         13 modules, integration tests prove equivalence
✓ python       55 tests, byte-identical to Rust
✓ cpp          matches deterministic JCS output
✓ c            5 tests match Rust JCS + hashes
✓ zig          5 tests match Rust JCS + BLAKE3-512
✓ typescript   29 tests, adapters prove equivalence

Results: 8 pass, 0 fail
\`\`\`

## Note on zig 0.16

Brew installs zig 0.16, but the kit's source uses \`std.ArrayList(u8).init(alloc)\` which 0.16 removed. Pinning to 0.14 for now; 0.16 update is separate work.