### PR TITLE
fix(c,csharp): PR #361 follow-up — c kit compile errors + csharp doc comment

### DIFF
--- a/implementations/c/provekit-ir/src/ir.c
+++ b/implementations/c/provekit-ir/src/ir.c
@@ -20,13 +20,49 @@ pk_sort *pk_sort_primitive(const char *name) {
     pk_sort *s = (pk_sort *)calloc(1, sizeof(pk_sort));
     if (!s) return NULL;
     s->kind = PK_SORT_PRIMITIVE;
-    s->name = pk_strdup(name);
+    s->data.primitive.name = pk_strdup(name);
+    return s;
+}
+
+pk_sort *pk_sort_function(pk_sort **args, size_t n_args, pk_sort *ret) {
+    pk_sort *s = (pk_sort *)calloc(1, sizeof(pk_sort));
+    if (!s) return NULL;
+    s->kind = PK_SORT_FUNCTION;
+    s->data.function.args = args;
+    s->data.function.n_args = n_args;
+    s->data.function.ret = ret;
+    return s;
+}
+
+pk_sort *pk_sort_dependent(const char *name, const char *index_var, pk_sort *index_sort) {
+    pk_sort *s = (pk_sort *)calloc(1, sizeof(pk_sort));
+    if (!s) return NULL;
+    s->kind = PK_SORT_DEPENDENT;
+    s->data.dependent.name = pk_strdup(name);
+    s->data.dependent.index_var = pk_strdup(index_var);
+    s->data.dependent.index_sort = index_sort;
     return s;
 }
 
 void pk_sort_free(pk_sort *s) {
     if (!s) return;
-    free(s->name);
+    switch (s->kind) {
+        case PK_SORT_PRIMITIVE:
+            free(s->data.primitive.name);
+            break;
+        case PK_SORT_FUNCTION:
+            for (size_t i = 0; i < s->data.function.n_args; i++) {
+                pk_sort_free(s->data.function.args[i]);
+            }
+            free(s->data.function.args);
+            pk_sort_free(s->data.function.ret);
+            break;
+        case PK_SORT_DEPENDENT:
+            free(s->data.dependent.name);
+            free(s->data.dependent.index_var);
+            pk_sort_free(s->data.dependent.index_sort);
+            break;
+    }
     free(s);
 }
 

--- a/implementations/c/provekit-ir/src/jcs.c
+++ b/implementations/c/provekit-ir/src/jcs.c
@@ -82,12 +82,53 @@ static void emit_formula_wrapper2(pk_buffer *buf, void *ctx) {
 /* Sort                                                                    */
 /* ----------------------------------------------------------------------- */
 
+typedef struct { pk_sort **args; size_t n; } sort_array_ctx;
+
+static void emit_sort_array_fn(pk_buffer *buf, void *ctx) {
+    sort_array_ctx *c = (sort_array_ctx *)ctx;
+    pk_buffer_append_char(buf, '[');
+    for (size_t i = 0; i < c->n; i++) {
+        if (i > 0) pk_buffer_append_char(buf, ',');
+        emit_sort(buf, c->args[i]);
+    }
+    pk_buffer_append_char(buf, ']');
+}
+
+static void emit_sort_wrapper(pk_buffer *buf, void *ctx) {
+    emit_sort(buf, (pk_sort *)ctx);
+}
+
 static void emit_sort(pk_buffer *buf, pk_sort *s) {
-    pk_field fields[] = {
-        {"kind",  (void (*)(pk_buffer *, void *))emit_string, "primitive"},
-        {"name",  (void (*)(pk_buffer *, void *))emit_string, s->name},
-    };
-    emit_object(buf, fields, 2);
+    switch (s->kind) {
+        case PK_SORT_PRIMITIVE: {
+            pk_field fields[] = {
+                {"kind", (void (*)(pk_buffer *, void *))emit_string, "primitive"},
+                {"name", (void (*)(pk_buffer *, void *))emit_string, s->data.primitive.name},
+            };
+            emit_object(buf, fields, 2);
+            break;
+        }
+        case PK_SORT_FUNCTION: {
+            sort_array_ctx args_ctx = { s->data.function.args, s->data.function.n_args };
+            pk_field fields[] = {
+                {"kind",   (void (*)(pk_buffer *, void *))emit_string, "function"},
+                {"args",   emit_sort_array_fn, &args_ctx},
+                {"return", emit_sort_wrapper, s->data.function.ret},
+            };
+            emit_object(buf, fields, 3);
+            break;
+        }
+        case PK_SORT_DEPENDENT: {
+            pk_field fields[] = {
+                {"kind",      (void (*)(pk_buffer *, void *))emit_string, "dependent"},
+                {"name",      (void (*)(pk_buffer *, void *))emit_string, s->data.dependent.name},
+                {"indexVar",  (void (*)(pk_buffer *, void *))emit_string, s->data.dependent.index_var},
+                {"indexSort", emit_sort_wrapper, s->data.dependent.index_sort},
+            };
+            emit_object(buf, fields, 4);
+            break;
+        }
+    }
 }
 
 void pk_emit_sort(pk_buffer *buf, pk_sort *s) {

--- a/implementations/csharp/Provekit.IR/Sort.cs
+++ b/implementations/csharp/Provekit.IR/Sort.cs
@@ -3,7 +3,7 @@
 namespace Provekit.IR;
 
 /// <summary>
-/// IR-JSON v1.4.0 sort. Primitive / Function / Dependent tagged unions.
+/// IR-JSON v1.5.0 sort. Primitive / Function / Dependent tagged unions.
 /// </summary>
 public abstract record Sort
 {


### PR DESCRIPTION
Targets `feat/329-per-kit-sort-regen` (the branch behind PR #361). Two fixes + one note.

## Fix 1: c kit doesn't compile

PR #361's header change to `pk_sort` (tagged union) leaves `ir.c` and `jcs.c` unchanged. They still reference `s->name` directly, which doesn't exist on the new struct.

`ir.c`:
- `pk_sort_primitive` field access fixed
- `pk_sort_free` rewritten to switch on `kind` and free per-variant fields (recursive for function args[]/ret and dependent indexSort)
- `pk_sort_function` + `pk_sort_dependent` constructor impls added (declared in header but missing implementations → linker error)

`jcs.c`:
- `emit_sort` rewritten to switch on `kind` and emit per-variant JCS shape
- Helpers added for sort-array (function.args[]) and recursive sort emission

Verified locally: `make` in `implementations/c/provekit-ir` builds clean, all 5 tests pass.

## Fix 2: csharp stale comment

`Sort.cs` doc comment said `IR-JSON v1.4.0` — corrected to v1.5.0 since this PR ships the v1.5.0 grammar grow.

## Note: rust gap

`provekit-ir-types::Sort` still only has `Primitive` variant. Function and Dependent are not added.

Adding them has cross-crate match-exhaustiveness impact (`smt-lib` compiler, `ir-symbolic`, etc.). Left intentionally — #331 (Coq compiler) and #332 (SMT-LIB compiler) need to land their compiler arms before rust types extend, otherwise we get unreachable match arms or non-exhaustive errors across the workspace.

If rust types should extend now anyway with `unimplemented!()` placeholders for the new arms, that's a separate decision and a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)