### PR TITLE
fix(php): replace placeholder signature in self-contracts attestation (#393)

### DIFF
--- a/.provekit/self-contracts-attestations/php.json
+++ b/.provekit/self-contracts-attestations/php.json
@@ -4,7 +4,7 @@
   "lang": "php",
   "cid": "blake3-512:16a8af822854fa6f4f1306b9f5e43030e21ccb901bea13f2cedb1a28a881c63e6daabbc4e93af472346c954759739f84debb8da174e6fda62e91319cb7dca555",
   "contractSetCid": "blake3-512:385e617be25516099e61118179fbb200967093448b85629f1cb5b8966dfcc06244cfcb9f59315780114fee7c9c415fcd1465fc8e85e8141d59f6b44a2df4a262",
-  "declaredAt": "2026-05-04T00:00:00Z",
+  "declaredAt": "2026-05-03T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:placeholder"
+  "signature": "ed25519:EmN1HwUmPHK7c9jxVFUgbp6bTyjycqnol42119oIjBsLlMGA4J582WTvaBzi4Rj1bCFvut9m7NNrtvxWHMFuCw=="
 }

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@
 #
 # Mainline targets:
 #   make help        — print this help
-#   make ci          — full conformance gate (catalog + protocol + 9 mints + tests)
-#   make conformance — catalog + protocol + 9 mint CIDs + self-contract tests
-#   make all-mint    — run all 9 mint commands; print CIDs (Linux/CI subset)
+#   make ci          — full conformance gate (catalog + protocol + 10 mints + tests)
+#   make conformance — catalog + protocol + 10 mint CIDs + self-contract tests
+#   make all-mint    — run all 10 mint commands; print CIDs (Linux/CI subset)
 #   make test-all    — run every language-native test suite (Linux/CI subset)
 #
 # Per-language targets:
@@ -64,9 +64,9 @@ help:
 	@echo "ProvekIt — top-level orchestrator"
 	@echo ""
 	@echo "Mainline:"
-	@echo "  make ci             full gate (conformance + test-all) [Linux/CI: 9 peer langs]"
-	@echo "  make conformance    catalog + protocol + 9 mint CIDs + self-contract tests"
-	@echo "  make all-mint       9 mint commands (Swift excluded: macOS-only, use mint-swift)"
+	@echo "  make ci             full gate (conformance + test-all) [Linux/CI: 10 peer langs]"
+	@echo "  make conformance    catalog + protocol + 10 mint CIDs + self-contract tests"
+	@echo "  make all-mint       10 mint commands (Swift excluded: macOS-only, use mint-swift)"
 	@echo "  make test-all       language test suites (Swift excluded: macOS-only, use test-swift)"
 	@echo ""
 	@echo "Per-language build:"
@@ -337,14 +337,15 @@ mint-php: build-rust
 		(echo "FAIL: php self-contracts attestation rejected; re-mint and commit:" && \
 		 echo "      $(PROVEKIT) mint --kit=php" && exit 1)
 
-# NOTE: all-mint runs 9 of 12 kits (Linux/CI subset).
+# NOTE: all-mint runs 10 of 12 kits (Linux/CI subset).
 # Excluded: swift (macOS-only; use mint-swift on macOS), ruby (attestation
-# exists but CI toolchain integration pending, #234), php (pending feat/php-kit).
+# exists but CI toolchain integration pending, #234).
 # zig and c were added after their Side A merges (#283, #272) and are included.
+# php was added after its self-contracts attestation was signed (#393).
 .PHONY: all-mint
-all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python mint-c mint-zig
+all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python mint-c mint-zig mint-php
 	@echo ""
-	@echo "==== all 9 core self-contract CIDs match pinned values ===="
+	@echo "==== all 10 core self-contract CIDs match pinned values ===="
 	@printf "  %-8s  %s\n" "rust"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/rust.json)"
 	@printf "  %-8s  %s\n" "go"     "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/go.json)"
 	@printf "  %-8s  %s\n" "cpp"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/cpp.json)"
@@ -354,6 +355,7 @@ all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python m
 	@printf "  %-8s  %s\n" "python" "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/python.json)"
 	@printf "  %-8s  %s\n" "c"      "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/c.json)"
 	@printf "  %-8s  %s\n" "zig"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/zig.json)"
+	@printf "  %-8s  %s\n" "php"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/php.json)"
 
 # --- Per-kit prove (C1-C8 conformance gate) ----------------------------------
 #

--- a/implementations/php/.provekit/lift/php-self-contracts/manifest.toml
+++ b/implementations/php/.provekit/lift/php-self-contracts/manifest.toml
@@ -1,0 +1,10 @@
+name = "php-self-contracts"
+version = "1.0.0"
+protocol_version = "provekit-lift/1"
+command = ["php", "cmd/mint-php-self-contracts/rpc.php", "--rpc"]
+working_dir = "provekit-self-contracts"
+
+[capabilities]
+authoring_surfaces = ["php-self-contracts"]
+ir_version = "v1.1.0"
+emits_signed_mementos = true


### PR DESCRIPTION
## Summary

- Replaces `ed25519:placeholder` with a real Ed25519 signature in `.provekit/self-contracts-attestations/php.json`
- Adds PHP to `all-mint` target (10 kits now, up from 9)
- Creates manifest at `implementations/php/.provekit/lift/php-self-contracts/manifest.toml` so the CLI can find it
- Updates Makefile comments from 9 to 10 kits throughout
- Attestation verified with `verify-self-contracts` tool