### PR TITLE
feat(walk): dropper / generative completion (Phase 1-3 of paper 07 §7) (#382)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1947,6 +1947,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-walk"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "proc-macro2",
+ "provekit-canonicalizer",
+ "provekit-claim-envelope",
+ "provekit-ir-types",
+ "provekit-proof-envelope",
+ "quote",
+ "serde_json",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/implementations/rust/provekit-walk/src/dropper.rs
+++ b/implementations/rust/provekit-walk/src/dropper.rs
@@ -1,0 +1,795 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// dropper.rs -- generative completion for the Rust kit (paper 07 §7).
+//
+// The dropper closes the lifter's loop. The lifter takes Rust source and
+// produces canonical IR with arrivals and accumulated WPs at each arrival.
+// A "gap" is an arrival at function entry where the accumulated WP contains
+// an undischarged leaf precondition -- a predicate the substrate cannot
+// verify from static facts alone.
+//
+// The dropper takes a gap description and writes a piece of Rust source back
+// into the caller that closes the gap. The output is a RUNTIME CHECK, not a
+// proof. The inserted code's surviving control-flow branch carries the
+// invariant the callsite required.
+//
+// Per paper 07 §11: drop shapes are kit-resident. The dropper carries
+// hardcoded knowledge of the host language's idioms for each predicate in
+// the foundation catalog. No protocol schema extension is needed. The
+// existing ContractDecl-overloaded edge memento (pre/post) is the wire
+// format; the dropper uses it as-is.
+//
+// Schema decision: Case A. The witness memento already exists via
+// ContractDecl-overloaded edges (ShadowArrival.pre_wp / post_wp). Drop
+// shapes are kit-resident per §11's adjudication. No protocol schema
+// extension is warranted until empirical scale demands it.
+//
+// Phase 1: gap detection -- identify arrivals where the WP contains an
+//   undischarged leaf predicate (currently: "not_null").
+// Phase 2: cached-witness lookup -- for each gap, find candidate templates
+//   from the kit's hardcoded predicate->template table.
+// Phase 3: source emission -- render the chosen template, splice into the
+//   source text, verify re-lift confirms DAG closure.
+// Phase 4 (deferred, #382 follow-up): mint-on-miss via solver portfolio.
+//
+// Fixture: fn caller(x: Option<i32>) { f(x.unwrap()) }
+//   where f requires not_null(x).
+//   Gap: FunctionEntry WP contains not_null(x).
+//   Template: Defensive (assert shape) emits
+//     `if x.is_none() { panic!("not_null: x must be Some"); }`
+//     before the callsite.
+//   Re-lift: the emitted if-then-panic is recognized by lift.rs as
+//     negation of the panic condition, producing !is_none(x) at entry.
+//     The substrate maps !is_none(x) -> not_null(x) via the cached
+//     witness chain, confirming closure.
+
+use provekit_ir_types::{IrFormula, IrTerm};
+
+use crate::walk::{walk_callsites_to_entry, CallsiteWalk};
+use crate::wp::Wp;
+
+// ---- Predicate recognition ----
+
+/// Returns true if the formula contains the named predicate (recursive scan).
+/// Used to identify gaps: an undischarged leaf precondition is a formula
+/// whose name matches a foundation-catalog predicate, not yet discharged by
+/// static facts.
+pub fn formula_contains_predicate(formula: &IrFormula, pred_name: &str) -> bool {
+    match formula {
+        IrFormula::Atomic { name, .. } => name == pred_name,
+        IrFormula::And { operands }
+        | IrFormula::Or { operands }
+        | IrFormula::Not { operands }
+        | IrFormula::Implies { operands } => {
+            operands.iter().any(|o| formula_contains_predicate(o, pred_name))
+        }
+        IrFormula::Forall { body, .. } | IrFormula::Exists { body, .. } => {
+            formula_contains_predicate(body, pred_name)
+        }
+        IrFormula::Choice { body, .. } => formula_contains_predicate(body, pred_name),
+    }
+}
+
+/// Extract the first variable name argument from a named predicate in a formula.
+/// For `not_null(x)` returns `Some("x")`. Used to identify the gap's variable.
+pub fn predicate_var_arg(formula: &IrFormula, pred_name: &str) -> Option<String> {
+    match formula {
+        IrFormula::Atomic { name, args } => {
+            if name == pred_name {
+                args.iter().find_map(|t| match t {
+                    IrTerm::Var { name } => Some(name.clone()),
+                    _ => None,
+                })
+            } else {
+                None
+            }
+        }
+        IrFormula::And { operands }
+        | IrFormula::Or { operands }
+        | IrFormula::Not { operands }
+        | IrFormula::Implies { operands } => {
+            operands.iter().find_map(|o| predicate_var_arg(o, pred_name))
+        }
+        IrFormula::Forall { body, .. }
+        | IrFormula::Exists { body, .. } => predicate_var_arg(body, pred_name),
+        IrFormula::Choice { body, .. } => predicate_var_arg(body, pred_name),
+    }
+}
+
+// ---- Gap ----
+
+/// A detected gap: an arrival where the accumulated WP contains an
+/// undischarged leaf predicate the substrate cannot discharge statically.
+///
+/// The gap's `stmt_index` is the position in the caller's body where
+/// the dropper should insert the closing guard. For a FunctionEntry gap
+/// the insert position is before the callsite (stmt_index 0 in the
+/// arrivals chain).
+#[derive(Debug, Clone)]
+pub struct Gap {
+    /// The caller function name.
+    pub caller_name: String,
+    /// The callee function name at the callsite producing this gap.
+    pub callee_name: String,
+    /// The undischarged predicate name (e.g. "not_null").
+    pub predicate: String,
+    /// The variable name the predicate applies to (extracted from the WP).
+    pub var_name: String,
+    /// The source statement index where the callsite was found (0-indexed
+    /// body position). The dropper inserts a guard BEFORE this index.
+    pub callsite_stmt_index: usize,
+    /// The full accumulated WP at function entry for this walk.
+    pub entry_wp: Wp,
+}
+
+/// Detect gaps in a set of callsite walks.
+///
+/// A gap is a walk whose FunctionEntry arrival's WP contains the named
+/// predicate undischarged. The predicate name is taken from the foundation
+/// catalog's set of leaf predicates that require runtime discharge.
+///
+/// Currently supports: "not_null".
+///
+/// Returns one Gap per walk where the gap is detected.
+pub fn detect_gaps(walks: &[CallsiteWalk], predicate: &str) -> Vec<Gap> {
+    let mut gaps = Vec::new();
+    for walk in walks {
+        let entry = walk.entry_wp();
+        if formula_contains_predicate(entry.as_formula(), predicate) {
+            let var_name = predicate_var_arg(entry.as_formula(), predicate)
+                .unwrap_or_else(|| "_".to_string());
+            // The callsite is the first arrival in the walk; its stmt_index
+            // is the body position of the callsite statement.
+            let callsite_stmt_index = walk.arrivals.first().map(|a| a.stmt_index).unwrap_or(0);
+            gaps.push(Gap {
+                caller_name: walk.caller_name.clone(),
+                callee_name: walk.callee_name.clone(),
+                predicate: predicate.to_string(),
+                var_name,
+                callsite_stmt_index,
+                entry_wp: entry.clone(),
+            });
+        }
+    }
+    gaps
+}
+
+// ---- Template families ----
+
+/// The policy family for the emitted drop. Each variant produces the same
+/// post-state invariant on the surviving branch; they differ in how they
+/// handle the alternative path.
+///
+/// Per paper 07 §7: the choice between templates is POLICY, not proof.
+/// The substrate is grounded by the runtime check; the dropper picks
+/// the family member according to user or curator policy.
+///
+/// Drop shapes are kit-resident per §11. This enum is the entire Rust
+/// kit's drop-shape catalog for the "not_null" predicate family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropTemplate {
+    /// Defensive: panic on violation. Surviving branch: not_null(x).
+    /// Substrate edge minted: assert(x.is_some()) -> not_null(x).
+    /// Shape: `if {var}.is_none() { panic!("not_null: {var} must be Some"); }`
+    Defensive,
+    /// Recoverable guard: if-let with early return. Surviving branch: not_null(x).
+    /// Shape: `if {var}.is_none() { return Err(NullInput); }`
+    /// Caller now handles Err. Used when the caller has a Result return type.
+    Recoverable,
+    /// Early-return shape without if-let sugar.
+    /// Shape: `if {var}.is_none() { return Default::default(); }`
+    EarlyReturn,
+    /// Defensive with documented panic message.
+    /// Shape: `let {var} = {var}.expect("invariant: caller must supply non-null {var}");`
+    Expect,
+}
+
+impl DropTemplate {
+    /// Render the template as Rust source text, with `var` substituted.
+    ///
+    /// The rendered text is a complete Rust statement (or pair of statements)
+    /// that should be inserted immediately before the callsite in the source.
+    /// Trailing newline included so splicing is text-clean.
+    pub fn render(&self, var: &str) -> String {
+        match self {
+            DropTemplate::Defensive => {
+                format!(
+                    "    if {var}.is_none() {{ panic!(\"not_null: {var} must be Some\"); }}\n",
+                    var = var
+                )
+            }
+            DropTemplate::Recoverable => {
+                format!(
+                    "    if {var}.is_none() {{ return Err(NullInput); }}\n",
+                    var = var
+                )
+            }
+            DropTemplate::EarlyReturn => {
+                format!(
+                    "    if {var}.is_none() {{ return Default::default(); }}\n",
+                    var = var
+                )
+            }
+            DropTemplate::Expect => {
+                format!(
+                    "    let {var} = {var}.expect(\"not_null: invariant: caller must supply non-null {var}\");\n",
+                    var = var
+                )
+            }
+        }
+    }
+
+    /// Human-readable name for the template family.
+    pub fn family_name(&self) -> &'static str {
+        match self {
+            DropTemplate::Defensive => "defensive",
+            DropTemplate::Recoverable => "recoverable",
+            DropTemplate::EarlyReturn => "early-return",
+            DropTemplate::Expect => "expect",
+        }
+    }
+}
+
+// ---- Phase 2: cached-witness lookup ----
+
+/// Look up candidate templates for a given predicate in the kit's
+/// hardcoded predicate->template table.
+///
+/// This is the kit-resident "cache" per §11. At larger scale, this
+/// table would be backed by the substrate's edge cache (CID lookup).
+/// For the MVP launch corpus it is hardcoded -- empirical question
+/// resolved after operating at scale.
+///
+/// Returns the full family for known predicates, empty slice for unknown.
+pub fn templates_for(predicate: &str) -> &'static [DropTemplate] {
+    match predicate {
+        "not_null" => &[
+            DropTemplate::Defensive,
+            DropTemplate::Recoverable,
+            DropTemplate::EarlyReturn,
+            DropTemplate::Expect,
+        ],
+        _ => &[],
+    }
+}
+
+// ---- Phase 3: source emission ----
+
+/// The result of splicing a drop template into a source string.
+#[derive(Debug, Clone)]
+pub struct EmitResult {
+    /// The modified source text with the guard inserted.
+    pub modified_source: String,
+    /// The template that was applied.
+    pub template: DropTemplate,
+    /// The variable name the guard was applied to.
+    pub var_name: String,
+    /// The line number (1-indexed) where the guard was inserted.
+    /// Approximate: derived from counting newlines before the callsite
+    /// statement, which is sufficient for the re-lift verification step.
+    pub insert_line: usize,
+}
+
+/// Splice the chosen template into `source` for the given gap.
+///
+/// Insertion strategy: we find the line that is a callsite expression (not a
+/// function definition). A callsite line matches `{callee_name}(` but does
+/// NOT start with `fn ` after trimming. We skip function-signature lines.
+/// This handles the common case where the callee name appears both as a
+/// function definition and as a call expression in the same file.
+///
+/// Nested callsites (inside if-branches) are deferred to Phase 4.
+///
+/// Returns `None` if the callee call pattern cannot be located in the source.
+pub fn emit_drop(
+    source: &str,
+    gap: &Gap,
+    template: DropTemplate,
+) -> Option<EmitResult> {
+    let guard_text = template.render(&gap.var_name);
+
+    // Find the line containing the callsite pattern `{callee_name}(` that is
+    // a call expression, not a function definition. A function-definition line
+    // contains `fn ` before the callee name; a call expression line does not.
+    let callee_pattern = format!("{}(", gap.callee_name);
+    let lines: Vec<&str> = source.lines().collect();
+
+    let insert_before = lines.iter().position(|l| {
+        let trimmed = l.trim();
+        // Must contain the call pattern.
+        if !trimmed.contains(&callee_pattern) {
+            return false;
+        }
+        // Must NOT be a function definition (fn keyword before callee name).
+        let fn_def_pattern = format!("fn {}", gap.callee_name);
+        !trimmed.starts_with("fn ") && !trimmed.contains(&fn_def_pattern)
+    })?;
+
+    let guard_trimmed = guard_text.trim_end_matches('\n');
+    let mut result_lines: Vec<&str> = Vec::with_capacity(lines.len() + 1);
+    for (i, line) in lines.iter().enumerate() {
+        if i == insert_before {
+            // Insert guard before the callsite line.
+            result_lines.push(guard_trimmed);
+        }
+        result_lines.push(line);
+    }
+
+    let modified_source = result_lines.join("\n");
+    Some(EmitResult {
+        modified_source,
+        template,
+        var_name: gap.var_name.clone(),
+        insert_line: insert_before + 1, // 1-indexed
+    })
+}
+
+// ---- Re-lift verification ----
+
+/// Verify that the dropper's emission closes the gap.
+///
+/// Closure criterion: after emitting the guard, the re-lift of the modified
+/// source must show that the CALLER function's lifted precondition contains
+/// a guard that discharges the required predicate. Specifically:
+///
+/// The lift.rs lifter reads the modified caller body and recognizes the
+/// emitted `if {var}.is_none() { panic!(...) }` as a precondition
+/// contributor via the if-then-panic pattern. This produces a formula of
+/// the form `!is_none({var})` in the caller's lifted precondition.
+///
+/// The substrate then maps `!is_none(x)` to `not_null(x)` via the cached
+/// edge in the foundation catalog. The DAG closes because the caller's
+/// lifted precondition now establishes the condition the substrate uses
+/// to discharge `not_null`.
+///
+/// For the MVP verification, we check that the caller's lifted precondition
+/// (via `lift_function_precondition`) contains either:
+/// (a) a formula referencing the variable with a guard shape (is_none / is_some
+///     method call style, which the lifter translates via if-then-panic), OR
+/// (b) the predicate is absent from the walker's entry WP entirely (fully
+///     discharged by static analysis), OR
+/// (c) the walker's entry WP is of the form `premise -> predicate` (the
+///     if-condition from the emitted guard became a premise in the walk).
+///
+/// This function implements check (b) and (c). Check (a) requires
+/// lift_function_precondition for the caller, which is the authoritative
+/// source of truth.
+///
+/// Returns `true` if the gap is closed.
+pub fn verify_closure(
+    modified_source: &str,
+    gap: &Gap,
+    callee_formal_params: &[String],
+    callee_precondition: Wp,
+) -> bool {
+    use crate::lift::lift_function_precondition;
+
+    let file: syn::File = match syn::parse_str(modified_source) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let caller_fn = match file.items.iter().find_map(|item| {
+        if let syn::Item::Fn(f) = item {
+            if f.sig.ident == gap.caller_name {
+                return Some(f.clone());
+            }
+        }
+        None
+    }) {
+        Some(f) => f,
+        None => return false,
+    };
+
+    // Primary check: the caller's lifted precondition (from lift.rs) must
+    // now contain a guard-shaped formula. The if-then-panic the dropper
+    // emitted is read by lift.rs's if-then-panic recognizer, producing
+    // `!is_none(x)` (encoded as a negated method-call condition). This
+    // appears in the lifted precondition, confirming the DAG closes.
+    let caller_pre = lift_function_precondition(&caller_fn);
+    let caller_pre_json = serde_json::to_string(caller_pre.as_formula()).unwrap_or_default();
+    // The if-then-panic emitted uses "is_none" which, when lifted via the
+    // if-then-panic path, produces a Not formula referencing the condition.
+    // The serialized form will contain "is_none" from the method-call lift.
+    // Alternatively, for the Expect template (let x = x.expect(...)) the
+    // lifter sees a plain let-binding and the precondition stays as-is; in
+    // that case we fall through to the walk-based check.
+    if caller_pre_json.contains("is_none") || caller_pre_json.contains("is_some") {
+        return true;
+    }
+
+    // Secondary check: the walker's entry WP is either wrapped in Implies
+    // (guard condition became a premise) or the predicate is absent entirely.
+    let walks = walk_callsites_to_entry(
+        &caller_fn,
+        &gap.callee_name,
+        callee_formal_params,
+        callee_precondition,
+    );
+
+    for walk in &walks {
+        let entry_wp = walk.entry_wp();
+        let formula = entry_wp.as_formula();
+        // Check: predicate wrapped in Implies -> guard is a premise.
+        if let IrFormula::Implies { operands } = formula {
+            if operands.len() >= 2
+                && formula_contains_predicate(&operands[operands.len() - 1], &gap.predicate)
+            {
+                return true;
+            }
+        }
+        // Check: predicate no longer appears at all -> fully discharged.
+        if !formula_contains_predicate(formula, &gap.predicate) {
+            return true;
+        }
+    }
+    false
+}
+
+// ---- Public API ----
+
+/// Run all three phases (detect + lookup + emit) for a source file and
+/// a known callee precondition. Returns the emit result for the first
+/// gap found using the default (Defensive) template.
+///
+/// This is the main entry point for the dropper's end-to-end path.
+/// Phase 4 (mint-on-miss via solver portfolio) is deferred.
+///
+/// Parameters:
+/// - `source`: the Rust source text containing both the callee and caller.
+/// - `callee_name`: the function whose precondition has a gap.
+/// - `callee_formal_params`: formal parameter names for the callee.
+/// - `callee_precondition`: the WP representing the callee's precondition.
+/// - `predicate`: the leaf predicate name to look for (e.g. "not_null").
+/// - `template`: which drop template to use (default: Defensive).
+///
+/// Returns `None` if no gap is found or no template matches the predicate.
+pub fn drop_gap(
+    source: &str,
+    callee_name: &str,
+    caller_name: &str,
+    callee_formal_params: &[String],
+    callee_precondition: Wp,
+    predicate: &str,
+    template: DropTemplate,
+) -> Option<EmitResult> {
+    let file: syn::File = syn::parse_str(source).ok()?;
+
+    let caller_fn = file.items.iter().find_map(|item| {
+        if let syn::Item::Fn(f) = item {
+            if f.sig.ident == caller_name {
+                return Some(f.clone());
+            }
+        }
+        None
+    })?;
+
+    // Phase 1: detect gaps.
+    let walks = walk_callsites_to_entry(
+        &caller_fn,
+        callee_name,
+        callee_formal_params,
+        callee_precondition,
+    );
+    let gaps = detect_gaps(&walks, predicate);
+    let gap = gaps.into_iter().next()?;
+
+    // Phase 2: look up candidate templates.
+    let candidates = templates_for(predicate);
+    if candidates.is_empty() {
+        return None;
+    }
+    // Verify the requested template is in the candidate list.
+    if !candidates.contains(&template) {
+        return None;
+    }
+
+    // Phase 3: emit.
+    emit_drop(source, &gap, template)
+}
+
+// ---- Tests ----
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use provekit_ir_types::{IrFormula, IrTerm};
+    use crate::wp::{var, Wp};
+
+    /// Build a not_null(x) WP for testing.
+    fn not_null_wp(var_name: &str) -> Wp {
+        Wp(IrFormula::Atomic {
+            name: "not_null".to_string(),
+            args: vec![IrTerm::Var {
+                name: var_name.to_string(),
+            }],
+        })
+    }
+
+    // ---- Fixture source ----
+
+    // Callee requiring not_null(x):
+    //   fn f(x: Option<i32>) -> i32 { x.unwrap() }
+    // Caller that does NOT satisfy not_null(x):
+    //   fn caller(x: Option<i32>) { f(x) }
+    const FIXTURE_SRC: &str = r#"
+fn f(x: Option<i32>) -> i32 {
+    x.unwrap()
+}
+
+fn caller(x: Option<i32>) {
+    f(x);
+}
+"#;
+
+    // ---- Phase 1: gap detection tests ----
+
+    #[test]
+    fn detects_not_null_gap_at_function_entry() {
+        let file: syn::File = syn::parse_str(FIXTURE_SRC).expect("parses");
+        let caller_fn = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Fn(f) if f.sig.ident == "caller" => Some(f.clone()),
+                _ => None,
+            })
+            .expect("caller fn");
+
+        let precondition = not_null_wp("x");
+        let walks = walk_callsites_to_entry(
+            &caller_fn,
+            "f",
+            &["x".to_string()],
+            precondition,
+        );
+
+        assert_eq!(walks.len(), 1, "one callsite in caller");
+
+        let gaps = detect_gaps(&walks, "not_null");
+        assert_eq!(gaps.len(), 1, "one gap detected");
+
+        let gap = &gaps[0];
+        assert_eq!(gap.predicate, "not_null");
+        assert_eq!(gap.var_name, "x");
+        assert_eq!(gap.caller_name, "caller");
+        assert_eq!(gap.callee_name, "f");
+    }
+
+    #[test]
+    fn no_gap_when_predicate_not_present() {
+        let src = r#"
+fn f(x: u32) -> u32 { x + 1 }
+fn caller(x: u32) { f(x); }
+"#;
+        let file: syn::File = syn::parse_str(src).expect("parses");
+        let caller_fn = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Fn(f) if f.sig.ident == "caller" => Some(f.clone()),
+                _ => None,
+            })
+            .expect("caller fn");
+
+        // Precondition: x >= 10 (not a "not_null" predicate).
+        use crate::wp::{atomic_ge, const_int};
+        let precondition = atomic_ge(var("x"), const_int(10));
+        let walks = walk_callsites_to_entry(
+            &caller_fn,
+            "f",
+            &["x".to_string()],
+            precondition,
+        );
+
+        let gaps = detect_gaps(&walks, "not_null");
+        assert_eq!(gaps.len(), 0, "no not_null gap for x >= 10 precondition");
+    }
+
+    // ---- Phase 2: cached-witness lookup tests ----
+
+    #[test]
+    fn templates_for_not_null_returns_all_four() {
+        let templates = templates_for("not_null");
+        assert_eq!(templates.len(), 4, "four template families for not_null");
+        assert!(templates.contains(&DropTemplate::Defensive));
+        assert!(templates.contains(&DropTemplate::Recoverable));
+        assert!(templates.contains(&DropTemplate::EarlyReturn));
+        assert!(templates.contains(&DropTemplate::Expect));
+    }
+
+    #[test]
+    fn templates_for_unknown_predicate_returns_empty() {
+        let templates = templates_for("some_unknown_predicate");
+        assert!(templates.is_empty());
+    }
+
+    // ---- Template rendering tests ----
+
+    #[test]
+    fn defensive_template_renders_panic_shape() {
+        let rendered = DropTemplate::Defensive.render("x");
+        assert!(rendered.contains("x.is_none()"), "must guard x");
+        assert!(rendered.contains("panic!"), "must panic on violation");
+        assert!(rendered.contains("not_null"), "panic msg must name invariant");
+    }
+
+    #[test]
+    fn recoverable_template_renders_err_shape() {
+        let rendered = DropTemplate::Recoverable.render("x");
+        assert!(rendered.contains("x.is_none()"), "must guard x");
+        assert!(rendered.contains("return Err"), "must return Err");
+    }
+
+    #[test]
+    fn early_return_template_renders_default_shape() {
+        let rendered = DropTemplate::EarlyReturn.render("x");
+        assert!(rendered.contains("x.is_none()"), "must guard x");
+        assert!(rendered.contains("Default::default()"), "must return default");
+    }
+
+    #[test]
+    fn expect_template_renders_expect_shape() {
+        let rendered = DropTemplate::Expect.render("x");
+        assert!(rendered.contains(".expect("), "must call .expect()");
+        assert!(rendered.contains("not_null"), "expect msg must name invariant");
+    }
+
+    #[test]
+    fn all_templates_substitute_var_name() {
+        let templates = [
+            DropTemplate::Defensive,
+            DropTemplate::Recoverable,
+            DropTemplate::EarlyReturn,
+            DropTemplate::Expect,
+        ];
+        for tmpl in &templates {
+            let rendered = tmpl.render("my_var");
+            assert!(
+                rendered.contains("my_var"),
+                "{} template must contain var name 'my_var': {}",
+                tmpl.family_name(),
+                rendered
+            );
+        }
+    }
+
+    // ---- Phase 3: source emission tests ----
+
+    #[test]
+    fn emit_drop_inserts_guard_before_callsite() {
+        let file: syn::File = syn::parse_str(FIXTURE_SRC).expect("parses");
+        let caller_fn = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Fn(f) if f.sig.ident == "caller" => Some(f.clone()),
+                _ => None,
+            })
+            .expect("caller fn");
+
+        let precondition = not_null_wp("x");
+        let walks = walk_callsites_to_entry(
+            &caller_fn,
+            "f",
+            &["x".to_string()],
+            precondition,
+        );
+        let gaps = detect_gaps(&walks, "not_null");
+        let gap = &gaps[0];
+
+        let result = emit_drop(FIXTURE_SRC, gap, DropTemplate::Defensive)
+            .expect("emit succeeds");
+
+        // The guard must appear before f( in the modified source.
+        let guard_pos = result.modified_source.find("x.is_none()").expect("guard present");
+        let callsite_pos = result.modified_source.find("f(x)").expect("callsite present");
+        assert!(
+            guard_pos < callsite_pos,
+            "guard must appear before callsite: guard_pos={}, callsite_pos={}",
+            guard_pos,
+            callsite_pos
+        );
+    }
+
+    #[test]
+    fn emitted_source_is_syntactically_valid() {
+        let file: syn::File = syn::parse_str(FIXTURE_SRC).expect("parses");
+        let caller_fn = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Fn(f) if f.sig.ident == "caller" => Some(f.clone()),
+                _ => None,
+            })
+            .expect("caller fn");
+
+        let precondition = not_null_wp("x");
+        let walks = walk_callsites_to_entry(
+            &caller_fn,
+            "f",
+            &["x".to_string()],
+            precondition,
+        );
+        let gaps = detect_gaps(&walks, "not_null");
+        let gap = &gaps[0];
+
+        let result = emit_drop(FIXTURE_SRC, gap, DropTemplate::Defensive)
+            .expect("emit succeeds");
+
+        // The modified source must parse cleanly (syn validates Rust syntax).
+        let parse_result: Result<syn::File, _> = syn::parse_str(&result.modified_source);
+        assert!(
+            parse_result.is_ok(),
+            "emitted source must be syntactically valid Rust: {:?}",
+            parse_result.err()
+        );
+    }
+
+    // ---- Re-lift verification tests ----
+
+    #[test]
+    fn re_lift_confirms_closure_after_defensive_drop() {
+        let file: syn::File = syn::parse_str(FIXTURE_SRC).expect("parses");
+        let caller_fn = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Fn(f) if f.sig.ident == "caller" => Some(f.clone()),
+                _ => None,
+            })
+            .expect("caller fn");
+
+        let precondition = not_null_wp("x");
+        let walks = walk_callsites_to_entry(
+            &caller_fn,
+            "f",
+            &["x".to_string()],
+            precondition.clone(),
+        );
+        let gaps = detect_gaps(&walks, "not_null");
+        let gap = &gaps[0];
+
+        let result = emit_drop(FIXTURE_SRC, gap, DropTemplate::Defensive)
+            .expect("emit succeeds");
+
+        // Re-lift: verify the modified source closes the gap.
+        let closed = verify_closure(
+            &result.modified_source,
+            gap,
+            &["x".to_string()],
+            precondition,
+        );
+        assert!(
+            closed,
+            "re-lift must confirm DAG closure after Defensive drop. Modified source:\n{}",
+            result.modified_source
+        );
+    }
+
+    // ---- End-to-end drop_gap API test ----
+
+    #[test]
+    fn end_to_end_drop_gap_defensive() {
+        let result = drop_gap(
+            FIXTURE_SRC,
+            "f",
+            "caller",
+            &["x".to_string()],
+            not_null_wp("x"),
+            "not_null",
+            DropTemplate::Defensive,
+        );
+
+        assert!(result.is_some(), "drop_gap must succeed for not_null fixture");
+        let emit = result.unwrap();
+        assert_eq!(emit.template, DropTemplate::Defensive);
+        assert_eq!(emit.var_name, "x");
+        // The modified source must be parseable.
+        let parse_result: Result<syn::File, _> = syn::parse_str(&emit.modified_source);
+        assert!(parse_result.is_ok(), "emitted source parses: {:?}", parse_result.err());
+        // The guard must appear before the callsite.
+        let guard_pos = emit.modified_source.find("x.is_none()").expect("guard present");
+        let callsite_pos = emit.modified_source.find("f(x)").expect("callsite present");
+        assert!(guard_pos < callsite_pos, "guard before callsite");
+    }
+}

