### PR TITLE
fix(makefile): bump CATALOG_CID to v1.4.1 dc2f42ff (closes #181)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@
 # `make help` echoes it. Follow-up: retire it the same way the
 # self-contracts CIDs are retired (read from the embedded catalog
 # signature attestation).
-CATALOG_CID := blake3-512:9cb8600c84f682502f3b7e9a9f23b8138988bd1ffbcdcf3cd4e4b1d9ab386d3bb5076cd4dda8330edc24b43e62041a2da5153801001ed700d0be727073ceda67
+CATALOG_CID := blake3-512:dc2f42ff8a4a66289cc19bfbd628898b8bd8e61d2148ecf609324cc2421c5c440a6c0e70e20ffbecabeb78e0253101d72823b7e3ab120a4d56cb67c8e31dc641
 
 PROVEKIT := implementations/rust/target/release/provekit
 VERIFY_SELF_CONTRACTS := tools/foundation-keygen/target/release/verify-self-contracts


### PR DESCRIPTION
## Summary

- PR #178 set `CATALOG_CID` in the Makefile to an interim/stale value `9cb8600c...`. PR #179 (merged to `main` as `0559ed7`) revealed the authoritative v1.4.1 catalog CID is `dc2f42ff8a4a66289cc19bfbd628898b8bd8e61d2148ecf609324cc2421c5c440a6c0e70e20ffbecabeb78e0253101d72823b7e3ab120a4d56cb67c8e31dc641`.
- This PR bumps the Makefile pin to match the on-disk catalog (`protocol/specs/2026-04-30-protocol-catalog.json`) so `make help` echoes the correct CID, satisfying the issue's first acceptance criterion.

## Files changed

- `Makefile` line 56: `CATALOG_CID` updated from `9cb8600c...` to `dc2f42ff...`.

## Verification

- `make help` echoes `catalog: blake3-512:dc2f42ff8a4a66289cc19bfbd628898b8bd8e61d2148ecf609324cc2421c5c440a6c0e70e20ffbecabeb78e0253101d72823b7e3ab120a4d56cb67c8e31dc641`. Acceptance criterion 1 met.
- `make catalog-verify` passes: `cargo run --release --manifest-path tools/recompute-spec-cids/Cargo.toml -- --verify` recomputes `dc2f42ff...` from the on-disk catalog and exits 0. The conformance gate's catalog step is therefore green.
- `make conformance` end-to-end was NOT run to completion in this branch because `build-ts`'s npm postinstall hangs on `npx provekit verify` (a pre-existing, unrelated bug being filed separately). The catalog-verify and protocol-verify steps that precede `build-ts` both pass; only the TypeScript install hook is affected.

## Scope of `CATALOG_CID`

The Makefile `CATALOG_CID` constant is referenced only by the `make help` echo on line 93. The conformance gate's `catalog-verify` target does not consume it; it recomputes the CID from the on-disk catalog via `tools/recompute-spec-cids -- --verify`. So this fix is, mechanically, a stale display string. It is, however, the exact constant the issue's acceptance criteria call out (`make help` should echo `dc2f42ff...`), and a stale CATALOG_CID actively misleads anyone reading the help output.

## Open question: catalog signature file

`.provekit/catalog-signatures/v1.4.1.json` still pins `9cb8600c...` in its `catalogCid` field. That field is inside the JCS-signed payload, so editing it without re-signing under the foundation Ed25519 key would produce an attestation that lies about being signed. I have left it untouched in this PR.

The conformance gate is not affected: the embedded catalog signature in `provekit-cli` (`implementations/rust/provekit-cli/src/protocol.rs`) is still v1.4.0 (`catalog-signature-v1.4.0.json` against `EXPECTED_CATALOG_CID = b0f2030d...`). So `make protocol-verify` runs against the binary's own embedded v1.4.0 pair and is independent of both the Makefile pin and the v1.4.1 signature file.

Re-signing `v1.4.1.json` is a follow-up: per `.provekit/catalog-signatures/` convention, the foundation private key would re-sign the JCS-encoded six-field message with `catalogCid = dc2f42ff...`. That is a key-holder action and should be its own PR with the signing tool's output as the diff. Recommend filing a separate issue tagged `area:conformance` to track.

## Acceptance against #181

- [x] `make help` echoes `dc2f42ff...`
- [~] `make conformance` passes (catalog hash verification): `make catalog-verify` is green; the gate's later `build-ts` step fails for an unrelated postinstall hang. Filing the TS hang separately.
- [x] No lingering `9cb8600c` strings in active config (Makefile fixed; the only other hit is the signature file, which is a load-bearing signed payload and cannot be silently edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)