### PR TITLE
feat(rust): provekit-lsp-rust LSP plugin (closes #113 gap C)

### DIFF
--- a/.provekit/self-contracts-attestations/rust.json
+++ b/.provekit/self-contracts-attestations/rust.json
@@ -2,9 +2,9 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "rust",
-  "cid": "blake3-512:63ca1c5440b085c30a6ecb70d34b83488feb9079819de5abbd8e0ee7c1415b6d09adf743381afda1d0f4872dcaf9f05b4dc5053773f9d8d221d7b11a10f711ac",
-  "contractSetCid": "blake3-512:0dbe7db3ffe0a171e3d82972eec753c01e53e5e5f8f2b0f7351666ce3af2fb33399223ae28a69e028e5e11b1504989f373792c0a2882fd2b027dae3c248fb8a8",
+  "cid": "blake3-512:902e254a934500485bf738fd84da461ae456469f3a48364f2b5324fff07272f2ef0ea963cf9bee431ca059c0e77790733c8ae42f1b1d07cb3091dd038e4b9c63",
+  "contractSetCid": "blake3-512:c4679062c8c71e62e7ec9d8e2bef76c37b5e56276315dd5e82cb255ec2a408e6a570b093b0c9906fee9778b0db417a542d34bec0552496275860123f4624dfc0",
   "declaredAt": "2026-05-02T17:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:11jbm0ecfWjUVJPaz4+8tq4gL0iFumkbni7hzSz2nU/Kl1H8Jf9G7h7EqgLFVNnGc9eORvZEHclA3xvT6aMWAg=="
+  "signature": "ed25519:1SajI2ldqXViJO4lY+32NBbi0ITDl9QvgCoD663pLx6NzcKQDt/gTL4pp4QMvnCQj3cuwjP3FcfuGmKD3b2RDg=="
 }

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1754,6 +1754,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-lsp-rust"
+version = "0.1.0"
+dependencies = [
+ "provekit-ir-symbolic",
+ "provekit-lift",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "provekit-macros"
 version = "0.1.0"
 dependencies = [

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "provekit-lift-verus",
     "provekit-lift-rust-tests",
     "provekit-lsp",
+    "provekit-lsp-rust",
     "provekit-build",
     "provekit-agent",
     "provekit-agent-claude-code",

--- a/implementations/rust/provekit-lsp-rust/Cargo.toml
+++ b/implementations/rust/provekit-lsp-rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "provekit-lsp-rust"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "NDJSON LSP plugin for Rust. Thin shim around provekit-lift adapters; speaks the per-language plugin protocol (initialize/parse/shutdown)."
+
+[[bin]]
+name = "provekit-lsp-rust"
+path = "src/main.rs"
+
+[dependencies]
+provekit-lift = { path = "../provekit-lift" }
+provekit-ir-symbolic = { path = "../provekit-ir-symbolic" }
+serde_json = { workspace = true }
+syn = { workspace = true }

--- a/implementations/rust/provekit-lsp-rust/src/main.rs
+++ b/implementations/rust/provekit-lsp-rust/src/main.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-lsp-rust — NDJSON LSP plugin for Rust.
+//
+// Thin shim around provekit-lift's adapter stack. Speaks the per-language
+// plugin protocol used by every kit's LSP plugin:
+//
+//   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+//   {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
+//   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
+//
+// The `parse` handler parses the source with `syn`, runs all registered
+// lift adapters (proptest, contracts, kani, prusti, rust-tests, etc.),
+// and returns the lifted ContractDecls as a JSON array in the shape:
+//
+//   {"declarations": [...], "warnings": [...]}
+//
+// Usage: provekit-lsp-rust (reads from stdin, writes to stdout)
+
+use std::io::{BufRead, Write};
+
+use provekit_ir_symbolic::serialize::marshal_declarations;
+use provekit_lift::{
+    adapter_contracts, adapter_proptest, adapter_rust_tests,
+};
+
+fn main() {
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let req: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(e) => {
+                let resp = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "error": {"code": -32700, "message": format!("parse error: {e}")}
+                });
+                let _ = writeln!(stdout, "{resp}");
+                let _ = stdout.flush();
+                continue;
+            }
+        };
+
+        let id = req.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let method = req
+            .get("method")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        match method {
+            "initialize" => {
+                let resp = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "name": "provekit-lsp-rust",
+                        "version": "0.1.0",
+                        "capabilities": ["parse"]
+                    }
+                });
+                let _ = writeln!(stdout, "{resp}");
+                let _ = stdout.flush();
+            }
+            "parse" => {
+                let params = req.get("params").cloned().unwrap_or_default();
+                let path = params
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("source.rs");
+                let source = params
+                    .get("source")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+
+                let resp = handle_parse(id.clone(), source, path);
+                let _ = writeln!(stdout, "{resp}");
+                let _ = stdout.flush();
+            }
+            "shutdown" => {
+                let resp = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": null
+                });
+                let _ = writeln!(stdout, "{resp}");
+                let _ = stdout.flush();
+                std::process::exit(0);
+            }
+            _ => {
+                let resp = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {
+                        "code": -32601,
+                        "message": format!("unknown method: {method}")
+                    }
+                });
+                let _ = writeln!(stdout, "{resp}");
+                let _ = stdout.flush();
+            }
+        }
+    }
+}
+
+/// Parse Rust `source` with syn, run the lift adapters, and return a
+/// JSON-RPC result object containing `declarations` and `warnings`.
+fn handle_parse(id: serde_json::Value, source: &str, path: &str) -> serde_json::Value {
+    let file = match syn::parse_str::<syn::File>(source) {
+        Ok(f) => f,
+        Err(e) => {
+            return serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {
+                    "code": -32603,
+                    "message": format!("syn parse error: {e}")
+                }
+            });
+        }
+    };
+
+    let mut decls = Vec::new();
+    let mut warnings: Vec<serde_json::Value> = Vec::new();
+
+    // Run adapters in the same order as provekit-lift dispatcher.
+
+    let p_out = adapter_proptest::lift_file(&file, path);
+    decls.extend(p_out.decls);
+    for w in &p_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "proptest",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    let c_out = adapter_contracts::lift_file(&file, path);
+    decls.extend(c_out.decls);
+    for w in &c_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "contracts",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    // rust-tests: Layer 2 first, then Layer 0 skipping claimed tests.
+    let l2_out = adapter_rust_tests::lift_file_layer2(&file, path);
+    let claimed = l2_out.claimed_tests.clone();
+    decls.extend(l2_out.decls);
+    for w in &l2_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "rust-tests-layer2",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    let rt_out = adapter_rust_tests::lift_file_with_skip(&file, path, &claimed);
+    decls.extend(rt_out.decls);
+    for w in &rt_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "rust-tests",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    // Marshal declarations to kit-shape JSON array, then parse it back so
+    // it embeds as JSON (not a string) in the response envelope.
+    let decls_json_str = if decls.is_empty() {
+        "[]".to_string()
+    } else {
+        marshal_declarations(&decls)
+    };
+
+    let decls_value: serde_json::Value = serde_json::from_str(&decls_json_str)
+        .unwrap_or(serde_json::Value::Array(vec![]));
+
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "declarations": decls_value,
+            "warnings": warnings
+        }
+    })
+}

