### PR TITLE
refactor(lift): factor shared lifter core into reusable lib (#219)

### DIFF
--- a/implementations/csharp/Provekit.Lift.Core/AnnotationScanner.cs
+++ b/implementations/csharp/Provekit.Lift.Core/AnnotationScanner.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Provekit.Lift.Core.AnnotationScanner — shared //provekit: annotation
+// scanner for the C# kit. Used by both Provekit.Lsp.Plugin (live editing)
+// and any future batch-CLI lift binary that consumes annotated source.
+//
+// Recognized annotations:
+//   //provekit:contract                  — declares the next function as a contract
+//   //provekit:implement <cid>           — declares the next function as an
+//                                          implementation bridge to <cid>
+
+using System.Text.RegularExpressions;
+using Provekit.IR;
+
+namespace Provekit.Lift.Core;
+
+public static partial class AnnotationScanner
+{
+    [GeneratedRegex(@"//\s*provekit:\s*contract")]
+    private static partial Regex ContractAnnotation();
+
+    [GeneratedRegex(@"//\s*provekit:\s*implement\s+([\w-]+)")]
+    private static partial Regex ImplementAnnotation();
+
+    [GeneratedRegex(@"(?:public|private|protected|internal|static)\s+\w+(?:\<[^>]*\>)?\s+(\w+)\s*\(")]
+    private static partial Regex FunctionSig();
+
+    /// <summary>
+    /// Scan C# source for //provekit:contract and //provekit:implement
+    /// annotations. Each annotation attaches to the first function-shaped
+    /// signature within 10 lines below it.
+    /// </summary>
+    public static List<ContractDecl> ScanAnnotations(string source)
+    {
+        var decls = new List<ContractDecl>();
+        var lines = source.Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (ContractAnnotation().IsMatch(lines[i]))
+            {
+                var fn = FindFn(lines, i);
+                if (fn.Length > 0)
+                    decls.Add(new ContractDecl(fn, null, Predicates.And(), null, "out"));
+            }
+            if (ImplementAnnotation().Match(lines[i]) is { Success: true } m)
+            {
+                var cid = m.Groups[1].Value;
+                var fn = FindFn(lines, i);
+                if (fn.Length > 0)
+                    decls.Add(new ContractDecl($"{fn}→{cid}", null, Predicates.And(), null, "out"));
+            }
+        }
+        return decls;
+    }
+
+    private static string FindFn(string[] lines, int start)
+    {
+        for (int j = start + 1; j < lines.Length && j < start + 10; j++)
+        {
+            var m = FunctionSig().Match(lines[j]);
+            if (m.Success) return m.Groups[1].Value;
+        }
+        return "";
+    }
+}

--- a/implementations/csharp/Provekit.Lift.Core/Provekit.Lift.Core.csproj
+++ b/implementations/csharp/Provekit.Lift.Core/Provekit.Lift.Core.csproj
@@ -1,17 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>Provekit.Lsp.Plugin</RootNamespace>
-    <AssemblyName>provekit-lsp-csharp</AssemblyName>
+    <RootNamespace>Provekit.Lift.Core</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Provekit.IR\Provekit.IR.csproj" />
-    <ProjectReference Include="..\Provekit.Lift.Core\Provekit.Lift.Core.csproj" />
+    <ProjectReference Include="..\Provekit.Lift.DataAnnotations\Provekit.Lift.DataAnnotations.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
   </ItemGroup>
 
 </Project>

