### PR TITLE
feat(cli): provekit prove --kit=<kit> — dogfood gate (closes #161)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,3 +298,167 @@ jobs:
         # the integration tests assert by file.
         run: cargo test -p provekit-cli --test mint_kit_integration -- swift_kit_pins
         working-directory: implementations/rust
+
+  # ---------------------------------------------------------------------------
+  # Per-kit conformance gate: provekit prove --kit=<kit>
+  #
+  # Each job spawns the kit's lifter via JSON-RPC and runs C1-C8 verifiers
+  # against the captured RPC messages.
+  #
+  # swift runs on macos-latest (Swift toolchain is macOS-only).
+  # All other kits run on self-hosted Linux.
+  # ---------------------------------------------------------------------------
+
+  prove-linux:
+    name: "prove-${{ matrix.kit }} (C1-C8 conformance)"
+    runs-on: self-hosted
+    timeout-minutes: 15
+    needs: conformance
+    strategy:
+      fail-fast: false
+      matrix:
+        kit:
+          - rust
+          - go
+          - cpp
+          - ts
+          - csharp
+          - java
+          - python
+          - ruby
+          - zig
+          - c
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust target dirs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            implementations/rust/target
+            tools/recompute-spec-cids/target
+            tools/foundation-keygen/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Set up Go 1.22
+        if: matrix.kit == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+          cache-dependency-path: |
+            implementations/go/provekit-ir-symbolic/go.sum
+            implementations/go/provekit-self-contracts/go.sum
+            implementations/go/provekit-lift-go-tests/go.sum
+
+      - name: Set up .NET 10 (preview)
+        if: matrix.kit == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Set up pnpm
+        if: matrix.kit == 'ts'
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10.33.0'
+
+      - name: Set up Node 22
+        if: matrix.kit == 'ts'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Set up Python 3.12
+        if: matrix.kit == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install system deps (cpp)
+        if: matrix.kit == 'cpp'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            clang \
+            libssl-dev \
+            nlohmann-json3-dev
+
+      - name: Install system deps (c)
+        if: matrix.kit == 'c'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            libssl-dev
+
+      - name: Set up Java (java)
+        if: matrix.kit == 'java'
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Install Ruby (ruby)
+        if: matrix.kit == 'ruby'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install Zig (zig)
+        if: matrix.kit == 'zig'
+        uses: mlugg/setup-zig@v1
+        with:
+          version: '0.13.0'
+
+      - name: "prove-${{ matrix.kit }}"
+        # Kits whose lift binaries don't yet implement the lift-plugin-protocol
+        # (java/python/ruby/zig/c) currently fail the C1-C8 gate. Allow those
+        # matrix entries to surface as red without blocking merge — the single
+        # `conformance` gate (which runs the wired kits) is the mandatory check.
+        # (Review feedback: PR #165 / Codex P1.)
+        continue-on-error: ${{ contains(fromJson('["java","python","ruby","zig","c"]'), matrix.kit) }}
+        run: make prove-${{ matrix.kit }}
+
+  prove-swift:
+    name: "prove-swift (C1-C8 conformance, macOS)"
+    runs-on: macos-latest
+    timeout-minutes: 20
+    needs: conformance
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust target dirs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            implementations/rust/target
+            tools/recompute-spec-cids/target
+            tools/foundation-keygen/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: prove-swift
+        run: make prove-swift

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,12 @@ help:
 	@echo "Per-language test:"
 	@echo "  make test-rust  test-go  test-cpp  test-ts  test-csharp  test-python  test-java  test-c  test-swift"
 	@echo ""
+	@echo "Per-kit conformance gate (C1-C8 lift-plugin-protocol verifiers):"
+	@echo "  make prove-all      all 10 kits (swift excluded: macOS-only)"
+	@echo "  make prove-rust  prove-go  prove-cpp  prove-ts  prove-csharp"
+	@echo "  make prove-java  prove-python  prove-ruby  prove-zig  prove-c"
+	@echo "  make prove-swift    macOS-only"
+	@echo ""
 	@echo "Self-lift experiments:"
 	@echo "  make self-lift-canonicalizer  run provekit-lift against the canonicalizer crate"
 	@echo ""
@@ -337,6 +343,87 @@ all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python m
 	@printf "  %-8s  %s\n" "python" "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/python.json)"
 	@printf "  %-8s  %s\n" "c"      "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/c.json)"
 	@printf "  %-8s  %s\n" "zig"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/zig.json)"
+
+# --- Per-kit prove (C1-C8 conformance gate) ----------------------------------
+#
+# Each `prove-<kit>` target:
+#   1. Builds the kit's lifter binary.
+#   2. Runs `provekit prove --kit=<kit>`, which:
+#      - Spawns the kit's lifter via JSON-RPC.
+#      - Drives the initialize -> lift -> shutdown sequence.
+#      - Runs C1-C8 verifiers against the captured RPC messages.
+#   3. Exits 0 iff all 8 contracts hold.
+#
+# NOTE: prove-swift requires a macOS host (Swift toolchain). It is excluded
+# from prove-all but can be run directly on macOS.
+#
+# Kits with no lifter yet (java/python/ruby/zig/c) exit 2 (user error) until
+# their lifters are wired up. They are listed in prove-all so CI knows which
+# need follow-up.
+
+.PHONY: prove-rust
+prove-rust: build-rust
+	@echo ">> proving rust lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=rust
+
+.PHONY: prove-go
+prove-go: build-rust build-go
+	@echo ">> proving go lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=go
+
+.PHONY: prove-cpp
+prove-cpp: build-rust build-cpp
+	@echo ">> proving cpp lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=cpp
+
+.PHONY: prove-ts
+prove-ts: build-rust build-ts
+	@echo ">> proving ts lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=ts
+
+.PHONY: prove-csharp
+prove-csharp: build-rust build-csharp
+	@echo ">> proving csharp lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=csharp
+
+# macOS-only: requires Swift toolchain.
+.PHONY: prove-swift
+prove-swift: build-rust build-swift
+	@echo ">> proving swift lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=swift
+
+.PHONY: prove-java
+prove-java: build-rust build-java
+	@echo ">> proving java lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=java
+
+.PHONY: prove-python
+prove-python: build-rust
+	@echo ">> proving python lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=python
+
+.PHONY: prove-ruby
+prove-ruby: build-rust
+	@echo ">> proving ruby lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=ruby
+
+.PHONY: prove-zig
+prove-zig: build-rust build-zig
+	@echo ">> proving zig lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=zig
+
+.PHONY: prove-c
+prove-c: build-rust build-c
+	@echo ">> proving c lift-plugin-protocol conformance (C1-C8)"
+	$(PROVEKIT) prove --kit=c
+
+# prove-all: run C1-C8 gate for the Linux/CI subset (swift excluded: macOS-only).
+# Kits without a wired lifter exit 2 (user error); all 10 targets are listed
+# so CI reports which need follow-up. prove-swift runs separately on macos-latest.
+.PHONY: prove-all
+prove-all: prove-rust prove-go prove-cpp prove-ts prove-csharp prove-java prove-python prove-ruby prove-zig prove-c
+	@echo ""
+	@echo "==== prove-all: complete ===="
 
 # --- Conformance gate --------------------------------------------------------
 

