### PR TITLE
feat(cpp): mint lift-plugin-protocol bridges to rust contracts (Phase 2)

### DIFF
--- a/.provekit/self-contracts-attestations/cpp.json
+++ b/.provekit/self-contracts-attestations/cpp.json
@@ -2,8 +2,8 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "cpp",
-  "cid": "blake3-512:9335e6376d776819cfd3b2458da29bc258e7c2ebaad542a8613dd84f50c51c31d6e1a4346cea3903b8ad12294d96aef445d0ed838aa630835b9be0bc17e62842",
+  "cid": "blake3-512:5a37fd2eddcc72aa8325c81bd235feb5cc0bee14f35653b76100a2d2e8c25994da2425974a503321d111a687b00df2886c11f5c7769d4db5af0e21c5290ddbc8",
   "declaredAt": "2026-05-02T17:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:LELpXeQXOZcJxqDXwRhOs0pgB/5OX0+BfNQMQUCIM84Xcdh3RadBDpmaLBtYce7CEZymFBnB+xFF0Nui8cMPAQ=="
+  "signature": "ed25519:7oM/HMaf5pNTse5lXmap/OGVuT7BX2jrm40fu1zAvXZq0UJY0nVCpvrKgQLLXnGAoBwVmLHMPoOrlg/xhtPJDw=="
 }

--- a/implementations/cpp/provekit-self-contracts/cross_kit_bridges.cpp
+++ b/implementations/cpp/provekit-self-contracts/cross_kit_bridges.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cross-kit conformance bridges (cpp peer): the `cross_kit_bridges_invariants`
+// registrar. Authors the 10 cpp counterpart contracts, one per rust
+// lift-plugin-protocol contract. Bridges live in cross_kit_bridges.hpp
+// alongside the rust source-CID pins; the test
+// (cross_kit_bridges_test.cpp) is the single point that pins the
+// JCS-of-the-bridge-array bytes.
+//
+// Each counterpart asserts "cpp-kit's lift adapter satisfies rust's
+// <contract name>" via a kit-defined named ctor whose paired-equality
+// with `true_const` encodes the protocol-level claim. Z3 has no
+// semantics for the ctor; the contract's value is the named-membership
+// shape, which the bridge pins into a closed source-target pair.
+//
+// See cross_kit_bridges.hpp for the full design notes; this file is the
+// extern-C entry point the cpp orchestrator (mint_cpp_self_contracts.cpp)
+// links and calls during slab authoring.
+
+#include "cross_kit_bridges.hpp"
+
+#include "provekit/ir.hpp"
+
+#include <memory>
+#include <string>
+
+extern "C" void cross_kit_bridges_invariants() {
+    using namespace provekit::ir;
+    using namespace provekit::cross_kit_bridges;
+
+    auto ctor1 = [](std::string name, std::shared_ptr<Term> arg) {
+        return std::make_shared<Term>(
+            Term{CtorTerm{std::move(name), {std::move(arg)}}});
+    };
+
+    for (const auto& rust_name : lift_plugin_protocol_contract_names()) {
+        const auto cp_name = counterpart_contract_name(rust_name);
+
+        // Counterpart: the cpp lift adapter satisfies the rust rule.
+        // Post is a paired-equality whose ctor name encodes the claim.
+        contract(
+            cp_name,
+            /*pre=*/nullptr,
+            /*post=*/eq(
+                ctor1("cpp_lift_satisfies_rust_contract", str_const(rust_name)),
+                ctor1("true_const", str_const(""))),
+            /*inv=*/nullptr,
+            /*outBinding=*/"out");
+    }
+}