--- a/implementations/rust/provekit-walk/src/dropper.rs
+++ b/implementations/rust/provekit-walk/src/dropper.rs
@@ -166,21 +166,44 @@ pub fn detect_gaps(walks: &[CallsiteWalk], predicate: &str) -> Vec<Gap> {
 ///
 /// Drop shapes are kit-resident per §11. This enum is the entire Rust
 /// kit's drop-shape catalog for the "not_null" predicate family.
+///
+/// **MVP closure verification status:**
+/// - `Defensive`: VERIFIED. The emitted `if {var}.is_none() { panic!(...) }` is
+///   recognized by lift.rs's if-then-panic path, producing a Not formula over
+///   the is_none method call. The re-lift confirms the predicate is discharged.
+/// - `Recoverable`: SCAFFOLDING, NOT CLOSURE-VERIFIED. The `return Err(NullInput)`
+///   body is not a panic; lift.rs's if-then-panic path does not recognize it.
+///   The lifter produces no guard-shaped precondition for this template.
+///   Also: `NullInput` is not defined in the caller's scope.
+/// - `EarlyReturn`: SCAFFOLDING, NOT CLOSURE-VERIFIED. Same as Recoverable.
+///   `return Default::default()` is not a panic; lifter does not recognize it.
+///   Additionally requires the return type to implement `Default`.
+/// - `Expect`: SCAFFOLDING, NOT CLOSURE-VERIFIED. `let x = x.expect(...)` is a
+///   let-binding, not an if-then-panic. The walker substitutes x -> x.expect(...),
+///   leaving the not_null predicate still present in the entry WP after re-lift.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DropTemplate {
     /// Defensive: panic on violation. Surviving branch: not_null(x).
     /// Substrate edge minted: assert(x.is_some()) -> not_null(x).
     /// Shape: `if {var}.is_none() { panic!("not_null: {var} must be Some"); }`
+    /// **Closure-verified for the MVP.**
     Defensive,
     /// Recoverable guard: if-let with early return. Surviving branch: not_null(x).
     /// Shape: `if {var}.is_none() { return Err(NullInput); }`
     /// Caller now handles Err. Used when the caller has a Result return type.
+    /// **SCAFFOLDING -- not closure-verified. Lift.rs does not recognize non-panic
+    /// early-return bodies as precondition contributors. Do not use until the
+    /// lifter is extended for return-value early-exit patterns.**
     Recoverable,
     /// Early-return shape without if-let sugar.
     /// Shape: `if {var}.is_none() { return Default::default(); }`
+    /// **SCAFFOLDING -- not closure-verified. Same limitation as Recoverable.**
     EarlyReturn,
     /// Defensive with documented panic message.
     /// Shape: `let {var} = {var}.expect("invariant: caller must supply non-null {var}");`
+    /// **SCAFFOLDING -- not closure-verified. The let-binding is not recognized by
+    /// lift.rs's if-then-panic path. The walker substitutes x -> x.expect(...),
+    /// leaving the predicate undischarged in the entry WP.**
     Expect,
 }
 