--- a/implementations/csharp/Provekit.Lift.Core/SourceLifter.cs
+++ b/implementations/csharp/Provekit.Lift.Core/SourceLifter.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Provekit.Lift.Core.SourceLifter — Roslyn-driven source-to-IR pipeline
+// for the C# kit. Compiles a C# source string in-process, applies
+// DataAnnotations reflection lift to every public class, and adds any
+// //provekit: annotation declarations.
+//
+// This is the shared core for the C# kit (task #219). Both the LSP plugin
+// and any future batch-CLI lift binary call into it; the binaries are
+// thin shells around this orchestration.
+
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Provekit.IR;
+using Provekit.Lift.DataAnnotations;
+
+namespace Provekit.Lift.Core;
+
+public static class SourceLifter
+{
+    /// <summary>
+    /// Compile <paramref name="source"/> to an in-memory assembly, lift
+    /// every public class via DataAnnotations, append annotation-scan
+    /// declarations, and return the combined ContractDecl list.
+    /// Returns just the annotation-scan results if compilation fails.
+    /// </summary>
+    public static List<ContractDecl> LiftSource(string source, string path = "Source.cs")
+    {
+        var decls = new List<ContractDecl>();
+
+        try
+        {
+            var assembly = CompileToAssembly(source, path);
+            if (assembly is not null)
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    if (type.IsClass
+                        && !type.IsNestedPrivate
+                        && type.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>() is null)
+                    {
+                        decls.AddRange(DataAnnotationsLift.LiftType(type));
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Compilation failed: fall through to annotation scan only.
+        }
+
+        decls.AddRange(AnnotationScanner.ScanAnnotations(source));
+        return decls;
+    }
+
+    /// <summary>
+    /// Compile a C# source string to an in-memory assembly with the
+    /// minimal references needed for DataAnnotations reflection.
+    /// Returns null on emit failure.
+    /// </summary>
+    public static Assembly? CompileToAssembly(string source, string path)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source, path: path);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.ComponentModel.DataAnnotations.RequiredAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(Assembly.Load("System.Runtime").Location),
+            MetadataReference.CreateFromFile(Assembly.Load("System.ComponentModel.Primitives").Location),
+        };
+
+        var netstandard = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "netstandard");
+        if (netstandard is not null)
+            references.Add(MetadataReference.CreateFromFile(netstandard.Location));
+
+        var compilation = CSharpCompilation.Create(
+            "LiftAssembly",
+            new[] { tree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var ms = new MemoryStream();
+        var result = compilation.Emit(ms);
+        if (!result.Success) return null;
+
+        ms.Seek(0, SeekOrigin.Begin);
+        return Assembly.Load(ms.ToArray());
+    }
+}

--- a/implementations/csharp/Provekit.Lsp.Plugin/Program.cs
+++ b/implementations/csharp/Provekit.Lsp.Plugin/Program.cs
@@ -2,22 +2,19 @@
 //
 // provekit-lsp-csharp — NDJSON LSP plugin for C#.
 //
-// Uses Microsoft.CodeAnalysis (Roslyn) to compile C# source in-process,
-// then applies Provekit.Lift.DataAnnotations reflection-based lifting
-// and Provekit.Lift.Linq LINQ-expression lifting to emit canonical IR.
+// Thin shell around Provekit.Lift.Core.SourceLifter (task #219). All
+// lift orchestration (Roslyn compile, DataAnnotations lift, annotation
+// scan, marshal) lives in the shared core library; the plugin here just
+// wires JSON-RPC to that pipeline.
 //
 // Protocol:
 //   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
 //   {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
 //   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
 
-using System.Reflection;
 using System.Text.Json;
-using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Provekit.IR;
-using Provekit.Lift.DataAnnotations;
+using Provekit.Lift.Core;
 
 namespace Provekit.Lsp.Plugin;
 
@@ -70,116 +67,13 @@ partial class Program
         var path = tParams.TryGetProperty("path", out var p) ? p.GetString() ?? "Source.cs" : "Source.cs";
         var source = tParams.TryGetProperty("source", out var s) ? s.GetString() ?? "" : "";
 
-        var decls = new List<ContractDecl>();
+        var decls = SourceLifter.LiftSource(source, path);
 
-        // 1. Roslyn compilation → reflection → DataAnnotations lift
-        try
-        {
-            var assembly = CompileToAssembly(source, path);
-            if (assembly is not null)
-            {
-                foreach (var type in assembly.GetTypes())
-                {
-                    if (type.IsClass && !type.IsNestedPrivate && type.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>() is null)
-                    {
-                        var lifted = DataAnnotationsLift.LiftType(type);
-                        decls.AddRange(lifted);
-                    }
-                }
-            }
-        }
-        catch
-        {
-            // Compilation failed — fall through to annotation scan
-        }
-
-        // 2. Annotation scan for //provekit: comments
-        decls.AddRange(ScanAnnotations(source));
-
-        // 3. Marshal
         var jcs = decls.Count > 0
             ? Serialize.MarshalDeclarations(decls)
             : "[]";
 
         Console.WriteLine($"{{\"jsonrpc\":\"2.0\",\"id\":{id},\"result\":{{\"declarations\":{jcs},\"warnings\":[]}}}}");