--- a/implementations/cpp/provekit-self-contracts/cross_kit_bridges.hpp
+++ b/implementations/cpp/provekit-self-contracts/cross_kit_bridges.hpp
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cross-kit conformance bridges for the lift-plugin protocol (cpp peer).
+//
+// Phase 2 of the cross-kit bridge work. Phase 1 landed in PR #84:
+// implementations/rust/provekit-self-contracts/src/lift_plugin_protocol.rs
+// authored 10 contracts encoding the rules of
+// protocol/specs/2026-04-30-lift-plugin-protocol.md (the "lift-plugin-
+// protocol spec", v1.2.0 normative). The rust .proof now ships those 10
+// contracts as signed mementos with content-addressed CIDs.
+//
+// This header carries:
+//
+//   * the 10 lift_plugin_protocol contract names in stable declaration
+//     order (insertion order from rust's `lift_plugin_protocol::invariants()`)
+//   * the rust memento envelope CID for each (frozen pin, see comment
+//     on `rust_contract_cid` for re-extraction)
+//   * `build_lift_plugin_protocol_bridges()` returning the 10 BridgeDecls
+//     used by the pinned-hash test
+//   * `marshal_bridges()` JCS emitter that stitches `write_bridge_decl`
+//     into a JSON array (matches go's `MarshalDeclarations` / ts's
+//     `canonicalEncode([...bridges])` byte shape)
+//
+// The matching .cpp file defines the `cross_kit_bridges_invariants()`
+// extern-C registrar that authors the 10 cpp counterpart contracts when
+// the cpp self-contracts orchestrator runs. The registrar pushes
+// counterparts into the kit collector (same path as every other
+// .invariant.cpp slab); bridges are not yet wired into the cpp bundle
+// because the orchestrator has no bridge-marshal pass — phase-3 work
+// will fix that and re-mint the bridges with real target_contract_cid
+// values.
+//
+// targetProofCid is `deferred:phase-3-proof-bundle` because computing
+// the cpp lift plugin's binary CID is phase-3 work (binary attestation
+// per protocol/specs/2026-05-02-binary-attestation-protocol.md).
+
+#pragma once
+
+#include "provekit/ir.hpp"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace provekit::cross_kit_bridges {
+
+// --- Constants shared between the slab and the test ------------------------
+
+inline constexpr const char* kRustKitLayer = "rust-kit";
+inline constexpr const char* kCppKitLayer = "cpp-kit";
+inline constexpr const char* kDeferredCppLiftBinaryCid =
+    "deferred:phase-3-proof-bundle";
+inline constexpr const char* kPhase2BridgeNotes =
+    "lift-plugin-protocol conformance bridge; phase 2";
+
+// 10 lift_plugin_protocol contract names in the order they're authored
+// in the rust slab. Hard-coded so adding/removing a rust contract
+// without updating the cpp slab fails loud (the pinned-hash test will
+// diverge).
+inline const std::vector<std::string>& lift_plugin_protocol_contract_names() {
+    static const std::vector<std::string> names = {
+        "lift_plugin_initialize_protocol_version_match",
+        "lift_plugin_initialize_capabilities_authoring_surfaces_nonempty",
+        "lift_plugin_initialize_capabilities_ir_version_starts_with_v",
+        "lift_plugin_lift_request_surface_is_string",
+        "lift_plugin_lift_request_source_paths_nonempty",
+        "lift_plugin_lift_request_source_paths_each_nonempty",
+        "lift_plugin_lift_request_surface_in_capabilities",
+        "lift_plugin_lift_response_kind_in_set",
+        "lift_plugin_lift_response_ir_document_array",
+        "lift_plugin_diagnostic_field_is_array",
+    };
+    return names;
+}
+
+// Rust memento envelope CIDs for each lift-plugin-protocol contract.
+// Extracted from `cargo run --release -p provekit-self-contracts --bin
+// print-lift-plugin-protocol-cids` on the post-PR-#84 quiescent tree.
+//
+// These are NOT JCS-of-the-formula hashes; they are the CIDs of the
+// signed CBOR claim envelopes produced by rust's `mint_contract` under
+// the foundation key (signer_seed = [0x42; 32]) with rust's pinned
+// produced_at. Peer kits cannot recompute them locally without
+// replicating the full sign pipeline, so we pin the values verbatim.
+inline std::string rust_contract_cid(const std::string& rust_name) {
+    if (rust_name == "lift_plugin_initialize_protocol_version_match") {
+        return "blake3-512:95163d00976803c3ef381494a8a940bd862529f7bdfb72aa523bd58359b86d6fce017991658932e3e3dee8b4c60b26066bfa270474b2896c19dd2ec85d4aa47a";
+    }
+    if (rust_name == "lift_plugin_initialize_capabilities_authoring_surfaces_nonempty") {
+        return "blake3-512:1898e2518e96628bbe46704f6f6a90cc57572f3b15bb3f4f6a7d8fef28a8c92e31b33b14f21d4011ed7ad11d4ea09c67c1549cbe1c2bf38e53b7e8cfdb656099";
+    }
+    if (rust_name == "lift_plugin_initialize_capabilities_ir_version_starts_with_v") {
+        return "blake3-512:08d09e6f677e77f5b501a07a5271cebdadb19c48c52375ae9e6edcb699b6515eacdea2d7966497c3b3aca4054340e7222fe97bbbb8f60e2ee62baaec6ef719f0";
+    }
+    if (rust_name == "lift_plugin_lift_request_surface_is_string") {
+        return "blake3-512:bf6ac4f7e481ba1fea26716f9d2e7756c86b1940610e2d9e35a5d6e11faa8993a92cd291f491c4d520e5daf1a54c32aeb492adac5aa8d61d224ca1104adaaf8a";
+    }
+    if (rust_name == "lift_plugin_lift_request_source_paths_nonempty") {
+        return "blake3-512:3f2915b063357c28cd2bd8132279e819424999b21a776824d3db9231ca4acb8fdc02ea6e5a8945e55a1d439fda94d07b365d0d160e4ece94b1012fe064ca7c22";
+    }
+    if (rust_name == "lift_plugin_lift_request_source_paths_each_nonempty") {
+        return "blake3-512:f57621c2ba995cbd13d9d06c4209ad9ecdb6369d1e90d902b90996275dd40a38804c986b77b9f28bdf7eefc2b0f242284d1612a4149f5abb0451097a72f95822";
+    }
+    if (rust_name == "lift_plugin_lift_request_surface_in_capabilities") {
+        return "blake3-512:61c67906e3b2ff0d0a61419436670140009556402b643516c4afb14212c057a080bf6f29a0c4c374fe2eb45f8016ddfc82ed12fae2735c7384a8b56a7597db51";
+    }
+    if (rust_name == "lift_plugin_lift_response_kind_in_set") {
+        return "blake3-512:7642bd5eb5262354921513ee6e01bf70dad917f3467464ad904750685e84d0241ef9b0f40b6e0d66dd73e0d5cc1908e4a0a45d45530dda511e1919786034e2a0";
+    }
+    if (rust_name == "lift_plugin_lift_response_ir_document_array") {
+        return "blake3-512:692df8b67bc3ad69943f5909779f489bdc8173bbb08fd61585bb1b8bc0a2c20c6891ba7b9a2a4e4e3a6e5a4441b1191f4618924783446cb07277879c885cbc20";
+    }
+    if (rust_name == "lift_plugin_diagnostic_field_is_array") {
+        return "blake3-512:ea5dd139fddc9e5ab6cfcb9854de1ce6bbedcccbe7b070c1aef9fbbef3b8579ebf33ff14cdc97013e1f3e1c391964f275a0275b615b8259037b0cb92d0e0dd35";
+    }
+    return "";  // unknown name -> empty (caller checks)
+}
+
+// Counterpart contract name for a given rust contract name.
+inline std::string counterpart_contract_name(const std::string& rust_name) {
+    return "cpp_" + rust_name;
+}
+
+// Bridge declaration name for a given rust contract name.
+inline std::string bridge_name(const std::string& rust_name) {
+    return "bridge_to_" + rust_name;
+}
+
+// Pending placeholder for `target_contract_cid`. The cpp mint
+// orchestrator does not yet have a bridge-resolution pass; until phase-3
+// work wires bridges into the bundle, the placeholder shape is what the
+// bridge bytes hash over. Mirrors go's `pending-go-counterpart:<name>`.
+inline std::string pending_target_contract_cid(const std::string& cp_name) {
+    return "pending-cpp-counterpart:" + cp_name;
+}
+
+// Build the 10 BridgeDecls in stable declaration order. Used by the
+// pinned-bytes test in cross_kit_bridges_test.cpp.
+inline std::vector<provekit::ir::BridgeDecl>
+build_lift_plugin_protocol_bridges() {
+    std::vector<provekit::ir::BridgeDecl> out;
+    out.reserve(10);
+    for (const auto& rust_name : lift_plugin_protocol_contract_names()) {
+        const auto cp_name = counterpart_contract_name(rust_name);
+        provekit::ir::BridgeDecl b{};
+        b.name = bridge_name(rust_name);
+        b.source_symbol = rust_name;
+        b.source_layer = kRustKitLayer;
+        b.source_contract_cid = rust_contract_cid(rust_name);
+        b.target_contract_cid = pending_target_contract_cid(cp_name);
+        b.target_proof_cid = kDeferredCppLiftBinaryCid;
+        b.target_layer = kCppKitLayer;
+        b.notes = kPhase2BridgeNotes;
+        out.push_back(std::move(b));
+    }
+    return out;
+}
+
+// Marshal a BridgeDecl array as a JSON array using ir::write_bridge_decl
+// for each element. JCS-canonical bytes used for the pinned hash test.
+inline std::string marshal_bridges(
+    const std::vector<provekit::ir::BridgeDecl>& bridges) {
+    std::ostringstream out;
+    out << "[";
+    for (size_t i = 0; i < bridges.size(); i++) {
+        if (i > 0) out << ",";
+        provekit::ir::write_bridge_decl(out, bridges[i]);
+    }
+    out << "]";
+    return out.str();
+}
+
+}  // namespace provekit::cross_kit_bridges

