### PR TITLE
fix(rust-lifter): deterministic workspace scan for cross-platform CID stability

### DIFF
--- a/implementations/rust/provekit-lift/src/lib.rs
+++ b/implementations/rust/provekit-lift/src/lib.rs
@@ -172,14 +172,14 @@ pub fn lift_path(root: &Path) -> LiftReport {
     // can re-use them without re-parsing. Only successfully parsed files are kept.
     let mut parsed_files: Vec<(String, syn::File)> = Vec::new();
 
-    for path in enumerate_rs_files(root) {
+    for (rel_posix, abs_path) in enumerate_rs_files(root) {
         report.files_scanned += 1;
-        let bytes = match std::fs::read(&path) {
+        let bytes = match std::fs::read(&abs_path) {
             Ok(b) => b,
             Err(e) => {
                 report
                     .parse_errors
-                    .push((path.display().to_string(), format!("read: {e}")));
+                    .push((rel_posix.clone(), format!("read: {e}")));
                 continue;
             }
         };
@@ -192,11 +192,16 @@ pub fn lift_path(root: &Path) -> LiftReport {
             Err(e) => {
                 report
                     .parse_errors
-                    .push((path.display().to_string(), format!("parse: {e}")));
+                    .push((rel_posix.clone(), format!("parse: {e}")));
                 continue;
             }
         };
-        let path_str = path.display().to_string();
+        // Use the relative POSIX path (not the absolute host path) as the
+        // path_str passed to every adapter and to call-edge extraction.
+        // This is the fix for cross-platform CID non-determinism: absolute
+        // paths embed the machine's directory prefix; relative POSIX paths
+        // are identical for identical source trees on any host.
+        let path_str = rel_posix.clone();
         parsed_files.push((path_str.clone(), file.clone()));
 
         // Adapter: proptest.
@@ -465,8 +470,53 @@ pub fn lift_path(root: &Path) -> LiftReport {
     report
 }
 
-fn enumerate_rs_files(root: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
+/// Directory names that are never part of a Rust workspace's source tree.
+/// Any directory whose name matches one of these is skipped entirely,
+/// at any depth, on any host platform.
+const IGNORED_DIRS: &[&str] = &[
+    "target",
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".DS_Store",
+    ".idea",
+    ".vscode",
+];
+
+/// Normalize `path` to a canonical, relative POSIX path rooted at `root`.
+///
+/// Rules (per spec #120 Locus, "File field semantics"):
+/// - The result is relative to `root` (no leading `/`, no drive letters).
+/// - Separators are forward slashes only.
+/// - Any leading `./` is stripped.
+/// - Paths that escape `root` (via `..`) are rejected; `None` is returned.
+fn to_relative_posix(root: &Path, path: &Path) -> Option<String> {
+    // Use `strip_prefix` to get a path relative to root.  Both `root` and
+    // `path` come from walkdir which emits descendants of root, so
+    // `strip_prefix` will succeed unless something unusual happened.
+    let rel = path.strip_prefix(root).ok()?;
+    // Convert separators to forward slashes (defensive on Windows too).
+    let posix = rel
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    // Reject empty (root itself) or any escaped path.
+    if posix.is_empty() || posix.starts_with("..") {
+        return None;
+    }
+    Some(posix)
+}
+
+/// Walk `root` for `.rs` source files, applying:
+///  - Ignore-list filtering (build artifacts, VCS dirs, IDE noise).
+///  - Deterministic lexicographic sort by relative POSIX path (byte order).
+///
+/// Returns a list of `(relative_posix_path, absolute_pathbuf)` pairs sorted
+/// so that identical source trees produce identical output regardless of
+/// host-filesystem readdir ordering (macOS APFS vs Linux ext4).
+pub fn enumerate_rs_files(root: &Path) -> Vec<(String, PathBuf)> {
+    let mut out: Vec<(String, PathBuf)> = Vec::new();
     if !root.exists() {
         return out;
     }
@@ -474,20 +524,25 @@ fn enumerate_rs_files(root: &Path) -> Vec<PathBuf> {
         .follow_links(false)
         .into_iter()
         .filter_entry(|e| {
-            // Skip target/ and .git/ unconditionally.
+            // Skip ignored directories at any depth.
             let n = e.file_name().to_string_lossy();
-            !(n == "target" || n == ".git" || n == "node_modules")
+            !IGNORED_DIRS.iter().any(|&ig| n == ig)
         })
         .filter_map(|e| e.ok())
     {
         if entry.file_type().is_file() {
             if let Some(ext) = entry.path().extension() {
                 if ext == "rs" {
-                    out.push(entry.path().to_path_buf());
+                    if let Some(rel) = to_relative_posix(root, entry.path()) {
+                        out.push((rel, entry.path().to_path_buf()));
+                    }
                 }
             }
         }
     }
+    // Sort lexicographically by the relative POSIX path (raw byte order,
+    // locale-independent) so walk order is deterministic across platforms.
+    out.sort_by(|a, b| a.0.cmp(&b.0));
     out
 }
 
@@ -888,11 +943,175 @@ proptest! {{
         );
         assert_eq!(flags.workspace.as_deref(), Some(Path::new("/a")));
     }
-}
 
-// ---------------------------------------------------------------------------
-// Tiny tempdir shim so we don't pull a new workspace dep just for tests.
-// ---------------------------------------------------------------------------
+    // -----------------------------------------------------------------------
+    // Determinism tests (spec #120 §"File field semantics" + §11 manifesto).
+    //
+    // Two instances of the SAME source tree at DIFFERENT absolute paths MUST
+    // produce byte-identical contractSetCid.  This is the empirical gate for
+    // cross-platform federated trust: different machines will always have
+    // different absolute paths, but the relative POSIX path within the project
+    // root is identical.
+    // -----------------------------------------------------------------------
+
+    /// Write a richer fixture: two .rs files in a nested sub-directory, a
+    /// target/ directory with a dummy file that must NOT be lifted, and a
+    /// .DS_Store file that must NOT be lifted.
+    fn write_determinism_fixture(dir: &Path) {
+        // Create nested source layout.
+        let sub = dir.join("src").join("nested");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        let mut f = std::fs::File::create(sub.join("alpha.rs")).unwrap();
+        writeln!(
+            f,
+            r#"
+#[requires(x > 0)]
+#[ensures(ret > 0)]
+fn positive(x: i64) -> i64 {{ x }}
+"#
+        )
+        .unwrap();
+
+        let mut f = std::fs::File::create(sub.join("beta.rs")).unwrap();
+        writeln!(
+            f,
+            r#"
+#[requires(n >= 0)]
+#[ensures(ret >= 0)]
+fn nonneg(n: i64) -> i64 {{ n }}
+"#
+        )
+        .unwrap();
+
+        // A top-level file too.
+        let mut f = std::fs::File::create(dir.join("lib.rs")).unwrap();
+        writeln!(
+            f,
+            r#"
+#[requires(a != 0)]
+#[ensures(ret != 0)]
+fn nonzero(a: i64) -> i64 {{ a }}
+"#
+        )
+        .unwrap();
+
+        // Build artifact directory — must be filtered.
+        let target = dir.join("target").join("release");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("artifact.rs"), b"fn build_artifact() {}").unwrap();
+
+        // macOS noise file — must be filtered.
+        std::fs::write(dir.join(".DS_Store"), b"").unwrap();
+    }
+
+    /// Empirical cross-machine determinism test.
+    ///
+    /// Lifts the same fixture from TWO different absolute roots (simulating
+    /// two machines with different directory prefixes) and asserts that
+    /// `contract_set_cid` and bundle `cid` are byte-identical.
+    #[test]
+    fn contract_set_cid_is_identical_across_different_absolute_roots() {
+        let td1 = tempdir_compat::TempDir::new("provekit-det-machine1").unwrap();
+        let td2 = tempdir_compat::TempDir::new("provekit-det-machine2").unwrap();
+
+        write_determinism_fixture(td1.path());
+        write_determinism_fixture(td2.path());
+
+        // Sanity: the two roots must NOT be the same directory.
+        assert_ne!(td1.path(), td2.path(), "test requires two distinct temp dirs");
+
+        let opts = LiftOptions::default();
+
+        let report1 = lift_path(td1.path());
+        let report2 = lift_path(td2.path());
+
+        // Both should have lifted the same number of contracts.
+        assert_eq!(
+            report1.decls.len(),
+            report2.decls.len(),
+            "declaration count must match across roots"
+        );
+
+        let mint1 = mint_proof(&report1.decls, &opts).expect("mint1");
+        let mint2 = mint_proof(&report2.decls, &opts).expect("mint2");
+
+        assert_eq!(
+            mint1.contract_set_cid, mint2.contract_set_cid,
+            "contractSetCid must be byte-identical across different absolute roots \
+             (simulates cross-machine CID stability)"
+        );
+        assert_eq!(
+            mint1.cid, mint2.cid,
+            "bundle CID must be byte-identical across different absolute roots"
+        );
+    }
+
+    /// Assert that target/ and .DS_Store artifacts are NOT in the lifted set.
+    #[test]
+    fn target_dir_and_ds_store_are_excluded() {
+        let td = tempdir_compat::TempDir::new("provekit-det-ignore").unwrap();
+        write_determinism_fixture(td.path());
+
+        let report = lift_path(td.path());
+
+        // Only 3 files (lib.rs, alpha.rs, beta.rs) should have been scanned;
+        // target/release/artifact.rs and .DS_Store must be excluded.
+        assert_eq!(
+            report.files_scanned, 3,
+            "expected 3 .rs files scanned; got {}. target/ or .DS_Store pollution?",
+            report.files_scanned
+        );
+    }
+
+    /// Assert that file paths embedded in call-edge loci are relative POSIX
+    /// paths, not absolute paths.
+    #[test]
+    fn call_edge_loci_use_relative_posix_paths() {
+        let td = tempdir_compat::TempDir::new("provekit-det-locus").unwrap();
+        write_determinism_fixture(td.path());
+
+        let report = lift_path(td.path());
+
+        for edge in &report.call_edges {
+            let file = &edge.call_site_locus.file;
+            assert!(
+                !file.starts_with('/'),
+                "call-edge locus file must be relative, got absolute: {file}"
+            );
+            // No Windows drive letters.
+            assert!(
+                !file.chars().nth(1).map_or(false, |c| c == ':'),
+                "call-edge locus file must not contain drive letter: {file}"
+            );
+            // No backslashes.
+            assert!(
+                !file.contains('\\'),
+                "call-edge locus file must use forward slashes only: {file}"
+            );
+        }
+
+        // enumerate_rs_files returns (rel_posix, abs) — verify the posix strings too.
+        let entries = enumerate_rs_files(td.path());
+        for (rel, _) in &entries {
+            assert!(!rel.starts_with('/'), "enumerate_rs_files returned absolute path: {rel}");
+            assert!(!rel.contains('\\'), "enumerate_rs_files returned backslash: {rel}");
+        }
+    }
+
+    /// Assert enumerate_rs_files output is sorted lexicographically.
+    #[test]
+    fn enumerate_rs_files_is_sorted() {
+        let td = tempdir_compat::TempDir::new("provekit-det-sort").unwrap();
+        write_determinism_fixture(td.path());
+
+        let entries = enumerate_rs_files(td.path());
+        let paths: Vec<&str> = entries.iter().map(|(r, _)| r.as_str()).collect();
+        let mut sorted = paths.clone();
+        sorted.sort();
+        assert_eq!(paths, sorted, "enumerate_rs_files must return lexicographically sorted paths");
+    }
+}
 
 #[cfg(test)]
 mod tempdir_compat {


### PR DESCRIPTION
## Summary

- **Root cause 1 (walk order):** `enumerate_rs_files` was returning files in OS-determined `readdir` order. Fixed by collecting all results into a `Vec<(relative_posix, PathBuf)>` and sorting by the relative POSIX path (byte-stable, locale-independent) before processing.
- **Root cause 2 (absolute paths in locus):** `path_str` was set to `path.display().to_string()` — an absolute host path — and passed to every adapter and call-edge extractor. Call-edge `CallSiteLocus.file` embedded this absolute path, producing different CIDs for the same content on different machines. Fixed by deriving a relative POSIX path via `strip_prefix(root)` and using that as `path_str` throughout.
- **Root cause 3 (ignore-list gaps):** `target/`, `.git/`, `node_modules` were the only filtered dirs. Added `__pycache__`, `.DS_Store`, `.idea`, `.vscode`.

Note: `contractSetCid` itself was already sort-stable (via `compute_contract_set_cid` which sorts its input). The actual drifting CIDs were call-edge memento CIDs (embedded absolute `locus.file`) and the proof bundle CID. Both are now deterministic.

Normative reference: spec #120 Locus §"File field semantics" — "Lifters MUST emit forward slashes regardless of host filesystem... cross-machine byte-equivalence depends on every kit emitting identical relative paths for identical projects."

## Test plan

- [x] 4 new determinism tests added to `provekit-lift/src/lib.rs`
- [x] `contract_set_cid_is_identical_across_different_absolute_roots` — lifts same fixture from two different `TempDir` roots (different absolute prefixes, simulating two machines), asserts `contract_set_cid` and bundle CID are byte-identical
- [x] `target_dir_and_ds_store_are_excluded` — asserts artifact dirs are filtered out of scan
- [x] `call_edge_loci_use_relative_posix_paths` — asserts no absolute paths or backslashes in call-edge locus file fields
- [x] `enumerate_rs_files_is_sorted` — asserts lexicographic sort invariant on returned paths
- [x] All 26 tests pass locally (`cargo test -p provekit-lift`)

## Sharp edges / caveats

The dispatch spec referenced a `sign-self-contracts -- rust <bundle-cid> <contract-set-cid>` re-sign step, but that binary does not exist in `provekit-self-contracts/src/bin/` (only `mint-self-contracts.rs` is present). The re-sign dance was not performed. If the rust kit's `contractSetCid` needs updating after path normalization changes what gets included, that requires a separate step once the binary exists or the mint script is invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-machine consistency for file processing by using relative paths instead of absolute paths, ensuring stable and deterministic results.
  * Enhanced file enumeration with additional exclusion rules for IDE and temporary directories.

* **Tests**
  * Added comprehensive tests validating deterministic behavior and correct file path handling across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->