--- a/implementations/c/provekit-lsp-c/main.c
+++ b/implementations/c/provekit-lsp-c/main.c
@@ -20,6 +20,14 @@
  *   cc -std=c11 -Wall -Wextra -o provekit-lsp-c main.c
  */
 
+/* `getline` and `ssize_t` are POSIX extensions; glibc gates them behind
+ * feature-test macros. Define _GNU_SOURCE before any system header is
+ * pulled in (review feedback: PR #165 / CodeRabbit).
+ *
+ * Also include <sys/types.h> explicitly for `ssize_t` so the build doesn't
+ * rely on transitive inclusion through <stdio.h>. */
+#define _GNU_SOURCE
+#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -396,8 +404,39 @@ static ParseResult parse_c_source(const char *source) {
                 }
                 annotate_next = 0;
 
-                /* If this line opens a body, set current_fn for call-edge tracking. */
-                if (strchr(line, '{') != NULL) {
+                /* If this line opens a body, set current_fn for call-edge tracking.
+                 * Also handle Allman-style functions where the opening brace is
+                 * on the next non-blank line (review feedback: PR #165 / CodeRabbit). */
+                int opens_body = (strchr(line, '{') != NULL);
+                if (!opens_body) {
+                    /* Peek forward for an Allman-style brace on the next non-blank line. */
+                    for (int j = i + 1; j < n_lines && j < i + 4; j++) {
+                        int jlen = lines_len[j];
+                        if (jlen < 0) jlen = 0;
+                        if (jlen >= (int)sizeof(line)) jlen = (int)sizeof(line) - 1;
+                        char nextline[4096];
+                        memcpy(nextline, lines_start[j], (size_t)jlen);
+                        nextline[jlen] = '\0';
+                        /* Skip blank lines. */
+                        int blank = 1;
+                        for (int ci = 0; nextline[ci]; ci++) {
+                            if (nextline[ci] != ' ' && nextline[ci] != '\t' &&
+                                nextline[ci] != '\r' && nextline[ci] != '\n') {
+                                blank = 0;
+                                break;
+                            }
+                        }
+                        if (blank) continue;
+                        /* First non-blank: a leading '{' (after whitespace) means Allman. */
+                        for (int ci = 0; nextline[ci]; ci++) {
+                            if (nextline[ci] == ' ' || nextline[ci] == '\t') continue;
+                            if (nextline[ci] == '{') opens_body = 1;
+                            break;
+                        }
+                        break;
+                    }
+                }
+                if (opens_body) {
                     snprintf(current_fn, MAX_NAME, "%s", fname);
                 }
             }
@@ -517,23 +556,21 @@ static void handle_parse(const char *id, const char *json_line) {
     }
     buf_append_char(&decls_buf, ']');
 
-    /* Build callEdges JSON array. */
+    /* Build callEdges JSON array.
+     *
+     * The canonical IR shape is {sourceContractCid, targetContractCid,
+     * targetSymbol, callSiteLocus, evidenceTerm} per spec #114. The C LSP
+     * cannot compute contract CIDs (no JCS encoder + BLAKE3 here), so the
+     * legacy {callee, caller, line} shape was silently dropped by the daemon.
+     * Emit an empty array until contract-CID computation is available; this
+     * is graceful downgrade rather than emitting a non-canonical shape.
+     * (Review feedback: PR #165 / Copilot.) */
     Buf edges_buf;
     buf_init(&edges_buf);
-    buf_append_char(&edges_buf, '[');
-    for (int i = 0; i < pr.n_edges; i++) {
-        if (i > 0) buf_append_char(&edges_buf, ',');
-        buf_append(&edges_buf, "{\"callee\":");
-        json_escape_str(&edges_buf, pr.edges[i].callee);
-        buf_append(&edges_buf, ",\"caller\":");
-        json_escape_str(&edges_buf, pr.edges[i].caller);
-        buf_append(&edges_buf, ",\"line\":");
-        char lstr[32];
-        snprintf(lstr, sizeof(lstr), "%d", pr.edges[i].line);
-        buf_append(&edges_buf, lstr);
-        buf_append_char(&edges_buf, '}');
-    }
-    buf_append_char(&edges_buf, ']');
+    buf_append(&edges_buf, "[]");
+    /* Suppress unused-variable warning: we still parse call sites for
+     * future shape upgrade; pr.n_edges is intentionally unread here. */
+    (void)pr.n_edges;
 
     /* Build warnings array. */
     Buf warn_buf;

--- a/implementations/c/provekit-lsp-c/tests/integration.sh
+++ b/implementations/c/provekit-lsp-c/tests/integration.sh
@@ -77,8 +77,14 @@ check "T6 parse: contract compute declared" "$LINE2" '"name":"compute"'
 # T7: parse response contains callEdges array
 check "T7 parse: callEdges key present" "$LINE2" '"callEdges":'
 
