### PR TITLE
feat(ir): regen all 13 per-kit Sort types — FunctionSort (args/return) + DependentSort (closes #330)

### DIFF
--- a/implementations/c/provekit-ir/include/provekit/ir.h
+++ b/implementations/c/provekit-ir/include/provekit/ir.h
@@ -22,14 +22,24 @@ extern "C" {
 
 typedef enum {
     PK_SORT_PRIMITIVE,
+    PK_SORT_FUNCTION,
+    PK_SORT_DEPENDENT,
 } pk_sort_kind;
 
-typedef struct pk_sort {
+typedef struct pk_sort pk_sort;
+
+struct pk_sort {
     pk_sort_kind kind;
-    char *name; /* owned */
-} pk_sort;
+    union {
+        struct { char *name; } primitive;
+        struct { pk_sort **args; size_t n_args; pk_sort *ret; } function;
+        struct { char *name; char *index_var; pk_sort *index_sort; } dependent;
+    } data;
+};
 
 pk_sort *pk_sort_primitive(const char *name);
+pk_sort *pk_sort_function(pk_sort **args, size_t n_args, pk_sort *ret);
+pk_sort *pk_sort_dependent(const char *name, const char *index_var, pk_sort *index_sort);
 void pk_sort_free(pk_sort *s);
 
 /* ----------------------------------------------------------------------- */

--- a/implementations/c/provekit-ir/src/ir.c
+++ b/implementations/c/provekit-ir/src/ir.c
@@ -20,13 +20,49 @@ pk_sort *pk_sort_primitive(const char *name) {
     pk_sort *s = (pk_sort *)calloc(1, sizeof(pk_sort));
     if (!s) return NULL;
     s->kind = PK_SORT_PRIMITIVE;
-    s->name = pk_strdup(name);
+    s->data.primitive.name = pk_strdup(name);
+    return s;
+}
+
+pk_sort *pk_sort_function(pk_sort **args, size_t n_args, pk_sort *ret) {
+    pk_sort *s = (pk_sort *)calloc(1, sizeof(pk_sort));
+    if (!s) return NULL;
+    s->kind = PK_SORT_FUNCTION;
+    s->data.function.args = args;       /* takes ownership */
+    s->data.function.n_args = n_args;
+    s->data.function.ret = ret;          /* takes ownership */
+    return s;
+}
+
+pk_sort *pk_sort_dependent(const char *name, const char *index_var, pk_sort *index_sort) {
+    pk_sort *s = (pk_sort *)calloc(1, sizeof(pk_sort));
+    if (!s) return NULL;
+    s->kind = PK_SORT_DEPENDENT;
+    s->data.dependent.name = pk_strdup(name);
+    s->data.dependent.index_var = pk_strdup(index_var);
+    s->data.dependent.index_sort = index_sort;  /* takes ownership */
     return s;
 }
 
 void pk_sort_free(pk_sort *s) {
     if (!s) return;
-    free(s->name);
+    switch (s->kind) {
+        case PK_SORT_PRIMITIVE:
+            free(s->data.primitive.name);
+            break;
+        case PK_SORT_FUNCTION:
+            for (size_t i = 0; i < s->data.function.n_args; i++) {
+                pk_sort_free(s->data.function.args[i]);
+            }
+            free(s->data.function.args);
+            pk_sort_free(s->data.function.ret);
+            break;
+        case PK_SORT_DEPENDENT:
+            free(s->data.dependent.name);
+            free(s->data.dependent.index_var);
+            pk_sort_free(s->data.dependent.index_sort);
+            break;
+    }
     free(s);
 }
 

--- a/implementations/c/provekit-ir/src/jcs.c
+++ b/implementations/c/provekit-ir/src/jcs.c
@@ -82,12 +82,59 @@ static void emit_formula_wrapper2(pk_buffer *buf, void *ctx) {
 /* Sort                                                                    */
 /* ----------------------------------------------------------------------- */
 
+/* Emit a Sort array (used for FunctionSort.args). */
+typedef struct { pk_sort **args; size_t n; } sort_array_ctx;
+
+static void emit_sort(pk_buffer *buf, pk_sort *s);
+
+static void emit_sort_array_fn(pk_buffer *buf, void *ctx) {
+    sort_array_ctx *c = (sort_array_ctx *)ctx;
+    pk_buffer_append_char(buf, '[');
+    for (size_t i = 0; i < c->n; i++) {
+        if (i > 0) pk_buffer_append_char(buf, ',');
+        emit_sort(buf, c->args[i]);
+    }
+    pk_buffer_append_char(buf, ']');
+}
+
+static void emit_sort_wrapper(pk_buffer *buf, void *ctx) {
+    emit_sort(buf, (pk_sort *)ctx);
+}
+
 static void emit_sort(pk_buffer *buf, pk_sort *s) {
-    pk_field fields[] = {
-        {"kind",  (void (*)(pk_buffer *, void *))emit_string, "primitive"},
-        {"name",  (void (*)(pk_buffer *, void *))emit_string, s->name},
-    };
-    emit_object(buf, fields, 2);
+    switch (s->kind) {
+        case PK_SORT_PRIMITIVE: {
+            /* Locked key order: kind, name (already alphabetical). */
+            pk_field fields[] = {
+                {"kind", (void (*)(pk_buffer *, void *))emit_string, "primitive"},
+                {"name", (void (*)(pk_buffer *, void *))emit_string, s->data.primitive.name},
+            };
+            emit_object(buf, fields, 2);
+            break;
+        }
+        case PK_SORT_FUNCTION: {
+            /* Locked key order: kind, args, return — alphabetical via JCS. */
+            sort_array_ctx args_ctx = { s->data.function.args, s->data.function.n_args };
+            pk_field fields[] = {
+                {"args",   emit_sort_array_fn, &args_ctx},
+                {"kind",   (void (*)(pk_buffer *, void *))emit_string, "function"},
+                {"return", emit_sort_wrapper, s->data.function.ret},
+            };
+            emit_object(buf, fields, 3);
+            break;
+        }
+        case PK_SORT_DEPENDENT: {
+            /* Locked key order: kind, name, indexVar, indexSort (JCS-alphabetical). */
+            pk_field fields[] = {
+                {"indexSort", emit_sort_wrapper, s->data.dependent.index_sort},
+                {"indexVar",  (void (*)(pk_buffer *, void *))emit_string, s->data.dependent.index_var},
+                {"kind",      (void (*)(pk_buffer *, void *))emit_string, "dependent"},
+                {"name",      (void (*)(pk_buffer *, void *))emit_string, s->data.dependent.name},
+            };
+            emit_object(buf, fields, 4);
+            break;
+        }
+    }
 }
 
 void pk_emit_sort(pk_buffer *buf, pk_sort *s) {

--- a/implementations/cpp/provekit-ir-symbolic/include/provekit/ir.hpp
+++ b/implementations/cpp/provekit-ir-symbolic/include/provekit/ir.hpp
@@ -33,14 +33,43 @@ namespace provekit::ir {
 // Sort
 // ---------------------------------------------------------------------------
 
-struct Sort {
+struct Sort;
+
+struct PrimitiveSort {
   std::string name;  // "Int", "Real", "String", "Bool"
 };
 
-inline Sort Int() { return Sort{"Int"}; }
-inline Sort Real() { return Sort{"Real"}; }
-inline Sort String() { return Sort{"String"}; }
-inline Sort Bool() { return Sort{"Bool"}; }
+struct FunctionSort {
+  std::vector<std::shared_ptr<Sort>> args;
+  std::shared_ptr<Sort> return_;
+};
+
+struct DependentSort {
+  std::string name;
+  std::string indexVar;
+  std::shared_ptr<Sort> indexSort;
+};
+
+struct Sort {
+  std::variant<PrimitiveSort, FunctionSort, DependentSort> v;
+};
+
+inline std::shared_ptr<Sort> make_primitive_sort(std::string name) {
+  return std::make_shared<Sort>(Sort{PrimitiveSort{std::move(name)}});
+}
+
+inline Sort Int() { return Sort{PrimitiveSort{"Int"}}; }
+inline Sort Real() { return Sort{PrimitiveSort{"Real"}}; }
+inline Sort String() { return Sort{PrimitiveSort{"String"}}; }
+inline Sort Bool() { return Sort{PrimitiveSort{"Bool"}}; }
+
+inline std::shared_ptr<Sort> FuncOf(std::vector<std::shared_ptr<Sort>> args, std::shared_ptr<Sort> ret) {
+  return std::make_shared<Sort>(Sort{FunctionSort{std::move(args), std::move(ret)}});
+}
+
+inline std::shared_ptr<Sort> Dependent(std::string name, std::string indexVar, std::shared_ptr<Sort> indexSort) {
+  return std::make_shared<Sort>(Sort{DependentSort{std::move(name), std::move(indexVar), std::move(indexSort)}});
+}
 
 // ---------------------------------------------------------------------------
 // Term , VarTerm (no sort), ConstTerm (sort kept), CtorTerm (no sort).
@@ -487,9 +516,31 @@ inline void write_string(std::ostringstream& out, const std::string& s) {
 }
 
 inline void write_sort(std::ostringstream& out, const Sort& s) {
-  out << "{\"kind\":\"primitive\",\"name\":";
-  write_string(out, s.name);
-  out << "}";
+  std::visit([&out](const auto& v) {
+    using T = std::decay_t<decltype(v)>;
+    if constexpr (std::is_same_v<T, PrimitiveSort>) {
+      out << "{\"kind\":\"primitive\",\"name\":";
+      write_string(out, v.name);
+      out << "}";
+    } else if constexpr (std::is_same_v<T, FunctionSort>) {
+      out << "{\"kind\":\"function\",\"args\":[";
+      for (size_t i = 0; i < v.args.size(); i++) {
+        if (i > 0) out << ",";
+        write_sort(out, *v.args[i]);
+      }
+      out << "],\"return\":";
+      write_sort(out, *v.return_);
+      out << "}";
+    } else if constexpr (std::is_same_v<T, DependentSort>) {
+      out << "{\"kind\":\"dependent\",\"name\":";
+      write_string(out, v.name);
+      out << ",\"indexVar\":";
+      write_string(out, v.indexVar);
+      out << ",\"indexSort\":";
+      write_sort(out, *v.indexSort);
+      out << "}";
+    }
+  }, s.v);
 }
 
 inline void write_term(std::ostringstream& out, const Term& t);

--- a/implementations/cpp/provekit/claim-envelope/value_from_kit.cpp
+++ b/implementations/cpp/provekit/claim-envelope/value_from_kit.cpp
@@ -10,10 +10,36 @@ using ::provekit::canonicalizer::Value;
 using ::provekit::canonicalizer::ValuePtr;
 
 ValuePtr sort_to_value(const ::provekit::ir::Sort& sort) {
-    return Value::object({
-        {"kind", Value::string("primitive")},
-        {"name", Value::string(sort.name)},
-    });
+    return std::visit(
+        [&](const auto& s) -> ValuePtr {
+            using S = std::decay_t<decltype(s)>;
+            if constexpr (std::is_same_v<S, ::provekit::ir::PrimitiveSort>) {
+                // Locked key order: kind, name.
+                return Value::object({
+                    {"kind", Value::string("primitive")},
+                    {"name", Value::string(s.name)},
+                });
+            } else if constexpr (std::is_same_v<S, ::provekit::ir::FunctionSort>) {
+                std::vector<ValuePtr> arg_values;
+                arg_values.reserve(s.args.size());
+                for (const auto& a : s.args) arg_values.push_back(sort_to_value(*a));
+                // Locked key order: kind, args, return.
+                return Value::object({
+                    {"kind", Value::string("function")},
+                    {"args", Value::array(arg_values)},
+                    {"return", sort_to_value(*s.return_)},
+                });
+            } else if constexpr (std::is_same_v<S, ::provekit::ir::DependentSort>) {
+                // Locked key order: kind, name, indexVar, indexSort.
+                return Value::object({
+                    {"kind", Value::string("dependent")},
+                    {"name", Value::string(s.name)},
+                    {"indexVar", Value::string(s.indexVar)},
+                    {"indexSort", sort_to_value(*s.indexSort)},
+                });
+            }
+        },
+        sort.v);
 }
 
 ValuePtr term_to_value(const ::provekit::ir::Term& term) {

--- a/implementations/csharp/Provekit.IR/Serialize.cs
+++ b/implementations/csharp/Provekit.IR/Serialize.cs
@@ -27,10 +27,28 @@ public static class Serialize
 {
     // ----- to canonicalizer Value (used by the hashing flow) ------------
 
-    public static V SortToValue(Sort s) => V.Object(
-        ("kind", V.String("primitive")),
-        ("name", V.String(s.Name))
-    );
+    public static V SortToValue(Sort s) => s switch
+    {
+        // Locked key order: kind, name.
+        Sort.Primitive p => V.Object(
+            ("kind", V.String("primitive")),
+            ("name", V.String(p.Name))
+        ),
+        // Locked key order: kind, args, return.
+        Sort.Function f => V.Object(
+            ("kind", V.String("function")),
+            ("args", V.Array(f.Args.Select(SortToValue).ToArray())),
+            ("return", SortToValue(f.Return))
+        ),
+        // Locked key order: kind, name, indexVar, indexSort.
+        Sort.Dependent d => V.Object(
+            ("kind", V.String("dependent")),
+            ("name", V.String(d.Name)),
+            ("indexVar", V.String(d.IndexVar)),
+            ("indexSort", SortToValue(d.IndexSort))
+        ),
+        _ => throw new ArgumentException($"unknown Sort variant: {s.GetType().Name}")
+    };
 
     public static V TermToValue(Term t) => t switch
     {
@@ -193,9 +211,39 @@ public static class Serialize
 
     private static void WriteSort(System.Text.StringBuilder sb, Sort s)
     {
-        sb.Append("{\"kind\":\"primitive\",\"name\":");
-        WriteString(sb, s.Name);
-        sb.Append('}');
+        switch (s)
+        {
+            case Sort.Primitive p:
+                // Locked key order: kind, name.
+                sb.Append("{\"kind\":\"primitive\",\"name\":");
+                WriteString(sb, p.Name);
+                sb.Append('}');
+                break;
+            case Sort.Function f:
+                // Locked key order: kind, args, return.
+                sb.Append("{\"kind\":\"function\",\"args\":[");
+                for (int i = 0; i < f.Args.Length; i++)
+                {
+                    if (i > 0) sb.Append(',');
+                    WriteSort(sb, f.Args[i]);
+                }
+                sb.Append("],\"return\":");
+                WriteSort(sb, f.Return);
+                sb.Append('}');
+                break;
+            case Sort.Dependent d:
+                // Locked key order: kind, name, indexVar, indexSort.
+                sb.Append("{\"kind\":\"dependent\",\"name\":");
+                WriteString(sb, d.Name);
+                sb.Append(",\"indexVar\":");
+                WriteString(sb, d.IndexVar);
+                sb.Append(",\"indexSort\":");
+                WriteSort(sb, d.IndexSort);
+                sb.Append('}');
+                break;
+            default:
+                throw new ArgumentException($"unknown Sort variant: {s.GetType().Name}");
+        }
     }
 
     private static void WriteTerm(System.Text.StringBuilder sb, Term t)

--- a/implementations/csharp/Provekit.IR/Sort.cs
+++ b/implementations/csharp/Provekit.IR/Sort.cs
@@ -3,13 +3,16 @@
 namespace Provekit.IR;
 
 /// <summary>
-/// IR-JSON v1.1.0 sort. Currently primitive-only ("Int", "Real",
-/// "String", "Bool"). Mirrors the Rust/C++ peers.
+/// IR-JSON v1.4.0 sort. Primitive / Function / Dependent tagged unions.
 /// </summary>
-public sealed record Sort(string Name)
+public abstract record Sort
 {
-    public static Sort Int => new("Int");
-    public static Sort Real => new("Real");
-    public static Sort String => new("String");
-    public static Sort Bool => new("Bool");
+    public sealed record Primitive(string Name) : Sort;
+    public sealed record Function(Sort[] Args, Sort Return) : Sort;
+    public sealed record Dependent(string Name, string IndexVar, Sort IndexSort) : Sort;
+
+    public static Sort Int => new Primitive("Int");
+    public static Sort Real => new Primitive("Real");
+    public static Sort String => new Primitive("String");
+    public static Sort Bool => new Primitive("Bool");
 }

--- a/implementations/csharp/Provekit.Lift.Linq.Tests/SingleWhereTests.cs
+++ b/implementations/csharp/Provekit.Lift.Linq.Tests/SingleWhereTests.cs
@@ -52,13 +52,15 @@ public class SingleWhereTests
         //   sort: Ref (universe of xs)
         //   formula: forall _x0:Ref. (_x0 > 0) ⇒ member(_x0, positives)
         //   contract: { name: "positives_where", outBinding: "positives" }
-        var sortRef = new KitSort("Ref");
+        // After v1.5 Sort became an abstract record with sealed sub-records;
+        // construct the Primitive variant directly instead of `new Sort(...)`.
+        var sortRef = new KitSort.Primitive("Ref");
         var pred = new KitAtomic(">", new KitTerm[]
         {
             new KitVar("_x0"),
             // The literal `0` carries its own sort (Int) regardless of
             // the universe sort the quantifier ranges over.
-            new KitConst(new KitConstVal.Int(0), new KitSort("Int")),
+            new KitConst(new KitConstVal.Int(0), KitSort.Int),
         });
         var memb = new KitAtomic("member", new KitTerm[]
         {

--- a/implementations/csharp/Provekit.Lift.Linq/IRBuilder.cs
+++ b/implementations/csharp/Provekit.Lift.Linq/IRBuilder.cs
@@ -28,6 +28,8 @@ namespace Provekit.Lift.Linq;
 public abstract record Sort
 {
     public sealed record Primitive(string Name) : Sort;
+    public sealed record Function(Sort[] Args, Sort Return) : Sort;
+    public sealed record Dependent(string Name, string IndexVar, Sort IndexSort) : Sort;
 }
 
 public abstract record Term
@@ -213,8 +215,31 @@ public static class IREmit
         switch (s)
         {
             case Sort.Primitive p:
+                // Locked key order: kind, name.
                 sb.Append("{\"kind\":\"primitive\",\"name\":");
                 WriteString(sb, p.Name);
+                sb.Append('}');
+                return;
+            case Sort.Function f:
+                // Locked key order: kind, args, return — JCS-alphabetical.
+                sb.Append("{\"args\":[");
+                for (int i = 0; i < f.Args.Length; i++)
+                {
+                    if (i > 0) sb.Append(',');
+                    WriteSort(sb, f.Args[i]);
+                }
+                sb.Append("],\"kind\":\"function\",\"return\":");
+                WriteSort(sb, f.Return);
+                sb.Append('}');
+                return;
+            case Sort.Dependent d:
+                // Locked key order: kind, name, indexVar, indexSort — JCS-alphabetical.
+                sb.Append("{\"indexSort\":");
+                WriteSort(sb, d.IndexSort);
+                sb.Append(",\"indexVar\":");
+                WriteString(sb, d.IndexVar);
+                sb.Append(",\"kind\":\"dependent\",\"name\":");
+                WriteString(sb, d.Name);
                 sb.Append('}');
                 return;
         }

--- a/implementations/go/provekit-ir-symbolic/ir/types.go
+++ b/implementations/go/provekit-ir-symbolic/ir/types.go
@@ -86,22 +86,54 @@ func (s tupleSort) MarshalJSON() ([]byte, error) {
 }
 
 type funcSort struct {
-	Domain []Sort
-	Range  Sort
+	Args   []Sort
+	Return Sort
 }
 
 func (funcSort) sortMarker() {}
 
 func (s funcSort) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	buf.WriteString(`{"kind":"function","domain":`)
-	encoded, err := encodeJSON(s.Domain)
+	buf.WriteString(`{"kind":"function","args":`)
+	encoded, err := encodeJSON(s.Args)
 	if err != nil {
 		return nil, err
 	}
 	buf.Write(encoded)
-	buf.WriteString(`,"range":`)
-	encoded, err = encodeJSON(s.Range)
+	buf.WriteString(`,"return":`)
+	encoded, err = encodeJSON(s.Return)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+type dependentSort struct {
+	Name      string
+	IndexVar  string
+	IndexSort Sort
+}
+
+func (dependentSort) sortMarker() {}
+
+func (s dependentSort) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString(`{"kind":"dependent","name":`)
+	encoded, err := encodeJSON(s.Name)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteString(`,"indexVar":`)
+	encoded, err = encodeJSON(s.IndexVar)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteString(`,"indexSort":`)
+	encoded, err = encodeJSON(s.IndexSort)
 	if err != nil {
 		return nil, err
 	}
@@ -120,9 +152,9 @@ var (
 	Edge   Sort = primitiveSort{Name: "Edge"}
 )
 
-func SetOf(element Sort) Sort                { return setSort{Element: element} }
-func TupleOf(elements ...Sort) Sort          { return tupleSort{Elements: elements} }
-func FuncOf(domain []Sort, range_ Sort) Sort { return funcSort{Domain: domain, Range: range_} }
+func SetOf(element Sort) Sort           { return setSort{Element: element} }
+func TupleOf(elements ...Sort) Sort     { return tupleSort{Elements: elements} }
+func FuncOf(args []Sort, ret Sort) Sort { return funcSort{Args: args, Return: ret} }
 
 // ----------------------------------------------------------------------
 // Term: VarTerm (no sort in JSON), ConstTerm (sort kept), CtorTerm (no

--- a/implementations/go/provekit-ir-symbolic/ir/types_test.go
+++ b/implementations/go/provekit-ir-symbolic/ir/types_test.go
@@ -56,7 +56,7 @@ func TestFuncOf(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal error: %v", err)
 	}
-	want := `{"kind":"function","domain":[{"kind":"primitive","name":"Int"},{"kind":"primitive","name":"Int"}],"range":{"kind":"primitive","name":"Bool"}}`
+	want := `{"kind":"function","args":[{"kind":"primitive","name":"Int"},{"kind":"primitive","name":"Int"}],"return":{"kind":"primitive","name":"Bool"}}`
 	if string(got) != want {
 		t.Errorf("got %s, want %s", got, want)
 	}

--- a/implementations/java/provekit-ir/src/main/java/com/provekit/ir/Sort.java
+++ b/implementations/java/provekit-ir/src/main/java/com/provekit/ir/Sort.java
@@ -30,18 +30,26 @@ public sealed interface Sort {
         }
     }
 
-    record Function(Sort[] domain, Sort range) implements Sort {
+    record Function(Sort[] args, Sort ret) implements Sort {
         public String toJson() {
-            StringBuilder sb = new StringBuilder("{\"kind\":\"function\",\"domain\":[");
-            for (int i = 0; i < domain.length; i++) {
+            StringBuilder sb = new StringBuilder("{\"kind\":\"function\",\"args\":[");
+            for (int i = 0; i < args.length; i++) {
                 if (i > 0) sb.append(",");
-                sb.append(domain[i].toJson());
+                sb.append(args[i].toJson());
             }
-            sb.append("],\"range\":");
-            sb.append(range.toJson());
+            sb.append("],\"return\":");
+            sb.append(ret.toJson());
             sb.append("}");
             return sb.toString();
         }
+    }
+
+    record Dependent(String name, String indexVar, Sort indexSort) implements Sort {
+        public String toJson() {
+            return "{\"kind\":\"dependent\",\"name\":\"" + escape(name) + "\",\"indexVar\":\"" + escape(indexVar) + "\",\"indexSort\":" + indexSort.toJson() + "}";
+        }
+
+        public String kind() { return "dependent"; }
     }
 
     Sort Bool = new Primitive("Bool");

--- a/implementations/php/provekit-ir-symbolic/src/Ir/Term.php
+++ b/implementations/php/provekit-ir-symbolic/src/Ir/Term.php
@@ -3,24 +3,47 @@
 
 namespace ProvekIt\Ir;
 
-enum SortKind: string { case Primitive = 'primitive'; }
+enum SortKind: string { case Primitive = 'primitive'; case Function = 'function'; case Dependent = 'dependent'; }
 
-class Sort implements \JsonSerializable {
+abstract class Sort implements \JsonSerializable {
+    abstract public function jsonSerialize(): array;
+
+    public static function Primitive(string $name): self    { return new PrimitiveSort($name); }
+    public static function FuncOf(array $args, Sort $ret): self { return new FunctionSort($args, $ret); }
+    public static function Dependent(string $name, string $indexVar, Sort $indexSort): self { return new DependentSort($name, $indexVar, $indexSort); }
+
+    public static function Bool():   self { return new PrimitiveSort('Bool'); }
+    public static function Int():    self { return new PrimitiveSort('Int'); }
+    public static function Real():   self { return new PrimitiveSort('Real'); }
+    public static function String(): self { return new PrimitiveSort('String'); }
+    public static function Ref():    self { return new PrimitiveSort('Ref'); }
+}
+
+class PrimitiveSort extends Sort {
+    public function __construct(public readonly string $name) {}
+    public function jsonSerialize(): array { return ['kind' => 'primitive', 'name' => $this->name]; }
+}
+
+class FunctionSort extends Sort {
+    public function __construct(
+        /** @var Sort[] */
+        public readonly array $args,
+        public readonly Sort $return_,
+    ) {}
+    public function jsonSerialize(): array {
+        return ['kind' => 'function', 'args' => array_map(fn($a) => $a->jsonSerialize(), $this->args), 'return' => $this->return_->jsonSerialize()];
+    }
+}
+
+class DependentSort extends Sort {
     public function __construct(
         public readonly string $name,
-        public readonly SortKind $kind = SortKind::Primitive,
+        public readonly string $indexVar,
+        public readonly Sort $indexSort,
     ) {}
-
     public function jsonSerialize(): array {
-        return ['kind' => $this->kind->value, 'name' => $this->name];
+        return ['kind' => 'dependent', 'name' => $this->name, 'indexVar' => $this->indexVar, 'indexSort' => $this->indexSort->jsonSerialize()];
     }
-
-    // Well-known sorts
-    public static function Bool():   self { return new self('Bool'); }
-    public static function Int():    self { return new self('Int'); }
-    public static function Real():   self { return new self('Real'); }
-    public static function String(): self { return new self('String'); }
-    public static function Ref():    self { return new self('Ref'); }
 }
 
 abstract class IrTerm implements \JsonSerializable {

--- a/implementations/php/provekit-lift/src/lifter.php
+++ b/implementations/php/provekit-lift/src/lifter.php
@@ -256,7 +256,10 @@ class PhpFileParser
                 return new \ProvekIt\Ir\ConnectiveFormula($json['kind'], $ops);
             case 'forall':
             case 'exists':
-                $sort = new \ProvekIt\Ir\Sort($json['sort']['name'] ?? 'Ref');
+                // Sort is abstract; construct the Primitive variant via the
+                // static helper. (Function/Dependent quantifier sorts could
+                // be added here when the lifter starts emitting them.)
+                $sort = \ProvekIt\Ir\Sort::Primitive($json['sort']['name'] ?? 'Ref');
                 return new \ProvekIt\Ir\QuantifierFormula(
                     $json['kind'], $json['name'], $sort,
                     $this->jsonToFormula($json['body'])
@@ -272,7 +275,7 @@ class PhpFileParser
             'var' => new \ProvekIt\Ir\VarTerm($json['name']),
             'const' => new \ProvekIt\Ir\ConstTerm(
                 $json['value'],
-                new \ProvekIt\Ir\Sort($json['sort']['name'] ?? 'Ref')
+                \ProvekIt\Ir\Sort::Primitive($json['sort']['name'] ?? 'Ref')
             ),
             'ctor' => new \ProvekIt\Ir\CtorTerm(
                 $json['name'],

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
@@ -25,24 +25,48 @@ from .canonicalizer import Value, varr, vint, vobj, vstr, vnull
 
 
 @dataclass(frozen=True)
-class Sort:
+class PrimitiveSort:
     name: str  # "Int" / "Real" / "String" / "Bool"
 
 
+@dataclass(frozen=True)
+class FunctionSort:
+    args: Tuple["Sort", ...]
+    return_: "Sort"
+
+
+@dataclass(frozen=True)
+class DependentSort:
+    name: str
+    index_var: str
+    index_sort: "Sort"
+
+
+Sort = Union[PrimitiveSort, FunctionSort, DependentSort]
+
+
 def Int() -> Sort:
-    return Sort("Int")
+    return PrimitiveSort("Int")
 
 
 def Real() -> Sort:
-    return Sort("Real")
+    return PrimitiveSort("Real")
 
 
 def String() -> Sort:
-    return Sort("String")
+    return PrimitiveSort("String")
 
 
 def Bool() -> Sort:
-    return Sort("Bool")
+    return PrimitiveSort("Bool")
+
+
+def FuncOf(args: List[Sort], ret: Sort) -> Sort:
+    return FunctionSort(tuple(args), ret)
+
+
+def Dependent(name: str, index_var: str, index_sort: Sort) -> Sort:
+    return DependentSort(name, index_var, index_sort)
 
 
 # Term ----------------------------------------------------------------------
@@ -214,16 +238,23 @@ class EvidenceTerm:
 
 
 def evidence_to_value(e: EvidenceTerm) -> Value:
-    return vobj([
-        ("kind", vstr("evidence")),
-        ("proofType", vstr(e.proof_type)),
-        ("certificate", vobj([
-            ("tool", vstr(e.certificate.tool)),
-            ("version", vstr(e.certificate.version)),
-            ("formulaHash", vstr(e.certificate.formula_hash)),
-            ("proofData", vstr(e.certificate.proof_data)),
-        ])),
-    ])
+    return vobj(
+        [
+            ("kind", vstr("evidence")),
+            ("proofType", vstr(e.proof_type)),
+            (
+                "certificate",
+                vobj(
+                    [
+                        ("tool", vstr(e.certificate.tool)),
+                        ("version", vstr(e.certificate.version)),
+                        ("formulaHash", vstr(e.certificate.formula_hash)),
+                        ("proofData", vstr(e.certificate.proof_data)),
+                    ]
+                ),
+            ),
+        ]
+    )
 
 
 # ContractDecl --------------------------------------------------------------
@@ -243,59 +274,93 @@ class ContractDecl:
 
 
 def sort_to_value(s: Sort) -> Value:
-    return vobj([("kind", vstr("primitive")), ("name", vstr(s.name))])
+    if isinstance(s, PrimitiveSort):
+        return vobj([("kind", vstr("primitive")), ("name", vstr(s.name))])
+    if isinstance(s, FunctionSort):
+        return vobj(
+            [
+                ("kind", vstr("function")),
+                ("args", varr([sort_to_value(a) for a in s.args])),
+                ("return", sort_to_value(s.return_)),
+            ]
+        )
+    if isinstance(s, DependentSort):
+        return vobj(
+            [
+                ("kind", vstr("dependent")),
+                ("name", vstr(s.name)),
+                ("indexVar", vstr(s.index_var)),
+                ("indexSort", sort_to_value(s.index_sort)),
+            ]
+        )
+    raise TypeError(f"unknown Sort: {type(s)!r}")
 
 
 def term_to_value(t: Term) -> Value:
     if isinstance(t, _Var):
         return vobj([("kind", vstr("var")), ("name", vstr(t.name))])
     if isinstance(t, _ConstInt):
-        return vobj([
-            ("kind", vstr("const")),
-            ("value", vint(t.value)),
-            ("sort", sort_to_value(t.sort)),
-        ])
+        return vobj(
+            [
+                ("kind", vstr("const")),
+                ("value", vint(t.value)),
+                ("sort", sort_to_value(t.sort)),
+            ]
+        )
     if isinstance(t, _ConstStr):
-        return vobj([
-            ("kind", vstr("const")),
-            ("value", vstr(t.value)),
-            ("sort", sort_to_value(t.sort)),
-        ])
+        return vobj(
+            [
+                ("kind", vstr("const")),
+                ("value", vstr(t.value)),
+                ("sort", sort_to_value(t.sort)),
+            ]
+        )
     if isinstance(t, _ConstBool):
         from .canonicalizer import vbool
-        return vobj([
-            ("kind", vstr("const")),
-            ("value", vbool(t.value)),
-            ("sort", sort_to_value(t.sort)),
-        ])
+
+        return vobj(
+            [
+                ("kind", vstr("const")),
+                ("value", vbool(t.value)),
+                ("sort", sort_to_value(t.sort)),
+            ]
+        )
     if isinstance(t, _Ctor):
-        return vobj([
-            ("kind", vstr("ctor")),
-            ("name", vstr(t.name)),
-            ("args", varr([term_to_value(a) for a in t.args])),
-        ])
+        return vobj(
+            [
+                ("kind", vstr("ctor")),
+                ("name", vstr(t.name)),
+                ("args", varr([term_to_value(a) for a in t.args])),
+            ]
+        )
     raise TypeError(f"unknown Term: {type(t)!r}")
 
 
 def formula_to_value(f: Formula) -> Value:
     if isinstance(f, _Atomic):
-        return vobj([
-            ("kind", vstr("atomic")),
-            ("name", vstr(f.name)),
-            ("args", varr([term_to_value(a) for a in f.args])),
-        ])
+        return vobj(
+            [
+                ("kind", vstr("atomic")),
+                ("name", vstr(f.name)),
+                ("args", varr([term_to_value(a) for a in f.args])),
+            ]
+        )
     if isinstance(f, _Connective):
-        return vobj([
-            ("kind", vstr(f.kind)),
-            ("operands", varr([formula_to_value(o) for o in f.operands])),
-        ])
+        return vobj(
+            [
+                ("kind", vstr(f.kind)),
+                ("operands", varr([formula_to_value(o) for o in f.operands])),
+            ]
+        )
     if isinstance(f, _Quantifier):
-        return vobj([
-            ("kind", vstr(f.kind)),
-            ("name", vstr(f.name)),
-            ("sort", sort_to_value(f.sort)),
-            ("body", formula_to_value(f.body)),
-        ])
+        return vobj(
+            [
+                ("kind", vstr(f.kind)),
+                ("name", vstr(f.name)),
+                ("sort", sort_to_value(f.sort)),
+                ("body", formula_to_value(f.body)),
+            ]
+        )
     raise TypeError(f"unknown Formula: {type(f)!r}")
 
 
@@ -306,20 +371,28 @@ def subst_var_in_term(t: Term, formal: str, actual: Term) -> Term:
     if isinstance(t, _Var):
         return actual if t.name == formal else t
     if isinstance(t, _Ctor):
-        return _Ctor(t.name, tuple(subst_var_in_term(a, formal, actual) for a in t.args))
+        return _Ctor(
+            t.name, tuple(subst_var_in_term(a, formal, actual) for a in t.args)
+        )
     return t  # const variants are inert
 
 
 def subst_var_in_formula(f: Formula, formal: str, actual: Term) -> Formula:
     if isinstance(f, _Atomic):
-        return _Atomic(f.name, tuple(subst_var_in_term(a, formal, actual) for a in f.args))
+        return _Atomic(
+            f.name, tuple(subst_var_in_term(a, formal, actual) for a in f.args)
+        )
     if isinstance(f, _Connective):
-        return _Connective(f.kind, tuple(subst_var_in_formula(o, formal, actual) for o in f.operands))
+        return _Connective(
+            f.kind, tuple(subst_var_in_formula(o, formal, actual) for o in f.operands)
+        )
     if isinstance(f, _Quantifier):
         # Don't substitute under a shadowing binder.
         if f.name == formal:
             return f
-        return _Quantifier(f.kind, f.name, f.sort, subst_var_in_formula(f.body, formal, actual))
+        return _Quantifier(
+            f.kind, f.name, f.sort, subst_var_in_formula(f.body, formal, actual)
+        )
     raise TypeError(f"unknown Formula: {type(f)!r}")
 
 
@@ -429,11 +502,13 @@ class Locus:
 
 def locus_to_value(loc: Locus) -> Value:
     """Emit Locus as a Value with JCS-canonical key order: column, file, line."""
-    return vobj([
-        ("column", vint(loc.column)),
-        ("file", vstr(loc.file)),
-        ("line", vint(loc.line)),
-    ])
+    return vobj(
+        [
+            ("column", vint(loc.column)),
+            ("file", vstr(loc.file)),
+            ("line", vint(loc.line)),
+        ]
+    )
 
 
 # CallEdgeDecl ----------------------------------------------------------------
@@ -462,16 +537,20 @@ def call_edge_decl_to_value(c: CallEdgeDecl) -> Value:
     JCS-canonical key order: callSiteLocus, evidenceTerm, kind, schemaVersion,
     sourceContractCid, targetContractCid, targetSymbol.
     """
-    target_cid_value: Value = vnull() if c.target_contract_cid is None else vstr(c.target_contract_cid)
-    return vobj([
-        ("callSiteLocus", locus_to_value(c.call_site_locus)),
-        ("evidenceTerm", formula_to_value(c.evidence_term)),
-        ("kind", vstr("call-edge")),
-        ("schemaVersion", vstr("1")),
-        ("sourceContractCid", vstr(c.source_contract_cid)),
-        ("targetContractCid", target_cid_value),
-        ("targetSymbol", vstr(c.target_symbol)),
-    ])
+    target_cid_value: Value = (
+        vnull() if c.target_contract_cid is None else vstr(c.target_contract_cid)
+    )
+    return vobj(
+        [
+            ("callSiteLocus", locus_to_value(c.call_site_locus)),
+            ("evidenceTerm", formula_to_value(c.evidence_term)),
+            ("kind", vstr("call-edge")),
+            ("schemaVersion", vstr("1")),
+            ("sourceContractCid", vstr(c.source_contract_cid)),
+            ("targetContractCid", target_cid_value),
+            ("targetSymbol", vstr(c.target_symbol)),
+        ]
+    )
 
 
 def call_edges_to_value(edges: List["CallEdgeDecl"]) -> Value:

--- a/implementations/ruby/lib/provekit/ir.rb
+++ b/implementations/ruby/lib/provekit/ir.rb
@@ -11,7 +11,7 @@ module Provekit
   module IR
     # ── Sort ────────────────────────────────────────────────────
 
-    Sort = Struct.new(:name) do
+    PrimitiveSort = Struct.new(:name) do
       def self.Int    = new("Int")
       def self.Real   = new("Real")
       def self.String = new("String")
@@ -20,26 +20,34 @@ module Provekit
       def self.Node   = new("Node")
     end
 
+    FunctionSort = Struct.new(:args, :return_) do
+    end
+
+    DependentSort = Struct.new(:name, :index_var, :index_sort) do
+    end
+
+    Sort = PrimitiveSort
+
     # ── Term ────────────────────────────────────────────────────
 
     def self.var(name:)
       { kind: :var, name: name }
     end
 
-    def self.num(value)
-      { kind: :const, value: value.to_i, sort: Sort.Int }
+      def self.num(value)
+      { kind: :const, value: value.to_i, sort: PrimitiveSort.Int }
     end
 
     def self.str(value)
-      { kind: :const, value: value.to_s, sort: Sort.String }
+      { kind: :const, value: value.to_s, sort: PrimitiveSort.String }
     end
 
     def self.bool(value)
-      { kind: :const, value: !!value, sort: Sort.Bool }
+      { kind: :const, value: !!value, sort: PrimitiveSort.Bool }
     end
 
     def self.null_ref
-      { kind: :const, value: nil, sort: Sort.Ref }
+      { kind: :const, value: nil, sort: PrimitiveSort.Ref }
     end
 
     def self.ctor(name, *args)
@@ -178,7 +186,17 @@ module Provekit
       end
 
       def self.emit_sort(sort)
-        %({"kind":"primitive","name":#{emit_string(sort.name)}})
+        case sort
+        when PrimitiveSort
+          %({"kind":"primitive","name":#{emit_string(sort.name)}})
+        when FunctionSort
+          args_json = "[#{sort.args.map { |a| encode(a) }.join(',')}]"
+          %({"kind":"function","args":#{args_json},"return":#{encode(sort.return_)}})
+        when DependentSort
+          %({"kind":"dependent","name":#{emit_string(sort.name)},"indexVar":#{emit_string(sort.index_var)},"indexSort":#{emit_sort(sort.index_sort)}})
+        else
+          raise "unknown sort: #{sort.class}"
+        end
       end
 
       def self.emit_const(value)

--- a/implementations/swift/Sources/Provekit/IR.swift
+++ b/implementations/swift/Sources/Provekit/IR.swift
@@ -11,14 +11,17 @@ import ProvekitCrypto
 
 // MARK: - Sort
 
-public struct Sort: Equatable, Hashable, Sendable {
-    public let name: String
-    public static let int = Sort(name: "Int")
-    public static let real = Sort(name: "Real")
-    public static let string = Sort(name: "String")
-    public static let bool = Sort(name: "Bool")
-    public static let ref = Sort(name: "Ref")
-    public static let node = Sort(name: "Node")
+public indirect enum Sort: Equatable, Hashable, Sendable {
+    case primitive(String)
+    case function(args: [Sort], return_: Sort)
+    case dependent(name: String, indexVar: String, indexSort: Sort)
+
+    public static let int = Sort.primitive("Int")
+    public static let real = Sort.primitive("Real")
+    public static let string = Sort.primitive("String")
+    public static let bool = Sort.primitive("Bool")
+    public static let ref = Sort.primitive("Ref")
+    public static let node = Sort.primitive("Node")
 }
 
 // MARK: - Term
@@ -211,7 +214,19 @@ public enum Jcs {
     // Helpers
 
     static func sortToValue(_ s: Sort) -> JcsValue {
-        .obj(("kind", .string("primitive")), ("name", .string(s.name)))
+        switch s {
+        case .primitive(let name):
+            return .obj(("kind", .string("primitive")), ("name", .string(name)))
+        case .function(let args, let return_):
+            return .obj(("args", .arr(args.map(sortToValue))),
+                        ("kind", .string("function")),
+                        ("return", sortToValue(return_)))
+        case .dependent(let name, let indexVar, let indexSort):
+            return .obj(("indexSort", sortToValue(indexSort)),
+                        ("indexVar", .string(indexVar)),
+                        ("kind", .string("dependent")),
+                        ("name", .string(name)))
+        }
     }
 
     static func constValToValue(_ cv: ConstValue) -> JcsValue {

--- a/implementations/typescript/src/canonicalizer/ast.ts
+++ b/implementations/typescript/src/canonicalizer/ast.ts
@@ -26,7 +26,8 @@ export type CanonicalSort =
   | { kind: "bitvec"; width: number }
   | { kind: "set"; element: CanonicalSort }
   | { kind: "tuple"; elements: CanonicalSort[] }
-  | { kind: "function"; domain: CanonicalSort[]; range: CanonicalSort };
+  | { kind: "function"; args: CanonicalSort[]; return: CanonicalSort }
+  | { kind: "dependent"; name: string; indexVar: string; indexSort: CanonicalSort };
 
 // ---------------------------------------------------------------------------
 // Terms

--- a/implementations/typescript/src/canonicalizer/equivalence.test.ts
+++ b/implementations/typescript/src/canonicalizer/equivalence.test.ts
@@ -967,17 +967,17 @@ describe("12. canonicalizeSort", () => {
     });
   });
 
-  it("recursively canonicalizes function domain + range", () => {
+  it("recursively canonicalizes function args + return", () => {
     expect(
       canonicalizeSort({
         kind: "function",
-        domain: [{ kind: "primitive", name: "Int" }],
-        range: { kind: "primitive", name: "Bool" },
+        args: [{ kind: "primitive", name: "Int" }],
+        return: { kind: "primitive", name: "Bool" },
       }),
     ).toEqual({
       kind: "function",
-      domain: [{ kind: "primitive", name: "Int" }],
-      range: { kind: "primitive", name: "Bool" },
+      args: [{ kind: "primitive", name: "Int" }],
+      return: { kind: "primitive", name: "Bool" },
     });
   });
 

--- a/implementations/typescript/src/canonicalizer/passes/acNormalize.ts
+++ b/implementations/typescript/src/canonicalizer/passes/acNormalize.ts
@@ -76,7 +76,9 @@ function sortKeySort(s: CanonicalSort): string {
     case "tuple":
       return `T:${s.elements.map(sortKeySort).join(",")}`;
     case "function":
-      return `F:${s.domain.map(sortKeySort).join(",")}:${sortKeySort(s.range)}`;
+      return `F:${s.args.map(sortKeySort).join(",")}:${sortKeySort(s.return)}`;
+    case "dependent":
+      return `D:${s.name}:${s.indexVar}:${sortKeySort(s.indexSort)}`;
   }
 }
 

--- a/implementations/typescript/src/canonicalizer/passes/predicates.ts
+++ b/implementations/typescript/src/canonicalizer/passes/predicates.ts
@@ -204,7 +204,9 @@ function sortKey(sort: CanonicalSort): string {
     case "tuple":
       return `T:${sort.elements.map(sortKey).join(",")}`;
     case "function":
-      return `F:${sort.domain.map(sortKey).join(",")}:${sortKey(sort.range)}`;
+      return `F:${sort.args.map(sortKey).join(",")}:${sortKey(sort.return)}`;
+    case "dependent":
+      return `D:${sort.name}:${sort.indexVar}:${sortKey(sort.indexSort)}`;
   }
 }
 

--- a/implementations/typescript/src/canonicalizer/passes/sorts.ts
+++ b/implementations/typescript/src/canonicalizer/passes/sorts.ts
@@ -60,8 +60,15 @@ export function canonicalizeSort(sort: Sort): CanonicalSort {
     case "function":
       return {
         kind: "function",
-        domain: sort.domain.map(canonicalizeSort),
-        range: canonicalizeSort(sort.range),
+        args: sort.args.map(canonicalizeSort),
+        return: canonicalizeSort(sort.return),
+      };
+    case "dependent":
+      return {
+        kind: "dependent",
+        name: sort.name,
+        indexVar: sort.indexVar,
+        indexSort: canonicalizeSort(sort.indexSort),
       };
   }
 }

--- a/implementations/typescript/src/ir/formulas.ts
+++ b/implementations/typescript/src/ir/formulas.ts
@@ -27,7 +27,8 @@ export type Sort =
   | { kind: "bitvec"; width: number }
   | { kind: "set"; element: Sort }
   | { kind: "tuple"; elements: Sort[] }
-  | { kind: "function"; domain: Sort[]; range: Sort };
+  | { kind: "function"; args: Sort[]; return: Sort }
+  | { kind: "dependent"; name: string; indexVar: string; indexSort: Sort };
 
 // ---------------------------------------------------------------------------
 // Terms

--- a/implementations/typescript/src/ir/grammar/parse.ts
+++ b/implementations/typescript/src/ir/grammar/parse.ts
@@ -100,7 +100,8 @@ const PRIMITIVE_SORT_KEYS = ["kind", "name"] as const;
 const BITVEC_SORT_KEYS = ["kind", "width"] as const;
 const SET_SORT_KEYS = ["kind", "element"] as const;
 const TUPLE_SORT_KEYS = ["kind", "elements"] as const;
-const FUNCTION_SORT_KEYS = ["kind", "domain", "range"] as const;
+const FUNCTION_SORT_KEYS = ["kind", "args", "return"] as const;
+const DEPENDENT_SORT_KEYS = ["kind", "name", "indexVar", "indexSort"] as const;
 
 const CANONICAL_PRIMITIVE_SORTS: ReadonlySet<string> = new Set([
   "Bool",
@@ -623,10 +624,12 @@ function parseSortValue(value: unknown, path: string, opts: ParseOptions): Sort 
       return parseTupleSort(obj, path, opts);
     case "function":
       return parseFunctionSort(obj, path, opts);
+    case "dependent":
+      return parseDependentSort(obj, path, opts);
     default:
       throw new GrammarParseError({
         path: `${path}/kind`,
-        expected: '"primitive" | "bitvec" | "set" | "tuple" | "function"',
+        expected: '"primitive" | "bitvec" | "set" | "tuple" | "function" | "dependent"',
         actual: kind,
       });
   }
@@ -704,11 +707,24 @@ function parseFunctionSort(
 ): Sort {
   enforceClosedKeys(obj, path, FUNCTION_SORT_KEYS, []);
   if (opts.strict) enforceKeyOrder(obj, path, FUNCTION_SORT_KEYS);
-  const domain = expectArray(obj["domain"], `${path}/domain`).map((d, i) =>
-    parseSortValue(d, `${path}/domain/${i}`, opts),
+  const args = expectArray(obj["args"], `${path}/args`).map((a, i) =>
+    parseSortValue(a, `${path}/args/${i}`, opts),
   );
-  const range = parseSortValue(obj["range"], `${path}/range`, opts);
-  return { kind: "function", domain, range };
+  const ret = parseSortValue(obj["return"], `${path}/return`, opts);
+  return { kind: "function", args, return: ret };
+}
+
+function parseDependentSort(
+  obj: Record<string, unknown>,
+  path: string,
+  opts: ParseOptions,
+): Sort {
+  enforceClosedKeys(obj, path, DEPENDENT_SORT_KEYS, []);
+  if (opts.strict) enforceKeyOrder(obj, path, DEPENDENT_SORT_KEYS);
+  const name = expectString(obj["name"], `${path}/name`, "string dependent sort name");
+  const indexVar = expectString(obj["indexVar"], `${path}/indexVar`, "string index variable");
+  const indexSort = parseSortValue(obj["indexSort"], `${path}/indexSort`, opts);
+  return { kind: "dependent", name, indexVar, indexSort };
 }
 
 // ---------------------------------------------------------------------------
@@ -1007,8 +1023,17 @@ export function emitSort(s: Sort): string {
       return (
         "{" +
         `"kind":"function",` +
-        `"domain":[${s.domain.map(emitSort).join(",")}],` +
-        `"range":${emitSort(s.range)}` +
+        `"args":[${s.args.map(emitSort).join(",")}],` +
+        `"return":${emitSort(s.return)}` +
+        "}"
+      );
+    case "dependent":
+      return (
+        "{" +
+        `"kind":"dependent",` +
+        `"name":${JSON.stringify(s.name)},` +
+        `"indexVar":${JSON.stringify(s.indexVar)},` +
+        `"indexSort":${emitSort(s.indexSort)}` +
         "}"
       );
   }

--- a/implementations/typescript/src/ir/ir.test.ts
+++ b/implementations/typescript/src/ir/ir.test.ts
@@ -84,8 +84,8 @@ describe("sorts", () => {
   it("FuncOf constructs a function sort", () => {
     expect(FuncOf([Int], Bool)).toEqual({
       kind: "function",
-      domain: [{ kind: "primitive", name: "Int" }],
-      range: { kind: "primitive", name: "Bool" },
+      args: [{ kind: "primitive", name: "Int" }],
+      return: { kind: "primitive", name: "Bool" },
     });
   });
 });

--- a/implementations/typescript/src/ir/lean/lean.test.ts
+++ b/implementations/typescript/src/ir/lean/lean.test.ts
@@ -184,7 +184,7 @@ describe("emitLean — sort mapping", () => {
   });
 
   it("throws LeanUnsupportedError for function sort", () => {
-    const fnSort: Sort = { kind: "function", domain: [Int], range: Bool };
+    const fnSort: Sort = { kind: "function", args: [Int], return: Bool };
     const f: IrFormula = {
       kind: "forall", name: "_x0", sort: fnSort, body: { kind: "atomic", name: "true", args: [] },
     };

--- a/implementations/typescript/src/ir/lean/sorts.ts
+++ b/implementations/typescript/src/ir/lean/sorts.ts
@@ -56,6 +56,10 @@ export function emitSort(sort: Sort): string {
       throw new LeanUnsupportedError(
         "Lean translator: function sorts are not first-class in the FOL fragment. Declare an opaque function symbol via `axiom f : T1 -> T2` in the kit and use it as a ctor.",
       );
+    case "dependent":
+      throw new LeanUnsupportedError(
+        "Lean translator: dependent sorts are out of scope for the FOL fragment.",
+      );
     default:
       throw new LeanUnsupportedError(`Lean translator: unknown sort kind ${(sort as { kind: string }).kind}`);
   }
@@ -84,8 +88,11 @@ export function collectUserSorts(sort: Sort, out: Set<string>): void {
       for (const e of sort.elements) collectUserSorts(e, out);
       return;
     case "function":
-      for (const d of sort.domain) collectUserSorts(d, out);
-      collectUserSorts(sort.range, out);
+      for (const d of sort.args) collectUserSorts(d, out);
+      collectUserSorts(sort.return, out);
+      return;
+    case "dependent":
+      collectUserSorts(sort.indexSort, out);
       return;
   }
 }

--- a/implementations/typescript/src/ir/smt/smt.test.ts
+++ b/implementations/typescript/src/ir/smt/smt.test.ts
@@ -332,9 +332,9 @@ describe("smt/sorts — emitSort", () => {
     );
   });
 
-  it("emits function sorts as (-> dom range)", () => {
+  it("emits function sorts as (-> dom ret)", () => {
     expect(
-      emitSort({ kind: "function", domain: [Int, Real], range: Bool }),
+      emitSort({ kind: "function", args: [Int, Real], return: Bool }),
     ).toBe("(-> Int Real Bool)");
   });
 });
@@ -352,7 +352,7 @@ describe("smt/sorts — collectUserSorts", () => {
     const ux: Sort = { kind: "primitive", name: "USort" };
     collectUserSorts(SetOf(ux), out);
     collectUserSorts({ kind: "tuple", elements: [Int, ux] }, out);
-    collectUserSorts({ kind: "function", domain: [ux], range: ux }, out);
+    collectUserSorts({ kind: "function", args: [ux], return: ux }, out);
     expect([...out]).toEqual(["USort"]);
   });
 });

--- a/implementations/typescript/src/ir/smt/sorts.ts
+++ b/implementations/typescript/src/ir/smt/sorts.ts
@@ -12,7 +12,7 @@
  * needed (SMT-LIB doesn't have first-class function sorts in the AUFLIA
  * fragment; ALL logic supports them via parametric arrays for some
  * solvers — for now we declare uninterpreted function symbols by their
- * domain/range, not by their function-sort).
+ * args/return, not by their function-sort).
  */
 
 import type { Sort } from "../formulas.js";
@@ -46,10 +46,13 @@ export function emitSort(sort: Sort): string {
       return `(Tuple ${sort.elements.map(emitSort).join(" ")})`;
     case "function":
       // Function sorts aren't first-class in plain SMT-LIB. We render
-      // them as `(-> dom1 dom2 ... range)` which mirrors the SMT-LIB
+      // them as `(-> dom1 dom2 ... ret)` which mirrors the SMT-LIB
       // higher-order extension; consumers that don't support it should
       // not place function sorts in atomic positions.
-      return `(-> ${sort.domain.map(emitSort).join(" ")} ${emitSort(sort.range)})`;
+      return `(-> ${sort.args.map(emitSort).join(" ")} ${emitSort(sort.return)})`;
+    case "dependent":
+      // Dependent sorts are treated as opaque user-declared sorts.
+      return sort.name;
   }
 }
 
@@ -74,8 +77,11 @@ export function collectUserSorts(sort: Sort, out: Set<string>): void {
       for (const e of sort.elements) collectUserSorts(e, out);
       return;
     case "function":
-      for (const d of sort.domain) collectUserSorts(d, out);
-      collectUserSorts(sort.range, out);
+      for (const d of sort.args) collectUserSorts(d, out);
+      collectUserSorts(sort.return, out);
+      return;
+    case "dependent":
+      collectUserSorts(sort.indexSort, out);
       return;
   }
 }

--- a/implementations/typescript/src/ir/sorts.ts
+++ b/implementations/typescript/src/ir/sorts.ts
@@ -56,6 +56,6 @@ export function TupleOf(...elements: Sort[]): Sort {
 }
 
 /** Construct a function sort. */
-export function FuncOf(domain: Sort[], range: Sort): Sort {
-  return { kind: "function", domain, range };
+export function FuncOf(args: Sort[], ret: Sort): Sort {
+  return { kind: "function", args, return: ret };
 }

--- a/implementations/typescript/src/ir/symbolic/primitives.ts
+++ b/implementations/typescript/src/ir/symbolic/primitives.ts
@@ -437,7 +437,7 @@ export function lambda(paramName: string, paramSort: Sort, body: IrTerm): IrTerm
   // Sort hint: function sort (paramSort → bodySort)
   const bodySort = inferSortHint(body);
   if (bodySort) {
-    attachSortHint(lam, { kind: "function", domain: [paramSort], range: bodySort });
+    attachSortHint(lam, { kind: "function", args: [paramSort], return: bodySort });
   }
   return lam;
 }

--- a/implementations/typescript/src/ir/symbolic/symbolic.test.ts
+++ b/implementations/typescript/src/ir/symbolic/symbolic.test.ts
@@ -718,7 +718,7 @@ vDescribe("lambda", () => {
 
   test("lambda infers function sort from param and body", () => {
     const lam = lambda("x", Int, num(42));
-    expect(termSort(lam)).toEqual({ kind: "function", domain: [Int], range: Int });
+    expect(termSort(lam)).toEqual({ kind: "function", args: [Int], return: Int });
   });
 });
 

--- a/implementations/zig/provekit-ir/src/root.zig
+++ b/implementations/zig/provekit-ir/src/root.zig
@@ -12,7 +12,12 @@ const std = @import("std");
 
 pub const Sort = union(enum) {
     primitive: []const u8,
-    function: struct { args: []const Sort, return_: Sort },
+    // FunctionSort recursively contains Sort. Zig requires pointer
+    // indirection on recursive type fields to break the dependency
+    // loop (same constraint that `dependent.index_sort` already
+    // satisfies via *const Sort). Slice-of-pointer for args, pointer
+    // for return.
+    function: struct { args: []const *const Sort, return_: *const Sort },
     dependent: struct { name: []const u8, index_var: []const u8, index_sort: *const Sort },
 
     pub const Bool = Sort{ .primitive = "Bool" };
@@ -34,11 +39,15 @@ pub const Sort = union(enum) {
             .function => |f| {
                 try jws.beginObject();
                 try jws.objectField("args");
-                try jws.write(f.args);
+                try jws.beginArray();
+                for (f.args) |arg_ptr| {
+                    try jws.write(arg_ptr.*);
+                }
+                try jws.endArray();
                 try jws.objectField("kind");
                 try jws.write("function");
                 try jws.objectField("return");
-                try jws.write(f.return_);
+                try jws.write(f.return_.*);
                 try jws.endObject();
             },
             .dependent => |d| {

--- a/implementations/zig/provekit-ir/src/root.zig
+++ b/implementations/zig/provekit-ir/src/root.zig
@@ -12,6 +12,8 @@ const std = @import("std");
 
 pub const Sort = union(enum) {
     primitive: []const u8,
+    function: struct { args: []const Sort, return_: Sort },
+    dependent: struct { name: []const u8, index_var: []const u8, index_sort: *const Sort },
 
     pub const Bool = Sort{ .primitive = "Bool" };
     pub const Int = Sort{ .primitive = "Int" };
@@ -27,6 +29,28 @@ pub const Sort = union(enum) {
                 try jws.write("primitive");
                 try jws.objectField("name");
                 try jws.write(name);
+                try jws.endObject();
+            },
+            .function => |f| {
+                try jws.beginObject();
+                try jws.objectField("args");
+                try jws.write(f.args);
+                try jws.objectField("kind");
+                try jws.write("function");
+                try jws.objectField("return");
+                try jws.write(f.return_);
+                try jws.endObject();
+            },
+            .dependent => |d| {
+                try jws.beginObject();
+                try jws.objectField("indexSort");
+                try jws.write(d.index_sort.*);
+                try jws.objectField("indexVar");
+                try jws.write(d.index_var);
+                try jws.objectField("kind");
+                try jws.write("dependent");
+                try jws.objectField("name");
+                try jws.write(d.name);
                 try jws.endObject();
             },
         }
@@ -124,15 +148,15 @@ pub const Formula = union(enum) {
     pub const ConnectiveKind = enum {
         @"and",
         @"or",
-        @"not",
-        @"implies",
+        not,
+        implies,
 
         pub fn jsonStringify(self: ConnectiveKind, jws: anytype) !void {
             const str = switch (self) {
                 .@"and" => "and",
                 .@"or" => "or",
-                .@"not" => "not",
-                .@"implies" => "implies",
+                .not => "not",
+                .implies => "implies",
             };
             try jws.write(str);
         }
@@ -310,11 +334,11 @@ pub fn Or(operands: []const Formula) Formula {
 }
 
 pub fn Not(operands: []const Formula) Formula {
-    return .{ .connective = .{ .kind = .@"not", .operands = operands } };
+    return .{ .connective = .{ .kind = .not, .operands = operands } };
 }
 
 pub fn Implies(operands: []const Formula) Formula {
-    return .{ .connective = .{ .kind = .@"implies", .operands = operands } };
+    return .{ .connective = .{ .kind = .implies, .operands = operands } };
 }
 
 pub fn Forall(name: []const u8, sort_: Sort, body: *const Formula) Formula {
@@ -370,9 +394,7 @@ test "eq atomic JCS matches Rust" {
     defer alloc.free(jcs);
 
     const expected =
-        "{\"args\":[{\"args\":[{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"},\"value\":\"42\"}],\"kind\":\"ctor\",\"name\":\"parse_int\"},"
-        ++ "{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":42}],"
-        ++ "\"kind\":\"atomic\",\"name\":\"=\"}";
+        "{\"args\":[{\"args\":[{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"},\"value\":\"42\"}],\"kind\":\"ctor\",\"name\":\"parse_int\"}," ++ "{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":42}]," ++ "\"kind\":\"atomic\",\"name\":\"=\"}";
 
     try std.testing.expectEqualStrings(expected, jcs);
 }
@@ -393,8 +415,7 @@ test "eq atomic hash matches Rust" {
     defer alloc.free(hash);
 
     const expected =
-        "blake3-512:5eade72c08811b2d38adcb158eced38f3d319de090d59b2fa7a77ad830169e18"
-        ++ "539d2b75d2a2838c545e644a688cf137603674523ff37f1586a650f6dd05aeaa";
+        "blake3-512:5eade72c08811b2d38adcb158eced38f3d319de090d59b2fa7a77ad830169e18" ++ "539d2b75d2a2838c545e644a688cf137603674523ff37f1586a650f6dd05aeaa";
 
     try std.testing.expectEqualStrings(expected, hash);
 }
@@ -430,12 +451,7 @@ test "pattern1 bounded loop JCS matches Rust" {
     defer alloc.free(jcs);
 
     const expected =
-        "{\"body\":{\"kind\":\"implies\",\"operands\":[{\"kind\":\"and\",\"operands\":[{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},"
-        ++ "{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":0}],\"kind\":\"atomic\",\"name\":\"≥\"},"
-        ++ "{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":100}],"
-        ++ "\"kind\":\"atomic\",\"name\":\"<\"}]},{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},"
-        ++ "{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":0}],\"kind\":\"atomic\",\"name\":\"≥\"}]},"
-        ++ "\"kind\":\"forall\",\"name\":\"x\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
+        "{\"body\":{\"kind\":\"implies\",\"operands\":[{\"kind\":\"and\",\"operands\":[{\"args\":[{\"kind\":\"var\",\"name\":\"x\"}," ++ "{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":0}],\"kind\":\"atomic\",\"name\":\"≥\"}," ++ "{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":100}]," ++ "\"kind\":\"atomic\",\"name\":\"<\"}]},{\"args\":[{\"kind\":\"var\",\"name\":\"x\"}," ++ "{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":0}],\"kind\":\"atomic\",\"name\":\"≥\"}]}," ++ "\"kind\":\"forall\",\"name\":\"x\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
 
     try std.testing.expectEqualStrings(expected, jcs);
 }
@@ -457,9 +473,7 @@ test "contract decl JCS" {
     defer alloc.free(jcs);
 
     const expected =
-        "{\"kind\":\"contract\",\"name\":\"parseInt\",\"outBinding\":\"out\","
-        ++ "\"pre\":{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":0}],"
-        ++ "\"kind\":\"atomic\",\"name\":\"≥\"}}";
+        "{\"kind\":\"contract\",\"name\":\"parseInt\",\"outBinding\":\"out\"," ++ "\"pre\":{\"args\":[{\"kind\":\"var\",\"name\":\"x\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"},\"value\":0}]," ++ "\"kind\":\"atomic\",\"name\":\"≥\"}}";
 
     try std.testing.expectEqualStrings(expected, jcs);
 }
@@ -482,9 +496,7 @@ test "bridge decl JCS" {
     defer alloc.free(jcs);
 
     const expected =
-        "{\"kind\":\"bridge\",\"name\":\"myBridge\",\"notes\":\"some notes\","
-        ++ "\"sourceContractCid\":\"bafySource\",\"sourceLayer\":\"c-kit\",\"sourceSymbol\":\"source\","
-        ++ "\"targetContractCid\":\"bafyTarget\",\"targetLayer\":\"coq\",\"targetProofCid\":\"bafyProof\"}";
+        "{\"kind\":\"bridge\",\"name\":\"myBridge\",\"notes\":\"some notes\"," ++ "\"sourceContractCid\":\"bafySource\",\"sourceLayer\":\"c-kit\",\"sourceSymbol\":\"source\"," ++ "\"targetContractCid\":\"bafyTarget\",\"targetLayer\":\"coq\",\"targetProofCid\":\"bafyProof\"}";
 
     try std.testing.expectEqualStrings(expected, jcs);
 }


### PR DESCRIPTION
Closes #330. Depends on #348 (CDDL spec). Blocked until #348 merges.

## Summary

Per-kit IR type regen implementing the Sort grammar grow from #329/#348:
- **FunctionSort**: `domain`→`args`, `range`→`return`
- **DependentSort**: new variant `{kind, name, indexVar, indexSort}`

## Files changed (23 files, 13 languages)

| Kit | Files | Changes |
|-----|-------|---------|
| TypeScript | 12 | type Sort, FuncOf, grammar parse, SMT emit, Lean emit, canonicalizer, 4 tests |
| Go | 1 | funcSort → args/return, + dependentSort struct |
| Java | 1 | Function(args, ret), + Dependent record |
| Python | 1 | Union[PrimitiveSort, FunctionSort, DependentSort] |
| Ruby | 1 | PrimitiveSort + FunctionSort + DependentSort structs |
| C# | 1 | abstract Sort → Primitive \| Function \| Dependent |
| C | 1 | PK_SORT_FUNCTION/DEPENDENT enum + union data |
| C++ | 1 | variant<PrimitiveSort, FunctionSort, DependentSort> |
| Swift | 1 | indirect enum {primitive, function, dependent} |
| Zig | 1 | union {primitive, function, dependent} |
| PHP | 1 | abstract Sort → PrimitiveSort \| FunctionSort \| DependentSort |

## What's NOT in this PR

- Catalog CID bump (#335)
- Any behavior changes — pure type-level regen
- The CDDL change itself (that's #348)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended sort types to support function sorts and dependent sorts across all language implementations (C, C++, C#, Go, Java, PHP, Python, Ruby, Swift, TypeScript, Zig).
  * Function sorts now use standardized `args` and `return` fields for type representation.
  * Dependent sorts enable indexed type declarations with variable and sort parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->