### PR TITLE
feat(c): mint-c-self-contracts orchestrator + slab + KIT_TABLE wiring (closes #215)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist/
 *.smt2
 .worktrees/
 
+# Vendored BLAKE3 build artifacts (compiled into Side B + Side A static libs)
+tools/blake3-vendored/*.o
+
 # Bazel convenience symlinks at the workspace root.
 /bazel-*
 .bazelrc.local

--- a/.provekit/self-contracts-attestations/c.json
+++ b/.provekit/self-contracts-attestations/c.json
@@ -2,9 +2,9 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "c",
-  "cid": "",
-  "contractSetCid": "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+  "cid": "blake3-512:f2723a762dd5d6ed5c16a4d3ba75cd39d4a63bbc021d018a22764bbfe5d74ae23d58820ed76f77e3fc8718df9d8f91fafb20437a0330c252817550c35ecd0aed",
+  "contractSetCid": "blake3-512:50d08f4df4f8e16073d70a168292f3b3850aa557030a2a9ae65892aaac2b0e889204fa2cf602f4074ea85680aed37490fcbdc2ff73aa87c162fba16e57f40577",
   "declaredAt": "2026-05-03T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:/CZaQd3YF1AeN8IldPJLGHfJRNSsn9PEAZXzsbUo0MaD2dQ5oQgbQmJ+xc+4Bl0YGsbPzsiPEmDw5+Zwgg+aAQ=="
+  "signature": "ed25519:yzErSKm2b/2gToUnxAFYkxsLuup3qpKPBxX938tOLZxiOFpDR49R16Napzxcyumxl2xmAcrTgIijGTlH+wbyBA=="
 }

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,13 @@ build-c:
 	$(MAKE) -C implementations/c/provekit-lsp-c all
 	$(MAKE) -C implementations/c/provekit-self-contracts lib
 
+.PHONY: build-c-self-contracts
+build-c-self-contracts:
+	# Build the c self-contracts orchestrator binary. Depends on the c
+	# Side B static library (libprovekit-self-contracts.a); the orchestrator
+	# Makefile invokes the Side B build as a sub-make if needed.
+	$(MAKE) -C implementations/c/mint-c-self-contracts
+
 .PHONY: build-java
 build-java: build-java-self-contracts
 	# provekit-lift-java-core depends on the sibling provekit-ir module.
@@ -301,7 +308,7 @@ mint-zig: build-rust
 		 echo "      $(PROVEKIT) mint --kit=zig" && exit 1)
 
 .PHONY: mint-c
-mint-c: build-rust
+mint-c: build-rust build-c-self-contracts
 	@echo ">> minting c self-contracts"
 	@mint_out=$$($(PROVEKIT) mint --kit=c --quiet); \
 	cid=$$(echo "$$mint_out" | head -1); \

--- a/implementations/c/.provekit/lift/c-self-contracts/manifest.toml
+++ b/implementations/c/.provekit/lift/c-self-contracts/manifest.toml
@@ -1,0 +1,11 @@
+name = "c-self-contracts"
+version = "1.0.0"
+protocol_version = "provekit-lift/1"
+command = ["./mint-c-self-contracts/run-rpc.sh"]
+working_dir = "."
+
+
+[capabilities]
+authoring_surfaces = ["c-self-contracts"]
+ir_version = "v1.1.0"
+emits_signed_mementos = true

--- a/implementations/c/mint-c-self-contracts/.gitignore
+++ b/implementations/c/mint-c-self-contracts/.gitignore
@@ -1,0 +1,3 @@
+# Build artifacts
+src/*.o
+mint-c-self-contracts

--- a/implementations/c/mint-c-self-contracts/Makefile
+++ b/implementations/c/mint-c-self-contracts/Makefile
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# mint-c-self-contracts (Side A orchestrator).
+#
+# Walks the C kit's slabs (src/c_kit_invariants.c) and emits a signed
+# proof-envelope catalog via the Side B static library
+# (libprovekit-self-contracts.a). Two modes:
+#
+#   ./mint-c-self-contracts [outDir]    standalone CLI
+#   ./mint-c-self-contracts --rpc       provekit-lift/1 daemon over stdio
+#
+# System dep: libsodium (transitively, via Side B). Hermetic on a C11
+# toolchain + libsodium. BLAKE3 is vendored under tools/blake3-vendored.
+
+CC      = cc
+
+# Mirror Side B's libsodium prefix detection so the orchestrator builds
+# in the same environments without manual config.
+SIDEB_DIR = ../provekit-self-contracts
+B3_DIR    = ../../../tools/blake3-vendored
+B3_FLAGS  = -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512 -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_USE_NEON=0
+
+SODIUM_PREFIX_HOMEBREW_ARM = /opt/homebrew
+SODIUM_PREFIX_HOMEBREW_X86 = /usr/local
+SODIUM_PREFIX ?= $(shell \
+    if [ -f $(SODIUM_PREFIX_HOMEBREW_ARM)/include/sodium.h ]; then echo $(SODIUM_PREFIX_HOMEBREW_ARM); \
+    elif [ -f $(SODIUM_PREFIX_HOMEBREW_X86)/include/sodium.h ]; then echo $(SODIUM_PREFIX_HOMEBREW_X86); \
+    else echo /usr; fi)
+
+SODIUM_INCLUDE = -I$(SODIUM_PREFIX)/include
+SODIUM_LDFLAGS = -L$(SODIUM_PREFIX)/lib -lsodium
+
+CFLAGS  = -Wall -Wextra -std=c11 \
+          -Isrc \
+          -I$(SIDEB_DIR)/include \
+          -I$(B3_DIR) \
+          $(SODIUM_INCLUDE) \
+          $(B3_FLAGS) \
+          -g
+LDFLAGS = $(SODIUM_LDFLAGS)
+
+LIB_SIDEB = $(SIDEB_DIR)/libprovekit-self-contracts.a
+
+SRC = src/slab.c src/c_kit_invariants.c src/orchestrator.c src/rpc.c src/main.c
+OBJ = $(SRC:.c=.o)
+
+BIN = mint-c-self-contracts
+
+.PHONY: all clean lib-sideb
+
+all: $(BIN)
+
+# Ensure the Side B static library exists. We delegate to its Makefile.
+lib-sideb:
+	$(MAKE) -C $(SIDEB_DIR) lib
+
+$(LIB_SIDEB):
+	$(MAKE) -C $(SIDEB_DIR) lib
+
+$(BIN): $(OBJ) $(LIB_SIDEB)
+	$(CC) $(CFLAGS) -o $@ $(OBJ) $(LIB_SIDEB) $(LDFLAGS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJ) $(BIN)

--- a/implementations/c/mint-c-self-contracts/run-rpc.sh
+++ b/implementations/c/mint-c-self-contracts/run-rpc.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Launcher for the c-self-contracts lift surface. The lift manifest spawns
+# this script (relative to implementations/c); we resolve the binary
+# relative to this script's directory so the manifest's working_dir
+# doesn't matter for binary discovery.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="$SCRIPT_DIR/mint-c-self-contracts"
+
+if [ ! -x "$BIN" ]; then
+    echo "ERROR: binary not built at $BIN. Run \`make build-c-self-contracts\`." >&2
+    exit 1
+fi
+
+exec "$BIN" --rpc "$@"

--- a/implementations/c/mint-c-self-contracts/src/c_kit_invariants.c
+++ b/implementations/c/mint-c-self-contracts/src/c_kit_invariants.c
@@ -1,0 +1,454 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * C kit-internal invariants. Each slab's contracts describe the
+ * shape-level guarantees of the public surface in
+ * implementations/c/provekit-self-contracts/src/ and the matching
+ * include/provekit/self_contracts.h.
+ *
+ * Mirrors the cross-kit pattern (java JavaKitInvariants.java, csharp
+ * .invariant.cs, cpp .invariant.cpp): IR cannot model collision
+ * resistance / signature soundness, but it CAN say things like "output
+ * length is exactly N", "function is deterministic", "self-identifying
+ * prefix is N chars".
+ *
+ * Naming convention: c_<slab>_<predicate>.
+ *
+ * Slab list:
+ *   blake3            5 contracts
+ *   cbor              5 contracts
+ *   claim_envelope    5 contracts
+ *   ed25519           5 contracts
+ *   jcs               5 contracts
+ *   proof_envelope    5 contracts
+ */
+
+#include "c_kit_invariants.h"
+#include "slab.h"
+
+#include <stdlib.h>
+
+/* ----------------------------------------------------------------------- */
+/* tiny helpers — reduce repetition without sacrificing clarity            */
+/* ----------------------------------------------------------------------- */
+
+/* Build ctor("name", arg). Convenience: most invariants apply a single
+ * input through a constructor representing an op (e.g. blake3_512(b)). */
+static pksc_value *ctor1(const char *name, pksc_value *arg) {
+    pksc_value *args[1] = { arg };
+    return mcsc_f_ctor(name, args, 1);
+}
+
+/* `b -> eq(len(blake3_512(b)), 139)` style body builders are passed as
+ * mcsc_body_fn callbacks. Each closure variant is implemented as a
+ * dedicated static function with a `void *` ctx for any literal it
+ * needs. C does not have closures, so each forall body is its own
+ * named function. The pattern keeps the slab authoring readable. */
+
+/* ============================================================== */
+/* Slab: blake3                                                    */
+/* ============================================================== */
+
+static pksc_value *body_blake3_len_eq_139(pksc_value *b, void *ctx) {
+    (void)ctx;
+    /* eq(len(blake3_512(b)), 139) */
+    return mcsc_f_eq(
+        ctor1("len", ctor1("blake3_512", b)),
+        mcsc_f_num(139));
+}
+
+static pksc_value *body_blake3_deterministic(pksc_value *b, void *ctx) {
+    (void)ctx;
+    /* eq(blake3_512(b), blake3_512(b))
+     * NOTE: the pksc value tree owns each child uniquely. We need TWO
+     * copies of the variable. We can't reuse `b`. We rebuild the rhs
+     * from the var name string. */
+    pksc_value *b2 = mcsc_f_var("b");
+    if (!b2) { pksc_value_free(b); return NULL; }
+    return mcsc_f_eq(ctor1("blake3_512", b),
+                     ctor1("blake3_512", b2));
+}
+
+static pksc_value *body_blake3_starts_with_prefix(pksc_value *b, void *ctx) {
+    (void)ctx;
+    return mcsc_f_starts_with(
+        ctor1("blake3_512", b),
+        mcsc_f_str("blake3-512:"));
+}
+
+static pksc_value *body_blake3_digest_64(pksc_value *b, void *ctx) {
+    (void)ctx;
+    return mcsc_f_eq(
+        ctor1("len_bytes", ctor1("blake3_digest", b)),
+        mcsc_f_num(64));
+}
+
+static int author_blake3(mcsc_slab_list *out) {
+    mcsc_slab *s = mcsc_slab_new(
+        "blake3",
+        "implementations/c/provekit-self-contracts/src/hash.c");
+    if (!s) return -1;
+
+    /* c_blake3_512_output_length_eq_139: forall b. len(blake3_512(b)) == 139 */
+    pksc_value *f1 = mcsc_f_forall("b", mcsc_f_sort("String"),
+                                   body_blake3_len_eq_139, NULL);
+    if (mcsc_slab_must(s, "c_blake3_512_output_length_eq_139", f1) != 0) goto fail;
+
+    /* c_blake3_512_is_deterministic: forall b. blake3_512(b) == blake3_512(b) */
+    pksc_value *f2 = mcsc_f_forall("b", mcsc_f_sort("String"),
+                                   body_blake3_deterministic, NULL);
+    if (mcsc_slab_must(s, "c_blake3_512_is_deterministic", f2) != 0) goto fail;
+
+    /* c_blake3_512_starts_with_self_identifying_prefix */
+    pksc_value *f3 = mcsc_f_forall("b", mcsc_f_sort("String"),
+                                   body_blake3_starts_with_prefix, NULL);
+    if (mcsc_slab_must(s, "c_blake3_512_starts_with_self_identifying_prefix", f3) != 0) goto fail;
+
+    /* c_blake3_prefix_length_eq_11: eq(len("blake3-512:"), 11)  (no forall) */
+    pksc_value *f4 = mcsc_f_eq(ctor1("len", mcsc_f_str("blake3-512:")),
+                               mcsc_f_num(11));
+    if (mcsc_slab_must(s, "c_blake3_prefix_length_eq_11", f4) != 0) goto fail;
+
+    /* c_blake3_digest_bytes_eq_64: forall b. len_bytes(blake3_digest(b)) == 64 */
+    pksc_value *f5 = mcsc_f_forall("b", mcsc_f_sort("String"),
+                                   body_blake3_digest_64, NULL);
+    if (mcsc_slab_must(s, "c_blake3_digest_bytes_eq_64", f5) != 0) goto fail;
+
+    return mcsc_slab_list_push(out, s);
+fail:
+    mcsc_slab_free(s);
+    return -1;
+}
+
+/* ============================================================== */
+/* Slab: cbor                                                      */
+/* ============================================================== */
+
+static pksc_value *body_cbor_uint_major_zero(pksc_value *n, void *ctx) {
+    (void)ctx;
+    return mcsc_f_eq(
+        ctor1("cbor_major_of", ctor1("cbor_encode_uint", n)),
+        mcsc_f_num(0));
+}
+static pksc_value *body_cbor_bstr_major_two(pksc_value *b, void *ctx) {
+    (void)ctx;
+    return mcsc_f_eq(
+        ctor1("cbor_major_of", ctor1("cbor_encode_bstr", b)),
+        mcsc_f_num(2));
+}
+static pksc_value *body_cbor_tstr_major_three(pksc_value *s, void *ctx) {
+    (void)ctx;
+    return mcsc_f_eq(
+        ctor1("cbor_major_of", ctor1("cbor_encode_tstr", s)),
+        mcsc_f_num(3));
+}
+static pksc_value *body_cbor_map_major_five(pksc_value *count, void *ctx) {
+    (void)ctx;
+    return mcsc_f_eq(
+        ctor1("cbor_major_of", ctor1("cbor_encode_map_head", count)),
+        mcsc_f_num(5));
+}
+static pksc_value *body_cbor_shortest_form(pksc_value *n, void *ctx) {
+    (void)ctx;
+    return mcsc_f_eq(
+        ctor1("cbor_extra_arg_bytes_of", ctor1("cbor_encode_uint", n)),
+        mcsc_f_num(0));
+}
+
+static int author_cbor(mcsc_slab_list *out) {
+    mcsc_slab *s = mcsc_slab_new(
+        "cbor",
+        "implementations/c/provekit-self-contracts/src/cbor.c");
+    if (!s) return -1;
+
+    pksc_value *f;
+    f = mcsc_f_forall("n", mcsc_f_sort("String"), body_cbor_uint_major_zero, NULL);
+    if (mcsc_slab_must(s, "c_cbor_encode_uint_major_type_zero", f) != 0) goto fail;
+    f = mcsc_f_forall("b", mcsc_f_sort("String"), body_cbor_bstr_major_two, NULL);
+    if (mcsc_slab_must(s, "c_cbor_encode_bstr_major_type_two", f) != 0) goto fail;
+    f = mcsc_f_forall("s", mcsc_f_sort("String"), body_cbor_tstr_major_three, NULL);
+    if (mcsc_slab_must(s, "c_cbor_encode_tstr_major_type_three", f) != 0) goto fail;
+    f = mcsc_f_forall("count", mcsc_f_sort("String"), body_cbor_map_major_five, NULL);
+    if (mcsc_slab_must(s, "c_cbor_encode_map_head_major_type_five", f) != 0) goto fail;
+    f = mcsc_f_forall("n", mcsc_f_sort("String"), body_cbor_shortest_form, NULL);
+    if (mcsc_slab_must(s, "c_cbor_shortest_form_under_24_no_extra_bytes", f) != 0) goto fail;
+
+    return mcsc_slab_list_push(out, s);
+fail:
+    mcsc_slab_free(s);
+    return -1;
+}
+
+/* ============================================================== */
+/* Slab: claim_envelope                                            */
+/* ============================================================== */
+
+static pksc_value *body_claim_signer_independent(pksc_value *args, void *ctx) {
+    (void)ctx;
+    pksc_value *args_b = mcsc_f_var("args");
+    if (!args_b) { pksc_value_free(args); return NULL; }
+    return mcsc_f_eq(
+        ctor1("contract_cid_with_seed_a", args),
+        ctor1("contract_cid_with_seed_b", args_b));
+}
+
+static pksc_value *body_claim_rejects_all_null(pksc_value *args, void *ctx) {
+    (void)ctx;
+    return mcsc_f_eq(
+        ctor1("mint_with_no_pre_post_inv", args),
+        ctor1("rejects", mcsc_f_str("")));
+}
+
+static pksc_value *body_claim_set_cid_order_independent(pksc_value *cids, void *ctx) {
+    (void)ctx;
+    pksc_value *cids_b = mcsc_f_var("cids");
+    if (!cids_b) { pksc_value_free(cids); return NULL; }
+    return mcsc_f_eq(
+        ctor1("compute_contract_set_cid", cids),
+        ctor1("compute_contract_set_cid_reversed", cids_b));
+}
+
+static pksc_value *body_claim_attestation_cid(pksc_value *e, void *ctx) {
+    (void)ctx;
+    pksc_value *e_b = mcsc_f_var("envelope");
+    if (!e_b) { pksc_value_free(e); return NULL; }
+    return mcsc_f_eq(
+        ctor1("attestation_cid_of", e),
+        ctor1("blake3_512",
+              ctor1("jcs_encode",
+                    ctor1("envelope_with_signature", e_b))));
+}
+
+static int author_claim_envelope(mcsc_slab_list *out) {
+    mcsc_slab *s = mcsc_slab_new(
+        "claim_envelope",
+        "implementations/c/provekit-self-contracts/src/proof_envelope.c");
+    if (!s) return -1;
+
+    pksc_value *f;
+    f = mcsc_f_forall("args", mcsc_f_sort("String"), body_claim_signer_independent, NULL);
+    if (mcsc_slab_must(s, "c_claim_envelope_contract_cid_is_signer_independent", f) != 0) goto fail;
+
+    f = mcsc_f_forall("args", mcsc_f_sort("String"), body_claim_rejects_all_null, NULL);
+    if (mcsc_slab_must(s, "c_claim_envelope_mint_contract_rejects_all_null", f) != 0) goto fail;
+
+    f = mcsc_f_forall("cids", mcsc_f_sort("String"), body_claim_set_cid_order_independent, NULL);
+    if (mcsc_slab_must(s, "c_claim_envelope_contract_set_cid_is_order_independent", f) != 0) goto fail;
+
+    /* Layered schema version is "2". */
+    f = mcsc_f_eq(ctor1("layered_schema_version", mcsc_f_str("")),
+                  mcsc_f_str("2"));
+    if (mcsc_slab_must(s, "c_claim_envelope_layered_schema_version_is_2", f) != 0) goto fail;
+
+    f = mcsc_f_forall("envelope", mcsc_f_sort("String"), body_claim_attestation_cid, NULL);
+    if (mcsc_slab_must(s, "c_claim_envelope_attestation_cid_is_blake3_of_jcs_envelope", f) != 0) goto fail;
+
+    return mcsc_slab_list_push(out, s);
+fail:
+    mcsc_slab_free(s);
+    return -1;
+}
+
+/* ============================================================== */
+/* Slab: ed25519                                                   */
+/* ============================================================== */
+
+static pksc_value *body_ed25519_sign_64(pksc_value *msg, void *ctx) {
+    (void)ctx;
+    return mcsc_f_eq(
+        ctor1("len_bytes", ctor1("ed25519_sign_with_seed", msg)),
+        mcsc_f_num(64));
+}
+
+static pksc_value *body_ed25519_sign_string_prefix(pksc_value *msg, void *ctx) {
+    (void)ctx;
+    return mcsc_f_starts_with(
+        ctor1("ed25519_sign_string", msg),
+        mcsc_f_str("ed25519:"));
+}
+
+static int author_ed25519(mcsc_slab_list *out) {
+    mcsc_slab *s = mcsc_slab_new(
+        "ed25519",
+        "implementations/c/provekit-self-contracts/src/sign.c");
+    if (!s) return -1;
+
+    pksc_value *f;
+    f = mcsc_f_eq(ctor1("ed25519_seed_bytes_const", mcsc_f_str("")),
+                  mcsc_f_num(32));
+    if (mcsc_slab_must(s, "c_ed25519_seed_bytes_eq_32", f) != 0) goto fail;
+
+    f = mcsc_f_eq(ctor1("ed25519_pubkey_bytes_const", mcsc_f_str("")),
+                  mcsc_f_num(32));
+    if (mcsc_slab_must(s, "c_ed25519_pubkey_bytes_eq_32", f) != 0) goto fail;
+
+    f = mcsc_f_eq(ctor1("ed25519_signature_bytes_const", mcsc_f_str("")),
+                  mcsc_f_num(64));
+    if (mcsc_slab_must(s, "c_ed25519_signature_bytes_eq_64", f) != 0) goto fail;
+
+    f = mcsc_f_forall("msg", mcsc_f_sort("String"), body_ed25519_sign_64, NULL);
+    if (mcsc_slab_must(s, "c_ed25519_sign_with_seed_output_length_eq_64", f) != 0) goto fail;
+
+    f = mcsc_f_forall("msg", mcsc_f_sort("String"), body_ed25519_sign_string_prefix, NULL);
+    if (mcsc_slab_must(s, "c_ed25519_sign_string_starts_with_self_identifying_prefix", f) != 0) goto fail;
+
+    return mcsc_slab_list_push(out, s);
+fail:
+    mcsc_slab_free(s);
+    return -1;
+}
+
+/* ============================================================== */
+/* Slab: jcs                                                       */
+/* ============================================================== */
+
+static pksc_value *body_jcs_non_empty(pksc_value *v, void *ctx) {
+    (void)ctx;
+    return mcsc_f_gte(
+        ctor1("len_bytes", ctor1("jcs_encode_utf8", v)),
+        mcsc_f_num(1));
+}
+
+static pksc_value *body_jcs_deterministic(pksc_value *v, void *ctx) {
+    (void)ctx;
+    pksc_value *v_b = mcsc_f_var("v");
+    if (!v_b) { pksc_value_free(v); return NULL; }
+    return mcsc_f_eq(
+        ctor1("jcs_encode_utf8", v),
+        ctor1("jcs_encode_utf8", v_b));
+}
+
+static pksc_value *body_jcs_key_order(pksc_value *v, void *ctx) {
+    (void)ctx;
+    pksc_value *v_b = mcsc_f_var("v");
+    if (!v_b) { pksc_value_free(v); return NULL; }
+    return mcsc_f_eq(
+        ctor1("jcs_encode_utf8", v),
+        ctor1("jcs_encode_utf8",
+              ctor1("reorder_object_keys", v_b)));
+}
+
+static pksc_value *body_jcs_control_chars(pksc_value *ch, void *ctx) {
+    (void)ctx;
+    pksc_value *ch_b = mcsc_f_var("c");
+    if (!ch_b) { pksc_value_free(ch); return NULL; }
+    return mcsc_f_eq(
+        ctor1("jcs_escape", ch),
+        ctor1("backslash_u00",
+              ctor1("hex_lower", ch_b)));
+}
+
+static int author_jcs(mcsc_slab_list *out) {
+    mcsc_slab *s = mcsc_slab_new(
+        "jcs",
+        "implementations/c/provekit-self-contracts/src/jcs.c");
+    if (!s) return -1;
+
+    pksc_value *f;
+    f = mcsc_f_forall("v", mcsc_f_sort("String"), body_jcs_non_empty, NULL);
+    if (mcsc_slab_must(s, "c_jcs_encode_non_empty", f) != 0) goto fail;
+
+    f = mcsc_f_forall("v", mcsc_f_sort("String"), body_jcs_deterministic, NULL);
+    if (mcsc_slab_must(s, "c_jcs_encode_is_deterministic", f) != 0) goto fail;
+
+    f = mcsc_f_forall("v", mcsc_f_sort("String"), body_jcs_key_order, NULL);
+    if (mcsc_slab_must(s, "c_jcs_object_key_order_independent", f) != 0) goto fail;
+
+    f = mcsc_f_forall("c", mcsc_f_sort("String"), body_jcs_control_chars, NULL);
+    if (mcsc_slab_must(s, "c_jcs_control_chars_encode_as_lowercase_uxxxx", f) != 0) goto fail;
+
+    /* Double-quote escapes to backslash + double-quote. (no forall) */
+    f = mcsc_f_eq(ctor1("jcs_escape", mcsc_f_str("\"")),
+                  mcsc_f_str("\\\""));
+    if (mcsc_slab_must(s, "c_jcs_double_quote_escapes_with_backslash", f) != 0) goto fail;
+
+    return mcsc_slab_list_push(out, s);
+fail:
+    mcsc_slab_free(s);
+    return -1;
+}
+
+/* ============================================================== */
+/* Slab: proof_envelope                                            */
+/* ============================================================== */
+
+static pksc_value *body_proof_filename_blake3(pksc_value *b, void *ctx) {
+    (void)ctx;
+    pksc_value *b_b = mcsc_f_var("bytes");
+    if (!b_b) { pksc_value_free(b); return NULL; }
+    return mcsc_f_eq(
+        ctor1("proof_envelope_filename_cid", b),
+        ctor1("blake3_512", b_b));
+}
+
+static pksc_value *body_proof_filename_prefix(pksc_value *b, void *ctx) {
+    (void)ctx;
+    return mcsc_f_starts_with(
+        ctor1("proof_envelope_filename_cid", b),
+        mcsc_f_str("blake3-512:"));
+}
+
+static pksc_value *body_proof_keys_sorted(pksc_value *m, void *ctx) {
+    (void)ctx;
+    pksc_value *m_b = mcsc_f_var("m");
+    if (!m_b) { pksc_value_free(m); return NULL; }
+    return mcsc_f_eq(
+        ctor1("emit_sorted_map_bytes", m),
+        ctor1("emit_sorted_map_bytes",
+              ctor1("permute_pairs", m_b)));
+}
+
+static pksc_value *body_proof_verify_rejects(pksc_value *b, void *ctx) {
+    (void)ctx;
+    return mcsc_f_eq(
+        ctor1("verify_with_wrong_expected_cid", b),
+        ctor1("rejects", mcsc_f_str("")));
+}
+
+static int author_proof_envelope(mcsc_slab_list *out) {
+    mcsc_slab *s = mcsc_slab_new(
+        "proof_envelope",
+        "implementations/c/provekit-self-contracts/src/proof_envelope.c");
+    if (!s) return -1;
+
+    pksc_value *f;
+    /* kind field is "catalog" (no forall) */
+    f = mcsc_f_eq(ctor1("proof_envelope_kind_field", mcsc_f_str("")),
+                  mcsc_f_str("catalog"));
+    if (mcsc_slab_must(s, "c_proof_envelope_kind_is_literal_catalog", f) != 0) goto fail;
+
+    f = mcsc_f_forall("bytes", mcsc_f_sort("String"), body_proof_filename_blake3, NULL);
+    if (mcsc_slab_must(s, "c_proof_envelope_filename_cid_is_blake3_of_bytes", f) != 0) goto fail;
+
+    f = mcsc_f_forall("bytes", mcsc_f_sort("String"), body_proof_filename_prefix, NULL);
+    if (mcsc_slab_must(s, "c_proof_envelope_filename_cid_starts_with_blake3_prefix", f) != 0) goto fail;
+
+    f = mcsc_f_forall("m", mcsc_f_sort("String"), body_proof_keys_sorted, NULL);
+    if (mcsc_slab_must(s, "c_proof_envelope_map_keys_sorted_bytewise", f) != 0) goto fail;
+
+    f = mcsc_f_forall("bytes", mcsc_f_sort("String"), body_proof_verify_rejects, NULL);
+    if (mcsc_slab_must(s, "c_proof_envelope_verify_rejects_cid_mismatch", f) != 0) goto fail;
+
+    return mcsc_slab_list_push(out, s);
+fail:
+    mcsc_slab_free(s);
+    return -1;
+}
+
+/* ============================================================== */
+/* author_all                                                      */
+/* ============================================================== */
+
+mcsc_slab_list *mcsc_author_all(void) {
+    mcsc_slab_list *l = mcsc_slab_list_new();
+    if (!l) return NULL;
+    if (author_blake3(l) != 0) goto fail;
+    if (author_cbor(l) != 0) goto fail;
+    if (author_claim_envelope(l) != 0) goto fail;
+    if (author_ed25519(l) != 0) goto fail;
+    if (author_jcs(l) != 0) goto fail;
+    if (author_proof_envelope(l) != 0) goto fail;
+    return l;
+fail:
+    mcsc_slab_list_free(l);
+    return NULL;
+}

--- a/implementations/c/mint-c-self-contracts/src/c_kit_invariants.h
+++ b/implementations/c/mint-c-self-contracts/src/c_kit_invariants.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#ifndef MCSC_C_KIT_INVARIANTS_H
+#define MCSC_C_KIT_INVARIANTS_H
+
+#include "slab.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Author every C-kit slab and return them as an mcsc_slab_list. Returns
+ * NULL on allocation failure. Caller owns the returned list and must
+ * free it with mcsc_slab_list_free. */
+mcsc_slab_list *mcsc_author_all(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MCSC_C_KIT_INVARIANTS_H */

--- a/implementations/c/mint-c-self-contracts/src/main.c
+++ b/implementations/c/mint-c-self-contracts/src/main.c
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * mint-c-self-contracts entry point.
+ *
+ * Two modes:
+ *   1. Standalone:  ./mint-c-self-contracts [outDir]
+ *                   Mints once, prints catalog CID + contractSetCid,
+ *                   asserts byte-determinism by minting twice into
+ *                   distinct dirs.
+ *
+ *   2. --rpc:       ./mint-c-self-contracts --rpc
+ *                   Speaks the lift-plugin protocol (provekit-lift/1)
+ *                   over NDJSON on stdio. The Rust CLI dispatcher
+ *                   (`provekit mint --kit=c`) uses this mode; spec is
+ *                   protocol/specs/2026-04-30-lift-plugin-protocol.md.
+ *
+ * Authoring surface: c-self-contracts. Slabs walked:
+ *   - blake3              5 contracts
+ *   - cbor                5 contracts
+ *   - claim_envelope      5 contracts
+ *   - ed25519             5 contracts
+ *   - jcs                 5 contracts
+ *   - proof_envelope      5 contracts
+ */
+
+#include "orchestrator.h"
+#include "rpc.h"
+
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+    /* Detect --rpc anywhere on argv (mirrors swift/go peers). */
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--rpc") == 0) {
+            return mcsc_run_rpc();
+        }
+    }
+    const char *out_dir = (argc >= 2) ? argv[1] : ".";
+    return mcsc_run_cli(out_dir);
+}

