### PR TITLE
feat(go-lifter): emit call-edge stream including cgo cross-kit edges (spec #114 R1)

### DIFF
--- a/implementations/go/cmd/provekit-lsp-go/cross_kit_call_edges_test.go
+++ b/implementations/go/cmd/provekit-lsp-go/cross_kit_call_edges_test.go
@@ -1,0 +1,230 @@
+// cross_kit_call_edges_test.go — conformance tests for call-edge stream
+// emission per protocol/specs/2026-05-03-bridge-linkage-protocol.md §1 R1.
+//
+// Test 1: same-kit call edge — Go function calling another Go function.
+//         Both sourceContractCid and targetContractCid are populated.
+//
+// Test 2: cross-kit cgo call edge — Go function calling C.rustFunc(...).
+//         targetContractCid is null; targetSymbol is "rust-kit:rustFunc".
+//
+// Test 3: JCS bytes are byte-deterministic across two runs of the same
+//         source fixture.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// sameKitSource is a Go file with two //provekit:contract annotated
+// functions where CallerFn calls CalleeFn. Both have contracts; the
+// lifter should emit one same-kit call-edge for the call site.
+const sameKitSource = `package demo
+
+//provekit:contract
+func CalleeFn(x int) int { return x + 1 }
+
+//provekit:contract
+func CallerFn(x int) int { return CalleeFn(x) }
+`
+
+// cgoSource is a Go file with a //provekit:contract annotated Go
+// function that calls C.rustFunc via cgo. The lifter should emit a
+// cross-kit call-edge with targetContractCid null and
+// targetSymbol "rust-kit:rustFunc".
+const cgoSource = `package demo
+
+/*
+#include <stdint.h>
+extern int64_t rustFunc(int64_t n);
+*/
+import "C"
+
+//provekit:contract
+func GoWrapper(n int) int {
+	return int(C.rustFunc(C.int64_t(n)))
+}
+`
+
+// TestCallEdge_SameKit asserts that a Go function calling another Go
+// function (both with //provekit:contract) emits a call-edge with
+// both sourceContractCid and targetContractCid populated.
+func TestCallEdge_SameKit(t *testing.T) {
+	done := capture()
+	msg := json.RawMessage(mustMarshal(parseParams{Path: "demo.go", Source: sameKitSource}))
+	handleRequest(mustMarshal(rpcRequest{JSONRPC: "2.0", ID: 10.0, Method: "parse", Params: msg}))
+	resp := done()
+
+	if resp.Error != nil {
+		t.Fatalf("parse error: %s", resp.Error.Message)
+	}
+
+	m := resultMap(resp)
+
+	// Expect 2 contract declarations (CalleeFn, CallerFn).
+	declList, ok := m["declarations"].([]interface{})
+	if !ok {
+		t.Fatal("declarations not a list")
+	}
+	if len(declList) != 2 {
+		t.Fatalf("expected 2 declarations, got %d", len(declList))
+	}
+
+	// Expect at least 1 call-edge in the callEdges stream.
+	edgesRaw, ok := m["callEdges"]
+	if !ok {
+		t.Fatal("callEdges field missing from parse result")
+	}
+	edgeList, ok := edgesRaw.([]interface{})
+	if !ok {
+		t.Fatalf("callEdges not a list: %T", edgesRaw)
+	}
+	if len(edgeList) == 0 {
+		t.Fatal("expected at least 1 call-edge for same-kit call, got 0")
+	}
+
+	// Find the call edge from CallerFn -> CalleeFn.
+	var found bool
+	for _, e := range edgeList {
+		edge, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if edge["kind"] != "call-edge" {
+			t.Errorf("unexpected call-edge kind: %v", edge["kind"])
+			continue
+		}
+		if edge["schemaVersion"] != "1" {
+			t.Errorf("unexpected schemaVersion: %v", edge["schemaVersion"])
+		}
+		// Both source and target CIDs must be non-null/non-empty strings.
+		srcCid, hasSrc := edge["sourceContractCid"].(string)
+		tgtCid, hasTgt := edge["targetContractCid"].(string)
+		if hasSrc && hasTgt && srcCid != "" && tgtCid != "" {
+			// targetContractCid must differ from sourceContractCid
+			// (different functions have different contracts).
+			if srcCid == tgtCid {
+				t.Error("sourceContractCid and targetContractCid must differ for same-kit call between two distinct contracts")
+			}
+			// Both CIDs must have the blake3-512 prefix.
+			if !strings.HasPrefix(srcCid, "blake3-512:") {
+				t.Errorf("sourceContractCid missing blake3-512 prefix: %s", srcCid)
+			}
+			if !strings.HasPrefix(tgtCid, "blake3-512:") {
+				t.Errorf("targetContractCid missing blake3-512 prefix: %s", tgtCid)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no call-edge with both CIDs populated found; edges: %v", edgeList)
+	}
+}
+
+// TestCallEdge_CgoRustKit asserts that a Go function calling C.rustFunc
+// via cgo emits a call-edge with targetContractCid null and
+// targetSymbol "rust-kit:rustFunc".
+func TestCallEdge_CgoRustKit(t *testing.T) {
+	done := capture()
+	msg := json.RawMessage(mustMarshal(parseParams{Path: "demo.go", Source: cgoSource}))
+	handleRequest(mustMarshal(rpcRequest{JSONRPC: "2.0", ID: 11.0, Method: "parse", Params: msg}))
+	resp := done()
+
+	if resp.Error != nil {
+		t.Fatalf("parse error: %s", resp.Error.Message)
+	}
+
+	m := resultMap(resp)
+
+	edgesRaw, ok := m["callEdges"]
+	if !ok {
+		t.Fatal("callEdges field missing from parse result")
+	}
+	edgeList, ok := edgesRaw.([]interface{})
+	if !ok {
+		t.Fatalf("callEdges not a list: %T", edgesRaw)
+	}
+	if len(edgeList) == 0 {
+		t.Fatal("expected at least 1 call-edge for cgo call, got 0")
+	}
+
+	// Find the cgo call edge.
+	var foundCgo bool
+	for _, e := range edgeList {
+		edge, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if edge["kind"] != "call-edge" {
+			continue
+		}
+		sym, hasSymbol := edge["targetSymbol"].(string)
+		if !hasSymbol || sym != "rust-kit:rustFunc" {
+			continue
+		}
+		// targetContractCid must be null (JSON null decodes to nil in
+		// the map[string]interface{} round-trip).
+		tgtCid, hasTgt := edge["targetContractCid"]
+		if hasTgt && tgtCid != nil {
+			t.Errorf("expected targetContractCid to be null for cgo edge, got %v", tgtCid)
+		}
+		// sourceContractCid must be a blake3-512 CID.
+		srcCid, hasSrc := edge["sourceContractCid"].(string)
+		if !hasSrc || !strings.HasPrefix(srcCid, "blake3-512:") {
+			t.Errorf("sourceContractCid missing or wrong format: %v", edge["sourceContractCid"])
+		}
+		foundCgo = true
+		break
+	}
+	if !foundCgo {
+		t.Fatalf("no cgo call-edge with targetSymbol=rust-kit:rustFunc found; edges: %v", edgeList)
+	}
+}
+
+// TestCallEdge_JCSBytesDeterministic asserts that lifting the same
+// source twice produces byte-identical callEdge JSON — confirming the
+// call-edge stream is content-addressed and deterministic.
+func TestCallEdge_JCSBytesDeterministic(t *testing.T) {
+	parseOnce := func() string {
+		done := capture()
+		msg := json.RawMessage(mustMarshal(parseParams{Path: "demo.go", Source: sameKitSource}))
+		handleRequest(mustMarshal(rpcRequest{JSONRPC: "2.0", ID: 20.0, Method: "parse", Params: msg}))
+		resp := done()
+		if resp.Error != nil {
+			t.Fatalf("parse error: %s", resp.Error.Message)
+		}
+		// Re-marshal the result to get the raw JSON bytes. This
+		// exercises the full marshal path, not just in-memory equality.
+		b, err := json.Marshal(resp.Result)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return string(b)
+	}
+
+	first := parseOnce()
+	second := parseOnce()
+
+	if first != second {
+		t.Errorf("call-edge bytes differ between runs:\n  first:  %s\n  second: %s", first, second)
+	}
+
+	// Verify callEdges is present and non-empty in the output.
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(first), &m); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	callEdgesRaw, ok := m["callEdges"]
+	if !ok {
+		t.Fatal("callEdges missing from result")
+	}
+	edgeList, ok := callEdgesRaw.([]interface{})
+	if !ok {
+		t.Fatalf("callEdges not a list: %T", callEdgesRaw)
+	}
+	if len(edgeList) == 0 {
+		t.Fatal("expected non-empty callEdges for determinism check")
+	}
+}

--- a/implementations/go/cmd/provekit-lsp-go/main.go
+++ b/implementations/go/cmd/provekit-lsp-go/main.go
@@ -8,7 +8,8 @@
 //
 // For parse, scans the source for //provekit: annotations and
 // go-playground/validator struct tags, lifts to canonical IR,
-// and returns JCS declarations JSON.
+// and returns JCS declarations JSON alongside call-edge mementos
+// per protocol/specs/2026-05-03-bridge-linkage-protocol.md §1 R1.
 package main
 
 import (
@@ -22,6 +23,7 @@ import (
 	"reflect"
 	"strings"
 
+	canonicalizer "github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
 	ir "github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 	validator "github.com/tsavo/provekit/go/provekit-lift-go-validator"
 )
@@ -58,6 +60,7 @@ type initializeResult struct {
 
 type parseResult struct {
 	Declarations json.RawMessage `json:"declarations"`
+	CallEdges    json.RawMessage `json:"callEdges"`
 	Warnings     []interface{}   `json:"warnings"`
 }
 
@@ -128,8 +131,22 @@ func handleParse(id interface{}, paramsRaw json.RawMessage) {
 		jcs = []byte("[]")
 	}
 
+	// Emit call-edge stream per spec #114 R1.
+	// Walk function bodies to find call sites; emit one CallEdgeDeclaration
+	// per call site where the calling function has a known contract.
+	callEdges := walkCallEdges(params.Source, params.Path, decls)
+	edgesJSON, err := json.Marshal(callEdges)
+	if err != nil {
+		sendError(id, -32603, fmt.Sprintf("marshal call edges: %v", err))
+		return
+	}
+	if len(edgesJSON) == 0 || string(edgesJSON) == "null" {
+		edgesJSON = []byte("[]")
+	}
+
 	send(id, parseResult{
 		Declarations: jcs,
+		CallEdges:    edgesJSON,
 		Warnings:     warnings,
 	})
 }
@@ -162,6 +179,165 @@ func sendError(id interface{}, code int, message string) {
 			Message: message,
 		},
 	})
+}
+
+// contractCidForDeclaration returns the BLAKE3-512 CID of a single
+// Declaration's canonical JSON bytes. Used to populate sourceContractCid
+// and targetContractCid in call-edge mementos.
+func contractCidForDeclaration(d ir.Declaration) string {
+	body, err := ir.MarshalDeclarations([]ir.Declaration{d})
+	if err != nil {
+		return ""
+	}
+	return canonicalizer.ComputeCID(body)
+}
+
+// buildContractIndex returns a map from function/contract name to
+// (CID, declaration) for each ContractDeclaration in decls.
+func buildContractIndex(decls []ir.Declaration) map[string]string {
+	idx := make(map[string]string)
+	for _, d := range decls {
+		if d.Kind() == "contract" {
+			cid := contractCidForDeclaration(d)
+			if cid != "" {
+				idx[d.DeclName()] = cid
+			}
+		}
+	}
+	return idx
+}
+
+// cgoKitPrefix returns the kit prefix for a cgo call target symbol.
+// For the Michael Jordan demo the convention is:
+//   - rust-kit: functions marked #[no_mangle] extern "C" in Rust
+//   - cpp-kit:  C++ functions
+//   - c-kit:    plain C functions
+//
+// Without build metadata the lifter defaults to "rust-kit" when the
+// symbol is not in the local Go contract index, per the spec's primary
+// demo case. Future work: a //provekit:cgo-kit hint annotation.
+func cgoKitPrefix(funcName string, contractIndex map[string]string) string {
+	// If we have a local contract for this name it's same-kit.
+	// cgo calls by definition cross kits; always use rust-kit as default
+	// per the Michael Jordan demo framing.
+	_ = contractIndex
+	return "rust-kit"
+}
+
+// walkCallEdges parses the Go source and, for every function body whose
+// function name has a contract in decls, emits one CallEdgeDeclaration
+// per call site within that body per spec #114 §1.
+//
+// Same-kit calls: both sourceContractCid and targetContractCid populated.
+// cgo calls (C.<name>(...)): targetContractCid = null, targetSymbol =
+// "<kit>:<name>".
+func walkCallEdges(src, path string, decls []ir.Declaration) []ir.CallEdgeDeclaration {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, src, 0)
+	if err != nil {
+		return nil
+	}
+
+	contractIndex := buildContractIndex(decls)
+	if len(contractIndex) == 0 {
+		return nil
+	}
+
+	var edges []ir.CallEdgeDeclaration
+
+	for _, d := range f.Decls {
+		funcDecl, ok := d.(*ast.FuncDecl)
+		if !ok || funcDecl.Name == nil || funcDecl.Body == nil {
+			continue
+		}
+
+		callerName := funcDecl.Name.Name
+		sourceCid, hasCid := contractIndex[callerName]
+		if !hasCid {
+			// Caller has no contract; skip per R1 (we only emit edges
+			// where the source is a lifted contract).
+			continue
+		}
+
+		// Walk the function body for call expressions.
+		ast.Inspect(funcDecl.Body, func(n ast.Node) bool {
+			callExpr, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			pos := fset.Position(callExpr.Pos())
+			locus := ir.Locus{
+				File:   path,
+				Line:   pos.Line,
+				Column: pos.Column,
+			}
+
+			// evidenceTerm: placeholder obligation term. The linker
+			// resolves the actual post_B ⊃ pre_A obligation; the lifter
+			// emits the structural placeholder per R1.
+			evidenceTerm := ir.Atomic("call-site-obligation",
+				ir.MakeVar(callerName, ir.String))
+
+			// Detect cgo calls: selector expression "C.<name>" where
+			// the package is the synthetic "C" package.
+			if sel, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
+				if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == "C" {
+					// cgo call: cross-kit edge.
+					targetName := sel.Sel.Name
+					kit := cgoKitPrefix(targetName, contractIndex)
+					sym := kit + ":" + targetName
+					edges = append(edges, ir.CallEdgeDeclaration{
+						SourceContractCid: sourceCid,
+						TargetContractCid: nil,
+						TargetSymbol:      sym,
+						CallSiteLocus:     locus,
+						EvidenceTerm:      evidenceTerm,
+					})
+					return true
+				}
+			}
+
+			// Same-kit or unresolved Go call.
+			calleeName := extractCalleeName(callExpr)
+			if calleeName == "" {
+				return true
+			}
+			targetCid, hasTarget := contractIndex[calleeName]
+			if hasTarget {
+				// Same-kit call: both CIDs known.
+				edges = append(edges, ir.CallEdgeDeclaration{
+					SourceContractCid: sourceCid,
+					TargetContractCid: &targetCid,
+					TargetSymbol:      calleeName,
+					CallSiteLocus:     locus,
+					EvidenceTerm:      evidenceTerm,
+				})
+			}
+			// If the target has no contract we don't emit an edge
+			// (the call can't be bridged without a contract on both ends
+			// for same-kit calls; cross-kit is covered by the cgo path).
+			return true
+		})
+	}
+
+	return edges
+}
+
+// extractCalleeName returns the simple function name from a call
+// expression. Returns "" for method calls (x.Foo()) that aren't cgo,
+// for function literals, and for other complex expressions.
+func extractCalleeName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		// Only return the selector for package-qualified calls (not method
+		// calls on values). We can't distinguish here without type info, so
+		// we return the selector name and let the contract index lookup miss.
+		return fn.Sel.Name
+	}
+	return ""
 }
 
 // walkSource parses Go source and lifts validator struct declarations.

