### PR TITLE
chore(github): issue templates + label config for 11/11 substrate dogfood

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,43 @@
+name: Bug
+description: Something that worked, broke, or never worked correctly.
+title: "[bug] <short title>"
+labels: ["regression"]
+body:
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+      description: What's happening? Include exact error messages, file paths, line numbers.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Exact commands, fixture paths, or commit SHA to check out.
+    validations:
+      required: true
+  - type: input
+    id: regressed-at
+    attributes:
+      label: Regressed at (if known)
+      description: Commit SHA or PR number where the regression was introduced.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      options:
+        - Rust CLI
+        - Linkerd / daemon
+        - LSP (editor diagnostics)
+        - Mint / sign / verify
+        - Conformance gate
+        - CI / build
+        - Documentation
+        - Other

--- a/.github/ISSUE_TEMPLATE/ci-break.yml
+++ b/.github/ISSUE_TEMPLATE/ci-break.yml
@@ -1,0 +1,46 @@
+name: CI / build break
+description: Fast-track for a CI failure or broken build (cross-impl conformance gate, peer-impl test, toolchain provisioning).
+title: "[ci] <short title>"
+labels: ["area:ci", "regression", "blocker"]
+body:
+  - type: input
+    id: workflow
+    attributes:
+      label: Failing workflow / job
+      description: Name + run URL.
+    validations:
+      required: true
+  - type: textarea
+    id: failure
+    attributes:
+      label: Failure excerpt
+      description: Paste the failing job's relevant log lines (exit code, error, stack).
+    validations:
+      required: true
+  - type: input
+    id: first-failed-at
+    attributes:
+      label: First failed at
+      description: Commit SHA on main where this first failed.
+  - type: dropdown
+    id: kit
+    attributes:
+      label: Affected kit (if specific)
+      options:
+        - "n/a — substrate-level"
+        - rust
+        - go
+        - java
+        - python
+        - typescript
+        - csharp
+        - cpp
+        - swift
+        - ruby
+        - zig
+        - c
+  - type: textarea
+    id: hypothesis
+    attributes:
+      label: Hypothesis
+      description: Best guess at root cause + diagnosis steps already tried.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Architectural manifesto
+    url: https://github.com/TSavo/provekit/blob/main/docs/launch/substrate-not-blockchain.md
+    about: Read this first if you're new — explains the substrate model, content addressing, multi-dimensional pinning.
+  - name: Two-persona quickstart
+    url: https://github.com/TSavo/provekit/blob/main/README.md
+    about: For end-users who want red squiggles, and for extenders who want architectural depth.

