### PR TITLE
chore(protocol): cut catalog v1.4.0 — substrate layering + 3 metadata-extension specs

### DIFF
--- a/.provekit/catalog-signatures/v1.4.0.json
+++ b/.provekit/catalog-signatures/v1.4.0.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1",
+  "protocolName": "provekit-protocol",
+  "protocolVersion": "v1.4.0",
+  "catalogCid": "blake3-512:b0f2030d56c2fddf0ecbd7032bf0344c43e30677930e3b77188fcdc4ca6325d34649e51b2efa97d6985e4be6c43173f803254a7b05fc8bf31b92eb399b60f52f",
+  "declaredAt": "2026-05-03T15:00:00Z",
+  "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+  "signature": "ed25519:QK9oaU/1JpgR6kWXC2AxVDb1JQlyuC77C05Q6/x8/XTplwf336Z/a017lO1WfIkiwLm/EGr/gn041wqsqFPZAA=="
+}

--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,11 @@
 # binary-specific elaboration. The source tree no longer carries
 # machine-local truth about its own bytes for any of the five peer kits.
 #
-# `CATALOG_CID` is bumped to v1.3.1 here; the constant remains because
+# `CATALOG_CID` is bumped to v1.4.0 here; the constant remains because
 # `make help` echoes it. Follow-up: retire it the same way the
 # self-contracts CIDs are retired (read from the embedded catalog
 # signature attestation).
-CATALOG_CID := blake3-512:dab2eca97eaea7cc107b1ff3f2326094d804a5e91749bf8e9caa36cd049dc0ae1cb65afb353af8fcd271f87e9e0fc7e7710ec6a68666da6a11f802bc304ff799
+CATALOG_CID := blake3-512:b0f2030d56c2fddf0ecbd7032bf0344c43e30677930e3b77188fcdc4ca6325d34649e51b2efa97d6985e4be6c43173f803254a7b05fc8bf31b92eb399b60f52f
 
 PROVEKIT := implementations/rust/target/release/provekit
 VERIFY_SELF_CONTRACTS := tools/foundation-keygen/target/release/verify-self-contracts
@@ -83,7 +83,7 @@ help:
 	@echo "Maintenance:"
 	@echo "  make clean          remove build artifacts"
 	@echo ""
-	@echo "Pinned CIDs (catalog v1.3.1):"
+	@echo "Pinned CIDs (catalog v1.4.0):"
 	@echo "  catalog: $(CATALOG_CID)"
 	@echo "  rust:    (envelope) $(SELF_CONTRACTS_ATTEST_DIR)/rust.json"
 	@echo "  go:      (envelope) $(SELF_CONTRACTS_ATTEST_DIR)/go.json"

--- a/docs/launch/bluepaper.md
+++ b/docs/launch/bluepaper.md
@@ -11,8 +11,8 @@ The reader verifies this document's authority by computing the BLAKE3-512 hash o
 ## §0. Pinned authority
 
 ```
-protocol catalog (v1.3.1)
-  blake3-512:dab2eca97eaea7cc107b1ff3f2326094d804a5e91749bf8e9caa36cd049dc0ae1cb65afb353af8fcd271f87e9e0fc7e7710ec6a68666da6a11f802bc304ff799
+protocol catalog (v1.4.0)
+  blake3-512:b0f2030d56c2fddf0ecbd7032bf0344c43e30677930e3b77188fcdc4ca6325d34649e51b2efa97d6985e4be6c43173f803254a7b05fc8bf31b92eb399b60f52f
 ```
 
 This is `BLAKE3-512(JCS(catalog-json))`, not `BLAKE3-512(catalog-file-bytes)`. The catalog is canonicalized first per RFC 8785 (sorted keys, no whitespace, deterministic number form), then hashed. Anything else gets a different number.
@@ -317,7 +317,7 @@ lattice tractability theorem   blake3-512:b6d7c2772c2929294d7f516f79559bd292e44f
 memento envelope grammar       blake3-512:58bba3e1a9f6439eac5cb0c681faf65d38de9e6b8ad539854acda451ca67562a9d238eb95a5d7df2c0776657015fa026c51059dff61e1ba9aa2438b57425d6a5
 proof substrate                blake3-512:ad53d6c59ee08270a48715376cc211f964ff44a55b3318d68a402e9c915ff593d5a5bbbd424f7777e2bcfe89d6c5bd2b49efcb5aae7de24752f3bcabb90484ae
 proof file format              blake3-512:7bb4589af25c6c3992520494869bbbe4cfbcf7a77b91ebd61d6327e78699ef16cd5bc34afbe4cdf88a717c055c16536b5106bc4dca2d9d6b5cfcc1eede68e1b3
