### PR TITLE
docs(self-contracts): collapse R10 into R11

### DIFF
--- a/implementations/rust/provekit-self-contracts/src/catalog_format.rs
+++ b/implementations/rust/provekit-self-contracts/src/catalog_format.rs
@@ -205,6 +205,12 @@ pub fn invariants() {
         }),
     );
 
+    // R10 + R11: collapsed. R10 ("every spec file referenced from
+    // `properties` exists at expected path") is subsumed by R11's
+    // hash-match check, since blake3_512_of_spec_file_for_key(k) reads
+    // the file -- non-existence fails the read, R10 falls out as a
+    // structural precondition to the hash equality. PR #53 listed R10
+    // as separately-deferred; this comment retires that separation.
     // -- R11: every spec file's raw-byte BLAKE3-512 matches its CID. ------
     //
     // forall key, file. properties_value(key) = spec_cid_of_file(file).


### PR DESCRIPTION
## Summary

- Collapses R10 into R11 with a doc comment explaining the subsumption
- R10 ("every spec file exists") is a structural precondition to R11's hash-match check, since `blake3_512_of_spec_file_for_key(k)` fails on missing files
- Retires PR #53's separate-deferred classification for R10