--- a/implementations/go/provekit-ir-symbolic/ir/property.go
+++ b/implementations/go/provekit-ir-symbolic/ir/property.go
@@ -264,6 +264,110 @@ func (b BridgeDeclaration) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// Locus identifies a source position for a call site.
+// JSON shape (locked key order: column, file, line).
+type Locus struct {
+	File   string `json:"file"`
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
+}
+
+func (l Locus) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString(`{"column":`)
+	encoded, err := encodeJSON(l.Column)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteString(`,"file":`)
+	encoded, err = encodeJSON(l.File)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteString(`,"line":`)
+	encoded, err = encodeJSON(l.Line)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// CallEdgeDeclaration encodes a call site found by the lifter per
+// protocol/specs/2026-05-03-bridge-linkage-protocol.md §1.
+//
+// JSON shape (JCS-canonical key order: callSiteLocus, evidenceTerm,
+// kind, schemaVersion, sourceContractCid, targetContractCid,
+// targetSymbol):
+//
+//	{
+//	  "callSiteLocus":     { "column": N, "file": "...", "line": N },
+//	  "evidenceTerm":      <IrFormula>,
+//	  "kind":              "call-edge",
+//	  "schemaVersion":     "1",
+//	  "sourceContractCid": "blake3-512:...",
+//	  "targetContractCid": "blake3-512:..." | null,
+//	  "targetSymbol":      "..."
+//	}
+//
+// targetContractCid is null for cross-kit calls (e.g. cgo); in that
+// case targetSymbol carries the kit-prefixed symbol name (e.g.
+// "rust-kit:rustFunc") for linker resolution per R3.
+type CallEdgeDeclaration struct {
+	SourceContractCid string
+	TargetContractCid *string // nil encodes as JSON null
+	TargetSymbol      string
+	CallSiteLocus     Locus
+	EvidenceTerm      IrFormula
+}
+
+func (CallEdgeDeclaration) declMarker()        {}
+func (CallEdgeDeclaration) Kind() string       { return "call-edge" }
+func (c CallEdgeDeclaration) DeclName() string { return c.SourceContractCid }
+
+func (c CallEdgeDeclaration) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString(`{"callSiteLocus":`)
+	encoded, err := encodeJSON(c.CallSiteLocus)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteString(`,"evidenceTerm":`)
+	encoded, err = encodeJSON(c.EvidenceTerm)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteString(`,"kind":"call-edge","schemaVersion":"1","sourceContractCid":`)
+	encoded, err = encodeJSON(c.SourceContractCid)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteString(`,"targetContractCid":`)
+	if c.TargetContractCid == nil {
+		buf.WriteString("null")
+	} else {
+		encoded, err = encodeJSON(*c.TargetContractCid)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(encoded)
+	}
+	buf.WriteString(`,"targetSymbol":`)
+	encoded, err = encodeJSON(c.TargetSymbol)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
 // ----------------------------------------------------------------------
 // Collector state
 // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `CallEdgeDeclaration` + `Locus` to `ir/property.go` with JCS-canonical `MarshalJSON` (locked key order per spec §1)
