### PR TITLE
feat(lsp): add ForwardPropagator for C# per #317

### DIFF
--- a/implementations/csharp/Provekit.LSP/ForwardPropagator.cs
+++ b/implementations/csharp/Provekit.LSP/ForwardPropagator.cs
@@ -1,0 +1,58 @@
+namespace Provekit.LSP;
+
+/// <summary>
+/// ForwardPropagator — accumulate posts and emit implication-check diagnostics.
+/// Per: docs/lsp/forward-propagation-floor-v1.md
+/// </summary>
+public class ForwardPropagator
+{
+    private Dictionary<string, Post> _seedCatalog = new();
+
+    public class Post
+    {
+        public List<string> Constraints { get; }
+        public bool IsTop { get; }
+
+        public Post(List<string> constraints, bool isTop)
+        {
+            Constraints = constraints;
+            IsTop = isTop;
+        }
+
+        public static Post Top() => new(new List<string>(), true);
+        public static Post Of(string constraint) => new(new List<string> { constraint }, false);
+    }
+
+    public class DiagnosticResult
+    {
+        public string Code { get; }
+        public string Message { get; }
+
+        public DiagnosticResult(string code, string message)
+        {
+            Code = code;
+            Message = message;
+        }
+    }
+
+    public void AddToCatalog(string calleeId, Post pre, Post post)
+    {
+        _seedCatalog[calleeId] = post;
+    }
+
+    public DiagnosticResult? CheckCallsite(string calleeId, Post currentPost)
+    {
+        if (currentPost.IsTop) return null;
+        if (!_seedCatalog.TryGetValue(calleeId, out var calleePre)) return null;
+
+        foreach (var c in currentPost.Constraints)
+        {
+            if (!calleePre.Constraints.Contains(c))
+            {
+                return new DiagnosticResult("implication-failed",
+                    $"post does not imply callee pre: {string.Join(" && ", calleePre.Constraints)}");
+            }
+        }
+        return null;
+    }
+}

--- a/tests/lsp/floor-fixture/csharp.cs
+++ b/tests/lsp/floor-fixture/csharp.cs
@@ -1,0 +1,33 @@
+// Forward-propagation floor fixture for C#
+// Tests: (1) callsite satisfies pre, no diagnostic | (2) callsite violates pre, diagnostic | (3) loop path, top fallback
+
+public class FloorFixture
+{
+    public static bool CheckPositive(int x)
+    {
+        if (x <= 0) return false;  // pre: x > 0
+        return true;
+    }
+
+    public static bool CallerSatisfiesPre()
+    {
+        bool result = CheckPositive(5);  // satisfies pre (x=5 > 0)
+        return result;
+    }
+
+    public static bool CallerViolatesPre()
+    {
+        bool result = CheckPositive(-1);  // violates pre (x=-1 <= 0)
+        return result;
+    }
+
+    public static bool CallerWithLoop()
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            bool result = CheckPositive(i);  // top fallback at loop entry
+            if (!result) return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Adds the ForwardPropagator module for C# LSP forward-propagation per issue #317.

Per docs/lsp/forward-propagation-floor-v1.md (per #309).

Closes #317