### PR TITLE
feat(lifter): v0.6: expanded assert! body predicate grammar

### DIFF
--- a/implementations/typescript/src/lift/adapters/vitest-tests.ts
+++ b/implementations/typescript/src/lift/adapters/vitest-tests.ts
@@ -381,6 +381,30 @@ function liftOperand(expr: ts.Expression): OperandLift {
     if (inner.kind === "skip") return inner;
     return { kind: "ok", term: { kind: "ctor", name, args: [inner.term] } };
   }
+  // v0.6: method call on operand. `recv.method(...args)` lifts as a
+  // UFCS-style ctor where the receiver becomes the first argument.
+  // Mirrors Rust v0.5 PR #55. We require both receiver and every
+  // argument to themselves be liftable; this composes recursively
+  // through nested chains.
+  if (
+    ts.isCallExpression(expr) &&
+    ts.isPropertyAccessExpression(expr.expression) &&
+    ts.isIdentifier(expr.expression.name) &&
+    !expr.expression.questionDotToken
+  ) {
+    const recv = liftOperand(expr.expression.expression);
+    if (recv.kind === "skip") return recv;
+    const argTerms: IrTerm[] = [];
+    for (const a of expr.arguments) {
+      const lifted = liftOperand(a);
+      if (lifted.kind === "skip") return lifted;
+      argTerms.push(lifted.term);
+    }
+    return {
+      kind: "ok",
+      term: { kind: "ctor", name: expr.expression.name.text, args: [recv.term, ...argTerms] },
+    };
+  }
   if (
     ts.isPropertyAccessExpression(expr) &&
     ts.isIdentifier(expr.expression) &&

--- a/implementations/typescript/src/lift/adapters/vitest-tests.ts
+++ b/implementations/typescript/src/lift/adapters/vitest-tests.ts
@@ -426,6 +426,23 @@ function liftOperand(expr: ts.Expression): OperandLift {
       term: { kind: "ctor", name: `${expr.expression.text}.${expr.name.text}`, args: [] },
     };
   }
+  // v0.6: binary operators in operand position (`a + b`, `a - b`,
+  // `a * b`, `a / b`, `a % b`). Lifts to `Ctor("<op>", [a, b])`. Both
+  // operands must themselves lift. Comparison and logical operators
+  // stay out of the term grammar; they live in formula position.
+  if (ts.isBinaryExpression(expr)) {
+    const opName = binaryOperatorCtorName(expr.operatorToken.kind);
+    if (opName) {
+      const left = liftOperand(expr.left);
+      if (left.kind === "skip") return left;
+      const right = liftOperand(expr.right);
+      if (right.kind === "skip") return right;
+      return {
+        kind: "ok",
+        term: { kind: "ctor", name: opName, args: [left.term, right.term] },
+      };
+    }
+  }
   if (ts.isToken(expr) && expr.kind === ts.SyntaxKind.TrueKeyword) {
     return { kind: "ok", term: { kind: "ctor", name: "True", args: [] } };
   }
@@ -843,6 +860,23 @@ function classifyCharacterization(
       itemName: testName,
       reason: `layer2 characterization: ${skipped.length} atoms skipped from conjunction: ${skipped.join("; ")}`,
     });
+  }
+}
+
+/**
+ * v0.6: map a binary operator token to a Ctor name when the operator
+ * is liftable in term (operand) position. Returns null for operators
+ * that don't belong here, like comparisons and short-circuit logicals,
+ * which live in formula position rather than term position.
+ */
+function binaryOperatorCtorName(kind: ts.SyntaxKind): string | null {
+  switch (kind) {
+    case ts.SyntaxKind.PlusToken: return "+";
+    case ts.SyntaxKind.MinusToken: return "-";
+    case ts.SyntaxKind.AsteriskToken: return "*";
+    case ts.SyntaxKind.SlashToken: return "/";
+    case ts.SyntaxKind.PercentToken: return "%";
+    default: return null;
   }
 }
 

--- a/implementations/typescript/src/lift/adapters/vitest-tests.ts
+++ b/implementations/typescript/src/lift/adapters/vitest-tests.ts
@@ -363,23 +363,32 @@ function liftOperand(expr: ts.Expression): OperandLift {
       term: { kind: "const", value: -Number(expr.operand.text), sort: Int },
     };
   }
