### PR TITLE
fix(conformance): add Swift extractor with --fixture mode

### DIFF
--- a/conformance/run.py
+++ b/conformance/run.py
@@ -586,6 +586,19 @@ def extract_csharp(fixture_name: str) -> Optional[str]:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def extract_swift(fixture_name: str) -> Optional[str]:
+    swift_dir = ROOT / "implementations" / "swift"
+    rc, stdout, stderr = run(
+        ["swift", "run", "conformance", "--fixture", fixture_name],
+        cwd=swift_dir,
+        timeout=120,
+    )
+    if rc != 0:
+        print(f"  {Colors.WARN}Swift run failed: {stderr[:200]}{Colors.RST}")
+        return None
+    return stdout.strip()
+
+
 # ═══════════════════════════════════════════════════════════════
 #  Main
 # ═══════════════════════════════════════════════════════════════
@@ -657,6 +670,18 @@ def main():
         except Exception as e:
             FAILS += 1
             print(f"  {Colors.FAIL}✗ csharp-{name}: {e}{Colors.RST}")
+
+        # Swift
+        try:
+            got = extract_swift(name)
+            if got and check_jcs(f"swift-{name}", got, golden):
+                PASSES += 1
+                print(f"  {Colors.PASS}✓ swift-{name}{Colors.RST}")
+            elif not got:
+                print(f"  {Colors.WARN}~ swift-{name}: could not extract{Colors.RST}")
+        except Exception as e:
+            FAILS += 1
+            print(f"  {Colors.FAIL}✗ swift-{name}: {e}{Colors.RST}")
 
     # Summary
     total = PASSES + FAILS

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -189,6 +189,16 @@ else
     report "ruby" "SKIP" "ruby >= 3.0 not found (kit uses endless-method syntax)"
 fi
 
+# --- Swift ---
+echo "[Swift] swift run conformance"
+if need_tool swift swift; then
+    if (cd implementations/swift && run_quiet swift run conformance); then
+        report "swift" "PASS" "5 assertions: eq_atomic JCS+hash, pattern1 JCS, contract JCS, bridge JCS"
+    else
+        report "swift" "FAIL" "swift run conformance failed"
+    fi
+fi
+
 # --- Summary ---
 echo ""
 echo "=========================================="

--- a/implementations/swift/.gitignore
+++ b/implementations/swift/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+build/

