### PR TITLE
feat(zig): native crypto substrate -- BLAKE3 + JCS + Ed25519 + CBOR + envelopes (closes #214)

### DIFF
--- a/implementations/zig/README.md
+++ b/implementations/zig/README.md
@@ -6,12 +6,36 @@ Zig-native implementation of the ProvekIt IR and lift tool.
 
 ```
 implementations/zig/
-├── provekit-ir/          # IR types library (Sort, Term, Formula, Document)
+├── provekit-ir/                    # IR types + JCS canonicalizer + BLAKE3
 │   ├── build.zig
 │   └── src/root.zig
-└── provekit-lift-zig/    # Lift tool: scans .zig → emits IR JSON
+├── provekit-proof-envelope-zig/    # Side B substrate: deterministic CBOR,
+│   │                               # Ed25519, .proof envelope build/verify
+│   ├── build.zig
+│   └── src/{root,cbor,sign,proof}.zig
+└── provekit-lift-zig/              # Lift tool: scans .zig -> emits IR JSON
     ├── build.zig
     └── src/main.zig
+```
+
+## provekit-proof-envelope-zig
+
+Side B (language-native) crypto substrate. Exposes BLAKE3-512, JCS
+(re-exported from provekit-ir), Ed25519 sign/verify, deterministic CBOR
+(RFC 8949 §4.2.1), and `.proof` envelope construction.
+
+Cross-kit byte-equivalence with the rust kit's `provekit-proof-envelope`
+is pinned by the canonical two-member fixture; same input produces
+byte-identical output and the same `blake3-512:...` CID.
+
+Primitive sources: BLAKE3 from `std.crypto.hash.Blake3`, Ed25519 from
+`std.crypto.sign.Ed25519` (deterministic mode via `noise=null`), CBOR
+hand-rolled (~90 LOC, 5 major types), JCS hand-rolled in provekit-ir
+via `std.json.Stringify` with strict alphabetical key order.
+
+```bash
+cd implementations/zig/provekit-proof-envelope-zig
+zig build test    # 26/26 tests pass, includes cross-kit byte-pin
 ```
 
 ## provekit-ir

--- a/implementations/zig/provekit-proof-envelope-zig/build.zig
+++ b/implementations/zig/provekit-proof-envelope-zig/build.zig
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Build for provekit-proof-envelope-zig.
+//
+// Side B (language-native) crypto substrate for the zig kit. Exposes:
+//   - BLAKE3-512 hashing (re-exported from std.crypto.hash.Blake3)
+//   - Deterministic CBOR encoder (RFC 8949 §4.2.1) — ~90 LOC, mirrors
+//     the rust kit's provekit-proof-envelope/src/cbor.rs
+//   - Ed25519 sign/verify (wraps std.crypto.sign.Ed25519)
+//   - .proof envelope builder, byte-identical to the rust kit's
+//     provekit-proof-envelope::build_proof_envelope for the same input
+//
+// JCS canonicalization for the IR ships in provekit-ir/src/root.zig
+// (jcsStringify + jcsHash); this package re-uses it via module import.
+
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Sibling module: provekit-ir provides JCS helpers + IR types. We
+    // import it so the public API of this package exposes the unified
+    // crypto substrate (BLAKE3 + JCS + Ed25519 + CBOR + envelope).
+    const provekit_ir = b.createModule(.{
+        .root_source_file = b.path("../provekit-ir/src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const lib = b.addModule("provekit-proof-envelope-zig", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "provekit-ir", .module = provekit_ir },
+        },
+    });
+
+    const lib_unit_tests = b.addTest(.{
+        .root_module = lib,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+}

--- a/implementations/zig/provekit-proof-envelope-zig/build.zig.zon
+++ b/implementations/zig/provekit-proof-envelope-zig/build.zig.zon
@@ -1,0 +1,9 @@
+.{
+    .name = .provekit_proof_envelope_zig,
+    .fingerprint = 0x9b059a361ca07667,
+    .version = "0.1.0",
+    .paths = .{
+        "build.zig",
+        "src",
+    },
+}

--- a/implementations/zig/provekit-proof-envelope-zig/src/cbor.zig
+++ b/implementations/zig/provekit-proof-envelope-zig/src/cbor.zig
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Deterministic CBOR encoder. RFC 8949 §4.2.1 rules:
+//   - shortest-form integer encoding (smallest of short / u8 / u16 / u32 / u64)
+//   - definite-length items only
+//   - map keys sorted in bytewise lex order of their CBOR-encoded form
+//   - we emit only the major types we need: unsigned int, byte string,
+//     text string, array, map.
+//
+// Mirrors implementations/rust/provekit-proof-envelope/src/cbor.rs 1:1
+// and implementations/cpp/provekit/proof-envelope/cbor.cpp.
+
+const std = @import("std");
+
+pub const CborMajor = enum(u8) {
+    unsigned_int = 0,
+    byte_string = 2,
+    text_string = 3,
+    array = 4,
+    map = 5,
+};
+
+pub fn appendHead(out: *std.ArrayList(u8), alloc: std.mem.Allocator, major: CborMajor, arg: u64) !void {
+    const mt: u8 = @as(u8, @intFromEnum(major)) << 5;
+    if (arg < 24) {
+        try out.append(alloc, mt | @as(u8, @intCast(arg)));
+        return;
+    }
+    if (arg <= 0xFF) {
+        try out.append(alloc, mt | 24);
+        try out.append(alloc, @as(u8, @intCast(arg)));
+        return;
+    }
+    if (arg <= 0xFFFF) {
+        try out.append(alloc, mt | 25);
+        try out.append(alloc, @as(u8, @intCast(arg >> 8)));
+        try out.append(alloc, @as(u8, @intCast(arg & 0xFF)));
+        return;
+    }
+    if (arg <= 0xFFFF_FFFF) {
+        try out.append(alloc, mt | 26);
+        try out.append(alloc, @as(u8, @intCast(arg >> 24)));
+        try out.append(alloc, @as(u8, @intCast((arg >> 16) & 0xFF)));
+        try out.append(alloc, @as(u8, @intCast((arg >> 8) & 0xFF)));
+        try out.append(alloc, @as(u8, @intCast(arg & 0xFF)));
+        return;
+    }
+    try out.append(alloc, mt | 27);
+    var i: u6 = 8;
+    while (i > 0) {
+        i -= 1;
+        try out.append(alloc, @as(u8, @intCast((arg >> (@as(u6, i) * 8)) & 0xFF)));
+    }
+}
+
+pub fn encodeUint(out: *std.ArrayList(u8), alloc: std.mem.Allocator, value: u64) !void {
+    try appendHead(out, alloc, .unsigned_int, value);
+}
+
+pub fn encodeBstr(out: *std.ArrayList(u8), alloc: std.mem.Allocator, bytes: []const u8) !void {
+    try appendHead(out, alloc, .byte_string, @as(u64, bytes.len));
+    try out.appendSlice(alloc, bytes);
+}
+
+pub fn encodeTstr(out: *std.ArrayList(u8), alloc: std.mem.Allocator, utf8: []const u8) !void {
+    try appendHead(out, alloc, .text_string, @as(u64, utf8.len));
+    try out.appendSlice(alloc, utf8);
+}
+
+pub fn encodeArrayHead(out: *std.ArrayList(u8), alloc: std.mem.Allocator, count: u64) !void {
+    try appendHead(out, alloc, .array, count);
+}
+
+pub fn encodeMapHead(out: *std.ArrayList(u8), alloc: std.mem.Allocator, count: u64) !void {
+    try appendHead(out, alloc, .map, count);
+}
+
+// ---------------------------------------------------------------------------
+// Tests — pinned vectors from RFC 8949 §3.3 + the rust kit.
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "shortest-form uint: 0..23 single byte" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+
+    try encodeUint(&buf, testing.allocator, 0);
+    try testing.expectEqualSlices(u8, &.{0x00}, buf.items);
+
+    buf.clearRetainingCapacity();
+    try encodeUint(&buf, testing.allocator, 23);
+    try testing.expectEqualSlices(u8, &.{0x17}, buf.items);
+}
+
+test "shortest-form uint: 24..255 two bytes" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+
+    try encodeUint(&buf, testing.allocator, 24);
+    try testing.expectEqualSlices(u8, &.{ 0x18, 24 }, buf.items);
+
+    buf.clearRetainingCapacity();
+    try encodeUint(&buf, testing.allocator, 255);
+    try testing.expectEqualSlices(u8, &.{ 0x18, 0xff }, buf.items);
+}
+
+test "shortest-form uint: 256..65535 three bytes" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+
+    try encodeUint(&buf, testing.allocator, 256);
+    try testing.expectEqualSlices(u8, &.{ 0x19, 0x01, 0x00 }, buf.items);
+}
+
+test "shortest-form uint: 65536..2^32-1 five bytes" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+
+    try encodeUint(&buf, testing.allocator, 65536);
+    try testing.expectEqualSlices(u8, &.{ 0x1a, 0x00, 0x01, 0x00, 0x00 }, buf.items);
+}
+
+test "tstr emits major-3 head then utf8 bytes" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+
+    try encodeTstr(&buf, testing.allocator, "hello");
+    // major 3 (text), len 5 short form: 0x60 | 5 = 0x65, then "hello"
+    try testing.expectEqualSlices(u8, &.{ 0x65, 'h', 'e', 'l', 'l', 'o' }, buf.items);
+}
+
+test "bstr emits major-2 head then raw bytes" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+
+    try encodeBstr(&buf, testing.allocator, &.{ 0xde, 0xad, 0xbe, 0xef });
+    try testing.expectEqualSlices(u8, &.{ 0x44, 0xde, 0xad, 0xbe, 0xef }, buf.items);
+}
+
+test "map head with 7 entries" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+
+    try encodeMapHead(&buf, testing.allocator, 7);
+    // major 5 (map), count 7 short form: 0xa0 | 7 = 0xa7
+    try testing.expectEqualSlices(u8, &.{0xa7}, buf.items);
+}

