### PR TITLE
fix(ruby): wrap mint-ruby-self-contracts in bundle exec (unblocks #282)

### DIFF
--- a/implementations/ruby/.provekit/lift/ruby-self-contracts/manifest.toml
+++ b/implementations/ruby/.provekit/lift/ruby-self-contracts/manifest.toml
@@ -1,7 +1,7 @@
 name = "ruby-self-contracts"
 version = "1.0.0"
 protocol_version = "provekit-lift/1"
-command = ["ruby", "-Ilib", "bin/mint-ruby-self-contracts"]
+command = ["bundle", "exec", "ruby", "-Ilib", "bin/mint-ruby-self-contracts"]
 working_dir = "."
 
 [capabilities]


### PR DESCRIPTION
## Bug

\`make mint-ruby\` fails on CI:

```
cannot load such file -- ffi (LoadError)
  from implementations/ruby/lib/provekit/blake3.rb:21:in \`<top (required)>\`
```

The manifest at \`implementations/ruby/.provekit/lift/ruby-self-contracts/manifest.toml\` invokes \`ruby -Ilib bin/mint-ruby-self-contracts\` directly. \`setup-ruby@v1\` with \`bundler-cache: true\` installs gems to \`vendor/bundle/\` (bundle-managed path), which plain \`ruby\` doesn't see on \$LOAD_PATH.

## Fix

Wrap the command in \`bundle exec\`. Standard Ruby pattern. The \`Gemfile\` + \`gemspec\` already declare the deps (\`ffi\`, \`ed25519\`); \`bundle exec\` activates the gem set bundler installed.

## Unblocks

- #282 (mint-ruby in all-mint, 9/12 toward #277)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the execution method for the Ruby tool to ensure proper dependency management through bundled packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->