### PR TITLE
fix(ci): install z3 in conformance gate (closes #215)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,23 @@ jobs:
       # at tools/blake3-vendored/, no system package required.
       # ---------------------------------------------------------------
 
-      - name: Install C++ system deps
+      - name: Install C++ system deps + z3
+        # z3 is the SMT solver invoked by the TS workflow producer's
+        # checkImplication / bridgeEnforcement / circularProof tests
+        # (`provekit prove` substrate). Without it on PATH, every
+        # solver invocation returns ENOENT, the producer maps that to
+        # `undecidable`, and ~10 tests fail with errors of the shape
+        # `expected 'undecidable' to be 'equivalent'`. The `prove`
+        # workflow in provekit.yml installed z3; this gate did not.
+        # Closes task #215 ("CI: TS workflow producer tests failing").
         run: |
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends \
             build-essential \
             clang \
             libssl-dev \
-            nlohmann-json3-dev
+            nlohmann-json3-dev \
+            z3
 
       # ---------------------------------------------------------------
       # The gate.


### PR DESCRIPTION
## Root cause

\`.github/workflows/ci.yml\` (the conformance gate) installed C++ system deps but **not z3**. \`provekit.yml\` (the prove workflow) did install z3. Inconsistent setup. The TS workflow producer tests in \`make test-all\` invoke z3 to discharge SMT queries; without z3 on PATH every invocation returns ENOENT, the producer maps that to \`undecidable\`, and ~10 tests fail with the shape \`expected 'undecidable' to be 'equivalent'\`.

The bug became visible at PR #120 merge because the self-hosted runner (battleaxe) likely had z3 from manual setup that got removed during a runner image rebuild or apt-get autoremove. PR #120 didn't introduce the bug; it just exposed the latent gap.

## Empirical confirmation

- **Local (Mac with z3 on PATH):** 7/7 pass on \`checkImplication.test.ts\`. The DIAG instrumentation added in PR #102 shows z3 invoking, returning \`unsat\` on both directions, classifying as \`equivalent\`.
- **CI (without z3):** same tests fail with \`undecidable\` verdicts.

## The fix

Add \`z3\` to the conformance gate's apt-get install list. One-line addition to the existing C++ deps install step. Closes task #215.

## Test plan

- [ ] Conformance gate passes after merge
- [ ] \`make test-all\` shows TS workflow producer tests passing
- [ ] No regressions in other kits' tests