@@ -240,15 +263,18 @@ impl DropTemplate {
 /// For the MVP launch corpus it is hardcoded -- empirical question
 /// resolved after operating at scale.
 ///
-/// Returns the full family for known predicates, empty slice for unknown.
+/// **MVP policy**: only `Defensive` is returned for "not_null" because it
+/// is the only template whose closure is verified by the current lifter
+/// (lift.rs recognizes if-then-panic bodies). The other three variants
+/// (`Recoverable`, `EarlyReturn`, `Expect`) are scaffolding -- their shapes
+/// exist in the enum for future extension but are not closure-verified.
+/// They will be added to this table when the lifter is extended to
+/// recognize their respective patterns.
+///
+/// Returns the verified template slice for known predicates, empty for unknown.
 pub fn templates_for(predicate: &str) -> &'static [DropTemplate] {
     match predicate {
-        "not_null" => &[
-            DropTemplate::Defensive,
-            DropTemplate::Recoverable,
-            DropTemplate::EarlyReturn,
-            DropTemplate::Expect,
-        ],
+        "not_null" => &[DropTemplate::Defensive],
         _ => &[],
     }
 }
@@ -326,36 +352,74 @@ pub fn emit_drop(
 
 // ---- Re-lift verification ----
 
+/// Structural helper: returns true if `formula` contains a `Not` node whose
+/// single operand is an `Atomic { name: "is_none" | "is_some", args }` where
+/// `args` contains a `Var { name: var_name }`.
+///
+/// This is the exact shape that lift.rs produces for the if-then-panic pattern:
+///   `if x.is_none() { panic!(...) }` => `Not([Atomic("is_none", [Var("x")])])`
+///
+/// We check this structurally rather than via substring search on serialized JSON
+/// to avoid false positives from other uses of "is_none" / "is_some" appearing
+/// as string literals, variable names, or comments in the source.
+fn formula_contains_guard_for(formula: &IrFormula, var_name: &str) -> bool {
+    match formula {
+        IrFormula::Not { operands } => {
+            // The canonical lift shape is Not with a single operand.
+            if operands.len() == 1 {
+                if let IrFormula::Atomic { name, args } = &operands[0] {
+                    let is_guard = matches!(name.as_str(), "is_none" | "is_some");
+                    let has_var = args.iter().any(|t| match t {
+                        IrTerm::Var { name } => name == var_name,
+                        _ => false,
+                    });
+                    if is_guard && has_var {
+                        return true;
+                    }
+                }
+            }
+            // Recurse into all Not operands in case the formula is nested.
+            operands.iter().any(|o| formula_contains_guard_for(o, var_name))
+        }
+        IrFormula::Atomic { .. } => false,
+        IrFormula::And { operands }
+        | IrFormula::Or { operands }
+        | IrFormula::Implies { operands } => {
+            operands.iter().any(|o| formula_contains_guard_for(o, var_name))
+        }
+        IrFormula::Forall { body, .. } | IrFormula::Exists { body, .. } => {
+            formula_contains_guard_for(body, var_name)
+        }
+        IrFormula::Choice { body, .. } => formula_contains_guard_for(body, var_name),
+    }
+}
+
 /// Verify that the dropper's emission closes the gap.
 ///
 /// Closure criterion: after emitting the guard, the re-lift of the modified
 /// source must show that the CALLER function's lifted precondition contains
-/// a guard that discharges the required predicate. Specifically:
+/// a structurally discharging formula for the required predicate.
 ///
 /// The lift.rs lifter reads the modified caller body and recognizes the
 /// emitted `if {var}.is_none() { panic!(...) }` as a precondition
-/// contributor via the if-then-panic pattern. This produces a formula of
-/// the form `!is_none({var})` in the caller's lifted precondition.
+/// contributor via the if-then-panic pattern. This produces:
+///   `Not { operands: [Atomic { name: "is_none", args: [Var { name: "x" }] }] }`
+/// in the caller's lifted precondition.
 ///
-/// The substrate then maps `!is_none(x)` to `not_null(x)` via the cached
-/// edge in the foundation catalog. The DAG closes because the caller's
-/// lifted precondition now establishes the condition the substrate uses
-/// to discharge `not_null`.
+/// Three structural closure criteria (any one suffices):
 ///
-/// For the MVP verification, we check that the caller's lifted precondition
-/// (via `lift_function_precondition`) contains either:
-/// (a) a formula referencing the variable with a guard shape (is_none / is_some
-///     method call style, which the lifter translates via if-then-panic), OR
-/// (b) the predicate is absent from the walker's entry WP entirely (fully
-///     discharged by static analysis), OR
-/// (c) the walker's entry WP is of the form `premise -> predicate` (the
-///     if-condition from the emitted guard became a premise in the walk).
+/// (a) The caller's lifted precondition (from `lift_function_precondition`)
+///     contains a `Not` formula whose single operand is `Atomic { name: "is_none"
+///     | "is_some" }` with a `Var` argument matching the gap variable. This is
+///     the exact shape the Defensive template's if-then-panic produces.
 ///
-/// This function implements check (b) and (c). Check (a) requires
-/// lift_function_precondition for the caller, which is the authoritative
-/// source of truth.
+/// (b) The gap predicate is absent from the walker's entry WP after re-walking
+///     the modified source.
 ///
-/// Returns `true` if the gap is closed.
+/// (c) The walker's entry WP is `Implies { premise, conclusion }` where the
+///     conclusion still contains the predicate but the premise encodes the guard.
+///
+/// Returns `true` if the gap is closed by any criterion.
 pub fn verify_closure(
     modified_source: &str,
     gap: &Gap,
@@ -380,25 +444,18 @@ pub fn verify_closure(
         None => return false,
     };
 
-    // Primary check: the caller's lifted precondition (from lift.rs) must
-    // now contain a guard-shaped formula. The if-then-panic the dropper
-    // emitted is read by lift.rs's if-then-panic recognizer, producing
-    // `!is_none(x)` (encoded as a negated method-call condition). This
-    // appears in the lifted precondition, confirming the DAG closes.
+    // Criterion (a): structural scan of the caller's lifted precondition.
+    //
+    // The Defensive template emits `if {var}.is_none() { panic!(...) }`.
+    // Lift.rs's if-then-panic path lifts this to:
+    //   Not { operands: [Atomic { name: "is_none", args: [Var { name: var }] }] }
+    // We check for that exact structure -- NOT a substring match on JSON.
     let caller_pre = lift_function_precondition(&caller_fn);
-    let caller_pre_json = serde_json::to_string(caller_pre.as_formula()).unwrap_or_default();
-    // The if-then-panic emitted uses "is_none" which, when lifted via the
-    // if-then-panic path, produces a Not formula referencing the condition.
-    // The serialized form will contain "is_none" from the method-call lift.
-    // Alternatively, for the Expect template (let x = x.expect(...)) the
-    // lifter sees a plain let-binding and the precondition stays as-is; in
-    // that case we fall through to the walk-based check.
-    if caller_pre_json.contains("is_none") || caller_pre_json.contains("is_some") {
+    if formula_contains_guard_for(caller_pre.as_formula(), &gap.var_name) {
         return true;
     }
 
-    // Secondary check: the walker's entry WP is either wrapped in Implies
-    // (guard condition became a premise) or the predicate is absent entirely.
+    // Criteria (b) and (c): re-walk the modified source and inspect entry WP.
     let walks = walk_callsites_to_entry(
         &caller_fn,
         &gap.callee_name,
@@ -409,7 +466,9 @@ pub fn verify_closure(
     for walk in &walks {
         let entry_wp = walk.entry_wp();
         let formula = entry_wp.as_formula();
-        // Check: predicate wrapped in Implies -> guard is a premise.
+
+        // Criterion (c): predicate is in conclusion of Implies.
+        // The guard became a premise on the surviving branch.
         if let IrFormula::Implies { operands } = formula {
             if operands.len() >= 2
                 && formula_contains_predicate(&operands[operands.len() - 1], &gap.predicate)
@@ -417,7 +476,8 @@ pub fn verify_closure(
                 return true;
             }
         }
-        // Check: predicate no longer appears at all -> fully discharged.
+
+        // Criterion (b): predicate absent entirely from entry WP.
         if !formula_contains_predicate(formula, &gap.predicate) {
             return true;
         }
@@ -588,13 +648,14 @@ fn caller(x: u32) { f(x); }
     // ---- Phase 2: cached-witness lookup tests ----
 
     #[test]
-    fn templates_for_not_null_returns_all_four() {
+    fn templates_for_not_null_returns_defensive_only() {
+        // Only the Defensive template is closure-verified for the MVP.
+        // Recoverable, EarlyReturn, and Expect are scaffolding variants in
+        // the enum but are not returned here until the lifter is extended
+        // to recognize their respective patterns as precondition contributors.
         let templates = templates_for("not_null");
-        assert_eq!(templates.len(), 4, "four template families for not_null");
+        assert_eq!(templates.len(), 1, "one verified template for not_null (MVP)");
         assert!(templates.contains(&DropTemplate::Defensive));
-        assert!(templates.contains(&DropTemplate::Recoverable));
-        assert!(templates.contains(&DropTemplate::EarlyReturn));
-        assert!(templates.contains(&DropTemplate::Expect));
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/dropper.rs
+++ b/implementations/rust/provekit-walk/src/dropper.rs
@@ -130,26 +130,44 @@ pub struct Gap {
 ///
 /// Currently supports: "not_null".
 ///
-/// Returns one Gap per walk where the gap is detected.
+/// **Skip policy**: if the predicate's argument is not a simple `Var` (e.g.
+/// it is a constructor expression, a function call, or a literal), the
+/// dropper has no concrete identifier to guard. Such gaps are skipped with
+/// a diagnostic to stderr (matching `walk.rs`'s eprintln pattern for
+/// arity-mismatch skips). The gap remains visible to a downstream tool that
+/// inspects walks directly; only the dropper's emission path is best-effort.
+///
+/// Returns one Gap per walk where the gap is detected and a Var argument
+/// was extracted.
 pub fn detect_gaps(walks: &[CallsiteWalk], predicate: &str) -> Vec<Gap> {
     let mut gaps = Vec::new();
     for walk in walks {
         let entry = walk.entry_wp();
-        if formula_contains_predicate(entry.as_formula(), predicate) {
-            let var_name = predicate_var_arg(entry.as_formula(), predicate)
-                .unwrap_or_else(|| "_".to_string());
-            // The callsite is the first arrival in the walk; its stmt_index
-            // is the body position of the callsite statement.
-            let callsite_stmt_index = walk.arrivals.first().map(|a| a.stmt_index).unwrap_or(0);
-            gaps.push(Gap {
-                caller_name: walk.caller_name.clone(),
-                callee_name: walk.callee_name.clone(),
-                predicate: predicate.to_string(),
-                var_name,
-                callsite_stmt_index,
-                entry_wp: entry.clone(),
-            });
+        if !formula_contains_predicate(entry.as_formula(), predicate) {
+            continue;
         }
+        let Some(var_name) = predicate_var_arg(entry.as_formula(), predicate) else {
+            // Non-Var argument: skip with a diagnostic. Matches walk.rs's
+            // arity-mismatch skip pattern (line 100). This preserves liveness
+            // for other walks; the gap is not silently rendered as `_.is_none()`.
+            eprintln!(
+                "provekit-walk/dropper: predicate `{}` in {}->{} entry WP has \
+                 non-Var argument; skipping gap (no concrete identifier to guard)",
+                predicate, walk.caller_name, walk.callee_name
+            );
+            continue;
+        };
+        // The callsite is the first arrival in the walk; its stmt_index
+        // is the body position of the callsite statement.
+        let callsite_stmt_index = walk.arrivals.first().map(|a| a.stmt_index).unwrap_or(0);
+        gaps.push(Gap {
+            caller_name: walk.caller_name.clone(),
+            callee_name: walk.callee_name.clone(),
+            predicate: predicate.to_string(),
+            var_name,
+            callsite_stmt_index,
+            entry_wp: entry.clone(),
+        });
     }
     gaps
 }
@@ -207,38 +225,78 @@ pub enum DropTemplate {
     Expect,
 }
 
+/// Reason a `DropTemplate` cannot currently be rendered to compilable Rust.
+///
+/// The Defensive template is the only currently-renderable variant. The other
+/// three exist in the enum for documenting the policy axis (paper 07 §7), but
+/// their render paths produce uncompilable Rust without additional context
+/// (caller-supplied error types, fresh-name binding for shadowing, etc.).
+/// The render method returns this error rather than emitting broken source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NotRenderable {
+    /// The template family is documented but not yet implemented in a
+    /// compilable form. Carries the family name for diagnostic context.
+    Scaffolding {
+        family: &'static str,
+        reason: &'static str,
+    },
+}
+
+impl std::fmt::Display for NotRenderable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NotRenderable::Scaffolding { family, reason } => {
+                write!(f, "DropTemplate::{family} is scaffolding only: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NotRenderable {}
+
 impl DropTemplate {
     /// Render the template as Rust source text, with `var` substituted.
+    ///
+    /// Returns `Ok(text)` for the Defensive template, which produces compilable
+    /// guard code. Returns `Err(NotRenderable::Scaffolding)` for the other three
+    /// templates because their render paths produce uncompilable Rust:
+    /// - `Recoverable` references an undefined `NullInput` error type.
+    /// - `EarlyReturn` requires the caller's return type to implement `Default`.
+    /// - `Expect` shadows `var` with the unwrapped type, breaking the callsite.
+    ///
+    /// The non-Defensive variants remain in the enum so the policy axis from
+    /// paper 07 §7 is documented in code, but their render paths are gated
+    /// behind this `Result` until the lifter and dropper are extended to
+    /// produce verified, compilable output for them. See follow-up issues
+    /// (#407 for Expect's shadowing, etc).
     ///
     /// The rendered text is a complete Rust statement (or pair of statements)
     /// that should be inserted immediately before the callsite in the source.
     /// Trailing newline included so splicing is text-clean.
-    pub fn render(&self, var: &str) -> String {
+    pub fn render(&self, var: &str) -> Result<String, NotRenderable> {
         match self {
-            DropTemplate::Defensive => {
-                format!(
-                    "    if {var}.is_none() {{ panic!(\"not_null: {var} must be Some\"); }}\n",
-                    var = var
-                )
-            }
-            DropTemplate::Recoverable => {
-                format!(
-                    "    if {var}.is_none() {{ return Err(NullInput); }}\n",
-                    var = var
-                )
-            }
-            DropTemplate::EarlyReturn => {
-                format!(
-                    "    if {var}.is_none() {{ return Default::default(); }}\n",
-                    var = var
-                )
-            }
-            DropTemplate::Expect => {
-                format!(
-                    "    let {var} = {var}.expect(\"not_null: invariant: caller must supply non-null {var}\");\n",
-                    var = var
-                )
-            }
+            DropTemplate::Defensive => Ok(format!(
+                "    if {var}.is_none() {{ panic!(\"not_null: {var} must be Some\"); }}\n",
+                var = var
+            )),
+            DropTemplate::Recoverable => Err(NotRenderable::Scaffolding {
+                family: "Recoverable",
+                reason:
+                    "render emits `return Err(NullInput)` but no error type is defined; \
+                     pending caller-supplied error_expr support",
+            }),
+            DropTemplate::EarlyReturn => Err(NotRenderable::Scaffolding {
+                family: "EarlyReturn",
+                reason:
+                    "render emits `return Default::default()` which requires the caller's \
+                     return type to implement Default; not closure-verified by current lifter",
+            }),
+            DropTemplate::Expect => Err(NotRenderable::Scaffolding {
+                family: "Expect",
+                reason:
+                    "render shadows the original variable with a different type, breaking \
+                     downstream callsites; pending fresh-name binding (see issue #407)",
+            }),
         }
     }
 
@@ -298,43 +356,74 @@ pub struct EmitResult {
 
 /// Splice the chosen template into `source` for the given gap.
 ///
-/// Insertion strategy: we find the line that is a callsite expression (not a
-/// function definition). A callsite line matches `{callee_name}(` but does
-/// NOT start with `fn ` after trimming. We skip function-signature lines.
-/// This handles the common case where the callee name appears both as a
-/// function definition and as a call expression in the same file.
+/// Insertion strategy is **AST-anchored**, not line-pattern-based:
 ///
-/// Nested callsites (inside if-branches) are deferred to Phase 4.
+/// 1. Parse `source` with `syn::parse_str`.
+/// 2. Locate the function whose `sig.ident` matches `gap.caller_name`.
+///    There may be multiple functions in the file calling the same callee;
+///    we splice into the SPECIFIC caller named by the gap.
+/// 3. Look up `caller.block.stmts[gap.callsite_stmt_index]` and read its
+///    span (`Spanned::span(stmt).start().line`). This is the exact 1-indexed
+///    source line of the callsite statement, robust to multi-line statements,
+///    multi-callsite functions, and shared callee names across functions.
+/// 4. Splice the rendered guard text immediately before that line.
 ///
-/// Returns `None` if the callee call pattern cannot be located in the source.
+/// Nested callsites within compound statements (e.g., inside `if` arms): the
+/// `stmt_index` from the walker still points at the enclosing statement, so
+/// the guard is inserted before the enclosing statement. This is conservative
+/// (the guard runs unconditionally), but correct in the sense that the
+/// invariant holds at the callsite. Per-branch guard placement is deferred.
+///
+/// Returns `None` if:
+/// - the source does not parse, OR
+/// - the named caller is not present in the file, OR
+/// - the `callsite_stmt_index` is out of range for the caller's body, OR
+/// - the chosen template is scaffolding (render returns NotRenderable).
 pub fn emit_drop(
     source: &str,
     gap: &Gap,
     template: DropTemplate,
 ) -> Option<EmitResult> {
-    let guard_text = template.render(&gap.var_name);
+    use syn::spanned::Spanned;
 
-    // Find the line containing the callsite pattern `{callee_name}(` that is
-    // a call expression, not a function definition. A function-definition line
-    // contains `fn ` before the callee name; a call expression line does not.
-    let callee_pattern = format!("{}(", gap.callee_name);
-    let lines: Vec<&str> = source.lines().collect();
+    let guard_text = template.render(&gap.var_name).ok()?;
 
-    let insert_before = lines.iter().position(|l| {
-        let trimmed = l.trim();
-        // Must contain the call pattern.
-        if !trimmed.contains(&callee_pattern) {
-            return false;
+    // Parse the source so we can resolve callsite locations via syn spans
+    // rather than line-pattern matching.
+    let file: syn::File = syn::parse_str(source).ok()?;
+
+    // Locate the SPECIFIC caller named by the gap. This is the P1a fix:
+    // a multi-function file with the same callee in multiple callers must
+    // route the splice to the function named on the gap.
+    let caller_fn = file.items.iter().find_map(|item| {
+        if let syn::Item::Fn(f) = item {
+            if f.sig.ident == gap.caller_name {
+                return Some(f);
+            }
         }
-        // Must NOT be a function definition (fn keyword before callee name).
-        let fn_def_pattern = format!("fn {}", gap.callee_name);
-        !trimmed.starts_with("fn ") && !trimmed.contains(&fn_def_pattern)
+        None
     })?;
+
+    // Resolve the callsite statement by index within the caller's body.
+    let callsite_stmt = caller_fn.block.stmts.get(gap.callsite_stmt_index)?;
+
+    // The span's start line is 1-indexed; convert to 0-indexed for splicing.
+    let callsite_line_1indexed = callsite_stmt.span().start().line;
+    if callsite_line_1indexed == 0 {
+        // Defensive: a span with line 0 would produce an underflow below.
+        return None;
+    }
+    let insert_before_idx = callsite_line_1indexed - 1;
+
+    let lines: Vec<&str> = source.lines().collect();
+    if insert_before_idx >= lines.len() {
+        return None;
+    }
 
     let guard_trimmed = guard_text.trim_end_matches('\n');
     let mut result_lines: Vec<&str> = Vec::with_capacity(lines.len() + 1);
     for (i, line) in lines.iter().enumerate() {
-        if i == insert_before {
+        if i == insert_before_idx {
             // Insert guard before the callsite line.
             result_lines.push(guard_trimmed);
         }
@@ -346,7 +435,7 @@ pub fn emit_drop(
         modified_source,
         template,
         var_name: gap.var_name.clone(),
-        insert_line: insert_before + 1, // 1-indexed
+        insert_line: callsite_line_1indexed,
     })
 }
 
@@ -487,22 +576,92 @@ pub fn verify_closure(
 
 // ---- Public API ----
 
-/// Run all three phases (detect + lookup + emit) for a source file and
-/// a known callee precondition. Returns the emit result for the first
-/// gap found using the default (Defensive) template.
+/// Reasons `drop_gap` may fail to produce a verified, closing emission.
 ///
-/// This is the main entry point for the dropper's end-to-end path.
+/// All variants are recoverable and inspectable. The `ClosureVerificationFailed`
+/// variant carries the failed `EmitResult` so callers can see the proposed
+/// emission even when re-lift didn't confirm DAG closure (useful for
+/// debugging the dropper or extending the verifier).
+#[derive(Debug, Clone)]
+pub enum DropFailure {
+    /// The source could not be parsed as a Rust file.
+    SourceParseFailed,
+    /// The named caller function does not appear in the source.
+    CallerNotFound { caller_name: String },
+    /// No gap matching `predicate` was detected in any walk from the caller.
+    NoGapDetected { predicate: String },
+    /// The predicate has no template family in the kit's `templates_for` table.
+    UnknownPredicate { predicate: String },
+    /// The requested template is not currently a verified candidate for this
+    /// predicate. For the MVP, only `DropTemplate::Defensive` is verified.
+    TemplateNotCandidate {
+        predicate: String,
+        requested: DropTemplate,
+    },
+    /// The template's render path is scaffolding-only (see `NotRenderable`).
+    NotRenderable(NotRenderable),
+    /// `emit_drop` could not splice the source (parse failure, missing caller,
+    /// or out-of-range stmt_index).
+    EmitFailed,
+    /// The emission was produced but `verify_closure` could not confirm that
+    /// the gap is structurally discharged after re-lift. The proposed
+    /// `EmitResult` is included for inspection.
+    ClosureVerificationFailed { emit: EmitResult },
+}
+
+impl std::fmt::Display for DropFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DropFailure::SourceParseFailed => write!(f, "source did not parse as Rust"),
+            DropFailure::CallerNotFound { caller_name } => {
+                write!(f, "caller `{caller_name}` not found in source")
+            }
+            DropFailure::NoGapDetected { predicate } => {
+                write!(f, "no gap for predicate `{predicate}` detected in any walk")
+            }
+            DropFailure::UnknownPredicate { predicate } => {
+                write!(f, "predicate `{predicate}` has no template family in this kit")
+            }
+            DropFailure::TemplateNotCandidate { predicate, requested } => {
+                write!(
+                    f,
+                    "template {:?} is not a verified candidate for predicate `{predicate}`",
+                    requested
+                )
+            }
+            DropFailure::NotRenderable(e) => write!(f, "{e}"),
+            DropFailure::EmitFailed => write!(f, "emit_drop could not splice the source"),
+            DropFailure::ClosureVerificationFailed { .. } => {
+                write!(f, "emission produced but re-lift did not confirm DAG closure")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DropFailure {}
+
+/// Run all four steps of the dropper end-to-end: detect, lookup, emit, **verify**.
+///
+/// This is the main entry point for the dropper. Per paper 07 §7, an emission
+/// that does not actually close the gap is not generative completion. This
+/// function therefore calls `verify_closure` after `emit_drop` and only
+/// returns `Ok(EmitResult)` when re-lift structurally confirms the gap is
+/// discharged. Failed verifications return `Err(DropFailure::ClosureVerificationFailed)`
+/// carrying the proposed emission for inspection.
+///
 /// Phase 4 (mint-on-miss via solver portfolio) is deferred.
 ///
 /// Parameters:
 /// - `source`: the Rust source text containing both the callee and caller.
 /// - `callee_name`: the function whose precondition has a gap.
+/// - `caller_name`: the function calling `callee_name` where the gap arises.
 /// - `callee_formal_params`: formal parameter names for the callee.
 /// - `callee_precondition`: the WP representing the callee's precondition.
 /// - `predicate`: the leaf predicate name to look for (e.g. "not_null").
-/// - `template`: which drop template to use (default: Defensive).
+/// - `template`: which drop template to use.
 ///
-/// Returns `None` if no gap is found or no template matches the predicate.
+/// Errors are returned as `DropFailure` rather than `None` so callers can
+/// distinguish parse failures from missing gaps from verification failures.
 pub fn drop_gap(
     source: &str,
     callee_name: &str,
@@ -511,40 +670,76 @@ pub fn drop_gap(
     callee_precondition: Wp,
     predicate: &str,
     template: DropTemplate,
-) -> Option<EmitResult> {
-    let file: syn::File = syn::parse_str(source).ok()?;
+) -> Result<EmitResult, DropFailure> {
+    let file: syn::File =
+        syn::parse_str(source).map_err(|_| DropFailure::SourceParseFailed)?;
 
-    let caller_fn = file.items.iter().find_map(|item| {
-        if let syn::Item::Fn(f) = item {
-            if f.sig.ident == caller_name {
-                return Some(f.clone());
+    let caller_fn = file
+        .items
+        .iter()
+        .find_map(|item| {
+            if let syn::Item::Fn(f) = item {
+                if f.sig.ident == caller_name {
+                    return Some(f.clone());
+                }
             }
-        }
-        None
-    })?;
+            None
+        })
+        .ok_or_else(|| DropFailure::CallerNotFound {
+            caller_name: caller_name.to_string(),
+        })?;
 
     // Phase 1: detect gaps.
     let walks = walk_callsites_to_entry(
         &caller_fn,
         callee_name,
         callee_formal_params,
-        callee_precondition,
+        callee_precondition.clone(),
     );
     let gaps = detect_gaps(&walks, predicate);
-    let gap = gaps.into_iter().next()?;
+    let gap = gaps
+        .into_iter()
+        .next()
+        .ok_or_else(|| DropFailure::NoGapDetected {
+            predicate: predicate.to_string(),
+        })?;
 
     // Phase 2: look up candidate templates.
     let candidates = templates_for(predicate);
     if candidates.is_empty() {
-        return None;
+        return Err(DropFailure::UnknownPredicate {
+            predicate: predicate.to_string(),
+        });
     }
-    // Verify the requested template is in the candidate list.
     if !candidates.contains(&template) {
-        return None;
+        return Err(DropFailure::TemplateNotCandidate {
+            predicate: predicate.to_string(),
+            requested: template,
+        });
     }
 
+    // Pre-render check: surface NotRenderable as a structured error rather
+    // than letting emit_drop swallow it as None.
+    template
+        .render(&gap.var_name)
+        .map_err(DropFailure::NotRenderable)?;
+
     // Phase 3: emit.
-    emit_drop(source, &gap, template)
+    let emit = emit_drop(source, &gap, template).ok_or(DropFailure::EmitFailed)?;
+
+    // Phase 4 (verification, not solver-portfolio): re-lift and confirm closure.
+    // The advisor flagged this as a correctness blocker -- a caller using
+    // drop_gap must only get back emissions that ACTUALLY close the gap.
+    if !verify_closure(
+        &emit.modified_source,
+        &gap,
+        callee_formal_params,
+        callee_precondition,
+    ) {
+        return Err(DropFailure::ClosureVerificationFailed { emit });
+    }
+
+    Ok(emit)
 }
 
 // ---- Tests ----
@@ -668,50 +863,67 @@ fn caller(x: u32) { f(x); }
 
     #[test]
     fn defensive_template_renders_panic_shape() {
-        let rendered = DropTemplate::Defensive.render("x");
+        let rendered = DropTemplate::Defensive
+            .render("x")
+            .expect("Defensive must render OK");
         assert!(rendered.contains("x.is_none()"), "must guard x");
         assert!(rendered.contains("panic!"), "must panic on violation");
         assert!(rendered.contains("not_null"), "panic msg must name invariant");
     }
 
     #[test]
-    fn recoverable_template_renders_err_shape() {
-        let rendered = DropTemplate::Recoverable.render("x");
-        assert!(rendered.contains("x.is_none()"), "must guard x");
-        assert!(rendered.contains("return Err"), "must return Err");
-    }
-
-    #[test]
-    fn early_return_template_renders_default_shape() {
-        let rendered = DropTemplate::EarlyReturn.render("x");
-        assert!(rendered.contains("x.is_none()"), "must guard x");
-        assert!(rendered.contains("Default::default()"), "must return default");
-    }
-
-    #[test]
-    fn expect_template_renders_expect_shape() {
-        let rendered = DropTemplate::Expect.render("x");
-        assert!(rendered.contains(".expect("), "must call .expect()");
-        assert!(rendered.contains("not_null"), "expect msg must name invariant");
-    }
-
-    #[test]
-    fn all_templates_substitute_var_name() {
-        let templates = [
-            DropTemplate::Defensive,
-            DropTemplate::Recoverable,
-            DropTemplate::EarlyReturn,
-            DropTemplate::Expect,
-        ];
-        for tmpl in &templates {
-            let rendered = tmpl.render("my_var");
-            assert!(
-                rendered.contains("my_var"),
-                "{} template must contain var name 'my_var': {}",
-                tmpl.family_name(),
-                rendered
-            );
+    fn recoverable_template_returns_not_renderable() {
+        // Recoverable's render path emits `return Err(NullInput)` referencing
+        // an undefined error type. Per P1c, render returns NotRenderable rather
+        // than producing uncompilable Rust. Match the Scaffolding variant
+        // rather than asserting a specific message; the message text is a
+        // doc-only diagnostic and can be tightened without breaking the test.
+        let result = DropTemplate::Recoverable.render("x");
+        let err = result.expect_err("Recoverable must return NotRenderable");
+        match err {
+            NotRenderable::Scaffolding { family, .. } => {
+                assert_eq!(family, "Recoverable");
+            }
         }
+    }
+
+    #[test]
+    fn early_return_template_returns_not_renderable() {
+        let result = DropTemplate::EarlyReturn.render("x");
+        let err = result.expect_err("EarlyReturn must return NotRenderable");
+        match err {
+            NotRenderable::Scaffolding { family, .. } => {
+                assert_eq!(family, "EarlyReturn");
+            }
+        }
+    }
+
+    #[test]
+    fn expect_template_returns_not_renderable() {
+        // Expect would shadow `var` with the unwrapped type, breaking the
+        // callsite. Render returns NotRenderable until issue #407 lands a
+        // fresh-name binding.
+        let result = DropTemplate::Expect.render("x");
+        let err = result.expect_err("Expect must return NotRenderable");
+        match err {
+            NotRenderable::Scaffolding { family, .. } => {
+                assert_eq!(family, "Expect");
+            }
+        }
+    }
+
+    #[test]
+    fn defensive_template_substitutes_var_name() {
+        // Only Defensive is currently renderable; other variants return
+        // NotRenderable and are exercised by their dedicated tests above.
+        let rendered = DropTemplate::Defensive
+            .render("my_var")
+            .expect("Defensive renders OK");
+        assert!(
+            rendered.contains("my_var"),
+            "Defensive template must contain var name 'my_var': {}",
+            rendered
+        );
     }
 
     // ---- Phase 3: source emission tests ----
@@ -841,8 +1053,7 @@ fn caller(x: u32) { f(x); }
             DropTemplate::Defensive,
         );
 
-        assert!(result.is_some(), "drop_gap must succeed for not_null fixture");
-        let emit = result.unwrap();
+        let emit = result.expect("drop_gap must succeed for not_null fixture");
         assert_eq!(emit.template, DropTemplate::Defensive);
         assert_eq!(emit.var_name, "x");
         // The modified source must be parseable.
@@ -852,5 +1063,270 @@ fn caller(x: u32) { f(x); }
         let guard_pos = emit.modified_source.find("x.is_none()").expect("guard present");
         let callsite_pos = emit.modified_source.find("f(x)").expect("callsite present");
         assert!(guard_pos < callsite_pos, "guard before callsite");
+    }
+
+    // ---- P1b: drop_gap calls verify_closure ----
+
+    #[test]
+    fn drop_gap_returns_template_not_candidate_for_scaffolding() {
+        // Recoverable is in the enum but not in templates_for("not_null"),
+        // so drop_gap should return TemplateNotCandidate (NOT swallow as None).
+        let result = drop_gap(
+            FIXTURE_SRC,
+            "f",
+            "caller",
+            &["x".to_string()],
+            not_null_wp("x"),
+            "not_null",
+            DropTemplate::Recoverable,
+        );
+        match result {
+            Err(DropFailure::TemplateNotCandidate { requested, .. }) => {
+                assert_eq!(requested, DropTemplate::Recoverable);
+            }
+            other => panic!("expected TemplateNotCandidate, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn drop_gap_returns_no_gap_detected_for_unrelated_predicate() {
+        // The fixture's WP is `not_null(x)`. Querying for an unrelated
+        // predicate ("some_unknown_predicate") never matches the WP, so
+        // no gap is detected. This is the documented short-circuit before
+        // template lookup -- detect_gaps runs first.
+        let result = drop_gap(
+            FIXTURE_SRC,
+            "f",
+            "caller",
+            &["x".to_string()],
+            not_null_wp("x"),
+            "some_unknown_predicate",
+            DropTemplate::Defensive,
+        );
+        match result {
+            Err(DropFailure::NoGapDetected { predicate }) => {
+                assert_eq!(predicate, "some_unknown_predicate");
+            }
+            other => panic!("expected NoGapDetected, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn drop_gap_returns_unknown_predicate_when_gap_exists_but_no_table_entry() {
+        // To hit UnknownPredicate, a gap MUST be detected first. We
+        // synthesize a precondition with predicate `unknown_pred(x)` and
+        // query for the same predicate. detect_gaps emits the gap;
+        // templates_for("unknown_pred") returns &[] -> UnknownPredicate.
+        let unknown_pred_wp = Wp(IrFormula::Atomic {
+            name: "unknown_pred".to_string(),
+            args: vec![IrTerm::Var {
+                name: "x".to_string(),
+            }],
+        });
+        let result = drop_gap(
+            FIXTURE_SRC,
+            "f",
+            "caller",
+            &["x".to_string()],
+            unknown_pred_wp,
+            "unknown_pred",
+            DropTemplate::Defensive,
+        );
+        match result {
+            Err(DropFailure::UnknownPredicate { predicate }) => {
+                assert_eq!(predicate, "unknown_pred");
+            }
+            other => panic!("expected UnknownPredicate, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn drop_gap_returns_caller_not_found_for_missing_caller() {
+        let result = drop_gap(
+            FIXTURE_SRC,
+            "f",
+            "nonexistent_caller",
+            &["x".to_string()],
+            not_null_wp("x"),
+            "not_null",
+            DropTemplate::Defensive,
+        );
+        match result {
+            Err(DropFailure::CallerNotFound { caller_name }) => {
+                assert_eq!(caller_name, "nonexistent_caller");
+            }
+            other => panic!("expected CallerNotFound, got {:?}", other),
+        }
+    }
+
+    // ---- P1a: multi-function placement (acceptance test) ----
+
+    #[test]
+    fn emit_drop_routes_to_correct_caller_in_multi_function_file() {
+        // Two callers, both call `f`. Only `caller_a` has a gap (passes a Var
+        // expression `x`). `caller_b` passes the same name but is a separate
+        // function -- the guard must land in `caller_a`'s body, NOT before
+        // `caller_b`'s call to `f`.
+        let src = "\
+fn f(x: Option<i32>) -> i32 {
+    x.unwrap()
+}
+
+fn caller_a(x: Option<i32>) {
+    f(x);
+}
+
+fn caller_b(x: Option<i32>) {
+    f(x);
+}
+";
+        let file: syn::File = syn::parse_str(src).expect("parses");
+        let caller_a = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Fn(f) if f.sig.ident == "caller_a" => Some(f.clone()),
+                _ => None,
+            })
+            .expect("caller_a fn");
+
+        let precondition = not_null_wp("x");
+        let walks =
+            walk_callsites_to_entry(&caller_a, "f", &["x".to_string()], precondition);
+        let gaps = detect_gaps(&walks, "not_null");
+        assert_eq!(gaps.len(), 1, "one gap in caller_a");
+        let gap = &gaps[0];
+        assert_eq!(gap.caller_name, "caller_a");
+
+        let result = emit_drop(src, gap, DropTemplate::Defensive).expect("emit succeeds");
+
+        // The guard line must be between caller_a's `fn` line and caller_b's
+        // `fn` line. We assert the structural invariant on the modified source.
+        let modified = &result.modified_source;
+        let caller_a_pos = modified.find("fn caller_a").expect("caller_a present");
+        let caller_b_pos = modified.find("fn caller_b").expect("caller_b present");
+        let guard_pos = modified.find("x.is_none()").expect("guard present");
+        assert!(
+            caller_a_pos < guard_pos && guard_pos < caller_b_pos,
+            "guard must land between caller_a and caller_b. \
+             caller_a@{}, guard@{}, caller_b@{}\nmodified:\n{}",
+            caller_a_pos,
+            guard_pos,
+            caller_b_pos,
+            modified
+        );
+
+        // Also: the modified source must parse cleanly (no broken Rust).
+        syn::parse_str::<syn::File>(modified).expect("modified source parses");
+    }
+
+    #[test]
+    fn emit_drop_routes_to_correct_callsite_in_multi_callsite_function() {
+        // Caller has TWO callsites to `f` separated by a let-binding. The gap
+        // points at the SECOND callsite (callsite_stmt_index = 2). The guard
+        // must land before the second callsite, not the first.
+        let src = "\
+fn f(x: Option<i32>) -> i32 {
+    x.unwrap()
+}
+
+fn caller(x: Option<i32>) {
+    f(x);
+    let y = x;
+    f(y);
+}
+";
+        let file: syn::File = syn::parse_str(src).expect("parses");
+        let caller_fn = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Fn(f) if f.sig.ident == "caller" => Some(f.clone()),
+                _ => None,
+            })
+            .expect("caller fn");
+
+        let precondition = not_null_wp("x");
+        let walks =
+            walk_callsites_to_entry(&caller_fn, "f", &["x".to_string()], precondition);
+        let gaps = detect_gaps(&walks, "not_null");
+        // Both callsites produce gaps (two separate walks). Pick the second gap
+        // explicitly by stmt_index.
+        assert!(gaps.len() >= 2, "two callsites yield two gaps");
+        let second_gap = gaps
+            .iter()
+            .find(|g| g.callsite_stmt_index == 2)
+            .expect("gap at stmt_index 2 (second f call)");
+
+        let result =
+            emit_drop(src, second_gap, DropTemplate::Defensive).expect("emit succeeds");
+        let modified = &result.modified_source;
+
+        // Locate the guard and the two callsites in the modified text.
+        // The guard must land BETWEEN the let-binding line and the second
+        // callsite, NOT before the first callsite.
+        let first_call_pos = modified.find("f(x);").expect("first call f(x) present");
+        let let_y_pos = modified.find("let y").expect("let y present");
+        let second_call_pos = modified.find("f(y);").expect("second call f(y) present");
+        let guard_pos = modified.find("is_none()").expect("guard present");
+
+        assert!(
+            first_call_pos < let_y_pos,
+            "first callsite must precede let-binding"
+        );
+        assert!(
+            let_y_pos < guard_pos,
+            "guard must follow let-binding (not precede first callsite)"
+        );
+        assert!(
+            guard_pos < second_call_pos,
+            "guard must precede second callsite"
+        );
+
+        syn::parse_str::<syn::File>(modified).expect("modified source parses");
+    }
+
+    // ---- P1d: detect_gaps skips non-Var arguments ----
+
+    #[test]
+    fn detect_gaps_skips_non_var_predicate_arg() {
+        // Construct a walks list with an entry WP whose predicate argument is
+        // NOT a Var (it's a Const). detect_gaps must skip rather than emit a
+        // Gap with var_name = "_". We synthesize a CallsiteWalk with a
+        // hand-crafted entry arrival containing the non-Var predicate.
+        use crate::walk::{Arrival, ArrivalKind, CallsiteWalk};
+        use crate::wp::const_int;
+
+        let non_var_formula = IrFormula::Atomic {
+            name: "not_null".to_string(),
+            args: vec![const_int(0)],
+        };
+        let walk = CallsiteWalk {
+            caller_name: "caller".to_string(),
+            callee_name: "f".to_string(),
+            arrivals: vec![
+                Arrival {
+                    kind: ArrivalKind::Callsite {
+                        callee: "f".to_string(),
+                    },
+                    stmt_index: 0,
+                    wp: Wp(non_var_formula.clone()),
+                },
+                Arrival {
+                    kind: ArrivalKind::FunctionEntry {
+                        fn_name: "caller".to_string(),
+                    },
+                    stmt_index: 1,
+                    wp: Wp(non_var_formula),
+                },
+            ],
+        };
+
+        let gaps = detect_gaps(std::slice::from_ref(&walk), "not_null");
+        assert!(
+            gaps.is_empty(),
+            "non-Var predicate argument must be skipped, got gaps: {:?}",
+            gaps
+        );
     }
 }

--- a/implementations/rust/provekit-walk/src/lib.rs
+++ b/implementations/rust/provekit-walk/src/lib.rs
@@ -19,12 +19,16 @@
 //  - rustc MIR integration (this MVP uses surface AST; MIR is planned).
 //  - Match-arm narrowing, while-let, if-let.
 //  - Cross-function call-graph propagation.
-//  - The dropper / generative-completion path.
 //  - C kit (Clang CFG).
 //  - Pointer aliasing.
+//
+// The dropper / generative-completion path (paper 07 §7) is implemented in
+// dropper.rs (issue #382, Phases 1-3). Phase 4 (mint-on-miss via solver
+// portfolio) is deferred.
 
 pub mod canonical;
 pub mod chain;
+pub mod dropper;
 pub mod charon_runner;
 pub mod contract;
 pub mod emit;
@@ -56,6 +60,10 @@ pub use lift::{lift_function_postcondition, lift_function_precondition, lift_pre
 pub use shadow::{
     build_shadow_source, compose_chain, compose_edges, edge_memento_cid, edge_memento_value,
     CalleeContract, ComposedEdge, ShadowArrival, ShadowSlot, ShadowSource,
+};
+pub use dropper::{
+    detect_gaps, drop_gap, emit_drop, formula_contains_predicate, predicate_var_arg,
+    templates_for, verify_closure, DropTemplate, EmitResult, Gap,
 };
 pub use walk::{walk_callsites_to_entry, Arrival, CallsiteWalk};
 pub use wp::{

--- a/implementations/rust/provekit-walk/src/lib.rs
+++ b/implementations/rust/provekit-walk/src/lib.rs
@@ -63,7 +63,7 @@ pub use shadow::{
 };
 pub use dropper::{
     detect_gaps, drop_gap, emit_drop, formula_contains_predicate, predicate_var_arg,
-    templates_for, verify_closure, DropTemplate, EmitResult, Gap,
+    templates_for, verify_closure, DropFailure, DropTemplate, EmitResult, Gap, NotRenderable,
 };
 pub use walk::{walk_callsites_to_entry, Arrival, CallsiteWalk};
 pub use wp::{

--- a/implementations/rust/provekit-walk/src/lift.rs
+++ b/implementations/rust/provekit-walk/src/lift.rs
@@ -366,6 +366,31 @@ fn lift_predicate_inner(expr: &Expr, ctx: &mut LiftCtx) -> Option<IrFormula> {
             Some(negate(inner))
         }
         Expr::Paren(p) => lift_predicate_inner(&p.expr, ctx),
+        // Zero-argument method calls that return bool: `.is_some()`, `.is_none()`,
+        // `.is_empty()`, `.is_err()`, `.is_ok()`. These are common predicate shapes
+        // in Rust and appear naturally in the dropper's emitted guard code.
+        // Each lifts to `IrFormula::Atomic { name: "is_some" (or similar), args: [recv] }`.
+        Expr::MethodCall(syn::ExprMethodCall {
+            receiver,
+            method,
+            args,
+            ..
+        }) if args.is_empty() => {
+            let method_name = method.to_string();
+            let is_bool_predicate = matches!(
+                method_name.as_str(),
+                "is_some" | "is_none" | "is_empty" | "is_err" | "is_ok"
+            );
+            if is_bool_predicate {
+                let recv_term = lift_expr_to_term_inner(receiver, ctx)?;
+                Some(IrFormula::Atomic {
+                    name: method_name,
+                    args: vec![recv_term],
+                })
+            } else {
+                None
+            }
+        }
         // Anything else is unrecognized in the MVP.
         _ => None,
     }
@@ -1134,6 +1159,49 @@ mod tests {
         assert!(
             json.contains("\"x\""),
             "explicit return expr must reference x: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn lifts_is_none_method_call_as_atomic_predicate() {
+        // `if x.is_none() { panic!() }` lifts to is_none(x) at the
+        // precondition (via the if-then-panic path: ¬panic_cond = ¬is_none(x)).
+        // This is the shape the dropper emits for the Defensive template.
+        let item_fn = parse_fn(
+            r#"
+            fn caller(x: Option<i32>) {
+                if x.is_none() { panic!("not_null: x must be Some"); }
+            }
+        "#,
+        );
+        let pre = lift_function_precondition(&item_fn);
+        let json = serde_json::to_string(pre.as_formula()).unwrap();
+        // The if-then-panic lifts ¬is_none(x) as the precondition.
+        // The JSON should contain "is_none" to confirm the method-call lift fired.
+        assert!(
+            json.contains("is_none"),
+            "if x.is_none() panic must lift is_none to precondition: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn lifts_is_some_method_call_as_atomic_predicate() {
+        // `if !x.is_some() { panic!() }` (double-negation via De Morgan)
+        // should also lift correctly.
+        let item_fn = parse_fn(
+            r#"
+            fn caller(x: Option<i32>) {
+                if !x.is_some() { panic!("not_null: x must be Some"); }
+            }
+        "#,
+        );
+        let pre = lift_function_precondition(&item_fn);
+        let json = serde_json::to_string(pre.as_formula()).unwrap();
+        assert!(
+            json.contains("is_some"),
+            "if !x.is_some() panic must lift is_some to precondition: {}",
             json
         );
     }


### PR DESCRIPTION
## Schema decision (Case A or B?)

**Case A.** Drop shapes are kit-resident per paper 07 §11's explicit adjudication:

> "In the kit. Each kit's dropper is per-kit code with hardcoded knowledge of the host language's idioms for the foundation-catalog predicates it cares about."

The existing `ContractDecl`-overloaded edge memento (`ShadowArrival.pre_wp / post_wp`) is the wire format. No protocol schema extension is warranted or proposed. This PR does not touch the CDDL or any protocol spec.

## What this PR does

Implements the dropper -- the generative-completion side of paper 07 §7 -- for the Rust kit. Three of four phases plus a structural verifier:

**Phase 1 (gap detection):** `detect_gaps()` in `dropper.rs`. Walks the `CallsiteWalk` result and identifies `FunctionEntry` arrivals whose accumulated WP contains an undischarged leaf predicate (currently: `"not_null"`). Skips with a stderr diagnostic when the predicate's argument is not a simple `Var` (matching `walk.rs`'s arity-mismatch skip pattern); never emits `_.is_none()` shapes that would not compile.

**Phase 2 (cached-witness lookup):** `templates_for()` -- the kit-resident predicate-to-template table. For `"not_null"` the MVP returns **only `Defensive`**, the only template whose closure is verified by the current lifter. Three other shapes exist in the `DropTemplate` enum:
- `Defensive` **(closure-verified)**: `if x.is_none() { panic!("not_null: x must be Some"); }` -- surviving branch carries `not_null(x)`.
- `Recoverable` *(scaffolding, render returns `NotRenderable`)*: would emit `return Err(NullInput)` referencing an undefined error type.
- `EarlyReturn` *(scaffolding, render returns `NotRenderable`)*: would emit `return Default::default()` requiring `Default` on the return type.
- `Expect` *(scaffolding, render returns `NotRenderable`)*: would shadow `var` with the unwrapped type, breaking the callsite (see #407).

`DropTemplate::render()` returns `Result<String, NotRenderable>`. Only `Defensive` returns `Ok`; the others return `Err(NotRenderable::Scaffolding { family, reason })` with a specific diagnostic so callers cannot accidentally splice broken Rust.

**Phase 3 (source emission):** `emit_drop()` is **AST-anchored**. It parses the source, locates the caller fn by name (using `gap.caller_name`), looks up `caller.block.stmts[gap.callsite_stmt_index]`, reads its span, and splices the rendered guard before that exact source line. Robust to multi-function files with shared callee names and to multi-callsite functions (covered by acceptance tests).

**Phase 4 (closure verification, not solver portfolio):** `verify_closure()` re-lifts the modified source and confirms DAG closure structurally via `formula_contains_guard_for()`. Three criteria (any one suffices):
- (a) caller's lifted precondition contains `Not { Atomic { is_none|is_some, [Var(x)] } }`
- (b) predicate is absent from entry WP
- (c) entry WP is `Implies { premise, conclusion }` with predicate in the conclusion

`drop_gap()` is the end-to-end public API. Signature: `Result<EmitResult, DropFailure>`. `DropFailure` is a structured error enum (`SourceParseFailed`, `CallerNotFound`, `NoGapDetected`, `UnknownPredicate`, `TemplateNotCandidate`, `NotRenderable`, `EmitFailed`, `ClosureVerificationFailed { emit }`). The `ClosureVerificationFailed` variant carries the proposed emission for caller inspection.

## Fixture demonstrating end-to-end

```rust
// Before dropper:
fn f(x: Option<i32>) -> i32 { x.unwrap() }
fn caller(x: Option<i32>) { f(x); }
// Gap: FunctionEntry WP = not_null(x). No static facts discharge it.

// After Defensive drop:
fn caller(x: Option<i32>) {
    if x.is_none() { panic!("not_null: x must be Some"); }
    f(x);
}
// Re-lift: caller's lifted precondition contains
// Not([Atomic("is_none", [Var("x")])]) via the if-then-panic path in lift.rs.
// formula_contains_guard_for() confirms this structurally. DAG closes.
```

## Boy-scout change in lift.rs

`lift_predicate_inner()` extended to recognize zero-arg bool method calls (`is_none`, `is_some`, `is_empty`, `is_err`, `is_ok`) as `IrFormula::Atomic` predicates. This is required for the dropper's Defensive template to produce a verifiable precondition. Two new tests cover the new path.

## Tests

201 total tests pass (zero failures). New tests added in this PR cover:
- gap detection (in-WP predicate, not-in-WP predicate, non-Var argument skip)
- template lookup (Defensive-only, unknown predicate empty)
- template render (Defensive `Ok`, three scaffolding `Err(NotRenderable)`)
- emit placement (single-caller, **multi-function with shared callee** -- the P1a acceptance test, **multi-callsite with stmt_index routing**)
- re-lift structural closure
- end-to-end `drop_gap` (success, `TemplateNotCandidate`, `NoGapDetected`, `UnknownPredicate`, `CallerNotFound`)

## What's deferred

- **Phase 4 mint-on-miss (solver portfolio):** when `templates_for()` returns empty, the dropper returns `UnknownPredicate`. Solver portfolio integration tracked in #382 follow-up.
- **Non-Defensive templates:** `Recoverable`, `EarlyReturn`, `Expect` exist in the enum but `render` returns `NotRenderable`. They will be unblocked when the lifter is extended for non-panic early-exit shapes and when the dropper grows callsite-rewrite (for fresh-name binding).
- **Multi-argument predicates:** `predicate_var_arg()` extracts the first `Var` argument; multi-var predicates are unsupported.
- **Premise-guarded predicates over-detect:** see #405 follow-up.
- **Expect template variable shadowing:** see #407 follow-up.

## P2 follow-ups (filed as issues, NOT in this PR)

- #405 [walk] detect_gaps: skip premise-guarded predicates
- #407 [walk] DropTemplate::Expect: bind to fresh name to preserve callsite types

## Open architect questions

**architect-call: predicate table extensibility.** `templates_for()` hardcodes `"not_null"`. As the foundation catalog grows, this table should be data-driven (e.g., loaded from a TOML config alongside the kit). The current hardcoded form is correct for the launch corpus but will need to grow. No schema change required -- the table is entirely kit-internal. Flagging for Sir to adjudicate the extensibility shape before the table grows past a handful of entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)