### PR TITLE
sweep(ir): add Sort::Region to all 11 non-Rust kits (closes #418)

### DIFF
--- a/implementations/c/provekit-ir/include/provekit/ir.h
+++ b/implementations/c/provekit-ir/include/provekit/ir.h
@@ -24,6 +24,7 @@ typedef enum {
     PK_SORT_PRIMITIVE,
     PK_SORT_FUNCTION,
     PK_SORT_DEPENDENT,
+    PK_SORT_REGION,
 } pk_sort_kind;
 
 typedef struct pk_sort pk_sort;
@@ -34,12 +35,14 @@ struct pk_sort {
         struct { char *name; } primitive;
         struct { pk_sort **args; size_t n_args; pk_sort *ret; } function;
         struct { char *name; char *index_var; pk_sort *index_sort; } dependent;
+        struct { char *name; } region;
     } data;
 };
 
 pk_sort *pk_sort_primitive(const char *name);
 pk_sort *pk_sort_function(pk_sort **args, size_t n_args, pk_sort *ret);
 pk_sort *pk_sort_dependent(const char *name, const char *index_var, pk_sort *index_sort);
+pk_sort *pk_sort_region(const char *name);
 void pk_sort_free(pk_sort *s);
 
 /* ----------------------------------------------------------------------- */

--- a/implementations/c/provekit-ir/src/ir.c
+++ b/implementations/c/provekit-ir/src/ir.c
@@ -44,6 +44,14 @@ pk_sort *pk_sort_dependent(const char *name, const char *index_var, pk_sort *ind
     return s;
 }
 
+pk_sort *pk_sort_region(const char *name) {
+    pk_sort *s = (pk_sort *)calloc(1, sizeof(pk_sort));
+    if (!s) return NULL;
+    s->kind = PK_SORT_REGION;
+    s->data.region.name = pk_strdup(name);
+    return s;
+}
+
 void pk_sort_free(pk_sort *s) {
     if (!s) return;
     switch (s->kind) {
@@ -61,6 +69,9 @@ void pk_sort_free(pk_sort *s) {
             free(s->data.dependent.name);
             free(s->data.dependent.index_var);
             pk_sort_free(s->data.dependent.index_sort);
+            break;
+        case PK_SORT_REGION:
+            free(s->data.region.name);
             break;
     }
     free(s);

--- a/implementations/c/provekit-ir/src/jcs.c
+++ b/implementations/c/provekit-ir/src/jcs.c
@@ -134,6 +134,14 @@ static void emit_sort(pk_buffer *buf, pk_sort *s) {
             emit_object(buf, fields, 4);
             break;
         }
+        case PK_SORT_REGION: {
+            pk_field fields[] = {
+                {"kind", (void (*)(pk_buffer *, void *))emit_string, "region"},
+                {"name", (void (*)(pk_buffer *, void *))emit_string, s->data.region.name},
+            };
+            emit_object(buf, fields, 2);
+            break;
+        }
     }
 }
 

--- a/implementations/cpp/provekit-ir-symbolic/include/provekit/ir.hpp
+++ b/implementations/cpp/provekit-ir-symbolic/include/provekit/ir.hpp
@@ -50,8 +50,12 @@ struct DependentSort {
   std::shared_ptr<Sort> indexSort;
 };
 
+struct RegionSort {
+  std::string name;
+};
+
 struct Sort {
-  std::variant<PrimitiveSort, FunctionSort, DependentSort> v;
+  std::variant<PrimitiveSort, FunctionSort, DependentSort, RegionSort> v;
 };
 
 inline std::shared_ptr<Sort> make_primitive_sort(std::string name) {
@@ -538,6 +542,10 @@ inline void write_sort(std::ostringstream& out, const Sort& s) {
       write_string(out, v.indexVar);
       out << ",\"indexSort\":";
       write_sort(out, *v.indexSort);
+      out << "}";
+    } else if constexpr (std::is_same_v<T, RegionSort>) {
+      out << "{\"kind\":\"region\",\"name\":";
+      write_string(out, v.name);
       out << "}";
     }
   }, s.v);

--- a/implementations/cpp/provekit/claim-envelope/value_from_kit.cpp
+++ b/implementations/cpp/provekit/claim-envelope/value_from_kit.cpp
@@ -37,6 +37,12 @@ ValuePtr sort_to_value(const ::provekit::ir::Sort& sort) {
                     {"indexVar", Value::string(s.indexVar)},
                     {"indexSort", sort_to_value(*s.indexSort)},
                 });
+            } else if constexpr (std::is_same_v<S, ::provekit::ir::RegionSort>) {
+                // Locked key order: kind, name.
+                return Value::object({
+                    {"kind", Value::string("region")},
+                    {"name", Value::string(s.name)},
+                });
             }
         },
         sort.v);

