### PR TITLE
docs: v1.4 cleanup: Bridge IR gap rewrite, call-edge mention, rank-3 refresh (closes #189)

### DIFF
--- a/docs/contributing/writing-a-kit/05-self-contracts.md
+++ b/docs/contributing/writing-a-kit/05-self-contracts.md
@@ -13,7 +13,7 @@ The exact contents are pinned in the protocol catalog. They include (at minimum)
 - A small set of canonical Term and Formula instances exercising each IR primitive.
 - A canonical Sort declaration.
 - A canonical contract declaration (pre/post pair).
-- A canonical bridge declaration (the v1.1.0 9-field shape).
+- A canonical bridge declaration (the v1.4 layered shape: envelope/header/metadata with tagged-union target).
 - Foundation key public key and signature over each member.
 
 Every kit writes a `mint-self-contracts` script (or equivalent) that constructs these mementos and packages them into a `.proof` bundle. The script's output, byte-for-byte, must hash to the pinned CID.
@@ -87,11 +87,13 @@ This is one of the few coordinated activities in ProvekIt. A v1.2.0 release is g
 
 ## Bridge IR gap
 
-Several kits today (C#, Java, Ruby, C++) ship "partial" bridge IR: they pass the happy-path bytes-equality fixture but cannot construct or round-trip the full v1.1.0 9-field BridgeDeclaration. These kits' self-contracts may include a bridge member, which means partial-bridge kits cannot fully mint self-contracts.
+The v1.4 bridge shape (envelope/header/metadata with tagged-union target, per [`protocol/specs/2026-05-03-bridge-target-dimensionality.md`](../../../protocol/specs/2026-05-03-bridge-target-dimensionality.md)) supersedes the v1.1.0 flat 9-field BridgeDeclaration. The v1.1 shape is no longer the canonical target; kits are migrating to the v1.4 layered shape in tracked per-kit PRs (#188, #190, #192, #193).
 
-This is a known issue tracked per-kit (see [`docs/reference/per-language-status.md`](../../reference/per-language-status.md)). Step 6 covers the full bridge IR.
+During this migration window, some kits may still mint self-contracts against the v1.1 shape while others have moved to v1.4. This creates a temporary gap: self-contracts produced by v1.1-era kits and v1.4-era kits are different, so their bundle CIDs will not converge until every kit has migrated.
 
-If you are porting a new kit, do step 6 before pinning self-contracts. If you ship without full bridge support, your kit is "self-contracts-partial": usable but not fully conformant.
+This gap is tracked per-kit in [`docs/reference/per-language-status.md`](../../reference/per-language-status.md). If you are porting a new kit, target the v1.4 layered shape from the start. Do not implement the v1.1 flat shape.
+
+If you ship before completing bridge IR, your kit is "self-contracts-partial": usable but not fully conformant. Bridge IR completeness gates full conformance.
 
 ## When this step is done
 
@@ -99,5 +101,5 @@ Your kit's `mint-self-contracts` produces a bundle whose outer CID matches a pin
 
 ## Read next
 
-- [06-bridge-IR.md](06-bridge-IR.md): the full v1.1.0 BridgeDeclaration shape.
+- [06-bridge-IR.md](06-bridge-IR.md): the full v1.4 layered bridge shape (envelope/header/metadata, tagged-union target).
 - [docs/contributing/release-process.md](../release-process.md) (when written): protocol version bumps and re-pinning.

--- a/docs/contributing/writing-a-lift-adapter/02-walk-the-AST.md
+++ b/docs/contributing/writing-a-lift-adapter/02-walk-the-AST.md
@@ -94,6 +94,19 @@ For each annotation you recognize, extract:
 
 These five pieces are enough to construct a canonical IR formula plus a binding to the call site.
 
+## Call-edge emission
+
+Under the Bridge Linkage Protocol ([`protocol/specs/2026-05-03-bridge-linkage-protocol.md`](../../../protocol/specs/2026-05-03-bridge-linkage-protocol.md) §1 R1), a lift adapter emits two streams per compilation unit:
+
+1. **Contract mementos** (`kind: "contract"`): the canonical IR formulas for recognized annotations (step 3).
+2. **Call-edge mementos** (`kind: "call-edge"`): one per call site within the lifted code.
+
+A call edge captures the caller-callee relationship: `sourceContractCid` (the calling function's contract), `targetContractCid` or `targetSymbol` (the callee), `callSiteLocus`, and an `evidenceTerm` encoding the satisfaction obligation `post_callee ⊃ pre_caller`. When the target contract is not yet known (cross-kit calls), set `targetContractCid: null` and populate `targetSymbol` for linker resolution.
+
+The two streams are emitted in the same response envelope. The linker (`provekit prove`) derives bridge mementos mechanically from the union of contracts and call edges across all kits. The adapter must NOT emit `kind: "bridge"` mementos directly; bridges are linker-derived.
+
+Walk the AST for call sites the same way you walk for annotations: parse, recognize the call graph, extract caller-callee pairs and locus information. This data flows alongside the canonical IR formulas produced in step 3.
+
 ## Type information matters
 
 The bridge's `boundCallSiteSorts` and `boundReturnSort` come from the type system. If your adapter cannot recover the type information from the AST, it cannot construct a full bridge.

--- a/docs/explanation/compared-to/coq-fstar-lean.md
+++ b/docs/explanation/compared-to/coq-fstar-lean.md
@@ -137,7 +137,7 @@ If you go pure-ITP without ProvekIt:
 - No content-addressed substrate. Sharing proofs across teams requires ad-hoc tooling.
 - No bridges between proofs in different languages. Cross-language proof transfer requires custom encoding per pair.
 - No cache effects. Every consumer re-runs the ITP (or trusts an ad-hoc artifact).
-- No supply-chain anchor (no `binaryCid` equivalent in standard ITP workflows).
+- No supply-chain anchor (no rank-3 pin equivalent in standard ITP workflows; see [`multi-dimensional-pinning.md`](../../security/multi-dimensional-pinning.md) for the `(contractCid, witnessCid, binaryCid)` framing).
 
 ProvekIt fills these gaps for the cases where ITP-level rigor is overkill but content-addressed verification is valuable.
 

--- a/docs/explanation/compared-to/kani-prusti-creusot.md
+++ b/docs/explanation/compared-to/kani-prusti-creusot.md
@@ -116,7 +116,7 @@ ProvekIt adds value when one or more of:
 
 - **You have Rust dependencies and non-Rust consumers** (or vice versa). The lift adapter promotes Rust annotations to canonical IR; bridges connect to non-Rust consumers' contracts.
 - **You're publishing a Rust library to a registry** (`crates.io`). Shipping a `.proof` alongside the crate makes consumers' verification cheaper. Cache effects help.
-- **You want supply-chain `binaryCid` pinning.** Kani/Prusti/Creusot don't pin compiled artifacts; ProvekIt's `binaryCid` adds this.
+- **You want supply-chain rank-3 pinning.** Kani/Prusti/Creusot don't pin compiled artifacts; ProvekIt's rank-3 pin (`contractCid`, `witnessCid`, `binaryCid`, per [`multi-dimensional-pinning.md`](../../security/multi-dimensional-pinning.md)) adds this.
 - **You want federated proof reuse.** A `(post, pre)` pair discharged by Kani in one project becomes available to every other project's verifier. Kani would re-run otherwise.
 
 The combination is: use Kani/Prusti/Creusot to verify, use ProvekIt to publish and distribute.

--- a/docs/explanation/compared-to/runtime-testing-frameworks.md
+++ b/docs/explanation/compared-to/runtime-testing-frameworks.md
@@ -114,7 +114,7 @@ Tests at your boundary aren't enough. The proof of dependency contracts comes fr
 
 Goal: supply-chain verification.
   ↓
-Tests don't help. ProvekIt's binaryCid + signed contracts is the path.
+Tests don't help. ProvekIt's rank-3 pin (`contractCid`, `witnessCid`, `binaryCid` per [`multi-dimensional-pinning.md`](../../security/multi-dimensional-pinning.md)) plus signed contracts is the path.
 
 Goal: cross-language behavioral guarantees.
   ↓

--- a/docs/explanation/compared-to/sbom-formats.md
+++ b/docs/explanation/compared-to/sbom-formats.md
@@ -45,12 +45,12 @@ Almost nowhere. The questions are orthogonal:
 A complete supply-chain artifact:
 
 1. **CycloneDX SBOM**: lists every component, every version, every license, every known vulnerability.
-2. **ProvekIt `.proof`**: signs behavioral contracts on the components, pins the binary CID, encodes bridges.
+2. **ProvekIt `.proof`**: signs behavioral contracts on the components, carries the rank-3 pin (`contractCid`, `witnessCid`, `binaryCid` per [`multi-dimensional-pinning.md`](../../security/multi-dimensional-pinning.md)), encodes bridges.
 
 A consumer's verification pipeline:
 
 1. Parse the SBOM. Confirm no known-vulnerable versions are present.
-2. Parse the `.proof`. Confirm the signature, verify the handshake, check `binaryCid` against the running artifact.
+2. Parse the `.proof`. Confirm the signature, verify the handshake, check the rank-3 axes (`binaryCid` against the running artifact, `contractCid` against the pinned contract, `witnessCid` against trusted prover chains).
 3. (Optional) Cross-reference: every component listed in the SBOM should have a corresponding `.proof` (if available) or be flagged as unverified.
 
 The SBOM's role is "is this list of components acceptable?" The `.proof`'s role is "does this artifact behave as claimed?"
@@ -84,9 +84,9 @@ If you have an SBOM but no behavioral verification, you know what's there but no
 The SBOM doesn't catch this. The version string is correct; the binary differs. You'd need either:
 
 - A registry that signs releases (Sigstore + transparency log).
-- A `.proof` whose `binaryCid` matches the legitimate binary; the malicious binary's hash mismatches; verification fails.
+- A `.proof` whose rank-3 pin (`contractCid`, `witnessCid`, `binaryCid`) matches the legitimate artifact and its contract; the malicious binary's hash mismatches; verification fails.
 
-ProvekIt's `binaryCid` provides exactly this defense. SBOM enumerates; `binaryCid` validates.
+ProvekIt's rank-3 pin provides exactly this defense. SBOM enumerates; rank-3 validates.
 
 ## ProvekIt limits SBOM addresses
 

--- a/docs/explanation/compared-to/slsa-sigstore-in-toto-scitt.md
+++ b/docs/explanation/compared-to/slsa-sigstore-in-toto-scitt.md
@@ -36,7 +36,7 @@ Imagine you ship a Rust crate. A complete posture combines all of these:
 4. **Sigstore signing.** The build artifact and its provenance are signed with a Sigstore identity rooted in the maintainer's OIDC issuer.
 5. **in-toto attestation chain.** Each pipeline step (build, test, sign, publish) is a signed in-toto attestation.
 6. **SCITT transparency log entry.** The Sigstore signature is recorded in a transparency log; consumers can verify.
-7. **ProvekIt `.proof`.** Behavioral contracts on the crate's exported functions are signed, content-addressed, with `binaryCid` pinning the compiled artifact.
+7. **ProvekIt `.proof`.** Behavioral contracts on the crate's exported functions are signed, content-addressed, with a rank-3 pin (`contractCid`, `witnessCid`, `binaryCid`) per [`multi-dimensional-pinning.md`](../../security/multi-dimensional-pinning.md).
 
 Each layer answers a different question:
 
@@ -52,7 +52,7 @@ A consumer downloading the crate runs all the verifications:
 - Verify SLSA provenance matches expected build environment.
 - Verify Sigstore signature against trusted identity.
 - Verify SCITT transparency log entry.
-- Verify ProvekIt `.proof`'s `binaryCid` matches the running artifact, all signatures verify, the handshake discharges the consumer's call sites.
+- Verify ProvekIt `.proof`: `binaryCid` matches the running artifact, `contractCid` resolves to the pinned contract, `witnessCid` chains to a trusted prover, all signatures verify, the handshake discharges the consumer's call sites.
 
 If all five layers pass, the consumer has high confidence in identity, provenance, integrity, inventory, and behavior. Each layer alone is partial; the combination is strong.
 
@@ -158,7 +158,7 @@ ProvekIt's relationship to the supply-chain space:
 
 - **Not competitive with SLSA / Sigstore / in-toto / SCITT.** They cover identity, provenance, transparency. ProvekIt covers behavior.
 - **Strongly complementary.** ProvekIt's signatures should ride on Sigstore identities. ProvekIt's discharge should be in-toto-attested. ProvekIt's bundles should land in SCITT.
-- **Independently valuable.** Even without the others, ProvekIt's `binaryCid` + content-addressed contracts adds a layer not present in any other framework.
+- **Independently valuable.** Even without the others, ProvekIt's rank-3 pin (`contractCid`, `witnessCid`, `binaryCid`) and content-addressed contracts add a layer not present in any other framework.
 
 For organizations with mature supply-chain practices: add ProvekIt as the behavioral layer.
 For organizations bootstrapping supply-chain practices: ProvekIt is one of several first-tier components; pick what's load-bearing for your threat model.


### PR DESCRIPTION
## Summary

Doc-only batch closing #189 with three v1.4 cleanups:

### 1. Bridge IR gap rewrite (`docs/contributing/writing-a-kit/05-self-contracts.md`)
Rewrote the Bridge IR gap section to reference the v1.4 layered shape (envelope/header/metadata, tagged-union target) instead of the deprecated v1.1 flat 9-field BridgeDeclaration. Updated the per-kit migration references to PRs #188/#190/#192/#193.

### 2. Call-edge emission mention (`docs/contributing/writing-a-lift-adapter/02-walk-the-AST.md`)
Added a Call-edge emission section per `protocol/specs/2026-05-03-bridge-linkage-protocol.md` R1, teaching that lift adapters emit two streams (contract mementos and call-edge mementos). Covers call-edge shape, linker derivation, and the rule that adapters must not emit bridge mementos directly.

### 3. Rank-3 refresh (`docs/explanation/compared-to/*.md`)
Updated five compared-to docs (coq-fstar-lean, kani-prusti-creusot, slsa-sigstore-in-toto-scitt, sbom-formats, runtime-testing-frameworks) to reference the rank-3 pin (`contractCid`, `witnessCid`, `binaryCid`) and link to `docs/security/multi-dimensional-pinning.md` where they previously discussed `binaryCid` alone.