-# T8: parse response has call edge from compute to add
-check "T8 parse: call edge compute->add present" "$LINE2" '"callee":"add"'
+# T8: callEdges is emitted as an empty array.
+#
+# The C LSP cannot compute contract CIDs (no JCS encoder + BLAKE3 here), so
+# the canonical IR shape (sourceContractCid, targetContractCid, targetSymbol,
+# callSiteLocus, evidenceTerm) cannot be produced. Until that's wired up,
+# emit []; the legacy {callee, caller, line} shape was silently dropped by
+# the daemon. (Review feedback: PR #165 / Copilot.)
+check "T8 parse: callEdges is empty array" "$LINE2" '"callEdges":[]'
 
 # T9: parse response contains warnings array
 check "T9 parse: warnings key present" "$LINE2" '"warnings":'

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1589,6 +1589,7 @@ dependencies = [
  "provekit-lift",
  "provekit-linker",
  "provekit-proof-envelope",
+ "provekit-self-contracts",
  "provekit-verifier",
  "serde",
  "serde_json",

--- a/implementations/rust/provekit-cli/Cargo.toml
+++ b/implementations/rust/provekit-cli/Cargo.toml
@@ -20,6 +20,7 @@ provekit-verifier = { path = "../provekit-verifier" }
 provekit-agent = { path = "../provekit-agent" }
 provekit-lift = { path = "../provekit-lift" }
 provekit-linker = { path = "../provekit-linker" }
+provekit-self-contracts = { path = "../provekit-self-contracts" }
 
 # External.
 clap = { version = "4", features = ["derive"] }

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -245,7 +245,13 @@ fn dispatch(
     if manifest.command.len() > 1 {
         cmd.args(&manifest.command[1..]);
     }
-    cmd.arg("--rpc");
+    // Append --rpc only if the manifest doesn't already include it.
+    // Several manifests (e.g. typescript) hard-code --rpc in their command
+    // array; appending unconditionally produces duplicate args, which some
+    // lifters reject. (Review feedback: PR #165 / Copilot.)
+    if !manifest.command.iter().any(|a| a == "--rpc") {
+        cmd.arg("--rpc");
+    }
     if let Some(wd) = &manifest.working_dir {
         let resolved = if wd.is_absolute() {
             wd.clone()

--- a/implementations/rust/provekit-cli/src/cmd_prove.rs
+++ b/implementations/rust/provekit-cli/src/cmd_prove.rs
@@ -220,7 +220,13 @@ fn capture_rpc(
     if manifest.command.len() > 1 {
         cmd.args(&manifest.command[1..]);
     }
-    cmd.arg("--rpc");
+    // Append --rpc only if the manifest doesn't already include it.
+    // Several manifests (e.g. typescript) hard-code --rpc in their command
+    // array; appending unconditionally produces duplicate args, which some
+    // lifters reject. (Review feedback: PR #165 / Copilot.)
+    if !manifest.command.iter().any(|a| a == "--rpc") {
+        cmd.arg("--rpc");
+    }
     if let Some(wd) = &manifest.working_dir {
         let resolved = if wd.is_absolute() {
             wd.clone()

--- a/implementations/rust/provekit-cli/src/cmd_prove.rs
+++ b/implementations/rust/provekit-cli/src/cmd_prove.rs
@@ -1,16 +1,501 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// `provekit prove` / `provekit verify` — runs the six-stage pipeline.
+// `provekit prove` / `provekit verify` — runs the six-stage pipeline,
+// or (when --kit is given) the lift-plugin-protocol conformance gate.
+//
+// Conformance gate (--kit=<kit>):
+//
+//   Spawns the kit's lifter via the lift-plugin-protocol JSON-RPC (same
+//   dispatch as `cmd_mint`), captures the raw initialize request/response
+//   and lift request/response, then runs every operational verifier from
+//   `provekit_self_contracts::lift_plugin_protocol` (C1-C8) against those
+//   captured messages.
+//
+//   Exit 0   all contracts hold.
+//   Exit 1   one or more contracts violated (VERIFY_FAIL).
+//   Exit 2   user error (unknown kit, lifter ENOENT, spawn failure).
+//
+//   The key difference from `cmd_mint`'s dispatch:
+//   - ENOENT on the lifter binary is a HARD error here (we need the RPC
+//     traffic to run the verifiers; an absent lifter means zero data).
+//   - We capture the full JSON-RPC envelopes (with `jsonrpc`/`id`/`result`
+//     keys) before stripping them, because the verifiers expect the
+//     full-envelope form.
+//   - The lift request uses `source_paths: ["."]` to satisfy C3's
+//     non-empty-paths invariant (most lifters walk their own working
+//     directory regardless of source_paths).
 
+use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 
 use owo_colors::OwoColorize;
+use serde_json::{json, Value};
+
+use provekit_self_contracts::lift_plugin_protocol::{
+    verify_c1_initialize_protocol_version_match,
+    verify_c2_initialize_capabilities_populated,
+    verify_c3_lift_request_well_formed,
+    verify_c4_surface_in_capabilities,
+    verify_c5_response_kind_in_set,
+    verify_c6_ir_document_array,
+    verify_c7_diagnostics_field_is_array,
+    verify_c8_call_edge_stream_present,
+};
 use provekit_verifier::{Runner, RunnerConfig};
 
 use crate::report_fmt;
 use crate::ProveArgs;
 
+// Re-use the same KIT_TABLE from cmd_mint for consistency.
+// The table is duplicated here to avoid a cross-module dependency; any
+// change to one must be reflected in the other.
+const KIT_TABLE: &[(&str, &str, &str)] = &[
+    // (kit_alias, project_subdir, surface)
+    ("rust",       "rust",       "rust"),
+    ("go",         "go",         "go"),
+    ("cpp",        "cpp",        "cpp"),
+    ("ts",         "typescript", "typescript"),
+    ("csharp",     "csharp",     "csharp"),
+    ("swift",      "swift",      "swift"),
+    ("java",       "java",       "java"),
+    ("python",     "python",     "python"),
+    ("ruby",       "ruby",       "ruby"),
+    ("zig",        "zig",        "zig"),
+    ("c",          "c",          "c"),
+];
+
+fn resolve_kit(kit: &str) -> Option<(PathBuf, String)> {
+    KIT_TABLE
+        .iter()
+        .find(|(alias, _, _)| *alias == kit)
+        .map(|(_, subdir, surface)| {
+            (
+                PathBuf::from("implementations").join(subdir),
+                surface.to_string(),
+            )
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Plugin manifest (mirrors cmd_mint — kept local to avoid coupling)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct PluginManifest {
+    name: String,
+    command: Vec<String>,
+    working_dir: Option<PathBuf>,
+}
+
+fn parse_manifest(path: &std::path::Path) -> Result<PluginManifest, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    let mut m = PluginManifest::default();
+    for line in text.lines() {
+        let line = match line.find('#') {
+            Some(p) => &line[..p],
+            None => line,
+        }
+        .trim();
+        if line.is_empty() || line.starts_with('[') {
+            continue;
+        }
+        let Some(eq) = line.find('=') else { continue };
+        let key = line[..eq].trim();
+        let val = line[eq + 1..].trim();
+        match key {
+            "name" => m.name = val.trim_matches('"').to_string(),
+            "working_dir" => m.working_dir = Some(PathBuf::from(val.trim_matches('"'))),
+            "command" => {
+                let inner = val.trim_matches(|c| c == '[' || c == ']');
+                m.command = inner
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            }
+            _ => {}
+        }
+    }
+    if m.command.is_empty() {
+        return Err(format!("manifest {} has no `command`", path.display()));
+    }
+    Ok(m)
+}
+
+fn find_manifest(project_root: &std::path::Path, surface: &str) -> Result<PluginManifest, String> {
+    let project_local = project_root
+        .join(".provekit")
+        .join("lift")
+        .join(surface)
+        .join("manifest.toml");
+    if project_local.exists() {
+        return parse_manifest(&project_local);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let user_global = PathBuf::from(home)
+            .join(".config")
+            .join("provekit")
+            .join("lift")
+            .join(surface)
+            .join("manifest.toml");
+        if user_global.exists() {
+            return parse_manifest(&user_global);
+        }
+    }
+    Err(format!(
+        "no plugin manifest for surface `{surface}` (looked in .provekit/lift/{surface}/manifest.toml and ~/.config/provekit/lift/{surface}/manifest.toml)"
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// RPC capture
+// ---------------------------------------------------------------------------
+
+/// Raw RPC messages captured during a lift-plugin-protocol session.
+///
+/// The verifiers in `lift_plugin_protocol` take:
+/// - `init_params`  — the `params` object from the initialize request (not the
+///   full envelope, just params).
+/// - `init_response` — the FULL initialize response envelope
+///   (`{"jsonrpc":"2.0","id":1,"result":{...}}`).
+/// - `lift_params` — the `params` object from the lift request.
+/// - `lift_response` — the FULL lift response envelope.
+struct CapturedRpc {
+    init_params: Value,
+    init_response: Value,
+    lift_params: Value,
+    lift_response: Value,
+}
+
+/// Read one line from `reader`, parse as JSON-RPC, assert the id matches,
+/// and return the FULL response envelope (jsonrpc+id+result or error).
+fn read_full_response(reader: &mut impl BufRead, expected_id: i64) -> Result<Value, String> {
+    let mut line = String::new();
+    let n = reader
+        .read_line(&mut line)
+        .map_err(|e| format!("read response id={expected_id}: {e}"))?;
+    if n == 0 {
+        return Err(format!(
+            "plugin closed stdout before responding to id={expected_id}"
+        ));
+    }
+    let v: Value = serde_json::from_str(line.trim()).map_err(|e| {
+        format!(
+            "parse JSON-RPC response id={expected_id}: {e}\n  raw: {line}"
+        )
+    })?;
+    if v.get("id").and_then(|id| id.as_i64()) != Some(expected_id) {
+        return Err(format!(
+            "response id mismatch: expected {expected_id}, got {:?}",
+            v.get("id")
+        ));
+    }
+    Ok(v)
+}
+
+/// Spawn the kit's lifter, drive initialize→lift→shutdown, and return the
+/// captured RPC messages for verifier consumption.
+///
+/// Unlike `cmd_mint::dispatch`, ENOENT is a hard error here because we need
+/// actual RPC traffic to run the verifiers.
+fn capture_rpc(
+    project_root: &std::path::Path,
+    surface: &str,
+    quiet: bool,
+) -> Result<CapturedRpc, String> {
+    let manifest = find_manifest(project_root, surface)?;
+    if !quiet {
+        println!(
+            "{}: surface=`{}` plugin=`{}` command={:?}",
+            "dispatch".green().bold(),
+            surface,
+            manifest.name,
+            manifest.command
+        );
+    }
+
+    let mut cmd = Command::new(&manifest.command[0]);
+    if manifest.command.len() > 1 {
+        cmd.args(&manifest.command[1..]);
+    }
+    cmd.arg("--rpc");
+    if let Some(wd) = &manifest.working_dir {
+        let resolved = if wd.is_absolute() {
+            wd.clone()
+        } else {
+            project_root.join(wd)
+        };
+        cmd.current_dir(resolved);
+    }
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::inherit());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            format!(
+                "lifter binary `{}` not found — cannot verify conformance without a running lifter",
+                manifest.command[0]
+            )
+        } else {
+            format!("spawn {:?}: {e}", manifest.command)
+        }
+    })?;
+
+    let mut stdin = child.stdin.take().ok_or("no stdin")?;
+    let stdout = child.stdout.take().ok_or("no stdout")?;
+    let mut reader = BufReader::new(stdout);
+
+    // 1. initialize
+    let init_params = json!({
+        "client": {"name": "provekit-cli", "version": env!("CARGO_PKG_VERSION")},
+        "protocol_version": "provekit-lift/1",
+        "workspace_root": project_root.canonicalize().unwrap_or_else(|_| project_root.to_path_buf()),
+        "config_path": ".provekit/config.toml"
+    });
+    let init_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": init_params
+    });
+    writeln!(stdin, "{init_req}").map_err(|e| format!("write initialize: {e}"))?;
+    let init_response = read_full_response(&mut reader, 1)?;
+
+    if !quiet {
+        if let Some(name) = init_response
+            .get("result")
+            .and_then(|r| r.get("name"))
+            .and_then(|v| v.as_str())
+        {
+            println!("{}: plugin `{}` ready", "ok".green().bold(), name);
+        }
+    }
+
+    // 2. lift — use source_paths: ["."] to satisfy C3 non-empty invariant.
+    //    Most lifters ignore source_paths and walk their own working dir.
+    let lift_params = json!({
+        "surface": surface,
+        "source_paths": ["."],
+        "options": {"layer": "all"}
+    });
+    let lift_req = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "lift",
+        "params": lift_params
+    });
+    writeln!(stdin, "{lift_req}").map_err(|e| format!("write lift: {e}"))?;
+    let lift_response = read_full_response(&mut reader, 2)?;
+
+    // 3. shutdown
+    let shutdown_req = json!({"jsonrpc":"2.0","id":3,"method":"shutdown"});
+    let _ = writeln!(stdin, "{shutdown_req}");
+    drop(stdin);
+    let _ = child.wait();
+
+    Ok(CapturedRpc {
+        init_params,
+        init_response,
+        lift_params,
+        lift_response,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Verifier runner
+// ---------------------------------------------------------------------------
+
+/// One contract's verdict.
+struct ContractResult {
+    name: &'static str,
+    result: Result<(), String>,
+}
+
+/// Run all 8 lift-plugin-protocol verifiers against the captured RPC messages.
+fn run_verifiers(rpc: &CapturedRpc) -> Vec<ContractResult> {
+    vec![
+        ContractResult {
+            name: "C1: initialize protocol_version_match",
+            result: verify_c1_initialize_protocol_version_match(
+                &rpc.init_params,
+                &rpc.init_response,
+            ),
+        },
+        ContractResult {
+            name: "C2: initialize capabilities_populated",
+            result: verify_c2_initialize_capabilities_populated(&rpc.init_response),
+        },
+        ContractResult {
+            name: "C3: lift request well_formed",
+            result: verify_c3_lift_request_well_formed(&rpc.lift_params),
+        },
+        ContractResult {
+            name: "C4: lift surface_in_capabilities",
+            result: verify_c4_surface_in_capabilities(&rpc.lift_params, &rpc.init_response),
+        },
+        ContractResult {
+            name: "C5: lift response kind_in_set",
+            result: verify_c5_response_kind_in_set(&rpc.lift_response),
+        },
+        ContractResult {
+            name: "C6: lift response ir_document_array",
+            result: verify_c6_ir_document_array(&rpc.lift_response),
+        },
+        ContractResult {
+            name: "C7: diagnostics field_is_array",
+            result: verify_c7_diagnostics_field_is_array(&rpc.lift_response),
+        },
+        ContractResult {
+            name: "C8: call_edge_stream_present",
+            result: verify_c8_call_edge_stream_present(&rpc.lift_response),
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Kit conformance entry point
+// ---------------------------------------------------------------------------
+
+fn run_kit(kit: &str, quiet: bool, json_out: bool) -> u8 {
+    let (project_root, surface) = match resolve_kit(kit) {
+        Some(v) => v,
+        None => {
+            let known: Vec<&str> = KIT_TABLE.iter().map(|(a, _, _)| *a).collect();
+            eprintln!(
+                "{}: unknown kit `{}`; known kits: {}",
+                "error".red().bold(),
+                kit,
+                known.join(", ")
+            );
+            return crate::EXIT_USER_ERROR;
+        }
+    };
+
+    if !project_root.exists() {
+        eprintln!(
+            "{}: kit project not found: {} (run from repo root)",
+            "error".red().bold(),
+            project_root.display()
+        );
+        return crate::EXIT_USER_ERROR;
+    }
+
+    // Pre-flight: print which contracts will be checked.
+    if !quiet && !json_out {
+        println!(
+            "{}: kit=`{}` surface=`{}` — checking 8 lift-plugin-protocol contracts (C1-C8)",
+            "provekit".cyan().bold(),
+            kit,
+            surface
+        );
+    }
+
+    let rpc = match capture_rpc(&project_root, &surface, quiet) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{}: {e}", "error".red().bold());
+            if !quiet && !json_out {
+                eprintln!();
+                eprintln!("Pre-flight: the following contracts could not be evaluated because the");
+                eprintln!("lifter binary was unavailable:");
+                eprintln!("  C1: initialize protocol_version_match");
+                eprintln!("  C2: initialize capabilities_populated");
+                eprintln!("  C3: lift request well_formed");
+                eprintln!("  C4: lift surface_in_capabilities");
+                eprintln!("  C5: lift response kind_in_set");
+                eprintln!("  C6: lift response ir_document_array");
+                eprintln!("  C7: diagnostics field_is_array");
+                eprintln!("  C8: call_edge_stream_present");
+                eprintln!();
+                eprintln!("Install the `{}` kit lifter and re-run.", kit);
+            }
+            return crate::EXIT_USER_ERROR;
+        }
+    };
+
+    let results = run_verifiers(&rpc);
+
+    if json_out {
+        let arr: Vec<serde_json::Value> = results
+            .iter()
+            .map(|r| {
+                json!({
+                    "contract": r.name,
+                    "pass": r.result.is_ok(),
+                    "error": r.result.as_ref().err().map(|e| e.as_str()).unwrap_or(""),
+                })
+            })
+            .collect();
+        let out = json!({
+            "kit": kit,
+            "surface": surface,
+            "contracts": arr,
+        });
+        match serde_json::to_string_pretty(&out) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("{}: serialize JSON: {e}", "error".red().bold());
+                return crate::EXIT_USER_ERROR;
+            }
+        }
+    } else {
+        let mut all_pass = true;
+        for r in &results {
+            match &r.result {
+                Ok(()) => {
+                    if !quiet {
+                        println!("  {} {}", "pass".green().bold(), r.name);
+                    }
+                }
+                Err(msg) => {
+                    all_pass = false;
+                    println!("  {} {}: {}", "FAIL".red().bold(), r.name, msg);
+                }
+            }
+        }
+        if !quiet {
+            println!();
+            let pass_count = results.iter().filter(|r| r.result.is_ok()).count();
+            let total = results.len();
+            if all_pass {
+                println!(
+                    "{}: kit=`{}` — all {total} contracts hold",
+                    "pass".green().bold(),
+                    kit
+                );
+            } else {
+                let fail_count = total - pass_count;
+                println!(
+                    "{}: kit=`{}` — {fail_count}/{total} contracts violated",
+                    "FAIL".red().bold(),
+                    kit
+                );
+            }
+        }
+    }
+
+    let all_pass = results.iter().all(|r| r.result.is_ok());
+    if all_pass {
+        crate::EXIT_OK
+    } else {
+        crate::EXIT_VERIFY_FAIL
+    }
+}
+
+// ---------------------------------------------------------------------------
+// pub fn run — entry point from main.rs
+// ---------------------------------------------------------------------------
+
 pub fn run(args: ProveArgs) -> u8 {
+    // When --kit is given, run the conformance gate.
+    if let Some(kit) = &args.kit {
+        return run_kit(kit, args.out.quiet, args.out.json);
+    }
+
+    // Otherwise, run the six-stage verifier pipeline.
     let project_root: PathBuf = args.project.unwrap_or_else(|| PathBuf::from("."));
     if !project_root.exists() {
         eprintln!(
@@ -43,4 +528,287 @@ pub fn run(args: ProveArgs) -> u8 {
     }
 
     report_fmt::report_exit_code(&report)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Helper: build a conformant initialize response envelope.
+    fn good_init_response(surface: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "name": format!("{surface}-lifter"),
+                "version": "1.0.0",
+                "protocol_version": "provekit-lift/1",
+                "capabilities": {
+                    "authoring_surfaces": [surface],
+                    "ir_version": "v1.1.0",
+                },
+            },
+        })
+    }
+
+    // Helper: build a conformant lift response (ir-document shape).
+    fn good_lift_response_ir() -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "kind": "ir-document",
+                "ir": [{"kind": "contract", "name": "example_contract", "outBinding": "out"}],
+                "diagnostics": [],
+            },
+        })
+    }
+
+    // Helper: build a conformant CapturedRpc with all 8 contracts passing.
+    fn good_rpc(surface: &str) -> CapturedRpc {
+        CapturedRpc {
+            init_params: json!({
+                "client": {"name": "provekit-cli", "version": "0.1.0"},
+                "protocol_version": "provekit-lift/1",
+                "workspace_root": "/tmp",
+                "config_path": ".provekit/config.toml"
+            }),
+            init_response: good_init_response(surface),
+            lift_params: json!({
+                "surface": surface,
+                "source_paths": ["."],
+                "options": {"layer": "all"}
+            }),
+            lift_response: good_lift_response_ir(),
+        }
+    }
+
+    #[test]
+    fn all_8_verifiers_pass_on_conformant_rpc() {
+        let rpc = good_rpc("rust");
+        let results = run_verifiers(&rpc);
+        assert_eq!(results.len(), 8, "must have exactly 8 contract results");
+        for r in &results {
+            assert!(
+                r.result.is_ok(),
+                "contract `{}` should pass on conformant RPC, got: {:?}",
+                r.name,
+                r.result
+            );
+        }
+    }
+
+    #[test]
+    fn c1_violation_caught_wrong_protocol_version() {
+        let mut rpc = good_rpc("rust");
+        // Drift: response returns a different protocol version without error code.
+        rpc.init_response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "name": "bad-plugin",
+                "version": "0.0.1",
+                "protocol_version": "provekit-lift/0",
+                "capabilities": {
+                    "authoring_surfaces": ["rust"],
+                    "ir_version": "v1.0.0",
+                },
+            },
+        });
+        let results = run_verifiers(&rpc);
+        let c1 = &results[0];
+        assert_eq!(c1.name, "C1: initialize protocol_version_match");
+        assert!(
+            c1.result.is_err(),
+            "C1 should fail when protocol versions disagree silently"
+        );
+    }
+
+    #[test]
+    fn c2_violation_caught_empty_authoring_surfaces() {
+        let mut rpc = good_rpc("rust");
+        rpc.init_response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "name": "bad-plugin",
+                "version": "0.0.1",
+                "protocol_version": "provekit-lift/1",
+                "capabilities": {
+                    "authoring_surfaces": [],
+                    "ir_version": "v1.0.0",
+                },
+            },
+        });
+        let results = run_verifiers(&rpc);
+        let c2 = &results[1];
+        assert_eq!(c2.name, "C2: initialize capabilities_populated");
+        assert!(c2.result.is_err(), "C2 should fail on empty authoring_surfaces");
+    }
+
+    #[test]
+    fn c3_violation_caught_empty_source_paths() {
+        let mut rpc = good_rpc("rust");
+        // Drift: empty source_paths (our CLI never sends this, but a buggy
+        // caller might; the verifier catches it).
+        rpc.lift_params = json!({
+            "surface": "rust",
+            "source_paths": [],
+        });
+        let results = run_verifiers(&rpc);
+        let c3 = &results[2];
+        assert_eq!(c3.name, "C3: lift request well_formed");
+        assert!(c3.result.is_err(), "C3 should fail on empty source_paths");
+    }
+
+    #[test]
+    fn c4_violation_caught_surface_not_in_capabilities() {
+        let mut rpc = good_rpc("rust");
+        // Drift: request asks for a surface not declared in init capabilities.
+        rpc.lift_params = json!({
+            "surface": "nonexistent-surface",
+            "source_paths": ["."],
+        });
+        let results = run_verifiers(&rpc);
+        let c4 = &results[3];
+        assert_eq!(c4.name, "C4: lift surface_in_capabilities");
+        assert!(c4.result.is_err(), "C4 should fail when surface not in capabilities");
+    }
+
+    #[test]
+    fn c5_violation_caught_unknown_kind() {
+        let mut rpc = good_rpc("rust");
+        rpc.lift_response = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "kind": "unknown-response-shape",
+                "data": {},
+            },
+        });
+        let results = run_verifiers(&rpc);
+        let c5 = &results[4];
+        assert_eq!(c5.name, "C5: lift response kind_in_set");
+        assert!(c5.result.is_err(), "C5 should fail on unknown kind");
+    }
+
+    #[test]
+    fn c6_violation_caught_ir_document_without_ir_array() {
+        let mut rpc = good_rpc("rust");
+        rpc.lift_response = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "kind": "ir-document",
+                "ir": "not-an-array",
+            },
+        });
+        let results = run_verifiers(&rpc);
+        let c6 = &results[5];
+        assert_eq!(c6.name, "C6: lift response ir_document_array");
+        assert!(c6.result.is_err(), "C6 should fail when ir is not an array");
+    }
+
+    #[test]
+    fn c7_violation_caught_diagnostics_not_array() {
+        let mut rpc = good_rpc("rust");
+        rpc.lift_response = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "kind": "ir-document",
+                "ir": [],
+                "diagnostics": "should-be-array",
+            },
+        });
+        let results = run_verifiers(&rpc);
+        let c7 = &results[6];
+        assert_eq!(c7.name, "C7: diagnostics field_is_array");
+        assert!(c7.result.is_err(), "C7 should fail when diagnostics is not an array");
+    }
+
+    #[test]
+    fn c8_violation_caught_proof_envelope_without_call_edges() {
+        let mut rpc = good_rpc("rust");
+        // proof-envelope with non-empty members but no call_edges.
+        rpc.lift_response = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "kind": "proof-envelope",
+                "members": {
+                    "blake3-512:deadbeef": "base64-bytes",
+                },
+                "filename_cid": "blake3-512:aabbcc",
+                // call_edges intentionally absent
+            },
+        });
+        let results = run_verifiers(&rpc);
+        let c8 = &results[7];
+        assert_eq!(c8.name, "C8: call_edge_stream_present");
+        assert!(c8.result.is_err(), "C8 should fail when proof-envelope has no call_edges");
+    }
+
+    #[test]
+    fn resolve_kit_rust_resolves() {
+        let (path, surface) = resolve_kit("rust").expect("rust must resolve");
+        assert_eq!(path, PathBuf::from("implementations/rust"));
+        assert_eq!(surface, "rust");
+    }
+
+    #[test]
+    fn resolve_kit_ts_resolves() {
+        let (path, surface) = resolve_kit("ts").expect("ts must resolve");
+        assert_eq!(path, PathBuf::from("implementations/typescript"));
+        assert_eq!(surface, "typescript");
+    }
+
+    #[test]
+    fn resolve_kit_all_11_kits() {
+        let kits = [
+            "rust", "go", "cpp", "ts", "csharp", "swift", "java", "python", "ruby", "zig", "c",
+        ];
+        for kit in kits {
+            assert!(resolve_kit(kit).is_some(), "kit `{kit}` must resolve");
+        }
+    }
+
+    #[test]
+    fn resolve_kit_unknown_returns_none() {
+        assert!(resolve_kit("haskell").is_none());
+    }
+
+    #[test]
+    fn missing_one_contract_yields_verify_fail() {
+        // A kit that passes C1-C7 but fails C8 (no call_edges in proof-envelope).
+        // run_verifiers returns 8 results; one is Err; all_pass is false.
+        let mut rpc = good_rpc("rust");
+        rpc.lift_response = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "kind": "proof-envelope",
+                "members": {"blake3-512:abc": "bytes"},
+                "filename_cid": "blake3-512:def",
+                // call_edges absent — C8 violation
+            },
+        });
+        let results = run_verifiers(&rpc);
+        let all_pass = results.iter().all(|r| r.result.is_ok());
+        assert!(!all_pass, "overall gate must fail when one contract is violated");
+        let failures: Vec<&str> = results
+            .iter()
+            .filter(|r| r.result.is_err())
+            .map(|r| r.name)
+            .collect();
+        assert!(
+            failures.contains(&"C8: call_edge_stream_present"),
+            "C8 must be in the failure list; got: {failures:?}"
+        );
+    }
 }

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -122,6 +122,14 @@ pub struct ProveArgs {
     /// Path to z3 binary (default: "z3" on PATH).
     #[arg(long, default_value = "z3")]
     pub z3: String,
+    /// Kit conformance gate: verify the named kit's lifter implements the
+    /// canonical lift-plugin-protocol contracts (C1-C8). When set, the six-stage
+    /// verifier is bypassed; instead the kit's lifter is spawned via JSON-RPC and
+    /// each verifier in `provekit-self-contracts::lift_plugin_protocol` is run
+    /// against the captured RPC messages.
+    /// Known kits: rust, go, cpp, ts, csharp, swift, java, python, ruby, zig, c.
+    #[arg(long, conflicts_with = "project")]
+    pub kit: Option<String>,
     #[command(flatten)]
     pub out: OutputFlags,
 }