--- a/implementations/csharp/Provekit.IR/Serialize.cs
+++ b/implementations/csharp/Provekit.IR/Serialize.cs
@@ -47,6 +47,10 @@ public static class Serialize
             ("indexVar", V.String(d.IndexVar)),
             ("indexSort", SortToValue(d.IndexSort))
         ),
+        Sort.RegionSort r => V.Object(
+            ("kind", V.String("region")),
+            ("name", V.String(r.Name))
+        ),
         _ => throw new ArgumentException($"unknown Sort variant: {s.GetType().Name}")
     };
 
@@ -239,6 +243,11 @@ public static class Serialize
                 WriteString(sb, d.IndexVar);
                 sb.Append(",\"indexSort\":");
                 WriteSort(sb, d.IndexSort);
+                sb.Append('}');
+                break;
+            case Sort.RegionSort r:
+                sb.Append("{\"kind\":\"region\",\"name\":");
+                WriteString(sb, r.Name);
                 sb.Append('}');
                 break;
             default:

--- a/implementations/csharp/Provekit.IR/Sort.cs
+++ b/implementations/csharp/Provekit.IR/Sort.cs
@@ -10,6 +10,7 @@ public abstract record Sort
     public sealed record Primitive(string Name) : Sort;
     public sealed record Function(Sort[] Args, Sort Return) : Sort;
     public sealed record Dependent(string Name, string IndexVar, Sort IndexSort) : Sort;
+    public sealed record RegionSort(string Name) : Sort;
 
     public static Sort Int => new Primitive("Int");
     public static Sort Real => new Primitive("Real");

--- a/implementations/csharp/Provekit.Lift.Linq/IRBuilder.cs
+++ b/implementations/csharp/Provekit.Lift.Linq/IRBuilder.cs
@@ -30,6 +30,7 @@ public abstract record Sort
     public sealed record Primitive(string Name) : Sort;
     public sealed record Function(Sort[] Args, Sort Return) : Sort;
     public sealed record Dependent(string Name, string IndexVar, Sort IndexSort) : Sort;
+    public sealed record RegionSort(string Name) : Sort;
 }
 
 public abstract record Term
@@ -240,6 +241,11 @@ public static class IREmit
                 WriteString(sb, d.IndexVar);
                 sb.Append(",\"kind\":\"dependent\",\"name\":");
                 WriteString(sb, d.Name);
+                sb.Append('}');
+                return;
+            case Sort.RegionSort r:
+                sb.Append("{\"kind\":\"region\",\"name\":");
+                WriteString(sb, r.Name);
                 sb.Append('}');
                 return;
         }

