### PR TITLE
chore(linker): cleanup #128 review nits — naming consistency + dead-code suppressor + explicit expect

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_link.rs
+++ b/implementations/rust/provekit-cli/src/cmd_link.rs
@@ -20,7 +20,7 @@ use std::process::{Command, Stdio};
 use owo_colors::OwoColorize;
 use provekit_claim_envelope::{contract_cid as compute_contract_cid, MintContractArgs, Authoring};
 use provekit_lift::lift_path;
-use provekit_linker::{link, KitCallEdge, KitContract, LinkerInputs};
+use provekit_linker::{link, LinkerCallEdge, LinkerContract, LinkerInputs};
 use serde_json::Value as Json;
 
 use crate::LinkArgs;
@@ -44,7 +44,8 @@ pub fn run(args: LinkArgs) -> u8 {
         Ok(output) => {
             let bundle = &output.bundle_json;
             let out_path = project_root.join("link-bundle.json");
-            let json = serde_json::to_string_pretty(bundle).unwrap_or_default();
+            let json = serde_json::to_string_pretty(bundle)
+                .expect("bundle JSON serialization is infallible for content-hashed data");
             if let Err(e) = std::fs::write(&out_path, &json) {
                 eprintln!("{}: write link-bundle.json: {e}", "error".red().bold());
                 return crate::EXIT_USER_ERROR;
@@ -104,7 +105,7 @@ fn gather_and_link(
 // Step 1: Lift rust contracts
 // -------------------------------------------------------------------
 
-fn lift_rust_contracts(rust_dir: &Path) -> Result<Vec<KitContract>, String> {
+fn lift_rust_contracts(rust_dir: &Path) -> Result<Vec<LinkerContract>, String> {
     if !rust_dir.exists() {
         return Ok(Vec::new());
     }
@@ -139,7 +140,7 @@ fn lift_rust_contracts(rust_dir: &Path) -> Result<Vec<KitContract>, String> {
         let pre_json = pre_v.map(value_arc_to_json);
         let post_json = post_v.map(value_arc_to_json);
 
-        contracts.push(KitContract {
+        contracts.push(LinkerContract {
             name: decl.name.clone(),
             kit: "rust-kit".into(),
             contract_cid: cid,
@@ -181,7 +182,7 @@ fn value_to_json(v: &provekit_canonicalizer::Value) -> Json {
 fn lift_go_call_edges(
     go_dir: &Path,
     go_lsp_bin: Option<&str>,
-) -> Result<(Vec<KitContract>, Vec<KitCallEdge>), String> {
+) -> Result<(Vec<LinkerContract>, Vec<LinkerCallEdge>), String> {
     if !go_dir.exists() {
         return Ok((Vec::new(), Vec::new()));
     }
@@ -214,8 +215,8 @@ fn lift_go_call_edges(
         .map_err(|e| format!("read initialize response: {e}"))?;
     line.clear();
 
-    let mut all_go_contracts: Vec<KitContract> = Vec::new();
-    let mut all_call_edges: Vec<KitCallEdge> = Vec::new();
+    let mut all_go_contracts: Vec<LinkerContract> = Vec::new();
+    let mut all_call_edges: Vec<LinkerCallEdge> = Vec::new();
 
     for (file_path, source) in &go_files {
         let parse_req = serde_json::json!({
@@ -259,7 +260,7 @@ fn lift_go_call_edges(
                     let cid = contract_cid_from_go_decl(decl);
                     let pre_json = decl.get("pre").cloned();
                     let post_json = decl.get("post").cloned();
-                    all_go_contracts.push(KitContract {
+                    all_go_contracts.push(LinkerContract {
                         name,
                         kit: "go-kit".into(),
                         contract_cid: cid,
@@ -300,7 +301,7 @@ fn lift_go_call_edges(
                         .cloned()
                         .unwrap_or(Json::Null);
 
-                    all_call_edges.push(KitCallEdge {
+                    all_call_edges.push(LinkerCallEdge {
                         source_contract_cid: source_cid,
                         target_contract_cid: target_cid,
                         target_symbol,

--- a/implementations/rust/provekit-cli/tests/polyglot_smoke.rs
+++ b/implementations/rust/provekit-cli/tests/polyglot_smoke.rs
@@ -27,7 +27,7 @@
 // Use provekit-linker directly — the extracted library the CLI now delegates
 // to.  No more provekit_cli_test_support shim needed.
 
-use provekit_linker::{link, KitCallEdge, KitContract, LinkerInputs};
+use provekit_linker::{link, LinkerCallEdge, LinkerContract, LinkerInputs};
 
 // -------------------------------------------------------------------
 // Fixture: rust-callee contract for `process`
@@ -38,12 +38,12 @@ use provekit_linker::{link, KitCallEdge, KitContract, LinkerInputs};
 // The contract CID is deterministic for a fixed input. We compute it
 // once and use it throughout.
 
-fn make_process_contract() -> KitContract {
+fn make_process_contract() -> LinkerContract {
     // Use a stable CID for test reproducibility — the actual byte value
     // is derived from the JCS-canonical form of
     // {name:"process", outBinding:"out", pre:{...}} hashed with BLAKE3-512.
     // For the smoke test we use a pre-computed stable fixture CID.
-    KitContract {
+    LinkerContract {
         name: "process".into(),
         kit: "rust-kit".into(),
         // Stable fixture CID computed from {name, outBinding, pre=(n>0)}.
@@ -72,8 +72,8 @@ fn make_process_contract() -> KitContract {
 // For the smoke test we model this as post_json: None, which is what the
 // linker sees when the go lifter emits no post annotation.
 
-fn make_go_caller_fail_contract() -> KitContract {
-    KitContract {
+fn make_go_caller_fail_contract() -> LinkerContract {
+    LinkerContract {
         name: "GoCallerFail".into(),
         kit: "go-kit".into(),
         contract_cid: "blake3-512:ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002".into(),
@@ -90,8 +90,8 @@ fn make_go_caller_fail_contract() -> KitContract {
 // call-edge to link.  The success case has a different contract CID
 // (different name) and zero call-edges.
 
-fn make_go_caller_ok_contract() -> KitContract {
-    KitContract {
+fn make_go_caller_ok_contract() -> LinkerContract {
+    LinkerContract {
         name: "GoCallerOk".into(),
         kit: "go-kit".into(),
         contract_cid: "blake3-512:ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003".into(),
@@ -104,8 +104,8 @@ fn make_go_caller_ok_contract() -> KitContract {
 // Fixture: cgo call-edge from GoCallerFail → rust-kit:process
 // -------------------------------------------------------------------
 
-fn make_cgo_call_edge(go_contract: &KitContract) -> KitCallEdge {
-    KitCallEdge {
+fn make_cgo_call_edge(go_contract: &LinkerContract) -> LinkerCallEdge {
+    LinkerCallEdge {
         source_contract_cid: go_contract.contract_cid.clone(),
         target_contract_cid: None, // cross-kit → null
         target_symbol: "rust-kit:process".into(),

--- a/implementations/rust/provekit-linker/src/lib.rs
+++ b/implementations/rust/provekit-linker/src/lib.rs
@@ -42,7 +42,7 @@ use serde_json::Value as Json;
 /// by go/other kit lifters are normalised into this shape before passing to
 /// `link()`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct KitContract {
+pub struct LinkerContract {
     /// Function / method name as declared in the source kit.
     pub name: String,
     /// Kit identifier, e.g. `"rust-kit"`, `"go-kit"`.
@@ -63,7 +63,7 @@ pub struct KitContract {
 /// calls have `target_contract_cid: None` and `target_symbol` set to a
 /// `"<kit>:<name>"` string for linker resolution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct KitCallEdge {
+pub struct LinkerCallEdge {
     /// CID of the calling function's contract.
     pub source_contract_cid: String,
     /// CID of the callee's contract if already known (same-kit call), or `None`
@@ -110,9 +110,9 @@ pub struct LinkerError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LinkerInputs {
     /// Union of all kit contracts.
-    pub contracts: Vec<KitContract>,
+    pub contracts: Vec<LinkerContract>,
     /// Union of all kit call-edges.
-    pub call_edges: Vec<KitCallEdge>,
+    pub call_edges: Vec<LinkerCallEdge>,
 }
 
 /// Output of a single `link()` invocation.
@@ -156,8 +156,8 @@ pub fn link(inputs: LinkerInputs) -> LinkerOutput {
 // -------------------------------------------------------------------
 
 fn derive_link_bundle_inner(
-    all_contracts: Vec<KitContract>,
-    all_call_edges: Vec<KitCallEdge>,
+    all_contracts: Vec<LinkerContract>,
+    all_call_edges: Vec<LinkerCallEdge>,
 ) -> LinkerOutput {
     // Build cross-kit resolution index: (name, kit) -> contract_cid
     let mut name_kit_index: BTreeMap<(String, String), String> = BTreeMap::new();
@@ -232,7 +232,6 @@ fn derive_link_bundle_inner(
                 );
                 bridges.push(bridge);
 
-                let _ = target_pre;
                 if let Some(mut err) = discharge_obligation(
                     source_post,
                     target_pre,
@@ -463,8 +462,8 @@ fn json_to_canon_value(j: &Json) -> CanonValue {
 mod tests {
     use super::*;
 
-    fn make_process_contract() -> KitContract {
-        KitContract {
+    fn make_process_contract() -> LinkerContract {
+        LinkerContract {
             name: "process".into(),
             kit: "rust-kit".into(),
             contract_cid: "blake3-512:aabbccdd00000001aabbccdd00000001aabbccdd00000001aabbccdd00000001aabbccdd00000001aabbccdd00000001aabbccdd00000001aabbccdd00000001".into(),
@@ -479,8 +478,8 @@ mod tests {
         }
     }
 
-    fn make_go_caller_fail_contract() -> KitContract {
-        KitContract {
+    fn make_go_caller_fail_contract() -> LinkerContract {
+        LinkerContract {
             name: "GoCallerFail".into(),
             kit: "go-kit".into(),
             contract_cid: "blake3-512:ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002ccddee1100000002".into(),
@@ -489,8 +488,8 @@ mod tests {
         }
     }
 
-    fn make_go_caller_ok_contract() -> KitContract {
-        KitContract {
+    fn make_go_caller_ok_contract() -> LinkerContract {
+        LinkerContract {
             name: "GoCallerOk".into(),
             kit: "go-kit".into(),
             contract_cid: "blake3-512:ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003ffeedd2200000003".into(),
@@ -499,8 +498,8 @@ mod tests {
         }
     }
 
-    fn make_cgo_call_edge(go_contract: &KitContract) -> KitCallEdge {
-        KitCallEdge {
+    fn make_cgo_call_edge(go_contract: &LinkerContract) -> LinkerCallEdge {
+        LinkerCallEdge {
             source_contract_cid: go_contract.contract_cid.clone(),
             target_contract_cid: None,
             target_symbol: "rust-kit:process".into(),


### PR DESCRIPTION
## Summary

- Remove dead-code suppressor `let _ = target_pre;` (line 235 of `lib.rs`): the variable is used immediately in the following `discharge_obligation()` call, making the suppressor both meaningless and misleading.
- Rename input types `KitContract` → `LinkerContract` and `KitCallEdge` → `LinkerCallEdge` across `provekit-linker/src/lib.rs`, `provekit-cli/src/cmd_link.rs`, and `provekit-cli/tests/polyglot_smoke.rs`. The entire public API now uses the `Linker*` prefix consistently, matching the existing `LinkerError`, `LinkerOutput`, and `LinkerInputs`.
- Replace `serde_json::to_string_pretty(bundle).unwrap_or_default()` with `.expect("bundle JSON serialization is infallible for content-hashed data")` in `cmd_link.rs`. Silent empty-write on serialization failure was the wrong failure shape; the `.expect()` panics loudly if the impossible occurs.

## Test plan

- [x] `cargo test -p provekit-linker`: 5/5 pass, including `test_link_bundle_cid_byte_identity_gate` (pins unchanged: `a0d04917...` failure, `31fab69f...` success)
- [x] `cargo test -p provekit-cli`: 4/4 polyglot_smoke + 45/45 unit tests pass
- [x] No new compiler warnings introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)