### PR TITLE
fix(ruby): rename BLAKE3 C extension to avoid name collision (unblocks #282)

### DIFF
--- a/implementations/ruby/ext/provekit_blake3/extconf.rb
+++ b/implementations/ruby/ext/provekit_blake3/extconf.rb
@@ -26,4 +26,8 @@ $objs = %w[provekit_blake3.o blake3.o blake3_portable.o blake3_dispatch.o]
 # Configure vendored BLAKE3 for portable build
 $CFLAGS << " -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512 -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41"
 
-create_makefile("provekit/blake3")
+# IMPORTANT: name MUST be `provekit_blake3` NOT `provekit/blake3`. The
+# pure-Ruby wrapper at lib/provekit/blake3.rb takes the `provekit/blake3`
+# logical name; the .so needs a distinct name so `require "provekit_blake3"`
+# from the wrapper loads the .so (not itself).
+create_makefile("provekit_blake3")

--- a/implementations/ruby/ext/provekit_blake3/extconf.rb
+++ b/implementations/ruby/ext/provekit_blake3/extconf.rb
@@ -3,20 +3,30 @@
 # Portable-only, zero system deps.
 
 require "mkmf"
+require "fileutils"
 
 dir_config("blake3")
 
 $CFLAGS << " -std=c11"
 $DEFLIBPATH = []
 
-# Vendored BLAKE3 root
-B3_DIR = File.expand_path("../../../../../tools/blake3-vendored", __dir__)
+# Vendored BLAKE3 root.
+#
+# Layout: __dir__ = implementations/ruby/ext/provekit_blake3 (4 levels deep).
+# Repo root = __dir__/../../../.. = 4 levels up. tools/blake3-vendored is
+# under repo root. So the relative path is "../../../../tools/blake3-vendored"
+# (NOT "../../../../../" which goes one too many).
+B3_DIR = File.expand_path("../../../../tools/blake3-vendored", __dir__)
 abort "vendored BLAKE3 not found at #{B3_DIR}" unless File.exist?(File.join(B3_DIR, "blake3.c"))
 
-# Copy vendored sources + headers into the ext dir
+# Copy vendored sources + headers into the ext dir IF they're not already
+# co-located. When the gem is built (`gem build`), gemspec ships the copied
+# files in the gem tarball under ext/, so a downstream `gem install` finds
+# them locally without needing tools/blake3-vendored at install time.
 %w[blake3.c blake3_portable.c blake3_dispatch.c blake3.h blake3_impl.h].each do |fn|
   src = File.join(B3_DIR, fn)
   dst = File.join(__dir__, fn)
+  next unless File.exist?(src)  # gem-install context: src may not exist
   FileUtils.cp(src, dst) unless File.exist?(dst) && File.mtime(dst) >= File.mtime(src)
 end
 

--- a/implementations/ruby/ext/provekit_blake3/provekit_blake3.c
+++ b/implementations/ruby/ext/provekit_blake3/provekit_blake3.c
@@ -64,8 +64,12 @@ blake3_hasher_finalize(VALUE self, VALUE hasher_str, VALUE out_len_val)
 
 /* ── Init ──────────────────────────────────────────── */
 
+/* Init function name MUST match the create_makefile basename in
+ * extconf.rb (`provekit_blake3`). Ruby's extension loader looks for
+ * Init_<basename> when loading the .so; mismatched names mean the
+ * methods never register and `Provekit::Blake3.hasher_init` is undef. */
 void
-Init_blake3(void)
+Init_provekit_blake3(void)
 {
     rb_cBlake3 = rb_define_module("Provekit");
     VALUE rb_cBlake3Inner = rb_define_class_under(rb_cBlake3, "Blake3", rb_cObject);

--- a/implementations/ruby/lib/provekit/blake3.rb
+++ b/implementations/ruby/lib/provekit/blake3.rb
@@ -15,10 +15,12 @@
 #   - Rust: implementations/rust/provekit-canonicalizer (blake3_512_of)
 #   - Python: blake3 PyPI package, .digest(length=64)
 
-require "provekit/blake3" rescue begin
-  # Native extension not yet compiled — try require directly
-  require_relative "../../ext/provekit_blake3/provekit_blake3"
-end
+# Load the native C extension. The extension's create_makefile name is
+# `provekit_blake3` (NOT `provekit/blake3`) to avoid colliding with this
+# pure-Ruby file at the same logical name. Without that distinction,
+# `require "provekit/blake3"` matches THIS .rb file (already loading),
+# the .so is never loaded, and `hasher_init` never gets registered.
+require "provekit_blake3"
 
 module Provekit
   class Blake3


### PR DESCRIPTION
## Bug

PR #291's vendored BLAKE3 C extension uses \`create_makefile(\"provekit/blake3\")\` which collides with the wrapper at \`lib/provekit/blake3.rb\` at the same logical name.

Result: \`require \"provekit/blake3\"\` from the wrapper matches the .rb file (already loading itself), the \`rescue\` branch never fires, the .so never loads, \`hasher_init\` is never registered. CI failure:

\`\`\`
LIFT_FAILED: undefined method 'hasher_init' for class Provekit::Blake3
\`\`\`

## Fix

Standard rubygems pattern: separate logical name for the lib wrapper vs the C extension. Three coordinated changes:

- \`extconf.rb\`: \`create_makefile(\"provekit/blake3\")\` → \`create_makefile(\"provekit_blake3\")\`
- \`provekit_blake3.c\`: \`Init_blake3\` → \`Init_provekit_blake3\` (matches the new basename)
- \`lib/provekit/blake3.rb\`: \`require \"provekit/blake3\"\` → \`require \"provekit_blake3\"\` (loads the .so)

## Unblocks

- PR #282 (mint-ruby + mint-zig in all-mint → 10/12 conformance)
- The 12/12 epic #277

## Test plan

- [ ] CI conformance gate passes (especially \`make mint-ruby\`)
- [ ] Pinned ruby contractSetCid still matches \`961be80d...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)