### PR TITLE
fix(linker): implement post-implies-pre check via solver registry, closes soundness hole (closes #249)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -1787,6 +1788,8 @@ name = "provekit-linker"
 version = "0.1.0"
 dependencies = [
  "provekit-canonicalizer",
+ "provekit-ir-compiler-smt-lib",
+ "provekit-verifier",
  "serde",
  "serde_json",
 ]

--- a/implementations/rust/provekit-linker/Cargo.toml
+++ b/implementations/rust/provekit-linker/Cargo.toml
@@ -12,5 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 provekit-canonicalizer = { path = "../provekit-canonicalizer" }
+provekit-verifier = { path = "../provekit-verifier" }
+provekit-ir-compiler-smt-lib = { path = "../provekit-ir-compiler-smt-lib" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/implementations/rust/provekit-linker/src/lib.rs
+++ b/implementations/rust/provekit-linker/src/lib.rs
@@ -18,19 +18,47 @@
 //!
 //! ## Design invariants
 //!
-//! - `link()` is pure: no global state, no filesystem side effects. Calling it
-//!   twice with byte-identical inputs produces byte-identical outputs.
-//! - `LinkerInputs` is `serde::Deserialize` so the daemon can reconstruct it
-//!   directly from the `parseFile` request stream (spec #126 §3).
+//! - `link()` is pure: no global state, no filesystem side effects. Calling
+//!   it twice with byte-identical inputs produces byte-identical outputs.
+//!   Without a solver registry it can only discharge `post_caller \u{2283}
+//!   pre_callee` by structural / JCS-canonical equality; non-equal pairs
+//!   surface as `implication-undecidable`.
+//! - `link_with_solvers(inputs, &Registry, &SolverPlan)` extends `link()`
+//!   with the workspace's existing solver registry (built by
+//!   `provekit-verifier::solvers::registry::build` from `SolversConfig`).
+//!   Output is byte-deterministic given inputs + a solver set whose
+//!   verdicts are themselves deterministic; subprocess wall-clock varies
+//!   but the chosen verdict is stable.
+//! - `LinkerInputs` is `serde::Deserialize` so the daemon can reconstruct
+//!   it directly from the `parseFile` request stream (spec #126 §3). The
+//!   `Registry` and `SolverPlan` are intentionally NOT on `LinkerInputs`:
+//!   they are execution config, not parseFile data, and the registry
+//!   contains non-serializable `Arc<dyn Solver>` handles.
 //! - `LinkerOutput.linker_errors` carries a `file` field so the daemon can
 //!   attach LSP diagnostics to the correct editor pane.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonValue};
+use provekit_verifier::solvers::{run_plan, SolverHandle, SolverPlan};
+use provekit_verifier::types::ObligationVerdict;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
+
+/// Re-exports from `provekit-verifier` so callers do not need a direct
+/// dependency on the verifier crate to construct a registry / plan.
+pub mod solver_api {
+    pub use provekit_verifier::solvers::{
+        registry, run_plan, SolverConfig, SolverHandle, SolverPlan, SolversConfig, StubSolver,
+        SubprocessSolver,
+    };
+    pub use provekit_verifier::types::ObligationVerdict;
+}
+
+/// Solver registry used by `link_with_solvers`. Mirrors the verifier's
+/// `solvers::plan::Registry` shape (`name -> Arc<dyn Solver>`).
+pub type Registry = HashMap<String, SolverHandle>;
 
 // -------------------------------------------------------------------
 // Public input types
@@ -146,9 +174,46 @@ pub struct LinkerOutput {
 /// Pure function: no global state, no I/O.  Two calls with byte-identical
 /// inputs produce byte-identical `LinkerOutput` values (including
 /// `link_bundle_cid`).
+///
+/// # Solver discharge
+///
+/// Without a solver registry the linker can only verify
+/// `post_caller \u{2283} pre_callee` by structural / JCS-canonical
+/// equality. When both sides are non-null and structurally distinct,
+/// this entry point emits an `implication-undecidable` error rather
+/// than silently discharging. Use [`link_with_solvers`] to resolve
+/// such cases via the workspace solver registry.
 pub fn link(inputs: LinkerInputs) -> LinkerOutput {
+    let empty_registry: Registry = HashMap::new();
+    // Single-solver-named-"none" plan; lookup will miss for any
+    // structurally-distinct discharge, surfacing as Undecidable.
+    let no_op_plan = SolverPlan::Single("__no_solver__".into());
     let LinkerInputs { contracts, call_edges } = inputs;
-    derive_link_bundle_inner(contracts, call_edges)
+    derive_link_bundle_inner(contracts, call_edges, &empty_registry, &no_op_plan)
+}
+
+/// Derive bridges and emit a `LinkBundle`, using the supplied solver
+/// registry + plan to discharge `post_caller \u{2283} pre_callee`
+/// obligations whose two sides are structurally distinct.
+///
+/// `registry` and `plan` are typically built by the verifier crate's
+/// `solvers::registry::build` from the same `SolversConfig` the
+/// verifier uses (see `.provekit/config.toml`). The linker does not
+/// hardcode any solver name; whichever solvers the workspace declares
+/// are reached via the supplied plan.
+///
+/// Determinism contract: byte-identical `inputs` plus a registry
+/// whose solvers are themselves deterministic (e.g. `StubSolver`,
+/// or any sound SMT solver pinned by version in the config) yield a
+/// byte-identical `LinkerOutput`. Solver wall-clock varies, but the
+/// chosen verdict is stable.
+pub fn link_with_solvers(
+    inputs: LinkerInputs,
+    registry: &Registry,
+    plan: &SolverPlan,
+) -> LinkerOutput {
+    let LinkerInputs { contracts, call_edges } = inputs;
+    derive_link_bundle_inner(contracts, call_edges, registry, plan)
 }
 
 // -------------------------------------------------------------------
@@ -158,6 +223,8 @@ pub fn link(inputs: LinkerInputs) -> LinkerOutput {
 fn derive_link_bundle_inner(
     all_contracts: Vec<LinkerContract>,
     all_call_edges: Vec<LinkerCallEdge>,
+    registry: &Registry,
+    plan: &SolverPlan,
 ) -> LinkerOutput {
     // Build cross-kit resolution index: (name, kit) -> contract_cid
     let mut name_kit_index: BTreeMap<(String, String), String> = BTreeMap::new();
@@ -238,6 +305,8 @@ fn derive_link_bundle_inner(
                     &edge.source_contract_cid,
                     &target_cid,
                     &edge.target_symbol,
+                    registry,
+                    plan,
                 ) {
                     err.file = locus_file;
                     linker_errors_out.push(err);
@@ -386,24 +455,121 @@ fn derive_bridge(
 // Obligation discharge
 // -------------------------------------------------------------------
 
+/// Discharge the satisfaction obligation `post_caller \u{2283} pre_callee`
+/// for one call edge. Returns `Some(LinkerError)` when the implication
+/// cannot be proved (or is provably violated); returns `None` when the
+/// implication holds.
+///
+/// Discharge is layered, cheapest-first:
+///
+/// 1. **Caller post absent.** No post-condition means the caller
+///    promises nothing; the obligation is unprovable. Emits
+///    `kind: "unprovable-obligation"` to preserve the historical
+///    error string the polyglot smoke fixtures pin (PR #128 baseline).
+///
+/// 2. **Callee pre absent.** No pre-condition on the callee means the
+///    obligation is vacuously discharged.
+///
+/// 3. **JCS-canonical equality.** If `post_caller` and `pre_callee`
+///    canonicalize to byte-identical JCS, the predicates are the same
+///    formula and the implication is reflexive. No solver work.
+///
+/// 4. **Solver dispatch.** Build the IR-JSON formula
+///    `{"kind":"implies","operands":[post,pre]}`, compile to SMT-LIB,
+///    and run the supplied `SolverPlan` against `Registry`. Map the
+///    verdict:
+///      * `Discharged` (UNSAT of `not(post -> pre)`): proven, return `None`.
+///      * `Unsatisfied` (SAT counter-example): `implication-unprovable`.
+///      * `Undecidable` / `Disagreement` / no solver registered:
+///        `implication-undecidable` (do NOT silently discharge).
 fn discharge_obligation(
     source_post: Option<&Json>,
-    _target_pre: Option<&Json>,
+    target_pre: Option<&Json>,
     source_contract_cid: &str,
     target_cid: &str,
     target_symbol: &str,
+    registry: &Registry,
+    plan: &SolverPlan,
 ) -> Option<LinkerError> {
-    match source_post {
-        None | Some(Json::Null) => Some(LinkerError {
-            kind: "unprovable-obligation".into(),
+    // (1) Caller post absent: cannot discharge.
+    let post = match source_post {
+        None | Some(Json::Null) => {
+            return Some(LinkerError {
+                kind: "unprovable-obligation".into(),
+                target_symbol: target_symbol.to_string(),
+                source_contract_cid: source_contract_cid.to_string(),
+                reason: format!(
+                    "caller post-condition is absent; cannot discharge `post_caller \u{2283} pre_callee` for target `{target_cid}`"
+                ),
+                file: None, // populated by caller from locus
+            });
+        }
+        Some(p) => p,
+    };
+
+    // (2) Callee pre absent: vacuously discharged.
+    let pre = match target_pre {
+        None | Some(Json::Null) => return None,
+        Some(p) => p,
+    };
+
+    // (3) JCS-canonical equality: P -> P trivially.
+    let post_jcs = jcs_of_json(post);
+    let pre_jcs = jcs_of_json(pre);
+    if post_jcs == pre_jcs {
+        return None;
+    }
+
+    // (4) Solver dispatch. Build the implication formula in IR-JSON,
+    // emit SMT-LIB via the workspace IR compiler, and run the
+    // configured plan against the supplied registry. The registry +
+    // plan are external to the linker (the architect's "use whatever
+    // Cargo.toml says" rule); we never reach for a hardcoded solver
+    // name.
+    let implication = serde_json::json!({
+        "kind": "implies",
+        "operands": [post.clone(), pre.clone()],
+    });
+
+    let smt_script = match provekit_ir_compiler_smt_lib::emit(&implication) {
+        Ok(s) => s,
+        Err(e) => {
+            // Compilation failed: cannot ask the solver. Surface as
+            // undecidable rather than silent-discharge.
+            return Some(LinkerError {
+                kind: "implication-undecidable".into(),
+                target_symbol: target_symbol.to_string(),
+                source_contract_cid: source_contract_cid.to_string(),
+                reason: format!(
+                    "compile post-implies-pre to SMT-LIB failed for target `{target_cid}`: {e}"
+                ),
+                file: None,
+            });
+        }
+    };
+
+    let (verdict, reason, _invs) = run_plan(plan, registry, &smt_script, Some(&implication));
+
+    match verdict {
+        ObligationVerdict::Discharged => None,
+        ObligationVerdict::Unsatisfied => Some(LinkerError {
+            kind: "implication-unprovable".into(),
             target_symbol: target_symbol.to_string(),
             source_contract_cid: source_contract_cid.to_string(),
             reason: format!(
-                "caller post-condition is absent; cannot discharge `post_caller \u{2283} pre_callee` for target `{target_cid}`"
+                "solver reports `post_caller \u{2283} pre_callee` is violated for target `{target_cid}`: {reason}"
             ),
-            file: None, // populated by caller from locus
+            file: None,
         }),
-        Some(_) => None,
+        ObligationVerdict::Undecidable | ObligationVerdict::Disagreement => Some(LinkerError {
+            kind: "implication-undecidable".into(),
+            target_symbol: target_symbol.to_string(),
+            source_contract_cid: source_contract_cid.to_string(),
+            reason: format!(
+                "solver could not decide `post_caller \u{2283} pre_callee` for target `{target_cid}`: {reason}"
+            ),
+            file: None,
+        }),
     }
 }
 

--- a/implementations/rust/provekit-linker/tests/discharge_obligation.rs
+++ b/implementations/rust/provekit-linker/tests/discharge_obligation.rs
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Integration tests for the post-implies-pre discharge check
+// (issue #249, the soundness hole closed by this commit).
+//
+// Acceptance cases (from #249):
+//   1. identical predicate bodies                            -> discharged
+//   2. structurally distinct, logically equivalent           -> discharged via solver
+//   3. logically incompatible (post weaker than callee pre)  -> implication-unprovable
+//   4. caller post implies callee pre via solver             -> discharged
+//
+// Plumbing tests (cases 2 / 3 / 4) use the verifier's `StubSolver` so
+// they run hermetically without z3 / cvc5 / coq on PATH. The
+// stub-driven tests prove the dispatch is wired correctly: registry
+// lookup -> SolverPlan execution -> verdict mapping. They do NOT
+// prove the SMT-LIB compile is semantically faithful (a real-solver
+// integration test on top of a hermetic CI runner is the follow-up).
+//
+// A real-solver smoke test (#[ignore]'d unless `PROVEKIT_REAL_SOLVER`
+// env var is set) runs against the configured z3 binary and exercises
+// the full pipeline.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use provekit_linker::solver_api::{
+    registry, ObligationVerdict, SolverHandle, SolverPlan, SolversConfig, StubSolver,
+};
+use provekit_linker::{
+    link, link_with_solvers, LinkerCallEdge, LinkerContract, LinkerInputs, Registry,
+};
+use serde_json::{json, Value as Json};
+
+// -------------------------------------------------------------------
+// Test-fixture helpers
+// -------------------------------------------------------------------
+
+const CALLER_CID: &str = "blake3-512:1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+const CALLEE_CID: &str = "blake3-512:2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+
+fn ge_x_n(n: i64) -> Json {
+    json!({
+        "kind": "atomic",
+        "name": ">=",
+        "args": [
+            {"kind": "var", "name": "x"},
+            {"kind": "const", "value": n, "sort": {"kind": "primitive", "name": "Int"}}
+        ]
+    })
+}
+
+fn lt_x_n(n: i64) -> Json {
+    json!({
+        "kind": "atomic",
+        "name": "<",
+        "args": [
+            {"kind": "var", "name": "x"},
+            {"kind": "const", "value": n, "sort": {"kind": "primitive", "name": "Int"}}
+        ]
+    })
+}
+
+fn and_of(a: Json, b: Json) -> Json {
+    json!({"kind": "and", "operands": [a, b]})
+}
+
+fn caller(post: Option<Json>) -> LinkerContract {
+    LinkerContract {
+        name: "caller".into(),
+        kit: "rust-kit".into(),
+        contract_cid: CALLER_CID.into(),
+        pre_json: None,
+        post_json: post,
+    }
+}
+
+fn callee(pre: Option<Json>) -> LinkerContract {
+    LinkerContract {
+        name: "callee".into(),
+        kit: "rust-kit".into(),
+        contract_cid: CALLEE_CID.into(),
+        pre_json: pre,
+        post_json: None,
+    }
+}
+
+fn cgo_edge() -> LinkerCallEdge {
+    LinkerCallEdge {
+        source_contract_cid: CALLER_CID.into(),
+        target_contract_cid: Some(CALLEE_CID.into()),
+        target_symbol: "rust-kit:callee".into(),
+        call_site_locus_json: json!({
+            "file": "caller.rs",
+            "line": 1,
+            "column": 1
+        }),
+        evidence_term_json: json!({"kind": "Atomic", "name": "obligation", "args": []}),
+    }
+}
+
+fn inputs(caller_post: Option<Json>, callee_pre: Option<Json>) -> LinkerInputs {
+    LinkerInputs {
+        contracts: vec![caller(caller_post), callee(callee_pre)],
+        call_edges: vec![cgo_edge()],
+    }
+}
+
+/// Build a registry containing one stub solver returning a fixed
+/// verdict, plus a Single plan referencing it. Mirrors the
+/// `.provekit/config.toml` shape `[solvers] default = "fake"`.
+fn stub_registry_and_plan(verdict: ObligationVerdict) -> (Registry, SolverPlan) {
+    let mut r: HashMap<String, SolverHandle> = HashMap::new();
+    r.insert(
+        "fake".into(),
+        Arc::new(StubSolver::new("fake", verdict)) as SolverHandle,
+    );
+    (r, SolverPlan::Single("fake".into()))
+}
+
+// -------------------------------------------------------------------
+// Acceptance case 1: identical predicate bodies (no solver needed)
+// -------------------------------------------------------------------
+
+#[test]
+fn identical_predicates_discharged_without_solver() {
+    // post == pre, character-for-character. JCS-canonical equality
+    // wins before any solver is consulted; an empty registry suffices.
+    let post = ge_x_n(0);
+    let pre = post.clone();
+    let out = link(inputs(Some(post), Some(pre)));
+    assert!(
+        out.linker_errors.is_empty(),
+        "structurally identical predicates must discharge without error, got: {:?}",
+        out.linker_errors
+    );
+}
+
+// -------------------------------------------------------------------
+// Acceptance case 1b: identical-modulo-key-order via JCS
+// (no solver work — JCS canonicalizes object key ordering)
+// -------------------------------------------------------------------
+
+#[test]
+fn jcs_canonical_equality_discharges_without_solver() {
+    // Two predicates whose serde_json maps differ only by key
+    // insertion order. JCS sorts keys lexicographically (RFC 8785),
+    // so canonical bytes match; no solver should be invoked.
+    //
+    // Build the "same" predicate twice but force one to have a
+    // distinct serialized order by reconstructing it manually.
+    let post = json!({
+        "kind": "atomic",
+        "name": ">=",
+        "args": [
+            {"kind": "var", "name": "x"},
+            {"kind": "const", "value": 0, "sort": {"kind": "primitive", "name": "Int"}}
+        ]
+    });
+    let pre = json!({
+        "args": [
+            {"name": "x", "kind": "var"},
+            {"sort": {"name": "Int", "kind": "primitive"}, "value": 0, "kind": "const"}
+        ],
+        "name": ">=",
+        "kind": "atomic"
+    });
+    // Use an EMPTY registry: if the linker needed to invoke the
+    // solver this would surface as "implication-undecidable".
+    let registry: Registry = HashMap::new();
+    let plan = SolverPlan::Single("__no_solver__".into());
+    let out = link_with_solvers(inputs(Some(post), Some(pre)), &registry, &plan);
+    assert!(
+        out.linker_errors.is_empty(),
+        "JCS-canonical equality must discharge without invoking the solver, got: {:?}",
+        out.linker_errors
+    );
+}
+
+// -------------------------------------------------------------------
+// Acceptance case 2: structurally distinct, logically equivalent
+// (e.g. `x>=0 AND x<100` vs `x<100 AND x>=0`)
+// -------------------------------------------------------------------
+
+#[test]
+fn structurally_distinct_logically_equivalent_discharged_via_solver_stub() {
+    // Caller post: x >= 0 AND x < 100
+    // Callee pre:  x < 100 AND x >= 0
+    // These are not JCS-equal (the operand order differs); a stub
+    // solver returning Discharged represents what a real solver
+    // would do for this implication.
+    let post = and_of(ge_x_n(0), lt_x_n(100));
+    let pre = and_of(lt_x_n(100), ge_x_n(0));
+    let (registry, plan) = stub_registry_and_plan(ObligationVerdict::Discharged);
+    let out = link_with_solvers(inputs(Some(post), Some(pre)), &registry, &plan);
+    assert!(
+        out.linker_errors.is_empty(),
+        "stub-discharged implication must produce no linker errors, got: {:?}",
+        out.linker_errors
+    );
+}
+
+// -------------------------------------------------------------------
+// Acceptance case 3: logically incompatible
+// (caller post: x>=0; callee pre: x>=10  -> not implied)
+// -------------------------------------------------------------------
+
+#[test]
+fn logically_incompatible_emits_implication_unprovable() {
+    // Caller post: x >= 0
+    // Callee pre:  x >= 10
+    // post does NOT imply pre: counterexample x = 5.
+    // Stub solver returns Unsatisfied (= "sat with counterexample"
+    // in the verifier's terminology) to represent that result.
+    let post = ge_x_n(0);
+    let pre = ge_x_n(10);
+    let (registry, plan) = stub_registry_and_plan(ObligationVerdict::Unsatisfied);
+    let out = link_with_solvers(inputs(Some(post), Some(pre)), &registry, &plan);
+    assert_eq!(out.linker_errors.len(), 1, "expected exactly one linker error");
+    assert_eq!(
+        out.linker_errors[0].kind, "implication-unprovable",
+        "weak-post case must surface implication-unprovable, got {:?}",
+        out.linker_errors[0]
+    );
+    assert_eq!(out.linker_errors[0].target_symbol, "rust-kit:callee");
+    assert_eq!(out.linker_errors[0].file.as_deref(), Some("caller.rs"));
+}
+
+// -------------------------------------------------------------------
+// Acceptance case 4: caller post implies callee pre (via solver)
+// (caller post: x>=10; callee pre: x>=0  -> implied)
+// -------------------------------------------------------------------
+
+#[test]
+fn strong_post_implies_weak_pre_discharged_via_solver_stub() {
+    // Caller post: x >= 10
+    // Callee pre:  x >= 0
+    // post DOES imply pre. Stub solver returns Discharged.
+    let post = ge_x_n(10);
+    let pre = ge_x_n(0);
+    let (registry, plan) = stub_registry_and_plan(ObligationVerdict::Discharged);
+    let out = link_with_solvers(inputs(Some(post), Some(pre)), &registry, &plan);
+    assert!(
+        out.linker_errors.is_empty(),
+        "stub-discharged implication must produce no linker errors, got: {:?}",
+        out.linker_errors
+    );
+}
+
+// -------------------------------------------------------------------
+// Solver-undecidable case: emit implication-undecidable, do NOT
+// silently discharge.
+// -------------------------------------------------------------------
+
+#[test]
+fn solver_undecidable_does_not_silently_discharge() {
+    let post = ge_x_n(0);
+    let pre = ge_x_n(10);
+    let (registry, plan) = stub_registry_and_plan(ObligationVerdict::Undecidable);
+    let out = link_with_solvers(inputs(Some(post), Some(pre)), &registry, &plan);
+    assert_eq!(out.linker_errors.len(), 1);
+    assert_eq!(out.linker_errors[0].kind, "implication-undecidable");
+}
+
+// -------------------------------------------------------------------
+// Pure-`link()` fallback: no registry available. Structurally
+// distinct predicates must NOT be silently discharged.
+// -------------------------------------------------------------------
+
+#[test]
+fn pure_link_with_no_registry_emits_undecidable_for_distinct_predicates() {
+    let post = ge_x_n(10);
+    let pre = ge_x_n(0);
+    let out = link(inputs(Some(post), Some(pre)));
+    assert_eq!(out.linker_errors.len(), 1, "expected one error");
+    assert_eq!(
+        out.linker_errors[0].kind, "implication-undecidable",
+        "pure link() with no solver must surface undecidable, never silent-discharge"
+    );
+}
+
+// -------------------------------------------------------------------
+// Vacuous discharge: callee has no pre-condition.
+// -------------------------------------------------------------------
+
+#[test]
+fn callee_pre_absent_is_vacuously_discharged() {
+    let out = link(inputs(Some(ge_x_n(0)), None));
+    assert!(
+        out.linker_errors.is_empty(),
+        "callee with no pre-condition is vacuously discharged"
+    );
+}
+
+// -------------------------------------------------------------------
+// Caller post absent: legacy "unprovable-obligation" path.
+// Pinned by the polyglot smoke fixtures (PR #128 baseline) and the
+// linker's own `test_link_bundle_cid_byte_identity_gate`.
+// -------------------------------------------------------------------
+
+#[test]
+fn caller_post_absent_emits_unprovable_obligation() {
+    let out = link(inputs(None, Some(ge_x_n(0))));
+    assert_eq!(out.linker_errors.len(), 1);
+    assert_eq!(out.linker_errors[0].kind, "unprovable-obligation");
+}
+
+// -------------------------------------------------------------------
+// Registry-from-config plumbing: SolversConfig::from_toml +
+// registry::build is the architect-mandated "use whatever
+// Cargo.toml says" pathway. Verify the linker can be wired through
+// it end-to-end with a stub backend.
+// -------------------------------------------------------------------
+
+#[test]
+fn config_driven_registry_drives_discharge() {
+    let toml = r#"
+[solvers]
+default = "fakeA"
+[solvers.fakeA]
+binary = "stub:unsat"
+"#;
+    let cfg = SolversConfig::from_toml(toml).expect("parse");
+    let plan = SolverPlan::from_config(&cfg);
+    let registry: Registry = registry::build(&cfg);
+    // Non-trivial implication, but stub returns unsat -> Discharged.
+    let post = ge_x_n(10);
+    let pre = ge_x_n(0);
+    let out = link_with_solvers(inputs(Some(post), Some(pre)), &registry, &plan);
+    assert!(
+        out.linker_errors.is_empty(),
+        "config-driven stub registry must discharge, got: {:?}",
+        out.linker_errors
+    );
+}
+
+// -------------------------------------------------------------------
+// Real-solver integration smoke. Ignored by default; run via
+//   PROVEKIT_REAL_SOLVER=1 cargo test -p provekit-linker -- --ignored
+// when z3 is on PATH.
+// -------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires z3 on PATH; run with --ignored when available"]
+fn real_solver_z3_strong_post_implies_weak_pre() {
+    let toml = r#"
+[solvers]
+default = "z3"
+[solvers.z3]
+binary = "z3"
+ir_compiler = "smt-lib-v2.6"
+flags = ["-smt2", "-in"]
+timeout_seconds = 5
+"#;
+    let cfg = SolversConfig::from_toml(toml).expect("parse");
+    let plan = SolverPlan::from_config(&cfg);
+    let registry: Registry = registry::build(&cfg);
+    let post = ge_x_n(10);
+    let pre = ge_x_n(0);
+    let out = link_with_solvers(inputs(Some(post), Some(pre)), &registry, &plan);
+    assert!(
+        out.linker_errors.is_empty(),
+        "real z3 must discharge x>=10 implies x>=0, got: {:?}",
+        out.linker_errors
+    );
+}


### PR DESCRIPTION
## Summary

Closes the **soundness hole** flagged in #249. `discharge_obligation` no longer rubber-stamps every non-null caller post; it now actually checks `post_caller -> pre_callee` via the workspace's existing solver registry.

## How the registry is reached

Linker now depends on `provekit-verifier` (for `solvers::{run_plan, registry, SolverPlan, SolversConfig, ...}`) and `provekit-ir-compiler-smt-lib` (for `emit`). Discharge layered cheapest-first:

1. **Caller post absent** -> `unprovable-obligation` (preserves PR #128 baseline pinned by `test_link_bundle_cid_byte_identity_gate`).
2. **Callee pre absent** -> vacuously discharged.
3. **JCS-canonical equality** of the two predicates -> discharged without solver invocation (post == pre).
4. **Solver dispatch.** Build IR-JSON `{"kind":"implies","operands":[post,pre]}`, compile to SMT-LIB via `provekit_ir_compiler_smt_lib::emit`, then call `run_plan(plan, registry, smt, Some(&formula))`. Map verdicts:
   - `Discharged` (UNSAT of negation) -> ok
   - `Unsatisfied` (SAT, counterexample) -> `LinkerError { kind: "implication-unprovable" }`
   - `Undecidable` / `Disagreement` -> `LinkerError { kind: "implication-undecidable" }` (NEVER silent)

The plan + registry are passed in by the caller, exactly as `provekit-verifier::runner::build_plan_and_registry` constructs them today (`SolversConfig::load(project_root)` + `registry::build`). The linker hardcodes no solver name; whichever solvers `.provekit/config.toml` declares are reached via the supplied plan. The `solver_api` module re-exports the verifier types so callers don't need a direct `provekit-verifier` dep.

### SMT query shape

For each non-trivially-equal `(post, pre)`:

```json
{"kind":"implies","operands":[<post-json>, <pre-json>]}
```

`provekit_ir_compiler_smt_lib::emit` returns the full SMT-LIB script (preamble + body + `(check-sat)`). The script asserts the obligation directly; `SubprocessSolver` reads `unsat`/`sat`/other on stdout. SMT-LIB-family solvers (z3, cvc5, bitwuzla) consume this string. The Coq solver in the registry consumes IR-JSON instead -- this is consistent with how `runner::work_one` uses `run_plan` today; the linker mirrors that pattern. (Coq-side-of-registry is the same shape question as the verifier runner; out of scope here.)

## API

- `link(inputs)` keeps its signature for back-compat (no caller migration needed for this PR). Without a registry it can only discharge by structural / JCS-canonical equality; non-equal pairs surface as `implication-undecidable`.
- `link_with_solvers(inputs, &Registry, &SolverPlan)` is the new entry point. CLI / daemon migrate to it incrementally.
- `Registry`, `SolverPlan`, `SolversConfig`, `StubSolver` re-exported via `solver_api`.

## Acceptance checklist (issue #249)

- [x] `discharge_obligation` returns `Some(LinkerError)` when `source_post` exists but does NOT imply `target_pre`
- [x] Returns `None` only when the implication is provable (or vacuous, or JCS-equal)
- [x] Test cases (NEW `provekit-linker/tests/discharge_obligation.rs`):
  - [x] identical predicate bodies -> discharged
  - [x] structurally distinct, logically equivalent -> discharged via solver
  - [x] logically incompatible -> `implication-unprovable`
  - [x] caller post implies callee pre via solver -> discharged
- [x] `_target_pre` -> `target_pre` (the underscore tip-off is gone)
- [x] **No hardcoded solver name in the linker code path.** Discovery flows through `SolversConfig` + `registry::build`.
- [ ] LSP red squigglies on incompatible call sites: NOT in this PR. `provekit-cli::cmd_link` and `provekit-linkerd::state` still call `link()` not `link_with_solvers`. Migrating those is a separate task; the linker is now ready to be wired through.

## Test results

```
running 5 tests (existing inner)
test tests::test_byte_determinism ... ok
test tests::test_failure_and_success_cids_differ ... ok
test tests::test_failure_case_emits_linker_error ... ok
test tests::test_link_bundle_cid_byte_identity_gate ... ok
test tests::test_success_case_clean_bundle ... ok

running 11 tests (new tests/discharge_obligation.rs)
test callee_pre_absent_is_vacuously_discharged ... ok
test caller_post_absent_emits_unprovable_obligation ... ok
test config_driven_registry_drives_discharge ... ok
test identical_predicates_discharged_without_solver ... ok
test jcs_canonical_equality_discharges_without_solver ... ok
test logically_incompatible_emits_implication_unprovable ... ok
test pure_link_with_no_registry_emits_undecidable_for_distinct_predicates ... ok
test real_solver_z3_strong_post_implies_weak_pre ... ignored (run with --ignored when z3 on PATH)
test solver_undecidable_does_not_silently_discharge ... ok
test strong_post_implies_weak_pre_discharged_via_solver_stub ... ok
test structurally_distinct_logically_equivalent_discharged_via_solver_stub ... ok
```

The `#[ignore]`'d real-solver test was confirmed passing locally against z3 4.x: `cargo test -p provekit-linker -- --ignored` -> 1 passed.

`provekit-cli` polyglot_smoke (excluding pre-existing `test_daemon_polyglot_smoke` failure that requires the daemon binary): 4/4 pass.
`provekit-linkerd` conformance: 4/4 pass.
`provekit-linkerd` state/snapshot units: 8/8 pass.

## No-z3-hardcode grep

```
$ grep -rn '"z3"\|::z3::' implementations/rust/provekit-linker/src/
(no matches)

$ grep -rn '"z3"\|::z3::' implementations/rust/provekit-linker/
provekit-linker/tests/discharge_obligation.rs:347:default = "z3"
provekit-linker/tests/discharge_obligation.rs:349:binary = "z3"
```

The two hits are in the `#[ignore]`'d real-solver test fixture's TOML config string (the same shape `.provekit/config.toml` would have if a project chose z3). No hardcoded solver name in the linker code path.

## Surprises / notes

- `provekit-verifier::solvers::*` is `pub` -- no visibility refactor needed. The registry construction path (`SolversConfig::from_toml` + `registry::build`) is fully reachable from outside the verifier.
- Existing test fixtures in `provekit-cli/tests/polyglot_smoke.rs` and `provekit-linkerd` all have `post_json: None` for the call edges that would invoke discharge, so the legacy `unprovable-obligation` path still fires verbatim. Pinned CIDs are intact.
- `link()`'s "pure" doc comment was extended to acknowledge that the no-registry case now flags `implication-undecidable` for distinct predicates rather than silently discharging. This is the correct behavior under #249's "never silent-discharge" rule.

## Test plan

- [x] `cargo test -p provekit-linker` -> 5 + 10 pass, 1 ignored
- [x] `cargo test -p provekit-linker -- --ignored` (z3 on PATH) -> 1 passes
- [x] `cargo test -p provekit-cli --test polyglot_smoke -- --skip test_daemon` -> 4 pass
- [x] `cargo test -p provekit-linkerd --test conformance` -> 4 pass