### PR TITLE
chore(self-contracts): re-sign rust attestation after PR #84

### DIFF
--- a/.provekit/self-contracts-attestations/rust.json
+++ b/.provekit/self-contracts-attestations/rust.json
@@ -2,8 +2,8 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "rust",
-  "cid": "blake3-512:69e2cf68d36948b3693f9758add5476006c8c3492c37b45dbaa9723518a98bbb1278d168a82378ea3def8a32533818704f7dc81905c2ddb55f34668d99bf3c65",
+  "cid": "blake3-512:42d236d4156c8e40c525e5b53bbc1ec37c089fabdc6ff4f8b8b8ea43c09e2b0601d7654ca93b03339c7df3d8e610064859870c9ea0147b5629494817614aa3d5",
   "declaredAt": "2026-05-02T17:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:ez+mOAoX0sK9IPk5AbvrgJUSlPtlP60csPeyitfrPotwAzREsOBPfssHArhaW11LxYyJuYmrXTiDY3hQ5l+WAA=="
+  "signature": "ed25519:WhfScm1G3C5196fE6+1q08Jb85iueuTAPNjOT3jVCuRdESt4r3wjs4QzIW+Ssi9Qsggnh+YU03DJydo/EB4yDw=="
 }


### PR DESCRIPTION
## Summary

PR #84 added the \`lift_plugin_protocol\` module to \`provekit-self-contracts\`, shifting the bundle CID from \`69e2cf68d3...8d99bf3c65\` to \`42d236d4156c...4a3d5\`. This re-signs the attestation per the Makefile bump-dance guidance.

Same shape as PR #79 (after the catalog-format work).

## Test plan

- [x] \`make mint-rust\` passes locally on main
- [ ] CI \`Cross-language conformance gate\` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)