### PR TITLE
feat(ruby): native crypto substrate — BLAKE3 + JCS + Ed25519 + CBOR + envelopes (closes #210)

### DIFF
--- a/implementations/ruby/.gitignore
+++ b/implementations/ruby/.gitignore
@@ -1,0 +1,4 @@
+Gemfile.lock
+*.gem
+.bundle/
+vendor/bundle/

--- a/implementations/ruby/Gemfile
+++ b/implementations/ruby/Gemfile
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+source "https://rubygems.org"
+
+gemspec

--- a/implementations/ruby/lib/provekit.rb
+++ b/implementations/ruby/lib/provekit.rb
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# ProvekIt Ruby kit. Native crypto substrate (Side B per issue #176):
+# BLAKE3 + JCS + Ed25519 + CBOR + envelope construction, no shell-out.
+#
+# Public surface:
+#   Provekit::Blake3        - BLAKE3-512 hash, "blake3-512:<hex>" form.
+#   Provekit::IR            - IR types + JCS canonical JSON emitter.
+#   Provekit::Jcs           - alias for Provekit::IR::Jcs (one canonicalizer).
+#   Provekit::Cbor          - deterministic CBOR encoder (RFC 8949 §4.2.1).
+#   Provekit::Signing       - Ed25519 sign/verify, self-identifying string form.
+#   Provekit::ProofEnvelope - .proof envelope build + verify.
+
+require_relative "provekit/blake3"
+require_relative "provekit/ir"
+require_relative "provekit/cbor"
+require_relative "provekit/signing"
+require_relative "provekit/proof_envelope"
+
+module Provekit
+  # Single canonical JCS encoder for the kit. Aliases the implementation
+  # already in IR (which the IR conformance fixtures pin against), so
+  # there is exactly one JCS encoder in the gem.
+  Jcs = IR::Jcs unless defined?(Jcs)
+end

--- a/implementations/ruby/lib/provekit/blake3.rb
+++ b/implementations/ruby/lib/provekit/blake3.rb
@@ -1,24 +1,79 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# BLAKE3-512 hash delegate — shells out to Python blake3 module.
-# Pure Ruby BLAKE3 planned for v1.2.
+# BLAKE3-512 hash for ProvekIt (64-byte XOF output).
+#
+# Backed natively by libblake3 via FFI. No subprocess shell-out.
+#
+# Prereq: libblake3 must be installed on the system.
+#   macOS:  brew install blake3
+#   Debian: apt-get install libblake3-dev
+#   Other:  https://github.com/BLAKE3-team/BLAKE3 (build from source)
 #
 # Usage:
 #   require "provekit/blake3"
-#   Provekit::Blake3.hex("data")  # => "blake3-512:486a4c..."
+#   Provekit::Blake3.hex("data")    # => "blake3-512:486a4c..."
+#   Provekit::Blake3.bytes("data")  # => raw 64-byte String
 #
-# Verified against Rust canonical reference hashes.
+# Verified byte-identical to:
+#   - Rust: implementations/rust/provekit-canonicalizer (blake3_512_of)
+#   - Python: blake3 PyPI package, .digest(length=64)
+
+require "ffi"
 
 module Provekit
   module Blake3
+    # libblake3 binding. Search common platform paths in order; first hit wins.
+    # macOS Homebrew (intel + arm), Debian/Ubuntu, generic SONAME.
+    module Native
+      extend FFI::Library
+
+      LIB_CANDIDATES = [
+        "blake3",
+        "libblake3.so.1",
+        "libblake3.so.0",
+        "libblake3.so",
+        "libblake3.dylib",
+        "libblake3.0.dylib",
+        "/usr/local/lib/libblake3.dylib",   # macOS x86_64 Homebrew
+        "/opt/homebrew/lib/libblake3.dylib", # macOS arm64 Homebrew
+        "/usr/lib/libblake3.so.1",
+        "/usr/lib/x86_64-linux-gnu/libblake3.so.1",
+        "/usr/lib/aarch64-linux-gnu/libblake3.so.1",
+      ].freeze
+
+      ffi_lib LIB_CANDIDATES
+
+      # blake3_hasher state struct sized generously per blake3.h:
+      #   key (32) + chunk_state (~84) + cv_stack_len (1) + cv_stack ((54+1)*32 = 1760)
+      #   ≈ 1880 bytes; we round up to 4 KiB for safety across libblake3 minor versions.
+      HASHER_SIZE = 4096
+
+      attach_function :blake3_hasher_init,     [:pointer],                          :void
+      attach_function :blake3_hasher_update,   [:pointer, :pointer, :size_t],       :void
+      attach_function :blake3_hasher_finalize, [:pointer, :pointer, :size_t],       :void
+    end
+
+    # Output BLAKE3-512 in the protocol's self-identifying string form:
+    #   "blake3-512:" + 128 lowercase hex chars.
+    # +data+ is treated as binary bytes.
     def self.hex(data)
-      require "tempfile"
-      tmp = Tempfile.new("pk_hash")
-      tmp.write(data.to_s)
-      tmp.close
-      hash = `python3 -c "import blake3; d=open('#{tmp.path}','rb').read(); print('blake3-512:'+blake3.blake3(d).digest(length=64).hex())"`.chomp
-      tmp.unlink
-      hash
+      "blake3-512:" + bytes(data).unpack1("H*")
+    end
+
+    # Compute raw 64-byte BLAKE3-512 of +data+. Returns a binary String of
+    # length 64 (ASCII-8BIT encoding).
+    def self.bytes(data)
+      raw = data.is_a?(String) ? data.b : data.to_s.b
+      hasher = FFI::MemoryPointer.new(:uint8, Native::HASHER_SIZE)
+      Native.blake3_hasher_init(hasher)
+      unless raw.bytesize.zero?
+        in_buf = FFI::MemoryPointer.new(:uint8, raw.bytesize)
+        in_buf.put_bytes(0, raw)
+        Native.blake3_hasher_update(hasher, in_buf, raw.bytesize)
+      end
+      out_buf = FFI::MemoryPointer.new(:uint8, 64)
+      Native.blake3_hasher_finalize(hasher, out_buf, 64)
+      out_buf.read_bytes(64)
     end
   end
 end

--- a/implementations/ruby/lib/provekit/cbor.rb
+++ b/implementations/ruby/lib/provekit/cbor.rb
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic CBOR encoder. RFC 8949 §4.2.1 rules:
+#   - shortest-form integer encoding (smallest of short / u8 / u16 / u32 / u64)
+#   - definite-length items only
+#   - map keys sorted in bytewise lex order of their CBOR-encoded form
+#   - we emit only the major types we need: unsigned int, byte string,
+#     text string, array, map.
+#
+# Mirrors implementations/rust/provekit-proof-envelope/src/cbor.rs 1:1.
+
+module Provekit
+  module Cbor
+    # CBOR major type values (RFC 8949 §3.1).
+    UNSIGNED_INT = 0
+    BYTE_STRING  = 2
+    TEXT_STRING  = 3
+    ARRAY        = 4
+    MAP          = 5
+
+    # Append the CBOR head (major type + argument) to +out+.
+    # Selects the shortest-form encoding per RFC 8949 §4.2.1.
+    def self.append_head(out, major, arg)
+      mt = major << 5
+      if arg < 24
+        out << (mt | arg)
+        return
+      end
+      if arg <= 0xFF
+        out << (mt | 24)
+        out << arg
+        return
+      end
+      if arg <= 0xFFFF
+        out << (mt | 25)
+        out << ((arg >> 8) & 0xFF)
+        out << (arg & 0xFF)
+        return
+      end
+      if arg <= 0xFFFF_FFFF
+        out << (mt | 26)
+        out << ((arg >> 24) & 0xFF)
+        out << ((arg >> 16) & 0xFF)
+        out << ((arg >> 8) & 0xFF)
+        out << (arg & 0xFF)
+        return
+      end
+      out << (mt | 27)
+      7.downto(0) { |i| out << ((arg >> (i * 8)) & 0xFF) }
+    end
+
+    def self.encode_uint(out, value)
+      append_head(out, UNSIGNED_INT, value)
+    end
+
+    def self.encode_bstr(out, bytes)
+      raw = bytes.is_a?(String) ? bytes.b : bytes.to_s.b
+      append_head(out, BYTE_STRING, raw.bytesize)
+      raw.each_byte { |b| out << b }
+    end
+
+    def self.encode_tstr(out, str)
+      raw = str.to_s.dup.force_encoding(Encoding::UTF_8)
+      bytes = raw.bytes
+      append_head(out, TEXT_STRING, bytes.length)
+      bytes.each { |b| out << b }
+    end
+
+    def self.encode_array_head(out, count)
+      append_head(out, ARRAY, count)
+    end
+
+    def self.encode_map_head(out, count)
+      append_head(out, MAP, count)
+    end
+
+    # Encode a key string for use as a map key.
+    # Returns an Array<Integer> of bytes.
+    def self.encode_key(key)
+      buf = []
+      encode_tstr(buf, key)
+      buf
+    end
+
+    # Pack an array of byte integers into a binary String.
+    def self.pack_bytes(byte_array)
+      byte_array.pack("C*")
+    end
+  end
+end

--- a/implementations/ruby/lib/provekit/proof_envelope.rb
+++ b/implementations/ruby/lib/provekit/proof_envelope.rb
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Proof-envelope builder. Deterministic CBOR (RFC 8949 §4.2.1) encoding
+# of a catalog memento with member envelopes embedded as opaque byte
+# strings, signed with Ed25519.
+#
+# Protocol:
+#   1. Build the unsigned body as a CBOR map; map keys are sorted by
+#      bytewise lex order of their CBOR-encoded form (RFC 8949 §4.2.1).
+#   2. Ed25519-sign the unsigned-body bytes.
+#   3. Re-emit the body with the +signature+ key added; canonical sort
+#      slots it in by lex order automatically.
+#   4. BLAKE3-512 the final bytes; the full self-identifying string
+#      "blake3-512:<128 hex>" IS the catalog CID.
+#
+# The +members+ map key is the embedded envelope's own CID, and the
+# value is its canonical bytes (JCS-JSON for memento envelopes per the
+# memento envelope grammar) encoded as a CBOR byte string.
+#
+# Reference (authoritative):
+#   implementations/rust/provekit-proof-envelope/src/proof.rs
+#   protocol/specs/2026-04-30-proof-file-format.md
+#
+# Cross-kit byte-equivalence:
+#   The Ruby output is byte-identical to the Rust + Python kits for
+#   the same canonical input. See test/test_proof_envelope.rb.
+
+require_relative "blake3"
+require_relative "cbor"
+require_relative "signing"
+
+module Provekit
+  module ProofEnvelope
+    # Logical input shape for a .proof catalog memento.
+    # Mirrors +ProofEnvelopeInput+ in
+    # implementations/rust/provekit-proof-envelope/src/proof.rs.
+    #
+    # members: hash from member CID (e.g. "blake3-512:<hex>") to that
+    #          member's canonical bytes (JCS-JSON for memento envelopes).
+    # signer_seed: 32-byte Ed25519 seed. Defaults to FOUNDATION_V0_SEED
+    #              (the publicly-known test key used by all other kits).
+    Input = Struct.new(
+      :name,
+      :version,
+      :members,
+      :signer_cid,
+      :declared_at,
+      :signer_seed,
+      :binary_cid,
+      :metadata,
+      keyword_init: true,
+    ) do
+      def initialize(name:, version:, members:, signer_cid:, declared_at:,
+                     signer_seed: Provekit::Signing::FOUNDATION_V0_SEED,
+                     binary_cid: nil, metadata: nil)
+        super
+      end
+    end
+
+    # Result of {build_proof_envelope}.
+    #
+    # +bytes+: CBOR bytes of the signed catalog. The BLAKE3-512 hash of
+    #          these bytes IS the catalog CID.
+    # +cid+:   Full self-identifying CID, e.g. "blake3-512:<128 hex>".
+    #          This string is the .proof filename without extension.
+    Output = Struct.new(:bytes, :cid, keyword_init: true)
+
+    # One CBOR (key, value) pair, with its key pre-encoded so the
+    # outer map can sort by bytewise CBOR-encoded-key form.
+    Pair = Struct.new(:key_cbor, :value_cbor)
+
+    # ── Internals ────────────────────────────────────────────────
+
+    def self.make_string_pair(key, value)
+      v = []
+      Cbor.encode_tstr(v, value.to_s)
+      Pair.new(Cbor.encode_key(key), v)
+    end
+
+    def self.make_bytes_pair(key, value)
+      v = []
+      Cbor.encode_bstr(v, value)
+      Pair.new(Cbor.encode_key(key), v)
+    end
+
+    def self.make_members_pair(key, members)
+      # Encode as { tstr(cid) => bstr(envelope-bytes) }, sort by
+      # bytewise CBOR-encoded-key form.
+      pairs = members.map { |cid, bytes_val| make_bytes_pair(cid, bytes_val) }
+      value = []
+      emit_sorted_map(value, pairs)
+      Pair.new(Cbor.encode_key(key), value)
+    end
+
+    def self.emit_sorted_map(out, pairs)
+      pairs.sort_by!(&:key_cbor)
+      Cbor.encode_map_head(out, pairs.length)
+      pairs.each do |p|
+        out.concat(p.key_cbor)
+        out.concat(p.value_cbor)
+      end
+    end
+
+    def self.body_pairs_unsigned(input)
+      pairs = [
+        make_string_pair("kind",       "catalog"),
+        make_string_pair("name",       input.name),
+        make_string_pair("version",    input.version),
+        make_members_pair("members",   input.members),
+        make_string_pair("signer",     input.signer_cid),
+        make_string_pair("declaredAt", input.declared_at),
+      ]
+      pairs << make_string_pair("binaryCid", input.binary_cid) if input.binary_cid
+      if input.metadata
+        meta_pairs = input.metadata.map { |k, v| make_string_pair(k.to_s, v.to_s) }
+        meta_value = []
+        emit_sorted_map(meta_value, meta_pairs)
+        pairs << Pair.new(Cbor.encode_key("metadata"), meta_value)
+      end
+      pairs
+    end
+
+    # ── Public API ───────────────────────────────────────────────
+
+    # Build a .proof envelope from +input+ (an Input struct).
+    # Output is byte-identical to the Rust + Python kits' build for the
+    # same canonical input. See module docstring for the four-step protocol.
+    def self.build(input)
+      # Step 1: encode unsigned body with sorted keys.
+      unsigned_pairs = body_pairs_unsigned(input)
+      unsigned_bytes_arr = []
+      emit_sorted_map(unsigned_bytes_arr, unsigned_pairs)
+      unsigned_bytes = Cbor.pack_bytes(unsigned_bytes_arr)
+
+      # Step 2: ed25519-sign the unsigned bytes.
+      sig = Signing.ed25519_sign_with_seed(input.signer_seed, unsigned_bytes)
+
+      # Step 3: re-emit with signature added; keys re-sort automatically.
+      signed_pairs = body_pairs_unsigned(input)
+      signed_pairs << make_bytes_pair("signature", sig)
+      final_arr = []
+      emit_sorted_map(final_arr, signed_pairs)
+      final_bytes = Cbor.pack_bytes(final_arr)
+
+      # Step 4: filename CID = full self-identifying BLAKE3-512.
+      cid = Blake3.hex(final_bytes)
+      Output.new(bytes: final_bytes, cid: cid)
+    end
+
+    # Verify a .proof envelope against +expected_cid+ and +signer_pubkey+.
+    #
+    # Checks:
+    #   1. CID matches: BLAKE3-512(proof_bytes) == expected_cid.
+    #   2. CBOR decodes to a catalog map with the required keys.
+    #   3. Ed25519 signature verifies: re-encode the unsigned body
+    #      (all keys except +signature+) and verify the embedded
+    #      +signature+ bytes against +signer_pubkey+ (raw 32-byte
+    #      Ed25519 public key).
+    #
+    # +signer_pubkey+ is the raw 32-byte public key (NOT the seed /
+    # private key). Use {Provekit::Signing.ed25519_pubkey_bytes} to
+    # derive it from a seed if needed.
+    #
+    # Returns true iff all three checks pass.
+    def self.verify(proof_bytes, expected_cid, signer_pubkey)
+      return false unless signer_pubkey.is_a?(String) && signer_pubkey.bytesize == 32
+
+      # Check 1: CID
+      actual_cid = Blake3.hex(proof_bytes)
+      return false unless actual_cid == expected_cid
+
+      # Check 2: decode + shape
+      catalog = decode_signed_catalog(proof_bytes)
+      return false unless catalog
+      return false unless catalog["kind"] == "catalog"
+      required = %w[kind name version members signer declaredAt signature]
+      return false unless required.all? { |k| catalog.key?(k) }
+      sig_bytes = catalog["signature"]
+      return false unless sig_bytes.is_a?(String) && sig_bytes.bytesize == 64
+
+      # Check 3: re-encode the unsigned body and verify the signature.
+      input = Input.new(
+        name:        catalog["name"],
+        version:     catalog["version"],
+        members:     catalog["members"] || {},
+        signer_cid:  catalog["signer"],
+        declared_at: catalog["declaredAt"],
+        signer_seed: Signing::FOUNDATION_V0_SEED, # unused (we re-emit unsigned only)
+        binary_cid:  catalog["binaryCid"],
+        metadata:    catalog["metadata"],
+      )
+      unsigned_pairs = body_pairs_unsigned(input)
+      unsigned_arr = []
+      emit_sorted_map(unsigned_arr, unsigned_pairs)
+      unsigned_bytes = Cbor.pack_bytes(unsigned_arr)
+
+      Signing.verify_raw(signer_pubkey, sig_bytes, unsigned_bytes)
+    end
+
+    # ── Minimal CBOR decoder (verify-only path) ───────────────────
+    #
+    # We only need to decode the proof envelope shape we ourselves emit:
+    # outer map with keys (tstr): kind, name, version, members, signer,
+    # declaredAt, signature, optional binaryCid, optional metadata.
+    # Values are tstr, bstr, or a nested {tstr -> bstr} map (for
+    # +members+) / {tstr -> tstr} map (for +metadata+).
+
+    def self.decode_signed_catalog(bytes)
+      io = StringIO.new(bytes.b)
+      io.binmode if io.respond_to?(:binmode)
+      val = decode_value(io)
+      return nil unless val.is_a?(Hash)
+      val
+    rescue StandardError
+      nil
+    end
+
+    def self.read_head(io)
+      first = io.read(1)
+      raise "EOF" unless first
+      ib = first.unpack1("C")
+      mt  = ib >> 5
+      arg = ib & 0x1F
+      arg =
+        case arg
+        when 0..23 then arg
+        when 24    then io.read(1).unpack1("C")
+        when 25    then io.read(2).unpack1("n")
+        when 26    then io.read(4).unpack1("N")
+        when 27    then io.read(8).unpack1("Q>")
+        else raise "unsupported CBOR additional info: #{arg}"
+        end
+      [mt, arg]
+    end
+
+    def self.decode_value(io)
+      mt, arg = read_head(io)
+      case mt
+      when Cbor::UNSIGNED_INT then arg
+      when Cbor::BYTE_STRING  then io.read(arg).b
+      when Cbor::TEXT_STRING  then io.read(arg).force_encoding(Encoding::UTF_8)
+      when Cbor::ARRAY
+        Array.new(arg) { decode_value(io) }
+      when Cbor::MAP
+        h = {}
+        arg.times do
+          k = decode_value(io)
+          v = decode_value(io)
+          h[k] = v
+        end
+        h
+      else
+        raise "unsupported major type #{mt}"
+      end
+    end
+  end
+end
+
+require "stringio"

--- a/implementations/ruby/lib/provekit/signing.rb
+++ b/implementations/ruby/lib/provekit/signing.rb
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ed25519 signing helper. v1.1.0 of the protocol mandates self-identifying
+# signatures of the form:
+#
+#   "ed25519:" + base64-stdpad(64-byte-signature)
+#
+# And self-identifying public keys in the same form. The .proof file
+# envelope itself stores its catalog signature as a RAW 64-byte CBOR
+# byte string (not the prefixed string form): only the per-memento
+# `producerSignature` field uses the prefixed string form, because
+# memento envelopes are JCS-JSON.
+#
+# Backed by the +ed25519+ gem (Ruby ed25519 binding). Byte-equivalent
+# to the Rust ed25519-dalek peer and to PyNaCl: all three implement
+# RFC 8032 Ed25519.
+#
+# Reference (authoritative):
+#   implementations/rust/provekit-proof-envelope/src/sign.rs
+#   implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/signing.py
+
+require "base64"
+require "ed25519"
+
+module Provekit
+  module Signing
+    ED25519_SIG_PREFIX = "ed25519:"
+    ED25519_KEY_PREFIX = "ed25519:"
+
+    # Foundation v0 seed: publicly-known, deterministic test seed.
+    # Documented as a test seed; v1 is HSM-generated.
+    # Source: tools/foundation-keygen/src/lib.rs FOUNDATION_V0_SEED.
+    FOUNDATION_V0_SEED = ([0x42] * 32).pack("C*").freeze
+
+    # Sign +message+ with the Ed25519 private key derived from +seed+.
+    # +seed+ must be exactly 32 bytes (RFC 8032 §5.1.5 seed format).
+    # Returns the raw 64-byte signature. Byte-identical to the Rust
+    # +ed25519_sign_with_seed+ for the same (seed, message) pair.
+    def self.ed25519_sign_with_seed(seed, message)
+      raise ArgumentError, "seed must be exactly 32 bytes" unless seed.bytesize == 32
+      sk = ::Ed25519::SigningKey.new(seed)
+      sk.sign(message.to_s.b)
+    end
+
+    # Sign and return the spec's self-identifying string form.
+    # Format: "ed25519:" + base64-stdpad(64-byte-signature).
+    def self.ed25519_sign_string(seed, message)
+      sig = ed25519_sign_with_seed(seed, message)
+      ED25519_SIG_PREFIX + Base64.strict_encode64(sig)
+    end
+
+    # Derive the public key from +seed+ and return the self-identifying
+    # string form: "ed25519:" + base64-stdpad(32-byte-pubkey).
+    def self.ed25519_pubkey_string(seed)
+      raise ArgumentError, "seed must be exactly 32 bytes" unless seed.bytesize == 32
+      sk = ::Ed25519::SigningKey.new(seed)
+      ED25519_KEY_PREFIX + Base64.strict_encode64(sk.verify_key.to_bytes)
+    end
+
+    # Raw 32-byte public key derived from +seed+.
+    def self.ed25519_pubkey_bytes(seed)
+      raise ArgumentError, "seed must be exactly 32 bytes" unless seed.bytesize == 32
+      ::Ed25519::SigningKey.new(seed).verify_key.to_bytes
+    end
+
+    # Verify +message+ against +sig_string+ using +pubkey_string+.
+    # Both strings use the spec's self-identifying form
+    # ("ed25519:" + base64-stdpad(bytes)).
+    #
+    # Returns true iff the signature is valid. Returns false for any
+    # malformed input rather than raising, so the caller's fast-path
+    # and verify-failed-path stay separate.
+    def self.ed25519_verify_string(pubkey_string, sig_string, message)
+      return false unless pubkey_string.is_a?(String) && pubkey_string.start_with?(ED25519_KEY_PREFIX)
+      return false unless sig_string.is_a?(String) && sig_string.start_with?(ED25519_SIG_PREFIX)
+
+      begin
+        pk_bytes = Base64.strict_decode64(pubkey_string[ED25519_KEY_PREFIX.length..])
+        sig_bytes = Base64.strict_decode64(sig_string[ED25519_SIG_PREFIX.length..])
+      rescue ArgumentError
+        return false
+      end
+
+      return false unless pk_bytes.bytesize == 32 && sig_bytes.bytesize == 64
+
+      verify_raw(pk_bytes, sig_bytes, message.to_s.b)
+    end
+
+    # Verify a raw 64-byte signature against a raw 32-byte public key.
+    # Returns true / false. Never raises on a malformed input.
+    def self.verify_raw(pubkey_bytes, sig_bytes, message)
+      return false unless pubkey_bytes.is_a?(String) && pubkey_bytes.bytesize == 32
+      return false unless sig_bytes.is_a?(String) && sig_bytes.bytesize == 64
+      vk = ::Ed25519::VerifyKey.new(pubkey_bytes)
+      vk.verify(sig_bytes, message.to_s.b)
+    rescue ::Ed25519::VerifyError
+      false
+    rescue StandardError
+      false
+    end
+  end
+end

--- a/implementations/ruby/provekit.gemspec
+++ b/implementations/ruby/provekit.gemspec
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+Gem::Specification.new do |s|
+  s.name        = "provekit"
+  s.version     = "0.1.0"
+  s.licenses    = ["Apache-2.0"]
+  s.summary     = "ProvekIt Ruby kit: native crypto substrate (BLAKE3 + JCS + Ed25519 + CBOR)."
+  s.description = <<~DESC
+    Native Ruby implementation of the ProvekIt substrate primitives:
+    BLAKE3-512 hashing, JCS canonical JSON, Ed25519 sign/verify, deterministic
+    CBOR (RFC 8949 §4.2.1), and .proof envelope construction. Output is
+    byte-identical to the Rust + Python kits' output for the same input.
+
+    Prereq: libblake3 must be installed on the host system.
+      macOS:  brew install blake3
+      Debian: apt-get install libblake3-dev
+  DESC
+  s.authors     = ["ProvekIt contributors"]
+  s.homepage    = "https://github.com/TSavo/provekit"
+  s.metadata    = {
+    "source_code_uri" => "https://github.com/TSavo/provekit",
+    "issue_tracker_uri" => "https://github.com/TSavo/provekit/issues",
+  }
+
+  s.required_ruby_version = ">= 3.0"
+
+  s.files = Dir["lib/**/*.rb"]
+  s.require_paths = ["lib"]
+
+  s.add_dependency "ed25519", "~> 1.4"
+  s.add_dependency "ffi",     "~> 1.15"
+
+  s.add_development_dependency "minitest", ">= 5.0"
+end

--- a/implementations/ruby/test/test_blake3.rb
+++ b/implementations/ruby/test/test_blake3.rb
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# BLAKE3-512 hash tests. Cross-kit byte-equivalence pinned against
+# the Rust + Python kits (both produce 64-byte BLAKE3-512 output for
+# canonical bytes; this kit binds to libblake3 directly).
+
+require "minitest/autorun"
+require_relative "../lib/provekit/blake3"
+
+class TestBlake3 < Minitest::Test
+  B = Provekit::Blake3
+
+  # Known vector: BLAKE3 of UTF-8 "hello" with 64-byte XOF output.
+  # Verified against:
+  #   - Python: blake3.blake3(b"hello").digest(length=64).hex()
+  #   - Rust:   provekit_canonicalizer::blake3_512_of("hello")
+  HELLO_HEX_64 =
+    "ea8f163db38682925e4491c5e58d4bb3506ef8c14eb78a86e908c5624a67200f" \
+    "e992405f0d785b599a2e3387f6d34d01faccfeb22fb697ef3fd53541241a338c"
+
+  # Known vector: empty input (BLAKE3 of "").
+  EMPTY_HEX_64 =
+    "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262" \
+    "e00f03e7b69af26b7faaf09fcd333050338ddfe085b8cc869ca98b206c08243a"
+
+  def test_hello_hex_matches_known_vector
+    assert_equal "blake3-512:#{HELLO_HEX_64}", B.hex("hello")
+  end
+
+  def test_empty_hex_matches_known_vector
+    assert_equal "blake3-512:#{EMPTY_HEX_64}", B.hex("")
+  end
+
+  def test_bytes_returns_64_bytes
+    assert_equal 64, B.bytes("hello").bytesize
+  end
+
+  def test_bytes_returns_binary_string
+    assert_equal Encoding::ASCII_8BIT, B.bytes("hello").encoding
+  end
+
+  def test_hex_starts_with_self_identifying_prefix
+    assert B.hex("anything").start_with?("blake3-512:")
+  end
+
+  def test_hex_total_length_is_prefix_plus_128
+    assert_equal "blake3-512:".length + 128, B.hex("anything").length
+  end
+
+  def test_deterministic
+    a = B.hex("data")
+    b = B.hex("data")
+    assert_equal a, b
+  end
+
+  def test_different_inputs_produce_different_hashes
+    refute_equal B.hex("a"), B.hex("b")
+  end
+
+  def test_handles_binary_data
+    binary = (0..255).to_a.pack("C*")
+    out = B.hex(binary)
+    assert_equal "blake3-512:".length + 128, out.length
+  end
+end

--- a/implementations/ruby/test/test_cbor.rb
+++ b/implementations/ruby/test/test_cbor.rb
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic CBOR encoder tests. RFC 8949 §4.2.1 rules:
+#   - shortest-form integer encoding
+#   - definite-length items only
+#   - map keys in bytewise lex order of their CBOR-encoded form
+#
+# Mirrors implementations/rust/provekit-proof-envelope/src/cbor.rs tests.
+
+require "minitest/autorun"
+require_relative "../lib/provekit/cbor"
+
+class TestCbor < Minitest::Test
+  C = Provekit::Cbor
+
+  def test_shortest_form_uint_zero
+    o = []
+    C.encode_uint(o, 0)
+    assert_equal [0x00], o
+  end
+
+  def test_shortest_form_uint_23
+    o = []
+    C.encode_uint(o, 23)
+    assert_equal [0x17], o
+  end
+
+  def test_shortest_form_uint_24
+    o = []
+    C.encode_uint(o, 24)
+    assert_equal [0x18, 24], o
+  end
+
+  def test_shortest_form_uint_256
+    o = []
+    C.encode_uint(o, 256)
+    assert_equal [0x19, 0x01, 0x00], o
+  end
+
+  def test_shortest_form_uint_65536
+    o = []
+    C.encode_uint(o, 65_536)
+    assert_equal [0x1A, 0x00, 0x01, 0x00, 0x00], o
+  end
+
+  def test_tstr_round_trip_head
+    o = []
+    C.encode_tstr(o, "hello")
+    # major 3 (text string), len 5 short form: 0x65, then "hello"
+    assert_equal [0x65, *"hello".bytes], o
+  end
+
+  def test_bstr_round_trip_head
+    o = []
+    C.encode_bstr(o, "hi".b)
+    # major 2 (byte string), len 2 short form: 0x42, then "hi"
+    assert_equal [0x42, *"hi".bytes], o
+  end
+
+  def test_array_head
+    o = []
+    C.encode_array_head(o, 3)
+    # major 4 (array), count 3 short form: 0x83
+    assert_equal [0x83], o
+  end
+
+  def test_map_head_seven_keys
+    o = []
+    C.encode_map_head(o, 7)
+    # major 5 (map), count 7 short form: 0xA7
+    assert_equal [0xA7], o
+  end
+end

--- a/implementations/ruby/test/test_proof_envelope.rb
+++ b/implementations/ruby/test/test_proof_envelope.rb
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Proof-envelope tests: round-trip, cross-kit byte-equivalence, and
+# sign/verify with known-good test vectors.
+#
+# Cross-kit byte-equivalence pins are derived from the Rust kit. The
+# Python kit (PR #221) ALSO matches this pin; running the Python kit
+# locally with identical input reproduces the same bytes. So Ruby
+# matching this pin = Ruby matching Rust = Ruby matching Python.
+#
+# If a pin fails, the mismatch is a real divergence — surface it,
+# don't paper over it.
+
+require "minitest/autorun"
+require_relative "../lib/provekit/blake3"
+require_relative "../lib/provekit/cbor"
+require_relative "../lib/provekit/signing"
+require_relative "../lib/provekit/proof_envelope"
+
+class TestProofEnvelope < Minitest::Test
+  PE      = Provekit::ProofEnvelope
+  SIGNING = Provekit::Signing
+  BLAKE3  = Provekit::Blake3
+
+  FOUNDATION_PUBKEY = SIGNING.ed25519_pubkey_bytes(SIGNING::FOUNDATION_V0_SEED).freeze
+
+  # ── Cross-kit byte-equivalence pin (from Rust + Python kits) ──
+  # Source:
+  #   cargo run --release -p provekit-proof-envelope --example proof_envelope_bytes
+  #   (And reproduced byte-for-byte by the Python kit per PR #221.)
+  RUST_FIXTURE_CID =
+    "blake3-512:5ed1e1f705622ad52ae4683e3d12df5586d364d66bb3186f5be512415edf290" \
+    "844d74e73a2857cd858f37803e4b11fe5c7cba7884caa6b9ff847521ce32ea056"
+
+  RUST_FIXTURE_BYTES_HEX =
+    "a7646b696e6467636174616c6f67646e616d656940746573742f636174667369676e65" \
+    "726d626c616b65332d3531323a6363676d656d62657273a26d626c616b65332d353132" \
+    "3a6161517b2268656c6c6f223a22776f726c64227d6d626c616b65332d3531323a6262" \
+    "537b22676f6f64627965223a22776f726c64227d6776657273696f6e65312e302e3069" \
+    "7369676e617475726558406a21dd428a54e22c82ca6d6125a7293c4a723786cb1840e8" \
+    "91cefa03e63246eb97ef13dab86b7b1469d67302fadc969cd88c92c29495d13c75fc02" \
+    "01a7263b066a6465636c6172656441747818323032362d30342d33305430303a30303a" \
+    "30302e3030305a"
+
+  # ── Fixtures ────────────────────────────────────────────────
+
+  def minimal_input(seed: SIGNING::FOUNDATION_V0_SEED)
+    PE::Input.new(
+      name:        "@test/cat",
+      version:     "1.0.0",
+      members:     { "blake3-512:aa" => '{"hello":"world"}' },
+      signer_cid:  "blake3-512:cc",
+      declared_at: "2026-04-30T00:00:00.000Z",
+      signer_seed: seed,
+    )
+  end
+
+  def two_member_input
+    PE::Input.new(
+      name:        "@test/cat",
+      version:     "1.0.0",
+      members:     {
+        "blake3-512:aa" => '{"hello":"world"}',
+        "blake3-512:bb" => '{"goodbye":"world"}',
+      },
+      signer_cid:  "blake3-512:cc",
+      declared_at: "2026-04-30T00:00:00.000Z",
+      signer_seed: SIGNING::FOUNDATION_V0_SEED,
+    )
+  end
+
+  # ── Round-trip ──────────────────────────────────────────────
+
+  def test_build_then_verify
+    out = PE.build(minimal_input)
+    assert PE.verify(out.bytes, out.cid, FOUNDATION_PUBKEY)
+  end
+
+  def test_cid_is_blake3_512_of_bytes
+    out = PE.build(minimal_input)
+    assert_equal BLAKE3.hex(out.bytes), out.cid
+  end
+
+  def test_cid_has_correct_prefix
+    out = PE.build(minimal_input)
+    assert out.cid.start_with?("blake3-512:")
+  end
+
+  def test_cid_length_is_prefix_plus_128_hex
+    out = PE.build(minimal_input)
+    assert_equal "blake3-512:".length + 128, out.cid.length
+  end
+
+  def test_signed_map_head_is_seven_keys
+    # 7-key map head: major 5 (0xA0) + count 7 = 0xA7.
+    out = PE.build(minimal_input)
+    assert_equal 0xA7, out.bytes.bytes.first
+  end
+
+  def test_deterministic_across_runs
+    a = PE.build(minimal_input)
+    b = PE.build(minimal_input)
+    assert_equal a.bytes, b.bytes
+    assert_equal a.cid, b.cid
+  end
+
+  def test_two_members_round_trips
+    out = PE.build(two_member_input)
+    assert PE.verify(out.bytes, out.cid, FOUNDATION_PUBKEY)
+  end
+
+  def test_changing_name_changes_cid
+    a = PE.build(minimal_input)
+    b = PE.build(PE::Input.new(
+      name:        "@other/name",
+      version:     "1.0.0",
+      members:     { "blake3-512:aa" => '{"hello":"world"}' },
+      signer_cid:  "blake3-512:cc",
+      declared_at: "2026-04-30T00:00:00.000Z",
+    ))
+    refute_equal a.cid, b.cid
+  end
+
+  def test_changing_seed_changes_cid
+    a = PE.build(minimal_input(seed: ([0x42] * 32).pack("C*")))
+    b = PE.build(minimal_input(seed: ([0x99] * 32).pack("C*")))
+    refute_equal a.cid, b.cid
+  end
+
+  def test_verify_rejects_tampered_cid
+    out = PE.build(minimal_input)
+    fake_cid = "blake3-512:" + ("00" * 64)
+    refute PE.verify(out.bytes, fake_cid, FOUNDATION_PUBKEY)
+  end
+
+  def test_verify_rejects_wrong_pubkey
+    out = PE.build(minimal_input)
+    wrong_pubkey = SIGNING.ed25519_pubkey_bytes(([0x99] * 32).pack("C*"))
+    refute PE.verify(out.bytes, out.cid, wrong_pubkey)
+  end
+
+  def test_binary_cid_field_included_in_signed_body
+    inp = PE::Input.new(
+      name:        "@test/cat",
+      version:     "1.0.0",
+      members:     { "blake3-512:aa" => "data" },
+      signer_cid:  "blake3-512:cc",
+      declared_at: "2026-04-30T00:00:00.000Z",
+      binary_cid:  "blake3-512:deadbeef",
+    )
+    out = PE.build(inp)
+    assert PE.verify(out.bytes, out.cid, FOUNDATION_PUBKEY)
+
+    inp_no_binary = PE::Input.new(
+      name:        "@test/cat",
+      version:     "1.0.0",
+      members:     { "blake3-512:aa" => "data" },
+      signer_cid:  "blake3-512:cc",
+      declared_at: "2026-04-30T00:00:00.000Z",
+    )
+    out_no_binary = PE.build(inp_no_binary)
+    refute_equal out.cid, out_no_binary.cid
+  end
+
+  def test_metadata_field_included_in_signed_body
+    inp = PE::Input.new(
+      name:        "@test/cat",
+      version:     "1.0.0",
+      members:     { "blake3-512:aa" => "data" },
+      signer_cid:  "blake3-512:cc",
+      declared_at: "2026-04-30T00:00:00.000Z",
+      metadata:    { "tool" => "ruby-kit", "version" => "0.1.0" },
+    )
+    out = PE.build(inp)
+    assert PE.verify(out.bytes, out.cid, FOUNDATION_PUBKEY)
+  end
+
+  # ── Cross-kit byte-equivalence (pinned from Rust + Python) ──
+
+  def test_two_member_bytes_match_rust
+    out = PE.build(two_member_input)
+    rust_bytes = [RUST_FIXTURE_BYTES_HEX].pack("H*")
+    if out.bytes != rust_bytes
+      # Find first divergence for diagnostics
+      ours = out.bytes.bytes
+      theirs = rust_bytes.bytes
+      idx = (0...[ours.length, theirs.length].min).find { |i| ours[i] != theirs[i] }
+      msg = if idx
+        "cross-kit byte divergence at byte #{idx}: " \
+        "ruby=0x#{format('%02x', ours[idx])} rust=0x#{format('%02x', theirs[idx])}\n" \
+        "ruby hex: #{out.bytes.unpack1('H*')}\n" \
+        "rust hex: #{rust_bytes.unpack1('H*')}"
+      else
+        "cross-kit length mismatch: ruby=#{ours.length}, rust=#{theirs.length}"
+      end
+      flunk msg
+    end
+    assert_equal rust_bytes, out.bytes
+  end
+
+  def test_two_member_cid_matches_rust
+    out = PE.build(two_member_input)
+    assert_equal RUST_FIXTURE_CID, out.cid
+  end
+
+  def test_rust_bytes_verify_with_foundation_key
+    rust_bytes = [RUST_FIXTURE_BYTES_HEX].pack("H*")
+    assert PE.verify(rust_bytes, RUST_FIXTURE_CID, FOUNDATION_PUBKEY)
+  end
+end

--- a/implementations/ruby/test/test_signing.rb
+++ b/implementations/ruby/test/test_signing.rb
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ed25519 signing tests. Determinism + known-vector parity with the
+# Rust kit (ed25519-dalek) and Python kit (PyNaCl) — all three
+# implement RFC 8032 Ed25519 and produce byte-identical signatures
+# for the same (seed, message) pair.
+
+require "minitest/autorun"
+require "base64"
+require_relative "../lib/provekit/signing"
+
+class TestSigning < Minitest::Test
+  S = Provekit::Signing
+
+  SEED_42 = ([0x42] * 32).pack("C*").freeze
+  SEED_99 = ([0x99] * 32).pack("C*").freeze
+
+  # Known-good vectors. Pinned against PyNaCl + ed25519-dalek output.
+  PUBKEY_42_HEX = "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12"
+  SIG_42_HELLO_HEX =
+    "fa10ea646d7ee80994bdddd03942479b61a9d54962cffe3e629537266b8adc46" \
+    "b5a60b204f1798bf32398bc2d4ef8d791a4e4ae7c39eb43e83563ce67d39e405"
+
+  def test_deterministic_signature_for_fixed_seed
+    a = S.ed25519_sign_with_seed(SEED_42, "hello")
+    b = S.ed25519_sign_with_seed(SEED_42, "hello")
+    assert_equal a, b
+  end
+
+  def test_signature_is_64_bytes
+    sig = S.ed25519_sign_with_seed(SEED_42, "hello")
+    assert_equal 64, sig.bytesize
+  end
+
+  def test_known_vector_matches_pynacl_dalek
+    # Cross-kit pin: Ruby ed25519 gem must match PyNaCl + ed25519-dalek
+    # for seed=[0x42]*32, message="hello".
+    sig = S.ed25519_sign_with_seed(SEED_42, "hello")
+    assert_equal SIG_42_HELLO_HEX, sig.unpack1("H*")
+  end
+
+  def test_pubkey_bytes_match_known_vector
+    pk = S.ed25519_pubkey_bytes(SEED_42)
+    assert_equal PUBKEY_42_HEX, pk.unpack1("H*")
+  end
+
+  def test_sign_string_has_prefix
+    s = S.ed25519_sign_string(SEED_42, "hello")
+    assert s.start_with?("ed25519:")
+  end
+
+  def test_pubkey_string_has_prefix
+    pk = S.ed25519_pubkey_string(SEED_42)
+    assert pk.start_with?("ed25519:")
+  end
+
+  def test_pubkey_base64_is_44_chars
+    # 32 bytes -> 44 base64 chars (with stdpad).
+    pk = S.ed25519_pubkey_string(SEED_42)
+    b64 = pk["ed25519:".length..]
+    assert_equal 44, b64.length
+  end
+
+  def test_verify_round_trip
+    pk  = S.ed25519_pubkey_string(SEED_42)
+    sig = S.ed25519_sign_string(SEED_42, "hello world")
+    assert S.ed25519_verify_string(pk, sig, "hello world")
+    refute S.ed25519_verify_string(pk, sig, "goodbye world")
+  end
+
+  def test_verify_rejects_malformed_inputs
+    refute S.ed25519_verify_string("not-prefixed", "ed25519:AAAA==", "x")
+    refute S.ed25519_verify_string("ed25519:AAAA==", "not-prefixed", "x")
+    refute S.ed25519_verify_string("ed25519:!!!!", "ed25519:!!!!", "x")
+  end
+
+  def test_foundation_v0_seed_is_42_repeated
+    assert_equal SEED_42, S::FOUNDATION_V0_SEED
+    assert_equal 32, S::FOUNDATION_V0_SEED.bytesize
+  end
+
+  def test_different_seeds_produce_different_signatures
+    sig_a = S.ed25519_sign_with_seed(SEED_42, "same message")
+    sig_b = S.ed25519_sign_with_seed(SEED_99, "same message")
+    refute_equal sig_a, sig_b
+  end
+
+  def test_different_messages_produce_different_signatures
+    sig_a = S.ed25519_sign_with_seed(SEED_42, "message a")
+    sig_b = S.ed25519_sign_with_seed(SEED_42, "message b")
+    refute_equal sig_a, sig_b
+  end
+
+  def test_verify_raw_round_trip
+    pk_bytes = S.ed25519_pubkey_bytes(SEED_42)
+    sig = S.ed25519_sign_with_seed(SEED_42, "hello")
+    assert S.verify_raw(pk_bytes, sig, "hello")
+    refute S.verify_raw(pk_bytes, sig, "world")
+  end
+
+  def test_invalid_seed_length_raises
+    assert_raises(ArgumentError) do
+      S.ed25519_sign_with_seed("short", "hello")
+    end
+    assert_raises(ArgumentError) do
+      S.ed25519_pubkey_bytes("short")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Side B port for the Ruby kit per #176: every crypto primitive needed for envelope construction, no shell-out to other kits.

- `Provekit::Blake3` — FFI binding to libblake3 for 64-byte XOF output. Replaces the previous Python-subprocess shellout in `blake3.rb`.
- `Provekit::Cbor` — Deterministic CBOR encoder, RFC 8949 §4.2.1. Ported 1:1 from `provekit-proof-envelope/src/cbor.rs`.
- `Provekit::Signing` — Ed25519 sign/verify on the `ed25519` gem. Self-identifying string form (`"ed25519:" + base64-stdpad(bytes)`) plus raw 64-byte form for CBOR envelope use.
- `Provekit::ProofEnvelope` — Four-step build (CBOR-sort → sign → re-emit → BLAKE3). Includes a minimal verify-only CBOR decoder so the unsigned body can be re-encoded for signature check.
- `Provekit::Jcs` — Re-export of `IR::Jcs` (single canonicalizer in the kit; keeps the existing `test_jcs_conformance.rb` fixture-pinned implementation as the source of truth).
- `Gemfile` + `provekit.gemspec` — proper gem packaging.

## Acceptance criteria (issue #210)

- [x] Ruby can natively compute BLAKE3 of canonical bytes (libblake3 via FFI; cross-checked against Python `blake3` and Rust `provekit_canonicalizer::blake3_512_of`).
- [x] Ruby can natively JCS-canonicalize JSON (re-export of existing `Provekit::IR::Jcs`, already passing the shared conformance fixtures).
- [x] Ruby can natively sign/verify Ed25519 (`ed25519` gem; known-vector pin matches PyNaCl + ed25519-dalek byte-for-byte for `seed=[0x42]*32, msg="hello"`).
- [x] Ruby can natively CBOR-encode the envelope (small RFC 8949 §4.2.1 encoder ported from `cbor.rs`).
- [x] Output round-trips byte-for-byte against rust + go reference envelopes (cross-kit pin from PR #221's Rust-derived fixture; Python kit reproduces the same bytes; Go kit's builder is RFC 8949 §4.2.1 by construction).
- [x] No shell-out to another kit required for envelope construction.

## Cross-kit pin

```
CID:    blake3-512:5ed1e1f705622ad52ae4683e3d12df5586d364d66bb3186f5be512415edf290844d74e73a2857cd858f37803e4b11fe5c7cba7884caa6b9ff847521ce32ea056
bytes:  252-byte CBOR catalog (full hex pinned in test_proof_envelope.rb)
input:  name=@test/cat, version=1.0.0, seed=[0x42;32],
        members={blake3-512:aa: '{"hello":"world"}',
                 blake3-512:bb: '{"goodbye":"world"}'},
        signer=blake3-512:cc, declaredAt=2026-04-30T00:00:00.000Z
```

`test_two_member_bytes_match_rust` and `test_two_member_cid_matches_rust` pass green. `test_rust_bytes_verify_with_foundation_key` confirms the signature on the Rust-produced bytes verifies under our pubkey-bytes verifier path.

## Test plan

- [x] `cd implementations/ruby && ruby -Ilib -Itest test/test_blake3.rb` — 9 runs, 9 assertions, 0 failures.
- [x] `ruby -Ilib -Itest test/test_cbor.rb` — 9 runs, 9 assertions, 0 failures.
- [x] `ruby -Ilib -Itest test/test_signing.rb` — 14 runs, 20 assertions, 0 failures (incl. PyNaCl byte-pin).
- [x] `ruby -Ilib -Itest test/test_proof_envelope.rb` — 16 runs, 18 assertions, 0 failures (incl. cross-kit pin).
- [x] Pre-existing tests still pass: `test_jcs_conformance.rb` (3/3), `test_daemon_protocol.rb` (8/8), `test_ffi_resolver.rb` (8/8). No regression on the IR/JCS path.

## Notes

- **libblake3 prereq**: the kit FFI-binds to `libblake3` (`brew install blake3` on macOS, `apt install libblake3-dev` on Debian). Lib search uses an array of common platform paths so the same gem builds on Intel + ARM Mac and Linux. Documented in the gemspec.
- **No Ruby CI today**: there is no Ruby job in `.github/workflows/ci.yml` at present (existing CI covers Python, Java, C++; C++ vendors BLAKE3, doesn't go through libblake3). Ran the suite locally on macOS Ruby 4.0.3. When a Ruby workflow is added, it will need `apt-get install libblake3-dev` (Linux) or equivalent so libblake3 is on the loader path.
- **No CBOR gem dep**: the Rust CBOR encoder was small enough to port directly (~80 LOC). This avoids gem-API drift on canonicalization and keeps byte-equivalence under our control.
- **Out of scope (mirrors PR #221's deferral)**: v1.2 layered claim envelope construction. Will follow as a separate issue.
- **Gemfile.lock** is gitignored per library-gem convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)