### PR TITLE
fix(ts-lsp): commit launcher bin/provekit-lsp-ts.cjs + daemon implementation (closes #167)

### DIFF
--- a/bin/provekit-lsp-ts.cjs
+++ b/bin/provekit-lsp-ts.cjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// provekit-lsp-ts CLI launcher.
+//
+// Mirrors bin/provekit-lift.cjs: tsx-driven, no precompiled dist/.
+// The underlying daemon is at
+//   implementations/typescript/src/lsp/daemon.ts
+
+const { spawn } = require("child_process");
+const path = require("path");
+
+const tsxCli = require.resolve("tsx/cli");
+const target = path.resolve(
+  __dirname,
+  "..",
+  "implementations",
+  "typescript",
+  "src",
+  "lsp",
+  "daemon-entry.ts",
+);
+
+const child = spawn(
+  process.execPath,
+  [tsxCli, target, ...process.argv.slice(2)],
+  { stdio: "inherit" },
+);
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});

--- a/implementations/typescript/src/lsp/daemon-entry.ts
+++ b/implementations/typescript/src/lsp/daemon-entry.ts
@@ -1,0 +1,7 @@
+/**
+ * Entry point for the provekit-lsp-ts daemon binary.
+ * Invokes the main loop.
+ */
+import { main } from "./daemon.js";
+
+main();