--- a/implementations/c/mint-c-self-contracts/src/orchestrator.c
+++ b/implementations/c/mint-c-self-contracts/src/orchestrator.c
@@ -1,0 +1,448 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Orchestrator. Drives one full author + mint + bundle pass:
+ *
+ *   1. Author every contract slab in c_kit_invariants.c.
+ *   2. For each ContractDecl, JCS-encode the canonical contract body
+ *      {name, outBinding, pre?, post?, inv?} and hash to BLAKE3-512 to
+ *      get the signer-independent contentCid (member CID).
+ *   3. The member bytes are those same JCS bytes; the catalog wraps
+ *      them via pksc_proof_build.
+ *   4. contractSetCid = BLAKE3-512(JCS(sorted(contentCids))) — byte-
+ *      identical to other kits per spec
+ *      protocol/specs/2026-05-03-contract-set-extension.md §1.
+ *
+ * Mirrors the rust contract_cid / compute_contract_set_cid model
+ * (implementations/rust/provekit-claim-envelope/src/lib.rs §1).
+ */
+
+#include "orchestrator.h"
+
+#include "c_kit_invariants.h"
+#include "slab.h"
+
+#include "provekit/self_contracts.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#define MCSC_DECLARED_AT     "2026-05-03T18:00:00Z"
+#define MCSC_PRODUCED_BY     "provekit-c-self-contracts@1.0"
+#define MCSC_CATALOG_NAME    "@provekit/c-self-contracts"
+#define MCSC_CATALOG_VERSION "1.0.0"
+
+/* ----------------------------------------------------------------------- */
+/* helpers                                                                  */
+/* ----------------------------------------------------------------------- */
+
+static char *dup_cstr(const char *s) {
+    if (!s) return NULL;
+    size_t n = strlen(s);
+    char *p = (char *)malloc(n + 1);
+    if (!p) return NULL;
+    memcpy(p, s, n + 1);
+    return p;
+}
+
+/* Deep-copy a pksc_value tree. Used because each contract decl's pre/post/inv
+ * is owned by the slab; we need an independent tree to assemble into the
+ * contract_body object passed to JCS. (We could mutate ownership instead, but
+ * that complicates slab teardown; copying is simpler and slabs are small.) */
+static pksc_value *value_copy(const pksc_value *v) {
+    if (!v) return NULL;
+    switch (v->kind) {
+        case PKSC_V_NULL: return pksc_v_null();
+        case PKSC_V_BOOL: return pksc_v_bool(v->as.b);
+        case PKSC_V_INT:  return pksc_v_int(v->as.i);
+        case PKSC_V_STR:  return pksc_v_str(v->as.s);
+        case PKSC_V_ARR: {
+            pksc_value *out = pksc_v_arr_new();
+            if (!out) return NULL;
+            for (size_t i = 0; i < v->as.arr.n; i++) {
+                pksc_value *child = value_copy(v->as.arr.items[i]);
+                if (!child || pksc_v_arr_push(out, child) != 0) {
+                    pksc_value_free(child);
+                    pksc_value_free(out);
+                    return NULL;
+                }
+            }
+            return out;
+        }
+        case PKSC_V_OBJ: {
+            pksc_value *out = pksc_v_obj_new();
+            if (!out) return NULL;
+            for (size_t i = 0; i < v->as.obj.n; i++) {
+                pksc_value *child = value_copy(v->as.obj.entries[i].value);
+                if (!child ||
+                    pksc_v_obj_set(out, v->as.obj.entries[i].key, child) != 0) {
+                    pksc_value_free(child);
+                    pksc_value_free(out);
+                    return NULL;
+                }
+            }
+            return out;
+        }
+    }
+    return NULL;
+}
+
+/* Compare for qsort(sort lex on `char *`). */
+static int cmp_str_ptr(const void *a, const void *b) {
+    const char *sa = *(const char *const *)a;
+    const char *sb = *(const char *const *)b;
+    return strcmp(sa, sb);
+}
+
+/* contractSetCid = BLAKE3-512(JCS(sorted([cids...]))). Returns malloc'd
+ * "blake3-512:<hex>" string or NULL on failure. */
+static char *compute_contract_set_cid(char **cids, size_t n) {
+    /* Sort lexicographically (stable; cids are unique per content). */
+    char **sorted = (char **)malloc(n * sizeof(*sorted));
+    if (!sorted && n > 0) return NULL;
+    for (size_t i = 0; i < n; i++) sorted[i] = cids[i];
+    qsort(sorted, n, sizeof(*sorted), cmp_str_ptr);
+
+    pksc_value *arr = pksc_v_arr_new();
+    if (!arr) { free(sorted); return NULL; }
+    for (size_t i = 0; i < n; i++) {
+        pksc_value *s = pksc_v_str(sorted[i]);
+        if (!s || pksc_v_arr_push(arr, s) != 0) {
+            pksc_value_free(s);
+            pksc_value_free(arr);
+            free(sorted);
+            return NULL;
+        }
+    }
+    free(sorted);
+
+    pksc_bytes jcs;
+    pksc_bytes_init(&jcs);
+    if (pksc_jcs_encode(&jcs, arr) != 0) {
+        pksc_value_free(arr);
+        pksc_bytes_free(&jcs);
+        return NULL;
+    }
+    pksc_value_free(arr);
+    char *cid = pksc_blake3_512_cid(jcs.data, jcs.len);
+    pksc_bytes_free(&jcs);
+    return cid;
+}
+
+/* Build the canonical contract body JCS-Value:
+ *   {"name":<name>,"outBinding":<out>,"pre"?:<pre>,"post"?:<post>,"inv"?:<inv>}
+ * Returns malloc'd value tree or NULL. The pre/post/inv args are
+ * deep-copied from the slab. */
+static pksc_value *build_contract_body(const mcsc_contract *c) {
+    pksc_value *o = pksc_v_obj_new();
+    if (!o) return NULL;
+    pksc_value *name_v = pksc_v_str(c->name);
+    pksc_value *out_v = pksc_v_str(c->out_binding);
+    if (!name_v || !out_v) {
+        pksc_value_free(name_v);
+        pksc_value_free(out_v);
+        pksc_value_free(o);
+        return NULL;
+    }
+    if (pksc_v_obj_set(o, "name", name_v) != 0) goto fail;
+    if (pksc_v_obj_set(o, "outBinding", out_v) != 0) goto fail;
+    if (c->pre) {
+        pksc_value *cp = value_copy(c->pre);
+        if (!cp || pksc_v_obj_set(o, "pre", cp) != 0) {
+            pksc_value_free(cp);
+            goto fail_o_only;
+        }
+    }
+    if (c->post) {
+        pksc_value *cp = value_copy(c->post);
+        if (!cp || pksc_v_obj_set(o, "post", cp) != 0) {
+            pksc_value_free(cp);
+            goto fail_o_only;
+        }
+    }
+    if (c->inv) {
+        pksc_value *cp = value_copy(c->inv);
+        if (!cp || pksc_v_obj_set(o, "inv", cp) != 0) {
+            pksc_value_free(cp);
+            goto fail_o_only;
+        }
+    }
+    return o;
+fail:
+    pksc_value_free(name_v);
+    pksc_value_free(out_v);
+fail_o_only:
+    pksc_value_free(o);
+    return NULL;
+}
+
+/* Make a directory if it doesn't exist. */
+static int ensure_dir(const char *path) {
+    if (!path) return 0;
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        return S_ISDIR(st.st_mode) ? 0 : -1;
+    }
+    if (mkdir(path, 0755) != 0) return -1;
+    return 0;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Public API                                                              */
+/* ----------------------------------------------------------------------- */
+
+void mcsc_mint_result_init(mcsc_mint_result *r) {
+    if (!r) return;
+    r->cid = NULL;
+    r->contract_set_cid = NULL;
+    r->contract_count = 0;
+    r->slab_count = 0;
+    r->bytes = NULL;
+    r->bytes_len = 0;
+}
+
+void mcsc_mint_result_free(mcsc_mint_result *r) {
+    if (!r) return;
+    free(r->cid);
+    free(r->contract_set_cid);
+    free(r->bytes);
+    mcsc_mint_result_init(r);
+}
+
+int mcsc_mint_one_run(const char *out_dir, mcsc_mint_result *out) {
+    if (!out) return -1;
+    mcsc_mint_result_init(out);
+
+    if (pksc_sodium_init() != 0) return -1;
+
+    if (out_dir && ensure_dir(out_dir) != 0) return -1;
+
+    mcsc_slab_list *slabs = mcsc_author_all();
+    if (!slabs) return -1;
+
+    /* Count total contracts upfront. */
+    size_t total = 0;
+    for (size_t i = 0; i < slabs->n; i++) total += slabs->slabs[i]->n;
+
+    pksc_member *members = (pksc_member *)calloc(total ? total : 1, sizeof(*members));
+    char       **content_cids = (char **)calloc(total ? total : 1, sizeof(*content_cids));
+    if (!members || !content_cids) {
+        free(members);
+        free(content_cids);
+        mcsc_slab_list_free(slabs);
+        return -1;
+    }
+
+    size_t idx = 0;
+    for (size_t si = 0; si < slabs->n; si++) {
+        mcsc_slab *s = slabs->slabs[si];
+        for (size_t ci = 0; ci < s->n; ci++) {
+            const mcsc_contract *c = s->contracts[ci];
+            pksc_value *body = build_contract_body(c);
+            if (!body) goto fail;
+
+            pksc_bytes jcs;
+            pksc_bytes_init(&jcs);
+            if (pksc_jcs_encode(&jcs, body) != 0) {
+                pksc_value_free(body);
+                pksc_bytes_free(&jcs);
+                goto fail;
+            }
+            pksc_value_free(body);
+
+            char *cid = pksc_blake3_512_cid(jcs.data, jcs.len);
+            if (!cid) {
+                pksc_bytes_free(&jcs);
+                goto fail;
+            }
+
+            /* Detect duplicate CIDs across slabs. */
+            for (size_t k = 0; k < idx; k++) {
+                if (strcmp(members[k].key, cid) == 0) {
+                    free(cid);
+                    pksc_bytes_free(&jcs);
+                    fprintf(stderr,
+                            "duplicate contract CID across slabs (contract `%s`)\n",
+                            c->name);
+                    goto fail;
+                }
+            }
+
+            members[idx].key = cid; /* takes ownership */
+            /* Move ownership of jcs.data into members[idx].bytes. */
+            members[idx].bytes = jcs.data;
+            members[idx].len = jcs.len;
+            jcs.data = NULL;
+            jcs.cap = jcs.len = 0;
+
+            content_cids[idx] = dup_cstr(cid);
+            if (!content_cids[idx]) goto fail;
+            idx++;
+        }
+    }
+
+    /* Catalog signer CID = BLAKE3-512 of the self-identifying pubkey string.
+     * Mirrors rust signer_cid = blake3_512_of(signer_pubkey.as_bytes()). */
+    char *pubkey_str = pksc_ed25519_pubkey_string(PKSC_FOUNDATION_V0_SEED);
+    if (!pubkey_str) goto fail;
+    char *signer_cid = pksc_blake3_512_cid(
+        (const uint8_t *)pubkey_str, strlen(pubkey_str));
+    free(pubkey_str);
+    if (!signer_cid) goto fail;
+
+    pksc_proof_input in;
+    memset(&in, 0, sizeof(in));
+    in.name = MCSC_CATALOG_NAME;
+    in.version = MCSC_CATALOG_VERSION;
+    in.binary_cid = NULL;
+    in.metadata = NULL;
+    in.n_metadata = 0;
+    in.members = members;
+    in.n_members = total;
+    in.signer_cid = signer_cid;
+    in.declared_at = MCSC_DECLARED_AT;
+    in.signer_seed = PKSC_FOUNDATION_V0_SEED;
+
+    pksc_proof_output po;
+    memset(&po, 0, sizeof(po));
+    int rc = pksc_proof_build(&in, &po);
+    free(signer_cid);
+    if (rc != 0) goto fail;
+
+    /* Compute contractSetCid from the per-contract content CIDs. */
+    char *cset = compute_contract_set_cid(content_cids, total);
+    if (!cset) {
+        pksc_proof_output_free(&po);
+        goto fail;
+    }
+
+    /* Write <cid>.proof if outDir requested. */
+    if (out_dir) {
+        size_t plen = strlen(out_dir) + 1 + strlen(po.cid) + 6 + 1;
+        char *path = (char *)malloc(plen);
+        if (!path) {
+            free(cset);
+            pksc_proof_output_free(&po);
+            goto fail;
+        }
+        snprintf(path, plen, "%s/%s.proof", out_dir, po.cid);
+        FILE *fp = fopen(path, "wb");
+        if (!fp) {
+            free(path);
+            free(cset);
+            pksc_proof_output_free(&po);
+            goto fail;
+        }
+        if (fwrite(po.bytes, 1, po.len, fp) != po.len) {
+            fclose(fp);
+            free(path);
+            free(cset);
+            pksc_proof_output_free(&po);
+            goto fail;
+        }
+        fclose(fp);
+        free(path);
+    }
+
+    out->cid = po.cid;             /* take ownership */
+    out->bytes = po.bytes;         /* take ownership */
+    out->bytes_len = po.len;
+    out->contract_set_cid = cset;
+    out->contract_count = total;
+    out->slab_count = slabs->n;
+    /* po.cid and po.bytes are now owned by `out`; clear po so its free
+     * doesn't double-free. */
+    po.cid = NULL;
+    po.bytes = NULL;
+    pksc_proof_output_free(&po);
+
+    /* Free intermediates: members (key+bytes were moved to po, then to out's
+     * bytes via the proof envelope; but pksc_proof_build COPIES the keys
+     * and bytes internally — see proof_envelope.c). So we still own the
+     * `members[*].key` and `.bytes` we passed in and must free them. */
+    for (size_t i = 0; i < total; i++) {
+        free(members[i].key);
+        free(members[i].bytes);
+    }
+    free(members);
+    for (size_t i = 0; i < total; i++) free(content_cids[i]);
+    free(content_cids);
+    mcsc_slab_list_free(slabs);
+    return 0;
+
+fail:
+    for (size_t i = 0; i < idx; i++) {
+        free(members[i].key);
+        free(members[i].bytes);
+        free(content_cids[i]);
+    }
+    free(members);
+    free(content_cids);
+    mcsc_slab_list_free(slabs);
+    mcsc_mint_result_free(out);
+    return -1;
+}
+
+int mcsc_run_cli(const char *out_dir) {
+    if (!out_dir) out_dir = ".";
+
+    fprintf(stdout, "== ProvekIt C self-contracts orchestrator ==\n\n");
+    fprintf(stdout, "output dir: %s\n\n", out_dir);
+
+    fprintf(stdout, "== mint #1 ==\n");
+    mcsc_mint_result run1;
+    mcsc_mint_result_init(&run1);
+    if (mcsc_mint_one_run(out_dir, &run1) != 0) {
+        fprintf(stderr, "mint #1 failed\n");
+        return 1;
+    }
+    fprintf(stdout, "  contracts:        %zu across %zu slabs\n",
+            run1.contract_count, run1.slab_count);
+    fprintf(stdout, "  catalog CID:      %s\n", run1.cid);
+    fprintf(stdout, "  contractSetCid:   %s\n", run1.contract_set_cid);
+    fprintf(stdout, "  proof bytes:      %zu\n", run1.bytes_len);
+    fprintf(stdout, "  .proof file:      %s/%s.proof\n", out_dir, run1.cid);
+
+    /* Determinism check: mint again into a sibling dir. */
+    size_t det_len = strlen(out_dir) + strlen("/_determinism_check") + 1;
+    char *det_dir = (char *)malloc(det_len);
+    if (!det_dir) {
+        mcsc_mint_result_free(&run1);
+        return 1;
+    }
+    snprintf(det_dir, det_len, "%s/_determinism_check", out_dir);
+
+    fprintf(stdout, "\n== mint #2 (determinism check) ==\n");
+    mcsc_mint_result run2;
+    mcsc_mint_result_init(&run2);
+    if (mcsc_mint_one_run(det_dir, &run2) != 0) {
+        fprintf(stderr, "mint #2 failed\n");
+        free(det_dir);
+        mcsc_mint_result_free(&run1);
+        return 1;
+    }
+    free(det_dir);
+
+    int ok = (strcmp(run1.cid, run2.cid) == 0)
+          && (strcmp(run1.contract_set_cid, run2.contract_set_cid) == 0);
+    if (!ok) {
+        fprintf(stderr, "DETERMINISM FAILURE:\n");
+        fprintf(stderr, "  run 1 cid:              %s\n", run1.cid);
+        fprintf(stderr, "  run 2 cid:              %s\n", run2.cid);
+        fprintf(stderr, "  run 1 contractSetCid:   %s\n", run1.contract_set_cid);
+        fprintf(stderr, "  run 2 contractSetCid:   %s\n", run2.contract_set_cid);
+        mcsc_mint_result_free(&run1);
+        mcsc_mint_result_free(&run2);
+        return 1;
+    }
+    fprintf(stdout, "  determinism check:  OK (two runs produced identical CIDs)\n\n");
+    fprintf(stdout, "== done. C self-application: live (%zu contracts across %zu slabs). ==\n",
+            run1.contract_count, run1.slab_count);
+
+    mcsc_mint_result_free(&run1);
+    mcsc_mint_result_free(&run2);
+    return 0;
+}

