### PR TITLE
chore(conformance): extend all-mint to include java + python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         # them up via the wheels in PyPI. Without this step, mint-python
         # fails with ModuleNotFoundError once it's wired into all-mint.
         # Mirrors how `cache: maven` + setup-java provisions java's deps.
-        run: pip install -e implementations/python
+        run: pip install -e implementations/python/provekit-lift-py-tests
 
       - name: Set up Java 21 + Maven
         # build-java (added by java-agent E2E work) calls `mvn package`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,15 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      - name: Install python kit wheels (blake3, pynacl, cbor2)
+        # mint-python invokes the mint-python-self-contracts orchestrator
+        # which imports blake3 / pynacl / cbor2 at runtime. The kit ships
+        # these as deps in its pyproject.toml; an editable install picks
+        # them up via the wheels in PyPI. Without this step, mint-python
+        # fails with ModuleNotFoundError once it's wired into all-mint.
+        # Mirrors how `cache: maven` + setup-java provisions java's deps.
+        run: pip install -e implementations/python
+
       - name: Set up Java 21 + Maven
         # build-java (added by java-agent E2E work) calls `mvn package`.
         # pom.xml sets maven.compiler.source/target=17; Temurin 21 is

--- a/Makefile
+++ b/Makefile
@@ -312,17 +312,22 @@ mint-c: build-rust
 		(echo "FAIL: c self-contracts attestation rejected; re-mint and commit:" && \
 		 echo "      $(PROVEKIT) mint --kit=c" && exit 1)
 
-# NOTE: mint-swift excluded from all-mint (macOS-only). New kits (java/python/
-# ruby/zig/c) produce empty-set attestations until their lifters are wired up.
+# NOTE: mint-swift excluded from all-mint (macOS-only). java + python wired up
+# after their Side A landings (#207, #205) — both produce content-meaningful
+# contractSetCids and ship pinned attestations. ruby/zig/c/php pending their
+# Side A merges (#234, #241, #272, feat/php-kit) and toolchain CI integration
+# (#245 in flight, #274 follow-up).
 .PHONY: all-mint
-all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp
+all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python
 	@echo ""
-	@echo "==== all 5 core self-contract CIDs match pinned values ===="
+	@echo "==== all 7 core self-contract CIDs match pinned values ===="
 	@printf "  %-8s  %s\n" "rust"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/rust.json)"
 	@printf "  %-8s  %s\n" "go"     "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/go.json)"
 	@printf "  %-8s  %s\n" "cpp"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/cpp.json)"
 	@printf "  %-8s  %s\n" "ts"     "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/ts.json)"
 	@printf "  %-8s  %s\n" "csharp" "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/csharp.json)"
+	@printf "  %-8s  %s\n" "java"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/java.json)"
+	@printf "  %-8s  %s\n" "python" "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/python.json)"
 
 # --- Conformance gate --------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Both java (#207) and python (#205) Side A landed tonight with content-meaningful contractSetCids and pinned attestation files. The conformance gate's `all-mint` target was still the original 5-kit list (rust/go/cpp/ts/csharp); java + python were unminted in CI.

This wires their mint targets in so `make conformance` empirically exercises the byte-equivalence gate across **7 of the 11 supported kits**, not 5.

## What's still outside `all-mint`

- **swift** — explicitly excluded (macOS-only per existing Makefile comment)
- **ruby** — pending Side A merge (#234) + toolchain CI integration (#245)
- **zig** — pending Side A merge (#241) + toolchain CI integration (#245, currently zig deferred)
- **c** — pending Side A merge (#272 mine — already passing locally; libsodium-dev added in CI by #230)
- **php** — pending kit merge (`feat/php-kit`) + conformance integration (#274)

Each will get its own `mint-X` added to `all-mint` as its dependencies land.

## Test plan

- [ ] `make conformance` green on this branch (the 2 new kits' attestations are already on main; should pass)
- [ ] CI ProvekIt + Cross-language conformance gate workflows green

🤖 Generated with [Claude Code](https://claude.com/claude-code)