### PR TITLE
feat(python): mint-python-self-contracts orchestrator + KIT_TABLE wiring (closes #205)

### DIFF
--- a/.provekit/self-contracts-attestations/python.json
+++ b/.provekit/self-contracts-attestations/python.json
@@ -2,9 +2,9 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "python",
-  "cid": "",
-  "contractSetCid": "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+  "cid": "blake3-512:64c8ddf3a7ef02c6d12665866e1c2483b59009830a5f27cee869b123d5ece63cccb7dc8d62002383f348b15cd866857de0c6a053dd2fc02e3d9356bd3295b0a4",
+  "contractSetCid": "blake3-512:b1de941756d0a3b352ca79ebed8b75644b7c782c3afe4163273220384125ec100457d5e969a921b7ceb277e329a24c5a4ea21ffd54963b51c1756befdb1793dc",
   "declaredAt": "2026-05-03T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:IrZWTveIn78k5UewWLDjAMM+4OaaKgwqaLNyxb97/2NFoOlZ1NW4I4DCkNY7e5Jevz84XtbQVgFIrK2bsun6Bg=="
+  "signature": "ed25519:IsW7B356VvsRLOQH9bggRPx/lagQQ5tyAoEm0d3mth0ecmzQjofGhnZY+ZByVs6QJhpwSnBEew86B9vtyGqlBw=="
 }

