### PR TITLE
fix(coq, stub): add missing opacity_manifest on CompiledFormula init

### DIFF
--- a/implementations/rust/provekit-ir-compiler-coq/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-coq/src/lib.rs
@@ -77,13 +77,17 @@ impl IrCompiler for CoqCompiler {
         if dialect != DIALECT {
             return Err(CompileError::UnsupportedDialect(dialect.to_string()));
         }
-        
         let (preamble, body, free_vars) = self.compile_inner(ir)?;
-        
         Ok(CompiledFormula {
             preamble,
             body,
             free_vars,
+            opacity_manifest: provekit_ir_compiler::OpacityManifest {
+                protocol_version: "ir-compiler-protocol/2".to_string(),
+                compiler: DIALECT.to_string(),
+                compiler_version: COMPILER_VERSION.to_string(),
+                opacities: vec![],
+            },
         })
     }
 

--- a/implementations/rust/provekit-ir-compiler-stub/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-stub/src/lib.rs
@@ -35,6 +35,12 @@ impl IrCompiler for StubCompiler {
                 name: "stub_var".to_string(),
                 sort: "Stub".to_string(),
             }],
+            opacity_manifest: provekit_ir_compiler::OpacityManifest {
+                protocol_version: "ir-compiler-protocol/2".to_string(),
+                compiler: DIALECT.to_string(),
+                compiler_version: env!("CARGO_PKG_VERSION").to_string(),
+                opacities: vec![],
+            },
         })
     }
 


### PR DESCRIPTION
PR #332 added the opacity_manifest field to CompiledFormula, but the coq and stub IrCompiler impls construct CompiledFormula directly in compile() without populating it. cargo build --workspace fails with E0063 on origin/main.

Adds a trivial OpacityManifest to both, matching the shape used by the inner Term-kind branch in the coq compiler.

Verification: cargo build --workspace clean.

Why this regressed: #332 added the field; coq + stub outer compile() impls were never updated; no test exercises the exact path.