### PR TITLE
feat(ruby): claim envelope + contractSetCid -- completes Side B (closes #236)

### DIFF
--- a/implementations/ruby/lib/provekit.rb
+++ b/implementations/ruby/lib/provekit.rb
@@ -10,12 +10,16 @@
 #   Provekit::Cbor          - deterministic CBOR encoder (RFC 8949 §4.2.1).
 #   Provekit::Signing       - Ed25519 sign/verify, self-identifying string form.
 #   Provekit::ProofEnvelope - .proof envelope build + verify.
+#   Provekit::ClaimEnvelope - v1.2 layered claim envelope minter.
+#   Provekit::ContractSet   - contractSetCid computation.
 
 require_relative "provekit/blake3"
 require_relative "provekit/ir"
 require_relative "provekit/cbor"
 require_relative "provekit/signing"
 require_relative "provekit/proof_envelope"
+require_relative "provekit/claim_envelope"
+require_relative "provekit/contract_set"
 
 module Provekit
   # Single canonical JCS encoder for the kit. Aliases the implementation

--- a/implementations/ruby/lib/provekit/claim_envelope.rb
+++ b/implementations/ruby/lib/provekit/claim_envelope.rb
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Provekit::ClaimEnvelope -- claim-envelope minter (v1.2 layered shape).
+#
+# `mint_contract` / `mint_bridge` / `mint_implication` build a signed
+# memento in the v1.2 LAYERED shape introduced by
+# `protocol/specs/2026-05-03-substrate-layers-envelope-header-body.md`:
+#
+#   { "envelope": {...}, "header": {...}, "metadata": {...} }
+#
+#   * envelope = { signer, declaredAt, signature }
+#       The signature is computed over JCS({"header": header,
+#       "metadata": metadata}). The envelope's CID (= attestation CID)
+#       is BLAKE3-512(JCS(envelope)) AFTER the signature has been
+#       embedded.
+#
+#   * header   = substrate-load-bearing data the verifier reads:
+#                schemaVersion, kind, cid, plus kind-specific REQUIRED
+#                fields and the derived hashes (bindingHash,
+#                propertyHash, verdict, inputCids) used by the
+#                resolve/index pipeline.
+#
+#   * metadata = everything else (authoring attribution, lifecycle
+#                strings like producedBy/producedAt, derived per-formula
+#                hashes that are pure tooling convenience). Opaque to
+#                the substrate verifier; signed transitively via the
+#                envelope.
+#
+# Reference (authoritative):
+#   implementations/rust/provekit-claim-envelope/src/lib.rs
+#   implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/claim_envelope.py
+#
+# Cross-kit byte-equivalence:
+#   The Ruby output is byte-identical to the Rust + Python kits for the
+#   same canonical input. See test/test_claim_envelope.rb.
+
+require_relative "blake3"
+require_relative "ir"
+require_relative "signing"
+
+module Provekit
+  module ClaimEnvelope
+    # The layered-shape schema version stamped into every memento header
+    # emitted by this kit. Older flat mementos carry "1"; verifiers
+    # branch on this string at load time.
+    LAYERED_SCHEMA_VERSION = "2".freeze
+
+    # ---- Errors ----------------------------------------------------------
+
+    class Error < StandardError; end
+    class EmptyContractError < Error; end
+    class EmptyOutBindingError < Error; end
+
+    # ---- Authoring (typed union mirrored from rust/python kits) ----------
+
+    # Hand-authored by a human or kit, no inference.
+    # `note` is optional; nil or empty string is treated as absent.
+    AuthoringKitAuthor = Struct.new(:author, :note, keyword_init: true) do
+      def initialize(author:, note: nil)
+        super
+      end
+    end
+
+    # Produced by a structural lifter from source.
+    # `evidence` is the lifter's classification ("tests", "types", ...).
+    # `source_cid` is optional; nil or empty string is treated as absent.
+    AuthoringLift = Struct.new(:lifter, :evidence, :source_cid, keyword_init: true) do
+      def initialize(lifter:, evidence:, source_cid: nil)
+        super
+      end
+    end
+
+    # Produced by an LLM, with prompt provenance.
+    # `confidence` is a Float in [0, 1]; serialized as `(confidence *
+    # 1000).to_i` (truncating toward zero for non-negative values; this
+    # matches Rust's `(c * 1000.0) as i64` cast which truncates toward
+    # zero, NOT rounding).
+    # `rationale` is optional; nil or empty string is treated as absent.
+    AuthoringLlm = Struct.new(
+      :llm, :llm_version, :prompt_cid, :confidence, :rationale,
+      keyword_init: true,
+    ) do
+      def initialize(llm:, llm_version:, prompt_cid:, confidence:, rationale: nil)
+        super
+      end
+    end
+
+    # ---- Result type -----------------------------------------------------
+
+    # Result of minting a layered claim envelope. Three fields:
+    # * canonical_bytes: JCS-canonical bytes of the full layered memento
+    #   `{envelope, header, metadata}`. Binary String (ASCII-8BIT).
+    # * cid: the attestation CID = BLAKE3-512(JCS(envelope)) AFTER the
+    #   signature has been embedded. Self-identifying string form
+    #   "blake3-512:<128 hex>".
+    # * contract_cid: signer-independent content CID for contract
+    #   mementos. Empty string for bridges and implications.
+    Minted = Struct.new(:canonical_bytes, :cid, :contract_cid, keyword_init: true)
+
+    # ---- Public surface --------------------------------------------------
+
+    # Build a v1.2-layered ClaimEnvelope from a Provekit::IR::ContractDecl.
+    #
+    # Required:
+    #   decl        -- ContractDecl with name, out_binding, and at least
+    #                  one of pre/post/inv populated.
+    #   signer      -- Provekit::Signing::Signer (Ed25519 seed + producer-id).
+    #   produced_at -- ISO-8601 timestamp (ms precision, trailing 'Z').
+    #
+    # Optional:
+    #   authoring   -- defaults to AuthoringKitAuthor.new(author: signer.producer_id).
+    #   input_cids  -- defaults to []; sorted lex inside the header.
+    def self.from_contract_decl(decl, signer, produced_at:, authoring: nil, input_cids: nil)
+      authoring ||= AuthoringKitAuthor.new(author: signer.producer_id)
+      mint_contract(
+        contract_name: decl.name,
+        out_binding: decl.out_binding,
+        pre: decl.pre,
+        post: decl.post,
+        inv: decl.inv,
+        produced_by: signer.producer_id,
+        produced_at: produced_at,
+        authoring: authoring,
+        signer_seed: signer.seed,
+        input_cids: input_cids || [],
+      )
+    end
+
+    # Compute the **content** CID of a contract (signer-independent).
+    #
+    # Per `protocol/specs/2026-05-03-contract-cid-vs-attestation-cid.md`
+    # §1, this is the BLAKE3-512 of the JCS encoding of the contract's
+    # substrate-load-bearing fields: name, outBinding, and any of
+    # pre/post/inv that are present. Two distinct signers attesting to
+    # the same logical contract produce the same contractCid.
+    def self.contract_cid(contract_name:, out_binding:, pre: nil, post: nil, inv: nil)
+      obj = {
+        "name" => contract_name,
+        "outBinding" => out_binding,
+      }
+      obj["pre"]  = pre  unless pre.nil?
+      obj["post"] = post unless post.nil?
+      obj["inv"]  = inv  unless inv.nil?
+      hash_value(obj)
+    end
+
+    # Mint a v1.2-layered contract claim envelope.
+    # Byte-identical to Rust's `mint_contract` for the same canonical
+    # inputs (see test/test_claim_envelope.rb cross-kit tests).
+    def self.mint_contract(contract_name:, out_binding:, produced_by:, produced_at:,
+                           authoring:, signer_seed:,
+                           pre: nil, post: nil, inv: nil, input_cids: nil)
+      if pre.nil? && post.nil? && inv.nil?
+        raise EmptyContractError, "mint_contract: at least one of pre/post/inv must be present"
+      end
+      if out_binding.to_s.empty?
+        raise EmptyOutBindingError, "mint_contract: outBinding must not be empty"
+      end
+
+      # DERIVED:
+      #   propertyHash = hash(JCS({pre?, post?, inv?, outBinding}))
+      #   bindingHash  = hash(JCS({producerId, contractName, propertyHash}))
+      ph = {}
+      ph["pre"]  = pre  unless pre.nil?
+      ph["post"] = post unless post.nil?
+      ph["inv"]  = inv  unless inv.nil?
+      ph["outBinding"] = out_binding
+      property_hash = hash_value(ph)
+
+      binding_hash = hash_value({
+        "producerId" => produced_by,
+        "contractName" => contract_name,
+        "propertyHash" => property_hash,
+      })
+
+      header_cid = contract_cid(
+        contract_name: contract_name,
+        out_binding: out_binding,
+        pre: pre, post: post, inv: inv,
+      )
+
+      header = {
+        "schemaVersion" => LAYERED_SCHEMA_VERSION,
+        "kind" => "contract",
+        "cid" => header_cid,
+        "name" => contract_name,
+        "outBinding" => out_binding,
+      }
+      header["pre"]  = pre  unless pre.nil?
+      header["post"] = post unless post.nil?
+      header["inv"]  = inv  unless inv.nil?
+      header["verdict"] = "holds"
+      header["bindingHash"] = binding_hash
+      header["propertyHash"] = property_hash
+      sorted_inputs = (input_cids || []).map(&:to_s).sort
+      header["inputCids"] = sorted_inputs
+
+      metadata = {
+        "authoring" => authoring_to_value(authoring),
+        "producedBy" => produced_by,
+        "producedAt" => produced_at,
+      }
+      metadata["preHash"]  = hash_value(pre)  unless pre.nil?
+      metadata["postHash"] = hash_value(post) unless post.nil?
+      metadata["invHash"]  = hash_value(inv)  unless inv.nil?
+
+      assemble_layered(header, metadata, produced_at, signer_seed, header_cid)
+    end
+
+    # Mint a v1.2-layered bridge claim envelope.
+    # Byte-identical to Rust's `mint_bridge` for the same canonical inputs.
+    #
+    # DERIVED:
+    #   bindingHash  = hash(JCS({sourceLayer, sourceSymbol}))
+    #   propertyHash = hash("bridge:" + sourceSymbol)
+    #   inputCids    = [target_contract_cid]
+    def self.mint_bridge(produced_by:, produced_at:, source_symbol:, source_layer:,
+                         target_contract_cid:, target_layer:, ir_arg_sorts:, ir_return_sort:,
+                         signer_seed:, notes: "")
+      arg_sorts = ir_arg_sorts.map(&:to_s)
+
+      binding_hash = hash_value({
+        "sourceLayer" => source_layer,
+        "sourceSymbol" => source_symbol,
+      })
+      property_hash = hash_string("bridge:#{source_symbol}")
+
+      header_cid = hash_value({
+        "sourceSymbol" => source_symbol,
+        "sourceLayer" => source_layer,
+        "targetContractCid" => target_contract_cid,
+        "targetLayer" => target_layer,
+        "irArgSorts" => arg_sorts,
+        "irReturnSort" => ir_return_sort,
+      })
+
+      header = {
+        "schemaVersion" => LAYERED_SCHEMA_VERSION,
+        "kind" => "bridge",
+        "cid" => header_cid,
+        "sourceSymbol" => source_symbol,
+        "sourceLayer" => source_layer,
+        "targetContractCid" => target_contract_cid,
+        "targetLayer" => target_layer,
+        "irArgSorts" => arg_sorts,
+        "irReturnSort" => ir_return_sort,
+        "verdict" => "holds",
+        "bindingHash" => binding_hash,
+        "propertyHash" => property_hash,
+        "inputCids" => [target_contract_cid],
+      }
+
+      metadata = {
+        "producedBy" => produced_by,
+        "producedAt" => produced_at,
+      }
+      metadata["notes"] = notes unless notes.to_s.empty?
+
+      assemble_layered(header, metadata, produced_at, signer_seed, "")
+    end
+
+    # Mint a v1.2-layered implication claim envelope.
+    # Byte-identical to Rust's `mint_implication` for the same canonical
+    # inputs.
+    #
+    # DERIVED:
+    #   bindingHash  = hash(JCS({antecedentHash, consequentHash}))
+    #   propertyHash = hash("implication:" + ah + ":" + ch)
+    #   inputCids    = sorted([antecedent_cid, consequent_cid])
+    def self.mint_implication(produced_by:, produced_at:, antecedent_hash:, consequent_hash:,
+                              antecedent_cid:, consequent_cid:, antecedent_slot:, consequent_slot:,
+                              prover:, prover_run_ms:, signer_seed:,
+                              smt_lib_input: "", proof_witness: "")
+      binding_hash = hash_value({
+        "antecedentHash" => antecedent_hash,
+        "consequentHash" => consequent_hash,
+      })
+      property_hash = hash_string("implication:#{antecedent_hash}:#{consequent_hash}")
+
+      header_cid = hash_value({
+        "antecedentHash" => antecedent_hash,
+        "consequentHash" => consequent_hash,
+        "antecedentCid" => antecedent_cid,
+        "consequentCid" => consequent_cid,
+        "antecedentSlot" => antecedent_slot,
+        "consequentSlot" => consequent_slot,
+      })
+
+      input_cids_sorted = [antecedent_cid, consequent_cid].sort
+
+      header = {
+        "schemaVersion" => LAYERED_SCHEMA_VERSION,
+        "kind" => "implication",
+        "cid" => header_cid,
+        "antecedentHash" => antecedent_hash,
+        "consequentHash" => consequent_hash,
+        "antecedentCid" => antecedent_cid,
+        "consequentCid" => consequent_cid,
+        "antecedentSlot" => antecedent_slot,
+        "consequentSlot" => consequent_slot,
+        "verdict" => "holds",
+        "bindingHash" => binding_hash,
+        "propertyHash" => property_hash,
+        "inputCids" => input_cids_sorted,
+      }
+
+      metadata = {
+        "producedBy" => produced_by,
+        "producedAt" => produced_at,
+        "prover" => prover,
+        "proverRunMs" => prover_run_ms.to_i,
+      }
+      metadata["smtLibInput"]  = smt_lib_input  unless smt_lib_input.to_s.empty?
+      metadata["proofWitness"] = proof_witness  unless proof_witness.to_s.empty?
+
+      assemble_layered(header, metadata, produced_at, signer_seed, "")
+    end
+
+    # ---- Internals (mirror rust lib.rs / python claim_envelope.py) -------
+
+    # BLAKE3-512(JCS(value)) -- "blake3-512:<128 hex>".
+    def self.hash_value(value)
+      Provekit::Blake3.hex(Provekit::IR::Jcs.encode(value))
+    end
+
+    # BLAKE3-512(s) -- s treated as UTF-8 bytes.
+    def self.hash_string(s)
+      Provekit::Blake3.hex(s.to_s)
+    end
+
+    # JCS-canonical bytes of `{"header": header, "metadata": metadata}`.
+    # This is the message the envelope's Ed25519 signature covers
+    # (substrate-layers spec §2 R2).
+    def self.signing_bytes(header, metadata)
+      Provekit::IR::Jcs.encode({"header" => header, "metadata" => metadata})
+    end
+
+    # Lower an Authoring block to a JCS-friendly Hash.
+    # Mirrors `authoring_to_value` in rust kit / `_authoring_to_value` in
+    # python kit. Empty notes/source_cid/rationale are treated as absent.
+    def self.authoring_to_value(a)
+      case a
+      when AuthoringKitAuthor
+        h = {"producerKind" => "kit-author", "author" => a.author}
+        h["note"] = a.note if a.note && !a.note.empty?
+        h
+      when AuthoringLift
+        h = {
+          "producerKind" => "lift",
+          "lifter" => a.lifter,
+          "evidence" => a.evidence,
+        }
+        h["sourceCid"] = a.source_cid if a.source_cid && !a.source_cid.empty?
+        h
+      when AuthoringLlm
+        # Rust's `(confidence * 1000.0) as i64` truncates toward zero.
+        # Ruby's `Integer(x)` raises; `x.to_i` truncates toward zero
+        # for both positive and negative finite floats, matching rust.
+        confidence_i = (a.confidence * 1000.0).to_i
+        h = {
+          "producerKind" => "llm",
+          "llm" => a.llm,
+          "llmVersion" => a.llm_version,
+          "promptCid" => a.prompt_cid,
+          "confidence" => confidence_i,
+        }
+        h["rationale"] = a.rationale if a.rationale && !a.rationale.empty?
+        h
+      else
+        raise ArgumentError, "unknown Authoring variant: #{a.class}"
+      end
+    end
+
+    # Sign (header, metadata), embed signature into envelope, JCS the
+    # full {envelope, header, metadata} triple. Returns Minted.
+    #
+    # Mirrors `assemble_layered` in rust:
+    #   1. signer_str  = ed25519_pubkey_string(seed)
+    #   2. signing_msg = JCS({"header": header, "metadata": metadata})
+    #   3. signature   = ed25519_sign_string(seed, signing_msg)
+    #   4. envelope    = {signer, declaredAt, signature}
+    #   5. attestation_cid = BLAKE3-512(JCS(envelope))
+    #   6. memento     = {envelope, header, metadata}
+    #   7. canonical_bytes = JCS(memento) -> bytes
+    def self.assemble_layered(header, metadata, declared_at, signer_seed, content_cid)
+      signer_str = Provekit::Signing.ed25519_pubkey_string(signer_seed)
+      signing_msg = signing_bytes(header, metadata)
+      signature = Provekit::Signing.ed25519_sign_string(signer_seed, signing_msg)
+
+      envelope = {
+        "signer" => signer_str,
+        "declaredAt" => declared_at,
+        "signature" => signature,
+      }
+      envelope_jcs = Provekit::IR::Jcs.encode(envelope)
+      attestation_cid = Provekit::Blake3.hex(envelope_jcs)
+
+      memento_jcs = Provekit::IR::Jcs.encode({
+        "envelope" => envelope,
+        "header" => header,
+        "metadata" => metadata,
+      })
+
+      Minted.new(
+        canonical_bytes: memento_jcs.b,
+        cid: attestation_cid,
+        contract_cid: content_cid,
+      )
+    end
+  end
+end

--- a/implementations/ruby/lib/provekit/contract_set.rb
+++ b/implementations/ruby/lib/provekit/contract_set.rb
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Provekit::ContractSet -- contractSetCid computation.
+#
+# Per `protocol/specs/2026-05-03-contract-set-extension.md` §1:
+#
+#   contractSetCid := "blake3-512:" || hex(BLAKE3-512(JCS(<sorted contractCids>)))
+#
+# Where `<sorted contractCids>` is the array of `contractCid` values
+# (per `2026-05-03-contract-cid-vs-attestation-cid.md`) sorted
+# lexicographically by their hex representation. The sort makes the
+# set order-independent: two implementations enumerating contracts in
+# different orders agree on the set's CID.
+#
+# Reference (authoritative):
+#   implementations/rust/provekit-claim-envelope/src/lib.rs (compute_contract_set_cid)
+#   implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/claim_envelope.py
+#
+# Cross-kit byte-equivalence:
+#   Output is byte-identical to Rust + Python kits for the same inputs.
+#   See test/test_claim_envelope.rb cross-kit tests.
+
+require_relative "blake3"
+require_relative "ir"
+
+module Provekit
+  module ContractSet
+    # Compute the contractSetCid from a sequence of contractCid strings.
+    # The sequence is sorted lexicographically before JCS-encoding, so
+    # callers may enumerate contracts in any order.
+    #
+    # NOTE: the spec treats the input as a SEQUENCE-of-CIDs, not a
+    # deduplicated set; duplicates in the input affect the output. If
+    # callers want set semantics (uniqueness), they must dedupe before
+    # calling.
+    def self.compute_cid(contract_cids)
+      sorted = contract_cids.map(&:to_s).sort
+      jcs = Provekit::IR::Jcs.encode(sorted)
+      Provekit::Blake3.hex(jcs)
+    end
+  end
+end

--- a/implementations/ruby/lib/provekit/self_contracts.rb
+++ b/implementations/ruby/lib/provekit/self_contracts.rb
@@ -32,6 +32,8 @@ require_relative "ir"
 require_relative "cbor"
 require_relative "signing"
 require_relative "proof_envelope"
+require_relative "claim_envelope"
+require_relative "contract_set"
 
 module Provekit
   module SelfContracts
@@ -39,7 +41,6 @@ module Provekit
     DECLARED_AT  = "2026-04-30T18:00:00.000Z".freeze
     CATALOG_NAME = "@provekit/ruby-self-contracts".freeze
     CATALOG_VERSION = "1.0.0".freeze
-    LAYERED_SCHEMA_VERSION = "2".freeze
 
     # ---- Slab authoring ---------------------------------------------------
     #
@@ -214,110 +215,55 @@ module Provekit
 
     # ---- Contract / contract-set CID --------------------------------------
     #
-    # contractCid is the signer-independent BLAKE3-512(JCS({name, outBinding,
-    # pre?, post?, inv?})). The contractSetCid is BLAKE3-512(JCS(<sorted
-    # contractCids>)). Both shapes are byte-identical to the rust/cpp/go/ts
-    # peers per spec 2026-05-03-contract-cid-vs-attestation-cid.md and
+    # Both delegate to the canonical kit lib. contractCid is signer-
+    # independent BLAKE3-512(JCS({name, outBinding, pre?, post?, inv?}));
+    # contractSetCid is BLAKE3-512(JCS(<sorted contractCids>)). Both
+    # shapes are byte-identical to the rust/cpp/go/ts/python peers per
+    # spec 2026-05-03-contract-cid-vs-attestation-cid.md and
     # 2026-05-03-contract-set-extension.md.
 
     def self.contract_cid(decl)
-      obj = { "name" => decl.name, "outBinding" => decl.out_binding }
-      obj["pre"]  = decl.pre  if decl.pre
-      obj["post"] = decl.post if decl.post
-      obj["inv"]  = decl.inv  if decl.inv
-      jcs = IR_M::Jcs.encode(obj)
-      Blake3.hex(jcs)
+      Provekit::ClaimEnvelope.contract_cid(
+        contract_name: decl.name,
+        out_binding: decl.out_binding,
+        pre: decl.pre,
+        post: decl.post,
+        inv: decl.inv,
+      )
     end
 
     def self.compute_contract_set_cid(content_cids)
-      sorted = content_cids.dup.sort
-      jcs = IR_M::Jcs.encode(sorted)
-      Blake3.hex(jcs)
+      Provekit::ContractSet.compute_cid(content_cids)
     end
 
     # ---- Layered memento mint --------------------------------------------
     #
-    # Ports rust `provekit-claim-envelope` mint_contract. The result is the
-    # JCS-canonical bytes of `{envelope, header, metadata}`; the attestation
-    # CID is BLAKE3-512(JCS(envelope)). Per
-    # protocol/specs/2026-04-30-memento-envelope-grammar.md.
-
-    def self.hash_value_jcs(value)
-      Blake3.hex(IR_M::Jcs.encode(value))
-    end
-
-    def self.mint_contract(decl, signer_seed: Provekit::Signing::FOUNDATION_V0_SEED, produced_by: PRODUCED_BY, produced_at: DECLARED_AT, source_path: "")
-      raise ArgumentError, "contract must carry at least one of pre/post/inv" if decl.pre.nil? && decl.post.nil? && decl.inv.nil?
-      raise ArgumentError, "out_binding must be non-empty" if decl.out_binding.to_s.empty?
-
-      # propertyHash = BLAKE3-512(JCS({pre?, post?, inv?, outBinding}))
-      ph = {}
-      ph["pre"]  = decl.pre  if decl.pre
-      ph["post"] = decl.post if decl.post
-      ph["inv"]  = decl.inv  if decl.inv
-      ph["outBinding"] = decl.out_binding
-      property_hash = hash_value_jcs(ph)
-
-      # bindingHash = BLAKE3-512(JCS({producerId, contractName, propertyHash}))
-      bh = {
-        "producerId" => produced_by,
-        "contractName" => decl.name,
-        "propertyHash" => property_hash,
-      }
-      binding_hash = hash_value_jcs(bh)
-
-      header_cid = contract_cid(decl)
-
-      header = { "schemaVersion" => LAYERED_SCHEMA_VERSION, "kind" => "contract", "cid" => header_cid }
-      header["name"] = decl.name
-      header["outBinding"] = decl.out_binding
-      header["pre"]  = decl.pre  if decl.pre
-      header["post"] = decl.post if decl.post
-      header["inv"]  = decl.inv  if decl.inv
-      header["verdict"] = "holds"
-      header["bindingHash"] = binding_hash
-      header["propertyHash"] = property_hash
-      header["inputCids"] = []
-
-      authoring = {
-        "producerKind" => "kit-author",
-        "author" => produced_by,
-      }
-      authoring["note"] = "self-contract from #{source_path}" unless source_path.empty?
-
-      metadata = {
-        "authoring" => authoring,
-        "producedBy" => produced_by,
-        "producedAt" => produced_at,
-      }
-      metadata["preHash"]  = hash_value_jcs(decl.pre)  if decl.pre
-      metadata["postHash"] = hash_value_jcs(decl.post) if decl.post
-      metadata["invHash"]  = hash_value_jcs(decl.inv)  if decl.inv
-
-      # Signing message = JCS({header, metadata}); signature is the spec's
-      # self-identifying string form ("ed25519:" + base64(64-byte sig)).
-      signing_msg = IR_M::Jcs.encode({ "header" => header, "metadata" => metadata })
-      signature   = Provekit::Signing.ed25519_sign_string(signer_seed, signing_msg)
-      signer_str  = Provekit::Signing.ed25519_pubkey_string(signer_seed)
-
-      envelope = {
-        "signer" => signer_str,
-        "declaredAt" => produced_at,
-        "signature" => signature,
-      }
-      envelope_jcs = IR_M::Jcs.encode(envelope)
-      attestation_cid = Blake3.hex(envelope_jcs)
-
-      memento_jcs = IR_M::Jcs.encode({
-        "envelope" => envelope,
-        "header" => header,
-        "metadata" => metadata,
-      })
-
+    # Delegates to Provekit::ClaimEnvelope.mint_contract (the canonical
+    # v1.2 layered shape per substrate-layers spec). Wraps it with the
+    # orchestrator's `source_path` -> authoring `note` convention.
+    # Returns a Hash {cid:, contract_cid:, canonical_bytes:} for the
+    # bundle composer below.
+    def self.mint_contract(decl, signer_seed: Provekit::Signing::FOUNDATION_V0_SEED,
+                           produced_by: PRODUCED_BY, produced_at: DECLARED_AT,
+                           source_path: "")
+      authoring = Provekit::ClaimEnvelope::AuthoringKitAuthor.new(
+        author: produced_by,
+        note: source_path.to_s.empty? ? nil : "self-contract from #{source_path}",
+      )
+      minted = Provekit::ClaimEnvelope.mint_contract(
+        contract_name: decl.name,
+        out_binding: decl.out_binding,
+        pre: decl.pre, post: decl.post, inv: decl.inv,
+        produced_by: produced_by,
+        produced_at: produced_at,
+        authoring: authoring,
+        signer_seed: signer_seed,
+        input_cids: [],
+      )
       {
-        cid: attestation_cid,
-        contract_cid: header_cid,
-        canonical_bytes: memento_jcs.b,
+        cid: minted.cid,
+        contract_cid: minted.contract_cid,
+        canonical_bytes: minted.canonical_bytes,
       }
     end
 

--- a/implementations/ruby/lib/provekit/signing.rb
+++ b/implementations/ruby/lib/provekit/signing.rb
@@ -98,5 +98,59 @@ module Provekit
     rescue StandardError
       false
     end
+
+    # ------------------------------------------------------------------
+    # Signer: minimal handle bundling per-actor stable fields.
+    #
+    # Used by Provekit::ClaimEnvelope.from_contract_decl(decl, signer).
+    # Only the fields stable per-actor live on the Signer; per-attestation
+    # fields (produced_at, authoring, input_cids) are passed at call time.
+    #
+    # The producer-id ("ruby-kit@1.0", "rust-test@1.0", etc.) is bound
+    # into the contract's bindingHash (per `mint_contract` derivation
+    # `bindingHash = hash(JCS({producerId, contractName, propertyHash}))`)
+    # so it lives on the Signer rather than being recomputed at every
+    # call.
+    # ------------------------------------------------------------------
+    class Signer
+      attr_reader :seed, :producer_id
+
+      def initialize(seed:, producer_id:)
+        unless seed.is_a?(String) && seed.bytesize == 32
+          raise ArgumentError, "Signer seed must be exactly 32 bytes"
+        end
+        unless producer_id.is_a?(String) && !producer_id.empty?
+          raise ArgumentError, "Signer producer_id must be a non-empty String"
+        end
+        @seed = seed.b.freeze
+        @producer_id = producer_id.dup.freeze
+      end
+
+      # Convenience: a Signer using the public foundation v0 test seed.
+      # Foundation v0 is the publicly-known cross-kit test seed; it is
+      # appropriate for fixtures and conformance tests, not production.
+      def self.foundation_v0(producer_id: "ruby-kit@1.0")
+        new(seed: FOUNDATION_V0_SEED, producer_id: producer_id)
+      end
+
+      # Self-identifying public-key string: "ed25519:<base64>".
+      def pubkey_string
+        Provekit::Signing.ed25519_pubkey_string(@seed)
+      end
+
+      # Build a v1.2-layered ClaimEnvelope from a `ContractDecl`.
+      # Convenience delegate to `Provekit::ClaimEnvelope.from_contract_decl`.
+      # Loaded lazily to avoid the signing -> claim_envelope -> signing
+      # require cycle.
+      def sign_claim(decl, produced_at:, authoring: nil, input_cids: nil)
+        require_relative "claim_envelope"
+        Provekit::ClaimEnvelope.from_contract_decl(
+          decl, self,
+          produced_at: produced_at,
+          authoring: authoring,
+          input_cids: input_cids,
+        )
+      end
+    end
   end
 end

--- a/implementations/ruby/test/test_claim_envelope.rb
+++ b/implementations/ruby/test/test_claim_envelope.rb
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# claim_envelope tests: layered-shape construction, byte-equivalence
+# against the Rust + Python references, error-path coverage, and the
+# contractSetCid conformance test.
+#
+# Cross-kit byte-equivalence pins are derived from the Rust kit:
+#   cargo test -p provekit-claim-envelope --test cross_kit_pin -- --nocapture
+#
+# The Rust kit is the reference; the Ruby kit must produce byte-identical
+# output for the same canonical input. If a pin fails, the mismatch is
+# a real divergence -- surface it, don't paper over it.
+
+require "minitest/autorun"
+require "json"
+require "base64"
+require "ed25519"
+
+require_relative "../lib/provekit"
+
+# ---------------------------------------------------------------------------
+# Canonical fixtures (match implementations/rust/.../tests/cross_kit_pin.rs)
+# ---------------------------------------------------------------------------
+
+# `forall n: Int. n > 0` -- the cross-kit pin's `pre` formula.
+PRE_N_GT_0 = {
+  "kind" => "forall",
+  "name" => "n",
+  "sort" => {"kind" => "primitive", "name" => "Int"},
+  "body" => {
+    "kind" => "atomic",
+    "name" => ">",
+    "args" => [
+      {"kind" => "var", "name" => "n"},
+      {"kind" => "const", "value" => 0,
+       "sort" => {"kind" => "primitive", "name" => "Int"}},
+    ],
+  },
+}.freeze
+
+# `out = 0` -- the cross-kit pin's `post` formula.
+POST_OUT_EQ_0 = {
+  "kind" => "atomic",
+  "name" => "=",
+  "args" => [
+    {"kind" => "var", "name" => "out"},
+    {"kind" => "const", "value" => 0,
+     "sort" => {"kind" => "primitive", "name" => "Int"}},
+  ],
+}.freeze
+
+def fixture_kwargs
+  {
+    contract_name: "demo",
+    out_binding: "out",
+    pre: PRE_N_GT_0,
+    post: POST_OUT_EQ_0,
+    inv: nil,
+    produced_by: "rust-test@1.0",
+    produced_at: "2026-04-30T00:00:00.000Z",
+    authoring: Provekit::ClaimEnvelope::AuthoringKitAuthor.new(author: "rust-test@1.0"),
+    signer_seed: Provekit::Signing::FOUNDATION_V0_SEED,
+    input_cids: [],
+  }
+end
+
+# ---------------------------------------------------------------------------
+# Cross-kit byte-equivalence pins (from rust cross_kit_pin.rs / python tests)
+# ---------------------------------------------------------------------------
+
+RUST_FIXTURE_BYTES_HEX_FULL =
+  "7b22656e76656c6f7065223a7b226465636c617265644174223a22323032362d30342d33" \
+  "305430303a30303a30302e3030305a222c227369676e6174757265223a22656432353531" \
+  "393a445549436e45753343647a4f76534a49756c5878314e4a794765746b73634f443755" \
+  "4857696b3264743733766d47332f375a2b763364673644516d6d6a4c744852556e793369" \
+  "454a61657a6c34326a6c584f655543513d3d222c227369676e6572223a22656432353531" \
+  "393a49564c34305a7435485352464d6b4c6858793672624c66502b6e747158744d416c35" \
+  "594f427069423278493d227d2c22686561646572223a7b2262696e64696e674861736822" \
+  "3a22626c616b65332d3531323a3465343962396465626338393963663865333461653931" \
+  "343662373234343832313139306662376631376136356534356561346265636465333033" \
+  "656337323865643636316132613336303763626432353361633730313264646534363836" \
+  "333737633664313966343464393633393232613465376539333034363932366466222c22" \
+  "636964223a22626c616b65332d3531323a62636130626239313434623362333565333261" \
+  "633039646334333832633838656336363337353031326235613166616663383965363539" \
+  "646239363637353637336435363161366436386234643138333138646330326638646437" \
+  "663838653665666661336439646262666237653764623137313631306630383731356462" \
+  "31222c22696e70757443696473223a5b5d2c226b696e64223a22636f6e7472616374222c" \
+  "226e616d65223a2264656d6f222c226f757442696e64696e67223a226f7574222c22706f" \
+  "7374223a7b2261726773223a5b7b226b696e64223a22766172222c226e616d65223a226f" \
+  "7574227d2c7b226b696e64223a22636f6e7374222c22736f7274223a7b226b696e64223a" \
+  "227072696d6974697665222c226e616d65223a22496e74227d2c2276616c7565223a307d" \
+  "5d2c226b696e64223a2261746f6d6963222c226e616d65223a223d227d2c22707265223a" \
+  "7b22626f6479223a7b2261726773223a5b7b226b696e64223a22766172222c226e616d65" \
+  "223a226e227d2c7b226b696e64223a22636f6e7374222c22736f7274223a7b226b696e64" \
+  "223a227072696d6974697665222c226e616d65223a22496e74227d2c2276616c7565223a" \
+  "307d5d2c226b696e64223a2261746f6d6963222c226e616d65223a223e227d2c226b696e" \
+  "64223a22666f72616c6c222c226e616d65223a226e222c22736f7274223a7b226b696e64" \
+  "223a227072696d6974697665222c226e616d65223a22496e74227d7d2c2270726f706572" \
+  "747948617368223a22626c616b65332d3531323a33636665633638326665646562336666" \
+  "656132346339373339653231343262633935323661636238653136326330303431386335" \
+  "363466383236663261363735633864616162636235313865366337663131666562363366" \
+  "346631336530373634353366643236623833323063336535356466393332383437313535" \
+  "65346132222c22736368656d6156657273696f6e223a2232222c2276657264696374223a" \
+  "22686f6c6473227d2c226d65746164617461223a7b22617574686f72696e67223a7b2261" \
+  "7574686f72223a22727573742d7465737440312e30222c2270726f64756365724b696e64" \
+  "223a226b69742d617574686f72227d2c22706f737448617368223a22626c616b65332d35" \
+  "31323a363530613835353463316362383831373832393965303637383238376638383939" \
+  "366636626633643733646139376238336539383330363264643565653736396338376631" \
+  "303830346561333333623237373937343366383837663661656266353235653734643836" \
+  "6662636165326461633964323937633235336536376135222c2270726548617368223a22" \
+  "626c616b65332d3531323a61663736323664646162346164343233636535653361326335" \
+  "633334643065616135346635373132303134376462663765396437363633323032633430" \
+  "396539303132383836663730303762616463386439366232396236623836333638646465" \
+  "32353461343237666466326632363138346263393834633036616239393232222c227072" \
+  "6f64756365644174223a22323032362d30342d33305430303a30303a30302e3030305a22" \
+  "2c2270726f64756365644279223a22727573742d7465737440312e30227d7d"
+
+RUST_FIXTURE_CID =
+  "blake3-512:b5cd82094dd4d7dab5c73ab8b0f236a031a546335cd0ef1c0d7d70a23ffa3" \
+  "6506455b5d5a47e197a61da91fdc64b79901320a6480617ff0c0195526f3523639c"
+
+RUST_FIXTURE_CONTRACT_CID =
+  "blake3-512:bca0bb9144b3b35e32ac09dc4382c88ec66375012b5a1fafc89e659db966" \
+  "75673d561a6d68b4d18318dc02f8dd7f88e6effa3d9dbbfb7e7db171610f08715db1"
+
+# contractSetCid pin from rust cross_kit_pin.rs: 2-element set
+# {contract("demo"), contract("second")}.
+RUST_CONTRACT_A_CID =
+  "blake3-512:bca0bb9144b3b35e32ac09dc4382c88ec66375012b5a1fafc89e659db966" \
+  "75673d561a6d68b4d18318dc02f8dd7f88e6effa3d9dbbfb7e7db171610f08715db1"
+RUST_CONTRACT_B_CID =
+  "blake3-512:3a59a4b9fd854d194250159d08438539730533371e7b4b1ef71ff458accd" \
+  "394bc06e67a88d5ba56f7fe1a6f545843cfeb206ec53404b1820b9766d8d91b00e63"
+RUST_CONTRACT_SET_CID =
+  "blake3-512:e42f67a1f994723791af102a0427c2563c63a526684a69a03264bc625aee" \
+  "b5081381a413ed5ce126800f5eb816d4c922e808cd325450825ef19933d075962506"
+
+# ---------------------------------------------------------------------------
+
+class TestCrossKitByteEquivalence < Minitest::Test
+  # Ruby output must be byte-identical to Rust + Python kits for the same input.
+
+  def test_fixture_bytes_match_rust
+    out = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    rust_bytes = [RUST_FIXTURE_BYTES_HEX_FULL].pack("H*")
+    if out.canonical_bytes != rust_bytes
+      limit = [out.canonical_bytes.bytesize, rust_bytes.bytesize].min
+      limit.times do |i|
+        rb = out.canonical_bytes.bytes[i]
+        rb2 = rust_bytes.bytes[i]
+        if rb != rb2
+          flunk(
+            "cross-kit byte divergence at byte #{i}: " \
+            "ruby=0x#{rb.to_s(16)} (#{out.canonical_bytes[i].inspect}) " \
+            "rust=0x#{rb2.to_s(16)} (#{rust_bytes[i].inspect})\n" \
+            "ruby length: #{out.canonical_bytes.bytesize}\n" \
+            "rust length: #{rust_bytes.bytesize}\n" \
+            "ruby[..120]: #{out.canonical_bytes[0, 120].inspect}\n" \
+            "rust[..120]: #{rust_bytes[0, 120].inspect}"
+          )
+        end
+      end
+      flunk(
+        "cross-kit length mismatch: ruby=#{out.canonical_bytes.bytesize}, " \
+        "rust=#{rust_bytes.bytesize}"
+      )
+    end
+    pass
+  end
+
+  def test_fixture_attestation_cid_matches_rust
+    out = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    assert_equal RUST_FIXTURE_CID, out.cid
+  end
+
+  def test_fixture_contract_cid_matches_rust
+    out = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    assert_equal RUST_FIXTURE_CONTRACT_CID, out.contract_cid
+  end
+
+  def test_contract_cid_function_matches_minted
+    # The standalone contract_cid() must equal the minted envelope's
+    # contract_cid field, since both compute the same thing.
+    kw = fixture_kwargs
+    direct = Provekit::ClaimEnvelope.contract_cid(
+      contract_name: kw[:contract_name],
+      out_binding: kw[:out_binding],
+      pre: kw[:pre], post: kw[:post], inv: kw[:inv],
+    )
+    minted = Provekit::ClaimEnvelope.mint_contract(**kw)
+    assert_equal RUST_FIXTURE_CONTRACT_CID, direct
+    assert_equal direct, minted.contract_cid
+  end
+
+  def test_compute_contract_set_cid_matches_rust
+    # Per spec §1: BLAKE3-512(JCS(<sorted contractCids>))
+    got = Provekit::ContractSet.compute_cid([RUST_CONTRACT_A_CID, RUST_CONTRACT_B_CID])
+    assert_equal RUST_CONTRACT_SET_CID, got
+  end
+
+  def test_compute_contract_set_cid_is_order_independent
+    a = Provekit::ContractSet.compute_cid([RUST_CONTRACT_A_CID, RUST_CONTRACT_B_CID])
+    b = Provekit::ContractSet.compute_cid([RUST_CONTRACT_B_CID, RUST_CONTRACT_A_CID])
+    assert_equal a, b
+    assert_equal RUST_CONTRACT_SET_CID, a
+  end
+end
+
+class TestLayeredShape < Minitest::Test
+  # Structural conformance with substrate-layers spec §1.
+
+  def parse(env)
+    JSON.parse(env.canonical_bytes)
+  end
+
+  def test_top_level_has_three_keys
+    env = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    assert_equal %w[envelope header metadata].sort, parse(env).keys.sort
+  end
+
+  def test_envelope_has_signer_declared_at_signature
+    env = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    e = parse(env)["envelope"]
+    assert_equal %w[declaredAt signature signer], e.keys.sort
+    assert e["signer"].start_with?("ed25519:")
+    assert e["signature"].start_with?("ed25519:")
+  end
+
+  def test_header_has_required_fields
+    env = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    h = parse(env)["header"]
+    assert_equal Provekit::ClaimEnvelope::LAYERED_SCHEMA_VERSION, h["schemaVersion"]
+    assert_equal "contract", h["kind"]
+    assert h["cid"].start_with?("blake3-512:")
+    %w[name outBinding verdict bindingHash propertyHash inputCids].each do |k|
+      assert h.key?(k), "header.#{k} missing"
+    end
+  end
+
+  def test_attestation_cid_equals_blake3_of_jcs_envelope
+    # Substrate-layers spec §2 R1: envelope CID = hash(JCS(envelope))
+    # AFTER signature is embedded.
+    env = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    e = parse(env)["envelope"]
+    recomputed = Provekit::Blake3.hex(Provekit::IR::Jcs.encode(e))
+    assert_equal recomputed, env.cid
+  end
+
+  def test_signature_covers_jcs_of_header_metadata
+    # Signature is over JCS({"header": header, "metadata": metadata}).
+    env = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    parsed = parse(env)
+    sig_str = parsed["envelope"]["signature"]
+    signer_str = parsed["envelope"]["signer"]
+    assert sig_str.start_with?("ed25519:")
+    assert signer_str.start_with?("ed25519:")
+
+    sig_bytes = Base64.strict_decode64(sig_str.sub("ed25519:", ""))
+    pk_bytes = Base64.strict_decode64(signer_str.sub("ed25519:", ""))
+    assert_equal 64, sig_bytes.bytesize
+    assert_equal 32, pk_bytes.bytesize
+
+    signing_msg = Provekit::IR::Jcs.encode({
+      "header" => parsed["header"],
+      "metadata" => parsed["metadata"],
+    })
+
+    # Should NOT raise.
+    vk = ::Ed25519::VerifyKey.new(pk_bytes)
+    vk.verify(sig_bytes, signing_msg)
+    pass
+  end
+end
+
+class TestErrors < Minitest::Test
+  def test_empty_contract_rejected
+    assert_raises(Provekit::ClaimEnvelope::EmptyContractError) do
+      Provekit::ClaimEnvelope.mint_contract(
+        contract_name: "x", out_binding: "out",
+        pre: nil, post: nil, inv: nil,
+        produced_by: "t", produced_at: "2026-04-30T00:00:00.000Z",
+        authoring: Provekit::ClaimEnvelope::AuthoringKitAuthor.new(author: "t"),
+        signer_seed: Provekit::Signing::FOUNDATION_V0_SEED,
+      )
+    end
+  end
+
+  def test_empty_out_binding_rejected
+    assert_raises(Provekit::ClaimEnvelope::EmptyOutBindingError) do
+      Provekit::ClaimEnvelope.mint_contract(
+        contract_name: "x", out_binding: "",
+        pre: PRE_N_GT_0, post: nil, inv: nil,
+        produced_by: "t", produced_at: "2026-04-30T00:00:00.000Z",
+        authoring: Provekit::ClaimEnvelope::AuthoringKitAuthor.new(author: "t"),
+        signer_seed: Provekit::Signing::FOUNDATION_V0_SEED,
+      )
+    end
+  end
+end
+
+class TestFromContractDecl < Minitest::Test
+  # ClaimEnvelope.from_contract_decl(decl, signer) packages a
+  # Provekit::IR::ContractDecl directly.
+
+  def test_from_contract_decl_round_trips
+    decl = Provekit::IR::ContractDecl.new(
+      name: "demo", out_binding: "out",
+      pre: PRE_N_GT_0,
+    )
+    signer = Provekit::Signing::Signer.foundation_v0(producer_id: "ruby-kit@1.0")
+    env = Provekit::ClaimEnvelope.from_contract_decl(
+      decl, signer, produced_at: "2026-04-30T00:00:00.000Z",
+    )
+    assert env.cid.start_with?("blake3-512:")
+    assert env.contract_cid.start_with?("blake3-512:")
+    parsed = JSON.parse(env.canonical_bytes)
+    assert_equal %w[envelope header metadata].sort, parsed.keys.sort
+    assert_equal "contract", parsed["header"]["kind"]
+    assert_equal "demo", parsed["header"]["name"]
+  end
+
+  def test_signer_producer_id_lands_in_metadata
+    decl = Provekit::IR::ContractDecl.new(
+      name: "demo", out_binding: "out", pre: PRE_N_GT_0,
+    )
+    signer = Provekit::Signing::Signer.foundation_v0(producer_id: "ruby-kit@1.0")
+    env = Provekit::ClaimEnvelope.from_contract_decl(
+      decl, signer, produced_at: "2026-04-30T00:00:00.000Z",
+    )
+    parsed = JSON.parse(env.canonical_bytes)
+    assert_equal "ruby-kit@1.0", parsed["metadata"]["producedBy"]
+    assert_equal "ruby-kit@1.0", parsed["metadata"]["authoring"]["author"]
+    assert_equal "kit-author", parsed["metadata"]["authoring"]["producerKind"]
+  end
+
+  def test_signer_sign_claim_delegates_to_from_contract_decl
+    # Signer#sign_claim is a convenience wrapper; bytes must be
+    # identical to ClaimEnvelope.from_contract_decl(decl, signer).
+    decl = Provekit::IR::ContractDecl.new(
+      name: "demo", out_binding: "out", pre: PRE_N_GT_0,
+    )
+    signer = Provekit::Signing::Signer.foundation_v0(producer_id: "ruby-kit@1.0")
+    a = signer.sign_claim(decl, produced_at: "2026-04-30T00:00:00.000Z")
+    b = Provekit::ClaimEnvelope.from_contract_decl(
+      decl, signer, produced_at: "2026-04-30T00:00:00.000Z",
+    )
+    assert_equal b.canonical_bytes, a.canonical_bytes
+    assert_equal b.cid, a.cid
+    assert_equal b.contract_cid, a.contract_cid
+  end
+end
+
+class TestAuthoring < Minitest::Test
+  def mint_with_authoring(authoring)
+    Provekit::ClaimEnvelope.mint_contract(
+      contract_name: "x", out_binding: "out",
+      pre: PRE_N_GT_0,
+      produced_by: "t", produced_at: "2026-04-30T00:00:00.000Z",
+      authoring: authoring,
+      signer_seed: Provekit::Signing::FOUNDATION_V0_SEED,
+    )
+  end
+
+  def test_kit_author_no_note_round_trips
+    env = mint_with_authoring(
+      Provekit::ClaimEnvelope::AuthoringKitAuthor.new(author: "alice"),
+    )
+    a = JSON.parse(env.canonical_bytes)["metadata"]["authoring"]
+    assert_equal({"producerKind" => "kit-author", "author" => "alice"}, a)
+  end
+
+  def test_kit_author_with_note_round_trips
+    env = mint_with_authoring(
+      Provekit::ClaimEnvelope::AuthoringKitAuthor.new(author: "alice", note: "hand"),
+    )
+    a = JSON.parse(env.canonical_bytes)["metadata"]["authoring"]
+    assert_equal(
+      {"producerKind" => "kit-author", "author" => "alice", "note" => "hand"},
+      a,
+    )
+  end
+
+  def test_kit_author_empty_note_treated_as_absent
+    env = mint_with_authoring(
+      Provekit::ClaimEnvelope::AuthoringKitAuthor.new(author: "alice", note: ""),
+    )
+    a = JSON.parse(env.canonical_bytes)["metadata"]["authoring"]
+    refute a.key?("note")
+  end
+
+  def test_lift_round_trips
+    env = mint_with_authoring(Provekit::ClaimEnvelope::AuthoringLift.new(
+      lifter: "lift-kit@1.0", evidence: "tests",
+      source_cid: "blake3-512:source",
+    ))
+    a = JSON.parse(env.canonical_bytes)["metadata"]["authoring"]
+    assert_equal "lift", a["producerKind"]
+    assert_equal "lift-kit@1.0", a["lifter"]
+    assert_equal "tests", a["evidence"]
+    assert_equal "blake3-512:source", a["sourceCid"]
+  end
+
+  def test_llm_confidence_truncates_toward_zero
+    # Match Rust's `(c * 1000.0) as i64`: truncate, do NOT round.
+    # 0.9009 -> 900, not 901.
+    env = mint_with_authoring(Provekit::ClaimEnvelope::AuthoringLlm.new(
+      llm: "claude", llm_version: "opus-4.7",
+      prompt_cid: "blake3-512:p", confidence: 0.9009,
+    ))
+    a = JSON.parse(env.canonical_bytes)["metadata"]["authoring"]
+    assert_equal 900, a["confidence"]
+  end
+end
+
+class TestDeterminism < Minitest::Test
+  def test_same_inputs_same_bytes
+    a = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    b = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    assert_equal b.canonical_bytes, a.canonical_bytes
+    assert_equal b.cid, a.cid
+  end
+
+  def test_changing_pre_changes_cid
+    a = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    different_pre = {"kind" => "atomic", "name" => "=", "args" => []}
+    b = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs.merge(pre: different_pre))
+    refute_equal a.cid, b.cid
+  end
+
+  def test_changing_signer_changes_attestation_cid_not_contract_cid
+    # Two distinct signers attesting to the same contract produce
+    # different attestation CIDs but identical contract CIDs.
+    a = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs)
+    other_seed = ([0x43] * 32).pack("C*")
+    b = Provekit::ClaimEnvelope.mint_contract(**fixture_kwargs.merge(signer_seed: other_seed))
+    refute_equal a.cid, b.cid
+    assert_equal a.contract_cid, b.contract_cid
+  end
+end
+
+class TestBridge < Minitest::Test
+  def test_mint_bridge_succeeds
+    env = Provekit::ClaimEnvelope.mint_bridge(
+      produced_by: "t", produced_at: "2026-04-30T00:00:00.000Z",
+      source_symbol: "parseInt", source_layer: "ts",
+      target_contract_cid: "blake3-512:target", target_layer: "rust",
+      ir_arg_sorts: ["String"], ir_return_sort: "Int",
+      signer_seed: Provekit::Signing::FOUNDATION_V0_SEED,
+    )
+    assert env.cid.start_with?("blake3-512:")
+    assert_equal "", env.contract_cid
+    parsed = JSON.parse(env.canonical_bytes)
+    assert_equal "bridge", parsed["header"]["kind"]
+    assert_equal "parseInt", parsed["header"]["sourceSymbol"]
+  end
+end
+
+class TestImplication < Minitest::Test
+  def test_mint_implication_succeeds
+    env = Provekit::ClaimEnvelope.mint_implication(
+      produced_by: "t", produced_at: "2026-04-30T00:00:00.000Z",
+      antecedent_hash: "blake3-512:ah", consequent_hash: "blake3-512:ch",
+      antecedent_cid: "blake3-512:acid", consequent_cid: "blake3-512:bcid",
+      antecedent_slot: "pre", consequent_slot: "post",
+      prover: "z3", prover_run_ms: 42,
+      signer_seed: Provekit::Signing::FOUNDATION_V0_SEED,
+    )
+    assert env.cid.start_with?("blake3-512:")
+    assert_equal "", env.contract_cid
+    parsed = JSON.parse(env.canonical_bytes)
+    assert_equal "implication", parsed["header"]["kind"]
+    assert_equal(
+      ["blake3-512:acid", "blake3-512:bcid"].sort,
+      parsed["header"]["inputCids"],
+    )
+  end
+end
+
+class TestContractSetCid < Minitest::Test
+  def test_empty_set_is_hash_of_empty_array
+    got = Provekit::ContractSet.compute_cid([])
+    expected = Provekit::Blake3.hex("[]")
+    assert_equal expected, got
+  end
+
+  def test_singleton_set
+    got = Provekit::ContractSet.compute_cid(["blake3-512:aa"])
+    expected = Provekit::Blake3.hex('["blake3-512:aa"]')
+    assert_equal expected, got
+  end
+
+  def test_duplicates_are_preserved
+    # The set CID is a function of the sorted sequence; duplicates in
+    # the input affect the output. (The spec treats the input as a
+    # sequence-of-cids, not a deduplicated set.)
+    a = Provekit::ContractSet.compute_cid(["blake3-512:aa"])
+    b = Provekit::ContractSet.compute_cid(["blake3-512:aa", "blake3-512:aa"])
+    refute_equal a, b
+  end
+end


