### PR TITLE
fix(catalog): restamp v1.4.1 CID to authoritative dc2f42ff (closes #181)

### DIFF
--- a/.provekit/catalog-signatures/v1.4.1.json
+++ b/.provekit/catalog-signatures/v1.4.1.json
@@ -2,8 +2,8 @@
   "schemaVersion": "1",
   "protocolName": "provekit-protocol",
   "protocolVersion": "v1.4.1",
-  "catalogCid": "blake3-512:9cb8600c84f682502f3b7e9a9f23b8138988bd1ffbcdcf3cd4e4b1d9ab386d3bb5076cd4dda8330edc24b43e62041a2da5153801001ed700d0be727073ceda67",
+  "catalogCid": "blake3-512:dc2f42ff8a4a66289cc19bfbd628898b8bd8e61d2148ecf609324cc2421c5c440a6c0e70e20ffbecabeb78e0253101d72823b7e3ab120a4d56cb67c8e31dc641",
   "declaredAt": "2026-05-03T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:qF9n8mjJc3yzNCtMa/AvXA4a6rZMFVMgn/S1yALKJqNWM7HG+gBtyP3bxa+y5JHZMGjcjjiVZV2vw/YfHPzjBw=="
+  "signature": "ed25519:jyiloz5cEFT1Ct0H7ELov+KuWUQRs9fo/aeHRRBLFApvPQ0iaVc/mw8xscL5zVphuda0+oQ0/AD7hIGzVfeMBA=="
 }

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@
 # `make help` echoes it. Follow-up: retire it the same way the
 # self-contracts CIDs are retired (read from the embedded catalog
 # signature attestation).
-CATALOG_CID := blake3-512:9cb8600c84f682502f3b7e9a9f23b8138988bd1ffbcdcf3cd4e4b1d9ab386d3bb5076cd4dda8330edc24b43e62041a2da5153801001ed700d0be727073ceda67
+CATALOG_CID := blake3-512:dc2f42ff8a4a66289cc19bfbd628898b8bd8e61d2148ecf609324cc2421c5c440a6c0e70e20ffbecabeb78e0253101d72823b7e3ab120a4d56cb67c8e31dc641
 
 PROVEKIT := implementations/rust/target/release/provekit
 VERIFY_SELF_CONTRACTS := tools/foundation-keygen/target/release/verify-self-contracts


### PR DESCRIPTION
## Summary

- Bumps `CATALOG_CID` in Makefile (line 56) from interim `9cb8600c...073ceda67` to authoritative `dc2f42ff...e31dc641`
- Re-signs `.provekit/catalog-signatures/v1.4.1.json` via `sign-catalog-v1-4-1` binary; both `catalogCid` and `signature` fields updated to match the authoritative CID
- `grep -r '9cb8600c' .` returns zero hits in active config after this patch

## Context

PR #178 pinned the interim v1.4.1 CID (`9cb8600c`). PR #179 (merged as `0559ed7`) revealed the authoritative v1.4.1 CID is `dc2f42ff`. PR #184 already swept `docs/reference/cids.md`; this PR closes the remaining gap in Makefile + catalog-signature.

## Verification

- `sign-catalog-v1-4-1` binary confirmed the catalog CID as `dc2f42ff...` before signing
- Historical signatures (v1.4.0.json and older) are untouched
- No other `9cb8600c` references remain in active config

## Test plan

- [ ] `make help` echoes `dc2f42ff...` catalog CID
- [ ] `make conformance` passes (catalog-verify + protocol-verify + all-mint + test-self-contracts)
- [ ] `grep -r '9cb8600c' .` returns no hits in active config

🤖 Generated with [Claude Code](https://claude.com/claude-code)