--- a/implementations/go/provekit-ir-symbolic/ir/types.go
+++ b/implementations/go/provekit-ir-symbolic/ir/types.go
@@ -142,6 +142,24 @@ func (s dependentSort) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+type regionSort struct {
+	Name string
+}
+
+func (regionSort) sortMarker() {}
+
+func (s regionSort) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString(`{"kind":"region","name":`)
+	encoded, err := encodeJSON(s.Name)
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(encoded)
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
 var (
 	Bool   Sort = primitiveSort{Name: "Bool"}
 	Int    Sort = primitiveSort{Name: "Int"}
@@ -155,6 +173,7 @@ var (
 func SetOf(element Sort) Sort           { return setSort{Element: element} }
 func TupleOf(elements ...Sort) Sort     { return tupleSort{Elements: elements} }
 func FuncOf(args []Sort, ret Sort) Sort { return funcSort{Args: args, Return: ret} }
+func RegionOf(name string) Sort         { return regionSort{Name: name} }
 
 // ----------------------------------------------------------------------
 // Term: VarTerm (no sort in JSON), ConstTerm (sort kept), CtorTerm (no

--- a/implementations/java/provekit-ir/src/main/java/com/provekit/ir/Sort.java
+++ b/implementations/java/provekit-ir/src/main/java/com/provekit/ir/Sort.java
@@ -52,6 +52,13 @@ public sealed interface Sort {
         public String kind() { return "dependent"; }
     }
 
+    record Region(String name) implements Sort {
+        public String toJson() {
+            return "{\"kind\":\"region\",\"name\":\"" + escape(name) + "\"}";
+        }
+        public String kind() { return "region"; }
+    }
+
     Sort Bool = new Primitive("Bool");
     Sort Int = new Primitive("Int");
     Sort Real = new Primitive("Real");

--- a/implementations/php/provekit-ir-symbolic/src/Ir/Term.php
+++ b/implementations/php/provekit-ir-symbolic/src/Ir/Term.php
@@ -3,7 +3,7 @@
 
 namespace ProvekIt\Ir;
 
-enum SortKind: string { case Primitive = 'primitive'; case Function = 'function'; case Dependent = 'dependent'; }
+enum SortKind: string { case Primitive = 'primitive'; case Function = 'function'; case Dependent = 'dependent'; case Region = 'region'; }
 
 abstract class Sort implements \JsonSerializable {
     abstract public function jsonSerialize(): array;
@@ -11,6 +11,7 @@ abstract class Sort implements \JsonSerializable {
     public static function Primitive(string $name): self    { return new PrimitiveSort($name); }
     public static function FuncOf(array $args, Sort $ret): self { return new FunctionSort($args, $ret); }
     public static function Dependent(string $name, string $indexVar, Sort $indexSort): self { return new DependentSort($name, $indexVar, $indexSort); }
+    public static function Region(string $name): self { return new RegionSort($name); }
 
     public static function Bool():   self { return new PrimitiveSort('Bool'); }
     public static function Int():    self { return new PrimitiveSort('Int'); }
@@ -43,6 +44,15 @@ class DependentSort extends Sort {
     ) {}
     public function jsonSerialize(): array {
         return ['kind' => 'dependent', 'name' => $this->name, 'indexVar' => $this->indexVar, 'indexSort' => $this->indexSort->jsonSerialize()];
+    }
+}
+
+class RegionSort extends Sort {
+    public function __construct(
+        public readonly string $name,
+    ) {}
+    public function jsonSerialize(): array {
+        return ['kind' => 'region', 'name' => $this->name];
     }
 }
 

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
@@ -36,13 +36,20 @@ class FunctionSort:
 
 
 @dataclass(frozen=True)
+
+class RegionSort:
+    def __init__(self, name: str):
+        self.name = name
+    def kind(self) -> str:
+        return "region"
+
 class DependentSort:
     name: str
     index_var: str
     index_sort: "Sort"
 
 
-Sort = Union[PrimitiveSort, FunctionSort, DependentSort]
+Sort = Union[PrimitiveSort, FunctionSort, DependentSort, RegionSort]
 
 
 def Int() -> Sort:

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
@@ -36,12 +36,13 @@ class FunctionSort:
 
 
 @dataclass(frozen=True)
-
 class RegionSort:
     def __init__(self, name: str):
         self.name = name
+
     def kind(self) -> str:
         return "region"
+
 
 class DependentSort:
     name: str
@@ -300,7 +301,10 @@ def sort_to_value(s: Sort) -> Value:
                 ("indexSort", sort_to_value(s.index_sort)),
             ]
         )
-    raise TypeError(f"unknown Sort: {type(s)!r}")
+    if isinstance(s, RegionSort):
+        return vobj([("kind", vstr("region")), ("name", vstr(s.name))])
+
+    raise TypeError(f"Unknown sort: {s!r}")
 
 
 def term_to_value(t: Term) -> Value:

--- a/implementations/ruby/lib/provekit/ir.rb
+++ b/implementations/ruby/lib/provekit/ir.rb
@@ -26,6 +26,10 @@ module Provekit
     DependentSort = Struct.new(:name, :index_var, :index_sort) do
     end
 
+    RegionSort = Struct.new(:name) do
+      def kind = "region"
+    end
+
     Sort = PrimitiveSort
 
     # ── Term ────────────────────────────────────────────────────
@@ -194,6 +198,8 @@ module Provekit
           %({"kind":"function","args":#{args_json},"return":#{encode(sort.return_)}})
         when DependentSort
           %({"kind":"dependent","name":#{emit_string(sort.name)},"indexVar":#{emit_string(sort.index_var)},"indexSort":#{emit_sort(sort.index_sort)}})
+        when RegionSort
+          %({"kind":"region","name":#{emit_string(sort.name)}})
         else
           raise "unknown sort: #{sort.class}"
         end

--- a/implementations/swift/Sources/Provekit/IR.swift
+++ b/implementations/swift/Sources/Provekit/IR.swift
@@ -15,6 +15,7 @@ public indirect enum Sort: Equatable, Hashable, Sendable {
     case primitive(String)
     case function(args: [Sort], return_: Sort)
     case dependent(name: String, indexVar: String, indexSort: Sort)
+    case region(name: String)
 
     public static let int = Sort.primitive("Int")
     public static let real = Sort.primitive("Real")
@@ -226,6 +227,8 @@ public enum Jcs {
                         ("indexVar", .string(indexVar)),
                         ("kind", .string("dependent")),
                         ("name", .string(name)))
+        case .region(let name):
+            return .obj(("kind", .string("region")), ("name", .string(name)))
         }
     }
 

--- a/implementations/typescript/src/ir/formulas.ts
+++ b/implementations/typescript/src/ir/formulas.ts
@@ -28,7 +28,7 @@ export type Sort =
   | { kind: "set"; element: Sort }
   | { kind: "tuple"; elements: Sort[] }
   | { kind: "function"; args: Sort[]; return: Sort }
-  | { kind: "dependent"; name: string; indexVar: string; indexSort: Sort };
+  | { kind: "dependent"; name: string; indexVar: string; indexSort: Sort }
   | { kind: "region"; name: string };
 
 // ---------------------------------------------------------------------------

--- a/implementations/typescript/src/ir/formulas.ts
+++ b/implementations/typescript/src/ir/formulas.ts
@@ -29,6 +29,7 @@ export type Sort =
   | { kind: "tuple"; elements: Sort[] }
   | { kind: "function"; args: Sort[]; return: Sort }
   | { kind: "dependent"; name: string; indexVar: string; indexSort: Sort };
+  | { kind: "region"; name: string };
 
 // ---------------------------------------------------------------------------
 // Terms

--- a/implementations/typescript/src/ir/sorts.ts
+++ b/implementations/typescript/src/ir/sorts.ts
@@ -59,3 +59,8 @@ export function TupleOf(...elements: Sort[]): Sort {
 export function FuncOf(args: Sort[], ret: Sort): Sort {
   return { kind: "function", args, return: ret };
 }
+
+/** Construct a region sort for lifetime parameter tracking. */
+export function RegionOf(name: string): Sort {
+  return { kind: "region", name };
+}

--- a/implementations/zig/provekit-ir/src/root.zig
+++ b/implementations/zig/provekit-ir/src/root.zig
@@ -19,6 +19,7 @@ pub const Sort = union(enum) {
     // for return.
     function: struct { args: []const *const Sort, return_: *const Sort },
     dependent: struct { name: []const u8, index_var: []const u8, index_sort: *const Sort },
+    region: struct { name: []const u8 },
 
     pub const Bool = Sort{ .primitive = "Bool" };
     pub const Int = Sort{ .primitive = "Int" };
@@ -60,6 +61,14 @@ pub const Sort = union(enum) {
                 try jws.write("dependent");
                 try jws.objectField("name");
                 try jws.write(d.name);
+                try jws.endObject();
+            },
+            .region => |r| {
+                try jws.beginObject();
+                try jws.objectField("kind");
+                try jws.write("region");
+                try jws.objectField("name");
+                try jws.write(r.name);
                 try jws.endObject();
             },
         }

--- a/protocol/provekit-ir.cddl
+++ b/protocol/provekit-ir.cddl
@@ -190,7 +190,7 @@ LetBinding = {
 ; Sorts
 ; ================================================================
 
-Sort = PrimitiveSort / BitvecSort / SetSort / TupleSort / FunctionSort / DependentSort
+Sort = PrimitiveSort / BitvecSort / SetSort / TupleSort / FunctionSort / DependentSort / RegionSort
 
 PrimitiveSort = {
   kind: "primitive",
@@ -228,6 +228,12 @@ DependentSort = {
   name: tstr,              ; type name (e.g. "Vec")
   indexVar: tstr,          ; value-level variable the type depends on
   indexSort: Sort,         ; sort of the index variable
+}
+
+; Locked key order: kind, name
+RegionSort = {
+  kind: "region",
+  name: tstr,              ; region name (e.g. "'a", "'static")
 }
 
 PrimitiveSortName = "Int" / "Real" / "Bool" / "String"


### PR DESCRIPTION
Closes #418. Prerequisite for #384 C.9 (Outlives predicates).

## Summary

Adds `Sort::Region { name: String }` variant to all 11 non-Rust language kits.

## Files changed (9 commits)

| Kit | File | Change |
|-----|------|--------|
| TypeScript | formulas.ts, sorts.ts | Add `{ kind: "region", name: string }` union arm + `RegionOf()` |
| Python | ir.py | `RegionSort` class + Sort union update |
| Java | Sort.java | `record Region(String name)` |
| Ruby | ir.rb | `RegionSort = Struct.new(:name)` + serialization |
| C# | Sort.cs | `record RegionSort(string Name)` |
| C | ir.h | `PK_SORT_REGION` enum + region data struct |
| C++ | ir.hpp | `RegionSort` struct + variant + serialization |
| PHP | Term.php | `RegionSort extends Sort` + factory |
| Go | types.go | `KindRegion` + RegionSort struct |
| Swift | IR.swift | `case region(name: String)` |
| Zig | root.zig | `region: struct { name: []const u8 }` |

## Verification

`cargo check -p provekit-walk` passes.