### PR TITLE
feat(c): scaffold provekit-lift-c — C kit via libclang (issue #380)

### DIFF
--- a/implementations/c/provekit-lift/Makefile
+++ b/implementations/c/provekit-lift/Makefile
@@ -1,0 +1,28 @@
+# makefile for provekit-lift-c
+
+CC = gcc
+CFLAGS = -Wall -Wextra -std=c11 -Iinclude -I../provekit-ir/include
+LDFLAGS = -lclang
+
+SRC = src/lift.c
+OBJ = $(SRC:.c=.o)
+BIN = bin/provekit-lift-c
+
+.PHONY: all clean stub test
+
+all: $(BIN)
+
+$(BIN): $(OBJ) | bin
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+%.o: %.c include/provekit/lift.h src/lift.h
+
+bin:
+	mkdir -p bin
+
+clean:
+	rm -f $(OBJ) $(BIN)
+
+stub: bin
+	$(CC) $(CFLAGS) -DPROVEKIT_LIFT_C_STUB -o bin/stub $(SRC)
+	./bin/stub --kernel

--- a/implementations/c/provekit-lift/include/provekit/lift.h
+++ b/implementations/c/provekit-lift/include/provekit/lift.h
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * provekit-lift-c — C kit lifter via libclang.
+ *
+ * Lifts C source to proof.ir bundles. Parses kernel annotations:
+ *   - BUG_ON, WARN_ON, assert
+ *   - sparse: __user, __rcu, __must_hold, __acquires, __releases
+ *
+ * Architecture mirrors provekit-walk:
+ *   - canonical: JCS + BLAKE3-512
+ *   - lift: AST → IR
+ *   - walk: WP propagation
+ *   - shadow: predicate capture
+ *   - emit: proof.ir bundle
+ */
+
+#ifndef PROVEKIT_LIFT_C_H
+#define PROVEKIT_LIFT_C_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ----------------------------------------------------------------------- */
+/* Lift result                                                           */
+/* ----------------------------------------------------------------------- */
+
+typedef struct {
+    char *cid;
+    char *proof_ir_bundle;  /* JCS-canonical JSON */
+    size_t n_errors;
+    char **errors;
+} pk_lift_result;
+
+void pk_lift_result_free(pk_lift_result *r);
+
+/* ----------------------------------------------------------------------- */
+/* API                                                                   */
+/* ----------------------------------------------------------------------- */
+
+/* Lift a C source file.
+ * Returns NULL on error (check pk_last_error).
+ */
+pk_lift_result *pk_lift_file(const char *path);
+
+/* Lift C source from memory.
+ * source: nul-terminated C code
+ * Returns NULL on error.
+ */
+pk_lift_result *pk_lift_source(const char *source);
+
+/* Enable kernel annotation parsing (default: disabled)
+ * Parses: BUG_ON, WARN_ON, __user, __rcu, __must_hold, __acquires, __releases
+ */
+void pk_enable_kernel_annotations(int enabled);
+
+/* Get last error message.
+ * Returns NULL if no error.
+ */
+const char *pk_last_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PROVEKIT_LIFT_C_H */

--- a/implementations/c/provekit-lift/src/lift.c
+++ b/implementations/c/provekit-lift/src/lift.c
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * provekit-lift-c — C kit lifter via libclang (stub implementation).
+ *
+ * TODO(#380): Wire libclang bindings.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "provekit/lift.h"
+
+/* kernel annotations: enabled via CLI flag, not default */
+static int g_kernel_annotations_enabled = 0;
+
+/* last error buffer */
+static char g_last_error[512] = {0};
+
+void pk_enable_kernel_annotations(int enabled) {
+    g_kernel_annotations_enabled = enabled;
+}
+
+const char *pk_last_error(void) {
+    return g_last_error[0] ? g_last_error : NULL;
+}
+
+static void set_error(const char *msg) {
+    strncpy(g_last_error, msg, sizeof(g_last_error) - 1);
+}
+
+pk_lift_result *pk_lift_file(const char *path) {
+    if (!path) {
+        set_error("null path");
+        return NULL;
+    }
+
+    /* stub: reject until libclang wired */
+    set_error("pk_lift_file: libclang integration TODO (#380)");
+    return NULL;
+}
+
+pk_lift_result *pk_lift_source(const char *source) {
+    (void)source;
+
+    /* stub: reject until libclang wired */
+    set_error("pk_lift_source: libclang integration TODO (#380)");
+    return NULL;
+}
+
+void pk_lift_result_free(pk_lift_result *r) {
+    if (!r) return;
+    free(r->cid);
+    free(r->proof_ir_bundle);
+    if (r->errors) {
+        for (size_t i = 0; i < r->n_errors; i++) {
+            free(r->errors[i]);
+        }
+        free(r->errors);
+    }
+    free(r);
+}
+
+/* ----------------------------------------------------------------------- */
+/* stub main for testing                                               */
+/* ----------------------------------------------------------------------- */
+
+#ifdef PROVEKIT_LIFT_C_STUB
+
+int main(int argc, char **argv) {
+    int kernel_mode = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--kernel") == 0) {
+            kernel_mode = 1;
+        } else {
+            fprintf(stderr, "Usage: %s [--kernel] <source.c>\n", argv[0]);
+            return 1;
+        }
+    }
+
+    pk_enable_kernel_annotations(kernel_mode);
+
+    pk_lift_result *r = pk_lift_source(
+        "void foo(int *x) {\n"
+        "    BUG_ON(!x);\n"
+        "}\n"
+    );
+
+    if (r) {
+        printf("CID: %s\n", r->cid ?: "(null)");
+        printf("Bundle: %s\n", r->proof_ir_bundle ?: "(null)");
+        pk_lift_result_free(r);
+    } else {
+        printf("Error: %s\n", pk_last_error() ?: "(unknown)");
+    }
+
+    return r ? 0 : 1;
+}
+
+#endif /* PROVEKIT_LIFT_C_STUB */


### PR DESCRIPTION
## Goal

Scaffold the C kit lifter using libclang. Mirrors provekit-walk's five-module architecture for C source → proof.ir bundles.

## Changes

Initial crate scaffold:

| File | Description |
|------|-------------|
| `implementations/c/provekit-lift/include/provekit/lift.h` | Public API: `pk_lift_result`, `pk_lift_file`, `pk_lift_source`, `pk_enable_kernel_annotations` |
| `implementations/c/provekit-lift/src/lift.c` | Stub implementation — rejects until libclang wired |
| `implementations/c/provekit-lift/Makefile` | Builds against `-lclang` |

## Next Steps

- [ ] Wire libclang AST parsing (`clang-sys` crate or direct C bindings)
- [ ] Lift: parse C AST → IR nodes (mirrors provekit-walk's `lift.rs`)
- [ ] Walk: WP propagation through C statements
- [ ] Kernel annotations: BUG_ON, WARN_ON, assert, sparse annotations
- [ ] Emit: proof.ir JCS bundle (matches Rust kit output)

## References

- Issue #380
- Paper 07 §8: Linux empirical case
- Parent epic: #368