### PR TITLE
fix(ts): cross-impl-golden test compares JCS-of-IR-tree, not canonicalizer output

### DIFF
--- a/conformance/fixtures.toml
+++ b/conformance/fixtures.toml
@@ -19,7 +19,7 @@ hash = "blake3-512:5eade72c08811b2d38adcb158eced38f3d319de090d59b2fa7a77ad830169
 name = "pattern1_bounded_loop"
 description = "forall x: (x >= 0 && x < 100) => x >= 0 — tests forall, and, implies, nested compare"
 jcs = '{"body":{"kind":"implies","operands":[{"kind":"and","operands":[{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":100}],"kind":"atomic","name":"<"}]},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"}]},"kind":"forall","name":"x","sort":{"kind":"primitive","name":"Int"}}'
-hash = "blake3-512:d1ad02579fbcedcd6366cca444023cb83a7a4c4f28be976198b167a521ab0db9e4931f568c9ab9c22c73e026d138d2a520d785576ec3ed570d7f49b344f84c3c"
+hash = "blake3-512:edace2a0634b696ec24a369d37580cf9ab77f2d7c3e83869240b77305aaefc4868054bc3cee789f74408e1adf0b1d88e6fdfcd9cc2e351ff586077dbb3a3bcea"
 
 [[fixture]]
 name = "contract_decl"

--- a/implementations/typescript/src/canonicalizer/cross-impl-golden.test.ts
+++ b/implementations/typescript/src/canonicalizer/cross-impl-golden.test.ts
@@ -20,8 +20,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { formulaToCanonicalAst } from "./canonicalize.js";
-import { serializeCanonicalAst } from "./serialize.js";
+import { canonicalEncode } from "../claimEnvelope/canonicalize.js";
 import { computeCid } from "./hash.js";
 import type { IrFormula, IrTerm, Sort } from "./irFormula.js";
 
@@ -205,8 +204,8 @@ function buildFormulaFor(name: string): IrFormula | null {
 const formulaFixtures = allFixtures.filter((f) => buildFormulaFor(f.name) !== null);
 const nonFormulaFixtures = allFixtures.filter((f) => buildFormulaFor(f.name) === null);
 
-describe("cross-impl golden: TS canonicalizer vs Rust-emitted fixtures", () => {
-  it.runIf(nonFormulaFixtures.length > 0)(
+describe("cross-impl golden: TS IR JCS vs Rust-emitted fixtures", () => {
+  (nonFormulaFixtures.length > 0 ? it : it.skip)(
     `skipped ${nonFormulaFixtures.length} non-formula fixture(s): ${nonFormulaFixtures.map((f) => f.name).join(", ")} (contract/bridge declarations are not formula-level)`,
     () => {
       // informational only
@@ -216,8 +215,7 @@ describe("cross-impl golden: TS canonicalizer vs Rust-emitted fixtures", () => {
   for (const fixture of formulaFixtures) {
     it(`"${fixture.name}" — JCS bytes match Rust golden`, () => {
       const formula = buildFormulaFor(fixture.name)!;
-      const ast = formulaToCanonicalAst(formula);
-      const bytes = serializeCanonicalAst(ast);
+      const bytes = canonicalEncode(formula);
       const actualJcs = bytes.toString("utf8");
 
       expect(actualJcs, `JCS byte mismatch for "${fixture.name}"`).toBe(
@@ -227,8 +225,7 @@ describe("cross-impl golden: TS canonicalizer vs Rust-emitted fixtures", () => {
 
     it(`"${fixture.name}" — BLAKE3-512 hash matches Rust golden`, () => {
       const formula = buildFormulaFor(fixture.name)!;
-      const ast = formulaToCanonicalAst(formula);
-      const bytes = serializeCanonicalAst(ast);
+      const bytes = canonicalEncode(formula);
       const actualHash = computeCid(bytes);
 
       expect(actualHash, `hash mismatch for "${fixture.name}"`).toBe(


### PR DESCRIPTION
## Summary

- The `cross-impl-golden.test.ts` was calling the 8-pass semantic canonicalizer (`formulaToCanonicalAst` + `serializeCanonicalAst`) and asserting byte-identity against `conformance/fixtures.toml` entries that contain **JCS-of-IR-tree** output. This is a category error: the canonicalizer rewrites variables to De Bruijn indices, eliminates `implies` by rewriting to `or(not a, b)`, NNF-normalizes, AC-normalizes, and attaches `sort: Ref` to ctors — output that structurally cannot match the IR-tree fixtures.
- **Fix**: Switch to `canonicalEncode` from `claimEnvelope/canonicalize.ts` — the generic JCS-of-IR-tree encoder (analogous to Ruby's `Provekit::IR::Jcs.encode`) that produces byte-identical output to every other kit's emitter.
- Replace vitest-only `it.runIf(...)` with `(condition ? it : it.skip)(...)` for bun compatibility.
- Correct stale `pattern1_bounded_loop` BLAKE3-512 hash in `fixtures.toml`.

## Verification

- `bun test src/canonicalizer/cross-impl-golden.test.ts` — 5 pass, 0 fail
- `vitest run` (from repo root) — 5 pass, 0 fail
- `conformance/run.sh` — 10 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)