### PR TITLE
fix(zig): build.zig API drift to zig 0.14+ (closes #113 gap D)

### DIFF
--- a/implementations/zig/provekit-lift-zig/build.zig
+++ b/implementations/zig/provekit-lift-zig/build.zig
@@ -6,15 +6,23 @@ pub fn build(b: *std.Build) void {
 
     const provekit_ir = b.createModule(.{
         .root_source_file = b.path("../provekit-ir/src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "provekit-ir", .module = provekit_ir },
+        },
     });
 
     const exe = b.addExecutable(.{
         .name = "provekit-lift-zig",
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = exe_mod,
     });
-    exe.root_module.addImport("provekit-ir", provekit_ir);
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);


### PR DESCRIPTION
## Summary

- Updates `implementations/zig/provekit-lift-zig/build.zig` to compile under Zig 0.14+/0.16 API
- `addExecutable` no longer accepts `root_source_file`; now requires a `*Module` via `root_module`
- Creates exe module via `b.createModule` with imports folded in, passes as `root_module` to `addExecutable`

## What this fixes (gap D from #113)

The `addExecutable` call in `provekit-lift-zig/build.zig` used the Zig ≤ 0.13 `root_source_file` field. Under Zig 0.14+, `ExecutableOptions.root_source_file` was removed; the correct API is:

```zig
const exe_mod = b.createModule(.{
    .root_source_file = b.path("src/main.zig"),
    .target = target,
    .optimize = optimize,
    .imports = &.{ .{ .name = "provekit-ir", .module = provekit_ir } },
});
const exe = b.addExecutable(.{ .name = "provekit-lift-zig", .root_module = exe_mod });
```

## What this does NOT fix (follow-up required)

`main.zig:232` has source-level API drift: `std.heap.GeneralPurposeAllocator` was renamed to `std.heap.DebugAllocator` in Zig 0.14+. Exact error:

```
src/main.zig:232:23: error: root source file struct 'heap' has no member named 'GeneralPurposeAllocator'
```

This is out of scope ("only `build.zig`"). Needs a follow-up task to update `main.zig`.

## Verification

- `zig test src/root.zig` in `implementations/zig/provekit-ir/` passes 11/11 under zig 0.16.0
- `zig build` in `provekit-lift-zig/` now fails at source layer (`main.zig:232`), not at the build-script layer — build.zig is clean

## Toolchain note

`./zig-toolchain/zig` referenced by the task does not exist in the worktree. Used system `/usr/local/bin/zig` (0.16.0). The pinned toolchain path should be fixed separately.

## Test plan

- [x] `zig test src/root.zig` from `implementations/zig/provekit-ir/` — 11/11 passed
- [x] `zig build` from `implementations/zig/provekit-lift-zig/` — build script parses and executes; source error is in main.zig (separate gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)