### PR TITLE
feat(java): native crypto substrate -- BLAKE3 + JCS + Ed25519 + CBOR + envelopes (closes #208)

### DIFF
--- a/implementations/java/pom.xml
+++ b/implementations/java/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>provekit-ir</module>
+        <module>provekit-claim-envelope</module>
         <module>provekit-lift-java-core</module>
         <module>provekit-lift-java-bean-validation</module>
         <module>provekit-lift-java-jml</module>

--- a/implementations/java/provekit-claim-envelope/pom.xml
+++ b/implementations/java/provekit-claim-envelope/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.provekit</groupId>
+        <artifactId>provekit-lift-java-parent</artifactId>
+        <version>0.1.0</version>
+    </parent>
+    <artifactId>provekit-claim-envelope</artifactId>
+    <packaging>jar</packaging>
+
+    <description>
+        Native Java crypto substrate for the ProvekIt protocol: BLAKE3,
+        JCS (RFC 8785), Ed25519, deterministic CBOR (RFC 8949 §4.2.1),
+        proof envelope construction, and v1.2 layered claim envelope
+        minting. Byte-for-byte cross-kit compatible with the rust,
+        c-sharp, c++, and python kits.
+    </description>
+
+    <dependencies>
+        <!--
+            BouncyCastle provides BLAKE3 (Blake3Digest) since 1.77 and a
+            mature Ed25519 implementation. One jar covers both primitives.
+        -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.78.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/Blake3.java
+++ b/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/Blake3.java
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// BLAKE3-512 hashing for the ProvekIt substrate. BLAKE3 has an
+// extendable output; the protocol fixes it at 64 bytes (512 bits)
+// and stamps the self-identifying prefix "blake3-512:".
+//
+// Mirrors implementations/csharp/Provekit.Canonicalizer/Hash.cs and
+// implementations/rust/provekit-canonicalizer/src/hash.rs 1:1.
+
+package com.provekit.claimenvelope;
+
+import org.bouncycastle.crypto.digests.Blake3Digest;
+
+public final class Blake3 {
+    public static final String PREFIX = "blake3-512:";
+    public static final int DIGEST_BITS = 512;
+    public static final int DIGEST_BYTES = DIGEST_BITS / 8;
+
+    private Blake3() {}
+
+    /** Raw 64-byte BLAKE3 digest of {@code input}. */
+    public static byte[] digest(byte[] input) {
+        Blake3Digest d = new Blake3Digest(DIGEST_BITS);
+        d.update(input, 0, input.length);
+        byte[] out = new byte[DIGEST_BYTES];
+        d.doFinal(out, 0, DIGEST_BYTES);
+        return out;
+    }
+
+    /** Self-identifying CID string: "blake3-512:" + lowercase hex of the 64-byte digest. */
+    public static String blake3_512(byte[] input) {
+        byte[] d = digest(input);
+        StringBuilder sb = new StringBuilder(PREFIX.length() + d.length * 2);
+        sb.append(PREFIX);
+        for (byte b : d) {
+            sb.append(HEX[(b >>> 4) & 0xF]);
+            sb.append(HEX[b & 0xF]);
+        }
+        return sb.toString();
+    }
+
+    private static final char[] HEX = {
+        '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'
+    };
+}

--- a/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/Cbor.java
+++ b/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/Cbor.java
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Deterministic CBOR encoder. RFC 8949 §4.2.1 rules:
+//   - shortest-form integer encoding (smallest of short / u8 / u16 / u32 / u64)
+//   - definite-length items only
+//   - map keys sorted in bytewise lex order of their CBOR-encoded form
+//
+// Only emits the major types needed by the proof-envelope shape:
+// unsigned int, byte string, text string, array, map.
+//
+// Mirrors implementations/rust/provekit-proof-envelope/src/cbor.rs and
+// implementations/csharp/Provekit.ProofEnvelope/Cbor.cs 1:1.
+
+package com.provekit.claimenvelope;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+public final class Cbor {
+    public static final int MAJOR_UNSIGNED_INT = 0;
+    public static final int MAJOR_BYTE_STRING = 2;
+    public static final int MAJOR_TEXT_STRING = 3;
+    public static final int MAJOR_ARRAY = 4;
+    public static final int MAJOR_MAP = 5;
+
+    private Cbor() {}
+
+    /** Append a CBOR head: major-type tag + shortest-form length / value. */
+    public static void appendHead(ByteArrayOutputStream out, int major, long arg) {
+        if (arg < 0) {
+            // We never emit negative integers from this kit; fail loudly.
+            throw new IllegalArgumentException("Cbor.appendHead: arg must be non-negative");
+        }
+        int mt = (major & 0x07) << 5;
+        if (arg < 24L) {
+            out.write(mt | (int) arg);
+            return;
+        }
+        if (arg <= 0xFFL) {
+            out.write(mt | 24);
+            out.write((int) arg);
+            return;
+        }
+        if (arg <= 0xFFFFL) {
+            out.write(mt | 25);
+            out.write((int) ((arg >>> 8) & 0xFF));
+            out.write((int) (arg & 0xFF));
+            return;
+        }
+        if (arg <= 0xFFFFFFFFL) {
+            out.write(mt | 26);
+            out.write((int) ((arg >>> 24) & 0xFF));
+            out.write((int) ((arg >>> 16) & 0xFF));
+            out.write((int) ((arg >>> 8) & 0xFF));
+            out.write((int) (arg & 0xFF));
+            return;
+        }
+        out.write(mt | 27);
+        for (int i = 7; i >= 0; i--) {
+            out.write((int) ((arg >>> (i * 8)) & 0xFF));
+        }
+    }
+
+    public static void encodeUint(ByteArrayOutputStream out, long value) {
+        appendHead(out, MAJOR_UNSIGNED_INT, value);
+    }
+
+    public static void encodeBstr(ByteArrayOutputStream out, byte[] bytes) {
+        appendHead(out, MAJOR_BYTE_STRING, bytes.length);
+        out.write(bytes, 0, bytes.length);
+    }
+
+    public static void encodeTstr(ByteArrayOutputStream out, String utf8) {
+        byte[] b = utf8.getBytes(StandardCharsets.UTF_8);
+        appendHead(out, MAJOR_TEXT_STRING, b.length);
+        out.write(b, 0, b.length);
+    }
+
+    public static void encodeArrayHead(ByteArrayOutputStream out, long count) {
+        appendHead(out, MAJOR_ARRAY, count);
+    }
+
+    public static void encodeMapHead(ByteArrayOutputStream out, long count) {
+        appendHead(out, MAJOR_MAP, count);
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/ClaimEnvelope.java
+++ b/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/ClaimEnvelope.java
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// {@code mintContract} / {@code mintBridge} / {@code mintImplication}
+// build a signed memento in the v1.2 LAYERED shape introduced by
+// `protocol/specs/2026-05-03-substrate-layers-envelope-header-body.md`:
+//
+//   { "envelope": {...}, "header": {...}, "metadata": {...} }
+//
+//   * envelope = { signer, declaredAt, signature }
+//       The signature is computed over JCS({"header": header, "metadata": metadata}).
+//       The envelope's CID (= attestation CID) is BLAKE3-512(JCS(envelope))
+//       AFTER the signature has been embedded.
+//
+//   * header   = substrate-load-bearing data the verifier reads:
+//                schemaVersion, kind, cid, plus kind-specific REQUIRED
+//                fields and the derived hashes (bindingHash,
+//                propertyHash, verdict, inputCids).
+//
+//   * metadata = everything else (authoring attribution, lifecycle
+//                strings, derived per-formula hashes that are pure
+//                tooling convenience). Opaque to the substrate verifier;
+//                signed transitively via the envelope.
+//
+// Mirrors implementations/rust/provekit-claim-envelope/src/lib.rs and
+// implementations/csharp/Provekit.ClaimEnvelope/Mint.cs 1:1.
+
+package com.provekit.claimenvelope;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+import com.provekit.claimenvelope.Jcs.Value;
+
+public final class ClaimEnvelope {
+
+    public static final String LAYERED_SCHEMA_VERSION = "2";
+
+    private ClaimEnvelope() {}
+
+    public static final class MintedEnvelope {
+        public final byte[] canonicalBytes;
+        /** Attestation CID: BLAKE3-512(JCS(envelope-with-signature)). */
+        public final String cid;
+        /** Content CID for contracts (signer-independent); empty for bridges/implications. */
+        public final String contractCid;
+
+        MintedEnvelope(byte[] canonicalBytes, String cid, String contractCid) {
+            this.canonicalBytes = canonicalBytes;
+            this.cid = cid;
+            this.contractCid = contractCid;
+        }
+    }
+
+    // =========================================================================
+    // Authoring (typed union mirroring the rust/csharp peers)
+    // =========================================================================
+
+    public static abstract sealed class Authoring
+            permits Authoring.KitAuthor, Authoring.Lift, Authoring.Llm {
+
+        public static final class KitAuthor extends Authoring {
+            public final String author;
+            public final String note; // nullable; empty/null both omitted
+            public KitAuthor(String author, String note) {
+                this.author = Objects.requireNonNull(author);
+                this.note = note;
+            }
+        }
+
+        public static final class Lift extends Authoring {
+            public final String lifter;
+            public final String evidence;
+            public final String sourceCid; // nullable
+            public Lift(String lifter, String evidence, String sourceCid) {
+                this.lifter = Objects.requireNonNull(lifter);
+                this.evidence = Objects.requireNonNull(evidence);
+                this.sourceCid = sourceCid;
+            }
+        }
+
+        public static final class Llm extends Authoring {
+            public final String llm;
+            public final String llmVersion;
+            public final String promptCid;
+            public final double confidence;
+            public final String rationale; // nullable
+            public Llm(String llm, String llmVersion, String promptCid, double confidence, String rationale) {
+                this.llm = Objects.requireNonNull(llm);
+                this.llmVersion = Objects.requireNonNull(llmVersion);
+                this.promptCid = Objects.requireNonNull(promptCid);
+                this.confidence = confidence;
+                this.rationale = rationale;
+            }
+        }
+    }
+
+    private static Value authoringToValue(Authoring a) {
+        if (a instanceof Authoring.KitAuthor ka) {
+            LinkedHashMap<String, Value> m = new LinkedHashMap<>();
+            m.put("producerKind", Value.string("kit-author"));
+            m.put("author", Value.string(ka.author));
+            if (ka.note != null && !ka.note.isEmpty()) {
+                m.put("note", Value.string(ka.note));
+            }
+            return Value.object(m);
+        }
+        if (a instanceof Authoring.Lift l) {
+            LinkedHashMap<String, Value> m = new LinkedHashMap<>();
+            m.put("producerKind", Value.string("lift"));
+            m.put("lifter", Value.string(l.lifter));
+            m.put("evidence", Value.string(l.evidence));
+            if (l.sourceCid != null && !l.sourceCid.isEmpty()) {
+                m.put("sourceCid", Value.string(l.sourceCid));
+            }
+            return Value.object(m);
+        }
+        if (a instanceof Authoring.Llm ll) {
+            LinkedHashMap<String, Value> m = new LinkedHashMap<>();
+            m.put("producerKind", Value.string("llm"));
+            m.put("llm", Value.string(ll.llm));
+            m.put("llmVersion", Value.string(ll.llmVersion));
+            m.put("promptCid", Value.string(ll.promptCid));
+            // Confidence is rendered as integer(confidence * 1000), matching
+            // the rust peer's wire format.
+            m.put("confidence", Value.integer((long) (ll.confidence * 1000.0)));
+            if (ll.rationale != null && !ll.rationale.isEmpty()) {
+                m.put("rationale", Value.string(ll.rationale));
+            }
+            return Value.object(m);
+        }
+        throw new IllegalStateException("unknown Authoring variant: " + a.getClass());
+    }
+
+    // =========================================================================
+    // Common helpers
+    // =========================================================================
+
+    private static String hashValue(Value v) {
+        return Blake3.blake3_512(Jcs.encodeUtf8(v));
+    }
+
+    private static String hashString(String s) {
+        return Blake3.blake3_512(s.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Build the JCS-canonical bytes of {@code {"header": header, "metadata": metadata}}.
+     * This is the message the envelope's Ed25519 signature covers.
+     */
+    private static byte[] signingBytes(Value header, Value metadata) {
+        LinkedHashMap<String, Value> m = new LinkedHashMap<>();
+        m.put("header", header);
+        m.put("metadata", metadata);
+        return Jcs.encodeUtf8(Value.object(m));
+    }
+
+    private static Value buildHeader(String kind, String headerCid, LinkedHashMap<String, Value> kindSpecific) {
+        LinkedHashMap<String, Value> m = new LinkedHashMap<>();
+        m.put("schemaVersion", Value.string(LAYERED_SCHEMA_VERSION));
+        m.put("kind", Value.string(kind));
+        m.put("cid", Value.string(headerCid));
+        m.putAll(kindSpecific);
+        return Value.object(m);
+    }
+
+    /**
+     * Assemble a layered memento, sign it, and compute the attestation CID
+     * (= BLAKE3-512(JCS(envelope-with-signature))).
+     */
+    private static MintedEnvelope assembleLayered(Value header,
+                                                  Value metadata,
+                                                  String declaredAt,
+                                                  byte[] signerSeed,
+                                                  String contentCid) {
+        String signer = Ed25519.pubkeyString(signerSeed);
+        byte[] signingMsg = signingBytes(header, metadata);
+        String signature = Ed25519.signString(signerSeed, signingMsg);
+
+        LinkedHashMap<String, Value> envEntries = new LinkedHashMap<>();
+        envEntries.put("signer", Value.string(signer));
+        envEntries.put("declaredAt", Value.string(declaredAt));
+        envEntries.put("signature", Value.string(signature));
+        Value envelope = Value.object(envEntries);
+
+        byte[] envelopeJcs = Jcs.encodeUtf8(envelope);
+        String attestationCid = Blake3.blake3_512(envelopeJcs);
+
+        LinkedHashMap<String, Value> mementoEntries = new LinkedHashMap<>();
+        mementoEntries.put("envelope", envelope);
+        mementoEntries.put("header", header);
+        mementoEntries.put("metadata", metadata);
+        Value memento = Value.object(mementoEntries);
+
+        byte[] mementoJcs = Jcs.encodeUtf8(memento);
+        return new MintedEnvelope(mementoJcs, attestationCid, contentCid);
+    }
+
+    // =========================================================================
+    // Contracts
+    // =========================================================================
+
+    public static final class MintContractArgs {
+        public String contractName;
+        public Value pre;          // nullable
+        public Value post;         // nullable
+        public Value inv;          // nullable
+        public String outBinding = "out";
+        public String producedBy;
+        public String producedAt;
+        public List<String> inputCids = List.of();
+        public Authoring authoring;
+        public byte[] signerSeed;
+    }
+
+    /** Compute the signer-independent contract CID for a logical contract. */
+    public static String contractCid(MintContractArgs args) {
+        LinkedHashMap<String, Value> m = new LinkedHashMap<>();
+        m.put("name", Value.string(args.contractName));
+        m.put("outBinding", Value.string(args.outBinding));
+        if (args.pre != null) m.put("pre", args.pre);
+        if (args.post != null) m.put("post", args.post);
+        if (args.inv != null) m.put("inv", args.inv);
+        return Blake3.blake3_512(Jcs.encodeUtf8(Value.object(m)));
+    }
+
+    /** Compute the contract-set CID from a list of contract CIDs (sort order independent). */
+    public static String computeContractSetCid(List<String> contractCids) {
+        List<String> sorted = new ArrayList<>(contractCids);
+        Collections.sort(sorted);
+        List<Value> arr = new ArrayList<>(sorted.size());
+        for (String c : sorted) arr.add(Value.string(c));
+        return Blake3.blake3_512(Jcs.encodeUtf8(Value.array(arr)));
+    }
+
+    public static MintedEnvelope mintContract(MintContractArgs args) {
+        if (args.pre == null && args.post == null && args.inv == null) {
+            throw new IllegalArgumentException("mintContract: at least one of pre/post/inv must be present");
+        }
+        if (args.outBinding == null || args.outBinding.isEmpty()) {
+            throw new IllegalArgumentException("mintContract: outBinding must not be empty");
+        }
+
+        LinkedHashMap<String, Value> phMap = new LinkedHashMap<>();
+        if (args.pre != null) phMap.put("pre", args.pre);
+        if (args.post != null) phMap.put("post", args.post);
+        if (args.inv != null) phMap.put("inv", args.inv);
+        phMap.put("outBinding", Value.string(args.outBinding));
+        String propertyHash = hashValue(Value.object(phMap));
+
+        LinkedHashMap<String, Value> bhMap = new LinkedHashMap<>();
+        bhMap.put("producerId", Value.string(args.producedBy));
+        bhMap.put("contractName", Value.string(args.contractName));
+        bhMap.put("propertyHash", Value.string(propertyHash));
+        String bindingHash = hashValue(Value.object(bhMap));
+
+        String headerCid = contractCid(args);
+
+        LinkedHashMap<String, Value> kindSpecific = new LinkedHashMap<>();
+        kindSpecific.put("name", Value.string(args.contractName));
+        kindSpecific.put("outBinding", Value.string(args.outBinding));
+        if (args.pre != null) kindSpecific.put("pre", args.pre);
+        if (args.post != null) kindSpecific.put("post", args.post);
+        if (args.inv != null) kindSpecific.put("inv", args.inv);
+        kindSpecific.put("verdict", Value.string("holds"));
+        kindSpecific.put("bindingHash", Value.string(bindingHash));
+        kindSpecific.put("propertyHash", Value.string(propertyHash));
+        List<String> sortedInputs = new ArrayList<>(args.inputCids);
+        Collections.sort(sortedInputs);
+        List<Value> inputs = new ArrayList<>(sortedInputs.size());
+        for (String s : sortedInputs) inputs.add(Value.string(s));
+        kindSpecific.put("inputCids", Value.array(inputs));
+
+        Value header = buildHeader("contract", headerCid, kindSpecific);
+
+        LinkedHashMap<String, Value> meta = new LinkedHashMap<>();
+        meta.put("authoring", authoringToValue(args.authoring));
+        meta.put("producedBy", Value.string(args.producedBy));
+        meta.put("producedAt", Value.string(args.producedAt));
+        if (args.pre != null) meta.put("preHash", Value.string(hashValue(args.pre)));
+        if (args.post != null) meta.put("postHash", Value.string(hashValue(args.post)));
+        if (args.inv != null) meta.put("invHash", Value.string(hashValue(args.inv)));
+        Value metadata = Value.object(meta);
+
+        return assembleLayered(header, metadata, args.producedAt, args.signerSeed, headerCid);
+    }
+
+    // =========================================================================
+    // Bridges
+    // =========================================================================
+
+    public static final class MintBridgeArgs {
+        public String producedBy;
+        public String producedAt;
+        public String sourceSymbol;
+        public String sourceLayer;
+        public String targetContractCid;
+        public String targetLayer;
+        public List<String> irArgSorts = List.of();
+        public String irReturnSort;
+        public String notes = "";
+        public byte[] signerSeed;
+    }
+
+    private static String bridgeContentCid(MintBridgeArgs args) {
+        List<Value> argSorts = new ArrayList<>(args.irArgSorts.size());
+        for (String s : args.irArgSorts) argSorts.add(Value.string(s));
+        LinkedHashMap<String, Value> m = new LinkedHashMap<>();
+        m.put("sourceSymbol", Value.string(args.sourceSymbol));
+        m.put("sourceLayer", Value.string(args.sourceLayer));
+        m.put("targetContractCid", Value.string(args.targetContractCid));
+        m.put("targetLayer", Value.string(args.targetLayer));
+        m.put("irArgSorts", Value.array(argSorts));
+        m.put("irReturnSort", Value.string(args.irReturnSort));
+        return Blake3.blake3_512(Jcs.encodeUtf8(Value.object(m)));
+    }
+
+    public static MintedEnvelope mintBridge(MintBridgeArgs args) {
+        List<Value> argSorts = new ArrayList<>(args.irArgSorts.size());
+        for (String s : args.irArgSorts) argSorts.add(Value.string(s));
+
+        LinkedHashMap<String, Value> bh = new LinkedHashMap<>();
+        bh.put("sourceLayer", Value.string(args.sourceLayer));
+        bh.put("sourceSymbol", Value.string(args.sourceSymbol));
+        String bindingHash = hashValue(Value.object(bh));
+        String propertyHash = hashString("bridge:" + args.sourceSymbol);
+
+        String headerCid = bridgeContentCid(args);
+        LinkedHashMap<String, Value> kindSpecific = new LinkedHashMap<>();
+        kindSpecific.put("sourceSymbol", Value.string(args.sourceSymbol));
+        kindSpecific.put("sourceLayer", Value.string(args.sourceLayer));
+        kindSpecific.put("targetContractCid", Value.string(args.targetContractCid));
+        kindSpecific.put("targetLayer", Value.string(args.targetLayer));
+        kindSpecific.put("irArgSorts", Value.array(argSorts));
+        kindSpecific.put("irReturnSort", Value.string(args.irReturnSort));
+        kindSpecific.put("verdict", Value.string("holds"));
+        kindSpecific.put("bindingHash", Value.string(bindingHash));
+        kindSpecific.put("propertyHash", Value.string(propertyHash));
+        List<Value> inputs = new ArrayList<>(1);
+        inputs.add(Value.string(args.targetContractCid));
+        kindSpecific.put("inputCids", Value.array(inputs));
+
+        Value header = buildHeader("bridge", headerCid, kindSpecific);
+
+        LinkedHashMap<String, Value> meta = new LinkedHashMap<>();
+        meta.put("producedBy", Value.string(args.producedBy));
+        meta.put("producedAt", Value.string(args.producedAt));
+        if (args.notes != null && !args.notes.isEmpty()) {
+            meta.put("notes", Value.string(args.notes));
+        }
+        Value metadata = Value.object(meta);
+
+        return assembleLayered(header, metadata, args.producedAt, args.signerSeed, "");
+    }
+
+    // =========================================================================
+    // Implications
+    // =========================================================================
+
+    public static final class MintImplicationArgs {
+        public String producedBy;
+        public String producedAt;
+        public String antecedentHash;
+        public String consequentHash;
+        public String antecedentCid;
+        public String consequentCid;
+        public String antecedentSlot = "";
+        public String consequentSlot = "";
+        public String prover = "";
+        public long proverRunMs;
+        public String smtLibInput = "";
+        public String proofWitness = "";
+        public byte[] signerSeed;
+    }
+
+    private static String implicationContentCid(MintImplicationArgs args) {
+        LinkedHashMap<String, Value> m = new LinkedHashMap<>();
+        m.put("antecedentHash", Value.string(args.antecedentHash));
+        m.put("consequentHash", Value.string(args.consequentHash));
+        m.put("antecedentCid", Value.string(args.antecedentCid));
+        m.put("consequentCid", Value.string(args.consequentCid));
+        m.put("antecedentSlot", Value.string(args.antecedentSlot));
+        m.put("consequentSlot", Value.string(args.consequentSlot));
+        return Blake3.blake3_512(Jcs.encodeUtf8(Value.object(m)));
+    }
+
+    public static MintedEnvelope mintImplication(MintImplicationArgs args) {
+        LinkedHashMap<String, Value> bh = new LinkedHashMap<>();
+        bh.put("antecedentHash", Value.string(args.antecedentHash));
+        bh.put("consequentHash", Value.string(args.consequentHash));
+        String bindingHash = hashValue(Value.object(bh));
+        String propertyHash = hashString("implication:" + args.antecedentHash + ":" + args.consequentHash);
+
+        String headerCid = implicationContentCid(args);
+        List<String> inputCids = new ArrayList<>();
+        inputCids.add(args.antecedentCid);
+        inputCids.add(args.consequentCid);
+        Collections.sort(inputCids);
+        List<Value> inputArr = new ArrayList<>(inputCids.size());
+        for (String s : inputCids) inputArr.add(Value.string(s));
+
+        LinkedHashMap<String, Value> kindSpecific = new LinkedHashMap<>();
+        kindSpecific.put("antecedentHash", Value.string(args.antecedentHash));
+        kindSpecific.put("consequentHash", Value.string(args.consequentHash));
+        kindSpecific.put("antecedentCid", Value.string(args.antecedentCid));
+        kindSpecific.put("consequentCid", Value.string(args.consequentCid));
+        kindSpecific.put("antecedentSlot", Value.string(args.antecedentSlot));
+        kindSpecific.put("consequentSlot", Value.string(args.consequentSlot));
+        kindSpecific.put("verdict", Value.string("holds"));
+        kindSpecific.put("bindingHash", Value.string(bindingHash));
+        kindSpecific.put("propertyHash", Value.string(propertyHash));
+        kindSpecific.put("inputCids", Value.array(inputArr));
+
+        Value header = buildHeader("implication", headerCid, kindSpecific);
+
+        LinkedHashMap<String, Value> meta = new LinkedHashMap<>();
+        meta.put("producedBy", Value.string(args.producedBy));
+        meta.put("producedAt", Value.string(args.producedAt));
+        meta.put("prover", Value.string(args.prover));
+        meta.put("proverRunMs", Value.integer(args.proverRunMs));
+        if (args.smtLibInput != null && !args.smtLibInput.isEmpty()) {
+            meta.put("smtLibInput", Value.string(args.smtLibInput));
+        }
+        if (args.proofWitness != null && !args.proofWitness.isEmpty()) {
+            meta.put("proofWitness", Value.string(args.proofWitness));
+        }
+        Value metadata = Value.object(meta);
+
+        return assembleLayered(header, metadata, args.producedAt, args.signerSeed, "");
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/Ed25519.java
+++ b/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/Ed25519.java
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ed25519 signing helper. v1.1.0 of the protocol mandates
+// self-identifying signatures of the form:
+//
+//   "ed25519:" + base64-stdpad(64-byte-signature)
+//
+// And self-identifying public keys of the same form. The .proof file
+// envelope itself stores its catalog signature as a RAW 64-byte CBOR
+// byte string (not the prefixed string form): only the per-memento
+// `producerSignature` field uses the prefixed string form, because
+// memento envelopes are JCS-JSON.
+//
+// Backed by BouncyCastle (RFC 8032 Ed25519). Byte-equivalent to the
+// rust ed25519-dalek peer for the same (seed, message) pair.
+//
+// Mirrors implementations/rust/provekit-proof-envelope/src/sign.rs and
+// implementations/csharp/Provekit.ProofEnvelope/Sign.cs 1:1.
+
+package com.provekit.claimenvelope;
+
+import java.util.Base64;
+
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
+import org.bouncycastle.crypto.signers.Ed25519Signer;
+
+public final class Ed25519 {
+    public static final String SIG_PREFIX = "ed25519:";
+    public static final String KEY_PREFIX = "ed25519:";
+    public static final int SEED_BYTES = 32;
+    public static final int PUBKEY_BYTES = 32;
+    public static final int SIGNATURE_BYTES = 64;
+
+    /**
+     * Foundation v0 publicly-known test seed: 32 bytes of 0x42.
+     * Source: tools/foundation-keygen/src/lib.rs FOUNDATION_V0_SEED.
+     * v1 is HSM-generated; do not use this for production signing.
+     */
+    public static final byte[] FOUNDATION_V0_SEED;
+    static {
+        FOUNDATION_V0_SEED = new byte[SEED_BYTES];
+        for (int i = 0; i < SEED_BYTES; i++) {
+            FOUNDATION_V0_SEED[i] = (byte) 0x42;
+        }
+    }
+
+    private Ed25519() {}
+
+    /** Sign {@code message} with the Ed25519 private key derived from {@code seed}. Returns 64 bytes. */
+    public static byte[] signWithSeed(byte[] seed, byte[] message) {
+        if (seed == null || seed.length != SEED_BYTES) {
+            throw new IllegalArgumentException("seed must be exactly " + SEED_BYTES + " bytes");
+        }
+        Ed25519PrivateKeyParameters sk = new Ed25519PrivateKeyParameters(seed, 0);
+        Ed25519Signer signer = new Ed25519Signer();
+        signer.init(true, sk);
+        signer.update(message, 0, message.length);
+        return signer.generateSignature();
+    }
+
+    /** "ed25519:" + base64-stdpad of the 64-byte signature. */
+    public static String signString(byte[] seed, byte[] message) {
+        byte[] sig = signWithSeed(seed, message);
+        return SIG_PREFIX + Base64.getEncoder().encodeToString(sig);
+    }
+
+    /** Derive the 32-byte public key from {@code seed}. */
+    public static byte[] pubkeyBytes(byte[] seed) {
+        if (seed == null || seed.length != SEED_BYTES) {
+            throw new IllegalArgumentException("seed must be exactly " + SEED_BYTES + " bytes");
+        }
+        Ed25519PrivateKeyParameters sk = new Ed25519PrivateKeyParameters(seed, 0);
+        Ed25519PublicKeyParameters vk = sk.generatePublicKey();
+        return vk.getEncoded();
+    }
+
+    /** "ed25519:" + base64-stdpad of the 32-byte public key. */
+    public static String pubkeyString(byte[] seed) {
+        byte[] pk = pubkeyBytes(seed);
+        return KEY_PREFIX + Base64.getEncoder().encodeToString(pk);
+    }
+
+    /**
+     * Verify {@code message} against a self-identifying string signature using a
+     * self-identifying string public key. Returns false (never throws) for any
+     * malformed input or invalid signature.
+     */
+    public static boolean verifyString(String pubkeyString, String sigString, byte[] message) {
+        if (pubkeyString == null || sigString == null || message == null) return false;
+        if (!pubkeyString.startsWith(KEY_PREFIX)) return false;
+        if (!sigString.startsWith(SIG_PREFIX)) return false;
+        byte[] pkBytes;
+        byte[] sigBytes;
+        try {
+            pkBytes = Base64.getDecoder().decode(pubkeyString.substring(KEY_PREFIX.length()));
+            sigBytes = Base64.getDecoder().decode(sigString.substring(SIG_PREFIX.length()));
+        } catch (IllegalArgumentException ex) {
+            return false;
+        }
+        if (pkBytes.length != PUBKEY_BYTES || sigBytes.length != SIGNATURE_BYTES) return false;
+        return verifyBytes(pkBytes, sigBytes, message);
+    }
+
+    /** Verify a raw 64-byte signature against a raw 32-byte public key. */
+    public static boolean verifyBytes(byte[] pubkey, byte[] signature, byte[] message) {
+        if (pubkey == null || pubkey.length != PUBKEY_BYTES) return false;
+        if (signature == null || signature.length != SIGNATURE_BYTES) return false;
+        if (message == null) return false;
+        try {
+            Ed25519PublicKeyParameters vk = new Ed25519PublicKeyParameters(pubkey, 0);
+            Ed25519Signer verifier = new Ed25519Signer();
+            verifier.init(false, vk);
+            verifier.update(message, 0, message.length);
+            return verifier.verifySignature(signature);
+        } catch (RuntimeException ex) {
+            return false;
+        }
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/Jcs.java
+++ b/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/Jcs.java
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// JCS-JSON encoder (RFC 8785 / "JSON Canonicalization Scheme") plus a
+// minimal {@link Value} algebraic type used as input.
+//
+// Rules (RFC 8785 + protocol/specs/2026-04-30-canonicalization-grammar.md
+// pass 7):
+//   - Object keys sorted by Unicode code-point order. For ASCII-only
+//     keys this collapses to byte-order; the protocol's keys are all
+//     ASCII so byte-order suffices and matches the rust/cpp/csharp peers.
+//   - Numbers: integers serialized as plain decimal digits (the kit
+//     never produces floats from the mint flow).
+//   - Strings: UTF-8 verbatim; escape double-quote and backslash and
+//     U+0000..U+001F as backslash-u-00XX (lowercase hex). RFC 8785
+//     also permits the named short escapes but the rust/cpp/csharp
+//     peers chose the u-form for determinism; we match.
+//   - true / false / null verbatim.
+//   - No whitespace anywhere.
+//
+// Mirrors implementations/rust/provekit-canonicalizer/src/jcs.rs and
+// implementations/csharp/Provekit.Canonicalizer/Jcs.cs 1:1.
+
+package com.provekit.claimenvelope;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class Jcs {
+
+    private Jcs() {}
+
+    // -------------------------------------------------------------------
+    // Value type
+    // -------------------------------------------------------------------
+
+    /**
+     * A simple algebraic value tree mirroring the rust/csharp peers'
+     * {@code Value}. Objects preserve insertion order at construction
+     * time, but the JCS encoder always emits keys in code-point order.
+     */
+    public static abstract sealed class Value
+            permits Value.Null, Value.Bool, Value.Integer,
+                    Value.Str, Value.Arr, Value.Obj {
+
+        public static final Value NULL = new Null();
+
+        public static Value bool(boolean b) {
+            return b ? Bool.TRUE : Bool.FALSE;
+        }
+
+        public static Value integer(long n) {
+            return new Integer(n);
+        }
+
+        public static Value string(String s) {
+            return new Str(Objects.requireNonNull(s, "string value"));
+        }
+
+        public static Value array(List<Value> items) {
+            return new Arr(List.copyOf(items));
+        }
+
+        public static Value array(Value... items) {
+            return new Arr(List.of(items));
+        }
+
+        /** Build an object from an even-length list of (key, value, key, value, ...) pairs. */
+        public static Value object(Object... kvs) {
+            if ((kvs.length & 1) != 0) {
+                throw new IllegalArgumentException("object: requires an even number of arguments");
+            }
+            LinkedHashMap<String, Value> entries = new LinkedHashMap<>();
+            for (int i = 0; i < kvs.length; i += 2) {
+                if (!(kvs[i] instanceof String key)) {
+                    throw new IllegalArgumentException("object: keys must be String");
+                }
+                if (!(kvs[i + 1] instanceof Value v)) {
+                    throw new IllegalArgumentException("object: values must be Value");
+                }
+                entries.put(key, v);
+            }
+            return new Obj(entries);
+        }
+
+        public static Value object(LinkedHashMap<String, Value> entries) {
+            return new Obj(new LinkedHashMap<>(entries));
+        }
+
+        public static final class Null extends Value {
+            private Null() {}
+        }
+
+        public static final class Bool extends Value {
+            public static final Bool TRUE = new Bool(true);
+            public static final Bool FALSE = new Bool(false);
+            public final boolean value;
+            private Bool(boolean v) { this.value = v; }
+        }
+
+        public static final class Integer extends Value {
+            public final long value;
+            private Integer(long v) { this.value = v; }
+        }
+
+        public static final class Str extends Value {
+            public final String value;
+            private Str(String v) { this.value = v; }
+        }
+
+        public static final class Arr extends Value {
+            public final List<Value> items;
+            private Arr(List<Value> items) { this.items = items; }
+        }
+
+        public static final class Obj extends Value {
+            public final LinkedHashMap<String, Value> entries;
+            private Obj(LinkedHashMap<String, Value> entries) { this.entries = entries; }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Encoder
+    // -------------------------------------------------------------------
+
+    /** Encode {@code v} to a JCS-canonical UTF-8 string. */
+    public static String encode(Value v) {
+        StringBuilder sb = new StringBuilder();
+        encodeValue(v, sb);
+        return sb.toString();
+    }
+
+    /** Encode {@code v} to JCS-canonical UTF-8 bytes. */
+    public static byte[] encodeUtf8(Value v) {
+        return encode(v).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static void encodeValue(Value v, StringBuilder out) {
+        if (v instanceof Value.Null) {
+            out.append("null");
+        } else if (v instanceof Value.Bool b) {
+            out.append(b.value ? "true" : "false");
+        } else if (v instanceof Value.Integer i) {
+            out.append(java.lang.Long.toString(i.value));
+        } else if (v instanceof Value.Str s) {
+            encodeString(s.value, out);
+        } else if (v instanceof Value.Arr a) {
+            out.append('[');
+            boolean first = true;
+            for (Value item : a.items) {
+                if (!first) out.append(',');
+                first = false;
+                encodeValue(item, out);
+            }
+            out.append(']');
+        } else if (v instanceof Value.Obj o) {
+            // Sort keys by Unicode code-point order. String#compareTo() in
+            // Java compares char-by-char which is UTF-16 code-unit order;
+            // that diverges from code-point order ONLY for chars in the
+            // surrogate range, which is irrelevant for the protocol's
+            // ASCII-only keys. The rust peer does byte-cmp; for ASCII keys
+            // both orderings collapse to byte order.
+            List<String> keys = new ArrayList<>(o.entries.keySet());
+            Collections.sort(keys, Jcs::compareCodePoints);
+            out.append('{');
+            boolean first = true;
+            for (String k : keys) {
+                if (!first) out.append(',');
+                first = false;
+                encodeString(k, out);
+                out.append(':');
+                encodeValue(o.entries.get(k), out);
+            }
+            out.append('}');
+        } else {
+            throw new IllegalStateException("Unknown Value variant: " + v.getClass());
+        }
+    }
+
+    private static int compareCodePoints(String a, String b) {
+        int i = 0, j = 0;
+        while (i < a.length() && j < b.length()) {
+            int ca = a.codePointAt(i);
+            int cb = b.codePointAt(j);
+            if (ca != cb) return java.lang.Integer.compare(ca, cb);
+            i += Character.charCount(ca);
+            j += Character.charCount(cb);
+        }
+        return java.lang.Integer.compare(a.length() - i, b.length() - j);
+    }
+
+    private static void encodeString(String s, StringBuilder out) {
+        out.append('"');
+        // Iterate by Unicode code points so non-ASCII chars round-trip
+        // verbatim; pushing a code point into a StringBuilder re-encodes
+        // it as the same UTF-8 bytes when the result is later UTF-8
+        // serialized. This matches the rust peer's char iteration.
+        int i = 0;
+        while (i < s.length()) {
+            int cp = s.codePointAt(i);
+            i += Character.charCount(cp);
+            if (cp == '"') {
+                out.append("\\\"");
+            } else if (cp == '\\') {
+                out.append("\\\\");
+            } else if (cp < 0x20) {
+                out.append("\\u00");
+                out.append(HEX[(cp >>> 4) & 0xF]);
+                out.append(HEX[cp & 0xF]);
+            } else {
+                out.appendCodePoint(cp);
+            }
+        }
+        out.append('"');
+    }
+
+    private static final char[] HEX = {
+        '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'
+    };
+
+    /** Convenience: BLAKE3-512 of JCS({@code v}). */
+    public static String blake3Cid(Value v) {
+        return Blake3.blake3_512(encodeUtf8(v));
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/ProofEnvelope.java
+++ b/implementations/java/provekit-claim-envelope/src/main/java/com/provekit/claimenvelope/ProofEnvelope.java
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// .proof envelope builder. Per RFC 8949 §4.2.1 + the .proof spec
+// (protocol/specs/2026-04-30-proof-file-format.md):
+//
+//   1. Build the unsigned body as a CBOR map with keys sorted by
+//      bytewise lex order of their CBOR-encoded form.
+//   2. Ed25519-sign the unsigned-body bytes.
+//   3. Re-emit the body with the signature added; keys re-sort
+//      automatically (the new "signature" key slots in by lex order).
+//   4. BLAKE3-512 the final bytes; the full self-identifying string
+//      "blake3-512:<128 hex>" IS the catalog CID.
+//
+// The `members` map key is the embedded envelope's own CID, and the
+// value is its canonical bytes (JCS-JSON for memento envelopes per the
+// memento envelope grammar) wrapped as a CBOR byte string.
+//
+// Mirrors implementations/rust/provekit-proof-envelope/src/proof.rs and
+// implementations/csharp/Provekit.ProofEnvelope/Proof.cs 1:1, plus the
+// optional `binaryCid` and `metadata` fields the rust peer carries.
+
+package com.provekit.claimenvelope;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+public final class ProofEnvelope {
+
+    private ProofEnvelope() {}
+
+    public static final class Input {
+        public final String name;
+        public final String version;
+        /** Map from member CID to member canonical bytes. Insertion order ignored: encoder sorts. */
+        public final Map<String, byte[]> members;
+        public final String signerCid;
+        public final byte[] signerSeed;
+        /** ISO-8601 with millisecond precision and trailing 'Z'. */
+        public final String declaredAt;
+        /** Optional binaryCid (omitted when null). */
+        public final String binaryCid;
+        /** Optional metadata key-value map (omitted when null). */
+        public final Map<String, String> metadata;
+
+        public Input(String name,
+                     String version,
+                     Map<String, byte[]> members,
+                     String signerCid,
+                     byte[] signerSeed,
+                     String declaredAt,
+                     String binaryCid,
+                     Map<String, String> metadata) {
+            this.name = Objects.requireNonNull(name, "name");
+            this.version = Objects.requireNonNull(version, "version");
+            this.members = Objects.requireNonNull(members, "members");
+            this.signerCid = Objects.requireNonNull(signerCid, "signerCid");
+            this.signerSeed = Objects.requireNonNull(signerSeed, "signerSeed");
+            this.declaredAt = Objects.requireNonNull(declaredAt, "declaredAt");
+            this.binaryCid = binaryCid;
+            this.metadata = metadata;
+        }
+
+        public Input(String name,
+                     String version,
+                     Map<String, byte[]> members,
+                     String signerCid,
+                     byte[] signerSeed,
+                     String declaredAt) {
+            this(name, version, members, signerCid, signerSeed, declaredAt, null, null);
+        }
+    }
+
+    public static final class Output {
+        /** CBOR bytes of the signed catalog. Hash of these bytes IS the CID. */
+        public final byte[] bytes;
+        /** Full self-identifying CID: "blake3-512:<128 hex>". */
+        public final String cid;
+
+        Output(byte[] bytes, String cid) {
+            this.bytes = bytes;
+            this.cid = cid;
+        }
+    }
+
+    private static final class CborPair {
+        final byte[] keyCbor;
+        final byte[] valueCbor;
+        CborPair(byte[] k, byte[] v) { this.keyCbor = k; this.valueCbor = v; }
+    }
+
+    public static Output build(Input input) {
+        // Step 1: encode unsigned body with sorted keys.
+        List<CborPair> unsignedPairs = bodyPairsUnsigned(input);
+        byte[] unsignedBytes = emitSortedMapBytes(unsignedPairs);
+
+        // Step 2: Ed25519-sign the unsigned bytes.
+        byte[] sig = Ed25519.signWithSeed(input.signerSeed, unsignedBytes);
+
+        // Step 3: re-emit with signature added; keys re-sort automatically.
+        List<CborPair> signedPairs = bodyPairsUnsigned(input);
+        signedPairs.add(makeBytesPair("signature", sig));
+        byte[] finalBytes = emitSortedMapBytes(signedPairs);
+
+        // Step 4: filename CID = full self-identifying BLAKE3-512.
+        String cid = Blake3.blake3_512(finalBytes);
+        return new Output(finalBytes, cid);
+    }
+
+    /**
+     * Verify a .proof envelope.
+     *
+     * Checks: BLAKE3-512(bytes) matches expectedCid; CBOR shape contains
+     * the catalog kind + required keys; the signature over the unsigned
+     * body verifies against {@code signerPubkey} (raw 32-byte Ed25519
+     * public key, not a seed).
+     *
+     * Returns true iff all checks pass; false (never throws) for malformed input.
+     */
+    public static boolean verify(byte[] proofBytes, String expectedCid, byte[] signerPubkey) {
+        if (proofBytes == null || expectedCid == null || signerPubkey == null) return false;
+        if (signerPubkey.length != Ed25519.PUBKEY_BYTES) return false;
+
+        // Check 1: CID
+        String actualCid = Blake3.blake3_512(proofBytes);
+        if (!actualCid.equals(expectedCid)) return false;
+
+        // Check 2 + 3: decode minimally, lift the signature out and re-encode the unsigned body.
+        DecodedCatalog dec;
+        try {
+            dec = decodeCatalog(proofBytes);
+        } catch (RuntimeException ex) {
+            return false;
+        }
+        if (dec == null) return false;
+        return Ed25519.verifyBytes(signerPubkey, dec.signature, dec.unsignedBytes);
+    }
+
+    // -------------------------------------------------------------------
+    // Body construction
+    // -------------------------------------------------------------------
+
+    private static List<CborPair> bodyPairsUnsigned(Input input) {
+        List<CborPair> pairs = new ArrayList<>(8);
+        pairs.add(makeStringPair("kind", "catalog"));
+        pairs.add(makeStringPair("name", input.name));
+        pairs.add(makeStringPair("version", input.version));
+        pairs.add(makeMembersPair("members", input.members));
+        pairs.add(makeStringPair("signer", input.signerCid));
+        pairs.add(makeStringPair("declaredAt", input.declaredAt));
+        if (input.binaryCid != null) {
+            pairs.add(makeStringPair("binaryCid", input.binaryCid));
+        }
+        if (input.metadata != null) {
+            pairs.add(makeMetadataPair("metadata", input.metadata));
+        }
+        return pairs;
+    }
+
+    private static byte[] encodeKey(String key) {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        Cbor.encodeTstr(b, key);
+        return b.toByteArray();
+    }
+
+    private static CborPair makeStringPair(String key, String value) {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        Cbor.encodeTstr(b, value);
+        return new CborPair(encodeKey(key), b.toByteArray());
+    }
+
+    private static CborPair makeBytesPair(String key, byte[] value) {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        Cbor.encodeBstr(b, value);
+        return new CborPair(encodeKey(key), b.toByteArray());
+    }
+
+    private static CborPair makeMembersPair(String key, Map<String, byte[]> members) {
+        // Encode as { tstr(cid) => bstr(envelope-bytes) }, sort by
+        // bytewise CBOR-encoded-key form.
+        List<CborPair> pairs = new ArrayList<>(members.size());
+        for (Map.Entry<String, byte[]> e : members.entrySet()) {
+            pairs.add(makeBytesPair(e.getKey(), e.getValue()));
+        }
+        byte[] valueBytes = emitSortedMapBytes(pairs);
+        return new CborPair(encodeKey(key), valueBytes);
+    }
+
+    private static CborPair makeMetadataPair(String key, Map<String, String> metadata) {
+        List<CborPair> pairs = new ArrayList<>(metadata.size());
+        for (Map.Entry<String, String> e : metadata.entrySet()) {
+            pairs.add(makeStringPair(e.getKey(), e.getValue()));
+        }
+        byte[] valueBytes = emitSortedMapBytes(pairs);
+        return new CborPair(encodeKey(key), valueBytes);
+    }
+
+    private static byte[] emitSortedMapBytes(List<CborPair> pairs) {
+        pairs.sort((a, b) -> compareBytewise(a.keyCbor, b.keyCbor));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Cbor.encodeMapHead(out, pairs.size());
+        for (CborPair p : pairs) {
+            out.write(p.keyCbor, 0, p.keyCbor.length);
+            out.write(p.valueCbor, 0, p.valueCbor.length);
+        }
+        return out.toByteArray();
+    }
+
+    private static int compareBytewise(byte[] a, byte[] b) {
+        int n = Math.min(a.length, b.length);
+        for (int i = 0; i < n; i++) {
+            int d = (a[i] & 0xFF) - (b[i] & 0xFF);
+            if (d != 0) return d;
+        }
+        return a.length - b.length;
+    }
+
+    // -------------------------------------------------------------------
+    // Minimal verifier-side decoder
+    // -------------------------------------------------------------------
+
+    private static final class DecodedCatalog {
+        final byte[] unsignedBytes;
+        final byte[] signature;
+        DecodedCatalog(byte[] unsignedBytes, byte[] signature) {
+            this.unsignedBytes = unsignedBytes;
+            this.signature = signature;
+        }
+    }
+
+    /**
+     * Walk the top-level CBOR map, lift out the {@code signature} field's
+     * raw bytes, and reconstruct the unsigned-body bytes by re-emitting
+     * the remaining keys in canonical order. Returns null if the shape
+     * is not a catalog (kind != "catalog") or the signature key is
+     * missing / not a 64-byte byte string.
+     */
+    private static DecodedCatalog decodeCatalog(byte[] bytes) {
+        Cursor c = new Cursor(bytes);
+        long n = readMapHead(c);
+        if (n < 0) return null;
+
+        // Capture all key/value pairs as raw byte slices, plus parse strings
+        // for the kind sentinel and the signature value.
+        List<byte[]> keyForms = new ArrayList<>((int) n);
+        List<byte[]> valueForms = new ArrayList<>((int) n);
+        String kind = null;
+        byte[] signature = null;
+
+        for (long i = 0; i < n; i++) {
+            int keyStart = c.pos;
+            String key = readTstr(c);
+            if (key == null) return null;
+            int keyEnd = c.pos;
+
+            int valStart = c.pos;
+            // Snapshot the current pos before consuming value.
+            String stringValueOrNull = peekIsTstr(c) ? readTstr(c) : null;
+            if (stringValueOrNull == null) {
+                // Reset — peek consumed bytes only if it was a tstr; otherwise
+                // we still need to consume the value as raw bytes. We use a
+                // straight-line skip to advance past the value.
+                c.pos = valStart;
+                if (!skipValue(c)) return null;
+            }
+            int valEnd = c.pos;
+
+            byte[] keyForm = slice(bytes, keyStart, keyEnd);
+            byte[] valueForm = slice(bytes, valStart, valEnd);
+            keyForms.add(keyForm);
+            valueForms.add(valueForm);
+
+            if ("kind".equals(key)) {
+                kind = stringValueOrNull;
+            } else if ("signature".equals(key)) {
+                // Re-parse the value as a byte string.
+                Cursor v = new Cursor(valueForm);
+                signature = readBstr(v);
+            }
+        }
+
+        if (!"catalog".equals(kind)) return null;
+        if (signature == null || signature.length != Ed25519.SIGNATURE_BYTES) return null;
+
+        // Re-emit unsigned body: drop the signature pair, keep the rest in
+        // their original (already-canonical) order, fresh map-head with
+        // count-1.
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Cbor.encodeMapHead(out, n - 1);
+        for (int i = 0; i < n; i++) {
+            byte[] kf = keyForms.get(i);
+            // Skip the signature pair.
+            if (isTstrEqual(kf, "signature")) continue;
+            out.write(kf, 0, kf.length);
+            byte[] vf = valueForms.get(i);
+            out.write(vf, 0, vf.length);
+        }
+        return new DecodedCatalog(out.toByteArray(), signature);
+    }
+
+    private static boolean isTstrEqual(byte[] tstrCbor, String s) {
+        Cursor c = new Cursor(tstrCbor);
+        String got = readTstr(c);
+        return s.equals(got);
+    }
+
+    private static byte[] slice(byte[] src, int start, int end) {
+        byte[] out = new byte[end - start];
+        System.arraycopy(src, start, out, 0, out.length);
+        return out;
+    }
+
+    // -------------------------------------------------------------------
+    // Tiny CBOR reader (only the major types this kit emits)
+    // -------------------------------------------------------------------
+
+    private static final class Cursor {
+        final byte[] buf;
+        int pos;
+        Cursor(byte[] buf) { this.buf = buf; this.pos = 0; }
+        int peek() { return pos < buf.length ? (buf[pos] & 0xFF) : -1; }
+    }
+
+    private static long readHead(Cursor c, int expectedMajor) {
+        if (c.pos >= c.buf.length) return -1;
+        int b = c.buf[c.pos++] & 0xFF;
+        int major = b >>> 5;
+        if (major != expectedMajor) {
+            // Caller decides whether to reset.
+            c.pos--;
+            return -1;
+        }
+        int low = b & 0x1F;
+        if (low < 24) return low;
+        long argLen = switch (low) {
+            case 24 -> 1;
+            case 25 -> 2;
+            case 26 -> 4;
+            case 27 -> 8;
+            default -> -1;
+        };
+        if (argLen < 0) return -1;
+        if (c.pos + argLen > c.buf.length) return -1;
+        long v = 0;
+        for (int i = 0; i < argLen; i++) {
+            v = (v << 8) | (c.buf[c.pos++] & 0xFF);
+        }
+        return v;
+    }
+
+    private static long readMapHead(Cursor c) {
+        return readHead(c, Cbor.MAJOR_MAP);
+    }
+
+    private static String readTstr(Cursor c) {
+        long len = readHead(c, Cbor.MAJOR_TEXT_STRING);
+        if (len < 0) return null;
+        if (c.pos + len > c.buf.length) return null;
+        String s = new String(c.buf, c.pos, (int) len, java.nio.charset.StandardCharsets.UTF_8);
+        c.pos += (int) len;
+        return s;
+    }
+
+    private static byte[] readBstr(Cursor c) {
+        long len = readHead(c, Cbor.MAJOR_BYTE_STRING);
+        if (len < 0) return null;
+        if (c.pos + len > c.buf.length) return null;
+        byte[] out = new byte[(int) len];
+        System.arraycopy(c.buf, c.pos, out, 0, out.length);
+        c.pos += (int) len;
+        return out;
+    }
+
+    private static boolean peekIsTstr(Cursor c) {
+        int b = c.peek();
+        if (b < 0) return false;
+        return (b >>> 5) == Cbor.MAJOR_TEXT_STRING;
+    }
+
+    /** Skip past the next CBOR value at {@code c.pos}. Returns false on malformed input. */
+    private static boolean skipValue(Cursor c) {
+        if (c.pos >= c.buf.length) return false;
+        int b = c.buf[c.pos++] & 0xFF;
+        int major = b >>> 5;
+        int low = b & 0x1F;
+        long arg;
+        if (low < 24) {
+            arg = low;
+        } else {
+            long argLen = switch (low) {
+                case 24 -> 1;
+                case 25 -> 2;
+                case 26 -> 4;
+                case 27 -> 8;
+                default -> -1;
+            };
+            if (argLen < 0) return false;
+            if (c.pos + argLen > c.buf.length) return false;
+            long v = 0;
+            for (int i = 0; i < argLen; i++) {
+                v = (v << 8) | (c.buf[c.pos++] & 0xFF);
+            }
+            arg = v;
+        }
+        switch (major) {
+            case Cbor.MAJOR_UNSIGNED_INT:
+                return true;
+            case Cbor.MAJOR_BYTE_STRING:
+            case Cbor.MAJOR_TEXT_STRING:
+                if (c.pos + arg > c.buf.length) return false;
+                c.pos += (int) arg;
+                return true;
+            case Cbor.MAJOR_ARRAY:
+                for (long i = 0; i < arg; i++) {
+                    if (!skipValue(c)) return false;
+                }
+                return true;
+            case Cbor.MAJOR_MAP:
+                for (long i = 0; i < arg; i++) {
+                    if (!skipValue(c)) return false; // key
+                    if (!skipValue(c)) return false; // value
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/Blake3Test.java
+++ b/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/Blake3Test.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.provekit.claimenvelope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class Blake3Test {
+
+    @Test
+    void empty_input_known_vector() {
+        // Pinned BLAKE3 (extended to 64 bytes) of the empty input. Known
+        // test vector from the BLAKE3 reference test suite. Confirms the
+        // BouncyCastle Blake3Digest output matches the canonical spec.
+        String cid = Blake3.blake3_512(new byte[0]);
+        assertEquals(
+            "blake3-512:" +
+                "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262" +
+                "e00f03e7b69af26b7faaf09fcd333050338ddfe085b8cc869ca98b206c08243a",
+            cid);
+    }
+
+    @Test
+    void prefix_and_length() {
+        String cid = Blake3.blake3_512("hello".getBytes());
+        assertTrue(cid.startsWith("blake3-512:"));
+        // 11-char prefix + 128 hex digits
+        assertEquals(11 + 128, cid.length());
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/CborTest.java
+++ b/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/CborTest.java
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.provekit.claimenvelope;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Mirrors implementations/rust/provekit-proof-envelope/src/cbor.rs unit tests.
+ */
+class CborTest {
+
+    @Test
+    void shortest_form_uint_zero() {
+        ByteArrayOutputStream o = new ByteArrayOutputStream();
+        Cbor.encodeUint(o, 0);
+        assertArrayEquals(new byte[]{0x00}, o.toByteArray());
+    }
+
+    @Test
+    void shortest_form_uint_23() {
+        ByteArrayOutputStream o = new ByteArrayOutputStream();
+        Cbor.encodeUint(o, 23);
+        assertArrayEquals(new byte[]{0x17}, o.toByteArray());
+    }
+
+    @Test
+    void shortest_form_uint_24() {
+        ByteArrayOutputStream o = new ByteArrayOutputStream();
+        Cbor.encodeUint(o, 24);
+        assertArrayEquals(new byte[]{0x18, 24}, o.toByteArray());
+    }
+
+    @Test
+    void shortest_form_uint_256() {
+        ByteArrayOutputStream o = new ByteArrayOutputStream();
+        Cbor.encodeUint(o, 256);
+        assertArrayEquals(new byte[]{0x19, 0x01, 0x00}, o.toByteArray());
+    }
+
+    @Test
+    void shortest_form_uint_65536() {
+        ByteArrayOutputStream o = new ByteArrayOutputStream();
+        Cbor.encodeUint(o, 65536);
+        assertArrayEquals(new byte[]{0x1a, 0x00, 0x01, 0x00, 0x00}, o.toByteArray());
+    }
+
+    @Test
+    void tstr_round_trip_head() {
+        ByteArrayOutputStream o = new ByteArrayOutputStream();
+        Cbor.encodeTstr(o, "hello");
+        // major 3 (text string), len 5 short form: 0x65, then "hello"
+        assertArrayEquals(new byte[]{0x65, 'h', 'e', 'l', 'l', 'o'}, o.toByteArray());
+    }
+
+    @Test
+    void map_head_seven() {
+        ByteArrayOutputStream o = new ByteArrayOutputStream();
+        Cbor.encodeMapHead(o, 7);
+        assertArrayEquals(new byte[]{(byte) 0xa7}, o.toByteArray());
+    }
+
+    @Test
+    void bstr_short() {
+        ByteArrayOutputStream o = new ByteArrayOutputStream();
+        Cbor.encodeBstr(o, new byte[]{1, 2, 3});
+        // major 2 (byte string), len 3 short form: 0x43, then 1 2 3
+        assertArrayEquals(new byte[]{0x43, 1, 2, 3}, o.toByteArray());
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/ClaimEnvelopeTest.java
+++ b/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/ClaimEnvelopeTest.java
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.provekit.claimenvelope;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.provekit.claimenvelope.ClaimEnvelope.Authoring;
+import com.provekit.claimenvelope.ClaimEnvelope.MintContractArgs;
+import com.provekit.claimenvelope.ClaimEnvelope.MintedEnvelope;
+import com.provekit.claimenvelope.Jcs.Value;
+
+/**
+ * Mirrors implementations/rust/provekit-claim-envelope/src/lib.rs unit tests.
+ */
+class ClaimEnvelopeTest {
+
+    private static byte[] dummySeed() {
+        byte[] s = new byte[32];
+        for (int i = 0; i < 32; i++) s[i] = (byte) 0x42;
+        return s;
+    }
+
+    @Test
+    void empty_contract_rejected() {
+        MintContractArgs args = new MintContractArgs();
+        args.contractName = "x";
+        args.outBinding = "out";
+        args.producedBy = "test";
+        args.producedAt = "2026-04-30T00:00:00.000Z";
+        args.authoring = new Authoring.KitAuthor("test", null);
+        args.signerSeed = dummySeed();
+        assertThrows(IllegalArgumentException.class, () -> ClaimEnvelope.mintContract(args));
+    }
+
+    @Test
+    void cid_is_blake3_512_prefixed() {
+        Value pre = Value.object(
+            "kind", Value.string("atomic"),
+            "name", Value.string(">"),
+            "args", Value.array(
+                Value.object("kind", Value.string("var"), "name", Value.string("n")),
+                Value.object(
+                    "kind", Value.string("const"),
+                    "value", Value.integer(0),
+                    "sort", Value.object(
+                        "kind", Value.string("primitive"),
+                        "name", Value.string("Int")))
+            ));
+        MintContractArgs args = new MintContractArgs();
+        args.contractName = "parseInt";
+        args.pre = pre;
+        args.outBinding = "out";
+        args.producedBy = "java-kit@1.0";
+        args.producedAt = "2026-04-30T00:00:00.000Z";
+        args.authoring = new Authoring.KitAuthor("java-kit@1.0", null);
+        args.signerSeed = dummySeed();
+
+        MintedEnvelope m = ClaimEnvelope.mintContract(args);
+        assertTrue(m.cid.startsWith("blake3-512:"));
+        assertEquals("blake3-512:".length() + 128, m.cid.length());
+    }
+
+    @Test
+    void contract_cid_signer_independent() {
+        // Two different seeds, same contract content -> same contractCid,
+        // different attestation cid.
+        MintContractArgs argsA = new MintContractArgs();
+        argsA.contractName = "p";
+        argsA.pre = Value.object("k", Value.string("v"));
+        argsA.outBinding = "out";
+        argsA.producedBy = "a";
+        argsA.producedAt = "2026-04-30T00:00:00.000Z";
+        argsA.authoring = new Authoring.KitAuthor("a", null);
+        argsA.signerSeed = dummySeed();
+
+        MintContractArgs argsB = new MintContractArgs();
+        argsB.contractName = "p";
+        argsB.pre = Value.object("k", Value.string("v"));
+        argsB.outBinding = "out";
+        argsB.producedBy = "b";
+        argsB.producedAt = "2026-04-30T00:00:00.000Z";
+        argsB.authoring = new Authoring.KitAuthor("b", null);
+        byte[] seedB = new byte[32];
+        for (int i = 0; i < 32; i++) seedB[i] = (byte) 0x43;
+        argsB.signerSeed = seedB;
+
+        String ccidA = ClaimEnvelope.contractCid(argsA);
+        String ccidB = ClaimEnvelope.contractCid(argsB);
+        assertEquals(ccidA, ccidB);
+
+        MintedEnvelope a = ClaimEnvelope.mintContract(argsA);
+        MintedEnvelope b = ClaimEnvelope.mintContract(argsB);
+        assertEquals(ccidA, a.contractCid);
+        assertEquals(ccidB, b.contractCid);
+        // Attestation cids differ (different signers).
+        assertNotEquals(a.cid, b.cid);
+    }
+
+    @Test
+    void contract_set_cid_order_independent() {
+        String c1 = "blake3-512:" + "11".repeat(64);
+        String c2 = "blake3-512:" + "22".repeat(64);
+        String c3 = "blake3-512:" + "33".repeat(64);
+        String setAB = ClaimEnvelope.computeContractSetCid(List.of(c1, c2, c3));
+        String setBA = ClaimEnvelope.computeContractSetCid(List.of(c3, c1, c2));
+        assertEquals(setAB, setBA);
+    }
+
+    @Test
+    void mint_contract_deterministic() {
+        MintContractArgs argsA = new MintContractArgs();
+        argsA.contractName = "p";
+        argsA.pre = Value.object("k", Value.string("v"));
+        argsA.outBinding = "out";
+        argsA.producedBy = "java-kit";
+        argsA.producedAt = "2026-04-30T00:00:00.000Z";
+        argsA.authoring = new Authoring.KitAuthor("java-kit", null);
+        argsA.signerSeed = dummySeed();
+
+        MintContractArgs argsB = new MintContractArgs();
+        argsB.contractName = "p";
+        argsB.pre = Value.object("k", Value.string("v"));
+        argsB.outBinding = "out";
+        argsB.producedBy = "java-kit";
+        argsB.producedAt = "2026-04-30T00:00:00.000Z";
+        argsB.authoring = new Authoring.KitAuthor("java-kit", null);
+        argsB.signerSeed = dummySeed();
+
+        MintedEnvelope a = ClaimEnvelope.mintContract(argsA);
+        MintedEnvelope b = ClaimEnvelope.mintContract(argsB);
+        assertArrayEquals(a.canonicalBytes, b.canonicalBytes);
+        assertEquals(a.cid, b.cid);
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/Ed25519Test.java
+++ b/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/Ed25519Test.java
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.provekit.claimenvelope;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class Ed25519Test {
+
+    private static byte[] seed42() {
+        byte[] s = new byte[32];
+        for (int i = 0; i < 32; i++) s[i] = (byte) 0x42;
+        return s;
+    }
+
+    @Test
+    void deterministic_signature_for_fixed_seed() {
+        byte[] seed = seed42();
+        byte[] a = Ed25519.signWithSeed(seed, "hello".getBytes());
+        byte[] b = Ed25519.signWithSeed(seed, "hello".getBytes());
+        assertArrayEquals(a, b);
+    }
+
+    @Test
+    void signature_is_64_bytes() {
+        byte[] sig = Ed25519.signWithSeed(seed42(), "hello".getBytes());
+        assertEquals(64, sig.length);
+    }
+
+    @Test
+    void sign_string_has_prefix() {
+        String s = Ed25519.signString(seed42(), "hello".getBytes());
+        assertTrue(s.startsWith("ed25519:"));
+    }
+
+    @Test
+    void pubkey_string_has_prefix() {
+        String pk = Ed25519.pubkeyString(seed42());
+        assertTrue(pk.startsWith("ed25519:"));
+    }
+
+    @Test
+    void pubkey_base64_is_44_chars() {
+        // 32 bytes -> 44 base64 chars
+        String pk = Ed25519.pubkeyString(seed42());
+        String b64 = pk.substring("ed25519:".length());
+        assertEquals(44, b64.length());
+    }
+
+    @Test
+    void verify_round_trip() {
+        byte[] seed = seed42();
+        String pk = Ed25519.pubkeyString(seed);
+        String sig = Ed25519.signString(seed, "hello world".getBytes());
+        assertTrue(Ed25519.verifyString(pk, sig, "hello world".getBytes()));
+        assertFalse(Ed25519.verifyString(pk, sig, "goodbye world".getBytes()));
+    }
+
+    @Test
+    void verify_rejects_malformed() {
+        assertFalse(Ed25519.verifyString("not-prefixed", "ed25519:AAAA", "x".getBytes()));
+        assertFalse(Ed25519.verifyString("ed25519:AAAA", "not-prefixed", "x".getBytes()));
+        assertFalse(Ed25519.verifyString("ed25519:!!!!", "ed25519:!!!!", "x".getBytes()));
+    }
+
+    @Test
+    void foundation_v0_seed_is_42_repeated() {
+        byte[] seed = Ed25519.FOUNDATION_V0_SEED;
+        assertEquals(32, seed.length);
+        for (byte b : seed) assertEquals((byte) 0x42, b);
+    }
+
+    @Test
+    void different_seeds_produce_different_signatures() {
+        byte[] seedA = new byte[32];
+        for (int i = 0; i < 32; i++) seedA[i] = (byte) 0x42;
+        byte[] seedB = new byte[32];
+        for (int i = 0; i < 32; i++) seedB[i] = (byte) 0x43;
+        byte[] sigA = Ed25519.signWithSeed(seedA, "same".getBytes());
+        byte[] sigB = Ed25519.signWithSeed(seedB, "same".getBytes());
+        assertFalse(java.util.Arrays.equals(sigA, sigB));
+    }
+
+    @Test
+    void verify_bytes_round_trip() {
+        byte[] seed = seed42();
+        byte[] pk = Ed25519.pubkeyBytes(seed);
+        byte[] sig = Ed25519.signWithSeed(seed, "hello".getBytes());
+        assertTrue(Ed25519.verifyBytes(pk, sig, "hello".getBytes()));
+        assertFalse(Ed25519.verifyBytes(pk, sig, "world".getBytes()));
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/JcsTest.java
+++ b/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/JcsTest.java
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.provekit.claimenvelope;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.provekit.claimenvelope.Jcs.Value;
+
+/**
+ * Unit tests mirroring implementations/rust/provekit-canonicalizer/src/jcs.rs.
+ */
+class JcsTest {
+
+    @Test
+    void encode_simple_object_sorts_keys() {
+        Value v = Value.object("b", Value.integer(1), "a", Value.string("x"));
+        assertEquals("{\"a\":\"x\",\"b\":1}", Jcs.encode(v));
+    }
+
+    @Test
+    void encode_nested_array_object() {
+        Value v = Value.object("xs", Value.array(Value.integer(1), Value.integer(2)));
+        assertEquals("{\"xs\":[1,2]}", Jcs.encode(v));
+    }
+
+    @Test
+    void escape_quotes_and_backslash() {
+        Value v = Value.string("a\"b\\c");
+        assertEquals("\"a\\\"b\\\\c\"", Jcs.encode(v));
+    }
+
+    @Test
+    void empty_object_and_array() {
+        assertEquals("{}", Jcs.encode(Value.object(new LinkedHashMap<>())));
+        assertEquals("[]", Jcs.encode(Value.array(List.of())));
+    }
+
+    @Test
+    void unicode_atomic_predicates_round_trip_verbatim() {
+        // U+2265 = >=, U+2264 = <=, U+2260 = !=. The kit's atomic predicate
+        // names use exactly these. Cross-language hash agreement depends on
+        // these chars round-tripping verbatim (UTF-8 bytes preserved).
+        for (String sym : new String[]{"≥", "≤", "≠"}) {
+            Value v = Value.string(sym);
+            String encoded = Jcs.encode(v);
+            assertEquals("\"" + sym + "\"", encoded);
+            String inner = encoded.substring(1, encoded.length() - 1);
+            assertArrayEquals(sym.getBytes(StandardCharsets.UTF_8), inner.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    void mixed_ascii_and_unicode_preserved() {
+        String s = "x ≥ 0";
+        Value v = Value.string(s);
+        String encoded = Jcs.encode(v);
+        assertEquals("\"" + s + "\"", encoded);
+    }
+
+    @Test
+    void unicode_in_object_key_and_value_matches_cpp_bytes() {
+        Value v = Value.object("name", Value.string("≥"));
+        byte[] encoded = Jcs.encodeUtf8(v);
+        // The cpp peer writes raw UTF-8 bytes for non-ASCII chars; we must match.
+        byte[] expected = new byte[]{
+            '{','"','n','a','m','e','"',':','"',
+            (byte) 0xe2, (byte) 0x89, (byte) 0xa5,
+            '"','}'
+        };
+        assertArrayEquals(expected, encoded);
+    }
+
+    @Test
+    void control_char_escapes_lowercase_hex() {
+        Value v = Value.string("\t\n");
+        assertEquals("\"\\u0009\\u000a\"", Jcs.encode(v));
+    }
+
+    @Test
+    void integer_zero_serializes_as_zero() {
+        assertEquals("0", Jcs.encode(Value.integer(0)));
+    }
+
+    @Test
+    void integer_negative_serializes_with_minus() {
+        assertEquals("-42", Jcs.encode(Value.integer(-42)));
+    }
+}

--- a/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/ProofEnvelopeTest.java
+++ b/implementations/java/provekit-claim-envelope/src/test/java/com/provekit/claimenvelope/ProofEnvelopeTest.java
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Round-trip + cross-kit byte-equivalence tests for the .proof envelope.
+//
+// The cross-kit pin is the exact two-member fixture pinned by the python
+// kit (PR #221) from the rust reference output. If the Java output is
+// not byte-identical to that fixture, the divergence is real, not a
+// near-miss; surface it.
+
+package com.provekit.claimenvelope;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+class ProofEnvelopeTest {
+
+    /**
+     * The python kit's pinned cross-kit fixture (cargo run --release -p
+     * provekit-proof-envelope --example proof_envelope_bytes), exact
+     * 252-byte signed-catalog output for a two-member input.
+     *
+     * Input: name=@test/cat, version=1.0.0, seed=[0x42;32],
+     *        members={blake3-512:aa: '{"hello":"world"}',
+     *                 blake3-512:bb: '{"goodbye":"world"}'},
+     *        signer=blake3-512:cc, declaredAt=2026-04-30T00:00:00.000Z
+     */
+    private static final String RUST_FIXTURE_BYTES_HEX =
+        "a7646b696e6467636174616c6f67646e616d656940746573742f636174667369676e65" +
+        "726d626c616b65332d3531323a6363676d656d62657273a26d626c616b65332d353132" +
+        "3a6161517b2268656c6c6f223a22776f726c64227d6d626c616b65332d3531323a6262" +
+        "537b22676f6f64627965223a22776f726c64227d6776657273696f6e65312e302e3069" +
+        "7369676e617475726558406a21dd428a54e22c82ca6d6125a7293c4a723786cb1840e8" +
+        "91cefa03e63246eb97ef13dab86b7b1469d67302fadc969cd88c92c29495d13c75fc02" +
+        "01a7263b066a6465636c6172656441747818323032362d30342d33305430303a30303a" +
+        "30302e3030305a";
+
+    private static final String RUST_FIXTURE_CID =
+        "blake3-512:5ed1e1f705622ad52ae4683e3d12df5586d364d66bb3186f5be512415edf290" +
+        "844d74e73a2857cd858f37803e4b11fe5c7cba7884caa6b9ff847521ce32ea056";
+
+    private static byte[] hex2bytes(String hex) {
+        int n = hex.length();
+        byte[] out = new byte[n / 2];
+        for (int i = 0; i < n; i += 2) {
+            out[i / 2] = (byte) Integer.parseInt(hex.substring(i, i + 2), 16);
+        }
+        return out;
+    }
+
+    private static ProofEnvelope.Input minimalInput() {
+        Map<String, byte[]> members = new LinkedHashMap<>();
+        members.put("blake3-512:aa", "{\"hello\":\"world\"}".getBytes(StandardCharsets.UTF_8));
+        return new ProofEnvelope.Input(
+            "@test/cat",
+            "1.0.0",
+            members,
+            "blake3-512:cc",
+            Ed25519.FOUNDATION_V0_SEED,
+            "2026-04-30T00:00:00.000Z"
+        );
+    }
+
+    private static ProofEnvelope.Input twoMemberInput() {
+        // Use TreeMap so iteration order is deterministic; the encoder sorts
+        // by CBOR-encoded-key bytes anyway, but matching python's input
+        // construction keeps the two impls obviously parallel.
+        Map<String, byte[]> members = new TreeMap<>();
+        members.put("blake3-512:aa", "{\"hello\":\"world\"}".getBytes(StandardCharsets.UTF_8));
+        members.put("blake3-512:bb", "{\"goodbye\":\"world\"}".getBytes(StandardCharsets.UTF_8));
+        return new ProofEnvelope.Input(
+            "@test/cat",
+            "1.0.0",
+            members,
+            "blake3-512:cc",
+            Ed25519.FOUNDATION_V0_SEED,
+            "2026-04-30T00:00:00.000Z"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Round-trip
+    // -------------------------------------------------------------------
+
+    @Test
+    void build_then_verify() {
+        ProofEnvelope.Output out = ProofEnvelope.build(minimalInput());
+        byte[] pk = Ed25519.pubkeyBytes(Ed25519.FOUNDATION_V0_SEED);
+        assertTrue(ProofEnvelope.verify(out.bytes, out.cid, pk));
+    }
+
+    @Test
+    void cid_is_blake3_512_of_bytes() {
+        ProofEnvelope.Output out = ProofEnvelope.build(minimalInput());
+        assertEquals(out.cid, Blake3.blake3_512(out.bytes));
+    }
+
+    @Test
+    void cid_has_correct_prefix_and_length() {
+        ProofEnvelope.Output out = ProofEnvelope.build(minimalInput());
+        assertTrue(out.cid.startsWith("blake3-512:"));
+        assertEquals("blake3-512:".length() + 128, out.cid.length());
+    }
+
+    @Test
+    void signed_map_head_is_seven_keys() {
+        // 7-key map head: major 5 (0xA0) + count 7 = 0xA7.
+        ProofEnvelope.Output out = ProofEnvelope.build(minimalInput());
+        assertEquals((byte) 0xA7, out.bytes[0]);
+    }
+
+    @Test
+    void deterministic_across_runs() {
+        ProofEnvelope.Output a = ProofEnvelope.build(minimalInput());
+        ProofEnvelope.Output b = ProofEnvelope.build(minimalInput());
+        assertArrayEquals(a.bytes, b.bytes);
+        assertEquals(a.cid, b.cid);
+    }
+
+    @Test
+    void empty_members_produces_valid_envelope() {
+        ProofEnvelope.Input inp = new ProofEnvelope.Input(
+            "x",
+            "1",
+            new LinkedHashMap<>(),
+            "blake3-512:cc",
+            Ed25519.FOUNDATION_V0_SEED,
+            "2026-04-30T00:00:00.000Z"
+        );
+        ProofEnvelope.Output out = ProofEnvelope.build(inp);
+        assertEquals((byte) 0xA7, out.bytes[0]);
+        assertTrue(out.cid.startsWith("blake3-512:"));
+        byte[] pk = Ed25519.pubkeyBytes(Ed25519.FOUNDATION_V0_SEED);
+        assertTrue(ProofEnvelope.verify(out.bytes, out.cid, pk));
+    }
+
+    @Test
+    void two_members_round_trip() {
+        ProofEnvelope.Output out = ProofEnvelope.build(twoMemberInput());
+        byte[] pk = Ed25519.pubkeyBytes(Ed25519.FOUNDATION_V0_SEED);
+        assertTrue(ProofEnvelope.verify(out.bytes, out.cid, pk));
+    }
+
+    @Test
+    void changing_name_changes_cid() {
+        ProofEnvelope.Output a = ProofEnvelope.build(minimalInput());
+        Map<String, byte[]> m = new LinkedHashMap<>();
+        m.put("blake3-512:aa", "{\"hello\":\"world\"}".getBytes(StandardCharsets.UTF_8));
+        ProofEnvelope.Input b = new ProofEnvelope.Input(
+            "@other/name", "1.0.0", m, "blake3-512:cc",
+            Ed25519.FOUNDATION_V0_SEED, "2026-04-30T00:00:00.000Z"
+        );
+        assertNotEquals(a.cid, ProofEnvelope.build(b).cid);
+    }
+
+    @Test
+    void verify_rejects_tampered_cid() {
+        ProofEnvelope.Output out = ProofEnvelope.build(minimalInput());
+        StringBuilder fake = new StringBuilder("blake3-512:");
+        for (int i = 0; i < 128; i++) fake.append('0');
+        byte[] pk = Ed25519.pubkeyBytes(Ed25519.FOUNDATION_V0_SEED);
+        assertFalse(ProofEnvelope.verify(out.bytes, fake.toString(), pk));
+    }
+
+    @Test
+    void verify_rejects_wrong_pubkey() {
+        ProofEnvelope.Output out = ProofEnvelope.build(minimalInput());
+        byte[] wrongSeed = new byte[32];
+        for (int i = 0; i < 32; i++) wrongSeed[i] = (byte) 0x99;
+        byte[] wrongPk = Ed25519.pubkeyBytes(wrongSeed);
+        assertFalse(ProofEnvelope.verify(out.bytes, out.cid, wrongPk));
+    }
+
+    // -------------------------------------------------------------------
+    // Cross-kit byte-equivalence — THE LOAD-BEARING TEST
+    // -------------------------------------------------------------------
+
+    @Test
+    void two_member_bytes_match_rust_fixture() {
+        ProofEnvelope.Output out = ProofEnvelope.build(twoMemberInput());
+        byte[] expected = hex2bytes(RUST_FIXTURE_BYTES_HEX);
+        if (!java.util.Arrays.equals(out.bytes, expected)) {
+            int n = Math.min(out.bytes.length, expected.length);
+            for (int i = 0; i < n; i++) {
+                if (out.bytes[i] != expected[i]) {
+                    fail(String.format(
+                        "cross-kit byte divergence at byte %d: java=0x%02x rust=0x%02x%n" +
+                        "java hex: %s%nrust hex: %s",
+                        i, out.bytes[i] & 0xFF, expected[i] & 0xFF,
+                        bytesToHex(out.bytes), RUST_FIXTURE_BYTES_HEX));
+                }
+            }
+            fail(String.format("cross-kit length mismatch: java=%d rust=%d",
+                out.bytes.length, expected.length));
+        }
+    }
+
+    @Test
+    void two_member_cid_matches_rust_fixture() {
+        ProofEnvelope.Output out = ProofEnvelope.build(twoMemberInput());
+        assertEquals(RUST_FIXTURE_CID, out.cid);
+    }
+
+    @Test
+    void rust_bytes_verify_with_foundation_pubkey() {
+        // The rust-produced bytes (from the fixture) must verify under our
+        // Java verifier using the foundation v0 pubkey.
+        byte[] rustBytes = hex2bytes(RUST_FIXTURE_BYTES_HEX);
+        byte[] pk = Ed25519.pubkeyBytes(Ed25519.FOUNDATION_V0_SEED);
+        assertTrue(ProofEnvelope.verify(rustBytes, RUST_FIXTURE_CID, pk));
+    }
+
+    private static String bytesToHex(byte[] b) {
+        StringBuilder sb = new StringBuilder(b.length * 2);
+        for (byte x : b) sb.append(String.format("%02x", x & 0xFF));
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary

New Maven module `provekit-claim-envelope` under `implementations/java/` provides the language-native crypto substrate per Side B of the (A)/(B) split (#176).

- **Blake3.java**: BLAKE3-512 via BouncyCastle's `Blake3Digest`, self-identifying `blake3-512:<hex>` CID
- **Cbor.java**: deterministic CBOR encoder per RFC 8949 §4.2.1 (shortest-form ints, definite-length only)
- **Ed25519.java**: BC-backed sign/verify, self-identifying `ed25519:` + base64 strings, `FOUNDATION_V0_SEED`
- **Jcs.java**: hand-rolled RFC 8785 canonicalizer with sealed `Value` type. Sorts keys, escapes only `"`, `\`, U+0000..U+001F as `\u00XX`, preserves UTF-8 bytes verbatim
- **ProofEnvelope.java**: 4-step `.proof` catalog builder plus a verifier with a minimal CBOR reader for signature liftout
- **ClaimEnvelope.java**: v1.2 layered memento minting (`mintContract` / `mintBridge` / `mintImplication`), `contractCid`, `computeContractSetCid`, `Authoring` union

## Acceptance (#208)

- [x] Java can natively compute BLAKE3 of canonical bytes
- [x] Java can natively JCS-canonicalize JSON
- [x] Java can natively sign/verify Ed25519
- [x] Java can natively CBOR-encode the envelope
- [x] Output round-trips byte-for-byte against rust reference envelopes
- [x] No shell-out to another kit required for envelope construction

## Cross-kit byte-equivalence: PASS

Java output is byte-identical to the rust kit for the two-member fixture pinned by the python kit (PR #221).

- 252-byte signed-catalog hex matches rust output exactly
- Catalog CID matches: `blake3-512:5ed1e1f705622ad52ae4683e3d12df5586d364d66bb3186f5be512415edf290844d74e73a2857cd858f37803e4b11fe5c7cba7884caa6b9ff847521ce32ea056`
- The rust-produced bytes also verify under the Java verifier with the foundation v0 pubkey

## Library choice rationale

- **BouncyCastle 1.78.1** (one jar): provides both `Blake3Digest` (since 1.77) and a mature Ed25519 (`Ed25519Signer` / `Ed25519PrivateKeyParameters`). One mature, deterministic dependency rather than two narrower ones.
- **Hand-rolled JCS + CBOR**: both specs are small (RFC 8785 sort+escape is ~30 lines, RFC 8949 §4.2.1 head encoder is ~40 lines). Pulling a JSON or CBOR library risks subtle determinism divergence (e.g. number formatting, surrogate pair handling, definite-vs-indefinite length) that would only surface as cross-kit byte mismatches under load. The substrate's correctness guarantee depends on byte-exact equivalence so we mirror the rust/cpp/csharp peers line-for-line.

## Test plan

- [x] `mvn -pl provekit-claim-envelope test` -- 48 passed, 0 failed
- [x] `JcsTest` (10): unicode round-trip, key sort, escape rules, ASCII-bytes pin
- [x] `CborTest` (8): shortest-form integer cases at 0/23/24/256/65536, tstr/bstr/map-head
- [x] `Ed25519Test` (10): deterministic signature, prefix forms, malformed-input rejection, foundation seed pin
- [x] `Blake3Test` (2): empty-input known-vector pin, length/prefix shape
- [x] `ProofEnvelopeTest` (13): build/verify round-trip, tamper rejection, cross-kit byte-equivalence (load-bearing)
- [x] `ClaimEnvelopeTest` (5): empty-contract rejection, signer-independent contract CID, contract-set CID order independence, deterministic mint
- [x] Module added to parent reactor; `mvn -pl provekit-claim-envelope -am compile` clean

Closes #208

Generated with [Claude Code](https://claude.com/claude-code)