### PR TITLE
spec+feat: refuse-on-effects + memento specs (addresses #384 B.5/B.6)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "provekit-ir-compiler-smt-lib",
  "provekit-ir-symbolic",
  "provekit-proof-envelope",
+ "provekit-walk",
  "rayon",
  "serde",
  "serde_json",

--- a/implementations/rust/provekit-verifier/Cargo.toml
+++ b/implementations/rust/provekit-verifier/Cargo.toml
@@ -9,6 +9,7 @@ description = "ProvekIt: six-stage verifier pipeline (load, enumerate, resolve, 
 [dependencies]
 provekit-canonicalizer = { path = "../provekit-canonicalizer" }
 provekit-proof-envelope = { path = "../provekit-proof-envelope" }
+provekit-walk = { path = "../provekit-walk" }
 provekit-ir-compiler-smt-lib = { path = "../provekit-ir-compiler-smt-lib" }
 provekit-ir-compiler = { path = "../provekit-ir-compiler" }
 provekit-ir-compiler-coq = { path = "../provekit-ir-compiler-coq" }

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -10,6 +10,7 @@
 
 use std::collections::BTreeMap;
 
+use provekit_walk::contract::OpacityMementoLookup;
 use serde_json::Value as Json;
 use serde::Serialize;
 
@@ -102,6 +103,28 @@ pub struct MementoPool {
     pub cid_to_name: BTreeMap<String, String>,
     /// Contract name -> CID (reverse index)
     pub name_to_cid: BTreeMap<String, String>,
+
+    // ---- Opacity discharge indexes (issue #384 B.5) ----
+    //
+    // These maps are indexed during `insert()` when a memento of the
+    // corresponding discharge kind is loaded. The substrate's
+    // `compose_function_contracts_checked` queries these via the
+    // `OpacityMementoLookup` impl below.
+
+    /// loopCid (from header.loopCid of a LoopInvariantMemento) ->
+    /// memento CID. Populated when a "loop-invariant" kind memento is
+    /// inserted. Spec: protocol/specs/2026-05-05-loop-invariant-memento.md
+    pub loop_cid_to_memento: BTreeMap<String, String>,
+
+    /// tryCid (from header.tryCid of a TryBranchMemento) -> memento CID.
+    /// Populated when a "try-branch" kind memento is inserted.
+    /// Spec: protocol/specs/2026-05-05-try-branch-memento.md
+    pub try_cid_to_memento: BTreeMap<String, String>,
+
+    /// bodyFnCid (from header.bodyFnCid of a ClosureBindingMemento) ->
+    /// memento CID. Populated when a "closure-binding" kind memento is
+    /// inserted. Spec: protocol/specs/2026-05-05-closure-binding-memento.md
+    pub body_fn_cid_to_memento: BTreeMap<String, String>,
 }
 
 /// Key for implication lookups: (antecedent CID, consequent CID).
@@ -294,9 +317,45 @@ impl MementoPool {
                     }
                 } else {
                     self.cid_to_name.insert(memento_cid.clone(), n.clone());
-                    self.name_to_cid.insert(n, memento_cid);
+                    self.name_to_cid.insert(n, memento_cid.clone());
                 }
             }
+        }
+
+        // ---- Opacity discharge indexing (issue #384 B.5) ----
+        // Index discharge mementos by their opacity-site CID fields so that
+        // OpacityMementoLookup queries are O(log n) BTreeMap lookups rather
+        // than a full pool scan.
+        //
+        // Both v1.1 flat (evidence.body.*) and v1.2 layered (header.*) shapes
+        // are covered by memento_body_field / memento_kind.
+        let kind = self.mementos.get(&memento_cid).and_then(|e| memento_kind(e)).map(str::to_string);
+        match kind.as_deref() {
+            Some("loop-invariant") => {
+                // header.loopCid (v1.2) or evidence.body.loopCid (v1.1)
+                if let Some(env) = self.mementos.get(&memento_cid) {
+                    if let Some(loop_cid) = memento_body_field(env, "loopCid").and_then(|v| v.as_str()) {
+                        self.loop_cid_to_memento.entry(loop_cid.to_string()).or_insert(memento_cid.clone());
+                    }
+                }
+            }
+            Some("try-branch") => {
+                // header.tryCid (v1.2) or evidence.body.tryCid (v1.1)
+                if let Some(env) = self.mementos.get(&memento_cid) {
+                    if let Some(try_cid) = memento_body_field(env, "tryCid").and_then(|v| v.as_str()) {
+                        self.try_cid_to_memento.entry(try_cid.to_string()).or_insert(memento_cid.clone());
+                    }
+                }
+            }
+            Some("closure-binding") => {
+                // header.bodyFnCid (v1.2) or evidence.body.bodyFnCid (v1.1)
+                if let Some(env) = self.mementos.get(&memento_cid) {
+                    if let Some(body_fn_cid) = memento_body_field(env, "bodyFnCid").and_then(|v| v.as_str()) {
+                        self.body_fn_cid_to_memento.entry(body_fn_cid.to_string()).or_insert(memento_cid.clone());
+                    }
+                }
+            }
+            _ => {}
         }
     }
 
@@ -392,6 +451,38 @@ impl MementoPool {
                 self.name_to_cid.insert(k, v);
             }
         }
+        // Opacity discharge indexes: first-insertion wins (same policy as
+        // other single-valued indexes). Collisions on these keys mean two
+        // proofs supply different discharge mementos for the same opacity
+        // site — keep the first, let the substrate use whichever it loaded
+        // first.
+        for (k, v) in other.loop_cid_to_memento {
+            self.loop_cid_to_memento.entry(k).or_insert(v);
+        }
+        for (k, v) in other.try_cid_to_memento {
+            self.try_cid_to_memento.entry(k).or_insert(v);
+        }
+        for (k, v) in other.body_fn_cid_to_memento {
+            self.body_fn_cid_to_memento.entry(k).or_insert(v);
+        }
+    }
+}
+
+/// `MementoPool` implements `OpacityMementoLookup` so that
+/// `compose_function_contracts_checked` in `provekit-walk` can query
+/// whether a discharge memento is present for a given opacity site CID.
+///
+/// Each lookup is an O(log n) BTreeMap probe against the three
+/// opacity-discharge indexes populated by `MementoPool::insert()`.
+impl OpacityMementoLookup for MementoPool {
+    fn has_loop_invariant(&self, loop_cid: &str) -> bool {
+        self.loop_cid_to_memento.contains_key(loop_cid)
+    }
+    fn has_try_branch(&self, try_cid: &str) -> bool {
+        self.try_cid_to_memento.contains_key(try_cid)
+    }
+    fn has_closure_binding(&self, body_fn_cid: &str) -> bool {
+        self.body_fn_cid_to_memento.contains_key(body_fn_cid)
     }
 }
 

--- a/implementations/rust/provekit-walk/src/contract.rs
+++ b/implementations/rust/provekit-walk/src/contract.rs
@@ -369,6 +369,110 @@ fn sort_to_value(s: &Sort) -> Arc<Value> {
     }
 }
 
