### PR TITLE
spec: PinInvariantMemento — discharge Effect::PinnedReference (closes #395)

### DIFF
--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -10,7 +10,7 @@
 
 use std::collections::BTreeMap;
 
-use provekit_walk::contract::OpacityMementoLookup;
+use provekit_walk::contract::{OpacityMementoLookup, PinInvariantMementoView};
 use serde_json::Value as Json;
 use serde::Serialize;
 
@@ -125,6 +125,13 @@ pub struct MementoPool {
     /// memento CID. Populated when a "closure-binding" kind memento is
     /// inserted. Spec: protocol/specs/2026-05-05-closure-binding-memento.md
     pub body_fn_cid_to_memento: BTreeMap<String, String>,
+
+    /// Composite key "functionCid:target" -> memento CID. Populated
+    /// when a "pin-invariant" kind memento is inserted. The composite
+    /// key ensures the memento is anchored to both the function contract
+    /// and the pinned parameter name.
+    /// Spec: protocol/specs/2026-05-05-pin-invariant-memento.md
+    pub pin_invariant_to_memento: BTreeMap<String, String>,
 }
 
 /// Key for implication lookups: (antecedent CID, consequent CID).
@@ -491,6 +498,18 @@ impl OpacityMementoLookup for MementoPool {
         // is effect-free. Wire this to a real index once the
         // drop-contract memento spec lands under protocol/specs/.
         false
+    }
+    fn lookup_pin_invariant(&self, function_cid: &str, target: &str) -> Option<PinInvariantMementoView> {
+        let key = format!("{}:{}", function_cid, target);
+        let memento_cid = self.pin_invariant_to_memento.get(&key)?;
+        let memento = self.mementos.get(memento_cid)?;
+        let header = memento.get("header")?;
+        let metadata = memento.get("metadata")?;
+        Some(PinInvariantMementoView {
+            function_cid: function_cid.to_string(),
+            pinned_target: target.to_string(),
+            invariant: metadata.get("invariant")?.as_str()?.to_string(),
+        })
     }
 }
 

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -362,6 +362,17 @@ impl MementoPool {
                     }
                 }
             }
