### PR TITLE
feat(ruby): mint-ruby-self-contracts orchestrator + KIT_TABLE wiring (closes #209)

### DIFF
--- a/.provekit/self-contracts-attestations/ruby.json
+++ b/.provekit/self-contracts-attestations/ruby.json
@@ -2,9 +2,9 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "ruby",
-  "cid": "",
-  "contractSetCid": "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+  "cid": "blake3-512:6358ad54d0535d87be144d765127b7dcdde7fa6d807e27b8d85f4d3549609cd7fb573a711e7668152339753398c68dbb5e23dc2e0083ca5e7dc2c00e439d69da",
+  "contractSetCid": "blake3-512:961be80d8a5ae8f3d8255462fc1845d5b45f30c0b4412c9d8b354078d63096ba363b6ae0dea4f2e35141213dc5c6b855156f434b5620a345bfbc20725bee00ff",
   "declaredAt": "2026-05-03T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:OwJ0xxHHKapwqdh3xVPARxj/9xPDUCrE0MZtXNdNeiSnW5nXLJ3PpuYAnb42gZ79yyRX7DMWsNG+m+cAiQOjBQ=="
+  "signature": "ed25519:gxKNFdrGsu4WXuIQuGwt7kOPevUrDH9STT2ZKz11J/Y9pkDD0vfYzZfY5RIyk9KcP5n0/vbPYSYTiAKuvW0GAg=="
 }

