### PR TITLE
feat(lsp): add ForwardPropagator for Ruby per #321

### DIFF
--- a/implementations/ruby/lib/provekit/lsp/forward_propagator.rb
+++ b/implementations/ruby/lib/provekit/lsp/forward_propagator.rb
@@ -1,0 +1,24 @@
+# ForwardPropagator — accumulate posts and emit implication-check diagnostics.
+# Per: docs/lsp/forward-propagation-floor-v1.md
+class ForwardPropagator
+  def initialize
+    @seed_catalog = {}
+  end
+
+  def add_to_catalog(callee_id, pre, post)
+    @seed_catalog[callee_id] = post
+  end
+
+  def check_callsite(callee_id, current_post)
+    return nil if current_post[:is_top]
+    callee_pre = @seed_catalog[callee_id]
+    return nil unless callee_pre
+
+    current_post[:constraints].each do |c|
+      unless callee_pre[:constraints].include?(c)
+        return { code: "implication-failed", message: "post does not imply callee pre: #{callee_pre[:constraints].join(' && ')}" }
+      end
+    end
+    nil
+  end
+end

--- a/tests/lsp/floor-fixture/ruby.rb
+++ b/tests/lsp/floor-fixture/ruby.rb
@@ -1,0 +1,27 @@
+# Forward-propagation floor fixture for Ruby
+# Tests: (1) callsite satisfies pre, no diagnostic | (2) callsite violates pre, diagnostic | (3) loop path, top fallback
+
+def checkPositive(x)
+  if x <= 0
+    return false  # pre: x > 0
+  end
+  true
+end
+
+def callerSatisfiesPre
+  result = checkPositive(5)  # satisfies pre (x=5 > 0)
+  result
+end
+
+def callerViolatesPre
+  result = checkPositive(-1)  # violates pre (x=-1 <= 0)
+  result
+end
+
+def callerWithLoop
+  for i in 0...10
+    result = checkPositive(i)  # top fallback at loop entry
+    return false unless result
+  end
+  true
+end


### PR DESCRIPTION
Per docs/lsp/forward-propagation-floor-v1.md (per #309). Closes #321.