### PR TITLE
feat(swift): Side B native crypto library (closes #212)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,6 +408,7 @@ test-java: build-java
 test-swift: build-swift
 	cd implementations/swift && swift run conformance
 	cd implementations/swift && swift run test-swift-lsp
+	cd implementations/swift && swift run test-swift-crypto
 
 .PHONY: test-zig
 test-zig:

--- a/implementations/swift/Package.swift
+++ b/implementations/swift/Package.swift
@@ -3,18 +3,104 @@
 
 import PackageDescription
 
+// Optional override for non-Homebrew OpenSSL prefix. Mirrors the C++
+// peer build script (tools/run-proof-envelope-conformance.sh):
+//   OPENSSL_PREFIX=/usr/local/opt/openssl@3 swift build
+import Foundation
+let opensslPrefix: String = {
+    if let env = ProcessInfo.processInfo.environment["OPENSSL_PREFIX"], !env.isEmpty {
+        return env
+    }
+    // Default for Homebrew on x86_64 macOS. ARM Macs use /opt/homebrew.
+    if FileManager.default.fileExists(atPath: "/opt/homebrew/opt/openssl@3/include/openssl/evp.h") {
+        return "/opt/homebrew/opt/openssl@3"
+    }
+    return "/usr/local/opt/openssl@3"
+}()
+
 let package = Package(
     name: "Provekit",
+    // Issue #155 / #212: swift kit is macOS-only. The Foundation v0
+    // ed25519 path uses OpenSSL libcrypto (same backing as the C and
+    // C++ peer kits) for RFC-8032 deterministic signatures; macOS 10.15
+    // is the minimum for the rest of the kit's API surface.
+    platforms: [
+        .macOS(.v10_15),
+    ],
     products: [
         .library(name: "Provekit", targets: ["Provekit"]),
+        .library(name: "ProvekitCrypto", targets: ["ProvekitCrypto"]),
         .library(name: "SwiftLifter", targets: ["SwiftLifter"]),
         .executable(name: "conformance", targets: ["ConformanceRunner"]),
         .executable(name: "provekit-lsp-swift", targets: ["ProveKitLSPSwift"]),
         .executable(name: "mint-swift-self-contracts", targets: ["MintSwiftSelfContracts"]),
         .executable(name: "test-swift-lsp", targets: ["LSPTests"]),
+        .executable(name: "test-swift-crypto", targets: ["CryptoTests"]),
     ],
     targets: [
-        .target(name: "Provekit"),
+        // CBlake3: vendored portable BLAKE3 reference C implementation.
+        // Source: tools/blake3-vendored/, BLAKE3 1.8.5, Apache-2.0.
+        // Public header: include/blake3.h. The portable path is selected
+        // unconditionally via -DBLAKE3_NO_AVX2/SSE2/SSE41/AVX512 + USE_NEON=0,
+        // matching the C++ peer self-contracts orchestrator's flags.
+        // Performance is irrelevant for the tens of contracts the kit hashes.
+        .target(
+            name: "CBlake3",
+            publicHeadersPath: "include",
+            cSettings: [
+                .define("BLAKE3_NO_AVX2"),
+                .define("BLAKE3_NO_AVX512"),
+                .define("BLAKE3_NO_SSE2"),
+                .define("BLAKE3_NO_SSE41"),
+                .define("BLAKE3_USE_NEON", to: "0"),
+            ]
+        ),
+        // CEd25519: vendored thin wrapper over OpenSSL EVP_PKEY_ED25519.
+        // Source: tools/ed25519-vendored/, Apache-2.0.
+        //
+        // Why OpenSSL: the cpp + c peer kits use the same backing
+        // (`EVP_PKEY_ED25519`) for byte-identical signatures with rust's
+        // ed25519-dalek and go's crypto/ed25519. Apple's CryptoKit on
+        // macOS / iOS implements `Curve25519.Signing` with intentional
+        // signature randomization (a fault-injection mitigation that
+        // mixes a CSPRNG nonce into every signature). RFC 8032 mandates
+        // deterministic signatures; CryptoKit deviates. swift-crypto's
+        // BoringSSL backend is gated off on Apple platforms (it
+        // re-exports CryptoKit), so neither library produces the
+        // deterministic signature the cross-kit byte-equivalence AC
+        // requires. Using the same OpenSSL primitive every other C-side
+        // kit uses guarantees byte-level agreement with zero ambiguity.
+        //
+        // Build requirement: OpenSSL 1.1+ or 3.x at $OPENSSL_PREFIX
+        // (default /usr/local/opt/openssl@3, falling back to
+        // /opt/homebrew/opt/openssl@3 on ARM Macs).
+        .target(
+            name: "CEd25519",
+            publicHeadersPath: "include",
+            cSettings: [
+                .unsafeFlags(["-I\(opensslPrefix)/include"]),
+            ],
+            linkerSettings: [
+                .unsafeFlags([
+                    "-L\(opensslPrefix)/lib",
+                    "-lcrypto",
+                ]),
+            ]
+        ),
+        // ProvekitCrypto: native Swift substrate (Side B per issue #176/#212).
+        // Provides BLAKE3-512, deterministic CBOR (RFC 8949 §4.2.1),
+        // RFC 8785 JCS, Ed25519 (vendored OpenSSL wrapper), and
+        // claim/proof envelope construction. No shell-out; all
+        // primitives are in-process and byte-equivalent to the rust /
+        // go / cpp / c peer kits.
+        .target(
+            name: "ProvekitCrypto",
+            dependencies: ["CBlake3", "CEd25519"]
+        ),
+        .target(
+            name: "Provekit",
+            dependencies: ["ProvekitCrypto"]
+        ),
         .target(
             name: "SwiftLifter",
             dependencies: []
@@ -36,6 +122,14 @@ let package = Package(
         .executableTarget(
             name: "LSPTests",
             dependencies: ["SwiftLifter"]
+        ),
+        // CryptoTests: substrate determinism + cross-kit byte-equivalence.
+        // Standalone executable runner mirroring LSPTests' pattern (no
+        // XCTest/Testing dep — neither is available on CI without full Xcode).
+        // `swift run test-swift-crypto` exits 0 on pass, 1 on any fail.
+        .executableTarget(
+            name: "CryptoTests",
+            dependencies: ["ProvekitCrypto"]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/implementations/swift/Sources/CBlake3/LICENSE_A2
+++ b/implementations/swift/Sources/CBlake3/LICENSE_A2
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Jack O'Connor and Samuel Neves
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/implementations/swift/Sources/CBlake3/README.md
+++ b/implementations/swift/Sources/CBlake3/README.md
@@ -1,0 +1,40 @@
+# CBlake3 — vendored BLAKE3 portable C source for the Swift kit
+
+**Canonical source:** `tools/blake3-vendored/`. This directory is a
+**copy**, NOT a symlink, because SwiftPM does not discover targets
+through directory symlinks (it requires the source files to live inside
+the package root tree, accessed without symlink traversal). All other
+ProvekIt kits reference `tools/blake3-vendored/` directly via Make /
+CMake / build scripts; only this Swift target needs the in-tree copy.
+
+The two copies MUST stay byte-identical. The header layout differs
+slightly: SwiftPM expects public headers under `include/` (so
+`blake3.h` lives at `Sources/CBlake3/include/blake3.h`), while the
+canonical layout has it alongside the `.c` files. Everything else is
+verbatim.
+
+## Refresh procedure
+
+When the canonical `tools/blake3-vendored/` is refreshed from upstream
+(per `tools/blake3-vendored/README.md`), mirror the change here:
+
+```sh
+cp tools/blake3-vendored/blake3.c \
+   tools/blake3-vendored/blake3_dispatch.c \
+   tools/blake3-vendored/blake3_impl.h \
+   tools/blake3-vendored/blake3_portable.c \
+   tools/blake3-vendored/LICENSE_A2 \
+   implementations/swift/Sources/CBlake3/
+
+cp tools/blake3-vendored/blake3.h \
+   implementations/swift/Sources/CBlake3/include/
+```
+
+## Verification
+
+`diff -r tools/blake3-vendored/ implementations/swift/Sources/CBlake3/`
+should report only:
+- `Only in tools/blake3-vendored: README.md` (canonical README, not needed in copy)
+- `Only in tools/blake3-vendored: blake3.h` (lives at `include/blake3.h` in the copy)
+- `Only in implementations/swift/Sources/CBlake3: include`
+- `Only in implementations/swift/Sources/CBlake3: README.md` (this file)

--- a/implementations/swift/Sources/CBlake3/blake3.c
+++ b/implementations/swift/Sources/CBlake3/blake3.c
@@ -1,0 +1,651 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "blake3.h"
+#include "blake3_impl.h"
+
+const char *blake3_version(void) { return BLAKE3_VERSION_STRING; }
+
+INLINE void chunk_state_init(blake3_chunk_state *self, const uint32_t key[8],
+                             uint8_t flags) {
+  memcpy(self->cv, key, BLAKE3_KEY_LEN);
+  self->chunk_counter = 0;
+  memset(self->buf, 0, BLAKE3_BLOCK_LEN);
+  self->buf_len = 0;
+  self->blocks_compressed = 0;
+  self->flags = flags;
+}
+
+INLINE void chunk_state_reset(blake3_chunk_state *self, const uint32_t key[8],
+                              uint64_t chunk_counter) {
+  memcpy(self->cv, key, BLAKE3_KEY_LEN);
+  self->chunk_counter = chunk_counter;
+  self->blocks_compressed = 0;
+  memset(self->buf, 0, BLAKE3_BLOCK_LEN);
+  self->buf_len = 0;
+}
+
+INLINE size_t chunk_state_len(const blake3_chunk_state *self) {
+  return (BLAKE3_BLOCK_LEN * (size_t)self->blocks_compressed) +
+         ((size_t)self->buf_len);
+}
+
+INLINE size_t chunk_state_fill_buf(blake3_chunk_state *self,
+                                   const uint8_t *input, size_t input_len) {
+  size_t take = BLAKE3_BLOCK_LEN - ((size_t)self->buf_len);
+  if (take > input_len) {
+    take = input_len;
+  }
+  uint8_t *dest = self->buf + ((size_t)self->buf_len);
+  memcpy(dest, input, take);
+  self->buf_len += (uint8_t)take;
+  return take;
+}
+
+INLINE uint8_t chunk_state_maybe_start_flag(const blake3_chunk_state *self) {
+  if (self->blocks_compressed == 0) {
+    return CHUNK_START;
+  } else {
+    return 0;
+  }
+}
+
+typedef struct {
+  uint32_t input_cv[8];
+  uint64_t counter;
+  uint8_t block[BLAKE3_BLOCK_LEN];
+  uint8_t block_len;
+  uint8_t flags;
+} output_t;
+
+INLINE output_t make_output(const uint32_t input_cv[8],
+                            const uint8_t block[BLAKE3_BLOCK_LEN],
+                            uint8_t block_len, uint64_t counter,
+                            uint8_t flags) {
+  output_t ret;
+  memcpy(ret.input_cv, input_cv, 32);
+  memcpy(ret.block, block, BLAKE3_BLOCK_LEN);
+  ret.block_len = block_len;
+  ret.counter = counter;
+  ret.flags = flags;
+  return ret;
+}
+
+// Chaining values within a given chunk (specifically the compress_in_place
+// interface) are represented as words. This avoids unnecessary bytes<->words
+// conversion overhead in the portable implementation. However, the hash_many
+// interface handles both user input and parent node blocks, so it accepts
+// bytes. For that reason, chaining values in the CV stack are represented as
+// bytes.
+INLINE void output_chaining_value(const output_t *self, uint8_t cv[32]) {
+  uint32_t cv_words[8];
+  memcpy(cv_words, self->input_cv, 32);
+  blake3_compress_in_place(cv_words, self->block, self->block_len,
+                           self->counter, self->flags);
+  store_cv_words(cv, cv_words);
+}
+
+INLINE void output_root_bytes(const output_t *self, uint64_t seek, uint8_t *out,
+                              size_t out_len) {
+  if (out_len == 0) {
+      return;
+  }
+  uint64_t output_block_counter = seek / 64;
+  size_t offset_within_block = seek % 64;
+  uint8_t wide_buf[64];
+  if(offset_within_block) {
+    blake3_compress_xof(self->input_cv, self->block, self->block_len, output_block_counter, self->flags | ROOT, wide_buf);
+    const size_t available_bytes = 64 - offset_within_block;
+    const size_t bytes = out_len > available_bytes ? available_bytes : out_len;
+    memcpy(out, wide_buf + offset_within_block, bytes);
+    out += bytes;
+    out_len -= bytes;
+    output_block_counter += 1;
+  }
+  if(out_len / 64) {
+    blake3_xof_many(self->input_cv, self->block, self->block_len, output_block_counter, self->flags | ROOT, out, out_len / 64);
+  }
+  output_block_counter += out_len / 64;
+  out += out_len & -64;
+  out_len -= out_len & -64;
+  if(out_len) {
+    blake3_compress_xof(self->input_cv, self->block, self->block_len, output_block_counter, self->flags | ROOT, wide_buf);
+    memcpy(out, wide_buf, out_len);
+  }
+}
+
+INLINE void chunk_state_update(blake3_chunk_state *self, const uint8_t *input,
+                               size_t input_len) {
+  if (self->buf_len > 0) {
+    size_t take = chunk_state_fill_buf(self, input, input_len);
+    input += take;
+    input_len -= take;
+    if (input_len > 0) {
+      blake3_compress_in_place(
+          self->cv, self->buf, BLAKE3_BLOCK_LEN, self->chunk_counter,
+          self->flags | chunk_state_maybe_start_flag(self));
+      self->blocks_compressed += 1;
+      self->buf_len = 0;
+      memset(self->buf, 0, BLAKE3_BLOCK_LEN);
+    }
+  }
+
+  while (input_len > BLAKE3_BLOCK_LEN) {
+    blake3_compress_in_place(self->cv, input, BLAKE3_BLOCK_LEN,
+                             self->chunk_counter,
+                             self->flags | chunk_state_maybe_start_flag(self));
+    self->blocks_compressed += 1;
+    input += BLAKE3_BLOCK_LEN;
+    input_len -= BLAKE3_BLOCK_LEN;
+  }
+
+  chunk_state_fill_buf(self, input, input_len);
+}
+
+INLINE output_t chunk_state_output(const blake3_chunk_state *self) {
+  uint8_t block_flags =
+      self->flags | chunk_state_maybe_start_flag(self) | CHUNK_END;
+  return make_output(self->cv, self->buf, self->buf_len, self->chunk_counter,
+                     block_flags);
+}
+
+INLINE output_t parent_output(const uint8_t block[BLAKE3_BLOCK_LEN],
+                              const uint32_t key[8], uint8_t flags) {
+  return make_output(key, block, BLAKE3_BLOCK_LEN, 0, flags | PARENT);
+}
+
+// Given some input larger than one chunk, return the number of bytes that
+// should go in the left subtree. This is the largest power-of-2 number of
+// chunks that leaves at least 1 byte for the right subtree.
+INLINE size_t left_subtree_len(size_t input_len) {
+  // Subtract 1 to reserve at least one byte for the right side. input_len
+  // should always be greater than BLAKE3_CHUNK_LEN.
+  size_t full_chunks = (input_len - 1) / BLAKE3_CHUNK_LEN;
+  return round_down_to_power_of_2(full_chunks) * BLAKE3_CHUNK_LEN;
+}
+
+// Use SIMD parallelism to hash up to MAX_SIMD_DEGREE chunks at the same time
+// on a single thread. Write out the chunk chaining values and return the
+// number of chunks hashed. These chunks are never the root and never empty;
+// those cases use a different codepath.
+INLINE size_t compress_chunks_parallel(const uint8_t *input, size_t input_len,
+                                       const uint32_t key[8],
+                                       uint64_t chunk_counter, uint8_t flags,
+                                       uint8_t *out) {
+#if defined(BLAKE3_TESTING)
+  assert(0 < input_len);
+  assert(input_len <= MAX_SIMD_DEGREE * BLAKE3_CHUNK_LEN);
+#endif
+
+  const uint8_t *chunks_array[MAX_SIMD_DEGREE];
+  size_t input_position = 0;
+  size_t chunks_array_len = 0;
+  while (input_len - input_position >= BLAKE3_CHUNK_LEN) {
+    chunks_array[chunks_array_len] = &input[input_position];
+    input_position += BLAKE3_CHUNK_LEN;
+    chunks_array_len += 1;
+  }
+
+  blake3_hash_many(chunks_array, chunks_array_len,
+                   BLAKE3_CHUNK_LEN / BLAKE3_BLOCK_LEN, key, chunk_counter,
+                   true, flags, CHUNK_START, CHUNK_END, out);
+
+  // Hash the remaining partial chunk, if there is one. Note that the empty
+  // chunk (meaning the empty message) is a different codepath.
+  if (input_len > input_position) {
+    uint64_t counter = chunk_counter + (uint64_t)chunks_array_len;
+    blake3_chunk_state chunk_state;
+    chunk_state_init(&chunk_state, key, flags);
+    chunk_state.chunk_counter = counter;
+    chunk_state_update(&chunk_state, &input[input_position],
+                       input_len - input_position);
+    output_t output = chunk_state_output(&chunk_state);
+    output_chaining_value(&output, &out[chunks_array_len * BLAKE3_OUT_LEN]);
+    return chunks_array_len + 1;
+  } else {
+    return chunks_array_len;
+  }
+}
+
+// Use SIMD parallelism to hash up to MAX_SIMD_DEGREE parents at the same time
+// on a single thread. Write out the parent chaining values and return the
+// number of parents hashed. (If there's an odd input chaining value left over,
+// return it as an additional output.) These parents are never the root and
+// never empty; those cases use a different codepath.
+INLINE size_t compress_parents_parallel(const uint8_t *child_chaining_values,
+                                        size_t num_chaining_values,
+                                        const uint32_t key[8], uint8_t flags,
+                                        uint8_t *out) {
+#if defined(BLAKE3_TESTING)
+  assert(2 <= num_chaining_values);
+  assert(num_chaining_values <= 2 * MAX_SIMD_DEGREE_OR_2);
+#endif
+
+  const uint8_t *parents_array[MAX_SIMD_DEGREE_OR_2];
+  size_t parents_array_len = 0;
+  while (num_chaining_values - (2 * parents_array_len) >= 2) {
+    parents_array[parents_array_len] =
+        &child_chaining_values[2 * parents_array_len * BLAKE3_OUT_LEN];
+    parents_array_len += 1;
+  }
+
+  blake3_hash_many(parents_array, parents_array_len, 1, key,
+                   0, // Parents always use counter 0.
+                   false, flags | PARENT,
+                   0, // Parents have no start flags.
+                   0, // Parents have no end flags.
+                   out);
+
+  // If there's an odd child left over, it becomes an output.
+  if (num_chaining_values > 2 * parents_array_len) {
+    memcpy(&out[parents_array_len * BLAKE3_OUT_LEN],
+           &child_chaining_values[2 * parents_array_len * BLAKE3_OUT_LEN],
+           BLAKE3_OUT_LEN);
+    return parents_array_len + 1;
+  } else {
+    return parents_array_len;
+  }
+}
+
+// The wide helper function returns (writes out) an array of chaining values
+// and returns the length of that array. The number of chaining values returned
+// is the dynamically detected SIMD degree, at most MAX_SIMD_DEGREE. Or fewer,
+// if the input is shorter than that many chunks. The reason for maintaining a
+// wide array of chaining values going back up the tree, is to allow the
+// implementation to hash as many parents in parallel as possible.
+//
+// As a special case when the SIMD degree is 1, this function will still return
+// at least 2 outputs. This guarantees that this function doesn't perform the
+// root compression. (If it did, it would use the wrong flags, and also we
+// wouldn't be able to implement extendable output.) Note that this function is
+// not used when the whole input is only 1 chunk long; that's a different
+// codepath.
+//
+// Why not just have the caller split the input on the first update(), instead
+// of implementing this special rule? Because we don't want to limit SIMD or
+// multi-threading parallelism for that update().
+size_t blake3_compress_subtree_wide(const uint8_t *input, size_t input_len,
+                                    const uint32_t key[8],
+                                    uint64_t chunk_counter, uint8_t flags,
+                                    uint8_t *out, bool use_tbb) {
+  // Note that the single chunk case does *not* bump the SIMD degree up to 2
+  // when it is 1. If this implementation adds multi-threading in the future,
+  // this gives us the option of multi-threading even the 2-chunk case, which
+  // can help performance on smaller platforms.
+  if (input_len <= blake3_simd_degree() * BLAKE3_CHUNK_LEN) {
+    return compress_chunks_parallel(input, input_len, key, chunk_counter, flags,
+                                    out);
+  }
+
+  // With more than simd_degree chunks, we need to recurse. Start by dividing
+  // the input into left and right subtrees. (Note that this is only optimal
+  // as long as the SIMD degree is a power of 2. If we ever get a SIMD degree
+  // of 3 or something, we'll need a more complicated strategy.)
+  size_t left_input_len = left_subtree_len(input_len);
+  size_t right_input_len = input_len - left_input_len;
+  const uint8_t *right_input = &input[left_input_len];
+  uint64_t right_chunk_counter =
+      chunk_counter + (uint64_t)(left_input_len / BLAKE3_CHUNK_LEN);
+
+  // Make space for the child outputs. Here we use MAX_SIMD_DEGREE_OR_2 to
+  // account for the special case of returning 2 outputs when the SIMD degree
+  // is 1.
+  uint8_t cv_array[2 * MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN];
+  size_t degree = blake3_simd_degree();
+  if (left_input_len > BLAKE3_CHUNK_LEN && degree == 1) {
+    // The special case: We always use a degree of at least two, to make
+    // sure there are two outputs. Except, as noted above, at the chunk
+    // level, where we allow degree=1. (Note that the 1-chunk-input case is
+    // a different codepath.)
+    degree = 2;
+  }
+  uint8_t *right_cvs = &cv_array[degree * BLAKE3_OUT_LEN];
+
+  // Recurse!
+  size_t left_n = SIZE_MAX;
+  size_t right_n = SIZE_MAX;
+
+#if defined(BLAKE3_USE_TBB)
+  blake3_compress_subtree_wide_join_tbb(
+      key, flags, use_tbb,
+      // left-hand side
+      input, left_input_len, chunk_counter, cv_array, &left_n,
+      // right-hand side
+      right_input, right_input_len, right_chunk_counter, right_cvs, &right_n);
+#else
+  left_n = blake3_compress_subtree_wide(
+      input, left_input_len, key, chunk_counter, flags, cv_array, use_tbb);
+  right_n = blake3_compress_subtree_wide(right_input, right_input_len, key,
+                                         right_chunk_counter, flags, right_cvs,
+                                         use_tbb);
+#endif // BLAKE3_USE_TBB
+
+  // The special case again. If simd_degree=1, then we'll have left_n=1 and
+  // right_n=1. Rather than compressing them into a single output, return
+  // them directly, to make sure we always have at least two outputs.
+  if (left_n == 1) {
+    memcpy(out, cv_array, 2 * BLAKE3_OUT_LEN);
+    return 2;
+  }
+
+  // Otherwise, do one layer of parent node compression.
+  size_t num_chaining_values = left_n + right_n;
+  return compress_parents_parallel(cv_array, num_chaining_values, key, flags,
+                                   out);
+}
+
+// Hash a subtree with compress_subtree_wide(), and then condense the resulting
+// list of chaining values down to a single parent node. Don't compress that
+// last parent node, however. Instead, return its message bytes (the
+// concatenated chaining values of its children). This is necessary when the
+// first call to update() supplies a complete subtree, because the topmost
+// parent node of that subtree could end up being the root. It's also necessary
+// for extended output in the general case.
+//
+// As with compress_subtree_wide(), this function is not used on inputs of 1
+// chunk or less. That's a different codepath.
+INLINE void
+compress_subtree_to_parent_node(const uint8_t *input, size_t input_len,
+                                const uint32_t key[8], uint64_t chunk_counter,
+                                uint8_t flags, uint8_t out[2 * BLAKE3_OUT_LEN],
+                                bool use_tbb) {
+#if defined(BLAKE3_TESTING)
+  assert(input_len > BLAKE3_CHUNK_LEN);
+#endif
+
+  uint8_t cv_array[MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN];
+  size_t num_cvs = blake3_compress_subtree_wide(input, input_len, key,
+                                                chunk_counter, flags, cv_array, use_tbb);
+  assert(num_cvs <= MAX_SIMD_DEGREE_OR_2);
+  // The following loop never executes when MAX_SIMD_DEGREE_OR_2 is 2, because
+  // as we just asserted, num_cvs will always be <=2 in that case. But GCC
+  // (particularly GCC 8.5) can't tell that it never executes, and if NDEBUG is
+  // set then it emits incorrect warnings here. We tried a few different
+  // hacks to silence these, but in the end our hacks just produced different
+  // warnings (see https://github.com/BLAKE3-team/BLAKE3/pull/380). Out of
+  // desperation, we ifdef out this entire loop when we know it's not needed.
+#if MAX_SIMD_DEGREE_OR_2 > 2
+  // If MAX_SIMD_DEGREE_OR_2 is greater than 2 and there's enough input,
+  // compress_subtree_wide() returns more than 2 chaining values. Condense
+  // them into 2 by forming parent nodes repeatedly.
+  uint8_t out_array[MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN / 2];
+  while (num_cvs > 2) {
+    num_cvs =
+        compress_parents_parallel(cv_array, num_cvs, key, flags, out_array);
+    memcpy(cv_array, out_array, num_cvs * BLAKE3_OUT_LEN);
+  }
+#endif
+  memcpy(out, cv_array, 2 * BLAKE3_OUT_LEN);
+}
+
+INLINE void hasher_init_base(blake3_hasher *self, const uint32_t key[8],
+                             uint8_t flags) {
+  memcpy(self->key, key, BLAKE3_KEY_LEN);
+  chunk_state_init(&self->chunk, key, flags);
+  self->cv_stack_len = 0;
+}
+
+void blake3_hasher_init(blake3_hasher *self) { hasher_init_base(self, IV, 0); }
+
+void blake3_hasher_init_keyed(blake3_hasher *self,
+                              const uint8_t key[BLAKE3_KEY_LEN]) {
+  uint32_t key_words[8];
+  load_key_words(key, key_words);
+  hasher_init_base(self, key_words, KEYED_HASH);
+}
+
+void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context,
+                                       size_t context_len) {
+  blake3_hasher context_hasher;
+  hasher_init_base(&context_hasher, IV, DERIVE_KEY_CONTEXT);
+  blake3_hasher_update(&context_hasher, context, context_len);
+  uint8_t context_key[BLAKE3_KEY_LEN];
+  blake3_hasher_finalize(&context_hasher, context_key, BLAKE3_KEY_LEN);
+  uint32_t context_key_words[8];
+  load_key_words(context_key, context_key_words);
+  hasher_init_base(self, context_key_words, DERIVE_KEY_MATERIAL);
+}
+
+void blake3_hasher_init_derive_key(blake3_hasher *self, const char *context) {
+  blake3_hasher_init_derive_key_raw(self, context, strlen(context));
+}
+
+// As described in hasher_push_cv() below, we do "lazy merging", delaying
+// merges until right before the next CV is about to be added. This is
+// different from the reference implementation. Another difference is that we
+// aren't always merging 1 chunk at a time. Instead, each CV might represent
+// any power-of-two number of chunks, as long as the smaller-above-larger stack
+// order is maintained. Instead of the "count the trailing 0-bits" algorithm
+// described in the spec, we use a "count the total number of 1-bits" variant
+// that doesn't require us to retain the subtree size of the CV on top of the
+// stack. The principle is the same: each CV that should remain in the stack is
+// represented by a 1-bit in the total number of chunks (or bytes) so far.
+INLINE void hasher_merge_cv_stack(blake3_hasher *self, uint64_t total_len) {
+  size_t post_merge_stack_len = (size_t)popcnt(total_len);
+  while (self->cv_stack_len > post_merge_stack_len) {
+    uint8_t *parent_node =
+        &self->cv_stack[(self->cv_stack_len - 2) * BLAKE3_OUT_LEN];
+    output_t output = parent_output(parent_node, self->key, self->chunk.flags);
+    output_chaining_value(&output, parent_node);
+    self->cv_stack_len -= 1;
+  }
+}
+
+// In reference_impl.rs, we merge the new CV with existing CVs from the stack
+// before pushing it. We can do that because we know more input is coming, so
+// we know none of the merges are root.
+//
+// This setting is different. We want to feed as much input as possible to
+// compress_subtree_wide(), without setting aside anything for the chunk_state.
+// If the user gives us 64 KiB, we want to parallelize over all 64 KiB at once
+// as a single subtree, if at all possible.
+//
+// This leads to two problems:
+// 1) This 64 KiB input might be the only call that ever gets made to update.
+//    In this case, the root node of the 64 KiB subtree would be the root node
+//    of the whole tree, and it would need to be ROOT finalized. We can't
+//    compress it until we know.
+// 2) This 64 KiB input might complete a larger tree, whose root node is
+//    similarly going to be the root of the whole tree. For example, maybe
+//    we have 196 KiB (that is, 128 + 64) hashed so far. We can't compress the
+//    node at the root of the 256 KiB subtree until we know how to finalize it.
+//
+// The second problem is solved with "lazy merging". That is, when we're about
+// to add a CV to the stack, we don't merge it with anything first, as the
+// reference impl does. Instead we do merges using the *previous* CV that was
+// added, which is sitting on top of the stack, and we put the new CV
+// (unmerged) on top of the stack afterwards. This guarantees that we never
+// merge the root node until finalize().
+//
+// Solving the first problem requires an additional tool,
+// compress_subtree_to_parent_node(). That function always returns the top
+// *two* chaining values of the subtree it's compressing. We then do lazy
+// merging with each of them separately, so that the second CV will always
+// remain unmerged. (That also helps us support extendable output when we're
+// hashing an input all-at-once.)
+INLINE void hasher_push_cv(blake3_hasher *self, uint8_t new_cv[BLAKE3_OUT_LEN],
+                           uint64_t chunk_counter) {
+  hasher_merge_cv_stack(self, chunk_counter);
+  memcpy(&self->cv_stack[self->cv_stack_len * BLAKE3_OUT_LEN], new_cv,
+         BLAKE3_OUT_LEN);
+  self->cv_stack_len += 1;
+}
+
+INLINE void blake3_hasher_update_base(blake3_hasher *self, const void *input,
+                                      size_t input_len, bool use_tbb) {
+  // Explicitly checking for zero avoids causing UB by passing a null pointer
+  // to memcpy. This comes up in practice with things like:
+  //   std::vector<uint8_t> v;
+  //   blake3_hasher_update(&hasher, v.data(), v.size());
+  if (input_len == 0) {
+    return;
+  }
+
+  const uint8_t *input_bytes = (const uint8_t *)input;
+
+  // If we have some partial chunk bytes in the internal chunk_state, we need
+  // to finish that chunk first.
+  if (chunk_state_len(&self->chunk) > 0) {
+    size_t take = BLAKE3_CHUNK_LEN - chunk_state_len(&self->chunk);
+    if (take > input_len) {
+      take = input_len;
+    }
+    chunk_state_update(&self->chunk, input_bytes, take);
+    input_bytes += take;
+    input_len -= take;
+    // If we've filled the current chunk and there's more coming, finalize this
+    // chunk and proceed. In this case we know it's not the root.
+    if (input_len > 0) {
+      output_t output = chunk_state_output(&self->chunk);
+      uint8_t chunk_cv[32];
+      output_chaining_value(&output, chunk_cv);
+      hasher_push_cv(self, chunk_cv, self->chunk.chunk_counter);
+      chunk_state_reset(&self->chunk, self->key, self->chunk.chunk_counter + 1);
+    } else {
+      return;
+    }
+  }
+
+  // Now the chunk_state is clear, and we have more input. If there's more than
+  // a single chunk (so, definitely not the root chunk), hash the largest whole
+  // subtree we can, with the full benefits of SIMD (and maybe in the future,
+  // multi-threading) parallelism. Two restrictions:
+  // - The subtree has to be a power-of-2 number of chunks. Only subtrees along
+  //   the right edge can be incomplete, and we don't know where the right edge
+  //   is going to be until we get to finalize().
+  // - The subtree must evenly divide the total number of chunks up until this
+  //   point (if total is not 0). If the current incomplete subtree is only
+  //   waiting for 1 more chunk, we can't hash a subtree of 4 chunks. We have
+  //   to complete the current subtree first.
+  // Because we might need to break up the input to form powers of 2, or to
+  // evenly divide what we already have, this part runs in a loop.
+  while (input_len > BLAKE3_CHUNK_LEN) {
+    size_t subtree_len = round_down_to_power_of_2(input_len);
+    uint64_t count_so_far = self->chunk.chunk_counter * BLAKE3_CHUNK_LEN;
+    // Shrink the subtree_len until it evenly divides the count so far. We know
+    // that subtree_len itself is a power of 2, so we can use a bitmasking
+    // trick instead of an actual remainder operation. (Note that if the caller
+    // consistently passes power-of-2 inputs of the same size, as is hopefully
+    // typical, this loop condition will always fail, and subtree_len will
+    // always be the full length of the input.)
+    //
+    // An aside: We don't have to shrink subtree_len quite this much. For
+    // example, if count_so_far is 1, we could pass 2 chunks to
+    // compress_subtree_to_parent_node. Since we'll get 2 CVs back, we'll still
+    // get the right answer in the end, and we might get to use 2-way SIMD
+    // parallelism. The problem with this optimization, is that it gets us
+    // stuck always hashing 2 chunks. The total number of chunks will remain
+    // odd, and we'll never graduate to higher degrees of parallelism. See
+    // https://github.com/BLAKE3-team/BLAKE3/issues/69.
+    while ((((uint64_t)(subtree_len - 1)) & count_so_far) != 0) {
+      subtree_len /= 2;
+    }
+    // The shrunken subtree_len might now be 1 chunk long. If so, hash that one
+    // chunk by itself. Otherwise, compress the subtree into a pair of CVs.
+    uint64_t subtree_chunks = subtree_len / BLAKE3_CHUNK_LEN;
+    if (subtree_len <= BLAKE3_CHUNK_LEN) {
+      blake3_chunk_state chunk_state;
+      chunk_state_init(&chunk_state, self->key, self->chunk.flags);
+      chunk_state.chunk_counter = self->chunk.chunk_counter;
+      chunk_state_update(&chunk_state, input_bytes, subtree_len);
+      output_t output = chunk_state_output(&chunk_state);
+      uint8_t cv[BLAKE3_OUT_LEN];
+      output_chaining_value(&output, cv);
+      hasher_push_cv(self, cv, chunk_state.chunk_counter);
+    } else {
+      // This is the high-performance happy path, though getting here depends
+      // on the caller giving us a long enough input.
+      uint8_t cv_pair[2 * BLAKE3_OUT_LEN];
+      compress_subtree_to_parent_node(input_bytes, subtree_len, self->key,
+                                      self->chunk.chunk_counter,
+                                      self->chunk.flags, cv_pair, use_tbb);
+      hasher_push_cv(self, cv_pair, self->chunk.chunk_counter);
+      hasher_push_cv(self, &cv_pair[BLAKE3_OUT_LEN],
+                     self->chunk.chunk_counter + (subtree_chunks / 2));
+    }
+    self->chunk.chunk_counter += subtree_chunks;
+    input_bytes += subtree_len;
+    input_len -= subtree_len;
+  }
+
+  // If there's any remaining input less than a full chunk, add it to the chunk
+  // state. In that case, also do a final merge loop to make sure the subtree
+  // stack doesn't contain any unmerged pairs. The remaining input means we
+  // know these merges are non-root. This merge loop isn't strictly necessary
+  // here, because hasher_push_chunk_cv already does its own merge loop, but it
+  // simplifies blake3_hasher_finalize below.
+  if (input_len > 0) {
+    chunk_state_update(&self->chunk, input_bytes, input_len);
+    hasher_merge_cv_stack(self, self->chunk.chunk_counter);
+  }
+}
+
+void blake3_hasher_update(blake3_hasher *self, const void *input,
+                          size_t input_len) {
+  bool use_tbb = false;
+  blake3_hasher_update_base(self, input, input_len, use_tbb);
+}
+
+#if defined(BLAKE3_USE_TBB)
+void blake3_hasher_update_tbb(blake3_hasher *self, const void *input,
+                              size_t input_len) {
+  bool use_tbb = true;
+  blake3_hasher_update_base(self, input, input_len, use_tbb);
+}
+#endif // BLAKE3_USE_TBB
+
+void blake3_hasher_finalize(const blake3_hasher *self, uint8_t *out,
+                            size_t out_len) {
+  blake3_hasher_finalize_seek(self, 0, out, out_len);
+}
+
+void blake3_hasher_finalize_seek(const blake3_hasher *self, uint64_t seek,
+                                 uint8_t *out, size_t out_len) {
+  // Explicitly checking for zero avoids causing UB by passing a null pointer
+  // to memcpy. This comes up in practice with things like:
+  //   std::vector<uint8_t> v;
+  //   blake3_hasher_finalize(&hasher, v.data(), v.size());
+  if (out_len == 0) {
+    return;
+  }
+
+  // If the subtree stack is empty, then the current chunk is the root.
+  if (self->cv_stack_len == 0) {
+    output_t output = chunk_state_output(&self->chunk);
+    output_root_bytes(&output, seek, out, out_len);
+    return;
+  }
+  // If there are any bytes in the chunk state, finalize that chunk and do a
+  // roll-up merge between that chunk hash and every subtree in the stack. In
+  // this case, the extra merge loop at the end of blake3_hasher_update
+  // guarantees that none of the subtrees in the stack need to be merged with
+  // each other first. Otherwise, if there are no bytes in the chunk state,
+  // then the top of the stack is a chunk hash, and we start the merge from
+  // that.
+  output_t output;
+  size_t cvs_remaining;
+  if (chunk_state_len(&self->chunk) > 0) {
+    cvs_remaining = self->cv_stack_len;
+    output = chunk_state_output(&self->chunk);
+  } else {
+    // There are always at least 2 CVs in the stack in this case.
+    cvs_remaining = self->cv_stack_len - 2;
+    output = parent_output(&self->cv_stack[cvs_remaining * 32], self->key,
+                           self->chunk.flags);
+  }
+  while (cvs_remaining > 0) {
+    cvs_remaining -= 1;
+    uint8_t parent_block[BLAKE3_BLOCK_LEN];
+    memcpy(parent_block, &self->cv_stack[cvs_remaining * 32], 32);
+    output_chaining_value(&output, &parent_block[32]);
+    output = parent_output(parent_block, self->key, self->chunk.flags);
+  }
+  output_root_bytes(&output, seek, out, out_len);
+}
+
+void blake3_hasher_reset(blake3_hasher *self) {
+  chunk_state_reset(&self->chunk, self->key, 0);
+  self->cv_stack_len = 0;
+}

--- a/implementations/swift/Sources/CBlake3/blake3_dispatch.c
+++ b/implementations/swift/Sources/CBlake3/blake3_dispatch.c
@@ -1,0 +1,332 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "blake3_impl.h"
+
+#if defined(_MSC_VER)
+#include <Windows.h>
+#endif
+
+#if defined(IS_X86)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif defined(__GNUC__)
+#include <immintrin.h>
+#else
+#undef IS_X86 /* Unimplemented! */
+#endif
+#endif
+
+#if !defined(BLAKE3_ATOMICS)
+#if defined(__has_include)
+#if __has_include(<stdatomic.h>) && !defined(_MSC_VER)
+#define BLAKE3_ATOMICS 1
+#else
+#define BLAKE3_ATOMICS 0
+#endif /* __has_include(<stdatomic.h>) && !defined(_MSC_VER) */
+#else
+#define BLAKE3_ATOMICS 0
+#endif /* defined(__has_include) */
+#endif /* BLAKE3_ATOMICS */
+
+#if BLAKE3_ATOMICS
+#define ATOMIC_INT _Atomic int
+#define ATOMIC_LOAD(x) x
+#define ATOMIC_STORE(x, y) x = y
+#elif defined(_MSC_VER)
+#define ATOMIC_INT LONG
+#define ATOMIC_LOAD(x) InterlockedOr(&x, 0)
+#define ATOMIC_STORE(x, y) InterlockedExchange(&x, y)
+#else
+#define ATOMIC_INT int
+#define ATOMIC_LOAD(x) x
+#define ATOMIC_STORE(x, y) x = y
+#endif
+
+#define MAYBE_UNUSED(x) (void)((x))
+
+#if defined(IS_X86)
+static uint64_t xgetbv(void) {
+#if defined(_MSC_VER)
+  return _xgetbv(0);
+#else
+  uint32_t eax = 0, edx = 0;
+  __asm__ __volatile__("xgetbv\n" : "=a"(eax), "=d"(edx) : "c"(0));
+  return ((uint64_t)edx << 32) | eax;
+#endif
+}
+
+static void cpuid(uint32_t out[4], uint32_t id) {
+#if defined(_MSC_VER)
+  __cpuid((int *)out, id);
+#elif defined(__i386__) || defined(_M_IX86)
+  __asm__ __volatile__("movl %%ebx, %1\n"
+                       "cpuid\n"
+                       "xchgl %1, %%ebx\n"
+                       : "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id));
+#else
+  __asm__ __volatile__("cpuid\n"
+                       : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id));
+#endif
+}
+
+static void cpuidex(uint32_t out[4], uint32_t id, uint32_t sid) {
+#if defined(_MSC_VER)
+  __cpuidex((int *)out, id, sid);
+#elif defined(__i386__) || defined(_M_IX86)
+  __asm__ __volatile__("movl %%ebx, %1\n"
+                       "cpuid\n"
+                       "xchgl %1, %%ebx\n"
+                       : "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id), "c"(sid));
+#else
+  __asm__ __volatile__("cpuid\n"
+                       : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id), "c"(sid));
+#endif
+}
+
+
+enum cpu_feature {
+  SSE2 = 1 << 0,
+  SSSE3 = 1 << 1,
+  SSE41 = 1 << 2,
+  AVX = 1 << 3,
+  AVX2 = 1 << 4,
+  AVX512F = 1 << 5,
+  AVX512VL = 1 << 6,
+  /* ... */
+  UNDEFINED = 1 << 30
+};
+
+#if !defined(BLAKE3_TESTING)
+static /* Allow the variable to be controlled manually for testing */
+#endif
+    ATOMIC_INT g_cpu_features = UNDEFINED;
+
+#if !defined(BLAKE3_TESTING)
+static
+#endif
+    enum cpu_feature
+    get_cpu_features(void) {
+
+  /* If TSAN detects a data race here, try compiling with -DBLAKE3_ATOMICS=1 */
+  enum cpu_feature features = ATOMIC_LOAD(g_cpu_features);
+  if (features != UNDEFINED) {
+    return features;
+  } else {
+#if defined(IS_X86)
+    uint32_t regs[4] = {0};
+    uint32_t *eax = &regs[0], *ebx = &regs[1], *ecx = &regs[2], *edx = &regs[3];
+    (void)edx;
+    features = 0;
+    cpuid(regs, 0);
+    const int max_id = *eax;
+    cpuid(regs, 1);
+#if defined(__amd64__) || defined(_M_X64)
+    features |= SSE2;
+#else
+    if (*edx & (1UL << 26))
+      features |= SSE2;
+#endif
+    if (*ecx & (1UL << 9))
+      features |= SSSE3;
+    if (*ecx & (1UL << 19))
+      features |= SSE41;
+
+    if (*ecx & (1UL << 27)) { // OSXSAVE
+      const uint64_t mask = xgetbv();
+      if ((mask & 6) == 6) { // SSE and AVX states
+        if (*ecx & (1UL << 28))
+          features |= AVX;
+        if (max_id >= 7) {
+          cpuidex(regs, 7, 0);
+          if (*ebx & (1UL << 5))
+            features |= AVX2;
+          if ((mask & 224) == 224) { // Opmask, ZMM_Hi256, Hi16_Zmm
+            if (*ebx & (1UL << 31))
+              features |= AVX512VL;
+            if (*ebx & (1UL << 16))
+              features |= AVX512F;
+          }
+        }
+      }
+    }
+    ATOMIC_STORE(g_cpu_features, features);
+    return features;
+#else
+    /* How to detect NEON? */
+    return 0;
+#endif
+  }
+}
+#endif
+
+void blake3_compress_in_place(uint32_t cv[8],
+                              const uint8_t block[BLAKE3_BLOCK_LEN],
+                              uint8_t block_len, uint64_t counter,
+                              uint8_t flags) {
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(BLAKE3_NO_AVX512)
+  if (features & AVX512VL) {
+    blake3_compress_in_place_avx512(cv, block, block_len, counter, flags);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+  if (features & SSE41) {
+    blake3_compress_in_place_sse41(cv, block, block_len, counter, flags);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE2)
+  if (features & SSE2) {
+    blake3_compress_in_place_sse2(cv, block, block_len, counter, flags);
+    return;
+  }
+#endif
+#endif
+  blake3_compress_in_place_portable(cv, block, block_len, counter, flags);
+}
+
+void blake3_compress_xof(const uint32_t cv[8],
+                         const uint8_t block[BLAKE3_BLOCK_LEN],
+                         uint8_t block_len, uint64_t counter, uint8_t flags,
+                         uint8_t out[64]) {
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(BLAKE3_NO_AVX512)
+  if (features & AVX512VL) {
+    blake3_compress_xof_avx512(cv, block, block_len, counter, flags, out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+  if (features & SSE41) {
+    blake3_compress_xof_sse41(cv, block, block_len, counter, flags, out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE2)
+  if (features & SSE2) {
+    blake3_compress_xof_sse2(cv, block, block_len, counter, flags, out);
+    return;
+  }
+#endif
+#endif
+  blake3_compress_xof_portable(cv, block, block_len, counter, flags, out);
+}
+
+
+void blake3_xof_many(const uint32_t cv[8],
+                     const uint8_t block[BLAKE3_BLOCK_LEN],
+                     uint8_t block_len, uint64_t counter, uint8_t flags,
+                     uint8_t out[64], size_t outblocks) {
+  if (outblocks == 0) {
+    // The current assembly implementation always outputs at least 1 block.
+    return;
+  }
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(BLAKE3_NO_AVX512)
+  if (features & AVX512VL) {
+    blake3_xof_many_avx512(cv, block, block_len, counter, flags, out, outblocks);
+    return;
+  }
+#endif
+#endif
+  for(size_t i = 0; i < outblocks; ++i) {
+    blake3_compress_xof(cv, block, block_len, counter + i, flags, out + 64*i);
+  }
+}
+
+void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
+                      size_t blocks, const uint32_t key[8], uint64_t counter,
+                      bool increment_counter, uint8_t flags,
+                      uint8_t flags_start, uint8_t flags_end, uint8_t *out) {
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(BLAKE3_NO_AVX512)
+  if ((features & (AVX512F|AVX512VL)) == (AVX512F|AVX512VL)) {
+    blake3_hash_many_avx512(inputs, num_inputs, blocks, key, counter,
+                            increment_counter, flags, flags_start, flags_end,
+                            out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_AVX2)
+  if (features & AVX2) {
+    blake3_hash_many_avx2(inputs, num_inputs, blocks, key, counter,
+                          increment_counter, flags, flags_start, flags_end,
+                          out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+  if (features & SSE41) {
+    blake3_hash_many_sse41(inputs, num_inputs, blocks, key, counter,
+                           increment_counter, flags, flags_start, flags_end,
+                           out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE2)
+  if (features & SSE2) {
+    blake3_hash_many_sse2(inputs, num_inputs, blocks, key, counter,
+                          increment_counter, flags, flags_start, flags_end,
+                          out);
+    return;
+  }
+#endif
+#endif
+
+#if BLAKE3_USE_NEON == 1
+  blake3_hash_many_neon(inputs, num_inputs, blocks, key, counter,
+                        increment_counter, flags, flags_start, flags_end, out);
+  return;
+#endif
+
+  blake3_hash_many_portable(inputs, num_inputs, blocks, key, counter,
+                            increment_counter, flags, flags_start, flags_end,
+                            out);
+}
+
+// The dynamically detected SIMD degree of the current platform.
+size_t blake3_simd_degree(void) {
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(BLAKE3_NO_AVX512)
+  if ((features & (AVX512F|AVX512VL)) == (AVX512F|AVX512VL)) {
+    return 16;
+  }
+#endif
+#if !defined(BLAKE3_NO_AVX2)
+  if (features & AVX2) {
+    return 8;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+  if (features & SSE41) {
+    return 4;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE2)
+  if (features & SSE2) {
+    return 4;
+  }
+#endif
+#endif
+#if BLAKE3_USE_NEON == 1
+  return 4;
+#endif
+  return 1;
+}

--- a/implementations/swift/Sources/CBlake3/blake3_impl.h
+++ b/implementations/swift/Sources/CBlake3/blake3_impl.h
@@ -1,0 +1,333 @@
+#ifndef BLAKE3_IMPL_H
+#define BLAKE3_IMPL_H
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "blake3.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// internal flags
+enum blake3_flags {
+  CHUNK_START         = 1 << 0,
+  CHUNK_END           = 1 << 1,
+  PARENT              = 1 << 2,
+  ROOT                = 1 << 3,
+  KEYED_HASH          = 1 << 4,
+  DERIVE_KEY_CONTEXT  = 1 << 5,
+  DERIVE_KEY_MATERIAL = 1 << 6,
+};
+
+// This C implementation tries to support recent versions of GCC, Clang, and
+// MSVC.
+#if defined(_MSC_VER)
+#define INLINE static __forceinline
+#else
+#define INLINE static inline __attribute__((always_inline))
+#endif
+
+#ifdef __cplusplus
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_M_ARM64EC)
+#define IS_X86
+#define IS_X86_64
+#endif
+
+#if defined(__i386__) || defined(_M_IX86)
+#define IS_X86
+#define IS_X86_32
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#define IS_AARCH64
+#endif
+
+#if defined(IS_X86)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+#endif
+
+#if !defined(BLAKE3_USE_NEON) 
+  // If BLAKE3_USE_NEON not manually set, autodetect based on AArch64ness
+  #if defined(IS_AARCH64)
+    #if defined(__ARM_BIG_ENDIAN)
+      #define BLAKE3_USE_NEON 0
+    #else
+      #define BLAKE3_USE_NEON 1
+    #endif
+  #else
+    #define BLAKE3_USE_NEON 0
+  #endif
+#endif
+
+#if defined(IS_X86)
+#define MAX_SIMD_DEGREE 16
+#elif BLAKE3_USE_NEON == 1
+#define MAX_SIMD_DEGREE 4
+#else
+#define MAX_SIMD_DEGREE 1
+#endif
+
+// There are some places where we want a static size that's equal to the
+// MAX_SIMD_DEGREE, but also at least 2.
+#define MAX_SIMD_DEGREE_OR_2 (MAX_SIMD_DEGREE > 2 ? MAX_SIMD_DEGREE : 2)
+
+static const uint32_t IV[8] = {0x6A09E667UL, 0xBB67AE85UL, 0x3C6EF372UL,
+                               0xA54FF53AUL, 0x510E527FUL, 0x9B05688CUL,
+                               0x1F83D9ABUL, 0x5BE0CD19UL};
+
+static const uint8_t MSG_SCHEDULE[7][16] = {
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+    {2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8},
+    {3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1},
+    {10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6},
+    {12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4},
+    {9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7},
+    {11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13},
+};
+
+/* Find index of the highest set bit */
+/* x is assumed to be nonzero.       */
+static unsigned int highest_one(uint64_t x) {
+#if defined(__GNUC__) || defined(__clang__)
+  return 63 ^ (unsigned int)__builtin_clzll(x);
+#elif defined(_MSC_VER) && defined(IS_X86_64)
+  unsigned long index;
+  _BitScanReverse64(&index, x);
+  return index;
+#elif defined(_MSC_VER) && defined(IS_X86_32)
+  if(x >> 32) {
+    unsigned long index;
+    _BitScanReverse(&index, (unsigned long)(x >> 32));
+    return 32 + index;
+  } else {
+    unsigned long index;
+    _BitScanReverse(&index, (unsigned long)x);
+    return index;
+  }
+#else
+  unsigned int c = 0;
+  if(x & 0xffffffff00000000ULL) { x >>= 32; c += 32; }
+  if(x & 0x00000000ffff0000ULL) { x >>= 16; c += 16; }
+  if(x & 0x000000000000ff00ULL) { x >>=  8; c +=  8; }
+  if(x & 0x00000000000000f0ULL) { x >>=  4; c +=  4; }
+  if(x & 0x000000000000000cULL) { x >>=  2; c +=  2; }
+  if(x & 0x0000000000000002ULL) {           c +=  1; }
+  return c;
+#endif
+}
+
+// Count the number of 1 bits.
+INLINE unsigned int popcnt(uint64_t x) {
+#if defined(__GNUC__) || defined(__clang__)
+  return (unsigned int)__builtin_popcountll(x);
+#else
+  unsigned int count = 0;
+  while (x != 0) {
+    count += 1;
+    x &= x - 1;
+  }
+  return count;
+#endif
+}
+
+// Largest power of two less than or equal to x. As a special case, returns 1
+// when x is 0. 
+INLINE uint64_t round_down_to_power_of_2(uint64_t x) {
+  return 1ULL << highest_one(x | 1);
+}
+
+INLINE uint32_t counter_low(uint64_t counter) { return (uint32_t)counter; }
+
+INLINE uint32_t counter_high(uint64_t counter) {
+  return (uint32_t)(counter >> 32);
+}
+
+INLINE uint32_t load32(const void *src) {
+  const uint8_t *p = (const uint8_t *)src;
+  return ((uint32_t)(p[0]) << 0) | ((uint32_t)(p[1]) << 8) |
+         ((uint32_t)(p[2]) << 16) | ((uint32_t)(p[3]) << 24);
+}
+
+INLINE void load_key_words(const uint8_t key[BLAKE3_KEY_LEN],
+                           uint32_t key_words[8]) {
+  key_words[0] = load32(&key[0 * 4]);
+  key_words[1] = load32(&key[1 * 4]);
+  key_words[2] = load32(&key[2 * 4]);
+  key_words[3] = load32(&key[3 * 4]);
+  key_words[4] = load32(&key[4 * 4]);
+  key_words[5] = load32(&key[5 * 4]);
+  key_words[6] = load32(&key[6 * 4]);
+  key_words[7] = load32(&key[7 * 4]);
+}
+
+INLINE void load_block_words(const uint8_t block[BLAKE3_BLOCK_LEN],
+                             uint32_t block_words[16]) {
+  for (size_t i = 0; i < 16; i++) {
+      block_words[i] = load32(&block[i * 4]);
+  }
+}
+
+INLINE void store32(void *dst, uint32_t w) {
+  uint8_t *p = (uint8_t *)dst;
+  p[0] = (uint8_t)(w >> 0);
+  p[1] = (uint8_t)(w >> 8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+}
+
+INLINE void store_cv_words(uint8_t bytes_out[32], uint32_t cv_words[8]) {
+  store32(&bytes_out[0 * 4], cv_words[0]);
+  store32(&bytes_out[1 * 4], cv_words[1]);
+  store32(&bytes_out[2 * 4], cv_words[2]);
+  store32(&bytes_out[3 * 4], cv_words[3]);
+  store32(&bytes_out[4 * 4], cv_words[4]);
+  store32(&bytes_out[5 * 4], cv_words[5]);
+  store32(&bytes_out[6 * 4], cv_words[6]);
+  store32(&bytes_out[7 * 4], cv_words[7]);
+}
+
+void blake3_compress_in_place(uint32_t cv[8],
+                              const uint8_t block[BLAKE3_BLOCK_LEN],
+                              uint8_t block_len, uint64_t counter,
+                              uint8_t flags);
+
+void blake3_compress_xof(const uint32_t cv[8],
+                         const uint8_t block[BLAKE3_BLOCK_LEN],
+                         uint8_t block_len, uint64_t counter, uint8_t flags,
+                         uint8_t out[64]);
+
+void blake3_xof_many(const uint32_t cv[8],
+                     const uint8_t block[BLAKE3_BLOCK_LEN],
+                     uint8_t block_len, uint64_t counter, uint8_t flags,
+                     uint8_t out[64], size_t outblocks);
+
+void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
+                      size_t blocks, const uint32_t key[8], uint64_t counter,
+                      bool increment_counter, uint8_t flags,
+                      uint8_t flags_start, uint8_t flags_end, uint8_t *out);
+
+size_t blake3_simd_degree(void);
+
+BLAKE3_PRIVATE size_t blake3_compress_subtree_wide(const uint8_t *input, size_t input_len,
+                                                   const uint32_t key[8],
+                                                   uint64_t chunk_counter, uint8_t flags,
+                                                   uint8_t *out, bool use_tbb);
+
+#if defined(BLAKE3_USE_TBB)
+BLAKE3_PRIVATE void blake3_compress_subtree_wide_join_tbb(
+    // shared params
+    const uint32_t key[8], uint8_t flags, bool use_tbb,
+    // left-hand side params
+    const uint8_t *l_input, size_t l_input_len, uint64_t l_chunk_counter,
+    uint8_t *l_cvs, size_t *l_n,
+    // right-hand side params
+    const uint8_t *r_input, size_t r_input_len, uint64_t r_chunk_counter,
+    uint8_t *r_cvs, size_t *r_n) NOEXCEPT;
+#endif
+
+// Declarations for implementation-specific functions.
+void blake3_compress_in_place_portable(uint32_t cv[8],
+                                       const uint8_t block[BLAKE3_BLOCK_LEN],
+                                       uint8_t block_len, uint64_t counter,
+                                       uint8_t flags);
+
+void blake3_compress_xof_portable(const uint32_t cv[8],
+                                  const uint8_t block[BLAKE3_BLOCK_LEN],
+                                  uint8_t block_len, uint64_t counter,
+                                  uint8_t flags, uint8_t out[64]);
+
+void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,
+                               size_t blocks, const uint32_t key[8],
+                               uint64_t counter, bool increment_counter,
+                               uint8_t flags, uint8_t flags_start,
+                               uint8_t flags_end, uint8_t *out);
+
+#if defined(IS_X86)
+#if !defined(BLAKE3_NO_SSE2)
+void blake3_compress_in_place_sse2(uint32_t cv[8],
+                                   const uint8_t block[BLAKE3_BLOCK_LEN],
+                                   uint8_t block_len, uint64_t counter,
+                                   uint8_t flags);
+void blake3_compress_xof_sse2(const uint32_t cv[8],
+                              const uint8_t block[BLAKE3_BLOCK_LEN],
+                              uint8_t block_len, uint64_t counter,
+                              uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_sse2(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+void blake3_compress_in_place_sse41(uint32_t cv[8],
+                                    const uint8_t block[BLAKE3_BLOCK_LEN],
+                                    uint8_t block_len, uint64_t counter,
+                                    uint8_t flags);
+void blake3_compress_xof_sse41(const uint32_t cv[8],
+                               const uint8_t block[BLAKE3_BLOCK_LEN],
+                               uint8_t block_len, uint64_t counter,
+                               uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_sse41(const uint8_t *const *inputs, size_t num_inputs,
+                            size_t blocks, const uint32_t key[8],
+                            uint64_t counter, bool increment_counter,
+                            uint8_t flags, uint8_t flags_start,
+                            uint8_t flags_end, uint8_t *out);
+#endif
+#if !defined(BLAKE3_NO_AVX2)
+void blake3_hash_many_avx2(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+#endif
+#if !defined(BLAKE3_NO_AVX512)
+void blake3_compress_in_place_avx512(uint32_t cv[8],
+                                     const uint8_t block[BLAKE3_BLOCK_LEN],
+                                     uint8_t block_len, uint64_t counter,
+                                     uint8_t flags);
+
+void blake3_compress_xof_avx512(const uint32_t cv[8],
+                                const uint8_t block[BLAKE3_BLOCK_LEN],
+                                uint8_t block_len, uint64_t counter,
+                                uint8_t flags, uint8_t out[64]);
+
+void blake3_hash_many_avx512(const uint8_t *const *inputs, size_t num_inputs,
+                             size_t blocks, const uint32_t key[8],
+                             uint64_t counter, bool increment_counter,
+                             uint8_t flags, uint8_t flags_start,
+                             uint8_t flags_end, uint8_t *out);
+
+#if !defined(_WIN32) && !defined(__CYGWIN__)
+void blake3_xof_many_avx512(const uint32_t cv[8],
+                            const uint8_t block[BLAKE3_BLOCK_LEN],
+                            uint8_t block_len, uint64_t counter, uint8_t flags,
+                            uint8_t* out, size_t outblocks);
+#endif
+#endif
+#endif
+
+#if BLAKE3_USE_NEON == 1
+void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BLAKE3_IMPL_H */

--- a/implementations/swift/Sources/CBlake3/blake3_portable.c
+++ b/implementations/swift/Sources/CBlake3/blake3_portable.c
@@ -1,0 +1,160 @@
+#include "blake3_impl.h"
+#include <string.h>
+
+INLINE uint32_t rotr32(uint32_t w, uint32_t c) {
+  return (w >> c) | (w << (32 - c));
+}
+
+INLINE void g(uint32_t *state, size_t a, size_t b, size_t c, size_t d,
+              uint32_t x, uint32_t y) {
+  state[a] = state[a] + state[b] + x;
+  state[d] = rotr32(state[d] ^ state[a], 16);
+  state[c] = state[c] + state[d];
+  state[b] = rotr32(state[b] ^ state[c], 12);
+  state[a] = state[a] + state[b] + y;
+  state[d] = rotr32(state[d] ^ state[a], 8);
+  state[c] = state[c] + state[d];
+  state[b] = rotr32(state[b] ^ state[c], 7);
+}
+
+INLINE void round_fn(uint32_t state[16], const uint32_t *msg, size_t round) {
+  // Select the message schedule based on the round.
+  const uint8_t *schedule = MSG_SCHEDULE[round];
+
+  // Mix the columns.
+  g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
+  g(state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
+  g(state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
+  g(state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
+
+  // Mix the rows.
+  g(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
+  g(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
+  g(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
+  g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
+}
+
+INLINE void compress_pre(uint32_t state[16], const uint32_t cv[8],
+                         const uint8_t block[BLAKE3_BLOCK_LEN],
+                         uint8_t block_len, uint64_t counter, uint8_t flags) {
+  uint32_t block_words[16];
+  block_words[0] = load32(block + 4 * 0);
+  block_words[1] = load32(block + 4 * 1);
+  block_words[2] = load32(block + 4 * 2);
+  block_words[3] = load32(block + 4 * 3);
+  block_words[4] = load32(block + 4 * 4);
+  block_words[5] = load32(block + 4 * 5);
+  block_words[6] = load32(block + 4 * 6);
+  block_words[7] = load32(block + 4 * 7);
+  block_words[8] = load32(block + 4 * 8);
+  block_words[9] = load32(block + 4 * 9);
+  block_words[10] = load32(block + 4 * 10);
+  block_words[11] = load32(block + 4 * 11);
+  block_words[12] = load32(block + 4 * 12);
+  block_words[13] = load32(block + 4 * 13);
+  block_words[14] = load32(block + 4 * 14);
+  block_words[15] = load32(block + 4 * 15);
+
+  state[0] = cv[0];
+  state[1] = cv[1];
+  state[2] = cv[2];
+  state[3] = cv[3];
+  state[4] = cv[4];
+  state[5] = cv[5];
+  state[6] = cv[6];
+  state[7] = cv[7];
+  state[8] = IV[0];
+  state[9] = IV[1];
+  state[10] = IV[2];
+  state[11] = IV[3];
+  state[12] = counter_low(counter);
+  state[13] = counter_high(counter);
+  state[14] = (uint32_t)block_len;
+  state[15] = (uint32_t)flags;
+
+  round_fn(state, &block_words[0], 0);
+  round_fn(state, &block_words[0], 1);
+  round_fn(state, &block_words[0], 2);
+  round_fn(state, &block_words[0], 3);
+  round_fn(state, &block_words[0], 4);
+  round_fn(state, &block_words[0], 5);
+  round_fn(state, &block_words[0], 6);
+}
+
+void blake3_compress_in_place_portable(uint32_t cv[8],
+                                       const uint8_t block[BLAKE3_BLOCK_LEN],
+                                       uint8_t block_len, uint64_t counter,
+                                       uint8_t flags) {
+  uint32_t state[16];
+  compress_pre(state, cv, block, block_len, counter, flags);
+  cv[0] = state[0] ^ state[8];
+  cv[1] = state[1] ^ state[9];
+  cv[2] = state[2] ^ state[10];
+  cv[3] = state[3] ^ state[11];
+  cv[4] = state[4] ^ state[12];
+  cv[5] = state[5] ^ state[13];
+  cv[6] = state[6] ^ state[14];
+  cv[7] = state[7] ^ state[15];
+}
+
+void blake3_compress_xof_portable(const uint32_t cv[8],
+                                  const uint8_t block[BLAKE3_BLOCK_LEN],
+                                  uint8_t block_len, uint64_t counter,
+                                  uint8_t flags, uint8_t out[64]) {
+  uint32_t state[16];
+  compress_pre(state, cv, block, block_len, counter, flags);
+
+  store32(&out[0 * 4], state[0] ^ state[8]);
+  store32(&out[1 * 4], state[1] ^ state[9]);
+  store32(&out[2 * 4], state[2] ^ state[10]);
+  store32(&out[3 * 4], state[3] ^ state[11]);
+  store32(&out[4 * 4], state[4] ^ state[12]);
+  store32(&out[5 * 4], state[5] ^ state[13]);
+  store32(&out[6 * 4], state[6] ^ state[14]);
+  store32(&out[7 * 4], state[7] ^ state[15]);
+  store32(&out[8 * 4], state[8] ^ cv[0]);
+  store32(&out[9 * 4], state[9] ^ cv[1]);
+  store32(&out[10 * 4], state[10] ^ cv[2]);
+  store32(&out[11 * 4], state[11] ^ cv[3]);
+  store32(&out[12 * 4], state[12] ^ cv[4]);
+  store32(&out[13 * 4], state[13] ^ cv[5]);
+  store32(&out[14 * 4], state[14] ^ cv[6]);
+  store32(&out[15 * 4], state[15] ^ cv[7]);
+}
+
+INLINE void hash_one_portable(const uint8_t *input, size_t blocks,
+                              const uint32_t key[8], uint64_t counter,
+                              uint8_t flags, uint8_t flags_start,
+                              uint8_t flags_end, uint8_t out[BLAKE3_OUT_LEN]) {
+  uint32_t cv[8];
+  memcpy(cv, key, BLAKE3_KEY_LEN);
+  uint8_t block_flags = flags | flags_start;
+  while (blocks > 0) {
+    if (blocks == 1) {
+      block_flags |= flags_end;
+    }
+    blake3_compress_in_place_portable(cv, input, BLAKE3_BLOCK_LEN, counter,
+                                      block_flags);
+    input = &input[BLAKE3_BLOCK_LEN];
+    blocks -= 1;
+    block_flags = flags;
+  }
+  store_cv_words(out, cv);
+}
+
+void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,
+                               size_t blocks, const uint32_t key[8],
+                               uint64_t counter, bool increment_counter,
+                               uint8_t flags, uint8_t flags_start,
+                               uint8_t flags_end, uint8_t *out) {
+  while (num_inputs > 0) {
+    hash_one_portable(inputs[0], blocks, key, counter, flags, flags_start,
+                      flags_end, out);
+    if (increment_counter) {
+      counter += 1;
+    }
+    inputs += 1;
+    num_inputs -= 1;
+    out = &out[BLAKE3_OUT_LEN];
+  }
+}

--- a/implementations/swift/Sources/CBlake3/include/blake3.h
+++ b/implementations/swift/Sources/CBlake3/include/blake3.h
@@ -1,0 +1,86 @@
+#ifndef BLAKE3_H
+#define BLAKE3_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if !defined(BLAKE3_API)
+# if defined(_WIN32) || defined(__CYGWIN__)
+#   if defined(BLAKE3_DLL)
+#     if defined(BLAKE3_DLL_EXPORTS)
+#       define BLAKE3_API __declspec(dllexport)
+#     else
+#       define BLAKE3_API __declspec(dllimport)
+#     endif
+#     define BLAKE3_PRIVATE
+#   else
+#     define BLAKE3_API
+#     define BLAKE3_PRIVATE
+#   endif
+# elif __GNUC__ >= 4
+#   define BLAKE3_API __attribute__((visibility("default")))
+#   define BLAKE3_PRIVATE __attribute__((visibility("hidden")))
+# else
+#   define BLAKE3_API
+#   define BLAKE3_PRIVATE
+# endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BLAKE3_VERSION_STRING "1.8.5"
+#define BLAKE3_KEY_LEN 32
+#define BLAKE3_OUT_LEN 32
+#define BLAKE3_BLOCK_LEN 64
+#define BLAKE3_CHUNK_LEN 1024
+#define BLAKE3_MAX_DEPTH 54
+
+// This struct is a private implementation detail. It has to be here because
+// it's part of the blake3_hasher structure defined below.
+typedef struct {
+  uint32_t cv[8];
+  uint64_t chunk_counter;
+  uint8_t buf[BLAKE3_BLOCK_LEN];
+  uint8_t buf_len;
+  uint8_t blocks_compressed;
+  uint8_t flags;
+} blake3_chunk_state;
+
+typedef struct {
+  uint32_t key[8];
+  blake3_chunk_state chunk;
+  uint8_t cv_stack_len;
+  // The stack size is MAX_DEPTH + 1 because we do lazy merging. For example,
+  // with 7 chunks, we have 3 entries in the stack. Adding an 8th chunk
+  // requires a 4th entry, rather than merging everything down to 1, because we
+  // don't know whether more input is coming. This is different from how the
+  // reference implementation does things.
+  uint8_t cv_stack[(BLAKE3_MAX_DEPTH + 1) * BLAKE3_OUT_LEN];
+} blake3_hasher;
+
+BLAKE3_API const char *blake3_version(void);
+BLAKE3_API void blake3_hasher_init(blake3_hasher *self);
+BLAKE3_API void blake3_hasher_init_keyed(blake3_hasher *self,
+                                         const uint8_t key[BLAKE3_KEY_LEN]);
+BLAKE3_API void blake3_hasher_init_derive_key(blake3_hasher *self, const char *context);
+BLAKE3_API void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context,
+                                                  size_t context_len);
+BLAKE3_API void blake3_hasher_update(blake3_hasher *self, const void *input,
+                                     size_t input_len);
+#if defined(BLAKE3_USE_TBB)
+BLAKE3_API void blake3_hasher_update_tbb(blake3_hasher *self, const void *input,
+                                         size_t input_len);
+#endif // BLAKE3_USE_TBB
+BLAKE3_API void blake3_hasher_finalize(const blake3_hasher *self, uint8_t *out,
+                                       size_t out_len);
+BLAKE3_API void blake3_hasher_finalize_seek(const blake3_hasher *self, uint64_t seek,
+                                            uint8_t *out, size_t out_len);
+BLAKE3_API void blake3_hasher_reset(blake3_hasher *self);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BLAKE3_H */

--- a/implementations/swift/Sources/CEd25519/README.md
+++ b/implementations/swift/Sources/CEd25519/README.md
@@ -1,0 +1,44 @@
+# CEd25519 — vendored Ed25519 thin wrapper for the Swift kit
+
+**Canonical source:** `tools/ed25519-vendored/`. This directory is a
+**copy**, NOT a symlink, because SwiftPM does not discover targets
+through directory symlinks (it requires the source files to live inside
+the package root tree, accessed without symlink traversal). The C kit
+references `tools/ed25519-vendored/` directly via its Makefile
+(`ED_DIR = ../../../tools/ed25519-vendored`); only this Swift target
+needs the in-tree copy.
+
+The two copies MUST stay byte-identical. The header layout differs:
+SwiftPM expects public headers under `include/` (so `ed25519.h` lives
+at `Sources/CEd25519/include/ed25519.h`), while the canonical layout
+has it alongside the `.c` file. Everything else is verbatim.
+
+## Backing library
+
+Both copies are thin wrappers around OpenSSL's `EVP_PKEY_ED25519`. The
+build links against `libcrypto`. See the canonical README at
+`tools/ed25519-vendored/README.md` for the rationale (byte-identical
+signatures with rust's ed25519-dalek and go's crypto/ed25519, RFC-8032
+deterministic).
+
+## Refresh procedure
+
+When the canonical `tools/ed25519-vendored/` is updated, mirror the
+change here:
+
+```sh
+cp tools/ed25519-vendored/ed25519.c \
+   implementations/swift/Sources/CEd25519/
+
+cp tools/ed25519-vendored/ed25519.h \
+   implementations/swift/Sources/CEd25519/include/
+```
+
+## Verification
+
+`diff -r tools/ed25519-vendored/ implementations/swift/Sources/CEd25519/`
+should report only:
+- `Only in tools/ed25519-vendored: README.md` (canonical README, not needed in copy)
+- `Only in tools/ed25519-vendored: ed25519.h` (lives at `include/ed25519.h` in the copy)
+- `Only in implementations/swift/Sources/CEd25519: include`
+- `Only in implementations/swift/Sources/CEd25519: README.md` (this file)

--- a/implementations/swift/Sources/CEd25519/ed25519.c
+++ b/implementations/swift/Sources/CEd25519/ed25519.c
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Ed25519 thin wrapper — OpenSSL EVP_PKEY_ED25519 backend.
+ *
+ * The C kit uses OpenSSL libcrypto for the same reason the C++ kit does:
+ * byte-identical signatures without vendoring ~1500 LOC of field arithmetic.
+ * Both kits link -lcrypto; the C++ kit's sign_ed25519.cpp is the reference.
+ *
+ * Compile: cc -std=c11 -I<openssl-include> ed25519.c -lcrypto
+ */
+
+#include "ed25519.h"
+
+#include <openssl/evp.h>
+#include <string.h>
+
+int pk_ed25519_pubkey_from_seed(const uint8_t seed[32], uint8_t pk_out[32]) {
+    EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL, seed, 32);
+    if (!pkey) return -1;
+    size_t pklen = 32;
+    int rc = EVP_PKEY_get_raw_public_key(pkey, pk_out, &pklen);
+    EVP_PKEY_free(pkey);
+    return (rc == 1 && pklen == 32) ? 0 : -1;
+}
+
+int pk_ed25519_sign(const uint8_t *msg, size_t msg_len,
+                    const uint8_t seed[32],
+                    uint8_t sig_out[64]) {
+    EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL, seed, 32);
+    if (!pkey) return -1;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx) { EVP_PKEY_free(pkey); return -1; }
+    int ok = 0;
+    if (EVP_DigestSignInit(ctx, NULL, NULL, NULL, pkey) == 1) {
+        size_t siglen = 64;
+        if (EVP_DigestSign(ctx, sig_out, &siglen, msg, msg_len) == 1 && siglen == 64)
+            ok = 1;
+    }
+    EVP_MD_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    return ok ? 0 : -1;
+}
+
+int pk_ed25519_verify(const uint8_t *msg, size_t msg_len,
+                      const uint8_t sig[64],
+                      const uint8_t pk[32]) {
+    EVP_PKEY *pkey = EVP_PKEY_new_raw_public_key(EVP_PKEY_ED25519, NULL, pk, 32);
+    if (!pkey) return 0;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx) { EVP_PKEY_free(pkey); return 0; }
+    int ok = 0;
+    if (EVP_DigestVerifyInit(ctx, NULL, NULL, NULL, pkey) == 1) {
+        ok = (EVP_DigestVerify(ctx, sig, 64, msg, msg_len) == 1) ? 1 : 0;
+    }
+    EVP_MD_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    return ok;
+}

--- a/implementations/swift/Sources/CEd25519/include/ed25519.h
+++ b/implementations/swift/Sources/CEd25519/include/ed25519.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Ed25519 thin wrapper over OpenSSL EVP_PKEY_ED25519 (libcrypto).
+ *
+ * Byte-identical to ed25519-dalek (Rust), OpenSSL EVP_PKEY_ED25519 (C++),
+ * and node:crypto's ed25519 for the same (seed, message) pairs.
+ *
+ * Build requirement: -lcrypto (OpenSSL 1.1+ or 3.x).
+ * The C kit Makefile sets LDFLAGS = -lcrypto and -I to the OpenSSL
+ * headers path.
+ *
+ * Rationale for OpenSSL over a self-rolled impl: the C++ kit already uses
+ * OpenSSL EVP_PKEY_ED25519 (see implementations/cpp/provekit/proof-envelope/
+ * sign_ed25519.cpp). Using the same underlying library guarantees byte-level
+ * agreement with the C++ kit without vendoring ~1500 LOC of field arithmetic.
+ */
+
+#ifndef PK_ED25519_H
+#define PK_ED25519_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Derive the 32-byte public key from a 32-byte seed.
+ * pk_out must point to a 32-byte buffer.
+ * Returns 0 on success, -1 on OpenSSL failure.
+ */
+int pk_ed25519_pubkey_from_seed(const uint8_t seed[32], uint8_t pk_out[32]);
+
+/*
+ * Sign message (msg, msg_len) with the private key derived from seed.
+ * sig_out must point to a 64-byte buffer.
+ * Returns 0 on success, -1 on OpenSSL failure.
+ */
+int pk_ed25519_sign(const uint8_t *msg, size_t msg_len,
+                    const uint8_t seed[32],
+                    uint8_t sig_out[64]);
+
+/*
+ * Verify signature sig (64 bytes) over message (msg, msg_len)
+ * with public key pk (32 bytes).
+ * Returns 1 if valid, 0 if invalid (including any OpenSSL failure).
+ */
+int pk_ed25519_verify(const uint8_t *msg, size_t msg_len,
+                      const uint8_t sig[64],
+                      const uint8_t pk[32]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PK_ED25519_H */

--- a/implementations/swift/Sources/CryptoTests/main.swift
+++ b/implementations/swift/Sources/CryptoTests/main.swift
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CryptoTests — standalone integration test runner for ProvekitCrypto.
+//
+// Does NOT depend on XCTest or Swift Testing (neither is available on
+// CI without full Xcode). Uses the kit-local PASS/FAIL idiom from
+// LSPTests / ConformanceRunner. Exits 0 on all pass, 1 on any fail.
+//
+// Coverage:
+//   * BLAKE3-512 reference vectors + cross-kit pinned hashes
+//   * RFC 8785 JCS encoder shapes
+//   * Deterministic CBOR (RFC 8949 §4.2.1)
+//   * Ed25519 sign/verify + Foundation v0 public-key pin
+//   * Claim envelope (mintContract / mintBridge) + contractCid +
+//     contractSetCid
+//   * Proof envelope determinism + members order-independence
+
+import Foundation
+import ProvekitCrypto
+
+// MARK: - test harness
+
+nonisolated(unsafe) var passed = 0
+nonisolated(unsafe) var failed = 0
+
+func test(_ name: String, block: () -> Bool) {
+    if block() {
+        print("PASS: \(name)")
+        passed += 1
+    } else {
+        print("FAIL: \(name)")
+        failed += 1
+    }
+}
+
+func eq<T: Equatable>(_ a: T, _ b: T, _ label: String = "") -> Bool {
+    if a != b {
+        print("  expected: \(b)")
+        print("  got:      \(a)")
+        if !label.isEmpty { print("  context:  \(label)") }
+        return false
+    }
+    return true
+}
+
+// MARK: - Blake3
+
+test("blake3 empty input vector") {
+    // BLAKE3 reference vector for input_len=0, first 64 bytes of output.
+    let h = Blake3.hex(Data())
+    return eq(
+        h,
+        "blake3-512:af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262e00f03e7b69af26b7faaf09fcd333050338ddfe085b8cc869ca98b206c08243a"
+    )
+}
+
+test("blake3 conformance pinned eq_atomic JCS hash") {
+    // Same hash pinned in ConformanceRunner/main.swift line 45,
+    // previously produced via python-blake3 shellout.
+    let jcs1 = #"{"args":[{"args":[{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"42"}],"kind":"ctor","name":"parse_int"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":42}],"kind":"atomic","name":"="}"#
+    let h = Blake3.hex(Data(jcs1.utf8))
+    return eq(
+        h,
+        "blake3-512:5eade72c08811b2d38adcb158eced38f3d319de090d59b2fa7a77ad830169e18539d2b75d2a2838c545e644a688cf137603674523ff37f1586a650f6dd05aeaa"
+    )
+}
+
+test("blake3 digest length = 64 bytes / 128 hex") {
+    return Blake3.digest(Data()).count == 64 && Blake3.hex64(Data()).count == 128
+}
+
+test("blake3 determinism") {
+    let payload = Data("hello world".utf8)
+    return Blake3.hex(payload) == Blake3.hex(payload)
+}
+
+// MARK: - JCS
+
+test("jcs empty object") {
+    return eq(JcsCanonicalizer.encodeString(.object([])), "{}")
+}
+
+test("jcs empty array") {
+    return eq(JcsCanonicalizer.encodeString(.array([])), "[]")
+}
+
+test("jcs sorted keys") {
+    let v: JcsCanonical = .object([
+        ("c", .int(3)), ("a", .int(1)), ("b", .int(2)),
+    ])
+    return eq(JcsCanonicalizer.encodeString(v), #"{"a":1,"b":2,"c":3}"#)
+}
+
+test("jcs string escapes") {
+    let v: JcsCanonical = .string("a\"b\\c\nd")
+    return eq(JcsCanonicalizer.encodeString(v), "\"a\\\"b\\\\c\\nd\"")
+}
+
+test("jcs control char escape") {
+    let v: JcsCanonical = .string("\u{01}")
+    return eq(JcsCanonicalizer.encodeString(v), "\"\\u0001\"")
+}
+
+test("jcs nested object") {
+    let v: JcsCanonical = .object([
+        ("z", .object([("b", .int(2)), ("a", .int(1))])),
+        ("a", .array([.int(1), .int(2), .int(3)])),
+    ])
+    return eq(
+        JcsCanonicalizer.encodeString(v),
+        #"{"a":[1,2,3],"z":{"a":1,"b":2}}"#
+    )
+}
+
+test("jcs nulls and bools") {
+    let v: JcsCanonical = .object([
+        ("a", .null), ("b", .bool(true)), ("c", .bool(false)),
+    ])
+    return eq(
+        JcsCanonicalizer.encodeString(v),
+        #"{"a":null,"b":true,"c":false}"#
+    )
+}
+
+test("jcs negative and zero ints") {
+    let v: JcsCanonical = .array([.int(-5), .int(0), .int(42)])
+    return eq(JcsCanonicalizer.encodeString(v), "[-5,0,42]")
+}
+
+test("jcs computeJcsCid shape") {
+    let cid = computeJcsCid(.object([("a", .int(1))]))
+    return cid.hasPrefix("blake3-512:")
+        && cid.count == "blake3-512:".count + 128
+}
+
+// MARK: - CBOR
+
+test("cbor empty map = 0xa0") {
+    var enc = CborEncoder()
+    enc.encodeMapHead(0)
+    return enc.data == Data([0xa0])
+}
+
+test("cbor empty array = 0x80") {
+    var enc = CborEncoder()
+    enc.encodeArrayHead(0)
+    return enc.data == Data([0x80])
+}
+
+test("cbor short uints (<24)") {
+    var enc = CborEncoder()
+    enc.encodeUInt(0)
+    enc.encodeUInt(23)
+    return enc.data == Data([0x00, 0x17])
+}
+
+test("cbor uint8 marker (24)") {
+    var enc = CborEncoder()
+    enc.encodeUInt(24)
+    return enc.data == Data([0x18, 0x18])
+}
+
+test("cbor uint16 marker (256)") {
+    var enc = CborEncoder()
+    enc.encodeUInt(256)
+    return enc.data == Data([0x19, 0x01, 0x00])
+}
+
+test("cbor uint32 marker (0x10000)") {
+    var enc = CborEncoder()
+    enc.encodeUInt(0x10000)
+    return enc.data == Data([0x1a, 0x00, 0x01, 0x00, 0x00])
+}
+
+test("cbor text string \"a\"") {
+    var enc = CborEncoder()
+    enc.encodeTStr("a")
+    return enc.data == Data([0x61, 0x61])
+}
+
+test("cbor empty byte string") {
+    var enc = CborEncoder()
+    enc.encodeBStr(Data())
+    return enc.data == Data([0x40])
+}
+
+test("cbor sorted-map reorders inputs") {
+    let pairs = [
+        CborKVPair(
+            key: CborHelpers.encodeKey("z"),
+            value: CborHelpers.encodeStringValue("zv")),
+        CborKVPair(
+            key: CborHelpers.encodeKey("a"),
+            value: CborHelpers.encodeStringValue("av")),
+    ]
+    var enc = CborEncoder()
+    CborHelpers.emitSortedMap(into: &enc, pairs: pairs)
+    return enc.data == Data([
+        0xa2,
+        0x61, 0x61, 0x62, 0x61, 0x76,
+        0x61, 0x7a, 0x62, 0x7a, 0x76,
+    ])
+}
+
+// MARK: - Ed25519
+
+test("ed25519 foundation v0 public key") {
+    let pk = Ed25519.publicKeyString(fromSeed: Ed25519.foundationV0Seed)
+    return eq(pk, "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=")
+}
+
+test("ed25519 sign/verify round-trip") {
+    let seed = Ed25519.foundationV0Seed
+    let msg = Data("hello provekit".utf8)
+    let sig = Ed25519.sign(message: msg, seed: seed)
+    if sig.count != 64 { return false }
+    let pk = Ed25519.publicKey(fromSeed: seed)
+    return Ed25519.verify(message: msg, signature: sig, pubKey: pk)
+}
+
+test("ed25519 sign is deterministic") {
+    let seed = Ed25519.foundationV0Seed
+    let msg = Data("provekit-self-contracts@1.0".utf8)
+    return Ed25519.sign(message: msg, seed: seed) ==
+        Ed25519.sign(message: msg, seed: seed)
+}
+
+test("ed25519 verify rejects tampered signature") {
+    let seed = Ed25519.foundationV0Seed
+    let pk = Ed25519.publicKey(fromSeed: seed)
+    let msg = Data("a".utf8)
+    var sig = Ed25519.sign(message: msg, seed: seed)
+    sig[0] ^= 0xFF
+    return Ed25519.verify(message: msg, signature: sig, pubKey: pk) == false
+}
+
+// MARK: - Claim envelope
+
+func sampleContractArgs() -> ContractMintArgs {
+    return ContractMintArgs(
+        contractName: "demo_contract",
+        post: .object([
+            ("kind", .string("atomic")),
+            ("name", .string("=")),
+            ("args", .array([
+                .object([("kind", .string("var")), ("name", .string("x"))]),
+                .object([
+                    ("kind", .string("const")),
+                    ("sort", .object([
+                        ("kind", .string("primitive")),
+                        ("name", .string("Int")),
+                    ])),
+                    ("value", .int(0)),
+                ]),
+            ])),
+        ]),
+        outBinding: "out",
+        producedBy: "swift-self-contracts@1.0",
+        producedAt: "2026-04-30T18:00:00.000Z",
+        authoring: .kitAuthor(author: "swift-self-contracts@1.0", note: nil)
+    )
+}
+
+test("claim envelope mintContract is byte-deterministic") {
+    let minter = ClaimMinter(signerSeed: Ed25519.foundationV0Seed)
+    do {
+        let m1 = try minter.mintContract(sampleContractArgs())
+        let m2 = try minter.mintContract(sampleContractArgs())
+        return m1.cid == m2.cid && m1.canonicalBytes == m2.canonicalBytes
+            && m1.cid.hasPrefix("blake3-512:")
+            && m1.cid.count == "blake3-512:".count + 128
+    } catch {
+        print("  threw: \(error)")
+        return false
+    }
+}
+
+test("claim envelope mintContract rejects all-nil formulae") {
+    let minter = ClaimMinter(signerSeed: Ed25519.foundationV0Seed)
+    var args = sampleContractArgs()
+    args.pre = nil; args.post = nil; args.inv = nil
+    do {
+        _ = try minter.mintContract(args)
+        return false
+    } catch {
+        return true
+    }
+}
+
+test("claim envelope contains cid + producerSignature fields") {
+    let minter = ClaimMinter(signerSeed: Ed25519.foundationV0Seed)
+    do {
+        let m = try minter.mintContract(sampleContractArgs())
+        guard let s = String(data: m.canonicalBytes, encoding: .utf8) else {
+            return false
+        }
+        return s.contains(#""cid":"blake3-512:"#)
+            && s.contains(#""producerSignature":"ed25519:"#)
+    } catch {
+        return false
+    }
+}
+
+test("contractCid is signer-independent") {
+    var a = sampleContractArgs()
+    var b = sampleContractArgs()
+    b.producedBy = "different-producer@9.9"
+    b.producedAt = "2099-01-01T00:00:00.000Z"
+    if contractCid(fromArgs: a) != contractCid(fromArgs: b) { return false }
+    a.post = .string("different")
+    return contractCid(fromArgs: a) != contractCid(fromArgs: b)
+}
+
+test("contractSetCid is order-independent") {
+    let cids = [
+        "blake3-512:a" + String(repeating: "0", count: 127),
+        "blake3-512:b" + String(repeating: "0", count: 127),
+        "blake3-512:c" + String(repeating: "0", count: 127),
+    ]
+    return computeContractSetCid(cids) == computeContractSetCid(cids.reversed())
+}
+
+test("claim envelope mintBridge produces well-formed CID") {
+    let minter = ClaimMinter(signerSeed: Ed25519.foundationV0Seed)
+    do {
+        let m = try minter.mintBridge(BridgeMintArgs(
+            producedBy: "swift-self-contracts@1.0",
+            producedAt: "2026-04-30T18:00:00.000Z",
+            sourceSymbol: "lift_plugin_initialize_protocol_version_match",
+            sourceLayer: "rust-kit",
+            targetContractCid: "blake3-512:" + String(repeating: "0", count: 128),
+            targetLayer: "swift-kit",
+            notes: "test bridge"
+        ))
+        return m.cid.hasPrefix("blake3-512:")
+            && m.cid.count == "blake3-512:".count + 128
+    } catch {
+        return false
+    }
+}
+
+test("claim envelope mintBridge requires target") {
+    let minter = ClaimMinter(signerSeed: Ed25519.foundationV0Seed)
+    do {
+        _ = try minter.mintBridge(BridgeMintArgs(
+            producedBy: "x", producedAt: "y",
+            sourceSymbol: "s", sourceLayer: "L",
+            targetContractCid: "",
+            targetLayer: "T"
+        ))
+        return false
+    } catch {
+        return true
+    }
+}
+
+// MARK: - Proof envelope
+
+func sampleProofInput() -> ProofEnvelopeInput {
+    return ProofEnvelopeInput(
+        name: "@provekit/swift-test",
+        version: "1.0.0",
+        members: [
+            ("blake3-512:" + String(repeating: "a", count: 128),
+             Data("memberA".utf8)),
+            ("blake3-512:" + String(repeating: "b", count: 128),
+             Data("memberB".utf8)),
+        ],
+        signerCid: Blake3.hex(Data(
+            Ed25519.publicKeyString(fromSeed: Ed25519.foundationV0Seed).utf8
+        )),
+        signerSeed: Ed25519.foundationV0Seed,
+        declaredAt: "2026-04-30T18:00:00.000Z"
+    )
+}
+
+test("proof envelope is byte-deterministic") {
+    let a = ProofEnvelopeBuilder.build(sampleProofInput())
+    let b = ProofEnvelopeBuilder.build(sampleProofInput())
+    return a.bytes == b.bytes && a.filenameCid == b.filenameCid
+        && a.filenameCid.hasPrefix("blake3-512:")
+        && a.filenameCid.count == "blake3-512:".count + 128
+}
+
+test("proof envelope members order-independent") {
+    let cidA = "blake3-512:" + String(repeating: "a", count: 128)
+    let cidB = "blake3-512:" + String(repeating: "b", count: 128)
+    let aBody = Data("aaa".utf8)
+    let bBody = Data("bbb".utf8)
+    let inForward = ProofEnvelopeInput(
+        name: "@x/y", version: "1.0.0",
+        members: [(cidA, aBody), (cidB, bBody)],
+        signerCid: "blake3-512:" + String(repeating: "c", count: 128),
+        signerSeed: Ed25519.foundationV0Seed,
+        declaredAt: "2026-04-30T18:00:00.000Z"
+    )
+    let inReverse = ProofEnvelopeInput(
+        name: "@x/y", version: "1.0.0",
+        members: [(cidB, bBody), (cidA, aBody)],
+        signerCid: "blake3-512:" + String(repeating: "c", count: 128),
+        signerSeed: Ed25519.foundationV0Seed,
+        declaredAt: "2026-04-30T18:00:00.000Z"
+    )
+    let f = ProofEnvelopeBuilder.build(inForward)
+    let r = ProofEnvelopeBuilder.build(inReverse)
+    return f.bytes == r.bytes && f.filenameCid == r.filenameCid
+}
+
+// MARK: - Cross-kit byte-equivalence
+//
+// Reproduce the canonical-bytes pipeline used by
+// tools/foundation-keygen/src/lib.rs::build_self_contracts_message to
+// sign the swift kit's self-contracts attestation. The rust signer
+// produced the signature pinned in
+// .provekit/self-contracts-attestations/swift.json. If the Swift
+// implementation here is byte-equivalent (JCS + BLAKE3 + Ed25519 all
+// matching), recomputing the signature for the same canonical bytes
+// must produce the same 64-byte ed25519 result.
+
+test("cross-kit signature equivalence: swift self-contracts attestation") {
+    // Pinned values from .provekit/self-contracts-attestations/swift.json.
+    let cid = "" // swift catalog CID is empty in the pinned attestation
+    let contractSetCid = "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229"
+    let declaredAt = "2026-05-03T18:00:00Z"
+    let signerPubkey = Ed25519.publicKeyString(fromSeed: Ed25519.foundationV0Seed)
+
+    // Build message — same field set as build_self_contracts_message
+    // in tools/foundation-keygen/src/lib.rs.
+    let message: JcsCanonical = .object([
+        ("schemaVersion", .string("1")),
+        ("kind", .string("self-contracts-attestation")),
+        ("lang", .string("swift")),
+        ("cid", .string(cid)),
+        ("contractSetCid", .string(contractSetCid)),
+        ("declaredAt", .string(declaredAt)),
+        ("signer", .string(signerPubkey)),
+    ])
+    let canonicalBytes = JcsCanonicalizer.encode(message)
+    let sigStr = Ed25519.signatureString(message: canonicalBytes, seed: Ed25519.foundationV0Seed)
+
+    // Pinned: signature emitted by tools/foundation-keygen (Rust
+    // ed25519-dalek backend). Byte-equivalence asserts:
+    //   * JCS encoder produces identical bytes;
+    //   * Ed25519 produces identical signatures (RFC 8032 deterministic).
+    let pinned = "ed25519:rfH8zqKIRJn5wANeE2LUqwsOTrTuicdv4J80eFBbls+y43jXOWJ55wPFm5/ktigYsmnzI3kUe2DHwgmyDIB7AQ=="
+    return eq(sigStr, pinned)
+}
+
+// MARK: - Summary
+
+print("")
+print("=== ProvekitCrypto test summary ===")
+print("PASSED: \(passed)")
+print("FAILED: \(failed)")
+if failed > 0 {
+    exit(1)
+}
+exit(0)

--- a/implementations/swift/Sources/Provekit/IR.swift
+++ b/implementations/swift/Sources/Provekit/IR.swift
@@ -7,6 +7,7 @@
 // tagged unions, and a custom JSON encoder for JCS key ordering.
 
 import Foundation
+import ProvekitCrypto
 
 // MARK: - Sort
 
@@ -237,22 +238,13 @@ public enum Jcs {
     }
 }
 
-// BLAKE3 not available in CryptoKit — delegate to Python for v1.1.
-public enum Blake3 {
-    public static func hex(_ data: Data) -> String {
-        let tmpDir = FileManager.default.temporaryDirectory
-        let path = tmpDir.appendingPathComponent("pk_hash_\(UUID().uuidString)").path
-        FileManager.default.createFile(atPath: path, contents: data)
-        let script = "import blake3; d=open('\(path)','rb').read(); print('blake3-512:'+blake3.blake3(d).digest(length=64).hex())"
-        let task = Process()
-        task.launchPath = "/usr/bin/python3"
-        task.arguments = ["-c", script]
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.launch()
-        task.waitUntilExit()
-        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        try? FileManager.default.removeItem(atPath: path)
-        return output.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-}
+// BLAKE3 — delegates to the native pure-Swift / vendored-C implementation
+// in ProvekitCrypto. The legacy python-shellout has been retired; output
+// is byte-equivalent to the previous shell-out behavior because both
+// ultimately call the BLAKE3 reference implementation.
+//
+// This typealias preserves the existing module-local API surface
+// (`Provekit.Blake3.hex(_:)`) used by CrossKitBridges, ConformanceRunner,
+// and MintSwiftSelfContracts. New code should `import ProvekitCrypto`
+// directly and use `ProvekitCrypto.Blake3`.
+public typealias Blake3 = ProvekitCrypto.Blake3

--- a/implementations/swift/Sources/ProvekitCrypto/Blake3.swift
+++ b/implementations/swift/Sources/ProvekitCrypto/Blake3.swift
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Blake3 — native BLAKE3-512 via the vendored portable C reference impl.
+//
+// Replaces the python-shellout in `Sources/Provekit/IR.swift`'s legacy
+// `Blake3.hex(_:)`. Same output shape ("blake3-512:" + 128 lowercase hex
+// chars), now in-process, deterministic, and dependency-free at runtime.
+//
+// Spec: protocol/specs/2026-04-30-canonicalization-grammar.md §11
+//       protocol/specs/2026-04-30-memento-envelope-grammar.md §"Self-identifying"
+//
+// Cross-kit conformance: digests MUST match the rust/go/cpp/python kits
+// for identical input bytes. The vendored C impl is the same source the
+// C++ peer orchestrator uses, so byte-equivalence is mechanical.
+//
+// Output length is 64 bytes (BLAKE3 default). The protocol calls this
+// "BLAKE3-512" (alias used elsewhere in the kit-source for parity with
+// the SHA-512 family). Despite the name, BLAKE3 always produces a single
+// 64-byte digest; "512" reflects the canonical bit-length used as the
+// protocol's content-address.
+
+import Foundation
+import CBlake3
+
+public enum Blake3 {
+
+    /// Self-identifying CID: "blake3-512:" + 128 lowercase hex chars of
+    /// the BLAKE3-512 digest of `data`. This is the protocol-mandated
+    /// content-address shape (cf. `canonicalizer/hasher.go::ComputeCID`).
+    public static func hex(_ data: Data) -> String {
+        return "blake3-512:" + hex64(data)
+    }
+
+    /// 128-character lowercase hex digest, NOT prefixed. Matches
+    /// `Hasher.Blake3_512Hex` in the go canonicalizer.
+    public static func hex64(_ data: Data) -> String {
+        let raw = digest(data)
+        return raw.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Raw 64-byte BLAKE3 digest of `data`. Allocates a fresh hasher per
+    /// call; the kit hashes only kilobytes of contract bytes per mint, so
+    /// reuse is not worth the API surface.
+    public static func digest(_ data: Data) -> [UInt8] {
+        var hasher = blake3_hasher()
+        blake3_hasher_init(&hasher)
+        data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            // BLAKE3 accepts zero-length updates per the reference impl;
+            // skip the call when raw.baseAddress is nil to avoid a Swift
+            // strictness warning about passing nil to a non-nullable arg.
+            if let base = raw.baseAddress, raw.count > 0 {
+                blake3_hasher_update(&hasher, base, raw.count)
+            }
+        }
+        var out = [UInt8](repeating: 0, count: 64)
+        out.withUnsafeMutableBufferPointer { buf in
+            blake3_hasher_finalize(&hasher, buf.baseAddress!, 64)
+        }
+        return out
+    }
+}

--- a/implementations/swift/Sources/ProvekitCrypto/Cbor.swift
+++ b/implementations/swift/Sources/ProvekitCrypto/Cbor.swift
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cbor — deterministic-CBOR encoder per RFC 8949 §4.2.1 (Core
+// Deterministic Encoding).
+//
+// Mirrors the go reference at
+// implementations/go/provekit-ir-symbolic/proof_envelope/cbor.go and the
+// rust crate provekit-proof-envelope's `cbor.rs`. Used exclusively by
+// the proof envelope catalog encoder. The kit does NOT need (and does
+// NOT support) the full CBOR data model; only:
+//
+//   major 0  unsigned ints (definite, shortest-form)
+//   major 2  byte strings  (raw bstr — used for ed25519 signatures + member envelope bodies)
+//   major 3  text strings  (UTF-8 — used for keys + most values)
+//   major 4  arrays        (definite-length)
+//   major 5  maps          (definite-length, keys sorted bytewise on CBOR-encoded form)
+//
+// The protocol's catalog body emits exactly these. No tags, no floats,
+// no signed-int negation, no indefinite lengths, no streamed buffers.
+
+import Foundation
+
+public enum CborMajor: UInt8 {
+    case uint  = 0
+    case bstr  = 2
+    case tstr  = 3
+    case array = 4
+    case map   = 5
+}
+
+public struct CborEncoder {
+    public private(set) var bytes: Data
+
+    public init() { self.bytes = Data() }
+
+    public var data: Data { bytes }
+
+    /// Reset the buffer so the encoder can be reused.
+    public mutating func reset() { bytes.removeAll(keepingCapacity: true) }
+
+    /// Append an "initial byte + argument" head (RFC 8949 §3) using the
+    /// shortest of {0..23, uint8, uint16, uint32, uint64} per §4.2.1.
+    public mutating func appendHead(_ major: CborMajor, _ arg: UInt64) {
+        let mt = UInt8(major.rawValue) << 5
+        switch arg {
+        case 0..<24:
+            bytes.append(mt | UInt8(arg))
+        case 24...0xFF:
+            bytes.append(mt | 24)
+            bytes.append(UInt8(arg))
+        case 0x100...0xFFFF:
+            bytes.append(mt | 25)
+            let v = UInt16(arg).bigEndian
+            withUnsafeBytes(of: v) { bytes.append(contentsOf: $0) }
+        case 0x10000...0xFFFF_FFFF:
+            bytes.append(mt | 26)
+            let v = UInt32(arg).bigEndian
+            withUnsafeBytes(of: v) { bytes.append(contentsOf: $0) }
+        default:
+            bytes.append(mt | 27)
+            let v = arg.bigEndian
+            withUnsafeBytes(of: v) { bytes.append(contentsOf: $0) }
+        }
+    }
+
+    public mutating func encodeUInt(_ value: UInt64) {
+        appendHead(.uint, value)
+    }
+
+    /// CBOR byte string (major 2): head + raw bytes.
+    public mutating func encodeBStr(_ data: Data) {
+        appendHead(.bstr, UInt64(data.count))
+        bytes.append(data)
+    }
+
+    public mutating func encodeBStr(_ data: [UInt8]) {
+        appendHead(.bstr, UInt64(data.count))
+        bytes.append(contentsOf: data)
+    }
+
+    /// CBOR text string (major 3, UTF-8). The caller is responsible for
+    /// the input being valid UTF-8 (Swift `String` always is).
+    public mutating func encodeTStr(_ s: String) {
+        let utf8 = Array(s.utf8)
+        appendHead(.tstr, UInt64(utf8.count))
+        bytes.append(contentsOf: utf8)
+    }
+
+    /// Definite-length array head; caller appends `count` element bodies.
+    public mutating func encodeArrayHead(_ count: UInt64) {
+        appendHead(.array, count)
+    }
+
+    /// Definite-length map head; caller MUST emit keys in bytewise lex
+    /// order of their CBOR-encoded form (RFC 8949 §4.2.1). The
+    /// `emitSortedMap` helper handles sorting.
+    public mutating func encodeMapHead(_ count: UInt64) {
+        appendHead(.map, count)
+    }
+
+    /// Append a pre-encoded blob of CBOR bytes (e.g. a value-blob from a
+    /// kvPair). Bypasses the encoder's structural state machine — the
+    /// caller asserts the blob is well-formed CBOR.
+    public mutating func appendRaw(_ raw: Data) {
+        bytes.append(raw)
+    }
+}
+
+/// One (key, value) pair where each component is already CBOR-encoded
+/// to bytes. Used by `emitSortedMap` so the sort key is the bytewise
+/// CBOR-encoded-key form (the protocol's deterministic order).
+public struct CborKVPair: Equatable {
+    public let keyCbor: Data
+    public let valCbor: Data
+
+    public init(key: Data, value: Data) {
+        self.keyCbor = key
+        self.valCbor = value
+    }
+}
+
+public enum CborHelpers {
+
+    /// CBOR-encode a text-string key into its own buffer.
+    public static func encodeKey(_ k: String) -> Data {
+        var enc = CborEncoder()
+        enc.encodeTStr(k)
+        return enc.data
+    }
+
+    /// CBOR-encode a text-string value (major 3).
+    public static func encodeStringValue(_ s: String) -> Data {
+        var enc = CborEncoder()
+        enc.encodeTStr(s)
+        return enc.data
+    }
+
+    /// CBOR-encode a byte-string value (major 2).
+    public static func encodeBStrValue(_ data: Data) -> Data {
+        var enc = CborEncoder()
+        enc.encodeBStr(data)
+        return enc.data
+    }
+
+    /// Emit a definite-length CBOR map with entries sorted by bytewise
+    /// lex order of their CBOR-encoded keys. The output bytes match the
+    /// go and rust kit envelopes byte-for-byte.
+    public static func emitSortedMap(
+        into encoder: inout CborEncoder,
+        pairs: [CborKVPair]
+    ) {
+        let sorted = pairs.sorted { lhs, rhs in
+            // Lexicographic byte comparison.
+            let l = lhs.keyCbor
+            let r = rhs.keyCbor
+            let n = min(l.count, r.count)
+            for i in 0..<n {
+                let li = l[l.startIndex + i]
+                let ri = r[r.startIndex + i]
+                if li != ri { return li < ri }
+            }
+            return l.count < r.count
+        }
+        encoder.encodeMapHead(UInt64(sorted.count))
+        for p in sorted {
+            encoder.appendRaw(p.keyCbor)
+            encoder.appendRaw(p.valCbor)
+        }
+    }
+
+    /// Encode a `{cid: bstr(envelope)}` map for the catalog `members`
+    /// field. Keys CBOR-sorted by §4.2.1.
+    public static func encodeMembersMap(_ members: [(String, Data)]) -> Data {
+        let pairs = members.map { (cid, body) -> CborKVPair in
+            CborKVPair(key: encodeKey(cid), value: encodeBStrValue(body))
+        }
+        var enc = CborEncoder()
+        emitSortedMap(into: &enc, pairs: pairs)
+        return enc.data
+    }
+}

--- a/implementations/swift/Sources/ProvekitCrypto/ClaimEnvelope.swift
+++ b/implementations/swift/Sources/ProvekitCrypto/ClaimEnvelope.swift
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ClaimEnvelope — mints signed contract / bridge ClaimEnvelopes.
+//
+// Mirrors the go reference at
+// implementations/go/provekit-ir-symbolic/claim_envelope/. v1.1.0 cut:
+//   * BLAKE3-512 with self-identifying "blake3-512:" prefix everywhere;
+//   * "ed25519:" + base64(sig) producer signatures;
+//   * bindingHash and propertyHash are DERIVED inside the minter
+//     (callers MUST NOT supply them);
+//   * canonical-input bytes for both CID and signature are
+//     `JCS(envelope minus cid + producerSignature)`.
+//
+// Spec:
+//   protocol/specs/2026-04-29-universal-claim-envelope.md
+//   protocol/specs/2026-04-30-memento-envelope-grammar.md
+
+import Foundation
+
+// MARK: - Constants
+
+public enum ClaimEnvelopeSchema {
+    /// Pinned schema CIDs from the go/rust references. Stable across
+    /// every conformant kit; producers MUST emit exactly these.
+    public static let contract =
+        "blake3-512:00000000000000000000000000000000000000000000000000000000000000d000000000000000000000000000000000000000000000000000000000000000d0"
+    public static let bridge =
+        "blake3-512:00000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000c0"
+    public static let implication =
+        "blake3-512:00000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000e0"
+}
+
+public enum Verdict: String, Sendable {
+    case holds
+    case violated
+    case decayed
+    case undecidable
+    case error
+}
+
+/// Authoring discriminator. Mirrors the `producerKind` enum in the
+/// memento envelope grammar.
+public enum AuthoringKind: Sendable {
+    case kitAuthor(author: String, note: String?)
+    case lift(lifter: String, evidence: String, sourceCid: String?)
+    case llm(llm: String, llmVersion: String, promptCid: String,
+             confidence: Double, rationale: String?)
+}
+
+/// One minted memento: the final signed JCS bytes + the envelope CID.
+public struct MintedMemento: Sendable, Equatable {
+    public let canonicalBytes: Data
+    public let cid: String
+
+    public init(canonicalBytes: Data, cid: String) {
+        self.canonicalBytes = canonicalBytes
+        self.cid = cid
+    }
+}
+
+// MARK: - Errors
+
+public enum ClaimEnvelopeError: Error, CustomStringConvertible {
+    case missingFormulae
+    case missingOutBinding
+    case missingContractName
+    case missingSourceSymbol
+    case missingSourceLayer
+    case missingTargetContractCid
+
+    public var description: String {
+        switch self {
+        case .missingFormulae:
+            return "MintContract: at least one of pre/post/inv must be non-nil"
+        case .missingOutBinding:
+            return "MintContract: outBinding is required"
+        case .missingContractName:
+            return "MintContract: contractName is required"
+        case .missingSourceSymbol:
+            return "MintBridge: sourceSymbol is required"
+        case .missingSourceLayer:
+            return "MintBridge: sourceLayer is required"
+        case .missingTargetContractCid:
+            return "MintBridge: targetContractCid is required"
+        }
+    }
+}
+
+// MARK: - Mint args
+
+public struct ContractMintArgs: Sendable {
+    public var contractName: String
+    public var pre: JcsCanonical?
+    public var post: JcsCanonical?
+    public var inv: JcsCanonical?
+    public var outBinding: String
+    public var producedBy: String
+    public var producedAt: String
+    public var inputCids: [String]
+    public var authoring: AuthoringKind
+
+    public init(
+        contractName: String,
+        pre: JcsCanonical? = nil,
+        post: JcsCanonical? = nil,
+        inv: JcsCanonical? = nil,
+        outBinding: String,
+        producedBy: String,
+        producedAt: String,
+        inputCids: [String] = [],
+        authoring: AuthoringKind
+    ) {
+        self.contractName = contractName
+        self.pre = pre
+        self.post = post
+        self.inv = inv
+        self.outBinding = outBinding
+        self.producedBy = producedBy
+        self.producedAt = producedAt
+        self.inputCids = inputCids
+        self.authoring = authoring
+    }
+}
+
+public struct BridgeMintArgs: Sendable {
+    public var producedBy: String
+    public var producedAt: String
+    public var sourceSymbol: String
+    public var sourceLayer: String
+    public var sourceContractCid: String
+    public var targetContractCid: String
+    public var targetProofCid: String
+    public var targetLayer: String
+    public var irArgSorts: [JcsCanonical]
+    public var irReturnSort: JcsCanonical
+    public var notes: String
+
+    public init(
+        producedBy: String,
+        producedAt: String,
+        sourceSymbol: String,
+        sourceLayer: String,
+        sourceContractCid: String = "",
+        targetContractCid: String,
+        targetProofCid: String = "",
+        targetLayer: String,
+        irArgSorts: [JcsCanonical] = [],
+        irReturnSort: JcsCanonical = .string("Bool"),
+        notes: String = ""
+    ) {
+        self.producedBy = producedBy
+        self.producedAt = producedAt
+        self.sourceSymbol = sourceSymbol
+        self.sourceLayer = sourceLayer
+        self.sourceContractCid = sourceContractCid
+        self.targetContractCid = targetContractCid
+        self.targetProofCid = targetProofCid
+        self.targetLayer = targetLayer
+        self.irArgSorts = irArgSorts
+        self.irReturnSort = irReturnSort
+        self.notes = notes
+    }
+}
+
+// MARK: - Minter
+
+/// Stateful envelope builder bound to one signing seed. The kit's mints
+/// per run use a single Minter; rotate by constructing a new one.
+public struct ClaimMinter: Sendable {
+    public let signerSeed: [UInt8]
+
+    public init(signerSeed: [UInt8]) {
+        precondition(signerSeed.count == 32, "Ed25519 seed must be 32 bytes")
+        self.signerSeed = signerSeed
+    }
+
+    /// Mint a v1.1.0 contract memento.
+    public func mintContract(_ args: ContractMintArgs) throws -> MintedMemento {
+        if args.pre == nil && args.post == nil && args.inv == nil {
+            throw ClaimEnvelopeError.missingFormulae
+        }
+        if args.outBinding.isEmpty { throw ClaimEnvelopeError.missingOutBinding }
+        if args.contractName.isEmpty { throw ClaimEnvelopeError.missingContractName }
+
+        // body: locked field set per memento envelope grammar.
+        var bodyPairs: [(String, JcsCanonical)] = [
+            ("contractName", .string(args.contractName)),
+            ("outBinding", .string(args.outBinding)),
+        ]
+        if let pre = args.pre {
+            bodyPairs.append(("pre", pre))
+            bodyPairs.append(("preHash", .string(hashValue(pre))))
+        }
+        if let post = args.post {
+            bodyPairs.append(("post", post))
+            bodyPairs.append(("postHash", .string(hashValue(post))))
+        }
+        if let inv = args.inv {
+            bodyPairs.append(("inv", inv))
+            bodyPairs.append(("invHash", .string(hashValue(inv))))
+        }
+        bodyPairs.append(("authoring", buildAuthoring(args.authoring)))
+
+        let evidence: JcsCanonical = .object([
+            ("kind", .string("contract")),
+            ("schema", .string(ClaimEnvelopeSchema.contract)),
+            ("body", .object(bodyPairs)),
+        ])
+
+        // propertyHash = ComputeCID(JCS({pre?, post?, inv?, outBinding}))
+        var phPairs: [(String, JcsCanonical)] = [
+            ("outBinding", .string(args.outBinding)),
+        ]
+        if let pre = args.pre { phPairs.append(("pre", pre)) }
+        if let post = args.post { phPairs.append(("post", post)) }
+        if let inv = args.inv { phPairs.append(("inv", inv)) }
+        let propertyHash = hashValue(.object(phPairs))
+
+        // bindingHash = ComputeCID(JCS({producerId, contractName, propertyHash}))
+        let bindingHash = hashValue(.object([
+            ("producerId", .string(args.producedBy)),
+            ("contractName", .string(args.contractName)),
+            ("propertyHash", .string(propertyHash)),
+        ]))
+
+        let unsigned = envelopeForHashing(
+            bindingHash: bindingHash,
+            propertyHash: propertyHash,
+            verdict: .holds,
+            producedBy: args.producedBy,
+            producedAt: args.producedAt,
+            inputCids: args.inputCids,
+            evidence: evidence
+        )
+        return finalize(unsigned: unsigned)
+    }
+
+    /// Mint a v1.1.0 bridge memento.
+    public func mintBridge(_ args: BridgeMintArgs) throws -> MintedMemento {
+        if args.sourceSymbol.isEmpty { throw ClaimEnvelopeError.missingSourceSymbol }
+        if args.sourceLayer.isEmpty { throw ClaimEnvelopeError.missingSourceLayer }
+        if args.targetContractCid.isEmpty { throw ClaimEnvelopeError.missingTargetContractCid }
+
+        var bodyPairs: [(String, JcsCanonical)] = [
+            ("sourceSymbol", .string(args.sourceSymbol)),
+            ("sourceLayer", .string(args.sourceLayer)),
+            ("targetContractCid", .string(args.targetContractCid)),
+            ("targetLayer", .string(args.targetLayer)),
+            ("irArgSorts", .array(args.irArgSorts)),
+            ("irReturnSort", args.irReturnSort),
+        ]
+        if !args.sourceContractCid.isEmpty {
+            bodyPairs.append(("sourceContractCid", .string(args.sourceContractCid)))
+        }
+        if !args.targetProofCid.isEmpty {
+            bodyPairs.append(("targetProofCid", .string(args.targetProofCid)))
+        }
+        if !args.notes.isEmpty {
+            bodyPairs.append(("notes", .string(args.notes)))
+        }
+
+        let evidence: JcsCanonical = .object([
+            ("kind", .string("bridge")),
+            ("schema", .string(ClaimEnvelopeSchema.bridge)),
+            ("body", .object(bodyPairs)),
+        ])
+
+        let bindingHash = hashValue(.object([
+            ("sourceLayer", .string(args.sourceLayer)),
+            ("sourceSymbol", .string(args.sourceSymbol)),
+        ]))
+        // bridge propertyHash is the literal-string content-address
+        // ("bridge:" + sourceSymbol), NOT a JCS-wrapped value. Mirrors
+        // the go and rust kit derivation.
+        let propertyHash = Blake3.hex(
+            Data(("bridge:" + args.sourceSymbol).utf8)
+        )
+
+        let unsigned = envelopeForHashing(
+            bindingHash: bindingHash,
+            propertyHash: propertyHash,
+            verdict: .holds,
+            producedBy: args.producedBy,
+            producedAt: args.producedAt,
+            inputCids: [args.targetContractCid],
+            evidence: evidence
+        )
+        return finalize(unsigned: unsigned)
+    }
+
+    // ----- helpers -----
+
+    /// Build the canonical-input value (envelope minus cid +
+    /// producerSignature). Hashing AND signing operate on JCS bytes of
+    /// this value.
+    private func envelopeForHashing(
+        bindingHash: String,
+        propertyHash: String,
+        verdict: Verdict,
+        producedBy: String,
+        producedAt: String,
+        inputCids: [String],
+        evidence: JcsCanonical
+    ) -> JcsCanonical {
+        let sortedInputs = inputCids.sorted()
+        return .object([
+            ("schemaVersion", .string("1")),
+            ("bindingHash", .string(bindingHash)),
+            ("propertyHash", .string(propertyHash)),
+            ("verdict", .string(verdict.rawValue)),
+            ("producedBy", .string(producedBy)),
+            ("producedAt", .string(producedAt)),
+            ("inputCids", .array(sortedInputs.map { .string($0) })),
+            ("evidence", evidence),
+        ])
+    }
+
+    private func finalize(unsigned: JcsCanonical) -> MintedMemento {
+        let canonical = JcsCanonicalizer.encode(unsigned)
+        let cid = Blake3.hex(canonical)
+        let sigStr = Ed25519.signatureString(message: canonical, seed: signerSeed)
+
+        // Rebuild as a signed object. Take the unsigned object's pairs
+        // and append producerSignature + cid; emit re-canonicalized.
+        guard case .object(let pairs) = unsigned else {
+            // unreachable: envelopeForHashing always returns an object
+            preconditionFailure("envelopeForHashing must return an object")
+        }
+        var signed = pairs
+        signed.append(("producerSignature", .string(sigStr)))
+        signed.append(("cid", .string(cid)))
+        let finalBytes = JcsCanonicalizer.encode(.object(signed))
+        return MintedMemento(canonicalBytes: finalBytes, cid: cid)
+    }
+}
+
+// MARK: - Helpers shared with the orchestrator
+
+/// `hashValue(v) := ComputeCID(JCS(v))` — the v1.1.0 protocol's standard
+/// content-address used for preHash / postHash / invHash, propertyHash,
+/// and bindingHash.
+public func hashValue(_ v: JcsCanonical) -> String {
+    return Blake3.hex(JcsCanonicalizer.encode(v))
+}
+
+/// Build the authoring block. Each variant is a typed-union with
+/// `producerKind` as the discriminator, mirroring the go reference.
+private func buildAuthoring(_ k: AuthoringKind) -> JcsCanonical {
+    switch k {
+    case .kitAuthor(let author, let note):
+        var pairs: [(String, JcsCanonical)] = [
+            ("producerKind", .string("kit-author")),
+            ("author", .string(author)),
+        ]
+        if let note = note { pairs.append(("note", .string(note))) }
+        return .object(pairs)
+
+    case .lift(let lifter, let evidence, let sourceCid):
+        var pairs: [(String, JcsCanonical)] = [
+            ("producerKind", .string("lift")),
+            ("lifter", .string(lifter)),
+            ("evidence", .string(evidence)),
+        ]
+        if let sourceCid = sourceCid {
+            pairs.append(("sourceCid", .string(sourceCid)))
+        }
+        return .object(pairs)
+
+    case .llm(let llm, let llmVersion, let promptCid, let confidence, let rationale):
+        var pairs: [(String, JcsCanonical)] = [
+            ("producerKind", .string("llm")),
+            ("llm", .string(llm)),
+            ("llmVersion", .string(llmVersion)),
+            ("promptCid", .string(promptCid)),
+            // Encoded losslessly as integer permille for v0; matches go.
+            ("confidence", .int(Int64(confidence * 1000))),
+        ]
+        if let rationale = rationale {
+            pairs.append(("rationale", .string(rationale)))
+        }
+        return .object(pairs)
+    }
+}
+
+// MARK: - contractCid + contractSetCid (spec #94 §1)
+
+/// Compute the signer-independent contractCid.
+///
+///     contractCid := blake3-512(JCS({name, outBinding, pre?, post?, inv?}))
+///
+/// Two distinct signers attesting to the same logical contract produce
+/// the same contractCid. NOT the attestation CID (envelope hash).
+public func contractCid(fromArgs args: ContractMintArgs) -> String {
+    var pairs: [(String, JcsCanonical)] = [
+        ("name", .string(args.contractName)),
+        ("outBinding", .string(args.outBinding)),
+    ]
+    if let pre = args.pre { pairs.append(("pre", pre)) }
+    if let post = args.post { pairs.append(("post", post)) }
+    if let inv = args.inv { pairs.append(("inv", inv)) }
+    return Blake3.hex(JcsCanonicalizer.encode(.object(pairs)))
+}
+
+/// Compute the contract set CID per spec 2026-05-03-contract-set-extension.md §1:
+///
+///     contractSetCid := blake3-512(JCS(<sorted contractCids>))
+///
+/// The sort is lexicographic on the raw "blake3-512:hex" strings so that
+/// two kits enumerating the same contracts in different order produce
+/// byte-identical contractSetCid values.
+public func computeContractSetCid(_ contractCids: [String]) -> String {
+    let sorted = contractCids.sorted()
+    let arr: JcsCanonical = .array(sorted.map { .string($0) })
+    return Blake3.hex(JcsCanonicalizer.encode(arr))
+}

--- a/implementations/swift/Sources/ProvekitCrypto/Ed25519.swift
+++ b/implementations/swift/Sources/ProvekitCrypto/Ed25519.swift
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ed25519 — sign / verify wrapper over the vendored OpenSSL backend.
+//
+// Why NOT CryptoKit: Apple's CryptoKit on macOS / iOS implements
+// `Curve25519.Signing` with intentional signature randomization (a
+// fault-injection mitigation that mixes a CSPRNG nonce into every
+// signature). RFC 8032 mandates deterministic signatures, and every
+// other ProvekIt kit (rust ed25519-dalek, go crypto/ed25519, cpp
+// OpenSSL EVP_PKEY_ED25519, c the same vendored wrapper) is RFC-8032
+// deterministic. CryptoKit's randomization breaks the byte-equivalence
+// contract Side B requires across all 11 kits.
+//
+// swift-crypto's `Crypto` module re-exports CryptoKit on Apple platforms
+// (the BoringSSL backend is gated off via the `CRYPTO_IN_SWIFTPM`
+// platform check; see swift-crypto's Package.swift), so it inherits the
+// same randomization. We use OpenSSL libcrypto via the kit's existing
+// `tools/ed25519-vendored/` thin wrapper — the same backing the C and
+// C++ peer kits use — for byte-identical signatures with rust's
+// ed25519-dalek and go's crypto/ed25519.
+//
+// Cross-kit conformance: the protocol pins the Foundation v0 ed25519
+// seed `[0x42; 32]` (cf. tools/foundation-keygen/src/lib.rs). The same
+// 32-byte seed produces the same 32-byte public key and the same
+// 64-byte signature across all 11 kits because Ed25519 is deterministic.
+
+import Foundation
+import CEd25519
+
+public enum Ed25519 {
+
+    /// Foundation v0 seed: 32 bytes of 0x42. Pinned across every kit so
+    /// the reproducible mints are byte-equivalent. Mirrors:
+    ///   tools/foundation-keygen/src/lib.rs::FOUNDATION_V0_SEED
+    public static let foundationV0Seed: [UInt8] = Array(repeating: 0x42, count: 32)
+
+    /// Derive the 32-byte raw public key from a 32-byte seed.
+    public static func publicKey(fromSeed seed: [UInt8]) -> [UInt8] {
+        precondition(seed.count == 32, "Ed25519 seed must be 32 bytes")
+        var pk = [UInt8](repeating: 0, count: 32)
+        let rc = seed.withUnsafeBufferPointer { sptr -> Int32 in
+            pk.withUnsafeMutableBufferPointer { pptr -> Int32 in
+                pk_ed25519_pubkey_from_seed(sptr.baseAddress, pptr.baseAddress)
+            }
+        }
+        precondition(rc == 0, "pk_ed25519_pubkey_from_seed failed")
+        return pk
+    }
+
+    /// Self-identifying form: "ed25519:" + base64(publicKey). Used as
+    /// the `signer` field in the self-contracts attestations.
+    public static func publicKeyString(fromSeed seed: [UInt8]) -> String {
+        let pk = publicKey(fromSeed: seed)
+        return "ed25519:" + Data(pk).base64EncodedString()
+    }
+
+    /// Sign `message` with `seed`. Returns a 64-byte raw signature
+    /// (RFC 8032 deterministic).
+    public static func sign(message: Data, seed: [UInt8]) -> [UInt8] {
+        precondition(seed.count == 32, "Ed25519 seed must be 32 bytes")
+        var sig = [UInt8](repeating: 0, count: 64)
+        let rc = message.withUnsafeBytes { mptr -> Int32 in
+            seed.withUnsafeBufferPointer { sptr -> Int32 in
+                sig.withUnsafeMutableBufferPointer { sigptr -> Int32 in
+                    pk_ed25519_sign(
+                        mptr.bindMemory(to: UInt8.self).baseAddress,
+                        message.count,
+                        sptr.baseAddress,
+                        sigptr.baseAddress
+                    )
+                }
+            }
+        }
+        precondition(rc == 0, "pk_ed25519_sign failed")
+        return sig
+    }
+
+    /// Verify `signature` over `message` for the public key `pubKey`.
+    public static func verify(message: Data, signature: [UInt8], pubKey: [UInt8]) -> Bool {
+        guard signature.count == 64, pubKey.count == 32 else { return false }
+        let rc = message.withUnsafeBytes { mptr -> Int32 in
+            signature.withUnsafeBufferPointer { sigptr -> Int32 in
+                pubKey.withUnsafeBufferPointer { pkptr -> Int32 in
+                    pk_ed25519_verify(
+                        mptr.bindMemory(to: UInt8.self).baseAddress,
+                        message.count,
+                        sigptr.baseAddress,
+                        pkptr.baseAddress
+                    )
+                }
+            }
+        }
+        return rc == 1
+    }
+
+    /// Self-identifying form for member-envelope signatures:
+    /// "ed25519:" + base64(signature). Mirrors
+    /// `Ed25519SigPrefix + base64.StdEncoding.EncodeToString(sig)` in
+    /// the go claim_envelope finalize step.
+    public static func signatureString(message: Data, seed: [UInt8]) -> String {
+        let sig = sign(message: message, seed: seed)
+        return "ed25519:" + Data(sig).base64EncodedString()
+    }
+}

--- a/implementations/swift/Sources/ProvekitCrypto/JcsValue.swift
+++ b/implementations/swift/Sources/ProvekitCrypto/JcsValue.swift
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// JcsValue + JcsCanonical — RFC 8785 JSON Canonicalization Scheme.
+//
+// Mirrors the go reference at
+// implementations/go/provekit-ir-symbolic/canonicalizer/encoder.go and the
+// rust crate provekit-canonicalizer. UTF-8 output, no whitespace, object
+// keys sorted by Unicode code-point order (ASCII keys reduce to byte
+// order), minimal string escapes.
+//
+// The kit-IR-specific JCS encoder lives in `Sources/Provekit/IR.swift`
+// (`Jcs.encode`). This module is the GENERAL-PURPOSE encoder used by
+// the claim and proof envelope minters: keys/values are arbitrary
+// canonicalizable values. The two share neither types nor code paths;
+// the IR encoder only canonicalizes IR shapes, this one canonicalizes
+// any JCS-shaped tree.
+
+import Foundation
+
+/// JCS-canonicalizable value tree. Mirrors `interface{}` in the go
+/// encoder's accepted type set. Object keys are stored as inserted; the
+/// emitter sorts at write time.
+public indirect enum JcsCanonical: Sendable, Equatable {
+    case null
+    case bool(Bool)
+    case int(Int64)
+    case string(String)
+    case array([JcsCanonical])
+    /// Object pairs in insertion order; the encoder lex-sorts by key
+    /// before emit. Allows callers to construct objects without paying
+    /// for an immediate sort at every nesting level.
+    case object([(String, JcsCanonical)])
+
+    public static func == (lhs: JcsCanonical, rhs: JcsCanonical) -> Bool {
+        switch (lhs, rhs) {
+        case (.null, .null): return true
+        case let (.bool(a), .bool(b)): return a == b
+        case let (.int(a), .int(b)): return a == b
+        case let (.string(a), .string(b)): return a == b
+        case let (.array(a), .array(b)): return a == b
+        case let (.object(a), .object(b)):
+            return a.count == b.count
+                && zip(a, b).allSatisfy { $0.0 == $1.0 && $0.1 == $1.1 }
+        default: return false
+        }
+    }
+}
+
+public enum JcsCanonicalizer {
+
+    /// Produce JCS-canonical UTF-8 bytes for `value`. Total order on
+    /// keys via Unicode code-point comparison; for the ASCII-only keys
+    /// the kit emits, that reduces to byte order.
+    public static func encode(_ value: JcsCanonical) -> Data {
+        var out = Data()
+        write(value, into: &out)
+        return out
+    }
+
+    /// Convenience: UTF-8 string view of `encode(value)`.
+    public static func encodeString(_ value: JcsCanonical) -> String {
+        return String(data: encode(value), encoding: .utf8) ?? ""
+    }
+
+    private static func write(_ value: JcsCanonical, into out: inout Data) {
+        switch value {
+        case .null:
+            out.append(contentsOf: "null".utf8)
+        case .bool(let b):
+            out.append(contentsOf: (b ? "true" : "false").utf8)
+        case .int(let n):
+            out.append(contentsOf: String(n).utf8)
+        case .string(let s):
+            writeString(s, into: &out)
+        case .array(let items):
+            out.append(0x5B) // [
+            for (i, item) in items.enumerated() {
+                if i > 0 { out.append(0x2C) } // ,
+                write(item, into: &out)
+            }
+            out.append(0x5D) // ]
+        case .object(let pairs):
+            // RFC 8785 §3.2.3: sort by Unicode code-point. For UTF-8
+            // strings without surrogates, byte-order on the UTF-8
+            // representation is equivalent. Swift's String comparison is
+            // canonical-equivalence-aware; we drop to UTF-8 bytes to
+            // match the protocol's byte-level expectation.
+            let sorted = pairs.sorted { lhs, rhs in
+                let l = Array(lhs.0.utf8)
+                let r = Array(rhs.0.utf8)
+                return l.lexicographicallyPrecedes(r)
+            }
+            out.append(0x7B) // {
+            for (i, pair) in sorted.enumerated() {
+                if i > 0 { out.append(0x2C) } // ,
+                writeString(pair.0, into: &out)
+                out.append(0x3A) // :
+                write(pair.1, into: &out)
+            }
+            out.append(0x7D) // }
+        }
+    }
+
+    /// RFC 8785 §3.2.2.5 minimal string escape: `"`, `\`, and the
+    /// control chars U+0000..U+001F. Everything else passes through as
+    /// its UTF-8 bytes verbatim.
+    private static func writeString(_ s: String, into out: inout Data) {
+        out.append(0x22) // "
+        for byte in s.utf8 {
+            switch byte {
+            case 0x22: // "
+                out.append(0x5C); out.append(0x22)
+            case 0x5C: // \
+                out.append(0x5C); out.append(0x5C)
+            case 0x08: // \b
+                out.append(0x5C); out.append(0x62)
+            case 0x09: // \t
+                out.append(0x5C); out.append(0x74)
+            case 0x0A: // \n
+                out.append(0x5C); out.append(0x6E)
+            case 0x0C: // \f
+                out.append(0x5C); out.append(0x66)
+            case 0x0D: // \r
+                out.append(0x5C); out.append(0x72)
+            case 0x00...0x1F:
+                // \u00XX, lowercase hex per RFC 8785 §3.2.2.5
+                out.append(contentsOf: "\\u00".utf8)
+                let hi = byte >> 4
+                let lo = byte & 0x0F
+                out.append(hexDigit(hi))
+                out.append(hexDigit(lo))
+            default:
+                out.append(byte)
+            }
+        }
+        out.append(0x22) // "
+    }
+
+    private static func hexDigit(_ n: UInt8) -> UInt8 {
+        return n < 10 ? (0x30 + n) : (0x61 + (n - 10))
+    }
+}
+
+/// Compute the protocol's content-address for `value`.
+///
+///     ComputeCID(JCS(value)) = "blake3-512:" + hex(BLAKE3_512(JCS(value)))
+///
+/// Equivalent to go's `canonicalizer.ComputeCID(canonicalizer.EncodeJCS(v))`.
+public func computeJcsCid(_ value: JcsCanonical) -> String {
+    let bytes = JcsCanonicalizer.encode(value)
+    return Blake3.hex(bytes)
+}

--- a/implementations/swift/Sources/ProvekitCrypto/ProofEnvelope.swift
+++ b/implementations/swift/Sources/ProvekitCrypto/ProofEnvelope.swift
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ProofEnvelope — assemble a complete .proof file.
+//
+// Mirrors the go reference at
+// implementations/go/provekit-ir-symbolic/proof_envelope/builder.go and
+// the rust crate provekit-proof-envelope's `proof.rs`.
+//
+// Per protocol/specs/2026-04-30-proof-file-format.md (v1.1.0):
+//   1. Build the unsigned body as a CBOR map with deterministic-CBOR-
+//      sorted keys (RFC 8949 §4.2.1).
+//   2. ed25519-sign the unsigned-body bytes.
+//   3. Re-emit with the signature added (keys re-sorted bytewise on
+//      their CBOR-encoded form). The `signature` field is RAW 64-byte
+//      CBOR bstr (mirrors go and C++; the self-identifying "ed25519:"
+//      prefix is for member-envelope `producerSignature` strings, NOT
+//      the catalog signature).
+//   4. filenameCID := "blake3-512:" + 128 hex (full digest, no truncation).
+
+import Foundation
+
+public struct ProofEnvelopeInput: Sendable {
+    public var name: String
+    public var version: String
+    public var binaryCid: String
+    /// `members` is a list of (cid, body-bytes) pairs. The encoder
+    /// sorts by CBOR-encoded key so insertion order is irrelevant; we
+    /// store as an array of pairs (not a Dictionary) because Swift's
+    /// `[String: Data]` would reorder unpredictably and the kit needs
+    /// determinism observable from the call site.
+    public var members: [(String, Data)]
+    public var signerCid: String
+    public var signerSeed: [UInt8]
+    /// RFC 3339 with millisecond precision and trailing 'Z',
+    /// e.g. "2026-04-30T18:00:00.000Z".
+    public var declaredAt: String
+
+    public init(
+        name: String,
+        version: String,
+        binaryCid: String = "",
+        members: [(String, Data)],
+        signerCid: String,
+        signerSeed: [UInt8],
+        declaredAt: String
+    ) {
+        precondition(signerSeed.count == 32, "Ed25519 seed must be 32 bytes")
+        self.name = name
+        self.version = version
+        self.binaryCid = binaryCid
+        self.members = members
+        self.signerCid = signerCid
+        self.signerSeed = signerSeed
+        self.declaredAt = declaredAt
+    }
+}
+
+public struct ProofEnvelopeOutput: Sendable {
+    public let bytes: Data
+    public let filenameCid: String
+}
+
+public enum ProofEnvelopeBuilder {
+
+    /// Build the full deterministic-CBOR .proof bytes + filename CID.
+    public static func build(_ input: ProofEnvelopeInput) -> ProofEnvelopeOutput {
+        let membersCbor = CborHelpers.encodeMembersMap(input.members)
+
+        // 1. Encode the unsigned body.
+        let unsignedPairs = bodyPairsUnsigned(input, membersCbor: membersCbor)
+        var unsignedEnc = CborEncoder()
+        CborHelpers.emitSortedMap(into: &unsignedEnc, pairs: unsignedPairs)
+        let unsignedBytes = unsignedEnc.data
+
+        // 2. ed25519 sign over the unsigned bytes (RAW 64-byte sig).
+        let sig = Ed25519.sign(message: unsignedBytes, seed: input.signerSeed)
+
+        // 3. Re-emit with the signature added. Re-sort by CBOR-key bytes.
+        var signedPairs = unsignedPairs
+        signedPairs.append(CborKVPair(
+            key: CborHelpers.encodeKey("signature"),
+            value: CborHelpers.encodeBStrValue(Data(sig))
+        ))
+        var finalEnc = CborEncoder()
+        CborHelpers.emitSortedMap(into: &finalEnc, pairs: signedPairs)
+        let finalBytes = finalEnc.data
+
+        // 4. filenameCID = "blake3-512:" + 128 hex (no truncation).
+        let cid = Blake3.hex(finalBytes)
+        return ProofEnvelopeOutput(bytes: finalBytes, filenameCid: cid)
+    }
+
+    /// `bodyPairsUnsigned` — emit every catalog field except `signature`.
+    /// `binaryCid` is appended only when set (mirrors rust's
+    /// `Option<String>` skip-when-None); the outer emitSortedMap
+    /// re-sorts by CBOR-encoded-key form, so insertion order does not
+    /// affect the final bytes.
+    private static func bodyPairsUnsigned(
+        _ input: ProofEnvelopeInput,
+        membersCbor: Data
+    ) -> [CborKVPair] {
+        var pairs: [CborKVPair] = [
+            CborKVPair(
+                key: CborHelpers.encodeKey("kind"),
+                value: CborHelpers.encodeStringValue("catalog")),
+            CborKVPair(
+                key: CborHelpers.encodeKey("name"),
+                value: CborHelpers.encodeStringValue(input.name)),
+            CborKVPair(
+                key: CborHelpers.encodeKey("version"),
+                value: CborHelpers.encodeStringValue(input.version)),
+            CborKVPair(
+                key: CborHelpers.encodeKey("members"),
+                value: membersCbor),
+            CborKVPair(
+                key: CborHelpers.encodeKey("signer"),
+                value: CborHelpers.encodeStringValue(input.signerCid)),
+            CborKVPair(
+                key: CborHelpers.encodeKey("declaredAt"),
+                value: CborHelpers.encodeStringValue(input.declaredAt)),
+        ]
+        if !input.binaryCid.isEmpty {
+            pairs.append(CborKVPair(
+                key: CborHelpers.encodeKey("binaryCid"),
+                value: CborHelpers.encodeStringValue(input.binaryCid)))
+        }
+        return pairs
+    }
+}

--- a/tools/ed25519-vendored/README.md
+++ b/tools/ed25519-vendored/README.md
@@ -1,0 +1,16 @@
+# ed25519-vendored
+
+Public-domain Ed25519 implementation vendored for the ProvekIt C kit.
+
+Source: derived from the reference implementation in
+  https://github.com/golang/crypto/tree/master/ed25519/internal/edwards25519
+  (itself derived from SUPERCOP ref10, public domain / CC0).
+
+Modifications for ProvekIt:
+  - Stripped to the minimum needed: keypair from seed, sign, verify.
+  - Bundled SHA-512 (FIPS 180-4, public domain from nacl/tweetnacl).
+  - Single compilation unit (ed25519.c) with no external dependencies.
+  - POSIX C11, no GNU extensions.
+
+Byte-identical signatures to ed25519-dalek (Rust), OpenSSL EVP_PKEY_ED25519,
+and node:crypto's ed25519 for the same (seed, message) pair.

--- a/tools/ed25519-vendored/ed25519.c
+++ b/tools/ed25519-vendored/ed25519.c
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Ed25519 thin wrapper — OpenSSL EVP_PKEY_ED25519 backend.
+ *
+ * The C kit uses OpenSSL libcrypto for the same reason the C++ kit does:
+ * byte-identical signatures without vendoring ~1500 LOC of field arithmetic.
+ * Both kits link -lcrypto; the C++ kit's sign_ed25519.cpp is the reference.
+ *
+ * Compile: cc -std=c11 -I<openssl-include> ed25519.c -lcrypto
+ */
+
+#include "ed25519.h"
+
+#include <openssl/evp.h>
+#include <string.h>
+
+int pk_ed25519_pubkey_from_seed(const uint8_t seed[32], uint8_t pk_out[32]) {
+    EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL, seed, 32);
+    if (!pkey) return -1;
+    size_t pklen = 32;
+    int rc = EVP_PKEY_get_raw_public_key(pkey, pk_out, &pklen);
+    EVP_PKEY_free(pkey);
+    return (rc == 1 && pklen == 32) ? 0 : -1;
+}
+
+int pk_ed25519_sign(const uint8_t *msg, size_t msg_len,
+                    const uint8_t seed[32],
+                    uint8_t sig_out[64]) {
+    EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL, seed, 32);
+    if (!pkey) return -1;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx) { EVP_PKEY_free(pkey); return -1; }
+    int ok = 0;
+    if (EVP_DigestSignInit(ctx, NULL, NULL, NULL, pkey) == 1) {
+        size_t siglen = 64;
+        if (EVP_DigestSign(ctx, sig_out, &siglen, msg, msg_len) == 1 && siglen == 64)
+            ok = 1;
+    }
+    EVP_MD_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    return ok ? 0 : -1;
+}
+
+int pk_ed25519_verify(const uint8_t *msg, size_t msg_len,
+                      const uint8_t sig[64],
+                      const uint8_t pk[32]) {
+    EVP_PKEY *pkey = EVP_PKEY_new_raw_public_key(EVP_PKEY_ED25519, NULL, pk, 32);
+    if (!pkey) return 0;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx) { EVP_PKEY_free(pkey); return 0; }
+    int ok = 0;
+    if (EVP_DigestVerifyInit(ctx, NULL, NULL, NULL, pkey) == 1) {
+        ok = (EVP_DigestVerify(ctx, sig, 64, msg, msg_len) == 1) ? 1 : 0;
+    }
+    EVP_MD_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    return ok;
+}

--- a/tools/ed25519-vendored/ed25519.h
+++ b/tools/ed25519-vendored/ed25519.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Ed25519 thin wrapper over OpenSSL EVP_PKEY_ED25519 (libcrypto).
+ *
+ * Byte-identical to ed25519-dalek (Rust), OpenSSL EVP_PKEY_ED25519 (C++),
+ * and node:crypto's ed25519 for the same (seed, message) pairs.
+ *
+ * Build requirement: -lcrypto (OpenSSL 1.1+ or 3.x).
+ * The C kit Makefile sets LDFLAGS = -lcrypto and -I to the OpenSSL
+ * headers path.
+ *
+ * Rationale for OpenSSL over a self-rolled impl: the C++ kit already uses
+ * OpenSSL EVP_PKEY_ED25519 (see implementations/cpp/provekit/proof-envelope/
+ * sign_ed25519.cpp). Using the same underlying library guarantees byte-level
+ * agreement with the C++ kit without vendoring ~1500 LOC of field arithmetic.
+ */
+
+#ifndef PK_ED25519_H
+#define PK_ED25519_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Derive the 32-byte public key from a 32-byte seed.
+ * pk_out must point to a 32-byte buffer.
+ * Returns 0 on success, -1 on OpenSSL failure.
+ */
+int pk_ed25519_pubkey_from_seed(const uint8_t seed[32], uint8_t pk_out[32]);
+
+/*
+ * Sign message (msg, msg_len) with the private key derived from seed.
+ * sig_out must point to a 64-byte buffer.
+ * Returns 0 on success, -1 on OpenSSL failure.
+ */
+int pk_ed25519_sign(const uint8_t *msg, size_t msg_len,
+                    const uint8_t seed[32],
+                    uint8_t sig_out[64]);
+
+/*
+ * Verify signature sig (64 bytes) over message (msg, msg_len)
+ * with public key pk (32 bytes).
+ * Returns 1 if valid, 0 if invalid (including any OpenSSL failure).
+ */
+int pk_ed25519_verify(const uint8_t *msg, size_t msg_len,
+                      const uint8_t sig[64],
+                      const uint8_t pk[32]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PK_ED25519_H */


### PR DESCRIPTION
## Summary

Side B for the Swift kit (issue #212): in-process BLAKE3-512 + RFC 8785 JCS + deterministic CBOR (RFC 8949 §4.2.1) + RFC 8032 Ed25519 + claim/proof envelope construction. Drops the python-blake3 shellout in `Provekit.Blake3.hex(_:)`. Output is byte-equivalent to the rust / go / cpp / c peer kits for the Foundation v0 ed25519 seed.

## What changed

- **`implementations/swift/Sources/CBlake3/`** — vendored portable BLAKE3 1.8.5 reference C impl (mirrors `tools/blake3-vendored/`).
- **`implementations/swift/Sources/CEd25519/`** — vendored thin wrapper over OpenSSL `EVP_PKEY_ED25519` (mirrors `tools/ed25519-vendored/`). Same backing as the C / C++ peer kits; produces byte-identical signatures with rust ed25519-dalek and go crypto/ed25519.
- **`implementations/swift/Sources/ProvekitCrypto/`** — pure-Swift substrate (Blake3, JcsValue, Cbor, Ed25519, ClaimEnvelope, ProofEnvelope).
- **`implementations/swift/Sources/CryptoTests/`** — 36-test exec runner (no XCTest dep, mirrors LSPTests pattern).
- **`tools/ed25519-vendored/`** — added to the tree (was untracked but referenced by the C kit Makefile).
- `Provekit.Blake3` is now a typealias for `ProvekitCrypto.Blake3`. All existing pins in `ConformanceRunner/main.swift` continue to pass.
- Makefile `test-swift` now runs `swift run test-swift-crypto` in addition to `conformance` + `test-swift-lsp`.

## Why not CryptoKit / swift-crypto

CryptoKit's `Curve25519.Signing` on Apple platforms intentionally randomizes Ed25519 signatures (a fault-injection mitigation). RFC 8032 mandates determinism, and every other ProvekIt kit is RFC-8032 deterministic. swift-crypto's BoringSSL backend is gated off on Apple platforms (it re-exports CryptoKit), so it inherits the same problem. Vendored OpenSSL is the same backing the C / C++ peer kits use; verified via the cross-kit signature equivalence test in CryptoTests.

## AC checklist (issue #212)

- [x] Swift can natively compute BLAKE3 of canonical bytes
- [x] Swift can natively JCS-canonicalize JSON (RFC 8785)
- [x] Swift can natively sign/verify Ed25519
- [x] Swift can natively CBOR-encode the envelope (RFC 8949 §4.2.1)
- [x] Output round-trips byte-for-byte against rust + go reference envelopes (cross-kit signature pin in CryptoTests asserts JCS + Ed25519 byte equivalence with rust's `tools/foundation-keygen` output for the swift self-contracts attestation message)
- [x] No shell-out required for envelope construction

## Test plan

- [x] `swift build` clean from a fresh checkout (Mac with `/usr/local/opt/openssl@3` or `OPENSSL_PREFIX` env var)
- [x] `swift run test-swift-crypto` → 36 PASS / 0 FAIL
- [x] `swift run conformance` → 10 PASS / 0 FAIL (existing pinned BLAKE3 hashes match the new native backend)
- [x] `swift run test-swift-lsp` → 11 PASS / 0 FAIL (untouched)
- [x] `make test-swift` → all three suites green
- [x] `make conformance` → green
- [x] No CI workflow change — issue #212 declares swift macOS-only; existing Makefile already excludes swift from `test-all` / `all-mint` / `ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)