### PR TITLE
chore(ci): wire self-contracts contract-assertion tests into conformance gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # Mainline targets:
 #   make help        — print this help
 #   make ci          — full conformance gate (catalog + protocol + 5 mints + tests)
-#   make conformance — catalog + protocol + 5 mint CIDs match pinned values
+#   make conformance — catalog + protocol + 5 mint CIDs + self-contract tests
 #   make all-mint    — run all 5 mint commands; print CIDs
 #   make test-all    — run every language-native test suite
 #
@@ -63,7 +63,7 @@ help:
 	@echo ""
 	@echo "Mainline:"
 	@echo "  make ci             full gate (conformance + test-all)"
-	@echo "  make conformance    catalog + protocol + 5 mint CIDs match pinned"
+	@echo "  make conformance    catalog + protocol + 5 mint CIDs + self-contract tests"
 	@echo "  make all-mint       run all 5 mint commands; print CIDs"
 	@echo "  make test-all       run all language-native test suites"
 	@echo ""
@@ -200,9 +200,34 @@ protocol-verify: build-rust
 	$(PROVEKIT) verify-protocol --signed
 
 .PHONY: conformance
-conformance: catalog-verify protocol-verify all-mint
+conformance: catalog-verify protocol-verify all-mint test-self-contracts
 	@echo ""
 	@echo "==== conformance: PASS ===="
+
+# --- Self-contracts contract-assertion tests --------------------------------
+#
+# `all-mint` proves each peer kit's bundle round-trips to its pinned CID.
+# That catches CID drift, but it does NOT catch a contract-assertion test
+# being weakened or deleted (e.g. an R1..R15 rule from
+# `protocol/specs/2026-04-30-protocol-catalog-format.md` losing its check).
+# `test-self-contracts` runs the kit-native unit tests that encode those
+# rule assertions, so the conformance gate fails when a regression flips
+# any one of them.
+#
+# Today only the Rust kit ships catalog-format contract-assertion tests
+# (`implementations/rust/provekit-self-contracts/src/catalog_format.rs`,
+# 19 `#[test]` fns covering R1..R15). The go/cpp/ts/csharp self-contracts
+# packages currently only carry the mint binary; once they grow their own
+# catalog-format test suites, add `test-self-contracts-<lang>` targets
+# alongside the rust one and append them to the aggregate dep list below.
+
+.PHONY: test-self-contracts
+test-self-contracts: test-self-contracts-rust
+
+.PHONY: test-self-contracts-rust
+test-self-contracts-rust:
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-self-contracts --lib
 
 # --- Per-language test suites ------------------------------------------------
 


### PR DESCRIPTION
## Summary

- The conformance gate (`make conformance`) currently runs `catalog-verify protocol-verify all-mint`. `all-mint` checks that each kit's self-contracts bundle round-trips to its pinned CID against a signed attestation. **CID drift is caught.** **Contract-assertion regressions are not.**
- A test that encodes an R1..R15 rule from `protocol/specs/2026-04-30-protocol-catalog-format.md` can be flipped to the wrong polarity (or deleted, or rewritten to `assert!(true)`) and the bundle CID is unchanged: the gate stays green.
- This PR adds `test-self-contracts` (and `test-self-contracts-rust` underneath it) to the conformance gate. The aggregate target depends only on the Rust kit today because Rust is the only kit that currently ships catalog-format unit tests.

## Scope per kit

| Kit | Has `catalog_format` contract-assertion tests? | Wired in? |
| --- | --- | --- |
| rust | yes, `implementations/rust/provekit-self-contracts/src/catalog_format.rs`, 19 `#[test]` fns covering R1..R15 | yes |
| go | no (self-contracts package = mint binary + slabs only) | skipped |
| cpp | no (self-contracts package = build script + bundle source) | skipped |
| ts | no (only the mint test that prints the CID) | skipped |
| csharp | no (`Provekit.SelfContracts` = `Program.cs` mint binary only; the canonicalizer-conformance suite lives in a sibling package) | skipped |

When go/cpp/ts/csharp grow their own catalog-format contract-assertion suites, the convention is to add `test-self-contracts-<lang>` targets next to the rust one and append them to `test-self-contracts`'s dep list. The Makefile comment block records this.

## Verification (TDD)

1. With the new target wired in, ran `make conformance` on a clean tree: PASS (29 tests in provekit-self-contracts ran, 0 failed; `==== conformance: PASS ====` printed).
2. Deliberately flipped one assertion in `r1_violation_kind_not_catalog_is_caught` (changed `matches!` to `!matches!`).
3. Re-ran `make conformance`: failed with

   ```
   test catalog_format::tests::r1_violation_kind_not_catalog_is_caught ... FAILED
   test result: FAILED. 28 passed; 1 failed; 0 ignored; ...
   error: test failed, to rerun pass `-p provekit-self-contracts --lib`
   make: *** [test-self-contracts-rust] Error 101
   ```

4. Reverted the deliberate weakening, re-ran `make test-self-contracts`: 29 passed, 0 failed, exit 0.

Note on detection scope: this gate catches a contract test that **fails** (assertion has wrong polarity, expected value moved, etc.). It does **not** catch a contract test that has been weakened to pass vacuously (e.g. `assert!(true)` or a test body deleted entirely). Closing that loophole would require a separate test-coverage / mutation-testing gate and is out of scope for this PR.

## Test plan

- [x] `make conformance` exits 0 on the unchanged tree
- [x] `make conformance` exits non-zero when an R1..R15 assertion is flipped
- [x] `make conformance` exits 0 again after the flip is reverted
- [x] No new em-dashes introduced in Makefile additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)