### PR TITLE
feat(conformance): zig 0.16 + ruby tests + rust PATH — 10/10 byte-identical

### DIFF
--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -11,6 +11,15 @@
 
 set -uo pipefail
 
+# Some installs symlink ~/.cargo/bin/cargo -> rustup. PATH must contain
+# ~/.cargo/bin for both to resolve.
+if [ -d "$HOME/.cargo/bin" ]; then
+    case ":$PATH:" in
+        *":$HOME/.cargo/bin:"*) ;;
+        *) PATH="$HOME/.cargo/bin:$PATH" ;;
+    esac
+fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -151,17 +160,33 @@ fi
 # --- C# ---
 echo "[C#] dotnet test"
 if need_tool dotnet csharp; then
-    if (cd implementations/csharp && run_quiet dotnet test); then
-        report "csharp" "PASS" "DataAnnotations lift + LSP plugin tests"
+    if (cd implementations/csharp && run_quiet dotnet test --nologo); then
+        report "csharp" "PASS" "DataAnnotations + Linq lift adapters byte-equivalent"
     else
         report "csharp" "FAIL" "dotnet test failed"
     fi
 fi
 
 # --- Ruby ---
-echo "[Ruby] (no test suite yet)"
-if need_tool ruby ruby; then
-    report "ruby" "SKIP" "no test infrastructure (PR #66 + #67 shipped impl + lift adapters; tests pending)"
+# Kit uses endless-method syntax (Ruby 3+); macOS system ruby is 2.6 and
+# can't even parse it. Prefer Homebrew's ruby when present.
+echo "[Ruby] minitest conformance"
+ruby_bin=""
+if [ -x /usr/local/opt/ruby/bin/ruby ]; then
+    ruby_bin=/usr/local/opt/ruby/bin/ruby
+elif [ -x /opt/homebrew/opt/ruby/bin/ruby ]; then
+    ruby_bin=/opt/homebrew/opt/ruby/bin/ruby
+elif command -v ruby >/dev/null 2>&1 && ruby -e 'exit RUBY_VERSION.to_f >= 3.0 ? 0 : 1' >/dev/null 2>&1; then
+    ruby_bin="$(command -v ruby)"
+fi
+if [ -n "$ruby_bin" ]; then
+    if (cd implementations/ruby && run_quiet "$ruby_bin" -Ilib -Itest test/test_jcs_conformance.rb); then
+        report "ruby" "PASS" "JCS bytes match canonical fixtures"
+    else
+        report "ruby" "FAIL" "test_jcs_conformance.rb failed"
+    fi
+else
+    report "ruby" "SKIP" "ruby >= 3.0 not found (kit uses endless-method syntax)"
 fi
 
 # --- Summary ---

--- a/implementations/ruby/test/test_jcs_conformance.rb
+++ b/implementations/ruby/test/test_jcs_conformance.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cross-language conformance: every JCS byte and BLAKE3-512 hash this
+# kit emits MUST match the canonical fixtures shared by every other
+# ProvekIt implementation. Source of truth: ../../conformance/fixtures.toml.
+
+require "minitest/autorun"
+require_relative "../lib/provekit/ir"
+
+class TestJcsConformance < Minitest::Test
+  IR = Provekit::IR
+
+  # Fixture: eq_atomic — parse_int('42') = 42
+  EXPECTED_EQ_ATOMIC =
+    '{"args":[{"args":[{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"42"}],"kind":"ctor","name":"parse_int"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":42}],"kind":"atomic","name":"="}'
+
+  # Fixture: pattern1_bounded_loop — forall x: (x ≥ 0 ∧ x < 100) ⇒ x ≥ 0
+  EXPECTED_PATTERN1 =
+    '{"body":{"kind":"implies","operands":[{"kind":"and","operands":[{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":100}],"kind":"atomic","name":"<"}]},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"}]},"kind":"forall","name":"x","sort":{"kind":"primitive","name":"Int"}}'
+
+  def test_eq_atomic
+    formula = IR.atomic("=",
+      IR.ctor("parse_int", IR.str("42")),
+      IR.num(42))
+    assert_equal EXPECTED_EQ_ATOMIC, IR::Jcs.encode(formula)
+  end
+
+  def test_pattern1_bounded_loop
+    x = IR.var(name: "x")
+    body = IR.implies(
+      IR.and(IR.gte(x, IR.num(0)), IR.lt(x, IR.num(100))),
+      IR.gte(x, IR.num(0)))
+    formula = IR.forall(name: "x", sort: IR::Sort.Int, body: body)
+    assert_equal EXPECTED_PATTERN1, IR::Jcs.encode(formula)
+  end
+end