--- a/implementations/c/mint-c-self-contracts/src/orchestrator.h
+++ b/implementations/c/mint-c-self-contracts/src/orchestrator.h
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#ifndef MCSC_ORCHESTRATOR_H
+#define MCSC_ORCHESTRATOR_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * One mint run's result. All `char *` fields are owned by the caller and
+ * must be freed via mcsc_mint_result_free; `bytes` must be freed via
+ * mcsc_mint_result_free as well.
+ */
+typedef struct mcsc_mint_result {
+    char    *cid;             /* "blake3-512:..." catalog filename CID */
+    char    *contract_set_cid; /* "blake3-512:..." */
+    size_t   contract_count;
+    size_t   slab_count;
+    uint8_t *bytes;            /* CBOR proof-envelope bytes */
+    size_t   bytes_len;
+} mcsc_mint_result;
+
+void mcsc_mint_result_init(mcsc_mint_result *r);
+void mcsc_mint_result_free(mcsc_mint_result *r);
+
+/*
+ * Author every slab in JavaKitInvariants C peer, JCS-encode each
+ * contract's {name, outBinding, pre?, post?, inv?} body, hash for
+ * contentCid, build the proof-envelope catalog, write
+ * <out_dir>/<cid>.proof. On success returns 0 and populates *out;
+ * caller owns and must free *out via mcsc_mint_result_free. If
+ * `out_dir` is NULL the function does NOT write a file (RPC mode);
+ * the caller still receives bytes + cid for the wire response.
+ */
+int mcsc_mint_one_run(const char *out_dir, mcsc_mint_result *out);
+
+/* CLI entry point: writes to outDir, prints a human-readable report,
+ * asserts byte-determinism by minting again into a sibling dir.
+ * Returns process exit code. */
+int mcsc_run_cli(const char *out_dir);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MCSC_ORCHESTRATOR_H */