--- a/implementations/swift/Package.swift
+++ b/implementations/swift/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Provekit",
+    products: [
+        .library(name: "Provekit", targets: ["Provekit"]),
+        .executable(name: "conformance", targets: ["ConformanceRunner"]),
+    ],
+    targets: [
+        .target(name: "Provekit"),
+        .executableTarget(
+            name: "ConformanceRunner",
+            dependencies: ["Provekit"]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/implementations/swift/Sources/ConformanceRunner/main.swift
+++ b/implementations/swift/Sources/ConformanceRunner/main.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Provekit
+
+let args = CommandLine.arguments
+
+if args.count > 1 && args[1] == "--fixture" {
+    let name = args.count > 2 ? args[2] : ""
+    switch name {
+    case "eq_atomic":
+        let lhs = Term.ctor("parse_int", Term.str("42"))
+        let rhs = Term.num(42)
+        let f = Formula.eq(lhs, rhs)
+        print(Jcs.encode(Jcs.formulaToValue(f)), terminator: "")
+    case "pattern1_bounded_loop":
+        let x = Term.var(name: "x")
+        let z = Term.num(0)
+        let h = Term.num(100)
+        let body = Formula.implies(Formula.and(Formula.gte(x, z), Formula.lt(x, h)), Formula.gte(x, z))
+        let q = Formula.forall(name: "x", sort: .int, body: body)
+        print(Jcs.encode(Jcs.formulaToValue(q)), terminator: "")
+    default:
+        break
+    }
+    exit(0)
+}
+
+func test(_ name: String, block: () -> Bool) {
+    if block() {
+        print("PASS: \(name)")
+    } else {
+        print("FAIL: \(name)")
+        exit(1)
+    }
+}
+
+let lhs = Term.ctor("parse_int", Term.str("42"))
+let rhs = Term.num(42)
+let f = Formula.eq(lhs, rhs)
+let jcs1 = Jcs.encode(Jcs.formulaToValue(f))
+let expected1 = #"{"args":[{"args":[{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"42"}],"kind":"ctor","name":"parse_int"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":42}],"kind":"atomic","name":"="}"#
+if jcs1 != expected1 { print("GOT:  \(jcs1)"); print("EXP:  \(expected1)") }
+test("eq_atomic JCS") { jcs1 == expected1 }
+
+let hash1 = Blake3.hex(Data(jcs1.utf8))
+test("eq_atomic hash") { hash1 == "blake3-512:5eade72c08811b2d38adcb158eced38f3d319de090d59b2fa7a77ad830169e18539d2b75d2a2838c545e644a688cf137603674523ff37f1586a650f6dd05aeaa" }
+
+let x = Term.var(name: "x")
+let z = Term.num(0)
+let h = Term.num(100)
+let lower = Formula.gte(x, z)
+let upper = Formula.lt(x, h)
+let ant = Formula.and(lower, upper)
+let inner = Formula.gte(x, z)
+let body = Formula.implies(ant, inner)
+let q = Formula.forall(name: "x", sort: .int, body: body)
+let jcs3 = Jcs.encode(Jcs.formulaToValue(q))
+let expected3 = #"{"body":{"kind":"implies","operands":[{"kind":"and","operands":[{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":100}],"kind":"atomic","name":"<"}]},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"}]},"kind":"forall","name":"x","sort":{"kind":"primitive","name":"Int"}}"#
+test("pattern1 JCS") { jcs3 == expected3 }
+
+let x2 = Term.var(name: "x")
+let z2 = Term.num(0)
+let pre = Formula.gte(x2, z2)
+let d = Declaration.contract(name: "parseInt", outBinding: "out", pre: pre, post: nil, inv: nil)
+let jcs4 = Jcs.encodeDeclarations([d])
+let expected4 = #"[{"kind":"contract","name":"parseInt","outBinding":"out","pre":{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"}}]"#
+test("contract JCS") { jcs4 == expected4 }
+
+let b = Declaration.bridge(
+    name: "myBridge", sourceSymbol: "source", sourceLayer: "c-kit",
+    sourceContractCid: "bafySource", targetContractCid: "bafyTarget",
+    targetProofCid: "bafyProof", targetLayer: "coq", notes: "some notes"
+)
+let jcs5 = Jcs.encodeDeclarations([b])
+let expected5 = #"[{"kind":"bridge","name":"myBridge","notes":"some notes","sourceContractCid":"bafySource","sourceLayer":"c-kit","sourceSymbol":"source","targetContractCid":"bafyTarget","targetLayer":"coq","targetProofCid":"bafyProof"}]"#
+if jcs5 != expected5 { print("GOT:  \(jcs5)"); print("EXP:  \(expected5)") }
+test("bridge JCS") { jcs5 == expected5 }
+
+print("ALL PASS")

--- a/implementations/swift/Sources/Provekit/IR.swift
+++ b/implementations/swift/Sources/Provekit/IR.swift
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ProvekIt IR types + JCS canonical JSON emitter for Swift.
+//
+// Mirrors the Rust, Go, Java, Python, C++, C, Zig, Ruby, C#, and
+// TypeScript kits. Uses Swift enums with associated values for
+// tagged unions, and a custom JSON encoder for JCS key ordering.
+
+import Foundation
+
+// MARK: - Sort
+
+public struct Sort: Equatable, Hashable, Sendable {
+    public let name: String
+    public static let int = Sort(name: "Int")
+    public static let real = Sort(name: "Real")
+    public static let string = Sort(name: "String")
+    public static let bool = Sort(name: "Bool")
+    public static let ref = Sort(name: "Ref")
+    public static let node = Sort(name: "Node")
+}
+
+// MARK: - Term
+
+public enum Term: Equatable, Hashable {
+    case `var`(name: String)
+    case const(value: ConstValue, sort: Sort)
+    case ctor(name: String, args: [Term])
+
+    public static func num(_ n: Int64) -> Term { .const(value: .int(n), sort: .int) }
+    public static func str(_ s: String) -> Term { .const(value: .string(s), sort: .string) }
+    public static func bool(_ b: Bool) -> Term { .const(value: .bool(b), sort: .bool) }
+    public static func nullRef() -> Term { .const(value: .null, sort: .ref) }
+    public static func ctor(_ name: String, _ args: Term...) -> Term {
+        .ctor(name: name, args: args)
+    }
+}
+
+public enum ConstValue: Equatable, Hashable {
+    case int(Int64)
+    case string(String)
+    case bool(Bool)
+    case null
+}
+
+// MARK: - Formula
+
+public indirect enum Formula: Equatable, Hashable {
+    case atomic(name: String, args: [Term])
+    case connective(kind: String, operands: [Formula])
+    case quantifier(kind: String, name: String, sort: Sort, body: Formula)
+
+    public static func eq(_ a: Term, _ b: Term) -> Formula {
+        .atomic(name: "=", args: [a, b])
+    }
+    public static func neq(_ a: Term, _ b: Term) -> Formula {
+        .atomic(name: "≠", args: [a, b])
+    }
+    public static func gte(_ a: Term, _ b: Term) -> Formula {
+        .atomic(name: "≥", args: [a, b])
+    }
+    public static func lte(_ a: Term, _ b: Term) -> Formula {
+        .atomic(name: "≤", args: [a, b])
+    }
+    public static func gt(_ a: Term, _ b: Term) -> Formula {
+        .atomic(name: ">", args: [a, b])
+    }
+    public static func lt(_ a: Term, _ b: Term) -> Formula {
+        .atomic(name: "<", args: [a, b])
+    }
+    public static func and(_ operands: Formula...) -> Formula {
+        .connective(kind: "and", operands: operands)
+    }
+    public static func or(_ operands: Formula...) -> Formula {
+        .connective(kind: "or", operands: operands)
+    }
+    public static func implies(_ a: Formula, _ b: Formula) -> Formula {
+        .connective(kind: "implies", operands: [a, b])
+    }
+    public static func not(_ a: Formula) -> Formula {
+        .connective(kind: "not", operands: [a])
+    }
+    public static func forall(name: String, sort: Sort, body: Formula) -> Formula {
+        .quantifier(kind: "forall", name: name, sort: sort, body: body)
+    }
+}
+
+// MARK: - Declaration
+
+public indirect enum Declaration: Equatable, Hashable {
+    case contract(name: String, outBinding: String, pre: Formula?, post: Formula?, inv: Formula?)
+    case bridge(name: String, sourceSymbol: String, sourceLayer: String,
+                sourceContractCid: String, targetContractCid: String,
+                targetProofCid: String, targetLayer: String, notes: String?)
+}
+
+// MARK: - JCS Value tree
+
+public enum JcsValue {
+    case string(String)
+    case number(String)
+    case bool(Bool)
+    case null
+    case object([(String, JcsValue)])
+    case array([JcsValue])
+
+    static func obj(_ pairs: (String, JcsValue)...) -> JcsValue {
+        .object(pairs)
+    }
+    static func arr(_ vals: [JcsValue]) -> JcsValue {
+        .array(vals)
+    }
+}
+
+// MARK: - JCS Canonical Emitter
+
+public enum Jcs {
+
+    public static func encode(_ value: JcsValue) -> String {
+        switch value {
+        case .string(let s):
+            return encodeString(s)
+        case .number(let n):
+            return n
+        case .bool(let b):
+            return b ? "true" : "false"
+        case .null:
+            return "null"
+        case .array(let arr):
+            return "[\(arr.map { encode($0) }.joined(separator: ","))]"
+        case .object(let pairs):
+            let sorted = pairs.sorted { $0.0 < $1.0 }
+            let items = sorted.map { "\(encodeString($0.0)):\(encode($0.1))" }
+            return "{\(items.joined(separator: ","))}"
+        }
+    }
+
+    // MARK: Term → JcsValue
+
+    public static func termToValue(_ t: Term) -> JcsValue {
+        switch t {
+        case .var(let name):
+            return .obj(("kind", .string("var")), ("name", .string(name)))
+        case .const(let val, let sort):
+            return .obj(("kind", .string("const")),
+                        ("sort", sortToValue(sort)),
+                        ("value", constValToValue(val)))
+        case .ctor(let name, let args):
+            return .obj(("args", .arr(args.map(termToValue))),
+                        ("kind", .string("ctor")),
+                        ("name", .string(name)))
+        }
+    }
+
+    // MARK: Formula → JcsValue
+
+    public static func formulaToValue(_ f: Formula) -> JcsValue {
+        switch f {
+        case .atomic(let name, let args):
+            return .obj(("args", .arr(args.map(termToValue))),
+                        ("kind", .string("atomic")),
+                        ("name", .string(name)))
+        case .connective(let kind, let ops):
+            return .obj(("kind", .string(kind)),
+                        ("operands", .arr(ops.map(formulaToValue))))
+        case .quantifier(let kind, let name, let sort, let body):
+            return .obj(("body", formulaToValue(body)),
+                        ("kind", .string(kind)),
+                        ("name", .string(name)),
+                        ("sort", sortToValue(sort)))
+        }
+    }
+
+    // MARK: Declaration → JcsValue → JSON
+
+    public static func encodeDeclarations(_ decls: [Declaration]) -> String {
+        let arr = decls.map(declToValue)
+        return encode(.array(arr))
+    }
+
+    public static func declToValue(_ d: Declaration) -> JcsValue {
+        switch d {
+        case .contract(let name, let outBinding, let pre, let post, let inv):
+            var pairs: [(String, JcsValue)] = []
+            if let inv = inv { pairs.append(("inv", formulaToValue(inv))) }
+            pairs.append(("kind", .string("contract")))
+            pairs.append(("name", .string(name)))
+            pairs.append(("outBinding", .string(outBinding)))
+            if let post = post { pairs.append(("post", formulaToValue(post))) }
+            if let pre = pre { pairs.append(("pre", formulaToValue(pre))) }
+            return .object(pairs)
+        case .bridge(let name, let sourceSymbol, let sourceLayer,
+                     let sourceContractCid, let targetContractCid,
+                     let targetProofCid, let targetLayer, let notes):
+            var pairs: [(String, JcsValue)] = [
+                ("kind", .string("bridge")),
+                ("name", .string(name)),
+                ("sourceContractCid", .string(sourceContractCid)),
+                ("sourceLayer", .string(sourceLayer)),
+                ("sourceSymbol", .string(sourceSymbol)),
+                ("targetContractCid", .string(targetContractCid)),
+                ("targetLayer", .string(targetLayer)),
+                ("targetProofCid", .string(targetProofCid)),
+            ]
+            if let notes = notes { pairs.append(("notes", .string(notes))) }
+            return .object(pairs)
+        }
+    }
+
+    // Helpers
+
+    static func sortToValue(_ s: Sort) -> JcsValue {
+        .obj(("kind", .string("primitive")), ("name", .string(s.name)))
+    }
+
+    static func constValToValue(_ cv: ConstValue) -> JcsValue {
+        switch cv {
+        case .int(let n): return .number(String(n))
+        case .string(let s): return .string(s)
+        case .bool(let b): return .bool(b)
+        case .null: return .null
+        }
+    }
+
+    static func encodeString(_ s: String) -> String {
+        var out = "\""
+        for c in s.unicodeScalars {
+            switch c.value {
+            case 0x0022: out += "\\\""
+            case 0x005C: out += "\\\\"
+            case 0..<0x20: out += String(format: "\\u00%02x", c.value)
+            default: out.append(Character(c))
+            }
+        }
+        out += "\""
+        return out
+    }
+}
+
+// BLAKE3 not available in CryptoKit — delegate to Python for v1.1.
+public enum Blake3 {
+    public static func hex(_ data: Data) -> String {
+        let tmpDir = FileManager.default.temporaryDirectory
+        let path = tmpDir.appendingPathComponent("pk_hash_\(UUID().uuidString)").path
+        FileManager.default.createFile(atPath: path, contents: data)
+        let script = "import blake3; d=open('\(path)','rb').read(); print('blake3-512:'+blake3.blake3(d).digest(length=64).hex())"
+        let task = Process()
+        task.launchPath = "/usr/bin/python3"
+        task.arguments = ["-c", script]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.launch()
+        task.waitUntilExit()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        try? FileManager.default.removeItem(atPath: path)
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
## Summary

Wires Swift into the cross-language conformance harness, making it language #11 (10/10 → 12/12 once Zig is fixed).

## Changes

- conformance/run.py: `extract_swift` dispatches to `swift run conformance --fixture <name>` via subprocess
- ConformanceRunner/main.swift: `--fixture eq_atomic|pattern1_bounded_loop` mode prints only JCS bytes (no test output) then exits
- Package.swift: removed XCTest-dependent testTarget (CLI tools only on macOS)

## Results

```
═══ Cross-Language Conformance Suite ═══

── eq_atomic
  ✓ python-eq_atomic
  ✓ c-eq_atomic
  ✓ cpp-eq_atomic
  ✓ csharp-eq_atomic
  ✓ swift-eq_atomic

── pattern1_bounded_loop
  ✓ python-pattern1
  ✓ c-pattern1
  ✓ cpp-pattern1
  ✓ csharp-pattern1
  ✓ swift-pattern1

Results: 10 pass, 0 fail
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Swift support to the conformance testing framework, enabling Swift implementation verification against canonical JSON output.
  * Integrated Swift conformance runner into the cross-language harness with automatic Swift toolchain detection.

* **Chores**
  * Added Swift package configuration and build artifact exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->