--- a/implementations/typescript/src/lsp/daemon.test.ts
+++ b/implementations/typescript/src/lsp/daemon.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Integration tests for the provekit-lsp-ts daemon protocol.
+ *
+ * Mirrors implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py.
+ *
+ * Asserts:
+ *   - initialize responds with name == "provekit-lsp-ts" and capabilities == ["parse"].
+ *   - parse returns result.declarations as a JSON array (not a string).
+ *   - parse returns result.callEdges as a JSON array.
+ *   - With a contract-bearing fixture, each declaration has kind == "contract".
+ *   - Empty source returns declarations == [] and callEdges == [].
+ *   - Byte-determinism: two runs on the same input produce identical parse output.
+ *   - Unknown method returns a JSON-RPC error with code -32601.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Resolve tsx/cli the same way the bin launchers do — works with pnpm's
+// node_modules/.pnpm symlink layout without needing an explicit repo root path.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const TSX_CLI: string = require.resolve("tsx/cli");
+const DAEMON_ENTRY = resolve(__dirname, "daemon-entry.ts");
+
+/** Spawn the daemon, feed ndjson, return parsed response lines. */
+function runLsp(ndjsonInput: string): Record<string, unknown>[] {
+  const result = spawnSync(process.execPath, [TSX_CLI, DAEMON_ENTRY], {
+    input: ndjsonInput,
+    encoding: "utf8",
+    timeout: 30000,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  // Tolerate non-zero exit (e.g. when shutdown causes early exit in some Node versions).
+  const lines = (result.stdout as string)
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+/** Build NDJSON for initialize -> parse -> shutdown. */
+function buildSession(source: string, path: string): string {
+  const msgs = [
+    { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+    { jsonrpc: "2.0", id: 2, method: "parse", params: { path, source } },
+    { jsonrpc: "2.0", id: 3, method: "shutdown" },
+  ];
+  return msgs.map((m) => JSON.stringify(m)).join("\n") + "\n";
+}
+
+// A fixture with a Zod schema to guarantee at least one declaration.
+const ZOD_FIXTURE_SOURCE = `
+import { z } from "zod";
+
+const UserSchema = z.object({
+  age: z.number().min(0).max(150),
+  name: z.string().min(1),
+});
+`.trim();
+const ZOD_FIXTURE_PATH = "fixture.ts";
+
+// ---------------------------------------------------------------------------
+// Shared state (run daemon once per describe block, not once per test).
+// Starting a tsx subprocess takes ~7-10s; amortise across all tests.
+// ---------------------------------------------------------------------------
+
+let zodResponses: Record<string, unknown>[] = [];
+let emptyResponses: Record<string, unknown>[] = [];
+let unknownMethodResponses: Record<string, unknown>[] = [];
+let unsupportedLanguageResponses: Record<string, unknown>[] = [];
+let zodResponses2: Record<string, unknown>[] = [];   // second run for determinism
+
+// Per-suite vitest timeout. Each individual test just reads cached data.
+const SUITE_TIMEOUT_MS = 60_000;
+
+describe("daemon protocol conformance (provekit-lsp-ts)", () => {
+  beforeAll(() => {
+    zodResponses = runLsp(buildSession(ZOD_FIXTURE_SOURCE, ZOD_FIXTURE_PATH));
+    emptyResponses = runLsp(buildSession("// no contracts here\n", "empty.ts"));
+    zodResponses2 = runLsp(buildSession(ZOD_FIXTURE_SOURCE, ZOD_FIXTURE_PATH));
+
+    const unknownMsgs = [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      { jsonrpc: "2.0", id: 2, method: "frobnicate", params: {} },
+      { jsonrpc: "2.0", id: 3, method: "shutdown" },
+    ];
+    unknownMethodResponses = runLsp(unknownMsgs.map((m) => JSON.stringify(m)).join("\n") + "\n");
+
+    const unsupportedMsgs = [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "parse",
+        params: { path: "f.rs", source: "fn foo() {}", language: "rust" },
+      },
+      { jsonrpc: "2.0", id: 3, method: "shutdown" },
+    ];
+    unsupportedLanguageResponses = runLsp(
+      unsupportedMsgs.map((m) => JSON.stringify(m)).join("\n") + "\n",
+    );
+  }, SUITE_TIMEOUT_MS);
+
+  it("initialize: name == provekit-lsp-ts and capabilities includes parse", () => {
+    const initResp = zodResponses.find((r) => r.id === 1);
+    expect(initResp).toBeDefined();
+    const result = initResp!.result as Record<string, unknown>;
+    expect(result.name).toBe("provekit-lsp-ts");
+    expect(Array.isArray(result.capabilities)).toBe(true);
+    expect(result.capabilities).toContain("parse");
+  });
+
+  it("parse: declarations is a JSON array (not a string)", () => {
+    const parseResp = zodResponses.find((r) => r.id === 2);
+    expect(parseResp).toBeDefined();
+    expect(parseResp!.error).toBeUndefined();
+    const result = parseResp!.result as Record<string, unknown>;
+    expect(Array.isArray(result.declarations)).toBe(true);
+  });
+
+  it("parse: callEdges is a JSON array", () => {
+    const parseResp = zodResponses.find((r) => r.id === 2);
+    const result = parseResp!.result as Record<string, unknown>;
+    expect(Array.isArray(result.callEdges)).toBe(true);
+  });
+
+  it("parse: zod fixture produces at least one declaration with kind == contract", () => {
+    const parseResp = zodResponses.find((r) => r.id === 2);
+    const result = parseResp!.result as Record<string, unknown>;
+    const decls = result.declarations as Record<string, unknown>[];
+    expect(decls.length).toBeGreaterThanOrEqual(1);
+    for (const d of decls) {
+      expect(typeof d).toBe("object");
+      expect(d.kind).toBe("contract");
+      expect(typeof d.name).toBe("string");
+      expect((d.name as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("parse: empty source returns declarations == [] and callEdges == []", () => {
+    const parseResp = emptyResponses.find((r) => r.id === 2);
+    const result = parseResp!.result as Record<string, unknown>;
+    expect(result.declarations).toEqual([]);
+    expect(result.callEdges).toEqual([]);
+  });
+
+  it("byte-determinism: two runs on the same input produce identical parse output", () => {
+    const parse1 = zodResponses.find((r) => r.id === 2);
+    const parse2 = zodResponses2.find((r) => r.id === 2);
+    const sortedKeys1 = Object.keys(parse1!).sort();
+    const sortedKeys2 = Object.keys(parse2!).sort();
+    expect(JSON.stringify(parse1, sortedKeys1)).toBe(JSON.stringify(parse2, sortedKeys2));
+  });
+
+  it("unknown method returns error with code -32601", () => {
+    const errResp = unknownMethodResponses.find((r) => r.id === 2);
+    expect(errResp).toBeDefined();
+    expect(errResp!.error).toBeDefined();
+    const err = errResp!.error as Record<string, unknown>;
+    expect(err.code).toBe(-32601);
+  });
+
+  it("parse: unsupported language returns error with code -32602", () => {
+    const parseResp = unsupportedLanguageResponses.find((r) => r.id === 2);
+    expect(parseResp!.error).toBeDefined();
+    const err = parseResp!.error as Record<string, unknown>;
+    expect(err.code).toBe(-32602);
+  });
+});

--- a/implementations/typescript/src/lsp/daemon.ts
+++ b/implementations/typescript/src/lsp/daemon.ts
@@ -1,0 +1,230 @@
+/**
+ * provekit-lsp-ts — NDJSON LSP plugin for TypeScript.
+ *
+ * Protocol (NDJSON over stdin/stdout):
+ *
+ *   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+ *   {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
+ *   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
+ *
+ * Implements the ProvekIt parse-protocol wire shape so the linkerd's
+ * multi-kit dispatch can use it via `spawn_kit_lifter`.
+ *
+ * Wire shape for parse response:
+ *   result.declarations — JSON array of IR contract objects:
+ *     { kind: "contract", name, outBinding, pre?, post?, inv? }
+ *   result.callEdges — JSON array (empty; TS lifter does not emit call edges)
+ *   result.warnings — JSON array of warning strings
+ *
+ * Mirrors implementations/go/cmd/provekit-lsp-go/main.go and
+ * implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py.
+ *
+ * JCS gotcha: do NOT pass IrFormula objects through JSON.stringify and embed
+ * the resulting string. JSON.parse them first so the response contains a
+ * JSON array, not a JSON-encoded string (the linkerd's extract_array_field
+ * handles the string fallback but the canonical shape is a native array).
+ */
+
+import { createInterface } from "node:readline";
+import ts from "typescript";
+import { liftFile as liftZodFile } from "../lift/adapters/zod.js";
+import { liftFile as liftFastCheckFile } from "../lift/adapters/fast-check.js";
+import { liftFile as liftClassValidatorFile } from "../lift/adapters/class-validator.js";
+import { liftFile as liftVitestTestsFile } from "../lift/adapters/vitest-tests.js";
+import type { ContractDecl } from "../lift/types.js";
+
+// ---------------------------------------------------------------------------
+// Version
+// ---------------------------------------------------------------------------
+
+const VERSION = "0.1.0";
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+interface RpcRequest {
+  jsonrpc: string;
+  id: unknown;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface ParseParams {
+  path: string;
+  source: string;
+  language?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Serialization helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a ContractDecl to the wire-format declaration object.
+ * The linkerd parses `kind == "contract"` with `name`, `outBinding`,
+ * and optional `pre`/`post`/`inv` fields (IrFormula objects).
+ */
+function contractDeclToWire(decl: ContractDecl): Record<string, unknown> {
+  const obj: Record<string, unknown> = {
+    kind: "contract",
+    name: decl.name,
+    outBinding: decl.outBinding,
+  };
+  if (decl.pre !== undefined) obj.pre = decl.pre;
+  if (decl.post !== undefined) obj.post = decl.post;
+  if (decl.inv !== undefined) obj.inv = decl.inv;
+  return obj;
+}
+
+// ---------------------------------------------------------------------------
+// I/O helpers
+// ---------------------------------------------------------------------------
+
+let _sendImpl: (obj: unknown) => void = (obj) => {
+  const line = JSON.stringify(obj);
+  process.stdout.write(line + "\n");
+};
+
+/** Override in tests to capture output without writing to process.stdout. */
+export function _setSendImpl(fn: (obj: unknown) => void): void {
+  _sendImpl = fn;
+}
+
+function send(obj: unknown): void {
+  _sendImpl(obj);
+}
+
+function respond(id: unknown, result: unknown): void {
+  send({ jsonrpc: "2.0", id, result });
+}
+
+function respondError(id: unknown, code: number, message: string): void {
+  send({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleInitialize(id: unknown): void {
+  respond(id, {
+    name: "provekit-lsp-ts",
+    version: VERSION,
+    capabilities: ["parse"],
+  });
+}
+
+function handleParse(id: unknown, params: Record<string, unknown>): void {
+  const p = params as ParseParams;
+  const path = p.path ?? "";
+  const source = p.source ?? "";
+  const language = p.language ?? "typescript";
+
+  if (language !== "typescript" && language !== "ts") {
+    respondError(id, -32602, `language '${language}' not supported by this plugin`);
+    return;
+  }
+
+  try {
+    const sf = ts.createSourceFile(path, source, ts.ScriptTarget.ES2022, true);
+
+    const decls: ContractDecl[] = [];
+    const warnings: string[] = [];
+
+    const z = liftZodFile(sf, path);
+    decls.push(...z.decls);
+    for (const w of z.warnings) warnings.push(`zod: ${w.itemName}: ${w.reason}`);
+
+    const f = liftFastCheckFile(sf, path);
+    decls.push(...f.decls);
+    for (const w of f.warnings) warnings.push(`fast-check: ${w.itemName}: ${w.reason}`);
+
+    const cv = liftClassValidatorFile(sf, path);
+    decls.push(...cv.decls);
+    for (const w of cv.warnings) warnings.push(`class-validator: ${w.itemName}: ${w.reason}`);
+
+    const vt = liftVitestTestsFile(sf, path);
+    decls.push(...vt.decls);
+    for (const w of vt.warnings) warnings.push(`vitest-tests: ${w.itemName}: ${w.reason}`);
+
+    // Convert ContractDecl[] to wire-format array.
+    // IrFormula values are plain objects — JSON.parse(JSON.stringify(x)) is
+    // equivalent to a deep clone; we skip it and embed directly since the
+    // values are already plain JSON-serializable objects. The `send()` call
+    // will serialize via JSON.stringify.
+    const declarations = decls.map(contractDeclToWire);
+
+    // TS lifter does not emit call edges. The linkerd treats absent/empty
+    // callEdges as an empty list (same as the zig lifter).
+    const callEdges: unknown[] = [];
+
+    respond(id, { declarations, callEdges, warnings });
+  } catch (err) {
+    respondError(id, -32603, (err as Error).message);
+  }
+}
+
+function handleShutdown(id: unknown): void {
+  respond(id, null);
+}
+
+// ---------------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a single NDJSON request line.
+ * Returns `true` to continue, `false` to stop (shutdown received).
+ */
+export function handleRequest(line: string): boolean {
+  let req: RpcRequest;
+  try {
+    req = JSON.parse(line) as RpcRequest;
+  } catch {
+    // Malformed JSON — skip.
+    return true;
+  }
+
+  const { id, method, params } = req;
+
+  switch (method) {
+    case "initialize":
+      handleInitialize(id);
+      return true;
+
+    case "parse":
+      handleParse(id, (params ?? {}) as Record<string, unknown>);
+      return true;
+
+    case "shutdown":
+      handleShutdown(id);
+      return false;
+
+    default:
+      respondError(id, -32601, `method '${method}' not found`);
+      return true;
+  }
+}
+
+/**
+ * Run the LSP daemon main loop (NDJSON over stdio).
+ * Reads one JSON line per request; writes one JSON line per response.
+ */
+export function main(): void {
+  const rl = createInterface({ input: process.stdin, terminal: false });
+  let active = true;
+
+  rl.on("line", (line: string) => {
+    if (!active) return;
+    const cont = handleRequest(line.trim());
+    if (!cont) {
+      active = false;
+      rl.close();
+    }
+  });
+
+  rl.on("close", () => {
+    // stdin closed (pipe closed after shutdown or EOF).
+  });
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "bin": {
     "provekit": "bin/provekit.cjs",
     "proveit": "bin/provekit.cjs",
-    "provekit-lift": "bin/provekit-lift.cjs"
+    "provekit-lift": "bin/provekit-lift.cjs",
+    "provekit-lsp-ts": "bin/provekit-lsp-ts.cjs"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Re-opening with correct head branch (PR #170 was mislabeled — its head ended up on \`feat/conformance-gate-prove\`).

## Summary

Cherry-picks commit \`ff6afee\` (originally on agent worktree \`worktree-agent-a4236f5f161f14de8\`) onto \`fix/ts-lsp-launcher\`. The commit was never properly merged from the agent worktree, so PR #163's wave was missing the TS LSP daemon implementation.

## What's in the diff

- \`bin/provekit-lsp-ts.cjs\` — tsx-driven launcher, executable, shebang \`#!/usr/bin/env node\`
- \`implementations/typescript/src/lsp/daemon.ts\` — NDJSON RPC loop
- \`implementations/typescript/src/lsp/daemon-entry.ts\` — entry shim
- \`implementations/typescript/src/lsp/daemon.test.ts\` — 8 protocol-conformance tests
- \`package.json\` — \`bin\` entry registration

## Test plan

- [x] All 775 TS tests pass; 8 daemon protocol conformance tests pass
- [x] Cherry-picked cleanly (zero conflicts)
- [ ] linkerd \`test5_typescript_kit_dispatch\` exercises the dispatch (requires \`provekit-lsp-ts\` on PATH; CI setup work)

Closes #167.