### PR TITLE
fix(ruby): vendor BLAKE3 C extension — drop libblake3 system dep (closes #247)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,30 +152,6 @@ jobs:
             nlohmann-json3-dev \
             z3
 
-      - name: Build + install libblake3 from upstream
-        # Ubuntu 24.04 LTS apt does not ship libblake3-dev (added in
-        # Ubuntu 25.10). The Ruby kit's BLAKE3 binding goes through FFI
-        # to libblake3 because no rubygem on Ruby 3.x exposes 64-byte
-        # XOF mode (per PR #226 notes: digest-blake3, blake3-rb,
-        # blake3ruby all 32-byte only). Build libblake3 from the
-        # official upstream and install to /usr/local/lib so Ruby's
-        # FFI loader finds it.
-        #
-        # Future: vendor BLAKE3 in the ruby kit itself (tools/blake3-vendored/
-        # is already in the repo for cpp). Tracked separately.
-        run: |
-          set -euxo pipefail
-          BLAKE3_VERSION=1.5.4
-          curl -fsSL "https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/${BLAKE3_VERSION}.tar.gz" -o /tmp/blake3.tar.gz
-          mkdir -p /tmp/blake3-build
-          tar -xzf /tmp/blake3.tar.gz -C /tmp/blake3-build
-          cd /tmp/blake3-build/BLAKE3-${BLAKE3_VERSION}/c
-          cmake -B build -DBLAKE3_USE_TBB=OFF -DBUILD_SHARED_LIBS=ON
-          cmake --build build --config Release
-          sudo cmake --install build
-          sudo ldconfig
-          ldconfig -p | grep -i blake3 || (echo "libblake3 not registered" && exit 1)
-
       - name: Set up Ruby 3.3
         # mint-ruby-self-contracts (PR #234, issue #209) ships a Ruby
         # orchestrator that the rust CLI invokes via the lift-plugin-protocol

--- a/implementations/ruby/ext/provekit_blake3/extconf.rb
+++ b/implementations/ruby/ext/provekit_blake3/extconf.rb
@@ -1,0 +1,29 @@
+# extconf.rb for provekit_blake3 C extension.
+# Statically links vendored BLAKE3 from tools/blake3-vendored/.
+# Portable-only, zero system deps.
+
+require "mkmf"
+
+dir_config("blake3")
+
+$CFLAGS << " -std=c11"
+$DEFLIBPATH = []
+
+# Vendored BLAKE3 root
+B3_DIR = File.expand_path("../../../../../tools/blake3-vendored", __dir__)
+abort "vendored BLAKE3 not found at #{B3_DIR}" unless File.exist?(File.join(B3_DIR, "blake3.c"))
+
+# Copy vendored sources + headers into the ext dir
+%w[blake3.c blake3_portable.c blake3_dispatch.c blake3.h blake3_impl.h].each do |fn|
+  src = File.join(B3_DIR, fn)
+  dst = File.join(__dir__, fn)
+  FileUtils.cp(src, dst) unless File.exist?(dst) && File.mtime(dst) >= File.mtime(src)
+end
+
+# Compile vendored .c files as part of the extension
+$objs = %w[provekit_blake3.o blake3.o blake3_portable.o blake3_dispatch.o]
+
+# Configure vendored BLAKE3 for portable build
+$CFLAGS << " -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512 -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41"
+
+create_makefile("provekit/blake3")

--- a/implementations/ruby/ext/provekit_blake3/provekit_blake3.c
+++ b/implementations/ruby/ext/provekit_blake3/provekit_blake3.c
@@ -1,0 +1,76 @@
+/**
+ * provekit_blake3 — Ruby C extension wrapping vendored BLAKE3.
+ *
+ * Exposes three methods on Provekit::Blake3 (class-level):
+ *   Blake3.hasher_init        → FFI::MemoryPointer (1 blake3_hasher, 4096 bytes)
+ *   Blake3.hasher_update(ptr, data_string) → nil
+ *   Blake3.hasher_finalize(ptr, out_len)   → raw bytes string
+ *
+ * Statically links blake3.c + blake3_portable.c + blake3_dispatch.c
+ * from tools/blake3-vendored/. Zero system deps.
+ */
+
+#include <ruby.h>
+#include "blake3.h"
+
+#define HASHER_SIZE 4096
+
+/* ── Module declarations ──────────────────────────── */
+
+static VALUE rb_cBlake3;
+
+/* ── hasher_init(self) → FFI::MemoryPointer ──────────── */
+
+static VALUE
+blake3_hasher_init(VALUE self)
+{
+    blake3_hasher *h = (blake3_hasher *)ruby_xmalloc(sizeof(blake3_hasher));
+    blake3_hasher_init(h);
+    return rb_str_new((const char *)h, sizeof(blake3_hasher));
+}
+
+/* ── hasher_update(self, hasher_str, data_str) → nil ── */
+
+static VALUE
+blake3_hasher_update(VALUE self, VALUE hasher_str, VALUE data_str)
+{
+    Check_Type(hasher_str, T_STRING);
+    Check_Type(data_str, T_STRING);
+
+    blake3_hasher *h = (blake3_hasher *)RSTRING_PTR(hasher_str);
+    blake3_hasher_update(h, RSTRING_PTR(data_str), RSTRING_LEN(data_str));
+
+    return Qnil;
+}
+
+/* ── hasher_finalize(self, hasher_str, out_len_fixnum) → String ─── */
+
+static VALUE
+blake3_hasher_finalize(VALUE self, VALUE hasher_str, VALUE out_len_val)
+{
+    Check_Type(hasher_str, T_STRING);
+
+    blake3_hasher *h = (blake3_hasher *)RSTRING_PTR(hasher_str);
+    size_t out_len = (size_t)NUM2ULONG(out_len_val);
+
+    VALUE out_str = rb_str_new(NULL, out_len);
+    blake3_hasher_finalize(h, (uint8_t *)RSTRING_PTR(out_str), out_len);
+
+    /* Free the hasher — finalize consumes it */
+    ruby_xfree(h);
+
+    return out_str;
+}
+
+/* ── Init ──────────────────────────────────────────── */
+
+void
+Init_blake3(void)
+{
+    rb_cBlake3 = rb_define_module("Provekit");
+    VALUE rb_cBlake3Inner = rb_define_class_under(rb_cBlake3, "Blake3", rb_cObject);
+
+    rb_define_singleton_method(rb_cBlake3Inner, "hasher_init",    RUBY_METHOD_FUNC(blake3_hasher_init),    0);
+    rb_define_singleton_method(rb_cBlake3Inner, "hasher_update",  RUBY_METHOD_FUNC(blake3_hasher_update),  2);
+    rb_define_singleton_method(rb_cBlake3Inner, "hasher_finalize",RUBY_METHOD_FUNC(blake3_hasher_finalize),2);
+}

--- a/implementations/ruby/lib/provekit/blake3.rb
+++ b/implementations/ruby/lib/provekit/blake3.rb
@@ -2,12 +2,9 @@
 #
 # BLAKE3-512 hash for ProvekIt (64-byte XOF output).
 #
-# Backed natively by libblake3 via FFI. No subprocess shell-out.
-#
-# Prereq: libblake3 must be installed on the system.
-#   macOS:  brew install blake3
-#   Debian: apt-get install libblake3-dev
-#   Other:  https://github.com/BLAKE3-team/BLAKE3 (build from source)
+# Backed by a vendored C extension that statically links
+# tools/blake3-vendored/. Zero system deps — no libblake3,
+# no FFI, no subprocess.
 #
 # Usage:
 #   require "provekit/blake3"
@@ -18,62 +15,27 @@
 #   - Rust: implementations/rust/provekit-canonicalizer (blake3_512_of)
 #   - Python: blake3 PyPI package, .digest(length=64)
 
-require "ffi"
+require "provekit/blake3" rescue begin
+  # Native extension not yet compiled — try require directly
+  require_relative "../../ext/provekit_blake3/provekit_blake3"
+end
 
 module Provekit
-  module Blake3
-    # libblake3 binding. Search common platform paths in order; first hit wins.
-    # macOS Homebrew (intel + arm), Debian/Ubuntu, generic SONAME.
-    module Native
-      extend FFI::Library
-
-      LIB_CANDIDATES = [
-        "blake3",
-        "libblake3.so.1",
-        "libblake3.so.0",
-        "libblake3.so",
-        "libblake3.dylib",
-        "libblake3.0.dylib",
-        "/usr/local/lib/libblake3.dylib",   # macOS x86_64 Homebrew
-        "/opt/homebrew/lib/libblake3.dylib", # macOS arm64 Homebrew
-        "/usr/lib/libblake3.so.1",
-        "/usr/lib/x86_64-linux-gnu/libblake3.so.1",
-        "/usr/lib/aarch64-linux-gnu/libblake3.so.1",
-      ].freeze
-
-      ffi_lib LIB_CANDIDATES
-
-      # blake3_hasher state struct sized generously per blake3.h:
-      #   key (32) + chunk_state (~84) + cv_stack_len (1) + cv_stack ((54+1)*32 = 1760)
-      #   ≈ 1880 bytes; we round up to 4 KiB for safety across libblake3 minor versions.
-      HASHER_SIZE = 4096
-
-      attach_function :blake3_hasher_init,     [:pointer],                          :void
-      attach_function :blake3_hasher_update,   [:pointer, :pointer, :size_t],       :void
-      attach_function :blake3_hasher_finalize, [:pointer, :pointer, :size_t],       :void
-    end
+  class Blake3
+    HASHER_SIZE = 4096
 
     # Output BLAKE3-512 in the protocol's self-identifying string form:
     #   "blake3-512:" + 128 lowercase hex chars.
-    # +data+ is treated as binary bytes.
     def self.hex(data)
       "blake3-512:" + bytes(data).unpack1("H*")
     end
 
-    # Compute raw 64-byte BLAKE3-512 of +data+. Returns a binary String of
-    # length 64 (ASCII-8BIT encoding).
+    # Compute raw 64-byte BLAKE3-512 of +data+. Returns a binary String.
     def self.bytes(data)
       raw = data.is_a?(String) ? data.b : data.to_s.b
-      hasher = FFI::MemoryPointer.new(:uint8, Native::HASHER_SIZE)
-      Native.blake3_hasher_init(hasher)
-      unless raw.bytesize.zero?
-        in_buf = FFI::MemoryPointer.new(:uint8, raw.bytesize)
-        in_buf.put_bytes(0, raw)
-        Native.blake3_hasher_update(hasher, in_buf, raw.bytesize)
-      end
-      out_buf = FFI::MemoryPointer.new(:uint8, 64)
-      Native.blake3_hasher_finalize(hasher, out_buf, 64)
-      out_buf.read_bytes(64)
+      hasher = Provekit::Blake3.hasher_init
+      Provekit::Blake3.hasher_update(hasher, raw) unless raw.bytesize.zero?
+      Provekit::Blake3.hasher_finalize(hasher, 64)
     end
   end
 end

--- a/implementations/ruby/provekit.gemspec
+++ b/implementations/ruby/provekit.gemspec
@@ -7,13 +7,9 @@ Gem::Specification.new do |s|
   s.summary     = "ProvekIt Ruby kit: native crypto substrate (BLAKE3 + JCS + Ed25519 + CBOR)."
   s.description = <<~DESC
     Native Ruby implementation of the ProvekIt substrate primitives:
-    BLAKE3-512 hashing, JCS canonical JSON, Ed25519 sign/verify, deterministic
-    CBOR (RFC 8949 §4.2.1), and .proof envelope construction. Output is
-    byte-identical to the Rust + Python kits' output for the same input.
-
-    Prereq: libblake3 must be installed on the host system.
-      macOS:  brew install blake3
-      Debian: apt-get install libblake3-dev
+    BLAKE3-512 hashing (vendored C extension, zero system deps), JCS canonical
+    JSON, Ed25519 sign/verify, deterministic CBOR (RFC 8949 §4.2.1), and .proof
+    envelope construction. Output is byte-identical to the Rust + Python kits.
   DESC
   s.authors     = ["ProvekIt contributors"]
   s.homepage    = "https://github.com/TSavo/provekit"
@@ -24,11 +20,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.0"
 
-  s.files = Dir["lib/**/*.rb"]
+  s.files = Dir["lib/**/*.rb"] + Dir["ext/**/*.{c,h,rb}"]
+  s.extensions = ["ext/provekit_blake3/extconf.rb"]
   s.require_paths = ["lib"]
 
   s.add_dependency "ed25519", "~> 1.4"
-  s.add_dependency "ffi",     "~> 1.15"
 
   s.add_development_dependency "minitest", ">= 5.0"
 end


### PR DESCRIPTION
Replaces the Ruby kit's FFI-to-system-libblake3 binding with a vendored C extension that statically links `tools/blake3-vendored/`.

## What changed

| File | Change |
|------|--------|
| `ext/provekit_blake3/extconf.rb` | mkmf build config — compiles vendored blake3.c/blake3_portable.c/blake3_dispatch.c, creates Makefile |
| `ext/provekit_blake3/provekit_blake3.c` | Thin C wrapper — `hasher_init`, `hasher_update`, `hasher_finalize` as Ruby singleton methods |
| `lib/provekit/blake3.rb` | Replaced 11-line FFI library search + `FFI::MemoryPointer` boilerplate with direct C extension calls |
| `provekit.gemspec` | Added `extensions` entry, removed `ffi` dependency |
| `.github/workflows/ci.yml` | Removed ~20s libblake3 build-from-upstream CI step |

## Before / After

**Before:** FFI loads system `libblake3` from 11 candidate paths. CI downloads BLAKE3 1.5.4 from GitHub, builds with cmake, installs to `/usr/local/`.

**After:** Zero system deps. C extension compiles the vendored BLAKE3 (already in `tools/blake3-vendored/`) as static objects. `gem install` in a clean environment works without `apt-get install libblake3-dev`.

## Acceptance checklist

- [x] No system `libblake3` required
- [x] CI libblake3 build-from-upstream step removed
- [x] `ffi` gem dependency dropped
- [ ] `contractSetCid` unchanged (needs CI run to confirm byte-equivalence)
- [ ] Cross-kit byte-equivalence test still passes