### PR TITLE
ci: retry-with-backoff for apt + curl flakes (unblocks #282 + future infra blips)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,35 +448,47 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Install build-essential (all kits)
+      - name: Install build-essential + kit-specific deps
         # Every kit's `make prove-<kit>` needs make on PATH. Without
         # this unconditional step, prove-{rust,ts,csharp,java,python,
         # ruby,zig} fail with `make: command not found` because the
         # ephemeral runners don't ship make pre-installed and PR #165's
         # original conditional install only fired for cpp/c.
+        #
+        # Routes through apt-cacher-ng on battleaxe + 5-attempt retry
+        # with linear backoff (matches conformance gate's pattern).
+        # Combines build-essential (all kits) with cpp/c-specific deps
+        # in one apt invocation so we only retry once per matrix entry.
         run: |
           set -euo pipefail
-          # Route through apt-cacher-ng on battleaxe if available
-          # (matches conformance gate's pattern).
+          # Route through apt-cacher-ng on battleaxe if available.
           if curl -fsS --max-time 2 http://localhost:3142/acng-report.html >/dev/null 2>&1; then
             echo 'Acquire::http::Proxy "http://localhost:3142";' | sudo tee /etc/apt/apt.conf.d/00-apt-cacher-ng >/dev/null
           fi
-          sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends build-essential
-
-      - name: Install system deps (cpp)
-        if: matrix.kit == 'cpp'
-        run: |
-          sudo apt-get install -y --no-install-recommends \
-            clang \
-            libssl-dev \
-            nlohmann-json3-dev
-
-      - name: Install system deps (c)
-        if: matrix.kit == 'c'
-        run: |
-          sudo apt-get install -y --no-install-recommends \
-            libssl-dev
+          # Build dep list per kit. build-essential is always needed
+          # for `make`; cpp/c add their own libs.
+          DEPS="build-essential"
+          case "${{ matrix.kit }}" in
+            cpp) DEPS="$DEPS clang libssl-dev nlohmann-json3-dev" ;;
+            c)   DEPS="$DEPS libssl-dev" ;;
+          esac
+          MAX_ATTEMPTS=5
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::apt install attempt $attempt"
+            if sudo apt-get update -y && sudo apt-get install -y --no-install-recommends $DEPS; then
+              echo "::endgroup::"
+              echo "apt install succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              wait_s=$((attempt * 30))
+              echo "apt install attempt $attempt failed; sleeping ${wait_s}s before retry"
+              sleep $wait_s
+            fi
+          done
+          echo "apt install failed after $MAX_ATTEMPTS attempts" >&2
+          exit 1
 
       - name: Set up Java (java)
         if: matrix.kit == 'java'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,10 @@ jobs:
         # archive.ubuntu.com flakes (which killed CI 4+ times this
         # session before the cache existed).
         #
-        # Belt-and-suspenders: 5-attempt retry with exponential backoff
-        # in case the cache itself is unreachable (apt-cacher-ng down,
+        # Belt-and-suspenders: 5-attempt retry with linear backoff
+        # (30s, 60s, 90s, 120s = 300s max wait, surfacing the failure
+        # immediately on attempt 5 without an extra trailing sleep) in
+        # case the cache itself is unreachable (apt-cacher-ng down,
         # network glitch, etc.).
         run: |
           set -euo pipefail
@@ -169,7 +171,8 @@ jobs:
           else
             echo "apt-cacher-ng not detected on localhost:3142; using direct upstream"
           fi
-          for attempt in 1 2 3 4 5; do
+          MAX_ATTEMPTS=5
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
             echo "::group::apt-get install attempt $attempt"
             if sudo apt-get update -y && sudo apt-get install -y --no-install-recommends $DEPS; then
               echo "::endgroup::"
@@ -177,11 +180,13 @@ jobs:
               exit 0
             fi
             echo "::endgroup::"
-            wait_s=$((attempt * 30))
-            echo "apt-get install attempt $attempt failed; sleeping ${wait_s}s before retry"
-            sleep $wait_s
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              wait_s=$((attempt * 30))
+              echo "apt-get install attempt $attempt failed; sleeping ${wait_s}s before retry"
+              sleep $wait_s
+            fi
           done
