### PR TITLE
feat(ci): add zig 0.16.0 toolchain via pinned upstream URL (closes #283, advances #277 to 9/12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,9 +187,31 @@ jobs:
           bundler-cache: true
           working-directory: implementations/ruby
 
-      # Zig setup deferred to a separate PR. mlugg/setup-zig@v1 with
-      # version: master gets 404s/503s across every mirror because the
-      # kit needs unreleased 0.16/0.17-dev API. Tracked as a follow-up.
+      - name: Install Zig 0.16.0 (pinned upstream stable)
+        # Issue #283. mint-zig-self-contracts (PR #241, issue #213) ships
+        # an orchestrator that the rust CLI invokes via lift-plugin-protocol
+        # RPC. Without zig on PATH the orchestrator binary errors at exec
+        # and the contractSetCid pinned-CID test sees the empty-set sentinel.
+        #
+        # The kit's std.ArrayList unmanaged-by-default usage (PR #168/#171)
+        # requires zig 0.16's std API. Issue #283 recommended pinning a
+        # 0.16-dev nightly URL because 0.16 was unreleased at the time it
+        # was filed; 0.16.0 shipped 2026-04-14, so we pin the stable
+        # release URL instead -- same pinned-URL property, no nightly-
+        # regression risk. ziglang.org keeps every release indefinitely.
+        # Refresh this URL only when the kit's std API requirements change.
+        #
+        # mlugg/setup-zig@v1 was tried in PR #245 and 404/503'd across
+        # every mirror; curl from ziglang.org is the simplest path that
+        # actually works.
+        run: |
+          set -euxo pipefail
+          ZIG_URL="https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
+          curl -fsSL "$ZIG_URL" -o /tmp/zig.tar.xz
+          sudo mkdir -p /usr/local/zig
+          sudo tar -xf /tmp/zig.tar.xz -C /usr/local/zig --strip-components=1
+          sudo ln -sf /usr/local/zig/zig /usr/local/bin/zig
+          zig version
 
       # ---------------------------------------------------------------
       # The gate.

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@
 #
 # Mainline targets:
 #   make help        — print this help
-#   make ci          — full conformance gate (catalog + protocol + 5 mints + tests)
-#   make conformance — catalog + protocol + 5 mint CIDs + self-contract tests
-#   make all-mint    — run all 5 mint commands; print CIDs (Linux/CI subset)
+#   make ci          — full conformance gate (catalog + protocol + 9 mints + tests)
+#   make conformance — catalog + protocol + 9 mint CIDs + self-contract tests
+#   make all-mint    — run all 9 mint commands; print CIDs (Linux/CI subset)
 #   make test-all    — run every language-native test suite (Linux/CI subset)
 #
 # Per-language targets:
@@ -64,9 +64,9 @@ help:
 	@echo "ProvekIt — top-level orchestrator"
 	@echo ""
 	@echo "Mainline:"
-	@echo "  make ci             full gate (conformance + test-all) [Linux/CI: 5 peer langs]"
-	@echo "  make conformance    catalog + protocol + 5 mint CIDs + self-contract tests"
-	@echo "  make all-mint       5 mint commands (Swift excluded: macOS-only, use mint-swift)"
+	@echo "  make ci             full gate (conformance + test-all) [Linux/CI: 9 peer langs]"
+	@echo "  make conformance    catalog + protocol + 9 mint CIDs + self-contract tests"
+	@echo "  make all-mint       9 mint commands (Swift excluded: macOS-only, use mint-swift)"
 	@echo "  make test-all       language test suites (Swift excluded: macOS-only, use test-swift)"
 	@echo ""
 	@echo "Per-language build:"
@@ -325,9 +325,9 @@ mint-c: build-rust build-c-self-contracts
 # Side A merges (#234, #241, #272, feat/php-kit) and toolchain CI integration
 # (#245 in flight, #274 follow-up).
 .PHONY: all-mint
-all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python mint-c
+all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python mint-c mint-zig
 	@echo ""
-	@echo "==== all 8 core self-contract CIDs match pinned values ===="
+	@echo "==== all 9 core self-contract CIDs match pinned values ===="
 	@printf "  %-8s  %s\n" "rust"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/rust.json)"
 	@printf "  %-8s  %s\n" "go"     "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/go.json)"
 	@printf "  %-8s  %s\n" "cpp"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/cpp.json)"
@@ -336,6 +336,7 @@ all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python m
 	@printf "  %-8s  %s\n" "java"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/java.json)"
 	@printf "  %-8s  %s\n" "python" "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/python.json)"
 	@printf "  %-8s  %s\n" "c"      "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/c.json)"
+	@printf "  %-8s  %s\n" "zig"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/zig.json)"
 
 # --- Conformance gate --------------------------------------------------------
 

--- a/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
+++ b/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
@@ -289,13 +289,12 @@ const KITS_WITHOUT_LIFTERS: &[&str] = &[];
 /// `swift` is on macOS only; the all-kits run handles Linux gracefully via the
 /// `failed_kits` skip path because the release binary is missing.
 ///
-/// zig: not in KITS_WITH_REAL_CONTRACTS until setup-zig is wired up in CI
-/// (mirror network reliability -- issue #277 follow-up). The binary exists
-/// in the repo; it just isn't built on the CI runner. The individual
-/// `zig_kit_contract_set_cid_is_pinned_to_self_contracts_canonical` test
-/// keeps its skip-on-empty-set guard so it passes locally when developers
-/// have zig 0.16-master on PATH.
-const KITS_WITH_REAL_CONTRACTS: &[&str] = &["rust", "go", "cpp", "python", "ruby"];
+/// zig: re-included after issue #283 wired zig 0.16.0 stable into CI via a
+/// pinned upstream URL (curl from ziglang.org/download/0.16.0). The
+/// `mint-zig-self-contracts` orchestrator builds cleanly on 0.16.0 and
+/// produces the pinned contractSetCid. Local dev still requires zig 0.16+
+/// on PATH; the per-kit pinned-CID test keeps its skip-on-empty-set guard.
+const KITS_WITH_REAL_CONTRACTS: &[&str] = &["rust", "go", "cpp", "python", "ruby", "zig"];
 
 /// Pinned contractSetCid for `--kit=go` after Tier 1 wiring fix (#176).
 /// Reflects the 11 canonical contracts in `implementations/go/provekit-self-contracts/slabs/`.