+// ---- Opacity discharge ----
+
+/// Trait for querying whether a discharge memento is present for a
+/// given opacity effect. Implemented by `MementoPool` in
+/// `provekit-verifier`; in-crate tests use a mock.
+///
+/// Each method returns `true` iff a conforming discharge memento for
+/// that specific site is present in the pool and has passed all
+/// validation rules defined in the corresponding spec:
+///   - `LoopInvariantMemento`  (protocol/specs/2026-05-05-loop-invariant-memento.md)
+///   - `TryBranchMemento`      (protocol/specs/2026-05-05-try-branch-memento.md)
+///   - `ClosureBindingMemento` (protocol/specs/2026-05-05-closure-binding-memento.md)
+///   - `UnresolvedCall`:       no memento kind yet; always undischarged.
+pub trait OpacityMementoLookup {
+    fn has_loop_invariant(&self, loop_cid: &str) -> bool;
+    fn has_try_branch(&self, try_cid: &str) -> bool;
+    fn has_closure_binding(&self, body_fn_cid: &str) -> bool;
+}
+
+/// A no-op pool that never has any discharge mementos. Used as the
+/// default when callers don't yet track opacity discharge.
+pub struct EmptyOpacityPool;
+impl OpacityMementoLookup for EmptyOpacityPool {
+    fn has_loop_invariant(&self, _: &str) -> bool { false }
+    fn has_try_branch(&self, _: &str) -> bool { false }
+    fn has_closure_binding(&self, _: &str) -> bool { false }
+}
+
+/// Error returned when composition is refused because an opacity effect
+/// is not discharged by a memento in the pool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpacityError {
+    /// An `Effect::OpaqueLoop { loop_cid }` is present but no
+    /// `LoopInvariantMemento` with that `loopCid` is in the pool.
+    LoopNotDischarged { loop_cid: String },
+    /// An `Effect::EarlyReturn { try_cid }` is present but no
+    /// `TryBranchMemento` with that `tryCid` is in the pool.
+    EarlyReturnNotDischarged { try_cid: String },
+    /// An `Effect::ClosureCapture { body_fn_cid, .. }` is present but
+    /// no `ClosureBindingMemento` with that `bodyFnCid` is in the pool.
+    ClosureCaptureNotDischarged { body_fn_cid: String },
+    /// An `Effect::UnresolvedCall { name }` is present. No discharge
+    /// memento kind exists yet; composition is always refused.
+    UnresolvedCallNotDischarged { name: String },
+}
+
+impl std::fmt::Display for OpacityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LoopNotDischarged { loop_cid } =>
+                write!(f, "opacity: OpaqueLoop(loopCid={loop_cid}) has no LoopInvariantMemento in pool"),
+            Self::EarlyReturnNotDischarged { try_cid } =>
+                write!(f, "opacity: EarlyReturn(tryCid={try_cid}) has no TryBranchMemento in pool"),
+            Self::ClosureCaptureNotDischarged { body_fn_cid } =>
+                write!(f, "opacity: ClosureCapture(bodyFnCid={body_fn_cid}) has no ClosureBindingMemento in pool"),
+            Self::UnresolvedCallNotDischarged { name } =>
+                write!(f, "opacity: UnresolvedCall({name}) has no discharge memento kind"),
+        }
+    }
+}
+
+impl EffectSet {
+    /// Check whether all opacity effects in this set are discharged by
+    /// the given pool. Returns `Ok(())` iff:
+    ///   - there are no opacity effects at all, OR
+    ///   - every opacity effect has a corresponding memento in `pool`.
+    ///
+    /// Non-opacity effects (Reads/Writes/Io/Unsafe/Panics) are NOT
+    /// checked here; composition with non-opacity effects is refused
+    /// by `compose_function_contracts` separately.
+    ///
+    /// Returns the FIRST undischarged opacity effect as an error.
+    /// The caller can collect all errors by iterating effects directly.
+    pub fn check_opacity_effects(&self, pool: &dyn OpacityMementoLookup) -> Result<(), OpacityError> {
+        for effect in &self.effects {
+            match effect {
+                Effect::OpaqueLoop { loop_cid } => {
+                    if !pool.has_loop_invariant(loop_cid) {
+                        return Err(OpacityError::LoopNotDischarged { loop_cid: loop_cid.clone() });
+                    }
+                }
+                Effect::EarlyReturn { try_cid } => {
+                    if !pool.has_try_branch(try_cid) {
+                        return Err(OpacityError::EarlyReturnNotDischarged { try_cid: try_cid.clone() });
+                    }
+                }
+                Effect::ClosureCapture { body_fn_cid, .. } => {
+                    if !pool.has_closure_binding(body_fn_cid) {
+                        return Err(OpacityError::ClosureCaptureNotDischarged { body_fn_cid: body_fn_cid.clone() });
+                    }
+                }
+                Effect::UnresolvedCall { name } => {
+                    return Err(OpacityError::UnresolvedCallNotDischarged { name: name.clone() });
+                }
+                // Non-opacity effects: Reads/Writes/Io/Unsafe/Panics do not
+                // participate in memento-based discharge.
+                Effect::Reads { .. } | Effect::Writes { .. } | Effect::Io
+                | Effect::Unsafe | Effect::Panics => {}
+            }
+        }
+        Ok(())
+    }
+}
+
 // ---- Composition ----
 
 #[derive(Debug, Clone)]
@@ -459,6 +563,117 @@ pub fn compose_function_contracts(
         canonical_bytes,
         cid,
     })
+}
+
+/// Compose two function contracts with opacity discharge checking.
+///
+/// This is the substrate-verifier-facing API. It distinguishes three
+/// refusal reasons:
+///
+/// 1. `Err(OpacityError::*)` — a contract carries an opacity effect
+///    (`OpaqueLoop`, `EarlyReturn`, `ClosureCapture`, `UnresolvedCall`)
+///    with no corresponding discharge memento in `pool`. The caller
+///    knows exactly which effect is undischarged.
+///
+/// 2. `Ok(None)` — composition refused for a non-opacity reason:
+///    an unconditionally-blocking effect (Reads/Writes/Io/Unsafe/Panics)
+///    is present, `formal_idx` is out of bounds, or the inner post has
+///    no result equation.
+///
+/// 3. `Ok(Some(composed))` — all opacity effects are discharged by
+///    mementos in `pool`, no unconditionally-blocking effects are
+///    present, and composition succeeded.
+///
+/// Design note: unlike `compose_function_contracts`, this function
+/// allows contracts whose ONLY impure effects are opacity effects that
+/// are fully discharged. The existing `compose_function_contracts`
+/// (which refuses on ANY effect) remains unchanged for pre-discharge
+/// callers.
+pub fn compose_function_contracts_checked(
+    outer: &FunctionContractMemento,
+    inner: &FunctionContractMemento,
+    formal_idx: usize,
+    pool: &dyn OpacityMementoLookup,
+) -> Result<Option<ComposedFunctionContract>, OpacityError> {
+    // Phase 1: check opacity effects on both sides. Returns the first
+    // undischarged opacity effect as a typed error.
+    outer.effects.check_opacity_effects(pool)?;
+    inner.effects.check_opacity_effects(pool)?;
+
+    // Phase 2: check for unconditionally-blocking effects. After opacity
+    // discharge, only Reads/Writes/Io/Unsafe/Panics can still block.
+    // A contract that had ONLY opacity effects — all now discharged — has
+    // no remaining blockers; one that still has non-opacity impure effects
+    // is still refused.
+    let outer_non_opacity_pure = outer.effects.effects.iter().all(|e| matches!(
+        e,
+        Effect::OpaqueLoop { .. } | Effect::EarlyReturn { .. }
+        | Effect::ClosureCapture { .. } | Effect::UnresolvedCall { .. }
+    ));
+    let inner_non_opacity_pure = inner.effects.effects.iter().all(|e| matches!(
+        e,
+        Effect::OpaqueLoop { .. } | Effect::EarlyReturn { .. }
+        | Effect::ClosureCapture { .. } | Effect::UnresolvedCall { .. }
+    ));
+    if !outer_non_opacity_pure || !inner_non_opacity_pure {
+        return Ok(None);
+    }
+
+    if formal_idx >= outer.formals.len() {
+        return Ok(None);
+    }
+
+    // Phase 3: perform the actual composition (same logic as
+    // compose_function_contracts, duplicated here to avoid the
+    // is_pure() gate in that function).
+    let inner_result_name = inner.result_var_name();
+    let inner_post_renamed = crate::wp::substitute_in_formula(
+        inner.post.clone(),
+        "result",
+        &IrTerm::Var { name: inner_result_name.clone() },
+    );
+    let inner_value = match find_result_equation(&inner_post_renamed, &inner_result_name) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+    let outer_formal = &outer.formals[formal_idx];
+    let outer_pre_substituted =
+        crate::wp::substitute_in_formula(outer.pre.clone(), outer_formal, &inner_value);
+    let outer_post_substituted =
+        crate::wp::substitute_in_formula(outer.post.clone(), outer_formal, &inner_value);
+    let pre = IrFormula::And {
+        operands: vec![
+            inner.pre.clone(),
+            IrFormula::Implies {
+                operands: vec![inner_post_renamed, outer_pre_substituted],
+            },
+        ],
+    };
+    let post = outer_post_substituted;
+    let value = Value::object([
+        ("schemaVersion", Value::string("1")),
+        ("kind", Value::string("composed-function-contract")),
+        (
+            "components",
+            Value::array(vec![
+                Value::string(outer.cid.clone()),
+                Value::string(inner.cid.clone()),
+            ]),
+        ),
+        ("formalIdx", Value::integer(formal_idx as i64)),
+        ("pre", formula_to_canonical(&pre)),
+        ("post", formula_to_canonical(&post)),
+    ]);
+    let canonical_bytes = jcs_bytes_of_value(&value);
+    let cid = cid_of_value(&value);
+    Ok(Some(ComposedFunctionContract {
+        component_cids: vec![outer.cid.clone(), inner.cid.clone()],
+        formal_idx,
+        pre,
+        post,
+        canonical_bytes,
+        cid,
+    }))
 }
 
 /// Compose with the inner being an already-composed contract. Used
@@ -1118,5 +1333,190 @@ mod tests {
             "Vec<u32> and SomeStruct formals must produce distinct sorts"
         );
         assert_ne!(f_vec.cid, f_struct.cid);
