### PR TITLE
fix(java-lsp): protocol conformance with daemon parseFile (closes #139 sharp edge)

### DIFF
--- a/implementations/java/provekit-lift-java-core/pom.xml
+++ b/implementations/java/provekit-lift-java-core/pom.xml
@@ -41,12 +41,36 @@
                         <phase>package</phase>
                         <goals><goal>shade</goal></goals>
                         <configuration>
+                            <outputFile>${project.build.directory}/provekit-lsp-java.jar</outputFile>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.provekit.lift.Main</mainClass>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>appassembler-maven-plugin</artifactId>
+                <version>2.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>assemble</goal></goals>
+                        <configuration>
+                            <assembleDirectory>${project.build.directory}/appassembler</assembleDirectory>
+                            <programs>
+                                <program>
+                                    <mainClass>com.provekit.lift.Main</mainClass>
+                                    <id>provekit-lsp-java</id>
+                                </program>
+                            </programs>
+                            <!-- Include all dependencies in the assembled repo -->
+                            <repositoryLayout>flat</repositoryLayout>
+                            <repositoryName>lib</repositoryName>
                         </configuration>
                     </execution>
                 </executions>

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/LiftHandler.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/LiftHandler.java
@@ -12,7 +12,51 @@ public class LiftHandler {
     private final List<Extractor> extractors = new ArrayList<>();
 
     public LiftHandler() {
-        ServiceLoader.load(Extractor.class).forEach(extractors::add);
+        List<Extractor> loaded = new ArrayList<>();
+        ServiceLoader.load(Extractor.class).forEach(loaded::add);
+        // Sort by name() for deterministic ordering across builds.
+        loaded.sort(java.util.Comparator.comparing(Extractor::name));
+        extractors.addAll(loaded);
+    }
+
+    /**
+     * Parse a single Java source file and return the canonical NDJSON parse result.
+     *
+     * This is the daemon-conformant counterpart to lift(): it accepts {path, source}
+     * and returns {declarations, callEdges, warnings} per the bridge-linkage protocol.
+     *
+     * @param path   absolute path of the file (used for locus in call edges)
+     * @param source full Java source text
+     * @return JSON string: {"declarations":[...],"callEdges":[...],"warnings":[]}
+     */
+    public String parseSource(String path, String source) {
+        List<ContractDecl> decls = new ArrayList<>();
+        List<CallEdgeDecl> callEdges = new ArrayList<>();
+
+        ParseResult<CompilationUnit> result = new JavaParser().parse(source);
+        if (result.isSuccessful() && result.getResult().isPresent()) {
+            CompilationUnit cu = result.getResult().get();
+            for (Extractor ex : extractors) {
+                decls.addAll(ex.extract(cu, source));
+            }
+            Map<String, String> contractIndex = buildContractIndex(decls);
+            callEdges.addAll(JniResolver.resolve(cu, path, contractIndex));
+        }
+
+        // Emit declarations array.
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"declarations\":[");
+        for (int i = 0; i < decls.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(decls.get(i).toJson());
+        }
+        sb.append("],\"callEdges\":[");
+        for (int i = 0; i < callEdges.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(callEdges.get(i).toJson());
+        }
+        sb.append("],\"warnings\":[]}");
+        return sb.toString();
     }
 
     public String lift(String workspace, String surface) {

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RpcServer.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RpcServer.java
@@ -29,7 +29,16 @@ public class RpcServer {
             String method = extractMethod(line);
             switch (method) {
                 case "initialize" -> sendResponse(id, initResult());
+                case "parse" -> {
+                    // Daemon-conformant wire protocol: {path, source} -> {declarations, callEdges, warnings}.
+                    // Uses decodeJsonString to correctly handle source code with embedded quotes/escapes.
+                    String path = decodeJsonStringField(line, "path");
+                    String source = decodeJsonStringField(line, "source");
+                    sendResponse(id, liftHandler.parseSource(path, source));
+                }
                 case "lift" -> {
+                    // Legacy CLI protocol: {workspace_root, surface}.
+                    // workspace_root and surface are short paths/identifiers without embedded quotes.
                     String workspace = extractStringField(line, "workspace_root");
                     String surface = extractStringField(line, "surface");
                     sendResponse(id, liftHandler.lift(workspace, surface));
@@ -46,7 +55,7 @@ public class RpcServer {
     }
 
     private String initResult() {
-        return "{\"name\":\"provekit-lift-java\",\"version\":\"0.1.0\",\"protocol_version\":\"provekit-lift/1\",\"capabilities\":{\"authoring_surfaces\":[\"java-bean-validation\",\"java-jml\",\"java-cofoja\"],\"ir_version\":\"v1.1.0\",\"emits_signed_mementos\":false}}";
+        return "{\"name\":\"provekit-lsp-java\",\"version\":\"0.1.0\",\"capabilities\":[\"parse\"]}";
     }
 
     private void sendResponse(String id, String result) {
@@ -75,6 +84,73 @@ public class RpcServer {
         return json.substring(q1 + 1, q2);
     }
 
+    /**
+     * Extract and decode a JSON string field value from a flat JSON object.
+     *
+     * This is the escape-aware counterpart to extractStringField. It correctly
+     * handles escaped quotes, escaped backslashes, newlines, carriage returns,
+     * tabs, and Unicode escape sequences within the value. Required for the
+     * 'source' field which may contain arbitrary Java source code.
+     *
+     * Returns "" if the field is not found.
+     */
+    static String decodeJsonStringField(String json, String field) {
+        String key = "\"" + field + "\"";
+        int ki = json.indexOf(key);
+        if (ki < 0) return "";
+
+        // Skip past the key, colon, optional whitespace, then opening quote.
+        int pos = ki + key.length();
+        while (pos < json.length() && (json.charAt(pos) == ':' || json.charAt(pos) == ' ' || json.charAt(pos) == '\t')) {
+            pos++;
+        }
+        if (pos >= json.length() || json.charAt(pos) != '"') return "";
+        pos++; // skip opening quote
+
+        StringBuilder sb = new StringBuilder();
+        while (pos < json.length()) {
+            char c = json.charAt(pos);
+            if (c == '"') {
+                // Closing quote — done.
+                break;
+            } else if (c == '\\') {
+                pos++;
+                if (pos >= json.length()) break;
+                char esc = json.charAt(pos);
+                switch (esc) {
+                    case '"'  -> sb.append('"');
+                    case '\\' -> sb.append('\\');
+                    case '/'  -> sb.append('/');
+                    case 'n'  -> sb.append('\n');
+                    case 'r'  -> sb.append('\r');
+                    case 't'  -> sb.append('\t');
+                    case 'b'  -> sb.append('\b');
+                    case 'f'  -> sb.append('\f');
+                    case 'u'  -> {
+                        if (pos + 4 < json.length()) {
+                            String hex = json.substring(pos + 1, pos + 5);
+                            try {
+                                sb.append((char) Integer.parseInt(hex, 16));
+                                pos += 4;
+                            } catch (NumberFormatException e) {
+                                sb.append('u'); // best-effort: emit raw
+                            }
+                        }
+                    }
+                    default -> sb.append(esc);
+                }
+            } else {
+                sb.append(c);
+            }
+            pos++;
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Legacy field extractor — terminates at the first closing quote.
+     * Safe for short fields like workspace_root and surface that never contain escapes.
+     */
     static String extractStringField(String json, String field) {
         String key = "\"" + field + "\"";
         int i = json.indexOf(key);

--- a/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/RpcServerParseTest.java
+++ b/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/RpcServerParseTest.java
@@ -1,0 +1,178 @@
+package com.provekit.lift;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Integration test: RpcServer parse method — daemon wire-protocol conformance.
+ *
+ * Verifies that the Java LSP plugin correctly handles the canonical NDJSON
+ * "parse" method with {path, source} params and returns {declarations, callEdges}
+ * per protocol/specs/2026-05-03-bridge-linkage-protocol.md §1 R1.
+ *
+ * We exercise the RpcServer directly (not as a subprocess) by swapping its
+ * PrintWriter target and invoking handle() — the same pattern used by the
+ * existing CrossDomainContractEquivalenceTest.
+ */
+public class RpcServerParseTest {
+
+    // Java fixture with @NotNull annotations — the core "@NotNull → Scala IDE" demo.
+    private static final String NOT_NULL_SOURCE = """
+            import jakarta.validation.constraints.NotNull;
+            public class UserService {
+                public String greet(@NotNull String name) {
+                    return "Hello " + name;
+                }
+                public void update(@NotNull String id, @NotNull String value) {
+                }
+            }
+            """;
+
+    // Source with embedded double-quotes in a string literal — exercises decodeJsonStringField.
+    private static final String QUOTED_SOURCE = """
+            import jakarta.validation.constraints.NotNull;
+            public class QuoteService {
+                public String label(@NotNull String msg) {
+                    return "value: \\"" + msg + "\\"";
+                }
+            }
+            """;
+
+    /**
+     * Invoke RpcServer.handle() with a parse request and capture the printed response.
+     *
+     * RpcServer.handle() is package-private. We reach it via a thin helper that
+     * sets up the PrintWriter to point at a ByteArrayOutputStream rather than
+     * System.out.
+     */
+    private String invokeHandle(String jsonLine) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8), true);
+
+        // Reflectively set the 'out' field so we capture output without spawning a process.
+        RpcServer server = new RpcServer();
+        java.lang.reflect.Field outField = RpcServer.class.getDeclaredField("out");
+        outField.setAccessible(true);
+        outField.set(server, pw);
+
+        // Call the private handle() method.
+        java.lang.reflect.Method handleMethod = RpcServer.class.getDeclaredMethod("handle", String.class);
+        handleMethod.setAccessible(true);
+        handleMethod.invoke(server, jsonLine);
+
+        pw.flush();
+        return baos.toString(StandardCharsets.UTF_8).trim();
+    }
+
+    @Test
+    public void parseReturnsDeclarationsArray() throws Exception {
+        // Build a JSON parse request. We encode the source as an escaped JSON string.
+        String encodedSource = jsonEncodeString(NOT_NULL_SOURCE);
+        String request = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"parse\",\"params\":{\"path\":\"/tmp/UserService.java\",\"source\":" + encodedSource + "}}";
+
+        String response = invokeHandle(request);
+
+        assertNotNull(response, "Response must not be null");
+        assertTrue(response.contains("\"jsonrpc\":\"2.0\""), "Response must be JSON-RPC 2.0");
+        assertTrue(response.contains("\"id\":1"), "Response id must match request id");
+        assertTrue(response.contains("\"result\""), "Response must have result field");
+        assertFalse(response.contains("\"error\""), "Response must not contain error");
+
+        // The result must contain a declarations array.
+        assertTrue(response.contains("\"declarations\""), "Result must contain declarations array");
+
+        // The result must contain a callEdges array.
+        assertTrue(response.contains("\"callEdges\""), "Result must contain callEdges array");
+
+        // At least one declaration for 'greet' or 'update' must be present.
+        // BeanValidationExtractor lifts @NotNull parameters as contract preconditions.
+        assertTrue(
+            response.contains("\"kind\":\"contract\""),
+            "Declarations must contain at least one contract: " + response
+        );
+    }
+
+    @Test
+    public void parseSourceWithEmbeddedQuotes() throws Exception {
+        // Verify that source containing Java string literals with \" is handled correctly.
+        String encodedSource = jsonEncodeString(QUOTED_SOURCE);
+        String request = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"parse\",\"params\":{\"path\":\"/tmp/QuoteService.java\",\"source\":" + encodedSource + "}}";
+
+        String response = invokeHandle(request);
+
+        assertNotNull(response);
+        assertFalse(response.contains("\"error\""), "Must not error on source with embedded quotes: " + response);
+        assertTrue(response.contains("\"declarations\""), "Must return declarations");
+        // @NotNull on 'msg' parameter must lift.
+        assertTrue(response.contains("\"kind\":\"contract\""), "Must lift @NotNull from quoted source: " + response);
+    }
+
+    @Test
+    public void parseByteDeterminism() throws Exception {
+        // Two identical requests must produce byte-for-byte identical responses.
+        String encodedSource = jsonEncodeString(NOT_NULL_SOURCE);
+        String request = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"parse\",\"params\":{\"path\":\"/tmp/UserService.java\",\"source\":" + encodedSource + "}}";
+
+        String response1 = invokeHandle(request);
+        String response2 = invokeHandle(request);
+
+        assertEquals(response1, response2, "parse responses must be byte-deterministic");
+    }
+
+    @Test
+    public void parseCallEdgesIsArray() throws Exception {
+        String encodedSource = jsonEncodeString(NOT_NULL_SOURCE);
+        String request = "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"parse\",\"params\":{\"path\":\"/tmp/UserService.java\",\"source\":" + encodedSource + "}}";
+
+        String response = invokeHandle(request);
+
+        // callEdges must be a JSON array (may be empty — no JNI in fixture).
+        int ceIdx = response.indexOf("\"callEdges\":");
+        assertTrue(ceIdx >= 0, "Response must have callEdges key");
+        int arrStart = response.indexOf('[', ceIdx);
+        assertTrue(arrStart >= 0 && arrStart < ceIdx + 20, "callEdges value must be an array: " + response);
+    }
+
+    @Test
+    public void initializeReturnsParseCapability() throws Exception {
+        String request = "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{}}";
+        String response = invokeHandle(request);
+
+        assertTrue(response.contains("provekit-lsp-java"), "initialize result must name the plugin");
+        assertTrue(response.contains("\"parse\""), "initialize capabilities must include 'parse'");
+    }
+
+    @Test
+    public void parseEmptySourceReturnsEmptyArrays() throws Exception {
+        String request = "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"parse\",\"params\":{\"path\":\"/tmp/Empty.java\",\"source\":\"\"}}";
+        String response = invokeHandle(request);
+
+        assertFalse(response.contains("\"error\""), "Empty source must not produce an error: " + response);
+        assertTrue(response.contains("\"declarations\":[]"), "Empty source must return empty declarations");
+        assertTrue(response.contains("\"callEdges\":[]"), "Empty source must return empty callEdges");
+    }
+
+    /**
+     * Encode a Java string as a JSON string literal (with surrounding quotes).
+     * Handles newlines, tabs, backslashes, and double-quotes.
+     */
+    static String jsonEncodeString(String s) {
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"'  -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default   -> sb.append(c);
+            }
+        }
+        sb.append("\"");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds canonical `parse` method to Java LSP plugin's `RpcServer`, accepting `{path, source}` params and returning `{declarations, callEdges, warnings}` -- matching the daemon's expected wire shape (same as Go LSP plugin)
- Fixes a load-bearing bug in JSON field extraction: the old `extractStringField` terminated at the first `"` character, silently truncating any Java source containing string literals; replaced with `decodeJsonStringField` that handles all JSON string escapes correctly
- Adds `parseSource(path, source)` to `LiftHandler` as the single-file counterpart to `lift()`, with deterministic extractor ordering (sorted by `name()`)
- Adds `appassembler-maven-plugin` to produce `target/appassembler/bin/provekit-lsp-java` launcher after `mvn package`
- 6 new integration tests in `RpcServerParseTest` covering response shape, embedded-quote source, byte-determinism, callEdges array type, initialize capabilities, and empty source

## What this does NOT do (honest scope statement)

The daemon's `methods.rs` still returns `LifterUnavailable` for the `java` kit (line 232). This PR makes Java's *side* of the protocol conformant -- it speaks the correct wire language. The daemon-side wiring to spawn `provekit-lsp-java` as a kit subprocess is the remaining step 3b and is out of scope per task constraints.

The `lift` legacy method is preserved -- `provekit-cli/src/cmd_mint.rs` still sends `method=lift` with `workspace_root`.

## Test plan

- [ ] `mvn test` in `implementations/java/` passes 18 tests (6 new + 12 existing), 0 failures
- [ ] `RpcServerParseTest.parseReturnsDeclarationsArray` -- `@NotNull` annotations on `UserService` lift to contract declarations
- [ ] `RpcServerParseTest.parseSourceWithEmbeddedQuotes` -- source with `\"` in string literals parses correctly
- [ ] `RpcServerParseTest.parseByteDeterminism` -- two identical requests produce identical responses
- [ ] `RpcServerParseTest.initializeReturnsParseCapability` -- `capabilities` includes `"parse"`
- [ ] Existing `CrossDomainContractEquivalenceTest` and `JniResolverTest` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)