### PR TITLE
docs: cleanup bundle, em-dash collateral, per-language drift, 9/12 framing (closes #360 #358 #369)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,11 +337,10 @@ mint-php: build-rust
 		(echo "FAIL: php self-contracts attestation rejected; re-mint and commit:" && \
 		 echo "      $(PROVEKIT) mint --kit=php" && exit 1)
 
-# NOTE: mint-swift excluded from all-mint (macOS-only). java + python wired up
-# after their Side A landings (#207, #205) — both produce content-meaningful
-# contractSetCids and ship pinned attestations. ruby/zig/c/php pending their
-# Side A merges (#234, #241, #272, feat/php-kit) and toolchain CI integration
-# (#245 in flight, #274 follow-up).
+# NOTE: all-mint runs 9 of 12 kits (Linux/CI subset).
+# Excluded: swift (macOS-only; use mint-swift on macOS), ruby (attestation
+# exists but CI toolchain integration pending, #234), php (pending feat/php-kit).
+# zig and c were added after their Side A merges (#283, #272) and are included.
 .PHONY: all-mint
 all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python mint-c mint-zig
 	@echo ""

--- a/docs/explanation/manifesto.md
+++ b/docs/explanation/manifesto.md
@@ -107,8 +107,8 @@ inverted because the DAG holds the constraints, not the actors.
 **Vibe coding becomes safe by default.** The dumbest LLM can write
 TypeScript. The same LLM can write invariants for the same TypeScript.
 Even shitty invariants raise the correctness floor. Once the invariants
-exist, they constrain every future code path through shadow AST walking
-- including paths the original LLM never imagined. The framework doesn't
+exist, they constrain every future code path through shadow AST walking,
+including paths the original LLM never imagined. The framework doesn't
 make LLMs smarter. It makes the GATE mechanical.
 
 **Library upgrades become proof-hash diffs.** Upgrading lodash 1.x to 2.x

--- a/docs/plans/2026-04-23-fix-loop/capability-gaps.md
+++ b/docs/plans/2026-04-23-fix-loop/capability-gaps.md
@@ -13,7 +13,7 @@
 | Bucket | Count | Principles |
 |--------|-------|-----------|
 | Migrated (match-only, no guard suppression) | 8 | addition-overflow, subtraction-underflow, multiplication-overflow, find-undefined-result, match-null-result, split-empty-string, falsy-default, empty-collection-loop |
-| Migrated (guard-aware / structurally complete) | 3 | reduce-no-initial, throw-uncaught, unguarded-await (partial (over-matches) |)
+| Migrated (guard-aware / structurally complete) | 3 | reduce-no-initial, throw-uncaught, unguarded-await (partial, over-matches) |
 | Migrated (guard predicate present, non-functional) | 3 | division-by-zero, modulo-by-zero, null-assertion |
 | Capability-gap (not migrated) | 9 | shell-injection, empty-catch, guard-narrowing, loop-accumulator-overflow, param-mutation, switch-no-default, ternary-branch-collapse, variable-staleness, while-loop-termination |
 

--- a/docs/plans/2026-04-25-bugsjs-harvest.md
+++ b/docs/plans/2026-04-25-bugsjs-harvest.md
@@ -101,7 +101,7 @@ Run the existing principle library against the buggy snapshot. For each principl
 
 This is the same operation Leak 6 win 2 implements at C1 in production fix loops. The harvest pipeline calls it in batch.
 
-**Discovery mode (fallback (full LLM call).**)
+**Discovery mode (fallback: full LLM call).**
 
 Triggered when no existing principle matches the buggy snapshot. The LLM derives a new principle from the diff:
 

--- a/docs/reference/per-language-status.md
+++ b/docs/reference/per-language-status.md
@@ -28,6 +28,7 @@ Legend: `+` shipping in v1.4.1 (current), `~` planned for v1.5 (next), `o` under
 | Ruby        | `+` | `~`  | `+ active_model, dry-validation, rspec`                 | `-`                      | `~`               | `~ (use Rust CLI)`   | `+`                  |
 | C#          | `+` | `+`  | `+ DataAnnotations, Linq`                               | `+ .NET attrs`           | `+`               | `~ (use Rust CLI)`   | `+`                  |
 | Swift       | `+` | `~`  | `~`                                                     | `-`                      | `~`               | `~ (use Rust CLI)`   | `+`                  |
+| PHP         | `~` | `~`  | `~`                                                     | `-`                      | `~`               | `~ (use Rust CLI)`   | `-`                  |
 
 ## Cross-kit bridge readiness
 
@@ -47,12 +48,13 @@ The v1.4 substrate guarantees that depend on per-kit compliance are spread acros
 | TypeScript  | `+ inline (mint-ts-self-contracts)`         | `~ flat universal-claim-envelope` | `+ contractCidFromArgs` | `+ computeContractSetCid` | `~ flat targetContractCid; v1.4 migration pending` | `~ Phase 2 in flight`           | `+`                      |
 | Python      | `~ via provekit-lift-py-tests`              | `not assessed`             | `not assessed`           | `not assessed`       | `~ flat targetContractCid; v1.4 migration pending` | `~ Phase 2 in flight`           | `-`                      |
 | C++         | `+ provekit-self-contracts`                 | `~ flat universal-claim-envelope` | `+ contract_cid_from_args` | `+ compute_contract_set_cid` | `~ flat targetContractCid; v1.4 migration pending` | `-`                              | `+`                      |
-| C           | `-`                                         | `not assessed`             | `not assessed`           | `not assessed`       | `~ v1.4 migration pending`           | `-`                              | `-`                      |
-| Zig         | `-`                                         | `not assessed`             | `not assessed`           | `not assessed`       | `~ v1.4 migration pending`           | `-`                              | `-`                      |
-| Java / JVM  | `-`                                         | `not assessed`             | `not assessed`           | `not assessed`       | `+ mintBridgeV14 (BridgeDeclarationV14)` | `-`                              | `-`                      |
-| Ruby        | `-`                                         | `not assessed`             | `not assessed`           | `not assessed`       | `~ v1.4 migration pending`           | `-`                              | `-`                      |
+| C           | `~ mint-c-self-contracts (attestation pinned)` | `not assessed`             | `not assessed`           | `not assessed`       | `~ v1.4 migration pending`           | `-`                              | `-`                      |
+| Zig         | `~ mint-zig-self-contracts (attestation pinned)` | `not assessed`           | `not assessed`           | `not assessed`       | `~ v1.4 migration pending`           | `-`                              | `-`                      |
+| Java / JVM  | `~ provekit-java-self-contracts (attestation pinned)` | `not assessed`       | `not assessed`           | `not assessed`       | `+ mintBridgeV14 (BridgeDeclarationV14)` | `-`                              | `-`                      |
+| Ruby        | `~ mint-ruby-self-contracts (attestation pinned)` | `not assessed`           | `not assessed`           | `not assessed`       | `~ v1.4 migration pending`           | `-`                              | `-`                      |
 | C#          | `+ Provekit.SelfContracts`                  | `~ flat universal-claim-envelope` | `+ Mint.ContractCid`     | `+ contractSetCid in attestation` | `~ flat targetContractCid; v1.4 migration pending` | `-`                              | `+`                      |
-| Swift       | `-`                                         | `~ flat (no full mint pipeline)` | `not assessed (consumes rustContractCids lookup)` | `+ contractSetCid in mint-swift-self-contracts` | `~ v1.4 migration pending` | `-`                              | `-`                      |
+| Swift       | `~ mint-swift-self-contracts (attestation pinned)` | `~ flat (no full mint pipeline)` | `not assessed (consumes rustContractCids lookup)` | `+ contractSetCid in mint-swift-self-contracts` | `~ v1.4 migration pending` | `-`                              | `-`                      |
+| PHP         | `~ (in progress; no pinned attestation)`    | `not assessed`             | `not assessed`           | `not assessed`       | `not assessed`                       | `-`                              | `-`                      |
 
 Column meanings:
 
@@ -290,6 +292,22 @@ Column meanings:
 **LSP Plugin:** Yes. `ProveKitLSPSwift` implements the ProvekIt NDJSON LSP plugin protocol (parse-protocol v1) with `initialize`, `parse`, and `shutdown`.
 
 **Bridge IR:** v1.1.0 9-field shape supported (`Declaration.bridge` enum case round-trips byte-identical to the bridge_decl fixture, per PR #76). Under v1.4's bridge target dimensionality spec the kit's bridge emission needs to migrate to the layered shape with a tagged-union `target` field; that migration is pending alongside the rest of the kits. Self-contracts package and Phase 2 lift-plugin-protocol bridges deferred until the kit accumulates a runtime surface beyond conformance.
+
+## PHP
+
+**Kit:** In progress (`feat/php-kit`). `implementations/php/provekit-ir-symbolic` provides IR types, JCS canonical JSON emitter, and BLAKE3-512 hashing. `implementations/php/provekit-lift` provides a lift adapter and LSP daemon. Self-contracts orchestrator structure is in place (`implementations/php/provekit-self-contracts`); no pinned attestation yet.
+
+**Libs:** Under evaluation.
+
+**Lift adapters:** In progress. `implementations/php/provekit-lift/src/lifter.php` is the active lift adapter; coverage of PHP annotation libraries under evaluation.
+
+**Decorator macros:** PHP attributes (PHP 8+) are the natural authoring surface; under evaluation.
+
+**Embedded verifier:** Planned.
+
+**CLI:** Deferred. Use the Rust CLI.
+
+**LSP Plugin:** In progress. `implementations/php/provekit-lift/src/lspd.php` implements the ProvekIt NDJSON LSP plugin protocol; not yet shipped.
 
 ## Cross-language conformance
 

--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -74,4 +74,4 @@ The handshake walks the catalog, runs the three tiers, and reports the discharge
 
 ---
 
-*This tutorial is a stub. Contributions welcome (see [docs/contributing/overview.md](../contributing/overview.md). Known gaps: actual npm package names, end-to-end runnable example, IDE wire-up once the LSP ships.*)
+*This tutorial is a stub. Contributions welcome; see [docs/contributing/overview.md](../contributing/overview.md). Known gaps: actual npm package names, end-to-end runnable example, IDE wire-up once the LSP ships.*


### PR DESCRIPTION
## Summary

- **#360 (em-dash sweep collateral):** Five files fixed. `capability-gaps.md` table cell `(partial — over-matches)` changed to `(partial, over-matches)`. `tutorials/typescript.md` stub footer semicoloned. `05-self-contracts.md` two em-dash connectors replaced with colons. `manifesto.md` hanging em-dash clause turned into a comma continuation. `bugsjs-harvest.md` bold-heading em-dash replaced with colon. `vscode.md:158` and `phase-ad-core.md:2867` flagged by Copilot but not broken in current main; noted as resolved upstream.

- **#358 (per-language-status drift):** Added PHP row to the Matrix table and cross-kit bridge readiness table; added PHP narrative section. PHP kit structure exists (`provekit-ir-symbolic`, `provekit-lift`, `provekit-self-contracts`) with no pinned attestation yet. Updated Self-contracts pkg column for C, Zig, Java, Ruby, Swift from `-` to `~ <orchestrator> (attestation pinned)` — all five have files in `.provekit/self-contracts-attestations/`; the old `-` was stale after their Side A merges. README is the source of truth; per-language-status now matches.

- **#369 (9/12 framing):** The all-mint target is correct: 9 kits (zig IS included, added in #283). The stale comment above `all-mint` incorrectly listed zig and c as pending when both had already landed. Rewrote the comment to state accurately: 9 of 12 kits, excluded are swift (macOS-only), ruby (CI integration pending #234), php (pending feat/php-kit). No change to the target dependency list.

## Ambiguous calls that need eyes

1. **#358 self-contracts reconciliation:** I chose `~ <orchestrator> (attestation pinned)` for C/Zig/Java/Ruby/Swift because the attestation files exist but there is no formal named package (unlike `+ Provekit.SelfContracts` for C#). If "self-contracts pkg" means a published package only, these should stay `-` and the README column should be softened instead. Current call: attestation existence = `~`, not `+`.

2. **#360 scope:** The `docs/diag/c6-sql-syntax-r6.md` "wording cleanup" item and `docs/how-to/ide-integration/overview.md:16` "empty Plugin column" items from the issue were not broken in current main and were not changed. If Copilot's review captured a prior state that was since fixed, these are done. If not, they need another look.

## Test plan

- [ ] Verify `docs/reference/per-language-status.md` Matrix table renders correctly (12 rows including PHP)
- [ ] Verify cross-kit bridge readiness table has PHP row and correct self-contracts entries for C/Zig/Java/Ruby/Swift
- [ ] Verify `make all-mint` comment matches the actual target dependency list (9 kits, zig included)
- [ ] Grep for em-dashes in changed files confirms none remain in prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)