### PR TITLE
fix(walk): add Effect::Drop for C.10 drop semantics (#384)

### DIFF
--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -484,6 +484,14 @@ impl OpacityMementoLookup for MementoPool {
     fn has_closure_binding(&self, body_fn_cid: &str) -> bool {
         self.body_fn_cid_to_memento.contains_key(body_fn_cid)
     }
+    fn has_drop_contract(&self, _type_name: &str) -> bool {
+        // No drop-contract discharge memento kind is specified yet
+        // (follow-up to issue #384). Return false so the substrate
+        // refuses composition rather than silently assuming the drop
+        // is effect-free. Wire this to a real index once the
+        // drop-contract memento spec lands under protocol/specs/.
+        false
+    }
 }
 
 /// Result of an implication check.

--- a/implementations/rust/provekit-walk/src/bin/walk_demo.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_demo.rs
@@ -237,6 +237,7 @@ fn effect_summary(effects: &[provekit_walk::contract::Effect]) -> String {
             PinnedReference { target } => format!("pinned_ref({})", target),
             RawPointerProvenance { target, mutable } => format!("raw_ptr({},mutable={})", target, mutable),
             AtomicAccess { target, kind, ordering } => format!("atomic({},{},{:?})", target, kind.as_str(), ordering),
+            Drop { name } => format!("drop({})", name),
         })
         .collect();
     format!("[{}]", parts.join(", "))

--- a/implementations/rust/provekit-walk/src/contract.rs
+++ b/implementations/rust/provekit-walk/src/contract.rs
@@ -132,6 +132,13 @@ pub enum Effect {
         kind: AtomicKind,
         ordering: Option<String>,
     },
+    /// Calls `drop_in_place`. Drops can run user-defined `Drop::drop`,
+    /// allocate, panic, or perform arbitrary side effects. The
+    /// substrate refuses to compose a contract carrying this effect
+    /// without an explicit discharge memento (or the callee's own
+    /// lifted contract, once the drop function body is liftable).
+    /// `name` is the name of the type being dropped.
+    Drop { name: String },
 }
 
 /// Operation class for `Effect::AtomicAccess`.
@@ -218,6 +225,10 @@ impl Effect {
                 }
                 Value::object(fields)
             }
+            Effect::Drop { name } => Value::object([
+                ("kind", Value::string("drop")),
+                ("name", Value::string(name.clone())),
+            ]),
         }
     }
 
@@ -250,6 +261,7 @@ impl Effect {
                 kind.as_str(),
                 ordering.as_deref().unwrap_or("")
             ),
+            Effect::Drop { name } => format!("12:drop:{}", name),
         }
     }
 }
@@ -482,6 +494,12 @@ pub trait OpacityMementoLookup {
     fn has_loop_invariant(&self, loop_cid: &str) -> bool;
     fn has_try_branch(&self, try_cid: &str) -> bool;
     fn has_closure_binding(&self, body_fn_cid: &str) -> bool;
+    /// Returns true when the pool contains a contract for the
+    /// type being dropped (i.e., the drop function has been lifted
+    /// and its effects have been reviewed). When false, composition
+    /// is refused — the substrate does not silently assume drops are
+    /// effect-free.
+    fn has_drop_contract(&self, type_name: &str) -> bool;
 }
 
 /// A no-op pool that never has any discharge mementos. Used as the
@@ -491,6 +509,7 @@ impl OpacityMementoLookup for EmptyOpacityPool {
     fn has_loop_invariant(&self, _: &str) -> bool { false }
     fn has_try_branch(&self, _: &str) -> bool { false }
     fn has_closure_binding(&self, _: &str) -> bool { false }
+    fn has_drop_contract(&self, _: &str) -> bool { false }
 }
 
 /// Error returned when composition is refused because an opacity effect
@@ -509,6 +528,7 @@ pub enum OpacityError {
     /// An `Effect::UnresolvedCall { name }` is present. No discharge
     /// memento kind exists yet; composition is always refused.
     UnresolvedCallNotDischarged { name: String },
+    DropNotDischarged { name: String },
 }
 
 impl std::fmt::Display for OpacityError {
@@ -522,6 +542,8 @@ impl std::fmt::Display for OpacityError {
                 write!(f, "opacity: ClosureCapture(bodyFnCid={body_fn_cid}) has no ClosureBindingMemento in pool"),
             Self::UnresolvedCallNotDischarged { name } =>
                 write!(f, "opacity: UnresolvedCall({name}) has no discharge memento kind"),
+            Self::DropNotDischarged { name } =>
+                write!(f, "opacity: Drop({name}) has no lifted drop function in pool"),
         }
     }
 }
