### PR TITLE
chore(conformance): add mint-ruby to all-mint (9/12 toward #277)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,9 +331,9 @@ mint-c: build-rust build-c-self-contracts
 # Side A merges (#234, #241, #272, feat/php-kit) and toolchain CI integration
 # (#245 in flight, #274 follow-up).
 .PHONY: all-mint
-all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python mint-c mint-zig
+all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python mint-c mint-ruby mint-zig
 	@echo ""
-	@echo "==== all 9 core self-contract CIDs match pinned values ===="
+	@echo "==== all 10 core self-contract CIDs match pinned values ===="
 	@printf "  %-8s  %s\n" "rust"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/rust.json)"
 	@printf "  %-8s  %s\n" "go"     "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/go.json)"
 	@printf "  %-8s  %s\n" "cpp"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/cpp.json)"
@@ -342,6 +342,7 @@ all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python m
 	@printf "  %-8s  %s\n" "java"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/java.json)"
 	@printf "  %-8s  %s\n" "python" "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/python.json)"
 	@printf "  %-8s  %s\n" "c"      "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/c.json)"
+	@printf "  %-8s  %s\n" "ruby"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/ruby.json)"
 	@printf "  %-8s  %s\n" "zig"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/zig.json)"
 
 # --- Per-kit prove (C1-C8 conformance gate) ----------------------------------

--- a/Makefile
+++ b/Makefile
@@ -289,8 +289,15 @@ mint-python: build-rust
 		(echo "FAIL: python self-contracts attestation rejected; re-mint and commit:" && \
 		 echo "      $(PROVEKIT) mint --kit=python" && exit 1)
 
+.PHONY: build-ruby-ext
+build-ruby-ext:
+	@echo ">> building ruby BLAKE3 C extension (vendored, zero-deps)"
+	@cd implementations/ruby/ext/provekit_blake3 && \
+		(test -f Makefile || ruby extconf.rb >/dev/null) && \
+		$(MAKE) --no-print-directory >/dev/null
+
 .PHONY: mint-ruby
-mint-ruby: build-rust
+mint-ruby: build-rust build-ruby-ext
 	@echo ">> minting ruby self-contracts"
 	@mint_out=$$($(PROVEKIT) mint --kit=ruby --quiet); \
 	cid=$$(echo "$$mint_out" | head -1); \
@@ -404,7 +411,7 @@ prove-python: build-rust
 	$(PROVEKIT) prove --kit=python
 
 .PHONY: prove-ruby
-prove-ruby: build-rust
+prove-ruby: build-rust build-ruby-ext
 	@echo ">> proving ruby lift-plugin-protocol conformance (C1-C8)"
 	$(PROVEKIT) prove --kit=ruby
 


### PR DESCRIPTION
## Summary

Ruby Side A landed via #234, Side B closure via #244. Ruby crypto + CI toolchain (#245) all in. Wires `mint-ruby` into the `all-mint` Makefile target so `make conformance` now exercises **9 of 12 kits**: rust, go, cpp, ts, csharp, java, python, c, ruby.

Step 4 of the [12/12 conformance epic #277](https://github.com/TSavo/provekit/issues/277).

## Still outside all-mint

- zig (pending setup-zig mirror reliability fix)
- swift (macOS-only; separate macOS-runner job)
- php (pending mint orchestrator)

## Test plan

- [ ] CI conformance gate green
- [ ] make conformance produces 9 attestations matching pinned CIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ruby contract minting to the aggregate build, so Ruby contracts are included in core minting runs.

* **Chores**
  * Build now ensures the Ruby native extension is prepared before minting/proving.
  * Updated build validation message to reflect 10 core self-contract CID checks (was 9).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->