### PR TITLE
fix(ruby): gemspec bump + defensive lib loader (unblocks #282)

### DIFF
--- a/implementations/ruby/lib/provekit/blake3.rb
+++ b/implementations/ruby/lib/provekit/blake3.rb
@@ -20,7 +20,30 @@
 # pure-Ruby file at the same logical name. Without that distinction,
 # `require "provekit/blake3"` matches THIS .rb file (already loading),
 # the .so is never loaded, and `hasher_init` never gets registered.
-require "provekit_blake3"
+#
+# Fallback chain handles bundler-cached layouts where the freshly
+# compiled .so isn't on $LOAD_PATH at first require time:
+#   1. require "provekit_blake3" -- gem-installed location
+#   2. require_relative the in-tree build artifact
+begin
+  require "provekit_blake3"
+rescue LoadError => primary_err
+  candidates = [
+    File.expand_path("../../ext/provekit_blake3/provekit_blake3", __dir__),
+    File.expand_path("../../ext/provekit_blake3/provekit/blake3", __dir__),
+  ]
+  loaded = false
+  candidates.each do |path|
+    begin
+      require path
+      loaded = true
+      break
+    rescue LoadError
+      next
+    end
+  end
+  raise primary_err unless loaded
+end
 
 module Provekit
   class Blake3

--- a/implementations/ruby/lib/provekit/blake3.rb
+++ b/implementations/ruby/lib/provekit/blake3.rb
@@ -24,10 +24,18 @@
 # Fallback chain handles bundler-cached layouts where the freshly
 # compiled .so isn't on $LOAD_PATH at first require time:
 #   1. require "provekit_blake3" -- gem-installed location
-#   2. require_relative the in-tree build artifact
+#   2. require absolute path to the in-tree build artifact (under
+#      both the new `provekit_blake3` and legacy `provekit/blake3`
+#      names produced by the cached older build)
+#
+# All LoadErrors are accumulated and surfaced together if every
+# candidate fails. Surfacing the full list rather than only the
+# primary makes diagnosis easier when the .so exists but fails to
+# load for a distinct reason (missing symbol, wrong arch, etc.).
 begin
   require "provekit_blake3"
 rescue LoadError => primary_err
+  errors = [primary_err]
   candidates = [
     File.expand_path("../../ext/provekit_blake3/provekit_blake3", __dir__),
     File.expand_path("../../ext/provekit_blake3/provekit/blake3", __dir__),
@@ -38,11 +46,15 @@ rescue LoadError => primary_err
       require path
       loaded = true
       break
-    rescue LoadError
+    rescue LoadError => fallback_err
+      errors << fallback_err
       next
     end
   end
-  raise primary_err unless loaded
+  unless loaded
+    detail = errors.map.with_index { |e, i| "  [#{i}] #{e.class}: #{e.message}" }.join("\n")
+    raise LoadError, "could not load provekit_blake3 native extension:\n#{detail}"
+  end
 end
 
 module Provekit

--- a/implementations/ruby/provekit.gemspec
+++ b/implementations/ruby/provekit.gemspec
@@ -2,7 +2,12 @@
 
 Gem::Specification.new do |s|
   s.name        = "provekit"
-  s.version     = "0.1.0"
+  # 0.1.1: BLAKE3 C extension renamed from `provekit/blake3` to
+  # `provekit_blake3` to avoid name collision with the lib wrapper
+  # (PR #294). Bumping the version busts setup-ruby@v1's
+  # bundler-cache, which keys on gemspec contents and was restoring
+  # a stale compiled .so under the old name.
+  s.version     = "0.1.1"
   s.licenses    = ["Apache-2.0"]
   s.summary     = "ProvekIt Ruby kit: native crypto substrate (BLAKE3 + JCS + Ed25519 + CBOR)."
   s.description = <<~DESC


### PR DESCRIPTION
## Bug

#282 CI failed at \`>> minting ruby self-contracts\` with:
\`\`\`
cannot load such file -- provekit_blake3 (LoadError)
\`\`\`

even though PR #294 already renamed the C extension to \`provekit_blake3\`. Root cause: setup-ruby@v1's \`bundler-cache: true\` restored a STALE compiled .so under the OLD name (\`provekit/blake3.so\`) because the cache key didn't bust on lib/ext changes.

## Fix

Two-pronged:

1. **Gemspec version 0.1.0 → 0.1.1.** Bundler-cache key includes gemspec contents, so bumping the version invalidates the cache and forces a fresh compile under the new name.

2. **Defensive lib loader** in \`lib/provekit/blake3.rb\`. If \`require \"provekit_blake3\"\` LoadErrors, falls back to \`require_relative\` the in-tree build artifact (under both new and old names). Belt-and-suspenders for any future cache reload edge case.

## Acceptance

- [ ] CI \`make mint-ruby\` succeeds in #282 after this rebases
- [ ] Pinned contractSetCid still \`blake3-512:961be80d...\` (no algorithm change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of native extension loading with enhanced error reporting when dependencies fail to initialize. Users will now receive detailed diagnostics instead of cryptic early failures.

* **Chores**
  * Version bumped to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->