### PR TITLE
fix(c): add _GNU_SOURCE + sys/types.h to rpc.c (unblocks #278)

### DIFF
--- a/implementations/c/mint-c-self-contracts/src/rpc.c
+++ b/implementations/c/mint-c-self-contracts/src/rpc.c
@@ -26,6 +26,13 @@
  * non-ASCII never appears.
  */
 
+/*
+ * _GNU_SOURCE: getline() is a POSIX 2008 / GNU extension, gated behind
+ * _GNU_SOURCE on glibc. Without this define, getline() declaration is
+ * suppressed and the build errors with "implicit declaration".
+ */
+#define _GNU_SOURCE
+
 #include "rpc.h"
 #include "orchestrator.h"
 
@@ -33,6 +40,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>  /* ssize_t */
 
 /* ----------------------------------------------------------------------- */
 /* Base64 (stdpad) — for bytes_base64 in lift response                      */


### PR DESCRIPTION
## Bug

C kit's `mint-c-self-contracts/src/rpc.c` uses `getline()` and `ssize_t` without the required feature-test macros. On glibc, `getline()` is gated behind `_GNU_SOURCE`; `ssize_t` comes from `<sys/types.h>`. PR #272 (c Side A) compiled locally because the developer's environment had `_GNU_SOURCE` defined globally; CI's apt-installed gcc does not.

CI failure on #278:
```
src/rpc.c:259:5: error: unknown type name 'ssize_t'; did you mean 'size_t'?
src/rpc.c:260:17: warning: implicit declaration of function 'getline'
```

(Run: https://github.com/TSavo/provekit/actions/runs/25317553924)

## Fix

Adds `#define _GNU_SOURCE` (file-local) and `#include <sys/types.h>` (for `ssize_t`). Standard glibc practice.

## Test plan

- [ ] CI conformance gate green on this branch (will exercise the c orchestrator build)
- [ ] After merge, #278's `mint-c` step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)