--- a/implementations/rust/provekit-lsp-rust/src/main.rs
+++ b/implementations/rust/provekit-lsp-rust/src/main.rs
@@ -21,7 +21,9 @@ use std::io::{BufRead, Write};
 
 use provekit_ir_symbolic::serialize::marshal_declarations;
 use provekit_lift::{
-    adapter_contracts, adapter_proptest, adapter_rust_tests,
+    adapter_contracts, adapter_creusot, adapter_flux, adapter_kani,
+    adapter_proptest, adapter_prusti, adapter_quickcheck, adapter_rust_tests,
+    adapter_verus,
 };
 
 fn main() {
@@ -151,6 +153,72 @@ fn handle_parse(id: serde_json::Value, source: &str, path: &str) -> serde_json::
     for w in &c_out.warnings {
         warnings.push(serde_json::json!({
             "adapter": "contracts",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    let k_out = adapter_kani::lift_file(&file, path);
+    decls.extend(k_out.decls);
+    for w in &k_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "kani",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    let pr_out = adapter_prusti::lift_file(&file, path);
+    decls.extend(pr_out.decls);
+    for w in &pr_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "prusti",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    let cr_out = adapter_creusot::lift_file(&file, path);
+    decls.extend(cr_out.decls);
+    for w in &cr_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "creusot",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    let fl_out = adapter_flux::lift_file(&file, path);
+    decls.extend(fl_out.decls);
+    for w in &fl_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "flux",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    let qc_out = adapter_quickcheck::lift_file(&file, path);
+    decls.extend(qc_out.decls);
+    for w in &qc_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "quickcheck",
+            "path": w.source_path,
+            "item": w.item_name,
+            "reason": w.reason
+        }));
+    }
+
+    let ve_out = adapter_verus::lift_file(&file, path);
+    decls.extend(ve_out.decls);
+    for w in &ve_out.warnings {
+        warnings.push(serde_json::json!({
+            "adapter": "verus",
             "path": w.source_path,
             "item": w.item_name,
             "reason": w.reason

--- a/implementations/rust/provekit-lsp-rust/tests/fixtures/simple.rs
+++ b/implementations/rust/provekit-lsp-rust/tests/fixtures/simple.rs
@@ -1,0 +1,5 @@
+#[test]
+fn value_is_non_negative() {
+    let x: i64 = 42;
+    assert!(x >= 0);
+}

--- a/implementations/rust/provekit-lsp-rust/tests/round_trip.rs
+++ b/implementations/rust/provekit-lsp-rust/tests/round_trip.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Integration test: spawn `provekit-lsp-rust`, drive it via NDJSON,
+// assert protocol contract per spec.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+fn plugin_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit-lsp-rust"))
+}
+
+struct Plugin {
+    child: std::process::Child,
+    stdin: std::process::ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+}
+
+impl Plugin {
+    fn spawn() -> Self {
+        let mut child = Command::new(plugin_bin())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn provekit-lsp-rust");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        Self { child, stdin, stdout }
+    }
+
+    fn exchange(&mut self, payload: &Value) -> Value {
+        let line = serde_json::to_string(payload).unwrap();
+        writeln!(self.stdin, "{line}").expect("write to plugin stdin");
+        self.stdin.flush().expect("flush");
+        let mut buf = String::new();
+        let n = self.stdout.read_line(&mut buf).expect("read from plugin stdout");
+        assert!(n > 0, "plugin closed stdout without responding");
+        serde_json::from_str(buf.trim()).expect("decode plugin response as JSON")
+    }
+
+    fn wait_for_exit(mut self, timeout: Duration) -> std::process::ExitStatus {
+        drop(self.stdin);
+        let start = Instant::now();
+        loop {
+            match self.child.try_wait().expect("try_wait") {
+                Some(status) => return status,
+                None => {
+                    if start.elapsed() > timeout {
+                        let _ = self.child.kill();
+                        panic!("plugin did not exit within {timeout:?}");
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. initialize returns a capabilities envelope
+// ---------------------------------------------------------------------------
+
+#[test]
+fn initialize_returns_capabilities() {
+    let mut plugin = Plugin::spawn();
+
+    let resp = plugin.exchange(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    }));
+
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], 1);
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("initialize returned error: {resp}"));
+
+    assert_eq!(
+        result["name"].as_str(),
+        Some("provekit-lsp-rust"),
+        "wrong plugin name: {result}"
+    );
+    assert!(
+        result.get("version").and_then(|v| v.as_str()).is_some(),
+        "missing version: {result}"
+    );
+    let caps = result["capabilities"]
+        .as_array()
+        .unwrap_or_else(|| panic!("missing capabilities array: {result}"));
+    assert!(
+        caps.iter().any(|c| c.as_str() == Some("parse")),
+        "capabilities must include 'parse': {caps:?}"
+    );
+
+    // Tidy shutdown.
+    let _ = plugin.exchange(&json!({"jsonrpc":"2.0","id":99,"method":"shutdown"}));
+    let _ = plugin.wait_for_exit(Duration::from_secs(10));
+}
+
+// ---------------------------------------------------------------------------
+// 2. parse over a fixture emits at least one contract declaration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_fixture_emits_contracts() {
+    let source = r#"
+#[test]
+fn value_is_non_negative() {
+    let x: i64 = 42;
+    assert!(x >= 0);
+}
+"#;
+
+    let mut plugin = Plugin::spawn();
+
+    let _ = plugin.exchange(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    }));
+
+    let resp = plugin.exchange(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "parse",
+        "params": {
+            "path": "simple.rs",
+            "source": source
+        }
+    }));
+
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], 2);
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("parse returned error: {resp}"));
+
+    let decls = result["declarations"]
+        .as_array()
+        .unwrap_or_else(|| panic!("declarations must be an array: {result}"));
+
+    assert!(
+        !decls.is_empty(),
+        "expected at least one contract declaration from fixture; got empty array.\nfull result: {result}"
+    );
+
+    // Each declaration must have a `name` field.
+    for d in decls {
+        assert!(
+            d.get("name").and_then(|n| n.as_str()).is_some(),
+            "declaration missing 'name': {d}"
+        );
+    }
+
+    // Tidy shutdown.
+    let _ = plugin.exchange(&json!({"jsonrpc":"2.0","id":99,"method":"shutdown"}));
+    let _ = plugin.wait_for_exit(Duration::from_secs(10));
+}
+
+// ---------------------------------------------------------------------------
+// 3. Unknown method returns JSON-RPC -32601
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_method_returns_method_not_found() {
+    let mut plugin = Plugin::spawn();
+
+    let _ = plugin.exchange(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    }));
+
+    let resp = plugin.exchange(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "no_such_method"
+    }));
+
+    let err = resp
+        .get("error")
+        .unwrap_or_else(|| panic!("expected JSON-RPC error, got: {resp}"));
+    assert_eq!(
+        err["code"].as_i64(),
+        Some(-32601),
+        "expected method-not-found error code (-32601): {err}"
+    );
+
+    // Tidy shutdown.
+    let _ = plugin.exchange(&json!({"jsonrpc":"2.0","id":99,"method":"shutdown"}));
+    let _ = plugin.wait_for_exit(Duration::from_secs(10));
+}
+
+// ---------------------------------------------------------------------------
+// 4. shutdown exits cleanly (exit code 0)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shutdown_exits_cleanly() {
+    let mut plugin = Plugin::spawn();
+
+    let _ = plugin.exchange(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    }));
+
+    let resp = plugin.exchange(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "shutdown"
+    }));
+
+    assert_eq!(resp["id"], 2);
+    assert!(
+        resp.get("result").map(|v| v.is_null()).unwrap_or(false),
+        "shutdown should return null result, got: {resp}"
+    );
+
+    let status = plugin.wait_for_exit(Duration::from_secs(10));
+    assert!(status.success(), "plugin exited with non-zero status: {status:?}");
+}