-  if (ts.isCallExpression(expr) && expr.arguments.length === 1) {
+  // Free-function call (zero-or-more args) and `Module.fn(...)` static
+  // call. v0.6 relaxes v0's single-arg gate; every argument must itself
+  // lift. Method calls (`recv.fn(...)`) are handled by the next clause.
+  if (
+    ts.isCallExpression(expr) &&
+    (ts.isIdentifier(expr.expression) ||
+      (ts.isPropertyAccessExpression(expr.expression) &&
+        ts.isIdentifier(expr.expression.expression) &&
+        ts.isIdentifier(expr.expression.name)))
+  ) {
     const callee = expr.expression;
-    let name: string | null = null;
-    if (ts.isIdentifier(callee)) name = callee.text;
-    else if (
-      ts.isPropertyAccessExpression(callee) &&
-      ts.isIdentifier(callee.expression) &&
-      ts.isIdentifier(callee.name)
-    ) {
-      // Allow `Module.fn(arg)` style ctor-call only when the receiver
-      // is itself a bare identifier (no chains).
-      name = `${callee.expression.text}.${callee.name.text}`;
+    let name: string;
+    if (ts.isIdentifier(callee)) {
+      name = callee.text;
+    } else {
+      // PropertyAccess; bare-identifier receiver only (no chains).
+      const pa = callee as ts.PropertyAccessExpression;
+      name = `${(pa.expression as ts.Identifier).text}.${pa.name.text}`;
     }
-    if (!name) return { kind: "skip", reason: "call target shape unsupported" };
-    const inner = liftOperand(expr.arguments[0]!);
-    if (inner.kind === "skip") return inner;
-    return { kind: "ok", term: { kind: "ctor", name, args: [inner.term] } };
+    const argTerms: IrTerm[] = [];
+    for (const a of expr.arguments) {
+      const lifted = liftOperand(a);
+      if (lifted.kind === "skip") return lifted;
+      argTerms.push(lifted.term);
+    }
+    return { kind: "ok", term: { kind: "ctor", name, args: argTerms } };
   }
   // v0.6: method call on operand. `recv.method(...args)` lifts as a
   // UFCS-style ctor where the receiver becomes the first argument.

--- a/implementations/typescript/src/lift/adapters/vitest-tests.ts
+++ b/implementations/typescript/src/lift/adapters/vitest-tests.ts
@@ -470,9 +470,21 @@ function liftOperand(expr: ts.Expression): OperandLift {
   if (ts.isToken(expr) && expr.kind === ts.SyntaxKind.NullKeyword) {
     return { kind: "ok", term: { kind: "ctor", name: "Null", args: [] } };
   }
+  // v0.6: ternary `cond ? a : b` is deliberately deferred. Lifting it
+  // would require either a Ctor("ternary", [cond, a, b]) shape or
+  // promotion to a formula-position if-then-else; both are out of
+  // scope for this slice. Skip with a named reason so the report
+  // taxonomy is searchable.
+  if (ts.isConditionalExpression(expr)) {
+    return {
+      kind: "skip",
+      reason: "ternary `cond ? a : b` operand is not lifted in v0.6",
+    };
+  }
   return {
     kind: "skip",
-    reason: "operand shape not in v0 lift whitelist (no method chains, member chains, multi-arg calls, complex nesting)",
+    reason:
+      "operand shape not in v0.6 lift whitelist (no member chains, indexing, field access, closures, blocks, ranges, comparisons in operand position, or template literals)",
   };
 }
 

--- a/implementations/typescript/src/lift/adapters/vitest-tests.ts
+++ b/implementations/typescript/src/lift/adapters/vitest-tests.ts
@@ -426,6 +426,24 @@ function liftOperand(expr: ts.Expression): OperandLift {
       term: { kind: "ctor", name: `${expr.expression.text}.${expr.name.text}`, args: [] },
     };
   }
+  // v0.6: array literal `[a, b, c]` lifts to `Ctor("array", [a, b, c])`.
+  // Mirrors Rust v0.5 (PR #55) `array` ctor naming. Every element
+  // must itself lift; sparse / spread elements skip.
+  if (ts.isArrayLiteralExpression(expr)) {
+    const argTerms: IrTerm[] = [];
+    for (const el of expr.elements) {
+      if (ts.isOmittedExpression(el) || ts.isSpreadElement(el)) {
+        return {
+          kind: "skip",
+          reason: "array literal with omitted or spread element is not in v0.6",
+        };
+      }
+      const lifted = liftOperand(el);
+      if (lifted.kind === "skip") return lifted;
+      argTerms.push(lifted.term);
+    }
+    return { kind: "ok", term: { kind: "ctor", name: "array", args: argTerms } };
+  }
   // v0.6: binary operators in operand position (`a + b`, `a - b`,
   // `a * b`, `a / b`, `a % b`). Lifts to `Ctor("<op>", [a, b])`. Both
   // operands must themselves lift. Comparison and logical operators

--- a/implementations/typescript/src/lift/vitest-tests.test.ts
+++ b/implementations/typescript/src/lift/vitest-tests.test.ts
@@ -113,6 +113,29 @@ it("method chain", () => {
     expect(recv.args.length).toBe(1);
   });
 
+  it("v0.6: lifts multi-arg free-function call as Ctor with all args", () => {
+    const td = tempDir();
+    writeFileSync(
+      join(td, "multi.test.ts"),
+      `
+import { it, expect } from "vitest";
+it("clamp_lift", () => {
+  expect(clamp(5, 0, 10)).toBe(5);
+});
+      `,
+    );
+    const r = liftPath(td);
+    const vt = r.adapterReports.find((a) => a.adapter === "vitest-tests")!;
+    expect(vt.lifted).toBe(1);
+
+    const decl = r.decls.find((d) => d.name === "clamp_lift::0")!;
+    const f = decl.inv as { kind: string; args: unknown[] };
+    const lhs = f.args[0] as { kind: string; name: string; args: unknown[] };
+    expect(lhs.kind).toBe("ctor");
+    expect(lhs.name).toBe("clamp");
+    expect(lhs.args.length).toBe(3);
+  });
+
   it("each lifted assertion mints its own content-addressed memento", () => {
     const td = tempDir();
     writeFileSync(

--- a/implementations/typescript/src/lift/vitest-tests.test.ts
+++ b/implementations/typescript/src/lift/vitest-tests.test.ts
@@ -190,6 +190,26 @@ it("array_lift", () => {
     expect(rhs.args.length).toBe(3);
   });
 
+  it("v0.6: ternary expression skips with a v0.6-named reason", () => {
+    const td = tempDir();
+    writeFileSync(
+      join(td, "tern.test.ts"),
+      `
+import { it, expect } from "vitest";
+it("ternary skips", () => {
+  expect(flag ? a : b).toBe(1);
+});
+      `,
+    );
+    const r = liftPath(td);
+    const vt = r.adapterReports.find((a) => a.adapter === "vitest-tests")!;
+    expect(vt.lifted).toBe(0);
+    expect(vt.warnings).toHaveLength(1);
+    // Better error reporting: deferred shapes name v0.6 explicitly so
+    // the report's skip taxonomy is searchable.
+    expect(vt.warnings[0]!.reason).toMatch(/ternary.*v0\.6/);
+  });
+
   it("each lifted assertion mints its own content-addressed memento", () => {
     const td = tempDir();
     writeFileSync(

--- a/implementations/typescript/src/lift/vitest-tests.test.ts
+++ b/implementations/typescript/src/lift/vitest-tests.test.ts
@@ -159,6 +159,37 @@ it("plus_lifts", () => {
     expect(lhs.args.length).toBe(2);
   });
 
+  it("v0.6: lifts array literal as Ctor named 'array'", () => {
+    const td = tempDir();
+    writeFileSync(
+      join(td, "arr.test.ts"),
+      `
+import { it, expect } from "vitest";
+it("array_lift", () => {
+  expect(sort([3, 1, 2])).toEqual([1, 2, 3]);
+});
+      `,
+    );
+    const r = liftPath(td);
+    const vt = r.adapterReports.find((a) => a.adapter === "vitest-tests")!;
+    expect(vt.lifted).toBe(1);
+
+    const decl = r.decls.find((d) => d.name === "array_lift::0")!;
+    const f = decl.inv as { kind: string; args: unknown[] };
+    const lhs = f.args[0] as { kind: string; name: string; args: unknown[] };
+    expect(lhs.kind).toBe("ctor");
+    expect(lhs.name).toBe("sort");
+    const inner = lhs.args[0] as { kind: string; name: string; args: unknown[] };
+    expect(inner.kind).toBe("ctor");
+    expect(inner.name).toBe("array");
+    expect(inner.args.length).toBe(3);
+
+    const rhs = f.args[1] as { kind: string; name: string; args: unknown[] };
+    expect(rhs.kind).toBe("ctor");
+    expect(rhs.name).toBe("array");
+    expect(rhs.args.length).toBe(3);
+  });
+
   it("each lifted assertion mints its own content-addressed memento", () => {
     const td = tempDir();
     writeFileSync(

--- a/implementations/typescript/src/lift/vitest-tests.test.ts
+++ b/implementations/typescript/src/lift/vitest-tests.test.ts
@@ -80,7 +80,10 @@ it("throws", () => {
     expect(vt.warnings[0]!.reason).toMatch(/toThrow/);
   });
 
-  it("skips operands with method-call chains (honest under-coverage)", () => {
+  // v0.6: method calls on the operand now lift as UFCS Ctor terms
+  // (the previous v0.5 negative test was inverted; the original lived
+  // here and asserted a skip).
+  it("v0.6: lifts operand method-call as UFCS Ctor", () => {
     const td = tempDir();
     writeFileSync(
       join(td, "method.test.ts"),
@@ -94,8 +97,20 @@ it("method chain", () => {
     const r = liftPath(td);
     const vt = r.adapterReports.find((a) => a.adapter === "vitest-tests")!;
     expect(vt.seen).toBe(1);
-    expect(vt.lifted).toBe(0);
-    expect(vt.warnings).toHaveLength(1);
+    expect(vt.lifted).toBe(1);
+    expect(vt.warnings).toHaveLength(0);
+
+    const decl = r.decls.find((d) => d.name === "method chain::0")!;
+    expect(decl).toBeDefined();
+    // Shape: atomic("=", [Ctor("toUpperCase", [Const("hello")]),
+    //                    Const("HELLO")])
+    const f = decl.inv as { kind: string; name: string; args: unknown[] };
+    expect(f.kind).toBe("atomic");
+    expect(f.name).toBe("=");
+    const recv = f.args[0] as { kind: string; name: string; args: unknown[] };
+    expect(recv.kind).toBe("ctor");
+    expect(recv.name).toBe("toUpperCase");
+    expect(recv.args.length).toBe(1);
   });
 
   it("each lifted assertion mints its own content-addressed memento", () => {

--- a/implementations/typescript/src/lift/vitest-tests.test.ts
+++ b/implementations/typescript/src/lift/vitest-tests.test.ts
@@ -136,6 +136,29 @@ it("clamp_lift", () => {
     expect(lhs.args.length).toBe(3);
   });
 
+  it("v0.6: lifts binary arithmetic op in operand position as Ctor", () => {
+    const td = tempDir();
+    writeFileSync(
+      join(td, "binop.test.ts"),
+      `
+import { it, expect } from "vitest";
+it("plus_lifts", () => {
+  expect(a + b).toBe(7);
+});
+      `,
+    );
+    const r = liftPath(td);
+    const vt = r.adapterReports.find((a) => a.adapter === "vitest-tests")!;
+    expect(vt.lifted).toBe(1);
+
+    const decl = r.decls.find((d) => d.name === "plus_lifts::0")!;
+    const f = decl.inv as { kind: string; args: unknown[] };
+    const lhs = f.args[0] as { kind: string; name: string; args: unknown[] };
+    expect(lhs.kind).toBe("ctor");
+    expect(lhs.name).toBe("+");
+    expect(lhs.args.length).toBe(2);
+  });
+
   it("each lifted assertion mints its own content-addressed memento", () => {
     const td = tempDir();
     writeFileSync(


### PR DESCRIPTION
## Summary

Brings the TypeScript `vitest-tests` lift adapter toward Rust v0.5 (PR #55) parity. Five coherent slices, one commit per slice, TDD throughout. Every shape gets a positive-or-negative test in `vitest-tests.test.ts` before its implementation lands; full suite stays green at 760 passing.

## New shapes accepted

1. **UFCS method calls.** `recv.method(...args)` lifts as `Ctor("method", [recv, ...args])`. The previous v0.5 negative test (`expect("hello".toUpperCase()).toBe("HELLO")` skips) was inverted in place to assert the new positive behavior, with a comment flagging the inversion.
   ```ts
   expect("hello".toUpperCase()).toBe("HELLO");
   // -> atomic("=", [Ctor("toUpperCase", [Const("hello")]), Const("HELLO")])
   ```

2. **Multi-arg AND zero-arg free-function calls.** Relaxes the v0 single-arg gate to accept any arity, including zero. Every argument must itself be liftable.
   ```ts
   expect(clamp(5, 0, 10)).toBe(5);
   // -> atomic("=", [Ctor("clamp", [Const(5), Const(0), Const(10)]), Const(5)])
   ```

3. **Binary arithmetic in operand position.** `+`, `-`, `*`, `/`, `%` lift to `Ctor("<op>", [a, b])`. Comparison and short-circuit logical operators are deliberately excluded from term position.
   ```ts
   expect(a + b).toBe(7);
   // -> atomic("=", [Ctor("+", [Var("a"), Var("b")]), Const(7)])
   ```

4. **Array literals.** `[a, b, c]` lifts as `Ctor("array", [a, b, c])`, matching Rust v0.5's naming. Sparse and spread elements skip with a named reason. Composes with slices 1-3, so `expect(sort([3, 1, 2])).toEqual([1, 2, 3])` lifts end to end.
   ```ts
   expect(sort([3, 1, 2])).toEqual([1, 2, 3]);
   // -> atomic("=", [Ctor("sort", [Ctor("array", [3, 1, 2])]),
   //                 Ctor("array", [1, 2, 3])])
   ```

5. **Better error reporting.** Ternary `cond ? a : b` in operand position now skips with a v0.6-specific reason (`ternary ... operand is not lifted in v0.6`) rather than falling through to the catch-all. The catch-all reason itself was bumped from "v0" to "v0.6" and the enumerated unsupported shapes were brought in line with what the new slices accept.
   ```ts
   expect(flag ? a : b).toBe(1);
   // -> warning: "ternary `cond ? a : b` operand is not lifted in v0.6"
   ```

## Considered but deferred

- **Ternary as a Ctor.** Could lift to `Ctor("ternary", [cond, a, b])`, but the semantics carry a control-flow choice that the IR currently models in formula position via `if-then-else`. Defer to a future slice that decides which side of the term/formula boundary it belongs on.
- **Comparisons in operand position** (`expect(a > b).toBe(true)`). Currently skip because the binary-op clause excludes comparisons. Lifting them would conflate term and formula position; better to extend the matcher dispatcher to detect `expect(<comparison>).toBe(true)` and rewrite it to the equivalent atomic.
- **Logical operators** (`a && b`, `a || b`, `!x`). Same reasoning: formula position, not term position.
- **Template literals, indexing, field access on chained receivers.** Out of scope for v0.6.

## Test plan

- [x] `pnpm test` from repo root passes (760 / 766, 2 skipped + 4 todo unchanged from baseline)
- [x] All 33 lift-directory tests pass (12 in `vitest-tests.test.ts`, up from 8)
- [x] Each slice was authored TDD: failing test landed first, minimal impl made it green, then committed
- [x] No em-dashes in commits, comments, or this PR body
- [x] No changes to canonicalizer, IR types, fixtures.toml, or other-language kits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for v0.6 operand expressions, including function calls with multiple arguments, method calls, array literals, and arithmetic operators in operand position.

* **Tests**
  * Added comprehensive test coverage for newly supported operand expression forms and their transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->