### PR TITLE
feat(rust-lifter): emit call-edge stream alongside contracts (spec #114 R1)

### DIFF
--- a/.provekit/self-contracts-attestations/rust.json
+++ b/.provekit/self-contracts-attestations/rust.json
@@ -2,9 +2,9 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "rust",
-  "cid": "blake3-512:902e254a934500485bf738fd84da461ae456469f3a48364f2b5324fff07272f2ef0ea963cf9bee431ca059c0e77790733c8ae42f1b1d07cb3091dd038e4b9c63",
-  "contractSetCid": "blake3-512:c4679062c8c71e62e7ec9d8e2bef76c37b5e56276315dd5e82cb255ec2a408e6a570b093b0c9906fee9778b0db417a542d34bec0552496275860123f4624dfc0",
+  "cid": "blake3-512:c4b12a2b517a411989d55fd17145e92c6453f339d82bc2366e98b871cac97115a53211ba67122e21945e8cea7a1c3a0bfa4be6624591c3e7dce8db6fe4293558",
+  "contractSetCid": "blake3-512:f2295c38c73db78ecb00b39f631456e96ba30340b90fbe5f013f6f751e1e0695054059728b6e08e489cf2d746e76ea097b42fe8865e4eaf853a6220705027e1c",
   "declaredAt": "2026-05-02T17:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:1SajI2ldqXViJO4lY+32NBbi0ITDl9QvgCoD663pLx6NzcKQDt/gTL4pp4QMvnCQj3cuwjP3FcfuGmKD3b2RDg=="
+  "signature": "ed25519:JToFBIrnS+qJV70wm68c2drlFz2zP/bzpRu5ipb/N/62/RSG+dhPbzbH+asrRG7JYgQoC93vYawdaV+Xhe5+BQ=="
 }

