### PR TITLE
fix(go): update CrossKitByteShape test to JCS-alphabetical key order

### DIFF
--- a/implementations/go/provekit-lift-go-tests/integration_test.go
+++ b/implementations/go/provekit-lift-go-tests/integration_test.go
@@ -133,7 +133,9 @@ func TestSquaresAreNonneg(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	want := `[{"kind":"contract","name":"TestSquaresAreNonneg","outBinding":"out","inv":{"kind":"forall","name":"x","sort":{"kind":"primitive","name":"Int"},"body":{"kind":"implies","operands":[{"kind":"and","operands":[{"kind":"atomic","name":"≥","args":[{"kind":"var","name":"x"},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}]},{"kind":"atomic","name":"<","args":[{"kind":"var","name":"x"},{"kind":"const","value":100,"sort":{"kind":"primitive","name":"Int"}}]}]},{"kind":"atomic","name":"≥","args":[{"kind":"var","name":"x"},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}]}]}}}]`
+	// JCS-alphabetical key order (enforced by ir.MarshalDeclarations
+	// after PR #72 — the marshaler now sorts every object's keys).
+	want := `[{"inv":{"body":{"kind":"implies","operands":[{"kind":"and","operands":[{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":100}],"kind":"atomic","name":"<"}]},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"}]},"kind":"forall","name":"x","sort":{"kind":"primitive","name":"Int"}},"kind":"contract","name":"TestSquaresAreNonneg","outBinding":"out"}]`
 	if string(body) != want {
 		t.Fatalf("canonical bytes diverged:\n got: %s\nwant: %s", string(body), want)
 	}


### PR DESCRIPTION
## Summary

PR #72 enforced JCS-alphabetical key order in \`ir.MarshalDeclarations\`, but \`integration_test.go:138\` still pinned the *expected* JSON in declaration order ({kind, name, outBinding, inv}). It tripped on every CI run since #72 landed.

Updated \`want\` to match what the marshaler actually emits (JCS-alphabetical: {inv, kind, name, outBinding}, with inner forall {body, kind, name, sort}). Byte-equivalence guarantee unchanged — only the literal was wrong.

## Test plan

- [x] \`go test -run TestIntegration_CrossKitByteShape ./...\` passes locally
- [ ] CI Cross-language conformance gate goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)