### PR TITLE
chore(examples): commit polyglot link bundles

### DIFF
--- a/examples/polyglot-rust-go/README.md
+++ b/examples/polyglot-rust-go/README.md
@@ -1,3 +1,21 @@
 # polyglot-rust-go
 
 Demonstrates ProvekIt's cross-language predicate-level correctness verification: a Go program calls a Rust function via cgo, the linker derives a bridge for the call edge, and either emits a `linker-error` memento (when the caller has no post-condition establishing the callee's precondition) or produces a clean link bundle (when the caller satisfies the obligation). The `link-bundle.json` artifact is content-addressed and byte-identical across consecutive runs over the same source.
+
+## Generated link bundles (committed)
+
+Both fixtures have a checked-in `link-bundle.json` produced by `provekit link`. These are sample outputs you can read without running the toolchain. The `linkBundleCid` field in each is the content-addressed identity of that bundle; recomputing it locally from the same source must produce the same value (cross-machine determinism is a substrate guarantee per manifesto §11).
+
+- `fixture-fail/link-bundle.json` — failure case with `linker-error` mementos. Today the cgo resolver emits `unresolved-symbol` because the Go caller's preamble (`extern int process(int n);`) lacks a kit-mapping signal (no `#include "rust*.h"` header reference); a follow-up will tune the fixture's preamble so the resolver maps to `rust-kit:process` and the failure shape becomes `unprovable-obligation` (the more interesting demo). The bundle as committed shows real linker behavior on the current fixture.
+- `fixture-ok/link-bundle.json` — success case with no linker errors and an empty bridge set (the success-case Go file has no cgo call; everything happens in pure Go).
+
+## Regenerate
+
+```sh
+make build-rust          # builds the provekit CLI
+go build -o /tmp/provekit-lsp-go ./implementations/go/cmd/provekit-lsp-go
+PATH="/tmp:$PATH" ./implementations/rust/target/release/provekit link examples/polyglot-rust-go/fixture-fail/
+PATH="/tmp:$PATH" ./implementations/rust/target/release/provekit link examples/polyglot-rust-go/fixture-ok/
+```
+
+The CLI writes `link-bundle.json` into each fixture directory.

--- a/examples/polyglot-rust-go/fixture-fail/link-bundle.json
+++ b/examples/polyglot-rust-go/fixture-fail/link-bundle.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "1",
+  "kind": "link-bundle",
+  "contractSetCid": "blake3-512:527c19f14085922a5fcbafda4976d5fa1de618897f1c8dd7a3d28e0e5a7bf68141b2042732fd452bbebca9cbbebf56251a3a2effb8f0673ad071d881c57c41f3",
+  "callEdgeSetCid": "blake3-512:017e35aff2526ec52fd7eb00acf8993054a6c1162461dbafa2ac076253624efe1f1ff6d8864e146b3c82c0244b91e82097383bf60de4a314a63b15b9f34c1fd1",
+  "bridgeSetCid": "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+  "linkerVersion": "0.1.0",
+  "linkerErrors": [
+    {
+      "kind": "linker-error",
+      "errorKind": "unresolved-symbol",
+      "targetSymbol": "resolver-error:process",
+      "sourceContractCid": "blake3-512:bfca60e0421a6a8a09f122407b1aa12027a33251c4c0d9fb50296f76368fda397211d8af9f72924d0c7d8d6b23960a1a69cb1b61cbbdc6a2e6150f488d795ead",
+      "reason": "targetSymbol `resolver-error:process` did not resolve to any contract in the union"
+    },
+    {
+      "kind": "linker-error",
+      "errorKind": "unresolved-symbol",
+      "targetSymbol": "resolver-error:int",
+      "sourceContractCid": "blake3-512:bfca60e0421a6a8a09f122407b1aa12027a33251c4c0d9fb50296f76368fda397211d8af9f72924d0c7d8d6b23960a1a69cb1b61cbbdc6a2e6150f488d795ead",
+      "reason": "targetSymbol `resolver-error:int` did not resolve to any contract in the union"
+    }
+  ],
+  "bridges": [],
+  "linkBundleCid": "blake3-512:6516a277d684ee804ae89befab2df912b0b8c99cc73d2b11e8e048d01d0dc67932571d33ad15b3ed2ab64b1e27d221e40af3a621bb4acbeddec4793dd8efdb49"
+}

--- a/examples/polyglot-rust-go/fixture-ok/link-bundle.json
+++ b/examples/polyglot-rust-go/fixture-ok/link-bundle.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "1",
+  "kind": "link-bundle",
+  "contractSetCid": "blake3-512:527c19f14085922a5fcbafda4976d5fa1de618897f1c8dd7a3d28e0e5a7bf68141b2042732fd452bbebca9cbbebf56251a3a2effb8f0673ad071d881c57c41f3",
+  "callEdgeSetCid": "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+  "bridgeSetCid": "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+  "linkerVersion": "0.1.0",
+  "linkerErrors": [],
+  "bridges": [],
+  "linkBundleCid": "blake3-512:f07cc20883de5bcbb5c0a5b8d63f9da0906a43bb949ee7fe2fd8a1fd32be97522bf6635d72a3e5705ddd6292a00bf26586d4080fc4c1c2b7cdbba84ce89cd5b9"
+}


### PR DESCRIPTION
## Summary

Checks in the two \`link-bundle.json\` artifacts from \`examples/polyglot-rust-go/\` so readers can see real \`provekit link\` output without running the toolchain.

- **fixture-fail/link-bundle.json** — has 2 linker-error mementos (unresolved-symbol, because the cgo preamble lacks a kit-mapping header reference). Bundle CID: \`blake3-512:6516a277...8efdb49\`.
- **fixture-ok/link-bundle.json** — clean bundle with no errors and an empty bridge set (success-case Go does the work in pure Go, no cgo). Bundle CID: \`blake3-512:f07cc208...e89cd5b9\`.

## Why

Sir asked: "what is a good file to see a .proof from the github?" The only \`.proof\` checked in today is the canonicalizer self-lift at \`.provekit/self-lifts/canonicalizer/blake3-512:5725...ce01.proof\`. Adding the polyglot link bundles gives a second canonical artifact class — the cross-language linker path output, distinct from the substrate self-lift dogfood path.

Together: one shows the substrate dogfooding itself; one shows the substrate doing cross-language predicate-level verification at compile time. Both are content-addressed and byte-deterministic across runs.

## Follow-up flagged in commit message

The fixture-fail's cgo preamble lacks a header signal that maps it to \`rust-kit\`, so the resolver returns \`resolver-error\` rather than the more demonstrative \`unprovable-obligation\` against the rust contract. A small fixture refinement (add \`#include "rust_callee.h"\` to the cgo preamble) would change the failure shape; not in scope for this PR.

## Test plan

- [ ] Both \`link-bundle.json\` files are valid JSON
- [ ] Each has a self-consistent \`linkBundleCid\` field
- [ ] The README's regenerate snippet reproduces these exact bytes locally