-    }
-
-    // ── Roslyn compilation pipeline ─────────────────────────────────
-
-    static Assembly? CompileToAssembly(string source, string path)
-    {
-        var tree = CSharpSyntaxTree.ParseText(source, path: path);
-
-        var references = new List<MetadataReference>
-        {
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(System.ComponentModel.DataAnnotations.RequiredAttribute).Assembly.Location),
-            MetadataReference.CreateFromFile(Assembly.Load("System.Runtime").Location),
-            MetadataReference.CreateFromFile(Assembly.Load("System.ComponentModel.Primitives").Location),
-        };
-
-        // Add netstandard / System.Linq for LINQ lift support
-        var netstandard = AppDomain.CurrentDomain.GetAssemblies()
-            .FirstOrDefault(a => a.GetName().Name == "netstandard");
-        if (netstandard is not null)
-            references.Add(MetadataReference.CreateFromFile(netstandard.Location));
-
-        var compilation = CSharpCompilation.Create(
-            "LiftAssembly",
-            new[] { tree },
-            references,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-
-        using var ms = new MemoryStream();
-        var result = compilation.Emit(ms);
-        if (!result.Success) return null;
-
-        ms.Seek(0, SeekOrigin.Begin);
-        return Assembly.Load(ms.ToArray());
-    }
-
-    // ── Annotation scanning ──────────────────────────────────────
-
-    [GeneratedRegex(@"//\s*provekit:\s*contract")]
-    private static partial Regex ContractAnnotation();
-
-    [GeneratedRegex(@"//\s*provekit:\s*implement\s+([\w-]+)")]
-    private static partial Regex ImplementAnnotation();
-
-    [GeneratedRegex(@"(?:public|private|protected|internal|static)\s+\w+(?:\<[^>]*\>)?\s+(\w+)\s*\(")]
-    private static partial Regex FunctionSig();
-
-    static List<ContractDecl> ScanAnnotations(string source)
-    {
-        var decls = new List<ContractDecl>();
-        var lines = source.Split('\n');
-        for (int i = 0; i < lines.Length; i++)
-        {
-            if (ContractAnnotation().IsMatch(lines[i]))
-            {
-                var fn = FindFn(lines, i);
-                if (fn.Length > 0)
-                    decls.Add(new ContractDecl(fn, null, Predicates.And(), null, "out"));
-            }
-            if (ImplementAnnotation().Match(lines[i]) is { Success: true } m)
-            {
-                var cid = m.Groups[1].Value;
-                var fn = FindFn(lines, i);
-                if (fn.Length > 0)
-                    decls.Add(new ContractDecl($"{fn}→{cid}", null, Predicates.And(), null, "out"));
-            }
-        }
-        return decls;
-    }
-
-    static string FindFn(string[] lines, int start)
-    {
-        for (int j = start + 1; j < lines.Length && j < start + 10; j++)
-        {
-            var m = FunctionSig().Match(lines[j]);
-            if (m.Success) return m.Groups[1].Value;
-        }
-        return "";
     }
 
     // ── JSON-RPC ─────────────────────────────────────────────────

