### PR TITLE
fix(csharp): add v1.1.0 9-field BridgeDeclaration record (task #224)

### DIFF
--- a/implementations/csharp/Provekit.IR/Bridge.cs
+++ b/implementations/csharp/Provekit.IR/Bridge.cs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// v1.1.0 spec-shaped BridgeDeclaration. Mirrors the
+// `Declaration::Bridge` variant in
+// implementations/rust/provekit-ir-types/src/lib.rs and the
+// `bridge_decl` fixture in conformance/fixtures.toml.
+//
+// Per protocol/specs/2026-04-30-ir-formal-grammar.md (BridgeDeclaration),
+// the wire form is a 9-field object:
+//
+//   {
+//     "kind":              "bridge",
+//     "name":              <string>,
+//     "sourceSymbol":      <string>,
+//     "sourceLayer":       <string>,
+//     "sourceContractCid": <CID>,
+//     "targetContractCid": <CID>,
+//     "targetProofCid":    <CID>,
+//     "targetLayer":       <string>,
+//     "notes":             <string?, optional>
+//   }
+//
+// `notes` is omitted from the JCS output when null (matches the Rust
+// peer's `skip_serializing_if = "Option::is_none"`).
+//
+// This record is DISTINCT from `Provekit.IR.BridgeDecl` in Collector.cs,
+// which is a lift-adapter helper carrying TargetContractName /
+// IrArgSorts / IrReturnSort. They serve different purposes and coexist
+// by design; do not unify them.
+
+namespace Provekit.IR;
+
+public sealed record BridgeDeclaration(
+    string Name,
+    string SourceSymbol,
+    string SourceLayer,
+    string SourceContractCid,
+    string TargetContractCid,
+    string TargetProofCid,
+    string TargetLayer,
+    string? Notes = null);

--- a/implementations/csharp/Provekit.IR/Serialize.cs
+++ b/implementations/csharp/Provekit.IR/Serialize.cs
@@ -99,6 +99,41 @@ public static class Serialize
         _ => throw new InvalidOperationException($"unknown formula kind: {f.GetType()}"),
     };
 
+    // ----- v1.1.0 BridgeDeclaration → canonicalizer Value ---------------
+    //
+    // Spec wire form (protocol/specs/2026-04-30-ir-formal-grammar.md
+    // §BridgeDeclaration; pinned by `bridge_decl` in
+    // conformance/fixtures.toml):
+    //
+    //   { "kind": "bridge", "name", "sourceSymbol", "sourceLayer",
+    //     "sourceContractCid", "targetContractCid", "targetProofCid",
+    //     "targetLayer", "notes"? }
+    //
+    // Insertion order here is irrelevant — `Jcs.Encode` re-sorts keys to
+    // Unicode code-point order at emit time (same discipline as
+    // `FormulaToValue`). `Notes` is omitted when null so JCS doesn't
+    // emit `"notes":null`; this matches the Rust peer's
+    // `skip_serializing_if = "Option::is_none"`.
+    public static V BridgeDeclarationToValue(BridgeDeclaration b)
+    {
+        var entries = new List<KeyValuePair<string, V>>(9)
+        {
+            new("kind", V.String("bridge")),
+            new("name", V.String(b.Name)),
+            new("sourceSymbol", V.String(b.SourceSymbol)),
+            new("sourceLayer", V.String(b.SourceLayer)),
+            new("sourceContractCid", V.String(b.SourceContractCid)),
+            new("targetContractCid", V.String(b.TargetContractCid)),
+            new("targetProofCid", V.String(b.TargetProofCid)),
+            new("targetLayer", V.String(b.TargetLayer)),
+        };
+        if (b.Notes is not null)
+        {
+            entries.Add(new("notes", V.String(b.Notes)));
+        }
+        return V.Object(entries);
+    }
+
     // ----- to insertion-order JSON (mirrors C++ marshal_declarations) ---
 
     public static string MarshalDeclarations(IReadOnlyList<ContractDecl> decls)