--- a/implementations/ruby/.provekit/lift/ruby-self-contracts/manifest.toml
+++ b/implementations/ruby/.provekit/lift/ruby-self-contracts/manifest.toml
@@ -1,0 +1,10 @@
+name = "ruby-self-contracts"
+version = "1.0.0"
+protocol_version = "provekit-lift/1"
+command = ["ruby", "-Ilib", "bin/mint-ruby-self-contracts"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["ruby-self-contracts"]
+ir_version = "v1.1.0"
+emits_signed_mementos = true

--- a/implementations/ruby/bin/mint-ruby-self-contracts
+++ b/implementations/ruby/bin/mint-ruby-self-contracts
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# SPDX-License-Identifier: Apache-2.0
+#
+# mint-ruby-self-contracts — RPC entry point for the ruby-self-contracts
+# lift surface, plus direct CLI invocation.
+#
+# Speaks the lift-plugin protocol (provekit-lift/1) over NDJSON on stdio
+# when invoked with --rpc. Otherwise mints once into the given output
+# directory (or a tmpdir) for human inspection.
+#
+# Spec: protocol/specs/2026-04-30-lift-plugin-protocol.md
+
+# Re-exec under a modern Ruby if started on the macOS system Ruby (< 3.0).
+# Endless-method syntax (def f = expr) and Struct keyword_init are 3.0+.
+if RUBY_VERSION < "3.0"
+  candidates = [
+    "/opt/homebrew/opt/ruby/bin/ruby",
+    "/usr/local/opt/ruby/bin/ruby",
+    "/opt/homebrew/bin/ruby",
+    "/usr/local/bin/ruby",
+  ]
+  better = candidates.find { |p| File.executable?(p) }
+  if better && better != RbConfig.ruby
+    exec(better, __FILE__, *ARGV)
+  end
+end
+
+require_relative "../lib/provekit/self_contracts"
+
+exit Provekit::SelfContracts.main(ARGV)

--- a/implementations/ruby/lib/provekit/self_contracts.rb
+++ b/implementations/ruby/lib/provekit/self_contracts.rb
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Provekit::SelfContracts
+#
+# Side A orchestrator for the Ruby kit. Walks the canonical Ruby slab,
+# mints each contract as a signed layered memento under the foundation
+# key, bundles them into a `.proof` envelope whose filename IS its CID.
+#
+# Mirrors the rust/cpp/go/ts Side A pattern. The contractSetCid we
+# produce is the BLAKE3-512 of the JCS encoding of the sorted list of
+# signer-independent contractCids; identical inputs produce byte-
+# identical CIDs across kits with the same authoring choices.
+#
+# Run modes:
+#   * Direct CLI invocation:   ruby -Ilib lib/provekit/self_contracts.rb [outDir]
+#   * Lift-protocol RPC mode:  ruby -Ilib lib/provekit/self_contracts.rb --rpc
+#
+# References:
+#   * implementations/cpp/provekit-self-contracts/mint_cpp_self_contracts.cpp
+#   * implementations/rust/provekit-self-contracts/src/bin/mint-self-contracts.rs
+#   * protocol/specs/2026-04-30-lift-plugin-protocol.md
+#   * protocol/specs/2026-05-03-contract-cid-vs-attestation-cid.md (contractCid)
+#   * protocol/specs/2026-05-03-contract-set-extension.md         (contractSetCid)
+
+require "base64"
+require "fileutils"
+require "json"
+require "tmpdir"
+
+require_relative "blake3"
+require_relative "ir"
+require_relative "cbor"
+require_relative "signing"
+require_relative "proof_envelope"
+
+module Provekit
+  module SelfContracts
+    PRODUCED_BY  = "provekit-ruby-self-contracts@1.0".freeze
+    DECLARED_AT  = "2026-04-30T18:00:00.000Z".freeze
+    CATALOG_NAME = "@provekit/ruby-self-contracts".freeze
+    CATALOG_VERSION = "1.0.0".freeze
+    LAYERED_SCHEMA_VERSION = "2".freeze
+
+    # ---- Slab authoring ---------------------------------------------------
+    #
+    # A "slab" is the set of contracts authored against one Ruby module.
+    # Each slab returns an array of Provekit::IR::ContractDecl values.
+    # Names MUST be unique across slabs. Predicates use the kit's IR
+    # primitives (already JCS-conformant per test_jcs_conformance.rb).
+    #
+    # Predicate style mirrors the cpp/go canonical slabs: shape-level
+    # claims (length, determinism) about the public API. Z3 cannot
+    # discharge most of these in isolation; the value is the living-doc
+    # IR shape the verifier indexes against.
+
+    IR_M = Provekit::IR
+
+    def self.slab_blake3
+      h_b = ->(s) { IR_M.ctor("Blake3.bytes", s) }
+      h_x = ->(s) { IR_M.ctor("Blake3.hex", s) }
+      [
+        IR_M::ContractDecl.new(
+          name: "ruby_blake3_bytes_length_eq_64",
+          out_binding: "out",
+          post: IR_M.eq(IR_M.ctor("byte_length", h_b.(IR_M.var(name: "s"))), IR_M.num(64)),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_blake3_hex_length_eq_139",
+          out_binding: "out",
+          post: IR_M.eq(IR_M.ctor("string_length", h_x.(IR_M.var(name: "s"))), IR_M.num(139)),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_blake3_hex_is_deterministic",
+          out_binding: "out",
+          post: IR_M.eq(h_x.(IR_M.var(name: "s")), h_x.(IR_M.var(name: "s"))),
+        ),
+      ]
+    end
+
+    def self.slab_jcs
+      enc = ->(v) { IR_M.ctor("Jcs.encode", v) }
+      [
+        IR_M::ContractDecl.new(
+          name: "ruby_jcs_encode_is_deterministic",
+          out_binding: "out",
+          post: IR_M.eq(enc.(IR_M.var(name: "v")), enc.(IR_M.var(name: "v"))),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_jcs_encode_true_length_eq_4",
+          out_binding: "out",
+          post: IR_M.eq(
+            IR_M.ctor("string_length", enc.(IR_M.bool(true))),
+            IR_M.num(4),
+          ),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_jcs_encode_null_length_eq_4",
+          out_binding: "out",
+          post: IR_M.eq(
+            IR_M.ctor("string_length", enc.(IR_M.null_ref)),
+            IR_M.num(4),
+          ),
+        ),
+      ]
+    end
+
+    def self.slab_cbor
+      [
+        IR_M::ContractDecl.new(
+          name: "ruby_cbor_tstr_roundtrip_length_gte_1",
+          out_binding: "out",
+          post: IR_M.gte(
+            IR_M.ctor("byte_length", IR_M.ctor("Cbor.encode_tstr", IR_M.var(name: "s"))),
+            IR_M.num(1),
+          ),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_cbor_bstr_roundtrip_length_gte_1",
+          out_binding: "out",
+          post: IR_M.gte(
+            IR_M.ctor("byte_length", IR_M.ctor("Cbor.encode_bstr", IR_M.var(name: "b"))),
+            IR_M.num(1),
+          ),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_cbor_encode_key_is_deterministic",
+          out_binding: "out",
+          post: IR_M.eq(
+            IR_M.ctor("Cbor.encode_key", IR_M.var(name: "k")),
+            IR_M.ctor("Cbor.encode_key", IR_M.var(name: "k")),
+          ),
+        ),
+      ]
+    end
+
+    def self.slab_signing
+      [
+        IR_M::ContractDecl.new(
+          name: "ruby_ed25519_signature_length_eq_64",
+          out_binding: "out",
+          post: IR_M.eq(
+            IR_M.ctor("byte_length",
+              IR_M.ctor("Signing.sign_with_seed",
+                IR_M.var(name: "seed"),
+                IR_M.var(name: "msg"))),
+            IR_M.num(64),
+          ),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_ed25519_pubkey_bytes_length_eq_32",
+          out_binding: "out",
+          post: IR_M.eq(
+            IR_M.ctor("byte_length",
+              IR_M.ctor("Signing.pubkey_bytes", IR_M.var(name: "seed"))),
+            IR_M.num(32),
+          ),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_ed25519_sign_is_deterministic",
+          out_binding: "out",
+          post: IR_M.eq(
+            IR_M.ctor("Signing.sign_with_seed",
+              IR_M.var(name: "seed"),
+              IR_M.var(name: "msg")),
+            IR_M.ctor("Signing.sign_with_seed",
+              IR_M.var(name: "seed"),
+              IR_M.var(name: "msg")),
+          ),
+        ),
+      ]
+    end
+
+    def self.slab_proof_envelope
+      [
+        IR_M::ContractDecl.new(
+          name: "ruby_proof_envelope_cid_has_blake3_512_prefix",
+          out_binding: "out",
+          post: IR_M.gte(
+            IR_M.ctor("string_length",
+              IR_M.ctor("ProofEnvelope.build_cid", IR_M.var(name: "input"))),
+            IR_M.num(11),
+          ),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_proof_envelope_cid_total_length_eq_139",
+          out_binding: "out",
+          post: IR_M.eq(
+            IR_M.ctor("string_length",
+              IR_M.ctor("ProofEnvelope.build_cid", IR_M.var(name: "input"))),
+            IR_M.num(139),
+          ),
+        ),
+        IR_M::ContractDecl.new(
+          name: "ruby_proof_envelope_build_is_deterministic",
+          out_binding: "out",
+          post: IR_M.eq(
+            IR_M.ctor("ProofEnvelope.build_cid", IR_M.var(name: "input")),
+            IR_M.ctor("ProofEnvelope.build_cid", IR_M.var(name: "input")),
+          ),
+        ),
+      ]
+    end
+
+    # Returns [{label:, path:, contracts:[ContractDecl]}, ...].
+    def self.author_all_invariants
+      [
+        { label: "blake3",         path: "implementations/ruby/lib/provekit/blake3.rb",         contracts: slab_blake3 },
+        { label: "jcs",            path: "implementations/ruby/lib/provekit/ir.rb",             contracts: slab_jcs },
+        { label: "cbor",           path: "implementations/ruby/lib/provekit/cbor.rb",           contracts: slab_cbor },
+        { label: "signing",        path: "implementations/ruby/lib/provekit/signing.rb",        contracts: slab_signing },
+        { label: "proof_envelope", path: "implementations/ruby/lib/provekit/proof_envelope.rb", contracts: slab_proof_envelope },
+      ]
+    end
+
+    # ---- Contract / contract-set CID --------------------------------------
+    #
+    # contractCid is the signer-independent BLAKE3-512(JCS({name, outBinding,
+    # pre?, post?, inv?})). The contractSetCid is BLAKE3-512(JCS(<sorted
+    # contractCids>)). Both shapes are byte-identical to the rust/cpp/go/ts
+    # peers per spec 2026-05-03-contract-cid-vs-attestation-cid.md and
+    # 2026-05-03-contract-set-extension.md.
+
+    def self.contract_cid(decl)
+      obj = { "name" => decl.name, "outBinding" => decl.out_binding }
+      obj["pre"]  = decl.pre  if decl.pre
+      obj["post"] = decl.post if decl.post
+      obj["inv"]  = decl.inv  if decl.inv
+      jcs = IR_M::Jcs.encode(obj)
+      Blake3.hex(jcs)
+    end
+
+    def self.compute_contract_set_cid(content_cids)
+      sorted = content_cids.dup.sort
+      jcs = IR_M::Jcs.encode(sorted)
+      Blake3.hex(jcs)
+    end
+
+    # ---- Layered memento mint --------------------------------------------
+    #
+    # Ports rust `provekit-claim-envelope` mint_contract. The result is the
+    # JCS-canonical bytes of `{envelope, header, metadata}`; the attestation
+    # CID is BLAKE3-512(JCS(envelope)). Per
+    # protocol/specs/2026-04-30-memento-envelope-grammar.md.
+
+    def self.hash_value_jcs(value)
+      Blake3.hex(IR_M::Jcs.encode(value))
+    end
+
+    def self.mint_contract(decl, signer_seed: Provekit::Signing::FOUNDATION_V0_SEED, produced_by: PRODUCED_BY, produced_at: DECLARED_AT, source_path: "")
+      raise ArgumentError, "contract must carry at least one of pre/post/inv" if decl.pre.nil? && decl.post.nil? && decl.inv.nil?
+      raise ArgumentError, "out_binding must be non-empty" if decl.out_binding.to_s.empty?
+
+      # propertyHash = BLAKE3-512(JCS({pre?, post?, inv?, outBinding}))
+      ph = {}
+      ph["pre"]  = decl.pre  if decl.pre
+      ph["post"] = decl.post if decl.post
+      ph["inv"]  = decl.inv  if decl.inv
+      ph["outBinding"] = decl.out_binding
+      property_hash = hash_value_jcs(ph)
+
+      # bindingHash = BLAKE3-512(JCS({producerId, contractName, propertyHash}))
+      bh = {
+        "producerId" => produced_by,
+        "contractName" => decl.name,
+        "propertyHash" => property_hash,
+      }
+      binding_hash = hash_value_jcs(bh)
+
+      header_cid = contract_cid(decl)
+
+      header = { "schemaVersion" => LAYERED_SCHEMA_VERSION, "kind" => "contract", "cid" => header_cid }
+      header["name"] = decl.name
+      header["outBinding"] = decl.out_binding
+      header["pre"]  = decl.pre  if decl.pre
+      header["post"] = decl.post if decl.post
+      header["inv"]  = decl.inv  if decl.inv
+      header["verdict"] = "holds"
+      header["bindingHash"] = binding_hash
+      header["propertyHash"] = property_hash
+      header["inputCids"] = []
+
+      authoring = {
+        "producerKind" => "kit-author",
+        "author" => produced_by,
+      }
+      authoring["note"] = "self-contract from #{source_path}" unless source_path.empty?
+
+      metadata = {
+        "authoring" => authoring,
+        "producedBy" => produced_by,
+        "producedAt" => produced_at,
+      }
+      metadata["preHash"]  = hash_value_jcs(decl.pre)  if decl.pre
+      metadata["postHash"] = hash_value_jcs(decl.post) if decl.post
+      metadata["invHash"]  = hash_value_jcs(decl.inv)  if decl.inv
+
+      # Signing message = JCS({header, metadata}); signature is the spec's
+      # self-identifying string form ("ed25519:" + base64(64-byte sig)).
+      signing_msg = IR_M::Jcs.encode({ "header" => header, "metadata" => metadata })
+      signature   = Provekit::Signing.ed25519_sign_string(signer_seed, signing_msg)
+      signer_str  = Provekit::Signing.ed25519_pubkey_string(signer_seed)
+
+      envelope = {
+        "signer" => signer_str,
+        "declaredAt" => produced_at,
+        "signature" => signature,
+      }
+      envelope_jcs = IR_M::Jcs.encode(envelope)
+      attestation_cid = Blake3.hex(envelope_jcs)
+
+      memento_jcs = IR_M::Jcs.encode({
+        "envelope" => envelope,
+        "header" => header,
+        "metadata" => metadata,
+      })
+
+      {
+        cid: attestation_cid,
+        contract_cid: header_cid,
+        canonical_bytes: memento_jcs.b,
+      }
+    end
+
+    # ---- Mint orchestrator ------------------------------------------------
+
+    MintResult = Struct.new(
+      :cid,
+      :contract_set_cid,
+      :bytes_len,
+      :path,
+      :member_count,
+      :total_contracts,
+      :per_source_counts,
+      keyword_init: true,
+    )
+
+    # Mints every authored contract as a layered memento, bundles into a
+    # `.proof` whose filename IS the catalog CID, writes to
+    # `<out_dir>/<catalog-cid>.proof`, and returns a MintResult.
+    def self.mint_self_proof(out_dir)
+      FileUtils.mkdir_p(out_dir)
+
+      slabs = author_all_invariants
+      seed = Provekit::Signing::FOUNDATION_V0_SEED
+      signer_pubkey = Provekit::Signing.ed25519_pubkey_string(seed)
+      signer_cid = Blake3.hex(signer_pubkey)
+
+      members = {}
+      seen_names = {}
+      content_cids = []
+      per_source_counts = []
+      total = 0
+
+      slabs.each do |slab|
+        per_source_counts << { label: slab[:label], count: slab[:contracts].length }
+        slab[:contracts].each do |decl|
+          if seen_names.key?(decl.name)
+            raise "duplicate contract name `#{decl.name}` across slabs"
+          end
+          seen_names[decl.name] = true
+          minted = mint_contract(decl, signer_seed: seed, source_path: slab[:path])
+          content_cids << minted[:contract_cid]
+          members[minted[:cid]] = minted[:canonical_bytes]
+          total += 1
+        end
+      end
+
+      input = Provekit::ProofEnvelope::Input.new(
+        name: CATALOG_NAME,
+        version: CATALOG_VERSION,
+        members: members,
+        signer_cid: signer_cid,
+        declared_at: DECLARED_AT,
+        signer_seed: seed,
+      )
+      built = Provekit::ProofEnvelope.build(input)
+
+      raise "internal: cid missing blake3-512 prefix: #{built.cid}" unless built.cid.start_with?("blake3-512:")
+
+      cset_cid = compute_contract_set_cid(content_cids)
+      out_path = File.join(out_dir, "#{built.cid}.proof")
+      File.binwrite(out_path, built.bytes)
+
+      MintResult.new(
+        cid: built.cid,
+        contract_set_cid: cset_cid,
+        bytes_len: built.bytes.bytesize,
+        path: out_path,
+        member_count: members.length,
+        total_contracts: total,
+        per_source_counts: per_source_counts,
+      )
+    end
+
+    # ---- RPC mode (lift-plugin-protocol over NDJSON stdio) ----------------
+    #
+    # Spec: protocol/specs/2026-04-30-lift-plugin-protocol.md
+    # Daemon-lifecycle pattern (issue #220 ts Side A): persistent stdio
+    # loop, EOF on stdin = graceful shutdown, explicit `shutdown` method
+    # acks then exits.
+
+    def self.run_rpc_mode(stdin: $stdin, stdout: $stdout)
+      stdin.binmode if stdin.respond_to?(:binmode)
+      stdout.sync = true if stdout.respond_to?(:sync=)
+
+      while (line = stdin.gets)
+        line = line.strip
+        next if line.empty?
+
+        begin
+          req = JSON.parse(line)
+        rescue JSON::ParserError => e
+          write_rpc(stdout, jsonrpc: "2.0", id: nil, error: { code: -32700, message: "Parse error: #{e}" })
+          next
+        end
+
+        id     = req["id"]
+        method = req["method"].to_s
+
+        case method
+        when "initialize"
+          write_rpc(stdout, jsonrpc: "2.0", id: id, result: {
+            name: "ruby-self-contracts",
+            version: "1.0.0",
+            protocol_version: "provekit-lift/1",
+            capabilities: {
+              authoring_surfaces: ["ruby-self-contracts"],
+              ir_version: "v1.1.0",
+              emits_signed_mementos: true,
+            },
+          })
+        when "lift"
+          tmp = Dir.mktmpdir("provekit-ruby-rpc-")
+          begin
+            mint = mint_self_proof(tmp)
+            bytes = File.binread(mint.path)
+            b64 = Base64.strict_encode64(bytes)
+            write_rpc(stdout, jsonrpc: "2.0", id: id, result: {
+              kind: "proof-envelope",
+              filename_cid: mint.cid,
+              contract_set_cid: mint.contract_set_cid,
+              bytes_base64: b64,
+              diagnostics: [],
+            })
+          rescue StandardError => e
+            write_rpc(stdout, jsonrpc: "2.0", id: id, error: { code: 1005, message: "LIFT_FAILED: #{e.message}" })
+          ensure
+            FileUtils.remove_entry(tmp) if File.directory?(tmp)
+          end
+        when "shutdown"
+          write_rpc(stdout, jsonrpc: "2.0", id: id, result: nil)
+          return 0
+        else
+          write_rpc(stdout, jsonrpc: "2.0", id: id, error: { code: -32601, message: "METHOD_NOT_FOUND: #{method}" })
+        end
+      end
+      0
+    end
+
+    def self.write_rpc(out, payload)
+      out.write(JSON.generate(payload))
+      out.write("\n")
+      out.flush if out.respond_to?(:flush)
+    end
+
+    # ---- Direct CLI (also used by smoke tests) ----------------------------
+
+    def self.main(argv)
+      if argv.include?("--rpc")
+        return run_rpc_mode
+      end
+
+      out_dir = argv[0] || File.join(Dir.tmpdir, "provekit-ruby-self-contracts-#{Process.pid}")
+      det_dir = File.join(Dir.tmpdir, "provekit-ruby-self-determinism-#{Process.pid}")
+      FileUtils.rm_rf(det_dir)
+
+      $stdout.puts "== ProvekIt Ruby self-contracts orchestrator =="
+      $stdout.puts ""
+      $stdout.puts "output dir: #{out_dir}"
+
+      begin
+        mint_a = mint_self_proof(det_dir)
+        mint_b = mint_self_proof(out_dir)
+      rescue StandardError => e
+        $stderr.puts "ERROR: mint failed: #{e.message}"
+        $stderr.puts e.backtrace.join("\n") if $DEBUG
+        return 1
+      end
+
+      $stdout.puts ""
+      $stdout.puts "authored:"
+      mint_b.per_source_counts.each do |row|
+        $stdout.puts format("  %22s  %2d contracts", row[:label], row[:count])
+      end
+      $stdout.puts format("  %22s  %2d contracts (TOTAL)", "[ALL]", mint_b.total_contracts)
+
+      $stdout.puts ""
+      $stdout.puts "minted:"
+      $stdout.puts "  .proof file:        #{mint_b.path}"
+      $stdout.puts "  bytes:              #{mint_b.bytes_len}"
+      $stdout.puts "  members:            #{mint_b.member_count}"
+      $stdout.puts "  total contracts:    #{mint_b.total_contracts}"
+      $stdout.puts "  catalog CID:        #{mint_b.cid}"
+      $stdout.puts "  contractSetCid:     #{mint_b.contract_set_cid}"
+
+      if mint_a.cid != mint_b.cid || mint_a.contract_set_cid != mint_b.contract_set_cid
+        $stderr.puts ""
+        $stderr.puts "ERROR: byte-determinism check FAILED:"
+        $stderr.puts "  run A CID:              #{mint_a.cid}"
+        $stderr.puts "  run B CID:              #{mint_b.cid}"
+        $stderr.puts "  run A contractSetCid:   #{mint_a.contract_set_cid}"
+        $stderr.puts "  run B contractSetCid:   #{mint_b.contract_set_cid}"
+        FileUtils.rm_rf(det_dir)
+        return 2
+      end
+
+      FileUtils.rm_rf(det_dir)
+      $stdout.puts "  determinism check:  OK (two runs produced identical CIDs)"
+      $stdout.puts ""
+      $stdout.puts "== done. Ruby self-application: live. =="
+      0
+    end
+  end
+end
+
+# Direct invocation guard
+if $PROGRAM_NAME == __FILE__
+  exit Provekit::SelfContracts.main(ARGV)
+end

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -102,7 +102,7 @@ const KIT_TABLE: &[(&str, &str, &str, &str)] = &[
     ("swift",      "swift",       "swift-self-contracts", "swift"),
     ("java",       "java",        "java-self-contracts",  "java"),
     ("python",     "python",      "python-self-contracts", "python"),
-    ("ruby",       "ruby",        "ruby",                 "ruby"),
+    ("ruby",       "ruby",        "ruby-self-contracts",  "ruby"),
     ("zig",        "zig",         "zig",                  "zig"),
     ("c",          "c",           "c-self-contracts",     "c"),
 ];

--- a/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
+++ b/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
@@ -154,12 +154,12 @@ fn assert_attestation_structure(v: &serde_json::Value, lang: &str) {
 /// fallback fires, producing an empty-set CID. The all-kits structure test
 /// tolerates this; the pinned-CID test (`swift_kit_pins_expected_contract_set_cid`)
 /// is `#[cfg_attr(not(target_os = "macos"), ignore)]` so it doesn't fail on Linux.
-const KITS_WITH_LIFTERS: &[&str] = &["rust", "go", "cpp", "ts", "csharp", "swift", "java", "python", "c"];
+const KITS_WITH_LIFTERS: &[&str] = &["rust", "go", "cpp", "ts", "csharp", "swift", "java", "python", "c", "ruby"];
 
 /// Kits without a lifter binary yet — produce the empty-set CID because the
 /// binary cannot be found (ENOENT on spawn). These declare the binary name but
 /// the binary is not installed; the gap surfaces as an empty-set attestation.
-const KITS_WITHOUT_LIFTERS: &[&str] = &["ruby", "zig"];
+const KITS_WITHOUT_LIFTERS: &[&str] = &["zig"];
 
 /// Kits that have a lifter AND are expected to find real contracts.
 /// Only include kits where the test environment reliably has the lifter built
@@ -167,7 +167,7 @@ const KITS_WITHOUT_LIFTERS: &[&str] = &["ruby", "zig"];
 ///
 /// `swift` is on macOS only; the all-kits run handles Linux gracefully via the
 /// `failed_kits` skip path because the release binary is missing.
-const KITS_WITH_REAL_CONTRACTS: &[&str] = &["rust", "go", "cpp", "python"];
+const KITS_WITH_REAL_CONTRACTS: &[&str] = &["rust", "go", "cpp", "python", "ruby"];
 
 /// Pinned contractSetCid for `--kit=go` after Tier 1 wiring fix (#176).
 /// Reflects the 11 canonical contracts in `implementations/go/provekit-self-contracts/slabs/`.
@@ -819,4 +819,53 @@ fn c_kit_pins_expected_contract_set_cid() {
     );
 
     eprintln!("c kit contractSetCid pinned correctly: {cset}");
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: ruby kit contractSetCid is pinned to the canonical self-contracts CID
+//          (issue #209 wiring -- ruby Side A bootstrap)
+// ---------------------------------------------------------------------------
+
+/// Pinned contractSetCid produced by `--kit=ruby` after routing to the
+/// `ruby-self-contracts` surface (mint-ruby-self-contracts RPC, canonical
+/// 5-slab, 15-contract set). Mirrors the rust/go/cpp/ts pinning pattern.
+///
+/// If this test fails with the empty-set CID (`d53d18c2...`), the KIT_TABLE
+/// routing regression has been reintroduced. If it fails with an unknown CID,
+/// the ruby slab contracts have changed -- update RUBY_KIT_CONTRACT_SET_CID.
+const RUBY_KIT_CONTRACT_SET_CID: &str =
+    "blake3-512:961be80d8a5ae8f3d8255462fc1845d5b45f30c0b4412c9d8b354078d63096ba363b6ae0dea4f2e35141213dc5c6b855156f434b5620a345bfbc20725bee00ff";
+
+#[test]
+#[serial(mint_kit_files)]
+fn ruby_kit_pins_expected_contract_set_cid() {
+    let root = repo_root();
+
+    let (ok, stdout, stderr) = run_mint("ruby");
+    if !ok {
+        eprintln!(
+            "ruby kit: mint failed (ruby toolchain may not be available)\n  stderr: {stderr}"
+        );
+        // Skip rather than fail -- ruby toolchain may not be present in all environments.
+        return;
+    }
+
+    assert!(
+        stdout.contains("contractSetCid:"),
+        "ruby kit: stdout must contain 'contractSetCid:'\n  stdout: {stdout}"
+    );
+
+    let attest = read_attestation(&root, "ruby");
+    let cset = attest["contractSetCid"].as_str().unwrap();
+
+    assert_ne!(
+        cset, EMPTY_SET_CID,
+        "ruby kit: contractSetCid must NOT be the empty-set sentinel -- routing regression detected (issue #209)"
+    );
+    assert_eq!(
+        cset, RUBY_KIT_CONTRACT_SET_CID,
+        "ruby kit: contractSetCid does not match pinned value from 5-slab, 15-contract set (issue #209)"
+    );
+
+    eprintln!("ruby kit contractSetCid pinned correctly: {cset}");
 }


### PR DESCRIPTION
## Summary

Side A bootstrap for the Ruby kit per issue #176. The orchestrator walks the canonical ruby slab (5 slabs, 15 contracts about `blake3` / `jcs` / `cbor` / `signing` / `proof_envelope`), mints each contract as a layered signed memento under the foundation key (test seed `[0x42; 32]`), and bundles the result into a `.proof` envelope whose filename IS its catalog CID. The KIT_TABLE flip routes `--kit=ruby` from the placeholder `ruby` surface to the new `ruby-self-contracts` surface, mirroring the rust / go / cpp / ts wiring pattern (PRs #180, #183, #217, #220).

The orchestrator imports the ruby crypto substrate that landed in PR #226 (`Provekit::Blake3`, `Provekit::Cbor`, `Provekit::Signing`, `Provekit::IR::Jcs`, `Provekit::ProofEnvelope`); no reimplementation. The layered-memento mint (`{envelope, header, metadata}` with v2 schema, propertyHash, bindingHash, verdict:"holds") is ported 1:1 from `implementations/rust/provekit-claim-envelope/src/lib.rs`.

The `--rpc` mode follows the daemon-lifecycle pattern PR #220 established: persistent stdio loop, EOF on stdin = graceful shutdown, explicit `shutdown` method acks then exits.

## Acceptance criteria (issue #209)

- [x] Create `implementations/ruby/lib/provekit/self_contracts.rb` orchestrator
- [x] Author the ruby slab with the canonical contracts
- [x] RPC layer emitting proof-envelope to stdout under canonical `--rpc` lift-protocol framing
- [x] Add `ruby-self-contracts` lift surface manifest at `implementations/ruby/.provekit/lift/ruby-self-contracts/manifest.toml`
- [x] Update `KIT_TABLE` in `implementations/rust/provekit-cli/src/cmd_mint.rs` to route the ruby entry to the new surface
- [x] Add a pinned-CID test in `mint_kit_integration.rs`
- [x] `make mint-ruby` produces a content-meaningful contractSetCid (not the empty-set sentinel)
- [x] `provekit prove implementations/ruby` exits 0
- [x] Pinned-CID test passes

## KIT_TABLE diff

```rust
// before
("ruby",       "ruby",        "ruby",                 "ruby"),
// after
("ruby",       "ruby",        "ruby-self-contracts",  "ruby"),
```

## `make mint-ruby` output

```
>> minting ruby self-contracts
  cid:            blake3-512:6358ad54d0535d87be144d765127b7dcdde7fa6d807e27b8d85f4d3549609cd7fb573a711e7668152339753398c68dbb5e23dc2e0083ca5e7dc2c00e439d69da
  contractSetCid: blake3-512:961be80d8a5ae8f3d8255462fc1845d5b45f30c0b4412c9d8b354078d63096ba363b6ae0dea4f2e35141213dc5c6b855156f434b5620a345bfbc20725bee00ff
OK  .provekit/self-contracts-attestations/ruby.json (contractSetCid blake3-512:961be80d8a5ae8f3d8255462fc1845d5b45f30c0b4412c9d8b354078d63096ba363b6ae0dea4f2e35141213dc5c6b855156f434b5620a345bfbc20725bee00ff)
```

The catalog CID (`6358ad54...`) and contractSetCid (`961be80d...`) are byte-deterministic across two consecutive mint runs (orchestrator's built-in determinism check, plus the rust integration test).

## Daemon-lifecycle adherence (PR #220)

- Persistent NDJSON stdio loop (one process serves multiple `lift` calls).
- `initialize` returns the protocol version, plugin name, and capabilities.
- `lift` returns the `proof-envelope` shape with base64-encoded bytes.
- `shutdown` writes the ack response and exits 0.
- EOF on stdin = graceful shutdown (loop exit returns 0).
- Errors emit JSON-RPC error objects (`-32700` parse, `-32601` method-not-found, `1005` LIFT_FAILED) without crashing the process.

## Test plan

- [x] `make mint-ruby` (passes; deterministic across runs).
- [x] `provekit prove implementations/ruby` (exit 0).
- [x] `cargo test --release -p provekit-cli --test mint_kit_integration ruby_kit_pins_expected_contract_set_cid` passes.
- [x] All pre-existing ruby unit tests in `implementations/ruby/test/` continue to pass on Homebrew ruby 3.x (test_blake3, test_cbor, test_daemon_protocol, test_ffi_resolver, test_jcs_conformance, test_proof_envelope, test_signing).
- [x] Direct CLI smoke (`ruby -Ilib bin/mint-ruby-self-contracts`) and RPC smoke (`echo '{"jsonrpc":"2.0","id":1,"method":"initialize"}' | ruby -Ilib bin/mint-ruby-self-contracts --rpc`) both green.

## Notes

- **Ruby version**: the orchestrator uses Ruby 3.0+ syntax (Struct keyword_init, endless methods inherited from `provekit/ir.rb`). The bin script re-execs under Homebrew ruby (`/opt/homebrew/opt/ruby/bin/ruby` or `/usr/local/opt/ruby/bin/ruby`) when launched under the macOS system Ruby (2.6.x), mirroring `provekit-lsp-ruby`.
- **Cross-kit byte-equality**: the contractSetCid is computed via `BLAKE3-512(JCS(sorted_contractCids))`, where each `contractCid = BLAKE3-512(JCS({name, outBinding, pre?, post?, inv?}))`. This is the cross-kit-shared shape from spec `2026-05-03-contract-cid-vs-attestation-cid.md` and `2026-05-03-contract-set-extension.md`. Different kits author different contracts, so their contractSetCids differ; what's byte-equal cross-kit is the *encoding*, not the *contracts*.
- **`libblake3` runtime dep** (from PR #226): the ruby kit FFI-binds to `libblake3`; CI Linux runners need `apt-get install libblake3-dev` once a ruby workflow is added (no ruby workflow exists today). Local macOS uses `brew install blake3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)