--- a/implementations/csharp/Provekit.sln
+++ b/implementations/csharp/Provekit.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Provekit.Lift.Linq", "Prove
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Provekit.Lift.Linq.Tests", "Provekit.Lift.Linq.Tests\Provekit.Lift.Linq.Tests.csproj", "{9EF36D93-3B69-4B8C-AEA9-696511D444C1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Provekit.Lift.Core", "Provekit.Lift.Core\Provekit.Lift.Core.csproj", "{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +153,18 @@ Global
 		{9EF36D93-3B69-4B8C-AEA9-696511D444C1}.Release|x64.Build.0 = Release|Any CPU
 		{9EF36D93-3B69-4B8C-AEA9-696511D444C1}.Release|x86.ActiveCfg = Release|Any CPU
 		{9EF36D93-3B69-4B8C-AEA9-696511D444C1}.Release|x86.Build.0 = Release|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Debug|x64.Build.0 = Debug|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Debug|x86.Build.0 = Debug|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Release|x64.ActiveCfg = Release|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Release|x64.Build.0 = Release|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Release|x86.ActiveCfg = Release|Any CPU
+		{F09DBF03-034E-4DEA-8CE4-B30A3DE3DE8C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/implementations/go/cmd/provekit-lsp-go/main.go
+++ b/implementations/go/cmd/provekit-lsp-go/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	ir "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
+	validator "github.com/tsavo/provekit/go/provekit-lift-go-validator"
 )
 
 type rpcRequest struct {
@@ -194,9 +195,13 @@ func walkSource(src, path string) []ir.Declaration {
 	return decls
 }
 
-// liftStructFromAST walks struct fields with validate tags and lifts to IR.
-// This mirrors the validator.LiftStruct logic but operates on the AST
-// rather than requiring a live struct value.
+// liftStructFromAST walks struct fields with validate tags and lifts to IR
+// by delegating to the shared validator core (task #219).
+//
+// This is the AST-driven counterpart to validator.LiftStruct: rather than
+// requiring a live struct value (reflection), it derives the field's
+// ir.Sort from the AST type expression and calls validator.LiftValidateTags,
+// the same source-agnostic core used by the batch-CLI lift binary.
 func liftStructFromAST(structName string, st *ast.StructType) []ir.Declaration {
 	var decls []ir.Declaration
 
@@ -211,19 +216,19 @@ func liftStructFromAST(structName string, st *ast.StructType) []ir.Declaration {
 		tag = strings.TrimSpace(tag)
 
 		// Parse as a struct tag key:"value"
-		st := reflect.StructTag(tag)
-		validate, ok := st.Lookup("validate")
-		if !ok || validate == "" {
+		structTag := reflect.StructTag(tag)
+		validateTag, ok := structTag.Lookup("validate")
+		if !ok || validateTag == "" {
 			continue
 		}
 
-		// Determine Go type kind from AST
-		goKind := inferGoKind(field.Type)
+		// Derive Sort from AST type expression
+		sort := sortFromASTType(field.Type)
 
 		// Multiple field names? (e.g. `a, b int`)
 		for _, name := range field.Names {
-			// Build IR formula from validate tags
-			f := liftValidateTags(goKind, name.Name, validate)
+			v := ir.MakeVar(name.Name, sort)
+			f := validator.LiftValidateTags(v, sort, validateTag)
 			if f != nil {
 				decls = append(decls, ir.ContractDeclaration{
 					Name:       fmt.Sprintf("%s.%s", structName, name.Name),
@@ -236,145 +241,14 @@ func liftStructFromAST(structName string, st *ast.StructType) []ir.Declaration {
 	return decls
 }
 
-// inferGoKind maps an AST type expression to a rough Go kind string.
-func inferGoKind(expr ast.Expr) string {
-	switch t := expr.(type) {
-	case *ast.Ident:
-		switch t.Name {
-		case "string":
-			return "string"
-		case "int", "int8", "int16", "int32", "int64",
-			"uint", "uint8", "uint16", "uint32", "uint64",
-			"float32", "float64":
-			return "int"
-		case "bool":
-			return "bool"
-		}
-	case *ast.StarExpr, *ast.InterfaceType, *ast.MapType, *ast.ArrayType:
-		return "ref"
+// sortFromASTType reduces an AST type expression to a ProvekIt Sort.
+// Idents are forwarded by name to validator.GoSortFromTypeName; pointers,
+// interfaces, maps, and arrays fall through to ir.Ref.
+func sortFromASTType(expr ast.Expr) ir.Sort {
+	if ident, ok := expr.(*ast.Ident); ok {
+		return validator.GoSortFromTypeName(ident.Name)
 	}
-	return "ref"
-}
-
-// liftValidateTags maps validate tag fragments to IR formulas.
-func liftValidateTags(goKind, varName, tag string) ir.IrFormula {
-	var constraints []ir.IrFormula
-	v := ir.MakeVar(varName, goSortFromKind(goKind))
-
-	parts := strings.Split(tag, ",")
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-
-		f := liftValidateTag(v, goKind, part)
-		if f != nil {
-			constraints = append(constraints, f)
-		}
-	}
-
-	switch len(constraints) {
-	case 0:
-		return nil
-	case 1:
-		return constraints[0]
-	default:
-		return ir.And(constraints...)
-	}
-}
-
-// liftValidateTag maps a single validate tag to an IR formula.
-// Duplicated from validator.go for AST-mode operation.
-func liftValidateTag(v ir.IrTerm, goKind, tag string) ir.IrFormula {
-	if tag == "required" {
-		if goKind == "string" {
-			return ir.Neq(v, ir.StrConst(""))
-		}
-		return ir.Neq(v, ir.Num(0))
-	}
-
-	for _, op := range []string{"gte=", "lte=", "gt=", "lt=", "eq=", "ne="} {
-		if !strings.HasPrefix(tag, op) {
-			continue
-		}
-		numStr := tag[len(op):]
-		n := 0
-		if _, err := fmt.Sscanf(numStr, "%d", &n); err != nil {
-			return nil
-		}
-		rhs := ir.Num(int64(n))
-		switch op[:len(op)-1] {
-		case "gte":
-			return ir.Gte(v, rhs)
-		case "lte":
-			return ir.Lte(v, rhs)
-		case "gt":
-			return ir.Gt(v, rhs)
-		case "lt":
-			return ir.Lt(v, rhs)
-		case "eq":
-			return ir.Eq(v, rhs)
-		case "ne":
-			return ir.Neq(v, rhs)
-		}
-	}
-
-	if strings.HasPrefix(tag, "min=") {
-		var n int
-		if _, err := fmt.Sscanf(tag[4:], "%d", &n); err != nil {
-			return nil
-		}
-		ni := ir.Num(int64(n))
-		if goKind == "int" {
-			return ir.Gte(v, ni)
-		}
-		return ir.Gte(ir.StringLength(v), ni)
-	}
-	if strings.HasPrefix(tag, "max=") {
-		var n int
-		if _, err := fmt.Sscanf(tag[4:], "%d", &n); err != nil {
-			return nil
-		}
-		ni := ir.Num(int64(n))
-		if goKind == "int" {
-			return ir.Lte(v, ni)
-		}
-		return ir.Lte(ir.StringLength(v), ni)
-	}
-	if strings.HasPrefix(tag, "len=") {
-		var n int
-		if _, err := fmt.Sscanf(tag[4:], "%d", &n); err != nil {
-			return nil
-		}
-		return ir.Eq(ir.StringLength(v), ir.Num(int64(n)))
-	}
-	if tag == "email" {
-		return ir.And() // true placeholder
-	}
-	if strings.HasPrefix(tag, "oneof=") {
-		values := strings.Fields(tag[6:])
-		var eqs []ir.IrFormula
-		for _, val := range values {
-			eqs = append(eqs, ir.Eq(v, ir.StrConst(val)))
-		}
-		return ir.Or(eqs...)
-	}
-	return nil
-}
-
-// goSortFromKind maps a Go kind string to a ProvekIt Sort.
-func goSortFromKind(kind string) ir.Sort {
-	switch kind {
-	case "string":
-		return ir.String
-	case "int":
-		return ir.Int
-	case "bool":
-		return ir.Bool
-	default:
-		return ir.Ref
-	}
+	return ir.Ref
 }
 
 // scanAnnotations scans source lines for //provekit: annotations.

--- a/implementations/go/provekit-lift-go-validator/validator.go
+++ b/implementations/go/provekit-lift-go-validator/validator.go
@@ -3,6 +3,12 @@
 // Maps struct field validate tags to ProvekIt ContractDeclarations with
 // byte-for-byte identical IR to sister kits for equivalent constraints.
 //
+// This package is the shared lifter core for the Go kit (task #219). Both
+// the batch-CLI binary (cmd/provekit-lift-go) and the LSP plugin
+// (cmd/provekit-lsp-go) call into it: the binary uses the reflection-driven
+// LiftStruct entry point; the LSP uses LiftValidateTags / LiftValidateTag
+// after deriving the sort from the AST.
+//
 // Example:
 //
 //	type User struct {
@@ -60,10 +66,20 @@ func LiftStruct(v interface{}) []ir.Declaration {
 // liftField parses a validate tag and returns the conjunctive IR formula
 // for all constraints on the field, or nil if nothing was recognized.
 func liftField(field reflect.StructField, tag string) ir.IrFormula {
-	var constraints []ir.IrFormula
-	fieldName := field.Name
 	sort := goSort(field.Type)
-	v := ir.MakeVar(fieldName, sort)
+	v := ir.MakeVar(field.Name, sort)
+	return LiftValidateTags(v, sort, tag)
+}
+
+// LiftValidateTags parses a comma-separated validate tag string against an
+// already-bound term v of the given sort, and returns the conjunctive IR
+// formula for all recognized constraints (or nil if nothing was recognized).
+//
+// This is the source-agnostic entry point shared between the reflection-based
+// LiftStruct driver and source-driven callers (the LSP plugin walks the Go
+// AST and converts type identifiers to ir.Sort before calling this).
+func LiftValidateTags(v ir.IrTerm, sort ir.Sort, tag string) ir.IrFormula {
+	var constraints []ir.IrFormula
 
 	parts := strings.Split(tag, ",")
 	for _, part := range parts {
@@ -72,7 +88,7 @@ func liftField(field reflect.StructField, tag string) ir.IrFormula {
 			continue
 		}
 
-		f := liftTag(v, sort, part)
+		f := LiftValidateTag(v, sort, part)
 		if f != nil {
 			constraints = append(constraints, f)
 		}
@@ -88,8 +104,9 @@ func liftField(field reflect.StructField, tag string) ir.IrFormula {
 	}
 }
 
-// liftTag maps a single validate tag fragment to an IR formula.
-func liftTag(v ir.IrTerm, sort ir.Sort, tag string) ir.IrFormula {
+// LiftValidateTag maps a single validate tag fragment to an IR formula.
+// Returns nil if the tag is unrecognized.
+func LiftValidateTag(v ir.IrTerm, sort ir.Sort, tag string) ir.IrFormula {
 	// required
 	if tag == "required" {
 		return requiredConstraint(v, sort)
@@ -202,6 +219,26 @@ func goSort(t reflect.Type) ir.Sort {
 		return ir.Bool
 	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice:
 		return ir.Ref
+	default:
+		return ir.Ref
+	}
+}
+
+// GoSortFromTypeName maps a Go type name (as it appears in source, e.g.
+// "string", "int", "int64", "bool") to a ProvekIt Sort. Used by the LSP
+// plugin when walking the AST: the type expression is reduced to a name
+// and converted here. Anything unrecognized (pointers, interfaces, named
+// types, generics) falls through to ir.Ref.
+func GoSortFromTypeName(name string) ir.Sort {
+	switch name {
+	case "string":
+		return ir.String
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64",
+		"float32", "float64":
+		return ir.Int
+	case "bool":
+		return ir.Bool
 	default:
 		return ir.Ref
 	}


### PR DESCRIPTION
## Summary

Closes #219. The lift adapter binary and the LSP plugin in each kit (go + csharp) now share a single source of truth for IR emission. The binaries become thin shells around kit-level cores.

### Go: real duplication eliminated

- `provekit-lift-go-validator` exposes `LiftValidateTags`, `LiftValidateTag`, `GoSortFromTypeName` as the source-agnostic core.
- `LiftStruct` (reflection, batch-CLI) still works exactly as before.
- `cmd/provekit-lsp-go` imports the validator and deletes ~100 lines of duplicated goKind-string-based reimplementation. AST-mode now derives `ir.Sort` and calls the shared core; LSP and batch-CLI emit byte-identical IR for the same tag string.

### C#: symmetric core added

`Provekit.Lift.DataAnnotations` was already a library that the LSP plugin imported, so reflection lifting was already shared. What remained duplicate-shaped was the Roslyn pipeline + annotation scanner: that now lives in a new `Provekit.Lift.Core` library that both the LSP plugin and any future C# batch-CLI lift binary can use.

- `Provekit.Lift.Core.AnnotationScanner` — `//provekit:contract` / `//provekit:implement` scanner.
- `Provekit.Lift.Core.SourceLifter` — Roslyn compile -> DataAnnotations lift -> annotation scan pipeline.
- `Provekit.Lsp.Plugin` becomes a JSON-RPC shell that calls `SourceLifter.LiftSource`. The `Microsoft.CodeAnalysis.CSharp` package reference moves to Core.

### Net change

```
 .../csharp/Provekit.Lsp.Plugin/Program.cs          | 118 +-------------
 .../Provekit.Lsp.Plugin/Provekit.Lsp.Plugin.csproj |   8 +-
 implementations/csharp/Provekit.sln                |  14 ++
 implementations/go/cmd/provekit-lsp-go/main.go     | 170 +++------------------
 .../go/provekit-lift-go-validator/validator.go     |  49 +++++-
 + Provekit.Lift.Core (new: csproj + 2 .cs files)
```

## Test plan

- [x] Go: `go build ./...` clean
- [x] Go: `go test ./cmd/provekit-lsp-go` passes (7/7)
- [x] Go: validator tests show only the 4 pre-existing json.Marshal-key-order failures (baseline-identical, out of scope)
- [x] C#: `dotnet build Provekit.sln` clean
- [x] C#: `dotnet test` passes 61/61 (Provekit.Tests 44, Provekit.Lift.Linq.Tests 9, Provekit.Lift.DataAnnotations 8)
- [x] Go LSP smoke (`type User struct { Name string \`validate:"required,min=1"\` }`) emits byte-identical declarations to pre-refactor
- [x] C# LSP smoke (`[Required] public string Name`) emits byte-identical declarations to pre-refactor

Scope: go and csharp only. Other kits (python, ruby, zig) follow as separate PRs if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)