### PR TITLE
fix(ruby/ext): BLAKE3 C extension memory safety + symbol collision (closes #295)

### DIFF
--- a/implementations/ruby/ext/provekit_blake3/provekit_blake3.c
+++ b/implementations/ruby/ext/provekit_blake3/provekit_blake3.c
@@ -2,40 +2,62 @@
  * provekit_blake3 — Ruby C extension wrapping vendored BLAKE3.
  *
  * Exposes three methods on Provekit::Blake3 (class-level):
- *   Blake3.hasher_init        → FFI::MemoryPointer (1 blake3_hasher, 4096 bytes)
- *   Blake3.hasher_update(ptr, data_string) → nil
- *   Blake3.hasher_finalize(ptr, out_len)   → raw bytes string
+ *   Blake3.hasher_init                            → Ruby String (sizeof(blake3_hasher) bytes,
+ *                                                                typically 1912; carries
+ *                                                                hasher state in-place)
+ *   Blake3.hasher_update(hasher_str, data_str)    → nil  (mutates hasher_str's buffer)
+ *   Blake3.hasher_finalize(hasher_str, out_len)   → raw bytes string of length out_len
  *
  * Statically links blake3.c + blake3_portable.c + blake3_dispatch.c
  * from tools/blake3-vendored/. Zero system deps.
+ *
+ * Memory model: the Ruby String returned by hasher_init owns the hasher
+ * state in its character buffer. Ruby's GC frees the string when it
+ * goes out of scope; we never call ruby_xmalloc / ruby_xfree on the
+ * hasher pointer ourselves. update/finalize call rb_str_modify before
+ * mutating to handle copy-on-write / frozen-string sharing.
+ *
+ * Wrapper functions are named provekit_rb_blake3_hasher_* to avoid
+ * symbol collision with the BLAKE3 C library's own
+ * blake3_hasher_init/update/finalize functions exported by blake3.h.
  */
 
 #include <ruby.h>
 #include "blake3.h"
 
-#define HASHER_SIZE 4096
-
 /* ── Module declarations ──────────────────────────── */
 
 static VALUE rb_cBlake3;
 
-/* ── hasher_init(self) → FFI::MemoryPointer ──────────── */
+/* ── hasher_init(self) → Ruby String ─────────────────── */
 
 static VALUE
-blake3_hasher_init(VALUE self)
+provekit_rb_blake3_hasher_init(VALUE self)
 {
-    blake3_hasher *h = (blake3_hasher *)ruby_xmalloc(sizeof(blake3_hasher));
-    blake3_hasher_init(h);
-    return rb_str_new((const char *)h, sizeof(blake3_hasher));
+    (void)self;
+    VALUE str = rb_str_new(NULL, sizeof(blake3_hasher));
+    blake3_hasher_init((blake3_hasher *)RSTRING_PTR(str));
+    return str;
 }
 
 /* ── hasher_update(self, hasher_str, data_str) → nil ── */
 
 static VALUE
-blake3_hasher_update(VALUE self, VALUE hasher_str, VALUE data_str)
+provekit_rb_blake3_hasher_update(VALUE self, VALUE hasher_str, VALUE data_str)
 {
+    (void)self;
     Check_Type(hasher_str, T_STRING);
     Check_Type(data_str, T_STRING);
+
+    if ((size_t)RSTRING_LEN(hasher_str) != sizeof(blake3_hasher)) {
+        rb_raise(rb_eArgError,
+                 "hasher_str length %ld does not match sizeof(blake3_hasher)=%zu",
+                 (long)RSTRING_LEN(hasher_str), sizeof(blake3_hasher));
+    }
+
+    /* Make hasher_str's buffer independent (handles copy-on-write /
+     * shared / frozen string buffers) before mutating. */
+    rb_str_modify(hasher_str);
 
     blake3_hasher *h = (blake3_hasher *)RSTRING_PTR(hasher_str);
     blake3_hasher_update(h, RSTRING_PTR(data_str), RSTRING_LEN(data_str));
@@ -46,9 +68,16 @@ blake3_hasher_update(VALUE self, VALUE hasher_str, VALUE data_str)
 /* ── hasher_finalize(self, hasher_str, out_len_fixnum) → String ─── */
 
 static VALUE
-blake3_hasher_finalize(VALUE self, VALUE hasher_str, VALUE out_len_val)
+provekit_rb_blake3_hasher_finalize(VALUE self, VALUE hasher_str, VALUE out_len_val)
 {
+    (void)self;
     Check_Type(hasher_str, T_STRING);
+
+    if ((size_t)RSTRING_LEN(hasher_str) != sizeof(blake3_hasher)) {
+        rb_raise(rb_eArgError,
+                 "hasher_str length %ld does not match sizeof(blake3_hasher)=%zu",
+                 (long)RSTRING_LEN(hasher_str), sizeof(blake3_hasher));
+    }
 
     blake3_hasher *h = (blake3_hasher *)RSTRING_PTR(hasher_str);
     size_t out_len = (size_t)NUM2ULONG(out_len_val);
@@ -56,8 +85,10 @@ blake3_hasher_finalize(VALUE self, VALUE hasher_str, VALUE out_len_val)
     VALUE out_str = rb_str_new(NULL, out_len);
     blake3_hasher_finalize(h, (uint8_t *)RSTRING_PTR(out_str), out_len);
 
-    /* Free the hasher — finalize consumes it */
-    ruby_xfree(h);
+    /* No ruby_xfree here: hasher_str's buffer is owned by the Ruby
+     * String, freed by GC when the string goes out of scope. The
+     * previous code ruby_xfree'd RSTRING_PTR(hasher_str), which
+     * freed memory the GC also tries to free — invalid free. */
 
     return out_str;
 }
@@ -74,7 +105,7 @@ Init_provekit_blake3(void)
     rb_cBlake3 = rb_define_module("Provekit");
     VALUE rb_cBlake3Inner = rb_define_class_under(rb_cBlake3, "Blake3", rb_cObject);
 
-    rb_define_singleton_method(rb_cBlake3Inner, "hasher_init",    RUBY_METHOD_FUNC(blake3_hasher_init),    0);
-    rb_define_singleton_method(rb_cBlake3Inner, "hasher_update",  RUBY_METHOD_FUNC(blake3_hasher_update),  2);
-    rb_define_singleton_method(rb_cBlake3Inner, "hasher_finalize",RUBY_METHOD_FUNC(blake3_hasher_finalize),2);
+    rb_define_singleton_method(rb_cBlake3Inner, "hasher_init",    RUBY_METHOD_FUNC(provekit_rb_blake3_hasher_init),    0);
+    rb_define_singleton_method(rb_cBlake3Inner, "hasher_update",  RUBY_METHOD_FUNC(provekit_rb_blake3_hasher_update),  2);
+    rb_define_singleton_method(rb_cBlake3Inner, "hasher_finalize",RUBY_METHOD_FUNC(provekit_rb_blake3_hasher_finalize),2);
 }


### PR DESCRIPTION
## Summary

Five Copilot-flagged issues in the ruby kit's BLAKE3 C extension from PR #291's review, all live on main post-PR #294. None crash today (Ruby's GC + short-lived hasher state masks them) but they're memory-unsound under load.

Closes #295.

## Fixes

| # | Bug | Fix |
|---|-----|-----|
| 1 | Symbol collision (wrapper functions named identically to BLAKE3 C API) | Renamed wrappers to \`provekit_rb_blake3_hasher_{init,update,finalize}\` |
| 2 | \`hasher_init\` leaks the \`ruby_xmalloc\`'d hasher (rb_str_new copies bytes, original allocation orphaned) | Allocate inside the Ruby string buffer directly; no separate heap alloc |
| 3 | \`hasher_update\` missing buffer-size validation + \`rb_str_modify\` (mutates shared/frozen string buffers) | Validates \`RSTRING_LEN == sizeof(blake3_hasher)\` (raises ArgError if not), calls \`rb_str_modify\` before mutating |
| 4 | \`hasher_finalize\` invalid free (\`ruby_xfree\` on a Ruby-String-owned pointer; double-free / corruption) | Removed the \`ruby_xfree\`; GC handles cleanup. Same size validation as update |
| 5 | Stale header comment claiming FFI::MemoryPointer / 4096 bytes | Replaced with accurate post-FFI Ruby String shape (\`sizeof(blake3_hasher)\` ~1912 bytes); removed unused \`HASHER_SIZE\` macro |

## Test plan

- [ ] \`make mint-ruby\` still produces the pinned contractSetCid (verifier rule-2 re-derivation; same hasher state shape, same output bytes)
- [ ] \`make conformance\` passes
- [ ] No new diagnostics from \`clang --analyze\` on the touched code

## Deferred

Issue #295 includes a 6th item (gem-publish vendored-sources-in-tarball, low priority since gem isn't published) — not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)