### PR TITLE
fix(test): serialize mint_kit_integration to eliminate attestation-file race (closes #186)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -741,6 +741,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1292,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1579,7 @@ dependencies = [
  "provekit-verifier",
  "serde",
  "serde_json",
+ "serial_test",
  "thiserror",
  "walkdir",
 ]
@@ -2069,10 +2091,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -2162,6 +2199,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/implementations/rust/provekit-cli/Cargo.toml
+++ b/implementations/rust/provekit-cli/Cargo.toml
@@ -33,3 +33,4 @@ base64 = { workspace = true }
 
 [dev-dependencies]
 provekit-linker = { path = "../provekit-linker" }
+serial_test = "3"

--- a/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
+++ b/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
@@ -22,6 +22,7 @@
 // All 11 kits are tested. Kits without lifter binaries are expected to
 // produce the EMPTY_SET_CID; this is explicitly asserted, not an error.
 
+use serial_test::serial;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -164,6 +165,7 @@ const KITS_WITH_REAL_CONTRACTS: &[&str] = &["rust", "go", "cpp"];
 const GO_CONTRACT_SET_CID: &str = "blake3-512:e23649f383162398556a508c2e69e035d6d231bfaf6e8926ced547fb19ddd9c65779f39fe31d85519c957bc40afa432c9be468eadfa5aac77f74f5de8c56324c";
 
 #[test]
+#[serial(mint_kit_files)]
 fn all_kits_mint_produces_valid_attestation_structure() {
     let all_kits: Vec<&str> = KITS_WITH_LIFTERS
         .iter()
@@ -221,6 +223,7 @@ fn all_kits_mint_produces_valid_attestation_structure() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial(mint_kit_files)]
 fn kits_without_lifters_produce_empty_set_cid() {
     let root = repo_root();
     for kit in KITS_WITHOUT_LIFTERS {
@@ -248,6 +251,7 @@ fn kits_without_lifters_produce_empty_set_cid() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial(mint_kit_files)]
 fn kits_with_real_contracts_produce_nonempty_contract_set() {
     let root = repo_root();
     for kit in KITS_WITH_REAL_CONTRACTS {
@@ -281,6 +285,7 @@ fn kits_with_real_contracts_produce_nonempty_contract_set() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial(mint_kit_files)]
 fn rust_kit_mint_is_byte_deterministic() {
     let root = repo_root();
 
@@ -313,6 +318,7 @@ fn rust_kit_mint_is_byte_deterministic() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial(mint_kit_files)]
 fn kit_shortcut_and_project_flag_are_equivalent() {
     let bin = provekit_bin();
     let root = repo_root();
@@ -375,6 +381,7 @@ fn kit_shortcut_and_project_flag_are_equivalent() {
 /// routing regression has been reintroduced. If it fails with an unknown CID,
 /// the go slab contracts have changed -- update GO_CONTRACT_SET_CID accordingly.
 #[test]
+#[serial(mint_kit_files)]
 fn go_kit_pins_expected_contract_set_cid() {
     let root = repo_root();
 
@@ -423,6 +430,7 @@ const RUST_KIT_CANONICAL_CONTRACT_SET_CID: &str =
     "blake3-512:8f4bcc3c3e748ae303f8c8da80245f291e803eb2d241224c75c7ac470631e4dee7ff2e0ff59af571db3d506485c115acaddfd91e4e4315eb04ee37c035ddbc69";
 
 #[test]
+#[serial(mint_kit_files)]
 fn rust_kit_contract_set_cid_is_pinned_to_self_contracts_canonical() {
     let root = repo_root();
 


### PR DESCRIPTION
## Summary

- Multiple integration tests in `mint_kit_integration.rs` invoked `provekit mint --kit=<lang>` concurrently, racing on the shared `.provekit/self-contracts-attestations/<lang>.json` write target
- Fix uses Option A from issue #186: add `serial_test = "3"` dev-dependency and decorate all 7 tests with `#[serial(mint_kit_files)]`
- Named lock serializes only tests within this file; tests in other files still parallelize

## Changes

- `implementations/rust/provekit-cli/Cargo.toml`: add `serial_test = "3"` to `[dev-dependencies]`
- `implementations/rust/provekit-cli/tests/mint_kit_integration.rs`: add `use serial_test::serial;` import and `#[serial(mint_kit_files)]` attribute to all 7 tests

## Test plan

- [ ] `cargo check -p provekit-cli --tests` passes cleanly (verified locally)
- [ ] All 7 tests pass: `kits_without_lifters_produce_empty_set_cid`, `kits_with_real_contracts_produce_nonempty_contract_set`, `rust_kit_mint_is_byte_deterministic`, `kit_shortcut_and_project_flag_are_equivalent`, `all_kits_mint_produces_valid_attestation_structure`, `go_kit_pins_expected_contract_set_cid`, `rust_kit_contract_set_cid_is_pinned_to_self_contracts_canonical`
- [ ] `cargo test -p provekit-cli --test mint_kit_integration` should be stable across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)