### PR TITLE
feat(go): mint lift-plugin-protocol bridges to rust contracts (Phase 2)

### DIFF
--- a/implementations/go/provekit-self-contracts/cmd/mint-go-self-contracts/main.go
+++ b/implementations/go/provekit-self-contracts/cmd/mint-go-self-contracts/main.go
@@ -3,14 +3,18 @@
 // Mirrors implementations/rust/provekit-self-contracts/src/bin/
 // mint-self-contracts.rs.
 //
-// 1. Walks every Invariants_<label>() function in the slabs package.
-// 2. Authors all contracts; mints them as signed mementos under the
-//    foundation key (test seed [0x42; 32]).
-// 3. Bundles every contract memento into a single `.proof` whose
-//    filename IS the catalog CID. No bridges (Go has no public-API
-//    counterpart of Rust's `parse_formula` closed-loop).
-// 4. Asserts byte-determinism by minting twice into separate temp dirs
-//    and comparing the resulting catalog CIDs. Fails loud on mismatch.
+//  1. Walks every Invariants_<label>() function in the slabs package.
+//  2. Authors all contracts AND bridges; mints them as signed mementos
+//     under the foundation key (test seed [0x42; 32]). Bridges may have
+//     a `pending-go-counterpart:<name>` placeholder in TargetContractCid
+//     that gets resolved to a real memento CID after every counterpart
+//     contract has been minted (mirrors rust lib.rs:368-385 closed-loop
+//     bridge resolution).
+//  3. Bundles every memento into a single `.proof` whose filename IS
+//     the catalog CID. Bridges include the phase-2 cross-kit bridges
+//     declared by slabs/lift_plugin_protocol.go.
+//  4. Asserts byte-determinism by minting twice into separate temp dirs
+//     and comparing the resulting catalog CIDs. Fails loud on mismatch.
 //
 // Cross-language conformance: the .proof bytes are produced by the
 // existing Go canonicalizer / claim_envelope / proof_envelope. Any
@@ -18,8 +22,9 @@
 // the protocol-mandated content-address.
 //
 // Run:
-//   go run ./cmd/mint-go-self-contracts
-//   go run ./cmd/mint-go-self-contracts /tmp/provekit-go-self
+//
+//	go run ./cmd/mint-go-self-contracts
+//	go run ./cmd/mint-go-self-contracts /tmp/provekit-go-self
 package main
 
 import (
@@ -30,16 +35,16 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/tsavo/provekit/go/provekit-self-contracts/slabs"
 	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
 	"github.com/tsavo/provekit/go/provekit-ir-symbolic/claim_envelope"
 	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 	"github.com/tsavo/provekit/go/provekit-ir-symbolic/proof_envelope"
+	"github.com/tsavo/provekit/go/provekit-self-contracts/slabs"
 )
 
 const (
-	producedBy = "provekit-go-self-contracts@1.0"
-	declaredAt = "2026-04-30T18:00:00.000Z"
+	producedBy     = "provekit-go-self-contracts@1.0"
+	declaredAt     = "2026-04-30T18:00:00.000Z"
 	catalogName    = "@provekit/go-self-contracts"
 	catalogVersion = "1.0.0"
 )
@@ -55,16 +60,27 @@ func foundationSeed() [32]byte {
 }
 
 // authoredSlab is one source-file's drained collector + label.
+//
+// A slab may carry contract declarations, bridge declarations, or both.
+// Phase-2 cross-kit bridges (slabs/lift_plugin_protocol.go) declare
+// only bridges; existing per-source-file slabs declare only contracts.
+// The orchestrator handles each kind separately at mint time.
 type authoredSlab struct {
-	label    string
-	path     string
+	label     string
+	path      string
 	contracts []ir.ContractDeclaration
+	bridges   []ir.BridgeDeclaration
 }
 
 // authorAllInvariants drives every Invariants_<label>() function in the
 // slabs package. Each slab is collected in isolation: ResetCollector +
 // BeginCollecting + Run + drain. The quantifier counter resets inside
 // BeginCollecting, so successive runs produce byte-identical IR.
