### PR TITLE
ci: move macOS jobs to self-hosted Mac runner (closes #305)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,9 +260,11 @@ jobs:
     # already protected by the Linux gate's pinned CIDs for the other
     # 10 kits, and JCS+BLAKE3 is architecture-independent.
     name: Cross-language conformance gate (macOS swift)
-    # macos-latest currently aliases to macos-14 (Apple Silicon, M1).
-    # GitHub-hosted, not self-hosted; that is the intended split.
-    runs-on: macos-latest
+    # Self-hosted Mac runner registered on the architect's machine
+    # (label `macOS`, X64). Closes #305 — moves the swift jobs off
+    # GitHub-hosted macos-latest onto our own infra. Toolchains
+    # (swift, rust) are pre-installed on the runner host.
+    runs-on: [self-hosted, macOS, X64]
     timeout-minutes: 45
 
     steps:
@@ -461,7 +463,8 @@ jobs:
 
   prove-swift:
     name: "prove-swift (C1-C8 conformance, macOS)"
-    runs-on: macos-latest
+    # Self-hosted Mac runner (issue #305).
+    runs-on: [self-hosted, macOS, X64]
     timeout-minutes: 20
     needs: conformance
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ concurrency:
 jobs:
   conformance:
     name: Cross-language conformance gate
-    runs-on: self-hosted
+    # [self-hosted, Linux, X64] not bare `self-hosted` — otherwise the
+    # macOS runner registered for #305 will pick up this Linux-only job
+    # (apt-get) and fail.
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
 
     steps:
@@ -338,7 +341,8 @@ jobs:
 
   prove-linux:
     name: "prove-${{ matrix.kit }} (C1-C8 conformance)"
-    runs-on: self-hosted
+    # Linux-only — exclude the macOS runner registered for #305.
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
     needs: conformance
     strategy:

--- a/.github/workflows/provekit.yml
+++ b/.github/workflows/provekit.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   prove:
-    runs-on: self-hosted
+    # [self-hosted, Linux, X64] not bare `self-hosted` — otherwise the
+    # macOS runner registered for #305 will pick up this Linux-only job
+    # (apt-get) and fail.
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Restores repo policy of \"self-hosted exclusively\" by moving both swift jobs off GitHub-hosted \`macos-latest\` onto a newly-registered macOS self-hosted runner.

**Runner:** \`tsavo-mac-x64\` — Intel MacBook Pro, macOS 26.3.1, swift 6.3.1 + rust 1.95.0 pre-installed. Online with labels \`self-hosted, macOS, X64\`. Installed as a launchd service so it survives reboots.

## Changes

Two jobs in \`.github/workflows/ci.yml\`:
- \`conformance-macos-swift\` (line 265): \`runs-on: macos-latest\` → \`[self-hosted, macOS, X64]\`
- \`prove-swift\` (line 466): same

## Closes

#305

🤖 Generated with [Claude Code](https://claude.com/claude-code)