### PR TITLE
fix(lsp): close gaps A and B from #113

### DIFF
--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
@@ -18,15 +18,15 @@ import traceback
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from ..ir import (
+from .ir import (
     ContractDecl,
     BridgeDecl,
     declarations_to_value,
     formula_to_value,
 )
-from ..canonicalizer import encode_jcs
-from ..layer2 import lift_file_layer2
-from ..decorators import collect_module
+from .canonicalizer import encode_jcs
+from .layer2 import lift_file_layer2
+from .decorators import collect_module
 from ..lift.pydantic import lift_pydantic_model
 
 

--- a/implementations/ruby/bin/provekit-lsp-ruby
+++ b/implementations/ruby/bin/provekit-lsp-ruby
@@ -48,13 +48,13 @@ STDIN.each_line do |line|
       if line =~ %r{//\s*provekit:\s*contract}
         fn = source.lines.drop(i + 1).take(10).find { |l| l =~ /def\s+(\w+)/ }
         fn_name = fn ? $1 : "unknown"
-        decls << ContractDecl.new(name: fn_name, post: and())
+        decls << ContractDecl.new(name: fn_name, post: Provekit::IR.and())
       end
       if line =~ %r{//\s*provekit:\s*implement\s+([\w-]+)}
         cid = $1
         fn = source.lines.drop(i + 1).take(10).find { |l| l =~ /def\s+(\w+)/ }
         fn_name = fn ? $1 : "unknown"
-        decls << ContractDecl.new(name: "#{fn_name}→#{cid}", post: and())
+        decls << ContractDecl.new(name: "#{fn_name}→#{cid}", post: Provekit::IR.and())
       end
     end
 


### PR DESCRIPTION
## Summary

Closes two of the four gaps surfaced by #113 (LSP round-trip tests):

- **Gap A (python):** `implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py` used `from ..ir` (and three other `..` imports) which crashes on import because `lsp.py` is at the package root, not inside a sub-package. Changed all four imports from `..` to `.` to import sibling submodules.
- **Gap B (ruby):** `implementations/ruby/bin/provekit-lsp-ruby` called `and()` (twice) which is a Ruby syntax error because `and` is a reserved keyword and bare-name calls parse as the keyword. Changed to `Provekit::IR.and()` which parses unambiguously as a module-method call.

Gaps C (rust LSP plugin missing) and D (zig build API drift) are out of scope here; each gets its own PR.

## Test plan

- [ ] Python: `python3 -c "from provekit_lift_py_tests import lsp"` no longer raises ImportError
- [ ] Ruby: `ruby -c bin/provekit-lsp-ruby` parses cleanly
- [ ] Both LSP plugins now respond to NDJSON `initialize → parse → shutdown` per #113's round-trip protocol