### PR DESCRIPTION
## Summary

- Adds `implementations/rust/provekit-lsp-rust/` -- a new crate that is the Rust kit's per-language NDJSON LSP plugin, matching the shape of go/csharp/python/ruby plugins
- `src/main.rs` is a thin NDJSON loop that delegates `parse` to provekit-lift's adapter stack (proptest, contracts, rust-tests Layer 0+2) via `syn::parse_str` + `adapter_*::lift_file`
- `tests/round_trip.rs` drives the binary end-to-end: initialize/capabilities, parse/at-least-one-contract, unknown-method/-32601, shutdown/exit-0
- Wires `provekit-lsp-rust` into the rust workspace `Cargo.toml`

## PR #113 follow-up

The existing `lsp_plugin_round_trip.rs` test lives only on the `test/lsp-plugin-round-trip` branch (not yet merged to main). Updating it to drive `provekit-lsp-rust` instead of `provekit-lift --rpc` requires rebasing that branch onto main after this merges. The step is mechanical: replace `plugin_bin()` to return `CARGO_BIN_EXE_provekit-lsp-rust`, change `"lift"` method to `"parse"` with `{path, source}` params, assert `declarations` array.

## Test plan

- `cargo test -p provekit-lsp-rust` -- 4/4 passing locally
- CI rust job covers the full workspace build

🤖 Generated with [Claude Code](https://claude.com/claude-code)