-protocol catalog (v1.3.1)      blake3-512:dab2eca97eaea7cc107b1ff3f2326094d804a5e91749bf8e9caa36cd049dc0ae1cb65afb353af8fcd271f87e9e0fc7e7710ec6a68666da6a11f802bc304ff799
+protocol catalog (v1.4.0)      blake3-512:b0f2030d56c2fddf0ecbd7032bf0344c43e30677930e3b77188fcdc4ca6325d34649e51b2efa97d6985e4be6c43173f803254a7b05fc8bf31b92eb399b60f52f
 self-contracts (stable; v1.1.0+)        blake3-512:a0f58941758d709739759cf166bf9cb73794958144e213eccfb28fbf5791ca824ce53da0c6ba801cca2b53400324a094f510d4bbc41bc6b73b17e486ad3838ab
 signatures and non-repudiation blake3-512:8b71229fcb7413f18a93a9b260012298311c1ce754850ee717780c181f1fda39a6600b2e5069e775cd7dd15e8c81e40b47bf7585aa0b23ab76c112c85116365c
 ```
@@ -386,6 +386,8 @@ v1.2.0 (2026-04-30): additive bump over v1.1.0. Adds four pluggability protocols
 v1.3.0 (2026-05-02): additive bump over v1.2.0. Adds four protocol enrichments and two new specs. (1) BridgeDeclaration gains `sourceContractCid` + `targetProofCid` for hash-bounded cross-bundle witness pinning. (2) ProofEnvelope catalog memento gains optional `binaryCid` for supply-chain anchoring (rule 5 is MAY in v1.3.0; promotion to MUST awaits a reference verifier in v1.4.0). (3) ProofEnvelope catalog memento gains optional `metadata` map for non-normative tooling/diagnostics. (4) `EvidenceTerm` proof-certificate carrier for `smt-lib`/`coq`/`custom` proof types. New specs: `correctness-is-a-hash` (the memcmp theorem) and `lsp-protocol` (real-time IDE integration with pluggable JSON-RPC backend). All v1.2.0 mementos and `.proof` bundles remain valid; v1.2.0's CID `1e5cfee6...17d0579f` stays attestable for anyone pinned. Catalog CID `5a3129f4...205d24c7`. Signed under the same foundation key.
 
 v1.3.1 (2026-05-02): patch bump over v1.3.0. Re-sync only; no protocol-level changes. Absorbs `ir-formal-grammar` spec-CID drift introduced by PR #10 (the `Bridge target pinning: the shim-poisoning vector` normative example landed without a follow-up catalog cut). Property re-baked: `ir-formal-grammar` from `99f09163...e37cc4bb` to `fc26a82b...29b72f42c`. The other 19 spec CIDs are unchanged. All v1.3.0 mementos and `.proof` bundles remain valid; v1.3.0's CID `5a3129f4...205d24c7` stays attestable via `.provekit/catalog-signatures/v1.3.0.json` for anyone pinned. Catalog CID `dab2eca9...304ff799`. Signed under the same foundation key.
+
+v1.4.0 (2026-05-03): additive bump over v1.3.1. Substrate layering plus three metadata-extension specs. (1) `substrate-layers-envelope-header-body` formalizes envelope/header/body separation as v1.2 of the memento schema; substrate verifiers inspect envelope + header, body fields are carried but verifier-opaque. (2) `contract-cid-vs-attestation-cid` separates the contract's content CID from the attestation CID over `(contractCid, signer, declaredAt, ...)` so contract identity is stable across re-attestation. (3) `contract-set-extension` adds `contractSetCid` and `previousContractSetCid` body fields for ordered, append-only contract-set evolution under semver-minor rules. (4) `version-chains-pinning` adds the three-axis pinning convention (`contractCid`, `witnessCid`, `binaryCid`) carried in the body, plus the version-chain walk used by package-manager-replacement tooling. Per `substrate-layers-envelope-header-body` §4, all v1.3.x mementos and `.proof` bundles remain valid: v1.1 flat structure is read as `header = entire flat object` with synthetic empty `body`; new attestations MUST emit the layered shape. v1.3.1's CID `dab2eca9...304ff799` stays attestable via `.provekit/catalog-signatures/v1.3.1.json` for anyone pinned. Catalog CID `b0f2030d...399b60f52f`. Signed under the same foundation key.
 
 ---
 

--- a/implementations/rust/provekit-cli/assets/catalog-signature-v1.4.0.json
+++ b/implementations/rust/provekit-cli/assets/catalog-signature-v1.4.0.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1",
+  "protocolName": "provekit-protocol",
+  "protocolVersion": "v1.4.0",
+  "catalogCid": "blake3-512:b0f2030d56c2fddf0ecbd7032bf0344c43e30677930e3b77188fcdc4ca6325d34649e51b2efa97d6985e4be6c43173f803254a7b05fc8bf31b92eb399b60f52f",
+  "declaredAt": "2026-05-03T15:00:00Z",
+  "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+  "signature": "ed25519:QK9oaU/1JpgR6kWXC2AxVDb1JQlyuC77C05Q6/x8/XTplwf336Z/a017lO1WfIkiwLm/EGr/gn041wqsqFPZAA=="
+}

--- a/implementations/rust/provekit-cli/assets/protocol-catalog.json
+++ b/implementations/rust/provekit-cli/assets/protocol-catalog.json
@@ -1,7 +1,7 @@
 {
   "kind": "catalog",
   "name": "provekit-protocol",
-  "version": "v1.3.1-2026-05-02",
+  "version": "v1.4.0-2026-05-03",
   "algorithms": {
     "hash": [
       "blake3-512"
@@ -33,10 +33,15 @@
     "multi-solver-protocol": "blake3-512:71fc7ac22997938629d835f87e4e8a322026d77c1e1f834c9fbe0f79cca4e903792c628e96d3004c88d29706f4d87bc042ff837fef571c0cb3012495a03003d3",
     "lift-plugin-protocol": "blake3-512:fa5e47b0650b07a3d7d37e3efc0ec006d079224b23c601464a69fd91f6cbdb3e9adf4f2f1d54eb73c0f553c73750d4ca9349eeeba2ec9d47d081c52f6de263b6",
     "correctness-is-a-hash": "blake3-512:5a41e9ad8b0e63df400b93b77a0106468160fb2b92db4099fa5b757c3c5596176c5891365dbc6a8263a57ea8a42866eaa9e1a41fa3a43a5aadef4b21f851a845",
-    "lsp-protocol": "blake3-512:75cac55f568b7363c3ae839ffdd11dc26d1a54d84d26ba43fca770b3fe2f7eca6305f77dad22b6b9f5f0bdb1cf10dc6fadd815ee3bf1507bb1eba6f106ee22bc"
+    "lsp-protocol": "blake3-512:75cac55f568b7363c3ae839ffdd11dc26d1a54d84d26ba43fca770b3fe2f7eca6305f77dad22b6b9f5f0bdb1cf10dc6fadd815ee3bf1507bb1eba6f106ee22bc",
+    "contract-cid-vs-attestation-cid": "blake3-512:53e136d9af29ce80b690f90c484e90c60f66f28c483b2038e03e7c6f6055f637527deb205e5558b47487b7d89ead461348d5e8981f2e9e8ccb30edd8867d47db",
+    "contract-set-extension": "blake3-512:839e82096d04b1241ffa1f6158fcea6bfeb78f3836664a66a13ff11b3cde58d72e6c85bfc619ba1341f13b8375f655bdf5582b0eac91d27648f0048bee8f9867",
+    "substrate-layers-envelope-header-body": "blake3-512:a76c7d0d6a5fecde40f579a8566f0199f61d5e3f7a0d48561f0ef765b5983a31fc96bb21fe56ea667337341dc798e7370229722ee7535fe7e2c22d4f7dad97dd",
+    "version-chains-pinning": "blake3-512:281bf014f6f0ebc9a5d455329ee033ff8b7ee85e001bcbdcb45a62c14e43855892c46462789ccb74961859e708eae70829fdf736798c17f59f0239ef78dd7e45"
   },
-  "declaredAt": "2026-05-02T17:00:00Z",
-  "_unsigned": "v1.3.1 patch bump (re-sync only over v1.3.0): no protocol changes; absorbs ir-formal-grammar spec-CID drift introduced by PR #10 (the `Bridge target pinning: the shim-poisoning vector` normative example landed without a follow-up catalog cut). Property re-baked: `ir-formal-grammar` 99f09163...e37cc4bb -> fc26a82b...29b72f42c. All other 19 spec CIDs unchanged. v1.3.0 mementos and .proof bundles remain valid; v1.3.0's CID 5a3129f4...205d24c7 stays attestable via .provekit/catalog-signatures/v1.3.0.json for anyone pinned. Catalog signed under the same foundation v0 key.",
+  "declaredAt": "2026-05-03T15:00:00Z",
+  "_unsigned": "v1.4.0 minor bump (additive over v1.3.1): substrate layering plus three metadata-extension specs. (1) `substrate-layers-envelope-header-body` formalizes the envelope/header/body separation as v1.2 of the memento schema: substrate verifiers inspect envelope + header; body fields are carried but verifier-opaque. (2) `contract-cid-vs-attestation-cid` separates the contract's content CID from the attestation's CID over `(contractCid, signer, declaredAt, ...)`, so contract identity is stable across re-attestation. (3) `contract-set-extension` adds `contractSetCid` and `previousContractSetCid` body fields for ordered, append-only contract-set evolution under semver-minor rules. (4) `version-chains-pinning` adds the three-axis pinning convention (`contractCid`, `witnessCid`, `binaryCid`) carried in the body, plus the version-chain walk used by package-manager-replacement tooling. Per `substrate-layers-envelope-header-body` §4, all v1.3.x mementos and .proof bundles remain valid: v1.1 flat structure is read as `header = entire flat object` with synthetic empty `body`; new attestations MUST emit the layered shape. v1.3.1's CID `dab2eca9...304ff799` stays attestable via .provekit/catalog-signatures/v1.3.1.json for anyone pinned. Catalog signed under the same foundation v0 key.",
+  "_v1_3_1_unsigned": "v1.3.1 patch bump (re-sync only over v1.3.0): no protocol changes; absorbs ir-formal-grammar spec-CID drift introduced by PR #10 (the `Bridge target pinning: the shim-poisoning vector` normative example landed without a follow-up catalog cut). Property re-baked: `ir-formal-grammar` 99f09163...e37cc4bb -> fc26a82b...29b72f42c. All other 19 spec CIDs unchanged. v1.3.0 mementos and .proof bundles remain valid; v1.3.0's CID 5a3129f4...205d24c7 stays attestable via .provekit/catalog-signatures/v1.3.0.json for anyone pinned. Catalog signed under the same foundation v0 key.",
   "_v1_3_0_unsigned": "v1.3.0 minor bump (additive over v1.2.0): four protocol-additive enrichments + two new specs. (1) BridgeDeclaration gains `sourceContractCid` + `targetProofCid` fields for hash-bounded cross-bundle witness pinning. (2) Catalog memento gains optional `binaryCid` for supply-chain anchoring (rule 5 is MAY in v1.3.0; promotion to MUST awaits a reference verifier in v1.4.0). (3) Catalog memento gains optional `metadata` map for non-normative tooling/diagnostics. (4) `EvidenceTerm` proof-certificate carrier for `smt-lib`/`coq`/`custom` proof types. New specs: `correctness-is-a-hash` (the memcmp theorem) and `lsp-protocol` (real-time IDE integration with pluggable JSON-RPC backend). All v1.2.0 mementos and .proof bundles remain valid; the bump is purely additive. Catalog signed under the same foundation v0 key. v1.2.0 attestation (1e5cfee6...17d0579f) remains valid for anyone pinned.",
   "_v1_2_0_unsigned": "v1.2.0 minor bump (additive over v1.1.0): adds four pluggability protocols — agent-plugin-protocol (LSP-shape JSON-RPC seam for coding agents), ir-compiler-protocol (per-solver IR translators), multi-solver-protocol (single/chain/portfolio dispatch), lift-plugin-protocol (one Rust CLI + per-language plugins via stdio JSON-RPC). All four are additive: any v1.1.0 memento or .proof remains valid under v1.2.0. The reference CLI plugins ship for Rust + Go + C++; TypeScript is consumed via toolchain (vitest), not as a CLI peer. v1.1.0's own catalog CID (5b770182...19f05cd4) remains the version anyone pinned to it. v1.2.0's catalog is signed under the same foundation key.",
   "_breakingChanges": [],
@@ -64,5 +69,12 @@
     "ir-formal-grammar enrichment: 27 named formal invariants documented in FOL across Terms / Formulas / Declarations / Sorts / Reference Parser / Test sections",
     "contract-merge-semantics enrichment: cross-bundle merge clarifications",
     "lift-plugin-protocol enrichment: minor clarifications"
+  ],
+  "_v1_4_0_additiveChanges": [
+    "substrate-layers-envelope-header-body: formalizes the envelope/header/body separation as v1.2 of the memento schema; substrate verifiers inspect envelope + header, body fields are verifier-opaque",
+    "contract-cid-vs-attestation-cid: separates contract content CID from attestation CID so contract identity is stable across re-attestation",
+    "contract-set-extension: adds contractSetCid + previousContractSetCid body fields for ordered, append-only contract-set evolution under semver-minor rules",
+    "version-chains-pinning: three-axis pinning (contractCid, witnessCid, binaryCid) carried in the body, plus the version-chain walk used by package-manager-replacement tooling",
+    "all v1.3.x mementos and .proof bundles remain valid; v1.1 flat structure is read as header = entire flat object with synthetic empty body, per substrate-layers spec section 4"
   ]
 }

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -204,7 +204,7 @@ pub struct VerifyProtocolArgs {
     /// Also verify the signed catalog attestation (Ed25519 signature
     /// over the catalog's CID by the ProvekIt Foundation Root Key).
     /// Default uses the embedded `foundation-v0.pub` and embedded
-    /// `catalog-signature-v1.3.1.json`; override via `--pubkey-file`
+    /// `catalog-signature-v1.4.0.json`; override via `--pubkey-file`
     /// and `--signature-file`.
     #[arg(long)]
     pub signed: bool,

--- a/implementations/rust/provekit-cli/src/protocol.rs
+++ b/implementations/rust/provekit-cli/src/protocol.rs
@@ -19,9 +19,10 @@ use serde_json::Value as Json;
 /// The protocol catalog CID this CLI declares conformance to. Kept in
 /// sync with `protocol/specs/2026-04-30-protocol-versioning.md`. If
 /// the catalog changes, bump this string AND ship a new CLI.
-/// Currently: v1.3.1 (re-sync over v1.3.0; absorbs ir-formal-grammar drift).
+/// Currently: v1.4.0 (additive over v1.3.1: substrate layering plus 3
+/// metadata-extension specs; no breaking changes).
 pub const EXPECTED_CATALOG_CID: &str =
-    "blake3-512:dab2eca97eaea7cc107b1ff3f2326094d804a5e91749bf8e9caa36cd049dc0ae1cb65afb353af8fcd271f87e9e0fc7e7710ec6a68666da6a11f802bc304ff799";
+    "blake3-512:b0f2030d56c2fddf0ecbd7032bf0344c43e30677930e3b77188fcdc4ca6325d34649e51b2efa97d6985e4be6c43173f803254a7b05fc8bf31b92eb399b60f52f";
 
 /// Catalog JSON bytes embedded at compile time. The CLI never reads
 /// the on-disk spec file at runtime; `verify-protocol` recomputes from
@@ -39,12 +40,12 @@ pub const EMBEDDED_FOUNDATION_PUBKEY: &[u8] =
 
 /// Signed attestation bytes (the JSON object) embedded at compile
 /// time. Mirrors the committed
-/// `.provekit/catalog-signatures/v1.3.1.json` (current). The v1.3.0,
-/// v1.2.0, and v1.1.0 attestations remain on-disk and as embedded
-/// asset siblings for callers pinning to those versions; pass
+/// `.provekit/catalog-signatures/v1.4.0.json` (current). The v1.3.1,
+/// v1.3.0, v1.2.0, and v1.1.0 attestations remain on-disk and as
+/// embedded asset siblings for callers pinning to those versions; pass
 /// `--signature-file` + `--catalog` to verify against them explicitly.
 pub const EMBEDDED_CATALOG_SIGNATURE: &[u8] =
-    include_bytes!("../assets/catalog-signature-v1.3.1.json");
+    include_bytes!("../assets/catalog-signature-v1.4.0.json");
 
 /// Recompute the embedded catalog's CID using the same routine
 /// `tools/recompute-spec-cids` uses: parse JSON, JCS-encode, BLAKE3-512.

--- a/protocol/specs/2026-04-30-protocol-catalog.json
+++ b/protocol/specs/2026-04-30-protocol-catalog.json
@@ -1,7 +1,7 @@
 {
   "kind": "catalog",
   "name": "provekit-protocol",
-  "version": "v1.3.1-2026-05-02",
+  "version": "v1.4.0-2026-05-03",
   "algorithms": {
     "hash": [
       "blake3-512"
@@ -33,10 +33,15 @@
     "multi-solver-protocol": "blake3-512:71fc7ac22997938629d835f87e4e8a322026d77c1e1f834c9fbe0f79cca4e903792c628e96d3004c88d29706f4d87bc042ff837fef571c0cb3012495a03003d3",
     "lift-plugin-protocol": "blake3-512:fa5e47b0650b07a3d7d37e3efc0ec006d079224b23c601464a69fd91f6cbdb3e9adf4f2f1d54eb73c0f553c73750d4ca9349eeeba2ec9d47d081c52f6de263b6",
     "correctness-is-a-hash": "blake3-512:5a41e9ad8b0e63df400b93b77a0106468160fb2b92db4099fa5b757c3c5596176c5891365dbc6a8263a57ea8a42866eaa9e1a41fa3a43a5aadef4b21f851a845",
-    "lsp-protocol": "blake3-512:75cac55f568b7363c3ae839ffdd11dc26d1a54d84d26ba43fca770b3fe2f7eca6305f77dad22b6b9f5f0bdb1cf10dc6fadd815ee3bf1507bb1eba6f106ee22bc"
+    "lsp-protocol": "blake3-512:75cac55f568b7363c3ae839ffdd11dc26d1a54d84d26ba43fca770b3fe2f7eca6305f77dad22b6b9f5f0bdb1cf10dc6fadd815ee3bf1507bb1eba6f106ee22bc",
+    "contract-cid-vs-attestation-cid": "blake3-512:53e136d9af29ce80b690f90c484e90c60f66f28c483b2038e03e7c6f6055f637527deb205e5558b47487b7d89ead461348d5e8981f2e9e8ccb30edd8867d47db",
+    "contract-set-extension": "blake3-512:839e82096d04b1241ffa1f6158fcea6bfeb78f3836664a66a13ff11b3cde58d72e6c85bfc619ba1341f13b8375f655bdf5582b0eac91d27648f0048bee8f9867",
+    "substrate-layers-envelope-header-body": "blake3-512:a76c7d0d6a5fecde40f579a8566f0199f61d5e3f7a0d48561f0ef765b5983a31fc96bb21fe56ea667337341dc798e7370229722ee7535fe7e2c22d4f7dad97dd",
+    "version-chains-pinning": "blake3-512:281bf014f6f0ebc9a5d455329ee033ff8b7ee85e001bcbdcb45a62c14e43855892c46462789ccb74961859e708eae70829fdf736798c17f59f0239ef78dd7e45"
   },
-  "declaredAt": "2026-05-02T17:00:00Z",
-  "_unsigned": "v1.3.1 patch bump (re-sync only over v1.3.0): no protocol changes; absorbs ir-formal-grammar spec-CID drift introduced by PR #10 (the `Bridge target pinning: the shim-poisoning vector` normative example landed without a follow-up catalog cut). Property re-baked: `ir-formal-grammar` 99f09163...e37cc4bb -> fc26a82b...29b72f42c. All other 19 spec CIDs unchanged. v1.3.0 mementos and .proof bundles remain valid; v1.3.0's CID 5a3129f4...205d24c7 stays attestable via .provekit/catalog-signatures/v1.3.0.json for anyone pinned. Catalog signed under the same foundation v0 key.",
+  "declaredAt": "2026-05-03T15:00:00Z",
+  "_unsigned": "v1.4.0 minor bump (additive over v1.3.1): substrate layering plus three metadata-extension specs. (1) `substrate-layers-envelope-header-body` formalizes the envelope/header/body separation as v1.2 of the memento schema: substrate verifiers inspect envelope + header; body fields are carried but verifier-opaque. (2) `contract-cid-vs-attestation-cid` separates the contract's content CID from the attestation's CID over `(contractCid, signer, declaredAt, ...)`, so contract identity is stable across re-attestation. (3) `contract-set-extension` adds `contractSetCid` and `previousContractSetCid` body fields for ordered, append-only contract-set evolution under semver-minor rules. (4) `version-chains-pinning` adds the three-axis pinning convention (`contractCid`, `witnessCid`, `binaryCid`) carried in the body, plus the version-chain walk used by package-manager-replacement tooling. Per `substrate-layers-envelope-header-body` §4, all v1.3.x mementos and .proof bundles remain valid: v1.1 flat structure is read as `header = entire flat object` with synthetic empty `body`; new attestations MUST emit the layered shape. v1.3.1's CID `dab2eca9...304ff799` stays attestable via .provekit/catalog-signatures/v1.3.1.json for anyone pinned. Catalog signed under the same foundation v0 key.",
+  "_v1_3_1_unsigned": "v1.3.1 patch bump (re-sync only over v1.3.0): no protocol changes; absorbs ir-formal-grammar spec-CID drift introduced by PR #10 (the `Bridge target pinning: the shim-poisoning vector` normative example landed without a follow-up catalog cut). Property re-baked: `ir-formal-grammar` 99f09163...e37cc4bb -> fc26a82b...29b72f42c. All other 19 spec CIDs unchanged. v1.3.0 mementos and .proof bundles remain valid; v1.3.0's CID 5a3129f4...205d24c7 stays attestable via .provekit/catalog-signatures/v1.3.0.json for anyone pinned. Catalog signed under the same foundation v0 key.",
   "_v1_3_0_unsigned": "v1.3.0 minor bump (additive over v1.2.0): four protocol-additive enrichments + two new specs. (1) BridgeDeclaration gains `sourceContractCid` + `targetProofCid` fields for hash-bounded cross-bundle witness pinning. (2) Catalog memento gains optional `binaryCid` for supply-chain anchoring (rule 5 is MAY in v1.3.0; promotion to MUST awaits a reference verifier in v1.4.0). (3) Catalog memento gains optional `metadata` map for non-normative tooling/diagnostics. (4) `EvidenceTerm` proof-certificate carrier for `smt-lib`/`coq`/`custom` proof types. New specs: `correctness-is-a-hash` (the memcmp theorem) and `lsp-protocol` (real-time IDE integration with pluggable JSON-RPC backend). All v1.2.0 mementos and .proof bundles remain valid; the bump is purely additive. Catalog signed under the same foundation v0 key. v1.2.0 attestation (1e5cfee6...17d0579f) remains valid for anyone pinned.",
   "_v1_2_0_unsigned": "v1.2.0 minor bump (additive over v1.1.0): adds four pluggability protocols — agent-plugin-protocol (LSP-shape JSON-RPC seam for coding agents), ir-compiler-protocol (per-solver IR translators), multi-solver-protocol (single/chain/portfolio dispatch), lift-plugin-protocol (one Rust CLI + per-language plugins via stdio JSON-RPC). All four are additive: any v1.1.0 memento or .proof remains valid under v1.2.0. The reference CLI plugins ship for Rust + Go + C++; TypeScript is consumed via toolchain (vitest), not as a CLI peer. v1.1.0's own catalog CID (5b770182...19f05cd4) remains the version anyone pinned to it. v1.2.0's catalog is signed under the same foundation key.",
   "_breakingChanges": [],
@@ -64,5 +69,12 @@
     "ir-formal-grammar enrichment: 27 named formal invariants documented in FOL across Terms / Formulas / Declarations / Sorts / Reference Parser / Test sections",
     "contract-merge-semantics enrichment: cross-bundle merge clarifications",
     "lift-plugin-protocol enrichment: minor clarifications"
+  ],
+  "_v1_4_0_additiveChanges": [
+    "substrate-layers-envelope-header-body: formalizes the envelope/header/body separation as v1.2 of the memento schema; substrate verifiers inspect envelope + header, body fields are verifier-opaque",
+    "contract-cid-vs-attestation-cid: separates contract content CID from attestation CID so contract identity is stable across re-attestation",
+    "contract-set-extension: adds contractSetCid + previousContractSetCid body fields for ordered, append-only contract-set evolution under semver-minor rules",
+    "version-chains-pinning: three-axis pinning (contractCid, witnessCid, binaryCid) carried in the body, plus the version-chain walk used by package-manager-replacement tooling",
+    "all v1.3.x mementos and .proof bundles remain valid; v1.1 flat structure is read as header = entire flat object with synthetic empty body, per substrate-layers spec section 4"
   ]
 }

--- a/tools/foundation-keygen/Cargo.toml
+++ b/tools/foundation-keygen/Cargo.toml
@@ -26,6 +26,10 @@ name = "sign-catalog-v1-3-1"
 path = "src/bin/sign_catalog_v1_3_1.rs"
 
 [[bin]]
+name = "sign-catalog-v1-4-0"
+path = "src/bin/sign_catalog_v1_4_0.rs"
+
+[[bin]]
 name = "sign-self-contracts"
 path = "src/bin/sign_self_contracts.rs"
 

--- a/tools/foundation-keygen/src/bin/sign_catalog_v1_4_0.rs
+++ b/tools/foundation-keygen/src/bin/sign_catalog_v1_4_0.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// sign-catalog-v1-4-0
+//
+// Compute the protocol catalog's CID, build the canonical attestation
+// JSON for protocolVersion `v1.4.0`, sign it under the v0 foundation
+// seed, and write the signed attestation to
+// `.provekit/catalog-signatures/v1.4.0.json`.
+//
+// Mirrors `sign_catalog_v1_3_1.rs` but parameterized for v1.4.0. Same
+// key, additive minor bump (substrate layering + 3 metadata-extension
+// specs over v1.3.1; no breaking changes).
+
+use std::fs;
+use std::process::ExitCode;
+
+use foundation_keygen::{
+    build_signed_attestation_for, catalog_path, compute_catalog_cid_from_path,
+    signature_path_for, FOUNDATION_V0_SEED, V1_4_0_DECLARED_AT,
+};
+
+const PROTOCOL_VERSION: &str = "v1.4.0";
+
+fn run() -> Result<(), String> {
+    let catalog = catalog_path();
+    let cid = compute_catalog_cid_from_path(&catalog)?;
+    let attestation = build_signed_attestation_for(
+        PROTOCOL_VERSION,
+        &FOUNDATION_V0_SEED,
+        &cid,
+        V1_4_0_DECLARED_AT,
+    )?;
+
+    let out_path = signature_path_for(PROTOCOL_VERSION);
+    if let Some(dir) = out_path.parent() {
+        fs::create_dir_all(dir).map_err(|e| format!("mkdir {}: {}", dir.display(), e))?;
+    }
+    let mut out = serde_json::to_string_pretty(&attestation)
+        .map_err(|e| format!("serialize attestation: {}", e))?;
+    out.push('\n');
+    fs::write(&out_path, out).map_err(|e| format!("write {}: {}", out_path.display(), e))?;
+
+    println!("# ProvekIt v1.4.0 catalog attestation");
+    println!();
+    println!("catalog file:    {}", catalog.display());
+    println!("catalog CID:     {}", cid);
+    println!("signer:          {}", attestation["signer"]);
+    println!("signature:       {}", attestation["signature"]);
+    println!();
+    println!("wrote signed attestation: {}", out_path.display());
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("sign-catalog-v1-4-0: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/tools/foundation-keygen/src/lib.rs
+++ b/tools/foundation-keygen/src/lib.rs
@@ -63,6 +63,12 @@ pub const V1_3_0_DECLARED_AT: &str = "2026-05-02T15:00:00Z";
 /// against the new catalog CID under the same foundation key.
 pub const V1_3_1_DECLARED_AT: &str = "2026-05-02T17:00:00Z";
 
+/// Pinned `declaredAt` for v1.4.0. Bumped to 2026-05-03T15:00:00Z; v1.4.0
+/// is additive over v1.3.1 (substrate layering + 3 metadata-extension
+/// specs); no breaking changes. Attestation signed against the new
+/// catalog CID under the same foundation key.
+pub const V1_4_0_DECLARED_AT: &str = "2026-05-03T15:00:00Z";
+
 /// Catalog file path, resolved relative to this crate's manifest dir.
 pub fn catalog_path() -> PathBuf {
     repo_root().join("protocol/specs/2026-04-30-protocol-catalog.json")

--- a/tools/recompute-spec-cids/src/main.rs
+++ b/tools/recompute-spec-cids/src/main.rs
@@ -2,7 +2,7 @@
 //
 // recompute-spec-cids
 //
-// Catalog freeze tool (current target: v1.3.1). Computes BLAKE3-512 CIDs for every protocol
+// Catalog freeze tool (current target: v1.4.0). Computes BLAKE3-512 CIDs for every protocol
 // spec file listed in `protocol/specs/2026-04-30-protocol-catalog.json`,
 // substitutes them into the catalog (replacing `RECOMPUTE-AFTER-*`
 // placeholders), then computes the catalog's own CID as
@@ -102,6 +102,22 @@ const SPEC_MAP: &[(&str, &str)] = &[
     (
         "lsp-protocol",
         "2026-04-30-lsp-protocol.md",
+    ),
+    (
+        "contract-cid-vs-attestation-cid",
+        "2026-05-03-contract-cid-vs-attestation-cid.md",
+    ),
+    (
+        "contract-set-extension",
+        "2026-05-03-contract-set-extension.md",
+    ),
+    (
+        "substrate-layers-envelope-header-body",
+        "2026-05-03-substrate-layers-envelope-header-body.md",
+    ),
+    (
+        "version-chains-pinning",
+        "2026-05-03-version-chains-pinning.md",
     ),
 ];
 
@@ -273,7 +289,7 @@ fn run(write: bool) -> Result<(), String> {
     }
 
     // 7. Report.
-    println!("# Protocol catalog freeze (v1.3.1)");
+    println!("# Protocol catalog freeze (v1.4.0)");
     println!();
     println!("Catalog file:    {}", catalog_path.display());
     println!("Catalog CID:     {}", catalog_cid);


### PR DESCRIPTION
## Summary

Cuts protocol catalog v1.4.0. Additive minor bump over v1.3.1.

### New properties (4)

| Spec key | CID |
|---|---|
| `contract-cid-vs-attestation-cid` | `blake3-512:53e136d9af29ce80b690f90c484e90c60f66f28c483b2038e03e7c6f6055f637527deb205e5558b47487b7d89ead461348d5e8981f2e9e8ccb30edd8867d47db` |
| `contract-set-extension` | `blake3-512:839e82096d04b1241ffa1f6158fcea6bfeb78f3836664a66a13ff11b3cde58d72e6c85bfc619ba1341f13b8375f655bdf5582b0eac91d27648f0048bee8f9867` |
| `substrate-layers-envelope-header-body` | `blake3-512:a76c7d0d6a5fecde40f579a8566f0199f61d5e3f7a0d48561f0ef765b5983a31fc96bb21fe56ea667337341dc798e7370229722ee7535fe7e2c22d4f7dad97dd` |
| `version-chains-pinning` | `blake3-512:281bf014f6f0ebc9a5d455329ee033ff8b7ee85e001bcbdcb45a62c14e43855892c46462789ccb74961859e708eae70829fdf736798c17f59f0239ef78dd7e45` |

### New catalog CID

```
blake3-512:b0f2030d56c2fddf0ecbd7032bf0344c43e30677930e3b77188fcdc4ca6325d34649e51b2efa97d6985e4be6c43173f803254a7b05fc8bf31b92eb399b60f52f
```

### Foundation v0 signature

```
signer:    ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=
signature: ed25519:QK9oaU/1JpgR6kWXC2AxVDb1JQlyuC77C05Q6/x8/XTplwf336Z/a017lO1WfIkiwLm/EGr/gn041wqsqFPZAA==
declaredAt: 2026-05-03T15:00:00Z
```

Written to `.provekit/catalog-signatures/v1.4.0.json` and embedded as
`implementations/rust/provekit-cli/assets/catalog-signature-v1.4.0.json`.

### Backward compatibility

All v1.3.x mementos and `.proof` bundles remain valid under v1.4.0.
The `substrate-layers-envelope-header-body` spec section 4 says it
explicitly: v1.1 flat structure is read as `header = entire flat
object` with synthetic empty `body`; new attestations MUST emit the
layered shape. Re-signing of historical artifacts is not required.

v1.3.1's CID `dab2eca9...304ff799` stays attestable via
`.provekit/catalog-signatures/v1.3.1.json` for anyone pinned. Verified
locally: `provekit verify-protocol --signed --catalog blake3-512:dab2eca9...304ff799
--signature-file .provekit/catalog-signatures/v1.3.1.json` returns
signer match + signature + attested CID all OK (the only `fail` is
`CID match`, which is expected because the embedded binary is now v1.4.0
and the `actual` field reports what the binary IS).

### What got updated to point at the new catalog

- `protocol/specs/2026-04-30-protocol-catalog.json`: 4 new properties under `properties`, `version` to `v1.4.0-2026-05-03`, `declaredAt` to `2026-05-03T15:00:00Z`, fresh `_unsigned`, prior `_unsigned` moved to `_v1_3_1_unsigned`, new `_v1_4_0_additiveChanges` block.
- `tools/recompute-spec-cids/src/main.rs`: `SPEC_MAP` gains 4 entries; freeze label bumped to v1.4.0.
- `tools/foundation-keygen/src/lib.rs`: new `V1_4_0_DECLARED_AT` constant.
- `tools/foundation-keygen/src/bin/sign_catalog_v1_4_0.rs`: new signer binary (mirrors `sign_catalog_v1_3_1.rs`).
- `tools/foundation-keygen/Cargo.toml`: registers `sign-catalog-v1-4-0` bin.
- `implementations/rust/provekit-cli/src/protocol.rs`: `EXPECTED_CATALOG_CID` and `EMBEDDED_CATALOG_SIGNATURE` bumped to v1.4.0.
- `implementations/rust/provekit-cli/src/main.rs`: CLI help text references `catalog-signature-v1.4.0.json`.
- `implementations/rust/provekit-cli/assets/protocol-catalog.json`: byte-identical copy of the new catalog.
- `implementations/rust/provekit-cli/assets/catalog-signature-v1.4.0.json`: byte-identical copy of the new attestation.
- `Makefile`: `CATALOG_CID` + `make help` text bumped.
- `docs/launch/bluepaper.md`: pinned-authority block + appendix C changelog gain a v1.4.0 entry; section 5.1 inventory line bumped.

## Test plan

- [x] `recompute-spec-cids --verify` reports clean (24 spec CIDs match).
- [x] `make catalog-verify` passes (no on-disk drift).
- [x] `make protocol-verify` passes: `verify-protocol --signed` returns CID match, attested CID, signer match, signature, and status all OK.
- [x] `cargo test -p provekit-cli` passes 45/45 (incl. `embedded_catalog_recomputes_to_expected_cid`, `embedded_signature_verifies_against_embedded_pubkey`, tampered-CID + tampered-signature negatives).
- [x] `cargo test -p provekit-self-contracts --lib` passes 56/56 (incl. R1..R15 catalog-format invariants against the 24-property catalog).
- [x] TDD red captured: between asset copy + constant bump, `embedded_catalog_recomputes_to_expected_cid` failed with the expected new-vs-old CID mismatch; turned green after `EXPECTED_CATALOG_CID` and `EMBEDDED_CATALOG_SIGNATURE` updates.
- [ ] CI to run full `make ci` (conformance + test-all across all 5 peer kits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)