### PR DESCRIPTION
## Summary

Closes #283. Adds a CI step that installs zig 0.16.0 from a pinned URL, then re-includes zig in the conformance gate so `make conformance` mints all 9 Linux/CI peer kits including zig.

## Deviation from issue text (read this)

Issue #283 recommended **Option D**: pin a specific 0.16-**dev nightly** URL because 0.16 was unreleased at write-time. Since the issue was filed, **zig 0.16.0 shipped (2026-04-14)** and is in `https://ziglang.org/download/index.json` alongside `master`.

This PR pins the **stable 0.16.0** release URL instead of a nightly. Strictly better than D:
- Same pinned-URL property (ziglang.org keeps every release indefinitely)
- No nightly-regression risk
- The architect's reason for rejecting Option C ("wait for release: months away") is no longer true

The acceptance checklist in #283 says "0.16-dev"; this delivers 0.16.0-stable, which I read as a strict superset of the spec. Calling that out explicitly so the issue author can reject if they disagree.

Verified empirically:

```
$ zig version
0.16.0
$ make mint-zig
>> minting zig self-contracts
  cid:            blake3-512:891887b2bdbefe6ff9bcb95dda6fca02711a58cac2b3cabac29b79ee0c47373ad223bc33ea98be141596d6943ffde64aba37865c9a08658c3cee71d27f822308
  contractSetCid: blake3-512:405ff171d26342acab133240baeac8774de95f66d03d4748ca9254233e1e143be6a8d2322319da73942650589bf54b2f3ac8875e6e3a34f5cd3699cad20e93e3
OK  .provekit/self-contracts-attestations/zig.json
$ curl -fsI https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | head -1
HTTP/1.1 200 OK
```

## Changes

### `.github/workflows/ci.yml`
Replace the deferred-zig comment block with a real install step that curls the pinned tarball, extracts to `/usr/local/zig`, and symlinks `/usr/local/bin/zig`. Comment in the step explains the chain of reasoning: why curl (mlugg/setup-zig 404/503'd in PR #245), why stable not nightly (0.16.0 shipped after #283 was filed).

### `Makefile`
- Add `mint-zig` to `all-mint`'s prerequisites
- Add the zig printf line to the post-mint banner
- Bump "5 mint commands" -> "9" in `make help` and the leading doc block (boy-scout: comments were stale even before this PR; current `all-mint` already has 8)

### `implementations/rust/provekit-cli/tests/mint_kit_integration.rs`
- Re-include `"zig"` in `KITS_WITH_REAL_CONTRACTS` (dropped at end of PR #241 because zig wasn't on the CI runner)
- Update the surrounding doc comment to reflect why it's safe now

## Pinned URL

`https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz`
- Verified 200 OK with `curl -fsI` (Last-Modified 2026-04-14, 53 MB)
- ziglang.org never deletes release artifacts

## Local mint-zig CID match

`blake3-512:405ff171d26342acab133240baeac8774de95f66d03d4748ca9254233e1e143be6a8d2322319da73942650589bf54b2f3ac8875e6e3a34f5cd3699cad20e93e3` — matches the pinned value baked into `.provekit/self-contracts-attestations/zig.json` and the `ZIG_CONTRACT_SET_CID` constant in the test file.

## Acceptance (from #283)

- [x] CI installs zig 0.16 at a pinned URL (0.16.0 stable, better than -dev)
- [x] `make mint-zig` runs in CI and produces the pinned contractSetCid `blake3-512:405ff171d26342acab133240baeac8774de95f66d03d4748ca9254233e1e143be6a8d2322319da73942650589bf54b2f3ac8875e6e3a34f5cd3699cad20e93e3` (verified locally on macOS aarch64; CID is JCS-deterministic over kit source bytes, expect match on Linux x86_64 too)
- [x] `mint-zig` added to `all-mint` in Makefile (count: 8 -> 9)
- [x] `KITS_WITH_REAL_CONTRACTS` re-includes `"zig"`
- [x] `zig_kit_contract_set_cid_is_pinned_to_self_contracts_canonical` no longer skips on CI (zig binary on PATH; the skip-on-empty-set guard remains for local dev without zig installed)

## Test plan

- [x] `zig version` -> 0.16.0
- [x] `zig build` succeeds for `mint-zig-self-contracts`
- [x] `make mint-zig` -> pinned CID match
- [x] `cargo test --release -p provekit-cli --test mint_kit_integration zig_kit_contract_set_cid_is_pinned_to_self_contracts_canonical` -> 1 pass
- [x] `yq eval . .github/workflows/ci.yml` -> valid YAML
- [ ] CI green (this PR)

## Note on `kits_with_real_contracts_produce_nonempty_contract_set`

Locally fails on `cpp` (cpp lifter binary not built in this dev env), which is the documented skip-on-not-built behavior; not introduced by this PR. CI will have all lifters built so this should pass with zig included.

## Step in epic #277

Step 4 (zig CI follow-up) -> done. Conformance gate count: 9/12. Remaining: ruby + c Makefile add (other PRs), swift macOS-runner, php Side A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)