--- a/implementations/zig/provekit-lift-zig/src/lift.zig
+++ b/implementations/zig/provekit-lift-zig/src/lift.zig
@@ -62,11 +62,41 @@ pub fn parseAnnotations(alloc: std.mem.Allocator, text: []const u8) ![]Annotatio
 fn findAheadFnName(text: []const u8, start_line: usize) []const u8 {
     var lines = std.mem.splitScalar(u8, text, '\n');
     var current: usize = 0;
+    // Recognize Zig function prefixes (review feedback: PR #165 / CodeRabbit):
+    // bare `fn`, `pub fn`, `export fn`, `extern fn`, `inline fn`, plus
+    // combinations such as `pub export fn`, `pub extern fn`, `pub inline fn`.
+    // Strip leading visibility/linkage qualifiers until we find `fn `.
+    const qualifiers = [_][]const u8{ "pub", "export", "extern", "inline", "noinline", "comptime" };
     while (lines.next()) |line| : (current += 1) {
         if (current <= start_line) continue;
         if (current > start_line + 10) break;
 
-        const trimmed = std.mem.trim(u8, line, " \t");
+        var trimmed = std.mem.trim(u8, line, " \t");
+        // Strip qualifiers iteratively. Each pass strips one qualifier (or an
+        // `extern "C"`-style calling-convention quoted string) so combinations
+        // like `pub extern "C" fn` are handled.
+        var stripped = true;
+        while (stripped) {
+            stripped = false;
+            for (qualifiers) |q| {
+                if (trimmed.len > q.len and
+                    std.mem.startsWith(u8, trimmed, q) and
+                    (trimmed[q.len] == ' ' or trimmed[q.len] == '\t'))
+                {
+                    trimmed = std.mem.trimStart(u8, trimmed[q.len..], " \t");
+                    stripped = true;
+                    break;
+                }
+            }
+            // Tolerate `extern "C"` calling-convention spec.
+            if (trimmed.len > 0 and trimmed[0] == '"') {
+                if (std.mem.indexOfScalar(u8, trimmed[1..], '"')) |close_idx| {
+                    const after = trimmed[1 + close_idx + 1 ..];
+                    trimmed = std.mem.trimStart(u8, after, " \t");
+                    stripped = true;
+                }
+            }
+        }
         if (std.mem.startsWith(u8, trimmed, "fn ")) {
             const after = trimmed[3..];
             const end = std.mem.indexOfAny(u8, after, " (\n") orelse after.len;
@@ -178,4 +208,69 @@ test "liftToDecls contract produces IR" {
         .contract => |c| try std.testing.expectEqualStrings("myFn", c.name),
         else => return error.WrongKind,
     }
+}
+
+// Zig function-prefix coverage (review feedback: PR #165 / CodeRabbit).
+// findAheadFnName must handle visibility/linkage qualifiers preceding `fn`.
+
+test "parseAnnotations finds pub fn" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\//provekit:contract
+        \\pub fn pubFn(x: i32) void {
+        \\    _ = x;
+        \\}
+    ;
+    const anns = try parseAnnotations(alloc, src);
+    defer alloc.free(anns);
+    try std.testing.expectEqual(@as(usize, 1), anns.len);
+    try std.testing.expectEqualStrings("pubFn", anns[0].function_name);
+}
+
+test "parseAnnotations finds export fn" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\//provekit:contract
+        \\export fn exportedFn() void {}
+    ;
+    const anns = try parseAnnotations(alloc, src);
+    defer alloc.free(anns);
+    try std.testing.expectEqual(@as(usize, 1), anns.len);
+    try std.testing.expectEqualStrings("exportedFn", anns[0].function_name);
+}
+
+test "parseAnnotations finds extern fn" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\//provekit:contract
+        \\extern fn externFn() void;
+    ;
+    const anns = try parseAnnotations(alloc, src);
+    defer alloc.free(anns);
+    try std.testing.expectEqual(@as(usize, 1), anns.len);
+    try std.testing.expectEqualStrings("externFn", anns[0].function_name);
+}
+
+test "parseAnnotations finds inline fn" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\//provekit:contract
+        \\inline fn inlinedFn() void {}
+    ;
+    const anns = try parseAnnotations(alloc, src);
+    defer alloc.free(anns);
+    try std.testing.expectEqual(@as(usize, 1), anns.len);
+    try std.testing.expectEqualStrings("inlinedFn", anns[0].function_name);
+}
+
+test "parseAnnotations finds pub extern \"C\" fn" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\//provekit:contract
+        \\pub extern "C" fn cAbiFn() void;
+    ;
+    const anns = try parseAnnotations(alloc, src);
+    defer alloc.free(anns);
+    try std.testing.expectEqual(@as(usize, 1), anns.len);
+    try std.testing.expectEqualStrings("cAbiFn", anns[0].function_name);
 }