+    }
+
+    // ---- Issue #384 B.5: opacity discharge tests ----
+
+    /// Mock pool for testing: pre-seeded with specific loop_cid values.
+    struct MockPool {
+        loop_cids: Vec<String>,
+        try_cids: Vec<String>,
+        body_fn_cids: Vec<String>,
+    }
+
+    impl MockPool {
+        fn empty() -> Self {
+            Self { loop_cids: vec![], try_cids: vec![], body_fn_cids: vec![] }
+        }
+        fn with_loop(mut self, cid: &str) -> Self {
+            self.loop_cids.push(cid.to_string());
+            self
+        }
+        fn with_try(mut self, cid: &str) -> Self {
+            self.try_cids.push(cid.to_string());
+            self
+        }
+        fn with_closure(mut self, cid: &str) -> Self {
+            self.body_fn_cids.push(cid.to_string());
+            self
+        }
+    }
+
+    impl OpacityMementoLookup for MockPool {
+        fn has_loop_invariant(&self, loop_cid: &str) -> bool {
+            self.loop_cids.iter().any(|c| c == loop_cid)
+        }
+        fn has_try_branch(&self, try_cid: &str) -> bool {
+            self.try_cids.iter().any(|c| c == try_cid)
+        }
+        fn has_closure_binding(&self, body_fn_cid: &str) -> bool {
+            self.body_fn_cids.iter().any(|c| c == body_fn_cid)
+        }
+    }
+
+    /// Build a FunctionContractMemento from a `fn f(x: u32) -> u32` shell
+    /// with a manually injected effect. Used by opacity tests below.
+    fn contract_with_effects(name: &str, effects: Vec<Effect>) -> FunctionContractMemento {
+        let mut c = build_function_contract(
+            &parse_fn(&format!("fn {}(x: u32) -> u32 {{ x }}", name)),
+            None,
+        );
+        for e in effects {
+            c.effects.add(e);
+        }
+        // Recompute cid so it reflects the new effects set.
+        let val = crate::contract::build_memento_value(&c);
+        c.canonical_bytes = crate::canonical::jcs_bytes_of_value(&val);
+        c.cid = crate::canonical::cid_of_value(&val);
+        c
+    }
+
+    /// A contract with OpaqueLoop + no LoopInvariantMemento in pool →
+    /// compose_function_contracts_checked returns Err.
+    #[test]
+    fn opaque_loop_without_memento_blocks_composition() {
+        let loop_cid = "blake3-512:aabb".repeat(8); // fake stable cid
+        let outer = contract_with_effects("outer", vec![Effect::OpaqueLoop { loop_cid: loop_cid.clone() }]);
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y + 1 }"#), None);
+        let pool = MockPool::empty(); // no loop invariant
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        assert!(
+            matches!(result, Err(OpacityError::LoopNotDischarged { .. })),
+            "expected LoopNotDischarged, got {:?}", result
+        );
+    }
+
+    /// Same contract with OpaqueLoop + matching LoopInvariantMemento in pool →
+    /// compose_function_contracts_checked succeeds (returns Ok(Some(...))).
+    #[test]
+    fn opaque_loop_with_memento_allows_composition() {
+        let loop_cid = "blake3-512:aabb".repeat(8);
+        let outer = contract_with_effects("outer", vec![Effect::OpaqueLoop { loop_cid: loop_cid.clone() }]);
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y + 1 }"#), None);
+        let pool = MockPool::empty().with_loop(&loop_cid);
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        // outer has only an OpaqueLoop (now discharged) and inner is pure →
+        // composition should succeed.
+        assert!(
+            matches!(result, Ok(Some(_))),
+            "expected Ok(Some(_)) after discharge, got {:?}", result
+        );
+    }
+
+    /// EarlyReturn + no TryBranchMemento → Err(EarlyReturnNotDischarged).
+    #[test]
+    fn early_return_without_memento_blocks_composition() {
+        let try_cid = "blake3-512:ccdd".repeat(8);
+        let outer = contract_with_effects("outer", vec![Effect::EarlyReturn { try_cid: try_cid.clone() }]);
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y }"#), None);
+        let pool = MockPool::empty();
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        assert!(
+            matches!(result, Err(OpacityError::EarlyReturnNotDischarged { .. })),
+            "expected EarlyReturnNotDischarged, got {:?}", result
+        );
+    }
+
+    /// EarlyReturn + matching TryBranchMemento → Ok(Some(_)).
+    #[test]
+    fn early_return_with_memento_allows_composition() {
+        let try_cid = "blake3-512:ccdd".repeat(8);
+        let outer = contract_with_effects("outer", vec![Effect::EarlyReturn { try_cid: try_cid.clone() }]);
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y }"#), None);
+        let pool = MockPool::empty().with_try(&try_cid);
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        assert!(
+            matches!(result, Ok(Some(_))),
+            "expected Ok(Some(_)) after discharge, got {:?}", result
+        );
+    }
+
+    /// ClosureCapture + no ClosureBindingMemento → Err(ClosureCaptureNotDischarged).
+    #[test]
+    fn closure_capture_without_memento_blocks_composition() {
+        let body_fn_cid = "blake3-512:eeff".repeat(8);
+        let outer = contract_with_effects("outer", vec![Effect::ClosureCapture { body_fn_cid: body_fn_cid.clone(), n_captures: 1 }]);
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y }"#), None);
+        let pool = MockPool::empty();
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        assert!(
+            matches!(result, Err(OpacityError::ClosureCaptureNotDischarged { .. })),
+            "expected ClosureCaptureNotDischarged, got {:?}", result
+        );
+    }
+
+    /// ClosureCapture + matching ClosureBindingMemento → Ok(Some(_)).
+    #[test]
+    fn closure_capture_with_memento_allows_composition() {
+        let body_fn_cid = "blake3-512:eeff".repeat(8);
+        let outer = contract_with_effects("outer", vec![Effect::ClosureCapture { body_fn_cid: body_fn_cid.clone(), n_captures: 1 }]);
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y }"#), None);
+        let pool = MockPool::empty().with_closure(&body_fn_cid);
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        assert!(
+            matches!(result, Ok(Some(_))),
+            "expected Ok(Some(_)) after discharge, got {:?}", result
+        );
+    }
+
+    /// UnresolvedCall always blocks composition regardless of pool contents.
+    #[test]
+    fn unresolved_call_always_blocks_composition() {
+        let outer = contract_with_effects("outer", vec![Effect::UnresolvedCall { name: "some_fn".to_string() }]);
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y }"#), None);
+        let pool = MockPool::empty();
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        assert!(
+            matches!(result, Err(OpacityError::UnresolvedCallNotDischarged { .. })),
+            "expected UnresolvedCallNotDischarged, got {:?}", result
+        );
+    }
+
+    /// Non-opacity impure effects (Io) still block composition even
+    /// after all opacity effects are discharged: returns Ok(None).
+    #[test]
+    fn non_opacity_effects_still_block_after_opacity_discharge() {
+        let loop_cid = "blake3-512:1122".repeat(8);
+        // Contract has both OpaqueLoop (dischargeable) and Io (not dischargeable).
+        let outer = contract_with_effects("outer", vec![
+            Effect::OpaqueLoop { loop_cid: loop_cid.clone() },
+            Effect::Io,
+        ]);
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y }"#), None);
+        let pool = MockPool::empty().with_loop(&loop_cid);
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        // OpaqueLoop is discharged → no OpacityError. But Io blocks → Ok(None).
+        assert!(
+            matches!(result, Ok(None)),
+            "expected Ok(None) when non-opacity effect blocks, got {:?}", result
+        );
+    }
+
+    /// check_opacity_effects returns Ok(()) for a pure contract.
+    #[test]
+    fn check_opacity_pure_contract_is_ok() {
+        let f = build_function_contract(&parse_fn(r#"fn f(x: u32) -> u32 { x * 2 }"#), None);
+        let pool = MockPool::empty();
+        assert!(f.effects.check_opacity_effects(&pool).is_ok());
     }
 }

--- a/protocol/specs/2026-05-05-closure-binding-memento.md
+++ b/protocol/specs/2026-05-05-closure-binding-memento.md
@@ -1,0 +1,268 @@
+# ClosureBindingMemento — Normative Spec
+
+**Status:** v1.4.0 normative
+**Date:** 2026-05-05
+**Related:**
+- `2026-05-03-substrate-layers-envelope-header-body.md` — envelope/header/metadata layering (v1.4 shape)
+- `2026-05-03-contract-cid-vs-attestation-cid.md` — `bodyFnCid` is a contract CID, not an attestation CID (see §0.1)
+- `2026-04-30-memento-envelope-grammar.md` — role taxonomy and CDDL conventions (v1.1 flat shape; historical)
+- `2026-04-30-canonicalization-grammar.md` — JCS canonicalization, normative
+- `2026-04-30-ir-formal-grammar.md` — IrFormula shape; capture-binding predicates are IrFormulas
+- `2026-05-05-loop-invariant-memento.md` — sibling discharge memento for `Effect::OpaqueLoop`
+- `2026-05-05-try-branch-memento.md` — sibling discharge memento for `Effect::EarlyReturn`
+
+## §0. Purpose
+
+A `FunctionContractMemento` carrying an `Effect::ClosureCapture { body_fn_cid, n_captures }` is **opaque at that closure-construction site**. The Rust closure body is emitted by Charon as a separate `fun_decl` (a `Fn`/`FnMut`/`FnOnce` trait impl method); its `FunctionContractMemento` is lifted normally. However, the CONTRACT of the CAPTURING function — the one that constructs the closure — cannot be composed downstream because the captures bind the closure body's free variables to the enclosing scope's state, and those bindings are not visible in the body's standalone contract.
+
+A `ClosureBindingMemento` is the discharge certificate: it supplies the per-capture binding predicate that connects the capturing scope's variables to the closure body's captured parameters. Once this memento is in the pool and verified, the substrate can compose contracts through closure boundaries.
+
+### §0.1 `bodyFnCid` is a FunctionContractMemento `cid`, not an attestation CID
+
+The `Effect::ClosureCapture.body_fn_cid` is the `FunctionContractMemento.cid` of the closure body's lifted contract. It is the content CID of the canonical bytes of the memento object itself — what `2026-05-03-contract-cid-vs-attestation-cid.md` calls the "contract CID" — not the attestation CID of any signed envelope wrapping it. This is flagged here as an architect-review item: if future protocol versions introduce a distinction between the substrate's reference to a contract and a signer's attestation of that contract, this field's semantics must be revisited.
+
+## §1. Wire shape (v1.4 layered)
+
+```cddl
+; Shared scalar types:
+;   hash, cid, signature, pubkey, iso8601, ir-formula
+
+; A single capture binding: one captured variable name bound to a predicate.
+capture-binding = {
+  captureName:    tstr,          ; the closure body's free variable that is captured
+  captureSort:    sort,          ; the sort of the captured value (IrSort per ir-formal-grammar.md)
+  bindingPred:    ir-formula,    ; predicate over the capturing scope's state that pins the capture
+  bindingPredHash: hash          ; DERIVED: hash(canonical(bindingPred))
+}
+
+closure-binding-memento = {
+  envelope: {
+    signer:     pubkey,
+    declaredAt: iso8601,
+    signature:  signature        ; over JCS(header ++ metadata)
+  },
+  header: {
+    schemaVersion:     "1",
+    kind:              "closure-binding",
+    cid:               cid,       ; DERIVED — see §3
+    bodyFnCid:         cid,       ; the FunctionContractMemento.cid of the closure body
+    nCaptures:         uint,      ; must equal the Effect::ClosureCapture.n_captures value
+    captureBindingSetHash: hash   ; DERIVED: hash(canonical(sorted capture-binding array))
+  },
+  metadata: {
+    captureBindings: [+ capture-binding],   ; one entry per captured variable; MUST have n_captures entries
+    ? note: tstr
+  }
+}
+```
+
+### §1.1 Field semantics
+
+| Layer    | Field                    | Required | Meaning |
+|----------|--------------------------|----------|---------|
+| envelope | `signer`                 | yes      | `ed25519:<base64>` public key of the minter. |
+| envelope | `declaredAt`             | yes      | ISO-8601 UTC minting timestamp. |
+| envelope | `signature`              | yes (swarm) | Ed25519 over JCS of `{header, metadata}`. OPTIONAL for local-only use. |
+| header   | `schemaVersion`          | yes      | MUST be `"1"`. |
+| header   | `kind`                   | yes      | MUST be `"closure-binding"`. |
+| header   | `cid`                    | yes      | Content CID of this memento (DERIVED — §3). |
+| header   | `bodyFnCid`              | yes      | The `cid` field of the closure body's `FunctionContractMemento`. This is the contract CID per `2026-05-03-contract-cid-vs-attestation-cid.md`. The substrate matches this against the effect's `body_fn_cid` field exactly. |
+| header   | `nCaptures`              | yes      | The count of captured variables. MUST equal `Effect::ClosureCapture.n_captures` for the effect this memento discharges. MUST equal `len(metadata.captureBindings)`. |
+| header   | `captureBindingSetHash`  | yes      | DERIVED: `hash(canonical(sorted capture-binding array))`. See §2.2. |
+| metadata | `captureBindings`        | yes      | Array of `capture-binding` entries, one per captured variable. MUST be non-empty. Ordering: sorted by `captureName` ascending (lexicographic) for canonical stability. |
+| metadata | `note`                   | no       | Human-readable annotation. MUST be omitted when absent. |
+
+### §1.2 `capture-binding` field semantics
+
+| Field            | Required | Meaning |
+|------------------|----------|---------|
+| `captureName`    | yes      | The name of the captured variable as it appears in the closure body's `FunctionContractMemento` formals. |
+| `captureSort`    | yes      | The IrSort of the captured value. |
+| `bindingPred`    | yes      | An IrFormula over the CAPTURING function's formals that pins the captured variable's value. Typically `capture = outer_var` or a more complex relational predicate. |
+| `bindingPredHash` | yes     | DERIVED: `hash(canonical(bindingPred))`. Substrate-load-bearing; the captureBindingSetHash is computed over these. |
+
+## §2. Content-addressing rules
+
+### §2.1 CID construction
+
+The `cid` is the BLAKE3-512 of the JCS-canonical bytes of the `header` object with `cid` elided:
+
+```
+cid_input = JCS({
+  "bodyFnCid":              <bodyFnCid>,
+  "captureBindingSetHash":  <captureBindingSetHash>,
+  "kind":                   "closure-binding",
+  "nCaptures":              <nCaptures>,
+  "schemaVersion":          "1"
+})
+cid = "blake3-512:" ++ hex(BLAKE3-512(cid_input))
+```
+
+**Canonicalization choice (flag for architect review):** The `cid` input includes `captureBindingSetHash` (a hash of the full capture-binding array) rather than individual `bindingPredHash` fields. This keeps the header compact regardless of capture count, and means that two mementos with the same `bodyFnCid` but different capture bindings have different `cid`s. The downside: you cannot look up a specific capture by its `bindingPredHash` in the header — only the set-level hash is indexed at the substrate layer.
+
+### §2.2 `captureBindingSetHash` construction
+
+Each `capture-binding` entry's canonical form is:
+
+```
+canonical_entry(b) = JCS({
+  "bindingPredHash": b.bindingPredHash,
+  "captureName":     b.captureName,
+  "captureSort":     <sort as canonical IrSort JSON>
+})
+```
+
+The full set hash covers the sorted array of canonical entries:
+
+```
+sorted_entries = sort(canonical_entry(b) for b in captureBindings, by captureName ascending)
+captureBindingSetHash = "blake3-512:" ++ hex(BLAKE3-512(JCS(sorted_entries)))
+```
+
+**ORDERING constraint:** Entries MUST be sorted by `captureName` ascending in `metadata.captureBindings`. The validator sorts a copy before computing the set hash and rejects if the stored array is not in sorted order.
+
+### §2.3 Per-binding `bindingPredHash` construction
+
+```
+bindingPredHash = "blake3-512:" ++ hex(BLAKE3-512(JCS(capture-binding.bindingPred)))
+```
+
+## §3. Mint procedure
+
+1. Identify the closure site: obtain `body_fn_cid` and `n_captures` from the `Effect::ClosureCapture` in the target `FunctionContractMemento`.
+2. For each captured variable, construct a `capture-binding` entry:
+   a. Set `captureName` to the variable name from the closure body's formals.
+   b. Set `captureSort` to the variable's IrSort.
+   c. Write `bindingPred` as an IrFormula over the capturing scope's state.
+   d. Compute `bindingPredHash` per §2.3.
+3. Sort the entries by `captureName` ascending.
+4. Compute `captureBindingSetHash` per §2.2.
+5. Build the `header` object (all fields except `cid`).
+6. Compute `cid` per §2.1.
+7. Build the `metadata` object.
+8. Sign `JCS({header, metadata})` with the minter's Ed25519 key.
+9. Emit the full envelope.
+
+**INVARIANT (n_captures check):** The minter MUST verify that `len(captureBindings) == nCaptures == Effect::ClosureCapture.n_captures`. A memento where `nCaptures` disagrees with `len(captureBindings)` is invalid and MUST be rejected by a conforming validator.
+
+**INVARIANT (minting idempotency):** Two mint operations for the same `bodyFnCid` and byte-identical sorted `captureBindings` MUST produce the same `cid`.
+
+## §4. Validation rules
+
+### §4.1 Pass 1: CDDL shape check
+
+Reject if:
+- Any required field is missing.
+- `kind` is not `"closure-binding"` or `schemaVersion` is not `"1"`.
+- Any hash field does not match the hash regexp.
+- `metadata.captureBindings` is empty (MUST have at least one entry; zero-capture closures are pure by definition and do not emit the effect).
+- `header.nCaptures` does not equal `len(metadata.captureBindings)`.
+- Any `capture-binding` entry is missing required fields.
+
+### §4.2 Pass 2: DERIVED and REFERENT constraints
+
+**DERIVED (bindingPredHash per entry):** For each `capture-binding` entry, recompute `hash(JCS(bindingPred))` and verify it equals the entry's `bindingPredHash`. Reject on any mismatch.
+
+**DERIVED (captureBindingSetHash):** Recompute per §2.2 (sort by captureName, build canonical entries, hash the array) and verify it equals `header.captureBindingSetHash`. Reject on mismatch.
+
+**ORDERING constraint:** Verify `metadata.captureBindings` is sorted by `captureName` ascending. Reject if not sorted.
+
+**DERIVED (cid):** Recompute per §2.1 and verify it equals `header.cid`. Reject on mismatch.
+
+**REFERENT (bodyFnCid):** The pool MUST contain a `FunctionContractMemento` (kind `"function-contract"`) whose `cid` equals `header.bodyFnCid`. A `ClosureBindingMemento` referencing a body function not in the pool cannot be validated in context. (This is a pool-level constraint; the memento's own CID and DERIVED constraints are still verifiable in isolation.)
+
+**REFERENT (n_captures match):** The pool MUST contain a `FunctionContractMemento` whose `effects` array contains `{"kind": "closure_capture", "bodyFnCid": <header.bodyFnCid>, "nCaptures": <header.nCaptures>}`. The `nCaptures` in the effect MUST equal `header.nCaptures`.
+
+**SIGNATURE:** For swarm-distributed mementos, verify `envelope.signature` over `JCS({header, metadata})` against `envelope.signer`. Reject on invalid signature.
+
+## §5. Discharge semantics (substrate behavior)
+
+The substrate's composition guard for `Effect::ClosureCapture`:
+
+```
+can_compose_closure(contract, pool) :=
+  for each Effect::ClosureCapture { body_fn_cid, n_captures } in contract.effects:
+    pool contains a valid ClosureBindingMemento M where:
+      M.header.bodyFnCid == body_fn_cid
+      M.header.nCaptures == n_captures
+```
+
+If false, `compose_function_contracts` returns `OpacityError::ClosureCaptureNotDischarged { body_fn_cid }`.
+
+A single `ClosureBindingMemento` discharges exactly one `ClosureCapture` effect keyed by `(bodyFnCid, nCaptures)`. A function that constructs two closures has two `ClosureCapture` effects (with distinct `body_fn_cid` values) and requires two distinct `ClosureBindingMemento` mementos.
+
+**Note on nCaptures ambiguity:** Two closures at the same site that capture different numbers of variables produce effects with the same `body_fn_cid` but different `n_captures`. The pair `(bodyFnCid, nCaptures)` is the discharge key. This pair uniquely identifies the effect in well-formed IR (Charon emits a distinct `fun_decl` per closure body, so `body_fn_cid` values differ across closure sites within the same function). The `nCaptures` field is belt-and-suspenders: the primary key is `bodyFnCid`.
+
+## §6. Worked example
+
+A function `fn apply_offset(offset: i64) -> impl Fn(i64) -> i64` constructs a closure `move |x| x + offset`, capturing `offset`:
+
+```json
+{
+  "envelope": {
+    "signer":     "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+    "declaredAt": "2026-05-05T12:00:00Z",
+    "signature":  "ed25519:MEUCIQDxxx=="
+  },
+  "header": {
+    "schemaVersion":          "1",
+    "kind":                   "closure-binding",
+    "cid":                    "blake3-512:c1d2e3...<128 hex chars>",
+    "bodyFnCid":              "blake3-512:f40516...<128 hex chars>",
+    "nCaptures":              1,
+    "captureBindingSetHash":  "blake3-512:192021...<128 hex chars>"
+  },
+  "metadata": {
+    "captureBindings": [
+      {
+        "captureName":    "offset",
+        "captureSort":    { "kind": "primitive", "name": "Int" },
+        "bindingPred": {
+          "kind": "atomic",
+          "name": "=",
+          "args": [
+            { "kind": "var", "name": "offset" },
+            { "kind": "var", "name": "outer_offset" }
+          ]
+        },
+        "bindingPredHash": "blake3-512:222324...<128 hex chars>"
+      }
+    ],
+    "note": "closure captures outer_offset as offset in the body contract."
+  }
+}
+```
+
+The `captureBindingSetHash` is computed as:
+
+```
+canonical_entry = JCS({
+  "bindingPredHash": "blake3-512:222324...",
+  "captureName":     "offset",
+  "captureSort":     {"kind": "primitive", "name": "Int"}
+})
+sorted_array = [canonical_entry]   ; single element, trivially sorted
+captureBindingSetHash = "blake3-512:" ++ hex(BLAKE3-512(JCS(sorted_array)))
+```
+
+The `cid` is computed as:
+
+```
+JCS_bytes = JCS({
+  "bodyFnCid":             "blake3-512:f40516...",
+  "captureBindingSetHash": "blake3-512:192021...",
+  "kind":                  "closure-binding",
+  "nCaptures":             1,
+  "schemaVersion":         "1"
+})
+cid = "blake3-512:" ++ hex(BLAKE3-512(JCS_bytes))
+```
+
+## §7. Cross-references
+
+- The `bodyFnCid` and `nCaptures` values are produced by `llbc_closures::extract_closure_captures()` in `implementations/rust/provekit-walk/src/llbc_closures.rs`. The `body_fn_cid` is the `content_cid` of the closure body's `fun_decl` once it is lifted through the normal pipeline.
+- The substrate check lives in `EffectSet::check_opacity` and `compose_function_contracts` in `implementations/rust/provekit-walk/src/contract.rs`.
+- The pool indexing lives in `MementoPool::insert` in `implementations/rust/provekit-verifier/src/types.rs`, keyed by `header.bodyFnCid`.
+- The `bodyFnCid` is the `FunctionContractMemento.cid` of the closure body — the contract CID, not the attestation CID. See `2026-05-03-contract-cid-vs-attestation-cid.md` for the distinction.
+- For the `LoopInvariantMemento` (discharges `Effect::OpaqueLoop`), see `2026-05-05-loop-invariant-memento.md`.
+- For the `TryBranchMemento` (discharges `Effect::EarlyReturn`), see `2026-05-05-try-branch-memento.md`.

--- a/protocol/specs/2026-05-05-loop-invariant-memento.md
+++ b/protocol/specs/2026-05-05-loop-invariant-memento.md
@@ -1,0 +1,258 @@
+# LoopInvariantMemento — Normative Spec
+
+**Status:** v1.4.0 normative
+**Date:** 2026-05-05
+**Related:**
+- `2026-05-03-substrate-layers-envelope-header-body.md` — envelope/header/metadata layering (v1.4 shape this spec conforms to)
+- `2026-04-30-memento-envelope-grammar.md` — role taxonomy and CDDL conventions (v1.1 flat shape; historical)
+- `2026-04-30-canonicalization-grammar.md` — JCS canonicalization, normative
+- `2026-04-30-ir-formal-grammar.md` — IrFormula shape; `invariant` and `decreasingFunction` are IrFormulas
+- `2026-05-04-linker-daemon-protocol.md` — the linker daemon pools discharge mementos for the substrate
+
+## §0. Purpose
+
+A `FunctionContractMemento` carrying an `Effect::OpaqueLoop { loop_cid }` is **opaque at that loop**. The substrate refuses to compose it downstream until the opacity is discharged. A `LoopInvariantMemento` is the discharge certificate for a single loop site: it supplies the loop invariant and (optionally) a decreasing function, signed and content-addressed, keyed by the loop's content CID.
+
+The substrate's composition rule (see §5) is: the contract's `OpaqueLoop` effect is cleared if and only if a `LoopInvariantMemento` whose `loopCid` matches the effect's `loop_cid` is present in the pool and passes all validation rules in this spec.
+
+## §1. Wire shape (v1.4 layered)
+
+The memento follows the substrate-layers spec's `envelope / header / metadata` cut.
+
+```cddl
+; Imports from the shared type namespace:
+;   hash         = tstr .regexp "^[a-z0-9]+-[0-9]+:[0-9a-f]+$"
+;   cid          = hash
+;   signature    = tstr .regexp "^[a-z0-9]+:[A-Za-z0-9+/]+=*$"
+;   pubkey       = tstr .regexp "^[a-z0-9]+:[A-Za-z0-9+/]+=*$"
+;   iso8601      = tstr .regexp "^[0-9]{4}-..."
+;   ir-formula   ; from 2026-04-30-ir-formal-grammar.md
+
+loop-invariant-memento = {
+  envelope: {
+    signer:     pubkey,
+    declaredAt: iso8601,
+    signature:  signature    ; over JCS(header ++ metadata)
+  },
+  header: {
+    schemaVersion: "1",
+    kind:          "loop-invariant",
+    cid:           cid,           ; DERIVED — see §3
+    loopCid:       cid,           ; the blake3-512 CID of the loop's LLBC body block
+    invariantHash: hash,          ; DERIVED: hash(canonical(invariant))
+    ? decreasingFunctionHash: hash ; DERIVED: hash(canonical(decreasingFunction)), when present
+  },
+  metadata: {
+    invariant:          ir-formula,        ; the loop invariant as an IrFormula
+    ? decreasingFunction: ir-formula,      ; the decreasing measure (well-founded ordinal)
+    ? note: tstr                           ; optional prose annotation
+  }
+}
+```
+
+### §1.1 Field semantics
+
+| Layer    | Field                    | Required | Meaning |
+|----------|--------------------------|----------|---------|
+| envelope | `signer`                 | yes      | `ed25519:<base64>` public key of the minter. |
+| envelope | `declaredAt`             | yes      | ISO-8601 UTC timestamp of minting. |
+| envelope | `signature`              | yes (swarm) | Ed25519 over JCS of `{header, metadata}`. REQUIRED for swarm-distributed mementos; OPTIONAL for local-only mementos consumed in-process. |
+| header   | `schemaVersion`          | yes      | MUST be `"1"`. |
+| header   | `kind`                   | yes      | MUST be the literal `"loop-invariant"`. |
+| header   | `cid`                    | yes      | Content CID of this memento (DERIVED — §3). |
+| header   | `loopCid`                | yes      | The `blake3-512:<hex>` CID that was emitted into `Effect::OpaqueLoop.loop_cid` by the lifter. This is the BLAKE3-512 of the JCS-canonical bytes of the loop's LLBC body block. The substrate matches this field against the effect's `loop_cid` string exactly. |
+| header   | `invariantHash`          | yes      | DERIVED: `"blake3-512:" ++ hex(BLAKE3-512(JCS(metadata.invariant)))`. Substrate-load-bearing index key. |
+| header   | `decreasingFunctionHash` | no       | DERIVED: same construction over `metadata.decreasingFunction`, when that field is present. MUST be absent when `decreasingFunction` is absent. |
+| metadata | `invariant`              | yes      | The loop invariant as an IrFormula. MUST be a closed formula (no free variables except those bound by the enclosing `FunctionContractMemento`'s `formals`). |
+| metadata | `decreasingFunction`     | no       | A decreasing function from loop state to a well-founded domain (Int or a user-defined ordinal sort). Required for a sound partial-to-total correctness argument; its absence means termination is not certified. |
+| metadata | `note`                   | no       | Human-readable annotation. Not substrate-load-bearing; MUST be omitted (not `null`) when absent. |
+
+## §2. Content-addressing rules
+
+### §2.1 CID construction
+
+The memento's `cid` is the BLAKE3-512 of the JCS-canonical bytes of an object that is the `header` with `cid` elided and `metadata` merged in:
+
+```
+cid_input = JCS({
+  "schemaVersion": "1",
+  "kind":          "loop-invariant",
+  "loopCid":       <loopCid>,
+  "invariantHash": <invariantHash>,
+  -- "decreasingFunctionHash": <decreasingFunctionHash>,  // included iff present
+})
+```
+
+More precisely: the CID input object is the `header` object with the `cid` field removed. Any optional header fields (`decreasingFunctionHash`) appear iff present; they are not force-included as `null`. After JCS canonicalization (sorted keys, no whitespace, UTF-8) the BLAKE3-512 digest is computed; `cid = "blake3-512:" ++ hex(digest)`.
+
+**Canonicalization choice (flag for architect review):** The `cid` input does NOT include `metadata.invariant` or `metadata.decreasingFunction` directly — it includes only their hashes (`invariantHash`, `decreasingFunctionHash`). This mirrors the ContractMemento pattern where `propertyHash` covers `pre/post/inv` hashes, not the raw formulas. Two mementos with the same `loopCid` and same invariant hash will have the same `cid` even if their `metadata.note` fields differ. This is intentional: the note is provenance annotation, not part of the discharge obligation's identity.
+
+### §2.2 `invariantHash` construction
+
+```
+invariantHash = "blake3-512:" ++ hex(BLAKE3-512(JCS(metadata.invariant)))
+```
+
+The JCS-canonical bytes of the IrFormula object are hashed directly. Implementations MUST produce a canonical IrFormula object per `2026-04-30-ir-formal-grammar.md` before hashing; non-canonical forms produce different hashes and fail the DERIVED constraint check.
+
+### §2.3 `decreasingFunctionHash` construction
+
+Same construction over `metadata.decreasingFunction` when present:
+
+```
+decreasingFunctionHash = "blake3-512:" ++ hex(BLAKE3-512(JCS(metadata.decreasingFunction)))
+```
+
+## §3. Mint procedure
+
+1. Identify the loop site: obtain the `loop_cid` string from the `Effect::OpaqueLoop` in the target `FunctionContractMemento`.
+2. Choose an invariant `I` (an IrFormula over the enclosing function's formals and the loop's variables).
+3. Optionally choose a decreasing measure `D` (an IrFormula mapping loop state to an ordinal).
+4. Compute `invariantHash = "blake3-512:" ++ hex(BLAKE3-512(JCS(I)))`.
+5. If `D` is present, compute `decreasingFunctionHash = "blake3-512:" ++ hex(BLAKE3-512(JCS(D)))`.
+6. Build the `header` object (all fields except `cid`).
+7. Compute `cid` per §2.1.
+8. Build the `metadata` object.
+9. Sign `JCS({header, metadata})` with the minter's Ed25519 key.
+10. Emit the full envelope.
+
+**INVARIANT (minting idempotency):** Two mint operations for the same `loopCid` and same `invariant` (byte-identical IrFormula) MUST produce the same `cid`. The `signer`, `declaredAt`, and `signature` differ across signers; the `cid` is content-derived and is the same.
+
+## §4. Validation rules
+
+A conforming verifier runs in two passes.
+
+### §4.1 Pass 1: CDDL shape check
+
+Validate the memento against the CDDL in §1. Reject if:
+- Any required field is missing.
+- `kind` is not the literal `"loop-invariant"`.
+- `schemaVersion` is not `"1"`.
+- Any hash field does not match the `^[a-z0-9]+-[0-9]+:[0-9a-f]+$` regexp.
+- `decreasingFunctionHash` is present but `metadata.decreasingFunction` is absent, or vice versa.
+
+### §4.2 Pass 2: DERIVED and REFERENT constraints
+
+**DERIVED (invariantHash):** Recompute `hash(JCS(metadata.invariant))` and verify it equals `header.invariantHash`. Reject on mismatch.
+
+**DERIVED (decreasingFunctionHash):** When present, recompute `hash(JCS(metadata.decreasingFunction))` and verify it equals `header.decreasingFunctionHash`. Reject on mismatch.
+
+**DERIVED (cid):** Recompute the `cid` per §2.1 and verify it equals `header.cid`. Reject on mismatch.
+
+**REFERENT:** The pool MUST contain a `FunctionContractMemento` (kind `"function-contract"`) whose `effects` array contains an entry `{"kind": "opaque_loop", "loopCid": <header.loopCid>}`. A `LoopInvariantMemento` whose `loopCid` does not match any loaded function contract's opacity effect is malformed in context (not a protocol-level reject, but the substrate refuses to treat it as a valid discharge certificate).
+
+**SIGNATURE:** For swarm-distributed mementos, verify `envelope.signature` over `JCS({header, metadata})` against `envelope.signer`. Reject on invalid signature. Local-only mementos MAY omit the signature; the substrate accepts them for in-process use without swarm verification.
+
+## §5. Discharge semantics (substrate behavior)
+
+The substrate's composition guard for `FunctionContractMemento` is:
+
+```
+can_compose(contract, pool) :=
+  for each Effect::OpaqueLoop { loop_cid } in contract.effects:
+    pool contains a valid LoopInvariantMemento M where M.header.loopCid == loop_cid
+```
+
+If `can_compose` is false for either the outer or inner contract in a `compose_function_contracts` call, composition returns an `OpacityError::LoopNotDischarged { loop_cid }`. Composition succeeds only when ALL opacity effects across BOTH contracts are discharged by corresponding mementos in the pool.
+
+A `LoopInvariantMemento` discharges exactly ONE `OpaqueLoop` effect — the one whose `loop_cid` matches `header.loopCid`. A function with two loops has two `OpaqueLoop` effects and requires two distinct `LoopInvariantMemento` mementos.
+
+## §6. Worked example
+
+```json
+{
+  "envelope": {
+    "signer":     "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+    "declaredAt": "2026-05-05T12:00:00Z",
+    "signature":  "ed25519:MEUCIQDxxx=="
+  },
+  "header": {
+    "schemaVersion":   "1",
+    "kind":            "loop-invariant",
+    "cid":             "blake3-512:a1b2c3...<128 hex chars>",
+    "loopCid":         "blake3-512:dead01...<128 hex chars>",
+    "invariantHash":   "blake3-512:cafe02...<128 hex chars>"
+  },
+  "metadata": {
+    "invariant": {
+      "kind": "atomic",
+      "name": ">=",
+      "args": [
+        { "kind": "var", "name": "i" },
+        { "kind": "const", "value": 0, "sort": { "kind": "primitive", "name": "Int" } }
+      ]
+    },
+    "decreasingFunction": {
+      "kind": "atomic",
+      "name": "-",
+      "args": [
+        { "kind": "var", "name": "n" },
+        { "kind": "var", "name": "i" }
+      ]
+    },
+    "note": "Loop index i stays non-negative; n - i decreases toward zero."
+  }
+}
+```
+
+In this example `decreasingFunctionHash` is absent from `header` because... wait, the example has `decreasingFunction` in metadata but no `decreasingFunctionHash` in header. Per §4.1 that is a reject. Corrected:
+
+```json
+{
+  "envelope": {
+    "signer":     "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+    "declaredAt": "2026-05-05T12:00:00Z",
+    "signature":  "ed25519:MEUCIQDxxx=="
+  },
+  "header": {
+    "schemaVersion":          "1",
+    "kind":                   "loop-invariant",
+    "cid":                    "blake3-512:a1b2c3...<128 hex chars>",
+    "loopCid":                "blake3-512:dead01...<128 hex chars>",
+    "invariantHash":          "blake3-512:cafe02...<128 hex chars>",
+    "decreasingFunctionHash": "blake3-512:bead03...<128 hex chars>"
+  },
+  "metadata": {
+    "invariant": {
+      "kind": "atomic",
+      "name": ">=",
+      "args": [
+        { "kind": "var", "name": "i" },
+        { "kind": "const", "value": 0, "sort": { "kind": "primitive", "name": "Int" } }
+      ]
+    },
+    "decreasingFunction": {
+      "kind": "atomic",
+      "name": "-",
+      "args": [
+        { "kind": "var", "name": "n" },
+        { "kind": "var", "name": "i" }
+      ]
+    },
+    "note": "Loop index i stays non-negative; n - i decreases toward zero."
+  }
+}
+```
+
+The `cid` is computed as:
+
+```
+JCS_bytes = JCS({
+  "decreasingFunctionHash": "blake3-512:bead03...",
+  "invariantHash":          "blake3-512:cafe02...",
+  "kind":                   "loop-invariant",
+  "loopCid":                "blake3-512:dead01...",
+  "schemaVersion":          "1"
+})
+cid = "blake3-512:" ++ hex(BLAKE3-512(JCS_bytes))
+```
+
+(Keys sorted per JCS rule. `cid` itself is excluded from the input.)
+
+## §7. Cross-references
+
+- The `loopCid` field's value is produced by `llbc_loops::extract_loops()` in `implementations/rust/provekit-walk/src/llbc_loops.rs`. It is the BLAKE3-512 of the JCS-canonical bytes of the loop's LLBC body block.
+- The substrate check lives in `EffectSet::check_opacity` and `compose_function_contracts` in `implementations/rust/provekit-walk/src/contract.rs`.
+- The pool indexing lives in `MementoPool::insert` in `implementations/rust/provekit-verifier/src/types.rs`, keyed by `header.loopCid`.
+- For the `TryBranchMemento` (discharges `Effect::EarlyReturn`), see `2026-05-05-try-branch-memento.md`.
+- For the `ClosureBindingMemento` (discharges `Effect::ClosureCapture`), see `2026-05-05-closure-binding-memento.md`.

--- a/protocol/specs/2026-05-05-loop-invariant-memento.md
+++ b/protocol/specs/2026-05-05-loop-invariant-memento.md
@@ -195,8 +195,6 @@ A `LoopInvariantMemento` discharges exactly ONE `OpaqueLoop` effect — the one 
 }
 ```
 
-In this example `decreasingFunctionHash` is absent from `header` because... wait, the example has `decreasingFunction` in metadata but no `decreasingFunctionHash` in header. Per §4.1 that is a reject. Corrected:
-
 ```json
 {
   "envelope": {

--- a/protocol/specs/2026-05-05-try-branch-memento.md
+++ b/protocol/specs/2026-05-05-try-branch-memento.md
@@ -1,0 +1,218 @@
+# TryBranchMemento — Normative Spec
+
+**Status:** v1.4.0 normative
+**Date:** 2026-05-05
+**Related:**
+- `2026-05-03-substrate-layers-envelope-header-body.md` — envelope/header/metadata layering (v1.4 shape)
+- `2026-04-30-memento-envelope-grammar.md` — role taxonomy and CDDL conventions (v1.1 flat shape; historical)
+- `2026-04-30-canonicalization-grammar.md` — JCS canonicalization, normative
+- `2026-04-30-ir-formal-grammar.md` — IrFormula shape; `successPathPred` and `failurePathPred` are IrFormulas
+- `2026-05-05-loop-invariant-memento.md` — sibling discharge memento for `Effect::OpaqueLoop`
+- `2026-05-05-closure-binding-memento.md` — sibling discharge memento for `Effect::ClosureCapture`
+
+## §0. Purpose
+
+A `FunctionContractMemento` carrying an `Effect::EarlyReturn { try_cid }` is **opaque at that Try-branch site**. The Rust `?` operator desugars to a `match` on `Result`/`Option` (in LLBC: `Switch::Match`) with an early-return on the `Err`/`None` arm. This early return is a genuine control-flow bifurcation: the function's post-condition holds only on the success path; the failure path exits before reaching any caller-visible return site.
+
+The substrate refuses to compose a function carrying this effect downstream until the opacity is discharged. A `TryBranchMemento` is the discharge certificate: it supplies a predicate for the success path and a predicate for the failure path, keyed by the try-site's content CID.
+
+The substrate's composition rule (§5): the contract's `EarlyReturn` effect is cleared if and only if a `TryBranchMemento` whose `tryCid` matches the effect's `try_cid` is present in the pool and passes all validation rules in this spec.
+
+## §1. Wire shape (v1.4 layered)
+
+```cddl
+; Shared scalar types from the canonicalization grammar:
+;   hash, cid, signature, pubkey, iso8601, ir-formula
+
+try-branch-memento = {
+  envelope: {
+    signer:     pubkey,
+    declaredAt: iso8601,
+    signature:  signature    ; over JCS(header ++ metadata)
+  },
+  header: {
+    schemaVersion:         "1",
+    kind:                  "try-branch",
+    cid:                   cid,         ; DERIVED — see §3
+    tryCid:                cid,         ; the blake3-512 CID of the Switch::Match LLBC block
+    successPathPredHash:   hash,        ; DERIVED: hash(canonical(metadata.successPathPred))
+    failurePathPredHash:   hash         ; DERIVED: hash(canonical(metadata.failurePathPred))
+  },
+  metadata: {
+    successPathPred:   ir-formula,   ; condition that holds when ? propagates Ok/Some
+    failurePathPred:   ir-formula,   ; condition that holds when ? early-returns Err/None
+    ? resultSort:      tstr,         ; "Result" or "Option" — which wrapper type this site desugars
+    ? note:            tstr          ; optional prose annotation
+  }
+}
+```
+
+### §1.1 Field semantics
+
+| Layer    | Field                 | Required | Meaning |
+|----------|-----------------------|----------|---------|
+| envelope | `signer`              | yes      | `ed25519:<base64>` public key of the minter. |
+| envelope | `declaredAt`          | yes      | ISO-8601 UTC minting timestamp. |
+| envelope | `signature`           | yes (swarm) | Ed25519 over JCS of `{header, metadata}`. OPTIONAL for local-only use. |
+| header   | `schemaVersion`       | yes      | MUST be `"1"`. |
+| header   | `kind`                | yes      | MUST be `"try-branch"`. |
+| header   | `cid`                 | yes      | Content CID of this memento (DERIVED — §3). |
+| header   | `tryCid`              | yes      | The `blake3-512:<hex>` CID emitted into `Effect::EarlyReturn.try_cid` by the LLBC lifter. It is the BLAKE3-512 of the JCS-canonical bytes of the `Switch::Match` block implementing the Try-branch shape. The substrate matches this field against the effect's `try_cid` string exactly. |
+| header   | `successPathPredHash` | yes      | DERIVED: `"blake3-512:" ++ hex(BLAKE3-512(JCS(metadata.successPathPred)))`. |
+| header   | `failurePathPredHash` | yes      | DERIVED: `"blake3-512:" ++ hex(BLAKE3-512(JCS(metadata.failurePathPred)))`. |
+| metadata | `successPathPred`     | yes      | An IrFormula that holds over the function's state when the Try-branch succeeds (the `Ok(v)` or `Some(v)` arm continues). Typically: `exists v. result_inner = v /\ <downstream_condition(v)>`. |
+| metadata | `failurePathPred`     | yes      | An IrFormula that holds when the Try-branch fails (early return). Typically: `exists e. early_return = Err(e)` or `early_return = None`. |
+| metadata | `resultSort`          | no       | A string hint: `"Result"` or `"Option"`. Informational; the substrate does not validate it. MUST be omitted (not `null`) when absent. |
+| metadata | `note`                | no       | Human-readable annotation. MUST be omitted when absent. |
+
+### §1.2 On the two predicates
+
+The `successPathPred` and `failurePathPred` form a partition: together they constrain what the Try-branch site contributes to the function's overall weakest-precondition. The substrate does not mechanically verify that they partition the value space — that is the minter's proof obligation. A minter who supplies an unsound pair produces a certificate that allows composition but does not imply soundness; the soundness argument is delegated to the minter, the same way the ContractMemento's pre/post are the minter's assertion, not the substrate's proof.
+
+## §2. Content-addressing rules
+
+### §2.1 CID construction
+
+The `cid` is the BLAKE3-512 of the JCS-canonical bytes of the `header` object with `cid` elided:
+
+```
+cid_input = JCS({
+  "failurePathPredHash": <failurePathPredHash>,
+  "kind":                "try-branch",
+  "schemaVersion":       "1",
+  "successPathPredHash": <successPathPredHash>,
+  "tryCid":              <tryCid>
+})
+cid = "blake3-512:" ++ hex(BLAKE3-512(cid_input))
+```
+
+(Keys are sorted by JCS rule. `cid` itself is excluded from the input. Optional `metadata` fields are NOT included in the CID input — only the header-tier hashes are.)
+
+**Canonicalization choice (flag for architect review):** Two `TryBranchMemento` mementos for the same `tryCid` and same predicate pair have the same `cid` regardless of `metadata.resultSort` or `metadata.note`. The discharge identity is the pair `(tryCid, successPathPredHash, failurePathPredHash)`; the `resultSort` hint and `note` are non-load-bearing.
+
+### §2.2 Formula hash construction
+
+```
+successPathPredHash = "blake3-512:" ++ hex(BLAKE3-512(JCS(metadata.successPathPred)))
+failurePathPredHash = "blake3-512:" ++ hex(BLAKE3-512(JCS(metadata.failurePathPred)))
+```
+
+The IrFormula MUST be in canonical form per `2026-04-30-ir-formal-grammar.md` before hashing.
+
+## §3. Mint procedure
+
+1. Identify the Try-branch site: obtain the `try_cid` string from `Effect::EarlyReturn` in the target `FunctionContractMemento`.
+2. Choose `successPathPred` and `failurePathPred` (IrFormulas).
+3. Compute `successPathPredHash` and `failurePathPredHash` per §2.2.
+4. Build the `header` object (all fields except `cid`).
+5. Compute `cid` per §2.1.
+6. Build the `metadata` object.
+7. Sign `JCS({header, metadata})` with the minter's Ed25519 key.
+8. Emit the full envelope.
+
+**INVARIANT (minting idempotency):** Two mint operations for the same `tryCid` and byte-identical `successPathPred` / `failurePathPred` MUST produce the same `cid`.
+
+## §4. Validation rules
+
+### §4.1 Pass 1: CDDL shape check
+
+Reject if:
+- Any required field is missing.
+- `kind` is not `"try-branch"` or `schemaVersion` is not `"1"`.
+- Any hash field does not match the hash regexp.
+- `metadata.successPathPred` or `metadata.failurePathPred` is absent.
+
+### §4.2 Pass 2: DERIVED and REFERENT constraints
+
+**DERIVED (successPathPredHash):** Recompute `hash(JCS(metadata.successPathPred))` and verify it equals `header.successPathPredHash`. Reject on mismatch.
+
+**DERIVED (failurePathPredHash):** Recompute `hash(JCS(metadata.failurePathPred))` and verify it equals `header.failurePathPredHash`. Reject on mismatch.
+
+**DERIVED (cid):** Recompute per §2.1 and verify it equals `header.cid`. Reject on mismatch.
+
+**REFERENT:** The pool MUST contain a `FunctionContractMemento` whose `effects` array contains `{"kind": "early_return", "tryCid": <header.tryCid>}`. A `TryBranchMemento` whose `tryCid` does not match any loaded function contract's opacity effect is a valid envelope but not a valid discharge certificate in context.
+
+**SIGNATURE:** For swarm-distributed mementos, verify `envelope.signature` over `JCS({header, metadata})` against `envelope.signer`. Reject on invalid signature.
+
+## §5. Discharge semantics (substrate behavior)
+
+The substrate's composition guard for `Effect::EarlyReturn`:
+
+```
+can_compose_early_return(contract, pool) :=
+  for each Effect::EarlyReturn { try_cid } in contract.effects:
+    pool contains a valid TryBranchMemento M where M.header.tryCid == try_cid
+```
+
+If false, `compose_function_contracts` returns `OpacityError::EarlyReturnNotDischarged { try_cid }`.
+
+A single `TryBranchMemento` discharges exactly one `EarlyReturn` effect. A function with two `?` sites has two `EarlyReturn` effects and requires two distinct `TryBranchMemento` mementos (each keyed by its own `tryCid`).
+
+**Note:** The predicates in the memento are not mechanically verified by the substrate to correctly characterize the `?` site's control flow. The substrate's role is structural: verify the memento exists, the CIDs match, and the DERIVED constraints hold. The minter is responsible for supplying correct predicates; downstream verifiers (SMT solvers, Coq) reason about the predicate's soundness through the normal verification pipeline.
+
+## §6. Worked example
+
+A function `fn parse_and_double(s: &str) -> Result<i64, ParseError>` containing one `?` site where `s.parse::<i64>()` is called:
+
+```json
+{
+  "envelope": {
+    "signer":     "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+    "declaredAt": "2026-05-05T12:00:00Z",
+    "signature":  "ed25519:MEUCIQDxxx=="
+  },
+  "header": {
+    "schemaVersion":       "1",
+    "kind":                "try-branch",
+    "cid":                 "blake3-512:b1c2d3...<128 hex chars>",
+    "tryCid":              "blake3-512:ef0102...<128 hex chars>",
+    "successPathPredHash": "blake3-512:031415...<128 hex chars>",
+    "failurePathPredHash": "blake3-512:162718...<128 hex chars>"
+  },
+  "metadata": {
+    "successPathPred": {
+      "kind": "exists",
+      "name": "v",
+      "sort": { "kind": "primitive", "name": "Int" },
+      "body": {
+        "kind": "atomic",
+        "name": "=",
+        "args": [
+          { "kind": "var", "name": "parsed_value" },
+          { "kind": "var", "name": "v" }
+        ]
+      }
+    },
+    "failurePathPred": {
+      "kind": "atomic",
+      "name": "is-parse-error",
+      "args": [
+        { "kind": "var", "name": "early_return" }
+      ]
+    },
+    "resultSort": "Result",
+    "note": "parse::<i64>() succeeds with parsed integer or fails with ParseError."
+  }
+}
+```
+
+The `cid` is computed as:
+
+```
+JCS_bytes = JCS({
+  "failurePathPredHash": "blake3-512:162718...",
+  "kind":                "try-branch",
+  "schemaVersion":       "1",
+  "successPathPredHash": "blake3-512:031415...",
+  "tryCid":              "blake3-512:ef0102..."
+})
+cid = "blake3-512:" ++ hex(BLAKE3-512(JCS_bytes))
+```
+
+## §7. Cross-references
+
+- The `tryCid` value is produced by `llbc_try::extract_try_branches()` in `implementations/rust/provekit-walk/src/llbc_try.rs`. It is the BLAKE3-512 of the JCS-canonical bytes of the `Switch::Match` block implementing the Try-branch shape.
+- The substrate check lives in `EffectSet::check_opacity` and `compose_function_contracts` in `implementations/rust/provekit-walk/src/contract.rs`.
+- The pool indexing lives in `MementoPool::insert` in `implementations/rust/provekit-verifier/src/types.rs`, keyed by `header.tryCid`.
+- For the `LoopInvariantMemento` (discharges `Effect::OpaqueLoop`), see `2026-05-05-loop-invariant-memento.md`.
+- For the `ClosureBindingMemento` (discharges `Effect::ClosureCapture`), see `2026-05-05-closure-binding-memento.md`.


### PR DESCRIPTION
$(cat <<'EOF'
## What lands

Addresses #384 B.5 and B.6. Does NOT close #384 (B.7 is in flight separately).

### B.6 — Normative memento specs (3 new spec files)

`protocol/specs/2026-05-05-loop-invariant-memento.md`
- `LoopInvariantMemento` discharges `Effect::OpaqueLoop { loop_cid }`
- Header: `kind`, `schemaVersion`, `loopCid`, `invariantHash`, optional `decreasingFunctionHash`, `cid`
- Metadata: `invariant` (IrFormula), optional `decreasingFunction`, optional `note`
- CID input: JCS of header with `cid` elided (covers predicate hashes, not raw formula strings)

`protocol/specs/2026-05-05-try-branch-memento.md`
- `TryBranchMemento` discharges `Effect::EarlyReturn { try_cid }`
- Header: `kind`, `schemaVersion`, `tryCid`, `successPathPredHash`, `failurePathPredHash`, `cid`
- Metadata: `successPathPred`, `failurePathPred`, optional `resultSort`, optional `note`

`protocol/specs/2026-05-05-closure-binding-memento.md`
- `ClosureBindingMemento` discharges `Effect::ClosureCapture { body_fn_cid, n_captures }`
- Header: `kind`, `schemaVersion`, `bodyFnCid`, `nCaptures`, `captureBindingSetHash`, `cid`
- Metadata: `captureBindings` array (sorted by `captureName`), each with `captureName`, `captureSort`, `bindingPred`, `bindingPredHash`
- `captureBindingSetHash`: hash of sorted array of `{bindingPredHash, captureName, captureSort}`

All three use the v1.4 layered envelope/header/metadata shape per `2026-05-03-substrate-layers-envelope-header-body.md` and JCS + BLAKE3-512 CIDs.

### B.5 — Verifier wiring (`provekit-walk` + `provekit-verifier`)

**`provekit-walk/src/contract.rs`** — new public API:
- `OpacityMementoLookup` trait: `has_loop_invariant`, `has_try_branch`, `has_closure_binding`
- `EmptyOpacityPool` no-op impl (for callers with no pool)
- `OpacityError` enum: `LoopNotDischarged`, `EarlyReturnNotDischarged`, `ClosureCaptureNotDischarged`, `UnresolvedCallNotDischarged`
- `EffectSet::check_opacity_effects(pool)` — checks opacity effects only; pure/Reads/Writes/Io/Unsafe/Panics pass through
- `compose_function_contracts_checked(outer, inner, formal_idx, pool)` — `Result<Option<ComposedFunctionContract>, OpacityError>`
  - Phase 1: opacity effects must all be discharged or → `Err`
  - Phase 2: non-opacity effects must be absent or → `Ok(None)` (same as existing `compose_function_contracts`)
  - Phase 3: inline composition (does NOT call `compose_function_contracts` — that function's `is_pure()` gate would reject even-discharged-opacity contracts)
- 9 new tests with `MockPool`

**`provekit-verifier/src/types.rs`** — `MementoPool` extended:
- Three new BTreeMap indexes: `loop_cid_to_memento`, `try_cid_to_memento`, `body_fn_cid_to_memento`
- `insert()` populates indexes for `"loop-invariant"`, `"try-branch"`, `"closure-binding"` kinds
- `impl OpacityMementoLookup for MementoPool`
- `merge()` merges new indexes (first-insertion-wins, consistent with existing merge policy)

**`provekit-verifier/Cargo.toml`** — adds `provekit-walk` dep (no circular dependency; walk does not depend on verifier).

## Canonicalization flags for architect review

1. **Loop/TryBranch CID input covers predicate hashes, not raw formula strings.** Raw formulas live only in metadata (not content-addressed into the header CID). Two mementos with the same `loopCid` + `invariantHash` are identical proof obligations even if their `note` differs. Deliberate; metadata.note is commentary, not substance.

2. **TryBranch: `resultSort` is non-load-bearing.** Two mementos with same `tryCid` + same predicate hashes share the same CID regardless of `resultSort`. If downstream consumers require distinct CIDs per sort annotation, `resultSort` must move to the header.

3. **ClosureBinding: `captureBindingSetHash` is a set-level hash, not a sorted list of per-binding hashes in the header.** This keeps the header fixed-width as capture count grows. The set hash is computed from `{bindingPredHash, captureName, captureSort}` triples sorted by `captureName`.

4. **`bodyFnCid` in `ClosureBindingMemento` is the `FunctionContractMemento.cid` (contract CID), not the attestation CID.** Per `2026-05-03-contract-cid-vs-attestation-cid.md`.

5. **`UnresolvedCall` is always `Err`, never dischargeable by any memento.** The spec treats unresolved calls as a hard gap, not a deferred obligation. If a `CallResolutionMemento` shape is wanted in the future, it needs a new spec.

## Follow-up (not in this PR)

- Integration test in `provekit-verifier`: build a JSON `loop-invariant` envelope, call `pool.insert()`, assert `pool.has_loop_invariant(&loop_cid)` — currently only covered by compilation
- Stronger test assertions: add `composed.cid.starts_with("blake3-512:")` check to `opaque_loop_with_memento_allows_composition` and peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)