### PR DESCRIPTION
## Summary

Closes #236. Adds the v1.2 layered claim-envelope subsystem to the Ruby kit. PR #226 shipped only the proof-side crypto primitives (Ed25519, CBOR, BLAKE3, JCS, proof envelope) and explicitly deferred the claim-envelope construction. PR #234 (ruby Side A) had to inline a local copy of `mint_contract` (~80 LOC) into `self_contracts.rb` as a workaround. This PR closes that gap so Side B is fully closed, and refactors `self_contracts.rb` to delegate to the new modules.

Stacks on #234 (ruby Side A). Targets `main`; merge after #234 lands.

## What landed

### `lib/provekit/claim_envelope.rb` (new)

`Provekit::ClaimEnvelope` with `mint_contract` / `mint_bridge` / `mint_implication` / `contract_cid`, the `Authoring` tagged union (`KitAuthor` / `Lift` / `Llm`), error types (`EmptyContractError` / `EmptyOutBindingError`), and `from_contract_decl` for `ContractDecl` ergonomics. 1:1 mirror of the rust canonical `provekit-claim-envelope/src/lib.rs` and the python port that landed in PR #232.

- `mint_contract` returns a `Minted` struct with `canonical_bytes`, `cid` (attestation CID = `BLAKE3-512(JCS(envelope))` after signature embedded), and `contract_cid` (signer-independent content CID).
- Authoring confidence is serialized as `(confidence * 1000.0).to_i`, truncating toward zero to match rust's `(c * 1000.0) as i64` cast.
- `signing_bytes(header, metadata)` JCS-encodes `{\"header\": header, \"metadata\": metadata}` -- the Ed25519 message per substrate-layers spec §2 R2.