--- a/implementations/rust/provekit-lift/src/call_edges.rs
+++ b/implementations/rust/provekit-lift/src/call_edges.rs
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// call_edges.rs — spec #114 §1: extract call-edge mementos from a syn AST.
+//
+// For each function `B` that has a contract in the current compilation unit,
+// walk its body and collect every call site to a named callee `A`. Emit one
+// `CallEdgeMemento` per call site.
+//
+// Resolution:
+//   - If the callee name is present in `known_contracts` (the current lift's
+//     name → contractCid map), set `target_contract_cid` to its CID.
+//   - Otherwise (callee in another crate, extern "C" import, or unresolvable
+//     path) set `target_contract_cid` to None and populate `target_symbol`.
+//
+// The `evidenceTerm` is a placeholder `{kind: "obligation", source: <cid_B>,
+// target: <cid_A or symbol>}` per the dispatch spec. The linker derives the
+// actual predicate-level check later; the lifter's job is to surface the call
+// edge as a content-addressable memento.
+//
+// Locus shape (no prior definition in this codebase; defined here per spec):
+//   { "file": <source_path>, "line": <u32 | null>, "col": <u32 | null> }
+// syn's Span has no runtime line/col information in proc-macro2 without
+// enabling `proc-macro2/span-locations`; we record file only, with null for
+// line/col. This is honest under-coverage per the codebase convention.
+
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
+
+/// A call-edge memento as defined in spec #114 §1.
+#[derive(Debug, Clone)]
+pub struct CallEdgeMemento {
+    /// CID of the calling function's contract (B).
+    pub source_contract_cid: String,
+    /// CID of the called function's contract (A), if resolved in this unit.
+    pub target_contract_cid: Option<String>,
+    /// Locus of the call site within the source file.
+    pub call_site_locus: CallSiteLocus,
+    /// Language-local symbol name for the callee. Always populated.
+    pub target_symbol: String,
+    /// JCS-canonical bytes of the full memento object.
+    pub canonical_bytes: Vec<u8>,
+    /// CID of the memento: blake3-512(canonical_bytes).
+    pub cid: String,
+}
+
+/// Source location of a call site.
+/// Line/col are null because proc-macro2 Span has no runtime location data
+/// without the `span-locations` feature (which we do not enable).
+#[derive(Debug, Clone)]
+pub struct CallSiteLocus {
+    pub file: String,
+    /// Always None in this implementation; linker may enrich later.
+    pub line: Option<u32>,
+    pub col: Option<u32>,
+}
+
+impl CallSiteLocus {
+    pub fn to_value(&self) -> Arc<Value> {
+        Value::object([
+            ("file", Value::string(self.file.clone())),
+            (
+                "line",
+                match self.line {
+                    Some(n) => Value::integer(n as i64),
+                    None => Value::null(),
+                },
+            ),
+            (
+                "col",
+                match self.col {
+                    Some(n) => Value::integer(n as i64),
+                    None => Value::null(),
+                },
+            ),
+        ])
+    }
+}
+
+/// Build the JCS-canonical bytes and CID for one call-edge memento.
+pub fn mint_call_edge(
+    source_contract_cid: &str,
+    target_contract_cid: Option<&str>,
+    locus: &CallSiteLocus,
+    target_symbol: &str,
+) -> CallEdgeMemento {
+    // evidenceTerm placeholder per dispatch spec.
+    let evidence_term = Value::object([
+        ("kind", Value::string("obligation")),
+        ("source", Value::string(source_contract_cid.to_string())),
+        (
+            "target",
+            Value::string(
+                target_contract_cid
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| target_symbol.to_string()),
+            ),
+        ),
+    ]);
+
+    let target_cid_value: Arc<Value> = match target_contract_cid {
+        Some(cid) => Value::string(cid.to_string()),
+        None => Value::null(),
+    };
+
+    let memento = Value::object([
+        ("schemaVersion", Value::string("1")),
+        ("kind", Value::string("call-edge")),
+        ("sourceContractCid", Value::string(source_contract_cid.to_string())),
+        ("targetContractCid", target_cid_value),
+        ("callSiteLocus", locus.to_value()),
+        ("targetSymbol", Value::string(target_symbol.to_string())),
+        ("evidenceTerm", evidence_term),
+    ]);
+
+    let canonical_bytes = encode_jcs(&memento).into_bytes();
+    let cid = blake3_512_of(&canonical_bytes);
+
+    CallEdgeMemento {
+        source_contract_cid: source_contract_cid.to_string(),
+        target_contract_cid: target_contract_cid.map(|s| s.to_string()),
+        call_site_locus: locus.clone(),
+        target_symbol: target_symbol.to_string(),
+        canonical_bytes,
+        cid,
+    }
+}
+
+/// Walk a syn::File and extract call-edge mementos.
+///
+/// `contracted_fns` is the set of function names that have contracts in this
+/// compilation unit (already lifted by the adapters). Only call sites within
+/// these functions emit call-edge mementos; uncontracted functions are ignored.
+///
+/// `contract_cids` is the name → contractCid map built during `mint_proof`.
+/// Because `lift_path` does not mint (it only lifts), we pass in a map built
+/// from `compute_contract_cid` directly from the ContractDecls.
+pub fn extract_call_edges_from_file(
+    file: &syn::File,
+    source_path: &str,
+    contract_cids: &BTreeMap<String, String>,
+) -> Vec<CallEdgeMemento> {
+    let mut edges = Vec::new();
+    let contracted_fn_names: HashSet<&str> =
+        contract_cids.keys().map(|s| s.as_str()).collect();
+    walk_items_for_edges(
+        &file.items,
+        source_path,
+        contract_cids,
+        &contracted_fn_names,
+        &mut edges,
+    );
+    edges
+}
+
+fn walk_items_for_edges(
+    items: &[syn::Item],
+    source_path: &str,
+    contract_cids: &BTreeMap<String, String>,
+    contracted_fn_names: &HashSet<&str>,
+    edges: &mut Vec<CallEdgeMemento>,
+) {
+    for item in items {
+        match item {
+            syn::Item::Fn(f) => {
+                let fn_name = f.sig.ident.to_string();
+                // Only look for edges within contracted functions.
+                if let Some(source_cid) = contract_cids.get(&fn_name) {
+                    let locus = CallSiteLocus {
+                        file: source_path.to_string(),
+                        line: None,
+                        col: None,
+                    };
+                    collect_call_sites_in_block(
+                        &f.block,
+                        source_cid,
+                        &locus,
+                        contract_cids,
+                        edges,
+                    );
+                }
+                // Recurse into nested items in function body.
+                for stmt in &f.block.stmts {
+                    if let syn::Stmt::Item(inner) = stmt {
+                        walk_items_for_edges(
+                            std::slice::from_ref(inner),
+                            source_path,
+                            contract_cids,
+                            contracted_fn_names,
+                            edges,
+                        );
+                    }
+                }
+            }
+            syn::Item::Mod(m) => {
+                if let Some((_, items)) = &m.content {
+                    walk_items_for_edges(
+                        items,
+                        source_path,
+                        contract_cids,
+                        contracted_fn_names,
+                        edges,
+                    );
+                }
+            }
+            syn::Item::ForeignMod(fm) => {
+                // extern "C" blocks: no call sites to extract here,
+                // but we record the symbol names for resolution later.
+                // The actual call-edge emission happens when contracted
+                // functions CALL these extern symbols (handled below via
+                // the call-site walker).
+                let _ = fm;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Collect all call sites in a block, emitting one CallEdgeMemento per site.
+fn collect_call_sites_in_block(
+    block: &syn::Block,
+    source_cid: &str,
+    locus: &CallSiteLocus,
+    contract_cids: &BTreeMap<String, String>,
+    edges: &mut Vec<CallEdgeMemento>,
+) {
+    for stmt in &block.stmts {
+        collect_call_sites_in_stmt(stmt, source_cid, locus, contract_cids, edges);
+    }
+}
+
+fn collect_call_sites_in_stmt(
+    stmt: &syn::Stmt,
+    source_cid: &str,
+    locus: &CallSiteLocus,
+    contract_cids: &BTreeMap<String, String>,
+    edges: &mut Vec<CallEdgeMemento>,
+) {
+    match stmt {
+        syn::Stmt::Expr(expr, _) => {
+            collect_call_sites_in_expr(expr, source_cid, locus, contract_cids, edges);
+        }
+        syn::Stmt::Local(local) => {
+            if let Some(init) = &local.init {
+                collect_call_sites_in_expr(&init.expr, source_cid, locus, contract_cids, edges);
+                if let Some((_, diverge)) = &init.diverge {
+                    collect_call_sites_in_expr(diverge, source_cid, locus, contract_cids, edges);
+                }
+            }
+        }
+        syn::Stmt::Item(_) => {
+            // Nested items handled at the items-walking level.
+        }
+        syn::Stmt::Macro(_) => {
+            // Macro statements (e.g. assert!) may contain call sites, but
+            // we cannot reliably parse their token streams here. Skipped.
+        }
+    }
+}
+
+fn collect_call_sites_in_expr(
+    expr: &syn::Expr,
+    source_cid: &str,
+    locus: &CallSiteLocus,
+    contract_cids: &BTreeMap<String, String>,
+    edges: &mut Vec<CallEdgeMemento>,
+) {
+    match expr {
+        syn::Expr::Call(c) => {
+            // Emit an edge for this call site.
+            if let Some(callee_name) = callee_name_from_expr(&c.func) {
+                let target_cid = contract_cids.get(&callee_name).map(|s| s.as_str());
+                let edge = mint_call_edge(source_cid, target_cid, locus, &callee_name);
+                edges.push(edge);
+            }
+            // Recurse into arguments.
+            for arg in &c.args {
+                collect_call_sites_in_expr(arg, source_cid, locus, contract_cids, edges);
+            }
+        }
+        syn::Expr::MethodCall(mc) => {
+            // Emit an edge for the method call.
+            let callee_name = mc.method.to_string();
+            // Methods don't resolve to contract CIDs by name alone; treat as unresolved.
+            let edge = mint_call_edge(source_cid, None, locus, &callee_name);
+            edges.push(edge);
+            // Recurse into receiver and arguments.
+            collect_call_sites_in_expr(&mc.receiver, source_cid, locus, contract_cids, edges);
+            for arg in &mc.args {
+                collect_call_sites_in_expr(arg, source_cid, locus, contract_cids, edges);
+            }
+        }
+        // Recurse into sub-expressions.
+        syn::Expr::Block(b) => {
+            collect_call_sites_in_block(&b.block, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::If(e) => {
+            collect_call_sites_in_expr(&e.cond, source_cid, locus, contract_cids, edges);
+            collect_call_sites_in_block(&e.then_branch, source_cid, locus, contract_cids, edges);
+            if let Some((_, else_b)) = &e.else_branch {
+                collect_call_sites_in_expr(else_b, source_cid, locus, contract_cids, edges);
+            }
+        }
+        syn::Expr::While(e) => {
+            collect_call_sites_in_expr(&e.cond, source_cid, locus, contract_cids, edges);
+            collect_call_sites_in_block(&e.body, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::ForLoop(e) => {
+            collect_call_sites_in_expr(&e.expr, source_cid, locus, contract_cids, edges);
+            collect_call_sites_in_block(&e.body, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Loop(e) => {
+            collect_call_sites_in_block(&e.body, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Match(e) => {
+            collect_call_sites_in_expr(&e.expr, source_cid, locus, contract_cids, edges);
+            for arm in &e.arms {
+                if let Some((_, guard)) = &arm.guard {
+                    collect_call_sites_in_expr(guard, source_cid, locus, contract_cids, edges);
+                }
+                collect_call_sites_in_expr(&arm.body, source_cid, locus, contract_cids, edges);
+            }
+        }
+        syn::Expr::Binary(e) => {
+            collect_call_sites_in_expr(&e.left, source_cid, locus, contract_cids, edges);
+            collect_call_sites_in_expr(&e.right, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Unary(e) => {
+            collect_call_sites_in_expr(&e.expr, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Return(e) => {
+            if let Some(v) = &e.expr {
+                collect_call_sites_in_expr(v, source_cid, locus, contract_cids, edges);
+            }
+        }
+        syn::Expr::Assign(e) => {
+            collect_call_sites_in_expr(&e.left, source_cid, locus, contract_cids, edges);
+            collect_call_sites_in_expr(&e.right, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Field(e) => {
+            collect_call_sites_in_expr(&e.base, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Index(e) => {
+            collect_call_sites_in_expr(&e.expr, source_cid, locus, contract_cids, edges);
+            collect_call_sites_in_expr(&e.index, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Paren(e) => {
+            collect_call_sites_in_expr(&e.expr, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Reference(e) => {
+            collect_call_sites_in_expr(&e.expr, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Cast(e) => {
+            collect_call_sites_in_expr(&e.expr, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Closure(e) => {
+            collect_call_sites_in_expr(&e.body, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Try(e) => {
+            collect_call_sites_in_expr(&e.expr, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Await(e) => {
+            collect_call_sites_in_expr(&e.base, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Unsafe(e) => {
+            collect_call_sites_in_block(&e.block, source_cid, locus, contract_cids, edges);
+        }
+        syn::Expr::Tuple(e) => {
+            for elem in &e.elems {
+                collect_call_sites_in_expr(elem, source_cid, locus, contract_cids, edges);
+            }
+        }
+        syn::Expr::Array(e) => {
+            for elem in &e.elems {
+                collect_call_sites_in_expr(elem, source_cid, locus, contract_cids, edges);
+            }
+        }
+        syn::Expr::Struct(e) => {
+            for field in &e.fields {
+                collect_call_sites_in_expr(&field.expr, source_cid, locus, contract_cids, edges);
+            }
+            if let Some(rest) = &e.rest {
+                collect_call_sites_in_expr(rest, source_cid, locus, contract_cids, edges);
+            }
+        }
+        syn::Expr::Repeat(e) => {
+            collect_call_sites_in_expr(&e.expr, source_cid, locus, contract_cids, edges);
+            collect_call_sites_in_expr(&e.len, source_cid, locus, contract_cids, edges);
+        }
+        // Paths, literals, macros — no sub-expressions with calls.
+        _ => {}
+    }
+}
+
+/// Extract the callee name from a function-call expression's func field.
+/// Returns None for closures, parenthesised exprs, and other non-path callees.
+fn callee_name_from_expr(func: &syn::Expr) -> Option<String> {
+    match func {
+        syn::Expr::Path(p) => Some(path_to_string(&p.path)),
+        syn::Expr::Paren(inner) => callee_name_from_expr(&inner.expr),
+        _ => None,
+    }
+}
+
+fn path_to_string(p: &syn::Path) -> String {
+    p.segments
+        .iter()
+        .map(|s| s.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn parse(src: &str) -> syn::File {
+        syn::parse_file(src).expect("parse_file")
+    }
+
+    #[test]
+    fn no_edges_from_uncontracted_function() {
+        let file = parse(
+            r#"
+            fn a() {}
+            fn b() { a(); }
+        "#,
+        );
+        let cids: BTreeMap<String, String> = BTreeMap::new();
+        let edges = extract_call_edges_from_file(&file, "test.rs", &cids);
+        assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn edge_from_contracted_caller_to_contracted_callee() {
+        let file = parse(
+            r#"
+            fn a() {}
+            fn b() { a(); }
+        "#,
+        );
+        let mut cids = BTreeMap::new();
+        cids.insert("a".to_string(), "blake3-512:aaa".to_string());
+        cids.insert("b".to_string(), "blake3-512:bbb".to_string());
+        let edges = extract_call_edges_from_file(&file, "test.rs", &cids);
+        assert_eq!(edges.len(), 1, "expected one edge b→a, got {edges:?}");
+        let e = &edges[0];
+        assert_eq!(e.source_contract_cid, "blake3-512:bbb");
+        assert_eq!(e.target_contract_cid.as_deref(), Some("blake3-512:aaa"));
+        assert_eq!(e.target_symbol, "a");
+    }
+
+    #[test]
+    fn edge_to_unknown_callee_has_null_target_cid() {
+        let file = parse(
+            r#"
+            fn b() { unknown_extern(); }
+        "#,
+        );
+        let mut cids = BTreeMap::new();
+        cids.insert("b".to_string(), "blake3-512:bbb".to_string());
+        let edges = extract_call_edges_from_file(&file, "test.rs", &cids);
+        assert_eq!(edges.len(), 1);
+        let e = &edges[0];
+        assert!(e.target_contract_cid.is_none(), "target_cid should be None");
+        assert_eq!(e.target_symbol, "unknown_extern");
+    }
+
+    #[test]
+    fn jcs_bytes_are_deterministic_across_two_calls() {
+        let file = parse(
+            r#"
+            fn a() {}
+            fn b() { a(); }
+        "#,
+        );
+        let mut cids = BTreeMap::new();
+        cids.insert("a".to_string(), "blake3-512:aaa".to_string());
+        cids.insert("b".to_string(), "blake3-512:bbb".to_string());
+        let edges1 = extract_call_edges_from_file(&file, "test.rs", &cids);
+        let edges2 = extract_call_edges_from_file(&file, "test.rs", &cids);
+        assert_eq!(edges1.len(), edges2.len());
+        for (e1, e2) in edges1.iter().zip(edges2.iter()) {
+            assert_eq!(e1.canonical_bytes, e2.canonical_bytes, "JCS bytes must be deterministic");
+            assert_eq!(e1.cid, e2.cid, "CID must be deterministic");
+        }
+    }
+}

--- a/implementations/rust/provekit-lift/src/lib.rs
+++ b/implementations/rust/provekit-lift/src/lib.rs
@@ -49,6 +49,9 @@ use provekit_claim_envelope::{
 use provekit_ir_symbolic::{serialize::formula_to_value, ContractDecl};
 use provekit_proof_envelope::{build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput};
 
+pub mod call_edges;
+pub use call_edges::{CallEdgeMemento, CallSiteLocus, extract_call_edges_from_file, mint_call_edge};
+
 pub use provekit_lift_contracts as adapter_contracts;
 pub use provekit_lift_creusot as adapter_creusot;
 pub use provekit_lift_flux as adapter_flux;
@@ -81,6 +84,9 @@ pub struct AdapterWarning {
 #[derive(Debug, Default)]
 pub struct LiftReport {
     pub decls: Vec<ContractDecl>,
+    /// Call-edge mementos extracted per spec #114 §1 R1.
+    /// One memento per call site within a contracted function.
+    pub call_edges: Vec<CallEdgeMemento>,
     pub adapter_reports: Vec<AdapterReport>,
     pub files_scanned: usize,
     pub parse_errors: Vec<(String, String)>,
@@ -162,6 +168,10 @@ pub fn lift_path(root: &Path) -> LiftReport {
     let mut l2_char_lifted = 0usize;
     let mut l2_char_skipped = 0usize;
 
+    // Retain (path_str, parsed_file) so the second pass (call-edge extraction)
+    // can re-use them without re-parsing. Only successfully parsed files are kept.
+    let mut parsed_files: Vec<(String, syn::File)> = Vec::new();
+
     for path in enumerate_rs_files(root) {
         report.files_scanned += 1;
         let bytes = match std::fs::read(&path) {
@@ -187,6 +197,7 @@ pub fn lift_path(root: &Path) -> LiftReport {
             }
         };
         let path_str = path.display().to_string();
+        parsed_files.push((path_str.clone(), file.clone()));
 
         // Adapter: proptest.
         let p_out = adapter_proptest::lift_file(&file, &path_str);
@@ -410,6 +421,47 @@ pub fn lift_path(root: &Path) -> LiftReport {
         l2_char_lifted,
         l2_char_skipped,
     );
+
+    // --- Second pass: call-edge extraction (spec #114 §1 R1) ----------------
+    //
+    // Build a signer-independent name → contractCid map from all lifted decls.
+    // This covers the full compilation unit; cross-crate callees won't appear
+    // here and will produce targetContractCid: null edges.
+    let contract_cid_map: BTreeMap<String, String> = {
+        let mut map = BTreeMap::new();
+        for d in &report.decls {
+            // Compute the signer-independent content CID using a minimal
+            // MintContractArgs (only the content-bearing fields matter;
+            // signer_seed, produced_at, etc. do not affect the CID per spec #94).
+            let args = MintContractArgs {
+                contract_name: d.name.clone(),
+                pre: d.pre.as_deref().map(formula_to_value),
+                post: d.post.as_deref().map(formula_to_value),
+                inv: d.inv.as_deref().map(formula_to_value),
+                out_binding: d.out_binding.clone(),
+                produced_by: "provekit-lift".into(),
+                produced_at: "2026-01-01T00:00:00.000Z".into(),
+                input_cids: vec![],
+                authoring: Authoring::Lift {
+                    lifter: "provekit-lift".into(),
+                    evidence: String::new(),
+                    source_cid: None,
+                },
+                signer_seed: [0u8; 32],
+            };
+            let ccid = compute_contract_cid(&args);
+            // If the same name was lifted multiple times (e.g. semantic dedup),
+            // use the first; they'll produce the same CID anyway.
+            map.entry(d.name.clone()).or_insert(ccid);
+        }
+        map
+    };
+
+    for (path_str, parsed_file) in &parsed_files {
+        let edges = extract_call_edges_from_file(parsed_file, path_str, &contract_cid_map);
+        report.call_edges.extend(edges);
+    }
+
     report
 }
 

--- a/implementations/rust/provekit-lift/tests/call_edges.rs
+++ b/implementations/rust/provekit-lift/tests/call_edges.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Integration tests for call-edge stream emission (spec #114 §1 R1).
+//
+// Test 1: b() calls a(), both have contracts → edge has correct source and
+//         target contractCids.
+// Test 2: b() calls an extern "C" function → targetContractCid is null,
+//         targetSymbol is populated.
+// Test 3: JCS bytes of a call-edge memento are byte-deterministic across
+//         two independent lifts of the same source.
+
+use std::collections::BTreeMap;
+
+use provekit_lift::{extract_call_edges_from_file};
+use provekit_lift::adapter_contracts;
+
+use provekit_claim_envelope::{contract_cid as compute_contract_cid, MintContractArgs, Authoring};
+use provekit_ir_symbolic::serialize::formula_to_value;
+
+// ---------------------------------------------------------------------------
+// Test 1: b() calls a(); both have contracts.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test1_call_edge_both_contracted_has_target_cid() {
+    // Source: `a` and `b` are annotated functions; `b` calls `a`.
+    let src = r#"
+#[requires(x > 0)]
+#[ensures(result >= 0)]
+fn a(x: i64) -> i64 { x }
+
+#[requires(n > 0)]
+#[ensures(result >= 0)]
+fn b(n: i64) -> i64 { a(n) }
+"#;
+
+    let parsed = syn::parse_file(src).expect("parse_file");
+
+    // Lift the contracts adapter to get the ContractDecls.
+    let adapter_out = adapter_contracts::lift_file(&parsed, "test1.rs");
+    assert!(adapter_out.lifted >= 2, "expected >=2 contracts (a and b)");
+
+    // Build the name→CID map the same way lift_path does.
+    let cid_map: BTreeMap<String, String> = adapter_out.decls.iter().map(|d| {
+        let args = MintContractArgs {
+            contract_name: d.name.clone(),
+            pre: d.pre.as_deref().map(formula_to_value),
+            post: d.post.as_deref().map(formula_to_value),
+            inv: d.inv.as_deref().map(formula_to_value),
+            out_binding: d.out_binding.clone(),
+            produced_by: "provekit-lift".into(),
+            produced_at: "2026-01-01T00:00:00.000Z".into(),
+            input_cids: vec![],
+            authoring: Authoring::Lift {
+                lifter: "provekit-lift".into(),
+                evidence: String::new(),
+                source_cid: None,
+            },
+            signer_seed: [0u8; 32],
+        };
+        (d.name.clone(), compute_contract_cid(&args))
+    }).collect();
+
+    assert!(cid_map.contains_key("a"), "expected `a` in contract map; got {:?}", cid_map.keys().collect::<Vec<_>>());
+    assert!(cid_map.contains_key("b"), "expected `b` in contract map");
+
+    let edges = extract_call_edges_from_file(&parsed, "test1.rs", &cid_map);
+
+    // b calls a → exactly one edge.
+    assert!(!edges.is_empty(), "expected at least one call edge");
+
+    let b_to_a = edges.iter().find(|e| {
+        e.source_contract_cid == *cid_map.get("b").unwrap()
+            && e.target_symbol == "a"
+    });
+
+    let b_to_a = b_to_a.expect("expected a call edge from b to a");
+
+    // target_contract_cid must be set (a is in the same unit).
+    assert_eq!(
+        b_to_a.target_contract_cid.as_deref(),
+        Some(cid_map.get("a").unwrap().as_str()),
+        "targetContractCid must match a's contractCid"
+    );
+
+    // sourceContractCid must match b's.
+    assert_eq!(
+        b_to_a.source_contract_cid,
+        *cid_map.get("b").unwrap(),
+        "sourceContractCid must match b's contractCid"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: b() calls extern "C" function → targetContractCid null, targetSymbol set.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test2_extern_c_callee_has_null_target_and_symbol() {
+    // Source: b calls `rust_add` which is declared extern "C".
+    let src = r#"
+extern "C" {
+    fn rust_add(x: i64, y: i64) -> i64;
+}
+
+#[requires(x > 0)]
+#[ensures(result >= 0)]
+fn b(x: i64) -> i64 {
+    unsafe { rust_add(x, 1) }
+}
+"#;
+
+    let parsed = syn::parse_file(src).expect("parse_file");
+    let adapter_out = adapter_contracts::lift_file(&parsed, "test2.rs");
+    assert!(adapter_out.lifted >= 1, "expected >=1 contract (b)");
+
+    let cid_map: BTreeMap<String, String> = adapter_out.decls.iter().map(|d| {
+        let args = MintContractArgs {
+            contract_name: d.name.clone(),
+            pre: d.pre.as_deref().map(formula_to_value),
+            post: d.post.as_deref().map(formula_to_value),
+            inv: d.inv.as_deref().map(formula_to_value),
+            out_binding: d.out_binding.clone(),
+            produced_by: "provekit-lift".into(),
+            produced_at: "2026-01-01T00:00:00.000Z".into(),
+            input_cids: vec![],
+            authoring: Authoring::Lift {
+                lifter: "provekit-lift".into(),
+                evidence: String::new(),
+                source_cid: None,
+            },
+            signer_seed: [0u8; 32],
+        };
+        (d.name.clone(), compute_contract_cid(&args))
+    }).collect();
+
+    // `rust_add` is not in the contract map (no annotations).
+    assert!(!cid_map.contains_key("rust_add"), "rust_add should not have a contract");
+
+    let edges = extract_call_edges_from_file(&parsed, "test2.rs", &cid_map);
+
+    let to_rust_add = edges.iter().find(|e| e.target_symbol == "rust_add");
+    let to_rust_add = to_rust_add.expect("expected call edge to rust_add");
+
+    // targetContractCid must be null (not in this unit's contract set).
+    assert!(
+        to_rust_add.target_contract_cid.is_none(),
+        "targetContractCid must be None for extern callee; got {:?}",
+        to_rust_add.target_contract_cid
+    );
+
+    // targetSymbol must be populated.
+    assert_eq!(
+        to_rust_add.target_symbol, "rust_add",
+        "targetSymbol must be `rust_add`"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: JCS bytes are byte-deterministic across two independent lifts.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test3_jcs_bytes_are_deterministic_across_two_lifts() {
+    let src = r#"
+#[requires(x > 0)]
+#[ensures(result >= 0)]
+fn a(x: i64) -> i64 { x }
+
+#[requires(n > 0)]
+#[ensures(result >= 0)]
+fn b(n: i64) -> i64 { a(n) }
+"#;
+
+    let parsed = syn::parse_file(src).expect("parse_file");
+
+    let build_cid_map = || {
+        let adapter_out = adapter_contracts::lift_file(&parsed, "test3.rs");
+        adapter_out.decls.iter().map(|d| {
+            let args = MintContractArgs {
+                contract_name: d.name.clone(),
+                pre: d.pre.as_deref().map(formula_to_value),
+                post: d.post.as_deref().map(formula_to_value),
+                inv: d.inv.as_deref().map(formula_to_value),
+                out_binding: d.out_binding.clone(),
+                produced_by: "provekit-lift".into(),
+                produced_at: "2026-01-01T00:00:00.000Z".into(),
+                input_cids: vec![],
+                authoring: Authoring::Lift {
+                    lifter: "provekit-lift".into(),
+                    evidence: String::new(),
+                    source_cid: None,
+                },
+                signer_seed: [0u8; 32],
+            };
+            (d.name.clone(), compute_contract_cid(&args))
+        }).collect::<BTreeMap<_, _>>()
+    };
+
+    let cid_map1 = build_cid_map();
+    let cid_map2 = build_cid_map();
+
+    // CID maps must be identical across two runs.
+    assert_eq!(cid_map1, cid_map2, "contractCid maps must be deterministic");
+
+    let edges1 = extract_call_edges_from_file(&parsed, "test3.rs", &cid_map1);
+    let edges2 = extract_call_edges_from_file(&parsed, "test3.rs", &cid_map2);
+
+    assert_eq!(edges1.len(), edges2.len(), "edge counts must match");
+
+    for (e1, e2) in edges1.iter().zip(edges2.iter()) {
+        assert_eq!(
+            e1.canonical_bytes, e2.canonical_bytes,
+            "JCS bytes must be byte-deterministic across two lifts"
+        );
+        assert_eq!(
+            e1.cid, e2.cid,
+            "CIDs must be byte-deterministic across two lifts"
+        );
+    }
+
+    // At least one edge must have been emitted.
+    assert!(!edges1.is_empty(), "expected at least one call edge");
+}

--- a/implementations/rust/provekit-self-contracts/src/bin/print-lift-plugin-protocol-cids.rs
+++ b/implementations/rust/provekit-self-contracts/src/bin/print-lift-plugin-protocol-cids.rs
@@ -42,6 +42,8 @@ const LIFT_PLUGIN_PROTOCOL_CONTRACT_NAMES: &[&str] = &[
     "lift_plugin_lift_response_kind_in_set",
     "lift_plugin_lift_response_ir_document_array",
     "lift_plugin_diagnostic_field_is_array",
+    // C8: lifter must emit call-edge stream alongside contracts (spec #114 R1).
+    "lift_emits_call_edge_stream",
 ];
 
 fn main() -> ExitCode {

--- a/implementations/rust/provekit-self-contracts/src/lift_plugin_protocol.rs
+++ b/implementations/rust/provekit-self-contracts/src/lift_plugin_protocol.rs
@@ -303,6 +303,31 @@ pub fn invariants() {
             ..Default::default()
         },
     );
+
+    // -- C8: lifter emits call-edge stream alongside contracts (spec #114 §1
+    //        R1: "A lifter that emits contracts but no call edges is
+    //        non-conformant under this spec").
+    //
+    // forall resp. when kind == "proof-envelope" OR kind == "signed-mementos",
+    //              call_edge_stream_present(resp) = true.
+    //
+    // Encoded as a post-condition: the call_edge_stream_present ctor
+    // discharges vacuously when the response carries no lifted contracts
+    // (empty compilation unit) and fires when a non-empty contract set is
+    // emitted with no accompanying call-edge stream.
+    contract(
+        "lift_emits_call_edge_stream",
+        ContractArgs {
+            post: Some(eq(
+                ctor1(
+                    "call_edge_stream_present_or_unit_empty",
+                    str_const("resp"),
+                ),
+                ctor1("true_const", str_const("")),
+            )),
+            ..Default::default()
+        },
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -617,6 +642,58 @@ pub fn verify_c7_diagnostics_field_is_array(
         return Err(format!(
             "C7: response.result.diagnostics is {}, expected array",
             type_label(diags)
+        ));
+    }
+    Ok(())
+}
+
+// --- C8 ---------------------------------------------------------------------
+
+/// Verify C8: the lift response includes a call-edge stream when the contract
+/// set is non-empty. Conforms to spec #114 §1 R1.
+///
+/// This verifier checks the `signed-mementos` and `proof-envelope` shapes,
+/// where the call-edge stream appears as `call_edges` (an array). For the
+/// `ir-document` shape, the verifier is vacuous (IR documents are an
+/// intermediate representation; call edges travel in a separate pass).
+///
+/// The verifier is vacuously OK when the contract set is empty (no contracts
+/// lifted → no call edges required).
+pub fn verify_c8_call_edge_stream_present(
+    response: &JsonValue,
+) -> Result<(), String> {
+    let result = match response.get("result") {
+        Some(r) => r,
+        None => return Ok(()), // error responses don't carry call edges
+    };
+    let kind = result.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    // Only check the signed-mementos and proof-envelope shapes; ir-document
+    // is vacuous (call edges are not part of the IR document shape).
+    if kind != "signed-mementos" && kind != "proof-envelope" {
+        return Ok(());
+    }
+    // If there are no contract members, call edges are vacuously satisfied.
+    let members_empty = result
+        .get("members")
+        .and_then(|m| m.as_object())
+        .map(|m| m.is_empty())
+        .unwrap_or(true);
+    if members_empty {
+        return Ok(());
+    }
+    // Non-empty contract set: call_edges must be present and an array.
+    let call_edges = match result.get("call_edges") {
+        Some(v) => v,
+        None => {
+            return Err(
+                "C8: response has non-empty contract set but no `call_edges` field".to_string(),
+            )
+        }
+    };
+    if !call_edges.is_array() {
+        return Err(format!(
+            "C8: response.result.call_edges must be an array, got {}",
+            type_label(call_edges)
         ));
     }
     Ok(())
@@ -983,12 +1060,12 @@ mod tests {
         begin_collecting();
         invariants();
         let decls = finish();
-        // C1, C2 (two facets), C3 (three facets), C4, C5, C6, C7
-        // = 1 + 2 + 3 + 1 + 1 + 1 + 1 = 10 ContractDecls.
+        // C1, C2 (two facets), C3 (three facets), C4, C5, C6, C7, C8
+        // = 1 + 2 + 3 + 1 + 1 + 1 + 1 + 1 = 11 ContractDecls.
         assert_eq!(
             decls.len(),
-            10,
-            "lift_plugin_protocol::invariants should author 10 contracts; got {}",
+            11,
+            "lift_plugin_protocol::invariants should author 11 contracts; got {}",
             decls.len()
         );
         // Spot-check a few names.
@@ -997,5 +1074,89 @@ mod tests {
         assert!(names.contains(&"lift_plugin_lift_response_kind_in_set"));
         assert!(names.contains(&"lift_plugin_lift_response_ir_document_array"));
         assert!(names.contains(&"lift_plugin_diagnostic_field_is_array"));
+        assert!(
+            names.contains(&"lift_emits_call_edge_stream"),
+            "expected lift_emits_call_edge_stream in invariants; got {names:?}"
+        );
+    }
+
+    // --- C8 ---------------------------------------------------------------
+
+    #[test]
+    fn c8_holds_when_call_edges_present_with_contracts() {
+        let resp = json!({
+            "result": {
+                "kind": "signed-mementos",
+                "members": {"blake3-512:aaa": "..."},
+                "call_edges": [
+                    {
+                        "schemaVersion": "1",
+                        "kind": "call-edge",
+                        "sourceContractCid": "blake3-512:bbb",
+                        "targetContractCid": "blake3-512:aaa",
+                        "callSiteLocus": {"file": "foo.rs", "line": null, "col": null},
+                        "targetSymbol": "a",
+                        "evidenceTerm": {"kind": "obligation", "source": "blake3-512:bbb", "target": "blake3-512:aaa"},
+                    }
+                ],
+            },
+        });
+        verify_c8_call_edge_stream_present(&resp).unwrap();
+    }
+
+    #[test]
+    fn c8_holds_vacuously_when_no_contract_members() {
+        let resp = json!({
+            "result": {
+                "kind": "signed-mementos",
+                "members": {},
+            },
+        });
+        verify_c8_call_edge_stream_present(&resp).unwrap();
+    }
+
+    #[test]
+    fn c8_holds_vacuously_for_ir_document_kind() {
+        let resp = json!({
+            "result": {
+                "kind": "ir-document",
+                "ir": [{"kind": "contract", "name": "foo", "outBinding": "out"}],
+            },
+        });
+        verify_c8_call_edge_stream_present(&resp).unwrap();
+    }
+
+    #[test]
+    fn c8_violation_missing_call_edges_field_is_caught() {
+        let resp = json!({
+            "result": {
+                "kind": "signed-mementos",
+                "members": {"blake3-512:aaa": "..."},
+                // call_edges field is absent
+            },
+        });
+        let err = verify_c8_call_edge_stream_present(&resp)
+            .expect_err("C8 should fire when call_edges absent and contracts non-empty");
+        assert!(
+            err.contains("call_edges"),
+            "expected call_edges mention; got: {err}"
+        );
+    }
+
+    #[test]
+    fn c8_violation_call_edges_not_array_is_caught() {
+        let resp = json!({
+            "result": {
+                "kind": "signed-mementos",
+                "members": {"blake3-512:aaa": "..."},
+                "call_edges": "not-an-array",
+            },
+        });
+        let err = verify_c8_call_edge_stream_present(&resp)
+            .expect_err("C8 should fire when call_edges is not an array");
+        assert!(
+            err.contains("array"),
+            "expected array mention; got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Implements Bridge Linkage Protocol spec #114 §1 R1: the rust lifter now emits two streams per compilation unit -- contract mementos (existing) and call-edge mementos (new).
- Each call-edge memento captures `sourceContractCid`, `targetContractCid` (null for cross-unit/extern "C"), `callSiteLocus`, `targetSymbol`, and a placeholder `evidenceTerm` per spec shape.
- Adds `lift_emits_call_edge_stream` contract (C8) to `lift_plugin_protocol.rs`, updating the slab from 10 to 11 contracts.

## New contractSetCid (lift-plugin-protocol slab)

`blake3-512:8f4bcc3c3e748ae303f8c8da80245f291e803eb2d241224c75c7ac470631e4dee7ff2e0ff59af571db3d506485c115acaddfd91e4e4315eb04ee37c035ddbc69`

## Test plan

- [x] `cargo test -p provekit-lift` — all 21 tests pass (7 lib unit, 4 unit in call_edges module, 3 integration in tests/call_edges.rs, 7 end_to_end, 4 layer2)
- [x] `cargo test -p provekit-self-contracts` — all 61 tests pass (includes 5 new C8 tests)
- [x] Full workspace `cargo test` — zero failures
- [x] `mint-self-contracts` determinism check passes

## Scope constraint

This PR emits call edges only. Bridge derivation is the linker's job (later PR). The `call_edges` field on `LiftReport` is in-memory; no changes to the `.proof` envelope format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)