### PR TITLE
fix: [URGENT] unhang provekit verify (#198)

### DIFF
--- a/implementations/rust/provekit-verifier/src/solvers/registry.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/registry.rs
@@ -81,6 +81,12 @@ fn build_one(name: &str, sc: &SolverConfig) -> SolverHandle {
 /// Convenience: build a registry with a single Z3 SubprocessSolver
 /// at the given binary path. Used by the legacy `RunnerConfig.z3_path`
 /// fallback when no `.provekit/config.toml` is present.
+///
+/// A 30-second per-invocation timeout is applied as defense-in-depth.
+/// Without a timeout, a Z3 invocation that reads from stdin without
+/// receiving EOF (e.g. when inherited in a subprocess chain) can block
+/// indefinitely.  30 s is a conservative upper bound for any SMT-LIB
+/// obligation that would arise from a ProvekIt proof graph.
 pub fn build_default_z3(z3_path: &str) -> HashMap<String, SolverHandle> {
     let mut out: HashMap<String, SolverHandle> = HashMap::new();
     out.insert(
@@ -91,7 +97,7 @@ pub fn build_default_z3(z3_path: &str) -> HashMap<String, SolverHandle> {
             "4.x",
             "smt-lib-v2.6",
             vec!["-smt2".into(), "-in".into()],
-            None,
+            Some(Duration::from_secs(30)),
         )) as SolverHandle,
     );
     out

--- a/implementations/rust/provekit-verifier/src/solvers/subprocess.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/subprocess.rs
@@ -66,8 +66,20 @@ impl Solver for SubprocessSolver {
         cmd.stderr(Stdio::piped());
 
         let mut child = match cmd.spawn() {
-            Ok(c) => c,
+            Ok(c) => {
+                eprintln!(
+                    "[provekit-verifier] spawned solver {:?} (binary={:?}) pid={}",
+                    self.name,
+                    self.binary,
+                    c.id()
+                );
+                c
+            }
             Err(e) => {
+                eprintln!(
+                    "[provekit-verifier] failed to spawn solver {:?} (binary={:?}): {e}",
+                    self.name, self.binary
+                );
                 return SolveResult {
                     verdict: ObligationVerdict::Undecidable,
                     solver_name: self.name.clone(),
@@ -143,6 +155,11 @@ impl Solver for SubprocessSolver {
             timed_out = false;
         }
 
+        eprintln!(
+            "[provekit-verifier] waiting for solver {:?} to exit (timeout={:?})",
+            self.name,
+            self.timeout
+        );
         let output = match child.wait_with_output() {
             Ok(o) => o,
             Err(e) => {

--- a/scripts/npm-postinstall.js
+++ b/scripts/npm-postinstall.js
@@ -18,6 +18,17 @@
  *
  * The default mode is trust (fast hash lookup). To force solver
  * re-verification, set PROVEKIT_FULL_VERIFY=1.
+ *
+ * Root cause of postinstall hang (2026-05-03): using `npx provekit verify`
+ * causes npx to attempt a remote registry fetch when the provekit binary
+ * is not found in the local node_modules/.bin/ (e.g. when provekit is
+ * being installed into itself, or when node_modules is not yet populated).
+ * Fix: resolve the binary directly from node_modules/.bin/provekit, and
+ * fall back gracefully if it is not found rather than going through npx.
+ *
+ * Defense-in-depth (2026-05-03): a 60-second hard timeout is added to
+ * prevent any future hang in the verify step from blocking npm install
+ * indefinitely, regardless of root cause.
  */
 
 const { execSync } = require("child_process");
@@ -29,9 +40,20 @@ if (process.env.PROVEKIT_SKIP_VERIFY === "1") {
   process.exit(0);
 }
 
-// Only run in project installs, not global or provekit's own install
+// Only run in project installs, not global or provekit's own install.
+// isGlobalInstall: INIT_CWD is unset for global installs.
 const isGlobalInstall = !process.env.INIT_CWD;
-const isSelfInstall = process.cwd().includes("node_modules/provekit");
+// isSelfInstall: the package being installed IS provekit itself.
+// Detection: npm sets INIT_CWD to the directory where the user ran install;
+// the postinstall cwd is the package root. If they match, this is the
+// provekit repo's own install (developer workflow, e.g. `pnpm install` in
+// the provekit repo), not a consumer install.
+// The node_modules/provekit path test is the secondary check for the case
+// where provekit is installed as a transitive dep inside another package's
+// node_modules tree (pnpm workspace peer installs, etc.).
+const isSelfInstall =
+  process.cwd() === (process.env.INIT_CWD || "") ||
+  process.cwd().includes("node_modules/provekit");
 if (isGlobalInstall || isSelfInstall) {
   process.exit(0);
 }
@@ -84,19 +106,66 @@ if (!shouldVerify) {
 
 console.log("[provekit] Verifying proof graph...");
 
-try {
-  const args = ["verify"];
-  if (process.env.PROVEKIT_FULL_VERIFY === "1") {
-    args.push("--full");
+// Resolve the provekit binary. Root cause of the postinstall hang was using
+// `npx provekit` which causes npx to attempt a remote registry fetch when
+// the binary is not in node_modules/.bin/ (e.g. during self-install or
+// when the registry is unreachable). Instead, resolve the binary directly.
+//
+// Resolution order:
+//   1. node_modules/.bin/provekit in the consumer project (standard consumer path)
+//   2. node_modules/provekit/bin/provekit.cjs   (pnpm deep-layout path)
+//   3. Not found — warn and exit 0 (don't fail the install over a missing binary)
+function resolveProvekitBinary(projectRoot) {
+  const candidates = [
+    join(projectRoot, "node_modules", ".bin", "provekit"),
+    join(projectRoot, "node_modules", "provekit", "bin", "provekit.cjs"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
   }
+  return null;
+}
 
-  execSync(`npx provekit ${args.join(" ")}`, {
+const binaryPath = resolveProvekitBinary(projectRoot);
+if (!binaryPath) {
+  console.warn(
+    "[provekit] Binary not found in node_modules/.bin/provekit. " +
+    "Skipping verification. (Set PROVEKIT_SKIP_VERIFY=1 to suppress this warning.)"
+  );
+  process.exit(0);
+}
+
+const args = ["verify"];
+if (process.env.PROVEKIT_FULL_VERIFY === "1") {
+  args.push("--full");
+}
+
+// Invoke via node so the shebang line is irrelevant and the binary works
+// on all platforms without shell resolution.
+const invokeCmd = binaryPath.endsWith(".cjs")
+  ? `node ${JSON.stringify(binaryPath)} ${args.join(" ")}`
+  : `${JSON.stringify(binaryPath)} ${args.join(" ")}`;
+
+try {
+  execSync(invokeCmd, {
     cwd: projectRoot,
     stdio: "inherit",
     encoding: "utf-8",
+    // Defense-in-depth: hard 60-second timeout. If verify hangs for any
+    // reason (WASM hang, daemon that doesn't exit, network stall) we must
+    // not block npm install indefinitely. On timeout we warn and exit 0
+    // (proceeding with install) rather than failing.
+    timeout: 60_000,
   });
   console.log("[provekit] Verification passed.");
 } catch (error) {
+  if (error.signal === "SIGTERM" || (error.code && error.code === "ETIMEDOUT")) {
+    console.warn(
+      "[provekit] Verification timed out after 60s. Proceeding with install. " +
+      "(Set PROVEKIT_SKIP_VERIFY=1 to skip verification.)"
+    );
+    process.exit(0);
+  }
   console.error("[provekit] Verification failed. Aborting install.");
   console.error("[provekit] Set PROVEKIT_SKIP_VERIFY=1 to skip verification.");
   process.exit(1);


### PR DESCRIPTION
## Summary

- **Root cause identified**: `npm-postinstall.js` calls `npx provekit verify` which causes npx to attempt a remote registry fetch when the provekit binary is not in `node_modules/.bin/` (the developer self-install path: `pnpm install` in the provekit repo). npx hangs indefinitely waiting for the npm registry, blocking `make conformance`.
- **Root cause fix**: replace `npx provekit` with direct binary resolution from `node_modules/.bin/provekit` or `node_modules/provekit/bin/provekit.cjs`. Eliminate the registry path entirely. Also add `process.cwd() === INIT_CWD` to `isSelfInstall` to short-circuit the developer self-install case before reaching binary resolution.
- **Defense-in-depth**: 60-second hard timeout on the `execSync` call — any future hang is bounded and warns rather than failing the install.
- **Secondary defense**: `build_default_z3()` in `registry.rs` now has a 30-second solver timeout instead of `None`, preventing indefinite Z3 block if the subprocess hang surface is ever reached from the Rust verifier path.
- **Diagnostics**: `subprocess.rs` now prints solver spawn PID and pre-wait messages to stderr so future hangs are debuggable.

## Files changed

- `scripts/npm-postinstall.js` — root cause fix + isSelfInstall detection + 60s timeout
- `implementations/rust/provekit-verifier/src/solvers/registry.rs` — 30s default timeout
- `implementations/rust/provekit-verifier/src/solvers/subprocess.rs` — diagnostic prints

## Test plan

- [x] `node scripts/npm-postinstall.js` with `INIT_CWD=/Users/tsavo/provekit` exits in 202ms (was: hangs indefinitely)
- [x] 27 Rust `provekit-verifier` tests pass
- [x] 775 TypeScript tests pass (0 regressions)
- [ ] `make conformance` runs end-to-end without `PROVEKIT_SKIP_VERIFY=1` (requires full Rust rebuild — the binary resolution + isSelfInstall fix means the postinstall exits immediately on self-install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)