### PR TITLE
fix(java): upgrade Bridge IR to v1.1.0 9-field shape (task #222)

### DIFF
--- a/implementations/java/provekit-ir/src/main/java/com/provekit/ir/Declaration.java
+++ b/implementations/java/provekit-ir/src/main/java/com/provekit/ir/Declaration.java
@@ -24,10 +24,41 @@ public sealed interface Declaration {
         }
     }
 
-    record Bridge(String sourceSymbol, String sourceContractCid, String targetContractCid, String evidence) implements Declaration {
+    /**
+     * BridgeDeclaration per IR formal grammar v1.1.0
+     * (protocol/specs/2026-04-30-ir-formal-grammar.md).
+     *
+     * Required fields: name, sourceSymbol, sourceLayer, sourceContractCid,
+     * targetContractCid, targetProofCid, targetLayer.
+     * Optional: notes (omitted from output when null).
+     *
+     * JCS canonical key order (RFC 8785, alphabetical by code unit):
+     * kind, name, [notes,] sourceContractCid, sourceLayer, sourceSymbol,
+     * targetContractCid, targetLayer, targetProofCid.
+     */
+    record Bridge(
+        String name,
+        String sourceSymbol,
+        String sourceLayer,
+        String sourceContractCid,
+        String targetContractCid,
+        String targetProofCid,
+        String targetLayer,
+        String notes
+    ) implements Declaration {
         public String toJson() {
-            StringBuilder sb = new StringBuilder("{\"kind\":\"bridge\",\"sourceSymbol\":\"" + Sort.escape(sourceSymbol) + "\",\"sourceContractCid\":\"" + Sort.escape(sourceContractCid) + "\",\"targetContractCid\":\"" + Sort.escape(targetContractCid) + "\"");
-            if (evidence != null) sb.append(",\"evidence\":\"").append(Sort.escape(evidence)).append("\"");
+            StringBuilder sb = new StringBuilder();
+            sb.append("{\"kind\":\"bridge\"");
+            sb.append(",\"name\":\"").append(Sort.escape(name)).append("\"");
+            if (notes != null) {
+                sb.append(",\"notes\":\"").append(Sort.escape(notes)).append("\"");
+            }
+            sb.append(",\"sourceContractCid\":\"").append(Sort.escape(sourceContractCid)).append("\"");
+            sb.append(",\"sourceLayer\":\"").append(Sort.escape(sourceLayer)).append("\"");
+            sb.append(",\"sourceSymbol\":\"").append(Sort.escape(sourceSymbol)).append("\"");
+            sb.append(",\"targetContractCid\":\"").append(Sort.escape(targetContractCid)).append("\"");
+            sb.append(",\"targetLayer\":\"").append(Sort.escape(targetLayer)).append("\"");
+            sb.append(",\"targetProofCid\":\"").append(Sort.escape(targetProofCid)).append("\"");
             sb.append("}");
             return sb.toString();
         }

--- a/implementations/java/provekit-ir/src/main/java/com/provekit/ir/IrDocument.java
+++ b/implementations/java/provekit-ir/src/main/java/com/provekit/ir/IrDocument.java
@@ -38,12 +38,37 @@ public class IrDocument {
             declarations.add(new Declaration.Property(name, params, body));
             return this;
         }
-        public Builder bridge(String sourceSymbol, String sourceCid, String targetCid) {
-            declarations.add(new Declaration.Bridge(sourceSymbol, sourceCid, targetCid, null));
+        /** v1.1.0 9-field bridge with no notes. */
+        public Builder bridge(
+            String name,
+            String sourceSymbol,
+            String sourceLayer,
+            String sourceContractCid,
+            String targetContractCid,
+            String targetProofCid,
+            String targetLayer
+        ) {
+            declarations.add(new Declaration.Bridge(
+                name, sourceSymbol, sourceLayer,
+                sourceContractCid, targetContractCid, targetProofCid, targetLayer,
+                null));
             return this;
         }
-        public Builder bridge(String sourceSymbol, String sourceCid, String targetCid, String evidence) {
-            declarations.add(new Declaration.Bridge(sourceSymbol, sourceCid, targetCid, evidence));
+        /** v1.1.0 9-field bridge including optional notes. */
+        public Builder bridge(
+            String name,
+            String sourceSymbol,
+            String sourceLayer,
+            String sourceContractCid,
+            String targetContractCid,
+            String targetProofCid,
+            String targetLayer,
+            String notes
+        ) {
+            declarations.add(new Declaration.Bridge(
+                name, sourceSymbol, sourceLayer,
+                sourceContractCid, targetContractCid, targetProofCid, targetLayer,
+                notes));
             return this;
         }
         public Builder contract(String symbol, Formula precondition, Formula postcondition) {

--- a/implementations/java/provekit-ir/src/test/java/com/provekit/ir/IrDocumentTest.java
+++ b/implementations/java/provekit-ir/src/test/java/com/provekit/ir/IrDocumentTest.java
@@ -39,12 +39,47 @@ public class IrDocumentTest {
 
     @Test
     public void testBridge() {
-        IrDocument doc = IrDocument.builder()
-            .bridge("parseInt", "bafy...js", "bafy...java")
-            .build();
+        Declaration.Bridge bridge = new Declaration.Bridge(
+            "myBridge",
+            "source",
+            "c-kit",
+            "bafySource",
+            "bafyTarget",
+            "bafyProof",
+            "coq",
+            null
+        );
 
-        String json = doc.toJson();
+        String json = bridge.toJson();
         assertTrue(json.contains("\"kind\":\"bridge\""));
-        assertTrue(json.contains("\"sourceSymbol\":\"parseInt\""));
+        assertTrue(json.contains("\"name\":\"myBridge\""));
+        assertTrue(json.contains("\"sourceSymbol\":\"source\""));
+        assertTrue(json.contains("\"sourceLayer\":\"c-kit\""));
+        assertTrue(json.contains("\"targetProofCid\":\"bafyProof\""));
+        assertTrue(json.contains("\"targetLayer\":\"coq\""));
+    }
+
+    /**
+     * Spec v1.1.0 — bridge_decl conformance fixture from conformance/fixtures.toml.
+     * The 9-field Bridge with optional notes must serialize to JCS-canonical
+     * (alphabetical key order) bytes that match the canonical fixture exactly.
+     */
+    @Test
+    public void testBridgeJcsRoundtripV110() {
+        Declaration.Bridge bridge = new Declaration.Bridge(
+            "myBridge",
+            "source",
+            "c-kit",
+            "bafySource",
+            "bafyTarget",
+            "bafyProof",
+            "coq",
+            "some notes"
+        );
+
+        String got = bridge.toJson();
+        String expected = "{\"kind\":\"bridge\",\"name\":\"myBridge\",\"notes\":\"some notes\",\"sourceContractCid\":\"bafySource\",\"sourceLayer\":\"c-kit\",\"sourceSymbol\":\"source\",\"targetContractCid\":\"bafyTarget\",\"targetLayer\":\"coq\",\"targetProofCid\":\"bafyProof\"}";
+
+        assertEquals(expected, got, "Bridge JCS bytes must match conformance/fixtures.toml bridge_decl");
     }
 }


### PR DESCRIPTION
## Summary

Upgrades Java's Bridge IR record at `implementations/java/provekit-ir/src/main/java/com/provekit/ir/Declaration.java` from the legacy 4-field shape (`sourceSymbol`, `sourceContractCid`, `targetContractCid`, `evidence`) to the v1.1.0 9-field `BridgeDeclaration` defined by `protocol/specs/2026-04-30-ir-formal-grammar.md`.

## Fields added

- `name` (required)
- `sourceLayer` (required)
- `targetProofCid` (required, the proof-pinning CID)
- `targetLayer` (required)
- `notes` (optional, omitted when null)

## Fields renamed/removed

- Removed `evidence` (legacy field, replaced by the proof-pinning CID model).
- Field set now matches Go (`property.go`), Zig (`root.zig`) Bridge serializers and the `bridge_decl` conformance fixture.

## Serialization

`Declaration.Bridge#toJson` emits JCS-canonical bytes in alphabetical key order: `kind, name, [notes,] sourceContractCid, sourceLayer, sourceSymbol, targetContractCid, targetLayer, targetProofCid`. This matches the `bridge_decl` JCS literal in `conformance/fixtures.toml` exactly.

## Round-trip test result

New `testBridgeJcsRoundtripV110` constructs a Bridge with all 9 fields (notes set to "some notes") and asserts byte-equality against the fixture literal. `IrDocument.Builder` ships two new `bridge(...)` overloads matching the new shape.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.provekit.ir.IrDocumentTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.123 s -- in com.provekit.ir.IrDocumentTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] BUILD SUCCESS
```

Full reactor `cd implementations/java && mvn test` is green across all 13 modules.

## Test plan

- [x] `cd implementations/java/provekit-ir && mvn test` (4/4)
- [x] `cd implementations/java && mvn test` (full reactor green)
- [x] Failing-first TDD: confirmed compile error against legacy 4-field record before changing source
- [x] No fixture, other-kit, or non-Bridge IR code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)