### PR TITLE
feat(conformance): byte-equivalence golden tests for declarations + fix bogus fixture hashes

### DIFF
--- a/conformance/fixtures.toml
+++ b/conformance/fixtures.toml
@@ -25,10 +25,10 @@ hash = "blake3-512:edace2a0634b696ec24a369d37580cf9ab77f2d7c3e83869240b77305aaef
 name = "contract_decl"
 description = "Contract with precondition: parseInt(x) requires x >= 0"
 jcs = '[{"kind":"contract","name":"parseInt","outBinding":"out","pre":{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"}}]'
-hash = "blake3-512:8a3c6e8b5b3c3274c7c2e6a1f9d8e7b6a5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0"
+hash = "blake3-512:5d1a287186e41d3fd9be0f4e9464e7905f35306e7bdeeeeb180279672eed4c8685e073d88ba8a222b34e1586adc3a05efb5ab4c71837299b48f2b4386353713f"
 
 [[fixture]]
 name = "bridge_decl"
 description = "Bridge declaration with all fields including optional notes"
 jcs = '{"kind":"bridge","name":"myBridge","notes":"some notes","sourceContractCid":"bafySource","sourceLayer":"c-kit","sourceSymbol":"source","targetContractCid":"bafyTarget","targetLayer":"coq","targetProofCid":"bafyProof"}'
-hash = "blake3-512:7f1a6b3c5d9e2f4a8c0b1d3e5f7a9c2b4d6e8f0a1c3b5d7e9f0a2c4d6e8f0a"
+hash = "blake3-512:e3ace4fc4fd49561bc29d1739d8256c6d573642e4bfd5f4eb2994bb2ba5442b1e925a34b1e2a36ecb0a5e587ccf67ccce4d3184fe5e1fac67e893dce5126305b"

--- a/implementations/typescript/src/canonicalizer/cross-impl-golden.test.ts
+++ b/implementations/typescript/src/canonicalizer/cross-impl-golden.test.ts
@@ -3,11 +3,8 @@
  *
  * Loads the canonical conformance fixtures (Rust-emitted JCS bytes +
  * BLAKE3-512 hashes) and asserts the TS canonicalizer produces
- * byte-identical output for every formula-level fixture.
- *
- * Fixtures that are not formula-level (contract / bridge declarations)
- * are documented and skipped. The formula-level fixtures prove whether
- * the TS pipeline matches the Rust canonical reference or reveals a gap.
+ * byte-identical output for every fixture: formula-level AND
+ * declaration-level (contract / bridge declarations).
  *
  * Spec: conformance/fixtures.toml -- canonical JCS bytes + BLAKE3-512
  *       hashes for cross-implementation byte-equality.
@@ -198,19 +195,83 @@ function buildFormulaFor(name: string): IrFormula | null {
 }
 
 // -----------------------------------------------------------------------
+// Declaration-level fixture builders -- contract_decl, bridge_decl.
+//
+// The JCS shapes differ from formula fixtures:
+//   - contract_decl emits an ARRAY of declaration objects (matching
+//     Rust's `marshal_declarations` and Ruby's `Provekit::IR.marshal_declarations`).
+//   - bridge_decl emits a single declaration OBJECT.
+//
+// Both shapes flow through the same generic `canonicalEncode` (sorted-keys
+// JCS) because there is no separate IR type for declarations on the TS
+// canonicalizer surface; the byte-equality contract is the JSON object
+// shape itself.
+// -----------------------------------------------------------------------
+
+function buildDeclarationsFor(name: string): unknown | null {
+  switch (name) {
+    case "contract_decl": {
+      const x = varTerm("x");
+      const zero = constTerm(0, Int);
+      const pre: IrFormula = {
+        kind: "atomic",
+        name: "≥",
+        args: [x, zero],
+      };
+      // Single-element array of contract decls (matches Rust / Ruby
+      // `marshal_declarations` shape).
+      return [
+        {
+          kind: "contract",
+          name: "parseInt",
+          outBinding: "out",
+          pre,
+        },
+      ];
+    }
+
+    case "bridge_decl": {
+      // Bare bridge-decl object (not array-wrapped), with optional `notes`
+      // present. Field order is irrelevant because canonicalEncode sorts
+      // keys lexicographically before emitting.
+      return {
+        kind: "bridge",
+        name: "myBridge",
+        sourceSymbol: "source",
+        sourceLayer: "c-kit",
+        sourceContractCid: "bafySource",
+        targetContractCid: "bafyTarget",
+        targetProofCid: "bafyProof",
+        targetLayer: "coq",
+        notes: "some notes",
+      };
+    }
+
+    default:
+      return null;
+  }
+}
+
+// -----------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------
 
 const formulaFixtures = allFixtures.filter((f) => buildFormulaFor(f.name) !== null);
