### PR TITLE
fix(go): enforce JCS alphabetical key order in serializer

### DIFF
--- a/implementations/go/provekit-ir-symbolic/ir/canonical_form_test.go
+++ b/implementations/go/provekit-ir-symbolic/ir/canonical_form_test.go
@@ -20,11 +20,11 @@ import (
 // reference, future TS port) must hash to the same JCS bytes for the
 // same logical claim.
 
-const goldenSimpleEq = `[{"kind":"contract","name":"zeroIsZero","outBinding":"out","pre":{"kind":"atomic","name":"=","args":[{"kind":"ctor","name":"parseInt","args":[{"kind":"const","value":"0","sort":{"kind":"primitive","name":"String"}}]},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}]}}]`
+const goldenSimpleEq = `[{"kind":"contract","name":"zeroIsZero","outBinding":"out","pre":{"args":[{"args":[{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"0"}],"kind":"ctor","name":"parseInt"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"="}}]`
 
-const goldenForAllEq = `[{"kind":"contract","name":"denominator-nonzero","outBinding":"out","pre":{"kind":"forall","name":"_x0","sort":{"kind":"primitive","name":"Int"},"body":{"kind":"atomic","name":"=","args":[{"kind":"var","name":"_x0"},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}]}}}]`
+const goldenForAllEq = `[{"kind":"contract","name":"denominator-nonzero","outBinding":"out","pre":{"body":{"args":[{"kind":"var","name":"_x0"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"="},"kind":"forall","name":"_x0","sort":{"kind":"primitive","name":"Int"}}}]`
 
-const goldenExistsParseInt = `[{"kind":"contract","name":"can-be-zero","outBinding":"out","pre":{"kind":"exists","name":"_x0","sort":{"kind":"primitive","name":"String"},"body":{"kind":"atomic","name":"=","args":[{"kind":"ctor","name":"parseInt","args":[{"kind":"var","name":"_x0"}]},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}]}}}]`
+const goldenExistsParseInt = `[{"kind":"contract","name":"can-be-zero","outBinding":"out","pre":{"body":{"args":[{"args":[{"kind":"var","name":"_x0"}],"kind":"ctor","name":"parseInt"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"="},"kind":"exists","name":"_x0","sort":{"kind":"primitive","name":"String"}}}]`
 
 func TestCanonicalFormSimpleEq(t *testing.T) {
 	ResetCollector()

--- a/implementations/go/provekit-ir-symbolic/ir/primitives_test.go
+++ b/implementations/go/provekit-ir-symbolic/ir/primitives_test.go
@@ -176,7 +176,7 @@ func TestAddJSONShape(t *testing.T) {
 		t.Fatalf("marshal error: %v", err)
 	}
 	// v1.1.0: ctor drops `sort` from JSON.
-	want := `{"kind":"ctor","name":"+","args":[{"kind":"const","value":2,"sort":{"kind":"primitive","name":"Int"}},{"kind":"const","value":3,"sort":{"kind":"primitive","name":"Int"}}]}`
+	want := `{"args":[{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":2},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":3}],"kind":"ctor","name":"+"}`
 	if string(got) != want {
 		t.Errorf("got %s, want %s", got, want)
 	}

--- a/implementations/go/provekit-ir-symbolic/ir/property.go
+++ b/implementations/go/provekit-ir-symbolic/ir/property.go
@@ -107,7 +107,27 @@ func (c ContractDeclaration) DeclName() string { return c.Name }
 
 func (c ContractDeclaration) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteString(`{"kind":"contract","name":`)
+	if c.Evidence != nil {
+		buf.WriteString(`{"evidence":`)
+		encoded, err := encodeJSON(c.Evidence)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(encoded)
+		buf.WriteByte(',')
+	} else {
+		buf.WriteByte('{')
+	}
+	if c.Inv != nil {
+		buf.WriteString(`"inv":`)
+		encoded, err := encodeJSON(c.Inv)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(encoded)
+		buf.WriteByte(',')
+	}
+	buf.WriteString(`"kind":"contract","name":`)
 	encoded, err := encodeJSON(c.Name)
 	if err != nil {
 		return nil, err
@@ -119,14 +139,6 @@ func (c ContractDeclaration) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	buf.Write(encoded)
-	if c.Pre != nil {
-		buf.WriteString(`,"pre":`)
-		encoded, err = encodeJSON(c.Pre)
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(encoded)
-	}
 	if c.Post != nil {
 		buf.WriteString(`,"post":`)
 		encoded, err = encodeJSON(c.Post)
@@ -135,17 +147,9 @@ func (c ContractDeclaration) MarshalJSON() ([]byte, error) {
 		}
 		buf.Write(encoded)
 	}
-	if c.Inv != nil {
-		buf.WriteString(`,"inv":`)
-		encoded, err = encodeJSON(c.Inv)
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(encoded)
-	}
-	if c.Evidence != nil {
-		buf.WriteString(`,"evidence":`)
-		encoded, err = encodeJSON(c.Evidence)
+	if c.Pre != nil {
+		buf.WriteString(`,"pre":`)
+		encoded, err = encodeJSON(c.Pre)
 		if err != nil {
 			return nil, err
 		}

--- a/implementations/go/provekit-ir-symbolic/ir/quantifiers_test.go
+++ b/implementations/go/provekit-ir-symbolic/ir/quantifiers_test.go
@@ -50,7 +50,7 @@ func TestMakeVarPreservesNameInJSON(t *testing.T) {
 func TestMakeCtorEmitsCanonicalCtor(t *testing.T) {
 	c := MakeCtor("parseInt", []IrTerm{StrConst("42")}, Int)
 	b, _ := json.Marshal(c)
-	want := `{"kind":"ctor","name":"parseInt","args":[{"kind":"const","value":"42","sort":{"kind":"primitive","name":"String"}}]}`
+	want := `{"args":[{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"42"}],"kind":"ctor","name":"parseInt"}`
 	if string(b) != want {
 		t.Fatalf("MakeCtor JSON wrong:\n got: %s\nwant: %s", string(b), want)
 	}

--- a/implementations/go/provekit-ir-symbolic/ir/types.go
+++ b/implementations/go/provekit-ir-symbolic/ir/types.go
@@ -170,14 +170,14 @@ func (t constTerm) TermSort() Sort { return t.Sort }
 
 func (t constTerm) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteString(`{"kind":"const","value":`)
-	encoded, err := encodeJSON(t.Value)
+	buf.WriteString(`{"kind":"const","sort":`)
+	encoded, err := encodeJSON(t.Sort)
 	if err != nil {
 		return nil, err
 	}
 	buf.Write(encoded)
-	buf.WriteString(`,"sort":`)
-	encoded, err = encodeJSON(t.Sort)
+	buf.WriteString(`,"value":`)
+	encoded, err = encodeJSON(t.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -197,14 +197,14 @@ func (t ctorTerm) TermSort() Sort { return t.Sort }
 
 func (t ctorTerm) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteString(`{"kind":"ctor","name":`)
-	encoded, err := encodeJSON(t.Name)
+	buf.WriteString(`{"args":`)
+	encoded, err := marshalTerms(t.Args)
 	if err != nil {
 		return nil, err
 	}
 	buf.Write(encoded)
-	buf.WriteString(`,"args":`)
-	encoded, err = marshalTerms(t.Args)
+	buf.WriteString(`,"kind":"ctor","name":`)
+	encoded, err = encodeJSON(t.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -243,20 +243,20 @@ func (t lambdaTerm) TermSort() Sort { return t.Sort }
 
 func (t lambdaTerm) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteString(`{"kind":"lambda","paramName":`)
-	encoded, err := encodeJSON(t.ParamName)
+	buf.WriteString("{\"body\":")
+	encoded, err := encodeJSON(t.Body)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteString(`,"kind":"lambda","paramName":`)
+	encoded, err = encodeJSON(t.ParamName)
 	if err != nil {
 		return nil, err
 	}
 	buf.Write(encoded)
 	buf.WriteString(",\"paramSort\":")
 	encoded, err = encodeJSON(t.ParamSort)
-	if err != nil {
-		return nil, err
-	}
-	buf.Write(encoded)
-	buf.WriteString(",\"body\":")
-	encoded, err = encodeJSON(t.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -283,19 +283,19 @@ func (t letTerm) TermSort() Sort { return t.Sort }
 
 func (t letTerm) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteString(`{"kind":"let","bindings":[`)
+	buf.WriteString(`{"bindings":[`)
 	for i, b := range t.Bindings {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteString(`{"name":`)
-		encoded, err := encodeJSON(b.Name)
+		buf.WriteString(`{"boundTerm":`)
+		encoded, err := encodeJSON(b.BoundTerm)
 		if err != nil {
 			return nil, err
 		}
 		buf.Write(encoded)
-		buf.WriteString(",\"boundTerm\":")
-		encoded, err = encodeJSON(b.BoundTerm)
+		buf.WriteString(",\"name\":")
+		encoded, err = encodeJSON(b.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +308,7 @@ func (t letTerm) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	buf.Write(encoded)
-	buf.WriteByte('}')
+	buf.WriteString(",\"kind\":\"let\"}")
 	return buf.Bytes(), nil
 }
 
@@ -337,8 +337,14 @@ func (quantFormula) formulaMarker() {}
 
 func (f quantFormula) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteString(`{"kind":`)
-	encoded, err := encodeJSON(f.Kind)
+	buf.WriteString(`{"body":`)
+	encoded, err := encodeJSON(f.Body)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteString(`,"kind":`)
+	encoded, err = encodeJSON(f.Kind)
 	if err != nil {
 		return nil, err
 	}
@@ -351,12 +357,6 @@ func (f quantFormula) MarshalJSON() ([]byte, error) {
 	buf.Write(encoded)
 	buf.WriteString(`,"sort":`)
 	encoded, err = encodeJSON(f.Sort)
-	if err != nil {
-		return nil, err
-	}
-	buf.Write(encoded)
-	buf.WriteString(`,"body":`)
-	encoded, err = encodeJSON(f.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -402,14 +402,14 @@ func (atomicFormula) formulaMarker() {}
 
 func (f atomicFormula) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteString(`{"kind":"atomic","name":`)
-	encoded, err := encodeJSON(f.Name)
+	buf.WriteString(`{"args":`)
+	encoded, err := marshalTerms(f.Args)
 	if err != nil {
 		return nil, err
 	}
 	buf.Write(encoded)
-	buf.WriteString(`,"args":`)
-	encoded, err = marshalTerms(f.Args)
+	buf.WriteString(`,"kind":"atomic","name":`)
+	encoded, err = encodeJSON(f.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -429,20 +429,20 @@ func (choiceFormula) formulaMarker() {}
 
 func (f choiceFormula) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteString(`{"kind":"choice","varName":`)
-	encoded, err := encodeJSON(f.VarName)
+	buf.WriteString("{\"body\":")
+	encoded, err := encodeJSON(f.Body)
 	if err != nil {
 		return nil, err
 	}
 	buf.Write(encoded)
-	buf.WriteString(",\"sort\":")
+	buf.WriteString(`,"kind":"choice","sort":`)
 	encoded, err = encodeJSON(f.Sort)
 	if err != nil {
 		return nil, err
 	}
 	buf.Write(encoded)
-	buf.WriteString(",\"body\":")
-	encoded, err = encodeJSON(f.Body)
+	buf.WriteString(",\"varName\":")
+	encoded, err = encodeJSON(f.VarName)
 	if err != nil {
 		return nil, err
 	}

--- a/implementations/go/provekit-ir-symbolic/ir/types_test.go
+++ b/implementations/go/provekit-ir-symbolic/ir/types_test.go
@@ -79,7 +79,7 @@ func TestConstTermMarshalKeepsSort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal error: %v", err)
 	}
-	want := `{"kind":"const","value":42,"sort":{"kind":"primitive","name":"Int"}}`
+	want := `{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":42}`
 	if string(got) != want {
 		t.Errorf("got %s, want %s", got, want)
 	}
@@ -90,7 +90,7 @@ func TestCtorTermMarshalDropsSort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal error: %v", err)
 	}
-	want := `{"kind":"ctor","name":"parseInt","args":[{"kind":"const","value":"0","sort":{"kind":"primitive","name":"String"}}]}`
+	want := `{"args":[{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"0"}],"kind":"ctor","name":"parseInt"}`
 	if string(got) != want {
 		t.Errorf("got %s, want %s", got, want)
 	}
@@ -101,7 +101,7 @@ func TestAtomicFormulaMarshalUsesName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal error: %v", err)
 	}
-	want := `{"kind":"atomic","name":"=","args":[{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}]}`
+	want := `{"args":[{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"="}`
 	if string(got) != want {
 		t.Errorf("got %s, want %s", got, want)
 	}
@@ -115,7 +115,7 @@ func TestConnectivesMarshalUseOperands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal error: %v", err)
 	}
-	wantNot := `{"kind":"not","operands":[{"kind":"atomic","name":"=","args":[{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}]}]}`
+	wantNot := `{"kind":"not","operands":[{"args":[{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"="}]}`
 	if string(notF) != wantNot {
 		t.Errorf("not:\n  got:  %s\n  want: %s", notF, wantNot)
 	}
@@ -168,7 +168,7 @@ func TestQuantifierFormulaMarshalIsFlat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal error: %v", err)
 	}
-	want := `{"kind":"forall","name":"_x0","sort":{"kind":"primitive","name":"Int"},"body":{"kind":"atomic","name":">","args":[{"kind":"var","name":"_x0"},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}]}}`
+	want := `{"body":{"args":[{"kind":"var","name":"_x0"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":">"},"kind":"forall","name":"_x0","sort":{"kind":"primitive","name":"Int"}}`
 	if string(got) != want {
 		t.Errorf("flat quantifier:\n  got:  %s\n  want: %s", got, want)
 	}


### PR DESCRIPTION
## Summary

Fixes the Go serializer to emit JSON object keys in strict **JCS alphabetical order** (RFC 8785), matching the Rust, C++, C, Zig, Python, Java, C#, and TypeScript kits **byte-for-byte**.

## Changes

### types.go — 7 MarshalJSON methods reordered

| Object | Before (logical) | After (JCS alpha) |
|--------|-----------------|--------------------|
| `constTerm` | kind, value, sort | kind, **sort, value** |
| `ctorTerm` | kind, name, args | **args**, kind, name |
| `lambdaTerm` | kind, paramName, paramSort, body | **body**, kind, paramName, paramSort |
| `letTerm` | kind, bindings, body | **bindings, body**, kind |
| `letBinding` | name, boundTerm | **boundTerm**, name |
| `atomicFormula` | kind, name, args | **args**, kind, name |
| `quantFormula` | kind, name, sort, body | **body**, kind, name, sort |
| `choiceFormula` | kind, varName, sort, body | **body**, kind, sort, varName |

### property.go — contract reordered

| Object | Before | After |
|--------|--------|-------|
| `ContractDeclaration` | kind,name,outBinding,pre?,post?,inv?,evidence? | evidence?,inv?,kind,name,outBinding,post?,pre? |

### Test updates

Updated all expected strings in types_test.go, primitives_test.go, quantifiers_test.go, and canonical_form_test.go to match the new JCS key order.

### Verification

```
go test ./...
ok  canonicalizer  0.542s
ok  ir             1.514s
ok  proof_envelope 1.019s
ok  verifier       2.077s
```