--- a/.github/ISSUE_TEMPLATE/cross-cutting.yml
+++ b/.github/ISSUE_TEMPLATE/cross-cutting.yml
@@ -1,0 +1,37 @@
+name: Cross-cutting infra
+description: Substrate-side work that spans multiple kits or components.
+title: "[infra] <short title>"
+labels: ["area:dogfood"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For substrate-level work that touches multiple kits or components — mint pipeline,
+        linkerd dispatch consolidation, conformance gate, CI provisioning, etc.
+        Add `kit:*` / `component:*` / `protocol:*` / `area:*` labels as relevant.
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What needs to happen and why? Reference any spec, PR, or commit that motivates this.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What's in scope? What's explicitly out of scope?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What does done look like? Checklist preferred.
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Implementation notes
+      description: Files to touch, agents dispatched, blockers surfaced.

--- a/.github/ISSUE_TEMPLATE/kit-coverage.yml
+++ b/.github/ISSUE_TEMPLATE/kit-coverage.yml
@@ -1,0 +1,65 @@
+name: Kit coverage (4-component substrate)
+description: Track the four RPC components (IR, Lifters, Linker, LSP) for one language kit.
+title: "[kit:<lang>] 4-component substrate coverage"
+labels: ["component:ir", "component:lifter", "component:linker", "component:lsp"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Per the dogfood architecture, every kit exposes 4 RPC services to the Rust CLI.
+        One CLI, N kits — every component speaks canonical substrate RPC.
+        Tag this issue with the matching `kit:<lang>` label.
+  - type: dropdown
+    id: kit
+    attributes:
+      label: Language kit
+      options: [rust, go, java, python, typescript, csharp, cpp, swift, ruby, zig, c]
+    validations:
+      required: true
+  - type: checkboxes
+    id: ir
+    attributes:
+      label: 1. IR (canonical contracts mirrored from rust)
+      options:
+        - label: IR slab present at `implementations/<kit>/.../slabs/`
+        - label: All canonical contracts mirrored from `provekit-self-contracts/src/lift_plugin_protocol.rs` (currently C1–C8)
+        - label: Speaks substrate IR-RPC with the canonical wire shape
+  - type: checkboxes
+    id: lifters
+    attributes:
+      label: 2. Lifters (the family — IR kit + annotation + test + proptest + …)
+      options:
+        - label: IR-kit lifter (lifts hand-authored contract types)
+        - label: Annotation lifter (`//provekit:contract` markers or kit-equivalent)
+        - label: Test lifter (lifts test invariants)
+        - label: Property-test lifter (proptest / quickcheck / hypothesis)
+        - label: Other language-idiomatic lifters (bean validation / data annotations / decorators / macros / …)
+        - label: Each lifter speaks lift-protocol RPC
+  - type: checkboxes
+    id: linker
+    attributes:
+      label: 3. Linker
+      options:
+        - label: Cross-kit bridge linkage participation per spec #114
+        - label: Linkerd dispatch arm at `implementations/rust/provekit-linkerd/src/methods.rs` invokes the kit's binary (not `LifterUnavailable`)
+  - type: checkboxes
+    id: lsp
+    attributes:
+      label: 4. LSP
+      options:
+        - label: "`provekit-lsp-<kit>` binary on PATH"
+        - label: Speaks parse-protocol (`{path, source} → {declarations, callEdges, warnings}` as JSON arrays)
+        - label: Integration tests pass
+  - type: checkboxes
+    id: dogfood
+    attributes:
+      label: Conformance dogfood
+      options:
+        - label: "`.provekit/self-contracts-attestations/<kit>.json` produced via substrate-side mint (no kit-specific mint code)"
+        - label: "`provekit prove --kit=<kit>` passes against canonical contracts"
+        - label: Bundle CID is real (not a placeholder)
+  - type: textarea
+    id: status
+    attributes:
+      label: Status notes
+      description: Recent commits, blockers, and pending follow-ups for this kit.

--- a/.github/ISSUE_TEMPLATE/protocol-design.yml
+++ b/.github/ISSUE_TEMPLATE/protocol-design.yml
@@ -1,0 +1,51 @@
+name: Protocol / spec design
+description: Design or modification of a canonical RPC protocol or substrate spec.
+title: "[protocol:<name>] <short title>"
+labels: ["draft"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For RPC contract design — lift, parse, bridge-linkage, linker-daemon, bundle-attestation, substrate-layers.
+        Tag with the matching `protocol:<name>` label and any relevant `component:*` labels.
+  - type: dropdown
+    id: protocol
+    attributes:
+      label: Protocol
+      options:
+        - lift
+        - parse
+        - bridge-linkage
+        - linker-daemon
+        - bundle-attestation
+        - substrate-layers
+        - new-protocol
+    validations:
+      required: true
+  - type: textarea
+    id: claim
+    attributes:
+      label: Architectural claim
+      description: One-paragraph claim of what this design enables or fixes.
+    validations:
+      required: true
+  - type: textarea
+    id: rpc-shape
+    attributes:
+      label: RPC shape (request / response)
+      description: Concrete wire shape. JSON Schema or example messages preferred.
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Contracts (pre / post / inv)
+      description: Canonical contracts the substrate enforces. Mirror the C1–C8 pattern in `provekit-self-contracts`.
+  - type: textarea
+    id: kit-impact
+    attributes:
+      label: Kit-side impact
+      description: What changes in each of the 11 kits' implementations? List per kit if non-uniform.
+  - type: textarea
+    id: spec-link
+    attributes:
+      label: Spec
+      description: Link to or draft the normative spec under `protocol/specs/`.


### PR DESCRIPTION
## Summary

Bootstraps GitHub-issue-based tracking for the 11/11 substrate dogfood work. Pairs with 30 labels + milestone #1 (created via gh CLI; not part of this diff).

## Five issue templates

- **kit-coverage** — per-kit 4-component checklist (IR / Lifters / Linker / LSP). One issue per of the 11 language kits.
- **cross-cutting** — substrate-level work across multiple kits (mint unification, linkerd dispatch arms, conformance gate, CI).
- **protocol-design** — canonical RPC contract design, with fields for wire shape + invariants + per-kit impact.
- **bug** — generic regression.
- **ci-break** — fast-track CI failures, pre-labeled `area:ci + regression + blocker`.

Plus a `config.yml` linking the manifesto + quickstart so new contributors orient before opening.

## Labels (created via `gh label create`, not in this diff)

- `kit:*` × 11 (rust, go, java, python, typescript, csharp, cpp, swift, ruby, zig, c) — green
- `component:*` × 4 (ir, lifter, linker, lsp) — blue
- `protocol:*` × 6 (lift, parse, bridge-linkage, linker-daemon, bundle-attestation, substrate-layers) — purple
- `area:*` × 4 (ci, conformance, dogfood, docs) — yellow
- Lifecycle × 5 (epic, blocker, follow-up, draft, regression)

## Milestone

- #1 — `11/11 substrate dogfood`. All per-kit + cross-cutting issues attach here.

## Test plan

- [ ] `gh issue create --template kit-coverage` produces a structured form
- [ ] `gh issue create --template cross-cutting` works
- [ ] All five templates render correctly in the GitHub UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced GitHub issue templates for improved issue organization and reporting consistency, covering bug reports, CI/build failures, protocol design discussions, cross-cutting infrastructure work, and kit coverage tracking.
  * Disabled generic blank issues and added reference links to project documentation to guide contributors in the issue creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->