--- a/implementations/zig/provekit-ir/build.zig
+++ b/implementations/zig/provekit-ir/build.zig
@@ -9,12 +9,9 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    _ = lib;
 
     const lib_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = lib,
     });
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);

--- a/implementations/zig/provekit-ir/src/root.zig
+++ b/implementations/zig/provekit-ir/src/root.zig
@@ -330,10 +330,7 @@ pub fn Exists(name: []const u8, sort_: Sort, body: *const Formula) Formula {
 // ---------------------------------------------------------------------------
 
 pub fn jcsStringify(alloc: std.mem.Allocator, value: anytype) ![]u8 {
-    var list = std.ArrayList(u8).init(alloc);
-    errdefer list.deinit();
-    try std.json.stringify(value, .{ .whitespace = .minified }, list.writer());
-    return list.toOwnedSlice();
+    return std.json.Stringify.valueAlloc(alloc, value, .{ .whitespace = .minified });
 }
 
 pub fn jcsHash(alloc: std.mem.Allocator, jcs_bytes: []const u8) ![]u8 {
@@ -342,11 +339,11 @@ pub fn jcsHash(alloc: std.mem.Allocator, jcs_bytes: []const u8) ![]u8 {
     hasher.update(jcs_bytes);
     hasher.final(&hash_out);
 
-    // Format as "blake3-512:" + 128 lowercase hex chars
     const prefix = "blake3-512:";
-    var result = try alloc.alloc(u8, prefix.len + 128);
+    const hex = std.fmt.bytesToHex(hash_out, .lower);
+    var result = try alloc.alloc(u8, prefix.len + hex.len);
     @memcpy(result[0..prefix.len], prefix);
-    _ = try std.fmt.bufPrint(result[prefix.len..], "{s}", .{std.fmt.fmtSliceHexLower(&hash_out)});
+    @memcpy(result[prefix.len..], &hex);
     return result;
 }
 


### PR DESCRIPTION
## Summary
- Zig kit migrated to 0.16: `addTest({root_module: ...})`, `std.json.Stringify.valueAlloc`, `std.fmt.bytesToHex` replace removed 0.14 APIs.
- Ruby kit gains a stdlib minitest spec covering `eq_atomic` and `pattern1_bounded_loop` fixtures — byte-identical to canonical Rust output.
- Harness ruby block prefers Homebrew ruby (`/usr/local/opt/ruby` or `/opt/homebrew/opt/ruby`) since the kit uses endless-method syntax that macOS system ruby 2.6 can't parse. Flips ruby report from SKIP to PASS on a stock dev box with brew ruby.
- Harness prepends `~/.cargo/bin` to PATH so cargo resolves through the rustup symlink on installs that don't source `~/.cargo/env`.

Result: harness goes from 7 PASS / 1 FAIL / 2 SKIP to 10 PASS / 0 FAIL.

## Test plan
- [x] `bash conformance/run.sh` returns 10 pass, 0 fail locally
- [x] zig kit's 5 tests pass under zig 0.16.0
- [x] ruby minitest test_jcs_conformance.rb passes under brew ruby 4.0.3
- [ ] CI runs through (CI may not have brew ruby; ruby block falls back to SKIP gracefully if `ruby >= 3.0` not present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Ruby conformance test suite for validating JCS encoding output now available.
  * Enhanced C# test runner output formatting and reporting.
  * Improved test infrastructure for better Rust toolchain detection.

* **Chores**
  * Optimized Zig implementation for JCS stringification and hash formatting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->