### PR TITLE
docs(readme): tighten software-engineering-shifts paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Every if-statement, assertion, and type signature becomes a signed, binding dema
 
 **Bug classes vanish.** NullPointerException is no longer a runtime event. Neither is use-after-free, SQL injection, path traversal, or any bug class your error handlers exist to catch.
 
-**Software engineering shifts.** The artifact stops being code; the artifact is the proof. Code becomes one implementation. Refactoring becomes proof-preserving rewrite. AI becomes a contract-implementation generator.
+**Software engineering shifts.** The artifact is the proof. Code is one implementation. Refactoring becomes proof-preserving rewrite. AI becomes a contract-implementation generator.
 
 **Supply chains compose.** Every dependency's signed contracts compose into your application's verified properties. Dependency confusion becomes arithmetically impossible. SBOMs become meaningful artifacts.
 


### PR DESCRIPTION
## Summary

Follow-up to PR #357 (which merged before this tightening could land on the same branch).

Two adjacent sentences in the README's "Software engineering shifts" paragraph saying the same thing:

> The artifact stops being code; the artifact is the proof. Code becomes one implementation.

Collapsed to two clean parallel beats:

> The artifact is the proof. Code is one implementation.

Same content, sharper parallelism, one fewer sentence. Every word in the paragraph now earns rent.

## Test plan

- [ ] Doc-only — no code change
- [ ] One-line diff (1 insertion, 1 deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)