### PR DESCRIPTION
## Summary

- Adds `--kit=<kit>` to `provekit prove` to run the lift-plugin-protocol conformance gate (C1-C8) against any of the 11 language kits
- Each prove job spawns the kit's lifter via JSON-RPC (initialize -> lift -> shutdown), captures RPC envelopes, and runs all 8 operational verifiers from `provekit-self-contracts::lift_plugin_protocol`
- Adds 11 `prove-<lang>` Makefile targets + `prove-all`, and CI matrix jobs (`prove-linux` for 10 kits on self-hosted, `prove-swift` on macos-latest)

## Architecture notes

The verifiers in `lift_plugin_protocol.rs` (`verify_c1_*` through `verify_c8_*`) take JSON-RPC request params and full response envelopes — not IR content or attestation bytes. This means bridge architecture is orthogonal to conformance: the verifier checks protocol-level behavior (protocol_version echo, capabilities shape, kind field, call_edges presence), not the semantic content of what the kit produces.

Key decision: `source_paths: ["."]` (non-empty) satisfies C3's invariant; most lifters walk their own working directory regardless of what source_paths contains.

## Test plan

- [x] 14 unit tests covering all 8 C1-C8 violation paths, the conformant pass, and kit resolution for all 11 kits (`cargo test -p provekit-cli cmd_prove`)
- [x] Full Rust workspace test suite passes (66 + 5 + 5 = 76 tests, 0 failures)
- [ ] CI matrix `prove-linux` (10 kits) and `prove-swift` green — depends on kit lifters being installed on self-hosted runners
- [ ] `make prove-rust` on a machine with the rust lifter wired — should exit 0
- [ ] `make prove-go` on a machine with the go lifter wired — should exit 0
- [ ] Kits without lifters (java/python/ruby/zig/c) exit 2 with pre-flight missing-lifter report

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--kit` flag to the `prove` command to run conformance tests for individual kits (Rust, Go, C++, TypeScript, C#, Swift, Java, Python, Ruby, Zig, C).
  * Added `make prove-all` and per-kit `make prove-*` targets for running conformance verification locally.

* **Chores**
  * Enhanced CI workflow to include per-kit conformance testing stages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review concerns addressed (post-rebase)

After the bot reviews flagged 14+ concerns at merge time, the load-bearing P1/P2 fixes were applied in commit `fix(pr-165): address load-bearing PR-165 review concerns` (rebased atop main):

**P1 fixes applied here:**
- ci.yml: kits without wired lift binaries (java/python/ruby/zig/c) get `continue-on-error: true` so the matrix doesn't gate merge on known gaps. The single-job conformance gate remains mandatory. (Codex P1.)
- cmd_mint::dispatch + cmd_prove::capture_rpc: append `--rpc` only if the manifest's command array doesn't already include it (TS / java / csharp manifests already pin it; double-flagging breaks strict lifters). (Copilot.)
- C lsp callEdges: emit `[]` until contract-CID computation is wired up. The legacy {callee, caller, line} shape was silently dropped by the daemon's `spawn_kit_lifter` — graceful downgrade per architect approval. (Copilot.)
- C lsp main.c: define `_GNU_SOURCE` before headers and include `<sys/types.h>` so getline / ssize_t are POSIX-portable. (CodeRabbit.)

**P2 fixes applied here:**
- C lsp main.c: detect Allman-style function bodies (brace on next non-blank line) so call-edge attribution is set for that style. (CodeRabbit.)
- Zig provekit-lift-zig: extend findAheadFnName to handle `pub fn`, `export fn`, `extern fn`, `inline fn`, `noinline fn`, `comptime fn`, and combinations including `pub extern "C" fn`. Adds 5 unit tests. (CodeRabbit.)

**Architect-call ambiguity surfaced (manifest renames):**
Investigation showed the proposed `provekit-lift-* → provekit-lsp-*` rename for Java/Swift/C surfaces a deeper protocol-shape mismatch (the dispatcher expects `proof-envelope`; java's lift returns `ir-document`; swift/c LSPs only speak `parse`, not `lift`). A simple manifest rename would shift the failure mode from ENOENT-fallback-to-empty-set to a hard mint error, breaking `mint_kit_integration` for those kits. The matrix `continue-on-error` is the load-bearing answer to "kits known to fail are blocking merge"; the deeper wiring is filed as #298.

**Already merged (no code change here):**
- P1 #5 `source_paths: []` was fixed in #169.

**Deferred to follow-up issues:**
- #298 — Wire java/swift/c lift protocol (manifest rename + ir-document handling)
- #299 — linkerd `spawn_kit_lifter` blocks tokio runtime (P2 #8, heavy lift)
- #300 — P3 cleanup batch (cpp lsp JSON escape, csharp WaitForExit, ruby nil-find, swift skip-counted-as-pass, build-cpp-lsp parent-dir mkdir, foundation-keygen declaredAt)

**Swift CallSiteLocus column-1-based fix (P2 #9):** out-of-scope after rebase — main has migrated SwiftLifter to SwiftSyntax-based AST parsing (PR #285?) and the new `CallEdgeVisitor` deliberately emits 0-based column to match the v0 wire shape for LSP consumers. The Copilot feedback applied to the regex-era code; the rewritten lifter has its own column convention documented in-place.

**Verified locally:** `cargo test -p provekit-cli` (68/68 unit tests); `provekit-lsp-c` integration tests (10/10 incl. updated callEdges-empty-array assertion); `swift run test-swift-lsp` (11/11); `zig build test` (12/12 incl. new prefix tests).