### PR TITLE
fix: P3 cleanup batch -- JSON escape, WaitForExit, nil-find, skip counter, mkdir, keygen (closes #300)

### DIFF
--- a/implementations/cpp/provekit-lsp-cpp/main.cpp
+++ b/implementations/cpp/provekit-lsp-cpp/main.cpp
@@ -184,9 +184,14 @@ static void send_result(const std::string& id, const std::string& result_json) {
 static void send_error(const std::string& id, int code, const std::string& msg) {
     std::string safe_msg;
     for (char c : msg) {
-        if (c == '"') safe_msg += "\\\"";
-        else if (c == '\\') safe_msg += "\\\\";
-        else safe_msg += c;
+        switch (c) {
+            case '"':  safe_msg += "\\\""; break;
+            case '\\': safe_msg += "\\\\"; break;
+            case '\n': safe_msg += "\\n";  break;
+            case '\r': safe_msg += "\\r";  break;
+            case '\t': safe_msg += "\\t";  break;
+            default:   safe_msg += c;      break;
+        }
     }
     std::cout << "{\"jsonrpc\":\"2.0\",\"id\":" << id
               << ",\"error\":{\"code\":" << code

--- a/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
+++ b/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
@@ -142,6 +142,7 @@ public class LspDaemonProtocolTests
             throw new Exception("Process did not exit within 15000ms");
         }
         var output = await outputTask;
+        await stderrDrain; // drain stderr to avoid unobserved exception
 
         Assert.Equal(0, proc.ExitCode);
 

--- a/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
+++ b/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
@@ -132,7 +132,11 @@ public class LspDaemonProtocolTests
         proc.StandardInput.Close();
 
         var output = proc.StandardOutput.ReadToEnd();
-        proc.WaitForExit(15_000);
+        if (!proc.WaitForExit(15_000))
+        {
+            proc.Kill(entireProcessTree: true);
+            throw new Exception("Process did not exit within 15000ms");
+        }
 
         Assert.Equal(0, proc.ExitCode);
 

--- a/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
+++ b/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
@@ -115,7 +115,7 @@ public class LspDaemonProtocolTests
         return sb.ToString();
     }
 
-    private static List<JsonDocument> RunLsp(string ndjson)
+    private static async Task<List<JsonDocument>> RunLsp(string ndjson)
     {
         var binary = BinaryPath();
         var psi = new ProcessStartInfo(binary, "--rpc")
@@ -131,12 +131,17 @@ public class LspDaemonProtocolTests
         proc.StandardInput.Write(ndjson);
         proc.StandardInput.Close();
 
-        var output = proc.StandardOutput.ReadToEnd();
+        // Drain stdout and stderr asynchronously so the timeout path
+        // is reachable even if the LSP process hangs. Blocking
+        // ReadToEnd() would deadlock before WaitForExit is called.
+        var outputTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrDrain = proc.StandardError.ReadToEndAsync(); // avoid pipe deadlock
         if (!proc.WaitForExit(15_000))
         {
             proc.Kill(entireProcessTree: true);
             throw new Exception("Process did not exit within 15000ms");
         }
+        var output = await outputTask;
 
         Assert.Equal(0, proc.ExitCode);
 
@@ -162,9 +167,9 @@ public class LspDaemonProtocolTests
     // ── Tests ────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Initialize_ReturnsExpectedShape()
+    public async Task Initialize_ReturnsExpectedShape()
     {
-        var responses = RunLsp(BuildSession());
+        var responses = await RunLsp(BuildSession());
         var initResp = FindById(responses, 1);
 
         Assert.True(initResp.TryGetProperty("result", out var result),
@@ -176,9 +181,9 @@ public class LspDaemonProtocolTests
     }
 
     [Fact]
-    public void Parse_DeclarationsIsArray()
+    public async Task Parse_DeclarationsIsArray()
     {
-        var responses = RunLsp(BuildSession());
+        var responses = await RunLsp(BuildSession());
         var parseResp = FindById(responses, 2);
 
         Assert.False(parseResp.TryGetProperty("error", out _),
@@ -188,9 +193,9 @@ public class LspDaemonProtocolTests
     }
 
     [Fact]
-    public void Parse_CallEdgesIsArray()
+    public async Task Parse_CallEdgesIsArray()
     {
-        var responses = RunLsp(BuildSession());
+        var responses = await RunLsp(BuildSession());
         var parseResp = FindById(responses, 2);
 
         Assert.True(parseResp.TryGetProperty("result", out var result));
@@ -198,9 +203,9 @@ public class LspDaemonProtocolTests
     }
 
     [Fact]
-    public void Parse_WarningsIsArray()
+    public async Task Parse_WarningsIsArray()
     {
-        var responses = RunLsp(BuildSession());
+        var responses = await RunLsp(BuildSession());
         var parseResp = FindById(responses, 2);
 
         Assert.True(parseResp.TryGetProperty("result", out var result));
@@ -208,9 +213,9 @@ public class LspDaemonProtocolTests
     }
 
     [Fact]
-    public void Parse_DeclarationsContainContracts()
+    public async Task Parse_DeclarationsContainContracts()
     {
-        var responses = RunLsp(BuildSession());
+        var responses = await RunLsp(BuildSession());
         var parseResp = FindById(responses, 2);
 
         Assert.True(parseResp.TryGetProperty("result", out var result));
@@ -224,9 +229,9 @@ public class LspDaemonProtocolTests
     }
 
     [Fact]
-    public void Parse_DeclarationsHaveNameField()
+    public async Task Parse_DeclarationsHaveNameField()
     {
-        var responses = RunLsp(BuildSession());
+        var responses = await RunLsp(BuildSession());
         var parseResp = FindById(responses, 2);
 
         Assert.True(parseResp.TryGetProperty("result", out var result));
@@ -238,10 +243,10 @@ public class LspDaemonProtocolTests
     }
 
     [Fact]
-    public void Parse_EmptySourceReturnsEmptyArrays()
+    public async Task Parse_EmptySourceReturnsEmptyArrays()
     {
         var ndjson = BuildSession(source: "// no contracts here\n");
-        var responses = RunLsp(ndjson);
+        var responses = await RunLsp(ndjson);
         var parseResp = FindById(responses, 2);
 
         Assert.True(parseResp.TryGetProperty("result", out var result));
@@ -250,11 +255,11 @@ public class LspDaemonProtocolTests
     }
 
     [Fact]
-    public void Parse_ByteDeterminism()
+    public async Task Parse_ByteDeterminism()
     {
         var ndjson = BuildSession();
-        var run1 = RunLsp(ndjson);
-        var run2 = RunLsp(ndjson);
+        var run1 = await RunLsp(ndjson);
+        var run2 = await RunLsp(ndjson);
 
         var parse1 = FindById(run1, 2);
         var parse2 = FindById(run2, 2);
@@ -267,7 +272,7 @@ public class LspDaemonProtocolTests
     }
 
     [Fact]
-    public void Parse_UnknownLanguageParam_IsIgnored()
+    public async Task Parse_UnknownLanguageParam_IsIgnored()
     {
         // The C# plugin ignores unknown params keys; a 'language' field that
         // isn't C# doesn't cause an error (unlike the Python plugin which
@@ -281,7 +286,7 @@ public class LspDaemonProtocolTests
             new { jsonrpc = "2.0", id = 3, method = "shutdown" },
         };
         var ndjson = string.Join("\n", msgs.Select(m => JsonSerializer.Serialize(m))) + "\n";
-        var responses = RunLsp(ndjson);
+        var responses = await RunLsp(ndjson);
         var parseResp = FindById(responses, 2);
         Assert.True(parseResp.TryGetProperty("result", out _),
             "Expected result (not error) when extra 'language' param is present");

--- a/implementations/ruby/test/test_daemon_protocol.rb
+++ b/implementations/ruby/test/test_daemon_protocol.rb
@@ -57,6 +57,7 @@ class TestDaemonProtocol < Minitest::Test
   def test_initialize_response
     responses = run_lsp(build_session)
     init_resp = responses.find { |r| r["id"] == 1 }
+    assert init_resp, "Expected id 1 not found. Available ids: #{responses.map { |r| r['id'] }}"
     result = init_resp["result"]
     assert_equal "provekit-lsp-ruby", result["name"]
     assert_includes result["capabilities"], "parse"
@@ -65,6 +66,7 @@ class TestDaemonProtocol < Minitest::Test
   def test_parse_declarations_is_array
     responses = run_lsp(build_session)
     parse_resp = responses.find { |r| r["id"] == 2 }
+    assert parse_resp, "Expected id 2 not found. Available ids: #{responses.map { |r| r['id'] }}"
     refute_includes parse_resp, "error",
                     "parse returned error: #{parse_resp.inspect}"
     assert_instance_of Array, parse_resp["result"]["declarations"],
@@ -74,6 +76,7 @@ class TestDaemonProtocol < Minitest::Test
   def test_parse_call_edges_is_array
     responses = run_lsp(build_session)
     parse_resp = responses.find { |r| r["id"] == 2 }
+    assert parse_resp, "Expected id 2 not found. Available ids: #{responses.map { |r| r['id'] }}"
     assert_instance_of Array, parse_resp["result"]["callEdges"],
                        "callEdges should be Array, not #{parse_resp["result"]["callEdges"].class}"
   end
@@ -81,6 +84,7 @@ class TestDaemonProtocol < Minitest::Test
   def test_declarations_contain_contracts
     responses = run_lsp(build_session)
     parse_resp = responses.find { |r| r["id"] == 2 }
+    assert parse_resp, "Expected id 2 not found. Available ids: #{responses.map { |r| r['id'] }}"
     decls = parse_resp["result"]["declarations"]
     assert decls.length >= 1,
            "Expected at least one declaration from contract-bearing fixture"
@@ -94,6 +98,7 @@ class TestDaemonProtocol < Minitest::Test
   def test_declarations_have_name_field
     responses = run_lsp(build_session)
     parse_resp = responses.find { |r| r["id"] == 2 }
+    assert parse_resp, "Expected id 2 not found. Available ids: #{responses.map { |r| r['id'] }}"
     parse_resp["result"]["declarations"].each do |d|
       assert d.key?("name"), "declaration missing 'name': #{d.inspect}"
     end
@@ -102,6 +107,7 @@ class TestDaemonProtocol < Minitest::Test
   def test_empty_source_returns_empty_arrays
     responses = run_lsp(build_session(source: "# no contracts here\n"))
     parse_resp = responses.find { |r| r["id"] == 2 }
+    assert parse_resp, "Expected id 2 not found. Available ids: #{responses.map { |r| r['id'] }}"
     result = parse_resp["result"]
     assert_equal [], result["declarations"]
     assert_equal [], result["callEdges"]
@@ -112,7 +118,9 @@ class TestDaemonProtocol < Minitest::Test
     run1 = run_lsp(ndjson)
     run2 = run_lsp(ndjson)
     parse1 = run1.find { |r| r["id"] == 2 }
+    assert parse1, "Expected id 2 not found in run1. Available ids: #{run1.map { |r| r['id'] }}"
     parse2 = run2.find { |r| r["id"] == 2 }
+    assert parse2, "Expected id 2 not found in run2. Available ids: #{run2.map { |r| r['id'] }}"
     assert_equal JSON.generate(parse1.sort.to_h),
                  JSON.generate(parse2.sort.to_h),
                  "parse response is not byte-deterministic across two runs"
@@ -121,6 +129,7 @@ class TestDaemonProtocol < Minitest::Test
   def test_unsupported_language_returns_error
     responses = run_lsp(build_session(source: "fn foo() {}", extra_params: { "language" => "go" }))
     parse_resp = responses.find { |r| r["id"] == 2 }
+    assert parse_resp, "Expected id 2 not found. Available ids: #{responses.map { |r| r['id'] }}"
     assert parse_resp.key?("error"),
            "Expected error for unsupported language, got: #{parse_resp.inspect}"
     assert_equal(-32602, parse_resp["error"]["code"])

--- a/implementations/swift/Sources/LSPTests/main.swift
+++ b/implementations/swift/Sources/LSPTests/main.swift
@@ -16,6 +16,7 @@ import SwiftLifter
 // MARK: - Test framework
 
 nonisolated(unsafe) var passed = 0
+nonisolated(unsafe) var skipped = 0
 nonisolated(unsafe) var failed = 0
 
 func test(_ name: String, block: () -> Bool) {
@@ -294,14 +295,13 @@ if let binaryPath = findLSPBinary() {
     }
 } else {
     print("SKIP: subprocess tests (binary not found; run `swift build` first, then `swift run test-swift-lsp`)")
-    print("PASS: subprocess tests (skipped — binary not yet built)")
-    passed += 1
+    skipped += 1
 }
 
 // MARK: - Result
 
 print("")
-print("Results: \(passed) passed, \(failed) failed")
+print("Results: \(passed) passed, \(skipped) skipped, \(failed) failed")
 if failed > 0 {
     exit(1)
 }

--- a/tools/build-cpp-lsp.sh
+++ b/tools/build-cpp-lsp.sh
@@ -20,6 +20,7 @@ OUT_BIN="$OUT_DIR/provekit-lsp-cpp"
 
 if [ "${1:-}" = "--out" ] && [ -n "${2:-}" ]; then
     OUT_BIN="$2"
+    mkdir -p "$(dirname "$OUT_BIN")"
 fi
 
 CXX="${CXX:-clang++}"

--- a/tools/foundation-keygen/Cargo.lock
+++ b/tools/foundation-keygen/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +210,7 @@ version = "0.1.0"
 dependencies = [
  "provekit-canonicalizer",
  "provekit-proof-envelope",
+ "regex",
  "serde_json",
 ]
 
@@ -321,6 +331,35 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc_version"

--- a/tools/foundation-keygen/Cargo.toml
+++ b/tools/foundation-keygen/Cargo.toml
@@ -58,3 +58,6 @@ path = "src/lib.rs"
 provekit-canonicalizer = { path = "../../implementations/rust/provekit-canonicalizer" }
 provekit-proof-envelope = { path = "../../implementations/rust/provekit-proof-envelope" }
 serde_json = { version = "1", features = ["preserve_order"] }
+
+[dev-dependencies]
+regex = "1"

--- a/tools/foundation-keygen/src/lib.rs
+++ b/tools/foundation-keygen/src/lib.rs
@@ -685,4 +685,27 @@ mod tests {
             &["rust", "go", "cpp", "ts", "csharp", "swift", "java", "python", "ruby", "zig", "c"]
         );
     }
+
+    #[test]
+    fn declared_at_constants_are_pinned_iso8601() {
+        let re = regex::Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$").unwrap();
+        let constants: &[(&str, &str)] = &[
+            ("V1_1_0_DECLARED_AT", V1_1_0_DECLARED_AT),
+            ("V1_2_0_DECLARED_AT", V1_2_0_DECLARED_AT),
+            ("V1_3_0_DECLARED_AT", V1_3_0_DECLARED_AT),
+            ("V1_3_1_DECLARED_AT", V1_3_1_DECLARED_AT),
+            ("V1_4_0_DECLARED_AT", V1_4_0_DECLARED_AT),
+            ("V1_4_1_DECLARED_AT", V1_4_1_DECLARED_AT),
+            ("V1_5_0_DECLARED_AT", V1_5_0_DECLARED_AT),
+            ("V1_6_0_DECLARED_AT", V1_6_0_DECLARED_AT),
+            ("SELF_CONTRACTS_DECLARED_AT_V1_3_1", SELF_CONTRACTS_DECLARED_AT_V1_3_1),
+        ];
+        assert_eq!(constants.len(), 9, "unexpected number of declared_at constants; update this test");
+        for (name, value) in constants {
+            assert!(
+                re.is_match(value),
+                "{name} = \"{value}\" is not a valid ISO 8601 UTC datetime"
+            );
+        }
+    }
 }

--- a/tools/foundation-keygen/src/lib.rs
+++ b/tools/foundation-keygen/src/lib.rs
@@ -688,23 +688,34 @@ mod tests {
 
     #[test]
     fn declared_at_constants_are_pinned_iso8601() {
-        let re = regex::Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$").unwrap();
-        let constants: &[(&str, &str)] = &[
-            ("V1_1_0_DECLARED_AT", V1_1_0_DECLARED_AT),
-            ("V1_2_0_DECLARED_AT", V1_2_0_DECLARED_AT),
-            ("V1_3_0_DECLARED_AT", V1_3_0_DECLARED_AT),
-            ("V1_3_1_DECLARED_AT", V1_3_1_DECLARED_AT),
-            ("V1_4_0_DECLARED_AT", V1_4_0_DECLARED_AT),
-            ("V1_4_1_DECLARED_AT", V1_4_1_DECLARED_AT),
-            ("V1_5_0_DECLARED_AT", V1_5_0_DECLARED_AT),
-            ("V1_6_0_DECLARED_AT", V1_6_0_DECLARED_AT),
-            ("SELF_CONTRACTS_DECLARED_AT_V1_3_1", SELF_CONTRACTS_DECLARED_AT_V1_3_1),
+        // Verify that all declaredAt constants are static ISO-8601 strings,
+        // never a live timestamp from SystemTime::now() or chrono::Utc::now().
+        // Adding a new version must pin the timestamp as a const -- not call
+        // into the clock at runtime -- to keep foundation-keygen output
+        // byte-identical across runs (closes item 6 of #300).
+        let pinned = [
+            V1_1_0_DECLARED_AT,
+            V1_2_0_DECLARED_AT,
+            V1_3_0_DECLARED_AT,
+            V1_3_1_DECLARED_AT,
+            V1_4_0_DECLARED_AT,
+            V1_4_1_DECLARED_AT,
+            V1_5_0_DECLARED_AT,
+            V1_6_0_DECLARED_AT,
+            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
         ];
-        assert_eq!(constants.len(), 9, "unexpected number of declared_at constants; update this test");
-        for (name, value) in constants {
+        for ts in &pinned {
+            // Must match ISO-8601 UTC shape: YYYY-MM-DDTHH:MM:SSZ (exactly 20 bytes)
+            let ts_bytes = ts.as_bytes();
             assert!(
-                re.is_match(value),
-                "{name} = \"{value}\" is not a valid ISO 8601 UTC datetime"
+                ts.len() == 20
+                    && ts.ends_with('Z')
+                    && ts_bytes[4] == b'-'
+                    && ts_bytes[7] == b'-'
+                    && ts_bytes[10] == b'T'
+                    && ts_bytes[13] == b':'
+                    && ts_bytes[16] == b':',
+                "declaredAt constant must be exactly YYYY-MM-DDTHH:MM:SSZ (20 bytes), got: {ts}"
             );
         }
     }


### PR DESCRIPTION
Six independent hygiene fixes deferred from PR #165.

1. **cpp JSON escape** (main.cpp send_error): Add missing backslash-n, backslash-r, backslash-t escapes. Round-trip is now lossless.

2. **csharp WaitForExit** (LspDaemonProtocolTests.cs): Check return value of WaitForExit(15000). If process does not exit, call Kill(entireProcessTree) and throw -- prevents CI hangs.

3. **ruby nil-find guard** (test_daemon_protocol.rb): Assert .find result is non-nil before dereference. Diagnostic message lists available ids.

4. **swift skip counter** (LSPTests/main.swift): Add skipped counter. SKIP path increments skipped, not passed. Summary: N passed, N skipped, N failed.

5. **build-cpp-lsp.sh mkdir**: When --out overrides the binary path, mkdir -p the parent directory so installs to new paths succeed.

6. **foundation-keygen declaredAt** (lib.rs): All nine declaredAt constants already pinned. Added declared_at_constants_are_pinned_iso8601 test to lock the invariant.

13/13 foundation-keygen tests pass.

Closes #300