### PR TITLE
docs: re-audit per-language-status matrix to v1.4.1 baseline (closes #185)

### DIFF
--- a/docs/reference/per-language-status.md
+++ b/docs/reference/per-language-status.md
@@ -11,23 +11,23 @@ The matrix of what's shipping, what's planned, and what's under evaluation acros
 - **Embedded verifier**: in-process verifier callable from the host language without spawning a subprocess.
 - **CLI**: shipping command-line implementation of `prove`, `verify-protocol`, `lift`, `dump`, etc.
 
-Legend: `+` shipping in v1.1, `~` planned for v1.2, `o` under evaluation, `-` not on roadmap.
+Legend: `+` shipping in v1.4.1 (current), `~` planned for v1.5 (next), `o` under evaluation, `-` not on roadmap.
 
 ## Matrix
 
 | Language    | Kit | Libs | Lift adapters                                           | Decorator macros        | Embedded verifier | CLI                  | LSP Plugin           |
 |-------------|-----|------|---------------------------------------------------------|--------------------------|-------------------|----------------------|----------------------|
-| Rust        | `+` | `+`  | `+ proptest, contracts` ; `~ kani, prusti` ; `o creusot, flux`     | `+ provekit-macros`      | `+`               | `+ provekit (canonical)` | `+`                  |
-| TypeScript  | `+` | `+`  | `+ zod, class-validator, fast-check` ; `~ io-ts, valibot, ajv`     | `~`                      | `+`               | `~ (use Rust CLI)`   | `~`                  |
-| Go          | `+` | `+`  | `~ go-playground/validator` ; `~ ozzo-validation`       | `~`                      | `+`               | `~ (use Rust CLI)`   | `~`                  |
-| C++         | `+` | `+`  | `~ [[expects:]]/[[ensures:]] (C++26)` ; `o assert.h`    | `~ (C++26 contracts)`    | `+`               | `~ (use Rust CLI)`   | `~`                  |
-| C           | `+` | `~`  | `~`                                                     | `~`                      | `~`               | `~ (use Rust CLI)`   | `~`                  |
-| Zig         | `+` | `~`  | `~`                                                     | `~`                      | `+`               | `~ (use Rust CLI)`   | `+`                  |
+| Rust        | `+` | `+`  | `+ proptest, contracts, kani, prusti` ; `o creusot, flux`          | `+ provekit-macros`      | `+`               | `+ provekit (canonical)` | `+`                  |
+| TypeScript  | `+` | `+`  | `+ zod, class-validator, fast-check` ; `~ io-ts, valibot, ajv`     | `~`                      | `+`               | `~ (use Rust CLI)`   | `+`                  |
+| Go          | `+` | `+`  | `+ go-playground/validator` ; `~ ozzo-validation`       | `~`                      | `+`               | `~ (use Rust CLI)`   | `+`                  |
+| C++         | `+` | `+`  | `+ [[expects:]]/[[ensures:]] (C++26)` ; `o assert.h`    | `~ (C++26 contracts)`    | `+`               | `~ (use Rust CLI)`   | `+`                  |
+| C           | `+` | `~`  | `~`                                                     | `~`                      | `~`               | `~ (use Rust CLI)`   | `+`                  |
+| Zig         | `+` | `~`  | `+ provekit-lift-zig (comment annotations)`             | `~`                      | `+`               | `~ (use Rust CLI)`   | `+`                  |
 | Python      | `+` | `+`  | `+ pydantic` ; `~ deal, hypothesis` ; `~ icontract, attrs`   | `+`                      | `+`               | `~ (use Rust CLI)`   | `+`                  |
-| Java / JVM  | `+` | `~`  | `+ Bean Validation, JML, Spring Web, Cofoja`            | `~`                      | `~`               | `~ (use Rust CLI)`   | `~`                  |
+| Java / JVM  | `+` | `+`  | `+ Bean Validation, JML, Spring Web, Cofoja`            | `~`                      | `~`               | `~ (use Rust CLI)`   | `~`                  |
 | Ruby        | `+` | `~`  | `+ active_model, dry-validation, rspec`                 | `-`                      | `~`               | `~ (use Rust CLI)`   | `+`                  |
-| C#          | `+` | `+`  | `+ DataAnnotations, Linq`                               | `+ .NET attrs`           | `~`               | `~ (use Rust CLI)`   | `+`                  |
-| Swift       | `+` | `~`  | `~`                                                     | `-`                      | `~`               | `~ (use Rust CLI)`   | `~`                  |
+| C#          | `+` | `+`  | `+ DataAnnotations, Linq`                               | `+ .NET attrs`           | `+`               | `~ (use Rust CLI)`   | `+`                  |
+| Swift       | `+` | `~`  | `~`                                                     | `-`                      | `~`               | `~ (use Rust CLI)`   | `+`                  |
 
 ## Cross-kit bridge readiness
 
@@ -71,7 +71,7 @@ Column meanings:
 - `provekit-lift-proptest`: walks `proptest!` blocks. Coverage: `prop_assume!`, `prop_assert!`, `prop_assert_eq!`, `prop_assert_ne!`.
 - `provekit-lift-contracts`: walks `#[requires(...)]`, `#[ensures(...)]`, `#[invariant(...)]` macros from the `contracts` crate.
 
-**Lift adapters (planned for v1.2):**
+**Lift adapters (shipping in v1.4.1):**
 - `provekit-lift-kani`: walks `#[kani::proof]` functions, `kani::assume`, `kani::assert`.
 - `provekit-lift-prusti`: walks `#[prusti_contracts::requires/ensures]`.
 
@@ -81,7 +81,7 @@ Column meanings:
 
 **Decorator macros:** `provekit-macros` ships `#[provekit::contract]` and `#[provekit::verify]` for direct authoring when no lift target exists. The `provekit-macros-rt` crate carries the runtime support.
 
-**Build-script integration (planned for v1.2):** `provekit-build` lifts contract violations into compile-time errors via `build.rs`. Currently in flight; see `implementations/rust/provekit-build/` and `examples/build_script_demo/`.
+**Build-script integration (planned for v1.5):** `provekit-build` lifts contract violations into compile-time errors via `build.rs`. Currently in flight; see `implementations/rust/provekit-build/` and `examples/build_script_demo/`.
 
 **Embedded verifier:** Yes. `provekit_verifier::run(project_root)` returns a `HandshakeReport` synchronously.
 
@@ -93,20 +93,22 @@ Column meanings:
 
 **Libs:** `ts-types-proof` lifts TypeScript type annotations into contract mementos. Embedded verifier shipping; usable from Node and from browsers (with the WASM build of the canonicalizer).
 
-**Lift adapters (shipping in v1.1):**
+**Lift adapters (shipping in v1.4.1):**
 - `provekit-lift-zod`: walks `z.object`, `z.string`, `z.number`, validator combinators. Full chain decoder for all major zod methods.
 - `provekit-lift-class-validator`: walks decorator-annotated class fields (`@IsNotEmpty`, `@MinLength`, `@Min`, `@Max`, `@IsEmail`, etc.).
 - `provekit-lift-fast-check`: walks `fc.assert(fc.property(...))` blocks. Lifts property tests to `forall` contracts.
 
-**Lift adapters (also planned):**
+**Lift adapters (planned for v1.5):**
 - `io-ts`, `runtypes`, `valibot`: validator-style schema libraries; lift logic is uniform across the family.
 - `ajv` schemas: JSON Schema Draft 7+ to canonical IR.
 
-**Decorator macros (planned):** A `@provekit.contract(...)` decorator for direct authoring when no lift target exists.
+**Decorator macros (planned for v1.5):** A `@provekit.contract(...)` decorator for direct authoring when no lift target exists.
 
 **Embedded verifier:** Yes. Available from Node directly; browser builds use the WASM canonicalizer plus a remote prover for Tier 3 fallback.
 
-**CLI:** Deferred to v1.2. Use the Rust CLI (`provekit prove`) for verification; the TypeScript libs handle authoring and lifting.
+**CLI:** Deferred to v1.5. Use the Rust CLI (`provekit prove`) for verification; the TypeScript libs handle authoring and lifting.
+
+**LSP Plugin:** Yes. `provekit-lsp` implements the ProvekIt NDJSON LSP plugin protocol (daemon mode over stdio) with `initialize`, `parse`, and `shutdown`.
 
 ## Go
 
@@ -114,15 +116,19 @@ Column meanings:
 
 **Libs:** Shipping. Embedded verifier callable from Go programs via a small CGO bridge to the canonicalizer; pure-Go verifier in flight.
 
-**Lift adapters (planned for v1.2):**
+**Lift adapters (shipping in v1.4.1):**
 - `provekit-lift-validator`: walks `validate:` struct tags from `go-playground/validator`.
+
+**Lift adapters (planned for v1.5):**
 - `provekit-lift-ozzo`: walks `ozzo-validation` rule chains.
 
 **Decorator macros:** Go has no decorator syntax. Comment-block annotations (`//provekit:contract`) under evaluation.
 
-**Embedded verifier:** Yes. CGO bridge to the Rust canonicalizer for v1.1; pure-Go canonicalizer planned for v1.2.
+**Embedded verifier:** Yes. CGO bridge to the Rust canonicalizer; pure-Go canonicalizer planned for v1.5.
 
 **CLI:** Deferred. Use the Rust CLI.
+
+**LSP Plugin:** Yes. `provekit-lsp-go` implements the ProvekIt NDJSON LSP plugin protocol with `initialize`, `parse`, and `shutdown`. Scans Go source for `//provekit:` annotations.
 
 ## C++
 
@@ -130,11 +136,11 @@ Column meanings:
 
 **Libs:** Shipping. Embedded verifier links into existing C++ projects.
 
-**Lift adapters (planned for v1.2):**
+**Lift adapters (shipping in v1.4.1):**
 - `provekit-lift-cpp-contracts`: walks `[[expects:]]` and `[[ensures:]]` attributes (C++26 contract syntax).
-- `provekit-lift-assert-h`: walks `assert(...)` macros under evaluation; coverage is partial because `assert.h` discards conditional information at compile time.
 
 **Lift adapters (under evaluation):**
+- `provekit-lift-assert-h`: walks `assert(...)` macros; coverage is partial because `assert.h` discards conditional information at compile time.
 - Boost.Hana metaprograms expressing type-level contracts.
 - Boost.Contract pre/post/invariant annotations.
 
@@ -144,17 +150,19 @@ Column meanings:
 
 **CLI:** Deferred. Use the Rust CLI.
 
+**LSP Plugin:** Yes. `provekit-lsp-cpp` implements the ProvekIt NDJSON LSP plugin protocol with `initialize`, `parse`, and `shutdown`.
+
 ## Python
 
 **Kit:** Shipping in v1.1. `implementations/python/provekit-lift-py-tests` provides the IR library, canonicalizer (JCS + BLAKE3-512), Layer 2 lift adapter, decorator macros, Pydantic lift adapter, and embedded verifier.
 
-**Libs:** Shipping. The canonicalizer is implemented in pure Python and is byte-identical to the Rust canonicalizer for all conformance tests. Performance is acceptable for typical project sizes; the WASM-backed path remains an option for v1.2 if profiling demands it.
+**Libs:** Shipping. The canonicalizer is implemented in pure Python and is byte-identical to the Rust canonicalizer for all conformance tests. Performance is acceptable for typical project sizes; the WASM-backed path remains an option for v1.5 if profiling demands it.
 
-**Lift adapters (shipping in v1.1):**
+**Lift adapters (shipping in v1.4.1):**
 - `provekit.lift.pydantic`: walks `BaseModel` field annotations and `Field` constraints. Emits the same IR as Bean Validation `@Min`/`@Max`/`@Pattern`/`@Size` for equivalent constraints.
 - Layer 2 structural lift: walks pytest/unittest test files and recognizes bounded loops, helper inlining, multi-assertion characterization, and `@pytest.mark.parametrize`.
 
-**Lift adapters (planned for v1.2):**
+**Lift adapters (planned for v1.5):**
 - `provekit-lift-deal`: walks `@deal.pre`, `@deal.post`, `@deal.raises`.
 - `provekit-lift-hypothesis`: walks `@given(...)` test functions; shape similar to proptest.
 - `icontract`, `attrs`, `dataclasses-json` schemas.
@@ -171,7 +179,7 @@ Column meanings:
 
 **Kit:** Shipping in v1.1. Multi-module Maven project with SLF4J-style architecture: `provekit-lift-java-core` (facade) + per-annotation binding JARs, discovered via `java.util.ServiceLoader`.
 
-**Libs:** Planned for v1.2.
+**Libs:** Shipping. `provekit-ir` provides IR types (`Formula`, `Term`, `Sort`, `Declaration`, `IrDocument`, `CallEdgeDecl`).
 
 **Lift adapters (shipping in v1.1):**
 - `provekit-lift-java-bean-validation`: walks `@NotNull`, `@Email`, `@Min`, `@Max`, `@Pattern`, `@Size`, `@Positive`, `@Negative`, `@AssertTrue`, `@AssertFalse`, `@DecimalMin`, `@DecimalMax`, `@Digits`, `@Future`, `@Past`.
@@ -184,27 +192,27 @@ Column meanings:
 
 **Decorator macros:** JVM annotations are the natural authoring surface.
 
-**Embedded verifier:** Planned for v1.2.
+**Embedded verifier:** Planned for v1.5.
 
 **CLI:** Deferred. Use the Rust CLI.
 
-**LSP Plugin:** Planned.
+**LSP Plugin:** Planned for v1.5.
 
 ## C
 
-**Kit:** Shipping in v1.1. `implementations/c/provekit-ir` provides the IR library, JCS canonical JSON emitter, and BLAKE3-512 hash wrapper.
+**Kit:** Shipping. `implementations/c/provekit-ir` provides the IR library, JCS canonical JSON emitter, and BLAKE3-512 hash wrapper.
 
-**Libs:** Under evaluation. Native C BLAKE3 binding planned for v1.2; v1.1 delegates hashing to the Python `blake3` module via subprocess.
+**Libs:** Under evaluation. Native C BLAKE3 binding planned for v1.5; current implementation delegates hashing to the Python `blake3` module via subprocess.
 
-**Lift adapters:** Planned for v1.2. `assert.h` macro walking under evaluation.
+**Lift adapters:** Planned for v1.5. `assert.h` macro walking under evaluation.
 
 **Decorator macros:** Under evaluation.
 
-**Embedded verifier:** Planned for v1.2.
+**Embedded verifier:** Planned for v1.5.
 
 **CLI:** Deferred. Use the Rust CLI.
 
-**LSP Plugin:** Planned.
+**LSP Plugin:** Yes. `provekit-lsp-c` implements the ProvekIt NDJSON LSP plugin protocol (provekit-lsp-plugin/1 over stdio) with `initialize`, `parse`, and `shutdown`.
 
 ## Zig
 
@@ -255,7 +263,7 @@ Column meanings:
 
 **Decorator macros:** .NET attributes are the natural authoring surface. Lift adapters consume them directly.
 
-**Embedded verifier:** Planned.
+**Embedded verifier:** Yes. `Provekit.Verifier` (in-process verifier) ships as part of the .NET 10 solution.
 
 **CLI:** Deferred. Use the Rust CLI.
 
@@ -273,11 +281,11 @@ Column meanings:
 
 **Decorator macros:** Swift property wrappers + macros (Swift 5.9+) under evaluation as the authoring surface.
 
-**Embedded verifier:** Planned.
+**Embedded verifier:** Planned for v1.5.
 
 **CLI:** Deferred. Use the Rust CLI.
 
-**LSP Plugin:** Planned.
+**LSP Plugin:** Yes. `ProveKitLSPSwift` implements the ProvekIt NDJSON LSP plugin protocol (parse-protocol v1) with `initialize`, `parse`, and `shutdown`.
 
 **Bridge IR:** v1.1.0 9-field shape supported (`Declaration.bridge` enum case round-trips byte-identical to the bridge_decl fixture, per PR #76). Under v1.4's bridge target dimensionality spec the kit's bridge emission needs to migrate to the layered shape with a tagged-union `target` field; that migration is pending alongside the rest of the kits. Self-contracts package and Phase 2 lift-plugin-protocol bridges deferred until the kit accumulates a runtime surface beyond conformance.
 


### PR DESCRIPTION
## Summary

- Legend updated: `+` shipping in v1.4.1 (current), `~` planned for v1.5 (next). The `o` (under evaluation) symbol is retained.
- 10 matrix cells bumped from `~` to `+` based on direct repo inspection of `implementations/<kit>/`.
- Prose section headings (\"planned for v1.2\", \"shipping in v1.1\") updated to match for newly-shipped features.
- Cross-kit bridge readiness sub-matrix (lines 43-62) intentionally untouched -- it tracks live v1.4 migration state, not stale v1.1/v1.2 labels.

## Cells changed

| Kit | Column | Before | After | Evidence |
|-----|--------|--------|-------|----------|
| Rust | Lift adapters | `~ kani, prusti` | `+` | `provekit-lift-kani/src/lib.rs` + `tests/integration.rs` + `tests/fixtures/`; `provekit-lift-prusti/src/lib.rs` (2 exported fns) |
| TypeScript | LSP Plugin | `~` | `+` | `src/lsp/` speaks canonical NDJSON wire shape (initialize/parse/shutdown) |
| Go | Lift adapters | `~ go-playground/validator` | `+` | `provekit-lift-go-validator/validator.go` (16 exported funcs + tests) |
| Go | LSP Plugin | `~` | `+` | `cmd/provekit-lsp-go/main.go` speaks canonical NDJSON wire shape |
| C++ | Lift adapters | `~ [[expects:]]/[[ensures:]]` | `+` | `provekit-lift-cpp/main.cpp` ships C++26 contract walker |
| C++ | LSP Plugin | `~` | `+` | `provekit-lsp-cpp/main.cpp` speaks canonical NDJSON wire shape |
| C | LSP Plugin | `~` | `+` | `provekit-lsp-c/main.c` speaks NDJSON/provekit-lsp-plugin/1 wire shape |
| Zig | Lift adapters | `~` | `+` | `provekit-lift-zig/` ships comment-annotation scanner (//provekit:contract etc.) |
| Java / JVM | Libs | `~` | `+` | `provekit-ir/src/main/java/com/provekit/ir/` ships IR types (Formula, Term, Sort, Declaration, IrDocument, CallEdgeDecl) |
| C# | Embedded verifier | `~` | `+` | `Provekit.Verifier/MementoPool.cs` ships `VerifyByHash` + `VerifyImplication` |
| Swift | LSP Plugin | `~` | `+` | `Sources/ProveKitLSPSwift/main.swift` speaks parse-protocol v1 (initialize/parse/shutdown) |

**Total: 10 cells bumped `~` → `+`. 0 cells set to `-`. 0 cells `+` → `~`.**

## Flagged / unverified

- **Java LSP Plugin**: No `provekit-lsp-java` or equivalent directory found in `implementations/java/`. Cell left as `~`. If a Java LSP plugin exists elsewhere, update this cell and the prose.
- **Go ozzo-validation**: No `provekit-lift-ozzo` directory found. Left as `~` (still planned, not shipped).
- **TypeScript decorator macros** (`@provekit.contract`): No `decorator.ts` found in `src/`. Left as `~`.
- **Rust build-script integration** (`provekit-build`): Directory exists but the matrix does not have a dedicated cell for this. Noted in prose only.

## Test plan

- [ ] Verify `implementations/rust/provekit-lift-kani/tests/integration.rs` passes (`cargo test` in that crate)
- [ ] Verify Go LSP wire shape: `echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | go run ./cmd/provekit-lsp-go` from `implementations/go/`
- [ ] Confirm Java LSP absence (or correct the cell if one ships before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)