### `lib/provekit/contract_set.rb` (new)

`Provekit::ContractSet.compute_cid(contracts)` per `protocol/specs/2026-05-03-contract-set-extension.md` §1: `BLAKE3-512(JCS(<sorted contractCids>))`. Order-independent.

### `lib/provekit/signing.rb` (additive only)

- `Provekit::Signing::Signer` minimal handle (`seed` + `producer_id`) with `foundation_v0(producer_id:)` convenience and `sign_claim(decl, produced_at:, ...)` delegate to `ClaimEnvelope.from_contract_decl`. Lazy require breaks the `signing -> claim_envelope -> signing` import cycle.
- PR #226's exported surface (`FOUNDATION_V0_SEED`, `ed25519_sign_with_seed`, `ed25519_sign_string`, `ed25519_pubkey_string`, `ed25519_verify_string`, `verify_raw`, `ed25519_pubkey_bytes`) is unchanged.

### `lib/provekit.rb`

Requires the two new modules so `require \"provekit/claim_envelope\"` works.

### `test/test_claim_envelope.rb` (new, 29 tests)

- 6 cross-kit byte-equivalence tests against the rust + python pinned 1615-byte fixture (canonical bytes, attestation CID, contract CID, contractSetCid, order-independence).
- 5 layered-shape conformance tests (top-level triple, envelope keys, header required fields, attestation CID = `BLAKE3-512(JCS(envelope))`, signature verifies via libsodium against `JCS({\"header\", \"metadata\"})`).
- 2 error-path tests, 5 `Authoring` round-trip tests (incl. confidence truncation), 3 determinism / sensitivity tests, 1 bridge + 1 implication smoke test, 3 `contractSetCid` edge cases, 3 `from_contract_decl` tests.

