### PR TITLE
feat(zig): native crypto library — Ed25519 + CBOR + JCS + envelopes (closes #214)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,8 @@ test-swift: build-swift
 .PHONY: test-zig
 test-zig:
 	cd implementations/zig/provekit-ir && zig build test
+	cd implementations/zig/provekit-self-contracts && zig build test
+	@echo "test-zig: native substrate (jcs + cbor + ed25519 + envelopes) verified"
 	cd implementations/zig/provekit-lift-zig && zig build test
 	cd implementations/zig/provekit-lift-zig && zig build
 	@echo "test-zig: lift-zig binary build verified"
@@ -421,6 +423,7 @@ test-zig:
 .PHONY: build-zig
 build-zig:
 	cd implementations/zig/provekit-ir && zig build
+	cd implementations/zig/provekit-self-contracts && zig build
 	cd implementations/zig/provekit-lift-zig && zig build
 	cd implementations/zig/provekit-lsp-zig && zig build
 

--- a/implementations/zig/provekit-self-contracts/build.zig
+++ b/implementations/zig/provekit-self-contracts/build.zig
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-self-contracts (zig) — Side B substrate library.
+//
+// Native Zig implementation of the substrate primitives required to mint
+// claim envelopes (JCS-canonical layered mementos) and proof envelopes
+// (deterministic-CBOR signed catalogs) without shelling out to another
+// kit. Mirrors the structure of:
+//
+//   * implementations/rust/provekit-canonicalizer        (jcs + hash)
+//   * implementations/rust/provekit-proof-envelope       (cbor + sign + proof)
+//   * implementations/rust/provekit-claim-envelope       (layered memento)
+//
+// Module layout:
+//   src/jcs.zig             - Value tree + RFC 8785 JCS encoder
+//   src/hash.zig            - BLAKE3-512 + self-identifying string form
+//   src/cbor.zig            - RFC 8949 §4.2.1 deterministic CBOR encoder
+//   src/signing.zig         - Ed25519 sign/verify (std.crypto.sign.Ed25519)
+//   src/claim_envelope.zig  - mint_contract / mint_bridge / mint_implication
+//   src/proof_envelope.zig  - build_proof_envelope (signed CBOR catalog)
+//   src/foundation.zig      - Foundation v0 ed25519 seed (= [0x42; 32])
+//   src/root.zig            - umbrella module re-exporting all of the above
+//   src/byte_equivalence_test.zig - cross-kit byte-equivalence pins
+
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Public umbrella module. Consumers depend on `provekit-self-contracts`
+    // and reach the sub-modules through namespaced re-exports in root.zig.
+    const lib_mod = b.addModule("provekit-self-contracts", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Test runner: pulls every src/*.zig test block via root.zig's
+    // `comptime` references.
+    const lib_unit_tests = b.addTest(.{
+        .root_module = lib_mod,
+    });
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+}

--- a/implementations/zig/provekit-self-contracts/build.zig.zon
+++ b/implementations/zig/provekit-self-contracts/build.zig.zon
@@ -1,0 +1,9 @@
+.{
+    .name = .provekit_self_contracts,
+    .fingerprint = 0xeef4e1eca2f29744,
+    .version = "0.1.0",
+    .paths = .{
+        "build.zig",
+        "src",
+    },
+}

--- a/implementations/zig/provekit-self-contracts/src/byte_equivalence_test.zig
+++ b/implementations/zig/provekit-self-contracts/src/byte_equivalence_test.zig
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Byte-equivalence pins for the substrate library. These tests demonstrate
+// that the Zig substrate produces byte-identical output to the Rust + Go
+// reference kits when given the same inputs.
+//
+// Anchor 1 — Foundation v0 pubkey (signing.zig):
+//   `ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=`
+//   Pinned in every .provekit/self-contracts-attestations/*.json file
+//   (the `signer` field). Rust derives this via ed25519-dalek; Zig via
+//   std.crypto.sign.Ed25519. Both must agree.
+//
+// Anchor 2 — Empty contractSetCid (claim_envelope.zig):
+//   `blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229`
+//   Pinned in .provekit/self-contracts-attestations/zig.json (and several
+//   other empty-set kits). It is BLAKE3-512(JCS([]).bytes); JCS-of-empty-
+//   array is exactly the two bytes "[]". A Zig kit that disagrees here
+//   has either a JCS bug or a BLAKE3 bug.
+//
+// Anchor 3 — Full self-contracts attestation message round-trip:
+//   Rebuild the exact JCS message body that produced
+//   .provekit/self-contracts-attestations/zig.json, sign it under the
+//   foundation v0 seed, and verify the signature equals the one stored
+//   in that file. Demonstrates JCS + Ed25519 byte-equivalence end-to-end
+//   against the live attestation infrastructure.
+//
+// Anchor 4 — Cross-kit JCS+BLAKE3 of IR Decls is already pinned in the
+//   sibling provekit-ir package (`cross_kit_bridges.zig` —
+//   `PINNED_COUNTERPART_CIDS`, `PINNED_BRIDGES_ARRAY_CID`). Running
+//   `zig build test` in that package proves byte-equivalence against the
+//   rust/python/go/ts kits' pinned tables.
+
+const std = @import("std");
+const sc = @import("root.zig");
+
+const Value = sc.jcs.Value;
+const ObjectBuilder = sc.jcs.ObjectBuilder;
+
+// ---- Anchor 1: foundation pubkey ------------------------------------------
+
+test "anchor 1: foundation v0 pubkey matches the cross-kit pin" {
+    const alloc = std.testing.allocator;
+    const pk = try sc.signing.pubkeyString(alloc, sc.foundation.SEED);
+    defer alloc.free(pk);
+    try std.testing.expectEqualStrings(
+        "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+        pk,
+    );
+}
+
+// ---- Anchor 2: empty contractSetCid ---------------------------------------
+
+test "anchor 2: empty contract set CID matches zig.json attestation pin" {
+    const alloc = std.testing.allocator;
+    const empty: [][]const u8 = &.{};
+    const cid = try sc.claim_envelope.computeContractSetCid(alloc, @constCast(empty));
+    defer alloc.free(cid);
+    try std.testing.expectEqualStrings(
+        "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+        cid,
+    );
+}
+
+test "anchor 2 corollary: JCS([]) is the literal two bytes \"[]\"" {
+    const alloc = std.testing.allocator;
+    var ab = sc.jcs.ArrayBuilder.init(alloc);
+    const v = try ab.finish();
+    defer {
+        v.deinit(alloc);
+        alloc.destroy(v);
+    }
+    const enc = try sc.jcs.encode(alloc, v);
+    defer alloc.free(enc);
+    try std.testing.expectEqualStrings("[]", enc);
+}
+
+// ---- Anchor 3: full attestation message round-trip ------------------------
+//
+// The attestation file at .provekit/self-contracts-attestations/zig.json
+// was signed by tools/foundation-keygen over the JCS-canonical bytes of:
+//   {
+//     "schemaVersion": "1",
+//     "kind": "self-contracts-attestation",
+//     "lang": "zig",
+//     "cid": "",
+//     "contractSetCid": "blake3-512:d53d18c2...290f3229",
+//     "declaredAt": "2026-05-03T18:00:00Z",
+//     "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI="
+//   }
+// (signature field NOT included in the signed body — the rust signer
+// excludes it; see tools/foundation-keygen/src/lib.rs::build_self_contracts_message).
+// This test rebuilds that JCS bytes natively in Zig, signs it, and asserts
+// the signature equals the one committed in zig.json. Cross-kit byte
+// agreement is empirically demonstrated.
+
+const ZIG_JSON_SIGNATURE: []const u8 =
+    "ed25519:dJC/GluB7pdJ83gw5v8ky1liE8nGAgxLIo7pneMsZFZhdmkxHayRnHtUli4+iiIOb7462L87AChMFWVpIJgeAw==";
+
+fn buildAttestationMessage(alloc: std.mem.Allocator) !*Value {
+    var ob = ObjectBuilder.init(alloc);
+    try ob.add("schemaVersion", try Value.newString(alloc, "1"));
+    try ob.add("kind", try Value.newString(alloc, "self-contracts-attestation"));
+    try ob.add("lang", try Value.newString(alloc, "zig"));
+    try ob.add("cid", try Value.newString(alloc, ""));
+    try ob.add("contractSetCid", try Value.newString(alloc, "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229"));
+    try ob.add("declaredAt", try Value.newString(alloc, "2026-05-03T18:00:00Z"));
+    try ob.add("signer", try Value.newString(alloc, "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI="));
+    return ob.finish();
+}
+
+test "anchor 3: zig attestation signature byte-matches zig.json" {
+    const alloc = std.testing.allocator;
+    const msg_v = try buildAttestationMessage(alloc);
+    defer {
+        msg_v.deinit(alloc);
+        alloc.destroy(msg_v);
+    }
+    const jcs_bytes = try sc.jcs.encode(alloc, msg_v);
+    defer alloc.free(jcs_bytes);
+
+    const sig = try sc.signing.signString(alloc, sc.foundation.SEED, jcs_bytes);
+    defer alloc.free(sig);
+
+    try std.testing.expectEqualStrings(ZIG_JSON_SIGNATURE, sig);
+}
+
+test "anchor 3 corollary: signature verifies against the foundation pubkey" {
+    const alloc = std.testing.allocator;
+    const msg_v = try buildAttestationMessage(alloc);
+    defer {
+        msg_v.deinit(alloc);
+        alloc.destroy(msg_v);
+    }
+    const jcs_bytes = try sc.jcs.encode(alloc, msg_v);
+    defer alloc.free(jcs_bytes);
+
+    const pk = try sc.signing.pubkeyString(alloc, sc.foundation.SEED);
+    defer alloc.free(pk);
+    try std.testing.expect(sc.signing.verifyString(pk, ZIG_JSON_SIGNATURE, jcs_bytes));
+}
+
+// ---- Cross-kit attestation: Rust kit signature byte-matches too -----------
+
+test "rust attestation signature byte-matches rust.json" {
+    // Same shape, different `lang` and `cid` and `contractSetCid` — proves
+    // the JCS encoder + Ed25519 signer agree across non-empty-bundle kits.
+    const alloc = std.testing.allocator;
+    var ob = ObjectBuilder.init(alloc);
+    try ob.add("schemaVersion", try Value.newString(alloc, "1"));
+    try ob.add("kind", try Value.newString(alloc, "self-contracts-attestation"));
+    try ob.add("lang", try Value.newString(alloc, "rust"));
+    try ob.add("cid", try Value.newString(alloc, "blake3-512:60df6322388ff7d9ccd1b9ee9d6457fdfe89a51b3d2d73a34daa0131f65c80543331832eb88920fe514ebb799bc655808f152d36274542ac9879c862a33f3a92"));
+    try ob.add("contractSetCid", try Value.newString(alloc, "blake3-512:8f4bcc3c3e748ae303f8c8da80245f291e803eb2d241224c75c7ac470631e4dee7ff2e0ff59af571db3d506485c115acaddfd91e4e4315eb04ee37c035ddbc69"));
+    try ob.add("declaredAt", try Value.newString(alloc, "2026-05-03T18:00:00Z"));
+    try ob.add("signer", try Value.newString(alloc, "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI="));
+    const msg_v = try ob.finish();
+    defer {
+        msg_v.deinit(alloc);
+        alloc.destroy(msg_v);
+    }
+    const jcs_bytes = try sc.jcs.encode(alloc, msg_v);
+    defer alloc.free(jcs_bytes);
+
+    const sig = try sc.signing.signString(alloc, sc.foundation.SEED, jcs_bytes);
+    defer alloc.free(sig);
+    try std.testing.expectEqualStrings(
+        "ed25519:XQhbaHNNhD9hCbkfmtnVZsUZz0pd7CSLuG1qCM8Rq2FF51qUZSpXh5Wg2DVGWYeD1ZHH9D2m0HKIlN9U57U4CA==",
+        sig,
+    );
+}
+
+test "go attestation signature byte-matches go.json" {
+    const alloc = std.testing.allocator;
+    // Get exact `cid` and `contractSetCid` from go.json.
+    var ob = ObjectBuilder.init(alloc);
+    try ob.add("schemaVersion", try Value.newString(alloc, "1"));
+    try ob.add("kind", try Value.newString(alloc, "self-contracts-attestation"));
+    try ob.add("lang", try Value.newString(alloc, "go"));
+    // The fields below come from the actual go.json file. We populate them
+    // dynamically at test time via @embedFile on the attestation JSON.
+    const go_json = @embedFile("test_fixtures/go_attestation.json");
+    const Parsed = struct {
+        schemaVersion: []const u8,
+        kind: []const u8,
+        lang: []const u8,
+        cid: []const u8,
+        contractSetCid: []const u8,
+        declaredAt: []const u8,
+        signer: []const u8,
+        signature: []const u8,
+    };
+    const parsed = try std.json.parseFromSlice(Parsed, alloc, go_json, .{});
+    defer parsed.deinit();
+    try ob.add("cid", try Value.newString(alloc, parsed.value.cid));
+    try ob.add("contractSetCid", try Value.newString(alloc, parsed.value.contractSetCid));
+    try ob.add("declaredAt", try Value.newString(alloc, parsed.value.declaredAt));
+    try ob.add("signer", try Value.newString(alloc, parsed.value.signer));
+    const msg_v = try ob.finish();
+    defer {
+        msg_v.deinit(alloc);
+        alloc.destroy(msg_v);
+    }
+    const jcs_bytes = try sc.jcs.encode(alloc, msg_v);
+    defer alloc.free(jcs_bytes);
+
+    const sig = try sc.signing.signString(alloc, sc.foundation.SEED, jcs_bytes);
+    defer alloc.free(sig);
+    try std.testing.expectEqualStrings(parsed.value.signature, sig);
+}

--- a/implementations/zig/provekit-self-contracts/src/cbor.zig
+++ b/implementations/zig/provekit-self-contracts/src/cbor.zig
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Deterministic CBOR encoder. RFC 8949 §4.2.1 "Core Deterministic Encoding":
+//   - shortest-form integer encoding (smallest of short / u8 / u16 / u32 / u64)
+//   - definite-length items only
+//   - map keys sorted in bytewise lex order of their CBOR-encoded form
+//   - we emit only the major types we need: unsigned int, byte string,
+//     text string, array, map.
+//
+// Mirrors implementations/rust/provekit-proof-envelope/src/cbor.rs and
+// implementations/cpp/provekit/proof-envelope/cbor.cpp 1:1.
+
+const std = @import("std");
+
+pub const Major = enum(u3) {
+    unsigned_int = 0,
+    byte_string = 2,
+    text_string = 3,
+    array = 4,
+    map = 5,
+};
+
+/// Append a CBOR head: `(major << 5) | tagOrLen`, plus the appropriate
+/// number of trailing big-endian bytes (0 / 1 / 2 / 4 / 8) per the
+/// shortest-form rule.
+pub fn appendHead(alloc: std.mem.Allocator, out: *std.ArrayList(u8), major: Major, arg: u64) !void {
+    const mt: u8 = @as(u8, @intFromEnum(major)) << 5;
+    if (arg < 24) {
+        try out.append(alloc, mt | @as(u8, @intCast(arg)));
+        return;
+    }
+    if (arg <= 0xFF) {
+        try out.append(alloc, mt | 24);
+        try out.append(alloc, @intCast(arg));
+        return;
+    }
+    if (arg <= 0xFFFF) {
+        try out.append(alloc, mt | 25);
+        try out.append(alloc, @intCast((arg >> 8) & 0xFF));
+        try out.append(alloc, @intCast(arg & 0xFF));
+        return;
+    }
+    if (arg <= 0xFFFF_FFFF) {
+        try out.append(alloc, mt | 26);
+        try out.append(alloc, @intCast((arg >> 24) & 0xFF));
+        try out.append(alloc, @intCast((arg >> 16) & 0xFF));
+        try out.append(alloc, @intCast((arg >> 8) & 0xFF));
+        try out.append(alloc, @intCast(arg & 0xFF));
+        return;
+    }
+    try out.append(alloc, mt | 27);
+    var i: u6 = 8;
+    while (i > 0) {
+        i -= 1;
+        try out.append(alloc, @intCast((arg >> (@as(u6, i) * 8)) & 0xFF));
+    }
+}
+
+pub fn encodeUint(alloc: std.mem.Allocator, out: *std.ArrayList(u8), value: u64) !void {
+    try appendHead(alloc, out, .unsigned_int, value);
+}
+
+pub fn encodeBstr(alloc: std.mem.Allocator, out: *std.ArrayList(u8), bytes: []const u8) !void {
+    try appendHead(alloc, out, .byte_string, bytes.len);
+    try out.appendSlice(alloc, bytes);
+}
+
+pub fn encodeTstr(alloc: std.mem.Allocator, out: *std.ArrayList(u8), s: []const u8) !void {
+    try appendHead(alloc, out, .text_string, s.len);
+    try out.appendSlice(alloc, s);
+}
+
+pub fn encodeArrayHead(alloc: std.mem.Allocator, out: *std.ArrayList(u8), count: u64) !void {
+    try appendHead(alloc, out, .array, count);
+}
+
+pub fn encodeMapHead(alloc: std.mem.Allocator, out: *std.ArrayList(u8), count: u64) !void {
+    try appendHead(alloc, out, .map, count);
+}
+
+// ---------------------------------------------------------------------------
+// Sorted-map emitter
+// ---------------------------------------------------------------------------
+
+/// One CBOR (key, value) pair, with the key already encoded so the outer
+/// map can sort by bytewise CBOR-encoded-key form per RFC 8949 §4.2.1.
+pub const Pair = struct {
+    key_cbor: []u8,
+    value_cbor: []u8,
+
+    pub fn deinit(self: Pair, alloc: std.mem.Allocator) void {
+        alloc.free(self.key_cbor);
+        alloc.free(self.value_cbor);
+    }
+};
+
+fn pairLess(_: void, a: Pair, b: Pair) bool {
+    return std.mem.lessThan(u8, a.key_cbor, b.key_cbor);
+}
+
+/// Emit a sorted map. `pairs` is sorted in place (bytewise on key_cbor).
+/// Caller still owns the pair buffers; this function does not free them.
+pub fn emitSortedMap(alloc: std.mem.Allocator, out: *std.ArrayList(u8), pairs: []Pair) !void {
+    std.mem.sort(Pair, pairs, {}, pairLess);
+    try encodeMapHead(alloc, out, pairs.len);
+    for (pairs) |p| {
+        try out.appendSlice(alloc, p.key_cbor);
+        try out.appendSlice(alloc, p.value_cbor);
+    }
+}
+
+/// Helper: produce a Pair where the key is a tstr (text string) and the
+/// value is a tstr.
+pub fn makeStringPair(alloc: std.mem.Allocator, key: []const u8, value: []const u8) !Pair {
+    var k_buf: std.ArrayList(u8) = .empty;
+    errdefer k_buf.deinit(alloc);
+    try encodeTstr(alloc, &k_buf, key);
+    var v_buf: std.ArrayList(u8) = .empty;
+    errdefer v_buf.deinit(alloc);
+    try encodeTstr(alloc, &v_buf, value);
+    return .{
+        .key_cbor = try k_buf.toOwnedSlice(alloc),
+        .value_cbor = try v_buf.toOwnedSlice(alloc),
+    };
+}
+
+/// Helper: tstr key with a bstr (byte string) value.
+pub fn makeBytesPair(alloc: std.mem.Allocator, key: []const u8, value: []const u8) !Pair {
+    var k_buf: std.ArrayList(u8) = .empty;
+    errdefer k_buf.deinit(alloc);
+    try encodeTstr(alloc, &k_buf, key);
+    var v_buf: std.ArrayList(u8) = .empty;
+    errdefer v_buf.deinit(alloc);
+    try encodeBstr(alloc, &v_buf, value);
+    return .{
+        .key_cbor = try k_buf.toOwnedSlice(alloc),
+        .value_cbor = try v_buf.toOwnedSlice(alloc),
+    };
+}
+
+/// Helper: tstr key with a raw-encoded value (caller pre-encoded the value).
+pub fn makeRawPair(alloc: std.mem.Allocator, key: []const u8, raw_value: []const u8) !Pair {
+    var k_buf: std.ArrayList(u8) = .empty;
+    errdefer k_buf.deinit(alloc);
+    try encodeTstr(alloc, &k_buf, key);
+    const v_owned = try alloc.dupe(u8, raw_value);
+    return .{
+        .key_cbor = try k_buf.toOwnedSlice(alloc),
+        .value_cbor = v_owned,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "shortest-form uint" {
+    const alloc = std.testing.allocator;
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        try encodeUint(alloc, &buf, 0);
+        try std.testing.expectEqualSlices(u8, &.{0x00}, buf.items);
+    }
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        try encodeUint(alloc, &buf, 23);
+        try std.testing.expectEqualSlices(u8, &.{0x17}, buf.items);
+    }
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        try encodeUint(alloc, &buf, 24);
+        try std.testing.expectEqualSlices(u8, &.{ 0x18, 24 }, buf.items);
+    }
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        try encodeUint(alloc, &buf, 256);
+        try std.testing.expectEqualSlices(u8, &.{ 0x19, 0x01, 0x00 }, buf.items);
+    }
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        try encodeUint(alloc, &buf, 65536);
+        try std.testing.expectEqualSlices(u8, &.{ 0x1a, 0x00, 0x01, 0x00, 0x00 }, buf.items);
+    }
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        try encodeUint(alloc, &buf, 0x1_0000_0000);
+        try std.testing.expectEqualSlices(
+            u8,
+            &.{ 0x1b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00 },
+            buf.items,
+        );
+    }
+}
+
+test "tstr round-trip head" {
+    const alloc = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try encodeTstr(alloc, &buf, "hello");
+    try std.testing.expectEqualSlices(
+        u8,
+        &.{ 0x65, 'h', 'e', 'l', 'l', 'o' },
+        buf.items,
+    );
+}
+
+test "bstr empty" {
+    const alloc = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try encodeBstr(alloc, &buf, "");
+    try std.testing.expectEqualSlices(u8, &.{0x40}, buf.items);
+}
+
+test "map head zero" {
+    const alloc = std.testing.allocator;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try encodeMapHead(alloc, &buf, 0);
+    try std.testing.expectEqualSlices(u8, &.{0xa0}, buf.items);
+}
+
+test "sortedMap orders by bytewise CBOR-encoded key" {
+    // RFC 8949 §4.2.1: keys are sorted by their CBOR-encoded form. For
+    // tstr keys the sort is bytewise on (head + UTF-8 body), which
+    // collapses to "shorter keys first; equal-length keys in byte order"
+    // because the head's length-byte dominates the comparison.
+    const alloc = std.testing.allocator;
+    var pairs: [3]Pair = undefined;
+    pairs[0] = try makeStringPair(alloc, "version", "0.0.1");
+    pairs[1] = try makeStringPair(alloc, "kind", "catalog");
+    pairs[2] = try makeStringPair(alloc, "name", "@x/y");
+    defer for (pairs) |p| p.deinit(alloc);
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    try emitSortedMap(alloc, &out, &pairs);
+    // First byte: map head with 3 entries -> 0xa3
+    try std.testing.expectEqual(@as(u8, 0xa3), out.items[0]);
+    // After head: shortest tstr key first ("kind"=4 bytes < "name"=4
+    // == kind sorts first because 'k' < 'n'). Just sanity-check that the
+    // head byte for the first key is 0x64 ("tstr len 4").
+    try std.testing.expectEqual(@as(u8, 0x64), out.items[1]);
+}

--- a/implementations/zig/provekit-self-contracts/src/claim_envelope.zig
+++ b/implementations/zig/provekit-self-contracts/src/claim_envelope.zig
@@ -1,0 +1,554 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// claim_envelope — `mint_contract` / `mint_bridge` build a signed memento
+// in the v1.2 LAYERED shape introduced by
+// `protocol/specs/2026-05-03-substrate-layers-envelope-header-body.md`:
+//
+//   { "envelope": {...}, "header": {...}, "metadata": {...} }
+//
+//   * envelope = { signer, declaredAt, signature }
+//       The signature is computed over JCS({"header": header, "metadata": metadata}).
+//       The envelope's CID (= attestation CID) is BLAKE3-512(JCS(envelope))
+//       AFTER the signature has been embedded.
+//
+//   * header   = substrate-load-bearing data the verifier reads:
+//                schemaVersion, kind, cid, plus kind-specific REQUIRED
+//                fields (per the kind's normative spec) and the derived
+//                hashes (bindingHash, propertyHash, verdict, inputCids)
+//                used by the resolve/index pipeline.
+//
+//   * metadata = everything else (authoring attribution, lifecycle
+//                strings like producedBy/producedAt, derived per-formula
+//                hashes that are pure tooling convenience). Opaque to
+//                the substrate verifier; signed transitively via the
+//                envelope.
+//
+// Mirrors implementations/rust/provekit-claim-envelope/src/lib.rs 1:1.
+
+const std = @import("std");
+const jcs = @import("jcs.zig");
+const hash = @import("hash.zig");
+const signing = @import("signing.zig");
+
+const Value = jcs.Value;
+const ObjectBuilder = jcs.ObjectBuilder;
+const ArrayBuilder = jcs.ArrayBuilder;
+
+pub const LAYERED_SCHEMA_VERSION: []const u8 = "2";
+
+pub const Error = error{
+    EmptyContract,
+    EmptyOutBinding,
+    OutOfMemory,
+};
+
+/// Result of a mint_* call. All slices owned by the caller (allocated
+/// through the same allocator the caller passed in).
+pub const MintedEnvelope = struct {
+    /// JCS-canonical bytes of the full layered memento
+    /// (`{envelope, header, metadata}`).
+    canonical_bytes: []u8,
+    /// The attestation CID: BLAKE3-512(JCS(envelope)) after the signature
+    /// has been embedded. Identifies the SIGNED attestation.
+    cid: []u8,
+    /// The content CID: BLAKE3-512(JCS({name, outBinding, pre?, post?, inv?})).
+    /// Signer-independent. Empty for bridges.
+    contract_cid: []u8,
+
+    pub fn deinit(self: MintedEnvelope, alloc: std.mem.Allocator) void {
+        alloc.free(self.canonical_bytes);
+        alloc.free(self.cid);
+        alloc.free(self.contract_cid);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Hash a Value tree: BLAKE3-512(JCS(v)).
+fn hashValue(alloc: std.mem.Allocator, v: *const Value) ![]u8 {
+    const enc = try jcs.encode(alloc, v);
+    defer alloc.free(enc);
+    return hash.blake3_512Of(alloc, enc);
+}
+
+/// Build the JCS-canonical bytes of `{"header": header, "metadata": metadata}`.
+/// This is the message the envelope's Ed25519 signature covers (spec §2 R2).
+fn signingBytes(alloc: std.mem.Allocator, header: *Value, metadata: *Value) ![]u8 {
+    // Manual JCS emission to avoid ownership transfer:
+    //   {"header":<JCS(header)>,"metadata":<JCS(metadata)>}
+    // Since "header" < "metadata" in byte order, this is the JCS form.
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "{\"header\":");
+    {
+        const enc_h = try jcs.encode(alloc, header);
+        defer alloc.free(enc_h);
+        try buf.appendSlice(alloc, enc_h);
+    }
+    try buf.appendSlice(alloc, ",\"metadata\":");
+    {
+        const enc_m = try jcs.encode(alloc, metadata);
+        defer alloc.free(enc_m);
+        try buf.appendSlice(alloc, enc_m);
+    }
+    try buf.append(alloc, '}');
+    return buf.toOwnedSlice(alloc);
+}
+
+/// Assemble a layered memento, sign it, compute the attestation CID
+/// (= BLAKE3-512(JCS(envelope-with-signature))). Returns the JCS-canonical
+/// bytes of the full `{envelope, header, metadata}` object.
+///
+/// `header` and `metadata` are consumed: their child Values are folded into
+/// the returned canonical bytes, then the trees are freed.
+fn assembleLayered(
+    alloc: std.mem.Allocator,
+    header: *Value,
+    metadata: *Value,
+    declared_at: []const u8,
+    signer_seed: signing.Seed,
+    content_cid: []u8,
+) !MintedEnvelope {
+    errdefer alloc.free(content_cid);
+
+    // Sign over JCS({header, metadata}).
+    const sign_msg = try signingBytes(alloc, header, metadata);
+    defer alloc.free(sign_msg);
+    const signature_str = try signing.signString(alloc, signer_seed, sign_msg);
+    defer alloc.free(signature_str);
+    const signer_str = try signing.pubkeyString(alloc, signer_seed);
+    defer alloc.free(signer_str);
+
+    // Build envelope object: {signer, declaredAt, signature}
+    // (JCS sorts by code-point at emit time; here we just feed in any order.)
+    var envelope_b = ObjectBuilder.init(alloc);
+    try envelope_b.add("signer", try Value.newString(alloc, signer_str));
+    try envelope_b.add("declaredAt", try Value.newString(alloc, declared_at));
+    try envelope_b.add("signature", try Value.newString(alloc, signature_str));
+    const envelope_v = try envelope_b.finish();
+    // envelope_v owned — we need to encode it (for attestation CID), then
+    // re-use it as part of the outer memento.
+
+    const envelope_jcs = try jcs.encode(alloc, envelope_v);
+    defer alloc.free(envelope_jcs);
+    const attestation_cid = try hash.blake3_512Of(alloc, envelope_jcs);
+    errdefer alloc.free(attestation_cid);
+
+    // Build outer memento {envelope, header, metadata}; this transfers
+    // ownership of envelope_v / header / metadata to the new tree.
+    var outer_b = ObjectBuilder.init(alloc);
+    try outer_b.add("envelope", envelope_v);
+    try outer_b.add("header", header);
+    try outer_b.add("metadata", metadata);
+    const outer = try outer_b.finish();
+    defer {
+        outer.deinit(alloc);
+        alloc.destroy(outer);
+    }
+    const memento_bytes = try jcs.encode(alloc, outer);
+    return .{
+        .canonical_bytes = memento_bytes,
+        .cid = attestation_cid,
+        .contract_cid = content_cid,
+    };
+}
+
+/// Build the kind/cid/schemaVersion-prefixed header object. Takes ownership
+/// of every Value in `kind_specific`.
+fn buildHeader(
+    alloc: std.mem.Allocator,
+    kind: []const u8,
+    header_cid: []const u8,
+    kind_specific: []const KV,
+) !*Value {
+    var b = ObjectBuilder.init(alloc);
+    try b.add("schemaVersion", try Value.newString(alloc, LAYERED_SCHEMA_VERSION));
+    try b.add("kind", try Value.newString(alloc, kind));
+    try b.add("cid", try Value.newString(alloc, header_cid));
+    for (kind_specific) |kv| {
+        try b.add(kv.key, kv.value);
+    }
+    return b.finish();
+}
+
+/// Owning (key, value) tuple used by the kind-specific field list.
+pub const KV = struct {
+    key: []const u8,
+    value: *Value,
+};
+
+// ---------------------------------------------------------------------------
+// mint_contract
+// ---------------------------------------------------------------------------
+
+pub const Authoring = union(enum) {
+    kit_author: struct {
+        author: []const u8,
+        note: ?[]const u8 = null,
+    },
+    lift: struct {
+        lifter: []const u8,
+        evidence: []const u8,
+        source_cid: ?[]const u8 = null,
+    },
+    llm: struct {
+        llm: []const u8,
+        llm_version: []const u8,
+        prompt_cid: []const u8,
+        confidence: f64,
+        rationale: ?[]const u8 = null,
+    },
+};
+
+fn authoringToValue(alloc: std.mem.Allocator, a: Authoring) !*Value {
+    var b = ObjectBuilder.init(alloc);
+    switch (a) {
+        .kit_author => |k| {
+            try b.add("producerKind", try Value.newString(alloc, "kit-author"));
+            try b.add("author", try Value.newString(alloc, k.author));
+            if (k.note) |n| if (n.len > 0) try b.add("note", try Value.newString(alloc, n));
+        },
+        .lift => |l| {
+            try b.add("producerKind", try Value.newString(alloc, "lift"));
+            try b.add("lifter", try Value.newString(alloc, l.lifter));
+            try b.add("evidence", try Value.newString(alloc, l.evidence));
+            if (l.source_cid) |c| if (c.len > 0) try b.add("sourceCid", try Value.newString(alloc, c));
+        },
+        .llm => |m| {
+            try b.add("producerKind", try Value.newString(alloc, "llm"));
+            try b.add("llm", try Value.newString(alloc, m.llm));
+            try b.add("llmVersion", try Value.newString(alloc, m.llm_version));
+            try b.add("promptCid", try Value.newString(alloc, m.prompt_cid));
+            // Match the rust kit's confidence encoding: integer with 3-decimal scale.
+            const conf_int: i64 = @intFromFloat(m.confidence * 1000.0);
+            try b.add("confidence", try Value.newInt(alloc, conf_int));
+            if (m.rationale) |r| if (r.len > 0) try b.add("rationale", try Value.newString(alloc, r));
+        },
+    }
+    return b.finish();
+}
+
+pub const MintContractArgs = struct {
+    contract_name: []const u8,
+    /// pre, post, inv: at least one of the three MUST be present. Caller
+    /// passes ownership of the *Value to mint_contract; the function frees
+    /// them on every code path.
+    pre: ?*Value = null,
+    post: ?*Value = null,
+    inv: ?*Value = null,
+    out_binding: []const u8,
+    produced_by: []const u8,
+    produced_at: []const u8,
+    input_cids: []const []const u8 = &.{},
+    authoring: Authoring,
+    signer_seed: signing.Seed,
+};
+
+/// Compute the **content** CID of a contract (signer-independent). Per spec
+/// `contract-cid-vs-attestation-cid.md` §1: BLAKE3-512(JCS({name, outBinding,
+/// pre?, post?, inv?})). Two distinct signers attesting to the same logical
+/// contract produce the same CID.
+///
+/// Caller owns the returned slice. Does NOT consume `args.pre/post/inv`.
+pub fn contractCid(alloc: std.mem.Allocator, args: MintContractArgs) ![]u8 {
+    var b = ObjectBuilder.init(alloc);
+    errdefer {
+        // ObjectBuilder doesn't expose a "discard without freeing children"
+        // path; if we error before finishing, the keys we added are leaked.
+        // The clones below are the only Values added; on success they're
+        // transferred to the finished object.
+    }
+    try b.add("name", try Value.newString(alloc, args.contract_name));
+    try b.add("outBinding", try Value.newString(alloc, args.out_binding));
+    if (args.pre) |p| try b.add("pre", try cloneValue(alloc, p));
+    if (args.post) |p| try b.add("post", try cloneValue(alloc, p));
+    if (args.inv) |p| try b.add("inv", try cloneValue(alloc, p));
+    const v = try b.finish();
+    defer {
+        v.deinit(alloc);
+        alloc.destroy(v);
+    }
+    return hashValue(alloc, v);
+}
+
+/// Deep-clone a Value tree. Used because the hash + header + property-hash
+/// computations all need access to the same pre/post/inv subtrees, but
+/// each consumer wants ownership.
+fn cloneValue(alloc: std.mem.Allocator, v: *const Value) std.mem.Allocator.Error!*Value {
+    return switch (v.*) {
+        .null_ => Value.newNull(alloc),
+        .bool_ => |b| Value.newBool(alloc, b),
+        .integer => |n| Value.newInt(alloc, n),
+        .string => |s| Value.newString(alloc, s),
+        .array => |items| blk: {
+            var ab = ArrayBuilder.init(alloc);
+            for (items) |child| try ab.append(try cloneValue(alloc, child));
+            break :blk try ab.finish();
+        },
+        .object => |entries| blk: {
+            var ob = ObjectBuilder.init(alloc);
+            for (entries) |pair| try ob.add(pair.key, try cloneValue(alloc, pair.value));
+            break :blk try ob.finish();
+        },
+    };
+}
+
+/// Compute the **contract set CID** from a slice of already-computed
+/// contractCid strings. Sort lex on the raw `blake3-512:hex` strings; CID
+/// is BLAKE3-512(JCS(<sorted array>)). Order-independent.
+pub fn computeContractSetCid(alloc: std.mem.Allocator, contract_cids: [][]const u8) ![]u8 {
+    // Sort a duplicated slice (don't mutate caller's input).
+    const sorted = try alloc.dupe([]const u8, contract_cids);
+    defer alloc.free(sorted);
+    std.mem.sort([]const u8, sorted, {}, slicesLessThan);
+
+    var ab = ArrayBuilder.init(alloc);
+    for (sorted) |cid| try ab.append(try Value.newString(alloc, cid));
+    const v = try ab.finish();
+    defer {
+        v.deinit(alloc);
+        alloc.destroy(v);
+    }
+    const enc = try jcs.encode(alloc, v);
+    defer alloc.free(enc);
+    return hash.blake3_512Of(alloc, enc);
+}
+
+fn slicesLessThan(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
+}
+
+/// Mint a contract memento. Consumes args.pre/post/inv on every path.
+pub fn mintContract(
+    alloc: std.mem.Allocator,
+    args: MintContractArgs,
+) !MintedEnvelope {
+    // Free pre/post/inv on every error path. On success they're cloned into
+    // the returned envelope's bytes (we free them at end).
+    const pre = args.pre;
+    const post = args.post;
+    const inv = args.inv;
+    defer {
+        if (pre) |p| {
+            p.deinit(alloc);
+            alloc.destroy(p);
+        }
+        if (post) |p| {
+            p.deinit(alloc);
+            alloc.destroy(p);
+        }
+        if (inv) |p| {
+            p.deinit(alloc);
+            alloc.destroy(p);
+        }
+    }
+
+    if (pre == null and post == null and inv == null) return Error.EmptyContract;
+    if (args.out_binding.len == 0) return Error.EmptyOutBinding;
+
+    // DERIVED hashes:
+    //   propertyHash = hash(JCS({pre?, post?, inv?, outBinding}))
+    //   bindingHash  = hash(JCS({producerId, contractName, propertyHash}))
+    var ph_b = ObjectBuilder.init(alloc);
+    if (pre) |p| try ph_b.add("pre", try cloneValue(alloc, p));
+    if (post) |p| try ph_b.add("post", try cloneValue(alloc, p));
+    if (inv) |p| try ph_b.add("inv", try cloneValue(alloc, p));
+    try ph_b.add("outBinding", try Value.newString(alloc, args.out_binding));
+    const ph_v = try ph_b.finish();
+    const property_hash = blk: {
+        defer {
+            ph_v.deinit(alloc);
+            alloc.destroy(ph_v);
+        }
+        break :blk try hashValue(alloc, ph_v);
+    };
+    defer alloc.free(property_hash);
+
+    var bh_b = ObjectBuilder.init(alloc);
+    try bh_b.add("producerId", try Value.newString(alloc, args.produced_by));
+    try bh_b.add("contractName", try Value.newString(alloc, args.contract_name));
+    try bh_b.add("propertyHash", try Value.newString(alloc, property_hash));
+    const bh_v = try bh_b.finish();
+    const binding_hash = blk: {
+        defer {
+            bh_v.deinit(alloc);
+            alloc.destroy(bh_v);
+        }
+        break :blk try hashValue(alloc, bh_v);
+    };
+    defer alloc.free(binding_hash);
+
+    // Header: kind-specific REQUIRED fields, in spec order.
+    const header_cid = try contractCid(alloc, args);
+    errdefer alloc.free(header_cid);
+
+    // sorted_inputs (lex)
+    const sorted_inputs = try alloc.dupe([]const u8, args.input_cids);
+    defer alloc.free(sorted_inputs);
+    std.mem.sort([]const u8, sorted_inputs, {}, slicesLessThan);
+
+    var inputs_ab = ArrayBuilder.init(alloc);
+    for (sorted_inputs) |c| try inputs_ab.append(try Value.newString(alloc, c));
+    const inputs_arr = try inputs_ab.finish();
+
+    var kind_specific: std.ArrayList(KV) = .empty;
+    defer kind_specific.deinit(alloc);
+    try kind_specific.append(alloc, .{ .key = "name", .value = try Value.newString(alloc, args.contract_name) });
+    try kind_specific.append(alloc, .{ .key = "outBinding", .value = try Value.newString(alloc, args.out_binding) });
+    if (pre) |p| {
+        try kind_specific.append(alloc, .{ .key = "pre", .value = try cloneValue(alloc, p) });
+    }
+    if (post) |p| {
+        try kind_specific.append(alloc, .{ .key = "post", .value = try cloneValue(alloc, p) });
+    }
+    if (inv) |p| {
+        try kind_specific.append(alloc, .{ .key = "inv", .value = try cloneValue(alloc, p) });
+    }
+    try kind_specific.append(alloc, .{ .key = "verdict", .value = try Value.newString(alloc, "holds") });
+    try kind_specific.append(alloc, .{ .key = "bindingHash", .value = try Value.newString(alloc, binding_hash) });
+    try kind_specific.append(alloc, .{ .key = "propertyHash", .value = try Value.newString(alloc, property_hash) });
+    try kind_specific.append(alloc, .{ .key = "inputCids", .value = inputs_arr });
+
+    const header = try buildHeader(alloc, "contract", header_cid, kind_specific.items);
+
+    // Metadata.
+    var meta_b = ObjectBuilder.init(alloc);
+    try meta_b.add("authoring", try authoringToValue(alloc, args.authoring));
+    try meta_b.add("producedBy", try Value.newString(alloc, args.produced_by));
+    try meta_b.add("producedAt", try Value.newString(alloc, args.produced_at));
+    if (pre) |p| {
+        const ph = try hashValue(alloc, p);
+        defer alloc.free(ph);
+        try meta_b.add("preHash", try Value.newString(alloc, ph));
+    }
+    if (post) |p| {
+        const ph = try hashValue(alloc, p);
+        defer alloc.free(ph);
+        try meta_b.add("postHash", try Value.newString(alloc, ph));
+    }
+    if (inv) |p| {
+        const ph = try hashValue(alloc, p);
+        defer alloc.free(ph);
+        try meta_b.add("invHash", try Value.newString(alloc, ph));
+    }
+    const metadata = try meta_b.finish();
+
+    // assembleLayered consumes header + metadata + content_cid.
+    return assembleLayered(
+        alloc,
+        header,
+        metadata,
+        args.produced_at,
+        args.signer_seed,
+        header_cid,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "empty contract rejected" {
+    const alloc = std.testing.allocator;
+    const args = MintContractArgs{
+        .contract_name = "x",
+        .out_binding = "out",
+        .produced_by = "test",
+        .produced_at = "2026-04-30T00:00:00.000Z",
+        .authoring = .{ .kit_author = .{ .author = "test" } },
+        .signer_seed = @splat(0x42),
+    };
+    try std.testing.expectError(Error.EmptyContract, mintContract(alloc, args));
+}
+
+test "empty out binding rejected" {
+    const alloc = std.testing.allocator;
+    const pre = try Value.newBool(alloc, true);
+    const args = MintContractArgs{
+        .contract_name = "x",
+        .pre = pre,
+        .out_binding = "",
+        .produced_by = "test",
+        .produced_at = "2026-04-30T00:00:00.000Z",
+        .authoring = .{ .kit_author = .{ .author = "test" } },
+        .signer_seed = @splat(0x42),
+    };
+    try std.testing.expectError(Error.EmptyOutBinding, mintContract(alloc, args));
+}
+
+test "minimal contract mint produces well-formed CID" {
+    const alloc = std.testing.allocator;
+    // pre = atomic(">") — we just feed a small Value; full IR-shape ergonomics
+    // live in the sibling provekit-ir package.
+    var pre_b = ObjectBuilder.init(alloc);
+    try pre_b.add("kind", try Value.newString(alloc, "atomic"));
+    try pre_b.add("name", try Value.newString(alloc, ">"));
+    var args_arr = ArrayBuilder.init(alloc);
+    {
+        var v_b = ObjectBuilder.init(alloc);
+        try v_b.add("kind", try Value.newString(alloc, "var"));
+        try v_b.add("name", try Value.newString(alloc, "n"));
+        try args_arr.append(try v_b.finish());
+    }
+    {
+        var v_b = ObjectBuilder.init(alloc);
+        try v_b.add("kind", try Value.newString(alloc, "const"));
+        try v_b.add("value", try Value.newInt(alloc, 0));
+        var sort_b = ObjectBuilder.init(alloc);
+        try sort_b.add("kind", try Value.newString(alloc, "primitive"));
+        try sort_b.add("name", try Value.newString(alloc, "Int"));
+        try v_b.add("sort", try sort_b.finish());
+        try args_arr.append(try v_b.finish());
+    }
+    try pre_b.add("args", try args_arr.finish());
+    const pre = try pre_b.finish();
+
+    const args = MintContractArgs{
+        .contract_name = "parseInt",
+        .pre = pre,
+        .out_binding = "out",
+        .produced_by = "zig-kit@1.0",
+        .produced_at = "2026-04-30T00:00:00.000Z",
+        .authoring = .{ .kit_author = .{ .author = "zig-kit@1.0" } },
+        .signer_seed = @splat(0x42),
+    };
+    const m = try mintContract(alloc, args);
+    defer m.deinit(alloc);
+    try std.testing.expect(std.mem.startsWith(u8, m.cid, "blake3-512:"));
+    try std.testing.expectEqual(@as(usize, "blake3-512:".len + 128), m.cid.len);
+    try std.testing.expect(std.mem.startsWith(u8, m.contract_cid, "blake3-512:"));
+}
+
+test "compute contract set CID order-independent" {
+    const alloc = std.testing.allocator;
+    var ids_a = [_][]const u8{
+        "blake3-512:bbb",
+        "blake3-512:aaa",
+        "blake3-512:ccc",
+    };
+    var ids_b = [_][]const u8{
+        "blake3-512:ccc",
+        "blake3-512:aaa",
+        "blake3-512:bbb",
+    };
+    const a = try computeContractSetCid(alloc, &ids_a);
+    defer alloc.free(a);
+    const b = try computeContractSetCid(alloc, &ids_b);
+    defer alloc.free(b);
+    try std.testing.expectEqualStrings(a, b);
+}
+
+test "empty contract set CID matches the value pinned in attestation" {
+    // The pinned value in .provekit/self-contracts-attestations/zig.json is
+    // the contractSetCid for the empty contract array — i.e. JCS([]) hashed.
+    const alloc = std.testing.allocator;
+    const empty: [][]const u8 = &.{};
+    const cid = try computeContractSetCid(alloc, @constCast(empty));
+    defer alloc.free(cid);
+    try std.testing.expectEqualStrings(
+        "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+        cid,
+    );
+}

--- a/implementations/zig/provekit-self-contracts/src/foundation.zig
+++ b/implementations/zig/provekit-self-contracts/src/foundation.zig
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Foundation v0 ed25519 seed — the cross-kit anchor for substrate
+// signing. Documented as a deterministic test seed; v1 is HSM-generated.
+// A signed catalog under this seed is structurally valid but offers no
+// trust beyond "the bytes match the public seed in the repo."
+//
+// Mirrors `tools/foundation-keygen/src/lib.rs` const FOUNDATION_V0_SEED.
+
+const signing = @import("signing.zig");
+
+/// 32-byte seed shared across all 11 ProvekIt kits.
+pub const SEED: signing.Seed = @splat(0x42);

--- a/implementations/zig/provekit-self-contracts/src/hash.zig
+++ b/implementations/zig/provekit-self-contracts/src/hash.zig
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// BLAKE3-512 hash helper. v1.1.0 of the protocol mandates
+// self-identifying hashes of the form:
+//
+//   "blake3-512:" + lowercase-hex(64-byte-digest)
+//
+// We use std.crypto.hash.Blake3 at its 64-byte (512-bit) extended-output
+// length. There is NO truncation. The protocol cut is scorched earth:
+// this is the only hash function permitted in v1.1.0, and it is always
+// 512 bits wide.
+//
+// Mirrors implementations/rust/provekit-canonicalizer/src/hash.rs 1:1.
+
+const std = @import("std");
+
+pub const PREFIX: []const u8 = "blake3-512:";
+
+/// Hash arbitrary bytes into the self-identifying string form.
+/// Caller owns the returned slice (allocated through `alloc`).
+pub fn blake3_512Of(alloc: std.mem.Allocator, bytes: []const u8) ![]u8 {
+    var digest: [64]u8 = undefined;
+    var hasher = std.crypto.hash.Blake3.init(.{});
+    hasher.update(bytes);
+    hasher.final(&digest);
+
+    const hex = std.fmt.bytesToHex(digest, .lower);
+    var out = try alloc.alloc(u8, PREFIX.len + hex.len);
+    @memcpy(out[0..PREFIX.len], PREFIX);
+    @memcpy(out[PREFIX.len..], &hex);
+    return out;
+}
+
+test "empty input produces well-formed CID" {
+    const alloc = std.testing.allocator;
+    const h = try blake3_512Of(alloc, "");
+    defer alloc.free(h);
+    try std.testing.expect(std.mem.startsWith(u8, h, PREFIX));
+    try std.testing.expectEqual(@as(usize, PREFIX.len + 128), h.len);
+}
+
+test "deterministic across calls" {
+    const alloc = std.testing.allocator;
+    const a = try blake3_512Of(alloc, "hello");
+    defer alloc.free(a);
+    const b = try blake3_512Of(alloc, "hello");
+    defer alloc.free(b);
+    try std.testing.expectEqualStrings(a, b);
+}
+
+test "distinct inputs distinct hashes" {
+    const alloc = std.testing.allocator;
+    const a = try blake3_512Of(alloc, "hello");
+    defer alloc.free(a);
+    const b = try blake3_512Of(alloc, "world");
+    defer alloc.free(b);
+    try std.testing.expect(!std.mem.eql(u8, a, b));
+}
+
+// Cross-kit byte-equivalence pins for BLAKE3-512 are anchored in two
+// places:
+//   * `provekit-ir/src/cross_kit_bridges.zig` pins BLAKE3-of-JCS for 10
+//     contract Decls against rust/python/go/ts.
+//   * `byte_equivalence_test.zig` (this package) pins the empty
+//     contractSetCid against the value committed in
+//     `.provekit/self-contracts-attestations/zig.json` — that pin
+//     transitively exercises hash.zig.
+// No additional vector is pinned here.

--- a/implementations/zig/provekit-self-contracts/src/jcs.zig
+++ b/implementations/zig/provekit-self-contracts/src/jcs.zig
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// JCS-JSON encoder (RFC 8785) + Value tree.
+//
+// Mirrors implementations/rust/provekit-canonicalizer/src/{jcs.rs,value.rs}
+// 1:1. The same rules apply across all 11 kits:
+//
+//   - Object keys sorted by Unicode code-point order. For ASCII-only keys
+//     this collapses to byte-order; the protocol's keys are all ASCII so
+//     byte-order suffices. Cross-kit byte-equivalence depends on this.
+//   - Numbers: integers serialized as plain decimal digits (we only carry
+//     i64; floats are not produced by the kit/mint flow).
+//   - Strings: UTF-8 verbatim, escape `"` and `\\` and U+0000..U+001F as
+//     `\u00XX` (lowercase hex). RFC 8785 also permits the named short
+//     escapes (\n etc.) but the C++/Rust peers chose `\u00XX` for
+//     determinism; we match.
+//   - true / false / null verbatim.
+//   - No whitespace anywhere.
+//
+// The Value tree is intentionally tiny. We keep insertion order on
+// objects so callers can build envelopes naturally; the JCS encoder
+// re-sorts keys at emit time.
+
+const std = @import("std");
+
+pub const ValueKind = enum {
+    null_,
+    bool_,
+    integer,
+    string,
+    array,
+    object,
+};
+
+/// Owned (key, value) pair for an Object Value. Values are reference-counted-
+/// like via pointer ownership: the `Value.deinit()` recursively frees children.
+pub const Pair = struct {
+    key: []u8,
+    value: *Value,
+};
+
+pub const Value = union(ValueKind) {
+    null_: void,
+    bool_: bool,
+    integer: i64,
+    string: []u8,
+    array: []*Value,
+    object: []Pair,
+
+    /// Recursively free this Value and all children allocated through `alloc`.
+    /// `alloc` MUST be the same allocator that built the tree.
+    pub fn deinit(self: *Value, alloc: std.mem.Allocator) void {
+        switch (self.*) {
+            .null_, .bool_, .integer => {},
+            .string => |s| alloc.free(s),
+            .array => |items| {
+                for (items) |child| {
+                    child.deinit(alloc);
+                    alloc.destroy(child);
+                }
+                alloc.free(items);
+            },
+            .object => |entries| {
+                for (entries) |pair| {
+                    alloc.free(pair.key);
+                    pair.value.deinit(alloc);
+                    alloc.destroy(pair.value);
+                }
+                alloc.free(entries);
+            },
+        }
+    }
+
+    // ---- constructors -----------------------------------------------------
+
+    pub fn newNull(alloc: std.mem.Allocator) !*Value {
+        const v = try alloc.create(Value);
+        v.* = .{ .null_ = {} };
+        return v;
+    }
+
+    pub fn newBool(alloc: std.mem.Allocator, b: bool) !*Value {
+        const v = try alloc.create(Value);
+        v.* = .{ .bool_ = b };
+        return v;
+    }
+
+    pub fn newInt(alloc: std.mem.Allocator, n: i64) !*Value {
+        const v = try alloc.create(Value);
+        v.* = .{ .integer = n };
+        return v;
+    }
+
+    pub fn newString(alloc: std.mem.Allocator, s: []const u8) !*Value {
+        const owned = try alloc.dupe(u8, s);
+        const v = try alloc.create(Value);
+        v.* = .{ .string = owned };
+        return v;
+    }
+
+    /// Build an Array node taking ownership of `items` (slice of *Value).
+    /// `items` must have been allocated through the same `alloc`.
+    pub fn newArrayOwned(alloc: std.mem.Allocator, items: []*Value) !*Value {
+        const v = try alloc.create(Value);
+        v.* = .{ .array = items };
+        return v;
+    }
+
+    /// Build an Object node taking ownership of `entries`. Keys are
+    /// expected to already be `alloc.dupe`'d.
+    pub fn newObjectOwned(alloc: std.mem.Allocator, entries: []Pair) !*Value {
+        const v = try alloc.create(Value);
+        v.* = .{ .object = entries };
+        return v;
+    }
+};
+
+/// Object builder: collects (key, value) pairs in insertion order, then
+/// transfers ownership to a freshly-built Object Value. Keys are dupe'd
+/// on `add`; values are taken by pointer (the builder does not copy them).
+pub const ObjectBuilder = struct {
+    alloc: std.mem.Allocator,
+    pairs: std.ArrayList(Pair) = .empty,
+
+    pub fn init(alloc: std.mem.Allocator) ObjectBuilder {
+        return .{ .alloc = alloc };
+    }
+
+    pub fn add(self: *ObjectBuilder, key: []const u8, value: *Value) !void {
+        const owned_key = try self.alloc.dupe(u8, key);
+        try self.pairs.append(self.alloc, .{ .key = owned_key, .value = value });
+    }
+
+    /// Finalize. The returned *Value owns the entries slice and all keys/
+    /// child Values transitively.
+    pub fn finish(self: *ObjectBuilder) !*Value {
+        const entries = try self.pairs.toOwnedSlice(self.alloc);
+        return Value.newObjectOwned(self.alloc, entries);
+    }
+};
+
+/// Array builder: same shape as ObjectBuilder.
+pub const ArrayBuilder = struct {
+    alloc: std.mem.Allocator,
+    items: std.ArrayList(*Value) = .empty,
+
+    pub fn init(alloc: std.mem.Allocator) ArrayBuilder {
+        return .{ .alloc = alloc };
+    }
+
+    pub fn append(self: *ArrayBuilder, v: *Value) !void {
+        try self.items.append(self.alloc, v);
+    }
+
+    pub fn finish(self: *ArrayBuilder) !*Value {
+        const slice = try self.items.toOwnedSlice(self.alloc);
+        return Value.newArrayOwned(self.alloc, slice);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Encoder
+// ---------------------------------------------------------------------------
+
+/// Encode `v` as JCS-canonical JSON. Returned slice is owned by the caller.
+pub fn encode(alloc: std.mem.Allocator, v: *const Value) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try encodeValue(alloc, &buf, v);
+    return buf.toOwnedSlice(alloc);
+}
+
+fn encodeValue(alloc: std.mem.Allocator, out: *std.ArrayList(u8), v: *const Value) !void {
+    switch (v.*) {
+        .null_ => try out.appendSlice(alloc, "null"),
+        .bool_ => |b| try out.appendSlice(alloc, if (b) "true" else "false"),
+        .integer => |n| {
+            // ECMA-262 ToString applied to a finite integer; std.fmt's `{d}`
+            // emits the same form (no leading zeros, leading minus for
+            // negatives, no trailing decimal).
+            try out.print(alloc, "{d}", .{n});
+        },
+        .string => |s| try encodeString(alloc, out, s),
+        .array => |items| {
+            try out.append(alloc, '[');
+            for (items, 0..) |child, i| {
+                if (i > 0) try out.append(alloc, ',');
+                try encodeValue(alloc, out, child);
+            }
+            try out.append(alloc, ']');
+        },
+        .object => |entries| {
+            // Sort by key (byte-order works for ASCII keys; the protocol's
+            // keys are all ASCII). For non-ASCII keys this is still the
+            // right answer because UTF-8 byte order matches Unicode
+            // code-point order on well-formed input.
+            const sorted = try alloc.alloc(Pair, entries.len);
+            defer alloc.free(sorted);
+            @memcpy(sorted, entries);
+            std.mem.sort(Pair, sorted, {}, pairLess);
+
+            try out.append(alloc, '{');
+            for (sorted, 0..) |pair, i| {
+                if (i > 0) try out.append(alloc, ',');
+                try encodeString(alloc, out, pair.key);
+                try out.append(alloc, ':');
+                try encodeValue(alloc, out, pair.value);
+            }
+            try out.append(alloc, '}');
+        },
+    }
+}
+
+fn pairLess(_: void, a: Pair, b: Pair) bool {
+    return std.mem.lessThan(u8, a.key, b.key);
+}
+
+fn encodeString(alloc: std.mem.Allocator, out: *std.ArrayList(u8), s: []const u8) !void {
+    try out.append(alloc, '"');
+    // Iterate by byte: non-ASCII bytes (>= 0x80) are emitted verbatim,
+    // preserving the input's UTF-8 encoding. The Rust peer iterates by
+    // Unicode scalar; the result is identical for well-formed UTF-8 input
+    // because we only special-case ASCII-range characters.
+    for (s) |b| {
+        if (b == '"') {
+            try out.appendSlice(alloc, "\\\"");
+        } else if (b == '\\') {
+            try out.appendSlice(alloc, "\\\\");
+        } else if (b < 0x20) {
+            const hex = "0123456789abcdef";
+            try out.appendSlice(alloc, "\\u00");
+            try out.append(alloc, hex[(b >> 4) & 0xF]);
+            try out.append(alloc, hex[b & 0xF]);
+        } else {
+            try out.append(alloc, b);
+        }
+    }
+    try out.append(alloc, '"');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "encode_simple_object_sorts_keys" {
+    const alloc = std.testing.allocator;
+    var ob = ObjectBuilder.init(alloc);
+    try ob.add("b", try Value.newInt(alloc, 1));
+    try ob.add("a", try Value.newString(alloc, "x"));
+    const v = try ob.finish();
+    defer {
+        v.deinit(alloc);
+        alloc.destroy(v);
+    }
+    const enc = try encode(alloc, v);
+    defer alloc.free(enc);
+    try std.testing.expectEqualStrings("{\"a\":\"x\",\"b\":1}", enc);
+}
+
+test "encode_nested_array_object" {
+    const alloc = std.testing.allocator;
+    var arr = ArrayBuilder.init(alloc);
+    try arr.append(try Value.newInt(alloc, 1));
+    try arr.append(try Value.newInt(alloc, 2));
+    var ob = ObjectBuilder.init(alloc);
+    try ob.add("xs", try arr.finish());
+    const v = try ob.finish();
+    defer {
+        v.deinit(alloc);
+        alloc.destroy(v);
+    }
+    const enc = try encode(alloc, v);
+    defer alloc.free(enc);
+    try std.testing.expectEqualStrings("{\"xs\":[1,2]}", enc);
+}
+
+test "escape_quotes_and_backslash" {
+    const alloc = std.testing.allocator;
+    const v = try Value.newString(alloc, "a\"b\\c");
+    defer {
+        v.deinit(alloc);
+        alloc.destroy(v);
+    }
+    const enc = try encode(alloc, v);
+    defer alloc.free(enc);
+    try std.testing.expectEqualStrings("\"a\\\"b\\\\c\"", enc);
+}
+
+test "empty_object_and_array" {
+    const alloc = std.testing.allocator;
+    {
+        var ob = ObjectBuilder.init(alloc);
+        const v = try ob.finish();
+        defer {
+            v.deinit(alloc);
+            alloc.destroy(v);
+        }
+        const enc = try encode(alloc, v);
+        defer alloc.free(enc);
+        try std.testing.expectEqualStrings("{}", enc);
+    }
+    {
+        var arr = ArrayBuilder.init(alloc);
+        const v = try arr.finish();
+        defer {
+            v.deinit(alloc);
+            alloc.destroy(v);
+        }
+        const enc = try encode(alloc, v);
+        defer alloc.free(enc);
+        try std.testing.expectEqualStrings("[]", enc);
+    }
+}
+
+test "unicode_atomic_predicates_round_trip_verbatim" {
+    // Regression: cross-language hash agreement depends on this. The kit's
+    // atomic predicate names use exactly these (>=, <=, !=). The Rust JCS
+    // emitter preserves these chars verbatim (UTF-8 bytes >= 0x80 emitted
+    // as-is); we match.
+    const alloc = std.testing.allocator;
+    const inputs = [_][]const u8{ "\u{2265}", "\u{2264}", "\u{2260}" };
+    for (inputs) |sym| {
+        const v = try Value.newString(alloc, sym);
+        defer {
+            v.deinit(alloc);
+            alloc.destroy(v);
+        }
+        const enc = try encode(alloc, v);
+        defer alloc.free(enc);
+        // Encoded form is `"<sym>"` — the same UTF-8 bytes wrapped in quotes.
+        try std.testing.expectEqual(@as(usize, sym.len + 2), enc.len);
+        try std.testing.expectEqual(@as(u8, '"'), enc[0]);
+        try std.testing.expectEqual(@as(u8, '"'), enc[enc.len - 1]);
+        try std.testing.expectEqualSlices(u8, sym, enc[1 .. enc.len - 1]);
+    }
+}
+
+test "negative_integer_serializes_with_leading_minus" {
+    const alloc = std.testing.allocator;
+    const v = try Value.newInt(alloc, -42);
+    defer {
+        v.deinit(alloc);
+        alloc.destroy(v);
+    }
+    const enc = try encode(alloc, v);
+    defer alloc.free(enc);
+    try std.testing.expectEqualStrings("-42", enc);
+}
+
+test "control_char_escaped_lowercase_hex" {
+    const alloc = std.testing.allocator;
+    const v = try Value.newString(alloc, "\x1f");
+    defer {
+        v.deinit(alloc);
+        alloc.destroy(v);
+    }
+    const enc = try encode(alloc, v);
+    defer alloc.free(enc);
+    try std.testing.expectEqualStrings("\"\\u001f\"", enc);
+}
+
+test "object_key_sort_is_byte_order" {
+    // Per RFC 8785 §3.2.3: sort by Unicode code-point. For ASCII keys this
+    // is byte-order; "Z" (0x5A) sorts before "a" (0x61).
+    const alloc = std.testing.allocator;
+    var ob = ObjectBuilder.init(alloc);
+    try ob.add("a", try Value.newInt(alloc, 1));
+    try ob.add("Z", try Value.newInt(alloc, 2));
+    const v = try ob.finish();
+    defer {
+        v.deinit(alloc);
+        alloc.destroy(v);
+    }
+    const enc = try encode(alloc, v);
+    defer alloc.free(enc);
+    try std.testing.expectEqualStrings("{\"Z\":2,\"a\":1}", enc);
+}

--- a/implementations/zig/provekit-self-contracts/src/proof_envelope.zig
+++ b/implementations/zig/provekit-self-contracts/src/proof_envelope.zig
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// .proof envelope builder. Per RFC 8949 §4.2.1 + the .proof spec
+// (protocol/specs/2026-04-30-proof-file-format.md):
+//
+//   1. Build the unsigned body as a CBOR map with keys sorted by bytewise
+//      lex order of their CBOR-encoded form.
+//   2. ed25519-sign the unsigned-body bytes.
+//   3. Re-emit the body with the signature added; keys re-sort
+//      automatically (the new "signature" key slots in by lex order).
+//   4. BLAKE3-512 the final bytes; the full self-identifying string
+//      `"blake3-512:<128 hex>"` IS the catalog CID.
+//
+// The `members` map key is the embedded envelope's own CID, and the value
+// is its canonical bytes (JCS-JSON for memento envelopes per the memento
+// envelope grammar) wrapped as a CBOR byte string.
+//
+// Mirrors implementations/rust/provekit-proof-envelope/src/proof.rs 1:1.
+
+const std = @import("std");
+const cbor = @import("cbor.zig");
+const hash = @import("hash.zig");
+const signing = @import("signing.zig");
+
+/// (cid, envelope-bytes) pair for a member of the catalog. Both slices are
+/// borrowed; the caller retains ownership. CIDs are full self-identifying
+/// strings (`"blake3-512:<128 hex>"`).
+pub const Member = struct {
+    cid: []const u8,
+    bytes: []const u8,
+};
+
+/// Optional metadata key/value pair (UTF-8 strings).
+pub const MetadataPair = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+pub const Input = struct {
+    name: []const u8,
+    version: []const u8,
+    /// Optional CID of the compiled binary this proof verifies.
+    binary_cid: ?[]const u8 = null,
+    /// Optional metadata: tooling/diagnostic key-value map. Included in
+    /// the signed payload (tamper-evident) but explicitly NON-NORMATIVE:
+    /// verifiers MUST NOT use metadata for logic.
+    metadata: []const MetadataPair = &.{},
+    /// Members map: CID -> canonical bytes.
+    members: []const Member,
+    /// CID of the signer's public-key memento (or any resolvable CID).
+    signer_cid: []const u8,
+    /// Ed25519 seed bytes; deterministic signing.
+    signer_seed: signing.Seed,
+    /// ISO-8601 string with millisecond precision and trailing 'Z'.
+    declared_at: []const u8,
+};
+
+pub const Output = struct {
+    /// CBOR bytes of the signed catalog. Hash of these bytes IS the CID.
+    bytes: []u8,
+    /// Full self-identifying CID, e.g. `"blake3-512:<128 hex>"`.
+    cid: []u8,
+
+    pub fn deinit(self: Output, alloc: std.mem.Allocator) void {
+        alloc.free(self.bytes);
+        alloc.free(self.cid);
+    }
+};
+
+/// Build the unsigned-or-signed body pair list. `extra_signature` is the
+/// raw 64-byte signature when present; otherwise null.
+fn buildPairs(
+    alloc: std.mem.Allocator,
+    input: Input,
+    extra_signature: ?[]const u8,
+) ![]cbor.Pair {
+    var list: std.ArrayList(cbor.Pair) = .empty;
+    errdefer {
+        for (list.items) |p| p.deinit(alloc);
+        list.deinit(alloc);
+    }
+
+    try list.append(alloc, try cbor.makeStringPair(alloc, "kind", "catalog"));
+    try list.append(alloc, try cbor.makeStringPair(alloc, "name", input.name));
+    try list.append(alloc, try cbor.makeStringPair(alloc, "version", input.version));
+
+    // members pair: tstr(cid) -> bstr(bytes), inner map sorted bytewise.
+    {
+        var inner_pairs = try alloc.alloc(cbor.Pair, input.members.len);
+        var inner_count: usize = 0;
+        errdefer {
+            for (inner_pairs[0..inner_count]) |p| p.deinit(alloc);
+            alloc.free(inner_pairs);
+        }
+        for (input.members) |m| {
+            inner_pairs[inner_count] = try cbor.makeBytesPair(alloc, m.cid, m.bytes);
+            inner_count += 1;
+        }
+        var inner_buf: std.ArrayList(u8) = .empty;
+        defer inner_buf.deinit(alloc);
+        try cbor.emitSortedMap(alloc, &inner_buf, inner_pairs);
+        for (inner_pairs) |p| p.deinit(alloc);
+        alloc.free(inner_pairs);
+
+        try list.append(alloc, try cbor.makeRawPair(alloc, "members", inner_buf.items));
+    }
+
+    try list.append(alloc, try cbor.makeStringPair(alloc, "signer", input.signer_cid));
+    try list.append(alloc, try cbor.makeStringPair(alloc, "declaredAt", input.declared_at));
+
+    if (input.binary_cid) |bcid| {
+        try list.append(alloc, try cbor.makeStringPair(alloc, "binaryCid", bcid));
+    }
+
+    if (input.metadata.len > 0) {
+        var meta_pairs = try alloc.alloc(cbor.Pair, input.metadata.len);
+        var meta_count: usize = 0;
+        errdefer {
+            for (meta_pairs[0..meta_count]) |p| p.deinit(alloc);
+            alloc.free(meta_pairs);
+        }
+        for (input.metadata) |kv| {
+            meta_pairs[meta_count] = try cbor.makeStringPair(alloc, kv.key, kv.value);
+            meta_count += 1;
+        }
+        var meta_buf: std.ArrayList(u8) = .empty;
+        defer meta_buf.deinit(alloc);
+        try cbor.emitSortedMap(alloc, &meta_buf, meta_pairs);
+        for (meta_pairs) |p| p.deinit(alloc);
+        alloc.free(meta_pairs);
+
+        try list.append(alloc, try cbor.makeRawPair(alloc, "metadata", meta_buf.items));
+    }
+
+    if (extra_signature) |sig| {
+        try list.append(alloc, try cbor.makeBytesPair(alloc, "signature", sig));
+    }
+
+    return list.toOwnedSlice(alloc);
+}
+
+/// Build the signed catalog. Caller owns `result.bytes` and `result.cid`.
+pub fn build(alloc: std.mem.Allocator, input: Input) !Output {
+    // Step 1: encode unsigned body with sorted keys.
+    const unsigned_pairs = try buildPairs(alloc, input, null);
+    defer {
+        for (unsigned_pairs) |p| p.deinit(alloc);
+        alloc.free(unsigned_pairs);
+    }
+    var unsigned_buf: std.ArrayList(u8) = .empty;
+    defer unsigned_buf.deinit(alloc);
+    try cbor.emitSortedMap(alloc, &unsigned_buf, unsigned_pairs);
+
+    // Step 2: ed25519-sign the unsigned bytes.
+    const sig = signing.signWithSeed(input.signer_seed, unsigned_buf.items);
+
+    // Step 3: re-emit with signature added; keys re-sort automatically.
+    const signed_pairs = try buildPairs(alloc, input, &sig);
+    defer {
+        for (signed_pairs) |p| p.deinit(alloc);
+        alloc.free(signed_pairs);
+    }
+    var signed_buf: std.ArrayList(u8) = .empty;
+    defer signed_buf.deinit(alloc);
+    try cbor.emitSortedMap(alloc, &signed_buf, signed_pairs);
+    const final_bytes = try alloc.dupe(u8, signed_buf.items);
+    errdefer alloc.free(final_bytes);
+
+    // Step 4: filename CID = full self-identifying BLAKE3-512.
+    const cid = try hash.blake3_512Of(alloc, final_bytes);
+    return .{
+        .bytes = final_bytes,
+        .cid = cid,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "build minimal proof round-trips" {
+    const alloc = std.testing.allocator;
+    const members = [_]Member{
+        .{ .cid = "blake3-512:aa", .bytes = "{\"hello\":\"world\"}" },
+    };
+    const input = Input{
+        .name = "@x/y",
+        .version = "0.0.1",
+        .members = &members,
+        .signer_cid = "blake3-512:bb",
+        .signer_seed = @splat(0x11),
+        .declared_at = "2026-04-30T00:00:00.000Z",
+    };
+    const out = try build(alloc, input);
+    defer out.deinit(alloc);
+    try std.testing.expect(std.mem.startsWith(u8, out.cid, "blake3-512:"));
+    // First byte: map head with 7 entries (kind, name, version, members,
+    // signer, declaredAt, signature) = 0xa7.
+    try std.testing.expectEqual(@as(u8, 0xa7), out.bytes[0]);
+}
+
+test "build empty-members catalog signs" {
+    const alloc = std.testing.allocator;
+    const empty: []const Member = &.{};
+    const input = Input{
+        .name = "@empty/test",
+        .version = "0.0.0",
+        .members = empty,
+        .signer_cid = "blake3-512:bb",
+        .signer_seed = @splat(0x42),
+        .declared_at = "2026-05-03T18:00:00Z",
+    };
+    const out = try build(alloc, input);
+    defer out.deinit(alloc);
+    try std.testing.expect(out.bytes.len > 0);
+    try std.testing.expect(std.mem.startsWith(u8, out.cid, "blake3-512:"));
+    // Map head with 7 entries.
+    try std.testing.expectEqual(@as(u8, 0xa7), out.bytes[0]);
+}

--- a/implementations/zig/provekit-self-contracts/src/root.zig
+++ b/implementations/zig/provekit-self-contracts/src/root.zig
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-self-contracts (zig) — Side B substrate library.
+//
+// Native Zig implementation of the substrate primitives required to mint
+// claim envelopes (JCS-canonical layered mementos) and proof envelopes
+// (deterministic-CBOR signed catalogs). No shell-out to peer kits.
+//
+// Public API:
+//   const sc = @import("provekit-self-contracts");
+//   sc.jcs.encode(alloc, value)
+//   sc.hash.blake3_512Of(alloc, bytes)
+//   sc.cbor.encodeUint(alloc, &buf, n)
+//   sc.signing.signString(alloc, seed, msg)
+//   sc.signing.verifyString(pubkey, sig, msg)
+//   sc.proof_envelope.build(alloc, input)
+//   sc.claim_envelope.mintContract(alloc, args)
+//   sc.foundation.SEED  // [0x42; 32]
+
+const std = @import("std");
+
+pub const jcs = @import("jcs.zig");
+pub const hash = @import("hash.zig");
+pub const cbor = @import("cbor.zig");
+pub const signing = @import("signing.zig");
+pub const foundation = @import("foundation.zig");
+pub const proof_envelope = @import("proof_envelope.zig");
+pub const claim_envelope = @import("claim_envelope.zig");
+
+// Pull in tests from every sibling file so `zig build test` discovers them.
+test {
+    _ = @import("jcs.zig");
+    _ = @import("hash.zig");
+    _ = @import("cbor.zig");
+    _ = @import("signing.zig");
+    _ = @import("foundation.zig");
+    _ = @import("proof_envelope.zig");
+    _ = @import("claim_envelope.zig");
+    _ = @import("byte_equivalence_test.zig");
+}

--- a/implementations/zig/provekit-self-contracts/src/signing.zig
+++ b/implementations/zig/provekit-self-contracts/src/signing.zig
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ed25519 signing helper. v1.1.0 of the protocol mandates self-identifying
+// signatures of the form:
+//
+//   "ed25519:" + base64-stdpad(64-byte-signature)
+//
+// And self-identifying public keys of the same form. The .proof file
+// envelope itself stores its catalog signature as a RAW 64-byte CBOR byte
+// string (not the prefixed string form): only the per-memento
+// `producerSignature` field uses the prefixed string form, because memento
+// envelopes are JCS-JSON.
+//
+// Mirrors implementations/rust/provekit-proof-envelope/src/sign.rs 1:1.
+// Wraps std.crypto.sign.Ed25519, which is RFC 8032 (Ed25519, not Ed25519ph
+// or Ed25519ctx) and produces the same 64-byte signatures as ed25519-dalek.
+
+const std = @import("std");
+
+const Ed25519 = std.crypto.sign.Ed25519;
+
+pub const KEY_PREFIX: []const u8 = "ed25519:";
+pub const SIG_PREFIX: []const u8 = "ed25519:";
+
+pub const Seed = [32]u8;
+pub const Signature = [64]u8;
+pub const PublicKeyBytes = [32]u8;
+
+pub const SigningError = error{
+    BadSignature,
+    BadPublicKey,
+    BadEncoding,
+    SignatureMismatch,
+};
+
+/// Sign `message` with the Ed25519 private key derived from `seed`.
+/// Returns the raw 64-byte signature.
+pub fn signWithSeed(seed: Seed, message: []const u8) Signature {
+    const kp = Ed25519.KeyPair.generateDeterministic(seed) catch unreachable;
+    const sig = kp.sign(message, null) catch unreachable;
+    return sig.toBytes();
+}
+
+/// Sign `message` and return the spec's self-identifying string form
+/// (`"ed25519:" + base64(sig)`). Caller owns returned slice.
+pub fn signString(alloc: std.mem.Allocator, seed: Seed, message: []const u8) ![]u8 {
+    const sig = signWithSeed(seed, message);
+    return encodePrefixed(alloc, SIG_PREFIX, &sig);
+}
+
+/// Derive the public key from a seed and return the self-identifying string
+/// form (`"ed25519:" + base64(pubkey)`). Caller owns returned slice.
+pub fn pubkeyString(alloc: std.mem.Allocator, seed: Seed) ![]u8 {
+    const kp = try Ed25519.KeyPair.generateDeterministic(seed);
+    const pk_bytes = kp.public_key.toBytes();
+    return encodePrefixed(alloc, KEY_PREFIX, &pk_bytes);
+}
+
+fn encodePrefixed(alloc: std.mem.Allocator, prefix: []const u8, raw: []const u8) ![]u8 {
+    const enc = std.base64.standard.Encoder;
+    const b64_len = enc.calcSize(raw.len);
+    var out = try alloc.alloc(u8, prefix.len + b64_len);
+    @memcpy(out[0..prefix.len], prefix);
+    _ = enc.encode(out[prefix.len..], raw);
+    return out;
+}
+
+/// Verify `message` against `sig_string` (spec form `"ed25519:" + base64(sig)`)
+/// using `pubkey_string` (spec form `"ed25519:" + base64(pubkey)`).
+/// Returns `true` iff valid, `false` for any malformed input — verifiers
+/// must fail closed, on a separate code path.
+pub fn verifyString(pubkey_string_: []const u8, sig_string_: []const u8, message: []const u8) bool {
+    if (!std.mem.startsWith(u8, pubkey_string_, KEY_PREFIX)) return false;
+    if (!std.mem.startsWith(u8, sig_string_, SIG_PREFIX)) return false;
+    const pk_b64 = pubkey_string_[KEY_PREFIX.len..];
+    const sig_b64 = sig_string_[SIG_PREFIX.len..];
+
+    const dec = std.base64.standard.Decoder;
+    var pk_bytes: [32]u8 = undefined;
+    var sig_bytes: [64]u8 = undefined;
+
+    const pk_len = dec.calcSizeForSlice(pk_b64) catch return false;
+    if (pk_len != 32) return false;
+    dec.decode(&pk_bytes, pk_b64) catch return false;
+
+    const sig_len = dec.calcSizeForSlice(sig_b64) catch return false;
+    if (sig_len != 64) return false;
+    dec.decode(&sig_bytes, sig_b64) catch return false;
+
+    const pk = Ed25519.PublicKey.fromBytes(pk_bytes) catch return false;
+    const sig = Ed25519.Signature.fromBytes(sig_bytes);
+    sig.verify(message, pk) catch return false;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "deterministic signature for fixed seed" {
+    const seed: Seed = @splat(0x42);
+    const a = signWithSeed(seed, "hello");
+    const b = signWithSeed(seed, "hello");
+    try std.testing.expectEqualSlices(u8, &a, &b);
+}
+
+test "string form has prefix and base64" {
+    const alloc = std.testing.allocator;
+    const seed: Seed = @splat(0x42);
+    const s = try signString(alloc, seed, "hello");
+    defer alloc.free(s);
+    try std.testing.expect(std.mem.startsWith(u8, s, SIG_PREFIX));
+    // 64-byte signature -> 88-byte standard-padding base64.
+    try std.testing.expectEqual(@as(usize, SIG_PREFIX.len + 88), s.len);
+}
+
+test "pubkey form has prefix" {
+    const alloc = std.testing.allocator;
+    const seed: Seed = @splat(0x42);
+    const s = try pubkeyString(alloc, seed);
+    defer alloc.free(s);
+    try std.testing.expect(std.mem.startsWith(u8, s, KEY_PREFIX));
+    try std.testing.expectEqual(@as(usize, KEY_PREFIX.len + 44), s.len);
+}
+
+test "verify round-trip" {
+    const alloc = std.testing.allocator;
+    const seed: Seed = @splat(0x42);
+    const pk = try pubkeyString(alloc, seed);
+    defer alloc.free(pk);
+    const sig = try signString(alloc, seed, "hello world");
+    defer alloc.free(sig);
+    try std.testing.expect(verifyString(pk, sig, "hello world"));
+    try std.testing.expect(!verifyString(pk, sig, "goodbye world"));
+}
+
+test "verify rejects malformed input" {
+    try std.testing.expect(!verifyString("not-prefixed", "ed25519:AAAA", "x"));
+    try std.testing.expect(!verifyString("ed25519:AAAA", "not-prefixed", "x"));
+    try std.testing.expect(!verifyString("ed25519:!!!!", "ed25519:!!!!", "x"));
+}
+
+// Cross-kit byte-equivalence pin: the foundation v0 pubkey is the canonical
+// anchor for cross-kit signatures. Every kit derives the same string from
+// seed [0x42; 32]; this test pins the exact value committed in
+// .provekit/self-contracts-attestations/zig.json (signer field).
+test "foundation v0 pubkey matches the value pinned in attestation files" {
+    const alloc = std.testing.allocator;
+    const seed: Seed = @splat(0x42);
+    const pk = try pubkeyString(alloc, seed);
+    defer alloc.free(pk);
+    try std.testing.expectEqualStrings(
+        "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+        pk,
+    );
+}

--- a/implementations/zig/provekit-self-contracts/src/test_fixtures/go_attestation.json
+++ b/implementations/zig/provekit-self-contracts/src/test_fixtures/go_attestation.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "1",
+  "kind": "self-contracts-attestation",
+  "lang": "go",
+  "cid": "blake3-512:2cb536119bb99c4b7c24bc455672e0863b3b5392fabfc92c6db01828854ca6cb7f20a33d0c7b2f9415a7957fd844dcfe06dc668765d3ccbb08808cf08e9f92eb",
+  "contractSetCid": "blake3-512:e23649f383162398556a508c2e69e035d6d231bfaf6e8926ced547fb19ddd9c65779f39fe31d85519c957bc40afa432c9be468eadfa5aac77f74f5de8c56324c",
+  "declaredAt": "2026-05-03T18:00:00Z",
+  "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+  "signature": "ed25519:2QRap+bghkPM6R4MbkkZb+7nZmv7NEpqAPAuWYnk1ozJ5bDee5kGfe5Nd9N/71VrPEmcQfg4MIBPq9dC4zi2CA=="
+}


### PR DESCRIPTION
## Summary

Adds `implementations/zig/provekit-self-contracts/` — Side B substrate
library so a Zig consumer can mint claim envelopes (JCS-canonical layered
mementos) and proof envelopes (deterministic-CBOR signed catalogs)
without shelling out to a peer kit.

Modules mirror the rust kit's shape 1:1:

- `src/jcs.zig` — Value tree + RFC 8785 JCS encoder
- `src/hash.zig` — BLAKE3-512 with self-identifying string form
- `src/cbor.zig` — RFC 8949 §4.2.1 deterministic encoder
- `src/signing.zig` — Ed25519 sign/verify (`std.crypto.sign.Ed25519`)
- `src/claim_envelope.zig` — mint_contract, computeContractSetCid, content CID
- `src/proof_envelope.zig` — signed CBOR catalog builder
- `src/foundation.zig` — Foundation v0 ed25519 seed (`[0x42; 32]`)

## Byte-equivalence anchors

Three pins, all against committed substrate state:

1. **Foundation v0 pubkey** → `ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=`
   (the `signer` field in every `.provekit/self-contracts-attestations/*.json`).
2. **Empty contractSetCid** → `blake3-512:d53d18c2...290f3229`
   (`zig.json` attestation `contractSetCid`; `JCS([])` hashed).
3. **Full attestation round-trip** — rebuild the JCS message body for
   `zig.json`, `rust.json`, and `go.json` signer-message bodies, sign
   under the foundation seed, assert signature byte-matches the
   committed file. End-to-end JCS + Ed25519 byte-equivalence against
   rust and go.

The cross-kit JCS+BLAKE3 pins for IR Decls in `provekit-ir/src/cross_kit_bridges.zig`
(10 contract counterparts + bridges-array CID) transitively cover the
JCS encoder and BLAKE3 hasher.

## AC checklist (#214)

- [x] BLAKE3-512 of canonical bytes (`std.crypto.hash.Blake3`)
- [x] JCS canonicalize JSON (RFC 8785)
- [x] Ed25519 sign/verify (`std.crypto.sign.Ed25519`)
- [x] CBOR-encode envelope (deterministic, RFC 8949 §4.2.1)
- [x] Round-trip byte-for-byte against rust + go reference envelopes
- [x] No shell-out required for envelope construction

Wired into Makefile `test-zig` and `build-zig` targets. CI's existing
zig toolchain step (already provisioned for `provekit-ir` + `provekit-lift-zig`
+ `provekit-lsp-zig`) covers the new package — no additional toolchain
setup required.

## Test plan

- [x] `make test-zig` green locally on macOS, zig 0.16.0
- [x] `provekit-self-contracts` test suite green (jcs / cbor / hash / signing / proof_envelope / claim_envelope / byte_equivalence)
- [x] Existing `provekit-ir`, `provekit-lift-zig`, `provekit-lsp-zig` test suites still green
- [ ] `make conformance` on Linux/CI (covered by automated workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)