### PR TITLE
fix(cpp): JCS bridge emitter for BridgeDecl (task #225)

### DIFF
--- a/implementations/cpp/provekit-ir-symbolic/example/evidence_term_test.cpp
+++ b/implementations/cpp/provekit-ir-symbolic/example/evidence_term_test.cpp
@@ -243,6 +243,68 @@ int main() {
         std::printf("  [PASS] present catalog map head: 0xa8 (8 keys)\n");
     }
 
+    // --- 5. BridgeDecl: locked IR-JSON shape (task #225) --------------------
+    //
+    // Cross-impl byte fixture from conformance/fixtures.toml `bridge_decl`:
+    //   {"kind":"bridge","name":"myBridge","notes":"some notes",
+    //    "sourceContractCid":"bafySource","sourceLayer":"c-kit",
+    //    "sourceSymbol":"source","targetContractCid":"bafyTarget",
+    //    "targetLayer":"coq","targetProofCid":"bafyProof"}
+    //
+    // JCS alphabetical key order: kind, name, [notes?], sourceContractCid,
+    // sourceLayer, sourceSymbol, targetContractCid, targetLayer, targetProofCid.
+    // The `notes` field is omitted entirely when empty (JCS "omit absent" rule);
+    // see protocol/specs/2026-04-30-ir-formal-grammar.md §BridgeDeclaration.
+    {
+        BridgeDecl b{};
+        b.name = "myBridge";
+        b.source_symbol = "source";
+        b.source_layer = "c-kit";
+        b.source_contract_cid = "bafySource";
+        b.target_contract_cid = "bafyTarget";
+        b.target_proof_cid = "bafyProof";
+        b.target_layer = "coq";
+        b.notes = "some notes";
+
+        std::ostringstream oss;
+        write_bridge_decl(oss, b);
+        const std::string bridge_got = oss.str();
+        const std::string bridge_want =
+            "{\"kind\":\"bridge\",\"name\":\"myBridge\","
+            "\"notes\":\"some notes\","
+            "\"sourceContractCid\":\"bafySource\","
+            "\"sourceLayer\":\"c-kit\","
+            "\"sourceSymbol\":\"source\","
+            "\"targetContractCid\":\"bafyTarget\","
+            "\"targetLayer\":\"coq\","
+            "\"targetProofCid\":\"bafyProof\"}";
+
+        if (!check_eq_str("BridgeDecl IR-JSON shape (all 9 fields)",
+                          bridge_got, bridge_want)) {
+            failures++;
+        }
+
+        // notes empty: field omitted entirely (not emitted as null/empty).
+        BridgeDecl b_no_notes = b;
+        b_no_notes.notes = "";
+        std::ostringstream oss2;
+        write_bridge_decl(oss2, b_no_notes);
+        const std::string nn_got = oss2.str();
+        const std::string nn_want =
+            "{\"kind\":\"bridge\",\"name\":\"myBridge\","
+            "\"sourceContractCid\":\"bafySource\","
+            "\"sourceLayer\":\"c-kit\","
+            "\"sourceSymbol\":\"source\","
+            "\"targetContractCid\":\"bafyTarget\","
+            "\"targetLayer\":\"coq\","
+            "\"targetProofCid\":\"bafyProof\"}";
+
+        if (!check_eq_str("BridgeDecl notes-absent (omit-when-empty)",
+                          nn_got, nn_want)) {
+            failures++;
+        }
+    }
+
     std::printf("\n");
     if (failures == 0) {
         std::printf("v1.3.0 CONFORMANCE SMOKE TEST OK.\n");

--- a/implementations/cpp/provekit-ir-symbolic/include/provekit/ir.hpp
+++ b/implementations/cpp/provekit-ir-symbolic/include/provekit/ir.hpp
@@ -427,6 +427,16 @@ struct BridgeDecl {
   std::vector<std::string> ir_arg_sorts;
   std::string ir_return_sort;
   std::string notes;
+  // v1.4.0 BridgeDeclaration fields per
+  // protocol/specs/2026-04-30-ir-formal-grammar.md §BridgeDeclaration.
+  // Defaulted-empty so existing call sites that aggregate-init the older
+  // 7-field shape continue to compile. Empty strings are JCS-absent for the
+  // optional `notes` field (see write_bridge_decl); the three CIDs and
+  // `name` are normatively required when emitting a real bridge memento.
+  std::string name;
+  std::string source_contract_cid;
+  std::string target_contract_cid;
+  std::string target_proof_cid;
 };
 
 inline std::vector<BridgeDecl>& bridge_collector() {
@@ -635,6 +645,44 @@ inline void write_evidence(std::ostringstream& out, const EvidenceTerm& e) {
   out << ",\"proofData\":";
   write_string(out, e.certificate.proof_data);
   out << "}}";
+}
+
+// Emit a BridgeDecl in locked IR-JSON shape per the v1.4.0 grammar
+// (protocol/specs/2026-04-30-ir-formal-grammar.md §BridgeDeclaration).
+//
+// JCS alphabetical key order:
+//   kind, name, [notes?], sourceContractCid, sourceLayer, sourceSymbol,
+//   targetContractCid, targetLayer, targetProofCid.
+//
+// `notes` is omitted entirely when empty (JCS "omit absent" rule). It is
+// never emitted as `null` or as `""`. This mirrors the TS kit's
+// `...(spec.notes !== undefined ? { notes } : {})` pattern and the Rust
+// kit's `serde(skip_serializing_if = "Option::is_none")`, which is what
+// keeps the four kits byte-equal when bridges have no notes.
+//
+// Cross-impl JCS conformance: byte-pinned to the `bridge_decl` fixture in
+// conformance/fixtures.toml; any change to this emitter MUST keep the
+// conformance smoke test in example/evidence_term_test.cpp passing.
+inline void write_bridge_decl(std::ostringstream& out, const BridgeDecl& b) {
+  out << "{\"kind\":\"bridge\",\"name\":";
+  write_string(out, b.name);
+  if (!b.notes.empty()) {
+    out << ",\"notes\":";
+    write_string(out, b.notes);
+  }
+  out << ",\"sourceContractCid\":";
+  write_string(out, b.source_contract_cid);
+  out << ",\"sourceLayer\":";
+  write_string(out, b.source_layer);
+  out << ",\"sourceSymbol\":";
+  write_string(out, b.source_symbol);
+  out << ",\"targetContractCid\":";
+  write_string(out, b.target_contract_cid);
+  out << ",\"targetLayer\":";
+  write_string(out, b.target_layer);
+  out << ",\"targetProofCid\":";
+  write_string(out, b.target_proof_cid);
+  out << "}";
 }
 
 // Marshal an array of ContractDecl into the IR-JSON Document shape.


### PR DESCRIPTION
## Summary

- Adds `write_bridge_decl` to the C++ IR kit (`implementations/cpp/provekit-ir-symbolic/include/provekit/ir.hpp`) emitting the v1.4.0 9-field BridgeDeclaration shape in JCS-alphabetical key order: `kind, name, [notes?], sourceContractCid, sourceLayer, sourceSymbol, targetContractCid, targetLayer, targetProofCid`. The `notes` field is omitted entirely when empty (JCS "omit absent" rule), never emitted as `null` or `""`.
- Extends `BridgeDecl` with the v1.4.0 fields (`name`, `source_contract_cid`, `target_contract_cid`, `target_proof_cid`) appended at the end with default-empty values so existing aggregate-init call sites keep compiling. Mirrors the v1.3.0 pattern already shipped on `PrimitiveBridgeDeclaration` in the same file.
- Test added inline in `example/evidence_term_test.cpp` covers the all-9-fields case and the notes-absent omit case, byte-pinned to the `bridge_decl` fixture in `conformance/fixtures.toml`.

## Spec

- `protocol/specs/2026-04-30-ir-formal-grammar.md` §BridgeDeclaration
- Fixture: `conformance/fixtures.toml` `[[fixture]] name = "bridge_decl"`

## Notes

- Pre-existing EvidenceTerm IR-JSON shape failure in the conformance smoke test is unchanged; not introduced by this PR.

## Test plan

- [x] `bash tools/run-cpp-v1-3-0-conformance.sh` shows both new BridgeDecl assertions PASS
- [x] All previously-passing assertions still PASS (no regression)
- [x] `git stash`-verified the pre-existing EvidenceTerm failure pre-dated this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)