--- a/implementations/zig/provekit-proof-envelope-zig/src/proof.zig
+++ b/implementations/zig/provekit-proof-envelope-zig/src/proof.zig
@@ -1,0 +1,554 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// .proof envelope builder. Per RFC 8949 §4.2.1 + the .proof spec
+// (protocol/specs/2026-04-30-proof-file-format.md):
+//
+//   1. Build the unsigned body as a CBOR map with keys sorted by
+//      bytewise lex order of their CBOR-encoded form.
+//   2. Ed25519-sign the unsigned-body bytes.
+//   3. Re-emit the body with the signature added; keys re-sort
+//      automatically (the new "signature" key slots in by lex order).
+//   4. BLAKE3-512 the final bytes; the full self-identifying string
+//      `"blake3-512:<128 hex>"` IS the catalog CID.
+//
+// The `members` map key is the embedded envelope's own CID, and the
+// value is its canonical bytes (JCS-JSON for memento envelopes per
+// the memento envelope grammar) wrapped as a CBOR byte string.
+//
+// Mirrors implementations/rust/provekit-proof-envelope/src/proof.rs.
+
+const std = @import("std");
+
+const cbor = @import("cbor.zig");
+const sign = @import("sign.zig");
+
+pub const Member = struct {
+    cid: []const u8,
+    bytes: []const u8,
+};
+
+pub const MetadataEntry = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+pub const ProofEnvelopeInput = struct {
+    name: []const u8,
+    version: []const u8,
+    members: []const Member,
+    signer_cid: []const u8,
+    declared_at: []const u8,
+    signer_seed: sign.Ed25519Seed = sign.FOUNDATION_V0_SEED,
+    binary_cid: ?[]const u8 = null,
+    metadata: ?[]const MetadataEntry = null,
+};
+
+pub const ProofEnvelopeOutput = struct {
+    /// CBOR bytes of the signed catalog. Caller owns the slice.
+    bytes: []u8,
+    /// Full self-identifying CID, e.g. `"blake3-512:<128 hex>"`.
+    /// Caller owns the slice.
+    cid: []u8,
+
+    pub fn deinit(self: *ProofEnvelopeOutput, alloc: std.mem.Allocator) void {
+        alloc.free(self.bytes);
+        alloc.free(self.cid);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Internal: pre-encoded (key, value) pairs for sortable map emission.
+// ---------------------------------------------------------------------------
+
+const Pair = struct {
+    key_cbor: []u8,
+    value_cbor: []u8,
+};
+
+fn pairLessThan(_: void, a: Pair, b: Pair) bool {
+    return std.mem.lessThan(u8, a.key_cbor, b.key_cbor);
+}
+
+fn encodeKey(alloc: std.mem.Allocator, key: []const u8) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(alloc);
+    try cbor.encodeTstr(&buf, alloc, key);
+    return buf.toOwnedSlice(alloc);
+}
+
+fn makeStringPair(alloc: std.mem.Allocator, key: []const u8, value: []const u8) !Pair {
+    var v: std.ArrayList(u8) = .empty;
+    errdefer v.deinit(alloc);
+    try cbor.encodeTstr(&v, alloc, value);
+    return .{
+        .key_cbor = try encodeKey(alloc, key),
+        .value_cbor = try v.toOwnedSlice(alloc),
+    };
+}
+
+fn makeBytesPair(alloc: std.mem.Allocator, key: []const u8, value: []const u8) !Pair {
+    var v: std.ArrayList(u8) = .empty;
+    errdefer v.deinit(alloc);
+    try cbor.encodeBstr(&v, alloc, value);
+    return .{
+        .key_cbor = try encodeKey(alloc, key),
+        .value_cbor = try v.toOwnedSlice(alloc),
+    };
+}
+
+fn makeMembersPair(alloc: std.mem.Allocator, key: []const u8, members: []const Member) !Pair {
+    // Encode as { tstr(cid) => bstr(envelope-bytes) }, sort by bytewise
+    // CBOR-encoded-key form.
+    var pairs = try alloc.alloc(Pair, members.len);
+    defer {
+        for (pairs) |p| {
+            alloc.free(p.key_cbor);
+            alloc.free(p.value_cbor);
+        }
+        alloc.free(pairs);
+    }
+    for (members, 0..) |m, i| {
+        pairs[i] = try makeBytesPair(alloc, m.cid, m.bytes);
+    }
+    var value: std.ArrayList(u8) = .empty;
+    errdefer value.deinit(alloc);
+    try emitSortedMap(&value, alloc, pairs);
+    return .{
+        .key_cbor = try encodeKey(alloc, key),
+        .value_cbor = try value.toOwnedSlice(alloc),
+    };
+}
+
+fn makeMetadataPair(alloc: std.mem.Allocator, key: []const u8, entries: []const MetadataEntry) !Pair {
+    var pairs = try alloc.alloc(Pair, entries.len);
+    defer {
+        for (pairs) |p| {
+            alloc.free(p.key_cbor);
+            alloc.free(p.value_cbor);
+        }
+        alloc.free(pairs);
+    }
+    for (entries, 0..) |e, i| {
+        pairs[i] = try makeStringPair(alloc, e.key, e.value);
+    }
+    var value: std.ArrayList(u8) = .empty;
+    errdefer value.deinit(alloc);
+    try emitSortedMap(&value, alloc, pairs);
+    return .{
+        .key_cbor = try encodeKey(alloc, key),
+        .value_cbor = try value.toOwnedSlice(alloc),
+    };
+}
+
+fn emitSortedMap(out: *std.ArrayList(u8), alloc: std.mem.Allocator, pairs: []Pair) !void {
+    std.mem.sort(Pair, pairs, {}, pairLessThan);
+    try cbor.encodeMapHead(out, alloc, @as(u64, pairs.len));
+    for (pairs) |p| {
+        try out.appendSlice(alloc, p.key_cbor);
+        try out.appendSlice(alloc, p.value_cbor);
+    }
+}
+
+// Build the full unsigned body pair list. Caller owns each pair's
+// inner slices and must free via freePairs.
+fn bodyPairsUnsigned(alloc: std.mem.Allocator, input: ProofEnvelopeInput) !std.ArrayList(Pair) {
+    var pairs: std.ArrayList(Pair) = .empty;
+    errdefer {
+        for (pairs.items) |p| {
+            alloc.free(p.key_cbor);
+            alloc.free(p.value_cbor);
+        }
+        pairs.deinit(alloc);
+    }
+    try pairs.append(alloc, try makeStringPair(alloc, "kind", "catalog"));
+    try pairs.append(alloc, try makeStringPair(alloc, "name", input.name));
+    try pairs.append(alloc, try makeStringPair(alloc, "version", input.version));
+    try pairs.append(alloc, try makeMembersPair(alloc, "members", input.members));
+    try pairs.append(alloc, try makeStringPair(alloc, "signer", input.signer_cid));
+    try pairs.append(alloc, try makeStringPair(alloc, "declaredAt", input.declared_at));
+    if (input.binary_cid) |bcid| {
+        try pairs.append(alloc, try makeStringPair(alloc, "binaryCid", bcid));
+    }
+    if (input.metadata) |meta| {
+        try pairs.append(alloc, try makeMetadataPair(alloc, "metadata", meta));
+    }
+    return pairs;
+}
+
+fn freePairs(alloc: std.mem.Allocator, pairs: *std.ArrayList(Pair)) void {
+    for (pairs.items) |p| {
+        alloc.free(p.key_cbor);
+        alloc.free(p.value_cbor);
+    }
+    pairs.deinit(alloc);
+}
+
+// ---------------------------------------------------------------------------
+// BLAKE3-512 helper. Mirrors provekit-ir/src/root.zig's jcsHash; using a
+// local copy here keeps the proof builder self-contained in one source
+// file dependency-wise (the package still re-exports the IR helper).
+// ---------------------------------------------------------------------------
+
+fn blake3_512_of(alloc: std.mem.Allocator, bytes: []const u8) ![]u8 {
+    var hash_out: [64]u8 = undefined;
+    var hasher = std.crypto.hash.Blake3.init(.{});
+    hasher.update(bytes);
+    hasher.final(&hash_out);
+
+    const prefix = "blake3-512:";
+    const hex = std.fmt.bytesToHex(hash_out, .lower);
+    var result = try alloc.alloc(u8, prefix.len + hex.len);
+    @memcpy(result[0..prefix.len], prefix);
+    @memcpy(result[prefix.len..], &hex);
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point.
+// ---------------------------------------------------------------------------
+
+pub fn buildProofEnvelope(
+    alloc: std.mem.Allocator,
+    input: ProofEnvelopeInput,
+) !ProofEnvelopeOutput {
+    // Step 1: encode unsigned body with sorted keys.
+    var unsigned_pairs = try bodyPairsUnsigned(alloc, input);
+    defer freePairs(alloc, &unsigned_pairs);
+
+    var unsigned_bytes: std.ArrayList(u8) = .empty;
+    defer unsigned_bytes.deinit(alloc);
+    try emitSortedMap(&unsigned_bytes, alloc, unsigned_pairs.items);
+
+    // Step 2: Ed25519-sign the unsigned bytes.
+    const sig = try sign.signWithSeed(input.signer_seed, unsigned_bytes.items);
+
+    // Step 3: re-emit with signature pair added; keys re-sort automatically.
+    var signed_pairs = try bodyPairsUnsigned(alloc, input);
+    defer freePairs(alloc, &signed_pairs);
+    try signed_pairs.append(alloc, try makeBytesPair(alloc, "signature", &sig));
+
+    var final_buf: std.ArrayList(u8) = .empty;
+    errdefer final_buf.deinit(alloc);
+    try emitSortedMap(&final_buf, alloc, signed_pairs.items);
+    const final_bytes = try final_buf.toOwnedSlice(alloc);
+    errdefer alloc.free(final_bytes);
+
+    // Step 4: filename CID = full self-identifying BLAKE3-512.
+    const cid = try blake3_512_of(alloc, final_bytes);
+
+    return .{ .bytes = final_bytes, .cid = cid };
+}
+
+// ---------------------------------------------------------------------------
+// Verifier — checks CID match, CBOR shape, and Ed25519 signature.
+// ---------------------------------------------------------------------------
+
+/// Verify a .proof envelope against expected_cid and signer_pubkey (raw 32 bytes).
+/// Returns true iff CID, shape, and signature all check out. Fails closed.
+///
+/// NOTE: This is a deliberately minimal verifier — it re-encodes the
+/// unsigned body from the input fields the caller passes (since fully
+/// parsing arbitrary CBOR is out of scope for this substrate). For
+/// canonical fixtures, callers pass the same ProofEnvelopeInput they
+/// built from and compare against the embedded raw bytes.
+pub fn verifyRebuilt(
+    alloc: std.mem.Allocator,
+    proof_bytes: []const u8,
+    expected_cid: []const u8,
+    signer_pubkey: sign.Ed25519PublicKey,
+    rebuilt_input: ProofEnvelopeInput,
+) !bool {
+    // 1. CID match.
+    const actual_cid = try blake3_512_of(alloc, proof_bytes);
+    defer alloc.free(actual_cid);
+    if (!std.mem.eql(u8, actual_cid, expected_cid)) return false;
+
+    // 2. Re-build unsigned body bytes from the rebuilt_input.
+    var unsigned_pairs = try bodyPairsUnsigned(alloc, rebuilt_input);
+    defer freePairs(alloc, &unsigned_pairs);
+
+    var unsigned_bytes: std.ArrayList(u8) = .empty;
+    defer unsigned_bytes.deinit(alloc);
+    try emitSortedMap(&unsigned_bytes, alloc, unsigned_pairs.items);
+
+    // 3. Find the signature inside proof_bytes. The signature key encodes
+    //    as 0x69 'signature' (text, len 9), followed by 0x58 0x40 (bstr,
+    //    len 64) followed by the 64 raw bytes. Search for the marker.
+    const marker: []const u8 = &.{ 0x69, 's', 'i', 'g', 'n', 'a', 't', 'u', 'r', 'e', 0x58, 0x40 };
+    const idx = std.mem.indexOf(u8, proof_bytes, marker) orelse return false;
+    if (idx + marker.len + 64 > proof_bytes.len) return false;
+    var sig: sign.Ed25519Signature = undefined;
+    @memcpy(&sig, proof_bytes[idx + marker.len ..][0..64]);
+
+    // 4. Verify against the rebuilt unsigned body.
+    return sign.verifyRaw(signer_pubkey, sig, unsigned_bytes.items);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn twoMemberInput() ProofEnvelopeInput {
+    const members_static = struct {
+        const list = [_]Member{
+            .{ .cid = "blake3-512:aa", .bytes = "{\"hello\":\"world\"}" },
+            .{ .cid = "blake3-512:bb", .bytes = "{\"goodbye\":\"world\"}" },
+        };
+    };
+    return .{
+        .name = "@test/cat",
+        .version = "1.0.0",
+        .members = &members_static.list,
+        .signer_cid = "blake3-512:cc",
+        .declared_at = "2026-04-30T00:00:00.000Z",
+        .signer_seed = sign.FOUNDATION_V0_SEED,
+    };
+}
+
+test "build minimal proof envelope round-trips" {
+    var out = try buildProofEnvelope(testing.allocator, .{
+        .name = "@test/cat",
+        .version = "1.0.0",
+        .members = &.{
+            .{ .cid = "blake3-512:aa", .bytes = "{\"hello\":\"world\"}" },
+        },
+        .signer_cid = "blake3-512:cc",
+        .declared_at = "2026-04-30T00:00:00.000Z",
+        .signer_seed = sign.FOUNDATION_V0_SEED,
+    });
+    defer out.deinit(testing.allocator);
+
+    try testing.expect(std.mem.startsWith(u8, out.cid, "blake3-512:"));
+    // 7-key map head: major 5 (0xA0) + count 7 = 0xA7.
+    try testing.expectEqual(@as(u8, 0xA7), out.bytes[0]);
+}
+
+test "deterministic across runs" {
+    var a = try buildProofEnvelope(testing.allocator, twoMemberInput());
+    defer a.deinit(testing.allocator);
+    var b = try buildProofEnvelope(testing.allocator, twoMemberInput());
+    defer b.deinit(testing.allocator);
+
+    try testing.expectEqualSlices(u8, a.bytes, b.bytes);
+    try testing.expectEqualStrings(a.cid, b.cid);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-kit byte-equivalence (pinned from rust kit reference output).
+//
+// Source (authoritative):
+//   implementations/python/provekit-lift-py-tests/tests/test_proof_envelope.py
+//   constant `RUST_FIXTURE_BYTES_HEX_FULL` and `RUST_FIXTURE_CID`.
+//
+// Generated on the rust kit via:
+//   cargo run --release -p provekit-proof-envelope --example proof_envelope_bytes
+//
+// If any test below fails, the divergence is a real cross-kit impedance
+// mismatch. Surface it with a clear message — DO NOT paper over.
+// ---------------------------------------------------------------------------
+
+const RUST_FIXTURE_CID =
+    "blake3-512:5ed1e1f705622ad52ae4683e3d12df5586d364d66bb3186f5be512415edf290" ++
+    "844d74e73a2857cd858f37803e4b11fe5c7cba7884caa6b9ff847521ce32ea056";
+
+const RUST_FIXTURE_BYTES_HEX_FULL =
+    "a7646b696e6467636174616c6f67646e616d656940746573742f636174667369676e65" ++
+    "726d626c616b65332d3531323a6363676d656d62657273a26d626c616b65332d353132" ++
+    "3a6161517b2268656c6c6f223a22776f726c64227d6d626c616b65332d3531323a6262" ++
+    "537b22676f6f64627965223a22776f726c64227d6776657273696f6e65312e302e3069" ++
+    "7369676e617475726558406a21dd428a54e22c82ca6d6125a7293c4a723786cb1840e8" ++
+    "91cefa03e63246eb97ef13dab86b7b1469d67302fadc969cd88c92c29495d13c75fc02" ++
+    "01a7263b066a6465636c6172656441747818323032362d30342d33305430303a30303a" ++
+    "30302e3030305a";
+
+fn hexToBytes(alloc: std.mem.Allocator, hex: []const u8) ![]u8 {
+    if (hex.len % 2 != 0) return error.InvalidHex;
+    var out = try alloc.alloc(u8, hex.len / 2);
+    errdefer alloc.free(out);
+    var i: usize = 0;
+    while (i < hex.len) : (i += 2) {
+        const hi = try std.fmt.charToDigit(hex[i], 16);
+        const lo = try std.fmt.charToDigit(hex[i + 1], 16);
+        out[i / 2] = (@as(u8, hi) << 4) | @as(u8, lo);
+    }
+    return out;
+}
+
+test "two-member envelope bytes match rust reference (cross-kit pin)" {
+    const alloc = testing.allocator;
+    var out = try buildProofEnvelope(alloc, twoMemberInput());
+    defer out.deinit(alloc);
+
+    const rust_bytes = try hexToBytes(alloc, RUST_FIXTURE_BYTES_HEX_FULL);
+    defer alloc.free(rust_bytes);
+
+    if (!std.mem.eql(u8, out.bytes, rust_bytes)) {
+        // Diagnose: find first divergence so the test message is actionable.
+        var i: usize = 0;
+        const min_len = @min(out.bytes.len, rust_bytes.len);
+        while (i < min_len) : (i += 1) {
+            if (out.bytes[i] != rust_bytes[i]) {
+                std.debug.print(
+                    "\ncross-kit byte divergence at offset {d}: zig=0x{x:0>2} rust=0x{x:0>2}\n" ++
+                        "zig hex:  ",
+                    .{ i, out.bytes[i], rust_bytes[i] },
+                );
+                for (out.bytes) |b| std.debug.print("{x:0>2}", .{b});
+                std.debug.print("\nrust hex: ", .{});
+                for (rust_bytes) |b| std.debug.print("{x:0>2}", .{b});
+                std.debug.print("\n", .{});
+                break;
+            }
+        }
+        if (out.bytes.len != rust_bytes.len) {
+            std.debug.print(
+                "\ncross-kit length mismatch: zig={d} rust={d}\n",
+                .{ out.bytes.len, rust_bytes.len },
+            );
+        }
+        try testing.expect(false);
+    }
+}
+
+test "two-member envelope CID matches rust reference (cross-kit pin)" {
+    const alloc = testing.allocator;
+    var out = try buildProofEnvelope(alloc, twoMemberInput());
+    defer out.deinit(alloc);
+
+    try testing.expectEqualStrings(RUST_FIXTURE_CID, out.cid);
+}
+
+test "rust reference bytes verify under our verifier" {
+    const alloc = testing.allocator;
+    const rust_bytes = try hexToBytes(alloc, RUST_FIXTURE_BYTES_HEX_FULL);
+    defer alloc.free(rust_bytes);
+
+    const foundation_pk = try sign.pubkeyFromSeed(sign.FOUNDATION_V0_SEED);
+    const ok = try verifyRebuilt(
+        alloc,
+        rust_bytes,
+        RUST_FIXTURE_CID,
+        foundation_pk,
+        twoMemberInput(),
+    );
+    try testing.expect(ok);
+}
+
+test "verifyRebuilt rejects tampered cid" {
+    const alloc = testing.allocator;
+    var out = try buildProofEnvelope(alloc, twoMemberInput());
+    defer out.deinit(alloc);
+
+    const fake_cid = "blake3-512:" ++ ("00" ** 64);
+    const foundation_pk = try sign.pubkeyFromSeed(sign.FOUNDATION_V0_SEED);
+    const ok = try verifyRebuilt(
+        alloc,
+        out.bytes,
+        fake_cid,
+        foundation_pk,
+        twoMemberInput(),
+    );
+    try testing.expect(!ok);
+}
+
+test "verifyRebuilt rejects wrong pubkey" {
+    const alloc = testing.allocator;
+    var out = try buildProofEnvelope(alloc, twoMemberInput());
+    defer out.deinit(alloc);
+
+    const wrong_seed: sign.Ed25519Seed = [_]u8{0x99} ** 32;
+    const wrong_pk = try sign.pubkeyFromSeed(wrong_seed);
+    const ok = try verifyRebuilt(
+        alloc,
+        out.bytes,
+        out.cid,
+        wrong_pk,
+        twoMemberInput(),
+    );
+    try testing.expect(!ok);
+}
+
+test "binaryCid changes envelope CID" {
+    const alloc = testing.allocator;
+    const members = [_]Member{
+        .{ .cid = "blake3-512:aa", .bytes = "data" },
+    };
+    var with_bcid = try buildProofEnvelope(alloc, .{
+        .name = "@test/cat",
+        .version = "1.0.0",
+        .members = &members,
+        .signer_cid = "blake3-512:cc",
+        .declared_at = "2026-04-30T00:00:00.000Z",
+        .signer_seed = sign.FOUNDATION_V0_SEED,
+        .binary_cid = "blake3-512:deadbeef",
+    });
+    defer with_bcid.deinit(alloc);
+    var without = try buildProofEnvelope(alloc, .{
+        .name = "@test/cat",
+        .version = "1.0.0",
+        .members = &members,
+        .signer_cid = "blake3-512:cc",
+        .declared_at = "2026-04-30T00:00:00.000Z",
+        .signer_seed = sign.FOUNDATION_V0_SEED,
+    });
+    defer without.deinit(alloc);
+
+    try testing.expect(!std.mem.eql(u8, with_bcid.cid, without.cid));
+}
+
+test "metadata field included in signed body" {
+    const alloc = testing.allocator;
+    const members = [_]Member{
+        .{ .cid = "blake3-512:aa", .bytes = "data" },
+    };
+    const meta = [_]MetadataEntry{
+        .{ .key = "tool", .value = "zig-kit" },
+        .{ .key = "version", .value = "0.1.0" },
+    };
+    var out = try buildProofEnvelope(alloc, .{
+        .name = "@test/cat",
+        .version = "1.0.0",
+        .members = &members,
+        .signer_cid = "blake3-512:cc",
+        .declared_at = "2026-04-30T00:00:00.000Z",
+        .signer_seed = sign.FOUNDATION_V0_SEED,
+        .metadata = &meta,
+    });
+    defer out.deinit(alloc);
+
+    const foundation_pk = try sign.pubkeyFromSeed(sign.FOUNDATION_V0_SEED);
+    const ok = try verifyRebuilt(
+        alloc,
+        out.bytes,
+        out.cid,
+        foundation_pk,
+        .{
+            .name = "@test/cat",
+            .version = "1.0.0",
+            .members = &members,
+            .signer_cid = "blake3-512:cc",
+            .declared_at = "2026-04-30T00:00:00.000Z",
+            .signer_seed = sign.FOUNDATION_V0_SEED,
+            .metadata = &meta,
+        },
+    );
+    try testing.expect(ok);
+}
+
+test "empty members produces valid envelope" {
+    const alloc = testing.allocator;
+    var out = try buildProofEnvelope(alloc, .{
+        .name = "x",
+        .version = "1",
+        .members = &.{},
+        .signer_cid = "blake3-512:cc",
+        .declared_at = "2026-04-30T00:00:00.000Z",
+        .signer_seed = sign.FOUNDATION_V0_SEED,
+    });
+    defer out.deinit(alloc);
+
+    try testing.expectEqual(@as(u8, 0xA7), out.bytes[0]);
+    try testing.expect(std.mem.startsWith(u8, out.cid, "blake3-512:"));
+}

--- a/implementations/zig/provekit-proof-envelope-zig/src/root.zig
+++ b/implementations/zig/provekit-proof-envelope-zig/src/root.zig
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-proof-envelope-zig — Side B (language-native) crypto
+// substrate for the zig kit.
+//
+// Surface (idiomatic Zig):
+//   - BLAKE3-512 hashing                — std.crypto.hash.Blake3 (stdlib)
+//   - JCS canonicalization (RFC 8785)   — re-exported from provekit-ir
+//   - Ed25519 sign/verify               — std.crypto.sign.Ed25519 (stdlib)
+//   - Deterministic CBOR (RFC 8949 §4.2.1) — local encoder, ~90 LOC
+//   - .proof envelope build/verify      — local, byte-identical to rust
+//
+// All four primitives ship from the language stdlib or this package;
+// nothing vendored. JCS is hand-rolled in provekit-ir using Zig's
+// jsonStringify hook on each IR variant; that gives strict alphabetical
+// key order and minified output, RFC 8785 conformant for the IR shapes.
+// We re-export it here so the proof envelope substrate has the full
+// crypto+canonicalization surface in one import.
+//
+// Cross-kit byte-equivalence with the rust reference is pinned in
+// proof.zig's tests using the canonical two-member fixture from
+// implementations/python/provekit-lift-py-tests/tests/test_proof_envelope.py.
+
+const std = @import("std");
+
+// CBOR primitives (deterministic encoder per RFC 8949 §4.2.1).
+pub const cbor = @import("cbor.zig");
+
+// Ed25519 helpers (raw + self-identifying string form).
+pub const sign = @import("sign.zig");
+
+// Proof envelope builder + verifier.
+pub const proof = @import("proof.zig");
+
+// Re-export the high-level proof envelope API at the package root for
+// idiomatic call sites.
+pub const ProofEnvelopeInput = proof.ProofEnvelopeInput;
+pub const ProofEnvelopeOutput = proof.ProofEnvelopeOutput;
+pub const Member = proof.Member;
+pub const MetadataEntry = proof.MetadataEntry;
+pub const buildProofEnvelope = proof.buildProofEnvelope;
+pub const verifyRebuilt = proof.verifyRebuilt;
+
+// Re-export the BLAKE3-512 helper signature from sign-adjacent space.
+pub const Ed25519Seed = sign.Ed25519Seed;
+pub const Ed25519Signature = sign.Ed25519Signature;
+pub const Ed25519PublicKey = sign.Ed25519PublicKey;
+pub const FOUNDATION_V0_SEED = sign.FOUNDATION_V0_SEED;
+
+// Re-export JCS helpers from provekit-ir for callers that want the full
+// substrate (BLAKE3 + JCS + Ed25519 + CBOR + envelope) from one import.
+const provekit_ir = @import("provekit-ir");
+pub const jcsStringify = provekit_ir.jcsStringify;
+pub const jcsHash = provekit_ir.jcsHash;
+
+// ---------------------------------------------------------------------------
+// Top-level BLAKE3-512 helper.
+//
+// Returns the full self-identifying string form `"blake3-512:<128 hex>"`.
+// Caller owns the returned slice. Mirrors provekit-canonicalizer's
+// `blake3_512_of` and the existing `jcsHash` in provekit-ir.
+// ---------------------------------------------------------------------------
+
+pub fn blake3_512_of(alloc: std.mem.Allocator, bytes: []const u8) ![]u8 {
+    var hash_out: [64]u8 = undefined;
+    var hasher = std.crypto.hash.Blake3.init(.{});
+    hasher.update(bytes);
+    hasher.final(&hash_out);
+
+    const prefix = "blake3-512:";
+    const hex = std.fmt.bytesToHex(hash_out, .lower);
+    var result = try alloc.alloc(u8, prefix.len + hex.len);
+    @memcpy(result[0..prefix.len], prefix);
+    @memcpy(result[prefix.len..], &hex);
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tests — pull in sibling test binaries.
+// ---------------------------------------------------------------------------
+
+test {
+    _ = @import("cbor.zig");
+    _ = @import("sign.zig");
+    _ = @import("proof.zig");
+}
+
+test "blake3_512_of empty input matches BLAKE3 spec" {
+    const alloc = std.testing.allocator;
+    const out = try blake3_512_of(alloc, "");
+    defer alloc.free(out);
+    // BLAKE3-512 of empty input (extended XOF output, first 64 bytes) is
+    // a known constant. The first 32 bytes match the standard BLAKE3
+    // 256-bit hash of "":
+    //   af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    try std.testing.expect(std.mem.startsWith(u8, out, "blake3-512:"));
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        out["blake3-512:".len..],
+        "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+    ));
+}

--- a/implementations/zig/provekit-proof-envelope-zig/src/sign.zig
+++ b/implementations/zig/provekit-proof-envelope-zig/src/sign.zig
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ed25519 signing helper. Wraps `std.crypto.sign.Ed25519` so the proof
+// envelope builder can request a deterministic 64-byte signature from a
+// 32-byte seed. Mirrors implementations/rust/provekit-proof-envelope/src/sign.rs.
+//
+// Notes on stdlib mapping:
+//   * `KeyPair.generateDeterministic(seed)` corresponds to ed25519-dalek's
+//     `SigningKey::from_bytes(seed)` — both interpret the 32 bytes as the
+//     RFC 8032 secret seed and SHA-512 expand it.
+//   * Passing `null` for `noise` to `kp.sign(msg, null)` selects the pure
+//     deterministic RFC 8032 mode, which matches ed25519-dalek's default.
+//   * `Signature.toBytes()` returns 64 bytes laid out as `R || s`.
+//
+// v1.1.0 of the protocol mandates self-identifying signatures of the form
+// "ed25519:" + base64-stdpad(64-byte-signature) for memento envelopes
+// (JCS-JSON), but the .proof catalog itself stores the raw 64-byte
+// signature as a CBOR byte string. The helpers here cover both shapes.
+
+const std = @import("std");
+
+const Ed25519 = std.crypto.sign.Ed25519;
+
+pub const Ed25519Seed = [32]u8;
+pub const Ed25519Signature = [64]u8;
+pub const Ed25519PublicKey = [32]u8;
+
+pub const SIG_PREFIX: []const u8 = "ed25519:";
+pub const KEY_PREFIX: []const u8 = "ed25519:";
+
+/// Foundation v0 test seed. Public, well-known. Used by every kit's
+/// cross-kit byte-equivalence fixture so signers agree without sharing
+/// secrets. Source: tools/foundation-keygen/src/lib.rs FOUNDATION_V0_SEED.
+pub const FOUNDATION_V0_SEED: Ed25519Seed = [_]u8{0x42} ** 32;
+
+/// Sign `message` with the Ed25519 private key derived from `seed`.
+/// Returns the raw 64-byte signature. Deterministic per RFC 8032
+/// (no noise, no randomization).
+pub fn signWithSeed(seed: Ed25519Seed, message: []const u8) !Ed25519Signature {
+    const kp = try Ed25519.KeyPair.generateDeterministic(seed);
+    const sig = try kp.sign(message, null);
+    return sig.toBytes();
+}
+
+/// Derive the 32-byte public key from a seed.
+pub fn pubkeyFromSeed(seed: Ed25519Seed) !Ed25519PublicKey {
+    const kp = try Ed25519.KeyPair.generateDeterministic(seed);
+    return kp.public_key.toBytes();
+}
+
+/// Verify `message` was signed by the private key corresponding to
+/// `public_key`. Returns true iff the signature is valid.
+pub fn verifyRaw(public_key: Ed25519PublicKey, signature: Ed25519Signature, message: []const u8) bool {
+    const pk = Ed25519.PublicKey.fromBytes(public_key) catch return false;
+    const sig = Ed25519.Signature.fromBytes(signature);
+    sig.verify(message, pk) catch return false;
+    return true;
+}
+
+/// Sign `message` and return the spec's self-identifying string form
+/// (`"ed25519:" + base64-stdpad(sig)`). Caller owns the returned slice.
+pub fn signString(alloc: std.mem.Allocator, seed: Ed25519Seed, message: []const u8) ![]u8 {
+    const sig = try signWithSeed(seed, message);
+    const b64 = std.base64.standard.Encoder;
+    const enc_len = b64.calcSize(sig.len);
+    var out = try alloc.alloc(u8, SIG_PREFIX.len + enc_len);
+    @memcpy(out[0..SIG_PREFIX.len], SIG_PREFIX);
+    _ = b64.encode(out[SIG_PREFIX.len..], &sig);
+    return out;
+}
+
+/// Derive the public key from a seed and return the self-identifying
+/// string form (`"ed25519:" + base64-stdpad(pubkey)`). Caller owns the slice.
+pub fn pubkeyString(alloc: std.mem.Allocator, seed: Ed25519Seed) ![]u8 {
+    const pk = try pubkeyFromSeed(seed);
+    const b64 = std.base64.standard.Encoder;
+    const enc_len = b64.calcSize(pk.len);
+    var out = try alloc.alloc(u8, KEY_PREFIX.len + enc_len);
+    @memcpy(out[0..KEY_PREFIX.len], KEY_PREFIX);
+    _ = b64.encode(out[KEY_PREFIX.len..], &pk);
+    return out;
+}
+
+/// Verify `message` against `sig_string` (spec form
+/// `"ed25519:" + base64(sig)`) using `pubkey_string`. Returns false for
+/// any malformed input rather than erroring — verifiers fail closed.
+pub fn verifyString(pubkey_string: []const u8, sig_string: []const u8, message: []const u8) bool {
+    if (!std.mem.startsWith(u8, pubkey_string, KEY_PREFIX)) return false;
+    if (!std.mem.startsWith(u8, sig_string, SIG_PREFIX)) return false;
+    const pk_b64 = pubkey_string[KEY_PREFIX.len..];
+    const sig_b64 = sig_string[SIG_PREFIX.len..];
+
+    const dec = std.base64.standard.Decoder;
+    var pk_buf: [32]u8 = undefined;
+    var sig_buf: [64]u8 = undefined;
+    const pk_dec_len = dec.calcSizeForSlice(pk_b64) catch return false;
+    if (pk_dec_len != 32) return false;
+    dec.decode(&pk_buf, pk_b64) catch return false;
+    const sig_dec_len = dec.calcSizeForSlice(sig_b64) catch return false;
+    if (sig_dec_len != 64) return false;
+    dec.decode(&sig_buf, sig_b64) catch return false;
+
+    return verifyRaw(pk_buf, sig_buf, message);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "deterministic signature for fixed seed" {
+    const a = try signWithSeed(FOUNDATION_V0_SEED, "hello");
+    const b = try signWithSeed(FOUNDATION_V0_SEED, "hello");
+    try testing.expectEqualSlices(u8, &a, &b);
+}
+
+test "signature is 64 bytes" {
+    const sig = try signWithSeed(FOUNDATION_V0_SEED, "hello");
+    try testing.expectEqual(@as(usize, 64), sig.len);
+}
+
+test "raw verify round-trip" {
+    const seed: Ed25519Seed = [_]u8{0x42} ** 32;
+    const sig = try signWithSeed(seed, "hello world");
+    const pk = try pubkeyFromSeed(seed);
+    try testing.expect(verifyRaw(pk, sig, "hello world"));
+    try testing.expect(!verifyRaw(pk, sig, "goodbye world"));
+}
+
+test "signString has prefix and decodes" {
+    const seed: Ed25519Seed = [_]u8{0x42} ** 32;
+    const s = try signString(testing.allocator, seed, "hello");
+    defer testing.allocator.free(s);
+    try testing.expect(std.mem.startsWith(u8, s, SIG_PREFIX));
+}
+
+test "verify string round-trip" {
+    const seed: Ed25519Seed = [_]u8{0x42} ** 32;
+    const sig_s = try signString(testing.allocator, seed, "hello world");
+    defer testing.allocator.free(sig_s);
+    const pk_s = try pubkeyString(testing.allocator, seed);
+    defer testing.allocator.free(pk_s);
+
+    try testing.expect(verifyString(pk_s, sig_s, "hello world"));
+    try testing.expect(!verifyString(pk_s, sig_s, "wrong message"));
+}
+
+test "verify string rejects malformed" {
+    try testing.expect(!verifyString("not-prefixed", "ed25519:AAAA", "x"));
+    try testing.expect(!verifyString("ed25519:AAAA", "not-prefixed", "x"));
+    try testing.expect(!verifyString("ed25519:!!!!", "ed25519:!!!!", "x"));
+}
+
+// Pinned cross-kit Ed25519 vector. The .proof envelope cross-kit fixture
+// extracts a 64-byte signature embedded inside the rust output bytes.
+// Unsigned-body bytes (the message that ends up signed) for the canonical
+// two-member fixture are derived in proof.zig's tests; here we pin the
+// raw signature that ed25519-dalek produces for that exact byte stream.
+//
+// Bytes pulled from RUST_FIXTURE_BYTES_HEX_FULL in
+// implementations/python/provekit-lift-py-tests/tests/test_proof_envelope.py:
+// the 64 bytes following the `signature` key + bstr-head `0x5840`:
+//   6a21dd428a54e22c82ca6d6125a7293c4a723786cb1840e891cefa03e63246eb
+//   97ef13dab86b7b1469d67302fadc969cd88c92c29495d13c75fc0201a7263b06
+//
+// If this test fails the entire envelope parity collapses; the failure
+// surfaces here with a clear cause rather than a nine-screen byte diff.
+test "stdlib Ed25519 matches ed25519-dalek for foundation seed and canonical unsigned body" {
+    // Hand-build the canonical unsigned body for the two-member fixture.
+    // Same construction as proof.zig's build_proof_envelope; we compute
+    // it here in isolation to discriminate Ed25519 drift from CBOR drift.
+    const cbor = @import("cbor.zig");
+    const alloc = testing.allocator;
+
+    // Build the unsigned body (6-key map, no signature yet) with sorted
+    // keys. Members map sub-CBOR built first.
+    var members: std.ArrayList(u8) = .empty;
+    defer members.deinit(alloc);
+    // Two members; key form sorts naturally because aa < bb lex.
+    try cbor.encodeMapHead(&members, alloc, 2);
+    try cbor.encodeTstr(&members, alloc, "blake3-512:aa");
+    try cbor.encodeBstr(&members, alloc, "{\"hello\":\"world\"}");
+    try cbor.encodeTstr(&members, alloc, "blake3-512:bb");
+    try cbor.encodeBstr(&members, alloc, "{\"goodbye\":\"world\"}");
+
+    // The 6-key body: kind, name, version, members, signer, declaredAt.
+    // Sort by bytewise lex of CBOR-encoded key. All keys are short text
+    // strings, so the prefix byte is the same and lex follows raw key
+    // bytes after that. Hand-sorted: kind < name < signer < members
+    // < version < declaredAt? No — let's compute properly: each key is
+    // tstr, head 0x6N (text + len), so the first byte differs by len.
+    //   "kind"      (4) -> 0x64
+    //   "name"      (4) -> 0x64
+    //   "signer"    (6) -> 0x66
+    //   "members"   (7) -> 0x67
+    //   "version"   (7) -> 0x67
+    //   "declaredAt"(10)-> 0x6a
+    // After head matches, compare bytes. So lex order on encoded form:
+    //   kind, name, signer, members, version, declaredAt.
+    //
+    // (declaredAt sorts last because its head 0x6a is greater than 0x67.)
+
+    var unsigned: std.ArrayList(u8) = .empty;
+    defer unsigned.deinit(alloc);
+    try cbor.encodeMapHead(&unsigned, alloc, 6);
+    try cbor.encodeTstr(&unsigned, alloc, "kind");
+    try cbor.encodeTstr(&unsigned, alloc, "catalog");
+    try cbor.encodeTstr(&unsigned, alloc, "name");
+    try cbor.encodeTstr(&unsigned, alloc, "@test/cat");
+    try cbor.encodeTstr(&unsigned, alloc, "signer");
+    try cbor.encodeTstr(&unsigned, alloc, "blake3-512:cc");
+    try cbor.encodeTstr(&unsigned, alloc, "members");
+    try unsigned.appendSlice(alloc, members.items);
+    try cbor.encodeTstr(&unsigned, alloc, "version");
+    try cbor.encodeTstr(&unsigned, alloc, "1.0.0");
+    try cbor.encodeTstr(&unsigned, alloc, "declaredAt");
+    try cbor.encodeTstr(&unsigned, alloc, "2026-04-30T00:00:00.000Z");
+
+    const sig = try signWithSeed(FOUNDATION_V0_SEED, unsigned.items);
+
+    // Pinned 64-byte signature from the rust kit's reference output.
+    // If this fails: zig stdlib Ed25519 disagrees with ed25519-dalek
+    // for the same seed + message. Hard blocker — STOP.
+    const expected_sig: [64]u8 = .{
+        0x6a, 0x21, 0xdd, 0x42, 0x8a, 0x54, 0xe2, 0x2c,
+        0x82, 0xca, 0x6d, 0x61, 0x25, 0xa7, 0x29, 0x3c,
+        0x4a, 0x72, 0x37, 0x86, 0xcb, 0x18, 0x40, 0xe8,
+        0x91, 0xce, 0xfa, 0x03, 0xe6, 0x32, 0x46, 0xeb,
+        0x97, 0xef, 0x13, 0xda, 0xb8, 0x6b, 0x7b, 0x14,
+        0x69, 0xd6, 0x73, 0x02, 0xfa, 0xdc, 0x96, 0x9c,
+        0xd8, 0x8c, 0x92, 0xc2, 0x94, 0x95, 0xd1, 0x3c,
+        0x75, 0xfc, 0x02, 0x01, 0xa7, 0x26, 0x3b, 0x06,
+    };
+    try testing.expectEqualSlices(u8, &expected_sig, &sig);
+}


### PR DESCRIPTION
## Summary

Side B (language-native) crypto substrate for the zig kit. New package `implementations/zig/provekit-proof-envelope-zig/` exposes:

- **BLAKE3-512**: `std.crypto.hash.Blake3` (stdlib)
- **JCS canonicalizer (RFC 8785)**: re-exported from `provekit-ir`'s `jcsStringify` / `jcsHash`
- **Ed25519 sign/verify**: `std.crypto.sign.Ed25519.KeyPair.generateDeterministic(seed)` + `kp.sign(msg, null)` for RFC 8032 deterministic mode (matches ed25519-dalek default)
- **Deterministic CBOR (RFC 8949 §4.2.1)**: hand-rolled, ~90 LOC, mirrors `implementations/rust/provekit-proof-envelope/src/cbor.rs` 1:1 (5 major types, shortest-form ints, definite length only)
- **`.proof` envelope build/verify**: mirrors rust `proof.rs` four-step protocol — unsigned body, Ed25519-sign, re-emit with signature, BLAKE3-512 the final bytes for the catalog CID

## Stdlib-vs-vendor rationale

| Primitive | Source | Why |
|---|---|---|
| BLAKE3 | `std.crypto.hash.Blake3` | stdlib, XOF interface gives us 64-byte output trivially |
| Ed25519 | `std.crypto.sign.Ed25519` | stdlib; `noise=null` selects deterministic mode |
| JCS | `provekit-ir/src/root.zig` | already shipped, zig kit's IR types use it; reusing avoids fork |
| CBOR | local `cbor.zig` | no zig stdlib CBOR; vendoring a full lib is overkill for 5 major types |
| Envelope | local `proof.zig` | mirrors rust shape exactly; cross-kit pin is load-bearing |

Nothing vendored. No shell-out to another kit.

## Round-trip / cross-kit test result

**PASS.** Zig output byte-identical to rust kit for the canonical two-member fixture from PR #221's pinned reference:
- Input: `name=@test/cat, version=1.0.0, seed=[0x42;32], members={blake3-512:aa: '{\"hello\":\"world\"}', blake3-512:bb: '{\"goodbye\":\"world\"}'}, signer=blake3-512:cc, declaredAt=2026-04-30T00:00:00.000Z`
- CID pin: `blake3-512:5ed1e1f705622ad52ae4683e3d12df5586d364d66bb3186f5be512415edf290844d74e73a2857cd858f37803e4b11fe5c7cba7884caa6b9ff847521ce32ea056`
- Rust-produced bytes also verify under the zig verifier (round-trip both directions)

26/26 tests pass:

```
Build Summary: 3/3 steps succeeded; 26/26 tests passed
test success
+- run test 26 pass (26 total) 87ms MaxRSS:1M
```

Risk-ordered validation: Ed25519 stdlib-vs-dalek pin runs first (catches seed-vs-secret-key drift before the full envelope pipeline). CBOR primitives next. Then full envelope byte-pin + CID-pin + verifier round-trip.

## Acceptance checklist

- [x] Zig can natively compute BLAKE3 of canonical bytes (`blake3_512_of` test pinned to BLAKE3 spec empty-input vector)
- [x] Zig can natively JCS-canonicalize JSON (re-exported from `provekit-ir`, already shipping)
- [x] Zig can natively sign/verify Ed25519 (`signWithSeed` / `verifyRaw` tested with dalek-pinned 64-byte vector)
- [x] Zig can natively CBOR-encode the envelope (`buildProofEnvelope` produces full RFC 8949 §4.2.1 deterministic output)
- [x] Output round-trips byte-for-byte against rust reference envelope (`test "two-member envelope bytes match rust reference (cross-kit pin)"`)
- [x] No shell-out to another kit required for envelope construction

## Out of scope

Claim envelope (v1.2 layered `{envelope, header, metadata}` shape per `protocol/specs/2026-05-03-substrate-layers-envelope-header-body.md`) deferred to a follow-up issue, matching PR #221 (python) precedent. The acceptance bar gates on proof envelope only; claim envelope is a separate subsystem.

## Test plan

- [x] `cd implementations/zig/provekit-proof-envelope-zig && zig build test` -- 26/26 pass
- [x] `cd implementations/zig/provekit-ir && zig build test` -- 11/11 pass (sibling, untouched)
- [x] Cross-kit byte-pin: `test "two-member envelope bytes match rust reference (cross-kit pin)"` PASS
- [x] Cross-kit CID-pin: `test "two-member envelope CID matches rust reference (cross-kit pin)"` PASS
- [x] Rust-bytes-verify-under-zig: `test "rust reference bytes verify under our verifier"` PASS

Closes #214

Generated with [Claude Code](https://claude.com/claude-code)