--- a/implementations/python/.provekit/lift/python-self-contracts/manifest.toml
+++ b/implementations/python/.provekit/lift/python-self-contracts/manifest.toml
@@ -1,0 +1,10 @@
+name = "python-self-contracts"
+version = "1.0.0"
+protocol_version = "provekit-lift/1"
+command = ["python3", "bin/mint-python-self-contracts"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-self-contracts"]
+ir_version = "v1.1.0"
+emits_signed_mementos = true

--- a/implementations/python/bin/mint-python-self-contracts
+++ b/implementations/python/bin/mint-python-self-contracts
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# mint-python-self-contracts — RPC entry point for the
+# python-self-contracts lift surface, plus direct CLI invocation.
+#
+# Speaks the lift-plugin protocol (provekit-lift/1) over NDJSON on
+# stdio when invoked with --rpc. Otherwise mints once into the given
+# output directory (or a tmpdir) for human inspection.
+#
+# Spec: protocol/specs/2026-04-30-lift-plugin-protocol.md
+
+import os
+import os.path
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PYTHON_ROOT = os.path.dirname(_HERE)
+_ORCH = os.path.join(_PYTHON_ROOT, "provekit-self-contracts.py")
+
+# Load the orchestrator module without depending on its filename being a
+# valid Python identifier (the hyphen makes it un-importable as a normal
+# package). Use the `runpy` approach: exec the file as `__main__` after
+# setting argv.
+import runpy
+
+# Ensure the orchestrator can locate its sibling lib via sys.path; it
+# also self-injects, so this is belt-and-suspenders.
+_LIB_SRC = os.path.join(_PYTHON_ROOT, "provekit-lift-py-tests", "src")
+if _LIB_SRC not in sys.path:
+    sys.path.insert(0, _LIB_SRC)
+
+# Forward argv (excluding our own program name); runpy.run_path expects
+# argv[0] to be the script path, so reconstruct.
+sys.argv = [_ORCH] + sys.argv[1:]
+runpy.run_path(_ORCH, run_name="__main__")

--- a/implementations/python/provekit-self-contracts.py
+++ b/implementations/python/provekit-self-contracts.py
@@ -1,0 +1,584 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# provekit-self-contracts.py
+#
+# Side A orchestrator for the Python kit. Walks the canonical Python
+# slab, mints each contract as a layered signed memento under the
+# foundation key, and bundles them into a `.proof` envelope whose
+# filename IS its catalog CID.
+#
+# Mirrors the rust/cpp/go/ts/ruby Side A pattern. The contractSetCid we
+# produce is the BLAKE3-512 of the JCS encoding of the sorted list of
+# signer-independent contractCids; identical inputs produce byte-
+# identical CIDs across kits with the same authoring choices.
+#
+# Run modes:
+#   * Direct CLI:      python3 bin/mint-python-self-contracts [outDir]
+#   * Lift-protocol:   python3 bin/mint-python-self-contracts --rpc
+#
+# References:
+#   * implementations/ruby/lib/provekit/self_contracts.rb
+#   * implementations/rust/provekit-self-contracts/src/lib.rs
+#   * protocol/specs/2026-04-30-lift-plugin-protocol.md
+#   * protocol/specs/2026-05-03-contract-cid-vs-attestation-cid.md
+#   * protocol/specs/2026-05-03-contract-set-extension.md
+#
+# Note on layout: this orchestrator lives at
+# `implementations/python/provekit-self-contracts.py` (not under the
+# `provekit-lift-py-tests` package) because it is the kit's
+# self-contracts authoring entry point, not a public library API. The
+# bin shim `bin/mint-python-self-contracts` invokes `main(argv)` here.
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import os.path
+import sys
+import tempfile
+import shutil
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# sys.path setup: locate provekit-lift-py-tests/src without requiring
+# `pip install -e .`. The `mint-python` Makefile target does not run a
+# build-python step; we depend on path-injection to find the modules.
+# ---------------------------------------------------------------------------
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_LIB_SRC = os.path.join(_THIS_DIR, "provekit-lift-py-tests", "src")
+if _LIB_SRC not in sys.path:
+    sys.path.insert(0, _LIB_SRC)
+
+
+from provekit_lift_py_tests.canonicalizer import (  # noqa: E402
+    blake3_512_of,
+)
+from provekit_lift_py_tests.claim_envelope import (  # noqa: E402
+    AuthoringKitAuthor,
+    ClaimEnvelope,
+    compute_contract_set_cid,
+)
+from provekit_lift_py_tests.ir import (  # noqa: E402
+    ContractDecl,
+    atomic,
+    ctor,
+    eq,
+    gte,
+    make_var,
+    num,
+    str_const,
+    bool_const,
+)
+from provekit_lift_py_tests.proof_envelope import (  # noqa: E402
+    ProofEnvelopeInput,
+    build_proof_envelope,
+)
+from provekit_lift_py_tests.signing import (  # noqa: E402
+    FOUNDATION_V0_SEED,
+    Signer,
+    ed25519_pubkey_string,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants (cross-kit canonical, mirror ruby/rust).
+# ---------------------------------------------------------------------------
+
+PRODUCED_BY = "provekit-python-self-contracts@1.0"
+DECLARED_AT = "2026-04-30T18:00:00.000Z"
+CATALOG_NAME = "@provekit/python-self-contracts"
+CATALOG_VERSION = "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Slab authoring
+#
+# A slab is the set of contracts authored against one Python module of
+# the kit's own crypto substrate. Each slab returns a list of
+# ContractDecl values. Names MUST be unique across slabs. Predicates
+# use the kit's IR primitives, mirroring ruby's slab style: shape-level
+# claims (length, determinism) about the public API. Z3 cannot
+# discharge most of these in isolation; the value is the living-doc IR
+# shape the verifier indexes against.
+# ---------------------------------------------------------------------------
+
+
+def _eq_lengths(a, b):
+    """Helper: return an `eq` Formula asserting two terms are equal."""
+    return eq(a, b)
+
+
+def slab_blake3() -> List[ContractDecl]:
+    """Contracts about `provekit_lift_py_tests.canonicalizer.blake3_512_of`.
+
+    The kit's own BLAKE3-512 binding (returns the self-identifying
+    string `"blake3-512:" + 128-hex`).
+    """
+    s = make_var("s")
+    h_str = lambda x: ctor("blake3_512_of", [x])  # noqa: E731
+    return [
+        ContractDecl(
+            name="python_blake3_512_of_total_length_eq_139",
+            out_binding="out",
+            post=eq(
+                ctor("string_length", [h_str(s)]),
+                num(139),
+            ),
+        ),
+        ContractDecl(
+            name="python_blake3_512_of_has_blake3_512_prefix",
+            out_binding="out",
+            post=gte(
+                ctor("string_length", [h_str(s)]),
+                num(11),
+            ),
+        ),
+        ContractDecl(
+            name="python_blake3_512_of_is_deterministic",
+            out_binding="out",
+            post=eq(h_str(s), h_str(s)),
+        ),
+    ]
+
+
+def slab_jcs() -> List[ContractDecl]:
+    """Contracts about `provekit_lift_py_tests.canonicalizer.encode_jcs`.
+
+    JCS (RFC 8785) is canonical-JSON serialization. Determinism is the
+    operative property; null/true literal lengths pin the spec corner.
+    """
+    v = make_var("v")
+    enc = lambda x: ctor("encode_jcs", [x])  # noqa: E731
+    return [
+        ContractDecl(
+            name="python_jcs_encode_is_deterministic",
+            out_binding="out",
+            post=eq(enc(v), enc(v)),
+        ),
+        ContractDecl(
+            name="python_jcs_encode_true_length_eq_4",
+            out_binding="out",
+            post=eq(
+                ctor("string_length", [enc(bool_const(True))]),
+                num(4),
+            ),
+        ),
+        ContractDecl(
+            name="python_jcs_encode_null_length_eq_4",
+            out_binding="out",
+            post=eq(
+                ctor("string_length", [enc(ctor("null", []))]),
+                num(4),
+            ),
+        ),
+    ]
+
+
+def slab_cbor() -> List[ContractDecl]:
+    """Contracts about `cbor2.dumps(_, canonical=True)` as used by
+    proof_envelope. Encoded length lower bounds and determinism."""
+    s = make_var("s")
+    b = make_var("b")
+    k = make_var("k")
+    return [
+        ContractDecl(
+            name="python_cbor_encode_tstr_length_gte_1",
+            out_binding="out",
+            post=gte(
+                ctor("byte_length", [ctor("cbor_encode_tstr", [s])]),
+                num(1),
+            ),
+        ),
+        ContractDecl(
+            name="python_cbor_encode_bstr_length_gte_1",
+            out_binding="out",
+            post=gte(
+                ctor("byte_length", [ctor("cbor_encode_bstr", [b])]),
+                num(1),
+            ),
+        ),
+        ContractDecl(
+            name="python_cbor_encode_key_is_deterministic",
+            out_binding="out",
+            post=eq(
+                ctor("cbor_encode_key", [k]),
+                ctor("cbor_encode_key", [k]),
+            ),
+        ),
+    ]
+
+
+def slab_signing() -> List[ContractDecl]:
+    """Contracts about `provekit_lift_py_tests.signing` Ed25519 helpers.
+
+    Length-pinning + determinism for the seed-driven path. RFC 8032 §5.1.5
+    fixes 32-byte seeds, 32-byte pubkeys, 64-byte signatures.
+    """
+    seed = make_var("seed")
+    msg = make_var("msg")
+    return [
+        ContractDecl(
+            name="python_ed25519_signature_length_eq_64",
+            out_binding="out",
+            post=eq(
+                ctor("byte_length", [
+                    ctor("ed25519_sign_with_seed", [seed, msg]),
+                ]),
+                num(64),
+            ),
+        ),
+        ContractDecl(
+            name="python_ed25519_pubkey_bytes_length_eq_32",
+            out_binding="out",
+            post=eq(
+                ctor("byte_length", [
+                    ctor("ed25519_pubkey_bytes", [seed]),
+                ]),
+                num(32),
+            ),
+        ),
+        ContractDecl(
+            name="python_ed25519_sign_is_deterministic",
+            out_binding="out",
+            post=eq(
+                ctor("ed25519_sign_with_seed", [seed, msg]),
+                ctor("ed25519_sign_with_seed", [seed, msg]),
+            ),
+        ),
+    ]
+
+
+def slab_proof_envelope() -> List[ContractDecl]:
+    """Contracts about `provekit_lift_py_tests.proof_envelope.build_proof_envelope`.
+
+    The catalog CID is the BLAKE3-512 of the signed CBOR bytes; per
+    `protocol/specs/2026-04-30-proof-file-format.md`, the
+    self-identifying form is `"blake3-512:" + 128-hex`, total length
+    139. Build is deterministic for fixed inputs.
+    """
+    inp = make_var("input")
+    build = lambda x: ctor("build_proof_envelope_cid", [x])  # noqa: E731
+    return [
+        ContractDecl(
+            name="python_proof_envelope_cid_has_blake3_512_prefix",
+            out_binding="out",
+            post=gte(
+                ctor("string_length", [build(inp)]),
+                num(11),
+            ),
+        ),
+        ContractDecl(
+            name="python_proof_envelope_cid_total_length_eq_139",
+            out_binding="out",
+            post=eq(
+                ctor("string_length", [build(inp)]),
+                num(139),
+            ),
+        ),
+        ContractDecl(
+            name="python_proof_envelope_build_is_deterministic",
+            out_binding="out",
+            post=eq(build(inp), build(inp)),
+        ),
+    ]
+
+
+@dataclass(frozen=True)
+class _Slab:
+    label: str
+    path: str
+    contracts: List[ContractDecl]
+
+
+def author_all_invariants() -> List[_Slab]:
+    return [
+        _Slab(
+            label="blake3",
+            path="implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/canonicalizer.py",
+            contracts=slab_blake3(),
+        ),
+        _Slab(
+            label="jcs",
+            path="implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/canonicalizer.py",
+            contracts=slab_jcs(),
+        ),
+        _Slab(
+            label="cbor",
+            path="implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/proof_envelope.py",
+            contracts=slab_cbor(),
+        ),
+        _Slab(
+            label="signing",
+            path="implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/signing.py",
+            contracts=slab_signing(),
+        ),
+        _Slab(
+            label="proof_envelope",
+            path="implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/proof_envelope.py",
+            contracts=slab_proof_envelope(),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Mint orchestrator
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MintResult:
+    cid: str
+    contract_set_cid: str
+    bytes_len: int
+    path: str
+    member_count: int
+    total_contracts: int
+    per_source_counts: List[Dict[str, Any]]
+
+
+def mint_self_proof(out_dir: str) -> MintResult:
+    """Mint every authored contract as a layered memento, bundle into a
+    .proof, write to ``<out_dir>/<catalog-cid>.proof``, and return a
+    :class:`MintResult`.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+
+    slabs = author_all_invariants()
+    seed = FOUNDATION_V0_SEED
+    signer = Signer.foundation_v0(producer_id=PRODUCED_BY)
+
+    # Catalog `signer` field: BLAKE3-512(JCS-encoded UTF-8 of the
+    # self-identifying pubkey string). Mirrors ruby (`signer_cid =
+    # Blake3.hex(signer_pubkey)`) and rust.
+    pubkey_str = ed25519_pubkey_string(seed)
+    signer_cid = blake3_512_of(pubkey_str.encode("utf-8"))
+
+    members: Dict[str, bytes] = {}
+    seen_names: Dict[str, bool] = {}
+    content_cids: List[str] = []
+    per_source_counts: List[Dict[str, Any]] = []
+    total = 0
+
+    for slab in slabs:
+        per_source_counts.append({"label": slab.label, "count": len(slab.contracts)})
+        for decl in slab.contracts:
+            if decl.name in seen_names:
+                raise RuntimeError(
+                    f"duplicate contract name `{decl.name}` across slabs"
+                )
+            seen_names[decl.name] = True
+            envelope = ClaimEnvelope.from_contract_decl(
+                decl,
+                signer,
+                produced_at=DECLARED_AT,
+                authoring=AuthoringKitAuthor(
+                    author=PRODUCED_BY,
+                    note=f"self-contract from {slab.path}",
+                ),
+            )
+            content_cids.append(envelope.contract_cid)
+            members[envelope.cid] = envelope.canonical_bytes
+            total += 1
+
+    inp = ProofEnvelopeInput(
+        name=CATALOG_NAME,
+        version=CATALOG_VERSION,
+        members=members,
+        signer_cid=signer_cid,
+        declared_at=DECLARED_AT,
+        signer_seed=seed,
+    )
+    built = build_proof_envelope(inp)
+
+    if not built.cid.startswith("blake3-512:"):
+        raise RuntimeError(f"internal: cid missing blake3-512 prefix: {built.cid}")
+
+    cset_cid = compute_contract_set_cid(content_cids)
+    out_path = os.path.join(out_dir, f"{built.cid}.proof")
+    with open(out_path, "wb") as fh:
+        fh.write(built.bytes)
+
+    return MintResult(
+        cid=built.cid,
+        contract_set_cid=cset_cid,
+        bytes_len=len(built.bytes),
+        path=out_path,
+        member_count=len(members),
+        total_contracts=total,
+        per_source_counts=per_source_counts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RPC mode (lift-plugin-protocol over NDJSON stdio).
+#
+# Spec: protocol/specs/2026-04-30-lift-plugin-protocol.md
+# Daemon-lifecycle pattern (PR #220 ts Side A): persistent stdio loop,
+# EOF on stdin = graceful shutdown, explicit `shutdown` method acks
+# then exits.
+# ---------------------------------------------------------------------------
+
+
+def _write_rpc(out, payload: Dict[str, Any]) -> None:
+    out.write(json.dumps(payload, separators=(",", ":")))
+    out.write("\n")
+    out.flush()
+
+
+def run_rpc_mode(stdin=None, stdout=None) -> int:
+    if stdin is None:
+        stdin = sys.stdin
+    if stdout is None:
+        stdout = sys.stdout
+
+    while True:
+        line = stdin.readline()
+        if not line:  # EOF -> graceful shutdown
+            return 0
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            req = json.loads(line)
+        except ValueError as e:
+            _write_rpc(stdout, {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": f"Parse error: {e}"},
+            })
+            continue
+
+        req_id = req.get("id")
+        method = str(req.get("method", ""))
+
+        if method == "initialize":
+            _write_rpc(stdout, {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "name": "python-self-contracts",
+                    "version": "1.0.0",
+                    "protocol_version": "provekit-lift/1",
+                    "capabilities": {
+                        "authoring_surfaces": ["python-self-contracts"],
+                        "ir_version": "v1.1.0",
+                        "emits_signed_mementos": True,
+                    },
+                },
+            })
+        elif method == "lift":
+            tmp = tempfile.mkdtemp(prefix="provekit-python-rpc-")
+            try:
+                mint = mint_self_proof(tmp)
+                with open(mint.path, "rb") as fh:
+                    raw = fh.read()
+                b64 = base64.b64encode(raw).decode("ascii")
+                _write_rpc(stdout, {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "kind": "proof-envelope",
+                        "filename_cid": mint.cid,
+                        "contract_set_cid": mint.contract_set_cid,
+                        "bytes_base64": b64,
+                        "diagnostics": [],
+                    },
+                })
+            except Exception as e:  # noqa: BLE001
+                _write_rpc(stdout, {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": 1005, "message": f"LIFT_FAILED: {e}"},
+                })
+            finally:
+                shutil.rmtree(tmp, ignore_errors=True)
+        elif method == "shutdown":
+            _write_rpc(stdout, {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": None,
+            })
+            return 0
+        else:
+            _write_rpc(stdout, {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"METHOD_NOT_FOUND: {method}"},
+            })
+
+
+# ---------------------------------------------------------------------------
+# Direct CLI (also used by smoke tests).
+# ---------------------------------------------------------------------------
+
+
+def main(argv: List[str]) -> int:
+    if "--rpc" in argv:
+        return run_rpc_mode()
+
+    out_dir = (
+        argv[0]
+        if argv and not argv[0].startswith("--")
+        else os.path.join(
+            tempfile.gettempdir(),
+            f"provekit-python-self-contracts-{os.getpid()}",
+        )
+    )
+    det_dir = os.path.join(
+        tempfile.gettempdir(),
+        f"provekit-python-self-determinism-{os.getpid()}",
+    )
+    shutil.rmtree(det_dir, ignore_errors=True)
+
+    print("== ProvekIt Python self-contracts orchestrator ==")
+    print()
+    print(f"output dir: {out_dir}")
+
+    try:
+        mint_a = mint_self_proof(det_dir)
+        mint_b = mint_self_proof(out_dir)
+    except Exception as e:  # noqa: BLE001
+        print(f"ERROR: mint failed: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        return 1
+
+    print()
+    print("authored:")
+    for row in mint_b.per_source_counts:
+        print(f"  {row['label']:>22}  {row['count']:>2} contracts")
+    print(f"  {'[ALL]':>22}  {mint_b.total_contracts:>2} contracts (TOTAL)")
+
+    print()
+    print("minted:")
+    print(f"  .proof file:        {mint_b.path}")
+    print(f"  bytes:              {mint_b.bytes_len}")
+    print(f"  members:            {mint_b.member_count}")
+    print(f"  total contracts:    {mint_b.total_contracts}")
+    print(f"  catalog CID:        {mint_b.cid}")
+    print(f"  contractSetCid:     {mint_b.contract_set_cid}")
+
+    if mint_a.cid != mint_b.cid or mint_a.contract_set_cid != mint_b.contract_set_cid:
+        print()
+        print("ERROR: byte-determinism check FAILED:", file=sys.stderr)
+        print(f"  run A CID:              {mint_a.cid}", file=sys.stderr)
+        print(f"  run B CID:              {mint_b.cid}", file=sys.stderr)
+        print(f"  run A contractSetCid:   {mint_a.contract_set_cid}", file=sys.stderr)
+        print(f"  run B contractSetCid:   {mint_b.contract_set_cid}", file=sys.stderr)
+        shutil.rmtree(det_dir, ignore_errors=True)
+        return 2
+
+    shutil.rmtree(det_dir, ignore_errors=True)
+    print("  determinism check:  OK (two runs produced identical CIDs)")
+    print()
+    print("== done. Python self-application: live. ==")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -101,7 +101,7 @@ const KIT_TABLE: &[(&str, &str, &str, &str)] = &[
     ("csharp",     "csharp",      "csharp",               "csharp"),
     ("swift",      "swift",       "swift-self-contracts", "swift"),
     ("java",       "java",        "java-self-contracts",  "java"),
-    ("python",     "python",      "python",               "python"),
+    ("python",     "python",      "python-self-contracts", "python"),
     ("ruby",       "ruby",        "ruby",                 "ruby"),
     ("zig",        "zig",         "zig",                  "zig"),
     ("c",          "c",           "c",                    "c"),

--- a/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
+++ b/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
@@ -154,12 +154,12 @@ fn assert_attestation_structure(v: &serde_json::Value, lang: &str) {
 /// fallback fires, producing an empty-set CID. The all-kits structure test
 /// tolerates this; the pinned-CID test (`swift_kit_pins_expected_contract_set_cid`)
 /// is `#[cfg_attr(not(target_os = "macos"), ignore)]` so it doesn't fail on Linux.
-const KITS_WITH_LIFTERS: &[&str] = &["rust", "go", "cpp", "ts", "csharp", "swift", "java"];
+const KITS_WITH_LIFTERS: &[&str] = &["rust", "go", "cpp", "ts", "csharp", "swift", "java", "python"];
 
 /// Kits without a lifter binary yet — produce the empty-set CID because the
 /// binary cannot be found (ENOENT on spawn). These declare the binary name but
 /// the binary is not installed; the gap surfaces as an empty-set attestation.
-const KITS_WITHOUT_LIFTERS: &[&str] = &["python", "ruby", "zig", "c"];
+const KITS_WITHOUT_LIFTERS: &[&str] = &["ruby", "zig", "c"];
 
 /// Kits that have a lifter AND are expected to find real contracts.
 /// Only include kits where the test environment reliably has the lifter built
@@ -167,7 +167,7 @@ const KITS_WITHOUT_LIFTERS: &[&str] = &["python", "ruby", "zig", "c"];
 ///
 /// `swift` is on macOS only; the all-kits run handles Linux gracefully via the
 /// `failed_kits` skip path because the release binary is missing.
-const KITS_WITH_REAL_CONTRACTS: &[&str] = &["rust", "go", "cpp"];
+const KITS_WITH_REAL_CONTRACTS: &[&str] = &["rust", "go", "cpp", "python"];
 
 /// Pinned contractSetCid for `--kit=go` after Tier 1 wiring fix (#176).
 /// Reflects the 11 canonical contracts in `implementations/go/provekit-self-contracts/slabs/`.
@@ -702,4 +702,65 @@ fn swift_kit_pins_expected_contract_set_cid() {
     );
 
     eprintln!("swift kit contractSetCid pinned correctly: {cset}");
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: --kit=python pins the expected contractSetCid (issue #205 wiring).
+// ---------------------------------------------------------------------------
+
+/// Pinned contractSetCid produced by `--kit=python` after routing to the
+/// `python-self-contracts` surface (mint-python-self-contracts orchestrator,
+/// canonical 5-slab, 15-contract set).
+///
+/// If this test fails with the old empty-set CID (`d53d18c2...`), the
+/// KIT_TABLE routing regression has been reintroduced. If it fails with an
+/// unknown CID, the python slab contracts have changed -- update
+/// PYTHON_CONTRACT_SET_CID accordingly.
+///
+/// The surface is reached via:
+///   `implementations/python/.provekit/lift/python-self-contracts/manifest.toml`
+/// which spawns: `python3 bin/mint-python-self-contracts`.
+const PYTHON_CONTRACT_SET_CID: &str =
+    "blake3-512:b1de941756d0a3b352ca79ebed8b75644b7c782c3afe4163273220384125ec100457d5e969a921b7ceb277e329a24c5a4ea21ffd54963b51c1756befdb1793dc";
+
+#[test]
+#[serial(mint_kit_files)]
+fn python_kit_pins_expected_contract_set_cid() {
+    let root = repo_root();
+
+    let (ok, stdout, stderr) = run_mint("python");
+    if !ok {
+        eprintln!(
+            "python kit: mint failed (python3 / blake3 / pynacl / cbor2 may not be available)\n  stderr: {stderr}"
+        );
+        // Skip rather than fail -- python toolchain or wheels may not be
+        // present in all environments. CI installs deps via test-python's
+        // `pip install -e .`, but if mint runs before test-python, the
+        // wheels are still installed because cbor2/blake3/pynacl are part
+        // of the package dependencies.
+        return;
+    }
+
+    assert!(
+        stdout.contains("contractSetCid:"),
+        "python kit: stdout must contain 'contractSetCid:'\n  stdout: {stdout}"
+    );
+
+    let attest = read_attestation(&root, "python");
+    let cset = attest["contractSetCid"].as_str().expect("contractSetCid must be string");
+
+    assert_ne!(
+        cset, EMPTY_SET_CID,
+        "python kit: contractSetCid must NOT be the empty-set sentinel -- routing regression detected (issue #205)"
+    );
+    assert_eq!(
+        cset, PYTHON_CONTRACT_SET_CID,
+        "python kit contractSetCid diverged from the pinned canonical self-contracts CID.\n\
+         This is the issue #205 regression gate.\n\
+         If the self-contracts changed intentionally, update PYTHON_CONTRACT_SET_CID.\n\
+         Current: {cset}\n\
+         Pinned:  {PYTHON_CONTRACT_SET_CID}"
+    );
+
+    eprintln!("python kit pinned contractSetCid confirmed: {cset}");
 }


### PR DESCRIPTION
## Summary

Side A bootstrap for the Python kit per issue #176. The orchestrator walks the canonical Python slab (5 slabs of 3 contracts each, 15 total: `blake3` / `jcs` / `cbor` / `signing` / `proof_envelope`), mints each contract as a v1.2 layered signed memento under the foundation key, and bundles them into a `.proof` envelope whose filename IS its catalog CID. The KIT_TABLE flip routes `--kit=python` from the placeholder `python` surface to the new `python-self-contracts` surface, mirroring the rust / go / cpp / ts / ruby wiring pattern (PRs #180, #183, #217, #220, #234).

The orchestrator imports the python claim-envelope substrate that landed in PR #232 (`ClaimEnvelope.from_contract_decl`, `compute_contract_set_cid`) plus the proof-envelope crypto primitives from PR #221 (`build_proof_envelope`, `Signer.foundation_v0`, `ed25519_pubkey_string`, `blake3_512_of`); no reimplementation. Unlike the ruby PR #234, no inline `mint_contract` port was needed because the python lib already exposes the full layered-mint API.

The `--rpc` mode follows the daemon-lifecycle pattern PR #220 established: persistent NDJSON stdio loop, EOF on stdin = graceful shutdown, explicit `shutdown` method acks then exits, JSON-RPC error objects on parse / method-not-found / lift-failed without crashing.

## Acceptance criteria (issue #205)

- [x] Orchestrator (`provekit-self-contracts.py` + bin shim `bin/mint-python-self-contracts`) walks the python slab, calls `ClaimEnvelope.from_contract_decl`, builds proof envelope via existing primitives.
- [x] Speaks the canonical `--rpc` lift-protocol, emits proof-envelope to stdout with `kind`, `filename_cid`, `contract_set_cid`, `bytes_base64`, `diagnostics`.
- [x] Add `python-self-contracts` lift surface manifest at `implementations/python/.provekit/lift/python-self-contracts/manifest.toml`.
- [x] Update `KIT_TABLE` in `implementations/rust/provekit-cli/src/cmd_mint.rs` python entry surface from `"python"` to `"python-self-contracts"`.
- [x] Add a pinned-CID test (`python_kit_pins_expected_contract_set_cid`) in `mint_kit_integration.rs`. Move `python` from `KITS_WITHOUT_LIFTERS` to `KITS_WITH_LIFTERS` AND `KITS_WITH_REAL_CONTRACTS`.
- [x] `make mint-python` produces a content-meaningful contractSetCid (`blake3-512:b1de9417...`), not the empty-set sentinel.
- [x] `provekit prove implementations/python` exits 0.
- [x] Pinned-CID test passes.
- [x] LSP daemon lifecycle is explicit (no orphan processes after the run): EOF on stdin or explicit `shutdown` returns 0.

## KIT_TABLE diff

```rust
// before
("python",     "python",      "python",                "python"),
// after
("python",     "python",      "python-self-contracts", "python"),
```

## `make mint-python` output

```
>> minting python self-contracts
  cid:            blake3-512:64c8ddf3a7ef02c6d12665866e1c2483b59009830a5f27cee869b123d5ece63cccb7dc8d62002383f348b15cd866857de0c6a053dd2fc02e3d9356bd3295b0a4
  contractSetCid: blake3-512:b1de941756d0a3b352ca79ebed8b75644b7c782c3afe4163273220384125ec100457d5e969a921b7ceb277e329a24c5a4ea21ffd54963b51c1756befdb1793dc
OK  .provekit/self-contracts-attestations/python.json (contractSetCid blake3-512:b1de941756d0a3b352ca79ebed8b75644b7c782c3afe4163273220384125ec100457d5e969a921b7ceb277e329a24c5a4ea21ffd54963b51c1756befdb1793dc)
```

The catalog CID and contractSetCid are byte-deterministic across two consecutive mint runs (orchestrator's built-in determinism check, plus the rust integration test).

## Daemon-lifecycle adherence (PR #220)

- Persistent NDJSON stdio loop (one process serves multiple `lift` calls).
- `initialize` returns the protocol version, plugin name, and capabilities.
- `lift` returns the `proof-envelope` shape with base64-encoded bytes.
- `shutdown` writes the ack response and exits 0.
- EOF on stdin = graceful shutdown (loop exit returns 0).
- Errors emit JSON-RPC error objects (`-32700` parse, `-32601` method-not-found, `1005` LIFT_FAILED) without crashing the process.

## Test plan

- [x] Direct CLI smoke (`python3 implementations/python/bin/mint-python-self-contracts /tmp/...`): passes; deterministic across runs.
- [x] RPC smoke (initialize / lift / shutdown over stdin pipe): all three responses well-formed.
- [x] `provekit mint --kit=python --quiet` (via the dispatcher): passes; emits the same `cid` / `contractSetCid`.
- [x] `cargo test --release -p provekit-cli --test mint_kit_integration python_kit_pins_expected_contract_set_cid`: passes.
- [x] `cargo test --release -p provekit-cli --test mint_kit_integration all_kits_mint_produces_valid_attestation_structure`: passes (python now in `KITS_WITH_LIFTERS` + `KITS_WITH_REAL_CONTRACTS`).
- [x] `provekit prove implementations/python`: exit 0.
- [x] All 143 pre-existing python pytest suites in `implementations/python/provekit-lift-py-tests/`: pass.

## Notes

- **Import path**: the bin shim prepends `provekit-lift-py-tests/src` to `sys.path` so the orchestrator works without `pip install -e .` (the `mint-python` Makefile target has no `build-python` dependency, unlike `test-python`). The orchestrator self-injects too as belt-and-suspenders.
- **Python wheels**: `blake3`, `pynacl`, `cbor2` are declared dependencies of `provekit-lift-py-tests` and are installed in CI via `make test-python`'s `pip install -e .`. The pinned-CID test skips on toolchain failure (mirrors ruby/cpp/ts), so a missing wheel surfaces as test-skip rather than test-fail.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)