--- a/implementations/cpp/provekit-self-contracts/cross_kit_bridges_test.cpp
+++ b/implementations/cpp/provekit-self-contracts/cross_kit_bridges_test.cpp
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase-2 cross-kit bridge test: cpp kit attestation that the cpp lift
+// adapter satisfies the Rust kit's `lift_plugin_protocol` contracts.
+//
+// For each of the 10 contracts in the Rust self-contracts bundle (see
+// `implementations/rust/provekit-self-contracts/src/lift_plugin_protocol.rs`),
+// this test:
+//
+//   1. Builds the 10 BridgeDecls via build_lift_plugin_protocol_bridges()
+//      (each links rust source CID -> cpp counterpart name placeholder,
+//      with target_proof_cid = `deferred:phase-3-proof-bundle`).
+//   2. Marshals the array via JCS-alphabetical write_bridge_decl emitter.
+//   3. Asserts the BLAKE3-512 of those bytes matches the pinned golden.
+//
+// On rust drift (rare but possible if the rust lift_plugin_protocol slab
+// is re-touched), the pinned `rust_contract_cid()` map will diverge from
+// the new mint output; the bridge bytes change, the pinned bridge-array
+// CID changes, this test fails. That's the desired behavior: drift must
+// be visible, not silent.
+//
+// The pinned hash is independent of the cpp bundle CID. The bundle CID
+// drifts because the slab adds 10 counterpart contracts to the mint;
+// the attestation re-sign is a follow-up tracked in the PR body.
+//
+// Spec sources:
+//   protocol/specs/2026-04-30-lift-plugin-protocol.md (the 10 rules)
+//   protocol/specs/2026-04-30-ir-formal-grammar.md §BridgeDeclaration
+//   protocol/specs/2026-05-02-binary-attestation-protocol.md (phase-3)
+
+#include "provekit/ir.hpp"
+#include "provekit/canonicalizer/hash.hpp"
+
+#include "cross_kit_bridges.hpp"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using ::provekit::canonicalizer::compute_cid;
+using ::provekit::ir::BridgeDecl;
+namespace ckb = provekit::cross_kit_bridges;
+
+namespace {
+
+bool check_eq_str(const char* label, const std::string& got, const std::string& want) {
+    if (got == want) {
+        std::printf("  [PASS] %s\n", label);
+        return true;
+    }
+    std::printf("  [FAIL] %s\n", label);
+    std::printf("         got:  %s\n", got.c_str());
+    std::printf("         want: %s\n", want.c_str());
+    return false;
+}
+
+bool starts_with(const std::string& s, const std::string& prefix) {
+    return s.size() >= prefix.size() &&
+           s.compare(0, prefix.size(), prefix) == 0;
+}
+
+bool is_lowercase_hex(const std::string& s) {
+    for (char c : s) {
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+// Pinned BLAKE3-512 over the JCS-canonical bytes of the 10 phase-2
+// BridgeDecls returned by ckb::build_lift_plugin_protocol_bridges().
+//
+// Drift in any of the following invalidates this hash:
+//   - rust contract memento CID for any of the 10 lift-plugin-protocol
+//     contracts (rust_contract_cid() in cross_kit_bridges.cpp)
+//   - bridge name spelling (bridge_to_<rust_name>)
+//   - cpp counterpart name spelling (cpp_<rust_name>)
+//   - source_layer / target_layer / notes literals
+//   - kDeferredCppLiftBinaryCid ("deferred:phase-3-proof-bundle")
+//   - declaration order
+//   - JCS write_bridge_decl emitter
+//
+// Computed at PR-authoring time over the BridgeDecl array returned by
+// build_lift_plugin_protocol_bridges() with target_contract_cid carrying
+// the `pending-cpp-counterpart:<name>` placeholder. The cpp orchestrator
+// has no bridge-resolution pass yet (that's phase-3 work), so the
+// placeholder shape IS what's frozen here: the bridge-list is content-
+// addressable independent of the transient cpp bundle's internal CIDs.
+static const char* kPinnedBridgeArrayCid =
+    "blake3-512:5815db0b992594bf120317c5e4a3f25132574ba3615106fd20a81f2dc8c1a4cf"
+    "1d37bae9753a6056ef8e9b53d4405aa1c36de24236437ba9baefc296949c91a6";
+
+int main() {
+    int failures = 0;
+    std::printf("phase-2 cross-kit bridges test (cpp peer):\n\n");
+
+    // --- 1. Bridge count ---------------------------------------------------
+    auto bridges = ckb::build_lift_plugin_protocol_bridges();
+    if (bridges.size() != 10) {
+        std::printf("  [FAIL] expected 10 bridges, got %zu\n", bridges.size());
+        failures++;
+        return 1;  // bail; subsequent checks assume 10
+    }
+    std::printf("  [PASS] bridge count == 10\n");
+
+    // --- 2. Bridge name + counterpart prefix invariants --------------------
+    bool prefix_ok = true;
+    for (const auto& b : bridges) {
+        if (!starts_with(b.name, "bridge_to_lift_plugin_")) {
+            std::printf("  [FAIL] bridge name must start with "
+                        "'bridge_to_lift_plugin_'; got %s\n",
+                        b.name.c_str());
+            prefix_ok = false;
+        }
+        if (!starts_with(b.source_symbol, "lift_plugin_")) {
+            std::printf("  [FAIL] bridge %s: source_symbol must start with "
+                        "'lift_plugin_'; got %s\n",
+                        b.name.c_str(), b.source_symbol.c_str());
+            prefix_ok = false;
+        }
+    }
+    if (prefix_ok) {
+        std::printf("  [PASS] all bridge + source names use lift_plugin_ prefix\n");
+    } else {
+        failures++;
+    }
+
+    // --- 3. Source/target layers, notes, target_proof_cid ------------------
+    bool fields_ok = true;
+    for (const auto& b : bridges) {
+        if (b.source_layer != "rust-kit") {
+            std::printf("  [FAIL] bridge %s: source_layer = %s, want rust-kit\n",
+                        b.name.c_str(), b.source_layer.c_str());
+            fields_ok = false;
+        }
+        if (b.target_layer != "cpp-kit") {
+            std::printf("  [FAIL] bridge %s: target_layer = %s, want cpp-kit\n",
+                        b.name.c_str(), b.target_layer.c_str());
+            fields_ok = false;
+        }
+        if (b.target_proof_cid != "deferred:phase-3-proof-bundle") {
+            std::printf("  [FAIL] bridge %s: target_proof_cid = %s, "
+                        "want deferred:phase-3-proof-bundle\n",
+                        b.name.c_str(), b.target_proof_cid.c_str());
+            fields_ok = false;
+        }
+        if (b.notes != "lift-plugin-protocol conformance bridge; phase 2") {
+            std::printf("  [FAIL] bridge %s: notes = %s\n",
+                        b.name.c_str(), b.notes.c_str());
+            fields_ok = false;
+        }
+    }
+    if (fields_ok) {
+        std::printf("  [PASS] all bridges carry expected layers + notes + "
+                    "deferred target_proof_cid\n");
+    } else {
+        failures++;
+    }
+
+    // --- 4. Source contract CIDs are well-formed BLAKE3-512 ----------------
+    bool cids_ok = true;
+    const std::string want_prefix = "blake3-512:";
+    for (const auto& b : bridges) {
+        if (!starts_with(b.source_contract_cid, want_prefix)) {
+            std::printf("  [FAIL] bridge %s: source_contract_cid missing "
+                        "blake3-512: prefix\n", b.name.c_str());
+            cids_ok = false;
+            continue;
+        }
+        const std::string hex = b.source_contract_cid.substr(want_prefix.size());
+        if (hex.size() != 128) {
+            std::printf("  [FAIL] bridge %s: source_contract_cid hex length "
+                        "%zu, want 128\n", b.name.c_str(), hex.size());
+            cids_ok = false;
+            continue;
+        }
+        if (!is_lowercase_hex(hex)) {
+            std::printf("  [FAIL] bridge %s: source_contract_cid hex not "
+                        "lowercase\n", b.name.c_str());
+            cids_ok = false;
+        }
+    }
+    if (cids_ok) {
+        std::printf("  [PASS] all 10 source_contract_cid values are "
+                    "well-formed blake3-512:<128-hex>\n");
+    } else {
+        failures++;
+    }
+
+    // --- 5. Pinned BLAKE3-512 of the JCS-canonical bridges array -----------
+    //
+    // Load-bearing pin: any drift in rust source CIDs, bridge field
+    // encoding, or declaration order surfaces here.
+    const std::string jcs_bytes = ckb::marshal_bridges(bridges);
+    const std::string got_cid = compute_cid(jcs_bytes);
+
+    if (!check_eq_str("phase-2 cpp bridges JCS hash matches pin",
+                       got_cid, std::string(kPinnedBridgeArrayCid))) {
+        std::printf("\n         If this drift is intentional, update "
+                    "kPinnedBridgeArrayCid in this file and re-sign\n"
+                    "         .provekit/self-contracts-attestations/cpp.json "
+                    "in a follow-up commit.\n");
+        std::printf("\n         marshalled bytes (%zu chars):\n  %s\n",
+                    jcs_bytes.size(), jcs_bytes.c_str());
+        failures++;
+    }
+
+    std::printf("\n");
+    if (failures == 0) {
+        std::printf("PHASE-2 CROSS-KIT BRIDGES (cpp) OK.\n");
+        return 0;
+    }
+    std::printf("PHASE-2 CROSS-KIT BRIDGES (cpp) FAILED: %d divergence(s).\n",
+                failures);
+    return 1;
+}

--- a/implementations/cpp/provekit-self-contracts/mint_cpp_self_contracts.cpp
+++ b/implementations/cpp/provekit-self-contracts/mint_cpp_self_contracts.cpp
@@ -62,6 +62,7 @@ extern "C" {
     void enumerate_callsites_invariants();
     void resolve_target_invariants();
     void instantiate_invariants();
+    void cross_kit_bridges_invariants();
 }
 
 static std::string mint_one_run(const std::string& out_dir, bool verbose) {
@@ -79,10 +80,11 @@ static std::string mint_one_run(const std::string& out_dir, bool verbose) {
     enumerate_callsites_invariants();
     resolve_target_invariants();
     instantiate_invariants();
+    cross_kit_bridges_invariants();
     auto contract_decls = finish();
 
     if (verbose) {
-        std::printf("authored %zu contracts across 11 .invariant.cpp slabs\n",
+        std::printf("authored %zu contracts across 12 .invariant.cpp slabs\n",
                     contract_decls.size());
     }
 

--- a/tools/build-cpp-self-contracts.sh
+++ b/tools/build-cpp-self-contracts.sh
@@ -160,6 +160,7 @@ done
     "$CPP/verifier/enumerate_callsites.invariant.cpp" \
     "$CPP/verifier/resolve_target.invariant.cpp" \
     "$CPP/verifier/instantiate.invariant.cpp" \
+    "$WORKSPACE/implementations/cpp/provekit-self-contracts/cross_kit_bridges.cpp" \
     "$WORKSPACE/implementations/cpp/provekit-self-contracts/mint_cpp_self_contracts.cpp" \
     -lcrypto \
     -o "$OUT_BIN"

--- a/tools/run-cpp-cross-kit-bridges.sh
+++ b/tools/run-cpp-cross-kit-bridges.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Build + run the C++ phase-2 cross-kit bridges test.
+#
+# Asserts the pinned BLAKE3-512 of the JCS-canonical bytes of the 10
+# lift-plugin-protocol BridgeDecls returned by
+# build_lift_plugin_protocol_bridges() in
+# implementations/cpp/provekit-self-contracts/cross_kit_bridges.hpp.
+#
+# Mirrors tools/build-cpp-self-contracts.sh: vendored-blake3, openssl@3
+# from brew or system. No Bazel; clang++ direct invocation is the
+# conformance-gate path until rules_foreign_cc ships.
+#
+# Usage:
+#   tools/run-cpp-cross-kit-bridges.sh
+
+set -e
+
+WORKSPACE="$(cd "$(dirname "$0")/.." && pwd)"
+CPP="$WORKSPACE/implementations/cpp/provekit"
+KIT_INC="$WORKSPACE/implementations/cpp/provekit-ir-symbolic/include"
+B3_DIR="$WORKSPACE/tools/blake3-vendored"
+SC_DIR="$WORKSPACE/implementations/cpp/provekit-self-contracts"
+
+# --- Resolve OpenSSL prefix --------------------------------------------------
+detect_openssl_prefix() {
+    if [ -n "${OPENSSL_PREFIX:-}" ] && [ -d "$OPENSSL_PREFIX/include/openssl" ]; then
+        echo "$OPENSSL_PREFIX"
+        return
+    fi
+    for cand in /usr/local/opt/openssl@3 /opt/homebrew/opt/openssl@3 /usr/local /usr; do
+        if [ -d "$cand/include/openssl" ]; then
+            echo "$cand"
+            return
+        fi
+    done
+    echo ""
+}
+OPENSSL_PREFIX="$(detect_openssl_prefix)"
+if [ -z "$OPENSSL_PREFIX" ]; then
+    echo "error: openssl headers not found." >&2
+    exit 1
+fi
+
+# --- Compile vendored BLAKE3 to objects --------------------------------------
+B3_FLAGS="-DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512 -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_USE_NEON=0"
+B3_OBJ_DIR="$(mktemp -d -t b3-obj.XXXXXX)"
+OUT_BIN="$(mktemp -t cross_kit_bridges_test.XXXXXX)"
+trap 'rm -rf "$B3_OBJ_DIR" "$OUT_BIN"' EXIT INT TERM
+
+CC="${CC:-clang}"
+CXX="${CXX:-clang++}"
+
+for src in blake3.c blake3_dispatch.c blake3_portable.c; do
+    "$CC" -O2 -Wall $B3_FLAGS -c "$B3_DIR/$src" \
+        -o "$B3_OBJ_DIR/${src%.c}.o"
+done
+
+# --- Compile + link the test -------------------------------------------------
+"$CXX" -std=c++17 -O2 -Wall -Wextra -Werror \
+    -I"$OPENSSL_PREFIX/include" \
+    -I"$B3_DIR" \
+    -I"$KIT_INC" \
+    -I"$WORKSPACE/implementations/cpp" \
+    -I"$SC_DIR" \
+    -L"$OPENSSL_PREFIX/lib" \
+    "$B3_OBJ_DIR/blake3.o" \
+    "$B3_OBJ_DIR/blake3_dispatch.o" \
+    "$B3_OBJ_DIR/blake3_portable.o" \
+    "$CPP/canonicalizer/hash.cpp" \
+    "$SC_DIR/cross_kit_bridges_test.cpp" \
+    -lcrypto \
+    -o "$OUT_BIN"
+
+"$OUT_BIN"


### PR DESCRIPTION
## Summary

Phase 2 of the cross-kit bridge work for the cpp peer. Mirrors PR #89 (python), PR #92 (go), PR #93 (ts) which already landed.

- Mints 10 cpp counterpart contracts (one per Rust `lift_plugin_protocol` contract from PR #84) and authors them through the cpp self-contracts orchestrator (slab count 11 -> 12, contract count 42 -> 52).
- Constructs 10 matching `BridgeDecl`s linking each Rust source memento CID to its `cpp_<rust_name>` counterpart placeholder. Frozen via a pinned BLAKE3-512 over the JCS-canonical bridge array.
- `targetProofCid = "deferred:phase-3-proof-bundle"`; phase-3 will re-mint with the real cpp lift binary CID. `targetContractCid` carries the `pending-cpp-counterpart:<name>` placeholder until the cpp orchestrator gains a bridge-marshal pass (mirrors Go's `pending-go-counterpart:` convention).

## Files

- `implementations/cpp/provekit-self-contracts/cross_kit_bridges.hpp` (constants, rust source-CID pins, `build_lift_plugin_protocol_bridges()`, `marshal_bridges()`)
- `implementations/cpp/provekit-self-contracts/cross_kit_bridges.cpp` (`extern "C" cross_kit_bridges_invariants()` registrar)
- `implementations/cpp/provekit-self-contracts/cross_kit_bridges_test.cpp` (5-check pinned-hash test)
- `implementations/cpp/provekit-self-contracts/mint_cpp_self_contracts.cpp` (wired into slab list)
- `tools/build-cpp-self-contracts.sh` (added cross_kit_bridges.cpp to compile list)
- `tools/run-cpp-cross-kit-bridges.sh` (new runner)

## Pinned bridge-array hash

```
blake3-512:5815db0b992594bf120317c5e4a3f25132574ba3615106fd20a81f2dc8c1a4cf
           1d37bae9753a6056ef8e9b53d4405aa1c36de24236437ba9baefc296949c91a6
```

## Bundle CID drift (follow-up)

The cpp self-contracts bundle drifts because the slab adds 10 counterpart contracts to the mint:

- before: `blake3-512:9335e6376d776819cfd3b2458da29bc258e7c2ebaad542a8613dd84f50c51c31d6e1a4346cea3903b8ad12294d96aef445d0ed838aa630835b9be0bc17e62842`
- after:  `blake3-512:5a37fd2eddcc72aa8325c81bd235feb5cc0bee14f35653b76100a2d2e8c25994da2425974a503321d111a687b00df2886c11f5c7769d4db5af0e21c5290ddbc8`

`.provekit/self-contracts-attestations/cpp.json` re-sign with the new bundle CID is a follow-up commit (dance documented in top-level Makefile).

## Test plan

- [x] `tools/build-cpp-self-contracts.sh /tmp/out` round-trips (52 contracts across 12 slabs, byte-deterministic across two runs).
- [x] `tools/run-cpp-cross-kit-bridges.sh` 5/5 PASS (count, name prefixes, layers/notes/targetProofCid, source-CID well-formedness, pinned hash match).
- [x] `tools/run-cpp-v1-3-0-conformance.sh` unchanged: 8/9 PASS, 1 failure (EvidenceTerm key-order in `marshal_declarations`) is pre-existing on `main` and called out in PR #101's commit body. Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)