### PR TITLE
fix(ruby): marshal_declarations dispatches on contract vs bridge kind (task #223)

### DIFF
--- a/implementations/ruby/lib/provekit/ir.rb
+++ b/implementations/ruby/lib/provekit/ir.rb
@@ -78,6 +78,30 @@ module Provekit
       end
     end
 
+    # Bridge declaration. Locked spec key order:
+    #   kind, name, sourceSymbol, sourceLayer, sourceContractCid,
+    #   targetContractCid, targetProofCid, targetLayer, notes (optional).
+    # `notes` is OMITTED entirely when nil — never emitted as null.
+    # Ruby Struct fields are snake_case; the JSON keys are camelCase
+    # and produced by the marshaler, not by `to_h`.
+    Bridge = Struct.new(
+      :name,
+      :source_symbol,
+      :source_layer,
+      :source_contract_cid,
+      :target_contract_cid,
+      :target_proof_cid,
+      :target_layer,
+      :notes,
+      keyword_init: true,
+    ) do
+      def initialize(name:, source_symbol:, source_layer:,
+                     source_contract_cid:, target_contract_cid:,
+                     target_proof_cid:, target_layer:, notes: nil)
+        super
+      end
+    end
+
     # ── JCS canonical JSON emitter ──────────────────────────────
 
     module Jcs
@@ -157,15 +181,36 @@ module Provekit
 
     def self.marshal_declarations(decls)
       arr = decls.map do |d|
-        obj = {
-          kind: "contract",
-          name: d.name,
-          outBinding: d.out_binding,
-        }
-        obj[:pre]  = d.pre  if d.pre
-        obj[:post] = d.post if d.post
-        obj[:inv]  = d.inv  if d.inv
-        obj
+        case d
+        when Bridge
+          obj = {
+            kind: "bridge",
+            name: d.name,
+            sourceSymbol: d.source_symbol,
+            sourceLayer: d.source_layer,
+            sourceContractCid: d.source_contract_cid,
+            targetContractCid: d.target_contract_cid,
+            targetProofCid: d.target_proof_cid,
+            targetLayer: d.target_layer,
+          }
+          # `notes` is omitted entirely when nil; never emitted as null.
+          # This is the byte-equality rule that keeps every kit in sync
+          # (spec 2026-04-30-ir-formal-grammar.md §BridgeDeclaration).
+          obj[:notes] = d.notes if d.notes
+          obj
+        when ContractDecl
+          obj = {
+            kind: "contract",
+            name: d.name,
+            outBinding: d.out_binding,
+          }
+          obj[:pre]  = d.pre  if d.pre
+          obj[:post] = d.post if d.post
+          obj[:inv]  = d.inv  if d.inv
+          obj
+        else
+          raise "unknown declaration type: #{d.class}"
+        end
       end
       Jcs.encode(arr)
     end

--- a/implementations/ruby/test/test_jcs_conformance.rb
+++ b/implementations/ruby/test/test_jcs_conformance.rb
@@ -18,6 +18,13 @@ class TestJcsConformance < Minitest::Test
   EXPECTED_PATTERN1 =
     '{"body":{"kind":"implies","operands":[{"kind":"and","operands":[{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":100}],"kind":"atomic","name":"<"}]},{"args":[{"kind":"var","name":"x"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":0}],"kind":"atomic","name":"≥"}]},"kind":"forall","name":"x","sort":{"kind":"primitive","name":"Int"}}'
 
+  # Fixture: bridge_decl — single Bridge declaration object with all fields
+  # including optional `notes`. `marshal_declarations` wraps a single decl in
+  # a JSON array per the Document grammar (`"[" Declaration* "]"`), so the
+  # full expected output is `[FIXTURE]`.
+  BRIDGE_DECL_FIXTURE =
+    '{"kind":"bridge","name":"myBridge","notes":"some notes","sourceContractCid":"bafySource","sourceLayer":"c-kit","sourceSymbol":"source","targetContractCid":"bafyTarget","targetLayer":"coq","targetProofCid":"bafyProof"}'
+
   def test_eq_atomic
     formula = IR.atomic("=",
       IR.ctor("parse_int", IR.str("42")),
@@ -32,5 +39,20 @@ class TestJcsConformance < Minitest::Test
       IR.gte(x, IR.num(0)))
     formula = IR.forall(name: "x", sort: IR::Sort.Int, body: body)
     assert_equal EXPECTED_PATTERN1, IR::Jcs.encode(formula)
+  end
+
+  def test_bridge_decl_marshal
+    bridge = IR::Bridge.new(
+      name: "myBridge",
+      source_symbol: "source",
+      source_layer: "c-kit",
+      source_contract_cid: "bafySource",
+      target_contract_cid: "bafyTarget",
+      target_proof_cid: "bafyProof",
+      target_layer: "coq",
+      notes: "some notes",
+    )
+    expected = "[#{BRIDGE_DECL_FIXTURE}]"
+    assert_equal expected, IR.marshal_declarations([bridge])
   end
 end


### PR DESCRIPTION
## Summary
- Adds `Provekit::IR::Bridge` Struct with the 9 fields from the v1.1.0 spec (`kind`, `name`, `sourceSymbol`, `sourceLayer`, `sourceContractCid`, `targetContractCid`, `targetProofCid`, `targetLayer`, optional `notes`).
- `marshal_declarations` now dispatches on `Bridge` vs `ContractDecl` and emits the right `kind` field and field set; `notes` is omitted entirely when nil (never emitted as `null`) per the spec's byte-equality rule.
- New minitest `test_bridge_decl_marshal` asserts byte equality of `marshal_declarations([bridge])` against the conformance fixture wrapped in the array literal the `Document` grammar requires.

## Test plan
- [x] `cd implementations/ruby && /usr/local/opt/ruby/bin/ruby -Ilib -Itest test/test_jcs_conformance.rb` — 3 runs, 3 assertions, 0 failures.
- [x] Failing test was written first (TDD); error was `NameError: uninitialized constant Provekit::IR::Bridge` until the Struct was added.
- [x] Existing `test_eq_atomic` and `test_pattern1_bounded_loop` still pass — `ContractDecl` callers (`bin/provekit-lsp-ruby`, `lib/provekit/lift/active_model.rb`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)