### PR TITLE
feat(coq): translate FunctionSort + DependentSort soundly (closes #331)

### DIFF
--- a/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
@@ -139,13 +139,16 @@ fn emit_sort(sort: &Sort) -> String {
     }
 }
 
-/// Wrap a sort emission in parens when it is a `Sort::Function`, so right-associative
-/// `->` does not silently re-bracket nested function args. Primitive and Dependent
-/// emissions are self-delimited (single token / leading `forall`) and need no parens.
+/// Wrap a sort emission in parens when its surface form would re-associate
+/// inside a function arrow chain. `Sort::Function` (right-associative `->`)
+/// and `Sort::Dependent` (leading `forall ...,`) both extend maximally to
+/// the right in Coq's grammar, so an unparenthesized occurrence in argument
+/// position silently changes scope. `Sort::Primitive` is a single token
+/// and needs no wrapping.
 fn emit_sort_paren(sort: &Sort) -> String {
     match sort {
-        Sort::Function { .. } => format!("({})", emit_sort(sort)),
-        _ => emit_sort(sort),
+        Sort::Function { .. } | Sort::Dependent { .. } => format!("({})", emit_sort(sort)),
+        Sort::Primitive { .. } => emit_sort(sort),
     }
 }
 
@@ -173,8 +176,8 @@ fn sort_to_coq(sort: &Sort) -> String {
 
 fn sort_to_coq_paren(sort: &Sort) -> String {
     match sort {
-        Sort::Function { .. } => format!("({})", sort_to_coq(sort)),
-        _ => sort_to_coq(sort),
+        Sort::Function { .. } | Sort::Dependent { .. } => format!("({})", sort_to_coq(sort)),
+        Sort::Primitive { .. } => sort_to_coq(sort),
     }
 }
 fn emit_const_value(value: &serde_json::Value, _sort_name: &str) -> String {

--- a/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
@@ -9,7 +9,13 @@ pub fn emit_term(term: &Term) -> String {
     match term {
         Term::Var { name, .. } => name.clone(),
         Term::Const { value, sort, .. } => {
-            let sort_name = match sort { Sort::Primitive { name } => name.as_str() };
+            let sort_name = match sort {
+                Sort::Primitive { name } => name.as_str(),
+                // FunctionSort/DependentSort: deferred to #331 (Coq compiler v1.5.0 grammar grow).
+                Sort::Function { .. } | Sort::Dependent { .. } => {
+                    unimplemented!("FunctionSort/DependentSort: deferred to #331 (Coq)")
+                }
+            };
             return emit_const_value(value, sort_name);
         },
         Term::Ctor { name, args, .. } => {
@@ -111,6 +117,10 @@ fn emit_sort(sort: &Sort) -> String {
     "Bool" => "bool".to_string(),
     _ => "Z".to_string(),
 },
+        // FunctionSort/DependentSort: deferred to #331 (Coq compiler v1.5.0 grammar grow).
+        Sort::Function { .. } | Sort::Dependent { .. } => {
+            unimplemented!("FunctionSort/DependentSort: deferred to #331 (Coq)")
+        }
     }
 }
 fn sort_to_coq(sort: &Sort) -> String {
@@ -121,6 +131,10 @@ fn sort_to_coq(sort: &Sort) -> String {
     "Bool" => "bool".to_string(),
     _ => "Z".to_string(),
 },
+        // FunctionSort/DependentSort: deferred to #331 (Coq compiler v1.5.0 grammar grow).
+        Sort::Function { .. } | Sort::Dependent { .. } => {
+            unimplemented!("FunctionSort/DependentSort: deferred to #331 (Coq)")
+        }
     }
 }
 fn emit_const_value(value: &serde_json::Value, _sort_name: &str) -> String {

--- a/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
@@ -9,12 +9,14 @@ pub fn emit_term(term: &Term) -> String {
     match term {
         Term::Var { name, .. } => name.clone(),
         Term::Const { value, sort, .. } => {
+            // Coq: Function/Dependent sorts on a Const are structurally unusual but
+            // not unsound — Coq's higher-order universe permits e.g. `(fun x => x) : nat -> nat`
+            // as a constant inhabiting a function sort. `emit_const_value` ignores the sort name
+            // (it only branches on the JSON value shape), so we feed it the empty string for
+            // non-primitive sorts and let the value's own JSON dictate the surface form.
             let sort_name = match sort {
                 Sort::Primitive { name } => name.as_str(),
-                // FunctionSort/DependentSort: deferred to #331 (Coq compiler v1.5.0 grammar grow).
-                Sort::Function { .. } | Sort::Dependent { .. } => {
-                    unimplemented!("FunctionSort/DependentSort: deferred to #331 (Coq)")
-                }
+                Sort::Function { .. } | Sort::Dependent { .. } => "",
             };
             return emit_const_value(value, sort_name);
         },
@@ -117,12 +119,36 @@ fn emit_sort(sort: &Sort) -> String {
     "Bool" => "bool".to_string(),
     _ => "Z".to_string(),
 },
-        // FunctionSort/DependentSort: deferred to #331 (Coq compiler v1.5.0 grammar grow).
-        Sort::Function { .. } | Sort::Dependent { .. } => {
-            unimplemented!("FunctionSort/DependentSort: deferred to #331 (Coq)")
-        }
+        // FunctionSort: Coq function arrow `A1 -> A2 -> ... -> Ret`. Coq's `->` is
+        // right-associative, so a function-typed argument MUST be parenthesized to
+        // preserve meaning: `(A -> B) -> C` differs from `A -> B -> C`. Soundness
+        // depends on this. Issue #331; see protocol/specs/multi-solver-protocol-v2.md
+        // — Coq's portfolio seat covers higher-order, so this position is NOT opaque.
+        Sort::Function { args, ret } => {
+            let mut parts: Vec<String> = args.iter().map(|a| emit_sort_paren(a)).collect();
+            parts.push(emit_sort_paren(ret));
+            return parts.join(" -> ");
+        },
+        // DependentSort: Coq Π-type. `Vec` indexed by `n: nat` becomes
+        // `forall n : nat, Vec n`. The instantiated form (`<name> <index_var>`)
+        // matches the canonical dependent-product shape in Coq, where the sort
+        // name is applied to the bound index. Issue #331.
+        Sort::Dependent { name, index_var, index_sort } => {
+            return format!("forall {} : {}, {} {}", index_var, emit_sort(index_sort), name, index_var);
+        },
     }
 }
+
+/// Wrap a sort emission in parens when it is a `Sort::Function`, so right-associative
+/// `->` does not silently re-bracket nested function args. Primitive and Dependent
+/// emissions are self-delimited (single token / leading `forall`) and need no parens.
+fn emit_sort_paren(sort: &Sort) -> String {
+    match sort {
+        Sort::Function { .. } => format!("({})", emit_sort(sort)),
+        _ => emit_sort(sort),
+    }
+}
+
 fn sort_to_coq(sort: &Sort) -> String {
     match sort {
         Sort::Primitive { name } => match name.as_str() {
@@ -131,10 +157,24 @@ fn sort_to_coq(sort: &Sort) -> String {
     "Bool" => "bool".to_string(),
     _ => "Z".to_string(),
 },
-        // FunctionSort/DependentSort: deferred to #331 (Coq compiler v1.5.0 grammar grow).
-        Sort::Function { .. } | Sort::Dependent { .. } => {
-            unimplemented!("FunctionSort/DependentSort: deferred to #331 (Coq)")
-        }
+        // Identical Coq syntax to `emit_sort`; this entry point is used in formula
+        // binder positions (Forall/Exists/Choice). See `emit_sort` for soundness
+        // notes on associativity (Function) and Π-type shape (Dependent).
+        Sort::Function { args, ret } => {
+            let mut parts: Vec<String> = args.iter().map(|a| sort_to_coq_paren(a)).collect();
+            parts.push(sort_to_coq_paren(ret));
+            return parts.join(" -> ");
+        },
+        Sort::Dependent { name, index_var, index_sort } => {
+            return format!("forall {} : {}, {} {}", index_var, sort_to_coq(index_sort), name, index_var);
+        },
+    }
+}
+
+fn sort_to_coq_paren(sort: &Sort) -> String {
+    match sort {
+        Sort::Function { .. } => format!("({})", sort_to_coq(sort)),
+        _ => sort_to_coq(sort),
     }
 }
 fn emit_const_value(value: &serde_json::Value, _sort_name: &str) -> String {

--- a/implementations/rust/provekit-ir-compiler-coq/tests/compiler.rs
+++ b/implementations/rust/provekit-ir-compiler-coq/tests/compiler.rs
@@ -76,6 +76,213 @@ fn lambda_produces_valid_coq_syntax() {
     assert!(coq_code.contains("Goal"), "Expected Goal");
 }
 
+// ----------------------------------------------------------------------------
+// FunctionSort + DependentSort (issue #331)
+//
+// Soundness rationale: Coq is the portfolio seat that covers higher-order and
+// dependent types. FunctionSort maps to Coq's `->` (with parenthesization for
+// right-associative correctness on nested function args); DependentSort maps
+// to a Π-type `forall <var> : <index_sort>, <name> <var>` (instantiated form,
+// matching the `Vec n` example in the issue body).
+//
+// "Round-trip" interpretation: the Coq compiler is emit-only — there is no
+// Coq parser. So round-trip here means (a) IR JSON serde round-trips, and
+// (b) emission is deterministic byte-for-byte across calls. Surface-shape
+// assertions cover the actual translation.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn function_sort_in_forall_emits_coq_arrow() {
+    let ir = json!({
+        "kind": "forall",
+        "name": "f",
+        "sort": {
+            "kind": "function",
+            "args": [{"kind": "primitive", "name": "Int"}],
+            "return": {"kind": "primitive", "name": "Bool"}
+        },
+        "body": {"kind": "atomic", "name": "true", "args": []}
+    });
+    let compiler = CoqCompiler::new();
+    let result = compiler.compile(&ir, DIALECT);
+    assert!(result.is_ok(), "compile failed: {:?}", result.err());
+    let coq_code = result.unwrap().body;
+    assert!(coq_code.contains("forall f : Z -> bool"),
+            "Expected Coq forall over function type, got:\n{}", coq_code);
+}
+
+#[test]
+fn function_sort_multi_arg_curries_left_to_right() {
+    // (Int, Int) -> Bool  =>  Z -> Z -> bool   (right-associative, equivalent shape)
+    let ir = json!({
+        "kind": "forall",
+        "name": "g",
+        "sort": {
+            "kind": "function",
+            "args": [
+                {"kind": "primitive", "name": "Int"},
+                {"kind": "primitive", "name": "Int"}
+            ],
+            "return": {"kind": "primitive", "name": "Bool"}
+        },
+        "body": {"kind": "atomic", "name": "true", "args": []}
+    });
+    let compiler = CoqCompiler::new();
+    let coq_code = compiler.compile(&ir, DIALECT).unwrap().body;
+    assert!(coq_code.contains("forall g : Z -> Z -> bool"),
+            "Expected curried multi-arg arrow, got:\n{}", coq_code);
+}
+
+#[test]
+fn function_sort_higher_order_arg_is_parenthesized() {
+    // `(Int -> Int) -> Bool` differs from `Int -> Int -> Bool` in Coq.
+    // The arg position is itself a Function, so it MUST be parenthesized.
+    let ir = json!({
+        "kind": "forall",
+        "name": "hof",
+        "sort": {
+            "kind": "function",
+            "args": [
+                {
+                    "kind": "function",
+                    "args": [{"kind": "primitive", "name": "Int"}],
+                    "return": {"kind": "primitive", "name": "Int"}
+                }
+            ],
+            "return": {"kind": "primitive", "name": "Bool"}
+        },
+        "body": {"kind": "atomic", "name": "true", "args": []}
+    });
+    let compiler = CoqCompiler::new();
+    let coq_code = compiler.compile(&ir, DIALECT).unwrap().body;
+    assert!(coq_code.contains("forall hof : (Z -> Z) -> bool"),
+            "Higher-order arg must be parenthesized for soundness, got:\n{}", coq_code);
+    // Negative check: the unparenthesized form would be wrong.
+    assert!(!coq_code.contains("forall hof : Z -> Z -> bool"),
+            "Must NOT collapse parens on a function-typed arg");
+}
+
+#[test]
+fn lambda_over_function_sort_emits_coq_fun() {
+    let ir = json!({
+        "kind": "lambda",
+        "paramName": "f",
+        "paramSort": {
+            "kind": "function",
+            "args": [{"kind": "primitive", "name": "Int"}],
+            "return": {"kind": "primitive", "name": "Int"}
+        },
+        "body": {"kind": "var", "name": "f"}
+    });
+    let compiler = CoqCompiler::new();
+    let coq_code = compiler.compile(&ir, DIALECT).unwrap().body;
+    assert!(coq_code.contains("fun (f : Z -> Z)"),
+            "Expected Coq fun over function sort, got:\n{}", coq_code);
+}
+
+#[test]
+fn dependent_sort_emits_coq_pi_type() {
+    // DependentSort `Vec` indexed by `n : Int`  =>  forall n : Z, Vec n
+    let ir = json!({
+        "kind": "forall",
+        "name": "v",
+        "sort": {
+            "kind": "dependent",
+            "name": "Vec",
+            "indexVar": "n",
+            "indexSort": {"kind": "primitive", "name": "Int"}
+        },
+        "body": {"kind": "atomic", "name": "true", "args": []}
+    });
+    let compiler = CoqCompiler::new();
+    let coq_code = compiler.compile(&ir, DIALECT).unwrap().body;
+    assert!(coq_code.contains("forall n : Z, Vec n"),
+            "Expected Coq Π-type with instantiated index, got:\n{}", coq_code);
+}
+
+#[test]
+fn dependent_sort_in_lambda_param_position() {
+    let ir = json!({
+        "kind": "lambda",
+        "paramName": "v",
+        "paramSort": {
+            "kind": "dependent",
+            "name": "Vec",
+            "indexVar": "n",
+            "indexSort": {"kind": "primitive", "name": "Int"}
+        },
+        "body": {"kind": "var", "name": "v"}
+    });
+    let compiler = CoqCompiler::new();
+    let coq_code = compiler.compile(&ir, DIALECT).unwrap().body;
+    assert!(coq_code.contains("fun (v : forall n : Z, Vec n)"),
+            "Expected lambda binder over Π-type, got:\n{}", coq_code);
+}
+
+#[test]
+fn function_sort_serde_roundtrip() {
+    // IR JSON -> Sort -> IR JSON: byte-identical via canonical serde.
+    let original = json!({
+        "kind": "function",
+        "args": [
+            {"kind": "primitive", "name": "Int"},
+            {
+                "kind": "function",
+                "args": [{"kind": "primitive", "name": "Bool"}],
+                "return": {"kind": "primitive", "name": "Int"}
+            }
+        ],
+        "return": {"kind": "primitive", "name": "Bool"}
+    });
+    let parsed: provekit_ir_types::Sort =
+        serde_json::from_value(original.clone()).expect("FunctionSort deserialization");
+    let reemitted = serde_json::to_value(&parsed).expect("FunctionSort serialization");
+    assert_eq!(original, reemitted, "FunctionSort IR JSON did not round-trip");
+}
+
+#[test]
+fn dependent_sort_serde_roundtrip() {
+    let original = json!({
+        "kind": "dependent",
+        "name": "Vec",
+        "indexVar": "n",
+        "indexSort": {"kind": "primitive", "name": "Int"}
+    });
+    let parsed: provekit_ir_types::Sort =
+        serde_json::from_value(original.clone()).expect("DependentSort deserialization");
+    let reemitted = serde_json::to_value(&parsed).expect("DependentSort serialization");
+    assert_eq!(original, reemitted, "DependentSort IR JSON did not round-trip");
+}
+
+#[test]
+fn coq_emission_is_deterministic_for_new_sorts() {
+    // Two compile calls on the same IR must produce byte-identical Coq output;
+    // any nondeterminism (HashMap iteration etc.) would break the conformance
+    // gate that pins compiler output by hash.
+    let ir = json!({
+        "kind": "forall",
+        "name": "f",
+        "sort": {
+            "kind": "function",
+            "args": [
+                {
+                    "kind": "function",
+                    "args": [{"kind": "primitive", "name": "Int"}],
+                    "return": {"kind": "primitive", "name": "Int"}
+                },
+                {"kind": "dependent", "name": "Vec", "indexVar": "k",
+                 "indexSort": {"kind": "primitive", "name": "Int"}}
+            ],
+            "return": {"kind": "primitive", "name": "Bool"}
+        },
+        "body": {"kind": "atomic", "name": "true", "args": []}
+    });
+    let compiler = CoqCompiler::new();
+    let a = compiler.compile(&ir, DIALECT).unwrap().body;
+    let b = compiler.compile(&ir, DIALECT).unwrap().body;
+    assert_eq!(a, b, "Coq emission must be byte-deterministic");
+}
+
 #[test]
 fn let_with_multiple_bindings() {
     let ir = json!({

--- a/implementations/rust/provekit-ir-compiler-coq/tests/compiler.rs
+++ b/implementations/rust/provekit-ir-compiler-coq/tests/compiler.rs
@@ -220,6 +220,36 @@ fn dependent_sort_in_lambda_param_position() {
 }
 
 #[test]
+fn dependent_sort_in_function_arg_position_is_parenthesized() {
+    // Coq's `forall` extends maximally to the right, so an unparenthesized
+    // DependentSort in a FunctionSort argument silently re-scopes the binder:
+    //   `forall n : Z, Vec n -> bool`     parses as   `forall n : Z, (Vec n -> bool)`
+    //   `(forall n : Z, Vec n) -> bool`   is the intended type
+    // The emitter must wrap Sort::Dependent in parens whenever it sits in
+    // function-argument position. Three reviewers (chatgpt-codex / Copilot /
+    // CodeRabbit) flagged this on PR #364; positive + negative assertions.
+    let ir = json!({
+        "kind": "forall",
+        "name": "f",
+        "sort": {
+            "kind": "function",
+            "args": [
+                {"kind": "dependent", "name": "Vec", "indexVar": "n",
+                 "indexSort": {"kind": "primitive", "name": "Int"}}
+            ],
+            "return": {"kind": "primitive", "name": "Bool"}
+        },
+        "body": {"kind": "atomic", "name": "true", "args": []}
+    });
+    let compiler = CoqCompiler::new();
+    let coq_code = compiler.compile(&ir, DIALECT).unwrap().body;
+    assert!(coq_code.contains("(forall n : Z, Vec n) -> bool"),
+            "Expected parenthesized Π-type in arg position, got:\n{}", coq_code);
+    assert!(!coq_code.contains("forall n : Z, Vec n -> bool"),
+            "Unparenthesized Π-type leaks binder into function arrow:\n{}", coq_code);
+}
+
+#[test]
 fn function_sort_serde_roundtrip() {
     // IR JSON -> Sort -> IR JSON: byte-identical via canonical serde.
     let original = json!({

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
@@ -9,7 +9,12 @@ pub fn emit_term(term: &Term) -> String {
     match term {
         Term::Var { name, .. } => name.clone(),
         Term::Const { value, sort, .. } => {
-            let sort_name = match sort { Sort::Primitive { name } => name.as_str() };
+            let sort_name = match sort {
+                Sort::Primitive { name } => name.as_str(),
+                Sort::Function { .. } | Sort::Dependent { .. } => {
+                    panic!("smt-lib: Const cannot carry a Function/Dependent sort in pure SMT-LIB v2.6");
+                }
+            };
             return emit_const_value(value, sort_name);
         },
         Term::Ctor { name, args, .. } => {
@@ -99,6 +104,12 @@ pub fn emit_formula(formula: &Formula) -> String {
 fn emit_sort(sort: &Sort) -> String {
     match sort {
         Sort::Primitive { name } => name.clone(),
+        Sort::Function { .. } => {
+            panic!("smt-lib emit_sort: FunctionSort unsupported (use a higher-order solver or curry into uninterpreted symbols)");
+        }
+        Sort::Dependent { .. } => {
+            panic!("smt-lib emit_sort: DependentSort unsupported in pure SMT-LIB v2.6");
+        }
     }
 }
 fn emit_const_value(value: &serde_json::Value, _sort_name: &str) -> String {

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
@@ -9,13 +9,7 @@ pub fn emit_term(term: &Term) -> String {
     match term {
         Term::Var { name, .. } => name.clone(),
         Term::Const { value, sort, .. } => {
-            let sort_name = match sort {
-                Sort::Primitive { name } => name.as_str(),
-                // FunctionSort/DependentSort: deferred to #332 (SMT-LIB compiler v1.5.0 grammar grow).
-                Sort::Function { .. } | Sort::Dependent { .. } => {
-                    unimplemented!("FunctionSort/DependentSort: deferred to #332 (SMT-LIB)")
-                }
-            };
+            let sort_name = match sort { Sort::Primitive { name } => name.as_str() };
             return emit_const_value(value, sort_name);
         },
         Term::Ctor { name, args, .. } => {
@@ -105,10 +99,6 @@ pub fn emit_formula(formula: &Formula) -> String {
 fn emit_sort(sort: &Sort) -> String {
     match sort {
         Sort::Primitive { name } => name.clone(),
-        // FunctionSort/DependentSort: deferred to #332 (SMT-LIB compiler v1.5.0 grammar grow).
-        Sort::Function { .. } | Sort::Dependent { .. } => {
-            unimplemented!("FunctionSort/DependentSort: deferred to #332 (SMT-LIB)")
-        }
     }
 }
 fn emit_const_value(value: &serde_json::Value, _sort_name: &str) -> String {

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
@@ -9,7 +9,13 @@ pub fn emit_term(term: &Term) -> String {
     match term {
         Term::Var { name, .. } => name.clone(),
         Term::Const { value, sort, .. } => {
-            let sort_name = match sort { Sort::Primitive { name } => name.as_str() };
+            let sort_name = match sort {
+                Sort::Primitive { name } => name.as_str(),
+                // FunctionSort/DependentSort: deferred to #332 (SMT-LIB compiler v1.5.0 grammar grow).
+                Sort::Function { .. } | Sort::Dependent { .. } => {
+                    unimplemented!("FunctionSort/DependentSort: deferred to #332 (SMT-LIB)")
+                }
+            };
             return emit_const_value(value, sort_name);
         },
         Term::Ctor { name, args, .. } => {
@@ -99,6 +105,10 @@ pub fn emit_formula(formula: &Formula) -> String {
 fn emit_sort(sort: &Sort) -> String {
     match sort {
         Sort::Primitive { name } => name.clone(),
+        // FunctionSort/DependentSort: deferred to #332 (SMT-LIB compiler v1.5.0 grammar grow).
+        Sort::Function { .. } | Sort::Dependent { .. } => {
+            unimplemented!("FunctionSort/DependentSort: deferred to #332 (SMT-LIB)")
+        }
     }
 }
 fn emit_const_value(value: &serde_json::Value, _sort_name: &str) -> String {

--- a/implementations/rust/provekit-ir-symbolic/src/convert.rs
+++ b/implementations/rust/provekit-ir-symbolic/src/convert.rs
@@ -32,6 +32,16 @@ impl From<ir::Sort> for Sort {
     fn from(s: ir::Sort) -> Self {
         match s {
             ir::Sort::Primitive { name } => Sort { name },
+            // The symbolic-side `Sort` wrapper is primitive-only; it does
+            // not yet model Function/Dependent. Deferred to #331 (Coq) /
+            // #332 (SMT-LIB) along with the rest of the v1.5.0 grammar
+            // grow downstream of the canonical `provekit-ir-types::Sort`.
+            ir::Sort::Function { .. } | ir::Sort::Dependent { .. } => {
+                unimplemented!(
+                    "FunctionSort/DependentSort not supported in symbolic Sort wrapper: \
+                     deferred to #331 (Coq) / #332 (SMT-LIB)"
+                )
+            }
         }
     }
 }

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -177,12 +177,34 @@ pub enum Value {
 
 pub type ProofType = String;
 
+// NOTE: The `Sort` enum below has been MANUALLY extended beyond the
+// codegen output to add Function + Dependent variants per the v1.5.0
+// grammar grow (issue #330, rust gap from PR #361). The codegen
+// (`provekit-ir-codegen`) currently only emits the Primitive arm even
+// though the CDDL spec defines a 6-way union. If you regenerate this
+// file via `cargo run -p provekit-ir-codegen`, you WILL clobber the
+// manual extension. Re-apply it from this comment block down through
+// the closing `}` of the `Sort` enum.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum Sort {
     #[serde(rename = "primitive")]
     Primitive {
         name: PrimitiveSortName,
+    },
+    #[serde(rename = "function")]
+    Function {
+        args: Vec<Sort>,
+        #[serde(rename = "return")]
+        ret: Box<Sort>,
+    },
+    #[serde(rename = "dependent")]
+    Dependent {
+        name: String,
+        #[serde(rename = "indexVar")]
+        index_var: String,
+        #[serde(rename = "indexSort")]
+        index_sort: Box<Sort>,
     },
 }
 

--- a/implementations/rust/provekit-ir-types/tests/sort_v15_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/sort_v15_serde.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Round-trip serde tests for the v1.5.0 Sort enum extensions.
+//
+// Source of truth:
+//   protocol/provekit-ir.cddl  (Sort = ... / FunctionSort / DependentSort)
+//
+// Issue context:
+//   #330 (grammar grow), #361 (rust gap closed by this PR)
+//
+// These tests pin:
+//   * `Sort::Function` serializes to `{"kind": "function", "args": [...], "return": ...}`
+//     and round-trips through serde_json without loss.
+//   * `Sort::Dependent` serializes to `{"kind": "dependent", "name": ..., "indexVar": ..., "indexSort": ...}`
+//     and round-trips through serde_json without loss.
+//   * `Sort::Primitive` continues to deserialize from the v1.4 wire shape
+//     (backward compatibility — existing kits emit only Primitive today).
+
+use provekit_ir_types::Sort;
+
+// ---------------------------------------------------------------------------
+// Backward-compat: Sort::Primitive still parses/serializes as before.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn primitive_sort_v14_backward_compat() {
+    let json = r#"{"kind":"primitive","name":"Int"}"#;
+    let parsed: Sort = serde_json::from_str(json).expect("parse primitive sort");
+    match &parsed {
+        Sort::Primitive { name } => assert_eq!(name, "Int"),
+        _ => panic!("expected Primitive variant, got {:?}", parsed),
+    }
+
+    let serialized = serde_json::to_string(&parsed).expect("serialize primitive sort");
+    let reparsed: Sort = serde_json::from_str(&serialized).expect("re-parse");
+    assert_eq!(parsed, reparsed);
+}
+
+// ---------------------------------------------------------------------------
+// FunctionSort
+// ---------------------------------------------------------------------------
+
+#[test]
+fn function_sort_serializes_to_cddl_shape() {
+    let sort = Sort::Function {
+        args: vec![Sort::Primitive { name: "Int".into() }],
+        ret: Box::new(Sort::Primitive { name: "Bool".into() }),
+    };
+
+    let serialized = serde_json::to_string(&sort).expect("serialize function sort");
+    let value: serde_json::Value =
+        serde_json::from_str(&serialized).expect("re-parse to Value");
+
+    // Shape check: exactly the keys CDDL specifies.
+    let obj = value.as_object().expect("function sort should serialize as object");
+    assert_eq!(obj.get("kind").and_then(|v| v.as_str()), Some("function"));
+    assert!(obj.contains_key("args"), "function sort must have `args`");
+    assert!(obj.contains_key("return"), "function sort must have `return`");
+    // No leaked rust field name (`ret`) — must be JSON `return`.
+    assert!(!obj.contains_key("ret"), "rust field `ret` must serialize as `return`");
+
+    // args is a list of one Sort.
+    let args = obj.get("args").and_then(|v| v.as_array()).expect("args is array");
+    assert_eq!(args.len(), 1);
+    let arg0 = args[0].as_object().expect("arg0 is object");
+    assert_eq!(arg0.get("kind").and_then(|v| v.as_str()), Some("primitive"));
+    assert_eq!(arg0.get("name").and_then(|v| v.as_str()), Some("Int"));
+
+    // return is a Sort.
+    let ret = obj.get("return").and_then(|v| v.as_object()).expect("return is object");
+    assert_eq!(ret.get("kind").and_then(|v| v.as_str()), Some("primitive"));
+    assert_eq!(ret.get("name").and_then(|v| v.as_str()), Some("Bool"));
+}
+
+#[test]
+fn function_sort_round_trip_preserves_value() {
+    let sort = Sort::Function {
+        args: vec![
+            Sort::Primitive { name: "Int".into() },
+            Sort::Primitive { name: "String".into() },
+        ],
+        ret: Box::new(Sort::Primitive { name: "Bool".into() }),
+    };
+
+    let serialized = serde_json::to_string(&sort).expect("serialize");
+    let parsed: Sort = serde_json::from_str(&serialized).expect("parse back");
+    assert_eq!(sort, parsed);
+}
+
+#[test]
+fn function_sort_deserializes_from_cddl_wire_shape() {
+    // Wire shape exactly as v1.5.0 spec defines (post-JCS, alphabetic key order
+    // the network would actually see).
+    let json = r#"{"args":[{"kind":"primitive","name":"Int"}],"kind":"function","return":{"kind":"primitive","name":"Bool"}}"#;
+    let parsed: Sort = serde_json::from_str(json).expect("parse function sort");
+    match parsed {
+        Sort::Function { args, ret } => {
+            assert_eq!(args.len(), 1);
+            match &args[0] {
+                Sort::Primitive { name } => assert_eq!(name, "Int"),
+                _ => panic!("arg0 should be Primitive Int"),
+            }
+            match *ret {
+                Sort::Primitive { name } => assert_eq!(name, "Bool"),
+                _ => panic!("return should be Primitive Bool"),
+            }
+        }
+        _ => panic!("expected Function variant"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DependentSort
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dependent_sort_serializes_to_cddl_shape() {
+    let sort = Sort::Dependent {
+        name: "Vec".into(),
+        index_var: "n".into(),
+        index_sort: Box::new(Sort::Primitive { name: "Int".into() }),
+    };
+
+    let serialized = serde_json::to_string(&sort).expect("serialize dependent sort");
+    let value: serde_json::Value =
+        serde_json::from_str(&serialized).expect("re-parse to Value");
+
+    let obj = value.as_object().expect("dependent sort should serialize as object");
+    assert_eq!(obj.get("kind").and_then(|v| v.as_str()), Some("dependent"));
+    assert_eq!(obj.get("name").and_then(|v| v.as_str()), Some("Vec"));
+    assert_eq!(obj.get("indexVar").and_then(|v| v.as_str()), Some("n"));
+    assert!(obj.contains_key("indexSort"), "dependent sort must have `indexSort`");
+    // No leaked rust snake_case field names.
+    assert!(!obj.contains_key("index_var"), "rust field `index_var` must serialize as `indexVar`");
+    assert!(!obj.contains_key("index_sort"), "rust field `index_sort` must serialize as `indexSort`");
+
+    let index_sort = obj
+        .get("indexSort")
+        .and_then(|v| v.as_object())
+        .expect("indexSort is object");
+    assert_eq!(index_sort.get("kind").and_then(|v| v.as_str()), Some("primitive"));
+    assert_eq!(index_sort.get("name").and_then(|v| v.as_str()), Some("Int"));
+}
+
+#[test]
+fn dependent_sort_round_trip_preserves_value() {
+    let sort = Sort::Dependent {
+        name: "Vec".into(),
+        index_var: "n".into(),
+        index_sort: Box::new(Sort::Primitive { name: "Int".into() }),
+    };
+
+    let serialized = serde_json::to_string(&sort).expect("serialize");
+    let parsed: Sort = serde_json::from_str(&serialized).expect("parse back");
+    assert_eq!(sort, parsed);
+}
+
+#[test]
+fn dependent_sort_deserializes_from_cddl_wire_shape() {
+    // Wire shape (alphabetic key order, JCS-canonical).
+    let json = r#"{"indexSort":{"kind":"primitive","name":"Int"},"indexVar":"n","kind":"dependent","name":"Vec"}"#;
+    let parsed: Sort = serde_json::from_str(json).expect("parse dependent sort");
+    match parsed {
+        Sort::Dependent { name, index_var, index_sort } => {
+            assert_eq!(name, "Vec");
+            assert_eq!(index_var, "n");
+            match *index_sort {
+                Sort::Primitive { name } => assert_eq!(name, "Int"),
+                _ => panic!("indexSort should be Primitive Int"),
+            }
+        }
+        _ => panic!("expected Dependent variant"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Recursive nesting (Function inside Dependent inside Function)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_sorts_round_trip() {
+    // (Vec<n: Int> -> Bool) — a function that takes a length-indexed Vec and
+    // returns Bool. Exercises Box<Sort> recursion through both new variants.
+    let sort = Sort::Function {
+        args: vec![Sort::Dependent {
+            name: "Vec".into(),
+            index_var: "n".into(),
+            index_sort: Box::new(Sort::Primitive { name: "Int".into() }),
+        }],
+        ret: Box::new(Sort::Primitive { name: "Bool".into() }),
+    };
+
+    let serialized = serde_json::to_string(&sort).expect("serialize");
+    let parsed: Sort = serde_json::from_str(&serialized).expect("parse back");
+    assert_eq!(sort, parsed);
+}


### PR DESCRIPTION
## Summary

Stacked on **#363** (Rust IR types adding `Sort::Function` + `Sort::Dependent`). Replaces the three `unimplemented!()` placeholders that PR #363 left in the Coq compiler.

### Translation

| Variant | Coq surface form |
|---|---|
| `Function { args, ret }` | `A1 -> A2 -> ... -> Ret`, with each function-typed arg parenthesized so right-associativity does not silently re-bracket the type |
| `Dependent { name, indexVar, indexSort }` | `forall <indexVar> : <indexSort>, <name> <indexVar>` (canonical Pi-type, instantiated form matching the `Vec n` example in #331) |
| `Term::Const` over non-primitive sort | feeds empty `sort_name` to `emit_const_value` (which branches on the JSON value shape, not the sort name) |

### Soundness

Coq is the portfolio seat in [multi-solver-protocol/2](../tree/main/protocol/specs/2026-05-02-multi-solver-protocol-v2.md) that covers higher-order and dependent types. These positions are **not** marked opaque, so the opacity manifest stays empty by construction (consistent with the four reason codes in [opacity-manifest-grammar §4](../tree/main/protocol/specs/2026-05-02-opacity-manifest-grammar.md): `predicate_quantification` and `dependent_type` belong to SMT-LIB, not Coq).

## Tests

`tests/compiler.rs` gains 9 new tests exercising both variants:

- `function_sort_in_forall_emits_coq_arrow`
- `function_sort_multi_arg_curries_left_to_right`
- `function_sort_higher_order_arg_is_parenthesized` (with negative assertion that the unparenthesized shape is **not** emitted — soundness gate)
- `lambda_over_function_sort_emits_coq_fun`
- `dependent_sort_emits_coq_pi_type`
- `dependent_sort_in_lambda_param_position`
- `function_sort_serde_roundtrip` (IR JSON -> `Sort` -> IR JSON byte-equal)
- `dependent_sort_serde_roundtrip`
- `coq_emission_is_deterministic_for_new_sorts` (two compiles, byte-identical output, over a mixed Function+Dependent IR)

The "round-trip" requirement in #331 is interpreted as serde JSON round-trip + emission determinism, since the Coq compiler is emit-only (no Coq parser exists). Documented in a test-file comment.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p provekit-ir-compiler-coq` — 14 integration tests pass (5 pre-existing + 9 new), 3 unit tests pass
- [x] `cargo test --workspace --no-fail-fast` — only pre-existing failures: `provekit-cli::mint_kit_integration::swift_kit_pins_expected_contract_set_cid` (issue #211, self-identified in panic message) and `provekit-linkerd::multi_kit::test4_java_kit_dispatch` (Java LSP broken-pipe, env-related; test file byte-identical to base)
- [x] `make conformance` — PASS

## Constraints honored

- Did not touch `provekit-ir-types` (PR #363's territory).
- Did not touch the unrelated PR-#363 botched-merge dead-code warnings on `Term::Ctor`/`Lambda`/`Let` duplicate arms in `generated.rs`.
- No refactor of unrelated Coq code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended IR type system to support function and dependent sorts with correct compilation to Coq's arrow types and Π-types respectively.
  * Improved handling of higher-order function arguments with proper parenthesization.

* **Tests**
  * Added comprehensive test coverage for function and dependent sort compilation in various contexts.
  * Included serialization round-trip validation and determinism verification for output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->