-          echo "apt-get install failed after 5 attempts (450s total backoff)" >&2
+          echo "apt-get install failed after $MAX_ATTEMPTS attempts" >&2
           exit 1
 
       - name: Install Vampire (upstream GitHub release)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,17 +148,27 @@ jobs:
         # bundler-cache fails with `libyaml-0.so.2: cannot open shared
         # object file` without it on Ubuntu 24.04 hosted runners.
         # Self-hosted runners on battleaxe are ephemeral (no persistent
-        # apt cache between jobs). Every run hits archive.ubuntu.com
-        # fresh. That mirror intermittently rate-limits or drops
-        # connections (seen 4+ times this session), failing the install
-        # step. Retry with exponential backoff so a transient flake
-        # doesn't kill the whole gate.
+        # apt cache between jobs). The host runs apt-cacher-ng on
+        # localhost:3142 so each run hits the local cache instead of
+        # archive.ubuntu.com directly. Cold cache pulls upstream once;
+        # warm cache makes subsequent jobs ~10x faster and immune to
+        # archive.ubuntu.com flakes (which killed CI 4+ times this
+        # session before the cache existed).
         #
-        # Proper fix: stand up apt-cacher-ng on battleaxe so all
-        # ephemeral runners share a local cache. Tracked separately.
+        # Belt-and-suspenders: 5-attempt retry with exponential backoff
+        # in case the cache itself is unreachable (apt-cacher-ng down,
+        # network glitch, etc.).
         run: |
           set -euo pipefail
           DEPS="build-essential clang cmake cvc5 libsodium-dev libssl-dev libyaml-dev maven nlohmann-json3-dev unzip z3"
+          # Point apt at the local apt-cacher-ng on battleaxe (issue #304).
+          # Skip silently if not running on battleaxe (e.g. dev fork CI).
+          if curl -fsS --max-time 2 http://localhost:3142/acng-report.html >/dev/null 2>&1; then
+            echo 'Acquire::http::Proxy "http://localhost:3142";' | sudo tee /etc/apt/apt.conf.d/00-apt-cacher-ng >/dev/null
+            echo "apt-cacher-ng on localhost:3142 detected; routing apt through it"
+          else
+            echo "apt-cacher-ng not detected on localhost:3142; using direct upstream"
+          fi
           for attempt in 1 2 3 4 5; do
             echo "::group::apt-get install attempt $attempt"
             if sudo apt-get update -y && sudo apt-get install -y --no-install-recommends $DEPS; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,12 +448,26 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      - name: Install build-essential (all kits)
+        # Every kit's `make prove-<kit>` needs make on PATH. Without
+        # this unconditional step, prove-{rust,ts,csharp,java,python,
+        # ruby,zig} fail with `make: command not found` because the
+        # ephemeral runners don't ship make pre-installed and PR #165's
+        # original conditional install only fired for cpp/c.
+        run: |
+          set -euo pipefail
+          # Route through apt-cacher-ng on battleaxe if available
+          # (matches conformance gate's pattern).
+          if curl -fsS --max-time 2 http://localhost:3142/acng-report.html >/dev/null 2>&1; then
+            echo 'Acquire::http::Proxy "http://localhost:3142";' | sudo tee /etc/apt/apt.conf.d/00-apt-cacher-ng >/dev/null
+          fi
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends build-essential
+
       - name: Install system deps (cpp)
         if: matrix.kit == 'cpp'
         run: |
-          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends \
-            build-essential \
             clang \
             libssl-dev \
             nlohmann-json3-dev
@@ -461,9 +475,7 @@ jobs:
       - name: Install system deps (c)
         if: matrix.kit == 'c'
         run: |
-          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends \
-            build-essential \
             libssl-dev
 
       - name: Set up Java (java)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,20 +147,32 @@ jobs:
         # libyaml-dev is needed for Ruby's psych (YAML) extension;
         # bundler-cache fails with `libyaml-0.so.2: cannot open shared
         # object file` without it on Ubuntu 24.04 hosted runners.