+//
+// Each declaration is sorted into its kind's bucket. Contract and bridge
+// are the v1.1.0 declaration kinds the kit currently emits; any other
+// kind (or a future addition) errors loud here so the orchestrator
+// stays the source of truth for what shapes get minted.
 func authorAllInvariants() ([]authoredSlab, error) {
 	out := make([]authoredSlab, 0, len(slabs.Slabs()))
 	for _, s := range slabs.Slabs() {
@@ -72,19 +88,27 @@ func authorAllInvariants() ([]authoredSlab, error) {
 		finish := ir.BeginCollecting()
 		s.Run()
 		decls := finish()
-		// Coerce — every slab authors only contracts (no bridges).
-		contracts := make([]ir.ContractDeclaration, 0, len(decls))
+		var (
+			contracts []ir.ContractDeclaration
+			bridges   []ir.BridgeDeclaration
+		)
 		for _, d := range decls {
-			c, ok := d.(ir.ContractDeclaration)
-			if !ok {
+			switch typed := d.(type) {
+			case ir.ContractDeclaration:
+				contracts = append(contracts, typed)
+			case ir.BridgeDeclaration:
+				bridges = append(bridges, typed)
+			default:
 				return nil, fmt.Errorf(
-					"slab %q: unexpected declaration kind %s (want contract)",
+					"slab %q: unsupported declaration kind %s (want contract or bridge)",
 					s.Label, d.Kind())
 			}
-			contracts = append(contracts, c)
 		}
 		out = append(out, authoredSlab{
-			label: s.Label, path: s.Path, contracts: contracts,
+			label:     s.Label,
+			path:      s.Path,
+			contracts: contracts,
+			bridges:   bridges,
 		})
 	}
 	return out, nil
@@ -92,13 +116,15 @@ func authorAllInvariants() ([]authoredSlab, error) {
 
 // mintResult is the outcome of one mint-self-proof run.
 type mintResult struct {
-	cid          string
-	bytesLen     int
-	path         string
-	memberCount  int
-	contractCIDs map[string]string
+	cid             string
+	bytesLen        int
+	path            string
+	memberCount     int
+	contractCIDs    map[string]string
+	bridgeCIDs      map[string]string // bridgeName -> memento CID
 	perSourceCounts []labeledCount
 	totalContracts  int
+	totalBridges    int
 }
 
 type labeledCount struct {
@@ -125,12 +151,25 @@ func mintSelfProof(outDir string) (*mintResult, error) {
 
 	members := map[string][]byte{}
 	contractCIDs := map[string]string{}
+	bridgeCIDs := map[string]string{}
 	perSource := make([]labeledCount, 0, len(authored))
 	totalContracts := 0
+	totalBridges := 0
 
+	// PASS 1: mint every contract.
+	//
+	// Bridges are deferred to PASS 2 because phase-2 cross-kit bridges
+	// reference go counterpart contracts via a `pending-go-counterpart:`
+	// placeholder in TargetContractCid; the placeholder can only be
+	// rewritten once the target counterpart contract has a real memento
+	// CID. Slab order ensures all contract slabs run before any bridge
+	// slab in PASS 1 here, but we explicitly skip bridge declarations
+	// in this pass for clarity (and so a future slab that mixes both
+	// declaration kinds in the same Invariants_*() function still works).
 	for _, slab := range authored {
-		perSource = append(perSource, labeledCount{label: slab.label, count: len(slab.contracts)})
+		perSource = append(perSource, labeledCount{label: slab.label, count: len(slab.contracts) + len(slab.bridges)})
 		totalContracts += len(slab.contracts)
+		totalBridges += len(slab.bridges)
 
 		for _, c := range slab.contracts {
 			// Convert kit IR formulas to JSON-shape values via the
@@ -158,13 +197,13 @@ func mintSelfProof(outDir string) (*mintResult, error) {
 			}
 
 			minted, err := minter.MintContract(claim_envelope.ContractMintArgs{
-				ContractName: c.Name,
-				Pre:          preV,
-				Post:         postV,
-				Inv:          invV,
-				OutBinding:   c.OutBinding,
-				ProducedBy:   producedBy,
-				ProducedAt:   declaredAt,
+				ContractName:  c.Name,
+				Pre:           preV,
+				Post:          postV,
+				Inv:           invV,
+				OutBinding:    c.OutBinding,
+				ProducedBy:    producedBy,
+				ProducedAt:    declaredAt,
 				AuthoringKind: claim_envelope.AuthoringKitAuthor,
 				AuthoringKitAuthor: claim_envelope.AuthoringKitAuthorArgs{
 					Author: producedBy,
@@ -181,6 +220,51 @@ func mintSelfProof(outDir string) (*mintResult, error) {
 					"duplicate contract name %q across slabs", c.Name)
 			}
 			contractCIDs[c.Name] = minted.CID
+			members[minted.CID] = minted.CanonicalBytes
+		}
+	}
+
+	// PASS 2: mint every bridge.
+	//
+	// Phase-2 cross-kit bridges may carry a `pending-go-counterpart:<name>`
+	// placeholder in TargetContractCid; resolve it here to the real
+	// memento CID of the named go counterpart contract minted in PASS 1.
+	// Bridges authored without the placeholder (e.g. plain rust-style
+	// closed-loop bridges) pass through untouched.
+	for _, slab := range authored {
+		for _, b := range slab.bridges {
+			targetCid := b.TargetContractCid
+			if strings.HasPrefix(targetCid, slabs.PendingTargetContractCidPrefix) {
+				counterpartName := strings.TrimPrefix(targetCid, slabs.PendingTargetContractCidPrefix)
+				resolved, ok := contractCIDs[counterpartName]
+				if !ok {
+					return nil, fmt.Errorf(
+						"bridge %q: cannot resolve target counterpart %q (no contract minted with that name)",
+						b.Name, counterpartName)
+				}
+				targetCid = resolved
+			}
+			minted, err := minter.MintBridge(claim_envelope.BridgeMintArgs{
+				ProducedBy:        producedBy,
+				ProducedAt:        declaredAt,
+				SourceSymbol:      b.SourceSymbol,
+				SourceLayer:       b.SourceLayer,
+				SourceContractCID: b.SourceContractCid,
+				TargetContractCID: targetCid,
+				TargetProofCID:    b.TargetProofCid,
+				TargetLayer:       b.TargetLayer,
+				IRArgSorts:        []interface{}{},
+				IRReturnSort:      "Bool",
+				Notes:             b.Notes,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("MintBridge %s: %w", b.Name, err)
+			}
+			if _, dup := bridgeCIDs[b.Name]; dup {
+				return nil, fmt.Errorf(
+					"duplicate bridge name %q across slabs", b.Name)
+			}
+			bridgeCIDs[b.Name] = minted.CID
 			members[minted.CID] = minted.CanonicalBytes
 		}
 	}
@@ -217,8 +301,10 @@ func mintSelfProof(outDir string) (*mintResult, error) {
 		path:            path,
 		memberCount:     len(members),
 		contractCIDs:    contractCIDs,
+		bridgeCIDs:      bridgeCIDs,
 		perSourceCounts: perSource,
 		totalContracts:  totalContracts,
+		totalBridges:    totalBridges,
 	}, nil
 }
 
@@ -276,12 +362,16 @@ func main() {
 	}
 	fmt.Println()
 	fmt.Println("authored:")
-	total := 0
+	totalContracts := 0
+	totalBridges := 0
 	for _, s := range authored {
-		total += len(s.contracts)
-		fmt.Printf("  %22s  %2d contracts  (%s)\n", s.label, len(s.contracts), s.path)
+		totalContracts += len(s.contracts)
+		totalBridges += len(s.bridges)
+		fmt.Printf("  %32s  %2d contracts  %2d bridges  (%s)\n",
+			s.label, len(s.contracts), len(s.bridges), s.path)
 	}
-	fmt.Printf("  %22s  %2d contracts (TOTAL)\n", "[ALL]", total)
+	fmt.Printf("  %32s  %2d contracts  %2d bridges  (TOTAL)\n",
+		"[ALL]", totalContracts, totalBridges)
 
 	// Determinism check: mint twice into distinct dirs.
 	detDir := filepath.Join(os.TempDir(), fmt.Sprintf("provekit-go-self-determinism-%d", os.Getpid()))
@@ -306,6 +396,7 @@ func main() {
 	fmt.Printf("  bytes:              %d\n", mintB.bytesLen)
 	fmt.Printf("  members:            %d\n", mintB.memberCount)
 	fmt.Printf("  total contracts:    %d\n", mintB.totalContracts)
+	fmt.Printf("  total bridges:      %d\n", mintB.totalBridges)
 	fmt.Printf("  catalog CID:        %s\n", mintB.cid)
 
 	if mintA.cid != mintB.cid {

--- a/implementations/go/provekit-self-contracts/cmd/mint-go-self-contracts/rpc.go
+++ b/implementations/go/provekit-self-contracts/cmd/mint-go-self-contracts/rpc.go
@@ -70,9 +70,9 @@ func runRPCMode() {
 					"version":          "1.0.0",
 					"protocol_version": "provekit-lift/1",
 					"capabilities": map[string]interface{}{
-						"authoring_surfaces":     []string{"go-self-contracts"},
-						"ir_version":             "v1.1.0",
-						"emits_signed_mementos":  true,
+						"authoring_surfaces":    []string{"go-self-contracts"},
+						"ir_version":            "v1.1.0",
+						"emits_signed_mementos": true,
 					},
 				},
 			})
@@ -106,10 +106,10 @@ func runRPCMode() {
 			writeRPC(writer, rpcResponse{
 				ID: req.ID,
 				Result: map[string]interface{}{
-					"kind":          "proof-envelope",
-					"filename_cid":  result.cid,
-					"bytes_base64":  base64.StdEncoding.EncodeToString(bytes),
-					"diagnostics":   []interface{}{},
+					"kind":         "proof-envelope",
+					"filename_cid": result.cid,
+					"bytes_base64": base64.StdEncoding.EncodeToString(bytes),
+					"diagnostics":  []interface{}{},
 				},
 			})
 

--- a/implementations/go/provekit-self-contracts/slabs/lift_plugin_protocol.go
+++ b/implementations/go/provekit-self-contracts/slabs/lift_plugin_protocol.go
@@ -1,0 +1,398 @@
+package slabs
+
+// Cross-kit conformance bridges for the lift-plugin protocol.
+//
+// Phase 2 of the cross-kit bridge work. Phase 1 landed in PR #84:
+// implementations/rust/provekit-self-contracts/src/lift_plugin_protocol.rs
+// authored 10 contracts encoding the rules of
+// protocol/specs/2026-04-30-lift-plugin-protocol.md (the "lift-plugin-
+// protocol spec", v1.2.0 normative). PR #88 re-signed rust's bundle
+// attestation. The rust .proof now ships those 10 contracts as
+// signed mementos with content-addressed CIDs.
+//
+// This file does the go-side counterpart:
+//
+//   1. Mints 10 GO COUNTERPART contracts named go_lift_plugin_<rule>.
+//      Each counterpart asserts "go-kit's lift plugin satisfies rust's
+//      <contract name>" as the go implementation should observe it.
+//      Same shape as the rust contracts (kit-defined named ctors with
+//      a paired-equality post against `true_const`); the verifier
+//      discharges the operational check at the per-callsite layer.
+//
+//   2. Mints 10 BRIDGE declarations linking each rust source contract
+//      (by its memento CID extracted from rust's .proof bundle) to its
+//      go counterpart contract. Per protocol/specs/2026-04-30-ir-formal-
+//      grammar.md the BridgeDeclaration locked-key-order shape is
+//        {kind, name, sourceSymbol, sourceLayer, sourceContractCid,
+//         targetContractCid, targetProofCid, targetLayer, notes?}
+//      and the verifier uses `sourceContractCid` + `targetContractCid`
+//      to look up envelopes in the unified pool, with `targetProofCid`
+//      providing the forward-pin gate (BridgeDeclaration.Consequent-
+//      BundlePinned, normative per PR #10).
+//
+// The rust contract CIDs in `rustContractCID` are the memento envelope
+// CIDs of rust's signed contract envelopes, extracted from the rust
+// .proof produced by `cargo run --release -p provekit-self-contracts
+// --bin mint-self-contracts`. They are stable under the rust
+// orchestrator's pinned producer ("provekit-self-contracts@1.0"),
+// pinned timestamp ("2026-04-30T18:00:00.000Z"), and pinned signer seed
+// ([0x42; 32]). Any drift (a rust contract body change, a producer-id
+// rename, a timestamp bump) will fail the pinned-hash test in
+// lift_plugin_protocol_test.go and signal a phase-2 re-mint event.
+//
+// The go counterpart contracts mint at run time inside the go
+// orchestrator (see cmd/mint-go-self-contracts/main.go), producing
+// their own memento CIDs from the go bundle. The bridge declarations
+// reference those targets by the counterpart contract NAME during
+// authoring; the orchestrator resolves name -> CID at mint time after
+// every counterpart contract has been minted (mirrors rust's
+// lib.rs:368-385 closed-loop bridge resolution). Until that resolution
+// pass runs, BridgeDeclaration.TargetContractCid is the placeholder
+// returned by `pendingTargetContractCidPlaceholder`; the orchestrator
+// rewrites it before bundling.
+//
+// targetProofCid is intentionally `deferred:phase-3-proof-bundle`
+// because computing the go lift plugin's binary CID is phase-3 work
+// (binary attestation per protocol/specs/2026-05-02-binary-attestation
+// -protocol.md). Phase 3 will replace the literal with the real CID.
+
+import "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+
+// rustContractCID maps each lift-plugin-protocol rust contract name to
+// the memento envelope CID found in the rust self-contracts .proof
+// bundle. Extracted via `cargo run -p provekit-self-contracts --bin
+// mint-self-contracts /tmp/<dir>` and walking the bundle's `members`
+// map for the 10 envelopes whose evidence.body.contractName has the
+// `lift_plugin_` prefix.
+//
+// Rust source: implementations/rust/provekit-self-contracts/src/
+//
+//	lift_plugin_protocol.rs (PR #84)
+//
+// Rust bundle CID at extraction time:
+//
+//	blake3-512:a6dcf733721f902c77c19a2e818e7638e37c0f9e6254ac607a39f6
+//	           8584aba2c9442b204fe536f25713988e271e684a8585f10d991fefa
+//	           08df7e99a8a3df7f60e
+//
+// Frozen here as static strings: rust's bundle CID and member CIDs are
+// load-bearing; if they drift, the pinned-hash test in
+// lift_plugin_protocol_test.go fails and signals that phase 2 must be
+// re-minted.
+var rustContractCID = map[string]string{
+	"lift_plugin_initialize_protocol_version_match":                   "blake3-512:95163d00976803c3ef381494a8a940bd862529f7bdfb72aa523bd58359b86d6fce017991658932e3e3dee8b4c60b26066bfa270474b2896c19dd2ec85d4aa47a",
+	"lift_plugin_initialize_capabilities_authoring_surfaces_nonempty": "blake3-512:1898e2518e96628bbe46704f6f6a90cc57572f3b15bb3f4f6a7d8fef28a8c92e31b33b14f21d4011ed7ad11d4ea09c67c1549cbe1c2bf38e53b7e8cfdb656099",
+	"lift_plugin_initialize_capabilities_ir_version_starts_with_v":    "blake3-512:08d09e6f677e77f5b501a07a5271cebdadb19c48c52375ae9e6edcb699b6515eacdea2d7966497c3b3aca4054340e7222fe97bbbb8f60e2ee62baaec6ef719f0",
+	"lift_plugin_lift_request_surface_is_string":                      "blake3-512:bf6ac4f7e481ba1fea26716f9d2e7756c86b1940610e2d9e35a5d6e11faa8993a92cd291f491c4d520e5daf1a54c32aeb492adac5aa8d61d224ca1104adaaf8a",
+	"lift_plugin_lift_request_source_paths_nonempty":                  "blake3-512:3f2915b063357c28cd2bd8132279e819424999b21a776824d3db9231ca4acb8fdc02ea6e5a8945e55a1d439fda94d07b365d0d160e4ece94b1012fe064ca7c22",
+	"lift_plugin_lift_request_source_paths_each_nonempty":             "blake3-512:f57621c2ba995cbd13d9d06c4209ad9ecdb6369d1e90d902b90996275dd40a38804c986b77b9f28bdf7eefc2b0f242284d1612a4149f5abb0451097a72f95822",
+	"lift_plugin_lift_request_surface_in_capabilities":                "blake3-512:61c67906e3b2ff0d0a61419436670140009556402b643516c4afb14212c057a080bf6f29a0c4c374fe2eb45f8016ddfc82ed12fae2735c7384a8b56a7597db51",
+	"lift_plugin_lift_response_kind_in_set":                           "blake3-512:7642bd5eb5262354921513ee6e01bf70dad917f3467464ad904750685e84d0241ef9b0f40b6e0d66dd73e0d5cc1908e4a0a45d45530dda511e1919786034e2a0",
+	"lift_plugin_lift_response_ir_document_array":                     "blake3-512:692df8b67bc3ad69943f5909779f489bdc8173bbb08fd61585bb1b8bc0a2c20c6891ba7b9a2a4e4e3a6e5a4441b1191f4618924783446cb07277879c885cbc20",
+	"lift_plugin_diagnostic_field_is_array":                           "blake3-512:ea5dd139fddc9e5ab6cfcb9854de1ce6bbedcccbe7b070c1aef9fbbef3b8579ebf33ff14cdc97013e1f3e1c391964f275a0275b615b8259037b0cb92d0e0dd35",
+}
+
+// LiftPluginRustContractCID returns the rust memento envelope CID for
+// the named lift-plugin-protocol contract. Empty string if the name is
+// not one of the 10 rust contracts. Exported for the orchestrator's
+// post-mint resolution pass and for the pinned-hash test.
+func LiftPluginRustContractCID(rustName string) string {
+	return rustContractCID[rustName]
+}
+
+// LiftPluginGoTargetProofCIDPlaceholder is the go-kit lift plugin's
+// `targetProofCid` value during phase 2. Phase 3 (binary-attestation
+// protocol; see protocol/specs/2026-05-02-binary-attestation-protocol.md)
+// will replace this with the real binary CID.
+//
+// The verifier accepts an empty string as the back-compat path and
+// flags it with a stderr warning ("ConsequentBundlePinned not
+// enforced"). Using a sentinel string instead means the field is
+// PRESENT and lookup-distinguishable: any verifier that tries to
+// resolve `deferred:phase-3-proof-bundle` will fail loud with
+// `BridgeTargetProofCidMismatch`, exactly the right signal that the
+// bridge has not yet been bound to a real binary.
+const LiftPluginGoTargetProofCIDPlaceholder = "deferred:phase-3-proof-bundle"
+
+// liftPluginBridgePairs lists the 10 (rust contract name, go counterpart
+// contract name, bridge name) triples in stable order. The order is
+// declaration order of the rust contracts in
+// implementations/rust/provekit-self-contracts/src/lift_plugin_protocol.rs.
+//
+// Bridge naming: `bridge_to_<rust_contract_name>` per the phase-2 PR
+// description.
+//
+// Counterpart naming: `go_<rust_contract_name>` per the phase-2 PR
+// description.
+type liftPluginBridgePair struct {
+	rustName      string // source of the conformance claim
+	goCounterpart string // go-kit contract that claims conformance
+	bridgeName    string // bridge_to_<rust_contract_name>
+}
+
+func liftPluginBridgePairs() []liftPluginBridgePair {
+	return []liftPluginBridgePair{
+		{
+			rustName:      "lift_plugin_initialize_protocol_version_match",
+			goCounterpart: "go_lift_plugin_initialize_protocol_version_match",
+			bridgeName:    "bridge_to_lift_plugin_initialize_protocol_version_match",
+		},
+		{
+			rustName:      "lift_plugin_initialize_capabilities_authoring_surfaces_nonempty",
+			goCounterpart: "go_lift_plugin_initialize_capabilities_authoring_surfaces_nonempty",
+			bridgeName:    "bridge_to_lift_plugin_initialize_capabilities_authoring_surfaces_nonempty",
+		},
+		{
+			rustName:      "lift_plugin_initialize_capabilities_ir_version_starts_with_v",
+			goCounterpart: "go_lift_plugin_initialize_capabilities_ir_version_starts_with_v",
+			bridgeName:    "bridge_to_lift_plugin_initialize_capabilities_ir_version_starts_with_v",
+		},
+		{
+			rustName:      "lift_plugin_lift_request_surface_is_string",
+			goCounterpart: "go_lift_plugin_lift_request_surface_is_string",
+			bridgeName:    "bridge_to_lift_plugin_lift_request_surface_is_string",
+		},
+		{
+			rustName:      "lift_plugin_lift_request_source_paths_nonempty",
+			goCounterpart: "go_lift_plugin_lift_request_source_paths_nonempty",
+			bridgeName:    "bridge_to_lift_plugin_lift_request_source_paths_nonempty",
+		},
+		{
+			rustName:      "lift_plugin_lift_request_source_paths_each_nonempty",
+			goCounterpart: "go_lift_plugin_lift_request_source_paths_each_nonempty",
+			bridgeName:    "bridge_to_lift_plugin_lift_request_source_paths_each_nonempty",
+		},
+		{
+			rustName:      "lift_plugin_lift_request_surface_in_capabilities",
+			goCounterpart: "go_lift_plugin_lift_request_surface_in_capabilities",
+			bridgeName:    "bridge_to_lift_plugin_lift_request_surface_in_capabilities",
+		},
+		{
+			rustName:      "lift_plugin_lift_response_kind_in_set",
+			goCounterpart: "go_lift_plugin_lift_response_kind_in_set",
+			bridgeName:    "bridge_to_lift_plugin_lift_response_kind_in_set",
+		},
+		{
+			rustName:      "lift_plugin_lift_response_ir_document_array",
+			goCounterpart: "go_lift_plugin_lift_response_ir_document_array",
+			bridgeName:    "bridge_to_lift_plugin_lift_response_ir_document_array",
+		},
+		{
+			rustName:      "lift_plugin_diagnostic_field_is_array",
+			goCounterpart: "go_lift_plugin_diagnostic_field_is_array",
+			bridgeName:    "bridge_to_lift_plugin_diagnostic_field_is_array",
+		},
+	}
+}
+
+// LiftPluginBridgePairNames returns the 10 bridge names in stable
+// declaration order. Exported for tests.
+func LiftPluginBridgePairNames() []string {
+	pairs := liftPluginBridgePairs()
+	out := make([]string, len(pairs))
+	for i, p := range pairs {
+		out[i] = p.bridgeName
+	}
+	return out
+}
+
+// LiftPluginGoCounterpartNames returns the 10 go-counterpart contract
+// names in stable declaration order. Exported for tests + the
+// orchestrator's post-mint bridge resolution.
+func LiftPluginGoCounterpartNames() []string {
+	pairs := liftPluginBridgePairs()
+	out := make([]string, len(pairs))
+	for i, p := range pairs {
+		out[i] = p.goCounterpart
+	}
+	return out
+}
+
+// InvariantsLiftPluginProtocolContracts authors the 10 go counterpart
+// contracts that assert "go-kit's lift plugin satisfies rust's
+// <contract name>". Each counterpart mirrors the rust contract's shape:
+// a kit-defined named ctor whose paired-equality with `true_const`
+// encodes the protocol-level claim.
+//
+// Operational verification of these claims is the same shape as the
+// rust verify_c*_* functions: a per-rule predicate that takes a
+// JSON-RPC message and returns Result<(), String>. The go-side
+// verifiers live in the lift plugin itself (cmd/mint-go-self-contracts/
+// rpc.go) and are exercised by the protocol-conformance tests at
+// implementations/go/provekit-lift-go-tests/.
+func InvariantsLiftPluginProtocolContracts() {
+	// -- C1: initialize protocol_version match. ------------------------
+	//
+	// go-kit's `--rpc` initialize handler emits
+	//   capabilities.protocol_version == "provekit-lift/1"
+	// matching the request, OR responds with PROTOCOL_VERSION_MISMATCH
+	// (the spec-named error).
+	ir.Contract("go_lift_plugin_initialize_protocol_version_match",
+		ir.ContractArgs{
+			Pre: ir.Eq(
+				ctor1("go_request_protocol_version", ir.StrConst("req")),
+				ir.StrConst("provekit-lift/1"),
+			),
+			Post: ir.Eq(
+				ctor1("go_response_confirms_protocol_or_errors_mismatch", ir.StrConst("req")),
+				ctor1("true_const", ir.StrConst("")),
+			),
+		})
+
+	// -- C2.a: initialize capabilities.authoring_surfaces is nonempty. -
+	ir.Must("go_lift_plugin_initialize_capabilities_authoring_surfaces_nonempty",
+		ir.ForAll(ir.String, func(resp ir.IrTerm) ir.IrFormula {
+			return ir.Gte(
+				ir.StringLength(ctor1("go_authoring_surfaces_of", resp)),
+				ir.Num(1),
+			)
+		}))
+
+	// -- C2.b: initialize capabilities.ir_version starts with "v". -----
+	ir.Contract("go_lift_plugin_initialize_capabilities_ir_version_starts_with_v",
+		ir.ContractArgs{
+			Post: ir.Eq(
+				ctor1("go_ir_version_starts_with_v", ir.StrConst("resp")),
+				ctor1("true_const", ir.StrConst("")),
+			),
+		})
+
+	// -- C3.a: lift request `surface` field is a string. ---------------
+	ir.Contract("go_lift_plugin_lift_request_surface_is_string",
+		ir.ContractArgs{
+			Post: ir.Eq(
+				ctor1("go_is_string", ctor1("go_surface_of", ir.StrConst("req"))),
+				ctor1("true_const", ir.StrConst("")),
+			),
+		})
+
+	// -- C3.b: lift request `source_paths` is nonempty. ----------------
+	ir.Must("go_lift_plugin_lift_request_source_paths_nonempty",
+		ir.ForAll(ir.String, func(req ir.IrTerm) ir.IrFormula {
+			return ir.Gte(
+				ir.StringLength(ctor1("go_source_paths_of", req)),
+				ir.Num(1),
+			)
+		}))
+
+	// -- C3.c: every lift request `source_paths` element is nonempty. --
+	ir.Contract("go_lift_plugin_lift_request_source_paths_each_nonempty",
+		ir.ContractArgs{
+			Post: ir.Eq(
+				ctor1("go_source_paths_each_nonempty", ir.StrConst("req")),
+				ctor1("true_const", ir.StrConst("")),
+			),
+		})
+
+	// -- C4: lift surface in capabilities (init handshake gate). -------
+	ir.Contract("go_lift_plugin_lift_request_surface_in_capabilities",
+		ir.ContractArgs{
+			Post: ir.Eq(
+				ctor2("go_surface_in_capabilities", ir.StrConst("req"), ir.StrConst("caps")),
+				ctor1("true_const", ir.StrConst("")),
+			),
+		})
+
+	// -- C5: lift response `kind` in {ir-document, signed-mementos,    -
+	//        proof-envelope}. -----------------------------------------
+	ir.Contract("go_lift_plugin_lift_response_kind_in_set",
+		ir.ContractArgs{
+			Post: ir.Eq(
+				ctor1("go_response_kind_in_allowed_set", ir.StrConst("resp")),
+				ctor1("true_const", ir.StrConst("")),
+			),
+		})
+
+	// -- C6: when kind == "ir-document", `ir` field is an array. -------
+	ir.Contract("go_lift_plugin_lift_response_ir_document_array",
+		ir.ContractArgs{
+			Post: ir.Eq(
+				ctor1("go_ir_field_is_array_when_kind_ir_document", ir.StrConst("resp")),
+				ctor1("true_const", ir.StrConst("")),
+			),
+		})
+
+	// -- C7: `diagnostics` field, when present, is an array. -----------
+	ir.Contract("go_lift_plugin_diagnostic_field_is_array",
+		ir.ContractArgs{
+			Post: ir.Eq(
+				ctor1("go_diagnostics_field_is_array_or_absent", ir.StrConst("resp")),
+				ctor1("true_const", ir.StrConst("")),
+			),
+		})
+}
+
+// InvariantsLiftPluginProtocolBridges authors the 10 cross-kit bridges
+// linking each rust source contract (by memento CID) to its go
+// counterpart contract.
+//
+// The orchestrator (cmd/mint-go-self-contracts/main.go) post-processes
+// the collected BridgeDeclarations: for each one, it resolves
+// `targetContractCid` from the placeholder to the real go counterpart
+// contract memento CID after the contract slabs have minted. This
+// mirrors rust's lib.rs:368-385 closed-loop bridge-resolution pass.
+func InvariantsLiftPluginProtocolBridges() {
+	for _, p := range liftPluginBridgePairs() {
+		ir.Bridge(p.bridgeName, ir.BridgeSpec{
+			SourceSymbol:      p.rustName,
+			SourceLayer:       "rust-kit",
+			SourceContractCid: rustContractCID[p.rustName],
+			// Placeholder: the orchestrator rewrites this to the
+			// counterpart's memento CID after minting all contracts.
+			// Tests that walk the collected BridgeDeclaration directly
+			// (without going through the orchestrator) see the
+			// counterpart NAME here so the bridge is still self-
+			// describing; orchestrator code knows the convention.
+			TargetContractCid: pendingTargetContractCidPlaceholder(p.goCounterpart),
+			TargetProofCid:    LiftPluginGoTargetProofCIDPlaceholder,
+			TargetLayer:       "go-kit",
+			Notes:             "lift-plugin-protocol conformance bridge; phase 2",
+		})
+	}
+}
+
+// pendingTargetContractCidPlaceholder embeds the go counterpart
+// contract NAME inside a sentinel CID-shaped string. The orchestrator
+// recognizes the "pending-go-counterpart:" prefix and rewrites the
+// field to the real memento CID after all counterpart contracts have
+// been minted. The shape is still a string, so JCS encoding succeeds
+// and the bridge is structurally well-formed.
+func pendingTargetContractCidPlaceholder(counterpartName string) string {
+	return "pending-go-counterpart:" + counterpartName
+}
+
+// PendingTargetContractCidPrefix is exported so the orchestrator can
+// detect-and-resolve the placeholder set by
+// InvariantsLiftPluginProtocolBridges.
+const PendingTargetContractCidPrefix = "pending-go-counterpart:"
+
+// BuildLiftPluginProtocolBridges constructs the 10 BridgeDeclarations
+// directly (without going through the kit collector). Used by the
+// pinned-hash test and any cross-kit consumer that wants the bridges
+// as values rather than collected declarations.
+//
+// Returned bridges have:
+//   - SourceContractCid set to the rust memento CID (frozen).
+//   - TargetContractCid set to the pending placeholder (the orchestrator
+//     resolves this at mint time).
+//   - TargetProofCid set to LiftPluginGoTargetProofCIDPlaceholder
+//     ("deferred:phase-3-proof-bundle").
+//
+// Bridges are returned in stable declaration order.
+func BuildLiftPluginProtocolBridges() []ir.BridgeDeclaration {
+	pairs := liftPluginBridgePairs()
+	out := make([]ir.BridgeDeclaration, len(pairs))
+	for i, p := range pairs {
+		out[i] = ir.BridgeDeclaration{
+			Name:              p.bridgeName,
+			SourceSymbol:      p.rustName,
+			SourceLayer:       "rust-kit",
+			SourceContractCid: rustContractCID[p.rustName],
+			TargetContractCid: pendingTargetContractCidPlaceholder(p.goCounterpart),
+			TargetProofCid:    LiftPluginGoTargetProofCIDPlaceholder,
+			TargetLayer:       "go-kit",
+			Notes:             "lift-plugin-protocol conformance bridge; phase 2",
+		}
+	}
+	return out
+}

--- a/implementations/go/provekit-self-contracts/slabs/lift_plugin_protocol_test.go
+++ b/implementations/go/provekit-self-contracts/slabs/lift_plugin_protocol_test.go
@@ -1,0 +1,163 @@
+package slabs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+)
+
+// pinnedLiftPluginBridgesBundleCID freezes the BLAKE3-512 of the
+// JCS-canonical bytes of the 10 phase-2 cross-kit bridges. Computed at
+// PR-authoring time over the BridgeDeclaration array returned by
+// BuildLiftPluginProtocolBridges() with TargetContractCid carrying the
+// `pending-go-counterpart:<name>` placeholder (the orchestrator
+// rewrites these at mint time; the placeholder shape IS what's frozen
+// here so the bridge-list itself is content-addressable independent of
+// the transient go bundle's internal CIDs).
+//
+// Drift in any of the following invalidates this hash:
+//   - rust contract memento CID for any of the 10 lift-plugin-protocol
+//     contracts (rustContractCID map in lift_plugin_protocol.go)
+//   - bridge name spelling (bridge_to_<rust_name>)
+//   - go counterpart name spelling (go_<rust_name>)
+//   - sourceLayer / targetLayer / notes literals
+//   - LiftPluginGoTargetProofCIDPlaceholder ("deferred:phase-3-proof-bundle")
+//   - declaration order
+//   - JCS emitter / Go MarshalJSON emitter
+//
+// Verified against:
+//   - Rust contract CIDs extracted from `cargo run -p
+//     provekit-self-contracts --bin mint-self-contracts /tmp/<dir>` at
+//     bundle CID
+//     blake3-512:a6dcf733721f902c77c19a2e818e7638e37c0f9e6254ac607a39f6
+//     8584aba2c9442b204fe536f25713988e271e684a8585f10d991fefa
+//     08df7e99a8a3df7f60e
+const pinnedLiftPluginBridgesBundleCID = "blake3-512:8b6e76853d7b54d0de3b72b07b21b77d7fdfc39b9d26aebccaab0d466ada88c09067a0ddcb34c6918e90c83d220e4a6f2b373463927c956d50e74940dd7d6599"
+
+// TestLiftPluginBridgePairsCount ensures all 10 expected bridge pairs
+// are declared exactly once.
+func TestLiftPluginBridgePairsCount(t *testing.T) {
+	pairs := liftPluginBridgePairs()
+	if len(pairs) != 10 {
+		t.Fatalf("liftPluginBridgePairs(): want 10 pairs, got %d", len(pairs))
+	}
+
+	// Every rust source name must appear in the rustContractCID map.
+	for _, p := range pairs {
+		if _, ok := rustContractCID[p.rustName]; !ok {
+			t.Errorf("rust name %q has no entry in rustContractCID map", p.rustName)
+		}
+		if !strings.HasPrefix(p.bridgeName, "bridge_to_lift_plugin_") {
+			t.Errorf("bridge %q must start with 'bridge_to_lift_plugin_'", p.bridgeName)
+		}
+		if !strings.HasPrefix(p.goCounterpart, "go_lift_plugin_") {
+			t.Errorf("counterpart %q must start with 'go_lift_plugin_'", p.goCounterpart)
+		}
+	}
+
+	// rustContractCID has exactly 10 entries (one per bridge).
+	if len(rustContractCID) != 10 {
+		t.Errorf("rustContractCID: want 10 entries, got %d", len(rustContractCID))
+	}
+}
+
+// TestLiftPluginRustContractCIDsAreBlake3_512 validates that every
+// frozen rust contract CID is well-formed: prefixed with "blake3-512:"
+// and 128 lowercase hex chars after the prefix.
+func TestLiftPluginRustContractCIDsAreBlake3_512(t *testing.T) {
+	const wantPrefix = "blake3-512:"
+	for name, cid := range rustContractCID {
+		if !strings.HasPrefix(cid, wantPrefix) {
+			t.Errorf("rust CID for %q missing %q prefix: %s", name, wantPrefix, cid)
+			continue
+		}
+		hex := strings.TrimPrefix(cid, wantPrefix)
+		if len(hex) != 128 {
+			t.Errorf("rust CID for %q: hex length %d, want 128", name, len(hex))
+		}
+		for _, c := range hex {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				t.Errorf("rust CID for %q: non-lowercase-hex char %q", name, c)
+				break
+			}
+		}
+	}
+}
+
+// TestBuildLiftPluginProtocolBridgesShape validates the structural
+// invariants of every BridgeDeclaration returned by
+// BuildLiftPluginProtocolBridges. Independent of the JCS pin so a shape
+// drift surfaces here with a clear message before the hash test sees it.
+func TestBuildLiftPluginProtocolBridgesShape(t *testing.T) {
+	bridges := BuildLiftPluginProtocolBridges()
+	if len(bridges) != 10 {
+		t.Fatalf("BuildLiftPluginProtocolBridges(): want 10 bridges, got %d", len(bridges))
+	}
+
+	for _, b := range bridges {
+		if b.Name == "" {
+			t.Errorf("bridge: empty Name")
+		}
+		if !strings.HasPrefix(b.Name, "bridge_to_lift_plugin_") {
+			t.Errorf("bridge %q: Name must start with 'bridge_to_lift_plugin_'", b.Name)
+		}
+		if b.SourceLayer != "rust-kit" {
+			t.Errorf("bridge %q: SourceLayer = %q, want rust-kit", b.Name, b.SourceLayer)
+		}
+		if b.TargetLayer != "go-kit" {
+			t.Errorf("bridge %q: TargetLayer = %q, want go-kit", b.Name, b.TargetLayer)
+		}
+		if b.SourceContractCid == "" {
+			t.Errorf("bridge %q: SourceContractCid must be set (rust memento CID)", b.Name)
+		}
+		if !strings.HasPrefix(b.SourceContractCid, "blake3-512:") {
+			t.Errorf("bridge %q: SourceContractCid must be blake3-512:; got %q", b.Name, b.SourceContractCid)
+		}
+		if !strings.HasPrefix(b.TargetContractCid, PendingTargetContractCidPrefix) {
+			t.Errorf("bridge %q: TargetContractCid must carry pending placeholder; got %q",
+				b.Name, b.TargetContractCid)
+		}
+		if b.TargetProofCid != LiftPluginGoTargetProofCIDPlaceholder {
+			t.Errorf("bridge %q: TargetProofCid = %q, want %q",
+				b.Name, b.TargetProofCid, LiftPluginGoTargetProofCIDPlaceholder)
+		}
+		if b.Notes != "lift-plugin-protocol conformance bridge; phase 2" {
+			t.Errorf("bridge %q: Notes = %q, want phase-2 marker", b.Name, b.Notes)
+		}
+	}
+}
+
+// TestLiftPluginBridgesPinnedJCSHash freezes the BLAKE3-512 of the
+// JCS-canonical bytes of the BridgeDeclaration array. Drift here is
+// load-bearing: any change to a rust contract memento CID, a bridge
+// name, layer string, notes, or the placeholder shape ripples through
+// to a different hash. The orchestrator's resolved-CID path (where
+// TargetContractCid gets rewritten to the real go counterpart memento
+// CID) deliberately produces a DIFFERENT hash and is intentionally not
+// pinned here: that hash is the go bundle's catalog CID, attested
+// separately under .provekit/self-contracts-attestations/go.json.
+func TestLiftPluginBridgesPinnedJCSHash(t *testing.T) {
+	bridges := BuildLiftPluginProtocolBridges()
+
+	// Convert to the Declaration-array shape that ir.MarshalDeclarations
+	// expects.
+	decls := make([]ir.Declaration, len(bridges))
+	for i, b := range bridges {
+		decls[i] = b
+	}
+
+	jcsBytes, err := ir.MarshalDeclarations(decls)
+	if err != nil {
+		t.Fatalf("MarshalDeclarations: %v", err)
+	}
+
+	got := canonicalizer.ComputeCID(jcsBytes)
+	if got != pinnedLiftPluginBridgesBundleCID {
+		t.Fatalf("phase-2 bridges JCS hash drift:\n  pinned: %s\n  actual: %s\n\n"+
+			"If this drift is intentional, update pinnedLiftPluginBridgesBundleCID "+
+			"and re-sign the go self-contracts attestation in a follow-up.",
+			pinnedLiftPluginBridgesBundleCID, got)
+	}
+}

--- a/implementations/go/provekit-self-contracts/slabs/slabs.go
+++ b/implementations/go/provekit-self-contracts/slabs/slabs.go
@@ -65,5 +65,21 @@ func Slabs() []Slab {
 		{Label: "proof_builder", Path: "proof_envelope/builder.go", Run: InvariantsProofBuilder},
 		{Label: "proof_cbor", Path: "proof_envelope/cbor.go", Run: InvariantsProofCBOR},
 		{Label: "load_all_proofs", Path: "verifier/load_all_proofs.go", Run: InvariantsLoadAllProofs},
+		// Phase-2 cross-kit bridges to rust's lift-plugin-protocol contracts.
+		// Two slabs: counterpart contracts first, then bridges. The order
+		// is load-bearing for the orchestrator's post-mint resolution
+		// pass: every counterpart contract MUST be minted before the
+		// bridges are processed so the placeholder targetContractCid
+		// values can be rewritten to real memento CIDs.
+		{
+			Label: "lift_plugin_protocol_contracts",
+			Path:  "provekit-self-contracts/slabs/lift_plugin_protocol.go",
+			Run:   InvariantsLiftPluginProtocolContracts,
+		},
+		{
+			Label: "lift_plugin_protocol_bridges",
+			Path:  "provekit-self-contracts/slabs/lift_plugin_protocol.go",
+			Run:   InvariantsLiftPluginProtocolBridges,
+		},
 	}
 }


### PR DESCRIPTION
## Summary

Phase 2 of the cross-kit bridge work. PR #84 landed 10 contracts in `implementations/rust/provekit-self-contracts/src/lift_plugin_protocol.rs` (re-signed in PR #88). This PR ships the go-side counterpart contracts and bridges so the go kit content-addresses the same protocol obligations.

## What changed

**New: `implementations/go/provekit-self-contracts/slabs/lift_plugin_protocol.go`**
* 10 go counterpart `ContractDeclaration`s, one per rust contract, mirroring rust's authoring shape.
* 10 `BridgeDeclaration`s linking each rust source contract to its go counterpart.
* Frozen rust contract memento CIDs (extracted from the rust .proof bundle at `blake3-512:a6dcf733721f902c77c19a2e818e7638e37c0f9e6254ac607a39f68584aba2c9442b204fe536f25713988e271e684a8585f10d991fefa08df7e99a8a3df7f60e`).

**New: `implementations/go/provekit-self-contracts/slabs/lift_plugin_protocol_test.go`**
* Pinned-hash test that JCS-encodes the 10 `BridgeDeclaration`s and asserts a frozen BLAKE3-512: `blake3-512:8b6e76853d7b54d0de3b72b07b21b77d7fdfc39b9d26aebccaab0d466ada88c09067a0ddcb34c6918e90c83d220e4a6f2b373463927c956d50e74940dd7d6599`.
* Structural shape tests over `BuildLiftPluginProtocolBridges()`.
* CID well-formedness checks (all 10 rust CIDs are blake3-512 + 128 lowercase hex).

**Modified: `cmd/mint-go-self-contracts/main.go`**
* `authoredSlab` now carries both `[]ContractDeclaration` and `[]BridgeDeclaration` (rust does this in `provekit-self-contracts/src/lib.rs:368-385`).
* Two-pass mint: PASS 1 mints contracts, PASS 2 resolves the `pending-go-counterpart:<name>` placeholder to the real go counterpart memento CID and mints bridges.

**Modified: `slabs/slabs.go`**
* Registers `lift_plugin_protocol_contracts` and `lift_plugin_protocol_bridges` slabs in stable order. Contract slab MUST run before the bridge slab so the placeholder resolution succeeds.

## Bridge / counterpart pairs

| Rust contract | Go counterpart | Bridge name |
| --- | --- | --- |
| `lift_plugin_initialize_protocol_version_match` | `go_lift_plugin_initialize_protocol_version_match` | `bridge_to_lift_plugin_initialize_protocol_version_match` |
| `lift_plugin_initialize_capabilities_authoring_surfaces_nonempty` | `go_lift_plugin_initialize_capabilities_authoring_surfaces_nonempty` | `bridge_to_lift_plugin_initialize_capabilities_authoring_surfaces_nonempty` |
| `lift_plugin_initialize_capabilities_ir_version_starts_with_v` | `go_lift_plugin_initialize_capabilities_ir_version_starts_with_v` | `bridge_to_lift_plugin_initialize_capabilities_ir_version_starts_with_v` |
| `lift_plugin_lift_request_surface_is_string` | `go_lift_plugin_lift_request_surface_is_string` | `bridge_to_lift_plugin_lift_request_surface_is_string` |
| `lift_plugin_lift_request_source_paths_nonempty` | `go_lift_plugin_lift_request_source_paths_nonempty` | `bridge_to_lift_plugin_lift_request_source_paths_nonempty` |
| `lift_plugin_lift_request_source_paths_each_nonempty` | `go_lift_plugin_lift_request_source_paths_each_nonempty` | `bridge_to_lift_plugin_lift_request_source_paths_each_nonempty` |
| `lift_plugin_lift_request_surface_in_capabilities` | `go_lift_plugin_lift_request_surface_in_capabilities` | `bridge_to_lift_plugin_lift_request_surface_in_capabilities` |
| `lift_plugin_lift_response_kind_in_set` | `go_lift_plugin_lift_response_kind_in_set` | `bridge_to_lift_plugin_lift_response_kind_in_set` |
| `lift_plugin_lift_response_ir_document_array` | `go_lift_plugin_lift_response_ir_document_array` | `bridge_to_lift_plugin_lift_response_ir_document_array` |
| `lift_plugin_diagnostic_field_is_array` | `go_lift_plugin_diagnostic_field_is_array` | `bridge_to_lift_plugin_diagnostic_field_is_array` |

## Design choice: `targetContractCid` placeholder

The pinned hash freezes the bridge declarations carrying `TargetContractCid = "pending-go-counterpart:<name>"`, NOT the resolved memento CID of the go counterpart. The orchestrator rewrites the field to the real CID at mint time before bundling (mirrors rust's `target_contract_name -> target_cid` resolution at `provekit-self-contracts/src/lib.rs:368-385`).

Why: the go counterpart contract memento CID depends on the go bundle's own minting (signer key, timestamp, body shape). Hardcoding it would couple the bridge declaration to the go bundle's own attestation in a way that prevents the bridge declaration from being content-addressable independent of the go bundle. The placeholder shape is what gets pinned; the bundle ships the resolved CIDs.

## Design choice: `targetProofCid = "deferred:phase-3-proof-bundle"`

Computing the go lift plugin's binary CID is phase-3 work (binary-attestation protocol per `protocol/specs/2026-05-02-binary-attestation-protocol.md`). The verifier accepts an empty string as the back-compat path, but a sentinel string is preferable: any verifier that tries to resolve `deferred:phase-3-proof-bundle` will fail loud with `BridgeTargetProofCidMismatch`, which is exactly the right signal that the bridge has not yet been bound to a real binary.

Note: there is no `provekit-lift-go` directory referenced in the prompt; the go lift plugin is the `--rpc` mode of `cmd/mint-go-self-contracts/main.go` (per `rpc.go` in the same package). The bridge sets `targetLayer = "go-kit"` regardless.

## Drift expected (needs follow-up)

Running `make mint-go` after this PR produces a NEW go bundle catalog CID:

```
blake3-512:3d676a5f391421dc5c50f785a4f89d264fa43a7988c470fca1bf4b0bf01eeecf705204fe90cd8aec25498e52e2bedb4b8ba5842720c6fab277bb24de2a1c2c00
```

This drifts from the existing `.provekit/self-contracts-attestations/go.json`. **A follow-up PR needs to re-sign the go attestation** (mirroring how PR #84 → PR #88 worked for rust). `make ci` and `make conformance` will fail at the go-attestation step until that follow-up lands; do not "fix" by editing the attestation file directly.

## Test plan

- [x] `go test ./slabs/ -v` passes (4 tests: pairs count, CID well-formedness, shape, pinned JCS hash).
- [x] `make test-go` passes across all go modules (no regressions).
- [x] `go run ./cmd/mint-go-self-contracts /tmp/<dir>` produces 67 members (57 contracts + 10 bridges) and passes the determinism check.
- [x] `gofmt -l` clean; `go vet ./...` clean.
- [x] No em-dashes or en-dashes added in diff.
- [ ] Reviewer to verify the placeholder design choice is acceptable.
- [ ] Follow-up: re-sign `.provekit/self-contracts-attestations/go.json` with the new bundle CID `blake3-512:3d676a5f...c2c00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)