--- a/implementations/csharp/Provekit.Tests/BridgeDeclarationConformanceTests.cs
+++ b/implementations/csharp/Provekit.Tests/BridgeDeclarationConformanceTests.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cross-language conformance test for Provekit.IR.BridgeDeclaration
+// (the v1.1.0 spec-shaped 9-field record).
+//
+// Fixture: `bridge_decl` from conformance/fixtures.toml.
+// See protocol/specs/2026-04-30-ir-formal-grammar.md (BridgeDeclaration).
+//
+// Build the BridgeDeclaration with all 9 fields, JCS-encode through the
+// canonicalizer Value tree, and assert byte-equality against the fixture
+// JCS literal. JCS sorts keys at emit time, so insertion order in the
+// emitter is irrelevant; the test pins the wire form.
+//
+// This is the spec record, NOT the lift-helper BridgeDecl in Collector.cs
+// (which carries TargetContractName / IrArgSorts / IrReturnSort, a
+// different shape used by the lift adapter). They coexist by design.
+
+using Provekit.Canonicalizer;
+using Provekit.IR;
+using Xunit;
+
+namespace Provekit.Tests;
+
+public class BridgeDeclarationConformanceTests
+{
+    // From conformance/fixtures.toml [[fixture]] name = "bridge_decl".
+    // JCS-sorted keys: kind, name, notes, sourceContractCid, sourceLayer,
+    // sourceSymbol, targetContractCid, targetLayer, targetProofCid.
+    private const string ExpectedFixtureJcs =
+        @"{""kind"":""bridge""," +
+        @"""name"":""myBridge""," +
+        @"""notes"":""some notes""," +
+        @"""sourceContractCid"":""bafySource""," +
+        @"""sourceLayer"":""c-kit""," +
+        @"""sourceSymbol"":""source""," +
+        @"""targetContractCid"":""bafyTarget""," +
+        @"""targetLayer"":""coq""," +
+        @"""targetProofCid"":""bafyProof""}";
+
+    [Fact]
+    public void BridgeDeclaration_AllFields_MatchesFixtureJcs()
+    {
+        var b = new BridgeDeclaration(
+            Name: "myBridge",
+            SourceSymbol: "source",
+            SourceLayer: "c-kit",
+            SourceContractCid: "bafySource",
+            TargetContractCid: "bafyTarget",
+            TargetProofCid: "bafyProof",
+            TargetLayer: "coq",
+            Notes: "some notes");
+
+        var v = Serialize.BridgeDeclarationToValue(b);
+        var bytes = Jcs.Encode(v);
+
+        Assert.Equal(ExpectedFixtureJcs, bytes);
+    }
+
+    [Fact]
+    public void BridgeDeclaration_OmittedNotes_DoesNotEmitNotesKey()
+    {
+        // notes is optional: when absent, the JCS output must not include
+        // a "notes" key at all (no `"notes":null`, no empty string). The
+        // spec marks it `<string?, optional>`; serde on the Rust peer uses
+        // `skip_serializing_if = "Option::is_none"`. We mirror that.
+        var b = new BridgeDeclaration(
+            Name: "myBridge",
+            SourceSymbol: "source",
+            SourceLayer: "c-kit",
+            SourceContractCid: "bafySource",
+            TargetContractCid: "bafyTarget",
+            TargetProofCid: "bafyProof",
+            TargetLayer: "coq",
+            Notes: null);
+
+        var v = Serialize.BridgeDeclarationToValue(b);
+        var bytes = Jcs.Encode(v);
+
+        Assert.DoesNotContain("notes", bytes);
+        Assert.DoesNotContain("null", bytes);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Provekit.IR.BridgeDeclaration`, the v1.1.0 spec-shaped 9-field record per `protocol/specs/2026-04-30-ir-formal-grammar.md` and `bridge_decl` in `conformance/fixtures.toml`.
- Adds `Serialize.BridgeDeclarationToValue` (canonicalizer `Value` tree, JCS sorts at emit time, `notes` omitted when null to match Rust peer's `skip_serializing_if = "Option::is_none"`).
- The existing `Provekit.IR.BridgeDecl` lift-adapter helper in `Collector.cs` is untouched; the two coexist by design.

## Test plan

- [x] `BridgeDeclarationConformanceTests.BridgeDeclaration_AllFields_MatchesFixtureJcs` asserts byte-equality vs the `bridge_decl` fixture JCS literal
- [x] `BridgeDeclarationConformanceTests.BridgeDeclaration_OmittedNotes_DoesNotEmitNotesKey` pins the optional-notes contract (no `"notes":null`)
- [x] `cd implementations/csharp && dotnet test --nologo` green: 44/44 in `Provekit.Tests`, 8/8 in `Provekit.Lift.DataAnnotations`, 9/9 in `Provekit.Lift.Linq.Tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)