-const nonFormulaFixtures = allFixtures.filter((f) => buildFormulaFor(f.name) === null);
+const declarationFixtures = allFixtures.filter(
+  (f) => buildDeclarationsFor(f.name) !== null,
+);
+const uncoveredFixtures = allFixtures.filter(
+  (f) => buildFormulaFor(f.name) === null && buildDeclarationsFor(f.name) === null,
+);
 
 describe("cross-impl golden: TS IR JCS vs Rust-emitted fixtures", () => {
-  (nonFormulaFixtures.length > 0 ? it : it.skip)(
-    `skipped ${nonFormulaFixtures.length} non-formula fixture(s): ${nonFormulaFixtures.map((f) => f.name).join(", ")} (contract/bridge declarations are not formula-level)`,
-    () => {
-      // informational only
-    },
-  );
+  if (uncoveredFixtures.length > 0) {
+    it(`uncovered fixtures: ${uncoveredFixtures.map((f) => f.name).join(", ")}`, () => {
+      throw new Error(
+        `These fixtures have no TS builder: ${uncoveredFixtures.map((f) => f.name).join(", ")}`,
+      );
+    });
+  }
 
   for (const fixture of formulaFixtures) {
     it(`"${fixture.name}" — JCS bytes match Rust golden`, () => {
@@ -226,6 +287,28 @@ describe("cross-impl golden: TS IR JCS vs Rust-emitted fixtures", () => {
     it(`"${fixture.name}" — BLAKE3-512 hash matches Rust golden`, () => {
       const formula = buildFormulaFor(fixture.name)!;
       const bytes = canonicalEncode(formula);
+      const actualHash = computeCid(bytes);
+
+      expect(actualHash, `hash mismatch for "${fixture.name}"`).toBe(
+        fixture.hash,
+      );
+    });
+  }
+
+  for (const fixture of declarationFixtures) {
+    it(`"${fixture.name}" — declaration JCS bytes match Rust golden`, () => {
+      const value = buildDeclarationsFor(fixture.name)!;
+      const bytes = canonicalEncode(value);
+      const actualJcs = bytes.toString("utf8");
+
+      expect(actualJcs, `JCS byte mismatch for "${fixture.name}"`).toBe(
+        fixture.jcs,
+      );
+    });
+
+    it(`"${fixture.name}" — declaration BLAKE3-512 hash matches Rust golden`, () => {
+      const value = buildDeclarationsFor(fixture.name)!;
+      const bytes = canonicalEncode(value);
       const actualHash = computeCid(bytes);
 
       expect(actualHash, `hash mismatch for "${fixture.name}"`).toBe(


### PR DESCRIPTION
## Summary

- Replaced two placeholder hashes in `conformance/fixtures.toml` that were never validated against their JCS bytes. The `contract_decl` hash was 64 hex chars and `bridge_decl` was 62 hex chars; BLAKE3-512 hashes are 128 hex chars, so any kit asserting these would have failed instantly. Real `BLAKE3-512(JCS bytes)` computed and pinned for both.
- Extended the TS cross-impl golden test with a parallel `buildDeclarationsFor()` covering the declaration-level fixtures (`contract_decl` and `bridge_decl`). Adds 4 new tests (2 JCS byte-equality + 2 BLAKE3-512 hash-equality), bringing the file from 4 pass / 1 informational skip to 8 pass / 0 skipped / 0 failed.
- Replaced the "skipped non-formula fixtures" branch with a strict uncovered-fixtures guard so future fixtures cannot silently land without a TS builder.

## Hash placeholder situation

The two declaration fixtures shipped with hand-typed hash strings (`8a3c6e8b...1e0` and `7f1a6b3c...0a`) that were too short to be real BLAKE3-512 outputs. A grep across all kits confirmed no kit copy-pasted these strings, so the correction is purely fixtures.toml and has no kit-side fallout. Verified by running the full conformance harness: kit pass/fail count is unchanged from main (the pre-existing Go validator failure is unrelated; its `validator_test.go` has hardcoded non-canonical expected JCS strings, which is out of scope for this PR).

## New tests

- `"contract_decl" — declaration JCS bytes match Rust golden`
- `"contract_decl" — declaration BLAKE3-512 hash matches Rust golden`
- `"bridge_decl" — declaration JCS bytes match Rust golden`
- `"bridge_decl" — declaration BLAKE3-512 hash matches Rust golden`

JCS shape distinction: `contract_decl` emits a single-element array (matches Rust `marshal_declarations` and Ruby `Provekit::IR.marshal_declarations`); `bridge_decl` emits a bare object with the optional `notes` field present.

## Test plan

- [x] `bun test src/canonicalizer/cross-impl-golden.test.ts` from `implementations/typescript/`: 8 pass, 0 fail, 0 skip
- [x] `bash conformance/run.sh` from repo root: kit pass/fail count unchanged from main (pre-existing Go failure not introduced by this PR)
- [x] Real BLAKE3-512 hashes verified: my Python computation reproduced the existing `eq_atomic` and `pattern1_bounded_loop` hashes byte-for-byte, validating the same procedure for the two corrections

🤖 Generated with [Claude Code](https://claude.com/claude-code)