### PR TITLE
fix(cli): cmd_mint dispatch sends source_paths:["."] (closes #166)

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -187,6 +187,18 @@ fn find_manifest(project_root: &Path, surface: &str) -> Result<PluginManifest, S
 // Lift-protocol dispatch
 // ---------------------------------------------------------------------------
 
+/// Build the `params` object for the lift JSON-RPC request.
+///
+/// Extracted as a pure function so unit tests can assert the C3 invariant
+/// (non-empty `source_paths`) without spawning a subprocess.
+fn build_lift_params(surface: &str) -> Value {
+    json!({
+        "surface": surface,
+        "source_paths": ["."],
+        "options": {"layer": "all"}
+    })
+}
+
 /// Result of a successful lift dispatch.
 struct DispatchResult {
     filename_cid: String,
@@ -282,16 +294,16 @@ fn dispatch(
         }
     }
 
-    // 2. lift
+    // 2. lift — send source_paths:["."] to satisfy C3 non-empty invariant.
+    //    Most lifters walk their own working directory regardless of source_paths,
+    //    but C3 (`verify_c3_lift_request_well_formed`) requires the array to be
+    //    non-empty. Mirror the pattern from cmd_prove::capture_rpc.
+    let lift_params = build_lift_params(surface);
     let lift_req = json!({
         "jsonrpc": "2.0",
         "id": 2,
         "method": "lift",
-        "params": {
-            "surface": surface,
-            "source_paths": [],
-            "options": {"layer": "all"}
-        }
+        "params": lift_params
     });
     writeln!(stdin, "{lift_req}").map_err(|e| format!("write lift: {e}"))?;
     let lift_resp = read_response(&mut reader, 2)?;
@@ -654,6 +666,28 @@ mod tests {
         let a = build_signed_attestation("go", "blake3-512:aa", "blake3-512:bb");
         let b = build_signed_attestation("go", "blake3-512:aa", "blake3-512:bb");
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn dispatch_lift_params_source_paths_non_empty() {
+        // C3 (verify_c3_lift_request_well_formed) requires source_paths to be
+        // a non-empty array. Sending [] was the bug fixed in issue #166.
+        let params = build_lift_params("rust");
+        let paths = params["source_paths"]
+            .as_array()
+            .expect("source_paths must be an array");
+        assert!(
+            !paths.is_empty(),
+            "source_paths must not be empty — was C3 violation (issue #166)"
+        );
+        assert_eq!(paths[0].as_str(), Some("."), "first entry should be '.'");
+    }
+
+    #[test]
+    fn dispatch_lift_params_has_surface_and_options() {
+        let params = build_lift_params("go");
+        assert_eq!(params["surface"].as_str(), Some("go"));
+        assert_eq!(params["options"]["layer"].as_str(), Some("all"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `cmd_mint::dispatch()` was sending `source_paths: []` in the lift JSON-RPC request, violating **C3** (`verify_c3_lift_request_well_formed` requires source_paths to be a non-empty array).
- Extracted `build_lift_params(surface)` pure helper (mirrors `cmd_prove::capture_rpc`'s pattern) and changed `dispatch()` to use it with `source_paths: ["."]`.
- Added two unit tests asserting the C3 invariant: `dispatch_lift_params_source_paths_non_empty` and `dispatch_lift_params_has_surface_and_options`.

## Exact diff in cmd_mint.rs

Added `build_lift_params(surface: &str) -> Value` before `dispatch()`:
```rust
fn build_lift_params(surface: &str) -> Value {
    json!({
        "surface": surface,
        "source_paths": ["."],
        "options": {"layer": "all"}
    })
}
```

Changed the inline `source_paths: []` in `dispatch()` to call `build_lift_params(surface)`.

## Re-mint results

`make all-mint` passed for all 5 in-scope kits (rust, go, cpp, ts, csharp). **No attestation drift** — all 5 contractSetCids matched pinned values. Lifters walk their own working directory regardless of source_paths content, as documented in cmd_prove.

## Dogfood test note

`provekit prove --kit=<kit>` is not available on `provenance/v1-scaffold` (that flag is in `feat/conformance-gate-prove` / commit `d197d82`, not yet merged here). C3 conformance is confirmed via the new unit test and `make all-mint` passing cleanly.

Closes #166.

## Test plan

- [x] `cargo test -p provekit-cli --bin provekit` — 54 passed, 0 failed (includes 2 new tests)
- [x] `make all-mint` — all 5 kits minted, all contractSetCids matched pinned values, no attestation drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)