--- a/implementations/c/mint-c-self-contracts/src/rpc.c
+++ b/implementations/c/mint-c-self-contracts/src/rpc.c
@@ -1,0 +1,309 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * lift-plugin protocol RPC handler. Speaks provekit-lift/1 over NDJSON
+ * on stdio. Persistent daemon: stays up across multiple lift calls,
+ * exits on `shutdown` or stdin EOF.
+ *
+ * Mirrors implementations/java/.../Rpc.java (the freshest cleanest peer)
+ * and implementations/typescript/.../mint-ts-self-contracts-rpc.cjs (the
+ * daemon-lifecycle pattern from PR #220).
+ *
+ * Handshake:
+ *   -> initialize
+ *   <- {name, version, protocol_version, capabilities}
+ *   -> lift
+ *   <- {kind:"proof-envelope", filename_cid, contract_set_cid, bytes_base64,
+ *       diagnostics:[]}
+ *   -> shutdown
+ *   <- null   (then process exits)
+ *
+ * Spec: protocol/specs/2026-04-30-lift-plugin-protocol.md
+ *
+ * JSON parsing is hand-rolled. The request shape is small and fixed
+ * (only `id` and `method` are read). Responses are emitted as strict
+ * JSON via a tiny writer that escapes the same characters JCS does.
+ * All emitted strings are CIDs / catalog literals / static names so
+ * non-ASCII never appears.
+ */
+
+#include "rpc.h"
+#include "orchestrator.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ----------------------------------------------------------------------- */
+/* Base64 (stdpad) — for bytes_base64 in lift response                      */
+/* ----------------------------------------------------------------------- */
+
+static const char B64_TABLE[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static char *base64_encode(const unsigned char *data, size_t len) {
+    size_t out_len = ((len + 2) / 3) * 4;
+    char *out = (char *)malloc(out_len + 1);
+    if (!out) return NULL;
+    size_t o = 0;
+    size_t i = 0;
+    while (i + 3 <= len) {
+        unsigned int n = ((unsigned)data[i] << 16) | ((unsigned)data[i+1] << 8) | data[i+2];
+        out[o++] = B64_TABLE[(n >> 18) & 0x3F];
+        out[o++] = B64_TABLE[(n >> 12) & 0x3F];
+        out[o++] = B64_TABLE[(n >> 6) & 0x3F];
+        out[o++] = B64_TABLE[n & 0x3F];
+        i += 3;
+    }
+    size_t rem = len - i;
+    if (rem == 1) {
+        unsigned int n = ((unsigned)data[i] << 16);
+        out[o++] = B64_TABLE[(n >> 18) & 0x3F];
+        out[o++] = B64_TABLE[(n >> 12) & 0x3F];
+        out[o++] = '=';
+        out[o++] = '=';
+    } else if (rem == 2) {
+        unsigned int n = ((unsigned)data[i] << 16) | ((unsigned)data[i+1] << 8);
+        out[o++] = B64_TABLE[(n >> 18) & 0x3F];
+        out[o++] = B64_TABLE[(n >> 12) & 0x3F];
+        out[o++] = B64_TABLE[(n >> 6) & 0x3F];
+        out[o++] = '=';
+    }
+    out[o] = '\0';
+    return out;
+}
+
+/* ----------------------------------------------------------------------- */
+/* tiny NDJSON request parsers                                              */
+/* ----------------------------------------------------------------------- */
+
+/* Find `"key"` in `s`, then return a pointer to the first non-whitespace
+ * character after the following `:`. Returns NULL if not found. Caller
+ * does NOT own the returned pointer (it's into `s`). */
+static const char *find_field(const char *s, const char *key) {
+    size_t klen = strlen(key);
+    /* Search for "<key>" */
+    const char *p = s;
+    while ((p = strchr(p, '"')) != NULL) {
+        if (strncmp(p + 1, key, klen) == 0 && p[1 + klen] == '"') {
+            const char *q = p + 1 + klen + 1;
+            while (*q && isspace((unsigned char)*q)) q++;
+            if (*q != ':') { p++; continue; }
+            q++;
+            while (*q && isspace((unsigned char)*q)) q++;
+            return q;
+        }
+        p++;
+    }
+    return NULL;
+}
+
+/* Parse a JSON string value at `p` into a malloc'd C string (no escape
+ * decoding beyond removing the surrounding quotes — sufficient for the
+ * `method` field we read). Returns NULL on failure. */
+static char *parse_string(const char *p) {
+    if (!p || *p != '"') return NULL;
+    p++;
+    const char *start = p;
+    while (*p && *p != '"') {
+        if (*p == '\\' && p[1]) p += 2;
+        else p++;
+    }
+    if (*p != '"') return NULL;
+    size_t len = (size_t)(p - start);
+    char *out = (char *)malloc(len + 1);
+    if (!out) return NULL;
+    memcpy(out, start, len);
+    out[len] = '\0';
+    return out;
+}
+
+/* Capture the literal id token (number, "string", true, false, null) at
+ * `p` into a malloc'd C string. We pass it through verbatim into the
+ * response. Returns NULL on failure (treat as id=null in caller). */
+static char *capture_id_literal(const char *p) {
+    if (!p) return NULL;
+    if (*p == '"') {
+        const char *q = p + 1;
+        while (*q && *q != '"') {
+            if (*q == '\\' && q[1]) q += 2; else q++;
+        }
+        if (*q != '"') return NULL;
+        size_t len = (size_t)(q - p + 1);
+        char *out = (char *)malloc(len + 1);
+        if (!out) return NULL;
+        memcpy(out, p, len);
+        out[len] = '\0';
+        return out;
+    }
+    /* number / true / false / null: read until terminator. */
+    const char *q = p;
+    while (*q && *q != ',' && *q != '}' && !isspace((unsigned char)*q)) q++;
+    size_t len = (size_t)(q - p);
+    if (len == 0) return NULL;
+    char *out = (char *)malloc(len + 1);
+    if (!out) return NULL;
+    memcpy(out, p, len);
+    out[len] = '\0';
+    return out;
+}
+
+/* ----------------------------------------------------------------------- */
+/* response writers                                                         */
+/* ----------------------------------------------------------------------- */
+
+/* Escape `s` as a JSON string literal (no surrounding quotes). All inputs
+ * here are ASCII-safe CIDs / catalog literals; we still escape `"` and
+ * `\` and control bytes for safety. */
+static char *json_escape(const char *s) {
+    if (!s) return NULL;
+    size_t n = strlen(s);
+    /* worst case: 6x growth (\u00XX) */
+    char *out = (char *)malloc(n * 6 + 1);
+    if (!out) return NULL;
+    size_t o = 0;
+    for (size_t i = 0; i < n; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (c == '"') { out[o++] = '\\'; out[o++] = '"'; }
+        else if (c == '\\') { out[o++] = '\\'; out[o++] = '\\'; }
+        else if (c < 0x20) {
+            out[o++] = '\\';
+            out[o++] = 'u';
+            out[o++] = '0';
+            out[o++] = '0';
+            const char *hex = "0123456789abcdef";
+            out[o++] = hex[(c >> 4) & 0xF];
+            out[o++] = hex[c & 0xF];
+        } else {
+            out[o++] = (char)c;
+        }
+    }
+    out[o] = '\0';
+    return out;
+}
+
+static const char *id_or_null(const char *id) {
+    return id ? id : "null";
+}
+
+static void write_initialize_response(const char *id) {
+    fprintf(stdout,
+        "{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{"
+        "\"name\":\"c-self-contracts\","
+        "\"version\":\"1.0.0\","
+        "\"protocol_version\":\"provekit-lift/1\","
+        "\"capabilities\":{"
+        "\"authoring_surfaces\":[\"c-self-contracts\"],"
+        "\"ir_version\":\"v1.1.0\","
+        "\"emits_signed_mementos\":true"
+        "}}}\n",
+        id_or_null(id));
+    fflush(stdout);
+}
+
+static void write_error(const char *id, int code, const char *message) {
+    char *esc = json_escape(message);
+    fprintf(stdout,
+        "{\"jsonrpc\":\"2.0\",\"id\":%s,\"error\":{\"code\":%d,\"message\":\"%s\"}}\n",
+        id_or_null(id), code, esc ? esc : "");
+    fflush(stdout);
+    free(esc);
+}
+
+static void write_shutdown_response(const char *id) {
+    fprintf(stdout, "{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":null}\n",
+            id_or_null(id));
+    fflush(stdout);
+}
+
+static void handle_lift(const char *id) {
+    mcsc_mint_result r;
+    mcsc_mint_result_init(&r);
+    if (mcsc_mint_one_run(NULL, &r) != 0) {
+        write_error(id, 1005, "LIFT_FAILED: mint_one_run returned non-zero");
+        return;
+    }
+    char *cid_esc = json_escape(r.cid);
+    char *cset_esc = json_escape(r.contract_set_cid);
+    char *b64 = base64_encode(r.bytes, r.bytes_len);
+    if (!cid_esc || !cset_esc || !b64) {
+        free(cid_esc); free(cset_esc); free(b64);
+        mcsc_mint_result_free(&r);
+        write_error(id, 1006, "LIFT_FAILED: out-of-memory encoding response");
+        return;
+    }
+    fprintf(stdout,
+        "{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{"
+        "\"kind\":\"proof-envelope\","
+        "\"filename_cid\":\"%s\","
+        "\"contract_set_cid\":\"%s\","
+        "\"bytes_base64\":\"%s\","
+        "\"diagnostics\":[]"
+        "}}\n",
+        id_or_null(id), cid_esc, cset_esc, b64);
+    fflush(stdout);
+    free(cid_esc);
+    free(cset_esc);
+    free(b64);
+    mcsc_mint_result_free(&r);
+}
+
+/* ----------------------------------------------------------------------- */
+/* Public entry                                                             */
+/* ----------------------------------------------------------------------- */
+
+int mcsc_run_rpc(void) {
+    char *line = NULL;
+    size_t cap = 0;
+#if defined(__APPLE__) || defined(__linux__)
+    ssize_t n;
+    while ((n = getline(&line, &cap, stdin)) != -1) {
+#else
+    /* Fallback: not used on POSIX systems we target. */
+    (void)cap;
+    while (fgets(line, 65536, stdin)) {
+        size_t n = strlen(line);
+#endif
+        if (n == 0) continue;
+        /* Trim trailing newline / whitespace. */
+        while (n > 0 && (line[n-1] == '\n' || line[n-1] == '\r' || isspace((unsigned char)line[n-1]))) {
+            line[--n] = '\0';
+        }
+        /* Skip leading whitespace. */
+        char *p = line;
+        while (*p && isspace((unsigned char)*p)) p++;
+        if (*p == '\0') continue;
+
+        const char *id_pos = find_field(p, "id");
+        char *id_lit = id_pos ? capture_id_literal(id_pos) : NULL;
+
+        const char *method_pos = find_field(p, "method");
+        char *method = method_pos ? parse_string(method_pos) : NULL;
+
+        if (!method) {
+            write_error(id_lit, -32600, "Invalid Request: missing `method`");
+            free(id_lit);
+            continue;
+        }
+
+        if (strcmp(method, "initialize") == 0) {
+            write_initialize_response(id_lit);
+        } else if (strcmp(method, "lift") == 0) {
+            handle_lift(id_lit);
+        } else if (strcmp(method, "shutdown") == 0 || strcmp(method, "exit") == 0) {
+            write_shutdown_response(id_lit);
+            free(id_lit);
+            free(method);
+            free(line);
+            return 0;
+        } else {
+            char buf[128];
+            snprintf(buf, sizeof(buf), "METHOD_NOT_FOUND: %s", method);
+            write_error(id_lit, -32601, buf);
+        }
+        free(id_lit);
+        free(method);
+    }
+    free(line);
+    return 0;
+}

--- a/implementations/c/mint-c-self-contracts/src/rpc.h
+++ b/implementations/c/mint-c-self-contracts/src/rpc.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#ifndef MCSC_RPC_H
+#define MCSC_RPC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Run the lift-plugin protocol RPC server on stdin/stdout. Returns
+ * process exit code (0 on graceful shutdown). */
+int mcsc_run_rpc(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MCSC_RPC_H */

--- a/implementations/c/mint-c-self-contracts/src/slab.c
+++ b/implementations/c/mint-c-self-contracts/src/slab.c
@@ -1,0 +1,268 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Slab + formula DSL implementations. See slab.h.
+ *
+ * Memory model: every constructor returns a freshly-malloc'd value;
+ * composing helpers take ownership of their argument values and place
+ * them inside the returned tree. On allocation failure the helpers
+ * return NULL after freeing partial state where possible — callers in
+ * c_kit_invariants.c check the final post-formula for NULL and error
+ * out the orchestrator if any author step OOMs.
+ */
+
+#include "slab.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* --- internal helpers --------------------------------------------------- */
+
+static char *dup_cstr(const char *s) {
+    if (!s) return NULL;
+    size_t n = strlen(s);
+    char *p = (char *)malloc(n + 1);
+    if (!p) return NULL;
+    memcpy(p, s, n + 1);
+    return p;
+}
+
+/* Build {"kind":<kind>, ... user pairs ... }. The user pairs are passed as
+ * (key, owned-value) parallel arrays; their values are placed into the
+ * resulting object via pksc_v_obj_set (which takes ownership). On failure
+ * everything is freed. Returns NULL on failure. */
+static pksc_value *build_obj(const char *kind,
+                             const char **keys,
+                             pksc_value **values,
+                             size_t n) {
+    pksc_value *o = pksc_v_obj_new();
+    if (!o) {
+        for (size_t i = 0; i < n; i++) pksc_value_free(values[i]);
+        return NULL;
+    }
+    pksc_value *kind_v = pksc_v_str(kind);
+    if (!kind_v) goto fail;
+    if (pksc_v_obj_set(o, "kind", kind_v) != 0) {
+        pksc_value_free(kind_v);
+        goto fail;
+    }
+    for (size_t i = 0; i < n; i++) {
+        if (pksc_v_obj_set(o, keys[i], values[i]) != 0) {
+            pksc_value_free(values[i]);
+            /* remaining values still owned by us; free them */
+            for (size_t j = i + 1; j < n; j++) pksc_value_free(values[j]);
+            goto fail;
+        }
+    }
+    return o;
+fail:
+    pksc_value_free(o);
+    return NULL;
+}
+
+/* --- Sort / var / const ------------------------------------------------- */
+
+pksc_value *mcsc_f_sort(const char *name) {
+    pksc_value *name_v = pksc_v_str(name);
+    if (!name_v) return NULL;
+    const char *keys[] = { "name" };
+    pksc_value *vals[] = { name_v };
+    return build_obj("primitive", keys, vals, 1);
+}
+
+pksc_value *mcsc_f_var(const char *name) {
+    pksc_value *name_v = pksc_v_str(name);
+    if (!name_v) return NULL;
+    const char *keys[] = { "name" };
+    pksc_value *vals[] = { name_v };
+    return build_obj("var", keys, vals, 1);
+}
+
+pksc_value *mcsc_f_str(const char *literal) {
+    pksc_value *value_v = pksc_v_str(literal);
+    pksc_value *sort_v = mcsc_f_sort("String");
+    if (!value_v || !sort_v) {
+        pksc_value_free(value_v);
+        pksc_value_free(sort_v);
+        return NULL;
+    }
+    const char *keys[] = { "value", "sort" };
+    pksc_value *vals[] = { value_v, sort_v };
+    return build_obj("const", keys, vals, 2);
+}
+
+pksc_value *mcsc_f_num(int64_t n) {
+    pksc_value *value_v = pksc_v_int(n);
+    pksc_value *sort_v = mcsc_f_sort("Int");
+    if (!value_v || !sort_v) {
+        pksc_value_free(value_v);
+        pksc_value_free(sort_v);
+        return NULL;
+    }
+    const char *keys[] = { "value", "sort" };
+    pksc_value *vals[] = { value_v, sort_v };
+    return build_obj("const", keys, vals, 2);
+}
+
+/* --- ctor / atomic ------------------------------------------------------ */
+
+static pksc_value *build_named_with_args(const char *kind, const char *name,
+                                         pksc_value **args, size_t n_args) {
+    pksc_value *name_v = pksc_v_str(name);
+    pksc_value *args_v = pksc_v_arr_new();
+    if (!name_v || !args_v) {
+        pksc_value_free(name_v);
+        pksc_value_free(args_v);
+        for (size_t i = 0; i < n_args; i++) pksc_value_free(args[i]);
+        return NULL;
+    }
+    for (size_t i = 0; i < n_args; i++) {
+        if (pksc_v_arr_push(args_v, args[i]) != 0) {
+            pksc_value_free(args[i]);
+            for (size_t j = i + 1; j < n_args; j++) pksc_value_free(args[j]);
+            pksc_value_free(name_v);
+            pksc_value_free(args_v);
+            return NULL;
+        }
+    }
+    const char *keys[] = { "name", "args" };
+    pksc_value *vals[] = { name_v, args_v };
+    return build_obj(kind, keys, vals, 2);
+}
+
+pksc_value *mcsc_f_ctor(const char *name, pksc_value **args, size_t n_args) {
+    return build_named_with_args("ctor", name, args, n_args);
+}
+
+pksc_value *mcsc_f_app(const char *name, pksc_value **args, size_t n_args) {
+    return build_named_with_args("atomic", name, args, n_args);
+}
+
+pksc_value *mcsc_f_eq(pksc_value *left, pksc_value *right) {
+    pksc_value *args[2] = { left, right };
+    return mcsc_f_app("eq", args, 2);
+}
+
+pksc_value *mcsc_f_gte(pksc_value *left, pksc_value *right) {
+    pksc_value *args[2] = { left, right };
+    return mcsc_f_app("gte", args, 2);
+}
+
+pksc_value *mcsc_f_starts_with(pksc_value *left, pksc_value *right) {
+    pksc_value *args[2] = { left, right };
+    return mcsc_f_app("starts_with", args, 2);
+}
+
+/* --- forall ------------------------------------------------------------- */
+
+pksc_value *mcsc_f_forall(const char *var_name, pksc_value *sort,
+                          mcsc_body_fn build_body, void *ctx) {
+    pksc_value *name_v = pksc_v_str(var_name);
+    pksc_value *bound = mcsc_f_var(var_name);
+    if (!name_v || !sort || !bound) {
+        pksc_value_free(name_v);
+        pksc_value_free(sort);
+        pksc_value_free(bound);
+        return NULL;
+    }
+    pksc_value *body = build_body(bound, ctx);
+    if (!body) {
+        pksc_value_free(name_v);
+        pksc_value_free(sort);
+        return NULL;
+    }
+    const char *keys[] = { "name", "sort", "body" };
+    pksc_value *vals[] = { name_v, sort, body };
+    return build_obj("forall", keys, vals, 3);
+}
+
+/* --- Slab + Collector --------------------------------------------------- */
+
+mcsc_slab *mcsc_slab_new(const char *label, const char *path) {
+    mcsc_slab *s = (mcsc_slab *)calloc(1, sizeof(*s));
+    if (!s) return NULL;
+    s->label = dup_cstr(label);
+    s->path = dup_cstr(path);
+    if (!s->label || !s->path) {
+        mcsc_slab_free(s);
+        return NULL;
+    }
+    return s;
+}
+
+static void mcsc_contract_free(mcsc_contract *c) {
+    if (!c) return;
+    free(c->name);
+    free(c->out_binding);
+    pksc_value_free(c->pre);
+    pksc_value_free(c->post);
+    pksc_value_free(c->inv);
+    free(c);
+}
+
+void mcsc_slab_free(mcsc_slab *s) {
+    if (!s) return;
+    free(s->label);
+    free(s->path);
+    for (size_t i = 0; i < s->n; i++) mcsc_contract_free(s->contracts[i]);
+    free(s->contracts);
+    free(s);
+}
+
+int mcsc_slab_must(mcsc_slab *s, const char *name, pksc_value *post_formula) {
+    if (!s || !name || !post_formula) {
+        pksc_value_free(post_formula);
+        return -1;
+    }
+    if (s->n == s->cap) {
+        size_t new_cap = s->cap ? s->cap * 2 : 4;
+        mcsc_contract **resized = (mcsc_contract **)realloc(
+            s->contracts, new_cap * sizeof(*resized));
+        if (!resized) {
+            pksc_value_free(post_formula);
+            return -1;
+        }
+        s->contracts = resized;
+        s->cap = new_cap;
+    }
+    mcsc_contract *c = (mcsc_contract *)calloc(1, sizeof(*c));
+    if (!c) {
+        pksc_value_free(post_formula);
+        return -1;
+    }
+    c->name = dup_cstr(name);
+    c->out_binding = dup_cstr("out");
+    if (!c->name || !c->out_binding) {
+        pksc_value_free(post_formula);
+        mcsc_contract_free(c);
+        return -1;
+    }
+    c->post = post_formula;
+    s->contracts[s->n++] = c;
+    return 0;
+}
+
+/* --- SlabList ----------------------------------------------------------- */
+
+mcsc_slab_list *mcsc_slab_list_new(void) {
+    return (mcsc_slab_list *)calloc(1, sizeof(mcsc_slab_list));
+}
+
+void mcsc_slab_list_free(mcsc_slab_list *l) {
+    if (!l) return;
+    for (size_t i = 0; i < l->n; i++) mcsc_slab_free(l->slabs[i]);
+    free(l->slabs);
+    free(l);
+}
+
+int mcsc_slab_list_push(mcsc_slab_list *l, mcsc_slab *s) {
+    if (!l || !s) return -1;
+    if (l->n == l->cap) {
+        size_t new_cap = l->cap ? l->cap * 2 : 4;
+        mcsc_slab **resized = (mcsc_slab **)realloc(l->slabs, new_cap * sizeof(*resized));
+        if (!resized) return -1;
+        l->slabs = resized;
+        l->cap = new_cap;
+    }
+    l->slabs[l->n++] = s;
+    return 0;
+}

--- a/implementations/c/mint-c-self-contracts/src/slab.h
+++ b/implementations/c/mint-c-self-contracts/src/slab.h
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Slab + ContractDecl + tiny formula DSL for the c self-contracts
+ * orchestrator. Mirrors implementations/java/.../Slab.java 1:1 in shape
+ * and JCS Value-tree output, so the bytes minted by this kit cohabit
+ * the same wire grammar as every other kit.
+ *
+ * Formula shapes track the cross-kit `formulaToValue` peer:
+ *   var:      {"kind":"var","name":<name>}
+ *   const:    {"kind":"const","value":<v>,"sort":<sort>}
+ *   ctor:     {"kind":"ctor","name":<name>,"args":[<term>...]}
+ *   atomic:   {"kind":"atomic","name":<name>,"args":[<term>...]}
+ *   forall:   {"kind":"forall","name":<name>,"sort":<sort>,"body":<formula>}
+ *   sort:     {"kind":"primitive","name":<name>}
+ *
+ * Each helper returns a freshly-malloc'd `pksc_value*` whose ownership
+ * passes to the caller. Composing helpers (`mcsc_f_app`, `mcsc_f_eq`,
+ * etc.) take ownership of their argument values and place them inside
+ * the returned tree, so callers never need to free intermediates.
+ */
+
+#ifndef MCSC_SLAB_H
+#define MCSC_SLAB_H
+
+#include <stddef.h>
+#include "provekit/self_contracts.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ----------------------------------------------------------------------- */
+/* ContractDecl + Slab + Collector                                          */
+/* ----------------------------------------------------------------------- */
+
+typedef struct mcsc_contract {
+    char       *name;        /* owned */
+    pksc_value *pre;         /* owned, nullable */
+    pksc_value *post;        /* owned, nullable */
+    pksc_value *inv;         /* owned, nullable */
+    char       *out_binding; /* owned */
+} mcsc_contract;
+
+typedef struct mcsc_slab {
+    char           *label;     /* owned */
+    char           *path;      /* owned */
+    mcsc_contract **contracts; /* owned array of owned ptrs */
+    size_t          n;
+    size_t          cap;
+} mcsc_slab;
+
+typedef struct mcsc_slab_list {
+    mcsc_slab **slabs; /* owned array of owned ptrs */
+    size_t      n;
+    size_t      cap;
+} mcsc_slab_list;
+
+mcsc_slab      *mcsc_slab_new(const char *label, const char *path);
+void            mcsc_slab_free(mcsc_slab *s);
+int             mcsc_slab_must(mcsc_slab *s, const char *name, pksc_value *post_formula);
+
+mcsc_slab_list *mcsc_slab_list_new(void);
+void            mcsc_slab_list_free(mcsc_slab_list *l);
+int             mcsc_slab_list_push(mcsc_slab_list *l, mcsc_slab *s);
+
+/* ----------------------------------------------------------------------- */
+/* Formula DSL — every constructor returns a malloc'd pksc_value tree.     */
+/* ----------------------------------------------------------------------- */
+
+pksc_value *mcsc_f_sort(const char *name);
+pksc_value *mcsc_f_var(const char *name);
+pksc_value *mcsc_f_str(const char *literal);
+pksc_value *mcsc_f_num(int64_t n);
+
+/* `name` is copied; `args` array is consumed (each element placed into the
+ * built tree; the `args` array itself is not freed by the helper). */
+pksc_value *mcsc_f_ctor(const char *name, pksc_value **args, size_t n_args);
+pksc_value *mcsc_f_app(const char *name, pksc_value **args, size_t n_args);
+
+pksc_value *mcsc_f_eq(pksc_value *left, pksc_value *right);
+pksc_value *mcsc_f_gte(pksc_value *left, pksc_value *right);
+pksc_value *mcsc_f_starts_with(pksc_value *left, pksc_value *right);
+
+/*
+ * Forall over a fresh variable named `var_name` of sort `sort` (consumed).
+ * `build_body` is called with the variable term to produce the body
+ * formula; both args go into the returned tree.
+ */
+typedef pksc_value *(*mcsc_body_fn)(pksc_value *bound_var, void *ctx);
+pksc_value *mcsc_f_forall(const char *var_name, pksc_value *sort,
+                          mcsc_body_fn build_body, void *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MCSC_SLAB_H */

--- a/implementations/c/provekit-self-contracts/.gitignore
+++ b/implementations/c/provekit-self-contracts/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts
+src/*.o
+tests/*.o
+tests/test_runner
+libprovekit-self-contracts.a

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -104,7 +104,7 @@ const KIT_TABLE: &[(&str, &str, &str, &str)] = &[
     ("python",     "python",      "python-self-contracts", "python"),
     ("ruby",       "ruby",        "ruby",                 "ruby"),
     ("zig",        "zig",         "zig",                  "zig"),
-    ("c",          "c",           "c",                    "c"),
+    ("c",          "c",           "c-self-contracts",     "c"),
 ];
 
 /// Resolve `--kit=<name>` to the canonical project path, lift surface, and lang key.

--- a/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
+++ b/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
@@ -154,12 +154,12 @@ fn assert_attestation_structure(v: &serde_json::Value, lang: &str) {
 /// fallback fires, producing an empty-set CID. The all-kits structure test
 /// tolerates this; the pinned-CID test (`swift_kit_pins_expected_contract_set_cid`)
 /// is `#[cfg_attr(not(target_os = "macos"), ignore)]` so it doesn't fail on Linux.
-const KITS_WITH_LIFTERS: &[&str] = &["rust", "go", "cpp", "ts", "csharp", "swift", "java", "python"];
+const KITS_WITH_LIFTERS: &[&str] = &["rust", "go", "cpp", "ts", "csharp", "swift", "java", "python", "c"];
 
 /// Kits without a lifter binary yet — produce the empty-set CID because the
 /// binary cannot be found (ENOENT on spawn). These declare the binary name but
 /// the binary is not installed; the gap surfaces as an empty-set attestation.
-const KITS_WITHOUT_LIFTERS: &[&str] = &["ruby", "zig", "c"];
+const KITS_WITHOUT_LIFTERS: &[&str] = &["ruby", "zig"];
 
 /// Kits that have a lifter AND are expected to find real contracts.
 /// Only include kits where the test environment reliably has the lifter built
@@ -763,4 +763,60 @@ fn python_kit_pins_expected_contract_set_cid() {
     );
 
     eprintln!("python kit pinned contractSetCid confirmed: {cset}");
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: --kit=c pins the expected contractSetCid (issue #215 regression gate)
+// ---------------------------------------------------------------------------
+
+/// Pinned contractSetCid produced by `--kit=c` after routing to the
+/// `c-self-contracts` surface (`mint-c-self-contracts --rpc`, canonical
+/// 6-slab, 30-contract set). Mirrors the rust / cpp / ts / go / java / swift
+/// pinning pattern.
+///
+/// If this test fails with the old empty-set CID (`d53d18c2...`), the
+/// KIT_TABLE routing regression has been reintroduced. If it fails with
+/// an unknown CID, the c slab contracts have changed -- update
+/// C_CONTRACT_SET_CID accordingly.
+///
+/// The surface is reached via:
+///   `implementations/c/.provekit/lift/c-self-contracts/manifest.toml`
+/// which spawns: `./mint-c-self-contracts/run-rpc.sh`.
+const C_CONTRACT_SET_CID: &str =
+    "blake3-512:50d08f4df4f8e16073d70a168292f3b3850aa557030a2a9ae65892aaac2b0e889204fa2cf602f4074ea85680aed37490fcbdc2ff73aa87c162fba16e57f40577";
+
+#[test]
+#[serial(mint_kit_files)]
+fn c_kit_pins_expected_contract_set_cid() {
+    let root = repo_root();
+
+    let (ok, stdout, stderr) = run_mint("c");
+    if !ok {
+        eprintln!(
+            "c kit: mint failed (libsodium / cc may not be available, or binary not built)\n  stderr: {stderr}"
+        );
+        // Skip rather than fail -- libsodium + the built binary may not be
+        // present in every test environment. CI builds via `make build-c-self-contracts`.
+        return;
+    }
+
+    assert!(
+        stdout.contains("contractSetCid:"),
+        "c kit: stdout must contain 'contractSetCid:'\n  stdout: {stdout}"
+    );
+
+    let attest = read_attestation(&root, "c");
+    let cset = attest["contractSetCid"].as_str().unwrap();
+
+    assert_ne!(
+        cset, EMPTY_SET_CID,
+        "c kit: contractSetCid must NOT be the empty-set sentinel -- routing regression detected (issue #215)"
+    );
+    assert_eq!(
+        cset, C_CONTRACT_SET_CID,
+        "c kit: contractSetCid does not match pinned value from 6-slab, 30-contract set (issue #215).\n\
+         If the self-contracts changed intentionally, update C_CONTRACT_SET_CID."
+    );
+
+    eprintln!("c kit contractSetCid pinned correctly: {cset}");
 }


### PR DESCRIPTION
## Summary

Side A of the c kit's substrate dogfood (closes #215). Mirrors the java Side A pattern (PR for #207), adapted to POSIX C and the c Side B library API (PR #230).

- New POSIX C orchestrator at \`implementations/c/mint-c-self-contracts/\` walking 6 slabs / 30 contracts (blake3, cbor, claim_envelope, ed25519, jcs, proof_envelope) authored against the c Side B static library
- CLI mode writes \`<cid>.proof\` and asserts byte-determinism; \`--rpc\` mode speaks \`provekit-lift/1\` over NDJSON
- KIT_TABLE wires \`--kit=c\` to the new \`c-self-contracts\` lift surface; pinned-CID test added to \`mint_kit_integration.rs\`; c moved from \`KITS_WITHOUT_LIFTERS\` to \`KITS_WITH_LIFTERS\`
- Boy-scout \`.gitignore\` entries for Side A + the pre-existing Side B gap from PR #230

## Acceptance (#215)

- [x] \`make mint-c\` produces a content-meaningful contractSetCid (\`blake3-512:50d08f4df4f8e160...\`)
- [x] \`provekit prove implementations/c\` exits 0
- [x] Pinned-CID test passes (\`c_kit_pins_expected_contract_set_cid\`)

## Stats

- 6 slabs, 30 contracts, all \`c_*\`-prefixed
- contractSetCid: \`blake3-512:50d08f4df4f8e16073d70a168292f3b3850aa557030a2a9ae65892aaac2b0e889204fa2cf602f4074ea85680aed37490fcbdc2ff73aa87c162fba16e57f40577\`
- catalog (filename) CID: \`blake3-512:f2723a762dd5d6ed5c16a4d3ba75cd39d4a63bbc021d018a22764bbfe5d74ae23d58820ed76f77e3fc8718df9d8f91fafb20437a0330c252817550c35ecd0aed\`
- 30 deterministic contract content CIDs

## Test plan

- [x] \`make -C implementations/c/mint-c-self-contracts\` builds clean (no warnings)
- [x] CLI: \`./mint-c-self-contracts /tmp/out\` produces a \`.proof\` file and prints CID + contractSetCid; second run into a sibling dir produces identical CIDs
- [x] RPC: \`initialize\` / \`lift\` / \`shutdown\` over stdio returns valid JSON-RPC v2 responses
- [x] \`make mint-c\` end-to-end: builds rust + c orchestrator, dispatches via \`provekit mint --kit=c\`, re-signs c.json, verify-self-contracts passes
- [x] \`make conformance\` PASS
- [x] \`cargo test -p provekit-cli --test mint_kit_integration c_kit_pins_expected_contract_set_cid\` passes
- [x] \`cargo test -p provekit-cli --test mint_kit_integration kits_without_lifters_produce_empty_set_cid\` still passes (after removing c from that list)
- [x] \`cargo test -p provekit-cli --test mint_kit_integration all_kits_mint_produces_valid_attestation_structure\` still passes

## Notes

The c orchestrator uses a simpler member model than java/go: each \`pksc_member\` has key = \`contentCid\` (BLAKE3-512(JCS({name, outBinding, pre?, post?, inv?}))) and bytes = those same JCS bytes. This is what the issue text explicitly specifies for c, since the c Side B library doesn't expose a \`mintContract\` (layered memento) API. The contractSetCid is byte-equivalent across kits because it's computed from the same contentCids regardless of kit; the catalog filename CID is unique to c because the member bytes differ from kits that ship signed mementos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)