### PR TITLE
feat(rust): emit/verify mementos in envelope/header/body layered shape (spec #95 impl)

### DIFF
--- a/.provekit/self-contracts-attestations/rust.json
+++ b/.provekit/self-contracts-attestations/rust.json
@@ -2,8 +2,8 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "rust",
-  "cid": "blake3-512:04caa512c8fbabd576ae0fc7e5371d3648b73a9d2dab2e4aa6614f52c8bca0d0bc7df814aa037d829ac9cbe64802d2e29265c4c959761a21e26f2f9b8d152541",
+  "cid": "blake3-512:63ca1c5440b085c30a6ecb70d34b83488feb9079819de5abbd8e0ee7c1415b6d09adf743381afda1d0f4872dcaf9f05b4dc5053773f9d8d221d7b11a10f711ac",
   "declaredAt": "2026-05-02T17:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:HYh0qSCqi3HyPP/tVIfDyOp1P/wHNXEOJxmcugHhxbHhKJQu9xwESlJWr3iyA/gRZ4k9IrH4JvBHjGlor8DCCg=="
+  "signature": "ed25519:dLrOUSsOF2MBm/2meJNqxK6j4+DhId43cCX4pqXmEnCQ0Zy8PItY9hFp1UzGM+CNuW/5jy8MQFkSmkPBN43vDQ=="
 }

--- a/.provekit/self-contracts-attestations/rust.json
+++ b/.provekit/self-contracts-attestations/rust.json
@@ -2,8 +2,8 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "rust",
-  "cid": "blake3-512:42d236d4156c8e40c525e5b53bbc1ec37c089fabdc6ff4f8b8b8ea43c09e2b0601d7654ca93b03339c7df3d8e610064859870c9ea0147b5629494817614aa3d5",
+  "cid": "blake3-512:04caa512c8fbabd576ae0fc7e5371d3648b73a9d2dab2e4aa6614f52c8bca0d0bc7df814aa037d829ac9cbe64802d2e29265c4c959761a21e26f2f9b8d152541",
   "declaredAt": "2026-05-02T17:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:WhfScm1G3C5196fE6+1q08Jb85iueuTAPNjOT3jVCuRdESt4r3wjs4QzIW+Ssi9Qsggnh+YU03DJydo/EB4yDw=="
+  "signature": "ed25519:HYh0qSCqi3HyPP/tVIfDyOp1P/wHNXEOJxmcugHhxbHhKJQu9xwESlJWr3iyA/gRZ4k9IrH4JvBHjGlor8DCCg=="
 }

--- a/.provekit/self-contracts-attestations/ts.json
+++ b/.provekit/self-contracts-attestations/ts.json
@@ -2,8 +2,8 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "ts",
-  "cid": "blake3-512:449339930add6457bf25542f2117a025daada4a4bd1de704737750ad6d1c1be814c284d31bb97159ca0b2d2c52f8c043a64533d3432195f5a0f338c5d4904d44",
+  "cid": "blake3-512:c3ec9665f68dc49f5ce76cb0be8a71a743c25ae2a328b5fce9eef9d541fc74d2d4605f7f71ca4b9100216340767a000859d472d3b952f7cca5aecba3debbfca7",
   "declaredAt": "2026-05-02T17:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:k0yBkqDNbRBEr3gQou4BAeFFKgz38BUSnXz3/ePfsHehg0Jae6bmleLbUvMNN+g0FU59hoBIUBfKz0iNzjwoCg=="
+  "signature": "ed25519:cHMguwoRWdAjAmFwnTYre4WplrasYr6D3/7bFZbTNIv7ABdxR7EUxANejLqoJ4CHFJBoHt0T/Sh/jUmaoVBIAw=="
 }

--- a/implementations/rust/provekit-claim-envelope/src/lib.rs
+++ b/implementations/rust/provekit-claim-envelope/src/lib.rs
@@ -3,23 +3,37 @@
 // provekit-claim-envelope
 //
 // `mint_contract` / `mint_bridge` / `mint_implication` build a signed
-// memento envelope (the universal claim-envelope wrapper around a
-// role-specific evidence body). Each returns `MintedEnvelope { canonical_bytes, cid }`.
+// memento in the v1.2 LAYERED shape introduced by
+// `protocol/specs/2026-05-03-substrate-layers-envelope-header-body.md`:
 //
-// Mirrors implementations/cpp/provekit/claim-envelope/mint.cpp 1:1 with
-// the v1.1.0 hash widening: every hash is BLAKE3-512 (full 64-byte
-// digest, hex-encoded) carrying the `"blake3-512:"` prefix. CIDs are
-// the same form: NO truncation.
+//   { "envelope": {...}, "header": {...}, "metadata": {...} }
 //
-// Per-formula hashes (preHash, postHash, invHash) and propertyHash /
-// bindingHash are DERIVED here from the caller-supplied formula
-// Values, never accepted from the caller. Validators recompute and
-// reject mismatches.
+//   * envelope = { signer, declaredAt, signature }
+//       The signature is computed over JCS({"header": header, "metadata": metadata}).
+//       The envelope's CID (= attestation CID) is BLAKE3-512(JCS(envelope))
+//       AFTER the signature has been embedded.
+//
+//   * header   = substrate-load-bearing data the verifier reads:
+//                schemaVersion, kind, cid, plus kind-specific REQUIRED
+//                fields (per the kind's normative spec) and the derived
+//                hashes (bindingHash, propertyHash, verdict, inputCids)
+//                used by the resolve/index pipeline.
+//
+//   * metadata = everything else (authoring attribution, lifecycle
+//                strings like producedBy/producedAt, derived per-formula
+//                hashes that are pure tooling convenience). Opaque to
+//                the substrate verifier; signed transitively via the
+//                envelope.
+//
+// Per spec §4: v1.1 flat-shape mementos remain valid as historical
+// artifacts. New emissions adopt the layered shape and carry
+// `schemaVersion: "2"` in the header. The verifier branches on
+// `schemaVersion` at load time.
 
 use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