+        # Self-hosted runners on battleaxe are ephemeral (no persistent
+        # apt cache between jobs). Every run hits archive.ubuntu.com
+        # fresh. That mirror intermittently rate-limits or drops
+        # connections (seen 4+ times this session), failing the install
+        # step. Retry with exponential backoff so a transient flake
+        # doesn't kill the whole gate.
+        #
+        # Proper fix: stand up apt-cacher-ng on battleaxe so all
+        # ephemeral runners share a local cache. Tracked separately.
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            clang \
-            cmake \
-            cvc5 \
-            libsodium-dev \
-            libssl-dev \
-            libyaml-dev \
-            maven \
-            nlohmann-json3-dev \
-            unzip \
-            z3
+          set -euo pipefail
+          DEPS="build-essential clang cmake cvc5 libsodium-dev libssl-dev libyaml-dev maven nlohmann-json3-dev unzip z3"
+          for attempt in 1 2 3 4 5; do
+            echo "::group::apt-get install attempt $attempt"
+            if sudo apt-get update -y && sudo apt-get install -y --no-install-recommends $DEPS; then
+              echo "::endgroup::"
+              echo "apt-get install succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "::endgroup::"
+            wait_s=$((attempt * 30))
+            echo "apt-get install attempt $attempt failed; sleeping ${wait_s}s before retry"
+            sleep $wait_s
+          done
+          echo "apt-get install failed after 5 attempts (450s total backoff)" >&2
+          exit 1
 
       - name: Install Vampire (upstream GitHub release)
         # Vampire joins the default solver portfolio per
@@ -171,9 +183,12 @@ jobs:
         # release at github.com/vprover/vampire ships a static x86_64
         # Linux binary in vampire-Linux-X64.zip. We pin to v5.0.1
         # (current latest as of 2026-05).
+        # `curl --retry 5 --retry-all-errors` handles transient github.com
+        # connection drops on the ephemeral runners.
         run: |
+          set -euo pipefail
           cd /tmp
-          curl -fsSL -o vampire.zip \
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 -o vampire.zip \
             https://github.com/vprover/vampire/releases/download/v5.0.1/vampire-Linux-X64.zip
           unzip -q vampire.zip
           sudo install -m 0755 vampire /usr/local/bin/vampire
@@ -211,7 +226,7 @@ jobs:
         run: |
           set -euxo pipefail
           ZIG_URL="https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
-          curl -fsSL "$ZIG_URL" -o /tmp/zig.tar.xz
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 "$ZIG_URL" -o /tmp/zig.tar.xz
           sudo mkdir -p /usr/local/zig
           sudo tar -xf /tmp/zig.tar.xz -C /usr/local/zig --strip-components=1
           sudo ln -sf /usr/local/zig/zig /usr/local/bin/zig


### PR DESCRIPTION
## Bug

Battleaxe self-hosted runners are ephemeral; every job hits \`archive.ubuntu.com\` fresh with no persistent apt cache. Ubuntu's mirror intermittently rate-limits or drops connections. Killed the conformance gate 4+ times this session on PRs #245, #278, #282, #289 with the same \`Connection refused\` errors.

## Fix

Three retry-with-backoff additions to \`.github/workflows/ci.yml\`:

1. **\`apt-get install\`**: 5 attempts, exponential backoff (30s, 60s, 90s, 120s, 150s = up to 7.5min total). Real failure surfaces only if all 5 attempts fail.

2. **Vampire download**: \`curl --retry 5 --retry-all-errors --retry-delay 10\`. Handles github.com release-tarball flakes.

3. **Zig download**: same curl flags for ziglang.org.

## Proper fix (deferred)

Stand up \`apt-cacher-ng\` on battleaxe so all ephemeral runners share a local apt cache. Filed as #303.

## Test plan

- [ ] CI conformance gate green on this branch
- [ ] After merge, #282 + future PRs no longer flake on apt mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability: dependency installs and tool downloads now retry on transient failures and use stricter shell execution settings.
  * Optional local package cache routing is supported when available.
  * Build-essential is now installed once for all Linux kits, removing duplicate per-kit installs and redundant update steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->