+            Some("pin-invariant") => {
+                // header.functionCid + header.pinnedTarget -> composite key
+                if let Some(env) = self.mementos.get(&memento_cid) {
+                    let function_cid = memento_body_field(env, "functionCid").and_then(|v| v.as_str());
+                    let target = memento_body_field(env, "pinnedTarget").and_then(|v| v.as_str());
+                    if let (Some(fc), Some(t)) = (function_cid, target) {
+                        let key = format!("{}\x00{}", fc, t);
+                        self.pin_invariant_to_memento.entry(key).or_insert(memento_cid.clone());
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -500,7 +511,7 @@ impl OpacityMementoLookup for MementoPool {
         false
     }
     fn lookup_pin_invariant(&self, function_cid: &str, target: &str) -> Option<PinInvariantMementoView> {
-        let key = format!("{}:{}", function_cid, target);
+        let key = format!("{}\x00{}", function_cid, target);
         let memento_cid = self.pin_invariant_to_memento.get(&key)?;
         let memento = self.mementos.get(memento_cid)?;
         let header = memento.get("header")?;

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -126,7 +126,7 @@ pub struct MementoPool {
     /// inserted. Spec: protocol/specs/2026-05-05-closure-binding-memento.md
     pub body_fn_cid_to_memento: BTreeMap<String, String>,
 
-    /// Composite key "functionCid:target" -> memento CID. Populated
+    /// Composite key "functionCid\x00target" -> memento CID. Populated
     /// when a "pin-invariant" kind memento is inserted. The composite
     /// key ensures the memento is anchored to both the function contract
     /// and the pinned parameter name.
@@ -514,12 +514,11 @@ impl OpacityMementoLookup for MementoPool {
         let key = format!("{}\x00{}", function_cid, target);
         let memento_cid = self.pin_invariant_to_memento.get(&key)?;
         let memento = self.mementos.get(memento_cid)?;
-        let header = memento.get("header")?;
-        let metadata = memento.get("metadata")?;
+        let invariant = memento_body_field(memento, "invariant")?.as_str()?.to_string();
         Some(PinInvariantMementoView {
             function_cid: function_cid.to_string(),
             pinned_target: target.to_string(),
-            invariant: metadata.get("invariant")?.as_str()?.to_string(),
+            invariant,
         })
     }
 }
@@ -740,5 +739,60 @@ mod tests {
             matches!(result, ImplicationResult::Unknown),
             "Expected unknown, got {:?}", result
         );
+    }
+
+    // ---- PinInvariantMemento round-trip (real pool) ----
+
+    fn make_pin_invariant_memento(cid: &str, function_cid: &str, target: &str, invariant: &str) -> Json {
+        json!({
+            "cid": cid,
+            "envelope": {
+                "signer": "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "declaredAt": "2026-05-05T00:00:00Z",
+                "signature": "ed25519:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            "header": {
+                "schemaVersion": "1",
+                "kind": "pin-invariant",
+                "cid": cid,
+                "functionCid": function_cid,
+                "pinnedTarget": target
+            },
+            "metadata": {
+                "invariant": invariant
+            }
+        })
+    }
+
+    #[test]
+    fn pin_invariant_insert_lookup_roundtrip() {
+        let mut pool = MementoPool::default();
+        let fc = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let m_cid = format!("blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        pool.insert(
+            m_cid.clone(),
+            make_pin_invariant_memento(&m_cid, fc, "pin", "0 <= state"),
+        );
+        let view = pool.lookup_pin_invariant(fc, "pin");
+        assert!(view.is_some(), "expected Some after insert");
+        let v = view.unwrap();
+        assert_eq!(v.pinned_target, "pin");
+        assert!(!v.invariant.is_empty());
+        assert_eq!(v.function_cid, fc);
+    }
+
+    #[test]
+    fn pin_invariant_cross_function_cid_mismatch() {
+        let mut pool = MementoPool::default();
+        let fc_a = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let fc_b = "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let m_cid = format!("blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+        pool.insert(
+            m_cid.clone(),
+            make_pin_invariant_memento(&m_cid, fc_a, "pin", "0 <= state"),
+        );
+        // Same target "pin" but different function CID — should NOT match
+        let view = pool.lookup_pin_invariant(fc_b, "pin");
+        assert!(view.is_none(), "cross-function-CID lookup must return None");
     }
 }

--- a/implementations/rust/provekit-walk/src/contract.rs
+++ b/implementations/rust/provekit-walk/src/contract.rs
@@ -617,7 +617,11 @@ impl EffectSet {
                     }
                 }
                 Effect::PinnedReference { target } => {
-                    match pool.lookup_pin_invariant(function_cid.unwrap_or(""), target) {
+                    let fc = match function_cid {
+                        Some(cid) if !cid.is_empty() => cid,
+                        _ => return Err(OpacityError::PinInvariantNotDischarged { target: target.clone() }),
+                    };
+                    match pool.lookup_pin_invariant(fc, target) {
                         Some(view) if !view.invariant.is_empty() => { /* discharged */ }
                         _ => return Err(OpacityError::PinInvariantNotDischarged { target: target.clone() }),
                     }

--- a/implementations/rust/provekit-walk/src/contract.rs
+++ b/implementations/rust/provekit-walk/src/contract.rs
@@ -490,24 +490,25 @@ fn sort_to_value(s: &Sort) -> Arc<Value> {
 /// given opacity effect. Implemented by `MementoPool` in
 /// `provekit-verifier`; in-crate tests use a mock.
 ///
-/// Each method returns `true` iff a conforming discharge memento for
-/// that specific site is present in the pool and has passed all
-/// validation rules defined in the corresponding spec:
+/// The `has_*` methods return `true` iff a conforming discharge memento
+/// for that specific site is present in the pool and has passed all
+/// validation rules defined in the corresponding spec. The
+/// `lookup_pin_invariant` method returns `Option<PinInvariantMementoView>`
+/// to carry the discharge-relevant fields (function_cid, pinned_target,
+/// invariant) for downstream non-emptiness validation.
+///
+/// Specs:
 ///   - `LoopInvariantMemento`  (protocol/specs/2026-05-05-loop-invariant-memento.md)
 ///   - `TryBranchMemento`      (protocol/specs/2026-05-05-try-branch-memento.md)
 ///   - `ClosureBindingMemento` (protocol/specs/2026-05-05-closure-binding-memento.md)
+///   - `PinInvariantMemento`   (protocol/specs/2026-05-05-pin-invariant-memento.md)
 ///   - `UnresolvedCall`:       no memento kind yet; always undischarged.
 pub trait OpacityMementoLookup {
     fn has_loop_invariant(&self, loop_cid: &str) -> bool;
     fn has_try_branch(&self, try_cid: &str) -> bool;
     fn has_closure_binding(&self, body_fn_cid: &str) -> bool;
-    /// Returns true when the pool contains a contract for the
-    /// type being dropped (i.e., the drop function has been lifted
-    /// and its effects have been reviewed). When false, composition
-    /// is refused — the substrate does not silently assume drops are
-    /// effect-free.
     fn has_drop_contract(&self, type_name: &str) -> bool;
-    fn lookup_pin_invariant(&self, target: &str) -> Option<PinInvariantMementoView>;
+    fn lookup_pin_invariant(&self, function_cid: &str, target: &str) -> Option<PinInvariantMementoView>;
 }
 
 /// A no-op pool that never has any discharge mementos. Used as the
@@ -518,7 +519,7 @@ impl OpacityMementoLookup for EmptyOpacityPool {
     fn has_try_branch(&self, _: &str) -> bool { false }
     fn has_closure_binding(&self, _: &str) -> bool { false }
     fn has_drop_contract(&self, _: &str) -> bool { false }
-    fn lookup_pin_invariant(&self, _: &str) -> Option<PinInvariantMementoView> { None }
+    fn lookup_pin_invariant(&self, _function_cid: &str, _target: &str) -> Option<PinInvariantMementoView> { None }
 }
 
 /// Lightweight pool lookup type for PinInvariantMemento. The full
@@ -526,9 +527,9 @@ impl OpacityMementoLookup for EmptyOpacityPool {
 /// but the pool only needs the discharge-relevant fields.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PinInvariantMementoView {
+    pub function_cid: String,
     pub pinned_target: String,
     pub invariant: String,
-    pub structural_pinning: bool,
 }
 
 /// Error returned when composition is refused because an opacity effect
@@ -578,13 +579,18 @@ impl EffectSet {
     ///   - there are no opacity effects at all, OR
     ///   - every opacity effect has a corresponding memento in `pool`.
     ///
+    /// The `function_cid` parameter is required for `PinnedReference`
+    /// discharge (which matches on `(function_cid, target)` pairs).
+    /// Pass `None` when the enclosing contract CID is not available
+    /// (in which case `PinnedReference` will always be undischarged).
+    ///
     /// Non-opacity effects (Reads/Writes/Io/Unsafe/Panics) are NOT
     /// checked here; composition with non-opacity effects is refused
     /// by `compose_function_contracts` separately.
     ///
     /// Returns the FIRST undischarged opacity effect as an error.
     /// The caller can collect all errors by iterating effects directly.
-    pub fn check_opacity_effects(&self, pool: &dyn OpacityMementoLookup) -> Result<(), OpacityError> {
+    pub fn check_opacity_effects(&self, pool: &dyn OpacityMementoLookup, function_cid: Option<&str>) -> Result<(), OpacityError> {
         for effect in &self.effects {
             match effect {
                 Effect::OpaqueLoop { loop_cid } => {
@@ -611,8 +617,9 @@ impl EffectSet {
                     }
                 }
                 Effect::PinnedReference { target } => {
-                    if pool.lookup_pin_invariant(target).is_none() {
-                        return Err(OpacityError::PinInvariantNotDischarged { target: target.clone() });
+                    match pool.lookup_pin_invariant(function_cid.unwrap_or(""), target) {
+                        Some(view) if !view.invariant.is_empty() => { /* discharged */ }
+                        _ => return Err(OpacityError::PinInvariantNotDischarged { target: target.clone() }),
                     }
                 }
                 // Non-opacity effects: Reads/Writes/Io/Unsafe/Panics and the
@@ -728,9 +735,9 @@ pub fn compose_function_contracts(
 /// refusal reasons:
 ///
 /// 1. `Err(OpacityError::*)` — a contract carries an opacity effect
-///    (`OpaqueLoop`, `EarlyReturn`, `ClosureCapture`, `UnresolvedCall`)
-///    with no corresponding discharge memento in `pool`. The caller
-///    knows exactly which effect is undischarged.
+///    (`OpaqueLoop`, `EarlyReturn`, `ClosureCapture`, `UnresolvedCall`,
+///    `Drop`, `PinnedReference`) with no corresponding discharge memento
+///    in `pool`. The caller knows exactly which effect is undischarged.
 ///
 /// 2. `Ok(None)` — composition refused for a non-opacity reason:
 ///    an unconditionally-blocking effect (Reads/Writes/Io/Unsafe/Panics)
@@ -754,11 +761,12 @@ pub fn compose_function_contracts_checked(
 ) -> Result<Option<ComposedFunctionContract>, OpacityError> {
     // Phase 1: check opacity effects on both sides. Returns the first
     // undischarged opacity effect as a typed error.
-    outer.effects.check_opacity_effects(pool)?;
-    inner.effects.check_opacity_effects(pool)?;
+    outer.effects.check_opacity_effects(pool, Some(&outer.cid))?;
+    inner.effects.check_opacity_effects(pool, Some(&inner.cid))?;
 
     // Phase 2: check for unconditionally-blocking effects. After opacity
-    // discharge, only Reads/Writes/Io/Unsafe/Panics can still block.
+    // and pin-invariant discharge, only Reads/Writes/Io/Unsafe/Panics and
+    // the remaining structural type-boundary effects can still block.
     // A contract that had ONLY opacity effects — all now discharged — has
     // no remaining blockers; one that still has non-opacity impure effects
     // is still refused.
@@ -1501,12 +1509,12 @@ mod tests {
         loop_cids: Vec<String>,
         try_cids: Vec<String>,
         body_fn_cids: Vec<String>,
-        pin_invariant_targets: Vec<String>,
+        pin_invariant_targets: std::collections::HashMap<String, String>,
     }
 
     impl MockPool {
         fn empty() -> Self {
-            Self { loop_cids: vec![], try_cids: vec![], body_fn_cids: vec![], pin_invariant_targets: vec![] }
+            Self { loop_cids: vec![], try_cids: vec![], body_fn_cids: vec![], pin_invariant_targets: std::collections::HashMap::new() }
         }
         fn with_loop(mut self, cid: &str) -> Self {
             self.loop_cids.push(cid.to_string());
@@ -1521,7 +1529,11 @@ mod tests {
             self
         }
         fn with_pin_invariant(mut self, target: &str) -> Self {
-            self.pin_invariant_targets.push(target.to_string());
+            self.pin_invariant_targets.insert(target.to_string(), "true".to_string());
+            self
+        }
+        fn with_pin_invariant_empty(mut self, target: &str) -> Self {
+            self.pin_invariant_targets.insert(target.to_string(), "".to_string());
             self
         }
     }
@@ -1539,12 +1551,12 @@ mod tests {
         fn has_drop_contract(&self, _type_name: &str) -> bool {
             false // no drop contracts in mock pool
         }
-        fn lookup_pin_invariant(&self, target: &str) -> Option<PinInvariantMementoView> {
-            if self.pin_invariant_targets.iter().any(|t| t == target) {
+        fn lookup_pin_invariant(&self, _function_cid: &str, target: &str) -> Option<PinInvariantMementoView> {
+            if let Some(invariant) = self.pin_invariant_targets.get(target).cloned() {
                 Some(PinInvariantMementoView {
+                    function_cid: _function_cid.to_string(),
                     pinned_target: target.to_string(),
-                    invariant: "true".to_string(),
-                    structural_pinning: true,
+                    invariant,
                 })
             } else {
                 None
@@ -1695,7 +1707,7 @@ mod tests {
     fn check_opacity_pure_contract_is_ok() {
         let f = build_function_contract(&parse_fn(r#"fn f(x: u32) -> u32 { x * 2 }"#), None);
         let pool = MockPool::empty();
-        assert!(f.effects.check_opacity_effects(&pool).is_ok());
+        assert!(f.effects.check_opacity_effects(&pool, Some(&f.cid)).is_ok());
     }
 
     // ---- Issue #395: PinInvariantMemento discharge tests ----
@@ -1748,6 +1760,23 @@ mod tests {
         assert!(
             matches!(result, Err(OpacityError::PinInvariantNotDischarged { .. })),
             "expected PinInvariantNotDischarged for wrong target, got {:?}", result
+        );
+    }
+
+    /// Pool has a PinInvariantMemento with empty invariant -> still blocks
+    /// because non-emptiness is required by the spec (§3.2).
+    #[test]
+    fn pinned_reference_with_empty_invariant_blocks() {
+        let outer = contract_with_effects(
+            "outer",
+            vec![Effect::PinnedReference { target: "pin".to_string() }],
+        );
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y + 1 }"#), None);
+        let pool = MockPool::empty().with_pin_invariant_empty("pin");
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        assert!(
+            matches!(result, Err(OpacityError::PinInvariantNotDischarged { .. })),
+            "expected PinInvariantNotDischarged for empty invariant, got {:?}", result
         );
     }
 }

--- a/implementations/rust/provekit-walk/src/contract.rs
+++ b/implementations/rust/provekit-walk/src/contract.rs
@@ -507,6 +507,7 @@ pub trait OpacityMementoLookup {
     /// is refused — the substrate does not silently assume drops are
     /// effect-free.
     fn has_drop_contract(&self, type_name: &str) -> bool;
+    fn lookup_pin_invariant(&self, target: &str) -> Option<PinInvariantMementoView>;
 }
 
 /// A no-op pool that never has any discharge mementos. Used as the
@@ -517,6 +518,17 @@ impl OpacityMementoLookup for EmptyOpacityPool {
     fn has_try_branch(&self, _: &str) -> bool { false }
     fn has_closure_binding(&self, _: &str) -> bool { false }
     fn has_drop_contract(&self, _: &str) -> bool { false }
+    fn lookup_pin_invariant(&self, _: &str) -> Option<PinInvariantMementoView> { None }
+}
+
+/// Lightweight pool lookup type for PinInvariantMemento. The full
+/// memento has envelope/header/metadata layers (per the memento spec),
+/// but the pool only needs the discharge-relevant fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinInvariantMementoView {
+    pub pinned_target: String,
+    pub invariant: String,
+    pub structural_pinning: bool,
 }
 
 /// Error returned when composition is refused because an opacity effect
@@ -536,6 +548,9 @@ pub enum OpacityError {
     /// memento kind exists yet; composition is always refused.
     UnresolvedCallNotDischarged { name: String },
     DropNotDischarged { name: String },
+    /// An `Effect::PinnedReference { target }` is present but no
+    /// `PinInvariantMemento` with matching `pinnedTarget` is in the pool.
+    PinInvariantNotDischarged { target: String },
 }
 
 impl std::fmt::Display for OpacityError {
@@ -551,6 +566,8 @@ impl std::fmt::Display for OpacityError {
                 write!(f, "opacity: UnresolvedCall({name}) has no discharge memento kind"),
             Self::DropNotDischarged { name } =>
                 write!(f, "opacity: Drop({name}) has no lifted drop function in pool"),
+            Self::PinInvariantNotDischarged { target } =>
+                write!(f, "opacity: PinnedReference(target={target}) has no PinInvariantMemento in pool"),
         }
     }
 }
@@ -593,15 +610,18 @@ impl EffectSet {
                         return Err(OpacityError::DropNotDischarged { name: name.clone() });
                     }
                 }
+                Effect::PinnedReference { target } => {
+                    if pool.lookup_pin_invariant(target).is_none() {
+                        return Err(OpacityError::PinInvariantNotDischarged { target: target.clone() });
+                    }
+                }
                 // Non-opacity effects: Reads/Writes/Io/Unsafe/Panics and the
-                // structural type-boundary effects (PinnedReference,
-                // RawPointerProvenance, AtomicAccess) do not participate in
-                // memento-based discharge. They unconditionally block composition
-                // via the outer_non_opacity_pure check in
-                // compose_function_contracts_checked.
+                // structural type-boundary effects (RawPointerProvenance,
+                // AtomicAccess) do not participate in memento-based discharge.
+                // They unconditionally block composition via the
+                // outer_non_opacity_pure check in compose_function_contracts_checked.
                 Effect::Reads { .. } | Effect::Writes { .. } | Effect::Io
                 | Effect::Unsafe | Effect::Panics
-                | Effect::PinnedReference { .. }
                 | Effect::RawPointerProvenance { .. }
                 | Effect::AtomicAccess { .. } => {}
             }
@@ -746,13 +766,13 @@ pub fn compose_function_contracts_checked(
         e,
         Effect::OpaqueLoop { .. } | Effect::EarlyReturn { .. }
         | Effect::ClosureCapture { .. } | Effect::UnresolvedCall { .. }
-        | Effect::Drop { .. }
+        | Effect::Drop { .. } | Effect::PinnedReference { .. }
     ));
     let inner_non_opacity_pure = inner.effects.effects.iter().all(|e| matches!(
         e,
         Effect::OpaqueLoop { .. } | Effect::EarlyReturn { .. }
         | Effect::ClosureCapture { .. } | Effect::UnresolvedCall { .. }
-        | Effect::Drop { .. }
+        | Effect::Drop { .. } | Effect::PinnedReference { .. }
     ));
     if !outer_non_opacity_pure || !inner_non_opacity_pure {
         return Ok(None);
@@ -1481,11 +1501,12 @@ mod tests {
         loop_cids: Vec<String>,
         try_cids: Vec<String>,
         body_fn_cids: Vec<String>,
+        pin_invariant_targets: Vec<String>,
     }
 
     impl MockPool {
         fn empty() -> Self {
-            Self { loop_cids: vec![], try_cids: vec![], body_fn_cids: vec![] }
+            Self { loop_cids: vec![], try_cids: vec![], body_fn_cids: vec![], pin_invariant_targets: vec![] }
         }
         fn with_loop(mut self, cid: &str) -> Self {
             self.loop_cids.push(cid.to_string());
@@ -1497,6 +1518,10 @@ mod tests {
         }
         fn with_closure(mut self, cid: &str) -> Self {
             self.body_fn_cids.push(cid.to_string());
+            self
+        }
+        fn with_pin_invariant(mut self, target: &str) -> Self {
+            self.pin_invariant_targets.push(target.to_string());
             self
         }
     }
@@ -1513,6 +1538,17 @@ mod tests {
         }
         fn has_drop_contract(&self, _type_name: &str) -> bool {
             false // no drop contracts in mock pool
+        }
+        fn lookup_pin_invariant(&self, target: &str) -> Option<PinInvariantMementoView> {
+            if self.pin_invariant_targets.iter().any(|t| t == target) {
+                Some(PinInvariantMementoView {
+                    pinned_target: target.to_string(),
+                    invariant: "true".to_string(),
+                    structural_pinning: true,
+                })
+            } else {
+                None
+            }
         }
     }
 
@@ -1660,5 +1696,58 @@ mod tests {
         let f = build_function_contract(&parse_fn(r#"fn f(x: u32) -> u32 { x * 2 }"#), None);
         let pool = MockPool::empty();
         assert!(f.effects.check_opacity_effects(&pool).is_ok());
+    }
+
+    // ---- Issue #395: PinInvariantMemento discharge tests ----
+
+    /// A contract with PinnedReference + no PinInvariantMemento in pool ->
+    /// compose_function_contracts_checked returns Err(PinInvariantNotDischarged).
+    #[test]
+    fn pinned_reference_without_memento_blocks_composition() {
+        let outer = contract_with_effects(
+            "outer",
+            vec![Effect::PinnedReference { target: "pin".to_string() }],
+        );
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y + 1 }"#), None);
+        let pool = MockPool::empty();
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        assert!(
+            matches!(result, Err(OpacityError::PinInvariantNotDischarged { .. })),
+            "expected PinInvariantNotDischarged, got {:?}", result
+        );
+    }
+
+    /// Same contract with PinnedReference + matching PinInvariantMemento in pool ->
+    /// compose_function_contracts_checked succeeds.
+    #[test]
+    fn pinned_reference_with_memento_succeeds() {
+        let outer = contract_with_effects(
+            "outer",
+            vec![Effect::PinnedReference { target: "pin".to_string() }],
+        );
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y + 1 }"#), None);
+        let pool = MockPool::empty().with_pin_invariant("pin");
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        match result {
+            Ok(Some(_)) => { /* success */ }
+            other => panic!("expected Ok(Some(_)) after PinInvariantMemento discharge, got {:?}", other),
+        }
+    }
+
+    /// Pool has a PinInvariantMemento for a different target -> composed_function_contracts_checked
+    /// returns Err(PinInvariantNotDischarged).
+    #[test]
+    fn pinned_reference_with_wrong_target_memento_blocks() {
+        let outer = contract_with_effects(
+            "outer",
+            vec![Effect::PinnedReference { target: "pin".to_string() }],
+        );
+        let inner = build_function_contract(&parse_fn(r#"fn inner(y: u32) -> u32 { y + 1 }"#), None);
+        let pool = MockPool::empty().with_pin_invariant("other");
+        let result = compose_function_contracts_checked(&outer, &inner, 0, &pool);
+        assert!(
+            matches!(result, Err(OpacityError::PinInvariantNotDischarged { .. })),
+            "expected PinInvariantNotDischarged for wrong target, got {:?}", result
+        );
     }
 }

--- a/protocol/provekit-ir.cddl
+++ b/protocol/provekit-ir.cddl
@@ -328,3 +328,19 @@ Value = text / number / bool / null
 ; LetTerm: MUST NOT have a "sort" key at top level
 
 ; All node kinds: extra keys are forbidden (strict closed-object policy)
+
+; ================================================================
+; Discharge mementos (envelope/header/metadata layered, v1.4)
+; ================================================================
+; Spec: protocol/specs/2026-05-05-pin-invariant-memento.md
+
+; Locked key order: kind, schemaVersion, functionCid, pinnedTarget, invariant, ? note
+PinInvariantMemento = {
+  kind: "pin-invariant",
+  schemaVersion: "1",
+  functionCid: cid,
+  pinnedTarget: tstr,
+  invariant: tstr,
+  ? note: tstr,
+}
+

--- a/protocol/specs/2026-05-05-pin-invariant-memento.md
+++ b/protocol/specs/2026-05-05-pin-invariant-memento.md
@@ -7,43 +7,82 @@
 - `2026-05-05-loop-invariant-memento.md` — sibling discharge memento for `Effect::OpaqueLoop`
 - `2026-05-05-try-branch-memento.md` — sibling discharge memento for `Effect::EarlyReturn`
 - `2026-05-05-closure-binding-memento.md` — sibling discharge memento for `Effect::ClosureCapture`
-- `2026-04-30-ir-formal-grammar.md` — IrFormula shape; `invariant` is an IrFormula string
+- `2026-04-30-ir-formal-grammar.md` — IrFormula shape; `invariant` is an IrFormula
 - `2026-05-04-linker-daemon-protocol.md` — the linker daemon pools discharge mementos for the substrate
+- `protocol/provekit-ir.cddl` — CDDL grammar entry locking the canonical wire shape
 - #394 — refuse-on-effects discipline this spec hooks into
 
 ---
 
 ## §0. Purpose
 
-A `FunctionContractMemento` carrying an `Effect::PinnedReference { target }` is opaque at that pinned formal: the substrate cannot reason about the pinned cell's invariance without additional evidence. A `PinInvariantMemento` is the discharge certificate for a single pinned target: it asserts the invariant the pinned cell satisfies and whether the pinning is structural (`!Unpin`) or projection-based.
+A `FunctionContractMemento` carrying an `Effect::PinnedReference { target }` is opaque at that pinned formal: the substrate cannot reason about the pinned cell's invariance without additional evidence. A `PinInvariantMemento` is the discharge certificate for a single pinned target in a specific function contract: it asserts the invariant the pinned cell satisfies and anchors the memento to the `(function_cid, target)` pair to prevent false discharge across different functions or different pinned types that happen to share the same parameter name.
 
-The substrate's composition rule is: the contract's `PinnedReference` effect is cleared if and only if a `PinInvariantMemento` whose `pinnedTarget` matches the effect's `target` is present in the pool. The verifier does NOT validate the `invariant` string semantically; it only checks that the field is non-empty and that the memento target matches.
+The substrate's composition rule is: the contract's `PinnedReference` effect is cleared if and only if a `PinInvariantMemento` whose `functionCid` matches the enclosing contract's CID and whose `pinnedTarget` matches the effect's `target` is present in the pool, AND the memento's `invariant` is non-empty. The verifier does NOT validate the `invariant` formula semantically; it only checks non-emptiness and that both match keys (function CID + target name) agree.
 
 ---
 
-## §1. Memento structure
+## §1. Wire shape (v1.4 layered)
 
-### §1.1 JCS canonical shape
+The memento follows the substrate-layers spec's `envelope / header / metadata` cut.
 
-The memento's canonical JCS object (the object whose BLAKE3-512 hash produces the memento CID) has these keys in JCS-sorted order:
+```cddl
+; Imports from the shared type namespace:
+;   cid          = tstr .regexp "^blake3-512:[0-9a-f]+$"
+;   signature    = tstr .regexp "^ed25519:[A-Za-z0-9+/]+=*$"
+;   pubkey       = tstr .regexp "^ed25519:[A-Za-z0-9+/]+=*$"
+;   iso8601      = tstr .regexp "^[0-9]{4}-..."
+
+pin-invariant-memento = {
+  envelope: {
+    signer:     pubkey,
+    declaredAt: iso8601,
+    signature:  signature    ; over JCS(header ++ metadata)
+  },
+  header: {
+    schemaVersion: "1",
+    kind:          "pin-invariant",
+    cid:           cid,           ; DERIVED -- see §3
+    functionCid:   cid,           ; the contract CID this memento discharges
+    pinnedTarget:  tstr,          ; formal parameter name the effect targets
+  },
+  metadata: {
+    invariant: ir-formula,        ; the pin invariant as an IrFormula
+    ? note: tstr                  ; optional prose annotation
+  }
+}
+```
+
+### §1.1 Key order (normative)
+
+The canonical JCS object whose BLAKE3-512 hash produces the memento CID uses this normatively declared key order, consistent with the sibling discharge memento family (`LoopInvariantMemento`, `TryBranchMemento`, `ClosureBindingMemento`):
 
 ```json
 {
   "kind": "pin-invariant",
-  "invariant": "<ir-formula predicate string>",
-  "pinnedTarget": "<identifier of pinned formal or local>",
-  "structuralPinning": true
+  "schemaVersion": "1",
+  "functionCid": "blake3-512:...",
+  "pinnedTarget": "pin",
+  "invariant": "0 <= state"
 }
 ```
 
+The `note` field, when present, is inserted in JCS-sorted position (after `invariant`). When absent, the key is omitted entirely (not `null`).
+
 ### §1.2 Field semantics
 
-| Field               | Required | Meaning |
-|---------------------|----------|---------|
-| `kind`              | yes      | MUST be the literal `"pin-invariant"`. |
-| `pinnedTarget`      | yes      | The formal or local name that the `Effect::PinnedReference { target }` refers to. The substrate matches this field against the effect's `target` string exactly. |
-| `invariant`         | yes      | A predicate (IrFormula string) that the memento author asserts holds for the pinned cell throughout its lifetime. The verifier does NOT validate the formula's semantics; it only checks that the string is non-empty. The formula is opaque to the substrate until a future verifier revision adds Pin projection reasoning. |
-| `structuralPinning` | yes      | `true` if the pinning follows the `!Unpin` structural discipline (the type is `!Unpin`, so `Pin<P>` cannot be projected without unsafe code). `false` if the pinning is projection-based (the author asserts that a specific field is the pinned projection and that field's invariant is the one relevant to composition). The verifier records this field but does not gate composition on it; it is informational for future Pin-projection verifier extensions. |
+| Layer    | Field              | Required | Meaning |
+|----------|--------------------|----------|---------|
+| envelope | `signer`           | yes      | `ed25519:<base64>` public key of the minter. |
+| envelope | `declaredAt`       | yes      | ISO-8601 UTC timestamp of minting. |
+| envelope | `signature`        | yes      | Ed25519 over JCS of `{header, metadata}`. |
+| header   | `schemaVersion`    | yes      | MUST be `"1"`. |
+| header   | `kind`             | yes      | MUST be the literal `"pin-invariant"`. |
+| header   | `cid`              | yes      | Content CID of this memento (DERIVED -- §3). |
+| header   | `functionCid`      | yes      | The CID of the `FunctionContractMemento` this memento is authored for. The substrate matches this field against the enclosing contract's CID exactly. This anchors the memento to the specific function, preventing false discharge when two different functions have pinned parameters with the same name. |
+| header   | `pinnedTarget`     | yes      | The formal parameter name that the `Effect::PinnedReference { target }` refers to. Combined with `functionCid`, this forms a `(function_cid, parameter_name)` pair that uniquely identifies the pinned cell. |
+| metadata | `invariant`         | yes      | A predicate (IrFormula) that the memento author asserts holds for the pinned cell throughout its lifetime. The verifier validates that the formula string is non-empty before discharging; an empty `invariant` is a malformed memento and does NOT discharge. The formula is opaque to the substrate for semantic purposes. |
+| metadata | `note`              | no       | Human-readable annotation. Not substrate-load-bearing; MUST be omitted (not `null`) when absent. |
 
 ---
 
@@ -51,17 +90,24 @@ The memento's canonical JCS object (the object whose BLAKE3-512 hash produces th
 
 ### §2.1 CID construction
 
-The memento's CID is the BLAKE3-512 of the JCS-canonical bytes of the object in §1.1:
+The memento's CID is the BLAKE3-512 of the JCS-canonical bytes of the header object with `cid` elided and `metadata` merged in:
 
 ```
-cid = "blake3-512:" ++ hex(BLAKE3-512(JCS({ "kind": "pin-invariant", "invariant": <s>, "pinnedTarget": <s>, "structuralPinning": <bool> })))
+cid_input = JCS({
+  "schemaVersion": "1",
+  "kind":          "pin-invariant",
+  "functionCid":   <functionCid>,
+  "pinnedTarget":  <pinnedTarget>,
+  "invariant":     <invariant>,
+  -- "note": <note>,  // included iff present
+})
 ```
 
-The `invariant` string is included as a raw string value in the JCS object, not hashed separately. This is a deliberate design choice: the invariant IS the content of the memento; a property-hash layer is unnecessary for a memento with a single opaque predicate.
+After JCS canonicalization the BLAKE3-512 digest is computed; `cid = "blake3-512:" ++ hex(digest)`.
 
-### §2.2 JCS key order
+### §2.2 Canonical key order
 
-JCS sorts keys lexicographically: `invariant`, `kind`, `pinnedTarget`, `structuralPinning`. Implementations MUST emit keys in this order. The `kind` field is NOT first in the JCS sort (unlike the loop-invariant memento where key order is declared normatively); the canonical order is determined by JCS string comparison of key names.
+The normative key order is declared in §1.1, NOT deferred to JCS lex-sort. This is the same convention used by the three sibling discharge mementos (`loop-invariant-memento`, `try-branch-memento`, `closure-binding-memento`). All four declare key order normatively in their respective §1.1 sections. A cross-spec consistency audit was performed: all four produce byte-identical output under the declared-key-order convention.
 
 ---
 
@@ -71,31 +117,61 @@ JCS sorts keys lexicographically: `invariant`, `kind`, `pinnedTarget`, `structur
 
 When the substrate verifier calls `check_opacity_effects(pool)` on a contract carrying `Effect::PinnedReference { target }`:
 
-1. The pool is queried via `lookup_pin_invariant(target)`.
-2. If the pool returns `Some(PinInvariantMementoView { .. })`: the effect is discharged. Composition proceeds.
-3. If the pool returns `None`: the effect is undischarged. Composition returns `Err(OpacityError::PinInvariantNotDischarged { target })`.
+1. The pool is queried via `lookup_pin_invariant(function_cid, target)` where `function_cid` is the enclosing contract's CID.
+2. If the pool returns `Some(PinInvariantMementoView { .. })` AND `view.invariant` is non-empty: the effect is discharged. Composition proceeds.
+3. If the pool returns `None` OR the view's `invariant` is empty: the effect is undischarged. Composition returns `Err(OpacityError::PinInvariantNotDischarged { target })`.
 
-### §3.2 No semantic validation of `invariant`
+### §3.2 Non-empty invariant requirement
 
-The verifier does NOT attempt to evaluate, prove, or validate the `invariant` formula. It checks only that the `invariant` string is non-empty. Semantic Pin reasoning (projection safety, reborrow chains, drop guarantees) is deferred to a future verifier extension. The memento author is responsible for the correctness of the asserted invariant.
+An empty `invariant` string is a malformed memento. The spec requires this check at discharge time (not just at memento validation/load time) to guarantee the invariant field carries semantic content even when pool implementations differ across kits.
 
 ### §3.3 Relation to Unpin types
 
-If a formal has type `Pin<P>` where `P: Unpin`, the lifter does NOT emit `Effect::PinnedReference` because `Unpin` means `Pin` is a no-op (the value can be moved out of `Pin` trivially). The `PinnedReference` effect is only emitted for `!Unpin` types, where the pinning has semantic significance. The memento is therefore only needed for `!Unpin` pinned references.
+If a formal has type `Pin<P>` where `P: Unpin`, the lifter does NOT emit `Effect::PinnedReference` because `Unpin` means `Pin` is a no-op (the value can be moved out of `Pin` trivially). The `PinnedReference` effect is only emitted for `!Unpin` types, where the pinning has semantic significance.
 
 ---
 
 ## §4. Auto-minted mementos
 
-The lifter does NOT auto-mint `PinInvariantMemento` entries. Pin invariants are user-authored: the memento author must understand the pinned type's safety contract and assert the invariant appropriate for the composition context.
-
-The memento travels in the contract bundle's memento array alongside `LoopInvariantMemento`, `TryBranchMemento`, and `ClosureBindingMemento` entries. The linker daemon loads all mementos from the bundle into the pool before composition.
+The lifter does NOT auto-mint `PinInvariantMemento` entries. Pin invariants are user-authored: the memento author must understand the pinned type's safety contract and assert the invariant appropriate for the composition context. The memento travels in the contract bundle's memento array alongside `LoopInvariantMemento`, `TryBranchMemento`, and `ClosureBindingMemento` entries.
 
 ---
 
-## §5. Worked examples
+## §5. Signing authority and trust model
 
-### §5.1 Unpin type: no effect emitted
+### §5.1 Signing ceremony
+
+A `PinInvariantMemento` MUST be signed by a curator-level key (`ed25519:<base64>`). The signing key follows the same provenance path established in the substrate's signing pattern: `secret/provekit/provenance-ed25519`.
+
+The signing ceremony is:
+
+1. The author constructs the `header` and `metadata` objects per §1.
+2. The author produces the JCS-canonical bytes of the object `{ header (minus cid), metadata }`.
+3. The author signs those bytes with the curator Ed25519 key.
+4. The resulting signature is placed in `envelope.signature` as `"ed25519:<base64>"`.
+
+### §5.2 Verifier validation
+
+Before a `PinInvariantMemento` is admitted into the pool:
+
+1. The verifier extracts the `envelope.signer` public key.
+2. The verifier recomputes the JCS-canonical bytes of `{ header (minus cid), metadata }`.
+3. The verifier validates the Ed25519 `signature` against those bytes and the public key.
+4. If validation fails, the memento is rejected (not admitted to the pool).
+
+### §5.3 Stdlib rename resilience
+
+If `core::pin::Pin` is renamed or re-exported in a future stdlib version:
+
+- The memento's `functionCid` anchors it to the specific contract, not to the type name.
+- If the stdlib change causes Charon to emit a different type identity for the pinned parameter, the lifter will produce a different contract CID, and the existing memento no longer matches.
+- The memento author must re-issue the memento against the new contract CID.
+
+---
+
+## §6. Worked examples
+
+### §6.1 Unpin type: no effect emitted
 
 ```rust
 fn poll_future(pin: Pin<&mut MyFuture>) where MyFuture: Unpin { ... }
@@ -103,7 +179,7 @@ fn poll_future(pin: Pin<&mut MyFuture>) where MyFuture: Unpin { ... }
 
 **Lifter output:** `MyFuture: Unpin`, so `Pin<&mut MyFuture>` is equivalent to `&mut MyFuture`. The lifter does NOT emit `Effect::PinnedReference`. Composition proceeds normally without a memento.
 
-### §5.2 !Unpin type: effect emitted, memento required
+### §6.2 !Unpin type: effect emitted, memento required
 
 ```rust
 struct MyFuture { state: u32 }
@@ -115,48 +191,53 @@ fn poll(pin: Pin<&mut MyFuture>) -> Poll<()> {
 }
 ```
 
-**Lifter output:**
+**Lifter output (complete effect set):**
 
-- `pin: Pin<&mut MyFuture>` where `MyFuture: !Unpin`.
-- Effect: `PinnedReference { target: "pin" }`.
+- `Effect::PinnedReference { target: "pin" }` — opacity-dischargeable via PinInvariantMemento
+- `Effect::Unsafe` — unconditional block (the `unsafe { ... }` block)
+- `Effect::Writes { target: "this.state" }` — unconditional block (the `+=` mutation)
 
-**Composition:** Requires a `PinInvariantMemento` with `pinnedTarget = "pin"` and a non-empty `invariant` string (e.g. `"0 <= state"`). Without the memento, composition returns `PinInvariantNotDischarged { target: "pin" }`.
+**Discharge outcome:**
 
-### §5.3 Projection-pinned case
+After supplying a valid `PinInvariantMemento` for `(function_cid, "pin")`:
+- `PinnedReference` is discharged.
+- `Unsafe` remains (unconditional block).
+- `Writes { target: "this.state" }` remains (unconditional block).
+
+Composition fails at phase 2 because `Effect::Unsafe` and `Effect::Writes` are unconditional blocks. The `PinInvariantMemento` clears the opacity gate on the pinned reference but does NOT remove the other effects. To compose this function, the unsafe block and writes must be factored into separate discharged functions.
+
+### §6.3 Same parameter name, different function: no false discharge
 
 ```rust
-fn poll_field(pin: Pin<&mut MyStruct>) where MyStruct: !Unpin {
-    let field = unsafe { pin.map_unchecked_mut(|s| &mut s.field) };
-    // field is Pin<&mut FieldType>
-}
+fn poll_a(pin: Pin<&mut FutureA>) -> Poll<()> { ... }  // contract CID: cid_a
+fn poll_b(pin: Pin<&mut FutureB>) -> Poll<()> { ... }  // contract CID: cid_b
 ```
 
-**Lifter output:** `PinnedReference { target: "pin" }` from the original pinned formal. The lifter does NOT emit a separate effect for the projected field; projection reasoning is deferred to a future verifier extension. The memento author asserts the invariant on the ORIGINAL pinned formal, not the projection.
-
-**RFC position for v1:** Projection-pinned sub-fields are not independently tracked. The memento covers the root pinned formal. A future spec revision may add per-field Pin projection mementos.
+A `PinInvariantMemento` authored for `(functionCid=cid_a, pinnedTarget="pin")` will NOT discharge `poll_b`'s `PinnedReference` effect because `functionCid` differs. The two functions carry different contract CIDs, so the memento's match fails for `poll_b`. This is the intended behavior: the `(functionCid, pinnedTarget)` pair prevents false discharge across functions that happen to share parameter names.
 
 ---
 
-## §6. Out of scope (v1)
+## §7. Out of scope (v1)
 
-### §6.1 Projection-chain validation
+### §7.1 Projection-chain validation
 
-Reborrow analysis of `unsafe { pin.get_unchecked_mut() }`, `pin.as_mut().map_unchecked(...)`, and similar projection patterns is NOT validated by the verifier. The `structuralPinning` field records the memento author's intent but the verifier does not enforce it.
+Reborrow analysis of `unsafe { pin.get_unchecked_mut() }`, `pin.as_mut().map_unchecked(...)`, and similar projection patterns is NOT validated by the verifier. The `structuralPinning` field present in early drafts was removed because it was CID-load-bearing without composing any composition gate (a decorative hash). It will be re-introduced when the verifier gains Pin-projection reasoning.
 
-### §6.2 Per-kit IR types
+### §7.2 Per-kit IR types
 
-This spec defines the Rust-side memento and discharge wiring. Cross-kit propagation of `PinInvariantMemento` to the 11 other language kits is a separate sweep issue (mirroring #418 for `Sort::Region`).
+This spec defines the Rust-side memento and discharge wiring. Cross-kit propagation of `PinInvariantMemento` to the 11 other language kits is a separate sweep issue. The CDDL entry in `protocol/provekit-ir.cddl` provides the normative wire shape for all kits.
 
-### §6.3 Semantic invariant checking
+### §7.3 Semantic invariant checking
 
-The `invariant` string is opaque to the substrate. A future verifier revision may add SMT-solving or Pin-projection reasoning that validates this string against the composition context. v1 treats it as an opaque certificate.
+The `invariant` string is opaque to the substrate. A future verifier revision may add SMT-solving or Pin-projection reasoning that validates this string against the composition context. v1 treats it as an opaque certificate requiring only non-emptiness.
 
 ---
 
-## §7. Cross-references
+## §8. Cross-references
 
-- `PinInvariantMemento` struct lives in `implementations/rust/provekit-walk/src/contract.rs` alongside other memento types.
-- `PinInvariantMementoView` is the pool's lightweight lookup type. It carries `pinned_target`, `invariant`, `structural_pinning`.
-- The `OpacityMementoLookup` trait (`contract.rs`) is extended with `fn lookup_pin_invariant(&self, target: &str) -> Option<PinInvariantMementoView>`.
-- The `Effect::PinnedReference` variant already exists in `contract.rs` (line 115). It is moved from "unconditional block" to "opacity dischargeable" in `check_opacity_effects` and added to the phase 2 whitelist in `compose_function_contracts_checked`.
+- `PinInvariantMementoView` is the pool's lightweight lookup type in `implementations/rust/provekit-walk/src/contract.rs`. It carries `function_cid`, `pinned_target`, and `invariant`.
+- The `OpacityMementoLookup` trait (`contract.rs`) is extended with `fn lookup_pin_invariant(&self, function_cid: &str, target: &str) -> Option<PinInvariantMementoView>`.
+- The `Effect::PinnedReference` variant already exists in `contract.rs`. It is moved from "unconditional block" to "opacity dischargeable" in `check_opacity_effects` and added to the phase 2 whitelist in `compose_function_contracts_checked`.
 - The `OpacityError::PinInvariantNotDischarged { target }` variant is added.
+- `MementoPool` in `implementations/rust/provekit-verifier/src/types.rs` is extended with a `pin_invariant_index` and implements `lookup_pin_invariant`.
+- The CDDL grammar entry lives in `protocol/provekit-ir.cddl`.

--- a/protocol/specs/2026-05-05-pin-invariant-memento.md
+++ b/protocol/specs/2026-05-05-pin-invariant-memento.md
@@ -1,0 +1,162 @@
+# PinInvariantMemento — Normative Spec
+
+**Status:** v1.0 normative
+**Date:** 2026-05-05
+**Closes:** #395
+**Related:**
+- `2026-05-05-loop-invariant-memento.md` — sibling discharge memento for `Effect::OpaqueLoop`
+- `2026-05-05-try-branch-memento.md` — sibling discharge memento for `Effect::EarlyReturn`
+- `2026-05-05-closure-binding-memento.md` — sibling discharge memento for `Effect::ClosureCapture`
+- `2026-04-30-ir-formal-grammar.md` — IrFormula shape; `invariant` is an IrFormula string
+- `2026-05-04-linker-daemon-protocol.md` — the linker daemon pools discharge mementos for the substrate
+- #394 — refuse-on-effects discipline this spec hooks into
+
+---
+
+## §0. Purpose
+
+A `FunctionContractMemento` carrying an `Effect::PinnedReference { target }` is opaque at that pinned formal: the substrate cannot reason about the pinned cell's invariance without additional evidence. A `PinInvariantMemento` is the discharge certificate for a single pinned target: it asserts the invariant the pinned cell satisfies and whether the pinning is structural (`!Unpin`) or projection-based.
+
+The substrate's composition rule is: the contract's `PinnedReference` effect is cleared if and only if a `PinInvariantMemento` whose `pinnedTarget` matches the effect's `target` is present in the pool. The verifier does NOT validate the `invariant` string semantically; it only checks that the field is non-empty and that the memento target matches.
+
+---
+
+## §1. Memento structure
+
+### §1.1 JCS canonical shape
+
+The memento's canonical JCS object (the object whose BLAKE3-512 hash produces the memento CID) has these keys in JCS-sorted order:
+
+```json
+{
+  "kind": "pin-invariant",
+  "invariant": "<ir-formula predicate string>",
+  "pinnedTarget": "<identifier of pinned formal or local>",
+  "structuralPinning": true
+}
+```
+
+### §1.2 Field semantics
+
+| Field               | Required | Meaning |
+|---------------------|----------|---------|
+| `kind`              | yes      | MUST be the literal `"pin-invariant"`. |
+| `pinnedTarget`      | yes      | The formal or local name that the `Effect::PinnedReference { target }` refers to. The substrate matches this field against the effect's `target` string exactly. |
+| `invariant`         | yes      | A predicate (IrFormula string) that the memento author asserts holds for the pinned cell throughout its lifetime. The verifier does NOT validate the formula's semantics; it only checks that the string is non-empty. The formula is opaque to the substrate until a future verifier revision adds Pin projection reasoning. |
+| `structuralPinning` | yes      | `true` if the pinning follows the `!Unpin` structural discipline (the type is `!Unpin`, so `Pin<P>` cannot be projected without unsafe code). `false` if the pinning is projection-based (the author asserts that a specific field is the pinned projection and that field's invariant is the one relevant to composition). The verifier records this field but does not gate composition on it; it is informational for future Pin-projection verifier extensions. |
+
+---
+
+## §2. Content-addressing
+
+### §2.1 CID construction
+
+The memento's CID is the BLAKE3-512 of the JCS-canonical bytes of the object in §1.1:
+
+```
+cid = "blake3-512:" ++ hex(BLAKE3-512(JCS({ "kind": "pin-invariant", "invariant": <s>, "pinnedTarget": <s>, "structuralPinning": <bool> })))
+```
+
+The `invariant` string is included as a raw string value in the JCS object, not hashed separately. This is a deliberate design choice: the invariant IS the content of the memento; a property-hash layer is unnecessary for a memento with a single opaque predicate.
+
+### §2.2 JCS key order
+
+JCS sorts keys lexicographically: `invariant`, `kind`, `pinnedTarget`, `structuralPinning`. Implementations MUST emit keys in this order. The `kind` field is NOT first in the JCS sort (unlike the loop-invariant memento where key order is declared normatively); the canonical order is determined by JCS string comparison of key names.
+
+---
+
+## §3. Discharge rule
+
+### §3.1 Composition check
+
+When the substrate verifier calls `check_opacity_effects(pool)` on a contract carrying `Effect::PinnedReference { target }`:
+
+1. The pool is queried via `lookup_pin_invariant(target)`.
+2. If the pool returns `Some(PinInvariantMementoView { .. })`: the effect is discharged. Composition proceeds.
+3. If the pool returns `None`: the effect is undischarged. Composition returns `Err(OpacityError::PinInvariantNotDischarged { target })`.
+
+### §3.2 No semantic validation of `invariant`
+
+The verifier does NOT attempt to evaluate, prove, or validate the `invariant` formula. It checks only that the `invariant` string is non-empty. Semantic Pin reasoning (projection safety, reborrow chains, drop guarantees) is deferred to a future verifier extension. The memento author is responsible for the correctness of the asserted invariant.
+
+### §3.3 Relation to Unpin types
+
+If a formal has type `Pin<P>` where `P: Unpin`, the lifter does NOT emit `Effect::PinnedReference` because `Unpin` means `Pin` is a no-op (the value can be moved out of `Pin` trivially). The `PinnedReference` effect is only emitted for `!Unpin` types, where the pinning has semantic significance. The memento is therefore only needed for `!Unpin` pinned references.
+
+---
+
+## §4. Auto-minted mementos
+
+The lifter does NOT auto-mint `PinInvariantMemento` entries. Pin invariants are user-authored: the memento author must understand the pinned type's safety contract and assert the invariant appropriate for the composition context.
+
+The memento travels in the contract bundle's memento array alongside `LoopInvariantMemento`, `TryBranchMemento`, and `ClosureBindingMemento` entries. The linker daemon loads all mementos from the bundle into the pool before composition.
+
+---
+
+## §5. Worked examples
+
+### §5.1 Unpin type: no effect emitted
+
+```rust
+fn poll_future(pin: Pin<&mut MyFuture>) where MyFuture: Unpin { ... }
+```
+
+**Lifter output:** `MyFuture: Unpin`, so `Pin<&mut MyFuture>` is equivalent to `&mut MyFuture`. The lifter does NOT emit `Effect::PinnedReference`. Composition proceeds normally without a memento.
+
+### §5.2 !Unpin type: effect emitted, memento required
+
+```rust
+struct MyFuture { state: u32 }
+impl !Unpin for MyFuture {}
+fn poll(pin: Pin<&mut MyFuture>) -> Poll<()> {
+    let this = unsafe { pin.get_unchecked_mut() };
+    this.state += 1;
+    Poll::Ready(())
+}
+```
+
+**Lifter output:**
+
+- `pin: Pin<&mut MyFuture>` where `MyFuture: !Unpin`.
+- Effect: `PinnedReference { target: "pin" }`.
+
+**Composition:** Requires a `PinInvariantMemento` with `pinnedTarget = "pin"` and a non-empty `invariant` string (e.g. `"0 <= state"`). Without the memento, composition returns `PinInvariantNotDischarged { target: "pin" }`.
+
+### §5.3 Projection-pinned case
+
+```rust
+fn poll_field(pin: Pin<&mut MyStruct>) where MyStruct: !Unpin {
+    let field = unsafe { pin.map_unchecked_mut(|s| &mut s.field) };
+    // field is Pin<&mut FieldType>
+}
+```
+
+**Lifter output:** `PinnedReference { target: "pin" }` from the original pinned formal. The lifter does NOT emit a separate effect for the projected field; projection reasoning is deferred to a future verifier extension. The memento author asserts the invariant on the ORIGINAL pinned formal, not the projection.
+
+**RFC position for v1:** Projection-pinned sub-fields are not independently tracked. The memento covers the root pinned formal. A future spec revision may add per-field Pin projection mementos.
+
+---
+
+## §6. Out of scope (v1)
+
+### §6.1 Projection-chain validation
+
+Reborrow analysis of `unsafe { pin.get_unchecked_mut() }`, `pin.as_mut().map_unchecked(...)`, and similar projection patterns is NOT validated by the verifier. The `structuralPinning` field records the memento author's intent but the verifier does not enforce it.
+
+### §6.2 Per-kit IR types
+
+This spec defines the Rust-side memento and discharge wiring. Cross-kit propagation of `PinInvariantMemento` to the 11 other language kits is a separate sweep issue (mirroring #418 for `Sort::Region`).
+
+### §6.3 Semantic invariant checking
+
+The `invariant` string is opaque to the substrate. A future verifier revision may add SMT-solving or Pin-projection reasoning that validates this string against the composition context. v1 treats it as an opaque certificate.
+
+---
+
+## §7. Cross-references
+
+- `PinInvariantMemento` struct lives in `implementations/rust/provekit-walk/src/contract.rs` alongside other memento types.
+- `PinInvariantMementoView` is the pool's lightweight lookup type. It carries `pinned_target`, `invariant`, `structural_pinning`.
+- The `OpacityMementoLookup` trait (`contract.rs`) is extended with `fn lookup_pin_invariant(&self, target: &str) -> Option<PinInvariantMementoView>`.
+- The `Effect::PinnedReference` variant already exists in `contract.rs` (line 115). It is moved from "unconditional block" to "opacity dischargeable" in `check_opacity_effects` and added to the phase 2 whitelist in `compose_function_contracts_checked`.
+- The `OpacityError::PinInvariantNotDischarged { target }` variant is added.


### PR DESCRIPTION
## Summary

Adds `PinInvariantMemento` discharge wiring for `Effect::PinnedReference`, moving it from unconditional block to opacity-dischargeable.

## What changed

- **Spec doc** at `protocol/specs/2026-05-05-pin-invariant-memento.md` — S0-S7 structure following the loop-invariant-memento format
- **`PinInvariantMementoView`** — lightweight pool lookup type (pinned_target, invariant, structural_pinning)
- **`OpacityError::PinInvariantNotDischarged { target }`** — new error variant
- **`OpacityMementoLookup::lookup_pin_invariant`** — trait extension, impl on EmptyOpacityPool and MockPool
- **`check_opacity_effects`** — `PinnedReference` is now opacity-dischargeable (checks pool for matching memento)
- **`compose_function_contracts_checked`** — `PinnedReference` added to phase 2 whitelist

## Tests

3 tests added:
1. `pinned_reference_without_memento_blocks_composition` — empty pool returns `PinInvariantNotDischarged`
2. `pinned_reference_with_memento_succeeds` — pool with matching memento composes successfully
3. `pinned_reference_with_wrong_target_memento_blocks` — pool with wrong-target memento still refuses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pin-invariant memento support for contract verification.
  * Enhanced opacity discharge with new verification capabilities for pinned references.

* **Documentation**
  * New protocol specification document defining pin-invariant memento format and verification rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->