-use provekit_proof_envelope::{ed25519_sign_string, Ed25519Seed};
+use provekit_proof_envelope::{ed25519_pubkey_string, ed25519_sign_string, Ed25519Seed};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClaimEnvelopeError {
@@ -33,22 +47,23 @@ pub enum ClaimEnvelopeError {
 
 #[derive(Debug, Clone)]
 pub struct MintedEnvelope {
+    /// JCS-canonical bytes of the full layered memento
+    /// (`{envelope, header, metadata}`).
     pub canonical_bytes: Vec<u8>,
+    /// The attestation CID: BLAKE3-512(JCS(envelope)) after the
+    /// signature has been embedded. This identifies the SIGNED
+    /// attestation; the content-only `contractCid` (the spec's
+    /// "what is this contract" identifier) is exposed as a separate
+    /// function (see PR 2 / `contract_cid()`).
     pub cid: String,
 }
 
-// Schema CIDs — placeholder full-shape blake3-512 strings tagged with
-// the role so they don't collide. The catalog itself isn't on
-// blake3-512 yet; once it lands these will be the real published
-// schema CIDs.
-const SCHEMA_CID_CONTRACT: &str =
-    "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c01";
-const SCHEMA_CID_BRIDGE: &str =
-    "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c03";
-const SCHEMA_CID_IMPLICATION: &str =
-    "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c08";
+/// The layered-shape schema version stamped into every memento header
+/// emitted by this kit. Older flat mementos carry `"1"`; verifiers
+/// branch on this string at load time.
+pub const LAYERED_SCHEMA_VERSION: &str = "2";
 
-// ----- DERIVED hash helpers --------------------------------------------------
+// ---------- DERIVED hash helpers --------------------------------------------
 
 fn hash_value(v: &Arc<Value>) -> String {
     let bytes = encode_jcs(v);
@@ -59,77 +74,67 @@ fn hash_string(s: &str) -> String {
     blake3_512_of(s.as_bytes())
 }
 
-// ----- Wrapper assembly ------------------------------------------------------
+// ---------- Envelope assembly -----------------------------------------------
 
-fn build_envelope_for_hashing(
-    binding_hash: &str,
-    property_hash: &str,
-    verdict: &str,
-    produced_by: &str,
-    produced_at: &str,
-    input_cids: &[String],
-    evidence: Arc<Value>,
-) -> Arc<Value> {
-    // ORDERING: inputCids MUST be lex-sorted (spec wrapper ORDERING).
-    let mut sorted: Vec<String> = input_cids.to_vec();
-    sorted.sort();
-    let cids_arr: Vec<Arc<Value>> = sorted.into_iter().map(Value::string).collect();
-
-    Value::object([
-        ("schemaVersion", Value::string("1")),
-        ("bindingHash", Value::string(binding_hash)),
-        ("propertyHash", Value::string(property_hash)),
-        ("verdict", Value::string(verdict)),
-        ("producedBy", Value::string(produced_by)),
-        ("producedAt", Value::string(produced_at)),
-        ("inputCids", Value::array(cids_arr)),
-        ("evidence", evidence),
-    ])
+/// Build the JCS-canonical bytes of `{"header": header, "metadata": metadata}`.
+/// This is the message the envelope's Ed25519 signature covers (spec §2 R2).
+fn signing_bytes(header: &Arc<Value>, metadata: &Arc<Value>) -> Vec<u8> {
+    let msg = Value::object([
+        ("header", header.clone()),
+        ("metadata", metadata.clone()),
+    ]);
+    encode_jcs(&msg).into_bytes()
 }
 
-fn mint_internal(
-    binding_hash: &str,
-    property_hash: &str,
-    verdict: &str,
-    produced_by: &str,
-    produced_at: &str,
-    input_cids: &[String],
-    evidence: Arc<Value>,
+/// Assemble a layered memento, sign it, and compute the attestation CID
+/// (= BLAKE3-512(JCS(envelope-with-signature))). Returns the JCS-canonical
+/// bytes of the full `{envelope, header, metadata}` object alongside the CID.
+fn assemble_layered(
+    header: Arc<Value>,
+    metadata: Arc<Value>,
+    declared_at: &str,
     signer_seed: &Ed25519Seed,
 ) -> MintedEnvelope {
-    // 1. Build the unsigned canonical envelope; hash it for the CID;
-    //    sign the canonical-bytes; re-emit with cid + producerSignature
-    //    appended.
-    let unsigned_v = build_envelope_for_hashing(
-        binding_hash,
-        property_hash,
-        verdict,
-        produced_by,
-        produced_at,
-        input_cids,
-        evidence,
-    );
-    let unsigned_canonical = encode_jcs(&unsigned_v);
-    let cid = blake3_512_of(unsigned_canonical.as_bytes());
-    let producer_sig = ed25519_sign_string(signer_seed, unsigned_canonical.as_bytes());
+    let signer = ed25519_pubkey_string(signer_seed);
+    let signing_msg = signing_bytes(&header, &metadata);
+    let signature = ed25519_sign_string(signer_seed, &signing_msg);
 
-    // Re-emit: clone the unsigned object's entries, append cid and
-    // producerSignature. JCS encoder re-sorts at emit time.
-    let mut entries: Vec<(String, Arc<Value>)> = match unsigned_v.as_ref() {
-        Value::Object(kvs) => kvs.clone(),
-        _ => unreachable!("envelope should be an object"),
-    };
-    entries.push(("cid".into(), Value::string(cid.clone())));
-    entries.push((
-        "producerSignature".into(),
-        Value::string(producer_sig),
-    ));
-    let signed_v = Arc::new(Value::Object(entries));
-    let final_canonical = encode_jcs(&signed_v);
+    // Build the envelope object with the embedded signature; its JCS
+    // hash is the attestation CID.
+    let envelope = Value::object([
+        ("signer", Value::string(signer.clone())),
+        ("declaredAt", Value::string(declared_at.to_string())),
+        ("signature", Value::string(signature.clone())),
+    ]);
+    let envelope_jcs = encode_jcs(&envelope);
+    let attestation_cid = blake3_512_of(envelope_jcs.as_bytes());
+
+    let memento = Value::object([
+        ("envelope", envelope),
+        ("header", header),
+        ("metadata", metadata),
+    ]);
+    let memento_jcs = encode_jcs(&memento);
+
     MintedEnvelope {
-        canonical_bytes: final_canonical.into_bytes(),
-        cid,
+        canonical_bytes: memento_jcs.into_bytes(),
+        cid: attestation_cid,
     }
+}
+
+/// Helper: build a header object from a vector of (key, value) pairs.
+/// Always prepends `schemaVersion`, `kind`, `cid` in that order; the
+/// kind-specific REQUIRED header fields follow.
+fn build_header(kind: &str, header_cid: &str, kind_specific: Vec<(String, Arc<Value>)>) -> Arc<Value> {
+    let mut entries: Vec<(String, Arc<Value>)> = Vec::with_capacity(3 + kind_specific.len());
+    entries.push((
+        "schemaVersion".into(),
+        Value::string(LAYERED_SCHEMA_VERSION),
+    ));
+    entries.push(("kind".into(), Value::string(kind.to_string())));
+    entries.push(("cid".into(), Value::string(header_cid.to_string())));
+    entries.extend(kind_specific);
+    Arc::new(Value::Object(entries))
 }
 
 // =============================================================================
@@ -205,6 +210,35 @@ pub struct MintContractArgs {
     pub signer_seed: Ed25519Seed,
 }
 
+/// Compute the **content** CID of a contract (signer-independent).
+///
+/// Per `protocol/specs/2026-05-03-contract-cid-vs-attestation-cid.md` §1,
+/// this is the BLAKE3-512 of the JCS encoding of the contract's
+/// substrate-load-bearing fields: `name`, `outBinding`, and any of
+/// `pre`/`post`/`inv` that are present. Two distinct signers attesting
+/// to the same logical contract produce the same `content_cid`.
+///
+/// PR 1 (substrate layering) places this CID in `header.cid`. PR 2 will
+/// expose it under the public name `contract_cid` per the spec's naming
+/// convention.
+fn contract_content_cid(args: &MintContractArgs) -> String {
+    let mut kvs: Vec<(String, Arc<Value>)> = vec![
+        ("name".into(), Value::string(args.contract_name.clone())),
+        ("outBinding".into(), Value::string(args.out_binding.clone())),
+    ];
+    if let Some(pre) = &args.pre {
+        kvs.push(("pre".into(), pre.clone()));
+    }
+    if let Some(post) = &args.post {
+        kvs.push(("post".into(), post.clone()));
+    }
+    if let Some(inv) = &args.inv {
+        kvs.push(("inv".into(), inv.clone()));
+    }
+    let v = Arc::new(Value::Object(kvs));
+    blake3_512_of(encode_jcs(&v).as_bytes())
+}
+
 pub fn mint_contract(args: &MintContractArgs) -> Result<MintedEnvelope, ClaimEnvelopeError> {
     if args.pre.is_none() && args.post.is_none() && args.inv.is_none() {
         return Err(ClaimEnvelopeError::EmptyContract);
@@ -213,35 +247,14 @@ pub fn mint_contract(args: &MintContractArgs) -> Result<MintedEnvelope, ClaimEnv
         return Err(ClaimEnvelopeError::EmptyOutBinding);
     }
 
-    // Build evidence.body. Insertion order mirrors C++ kit.
-    let mut body_kvs: Vec<(String, Arc<Value>)> = vec![
-        ("contractName".into(), Value::string(args.contract_name.clone())),
-        ("outBinding".into(), Value::string(args.out_binding.clone())),
-    ];
-    if let Some(pre) = &args.pre {
-        body_kvs.push(("pre".into(), pre.clone()));
-        body_kvs.push(("preHash".into(), Value::string(hash_value(pre))));
-    }
-    if let Some(post) = &args.post {
-        body_kvs.push(("post".into(), post.clone()));
-        body_kvs.push(("postHash".into(), Value::string(hash_value(post))));
-    }
-    if let Some(inv) = &args.inv {
-        body_kvs.push(("inv".into(), inv.clone()));
-        body_kvs.push(("invHash".into(), Value::string(hash_value(inv))));
-    }
-    body_kvs.push(("authoring".into(), authoring_to_value(&args.authoring)));
-    let body = Arc::new(Value::Object(body_kvs));
-
-    let evidence = Value::object([
-        ("kind", Value::string("contract")),
-        ("schema", Value::string(SCHEMA_CID_CONTRACT)),
-        ("body", body),
-    ]);
-
     // DERIVED:
-    //   propertyHash = hash(canonical({pre?, post?, inv?, outBinding}))
-    //   bindingHash  = hash(canonical({producerId, contractName, propertyHash}))
+    //   propertyHash = hash(JCS({pre?, post?, inv?, outBinding}))
+    //   bindingHash  = hash(JCS({producerId, contractName, propertyHash}))
+    //
+    // These ride in the header because the verifier uses them to index
+    // and resolve callsites; they are substrate-load-bearing despite
+    // being derivable (see spec §1 "kind-specific REQUIRED header
+    // fields").
     let mut ph_kvs: Vec<(String, Arc<Value>)> = Vec::new();
     if let Some(pre) = &args.pre {
         ph_kvs.push(("pre".into(), pre.clone()));
@@ -265,14 +278,53 @@ pub fn mint_contract(args: &MintContractArgs) -> Result<MintedEnvelope, ClaimEnv
     ]);
     let binding_hash = hash_value(&bh_obj);
 
-    Ok(mint_internal(
-        &binding_hash,
-        &property_hash,
-        "holds",
-        &args.produced_by,
+    // Header: schemaVersion + kind + cid + kind-specific REQUIRED fields.
+    let header_cid = contract_content_cid(args);
+    let mut kind_specific: Vec<(String, Arc<Value>)> = vec![
+        ("name".into(), Value::string(args.contract_name.clone())),
+        ("outBinding".into(), Value::string(args.out_binding.clone())),
+    ];
+    if let Some(pre) = &args.pre {
+        kind_specific.push(("pre".into(), pre.clone()));
+    }
+    if let Some(post) = &args.post {
+        kind_specific.push(("post".into(), post.clone()));
+    }
+    if let Some(inv) = &args.inv {
+        kind_specific.push(("inv".into(), inv.clone()));
+    }
+    kind_specific.push(("verdict".into(), Value::string("holds")));
+    kind_specific.push(("bindingHash".into(), Value::string(binding_hash)));
+    kind_specific.push(("propertyHash".into(), Value::string(property_hash)));
+    let mut sorted_inputs: Vec<String> = args.input_cids.clone();
+    sorted_inputs.sort();
+    let inputs_arr: Vec<Arc<Value>> = sorted_inputs.into_iter().map(Value::string).collect();
+    kind_specific.push(("inputCids".into(), Value::array(inputs_arr)));
+
+    let header = build_header("contract", &header_cid, kind_specific);
+
+    // Metadata: producer attribution + per-formula derived hashes
+    // (purely tooling convenience; not used by the substrate verifier).
+    let mut metadata_kvs: Vec<(String, Arc<Value>)> = vec![
+        ("authoring".into(), authoring_to_value(&args.authoring)),
+        ("producedBy".into(), Value::string(args.produced_by.clone())),
+        ("producedAt".into(), Value::string(args.produced_at.clone())),
+    ];
+    if let Some(pre) = &args.pre {
+        metadata_kvs.push(("preHash".into(), Value::string(hash_value(pre))));
+    }
+    if let Some(post) = &args.post {
+        metadata_kvs.push(("postHash".into(), Value::string(hash_value(post))));
+    }
+    if let Some(inv) = &args.inv {
+        metadata_kvs.push(("invHash".into(), Value::string(hash_value(inv))));
+    }
+    let metadata = Arc::new(Value::Object(metadata_kvs));
+
+    Ok(assemble_layered(
+        header,
+        metadata,
         &args.produced_at,
-        &args.input_cids,
-        evidence,
         &args.signer_seed,
     ))
 }
@@ -294,31 +346,30 @@ pub struct MintBridgeArgs {
     pub signer_seed: Ed25519Seed,
 }
 
+/// Compute the content CID of a bridge declaration (signer-independent).
+fn bridge_content_cid(args: &MintBridgeArgs) -> String {
+    let arg_sorts: Vec<Arc<Value>> = args
+        .ir_arg_sorts
+        .iter()
+        .map(|s| Value::string(s.clone()))
+        .collect();
+    let v = Value::object([
+        ("sourceSymbol", Value::string(args.source_symbol.clone())),
+        ("sourceLayer", Value::string(args.source_layer.clone())),
+        ("targetContractCid", Value::string(args.target_contract_cid.clone())),
+        ("targetLayer", Value::string(args.target_layer.clone())),
+        ("irArgSorts", Value::array(arg_sorts)),
+        ("irReturnSort", Value::string(args.ir_return_sort.clone())),
+    ]);
+    blake3_512_of(encode_jcs(&v).as_bytes())
+}
+
 pub fn mint_bridge(args: &MintBridgeArgs) -> MintedEnvelope {
     let arg_sorts: Vec<Arc<Value>> = args
         .ir_arg_sorts
         .iter()
         .map(|s| Value::string(s.clone()))
         .collect();
-
-    let mut body_kvs: Vec<(String, Arc<Value>)> = vec![
-        ("sourceSymbol".into(), Value::string(args.source_symbol.clone())),
-        ("sourceLayer".into(), Value::string(args.source_layer.clone())),
-        ("targetContractCid".into(), Value::string(args.target_contract_cid.clone())),
-        ("targetLayer".into(), Value::string(args.target_layer.clone())),
-        ("irArgSorts".into(), Value::array(arg_sorts)),
-        ("irReturnSort".into(), Value::string(args.ir_return_sort.clone())),
-    ];
-    if !args.notes.is_empty() {
-        body_kvs.push(("notes".into(), Value::string(args.notes.clone())));
-    }
-    let body = Arc::new(Value::Object(body_kvs));
-
-    let evidence = Value::object([
-        ("kind", Value::string("bridge")),
-        ("schema", Value::string(SCHEMA_CID_BRIDGE)),
-        ("body", body),
-    ]);
 
     // DERIVED per spec:
     //   bindingHash  = hash(canonical({sourceLayer, sourceSymbol}))
@@ -330,16 +381,35 @@ pub fn mint_bridge(args: &MintBridgeArgs) -> MintedEnvelope {
     let binding_hash = hash_value(&bh_obj);
     let property_hash = hash_string(&format!("bridge:{}", args.source_symbol));
 
-    mint_internal(
-        &binding_hash,
-        &property_hash,
-        "holds",
-        &args.produced_by,
-        &args.produced_at,
-        &[args.target_contract_cid.clone()],
-        evidence,
-        &args.signer_seed,
-    )
+    let header_cid = bridge_content_cid(args);
+    let kind_specific: Vec<(String, Arc<Value>)> = vec![
+        ("sourceSymbol".into(), Value::string(args.source_symbol.clone())),
+        ("sourceLayer".into(), Value::string(args.source_layer.clone())),
+        ("targetContractCid".into(), Value::string(args.target_contract_cid.clone())),
+        ("targetLayer".into(), Value::string(args.target_layer.clone())),
+        ("irArgSorts".into(), Value::array(arg_sorts)),
+        ("irReturnSort".into(), Value::string(args.ir_return_sort.clone())),
+        ("verdict".into(), Value::string("holds")),
+        ("bindingHash".into(), Value::string(binding_hash)),
+        ("propertyHash".into(), Value::string(property_hash)),
+        (
+            "inputCids".into(),
+            Value::array(vec![Value::string(args.target_contract_cid.clone())]),
+        ),
+    ];
+
+    let header = build_header("bridge", &header_cid, kind_specific);
+
+    let mut metadata_kvs: Vec<(String, Arc<Value>)> = vec![
+        ("producedBy".into(), Value::string(args.produced_by.clone())),
+        ("producedAt".into(), Value::string(args.produced_at.clone())),
+    ];
+    if !args.notes.is_empty() {
+        metadata_kvs.push(("notes".into(), Value::string(args.notes.clone())));
+    }
+    let metadata = Arc::new(Value::Object(metadata_kvs));
+
+    assemble_layered(header, metadata, &args.produced_at, &args.signer_seed)
 }
 
 // =============================================================================
@@ -362,31 +432,19 @@ pub struct MintImplicationArgs {
     pub signer_seed: Ed25519Seed,
 }
 
-pub fn mint_implication(args: &MintImplicationArgs) -> MintedEnvelope {
-    let mut body_kvs: Vec<(String, Arc<Value>)> = vec![
-        ("antecedentHash".into(), Value::string(args.antecedent_hash.clone())),
-        ("consequentHash".into(), Value::string(args.consequent_hash.clone())),
-        ("antecedentCid".into(), Value::string(args.antecedent_cid.clone())),
-        ("consequentCid".into(), Value::string(args.consequent_cid.clone())),
-        ("antecedentSlot".into(), Value::string(args.antecedent_slot.clone())),
-        ("consequentSlot".into(), Value::string(args.consequent_slot.clone())),
-        ("prover".into(), Value::string(args.prover.clone())),
-        ("proverRunMs".into(), Value::integer(args.prover_run_ms)),
-    ];
-    if !args.smt_lib_input.is_empty() {
-        body_kvs.push(("smtLibInput".into(), Value::string(args.smt_lib_input.clone())));
-    }
-    if !args.proof_witness.is_empty() {
-        body_kvs.push(("proofWitness".into(), Value::string(args.proof_witness.clone())));
-    }
-    let body = Arc::new(Value::Object(body_kvs));
-
-    let evidence = Value::object([
-        ("kind", Value::string("implication")),
-        ("schema", Value::string(SCHEMA_CID_IMPLICATION)),
-        ("body", body),
+fn implication_content_cid(args: &MintImplicationArgs) -> String {
+    let v = Value::object([
+        ("antecedentHash", Value::string(args.antecedent_hash.clone())),
+        ("consequentHash", Value::string(args.consequent_hash.clone())),
+        ("antecedentCid", Value::string(args.antecedent_cid.clone())),
+        ("consequentCid", Value::string(args.consequent_cid.clone())),
+        ("antecedentSlot", Value::string(args.antecedent_slot.clone())),
+        ("consequentSlot", Value::string(args.consequent_slot.clone())),
     ]);
+    blake3_512_of(encode_jcs(&v).as_bytes())
+}
 
+pub fn mint_implication(args: &MintImplicationArgs) -> MintedEnvelope {
     // DERIVED per spec:
     //   bindingHash  = hash(canonical({antecedentHash, consequentHash}))
     //   propertyHash = hash("implication:" || antecedentHash || ":" || consequentHash)
@@ -400,18 +458,41 @@ pub fn mint_implication(args: &MintImplicationArgs) -> MintedEnvelope {
         args.antecedent_hash, args.consequent_hash
     ));
 
-    let input_cids = vec![args.antecedent_cid.clone(), args.consequent_cid.clone()];
+    let header_cid = implication_content_cid(args);
+    let mut input_cids = vec![args.antecedent_cid.clone(), args.consequent_cid.clone()];
+    input_cids.sort();
+    let input_arr: Vec<Arc<Value>> = input_cids.into_iter().map(Value::string).collect();
 
-    mint_internal(
-        &binding_hash,
-        &property_hash,
-        "holds",
-        &args.produced_by,
-        &args.produced_at,
-        &input_cids,
-        evidence,
-        &args.signer_seed,
-    )
+    let kind_specific: Vec<(String, Arc<Value>)> = vec![
+        ("antecedentHash".into(), Value::string(args.antecedent_hash.clone())),
+        ("consequentHash".into(), Value::string(args.consequent_hash.clone())),
+        ("antecedentCid".into(), Value::string(args.antecedent_cid.clone())),
+        ("consequentCid".into(), Value::string(args.consequent_cid.clone())),
+        ("antecedentSlot".into(), Value::string(args.antecedent_slot.clone())),
+        ("consequentSlot".into(), Value::string(args.consequent_slot.clone())),
+        ("verdict".into(), Value::string("holds")),
+        ("bindingHash".into(), Value::string(binding_hash)),
+        ("propertyHash".into(), Value::string(property_hash)),
+        ("inputCids".into(), Value::array(input_arr)),
+    ];
+
+    let header = build_header("implication", &header_cid, kind_specific);
+
+    let mut metadata_kvs: Vec<(String, Arc<Value>)> = vec![
+        ("producedBy".into(), Value::string(args.produced_by.clone())),
+        ("producedAt".into(), Value::string(args.produced_at.clone())),
+        ("prover".into(), Value::string(args.prover.clone())),
+        ("proverRunMs".into(), Value::integer(args.prover_run_ms)),
+    ];
+    if !args.smt_lib_input.is_empty() {
+        metadata_kvs.push(("smtLibInput".into(), Value::string(args.smt_lib_input.clone())));
+    }
+    if !args.proof_witness.is_empty() {
+        metadata_kvs.push(("proofWitness".into(), Value::string(args.proof_witness.clone())));
+    }
+    let metadata = Arc::new(Value::Object(metadata_kvs));
+
+    assemble_layered(header, metadata, &args.produced_at, &args.signer_seed)
 }
 
 #[cfg(test)]

--- a/implementations/rust/provekit-claim-envelope/tests/layered_shape.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/layered_shape.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Layered shape tests for `mint_contract` / `mint_bridge` /
+// `mint_implication`.
+//
+// Spec: protocol/specs/2026-05-03-substrate-layers-envelope-header-body.md
+//
+// Every newly-minted memento has exactly three top-level layers:
+//
+//   { "envelope": {...}, "header": {...}, "metadata": {...} }
+//
+// The envelope is the signed wrapper. The header is the substrate-load-
+// bearing data (kind / cid / kind-specific REQUIRED fields, plus the
+// derived hashes the verifier indexes by). The metadata block is opaque
+// to the substrate verifier; tooling reads it.
+//
+// The signature covers `JCS({"header": header, "metadata": metadata})`.
+// Tampering with body fields therefore invalidates the envelope; the
+// metadata inherits cryptographic provenance from the envelope's
+// signer.
+//
+// schemaVersion is bumped to "2" to mark the layered shape; v1 (flat)
+// remains valid as a historical artifact and is read by the verifier
+// via a separate code path.
+
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
+use provekit_claim_envelope::{
+    mint_bridge, mint_contract, Authoring, MintBridgeArgs, MintContractArgs,
+};
+use provekit_proof_envelope::{ed25519_pubkey_string, ed25519_verify_string, Ed25519Seed};
+use serde_json::Value as Json;
+
+fn seed() -> Ed25519Seed {
+    [0x42u8; 32]
+}
+
+fn pre_n_gt_0() -> Arc<Value> {
+    Value::object([
+        ("kind", Value::string("forall")),
+        ("name", Value::string("n")),
+        (
+            "sort",
+            Value::object([
+                ("kind", Value::string("primitive")),
+                ("name", Value::string("Int")),
+            ]),
+        ),
+        (
+            "body",
+            Value::object([
+                ("kind", Value::string("atomic")),
+                ("name", Value::string(">")),
+                (
+                    "args",
+                    Value::array(vec![
+                        Value::object([
+                            ("kind", Value::string("var")),
+                            ("name", Value::string("n")),
+                        ]),
+                        Value::object([
+                            ("kind", Value::string("const")),
+                            ("value", Value::integer(0)),
+                            (
+                                "sort",
+                                Value::object([
+                                    ("kind", Value::string("primitive")),
+                                    ("name", Value::string("Int")),
+                                ]),
+                            ),
+                        ]),
+                    ]),
+                ),
+            ]),
+        ),
+    ])
+}
+
+fn contract_args() -> MintContractArgs {
+    MintContractArgs {
+        contract_name: "demo".into(),
+        pre: Some(pre_n_gt_0()),
+        post: None,
+        inv: None,
+        out_binding: "out".into(),
+        produced_by: "rust-test@1.0".into(),
+        produced_at: "2026-04-30T00:00:00.000Z".into(),
+        input_cids: vec![],
+        authoring: Authoring::KitAuthor {
+            author: "rust-test@1.0".into(),
+            note: None,
+        },
+        signer_seed: seed(),
+    }
+}
+
+fn json_to_value(j: &Json) -> Arc<Value> {
+    match j {
+        Json::Null => Value::null(),
+        Json::Bool(b) => Value::boolean(*b),
+        Json::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                Value::integer(u as i64)
+            } else if let Some(f) = n.as_f64() {
+                Value::integer(f as i64)
+            } else {
+                Value::integer(0)
+            }
+        }
+        Json::String(s) => Value::string(s.clone()),
+        Json::Array(items) => {
+            let v: Vec<_> = items.iter().map(json_to_value).collect();
+            Value::array(v)
+        }
+        Json::Object(map) => {
+            let entries: Vec<(String, _)> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), json_to_value(v)))
+                .collect();
+            Arc::new(Value::Object(entries))
+        }
+    }
+}
+
+#[test]
+fn contract_memento_has_exactly_three_top_level_layers() {
+    let m = mint_contract(&contract_args()).expect("mint");
+    let env: Json = serde_json::from_slice(&m.canonical_bytes).expect("json");
+    let obj = env.as_object().expect("top-level object");
+    let mut keys: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+    keys.sort();
+    assert_eq!(
+        keys,
+        vec!["envelope", "header", "metadata"],
+        "spec §1: top-level layers MUST be exactly envelope/header/metadata; got {keys:?}"
+    );
+}
+
+#[test]
+fn contract_envelope_has_exactly_signer_declared_at_signature() {
+    let m = mint_contract(&contract_args()).expect("mint");
+    let env: Json = serde_json::from_slice(&m.canonical_bytes).expect("json");
+    let envelope = env.pointer("/envelope").expect("envelope").as_object().unwrap();
+    let mut keys: Vec<&str> = envelope.keys().map(|k| k.as_str()).collect();
+    keys.sort();
+    assert_eq!(
+        keys,
+        vec!["declaredAt", "signature", "signer"],
+        "spec §1: envelope MUST be exactly {{signer, declaredAt, signature}}; got {keys:?}"
+    );
+}
+
+#[test]
+fn contract_header_carries_kind_and_substrate_fields() {
+    let m = mint_contract(&contract_args()).expect("mint");
+    let env: Json = serde_json::from_slice(&m.canonical_bytes).expect("json");
+    let header = env.pointer("/header").expect("header").as_object().unwrap();
+
+    // Universal header fields (spec §1).
+    assert_eq!(header.get("schemaVersion").and_then(|v| v.as_str()), Some("2"));
+    assert_eq!(header.get("kind").and_then(|v| v.as_str()), Some("contract"));
+    assert!(header
+        .get("cid")
+        .and_then(|v| v.as_str())
+        .map(|s| s.starts_with("blake3-512:"))
+        .unwrap_or(false));
+
+    // Kind-specific REQUIRED contract fields (spec §3 example).
+    assert_eq!(header.get("name").and_then(|v| v.as_str()), Some("demo"));
+    assert_eq!(header.get("outBinding").and_then(|v| v.as_str()), Some("out"));
+    assert!(header.get("pre").is_some(), "header.pre is REQUIRED for contract memento with pre clause");
+}
+
+#[test]
+fn contract_metadata_carries_authoring_and_producer_attribution() {
+    let m = mint_contract(&contract_args()).expect("mint");
+    let env: Json = serde_json::from_slice(&m.canonical_bytes).expect("json");
+    let metadata = env.pointer("/metadata").expect("metadata").as_object().unwrap();
+    assert!(metadata.get("authoring").is_some(), "metadata.authoring");
+    assert_eq!(
+        metadata.get("producedBy").and_then(|v| v.as_str()),
+        Some("rust-test@1.0")
+    );
+    assert!(metadata.get("producedAt").is_some(), "metadata.producedAt");
+}
+
+#[test]
+fn signature_covers_header_and_metadata_via_jcs() {
+    // spec §2 R2: the signature MUST verify against `JCS({header, metadata})`
+    // where the unsigned message is the JCS encoding of the JSON object
+    // {"header": header, "metadata": metadata}.
+    let m = mint_contract(&contract_args()).expect("mint");
+    let env: Json = serde_json::from_slice(&m.canonical_bytes).expect("json");
+    let header = env.get("header").expect("header").clone();
+    let metadata = env.get("metadata").expect("metadata").clone();
+    let signer = env
+        .pointer("/envelope/signer")
+        .and_then(|v| v.as_str())
+        .expect("envelope.signer");
+    let sig = env
+        .pointer("/envelope/signature")
+        .and_then(|v| v.as_str())
+        .expect("envelope.signature");
+
+    let msg = Json::Object(serde_json::Map::from_iter([
+        ("header".to_string(), header),
+        ("metadata".to_string(), metadata),
+    ]));
+    let v = json_to_value(&msg);
+    let bytes = encode_jcs(&v);
+
+    assert!(
+        ed25519_verify_string(signer, sig, bytes.as_bytes()),
+        "spec §2 R2: signature MUST verify against JCS({{header, metadata}})"
+    );
+
+    // Sanity: the embedded signer matches the seed-derived pubkey.
+    assert_eq!(signer, ed25519_pubkey_string(&seed()));
+}
+
+#[test]
+fn attestation_cid_is_blake3_of_jcs_envelope() {
+    // spec §1 (substrate-layers): the envelope's CID is `hash(JCS(envelope))`.
+    // This is what `MintedEnvelope.cid` returns post-PR; PR 2 adds the
+    // separate `contract_cid()` that hashes the header content directly.
+    let m = mint_contract(&contract_args()).expect("mint");
+    let env: Json = serde_json::from_slice(&m.canonical_bytes).expect("json");
+    let envelope = env.get("envelope").expect("envelope").clone();
+    let v = json_to_value(&envelope);
+    let recomputed = blake3_512_of(encode_jcs(&v).as_bytes());
+    assert_eq!(
+        m.cid, recomputed,
+        "MintedEnvelope.cid MUST equal blake3_512(JCS(envelope))"
+    );
+}
+
+#[test]
+fn body_tamper_invalidates_signature() {
+    // Spec §2 R2: "Any tampering with body fields invalidates the
+    // signature; tooling can trust body content as having signer
+    // provenance."
+    let m = mint_contract(&contract_args()).expect("mint");
+    let mut env: Json = serde_json::from_slice(&m.canonical_bytes).expect("json");
+    let signer = env
+        .pointer("/envelope/signer")
+        .and_then(|v| v.as_str())
+        .expect("signer")
+        .to_string();
+    let sig = env
+        .pointer("/envelope/signature")
+        .and_then(|v| v.as_str())
+        .expect("signature")
+        .to_string();
+
+    // Tamper: rewrite metadata.producedBy.
+    env.pointer_mut("/metadata")
+        .and_then(|m| m.as_object_mut())
+        .expect("metadata is object")
+        .insert("producedBy".into(), Json::String("attacker".into()));
+
+    let header = env.get("header").expect("header").clone();
+    let metadata = env.get("metadata").expect("metadata").clone();
+    let msg = Json::Object(serde_json::Map::from_iter([
+        ("header".to_string(), header),
+        ("metadata".to_string(), metadata),
+    ]));
+    let v = json_to_value(&msg);
+    let bytes = encode_jcs(&v);
+
+    assert!(
+        !ed25519_verify_string(&signer, &sig, bytes.as_bytes()),
+        "tampering with metadata MUST invalidate the envelope signature"
+    );
+}
+
+#[test]
+fn bridge_memento_has_layered_shape() {
+    let args = MintBridgeArgs {
+        produced_by: "rust-test@1.0".into(),
+        produced_at: "2026-04-30T00:00:00.000Z".into(),
+        source_symbol: "foo".into(),
+        source_layer: "rust".into(),
+        target_contract_cid:
+            "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0c0"
+                .into(),
+        target_layer: "ir".into(),
+        ir_arg_sorts: vec!["Int".into()],
+        ir_return_sort: "Int".into(),
+        notes: String::new(),
+        signer_seed: seed(),
+    };
+    let m = mint_bridge(&args);
+    let env: Json = serde_json::from_slice(&m.canonical_bytes).expect("json");
+    let obj = env.as_object().expect("top-level object");
+    let mut keys: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+    keys.sort();
+    assert_eq!(keys, vec!["envelope", "header", "metadata"]);
+
+    let header = env.pointer("/header").unwrap().as_object().unwrap();
+    assert_eq!(header.get("schemaVersion").and_then(|v| v.as_str()), Some("2"));
+    assert_eq!(header.get("kind").and_then(|v| v.as_str()), Some("bridge"));
+    assert_eq!(header.get("sourceSymbol").and_then(|v| v.as_str()), Some("foo"));
+    assert_eq!(header.get("sourceLayer").and_then(|v| v.as_str()), Some("rust"));
+    assert!(header.get("targetContractCid").is_some());
+}

--- a/implementations/rust/provekit-claim-envelope/tests/mint_bridge_implication.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/mint_bridge_implication.rs
@@ -58,7 +58,7 @@ fn bridge_cid_is_blake3_512_prefixed() {
 fn bridge_property_hash_is_blake3_of_bridge_prefix_plus_source_symbol() {
     let m = mint_bridge(&bridge_args());
     let env = parse(&m.canonical_bytes);
-    let ph = env.get("propertyHash").and_then(|v| v.as_str()).unwrap();
+    let ph = env.pointer("/header/propertyHash").and_then(|v| v.as_str()).unwrap();
     let expected = blake3_512_of(b"bridge:parseInt");
     assert_eq!(ph, expected);
 }
@@ -67,7 +67,7 @@ fn bridge_property_hash_is_blake3_of_bridge_prefix_plus_source_symbol() {
 fn bridge_binding_hash_is_blake3_of_jcs_source_layer_and_source_symbol() {
     let m = mint_bridge(&bridge_args());
     let env = parse(&m.canonical_bytes);
-    let bh = env.get("bindingHash").and_then(|v| v.as_str()).unwrap();
+    let bh = env.pointer("/header/bindingHash").and_then(|v| v.as_str()).unwrap();
 
     let v = Value::object([
         ("sourceLayer", Value::string("ts")),
@@ -82,7 +82,7 @@ fn bridge_input_cids_first_entry_is_target_contract_cid() {
     let m = mint_bridge(&bridge_args());
     let env = parse(&m.canonical_bytes);
     let cids = env
-        .get("inputCids")
+        .pointer("/header/inputCids")
         .and_then(|v| v.as_array())
         .expect("inputCids array");
     assert_eq!(cids.len(), 1);
@@ -93,34 +93,38 @@ fn bridge_input_cids_first_entry_is_target_contract_cid() {
 fn bridge_evidence_kind_is_bridge() {
     let m = mint_bridge(&bridge_args());
     let env = parse(&m.canonical_bytes);
-    let kind = env.pointer("/evidence/kind").and_then(|v| v.as_str()).unwrap();
+    let kind = env.pointer("/header/kind").and_then(|v| v.as_str()).unwrap();
     assert_eq!(kind, "bridge");
 }
 
 #[test]
 fn bridge_body_carries_all_input_fields() {
+    // Substrate-load-bearing bridge fields live in the header (spec §3
+    // bridge example). The legacy `/evidence/body/X` location is gone.
     let m = mint_bridge(&bridge_args());
     let env = parse(&m.canonical_bytes);
-    let body = env.pointer("/evidence/body").unwrap();
-    assert_eq!(body.get("sourceSymbol").and_then(|v| v.as_str()), Some("parseInt"));
-    assert_eq!(body.get("sourceLayer").and_then(|v| v.as_str()), Some("ts"));
+    let header = env.pointer("/header").unwrap();
+    assert_eq!(header.get("sourceSymbol").and_then(|v| v.as_str()), Some("parseInt"));
+    assert_eq!(header.get("sourceLayer").and_then(|v| v.as_str()), Some("ts"));
     assert_eq!(
-        body.get("targetContractCid").and_then(|v| v.as_str()),
+        header.get("targetContractCid").and_then(|v| v.as_str()),
         Some("blake3-512:cccc")
     );
-    assert_eq!(body.get("targetLayer").and_then(|v| v.as_str()), Some("rust-kit"));
-    assert_eq!(body.get("irReturnSort").and_then(|v| v.as_str()), Some("Int"));
-    let arg_sorts = body.get("irArgSorts").and_then(|v| v.as_array()).unwrap();
+    assert_eq!(header.get("targetLayer").and_then(|v| v.as_str()), Some("rust-kit"));
+    assert_eq!(header.get("irReturnSort").and_then(|v| v.as_str()), Some("Int"));
+    let arg_sorts = header.get("irArgSorts").and_then(|v| v.as_array()).unwrap();
     assert_eq!(arg_sorts.len(), 1);
     assert_eq!(arg_sorts[0].as_str(), Some("String"));
 }
 
 #[test]
 fn bridge_notes_omitted_when_empty() {
+    // `notes` is producer-attached metadata, not substrate. It rides
+    // in the body (`metadata`) when non-empty; absent when empty.
     let m = mint_bridge(&bridge_args());
     let env = parse(&m.canonical_bytes);
-    let body = env.pointer("/evidence/body").unwrap();
-    assert!(body.get("notes").is_none());
+    let metadata = env.pointer("/metadata").unwrap();
+    assert!(metadata.get("notes").is_none());
 }
 
 #[test]
@@ -129,8 +133,8 @@ fn bridge_notes_included_when_provided() {
     a.notes = "smoke from kit".into();
     let m = mint_bridge(&a);
     let env = parse(&m.canonical_bytes);
-    let body = env.pointer("/evidence/body").unwrap();
-    assert_eq!(body.get("notes").and_then(|v| v.as_str()), Some("smoke from kit"));
+    let metadata = env.pointer("/metadata").unwrap();
+    assert_eq!(metadata.get("notes").and_then(|v| v.as_str()), Some("smoke from kit"));
 }
 
 #[test]
@@ -150,8 +154,8 @@ fn bridge_changing_source_symbol_changes_property_hash() {
     let m_b = mint_bridge(&b);
     let env_a = parse(&m_a.canonical_bytes);
     let env_b = parse(&m_b.canonical_bytes);
-    let ph_a = env_a.get("propertyHash").and_then(|v| v.as_str()).unwrap();
-    let ph_b = env_b.get("propertyHash").and_then(|v| v.as_str()).unwrap();
+    let ph_a = env_a.pointer("/header/propertyHash").and_then(|v| v.as_str()).unwrap();
+    let ph_b = env_b.pointer("/header/propertyHash").and_then(|v| v.as_str()).unwrap();
     assert_ne!(ph_a, ph_b);
     a.source_symbol = "x".into();
     let _ = a;
@@ -190,7 +194,7 @@ fn implication_cid_is_blake3_512_prefixed() {
 fn implication_evidence_kind_is_implication() {
     let m = mint_implication(&impl_args());
     let env = parse(&m.canonical_bytes);
-    let kind = env.pointer("/evidence/kind").and_then(|v| v.as_str()).unwrap();
+    let kind = env.pointer("/header/kind").and_then(|v| v.as_str()).unwrap();
     assert_eq!(kind, "implication");
 }
 
@@ -198,7 +202,7 @@ fn implication_evidence_kind_is_implication() {
 fn implication_property_hash_is_blake3_of_implication_prefix_plus_hashes() {
     let m = mint_implication(&impl_args());
     let env = parse(&m.canonical_bytes);
-    let ph = env.get("propertyHash").and_then(|v| v.as_str()).unwrap();
+    let ph = env.pointer("/header/propertyHash").and_then(|v| v.as_str()).unwrap();
     let expected = blake3_512_of(b"implication:blake3-512:aaa:blake3-512:ccc");
     assert_eq!(ph, expected);
 }
@@ -207,7 +211,7 @@ fn implication_property_hash_is_blake3_of_implication_prefix_plus_hashes() {
 fn implication_binding_hash_is_blake3_of_jcs_antecedent_consequent_hashes() {
     let m = mint_implication(&impl_args());
     let env = parse(&m.canonical_bytes);
-    let bh = env.get("bindingHash").and_then(|v| v.as_str()).unwrap();
+    let bh = env.pointer("/header/bindingHash").and_then(|v| v.as_str()).unwrap();
 
     let v = Value::object([
         ("antecedentHash", Value::string("blake3-512:aaa")),
@@ -221,7 +225,7 @@ fn implication_binding_hash_is_blake3_of_jcs_antecedent_consequent_hashes() {
 fn implication_input_cids_contain_both_antecedent_and_consequent_lex_sorted() {
     let m = mint_implication(&impl_args());
     let env = parse(&m.canonical_bytes);
-    let cids = env.get("inputCids").and_then(|v| v.as_array()).expect("array");
+    let cids = env.pointer("/header/inputCids").and_then(|v| v.as_array()).expect("array");
     // antecedent_cid="zzz", consequent_cid="bbb"; envelope wrapper sorts.
     assert_eq!(cids.len(), 2);
     assert_eq!(cids[0].as_str(), Some("blake3-512:bbb"));
@@ -230,20 +234,25 @@ fn implication_input_cids_contain_both_antecedent_and_consequent_lex_sorted() {
 
 #[test]
 fn implication_body_carries_slots_verbatim() {
+    // antecedentSlot / consequentSlot are header-level: they bind the
+    // implication to specific slots in the antecedent/consequent
+    // contracts and are part of the substrate's resolution view.
     let m = mint_implication(&impl_args());
     let env = parse(&m.canonical_bytes);
-    let body = env.pointer("/evidence/body").unwrap();
-    assert_eq!(body.get("antecedentSlot").and_then(|v| v.as_str()), Some("pre"));
-    assert_eq!(body.get("consequentSlot").and_then(|v| v.as_str()), Some("post"));
+    let header = env.pointer("/header").unwrap();
+    assert_eq!(header.get("antecedentSlot").and_then(|v| v.as_str()), Some("pre"));
+    assert_eq!(header.get("consequentSlot").and_then(|v| v.as_str()), Some("post"));
 }
 
 #[test]
 fn implication_smt_input_omitted_when_empty() {
+    // SMT input + proof witness ride in metadata: prover-generated
+    // tooling artifacts, not substrate-load-bearing.
     let m = mint_implication(&impl_args());
     let env = parse(&m.canonical_bytes);
-    let body = env.pointer("/evidence/body").unwrap();
-    assert!(body.get("smtLibInput").is_none());
-    assert!(body.get("proofWitness").is_none());
+    let metadata = env.pointer("/metadata").unwrap();
+    assert!(metadata.get("smtLibInput").is_none());
+    assert!(metadata.get("proofWitness").is_none());
 }
 
 #[test]
@@ -253,20 +262,20 @@ fn implication_smt_input_included_when_provided() {
     a.proof_witness = "(unsat)".into();
     let m = mint_implication(&a);
     let env = parse(&m.canonical_bytes);
-    let body = env.pointer("/evidence/body").unwrap();
+    let metadata = env.pointer("/metadata").unwrap();
     assert_eq!(
-        body.get("smtLibInput").and_then(|v| v.as_str()),
+        metadata.get("smtLibInput").and_then(|v| v.as_str()),
         Some("(declare-const x Int)\n(check-sat)")
     );
-    assert_eq!(body.get("proofWitness").and_then(|v| v.as_str()), Some("(unsat)"));
+    assert_eq!(metadata.get("proofWitness").and_then(|v| v.as_str()), Some("(unsat)"));
 }
 
 #[test]
 fn implication_prover_run_ms_round_trips() {
     let m = mint_implication(&impl_args());
     let env = parse(&m.canonical_bytes);
-    let body = env.pointer("/evidence/body").unwrap();
-    assert_eq!(body.get("proverRunMs").and_then(|v| v.as_i64()), Some(42));
+    let metadata = env.pointer("/metadata").unwrap();
+    assert_eq!(metadata.get("proverRunMs").and_then(|v| v.as_i64()), Some(42));
 }
 
 #[test]
@@ -285,8 +294,8 @@ fn implication_changing_antecedent_hash_changes_property_hash() {
     let env_a = parse(&a.canonical_bytes);
     let env_b = parse(&b.canonical_bytes);
     assert_ne!(
-        env_a.get("propertyHash").and_then(|v| v.as_str()).unwrap(),
-        env_b.get("propertyHash").and_then(|v| v.as_str()).unwrap()
+        env_a.pointer("/header/propertyHash").and_then(|v| v.as_str()).unwrap(),
+        env_b.pointer("/header/propertyHash").and_then(|v| v.as_str()).unwrap()
     );
 }
 
@@ -294,7 +303,7 @@ fn implication_changing_antecedent_hash_changes_property_hash() {
 fn implication_envelope_carries_producer_signature() {
     let m = mint_implication(&impl_args());
     let env = parse(&m.canonical_bytes);
-    let sig = env.get("producerSignature").and_then(|v| v.as_str()).unwrap();
+    let sig = env.pointer("/envelope/signature").and_then(|v| v.as_str()).unwrap();
     assert!(sig.starts_with("ed25519:"));
 }
 
@@ -302,6 +311,6 @@ fn implication_envelope_carries_producer_signature() {
 fn bridge_envelope_carries_producer_signature() {
     let m = mint_bridge(&bridge_args());
     let env = parse(&m.canonical_bytes);
-    let sig = env.get("producerSignature").and_then(|v| v.as_str()).unwrap();
+    let sig = env.pointer("/envelope/signature").and_then(|v| v.as_str()).unwrap();
     assert!(sig.starts_with("ed25519:"));
 }

--- a/implementations/rust/provekit-claim-envelope/tests/mint_contract.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/mint_contract.rs
@@ -210,28 +210,23 @@ fn cid_is_blake3_512_prefixed_and_correct_length() {
 }
 
 #[test]
-fn cid_matches_blake3_of_unsigned_canonical_bytes() {
-    // Per mint.rs: the CID is BLAKE3-512(unsigned canonical bytes), and
-    // the signed envelope's bytes are the canonical bytes of the
-    // signed-envelope object (different bytes, same CID — caller stores
-    // signed bytes but trusts CID derived from unsigned bytes). We can
-    // strip cid + producerSignature from the canonical_bytes and
-    // recompute the CID; that reproduces the trust-root rule used by
-    // the verifier.
+fn cid_matches_blake3_of_jcs_envelope() {
+    // Layered shape: the attestation CID is BLAKE3-512(JCS(envelope))
+    // where `envelope` is the embedded {signer, declaredAt, signature}
+    // sub-object after signing. Verifiers re-derive the CID from the
+    // envelope alone; the trust root is the envelope hash, not a
+    // strip-and-rehash of the whole memento.
     let m = mint_contract(&args_with(Some(pre_n_gt_0()), None, None)).expect("mint");
-
-    // Parse canonical bytes as JSON, drop cid + producerSignature, JCS-encode,
-    // hash, compare to m.cid.
     let signed_text = std::str::from_utf8(&m.canonical_bytes).expect("utf8");
-    let mut signed_json: serde_json::Value =
+    let signed_json: serde_json::Value =
         serde_json::from_str(signed_text).expect("json parse");
-    if let serde_json::Value::Object(map) = &mut signed_json {
-        map.shift_remove("cid");
-        map.shift_remove("producerSignature");
-    }
-    let v = json_to_value(&signed_json);
+    let envelope = signed_json.get("envelope").expect("envelope present").clone();
+    let v = json_to_value(&envelope);
     let recomputed = blake3_512_of(encode_jcs(&v).as_bytes());
-    assert_eq!(m.cid, recomputed, "cid does not match strip-and-rehash");
+    assert_eq!(
+        m.cid, recomputed,
+        "cid must equal blake3_512(JCS(envelope))"
+    );
 }
 
 fn json_to_value(j: &serde_json::Value) -> Arc<Value> {
@@ -270,20 +265,20 @@ fn parse_envelope(m: &MintedEnvelope) -> serde_json::Value {
     serde_json::from_slice(&m.canonical_bytes).expect("json parse")
 }
 
+// preHash / postHash / invHash are pure tooling-convenience derivations
+// from the formula bytes (the verifier doesn't read them; consumers
+// can reconstruct them locally). Layered shape places them in
+// `metadata`, where opaque-to-substrate body fields live.
+
 #[test]
 fn pre_hash_is_blake3_of_jcs_encoded_pre() {
     let m = mint_contract(&args_with(Some(pre_n_gt_0()), None, None)).expect("mint");
     let env = parse_envelope(&m);
-    let body = env
-        .pointer("/evidence/body")
-        .expect("evidence.body")
-        .clone();
-    let pre_hash = body
+    let metadata = env.pointer("/metadata").expect("metadata").clone();
+    let pre_hash = metadata
         .get("preHash")
         .and_then(|v| v.as_str())
         .expect("preHash present");
-
-    // Recompute preHash from the kit's formula bytes.
     let expected = blake3_512_of(encode_jcs(&pre_n_gt_0()).as_bytes());
     assert_eq!(pre_hash, expected);
 }
@@ -292,8 +287,8 @@ fn pre_hash_is_blake3_of_jcs_encoded_pre() {
 fn post_hash_is_blake3_of_jcs_encoded_post() {
     let m = mint_contract(&args_with(None, Some(post_out_eq_0()), None)).expect("mint");
     let env = parse_envelope(&m);
-    let body = env.pointer("/evidence/body").expect("body").clone();
-    let post_hash = body.get("postHash").and_then(|v| v.as_str()).expect("postHash");
+    let metadata = env.pointer("/metadata").expect("metadata").clone();
+    let post_hash = metadata.get("postHash").and_then(|v| v.as_str()).expect("postHash");
     let expected = blake3_512_of(encode_jcs(&post_out_eq_0()).as_bytes());
     assert_eq!(post_hash, expected);
 }
@@ -302,8 +297,8 @@ fn post_hash_is_blake3_of_jcs_encoded_post() {
 fn inv_hash_is_blake3_of_jcs_encoded_inv() {
     let m = mint_contract(&args_with(None, None, Some(inv_true()))).expect("mint");
     let env = parse_envelope(&m);
-    let body = env.pointer("/evidence/body").expect("body").clone();
-    let inv_hash = body.get("invHash").and_then(|v| v.as_str()).expect("invHash");
+    let metadata = env.pointer("/metadata").expect("metadata").clone();
+    let inv_hash = metadata.get("invHash").and_then(|v| v.as_str()).expect("invHash");
     let expected = blake3_512_of(encode_jcs(&inv_true()).as_bytes());
     assert_eq!(inv_hash, expected);
 }
@@ -312,10 +307,10 @@ fn inv_hash_is_blake3_of_jcs_encoded_inv() {
 fn omitted_clauses_omit_their_hash_fields() {
     let m = mint_contract(&args_with(Some(pre_n_gt_0()), None, None)).expect("mint");
     let env = parse_envelope(&m);
-    let body = env.pointer("/evidence/body").expect("body");
-    assert!(body.get("preHash").is_some(), "preHash should be present");
-    assert!(body.get("postHash").is_none(), "postHash should be absent");
-    assert!(body.get("invHash").is_none(), "invHash should be absent");
+    let metadata = env.pointer("/metadata").expect("metadata");
+    assert!(metadata.get("preHash").is_some(), "preHash should be present");
+    assert!(metadata.get("postHash").is_none(), "postHash should be absent");
+    assert!(metadata.get("invHash").is_none(), "invHash should be absent");
 }
 
 // ---------------------------------------------------------------------------
@@ -332,7 +327,7 @@ fn property_hash_is_blake3_of_jcs_pre_post_inv_outbinding() {
     .expect("mint");
     let env = parse_envelope(&m);
     let claimed = env
-        .get("propertyHash")
+        .pointer("/header/propertyHash")
         .and_then(|v| v.as_str())
         .expect("propertyHash");
 
@@ -352,9 +347,9 @@ fn property_hash_is_blake3_of_jcs_pre_post_inv_outbinding() {
 fn binding_hash_is_blake3_of_jcs_producer_id_contract_name_property_hash() {
     let m = mint_contract(&args_with(Some(pre_n_gt_0()), None, None)).expect("mint");
     let env = parse_envelope(&m);
-    let property_hash = env.get("propertyHash").and_then(|v| v.as_str()).unwrap();
+    let property_hash = env.pointer("/header/propertyHash").and_then(|v| v.as_str()).unwrap();
     let claimed = env
-        .get("bindingHash")
+        .pointer("/header/bindingHash")
         .and_then(|v| v.as_str())
         .expect("bindingHash");
 
@@ -401,8 +396,8 @@ fn changing_contract_name_changes_binding_hash() {
 
     let env_a = parse_envelope(&a);
     let env_b = parse_envelope(&b);
-    let bh_a = env_a.get("bindingHash").and_then(|v| v.as_str()).unwrap();
-    let bh_b = env_b.get("bindingHash").and_then(|v| v.as_str()).unwrap();
+    let bh_a = env_a.pointer("/header/bindingHash").and_then(|v| v.as_str()).unwrap();
+    let bh_b = env_b.pointer("/header/bindingHash").and_then(|v| v.as_str()).unwrap();
     assert_ne!(bh_a, bh_b);
 }
 
@@ -415,11 +410,11 @@ fn changing_producer_id_changes_binding_hash_but_not_property_hash() {
 
     let env_a = parse_envelope(&a);
     let env_b = parse_envelope(&b);
-    let ph_a = env_a.get("propertyHash").and_then(|v| v.as_str()).unwrap();
-    let ph_b = env_b.get("propertyHash").and_then(|v| v.as_str()).unwrap();
+    let ph_a = env_a.pointer("/header/propertyHash").and_then(|v| v.as_str()).unwrap();
+    let ph_b = env_b.pointer("/header/propertyHash").and_then(|v| v.as_str()).unwrap();
     assert_eq!(ph_a, ph_b, "propertyHash must be producer-independent");
-    let bh_a = env_a.get("bindingHash").and_then(|v| v.as_str()).unwrap();
-    let bh_b = env_b.get("bindingHash").and_then(|v| v.as_str()).unwrap();
+    let bh_a = env_a.pointer("/header/bindingHash").and_then(|v| v.as_str()).unwrap();
+    let bh_b = env_b.pointer("/header/bindingHash").and_then(|v| v.as_str()).unwrap();
     assert_ne!(bh_a, bh_b, "bindingHash must depend on producerId");
 }
 
@@ -437,7 +432,7 @@ fn authoring_kit_author_round_trips() {
     let m = mint_contract(&args).expect("mint");
     let env = parse_envelope(&m);
     let auth = env
-        .pointer("/evidence/body/authoring")
+        .pointer("/metadata/authoring")
         .expect("authoring");
     assert_eq!(auth.get("producerKind").and_then(|v| v.as_str()), Some("kit-author"));
     assert_eq!(auth.get("author").and_then(|v| v.as_str()), Some("alice"));
@@ -454,7 +449,7 @@ fn authoring_lift_round_trips() {
     };
     let m = mint_contract(&args).expect("mint");
     let env = parse_envelope(&m);
-    let auth = env.pointer("/evidence/body/authoring").expect("authoring");
+    let auth = env.pointer("/metadata/authoring").expect("authoring");
     assert_eq!(auth.get("producerKind").and_then(|v| v.as_str()), Some("lift"));
     assert_eq!(auth.get("lifter").and_then(|v| v.as_str()), Some("lift-kit@1.0"));
     assert_eq!(auth.get("sourceCid").and_then(|v| v.as_str()), Some("blake3-512:source"));
@@ -472,7 +467,7 @@ fn authoring_llm_round_trips() {
     };
     let m = mint_contract(&args).expect("mint");
     let env = parse_envelope(&m);
-    let auth = env.pointer("/evidence/body/authoring").expect("authoring");
+    let auth = env.pointer("/metadata/authoring").expect("authoring");
     assert_eq!(auth.get("producerKind").and_then(|v| v.as_str()), Some("llm"));
     assert_eq!(auth.get("llm").and_then(|v| v.as_str()), Some("claude"));
     // confidence was scaled by 1000 and stored as integer

--- a/implementations/rust/provekit-verifier/src/load_all_proofs.rs
+++ b/implementations/rust/provekit-verifier/src/load_all_proofs.rs
@@ -7,6 +7,15 @@
 // v1.1.0: filenames MUST be `blake3-512:<128 hex>.proof` and member
 // CIDs MUST start with `"blake3-512:"`. Producer signatures MUST start
 // with `"ed25519:"`. Anything else is rejected loud.
+//
+// v1.2 layered shape (per protocol/specs/2026-05-03-substrate-layers-
+// envelope-header-body.md): mementos are `{envelope, header, metadata}`
+// with `envelope = {signer, declaredAt, signature}`. The attestation
+// CID is `blake3_512(JCS(envelope))`. The verifier branches on the
+// presence of a top-level `envelope` key vs. `producerSignature` to
+// pick the legacy strip-and-rehash path or the envelope-hash path.
+// Both shapes coexist; the catalog cut elsewhere bumps the per-memento
+// `schemaVersion` from "1" to "2".
 
 use std::path::{Path, PathBuf};
 
@@ -137,8 +146,14 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
                 continue;
             }
         };
-        // Tag-dispatch on producerSignature.
-        if let Some(sig) = env.get("producerSignature").and_then(|v| v.as_str()) {
+        // Tag-dispatch on whichever signature field is present.
+        // v1.1 flat shape: `producerSignature` at top level.
+        // v1.2 layered shape: `envelope.signature`.
+        let sig_str_opt = env
+            .pointer("/envelope/signature")
+            .and_then(|v| v.as_str())
+            .or_else(|| env.get("producerSignature").and_then(|v| v.as_str()));
+        if let Some(sig) = sig_str_opt {
             if !sig.starts_with(SIG_TAG_PREFIX) {
                 pool.load_errors.push(LoadError {
                     proof_path: path.display().to_string(),
@@ -149,7 +164,7 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
                 continue;
             }
         }
-        // Rule 2: re-derive envelope CID.
+        // Rule 2: re-derive envelope CID. Branch on shape.
         let derived = compute_envelope_cid(&env);
         if derived != *cid {
             pool.load_errors.push(LoadError {
@@ -170,15 +185,27 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
             .entry(derived_full.clone())
             .or_default()
             .insert(cid.clone());
-        if let Some(ev) = env.get("evidence") {
-            if ev.get("kind").and_then(|k| k.as_str()) == Some("bridge") {
-                if let Some(body) = ev.get("body") {
-                    if let Some(sym) = body.get("sourceSymbol").and_then(|v| v.as_str()) {
-                        if !sym.is_empty() {
-                            pool.bridges_by_symbol
-                                .insert(sym.to_string(), env.clone());
-                        }
-                    }
+
+        // Bridge indexing. Same dual-shape rule:
+        //   v1.1: evidence.kind == "bridge", evidence.body.sourceSymbol
+        //   v1.2: header.kind == "bridge",   header.sourceSymbol
+        let (bridge_kind, source_symbol) = if env.get("envelope").is_some() {
+            (
+                env.pointer("/header/kind").and_then(|k| k.as_str()),
+                env.pointer("/header/sourceSymbol").and_then(|v| v.as_str()),
+            )
+        } else {
+            (
+                env.pointer("/evidence/kind").and_then(|k| k.as_str()),
+                env.pointer("/evidence/body/sourceSymbol")
+                    .and_then(|v| v.as_str()),
+            )
+        };
+        if bridge_kind == Some("bridge") {
+            if let Some(sym) = source_symbol {
+                if !sym.is_empty() {
+                    pool.bridges_by_symbol
+                        .insert(sym.to_string(), env.clone());
                 }
             }
         }
@@ -186,9 +213,20 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
     Ok(())
 }
 
-/// Re-derive an envelope's CID by stripping `cid` and `producerSignature`,
-/// JCS-encoding, BLAKE3-512.
+/// Re-derive an envelope's CID. Branches on memento shape:
+///
+/// * v1.2 layered: top-level `envelope` is present; CID is
+///   `blake3_512(JCS(envelope))` directly. The header and metadata
+///   stay outside the hash, but the signature inside the envelope
+///   covers them transitively.
+///
+/// * v1.1 flat: strip `cid` + `producerSignature`, JCS-encode, hash.
 fn compute_envelope_cid(env: &Json) -> String {
+    if let Some(envelope) = env.get("envelope") {
+        let value_tree = json_to_value(envelope);
+        let canonical = encode_jcs(&value_tree);
+        return blake3_512_of(canonical.as_bytes());
+    }
     let mut stripped = env.clone();
     if let Json::Object(map) = &mut stripped {
         map.shift_remove("cid");

--- a/implementations/rust/provekit-verifier/src/resolve_target.rs
+++ b/implementations/rust/provekit-verifier/src/resolve_target.rs
@@ -10,24 +10,20 @@
 // `targetProofCid`. See protocol/specs/2026-04-30-ir-formal-grammar.md
 // § "Bridge target pinning: the shim-poisoning vector".
 
-use crate::types::{CallSite, MementoPool, ResolvedProperty};
+use crate::types::{memento_body, memento_kind, CallSite, MementoPool, ResolvedProperty};
 
 pub fn run(cs: &CallSite, pool: &MementoPool) -> Result<ResolvedProperty, String> {
     let env = pool
         .mementos
         .get(&cs.bridge_target_cid)
         .ok_or_else(|| format!("bridge target CID {} not in pool", cs.bridge_target_cid))?;
-    let ev = env
-        .get("evidence")
-        .filter(|v| v.is_object())
-        .ok_or("target memento has no evidence object")?;
-    if ev.get("kind").and_then(|k| k.as_str()) != Some("contract") {
+    if memento_kind(env) != Some("contract") {
         return Err("target memento is not a contract memento".into());
     }
-    let body = ev
-        .get("body")
+    // Shape-agnostic body: v1.2 layered -> `header`, v1.1 flat -> `evidence.body`.
+    let body = memento_body(env)
         .filter(|v| v.is_object())
-        .ok_or("contract evidence has no body object")?;
+        .ok_or("contract memento has no body/header object")?;
 
     // Forward pin: BridgeDeclaration.ConsequentBundlePinned.
     //

--- a/implementations/rust/provekit-verifier/src/runner.rs
+++ b/implementations/rust/provekit-verifier/src/runner.rs
@@ -615,38 +615,11 @@ fn mint_and_cache(
     let pubkey = ed25519_pubkey_string(seed);
     let _ = (post_formula, pre_formula);
 
-    let mut body_kvs: Vec<(String, std::sync::Arc<Value>)> = vec![
-        ("antecedentHash".into(), Value::string(post_hash.to_string())),
-        ("consequentHash".into(), Value::string(pre_hash.to_string())),
-        ("antecedentCid".into(), Value::string("blake3-512:0000".to_string())),
-        ("consequentCid".into(), Value::string("blake3-512:0000".to_string())),
-        ("antecedentSlot".into(), Value::string("post".to_string())),
-        ("consequentSlot".into(), Value::string("pre".to_string())),
-        ("prover".into(), Value::string(prover_tag.to_string())),
-        ("proverRunMs".into(), Value::integer(prover_run_ms)),
-        ("producerPubkey".into(), Value::string(pubkey.clone())),
-    ];
-    if !smt_lib_input.is_empty() {
-        body_kvs.push((
-            "smtLibInput".into(),
-            Value::string(smt_lib_input.to_string()),
-        ));
-    }
-    body_kvs.push(("proofWitness".into(), Value::string("(unsat)".to_string())));
-
-    let body = std::sync::Arc::new(Value::Object(body_kvs));
-
-    let evidence = Value::object([
-        ("kind", Value::string("implication")),
-        (
-            "schema",
-            Value::string(
-                "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c08",
-            ),
-        ),
-        ("body", body),
-    ]);
-
+    // Layered shape (v1.2). The verifier's own implication-extension
+    // mint emits the same `{envelope, header, metadata}` shape that
+    // `provekit-claim-envelope::mint_implication` produces; mirroring
+    // it inline keeps the runner free of an extra runtime dep on the
+    // claim-envelope crate.
     let bh = Value::object([
         ("antecedentHash", Value::string(post_hash.to_string())),
         ("consequentHash", Value::string(pre_hash.to_string())),
@@ -662,31 +635,74 @@ fn mint_and_cache(
     let cids_arr: Vec<std::sync::Arc<Value>> =
         input_cids.into_iter().map(Value::string).collect();
 
-    let unsigned_v = Value::object([
-        ("schemaVersion", Value::string("1")),
+    // Header: schemaVersion / kind / cid + kind-specific REQUIRED.
+    // The header CID hashes the substrate-load-bearing claim content
+    // (antecedent/consequent hashes + slots).
+    let header_content = Value::object([
+        ("antecedentHash", Value::string(post_hash.to_string())),
+        ("consequentHash", Value::string(pre_hash.to_string())),
+        ("antecedentCid", Value::string("blake3-512:0000".to_string())),
+        ("consequentCid", Value::string("blake3-512:0000".to_string())),
+        ("antecedentSlot", Value::string("post".to_string())),
+        ("consequentSlot", Value::string("pre".to_string())),
+    ]);
+    let header_cid = blake3_512_of(encode_jcs(&header_content).as_bytes());
+
+    let header = Value::object([
+        ("schemaVersion", Value::string("2")),
+        ("kind", Value::string("implication")),
+        ("cid", Value::string(header_cid)),
+        ("antecedentHash", Value::string(post_hash.to_string())),
+        ("consequentHash", Value::string(pre_hash.to_string())),
+        ("antecedentCid", Value::string("blake3-512:0000".to_string())),
+        ("consequentCid", Value::string("blake3-512:0000".to_string())),
+        ("antecedentSlot", Value::string("post".to_string())),
+        ("consequentSlot", Value::string("pre".to_string())),
+        ("verdict", Value::string("holds")),
         ("bindingHash", Value::string(binding_hash)),
         ("propertyHash", Value::string(property_hash.clone())),
-        ("verdict", Value::string("holds")),
-        ("producedBy", Value::string(producer_id.to_string())),
-        ("producedAt", Value::string(now.to_string())),
         ("inputCids", Value::array(cids_arr)),
-        ("evidence", evidence),
     ]);
-    let unsigned_canonical = encode_jcs(&unsigned_v);
-    let cid = blake3_512_of(unsigned_canonical.as_bytes());
-    let producer_sig = ed25519_sign_string(seed, unsigned_canonical.as_bytes());
 
-    let mut entries = match unsigned_v.as_ref() {
-        Value::Object(kvs) => kvs.clone(),
-        _ => unreachable!("envelope is an object"),
-    };
-    entries.push(("cid".into(), Value::string(cid.clone())));
-    entries.push((
-        "producerSignature".into(),
-        Value::string(producer_sig),
-    ));
-    let signed_v = std::sync::Arc::new(Value::Object(entries));
-    let final_canonical = encode_jcs(&signed_v).into_bytes();
+    let mut metadata_kvs: Vec<(String, std::sync::Arc<Value>)> = vec![
+        ("producedBy".into(), Value::string(producer_id.to_string())),
+        ("producedAt".into(), Value::string(now.to_string())),
+        ("prover".into(), Value::string(prover_tag.to_string())),
+        ("proverRunMs".into(), Value::integer(prover_run_ms)),
+        ("producerPubkey".into(), Value::string(pubkey.clone())),
+    ];
+    if !smt_lib_input.is_empty() {
+        metadata_kvs.push((
+            "smtLibInput".into(),
+            Value::string(smt_lib_input.to_string()),
+        ));
+    }
+    metadata_kvs.push(("proofWitness".into(), Value::string("(unsat)".to_string())));
+    let metadata = std::sync::Arc::new(Value::Object(metadata_kvs));
+
+    // Sign over JCS({header, metadata}) per spec §2 R2.
+    let signing_msg = Value::object([
+        ("header", header.clone()),
+        ("metadata", metadata.clone()),
+    ]);
+    let signing_bytes = encode_jcs(&signing_msg);
+    let producer_sig = ed25519_sign_string(seed, signing_bytes.as_bytes());
+
+    // Envelope CID is blake3_512(JCS(envelope-with-signature)).
+    let envelope = Value::object([
+        ("signer", Value::string(pubkey.clone())),
+        ("declaredAt", Value::string(now.to_string())),
+        ("signature", Value::string(producer_sig)),
+    ]);
+    let envelope_jcs = encode_jcs(&envelope);
+    let cid = blake3_512_of(envelope_jcs.as_bytes());
+
+    let memento = Value::object([
+        ("envelope", envelope),
+        ("header", header),
+        ("metadata", metadata),
+    ]);
+    let final_canonical = encode_jcs(&memento).into_bytes();
 
     let mut members: BTreeMap<String, Vec<u8>> = BTreeMap::new();
     members.insert(cid.clone(), final_canonical.clone());

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -1,10 +1,70 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Pipeline types. Mirrors implementations/cpp/.../verifier/types.hpp.
+//
+// Shape compatibility: a memento envelope is either the v1.1 flat
+// shape (top-level `evidence`/`bindingHash`/`producerSignature`/...) or
+// the v1.2 layered shape (top-level `envelope`/`header`/`metadata`).
+// The accessors `memento_kind` and `memento_body` paper over the cut so
+// the rest of the verifier doesn't have to branch.
 
 use std::collections::BTreeMap;
 
 use serde_json::Value as Json;
+
+/// Return the kind discriminator of a memento, regardless of shape:
+///
+/// * v1.2 layered: `header.kind`
+/// * v1.1 flat:    `evidence.kind`
+pub fn memento_kind(envelope: &Json) -> Option<&str> {
+    if envelope.get("envelope").is_some() {
+        envelope.pointer("/header/kind").and_then(|v| v.as_str())
+    } else {
+        envelope.pointer("/evidence/kind").and_then(|v| v.as_str())
+    }
+}
+
+/// Return the substrate-relevant inner object of a memento (the
+/// container of kind-specific fields), regardless of shape:
+///
+/// * v1.2 layered: `header`
+/// * v1.1 flat:    `evidence.body`
+///
+/// Note: for v1.1, formula references like `preHash`/`antecedentHash`
+/// live under `evidence.body`; under v1.2 they live in `metadata`. Use
+/// `memento_body_field` for those lookups.
+pub fn memento_body(envelope: &Json) -> Option<&Json> {
+    if envelope.get("envelope").is_some() {
+        envelope.get("header")
+    } else {
+        envelope.pointer("/evidence/body")
+    }
+}
+
+/// Look up a body-tier field that the verifier needs (formula-hash
+/// references and similar) regardless of shape:
+///
+/// * v1.2 layered: prefer `header.<field>` (substrate-load-bearing
+///   bridge/contract/implication kind-specific fields), then fall back
+///   to `metadata.<field>` (per-formula derived hashes like preHash).
+/// * v1.1 flat:    `evidence.body.<field>` (legacy flat).
+///
+/// This single helper covers both the substrate references the
+/// verifier indexes by (antecedentHash / consequentHash on
+/// implications, sourceSymbol on bridges) and the convenience hashes
+/// (preHash / postHash / invHash) that ride in metadata under v1.2.
+pub fn memento_body_field<'a>(envelope: &'a Json, field: &str) -> Option<&'a Json> {
+    if envelope.get("envelope").is_some() {
+        envelope
+            .pointer("/header")
+            .and_then(|h| h.get(field))
+            .or_else(|| envelope.pointer("/metadata").and_then(|m| m.get(field)))
+    } else {
+        envelope
+            .pointer("/evidence/body")
+            .and_then(|b| b.get(field))
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct LoadError {
@@ -75,17 +135,17 @@ impl MementoPool {
         let _ant_memento = self.verify_by_hash(antecedent_cid)?;
         let _con_memento = self.verify_by_hash(consequent_cid)?;
 
-        // Scan for implication mementos that link these two
+        // Scan for implication mementos that link these two.
+        // Shape-agnostic: under v1.2 these references live in the
+        // metadata; under v1.1 they live in evidence.body.
         for (_, envelope) in &self.mementos {
-            if let Some(evidence) = envelope.get("evidence") {
-                if evidence.get("kind").and_then(|v| v.as_str()) == Some("implication") {
-                    if let Some(body) = evidence.get("body") {
-                        let ant = body.get("antecedentHash").and_then(|v| v.as_str());
-                        let con = body.get("consequentHash").and_then(|v| v.as_str());
-                        if ant == Some(antecedent_cid) && con == Some(consequent_cid) {
-                            return Some(envelope);
-                        }
-                    }
+            if memento_kind(envelope) == Some("implication") {
+                let ant = memento_body_field(envelope, "antecedentHash")
+                    .and_then(|v| v.as_str());
+                let con = memento_body_field(envelope, "consequentHash")
+                    .and_then(|v| v.as_str());
+                if ant == Some(antecedent_cid) && con == Some(consequent_cid) {
+                    return Some(envelope);
                 }
             }
         }
@@ -100,19 +160,16 @@ impl MementoPool {
             return Some(vec![antecedent_cid.to_string()]);
         }
 
-        // Build implication graph adjacency list on-the-fly
+        // Build implication graph adjacency list on-the-fly.
+        // Shape-agnostic per the body/header accessors.
         let mut graph: BTreeMap<String, Vec<String>> = BTreeMap::new();
         for (_, envelope) in &self.mementos {
-            if let Some(evidence) = envelope.get("evidence") {
-                if evidence.get("kind").and_then(|v| v.as_str()) == Some("implication") {
-                    if let Some(body) = evidence.get("body") {
-                        if let (Some(ant), Some(con)) = (
-                            body.get("antecedentHash").and_then(|v| v.as_str()),
-                            body.get("consequentHash").and_then(|v| v.as_str()),
-                        ) {
-                            graph.entry(ant.to_string()).or_default().push(con.to_string());
-                        }
-                    }
+            if memento_kind(envelope) == Some("implication") {
+                if let (Some(ant), Some(con)) = (
+                    memento_body_field(envelope, "antecedentHash").and_then(|v| v.as_str()),
+                    memento_body_field(envelope, "consequentHash").and_then(|v| v.as_str()),
+                ) {
+                    graph.entry(ant.to_string()).or_default().push(con.to_string());
                 }
             }
         }
@@ -174,21 +231,22 @@ impl MementoPool {
     /// The .proof protocol IS the cache: storing a memento IS caching
     /// the verification result.
     pub fn insert(&mut self, memento_cid: String, envelope: Json) {
-        // Index by the formula hashes referenced in the evidence
-        if let Some(evidence) = envelope.get("evidence") {
-            if let Some(body) = evidence.get("body") {
-                // Contract evidence: preHash/postHash/invHash
-                for field in &["preHash", "postHash", "invHash"] {
-                    if let Some(hash) = body.get(field).and_then(|v| v.as_str()) {
-                        self.formula_to_memento.insert(hash.to_string(), memento_cid.clone());
-                    }
-                }
-                // Implication evidence: antecedentHash/consequentHash
-                for field in &["antecedentHash", "consequentHash"] {
-                    if let Some(hash) = body.get(field).and_then(|v| v.as_str()) {
-                        self.formula_to_memento.insert(hash.to_string(), memento_cid.clone());
-                    }
-                }
+        // Index by the formula hashes referenced in the body. Layout
+        // depends on shape; `memento_body_field` papers over the cut.
+        // Contract: preHash/postHash/invHash (in metadata under v1.2,
+        //           in evidence.body under v1.1).
+        // Implication: antecedentHash/consequentHash (in header under
+        //           v1.2, in evidence.body under v1.1).
+        for field in &[
+            "preHash",
+            "postHash",
+            "invHash",
+            "antecedentHash",
+            "consequentHash",
+        ] {
+            if let Some(hash) = memento_body_field(&envelope, field).and_then(|v| v.as_str()) {
+                self.formula_to_memento
+                    .insert(hash.to_string(), memento_cid.clone());
             }
         }
         self.mementos.insert(memento_cid, envelope);


### PR DESCRIPTION
## Summary

Implements `protocol/specs/2026-05-03-substrate-layers-envelope-header-body.md` for the Rust kit. Every newly minted memento now carries the three substrate layers explicitly:

```
{ "envelope": {...}, "header": {...}, "metadata": {...} }
```

- **envelope** = `{signer, declaredAt, signature}`. Signature covers `JCS({header, metadata})` per spec §2 R2.
- **header** = `{schemaVersion: \"2\", kind, cid}` + kind-specific REQUIRED fields (per kind's normative spec). For contracts: `name`, `outBinding`, `pre`/`post`/`inv`. The substrate-load-bearing derived hashes (`bindingHash`, `propertyHash`, `inputCids`, `verdict`) ride here too because the verifier reads them at resolve time.
- **metadata** = `authoring`, `producedBy`, `producedAt`, and the per-formula convenience hashes (`preHash`/`postHash`/`invHash`). Opaque to the substrate verifier; transitively signed via the envelope.

## Affected paths

- `provekit-claim-envelope/src/lib.rs` rewritten: `mint_contract` / `mint_bridge` / `mint_implication` emit layered shape via a single `assemble_layered` helper. Adds private `contract_content_cid` (PR 2 will rename to public `contract_cid()` per the contractCid spec).
- `provekit-verifier/src/load_all_proofs.rs` branches CID derivation on shape (v1.2 hashes the embedded envelope; v1.1 keeps strip-and-rehash). Bridge indexing reads `header.sourceSymbol` or `evidence.body.sourceSymbol` depending on shape.
- `provekit-verifier/src/types.rs` adds shape-agnostic accessors (`memento_kind`, `memento_body`, `memento_body_field`) used throughout `resolve_target`, `verify_implication`, `implies_transitive`, and the formula-hash index.
- `provekit-verifier/src/runner.rs`'s own implication-extension mint emits layered shape so cached extensions agree with claim-envelope output.

## Migration

Existing v1.1 (flat) attestations remain valid as historical artifacts per spec §4. The verifier reads both shapes via the shape-branched accessors. Existing tests rewritten mechanically (`env.get(X)` -> `env.pointer(\"/header/X\")` for substrate fields, `evidence/body/X` -> `metadata/X` for body fields, `producerSignature` -> `envelope.signature`).

The self-contracts-attestation envelope (in `tools/foundation-keygen`) intentionally stays flat in this PR. **PR 3 layers it when it adds `contractSetCid` as body metadata**, so the cross-kit blast radius lands in a single PR.

`provekit-self-contracts.proof` bundle CID drifted (expected: every member memento changed shape). New CID:

```
blake3-512:04caa512c8fbabd576ae0fc7e5371d3648b73a9d2dab2e4aa6614f52c8bca0d0bc7df814aa037d829ac9cbe64802d2e29265c4c959761a21e26f2f9b8d152541
```

`rust.json` re-signed under the v0 foundation key. Peer-kit equivalents (`cpp.json`, `go.json`, `ts.json`, `csharp.json`) stay on prior mint-format CIDs; they re-sign in their own per-kit follow-up PRs.

## Test plan

- [x] `cargo test -p provekit-claim-envelope` (24 passed; new `layered_shape.rs` has 8 spec-conformance tests)
- [x] `cargo test -p provekit-verifier` (load_all_proofs round-trips the new shape)
- [x] `cargo test --workspace --no-fail-fast` (all green; no FAILED)
- [x] `cargo build --workspace --examples` (clean, only pre-existing unused-variable warnings)
- [x] `cargo test -p foundation-keygen` (unchanged; still green)
- [x] `mint-self-contracts` produces a deterministic .proof and the verifier loads all 108 members cleanly
- [x] `sign-self-contracts rust <new-cid>` re-signed `.provekit/self-contracts-attestations/rust.json`

## Follow-ups (out of scope for this PR)

- PR 2 (`feat/rust-contract-cid-distinct`): expose `contract_cid()` distinct from the envelope hash; rename the existing public surface where it was called \"contract cid\" but returned an envelope hash.
- PR 3 (`feat/rust-contract-set-extension`): layer `self-contracts-attestation` in `foundation-keygen` and add `contractSetCid` (REQUIRED) + `previousContractSetCid` (OPTIONAL) body metadata.
- PR 4 (`feat/rust-version-chain-walking`): DAG walks for version chains, yank policy, dependency resolution.
- Peer kits (cpp/go/ts/csharp/python/ruby/c/zig/java) mirror in their own per-kit PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)