### PR TITLE
chore(ci): switch provekit workflows to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   conformance:
     name: Cross-language conformance gate
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/provekit.yml
+++ b/.github/workflows/provekit.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   prove:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Swap \`runs-on: ubuntu-latest\` → \`runs-on: self-hosted\` on both CI and ProvekIt workflows. Runners are now spawned on demand by the wopr-network runner-autoscaler on battleaxe — \`GITHUB_REPOS\` env was extended to include \`TSavo/provekit\` alongside \`TSavo/nefariousplan\`.

Verified: pushing this branch immediately triggered a runner spawn for \`repo:TSavo/provekit\` in the autoscaler logs.

## Test plan

- [x] Autoscaler whitelist updated + container restarted
- [x] CI run on this branch picks up a self-hosted runner
- [ ] Conformance gate completes green on self-hosted

🤖 Generated with [Claude Code](https://claude.com/claude-code)