- Extends `cmd/provekit-lsp-go/main.go` to walk Go AST function bodies and emit call-edge mementos alongside contract mementos in every `parse` response; detects same-kit calls (both CIDs populated) and cgo calls (`targetContractCid: null`, `targetSymbol: "rust-kit:<name>"`)
- Adds `cross_kit_call_edges_test.go` with three conformance tests: same-kit edge, cgo/rust-kit edge, JCS byte determinism

## Michael Jordan demo path

`GoWrapper` calling `C.rustFunc(n)` emits:
```json
{
  "kind": "call-edge",
  "schemaVersion": "1",
  "sourceContractCid": "blake3-512:...",
  "targetContractCid": null,
  "targetSymbol": "rust-kit:rustFunc",
  "callSiteLocus": { "column": N, "file": "demo.go", "line": N },
  "evidenceTerm": { "args": [...], "kind": "atomic", "name": "call-site-obligation" }
}
```

The linker resolves `rust-kit:rustFunc` against the Rust kit's contract set per R3.

## Test plan

- [x] `go test ./implementations/go/...` — all pass (3 new tests added)
- [x] `go test ./implementations/go/provekit-ir-symbolic/...` — all pass
- [x] `go test ./implementations/go/provekit-lift-go-tests/...` — all pass (no regressions)
- [x] `go test ./implementations/go/provekit-self-contracts/...` — all pass

## Follow-up notes (per dispatch)

The Rust agent is adding `lift_emits_call_edge_stream` to rust's self-contracts in parallel. The go self-contracts bundle (`provekit-self-contracts/slabs/lift_plugin_protocol.go`) is not updated here — adding the counterpart contract requires the rust CID first. Leave for a follow-up PR once the rust side lands and its bundle CID is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)