### `lib/provekit/self_contracts.rb` (refactored)

The inline `mint_contract` / `contract_cid` / `compute_contract_set_cid` / `hash_value_jcs` / `LAYERED_SCHEMA_VERSION` are gone; replaced by 3-line wrappers that delegate to `Provekit::ClaimEnvelope` and `Provekit::ContractSet`. Net: ~94 LOC removed (134 lines deleted, 40 lines added).

## Cross-kit byte-equivalence result

PASS. Ruby output is byte-identical to Rust + Python kits for the canonical 1615-byte fixture (the same fixture pinned in PR #232's `cross_kit_pin.rs` and `test_claim_envelope.py`).

- attestation CID:   `blake3-512:b5cd82094dd4d7da...3523639c`
- contract CID:      `blake3-512:bca0bb9144b3b35e...8715db1`
- contractSetCid:    `blake3-512:e42f67a1f9947237...75962506`

## Self-contracts contractSetCid (refactor invariant)

The pinned ruby self-contracts contractSetCid from PR #234 (`blake3-512:961be80d...`) is unchanged after the refactor. Verified via `make mint-ruby` and the rust `ruby_kit_pins_expected_contract_set_cid` integration test.

## Acceptance criteria (issue #236)

- [x] `require \"provekit/claim_envelope\"` works
- [x] `Provekit::ClaimEnvelope.from_contract_decl(decl, signer)` produces a v1.2-layered envelope
- [x] `Provekit::ContractSet.compute_cid(contracts)` matches rust + python kits for the same inputs
- [x] Cross-kit byte-equivalence test against rust fixture (the 1615-byte fixture pinned in PR #232's `cross_kit_pin.rs`)
- [x] `implementations/ruby/lib/provekit/self_contracts.rb` refactored to import from the new module (drops the inline `mint_contract` copy)

## Test plan

- [x] `ruby -Ilib -Itest test/test_claim_envelope.rb` -- 29 passed
- [x] `ruby -Ilib -Itest test/test_*.rb` -- 96 passed (full ruby suite, no regressions)
- [x] `make mint-ruby` -- contractSetCid `961be80d...` (matches PR #234's pinned value)
- [x] `cargo test -p provekit-cli --test mint_kit_integration ruby_kit_pins_expected_contract_set_cid` -- pass
- [x] `cargo test -p provekit-claim-envelope` -- 24 passed (cross_kit_pin printing tests still ok)