@@ -558,6 +580,11 @@ impl EffectSet {
                 }
                 Effect::UnresolvedCall { name } => {
                     return Err(OpacityError::UnresolvedCallNotDischarged { name: name.clone() });
+                }
+                Effect::Drop { name } => {
+                    if !pool.has_drop_contract(name) {
+                        return Err(OpacityError::DropNotDischarged { name: name.clone() });
+                    }
                 }
                 // Non-opacity effects: Reads/Writes/Io/Unsafe/Panics and the
                 // structural type-boundary effects (PinnedReference,
@@ -712,11 +739,13 @@ pub fn compose_function_contracts_checked(
         e,
         Effect::OpaqueLoop { .. } | Effect::EarlyReturn { .. }
         | Effect::ClosureCapture { .. } | Effect::UnresolvedCall { .. }
+        | Effect::Drop { .. }
     ));
     let inner_non_opacity_pure = inner.effects.effects.iter().all(|e| matches!(
         e,
         Effect::OpaqueLoop { .. } | Effect::EarlyReturn { .. }
         | Effect::ClosureCapture { .. } | Effect::UnresolvedCall { .. }
+        | Effect::Drop { .. }
     ));
     if !outer_non_opacity_pure || !inner_non_opacity_pure {
         return Ok(None);
@@ -1474,6 +1503,9 @@ mod tests {
         }
         fn has_closure_binding(&self, body_fn_cid: &str) -> bool {
             self.body_fn_cids.iter().any(|c| c == body_fn_cid)
+        }
+        fn has_drop_contract(&self, _type_name: &str) -> bool {
+            false // no drop contracts in mock pool
         }
     }
 

--- a/implementations/rust/provekit-walk/src/llbc_lift.rs
+++ b/implementations/rust/provekit-walk/src/llbc_lift.rs
@@ -1051,6 +1051,18 @@ fn collect_call_contributions(
         let Some(callee_name) = crate::llbc_calls::fundecl_name_by_id(fun_decls, func_id) else {
             continue;
         };
+
+        // C.10 drop semantics: calls to drop_in_place are treated as opacity
+        // effects rather than ordinary calls. Drops can run user-defined
+        // Drop::drop, allocate, panic, or perform arbitrary side effects.
+        // The substrate refuses composition until a Drop function contract
+        // is present in the pool (or the drop body has been independently
+        // lifted and its contract reviewed).
+        if callee_name == "drop_in_place" {
+            effects.add(Effect::Drop { name: format!("drop:{}", callee_name) });
+            continue;
+        }
+
         let Some(callee) = registry.get(&callee_name) else {
             // Task B: callee name resolved but not in registry -> UnresolvedCall.
             effects.add(Effect::UnresolvedCall { name: callee_name });


### PR DESCRIPTION
Closes C.10 from #384 — drops were silently treated as ordinary calls.

## What changed

- **Effect::Drop { name }** — new opacity-classified effect
- **collect_call_contributions** — detects `drop_in_place` calls and emits `Effect::Drop` instead of attempting composition
- **OpacityMementoLookup** — `has_drop_contract` trait method
- **check_opacity_effects** — refuses composition when `Effect::Drop` is undischarged
- **compose_function_contracts_checked** — Drop is opacity-classified (doesn't block composition after discharge)

## Why opacity-classified

Drops can run user-defined `Drop::drop`, allocate, panic, or perform arbitrary side effects. The substrate must NOT silently assume drops are effect-free. The `Effect::Drop` effect acts as an honest-opacity marker — composition is refused until the pool contains a lifted contract for the drop body.

## Remaining #384 gaps (C.8, C.9, C.11)

Design guidance from issue discussion:

- **C.8 Aliasing** — `Effect::PossibleAliasing { formal_a, formal_b }` + `AliasingMemento { status: Disjoint|MaybeAlias|DefinitelyAlias }`. Auto-mint `Disjoint` for `&mut T` pairs from rustc's borrow checker. Interior-mutability classifier (Cell/RefCell/UnsafeCell walk). ~300 lines.

- **C.9 Outlives** — `Sort::Region` + `Outlives(r1, r2) -> Bool` built-in. Needs design RFC first (substrate kernel rules: reflexivity, transitivity, 'static). ~600 lines + RFC.

- **C.11 Generics Path A** — structural shape dedup post-lift. `PolymorphicContractMemento { shape_cid, instantiations }`. Substrate-side only, zero lifter changes. ~400 lines. Path B (true polymorphic substrate) is paper-track research.