### PR TITLE
[codex] add Bug Zoo v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# ProvekIt
+# ProvekIt: Prove `k(I)=t`
 
 > *Supra omnia, rectum.*
 > — T
+
+The name is literal: **Prove `k(I)=t`**. `I` is an implementation artifact, `k` is the canonical projection that reads the contract boundary, and `t` is the truth claim the artifact is supposed to yield. ProvekIt does not ask you to trust the artifact; it asks for signed, content-addressed evidence that applying `k` to `I` produces `t`.
 
 Every if-statement is a contract — a guarantee about state, time, and place. Get any of it wrong, and the whole contract breaks. This is the bug class that exists in all upstream code; it's why if-statements exist at all.
 
@@ -26,6 +28,14 @@ Every if-statement, assertion, and type signature becomes a signed, binding dema
 **Software engineering shifts.** The artifact is the proof. Code is one implementation. Refactoring becomes proof-preserving rewrite. AI becomes a contract-implementation generator.
 
 **Supply chains compose.** Every dependency's signed contracts compose into your application's verified properties. Dependency confusion becomes arithmetically impossible. SBOMs become meaningful artifacts.
+
+## ProofIR is allowed to be lossy
+
+ProofIR is not a universal language for re-expressing every implementation detail of every programming language. It is a universal language for contract boundaries: preconditions, postconditions, invariants, protocol obligations, value predicates, resource states, signer claims, and the implication edges that connect them.
+
+That is why it can work across domains. A Spring annotation, a Zod validator, an OpenAPI schema, a Rust type invariant, and a ProvekIt-native contract can all collapse to the same canonical predicate when they assert the same boundary fact. The host-language texture can be discarded; the obligation survives.
+
+Once lifted, that boundary is universal, comparable, solvable, translatable, content-addressable, and signable. It has canonical bytes and a CID. It can be carried across languages, repositories, package ecosystems, commits, and time. The contracts were often already in your code; ProvekIt turns them into accountable edges the rest of the graph must satisfy.
 
 ## I want to...
 

--- a/bug-zoo/README.md
+++ b/bug-zoo/README.md
@@ -1,0 +1,14 @@
+# Bug Zoo
+
+Bug Zoo is ProvekIt's executable laboratory.
+
+Each species is a small, realistic specimen with four possible states:
+
+- `lab/`: normal code or metadata that passes its ordinary host checks.
+- `exposed/`: the same bug species lifted through one or more native surfaces until ProofIR exposes the missing contract edge.
+- `dropped/`: generated native shape that closes the edge, accepted only after re-lift verifies closure.
+- `wild/`: real OSS specimens pinned by advisory, commit, and affected path.
+
+The zoo is not a patch archive. Historical fixes are context only. The receipt is independent rediscovery: can ProvekIt lift the latent contract boundary, make the missing `p => q` edge visible, and, where a dropper exists, synthesize a verified closure?
+
+ProofIR is allowed to be lossy here. Specimens compare contract boundaries, not host-language implementation detail.

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/.gitignore
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/.gitignore
@@ -1,0 +1,1 @@
+lab/harness/.classes/

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/README.md
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/README.md
@@ -1,0 +1,16 @@
+# BZ-SHAPE-005: Java Null Boundary Equivalence
+
+This specimen shows a null-boundary bug species.
+
+The lab library compiles and runs with ordinary Java checks. The exposed variants add contract surfaces that engineers already use:
+
+- `provekit-native`: explicit ProvekIt-style `@Requires("name != null")`
+- `spring-web`: Spring's default required `@RequestParam`
+
+The source surfaces are not equivalent as Java programs. Their contract boundary is equivalent. Both lift to the same ProofIR precondition: `neq(name, null)`.
+
+The exposed bug is the missing edge from a caller that may provide null to a sink requiring non-null:
+
+```text
+maybe_null(name) => non_null(name)
+```

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/equivalence.json
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/equivalence.json
@@ -1,0 +1,6 @@
+{
+  "required": [
+    ["provekit-native", "spring-web"]
+  ],
+  "claim": "Both surfaces erase host-language texture and preserve the same boundary predicate: neq(name, null)."
+}

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/expected-diagnostic.txt
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/expected-diagnostic.txt
@@ -1,0 +1,1 @@
+BZ-SHAPE-005 exposes missing edge: maybe_null(name) => non_null(name)

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/expected.proofir.json
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/expected.proofir.json
@@ -1,0 +1,14 @@
+[
+  {
+    "kind": "contract",
+    "symbol": "lookup",
+    "precondition": {
+      "kind": "atomic",
+      "name": "neq",
+      "args": [
+        { "kind": "var", "name": "name" },
+        { "kind": "const", "value": null, "sort": { "kind": "primitive", "name": "Ref" } }
+      ]
+    }
+  }
+]

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/harness/src/main/java/com/provekit/contract/Requires.java
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/harness/src/main/java/com/provekit/contract/Requires.java
@@ -1,0 +1,5 @@
+package com.provekit.contract;
+
+public @interface Requires {
+    String value();
+}

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/harness/src/main/java/zoo/UserDirectory.java
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/harness/src/main/java/zoo/UserDirectory.java
@@ -1,0 +1,10 @@
+package zoo;
+
+import com.provekit.contract.Requires;
+
+public final class UserDirectory {
+    @Requires("name != null")
+    public String lookup(String name) {
+        return "user:" + name.toUpperCase();
+    }
+}

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/kit-rpc/run-java-lifter.sh
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/kit-rpc/run-java-lifter.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../../../.." && pwd)"
+java_root="$repo_root/implementations/java"
+core_jar="$java_root/provekit-lift-java-core/target/provekit-lsp-java.jar"
+adapter_jar="$java_root/provekit-lift-java-provekit-native/target/provekit-lift-java-provekit-native-0.1.0.jar"
+
+ensure_jdk() {
+  if java -version >/dev/null 2>&1 && javac -version >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for candidate in /usr/local/opt/openjdk/bin /opt/homebrew/opt/openjdk/bin; do
+    if [[ -x "$candidate/java" && -x "$candidate/javac" ]]; then
+      export PATH="$candidate:$PATH"
+      if java -version >/dev/null 2>&1 && javac -version >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+  done
+
+  echo "Unable to locate a usable Java runtime/compiler pair." >&2
+  echo "Install OpenJDK or expose java and javac on PATH." >&2
+  echo "Checked: PATH, /usr/local/opt/openjdk/bin, /opt/homebrew/opt/openjdk/bin" >&2
+  exit 1
+}
+
+ensure_jdk
+
+mvn -f "$java_root/pom.xml" -pl provekit-lift-java-core,provekit-lift-java-provekit-native -am package -DskipTests >&2
+
+for jar in "$core_jar" "$adapter_jar"; do
+  if [[ ! -f "$jar" ]]; then
+    echo "Missing required Java lifter jar: $jar" >&2
+    echo "Try: mvn -f \"$java_root/pom.xml\" -pl provekit-lift-java-core,provekit-lift-java-provekit-native -am package -DskipTests" >&2
+    exit 1
+  fi
+done
+
+java -cp "$core_jar:$adapter_jar" \
+  com.provekit.lift.Main --rpc

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/sat-witness.json
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/sat-witness.json
@@ -1,0 +1,6 @@
+{
+  "condition": "name == null",
+  "has": "maybe_null(name)",
+  "requires": "non_null(name)",
+  "missingEdge": "maybe_null(name) => non_null(name)"
+}

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/expected-diagnostic.txt
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/expected-diagnostic.txt
@@ -1,0 +1,1 @@
+BZ-SHAPE-005 exposes missing edge: maybe_null(name) => non_null(name)

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/expected.proofir.json
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/expected.proofir.json
@@ -1,0 +1,14 @@
+[
+  {
+    "kind": "contract",
+    "symbol": "lookup",
+    "precondition": {
+      "kind": "atomic",
+      "name": "neq",
+      "args": [
+        { "kind": "var", "name": "name" },
+        { "kind": "const", "value": null, "sort": { "kind": "primitive", "name": "Ref" } }
+      ]
+    }
+  }
+]

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/harness/src/main/java/org/springframework/web/bind/annotation/RequestParam.java
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/harness/src/main/java/org/springframework/web/bind/annotation/RequestParam.java
@@ -1,0 +1,5 @@
+package org.springframework.web.bind.annotation;
+
+public @interface RequestParam {
+    boolean required() default true;
+}

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/harness/src/main/java/zoo/UserDirectory.java
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/harness/src/main/java/zoo/UserDirectory.java
@@ -1,0 +1,9 @@
+package zoo;
+
+import org.springframework.web.bind.annotation.RequestParam;
+
+public final class UserDirectory {
+    public String lookup(@RequestParam String name) {
+        return "user:" + name.toUpperCase();
+    }
+}

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/kit-rpc/run-java-lifter.sh
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/kit-rpc/run-java-lifter.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../../../.." && pwd)"
+java_root="$repo_root/implementations/java"
+core_jar="$java_root/provekit-lift-java-core/target/provekit-lsp-java.jar"
+adapter_jar="$java_root/provekit-lift-java-spring-web/target/provekit-lift-java-spring-web-0.1.0.jar"
+
+ensure_jdk() {
+  if java -version >/dev/null 2>&1 && javac -version >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for candidate in /usr/local/opt/openjdk/bin /opt/homebrew/opt/openjdk/bin; do
+    if [[ -x "$candidate/java" && -x "$candidate/javac" ]]; then
+      export PATH="$candidate:$PATH"
+      if java -version >/dev/null 2>&1 && javac -version >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+  done
+
+  echo "Unable to locate a usable Java runtime/compiler pair." >&2
+  echo "Install OpenJDK or expose java and javac on PATH." >&2
+  echo "Checked: PATH, /usr/local/opt/openjdk/bin, /opt/homebrew/opt/openjdk/bin" >&2
+  exit 1
+}
+
+ensure_jdk
+
+mvn -f "$java_root/pom.xml" -pl provekit-lift-java-core,provekit-lift-java-spring-web -am package -DskipTests >&2
+
+for jar in "$core_jar" "$adapter_jar"; do
+  if [[ ! -f "$jar" ]]; then
+    echo "Missing required Java lifter jar: $jar" >&2
+    echo "Try: mvn -f \"$java_root/pom.xml\" -pl provekit-lift-java-core,provekit-lift-java-spring-web -am package -DskipTests" >&2
+    exit 1
+  fi
+done
+
+java -cp "$core_jar:$adapter_jar" \
+  com.provekit.lift.Main --rpc

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/harness/run.sh
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/harness/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+ensure_jdk() {
+  if java -version >/dev/null 2>&1 && javac -version >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for candidate in /usr/local/opt/openjdk/bin /opt/homebrew/opt/openjdk/bin; do
+    if [[ -x "$candidate/java" && -x "$candidate/javac" ]]; then
+      export PATH="$candidate:$PATH"
+      if java -version >/dev/null 2>&1 && javac -version >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+  done
+
+  echo "Unable to locate a usable Java runtime/compiler pair." >&2
+  echo "Install OpenJDK or expose java and javac on PATH." >&2
+  echo "Checked: PATH, /usr/local/opt/openjdk/bin, /opt/homebrew/opt/openjdk/bin" >&2
+  exit 1
+}
+
+ensure_jdk
+
+rm -rf .classes
+mkdir -p .classes
+javac -d .classes ../library/src/main/java/zoo/UserDirectory.java src/main/java/zoo/UserDirectoryHarness.java
+java -cp .classes zoo.UserDirectoryHarness

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/harness/src/main/java/zoo/UserDirectoryHarness.java
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/harness/src/main/java/zoo/UserDirectoryHarness.java
@@ -1,0 +1,10 @@
+package zoo;
+
+public final class UserDirectoryHarness {
+    public static void main(String[] args) {
+        String value = new UserDirectory().lookup("ada");
+        if (!"user:ADA".equals(value)) {
+            throw new IllegalStateException(value);
+        }
+    }
+}

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/kit-rpc/README.md
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/kit-rpc/README.md
@@ -1,0 +1,3 @@
+# Lab Kit RPC
+
+The lab state is ordinary code with no lifted boundary contract. Exposed variants own their kit RPC launchers.

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/library/src/main/java/zoo/UserDirectory.java
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/library/src/main/java/zoo/UserDirectory.java
@@ -1,0 +1,7 @@
+package zoo;
+
+public final class UserDirectory {
+    public String lookup(String name) {
+        return "user:" + name.toUpperCase();
+    }
+}

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/specimen.yaml
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/specimen.yaml
@@ -1,0 +1,60 @@
+id: BZ-SHAPE-005
+name: Java Null Boundary Equivalence
+kingdom: shape
+surface: java-provekit-native-and-spring-web
+status: lab
+paths:
+  labLibrary: lab/library
+  labHarness: lab/harness
+  labKitRpc: lab/kit-rpc
+commands:
+  hostCheck:
+    cwd: lab/harness
+    argv: ["./run.sh"]
+predicates:
+  boundary: maybe_null(name)
+  sink: non_null(name)
+  missingEdge: maybe_null(name) => non_null(name)
+exposures:
+  - id: provekit-native
+    surface: java-provekit-native
+    harness: exposed/provekit-native/harness
+    kitRpc: exposed/provekit-native/kit-rpc
+    liftRpc:
+      cwd: exposed/provekit-native/kit-rpc
+      argv: ["./run-java-lifter.sh"]
+    proofIrFile: exposed/provekit-native/expected.proofir.json
+    diagnosticFile: exposed/provekit-native/expected-diagnostic.txt
+    lossiness:
+      erased:
+        - Java method body string concatenation
+        - concrete annotation package name
+      preserved:
+        - precondition neq(name, null)
+  - id: spring-web
+    surface: java-spring-web
+    harness: exposed/spring-web/harness
+    kitRpc: exposed/spring-web/kit-rpc
+    liftRpc:
+      cwd: exposed/spring-web/kit-rpc
+      argv: ["./run-java-lifter.sh"]
+    proofIrFile: exposed/spring-web/expected.proofir.json
+    diagnosticFile: exposed/spring-web/expected-diagnostic.txt
+    lossiness:
+      erased:
+        - Spring request binding machinery
+        - Java method body string concatenation
+      preserved:
+        - precondition neq(name, null)
+equivalence:
+  required:
+    - [provekit-native, spring-web]
+expectations:
+  hostCompiler: pass
+  ordinaryTests: pass
+  provekitVerify: fail
+exposure:
+  satWitnessFile: exposed/sat-witness.json
+dropper:
+  available: false
+wildSightings: []

--- a/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/wild/README.md
+++ b/bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/wild/README.md
@@ -1,0 +1,5 @@
+# Wild Specimens
+
+Add only real OSS specimens here.
+
+Each entry must pin an advisory ID, project slug, vulnerable commit, affected paths, source URL, exposure artifacts, and a verdict. Historical remediation is optional context only and must not be used as the oracle.

--- a/docs/papers/09-lossy-boundary-compression.md
+++ b/docs/papers/09-lossy-boundary-compression.md
@@ -1,0 +1,790 @@
+# Lossy Boundary Compression: Why ProofIR Is Universal Because It Forgets
+
+> **Status.** Draft whitepaper. Sustained argument. Contains a lemma. Written to be cite-able after review.
+>
+> **Companion to.** [01 Whitepaper](01-whitepaper.md), [02 Bluepaper](02-bluepaper.md), [03 Substrate, not Blockchain](03-substrate-not-blockchain.md), [04 Vertical Stack and Standardization](04-vertical-stack-and-standardization.md), [05 Witness Pluralism and Jurisdiction-Neutral Transport](05-witness-pluralism-and-jurisdiction-neutral-transport.md), [06 After Reputation](06-after-reputation-software-as-federated-truth-claims.md), [07 After Verification](07-after-verification-bug-classes-as-missing-edges.md), [08 After Types](08-after-types-stop-logging-trust-the-invariant-solver.md).
+>
+> **Premise the earlier papers established.** A protocol for content-addressable, cryptographically-signed, byte-deterministic claims about software behavior, federated across signers, composable end-to-end, jurisdiction-neutral, and machine-checkable. Papers 06 through 08 argued that once those claims become a substrate, reputation, verification, types, and logs are all demoted from load-bearing trust infrastructure into policy, tooling, and observability layers.
+>
+> **What this paper argues.** That ProofIR's universality over contract boundaries does not come from representing every implementation detail of every host language. It comes from refusing to. ProofIR is universal over contract boundaries: preconditions, postconditions, invariants, protocol obligations, value predicates, resource states, signer claims, and implication edges. Because the domain is narrow, lifters may discard implementation texture while preserving the obligation. That deliberate loss is what makes cross-language, cross-framework, cross-time equivalence possible. It also constrains generation: a probabilistic producer may emit many possible implementations, but only the outputs whose lifted boundary edges close are admissible.
+
+## §0: The claim
+
+The mistake to avoid is obvious and fatal: treating ProofIR as a universal programming language.
+
+It is not that. ProofIR is not a second Java, a second TypeScript, a second Rust, a second OpenAPI schema language, a second JML, a second Cofoja, a second Zod, a second Pydantic, a second Spring reflection model, or a second test runner. It is not a place to re-express every implementation detail of every host artifact. It is not the full semantics of the source program in canonical costume.
+
+ProofIR is universal in a narrower and stronger sense. It is universal over contract boundaries.
+
+The contract-boundary domain includes:
+
+- preconditions;
+- postconditions;
+- invariants;
+- protocol obligations;
+- value predicates;
+- resource states;
+- signer claims;
+- implication edges.
+
+That is the domain. Nothing else is promised.
+
+The surprise is that "contract boundary" is a narrow kind of object and an enormous part of software. ProofIR is not universal over contract boundaries because the boundary domain is small. It is universal over contract boundaries because nearly every meaningful software obligation eventually appears at a boundary: a trust boundary, a call boundary, a protocol boundary, a resource boundary, an authority boundary, a privacy boundary, a concurrency boundary, a serialization boundary, a cryptographic boundary, an audit boundary, a business-rule boundary.
+
+ProofIR does not cover less by refusing implementation semantics. It covers more, because the thing it keeps, the boundary obligation, is the part every language, framework, protocol, and organization already has to express somehow.
+
+Within that domain, lossy compression is not a defect. It is the design. A lifter may discard implementation texture, framework idiom, annotation syntax, validator control flow, test harness structure, and historical commit context, as long as it preserves the boundary obligation. The obligation is the invariant-bearing part. The rest is authoring texture.
+
+The more precise name is **obligation-preserving loss**. The lift is allowed to lose source detail only when the lost detail is outside the boundary obligation being preserved. "Lossy" here does not mean approximate. It means the equivalence relation is drawn at the contract boundary rather than at the full implementation.
+
+This is what lets the same boundary predicate be lifted from a Spring annotation, a ProvekIt-native annotation, an OpenAPI schema, a Zod validator, and a historical OSS commit. The source implementations are not equivalent. The boundary obligations are.
+
+The difference matters because adoption depends on it. ProvekIt-native contracts are a reference surface, not a required authoring style. Existing code already contains latent contracts in Spring, Bean Validation, Swagger/OpenAPI, Zod, Pydantic, JML, Cofoja, tests, types, schemas, comments, metadata, framework declarations, and old patches. ProvekIt's move is to lift those latent contracts into universal, comparable, solvable, translatable, content-addressable, signable ProofIR edges.
+
+The substrate does not begin when developers agree to write ProvekIt-native annotations. The substrate begins when their existing boundary claims can be read.
+
+## §1: The lemma
+
+**Lemma (Lossy Boundary Compression / Output Constraint).** Let `S` be a source artifact in some host language or framework. Let `B(S)` be the set of boundary obligations expressed by `S`: preconditions, postconditions, invariants, protocol obligations, value predicates, resource states, signer claims, and implication edges. Let `L` be a lifter from `S` into ProofIR. Let `A` be the set of admissible outputs for some requested change, where admissibility is defined by closure of the required ProofIR boundary edges under an accepted witness policy.
+
+If `L` preserves `B(S)` up to the canonical equivalence relation on boundary predicates, then:
+
+1. `L` may discard every source-level feature outside `B(S)` without loss for any substrate operation whose semantics are defined only over boundary obligations; and
+2. for any producer `P` that emits candidate artifacts `S'`, deterministic lift-and-check induces a constraint function `C(S') = edge_closed(L(S'))`, reducing `P`'s effective output space from all syntactically possible artifacts to the subset `A`.
+
+Equivalently:
+
+```
+preserve_boundary(S) => may_forget_implementation_texture(S)
+edge_closed(L(S')) => output_admissible(S')
+```
+
+provided the consumer asks only boundary-domain questions and output admissibility is defined over those questions.
+
+The lemma is almost embarrassingly small. Its consequence is not.
+
+ProofIR's operations are over predicates and edges. Predicate canonicalization, CID computation, implication checking, witness verification, signing, edge composition, policy acceptance, and dropper translation all operate on the boundary object. They do not require the source's complete implementation semantics. Therefore a lifter that preserves the boundary object has preserved all information relevant to those operations.
+
+This is ordinary abstraction discipline, applied aggressively. If the interface contract is the object of study, the implementation is not part of the equivalence class. Two implementations can differ in timing, memory allocation, framework machinery, reflection paths, exception formatting, logging, helper functions, and code style while expressing the same boundary predicate. For contract-boundary purposes, they are the same.
+
+The proof is one line:
+
+For every substrate operation `O` defined only over `B(S)`, if `L1(S1) = L2(S2)` in canonical boundary form, then `O(L1(S1)) = O(L2(S2))`. For every generated candidate `S'`, if `edge_closed(L(S'))` is false, then `S' ∉ A` by definition of admissibility; if it is true under accepted witness policy, then `S' ∈ A` for boundary-domain purposes.
+
+Everything else is consequence.
+
+**Corollary (Probabilistic producers become admissibility-searched producers).** Once output acceptance is defined as `edge_closed(L(S'))`, an LLM is not a trusted authority over correctness. It is a search procedure over candidate artifacts. The substrate is the acceptance function.
+
+This is the correct division of labor. The model explores the space of possible patches, schemas, validators, annotations, migrations, tests, and native contracts. The substrate rejects every candidate outside the admissible set. The model's probability distribution may be useful for finding candidates quickly; it is not part of the proof that any candidate is acceptable.
+
+### §1.1: Why the output side matters
+
+The first half of the lemma is about equivalence: different source surfaces can collapse to the same boundary object. The second half is about constraint: once the boundary object is canonical, it can reject candidate outputs.
+
+That rejection property is the part that matters most in the LLM era.
+
+A deterministic compiler emits one output for a given input. A probabilistic model emits a distribution over possible outputs. Some candidates are good. Some are subtly wrong. Some satisfy the user's prose but violate a boundary obligation the prose did not mention. Some preserve behavior but weaken validation. Some add a guard in the wrong layer. Some pass tests while expanding the accepted input domain. The model's fluency is not evidence of admissibility.
+
+The substrate changes the question from:
+
+```
+Did the model produce plausible code?
+```
+
+to:
+
+```
+Does the model's output lift to boundary edges that close?
+```
+
+That is a codomain restriction. The model may sample from a huge space of syntactically plausible patches, schemas, validators, annotations, migrations, and tests. ProvekIt narrows that space after generation to the subset whose boundary predicates satisfy the required edges. The narrowing is not a prompt trick. It is not "be careful" in system-message form. It is a mechanical acceptance gate over lifted output.
+
+This connects to the earlier constraint-driven-development spec: each fix mints a permanent constraint on what the codebase cannot become. It also connects to paper 07's generative-completion section: models may generate candidate code, but the substrate verifies mechanically whether the candidate closes the DAG. This paper adds the boundary-compression reason that loop can be cross-language and cross-framework. The model can output Spring, Zod, OpenAPI, Pydantic, JML, Cofoja, SQL migrations, tests, or ProvekIt-native declarations. The substrate does not need to trust the surface. It lifts the boundary obligation and checks the edge.
+
+This is why obligation-preserving loss is stronger than faithful re-expression for AI-produced artifacts. A faithful host-language IR would inherit the model's implementation sprawl and make every candidate hard to compare. A boundary IR discards the sprawl and asks the only admissibility question that matters at the contract layer: did this output preserve or strengthen the required obligation?
+
+In a probabilistic-output regime, the valuable object is not the model's preferred completion. The valuable object is the constraint that filters completions.
+
+### §1.2: What the lemma does not say
+
+The lemma does not say that implementation details are unimportant. They are important for performance, debugging, ergonomics, security side channels, resource consumption, exception shape, deployability, maintainability, and business logic.
+
+The lemma says only that those details are outside the ProofIR boundary-domain unless they themselves are lifted as boundary obligations.
+
+If a resource constraint matters, lift it as a resource-state predicate. If timing matters, lift it as a protocol or resource obligation. If authorization matters, lift it as a precondition. If mutation order matters, lift it as a state-transition invariant. If exception behavior matters to a caller, lift it as a postcondition. But do not pretend the entire host implementation must become ProofIR merely because some implementation detail matters somewhere.
+
+ProofIR is not universal by being maximally expressive. It is universal by choosing the right cut.
+
+## §2: The domain cut
+
+The domain cut is the whole architecture.
+
+Prior formal methods often fail adoption by asking developers to move their authoring surface into the verifier's preferred language. Write the spec in this syntax. Rewrite the function in that subset. Add annotations in the verifier's house style. Avoid framework features the tool cannot understand. Use the blessed encoding. The work may be sound, but the adoption path is narrow: become the kind of team that authors formal contracts directly.
+
+ProvekIt reverses the posture.
+
+The world already writes contracts. It just does not call them that consistently.
+
+A Spring controller method with `@RequestParam @Min(1) @Max(100)` is a boundary contract. A Bean Validation DTO with `@NotNull`, `@Email`, and `@Size(max = 255)` is a boundary contract. An OpenAPI schema with `minimum`, `maxLength`, `required`, and `format: email` is a boundary contract. A Zod validator that says `z.string().email().max(255)` is a boundary contract. A Pydantic model with `Field(gt=0, le=100)` is a boundary contract. A JML clause `requires amount > 0; ensures balance == \old(balance) - amount;` is a boundary contract. A Cofoja `@Requires("x >= 0")` is a boundary contract. A regression test asserting that negative quantities are rejected is a boundary contract, albeit a sampled and weaker one. A historical OSS commit that adds a null check before a dereference is a boundary contract made visible by repair.
+
+The authoring surfaces differ. The boundary obligation may not.
+
+ProofIR lives at the cut where those surfaces collapse:
+
+```
+input.amount: integer
+requires input.amount >= 1
+requires input.amount <= 100
+```
+
+That predicate can arrive from an annotation, a schema, a validator, a native ProvekIt declaration, a test, or a patch. Once lifted, its origin is provenance, not semantics. The semantics are the canonical predicate and its implication edges.
+
+This is why ProvekIt-native contracts must be understood as a reference surface, not a required authoring style. Native contracts matter because they show the substrate's object model cleanly. They give authors a direct way to write the thing itself. But requiring native authoring as the adoption path would throw away the largest contract corpus in existence: the contracts already embedded in ordinary code.
+
+The substrate does not need developers to become formal-methods people before it can read them. It needs lifters that can see the formal boundary claims they are already making.
+
+## §3: Java equivalence without Java equivalence
+
+Consider a Java service boundary requiring an account transfer amount to be positive and no larger than a configured limit.
+
+In Bean Validation:
+
+```java
+record TransferRequest(
+    @NotNull
+    @Min(1)
+    @Max(10000)
+    Long amount
+) {}
+```
+
+In Spring MVC:
+
+```java
+@PostMapping("/transfer")
+ResponseEntity<?> transfer(
+    @RequestParam @Min(1) @Max(10000) long amount
+) { ... }
+```
+
+In JML:
+
+```java
+/*@ requires amount >= 1 && amount <= 10000;
+  @ ensures \result.accepted ==> balance == \old(balance) - amount;
+  @*/
+TransferResult transfer(long amount) { ... }
+```
+
+In Cofoja:
+
+```java
+@Requires("amount >= 1 && amount <= 10000")
+@Ensures("result.accepted() ==> balance() == old(balance()) - amount")
+TransferResult transfer(long amount) { ... }
+```
+
+These artifacts are not equivalent as Java. They have different toolchains, retention policies, runtime behavior, reflection surfaces, failure modes, exception types, annotation processors, and enforcement points. A Spring parameter annotation is not a JML method contract. A Bean Validation DTO is not a Cofoja-instrumented method. A JML specification may be statically checked by tooling that never runs in production. A Spring annotation may be enforced by runtime binding.
+
+ProofIR does not need them to be equivalent as Java.
+
+It needs to know whether they express the same boundary obligation:
+
+```
+requires amount != null
+requires amount >= 1
+requires amount <= 10000
+```
+
+and, if present:
+
+```
+ensures accepted(result) -> balance_after = balance_before - amount
+```
+
+The lifter is allowed to forget that one source used Java annotations, another used specification comments, another used annotation instrumentation, and another used framework binding. It is allowed to forget the exact exception class thrown on failure. It is allowed to forget whether validation occurred before controller dispatch or inside an instrumented method wrapper, unless that enforcement phase is itself the boundary obligation under analysis.
+
+That forgetting is what creates equivalence.
+
+The same predicate CID can be shared by:
+
+- a Spring endpoint in a bank;
+- a JML-specified method in a university verification suite;
+- a Cofoja contract in an old enterprise Java codebase;
+- a Bean Validation DTO in a payment processor;
+- a ProvekIt-native declaration in a new service.
+
+The Java implementations are not equivalent. The boundary predicate is.
+
+Once they lift to the same predicate CID, their implication edges can be compared, solved, signed, and reused. If one organization has a signed witness that `1 <= amount <= 10000` implies `amount > 0`, every other organization can reuse that edge, regardless of whether its source surface was Spring, JML, Cofoja, or ProvekIt-native.
+
+That is the substrate doing the thing. It is not translating Java into another Java. It is extracting the obligation from Java-shaped surfaces and placing that obligation into a shared contract-boundary edge space.
+
+## §4: TypeScript, OpenAPI, and the same edge
+
+Now cross the language boundary.
+
+A TypeScript service might define:
+
+```ts
+const TransferRequest = z.object({
+  amount: z.number().int().min(1).max(10000),
+  destination: z.string().uuid()
+});
+```
+
+The public API might also publish:
+
+```yaml
+components:
+  schemas:
+    TransferRequest:
+      type: object
+      required: [amount, destination]
+      properties:
+        amount:
+          type: integer
+          minimum: 1
+          maximum: 10000
+        destination:
+          type: string
+          format: uuid
+```
+
+A Python implementation might use Pydantic:
+
+```python
+class TransferRequest(BaseModel):
+    amount: int = Field(ge=1, le=10000)
+    destination: UUID
+```
+
+Again, these artifacts are not equivalent as implementations. Zod executes as TypeScript/JavaScript validation code. OpenAPI is a schema document. Pydantic is Python runtime validation plus model construction. Their coercion behavior can differ. Their error messages can differ. Their default handling can differ. Their unknown-field policy can differ. Their integer semantics can differ at the host-language edge.
+
+ProofIR must not erase those differences if those differences are part of the boundary obligation. If coercion is allowed in one surface and forbidden in another, that is a predicate difference. If unknown fields are rejected in one and ignored in another, that is a predicate difference. If JavaScript number precision changes the accepted domain, that is a predicate difference.
+
+But where the boundary obligation is the same, the canonical predicate is the same:
+
+```
+requires integer(amount)
+requires 1 <= amount
+requires amount <= 10000
+requires uuid(destination)
+```
+
+The lossy compression rule is not "pretend all validators are the same." It is "preserve the boundary predicate and discard everything else."
+
+That discipline gives us cross-language call-boundary verification.
+
+Suppose a Java service calls a TypeScript service through HTTP. The Java caller has a Bean Validation object. The TypeScript callee has a Zod validator. The OpenAPI document sits between them as the published protocol. Today, teams ask whether the generated client is up to date, whether the schema matches the implementation, whether the runtime validator is stricter than the docs, whether the caller's DTO drifted from the callee's accepted shape.
+
+In the substrate, each surface lifts to ProofIR:
+
+```
+Java DTO predicate      -> CID A
+OpenAPI schema predicate -> CID B
+Zod predicate           -> CID C
+```
+
+If `A = B = C`, the surfaces express the same boundary obligation.
+
+If `A -> B` but not `B -> A`, the caller is stricter than the published schema.
+
+If `B -> C` but not `C -> B`, the implementation is weaker than the published schema.
+
+If no implication holds in one direction, the boundary has drift.
+
+This is the ordinary work API teams already do by review, integration tests, generated clients, and staging failures. The substrate turns it into signed implication edges.
+
+The result is not "Java and TypeScript are equivalent." They are not. The result is "this Java caller's outbound predicate implies this TypeScript callee's inbound predicate." That is the contract-boundary question, and it is exactly the question ProofIR is built to answer.
+
+## §5: Latent contracts and adoption
+
+The adoption corollary is more important than the technical point.
+
+If ProvekIt required native annotations everywhere, adoption would depend on a rewrite of developer behavior. That is the wrong shape. The world's software supply chain is not going to stop and re-author itself in a new contract language before receiving value.
+
+The better claim is stronger:
+
+Most useful contracts already exist. They are latent.
+
+They appear as framework annotations, schemas, validators, type refinements, tests, examples, CI checks, database constraints, migration files, sanitizer wrappers, linter rules, static analyzer suppressions, comments attached to dangerous APIs, issue fixes, and old commits that patched bugs by adding guards.
+
+A database migration:
+
+```sql
+ALTER TABLE users
+  ADD CONSTRAINT email_present CHECK (email IS NOT NULL),
+  ADD CONSTRAINT email_unique UNIQUE (email);
+```
+
+is a boundary contract.
+
+A test:
+
+```ts
+expect(() => TransferRequest.parse({ amount: 0 })).toThrow();
+```
+
+is a sampled boundary contract:
+
+```
+rejects amount = 0
+```
+
+which is weaker than:
+
+```
+requires amount >= 1
+```
+
+but still useful as evidence.
+
+A historical patch:
+
+```diff
+- return read(buf, len);
++ if (len > MAX_PACKET) return -EINVAL;
++ return read(buf, len);
+```
+
+is a boundary contract discovered by repair:
+
+```
+requires len <= MAX_PACKET before read
+```
+
+The patch does not need to have been authored as a specification. It became one by fixing a missing obligation.
+
+This is the lift-not-author posture. ProvekIt-native contracts are clean and useful, but the substrate's bootstrapping path is extraction. Read what exists. Canonicalize the boundary predicate. Preserve provenance. Sign the edge. Make it comparable.
+
+This is also why lossy compression must be permitted. A lifter that tries to preserve all source texture becomes a host-language reimplementation project. A lifter that preserves boundary obligations becomes feasible, useful, and compositional. The difference between those two projects is the difference between never shipping and becoming infrastructure.
+
+## §6: Constraint-driven development needs a boundary cut
+
+The constraint-driven-development spec gave ProvekIt its development methodology: every fix mints a permanent constraint on what the codebase cannot become. The change request is the trigger; the constraint is the product; the accumulated constraint corpus monotonically reduces the codebase's degrees of freedom.
+
+This paper supplies the boundary-theoretic reason that methodology can work across ordinary software.
+
+CDD needs three facts at once:
+
+1. A constraint must be stronger than a test because it must constrain paths that do not exist yet.
+2. A constraint must be liftable from existing artifacts because adoption cannot wait for everyone to author native contracts.
+3. A constraint must be able to reject generated output because more and more code will be produced by probabilistic tools.
+
+Lossy boundary compression is the thing that lets all three coexist. The constraint is not "the implementation must keep looking like this patch." The constraint is "future artifacts must preserve or strengthen this boundary obligation." That is why a bug fix in Java can constrain a future TypeScript validator, why a database migration can constrain a future API schema, and why an LLM-generated patch can be accepted or rejected without trusting the model.
+
+The CDD loop becomes:
+
+```
+problem or patch -> lifted boundary obligation -> signed constraint edge
+future candidate -> lift -> edge closure check -> accept or reject
+```
+
+The important object is the rejection surface. A codebase under CDD is not merely accumulating facts about itself. It is accumulating impossibilities. Every accepted constraint removes a region from the future output space. The more probabilistic the producer, the more valuable that rejection surface becomes.
+
+### §6.1: A concrete LLM admissibility example
+
+Suppose an LLM is asked to fix SQL injection in a TypeScript service. It proposes three plausible patches.
+
+Patch A escapes strings:
+
+```ts
+const q = `select * from orders where user_id = '${escapeSql(input)}'`;
+await db.query(q);
+```
+
+Patch B uses a prepared statement:
+
+```ts
+await db.query("select * from orders where user_id = ?", [input]);
+```
+
+Patch C rejects suspicious input with a regex:
+
+```ts
+if (!/^[0-9]+$/.test(input)) throw new Error("bad input");
+const q = `select * from orders where user_id = ${input}`;
+await db.query(q);
+```
+
+All three may look plausible to a reviewer skimming for "SQL injection fixed." All three may pass the narrow regression test the model wrote. All three may satisfy the user's prose request at a surface level.
+
+The substrate does not ask whether the patch looks plausible. It lifts each candidate and checks the required boundary edge:
+
+```
+untrusted(input) -> safe_for_sql(query)
+```
+
+Under a policy that accepts parameterization but does not accept ad-hoc escaping or regex validation as a general SQL-safety proof, only Patch B closes:
+
+```
+untrusted(input) -> parameterized_query(query) -> safe_for_sql(query)
+```
+
+Patch A may close only if `escapeSql` has an accepted signer, precise dialect scope, and an edge from its output to `safe_for_sql` for this sink. Patch C may close a numeric-domain predicate but still fail the SQL-safety edge unless the query construction rule and database dialect make that implication valid under policy.
+
+The point is not that prepared statements are always the only acceptable fix. The point is that admissibility is not the model's confidence, the prettiness of the code, or the presence of a test. Admissibility is edge closure under policy. The LLM generated candidates. ProvekIt constrained the output set.
+
+This is the clean CDD posture for probabilistic software production: let the model search, let the substrate reject.
+
+This is also the right way to understand droppers. A dropper is not a compiler from ProofIR to a host language. It is a host-language repair emitter for a missing boundary edge. It may render a native guard, wrapper, validator, prepared statement, state transition, or annotation, but the rendered source is not trusted by virtue of being rendered. It is accepted only after the lifter reads it back and the verifier confirms that the emitted native shape closes the graph.
+
+The direction matters:
+
+```
+missing edge -> native repair candidate -> re-lift -> closure check
+```
+
+not:
+
+```
+ProofIR + values -> host implementation
+```
+
+The first is generative completion under constraint. The second would turn ProofIR into a universal programming language by another route, which is precisely the category error this paper rejects.
+
+## §7: Content addressing turns sameness into infrastructure
+
+Once lifted, a boundary predicate has bytes. Once it has bytes, it has a CID. Once it has a CID, sameness is no longer a social claim.
+
+The sentence "our OpenAPI schema matches our Zod validator" becomes:
+
+```
+cid(openapi_predicate) == cid(zod_predicate)
+```
+
+or, if one is intentionally stricter:
+
+```
+edge(openapi_predicate -> zod_predicate)
+edge(zod_predicate -> openapi_predicate) absent
+```
+
+depending on policy.
+
+The sentence "this Java caller satisfies that TypeScript callee" becomes:
+
+```
+edge(java_outbound_predicate -> ts_inbound_predicate)
+```
+
+The sentence "this fix closes the old bug" becomes:
+
+```
+edge(pre_patch_state -> required_sink_precondition)
+```
+
+with the post-patch program supplying an intermediate predicate that makes the path exist.
+
+This is the operational consequence of the lemma. Lossy boundary compression produces stable predicate identity. Stable predicate identity enables reusable implication edges. Reusable implication edges make the substrate federated.
+
+Without loss, no identity. If every annotation-retention policy, framework exception type, validator stack trace, AST location, source formatting choice, and helper-function name remains part of the canonical object, then two artifacts almost never hash together. The cache fragments. Cross-language equivalence fails. The substrate degenerates into one silo per framework.
+
+With disciplined loss, the cache compounds. The same predicate lifted from Spring, ProvekIt-native annotations, OpenAPI, Zod, Pydantic, JML, Cofoja, tests, and historical commits lands in the same address space. Every signed edge against that predicate becomes reusable.
+
+The substrate's economic claim rests on this. The global lemma cache works only if common obligations collapse to common addresses. Common addresses require forgetting everything outside the obligation.
+
+Forgetfulness is not a concession. It is the compression function.
+
+### §7.1: What stable boundary identity buys
+
+Stable boundary identity is not merely a nice property of the IR. It changes the operating model around software.
+
+**API drift becomes algebraic.** Today, API drift is discovered by broken clients, stale generated SDKs, integration-test failures, schema diff tools, and production incidents. Under boundary compression, drift is an implication result. The published schema, the caller's outbound object, the callee's runtime validator, and the database constraint each lift to predicates. Compatibility is equality or implication. Incompatibility is a missing edge. The question "did the API break?" stops being a meeting and becomes a substrate query.
+
+**Framework migration stops being a trust reset.** A team migrating from Spring MVC to Micronaut, from Java to Kotlin, from Express to Fastify, from Pydantic v1 to Pydantic v2, or from hand-written validators to Zod does not need to re-establish every contract socially. The old surface and the new surface both lift. If their boundary predicates match, the migration preserved the contract boundary even though the implementation changed. If the predicates differ, the substrate names the difference. Migration review moves from "does this look equivalent?" to "which boundary CIDs changed, and were those changes intended?"
+
+**Security review moves to the edge where security lives.** Many application-security failures are boundary failures: untrusted input treated as trusted, unchecked resource state reaching a sink, missing authorization predicates before sensitive operations, protocol states skipped. Lossy boundary compression makes those predicates first-class. Reviewers no longer have to infer the security posture from framework texture. They can ask for the edge: does `caller_claims(role=admin)` imply `may_execute(refund)` under the accepted signer policy? Does `untrusted(body.email)` imply `email(body.email)` before persistence? Does `maybe_closed(handle)` imply `open(handle)` before read? The review object becomes the obligation, not the host-language ritual that happened to express it.
+
+**Compliance evidence becomes portable.** A regulatory control often says, in prose, that some boundary condition must hold: reject malformed requests, enforce authorization before access, retain audit claims, validate signed messages, preserve consent state. Today each implementation produces its own evidence packet: screenshots, logs, test reports, code review links, policy documents. With stable boundary identity, the evidence can point at signed predicates and signed implication edges. The auditor does not need to believe that a Spring annotation, a Zod validator, and an OpenAPI schema are "basically the same." The auditor can verify whether they lift to the same predicate or whether signed implication edges connect them.
+
+**Droppers get a target, not a vibe.** A dropper cannot safely generate "the code that seems right." It needs a missing edge. Lossy boundary compression gives it one. If the substrate says the missing edge is `untrusted(query) -> safe_for_sql(query)`, the dropper may choose a host-language idiom: prepared statement in Java, parameterized query in Python, tagged SQL template in TypeScript, query builder in Ruby. The generated code differs; the target edge is the same. This is what makes cross-language repair possible without pretending languages share implementation semantics.
+
+**Standard libraries become lemma libraries.** Once boundary predicates have stable addresses, every framework's common validators and guards become reusable theorem material. `@Email`, `z.string().email()`, `format: email`, `EmailStr`, and a ProvekIt-native `email(x)` predicate can all point at the same obligation when their accepted domains align. The common validators stop being isolated helpers and become entry points into a shared implication graph.
+
+These are not downstream conveniences. They are the reason the lemma matters. If the lifter preserves too much, none of this composes. If it preserves too little, it is unsound. The engineering art is preserving exactly the boundary obligation, then letting the consequences compound.
+
+## §8: Signing preserves provenance without polluting semantics
+
+Forgetting source texture does not mean losing provenance.
+
+The boundary predicate and the provenance record are different objects.
+
+The predicate says:
+
+```
+requires amount >= 1
+requires amount <= 10000
+```
+
+The provenance record says:
+
+```
+lifted_from:
+  kind: spring_request_param
+  repository: example/payment-service
+  path: src/main/java/.../TransferController.java
+  commit: ...
+  signer: ...
+  lifter: provekit-java-kit
+```
+
+or:
+
+```
+lifted_from:
+  kind: openapi_schema
+  path: openapi.yaml#/components/schemas/TransferRequest
+  signer: ...
+```
+
+The predicate's CID must not change merely because the source path, repository, lifter version, or signer changes. Those are provenance facts. They matter for policy. They do not define the boundary predicate.
+
+This separation is load-bearing.
+
+If provenance is mixed into predicate identity, the same obligation lifted from two places becomes two predicates. The cache splits. Equivalence becomes expensive. Federation weakens.
+
+If provenance is discarded entirely, consumers cannot decide which edges to trust. A predicate lifted from an audited Spring service, a generated OpenAPI file, a hand-written test, and an unreviewed fork may be semantically identical, but policy may treat their signatures differently.
+
+The substrate needs both:
+
+- predicate identity by canonical boundary bytes;
+- trust decisions by signed provenance and witness policy.
+
+That is the same move paper 06 made for reputation. Reputation leaves the substrate and moves to policy. Here, source texture leaves predicate identity and moves to provenance. The substrate stays clean; consumers stay sovereign.
+
+## §9: The cross-time case
+
+Cross-language equivalence is only half the consequence. The same lemma gives cross-time equivalence.
+
+A historical OSS commit that fixes a vulnerability often has the shape:
+
+1. an unsafe boundary was accepted;
+2. a sink required a predicate;
+3. the old path did not prove it;
+4. the patch inserted a guard, sanitizer, state transition, or resource check;
+5. the new path proves it.
+
+The commit is not written as a proof. It is written as code. It has review comments, issue references, release notes, test additions, and maybe a CVE. But under the boundary-domain cut, it contains a before-and-after obligation.
+
+Example:
+
+```diff
+- if (user.role == "admin") allow();
++ if (user != null && user.role == "admin") allow();
+```
+
+At the boundary level, the patch exposes:
+
+```
+requires user != null before role dereference
+```
+
+Another project in another language may have the same missing obligation:
+
+```ts
+if (user.role === "admin") allow();
+```
+
+The source artifacts are not equivalent. The historical Java patch and the current TypeScript code do not share implementation semantics. But the missing boundary edge is the same:
+
+```
+maybe_null(user) -> non_null(user)
+```
+
+If the historical patch has been lifted, witnessed, and signed, it becomes a receipt for the obligation. Not a proof that the TypeScript code is safe. A receipt that this class of boundary obligation has appeared before, was repaired before, and has a canonical edge shape the substrate can test against.
+
+This is how software history becomes infrastructure. Old fixes stop being prose in changelogs and become signed edges in a federated proof DAG.
+
+## §10: Bug Zoo as receipt infrastructure
+
+Bug Zoo belongs here, but carefully.
+
+Bug Zoo is not the design center of this paper. The design center is lossy boundary compression. Bug Zoo is the empirical receipt infrastructure that makes the claim falsifiable at scale.
+
+A Bug Zoo entry can carry:
+
+- the pre-fix artifact;
+- the post-fix artifact;
+- the lifted pre-fix boundary predicates;
+- the lifted post-fix boundary predicates;
+- the missing edge exposed by the bug;
+- the edge closed by the fix;
+- the witnesses accepted by policy;
+- the signers who attest the lift, the witness, and the classification.
+
+That turns a bug corpus into more than examples. It becomes a receipt set for boundary obligations.
+
+For a SQL injection fix, the receipt says:
+
+```
+pre-fix:  untrusted(input) reaches execute_query requiring safe_for_sql(query)
+missing:  untrusted(query) -> safe_for_sql(query)
+post-fix: untrusted(input) -> parameterized_query(query) -> safe_for_sql(query)
+```
+
+For a null dereference fix:
+
+```
+pre-fix:  maybe_null(user) reaches dereference requiring non_null(user)
+missing:  maybe_null(user) -> non_null(user)
+post-fix: maybe_null(user) -> checked_non_null(user) -> non_null(user)
+```
+
+For a resource-state fix:
+
+```
+pre-fix:  maybe_closed(handle) reaches read requiring open(handle)
+missing:  maybe_closed(handle) -> open(handle)
+post-fix: maybe_closed(handle) -> checked_open(handle) -> open(handle)
+```
+
+These receipts do not prove that every future program is safe. They prove something narrower and more useful: this boundary obligation shape exists in real software history, this source repair closed it, this lift preserved the obligation, and this edge can now be looked up by CID.
+
+Bug Zoo is the empirical answer to "are these predicates real or invented?" It grounds the substrate in the bug record. It lets the ecosystem say: here is the exact obligation that was missing in real code; here is the patch that closed it; here is the canonical edge; here are the signatures.
+
+The zoo is not a design doc. It is the receipt drawer.
+
+The implication is that empirical software history becomes a prioritization engine for the substrate. Edges that recur across Bug Zoo entries deserve foundation-catalog treatment. Predicates that appear in many languages deserve first-class vocabulary. Lifters that fail to recover known historical obligations can be tested against the receipt set. Droppers that claim to repair a class can be evaluated by whether their output closes the same edge the historical fix closed.
+
+This is how the substrate avoids becoming a beautiful taxonomy detached from practice. The bug corpus pushes back. If a predicate never appears in real repairs, maybe it is not foundational. If a missing edge appears in a hundred ecosystems, it belongs near the root catalog. If a lifter preserves source texture but misses the obligation the patch actually repaired, the lifter is wrong. Bug Zoo turns the lossy-compression lemma into an empirical test: did the loss preserve the edge that mattered?
+
+## §11: Counterarguments
+
+### "Lossy compression is unsound."
+
+Lossy compression is unsound when the discarded information is relevant to the question being asked.
+
+This paper's lemma is explicitly conditional: the lifter may discard source features outside `B(S)` for operations defined only over `B(S)`. If an implementation feature affects the boundary obligation, it is inside `B(S)` and must be preserved. If it does not affect the boundary obligation, retaining it in predicate identity is noise.
+
+Unsoundness comes from drawing the boundary wrong, not from loss as such.
+
+### "But source implementations really differ."
+
+Yes. That is the point.
+
+A Spring annotation, a ProvekIt-native annotation, an OpenAPI schema, a Zod validator, and a historical OSS commit are not equivalent source artifacts. They differ dramatically. The claim is not source equivalence. The claim is boundary-obligation equivalence.
+
+The source implementations are not equivalent; the boundary obligations are.
+
+### "OpenAPI and Zod differ on coercion, defaults, and unknown fields."
+
+Then the lifted predicates differ.
+
+Lossy boundary compression does not license vague matching. It requires precise preservation of the boundary obligation. If Zod coerces `"3"` into `3` and the OpenAPI contract does not, that is a predicate difference. If Pydantic accepts a default that the published schema marks required, that is a predicate difference. If one validator rejects unknown fields and another preserves them, that is a predicate difference.
+
+The point is not to collapse non-equivalent boundaries. The point is to collapse equivalent obligations despite different authoring surfaces.
+
+### "Tests are not contracts."
+
+Tests are not full contracts. They are evidence about contracts.
+
+A test that rejects `amount = 0` does not by itself prove `amount >= 1`. It proves a sampled fact: `amount = 0` is outside the accepted set. A cluster of property-based tests may imply a stronger conjecture. A human or solver may promote that evidence into a signed predicate. But the substrate must preserve the difference between sampled evidence and universal obligation.
+
+This is another place where provenance matters. A predicate lifted from a formal JML `requires` clause, an OpenAPI schema, and one unit test may canonically state the same boundary only if policy accepts the lifting evidence. The predicate identity can be the same; the trust in its provenance can differ.
+
+### "Native ProvekIt annotations are clearer."
+
+Yes. They are the clean reference surface.
+
+For new code that wants maximum explicitness, ProvekIt-native contracts may be the best authoring style. The point is adoption, not aesthetics. The substrate cannot require the world to begin there. It must be able to lift latent contracts first and let native authoring grow where teams want it.
+
+### "ProofIR is too narrow."
+
+Narrowness is the universality mechanism.
+
+A universal host-language IR would have to model every object system, exception system, macro system, reflection system, effect system, runtime library, concurrency primitive, memory model, and framework lifecycle. It would fail by ambition.
+
+A universal boundary IR has a smaller job: represent the obligations that cross boundaries and the implication edges between them. That job is hard, but it is the right hard problem. It is exactly where correctness, security, API compatibility, signing, and supply-chain trust meet.
+
+### "What about business logic?"
+
+Business logic matters when it is made contractual.
+
+"Premium users receive a 10% discount" can be a postcondition. "A transfer may not exceed the account balance" can be a precondition or invariant. "A refund may occur only after settlement" can be a protocol obligation. If business logic remains informal, ProofIR cannot prove it. If it becomes a boundary obligation, ProofIR can carry it.
+
+The substrate does not read minds. It reads contracts.
+
+## §12: Why this matters now
+
+The next adoption fight is not whether formal contracts are good. That argument is over among people who have debugged enough production systems. The fight is whether formal contracts can be introduced without making every team change its authoring style first.
+
+Lossy boundary compression is the adoption bridge.
+
+It says:
+
+- Keep your Spring annotations.
+- Keep your Bean Validation DTOs.
+- Keep your OpenAPI schemas.
+- Keep your Zod validators.
+- Keep your Pydantic models.
+- Keep your JML and Cofoja where you already use them.
+- Keep your tests.
+- Keep your database constraints.
+- Keep your historical patches.
+- Add ProvekIt-native contracts where they make sense.
+
+The substrate will read the boundary obligations underneath those surfaces and place them into the shared edge space.
+
+That is a more radical claim than "write contracts in our syntax." It is also a more practical one. The world is already saturated with boundary claims. The missing piece is not author intent. The missing piece is canonicalization.
+
+Once canonicalized, those claims become comparable. Once comparable, they become solvable. Once solvable, they become translatable. Once translated, they become droppable. Once content-addressed, they become durable. Once signed, they become trust-carrying. Once federated, they become infrastructure.
+
+The first move is forgetting the right things.
+
+The larger implication is that ProvekIt can become useful before it becomes culturally dominant.
+
+That is rare. Most verification systems require cultural conversion before first value: write in this language, adopt this proof assistant, annotate in this style, restrict this dynamic feature, train the team in this logic. The value arrives after the organization has paid the conversion cost.
+
+Lossy boundary compression reverses the curve. A team can get value from contracts it already wrote accidentally. The first useful artifact might be an OpenAPI file, not a ProvekIt-native annotation. The first signed edge might come from a historical bug fix, not a new proof effort. The first cross-service compatibility check might compare a Java DTO to a Zod validator, not two formal specs. The first compliance packet might cite lifted framework annotations, not a hand-authored proof document.
+
+This changes the adoption politics. ProvekIt-native authoring becomes the high-fidelity path for teams ready to be explicit. Lifting becomes the low-friction path for everyone else. The two paths meet in the same ProofIR edge space. Early adopters do not strand their work in a private formalism; late adopters do not have to rewrite their software before joining the substrate.
+
+It also changes the supply-chain story. A dependency does not need to expose its source implementation to expose its boundary obligations. A vendor can sign the predicates its package promises at public boundaries. A consumer can check whether local calls imply those predicates. A distributor can compare version `n` and version `n+1` by the predicates that changed. A regulator can ask for signed boundary claims without demanding the proprietary implementation behind them. Lossy compression is what makes that politically possible: the compressed object is small enough to share and precise enough to verify.
+
+And it changes standardization. Standards bodies do not need to standardize every host language's contract syntax. They need to standardize the boundary object, its canonical bytes, its implication-edge form, its witness envelope, and its signing/provenance discipline. Spring, Zod, OpenAPI, Pydantic, JML, Cofoja, and ProvekIt-native annotations can keep evolving. The standard sits beneath them at the obligation layer. That is a tractable standardization target.
+
+This is the paper's strategic claim: the substrate wins not by replacing the world's authoring surfaces, but by making them comparable after the fact.
+
+## §13: What this paper is NOT
+
+It is not a claim that ProofIR represents all implementation semantics. It does not. That is the whole point.
+
+It is not a claim that source artifacts with the same lifted predicate are operationally identical. They are not. A Spring validator, a Zod validator, an OpenAPI schema, a JML clause, and a historical patch can share a boundary predicate while differing in execution, ergonomics, timing, failure behavior, and enforcement.
+
+It is not a license for sloppy lifting. Obligation-preserving loss is precise: anything relevant to the boundary obligation must be preserved; anything outside it belongs in provenance, policy, host implementation, or some other predicate if it matters.
+
+It is not a claim that ProofIR plus a set of values compiles into host-language implementation. Droppers emit native repair candidates for missing boundary edges; their output is accepted only after re-lift proves closure.
+
+It is not a mandate to author ProvekIt-native contracts. Native contracts are the reference surface and often the cleanest one. They are not the required starting point for adoption.
+
+It is not a Bug Zoo design document, and it is not a claim that trust disappears. Bug Zoo appears as receipt infrastructure; signing, provenance, witness policy, and curator choice remain essential.
+
+## §14: The compressed future
+
+The substrate's future is not a world where every codebase looks ProvekIt-native.
+
+It is a world where a Java annotation, a TypeScript validator, an OpenAPI schema, a Python model, a formal method contract, a database constraint, a unit test, and a ten-year-old vulnerability patch can all point at the same boundary predicate.
+
+It is a world where a caller in one language proves it satisfies a callee in another without either side pretending their implementations are equivalent.
+
+It is a world where API drift is an implication failure, not a staging incident.
+
+It is a world where a bug fix becomes a signed receipt for the missing edge it closed.
+
+It is a world where the proof substrate gets stronger because old software was already full of contracts waiting to be lifted.
+
+That world requires ProofIR to forget. Not carelessly. Not vaguely. Precisely.
+
+ProofIR is universal over contract boundaries because it is narrow. It composes because its loss is obligation-preserving. It can compare the world's software because it refuses to carry the world's implementation texture into the identity of a boundary obligation.
+
+The compressed object is not the program.
+
+The compressed object is the promise the program makes at its boundary.
+
+## §15: Citation
+
+Cite as:
+
+> ProvekIt Substrate Working Notes (2026). *Lossy Boundary Compression: Why ProofIR Is Universal Because It Forgets*. Paper 09 of the After-X arc.

--- a/docs/papers/README.md
+++ b/docs/papers/README.md
@@ -22,6 +22,10 @@ The papers compose. Read them in order; later papers assume the framing earlier 
 
 7. **[After Verification: Bug Classes as Missing Edges in the Federated Proof Substrate](07-after-verification-bug-classes-as-missing-edges.md)**: The deeper consequence. Once droppers close the loop with lifters over weakest-precondition propagation, leaf-discharge bug classes become structurally impossible. Contains a constructive theorem (Structural Elimination of Leaf-Discharge Bug Classes) with proof by induction on data-flow path length. Articulates the substrate's algebraic shape (thin Heyting category over content-addressed predicates), the completeness lemma (`Allocations × Reads` is enumerable and exhaustive), and the generative-completion property (the substrate computes what is missing and writes the code that supplies it). Cousot 1977 plus content-addressing plus federation, lifted to a planet-scale proof DAG.
 
+8. **[After Types: How I Learned to Stop Logging and Trust the Invariant Solver](08-after-types-stop-logging-trust-the-invariant-solver.md)**: The developer-workflow consequence. Types and forensic logs survive, but lose their load-bearing correctness role once invariant proof is a federated substrate. Types become editorial scaffolding; logs remain operational observability. The wall against leaf-discharge bugs moves to content-addressed invariant edges.
+
+9. **[Lossy Boundary Compression: Why ProofIR Is Universal Because It Forgets](09-lossy-boundary-compression.md)**: The universality argument for ProofIR. ProofIR is not a universal language for re-expressing every implementation detail; it is universal over contract boundaries. Lifters may discard implementation texture while preserving obligations, making cross-language, cross-framework, cross-time equivalence possible and turning LLM output into an admissibility-search problem.
+
 ## Future papers (planned)
 
 - *Multi-dimensional pinning as supply-chain integrity*: rank-3 pins close the lying-contract attack class that single-CID pinning leaves open. Why v1.4's address-space-as-vector-space framing is the substrate the standards-track work needs.

--- a/docs/superpowers/plans/2026-05-06-bug-zoo-v0.md
+++ b/docs/superpowers/plans/2026-05-06-bug-zoo-v0.md
@@ -1,0 +1,1430 @@
+# Bug Zoo v0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first executable Bug Zoo slice: a Rust CLI `provekit zoo` runner plus one Java null-boundary specimen whose ProvekIt-native and ecosystem-native surfaces lift to the same boundary ProofIR and expose the missing `maybe_null(name) => non_null(name)` edge.
+
+**Architecture:** The Rust CLI is only the orchestrator. Each specimen owns its library, harnesses, and kit RPC launch scripts. The first specimen proves the lossy-boundary lemma: different Java surfaces keep only the contract boundary and collapse to identical canonical ProofIR CIDs.
+
+**Tech Stack:** Rust CLI with `clap`, `serde`, `serde_yaml`, `serde_json`, `std::process::Command`; Java Maven modules and JavaParser lifters; Bug Zoo fixtures under `bug-zoo/`.
+
+---
+
+## File Structure
+
+Create:
+
+- `bug-zoo/README.md` - one-screen explanation of lab, exposed, dropped, wild.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/README.md` - exhibit label for the first species.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/specimen.yaml` - specimen-owned commands, exposures, lossiness notes, expected edge.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/library/src/main/java/zoo/UserDirectory.java` - realistic vulnerable Java library.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/harness/src/main/java/zoo/UserDirectoryHarness.java` - normal passing usage of the library.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/kit-rpc/README.md` - note that lab has no contract lift; exposures own lift surfaces.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/harness/src/main/java/com/provekit/contract/Requires.java` - tiny local ProvekIt-native annotation stub.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/harness/src/main/java/zoo/UserDirectory.java` - ProvekIt-native Java contract surface.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/harness/src/main/java/org/springframework/web/bind/annotation/RequestParam.java` - tiny local Spring Web annotation stub.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/harness/src/main/java/zoo/UserDirectory.java` - Spring Web contract surface.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/*/kit-rpc/run-java-lifter.sh` - specimen-owned Java lifter launcher.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/*/expected.proofir.json` - canonical expected boundary IR.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/*/expected-diagnostic.txt` - expected red-squiggle text.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/equivalence.json` - required exposure CID equality.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/sat-witness.json` - witness condition for the missing edge.
+- `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/wild/README.md` - placeholder-free policy for adding real OSS specimens later.
+- `implementations/java/provekit-lift-java-provekit-native/pom.xml` - Java kit module for ProvekIt-native annotations.
+- `implementations/java/provekit-lift-java-provekit-native/src/main/java/com/provekit/lift/provekitnative/ProvekitNativeExtractor.java` - lifts `@Requires`, `@Ensures`, `@Invariant`.
+- `implementations/java/provekit-lift-java-provekit-native/src/main/resources/META-INF/services/com.provekit.lift.Extractor` - service loader registration.
+- `implementations/rust/provekit-cli/src/cmd_zoo.rs` - Rust CLI runner and JSON-RPC lifter client.
+- `implementations/rust/provekit-cli/tests/zoo_smoke.rs` - CLI integration smoke test using the real specimen.
+
+Modify:
+
+- `implementations/java/pom.xml` - add `provekit-lift-java-provekit-native` module.
+- `implementations/java/provekit-lift-java-integration-tests/pom.xml` - depend on the ProvekIt-native extractor.
+- `implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/CrossDomainContractEquivalenceTest.java` - add ProvekIt-native surface to existing equivalence tests.
+- `implementations/rust/provekit-cli/Cargo.toml` - add `serde_yaml = "0.9"`.
+- `implementations/rust/provekit-cli/src/main.rs` - add `Zoo` subcommand.
+
+Do not modify unrelated dirty files unless the task explicitly says so.
+
+---
+
+### Task 1: Java ProvekIt-Native Surface
+
+**Files:**
+- Create: `implementations/java/provekit-lift-java-provekit-native/pom.xml`
+- Create: `implementations/java/provekit-lift-java-provekit-native/src/main/java/com/provekit/lift/provekitnative/ProvekitNativeExtractor.java`
+- Create: `implementations/java/provekit-lift-java-provekit-native/src/main/resources/META-INF/services/com.provekit.lift.Extractor`
+- Modify: `implementations/java/pom.xml`
+- Modify: `implementations/java/provekit-lift-java-integration-tests/pom.xml`
+- Modify: `implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/CrossDomainContractEquivalenceTest.java`
+
+- [ ] **Step 1: Add failing equivalence test**
+
+In `CrossDomainContractEquivalenceTest.java`, add import:
+
+```java
+import com.provekit.lift.provekitnative.ProvekitNativeExtractor;
+```
+
+In `notNullConstraintIsUniversal()`, add this source:
+
+```java
+String provekitSource = """
+    import com.provekit.contract.Requires;
+    public class ProvekitService {
+        @Requires("name != null")
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+    """;
+```
+
+Then lift and assert:
+
+```java
+String provekitIr = lift(new ProvekitNativeExtractor(), provekitSource);
+assertEquals(beanIr, provekitIr, "ProvekIt-native and Bean Validation IR must be identical");
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+mvn -f implementations/java/pom.xml -pl provekit-lift-java-integration-tests -am test -Dtest=CrossDomainContractEquivalenceTest
+```
+
+Expected: compilation fails because `com.provekit.lift.provekitnative.ProvekitNativeExtractor` does not exist.
+
+- [ ] **Step 3: Add Java module**
+
+Create `implementations/java/provekit-lift-java-provekit-native/pom.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.provekit</groupId>
+        <artifactId>provekit-lift-java-parent</artifactId>
+        <version>0.1.0</version>
+    </parent>
+    <artifactId>provekit-lift-java-provekit-native</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.provekit</groupId>
+            <artifactId>provekit-lift-java-core</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+Add module in `implementations/java/pom.xml` immediately after `provekit-lift-java-core`:
+
+```xml
+<module>provekit-lift-java-provekit-native</module>
+```
+
+Add dependency in `provekit-lift-java-integration-tests/pom.xml`:
+
+```xml
+<dependency>
+    <groupId>com.provekit</groupId>
+    <artifactId>provekit-lift-java-provekit-native</artifactId>
+    <version>0.1.0</version>
+</dependency>
+```
+
+- [ ] **Step 4: Implement extractor**
+
+Create `ProvekitNativeExtractor.java`:
+
+```java
+package com.provekit.lift.provekitnative;
+
+import java.util.*;
+import com.github.javaparser.ast.*;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.expr.*;
+import com.provekit.lift.*;
+
+public class ProvekitNativeExtractor implements Extractor {
+    public String name() { return "provekit-native"; }
+
+    public List<ContractDecl> extract(CompilationUnit cu, String rawSource) {
+        List<ContractDecl> out = new ArrayList<>();
+        for (TypeDeclaration<?> type : cu.getTypes()) {
+            for (BodyDeclaration<?> member : type.getMembers()) {
+                if (member instanceof MethodDeclaration method) extractMethod(method, out);
+            }
+        }
+        return out;
+    }
+
+    private void extractMethod(MethodDeclaration method, List<ContractDecl> out) {
+        String symbol = method.getNameAsString();
+        List<String> pres = new ArrayList<>(), posts = new ArrayList<>(), invs = new ArrayList<>();
+        for (AnnotationExpr ann : method.getAnnotations()) {
+            String name = simpleName(ann.getNameAsString());
+            switch (name) {
+                case "Requires" -> extractString(ann).ifPresent(s -> pres.add(toIr(s)));
+                case "Ensures" -> extractString(ann).ifPresent(s -> posts.add(toIr(s)));
+                case "Invariant" -> extractString(ann).ifPresent(s -> invs.add(toIr(s)));
+            }
+        }
+        if (!pres.isEmpty() || !posts.isEmpty() || !invs.isEmpty()) {
+            out.add(new ContractDecl(symbol, pres, posts, invs));
+        }
+    }
+
+    private String simpleName(String fq) {
+        int dot = fq.lastIndexOf('.');
+        return dot >= 0 ? fq.substring(dot + 1) : fq;
+    }
+
+    private Optional<String> extractString(AnnotationExpr ann) {
+        if (ann instanceof SingleMemberAnnotationExpr sma && sma.getMemberValue() instanceof StringLiteralExpr sle) {
+            return Optional.of(sle.getValue());
+        }
+        if (ann instanceof NormalAnnotationExpr na) {
+            for (MemberValuePair pair : na.getPairs()) {
+                if (pair.getNameAsString().equals("value") && pair.getValue() instanceof StringLiteralExpr sle) {
+                    return Optional.of(sle.getValue());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String toIr(String expr) {
+        String e = expr.trim();
+        if (e.matches("[A-Za-z_][A-Za-z0-9_]*\\s*!=\\s*null")) {
+            String varName = e.substring(0, e.indexOf("!")).trim();
+            return atom("neq", var(varName), cNull());
+        }
+        if (e.matches("[A-Za-z_][A-Za-z0-9_]*\\s*>=\\s*[0-9]+")) {
+            String[] parts = e.split(">=");
+            return atom("gte", var(parts[0].trim()), cInt(Long.parseLong(parts[1].trim())));
+        }
+        if (e.matches("[A-Za-z_][A-Za-z0-9_]*\\s*<=\\s*[0-9]+")) {
+            String[] parts = e.split("<=");
+            return atom("lte", var(parts[0].trim()), cInt(Long.parseLong(parts[1].trim())));
+        }
+        return "{\"kind\":\"atomic\",\"name\":\"provekit_predicate\",\"args\":[{\"kind\":\"const\",\"value\":\"" + esc(e) + "\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}]}";
+    }
+
+    private String var(String n) { return "{\"kind\":\"var\",\"name\":\"" + n + "\"}"; }
+    private String cNull() { return "{\"kind\":\"const\",\"value\":null,\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"}}"; }
+    private String cInt(long v) { return "{\"kind\":\"const\",\"value\":" + v + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}"; }
+    private String atom(String name, String... args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"atomic\",\"name\":\"" + name + "\",\"args\":[");
+        for (int i = 0; i < args.length; i++) { if (i > 0) sb.append(","); sb.append(args[i]); }
+        sb.append("]}");
+        return sb.toString();
+    }
+    private String esc(String s) { return s.replace("\\", "\\\\").replace("\"", "\\\""); }
+}
+```
+
+Create service file `META-INF/services/com.provekit.lift.Extractor`:
+
+```text
+com.provekit.lift.provekitnative.ProvekitNativeExtractor
+```
+
+- [ ] **Step 5: Run Java equivalence test**
+
+Run:
+
+```bash
+mvn -f implementations/java/pom.xml -pl provekit-lift-java-integration-tests -am test -Dtest=CrossDomainContractEquivalenceTest
+```
+
+Expected: PASS. The new ProvekIt-native surface emits byte-identical IR to Bean Validation for `name != null`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add implementations/java/pom.xml implementations/java/provekit-lift-java-provekit-native implementations/java/provekit-lift-java-integration-tests/pom.xml implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/CrossDomainContractEquivalenceTest.java
+git commit -m "feat(java): lift provekit-native contracts"
+```
+
+---
+
+### Task 2: First Bug Zoo Specimen
+
+**Files:**
+- Create: `bug-zoo/README.md`
+- Create: `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/**`
+
+- [ ] **Step 1: Create root zoo README**
+
+Create `bug-zoo/README.md`:
+
+```markdown
+# Bug Zoo
+
+Bug Zoo is ProvekIt's executable laboratory.
+
+Each species is a small, realistic specimen with four possible states:
+
+- `lab/`: normal code or metadata that passes its ordinary host checks.
+- `exposed/`: the same bug species lifted through one or more native surfaces until ProofIR exposes the missing contract edge.
+- `dropped/`: generated native shape that closes the edge, accepted only after re-lift verifies closure.
+- `wild/`: real OSS specimens pinned by advisory, commit, and affected path.
+
+The zoo is not a patch archive. Historical fixes are context only. The receipt is independent rediscovery: can ProvekIt lift the latent contract boundary, make the missing `p => q` edge visible, and, where a dropper exists, synthesize a verified closure?
+
+ProofIR is allowed to be lossy here. Specimens compare contract boundaries, not host-language implementation detail.
+```
+
+- [ ] **Step 2: Create specimen manifest**
+
+Create `bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/specimen.yaml`:
+
+```yaml
+id: BZ-SHAPE-005
+name: Java Null Boundary Equivalence
+kingdom: shape
+surface: java-provekit-native-and-spring-web
+status: lab
+paths:
+  labLibrary: lab/library
+  labHarness: lab/harness
+  labKitRpc: lab/kit-rpc
+commands:
+  hostCheck:
+    cwd: lab/harness
+    argv: ["./run.sh"]
+predicates:
+  boundary: maybe_null(name)
+  sink: non_null(name)
+  missingEdge: maybe_null(name) => non_null(name)
+exposures:
+  - id: provekit-native
+    surface: java-provekit-native
+    harness: exposed/provekit-native/harness
+    kitRpc: exposed/provekit-native/kit-rpc
+    liftRpc:
+      cwd: exposed/provekit-native/kit-rpc
+      argv: ["./run-java-lifter.sh"]
+    proofIrFile: exposed/provekit-native/expected.proofir.json
+    diagnosticFile: exposed/provekit-native/expected-diagnostic.txt
+    lossiness:
+      erased:
+        - Java method body string concatenation
+        - concrete annotation package name
+      preserved:
+        - precondition neq(name, null)
+  - id: spring-web
+    surface: java-spring-web
+    harness: exposed/spring-web/harness
+    kitRpc: exposed/spring-web/kit-rpc
+    liftRpc:
+      cwd: exposed/spring-web/kit-rpc
+      argv: ["./run-java-lifter.sh"]
+    proofIrFile: exposed/spring-web/expected.proofir.json
+    diagnosticFile: exposed/spring-web/expected-diagnostic.txt
+    lossiness:
+      erased:
+        - Spring request binding machinery
+        - Java method body string concatenation
+      preserved:
+        - precondition neq(name, null)
+equivalence:
+  required:
+    - [provekit-native, spring-web]
+expectations:
+  hostCompiler: pass
+  ordinaryTests: pass
+  provekitVerify: fail
+exposure:
+  satWitnessFile: exposed/sat-witness.json
+dropper:
+  available: false
+wildSightings: []
+```
+
+- [ ] **Step 3: Add lab library and harness**
+
+Create `lab/library/src/main/java/zoo/UserDirectory.java`:
+
+```java
+package zoo;
+
+public final class UserDirectory {
+    public String lookup(String name) {
+        return "user:" + name.toUpperCase();
+    }
+}
+```
+
+Create `lab/harness/src/main/java/zoo/UserDirectoryHarness.java`:
+
+```java
+package zoo;
+
+public final class UserDirectoryHarness {
+    public static void main(String[] args) {
+        String value = new UserDirectory().lookup("ada");
+        if (!"user:ADA".equals(value)) {
+            throw new IllegalStateException(value);
+        }
+    }
+}
+```
+
+Create `lab/harness/run.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+rm -rf .classes
+mkdir -p .classes
+javac -d .classes ../library/src/main/java/zoo/UserDirectory.java src/main/java/zoo/UserDirectoryHarness.java
+java -cp .classes zoo.UserDirectoryHarness
+```
+
+Mark it executable:
+
+```bash
+chmod +x bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/harness/run.sh
+```
+
+Create `lab/kit-rpc/README.md`:
+
+```markdown
+# Lab Kit RPC
+
+The lab state is ordinary code with no lifted boundary contract. Exposed variants own their kit RPC launchers.
+```
+
+- [ ] **Step 4: Add ProvekIt-native exposure**
+
+Create `exposed/provekit-native/harness/src/main/java/com/provekit/contract/Requires.java`:
+
+```java
+package com.provekit.contract;
+
+public @interface Requires {
+    String value();
+}
+```
+
+Create `exposed/provekit-native/harness/src/main/java/zoo/UserDirectory.java`:
+
+```java
+package zoo;
+
+import com.provekit.contract.Requires;
+
+public final class UserDirectory {
+    @Requires("name != null")
+    public String lookup(String name) {
+        return "user:" + name.toUpperCase();
+    }
+}
+```
+
+- [ ] **Step 5: Add Spring Web exposure**
+
+Create `exposed/spring-web/harness/src/main/java/org/springframework/web/bind/annotation/RequestParam.java`:
+
+```java
+package org.springframework.web.bind.annotation;
+
+public @interface RequestParam {
+    boolean required() default true;
+}
+```
+
+Create `exposed/spring-web/harness/src/main/java/zoo/UserDirectory.java`:
+
+```java
+package zoo;
+
+import org.springframework.web.bind.annotation.RequestParam;
+
+public final class UserDirectory {
+    public String lookup(@RequestParam String name) {
+        return "user:" + name.toUpperCase();
+    }
+}
+```
+
+- [ ] **Step 6: Add specimen-owned Java lifter launchers**
+
+Create `exposed/provekit-native/kit-rpc/run-java-lifter.sh` and `exposed/spring-web/kit-rpc/run-java-lifter.sh` with identical content:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../../../.." && pwd)"
+
+java -cp "$repo_root/implementations/java/provekit-lift-java-core/target/provekit-lsp-java.jar:$repo_root/implementations/java/provekit-lift-java-provekit-native/target/provekit-lift-java-provekit-native-0.1.0.jar:$repo_root/implementations/java/provekit-lift-java-spring-web/target/provekit-lift-java-spring-web-0.1.0.jar" \
+  com.provekit.lift.Main --rpc
+```
+
+Mark both executable:
+
+```bash
+chmod +x bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/provekit-native/kit-rpc/run-java-lifter.sh
+chmod +x bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/spring-web/kit-rpc/run-java-lifter.sh
+```
+
+Task 5 will spawn this script from `kit-rpc/` and send the exposure harness path as the JSON-RPC `workspace_root`.
+
+- [ ] **Step 7: Add expected ProofIR and diagnostics**
+
+Create both `exposed/provekit-native/expected.proofir.json` and `exposed/spring-web/expected.proofir.json`:
+
+```json
+[
+  {
+    "kind": "contract",
+    "symbol": "lookup",
+    "precondition": {
+      "kind": "atomic",
+      "name": "neq",
+      "args": [
+        { "kind": "var", "name": "name" },
+        { "kind": "const", "value": null, "sort": { "kind": "primitive", "name": "Ref" } }
+      ]
+    }
+  }
+]
+```
+
+Create both `expected-diagnostic.txt` files:
+
+```text
+BZ-SHAPE-005 exposes missing edge: maybe_null(name) => non_null(name)
+```
+
+Create `exposed/equivalence.json`:
+
+```json
+{
+  "required": [
+    ["provekit-native", "spring-web"]
+  ],
+  "claim": "Both surfaces erase host-language texture and preserve the same boundary predicate: neq(name, null)."
+}
+```
+
+Create `exposed/sat-witness.json`:
+
+```json
+{
+  "condition": "name == null",
+  "has": "maybe_null(name)",
+  "requires": "non_null(name)",
+  "missingEdge": "maybe_null(name) => non_null(name)"
+}
+```
+
+- [ ] **Step 8: Add specimen README and wild policy**
+
+Create specimen `README.md`:
+
+```markdown
+# BZ-SHAPE-005: Java Null Boundary Equivalence
+
+This specimen shows a null-boundary bug species.
+
+The lab library compiles and runs with ordinary Java checks. The exposed variants add contract surfaces that engineers already use:
+
+- `provekit-native`: explicit ProvekIt-style `@Requires("name != null")`
+- `spring-web`: Spring's default required `@RequestParam`
+
+The source surfaces are not equivalent as Java programs. Their contract boundary is equivalent. Both lift to the same ProofIR precondition: `neq(name, null)`.
+
+The exposed bug is the missing edge from a caller that may provide null to a sink requiring non-null:
+
+```text
+maybe_null(name) => non_null(name)
+```
+```
+
+Create `wild/README.md`:
+
+```markdown
+# Wild Specimens
+
+Add only real OSS specimens here.
+
+Each entry must pin an advisory ID, project slug, vulnerable commit, affected paths, source URL, exposure artifacts, and a verdict. Historical remediation is optional context only and must not be used as the oracle.
+```
+
+- [ ] **Step 9: Run host check**
+
+Run:
+
+```bash
+bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/lab/harness/run.sh
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add bug-zoo
+git commit -m "feat: add java null boundary bug zoo specimen"
+```
+
+---
+
+### Task 3: Rust CLI Manifest Parser
+
+**Files:**
+- Modify: `implementations/rust/provekit-cli/Cargo.toml`
+- Create: `implementations/rust/provekit-cli/src/cmd_zoo.rs`
+
+- [ ] **Step 1: Add dependency**
+
+Add to `implementations/rust/provekit-cli/Cargo.toml`:
+
+```toml
+serde_yaml = "0.9"
+```
+
+- [ ] **Step 2: Add parser unit test**
+
+At the bottom of new `cmd_zoo.rs`, start with this test:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_manifest_with_exposures_and_equivalence() {
+        let raw = r#"
+id: BZ-SHAPE-005
+name: Java Null Boundary Equivalence
+kingdom: shape
+surface: java
+status: lab
+paths:
+  labLibrary: lab/library
+  labHarness: lab/harness
+  labKitRpc: lab/kit-rpc
+commands:
+  hostCheck:
+    cwd: lab/harness
+    argv: ["./run.sh"]
+predicates:
+  boundary: maybe_null(name)
+  sink: non_null(name)
+  missingEdge: maybe_null(name) => non_null(name)
+exposures:
+  - id: provekit-native
+    surface: java-provekit-native
+    harness: exposed/provekit-native/harness
+    kitRpc: exposed/provekit-native/kit-rpc
+    liftRpc:
+      cwd: exposed/provekit-native/kit-rpc
+      argv: ["./run-java-lifter.sh"]
+    proofIrFile: exposed/provekit-native/expected.proofir.json
+    diagnosticFile: exposed/provekit-native/expected-diagnostic.txt
+    lossiness:
+      erased: ["Java body"]
+      preserved: ["precondition neq(name, null)"]
+  - id: spring-web
+    surface: java-spring-web
+    harness: exposed/spring-web/harness
+    kitRpc: exposed/spring-web/kit-rpc
+    liftRpc:
+      cwd: exposed/spring-web/kit-rpc
+      argv: ["./run-java-lifter.sh"]
+    proofIrFile: exposed/spring-web/expected.proofir.json
+    diagnosticFile: exposed/spring-web/expected-diagnostic.txt
+    lossiness:
+      erased: ["Spring binding"]
+      preserved: ["precondition neq(name, null)"]
+equivalence:
+  required:
+    - [provekit-native, spring-web]
+expectations:
+  hostCompiler: pass
+  ordinaryTests: pass
+  provekitVerify: fail
+exposure:
+  satWitnessFile: exposed/sat-witness.json
+dropper:
+  available: false
+wildSightings: []
+"#;
+        let manifest: SpecimenManifest = serde_yaml::from_str(raw).expect("parse manifest");
+        assert_eq!(manifest.id, "BZ-SHAPE-005");
+        assert_eq!(manifest.exposures.len(), 2);
+        assert_eq!(manifest.equivalence.required[0], ["provekit-native", "spring-web"]);
+    }
+}
+```
+
+- [ ] **Step 3: Implement manifest types**
+
+Add these types above the tests:
+
+```rust
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use clap::Parser;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
+
+#[derive(Parser, Debug, Clone)]
+pub struct ZooArgs {
+    /// Specimen directory or specimen.yaml path. Defaults to bug-zoo/species.
+    pub specimen: Option<PathBuf>,
+    /// Check every species under bug-zoo/species.
+    #[arg(long)]
+    pub all: bool,
+    #[command(flatten)]
+    pub out: OutputFlags,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SpecimenManifest {
+    id: String,
+    name: String,
+    kingdom: String,
+    surface: String,
+    status: String,
+    paths: SpecimenPaths,
+    commands: SpecimenCommands,
+    predicates: Predicates,
+    exposures: Vec<Exposure>,
+    equivalence: Equivalence,
+    expectations: Expectations,
+    exposure: ExposureFiles,
+    dropper: Dropper,
+    #[serde(default)]
+    wild_sightings: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SpecimenPaths {
+    lab_library: PathBuf,
+    lab_harness: PathBuf,
+    lab_kit_rpc: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SpecimenCommands {
+    host_check: CommandSpec,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct CommandSpec {
+    cwd: PathBuf,
+    argv: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Predicates {
+    boundary: String,
+    sink: String,
+    missing_edge: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Exposure {
+    id: String,
+    surface: String,
+    harness: PathBuf,
+    kit_rpc: PathBuf,
+    lift_rpc: CommandSpec,
+    proof_ir_file: PathBuf,
+    diagnostic_file: PathBuf,
+    lossiness: Lossiness,
+}
+
+#[derive(Debug, Deserialize)]
+struct Lossiness {
+    erased: Vec<String>,
+    preserved: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Equivalence {
+    #[serde(default)]
+    required: Vec<[String; 2]>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Expectations {
+    host_compiler: String,
+    ordinary_tests: String,
+    provekit_verify: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExposureFiles {
+    sat_witness_file: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct Dropper {
+    available: bool,
+}
+```
+
+- [ ] **Step 4: Run parser test**
+
+Run:
+
+```bash
+cd implementations/rust
+cargo test -p provekit-cli cmd_zoo::tests::parses_manifest_with_exposures_and_equivalence
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add implementations/rust/provekit-cli/Cargo.toml implementations/rust/provekit-cli/src/cmd_zoo.rs
+git commit -m "feat(cli): parse bug zoo specimen manifests"
+```
+
+---
+
+### Task 4: Rust CLI Structural Validation
+
+**Files:**
+- Modify: `implementations/rust/provekit-cli/src/cmd_zoo.rs`
+
+- [ ] **Step 1: Add failing structural validation test**
+
+Add:
+
+```rust
+#[test]
+fn validation_rejects_missing_lossiness() {
+    let manifest = SpecimenManifest {
+        id: "BZ-SHAPE-005".into(),
+        name: "x".into(),
+        kingdom: "shape".into(),
+        surface: "java".into(),
+        status: "lab".into(),
+        paths: SpecimenPaths {
+            lab_library: "lab/library".into(),
+            lab_harness: "lab/harness".into(),
+            lab_kit_rpc: "lab/kit-rpc".into(),
+        },
+        commands: SpecimenCommands {
+            host_check: CommandSpec { cwd: "lab/harness".into(), argv: vec!["./run.sh".into()] },
+        },
+        predicates: Predicates {
+            boundary: "maybe_null(name)".into(),
+            sink: "non_null(name)".into(),
+            missing_edge: "maybe_null(name) => non_null(name)".into(),
+        },
+        exposures: vec![Exposure {
+            id: "spring-web".into(),
+            surface: "java-spring-web".into(),
+            harness: "exposed/spring-web/harness".into(),
+            kit_rpc: "exposed/spring-web/kit-rpc".into(),
+            lift_rpc: CommandSpec { cwd: "exposed/spring-web/kit-rpc".into(), argv: vec!["./run-java-lifter.sh".into()] },
+            proof_ir_file: "exposed/spring-web/expected.proofir.json".into(),
+            diagnostic_file: "exposed/spring-web/expected-diagnostic.txt".into(),
+            lossiness: Lossiness { erased: vec![], preserved: vec![] },
+        }],
+        equivalence: Equivalence { required: vec![] },
+        expectations: Expectations { host_compiler: "pass".into(), ordinary_tests: "pass".into(), provekit_verify: "fail".into() },
+        exposure: ExposureFiles { sat_witness_file: "exposed/sat-witness.json".into() },
+        dropper: Dropper { available: false },
+        wild_sightings: vec![],
+    };
+    let errors = validate_manifest_shape(&manifest);
+    assert!(errors.iter().any(|e| e.contains("lossiness")));
+}
+```
+
+- [ ] **Step 2: Implement `validate_manifest_shape`**
+
+Add:
+
+```rust
+fn validate_manifest_shape(manifest: &SpecimenManifest) -> Vec<String> {
+    let mut errors = Vec::new();
+    if manifest.id.trim().is_empty() { errors.push("id is required".into()); }
+    if manifest.exposures.is_empty() { errors.push("at least one exposure is required".into()); }
+    if manifest.predicates.boundary.trim().is_empty() { errors.push("predicates.boundary is required".into()); }
+    if manifest.predicates.sink.trim().is_empty() { errors.push("predicates.sink is required".into()); }
+    if manifest.predicates.missing_edge.trim().is_empty() { errors.push("predicates.missingEdge is required".into()); }
+    if manifest.commands.host_check.argv.is_empty() { errors.push("commands.hostCheck.argv is required".into()); }
+
+    let mut ids = BTreeSet::new();
+    for exposure in &manifest.exposures {
+        if !ids.insert(exposure.id.clone()) {
+            errors.push(format!("duplicate exposure id `{}`", exposure.id));
+        }
+        if exposure.lift_rpc.argv.is_empty() {
+            errors.push(format!("exposure `{}` liftRpc.argv is required", exposure.id));
+        }
+        if exposure.lossiness.erased.is_empty() || exposure.lossiness.preserved.is_empty() {
+            errors.push(format!("exposure `{}` must describe lossiness erased and preserved boundaries", exposure.id));
+        }
+    }
+    for [a, b] in &manifest.equivalence.required {
+        if !ids.contains(a) { errors.push(format!("equivalence references unknown exposure `{a}`")); }
+        if !ids.contains(b) { errors.push(format!("equivalence references unknown exposure `{b}`")); }
+    }
+    errors
+}
+```
+
+- [ ] **Step 3: Add filesystem validation**
+
+Add:
+
+```rust
+fn validate_paths(specimen_dir: &Path, manifest: &SpecimenManifest) -> Vec<String> {
+    let mut errors = Vec::new();
+    for path in [
+        &manifest.paths.lab_library,
+        &manifest.paths.lab_harness,
+        &manifest.paths.lab_kit_rpc,
+        &manifest.exposure.sat_witness_file,
+    ] {
+        if !specimen_dir.join(path).exists() {
+            errors.push(format!("missing {}", specimen_dir.join(path).display()));
+        }
+    }
+    for exposure in &manifest.exposures {
+        for path in [&exposure.harness, &exposure.kit_rpc, &exposure.proof_ir_file, &exposure.diagnostic_file] {
+            if !specimen_dir.join(path).exists() {
+                errors.push(format!("missing {}", specimen_dir.join(path).display()));
+            }
+        }
+    }
+    errors
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+cd implementations/rust
+cargo test -p provekit-cli cmd_zoo::tests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add implementations/rust/provekit-cli/src/cmd_zoo.rs
+git commit -m "feat(cli): validate bug zoo manifests"
+```
+
+---
+
+### Task 5: Rust CLI Zoo Runner and RPC Client
+
+**Files:**
+- Modify: `implementations/rust/provekit-cli/src/cmd_zoo.rs`
+- Modify: `implementations/rust/provekit-cli/src/main.rs`
+
+- [ ] **Step 1: Wire CLI subcommand**
+
+In `main.rs`, add module:
+
+```rust
+mod cmd_zoo;
+```
+
+Add enum variant:
+
+```rust
+/// Run Bug Zoo specimens: host check, lift exposures, compare boundary ProofIR.
+Zoo(cmd_zoo::ZooArgs),
+```
+
+Add dispatch arm:
+
+```rust
+Cmd::Zoo(a) => cmd_zoo::run(a),
+```
+
+- [ ] **Step 2: Implement `run` high-level flow**
+
+Add:
+
+```rust
+pub fn run(args: ZooArgs) -> u8 {
+    let targets = match resolve_targets(&args) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("zoo: {e}");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let mut failures = Vec::new();
+    let mut reports = Vec::new();
+    for specimen_dir in targets {
+        match check_specimen(&specimen_dir, args.out.quiet) {
+            Ok(report) => reports.push(report),
+            Err(e) => failures.push(format!("{}: {e}", specimen_dir.display())),
+        }
+    }
+    if args.out.json {
+        let out = json!({ "ok": failures.is_empty(), "reports": reports, "errors": failures });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    } else if !args.out.quiet {
+        for report in &reports {
+            println!("zoo: {} PASS", report["id"].as_str().unwrap_or("specimen"));
+        }
+        for failure in &failures {
+            eprintln!("zoo: {failure}");
+        }
+    }
+    if failures.is_empty() { EXIT_OK } else { EXIT_VERIFY_FAIL }
+}
+```
+
+- [ ] **Step 3: Implement target resolution**
+
+Add:
+
+```rust
+fn resolve_targets(args: &ZooArgs) -> Result<Vec<PathBuf>, String> {
+    if args.all {
+        let root = args.specimen.clone().unwrap_or_else(|| PathBuf::from("bug-zoo/species"));
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(&root).map_err(|e| format!("read {}: {e}", root.display()))? {
+            let entry = entry.map_err(|e| format!("read dir entry: {e}"))?;
+            let path = entry.path();
+            if path.join("specimen.yaml").exists() { out.push(path); }
+        }
+        out.sort();
+        return Ok(out);
+    }
+    let path = args.specimen.clone().unwrap_or_else(|| PathBuf::from("bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence"));
+    if path.file_name().and_then(|s| s.to_str()) == Some("specimen.yaml") {
+        Ok(vec![path.parent().unwrap_or(Path::new(".")).to_path_buf()])
+    } else {
+        Ok(vec![path])
+    }
+}
+```
+
+- [ ] **Step 4: Implement specimen check**
+
+Add:
+
+```rust
+fn check_specimen(specimen_dir: &Path, quiet: bool) -> Result<Value, String> {
+    let manifest_path = specimen_dir.join("specimen.yaml");
+    let text = std::fs::read_to_string(&manifest_path)
+        .map_err(|e| format!("read {}: {e}", manifest_path.display()))?;
+    let manifest: SpecimenManifest = serde_yaml::from_str(&text)
+        .map_err(|e| format!("parse {}: {e}", manifest_path.display()))?;
+
+    let mut errors = validate_manifest_shape(&manifest);
+    errors.extend(validate_paths(specimen_dir, &manifest));
+    if !errors.is_empty() { return Err(errors.join("; ")); }
+
+    run_host_check(specimen_dir, &manifest.commands.host_check)?;
+
+    let mut cids = BTreeMap::new();
+    for exposure in &manifest.exposures {
+        let lifted = invoke_lift_rpc(specimen_dir, exposure)?;
+        let expected = read_json(specimen_dir.join(&exposure.proof_ir_file))?;
+        let lifted_ir = lifted.get("ir").cloned().ok_or_else(|| format!("exposure `{}` missing ir", exposure.id))?;
+        let lifted_cid = proof_ir_cid(&lifted_ir)?;
+        let expected_cid = proof_ir_cid(&expected)?;
+        if lifted_cid != expected_cid {
+            return Err(format!("exposure `{}` ProofIR CID mismatch: lifted {lifted_cid}, expected {expected_cid}", exposure.id));
+        }
+        let diag = std::fs::read_to_string(specimen_dir.join(&exposure.diagnostic_file))
+            .map_err(|e| format!("read diagnostic for `{}`: {e}", exposure.id))?;
+        if !diag.contains(&manifest.predicates.missing_edge) {
+            return Err(format!("diagnostic for `{}` does not mention missing edge `{}`", exposure.id, manifest.predicates.missing_edge));
+        }
+        cids.insert(exposure.id.clone(), lifted_cid);
+    }
+
+    for [a, b] in &manifest.equivalence.required {
+        if cids.get(a) != cids.get(b) {
+            return Err(format!("equivalence failed: `{a}` CID {:?} != `{b}` CID {:?}", cids.get(a), cids.get(b)));
+        }
+    }
+
+    let sat_witness = read_json(specimen_dir.join(&manifest.exposure.sat_witness_file))?;
+    if !quiet {
+        println!("zoo: {} hostCheck PASS", manifest.id);
+        for (id, cid) in &cids {
+            println!("zoo: exposure {id} {cid}");
+        }
+        for [a, b] in &manifest.equivalence.required {
+            println!("zoo: equivalence {a} == {b} PASS");
+        }
+        println!("zoo: expected verify failure {} PASS", manifest.predicates.missing_edge);
+    }
+
+    Ok(json!({
+        "id": manifest.id,
+        "name": manifest.name,
+        "proofIrCids": cids,
+        "missingEdge": manifest.predicates.missing_edge,
+        "satWitness": sat_witness
+    }))
+}
+```
+
+- [ ] **Step 5: Implement helpers**
+
+Add:
+
+```rust
+fn run_host_check(specimen_dir: &Path, command: &CommandSpec) -> Result<(), String> {
+    run_command(specimen_dir, command).map(|_| ())
+}
+
+fn run_command(specimen_dir: &Path, command: &CommandSpec) -> Result<String, String> {
+    if command.argv.is_empty() { return Err("empty argv".into()); }
+    let cwd = specimen_dir.join(&command.cwd);
+    let output = Command::new(&command.argv[0])
+        .args(&command.argv[1..])
+        .current_dir(&cwd)
+        .output()
+        .map_err(|e| format!("spawn {:?} in {}: {e}", command.argv, cwd.display()))?;
+    if !output.status.success() {
+        return Err(format!(
+            "command {:?} failed in {}\nstdout:\n{}\nstderr:\n{}",
+            command.argv,
+            cwd.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn read_json(path: PathBuf) -> Result<Value, String> {
+    let text = std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    serde_json::from_str(&text).map_err(|e| format!("parse {}: {e}", path.display()))
+}
+```
+
+- [ ] **Step 6: Implement JSON-RPC lifter client**
+
+Add:
+
+```rust
+fn invoke_lift_rpc(specimen_dir: &Path, exposure: &Exposure) -> Result<Value, String> {
+    let cwd = specimen_dir.join(&exposure.lift_rpc.cwd);
+    let harness = specimen_dir.join(&exposure.harness);
+    let harness_root = harness.canonicalize().unwrap_or(harness);
+    let mut cmd = Command::new(&exposure.lift_rpc.argv[0]);
+    cmd.args(&exposure.lift_rpc.argv[1..])
+        .current_dir(&cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+
+    let mut child = cmd.spawn().map_err(|e| format!("spawn lift RPC for `{}` in {}: {e}", exposure.id, cwd.display()))?;
+    let mut stdin = child.stdin.take().ok_or("lifter has no stdin")?;
+    let stdout = child.stdout.take().ok_or("lifter has no stdout")?;
+    let mut reader = BufReader::new(stdout);
+
+    let init_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "client": {"name": "provekit-zoo", "version": env!("CARGO_PKG_VERSION")},
+            "protocol_version": "provekit-lift/1",
+            "workspace_root": harness_root.to_string_lossy(),
+            "config_path": ".provekit/config.toml"
+        }
+    });
+    writeln!(stdin, "{init_req}").map_err(|e| format!("write initialize: {e}"))?;
+    let _ = read_response(&mut reader, 1)?;
+
+    let lift_req = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "lift",
+        "params": {
+            "surface": exposure.surface,
+            "workspace_root": harness_root.to_string_lossy(),
+            "source_paths": [harness_root.to_string_lossy()],
+            "options": {"layer": "all"}
+        }
+    });
+    writeln!(stdin, "{lift_req}").map_err(|e| format!("write lift: {e}"))?;
+    let lift_resp = read_response(&mut reader, 2)?;
+
+    let shutdown_req = json!({"jsonrpc": "2.0", "id": 3, "method": "shutdown"});
+    let _ = writeln!(stdin, "{shutdown_req}");
+    drop(stdin);
+    let _ = child.wait();
+
+    match lift_resp.get("kind").and_then(|v| v.as_str()) {
+        Some("ir-document") => Ok(lift_resp),
+        other => Err(format!("exposure `{}` returned unsupported lift kind {:?}", exposure.id, other)),
+    }
+}
+
+fn read_response(reader: &mut impl BufRead, id: i64) -> Result<Value, String> {
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).map_err(|e| format!("read RPC response: {e}"))?;
+    if n == 0 { return Err("plugin closed stdout before responding".into()); }
+    let v: Value = serde_json::from_str(line.trim()).map_err(|e| format!("parse JSON-RPC response: {e}\nraw: {line}"))?;
+    if v.get("id").and_then(|v| v.as_i64()) != Some(id) {
+        return Err(format!("response id mismatch: expected {id}, got {v:?}"));
+    }
+    if let Some(err) = v.get("error") { return Err(format!("plugin returned error: {err}")); }
+    v.get("result").cloned().ok_or_else(|| "response missing result".into())
+}
+```
+
+- [ ] **Step 7: Implement canonical ProofIR CID**
+
+Use the Rust canonicalizer to hash the JSON value:
+
+```rust
+fn proof_ir_cid(value: &Value) -> Result<String, String> {
+    let canonical = json_to_cvalue(value);
+    let bytes = provekit_canonicalizer::encode_jcs(&canonical).into_bytes();
+    Ok(provekit_canonicalizer::blake3_512_of(&bytes))
+}
+
+fn json_to_cvalue(j: &Value) -> std::sync::Arc<provekit_canonicalizer::Value> {
+    use provekit_canonicalizer::Value as CValue;
+    match j {
+        Value::Null => CValue::null(),
+        Value::Bool(b) => CValue::boolean(*b),
+        Value::Number(n) => CValue::integer(n.as_i64().unwrap_or_else(|| n.as_u64().unwrap_or(0) as i64)),
+        Value::String(s) => CValue::string(s.clone()),
+        Value::Array(items) => CValue::array(items.iter().map(json_to_cvalue).collect()),
+        Value::Object(map) => CValue::object(map.iter().map(|(k, v)| (k.clone(), json_to_cvalue(v))).collect()),
+    }
+}
+```
+
+- [ ] **Step 8: Build CLI**
+
+Run:
+
+```bash
+cd implementations/rust
+cargo build -p provekit-cli
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add implementations/rust/provekit-cli/src/main.rs implementations/rust/provekit-cli/src/cmd_zoo.rs implementations/rust/provekit-cli/Cargo.toml
+git commit -m "feat(cli): run bug zoo specimens"
+```
+
+---
+
+### Task 6: End-to-End Verification
+
+**Files:**
+- Create: `implementations/rust/provekit-cli/tests/zoo_smoke.rs`
+- Modify if needed: specimen `run-java-lifter.sh` scripts
+
+- [ ] **Step 1: Add smoke test**
+
+Create `zoo_smoke.rs`:
+
+```rust
+use std::path::PathBuf;
+use std::process::Command;
+
+fn provekit_bin() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let workspace = PathBuf::from(manifest_dir).parent().unwrap().to_path_buf();
+    let release = workspace.join("target").join("release").join("provekit");
+    let debug = workspace.join("target").join("debug").join("provekit");
+    if release.exists() { release } else { debug }
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent().unwrap()
+        .parent().unwrap()
+        .parent().unwrap()
+        .to_path_buf()
+}
+
+#[test]
+fn java_null_boundary_specimen_checks() {
+    let root = repo_root();
+    let specimen = root.join("bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence");
+    let out = Command::new(provekit_bin())
+        .arg("zoo")
+        .arg(&specimen)
+        .arg("--json")
+        .current_dir(&root)
+        .output()
+        .expect("spawn provekit zoo");
+
+    assert!(out.status.success(), "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr));
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json output");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["reports"][0]["missingEdge"], "maybe_null(name) => non_null(name)");
+    assert!(json["reports"][0]["proofIrCids"]["provekit-native"].as_str().unwrap().starts_with("blake3-512:"));
+    assert_eq!(
+        json["reports"][0]["proofIrCids"]["provekit-native"],
+        json["reports"][0]["proofIrCids"]["spring-web"]
+    );
+}
+```
+
+- [ ] **Step 2: Build Java lifter jars**
+
+Run:
+
+```bash
+mvn -f implementations/java/pom.xml -pl provekit-lift-java-core,provekit-lift-java-provekit-native,provekit-lift-java-spring-web -am package -DskipTests
+```
+
+Expected: PASS and jars exist under each module's `target/`.
+
+- [ ] **Step 3: Run specimen manually**
+
+Run:
+
+```bash
+cd implementations/rust
+cargo run -p provekit-cli -- zoo ../../bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence
+```
+
+Expected output includes:
+
+```text
+zoo: BZ-SHAPE-005 hostCheck PASS
+zoo: equivalence provekit-native == spring-web PASS
+zoo: expected verify failure maybe_null(name) => non_null(name) PASS
+```
+
+- [ ] **Step 4: Run Rust smoke test**
+
+Run:
+
+```bash
+cd implementations/rust
+cargo test -p provekit-cli --test zoo_smoke
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run focused Java tests again**
+
+Run:
+
+```bash
+mvn -f implementations/java/pom.xml -pl provekit-lift-java-integration-tests -am test -Dtest=CrossDomainContractEquivalenceTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add implementations/rust/provekit-cli/tests/zoo_smoke.rs bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence/exposed/*/kit-rpc/run-java-lifter.sh
+git commit -m "test: verify java bug zoo specimen"
+```
+
+---
+
+### Task 7: Documentation Checkpoint
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-05-06-bug-zoo-design.md`
+
+- [ ] **Step 1: Confirm README contains lossy-boundary section**
+
+Run:
+
+```bash
+rg -n "ProofIR is allowed to be lossy|universal language for contract boundaries|content-addressable, and signable" README.md
+```
+
+Expected: three matching lines.
+
+- [ ] **Step 2: Confirm design spec captures corrected architecture**
+
+Run:
+
+```bash
+rg -n "specimen-owned|Surface-equivalent exposure|Boundary-preserving lift|Rust CLI is the orchestrator|not become a TypeScript, Java" docs/superpowers/specs/2026-05-06-bug-zoo-design.md
+```
+
+Expected: matches for each phrase.
+
+- [ ] **Step 3: Commit docs**
+
+```bash
+git add README.md docs/superpowers/specs/2026-05-06-bug-zoo-design.md docs/superpowers/plans/2026-05-06-bug-zoo-v0.md
+git commit -m "docs: plan bug zoo v0"
+```
+
+---
+
+## Final Verification
+
+Run:
+
+```bash
+mvn -f implementations/java/pom.xml -pl provekit-lift-java-core,provekit-lift-java-provekit-native,provekit-lift-java-spring-web,provekit-lift-java-integration-tests -am test
+cd implementations/rust
+cargo test -p provekit-cli cmd_zoo::tests
+cargo test -p provekit-cli --test zoo_smoke
+cargo run -p provekit-cli -- zoo ../../bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence --json
+```
+
+Expected:
+
+- Maven tests pass.
+- Rust unit tests pass.
+- Rust integration test passes.
+- `provekit zoo ... --json` returns `"ok": true`.
+- The JSON has identical CIDs for `provekit-native` and `spring-web`.
+- The reported missing edge is `maybe_null(name) => non_null(name)`.
+
+## Spec Coverage
+
+- Specimen-owned tooling: Task 2 creates library, harnesses, and kit RPC scripts inside the specimen.
+- Rust CLI orchestration: Tasks 3-6 add `provekit zoo`.
+- Surface-equivalent exposure: Tasks 1, 2, and 6 prove ProvekIt-native and Spring Web lift to the same boundary ProofIR.
+- Lossy ProofIR boundary semantics: Task 2 manifest requires `lossiness.erased` and `lossiness.preserved`; Task 4 validates it.
+- Content addressing: Task 5 computes canonical ProofIR CIDs with Rust canonicalizer.
+- Exposed, not fixed: Task 2 records expected diagnostic and SAT witness; no patched/fixed tree is created.
+- Dropped phase: explicitly out of first slice because no Java null-boundary dropper exists yet.

--- a/docs/superpowers/specs/2026-05-06-bug-zoo-design.md
+++ b/docs/superpowers/specs/2026-05-06-bug-zoo-design.md
@@ -1,0 +1,409 @@
+# Bug Zoo v0 Design
+
+Date: 2026-05-06
+Status: Draft for review
+
+## Purpose
+
+Bug Zoo is a reproducible laboratory of bug species. Its job is to turn broad ProvekIt claims into concrete receipts:
+
+1. a specimen-native library or project looks plausible and passes its normal gate;
+2. that specimen's own kit/lifter lifts contracts already latent in the specimen's code, framework annotations, schemas, tests, or metadata through the kit RPC boundary;
+3. the Rust `provekit` CLI orchestrates the specimen and reports the missing `p => q` edge as a red squiggle or build refusal;
+4. an optional dropper pass independently emits a native-language edge-closing shape and re-verifies closure.
+
+Bug Zoo is not a patch museum. It does not lead with vulnerable-versus-fixed diffs, and it does not grade droppers by whether they match the historical remediation. The primary artifact is vulnerable-and-exposed: the same code engineers might ship, caught by ProvekIt before it ships. When a dropped specimen exists, the claim is that ProvekIt discovered the missing obligation and synthesized a verified closure from the exposed shape itself.
+
+The adoption claim is just as important as the verification claim: ProvekIt-native contracts are a reference surface, not a required authoring style. The zoo should show that many contracts were already built into ordinary code through frameworks and libraries; ProvekIt turns those latent contracts into universal ProofIR and shows where the graph stops composing.
+
+The deeper claim is that the exposed edge becomes universal, comparable, solvable, translatable, content-addressable, and signable. A Spring annotation, a ProvekIt-native annotation, an OpenAPI schema, a Zod validator, and a historical OSS commit can all name the same contract edge once lifted. The edge has canonical bytes, a CID, and signing semantics, so it can move across language domains, repositories, package ecosystems, commits, and time without becoming folklore again.
+
+ProofIR is allowed to be lossy. It is not a universal language for re-expressing every implementation detail of every programming language. It is a universal language for contract boundaries: preconditions, postconditions, invariants, protocol obligations, value predicates, resource states, signer claims, and the implication edges that connect them. That boundary language looks like first-order logic because contract composition is predicate composition: given `p`, can this edge establish required `q`?
+
+## Core Terms
+
+**Species.** A recurring bug shape reducible to predicates and an implication obligation. Example: SQL identifier injection is a species where some boundary predicate reaches a SQL identifier sink without proving `safe_sql_identifier`.
+
+**Lab specimen.** A controlled, runnable fixture that isolates a species. It should fit in one or two pages, but it must look like realistic production-shaped code or metadata rather than a toy line.
+
+**Specimen tooling.** The build files, harnesses, lifter entrypoint, and kit RPC adapter that belong to one specimen. This tooling lives inside the specimen, not in a central zoo library. A Java specimen may expose the same species through ProvekIt-native annotations, Spring, Bean Validation, Swagger, JML, or another realistic Java surface. The important thing is that each surface is lifted by the Java kit and compared through ProofIR.
+
+**Surface-equivalent exposure.** Two or more exposed variants of the same species that express the same contract in different source surfaces and lift to identical canonical ProofIR. Example: a ProvekIt-native Java annotation and a Spring request annotation can be separate exposed variants; the zoo should show their lifters produce the same contract bytes/CID before checking the missing edge.
+
+**Boundary-preserving lift.** A lift that may discard host-language implementation detail while preserving the contract boundary needed for verification. This is the key to cross-domain equivalence: two very different source artifacts can collapse to the same ProofIR when they assert the same boundary predicate.
+
+**Wild specimen.** Real OSS code pinned at a vulnerable commit, with an exposure artifact showing ProvekIt reports the same missing edge. A historical remediation may be linked for context, but it is neither the proof nor the target. The exposure is the proof.
+
+**Exposed.** The state where ProvekIt has lifted the specimen and emitted the red squiggle/build refusal. This includes expected ProofIR, missing edge, diagnostic location, and SAT witness or countercondition when available.
+
+**Dropped.** The state after a dropper emits a native edge-closing shape and ProvekIt re-lifts and verifies closure. "Dropped" is not "fixed": it means the missing contract edge was discharged by a generated native-language shape and confirmed by the substrate, independent of whatever remediation a maintainer eventually chose.
+
+## Taxonomy
+
+Bug Zoo v0 has two top-level kingdoms.
+
+### Shape Bugs
+
+The graph does not compose. These are ProvekIt's direct structural catches:
+
+- missing implication edge;
+- wrong pin rank;
+- wrong pin dimension;
+- unsatisfied sink precondition;
+- unresolved bridge;
+- malformed attestation;
+- protocol shape mismatch.
+
+These bugs are red-squiggle candidates. The code/config may run, but the ProofIR graph fails.
+
+### Value Bugs
+
+The graph shape composes, but a signed value, axiom, contract, or policy is wrong. ProvekIt cannot make false values true; it makes the false claim explicit, attributable, revocable, and linkable to downstream failures.
+
+Examples:
+
+- OpenAPI claims a value is safe, but the implementation does not enforce it;
+- a trusted signer signs a bad reference contract;
+- a boundary axiom overstates what an upstream service guarantees;
+- a policy memento accepts an overbroad signer set.
+
+Value bugs teach the boundary of the claim: ProvekIt exposes structure and provenance; it does not turn bad axioms into good ones.
+
+## v0 Species Pack
+
+Bug Zoo v0 should start with a mixed receipt pack rather than a single language or single domain.
+
+1. **BZ-SHAPE-001: SQL Identifier Injection**
+   - Surface: TypeScript + Zod + Express.
+   - Shape: a query parameter is validated for shape but flows into an SQL identifier position.
+   - Missing edge: `validated_query_param(sort) => safe_sql_identifier(sort)`.
+
+2. **BZ-SHAPE-002: Path Traversal**
+   - Surface: Python + FastAPI + Pydantic.
+   - Shape: filename passes string/shape validation but reaches a file-read sink without confinement.
+   - Missing edge: `validated_path_param(name) => confined_path(name)`.
+
+3. **BZ-SHAPE-003: Missing Authorization**
+   - Surface: OpenAPI plus implementation.
+   - Shape: endpoint establishes authentication but sink requires resource-specific authorization.
+   - Missing edge: `authenticated(user) => authorized(user, resource)`.
+
+4. **BZ-SHAPE-004: Header or Log Injection**
+   - Surface: Java Bean Validation or TypeScript.
+   - Shape: bounded/non-null string flows into a header/log sink without sink-specific safety.
+   - Missing edge: `bounded_string(x) => safe_for_header(x)` or `safe_for_log(x)`.
+
+5. **BZ-SHAPE-005: Optional or Null Misuse**
+   - Surface: TypeScript, Java, or Rust where the species is natural.
+   - Shape: optional/maybe-null value reaches a dereference/use sink.
+   - Missing edge: `maybe_null(x) => non_null(x)`.
+
+6. **BZ-SHAPE-006: Typestate or Resource Edge**
+   - Surface: Rust or Go.
+   - Shape: operation requires `resource_open`, `transaction_active`, or `lock_held`; caller has weaker state.
+   - Missing edge: weaker state to required typestate predicate.
+
+7. **BZ-SHAPE-007: Wrong Pin Rank**
+   - Surface: `.proof` or package metadata.
+   - Shape: binary is pinned without the complete contract/witness/binary tuple.
+   - Missing relation: rank-1 pin is used where a rank-3 assertion is required.
+
+8. **BZ-VALUE-001: Bad Boundary Axiom**
+   - Surface: OpenAPI/schema plus implementation.
+   - Shape: graph composes against an asserted boundary claim, but the boundary claim is false or unenforced.
+   - Exposure: not a missing edge; the bad value is explicit, signed, attributable, and linked to the relying proof.
+
+## Repository Layout
+
+Bug Zoo is executable evidence, so it should live at the repository root, not only under `docs/`. The root zoo may contain shared README material, but it must not become the place where language-specific truth lives. Each specimen owns the library, harness, and lifter surface needed to make the bug species real.
+
+```text
+bug-zoo/
+  README.md
+  species/
+    BZ-SHAPE-001-sql-identifier-injection/
+      README.md
+      specimen.yaml
+      lab/
+        library/
+          package manifest and source for the vulnerable specimen-native library
+        harness/
+          code that imports the library and exercises the vulnerable shape
+        kit-rpc/
+          specimen-owned lifter command or adapter manifest
+      exposed/
+        provekit-native/
+          harness/
+            code that depends on the same lab library and exercises the ProvekIt reference surface
+          kit-rpc/
+            specimen-owned lifter command or adapter manifest
+          expected.proofir.json
+          expected-diagnostic.txt
+        ecosystem-native/
+          harness/
+            code that depends on the same lab library and exercises an existing framework surface
+          kit-rpc/
+            specimen-owned lifter command or adapter manifest
+          expected.proofir.json
+          expected-diagnostic.txt
+        equivalence.json
+        sat-witness.json
+      dropped/
+        library/
+          generated native edge-closing shape, when a verified dropper exists
+        harness/
+          code that depends on the dropped library and re-runs the lifter
+        closure.proofir.json
+        verify-output.txt
+      wild/
+        README.md
+```
+
+For a TypeScript specimen, `library/` might contain `package.json`, `src/app.ts`, and tests. For a Java specimen, it might contain `pom.xml` or `build.gradle`, one ProvekIt-native exposure, one Spring or Bean Validation exposure, source files, and a Java kit RPC entrypoint. For an OpenAPI specimen, the "library" can be the protocol artifact itself plus the harness that consumes it.
+
+The Rust CLI is the orchestrator for all of this. It reads `specimen.yaml`, runs the declared host command, invokes the declared lifter through the kit RPC protocol, and compares the resulting ProofIR/diagnostic behavior to the specimen's exposed or dropped expectations.
+
+This direction intentionally replaces a central TypeScript zoo tool with specimen-owned tooling plus Rust CLI orchestration. A specimen should be portable as a small native project; the zoo runner should be able to treat it as a black box.
+
+Older sketches of the layout used a central `bug-zoo/tools/` directory. v0 should avoid that for language behavior. Shared root tooling is allowed only for documentation helpers or schema linting that does not know how any particular language works.
+
+Canonical specimen state:
+
+```text
+bug-zoo/species/BZ-SHAPE-001-sql-identifier-injection/
+  specimen.yaml
+  lab/
+    library/
+    harness/
+    kit-rpc/
+  exposed/
+    provekit-native/
+      harness/
+      kit-rpc/
+      expected.proofir.json
+      expected-diagnostic.txt
+      sat-witness.json
+    framework-native/
+      harness/
+      kit-rpc/
+      expected.proofir.json
+      expected-diagnostic.txt
+      sat-witness.json
+    equivalence.json
+  dropped/
+    library/
+    harness/
+    closure.proofir.json
+    verify-output.txt
+  wild/
+    README.md
+```
+
+`lab/` is required. `exposed/` is required. Each species needs at least one exposed variant; species with a meaningful framework/library surface should prefer two variants: one ProvekIt-native reference surface and one ecosystem-native surface. `dropped/` is optional in v0 and required only for species where a verified dropper exists. `wild/` is optional per species at first, but every v0 species should have room for at least one wild specimen. Each wild child directory must be named from a real advisory ID and project slug, and the validator must reject entries whose advisory URL, commit hash, or affected path cannot be resolved.
+
+When a specimen has multiple exposed variants, `exposed/equivalence.json` records the canonical ProofIR CIDs that must match. This is a first-class receipt: the zoo demonstrates that ProvekIt did not require a new authoring style, only a lifter that could recognize the contract already present in code. The equivalence is intentionally at the contract boundary, not at the implementation level.
+
+Example TypeScript-shaped lab internals:
+
+```text
+lab/
+  library/
+    package.json
+    src/
+      app.ts
+    tests/
+      app.test.ts
+  harness/
+    package.json
+    src/
+      exercise.ts
+  kit-rpc/
+    manifest.json
+```
+
+Example Java-shaped lab internals:
+
+```text
+lab/
+  library/
+    pom.xml
+    src/main/java/
+      example/
+        ReportController.java
+        SortParam.java
+  harness/
+    pom.xml
+    src/test/java/
+      example/
+        ReportControllerTest.java
+  kit-rpc/
+    manifest.json
+```
+
+Example Java-shaped exposed variants:
+
+```text
+exposed/
+  provekit-native/
+    harness/
+      pom.xml
+      src/main/java/example/ReportController.java
+    kit-rpc/
+      manifest.toml
+    expected.proofir.json
+    expected-diagnostic.txt
+  spring-web/
+    harness/
+      pom.xml
+      src/main/java/example/ReportController.java
+    kit-rpc/
+      manifest.toml
+    expected.proofir.json
+    expected-diagnostic.txt
+  equivalence.json
+```
+
+The exact files differ by language, but the dependency direction does not: harnesses depend on the specimen library; the Rust CLI invokes the lifter via RPC; ProvekIt does not import specimen internals as a central library.
+
+Obsolete layout, kept here only as a warning against the wrong dependency direction:
+
+```text
+do not build:
+bug-zoo/
+  tools/
+    validate-specimens.ts
+    run-lab.ts
+```
+
+## Specimen Contract
+
+Every `specimen.yaml` should include the minimum data needed to validate and present the specimen.
+
+```yaml
+id: BZ-SHAPE-001
+name: SQL Identifier Injection
+kingdom: shape
+surface: typescript-zod-express
+status: lab
+paths:
+  labLibrary: lab/library
+  labHarness: lab/harness
+  labKitRpc: lab/kit-rpc
+exposures:
+  - id: provekit-native
+    surface: typescript-provekit-native
+    harness: exposed/provekit-native/harness
+    kitRpc: exposed/provekit-native/kit-rpc
+    liftRpc:
+      cwd: exposed/provekit-native/kit-rpc
+      argv: ["pnpm", "start", "--", "--rpc", "../harness"]
+    proofIrFile: exposed/provekit-native/expected.proofir.json
+    diagnosticFile: exposed/provekit-native/expected-diagnostic.txt
+  - id: zod-express
+    surface: typescript-zod-express
+    harness: exposed/zod-express/harness
+    kitRpc: exposed/zod-express/kit-rpc
+    liftRpc:
+      cwd: exposed/zod-express/kit-rpc
+      argv: ["pnpm", "start", "--", "--rpc", "../harness"]
+    proofIrFile: exposed/zod-express/expected.proofir.json
+    diagnosticFile: exposed/zod-express/expected-diagnostic.txt
+equivalence:
+  required:
+    - [provekit-native, zod-express]
+commands:
+  hostCheck:
+    cwd: lab/library
+    argv: ["pnpm", "test"]
+predicates:
+  boundary: validated_query_param(sort)
+  sink: safe_sql_identifier(sort)
+  missingEdge: validated_query_param(sort) => safe_sql_identifier(sort)
+expectations:
+  hostCompiler: pass
+  ordinaryTests: pass
+  provekitVerify: fail
+exposure:
+  satWitnessFile: exposed/sat-witness.json
+dropper:
+  available: false
+wildSightings: []
+```
+
+The command shape is intentionally generic so Java, Python, TypeScript, Rust, OpenAPI, and metadata specimens can remain native. The Rust CLI should understand command execution, kit RPC, and canonical ProofIR equivalence; it should not understand Spring, Zod, Maven, or Swagger semantics.
+
+Wild specimens extend this with pinned upstream context. A wild `specimen.yaml` must include exact advisory ID, project slug, vulnerable commit, affected paths, advisory URL, source URL, species ID, exposure artifact paths, and verdict fields for `provekitExposes` and `dropperAvailable`. Historical remediation links are optional context only. No fake or unresolved wild entry should merge.
+
+## Validation Rules
+
+The v0 validator should enforce structure first, then execution as support lands.
+
+Required structural checks:
+
+- every species has `README.md`, `specimen.yaml`, `lab/library/`, `lab/harness/`, `lab/kit-rpc/`, and `exposed/`;
+- every listed exposure has its own `harness/`, `kit-rpc/`, `expected.proofir.json`, and `expected-diagnostic.txt`;
+- species IDs are unique and stable;
+- shape species define `boundary`, `sink`, and `missingEdge`;
+- value species define the bad value/axiom and the proof or consumer that relies on it;
+- every command has `cwd` and `argv`, with `cwd` resolving inside the specimen;
+- every exposure describes which host-language details were erased and which boundary predicates were preserved;
+- each exposure diagnostic names the red-squiggle location and missing edge;
+- every `equivalence.required` pair names known exposure IDs;
+- `dropped/` may not exist unless it includes closure evidence.
+
+Execution checks, added incrementally:
+
+- run the specimen's ordinary host command and confirm pass;
+- invoke each exposure's lifter through the kit RPC command declared in `specimen.yaml`;
+- confirm required exposure pairs produce identical canonical ProofIR CIDs;
+- confirm exposure equivalence compares boundary predicates, not host implementation details;
+- run `provekit verify` through the Rust CLI orchestration and confirm fail for `lab/`;
+- when `dropped/` exists, invoke the dropped harness/lifter and confirm `provekit verify` passes;
+- for wild specimens, verify the pinned upstream commit exists and the affected file path resolves;
+- never compare dropped output to the historical remediation as an acceptance criterion.
+
+## Dropper Relationship
+
+Bug Zoo v0 is primarily an exposure suite. Droppers are a third-stage demonstration:
+
+1. specimen-native lifter exposes missing edge through RPC;
+2. Rust CLI verifier refuses;
+3. dropper emits edge-closing native shape in the specimen's own language or artifact format;
+4. Rust CLI re-invokes the specimen lifter and confirms closure.
+
+The dropper is not trusted by itself. A dropped specimen is accepted only when the verifier confirms the dropped output closes the graph. This mirrors the existing Rust dropper pipeline in `implementations/rust/provekit-walk/src/dropper/`.
+
+The historical remediation for a wild bug is not an oracle. It can help a reader understand why the bug mattered, but it must not drive specimen construction, validator success, or dropper scoring. The stronger claim is independent rediscovery and independent closure.
+
+## Non-Goals
+
+- Bug Zoo v0 does not attempt broad CVE coverage.
+- Bug Zoo v0 does not require every species to have a dropper.
+- Bug Zoo v0 does not claim all bugs are covered.
+- Bug Zoo v0 does not treat historical patches as proof.
+- Bug Zoo v0 does not require or prefer the same remediation that landed upstream.
+- Bug Zoo v0 does not require vendoring full upstream OSS repositories.
+
+## Success Criteria
+
+Bug Zoo v0 succeeds when:
+
+- at least eight species are represented by minimal realistic lab fixtures;
+- each lab fixture has a clear exposed ProofIR/missing-edge artifact;
+- at least one species has two exposed variants where a ProvekIt-native surface and an ecosystem-native surface lift to identical canonical ProofIR;
+- at least two surfaces are non-code artifacts, such as OpenAPI or `.proof` metadata;
+- at least one species has a dropped variant verified by re-lift;
+- at least one wild specimen pins real OSS vulnerable code and shows exposure;
+- `bug-zoo/README.md` explains the lifecycle in one screen: lab, exposed, dropped, wild;
+- the Rust CLI can run a specimen without importing language-specific specimen code into a central zoo package.
+
+## Implementation Decisions For v0
+
+- First implementation target: `BZ-SHAPE-005: Optional or Null Misuse` on Java, because the repository already has Java lifter surfaces for ProvekIt-style contracts, Bean Validation, JML, Cofoja, and Spring Web. This first specimen should prove the corrected architecture: ordinary framework contracts and explicit contract surfaces lift to the same boundary ProofIR, then the missing `maybe_null(x) => non_null(x)` edge is exposed by Rust CLI orchestration.
+- Specimen metadata format: YAML, because the files are meant to be read as exhibit labels as much as machine manifests.
+- Wild specimen storage: store minimal extracts plus exact upstream commit metadata and source links; fetch full upstream repositories only in optional validation paths.
+- Runner architecture: implement a Rust CLI subcommand that reads specimen manifests, executes specimen-declared host checks, invokes each specimen-declared exposure through kit RPC, compares canonical ProofIR equivalence where required, and checks exposed/dropped expectations.
+- Language boundary: specimens own lifters and language tooling. Rust CLI orchestration may call RPC and compare outputs, but it must not become a TypeScript, Java, OpenAPI, or Rust specimen library.
+- Exposure strategy: prefer paired surfaces when available. One variant may use a ProvekIt-native contract surface as the reference; another should use the ecosystem contract surface engineers already have, such as Spring, Bean Validation, Swagger/OpenAPI, Zod, Pydantic, JML, or framework metadata.
+- ProofIR scope: treat ProofIR as boundary-preserving and deliberately lossy. The implementation plan should avoid any goal that requires reconstructing host-language semantics beyond the predicates and edges needed to verify the specimen.
+- Dropped phase: include it only where a verified dropper exists. For v0 that means the Rust not-null dropper path is eligible; non-Rust species may remain exposure-only until their droppers exist.

--- a/implementations/java/pom.xml
+++ b/implementations/java/pom.xml
@@ -21,6 +21,7 @@
         <module>provekit-java-self-contracts</module>
         <module>provekit-lift-java-core</module>
         <module>provekit-lift-java-bean-validation</module>
+        <module>provekit-lift-java-provekit-native</module>
         <module>provekit-lift-java-jml</module>
         <module>provekit-lift-java-cofoja</module>
         <module>provekit-lift-java-spring-web</module>
@@ -51,4 +52,27 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>targeted-test-reactor</id>
+            <activation>
+                <property>
+                    <name>test</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.5.4</version>
+                        <configuration>
+                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/AnnotationSupport.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/AnnotationSupport.java
@@ -1,0 +1,51 @@
+package com.provekit.lift;
+
+import java.util.*;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+
+public final class AnnotationSupport {
+    private AnnotationSupport() {}
+
+    public static boolean belongsToFamily(
+            CompilationUnit cu,
+            AnnotationExpr annotation,
+            String packageName,
+            Set<String> annotationNames,
+            Set<String> competingPackages) {
+        String name = annotation.getNameAsString();
+        String simple = simpleName(name);
+        if (!annotationNames.contains(simple)) return false;
+
+        if (name.contains(".")) {
+            return name.equals(packageName + "." + simple);
+        }
+
+        String currentPackage = cu.getPackageDeclaration()
+            .map(pd -> pd.getNameAsString())
+            .orElse("");
+        if (currentPackage.equals(packageName)) return true;
+
+        if (!hasImport(cu, packageName, simple)) return false;
+        for (String competingPackage : competingPackages) {
+            if (hasImport(cu, competingPackage, simple)) return false;
+        }
+        return true;
+    }
+
+    private static boolean hasImport(CompilationUnit cu, String packageName, String simpleName) {
+        for (ImportDeclaration importDecl : cu.getImports()) {
+            if (importDecl.isStatic()) continue;
+            String imported = importDecl.getNameAsString();
+            if (importDecl.isAsterisk() && imported.equals(packageName)) return true;
+            if (!importDecl.isAsterisk() && imported.equals(packageName + "." + simpleName)) return true;
+        }
+        return false;
+    }
+
+    private static String simpleName(String fq) {
+        int dot = fq.lastIndexOf('.');
+        return dot >= 0 ? fq.substring(dot + 1) : fq;
+    }
+}

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/ContractExpressionParser.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/ContractExpressionParser.java
@@ -1,0 +1,246 @@
+package com.provekit.lift;
+
+import java.util.*;
+
+public final class ContractExpressionParser {
+    private ContractExpressionParser() {}
+
+    public static String parseOrFallback(String expression, String fallbackAtomName) {
+        String trimmed = expression.trim();
+        try {
+            List<Token> tokens = new Tokenizer(trimmed).tokenize();
+            String parsed = new Parser(tokens).parse();
+            if (parsed != null) return parsed;
+        } catch (Exception ex) {
+            // Fall through to an opaque predicate for expressions outside this subset.
+        }
+        return "{\"kind\":\"atomic\",\"name\":\"" + fallbackAtomName + "\",\"args\":[{\"kind\":\"const\",\"value\":\""
+            + esc(trimmed) + "\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}]}";
+    }
+
+    private enum TokenType { EOF, IDENT, NUMBER, STRING, GE, LE, NE, EQ, GT, LT, AND, OR, LPAREN, RPAREN }
+
+    private record Token(TokenType type, String text) {}
+
+    private static final class Tokenizer {
+        private final String input;
+        private int pos;
+
+        Tokenizer(String input) {
+            this.input = input;
+            this.pos = 0;
+        }
+
+        List<Token> tokenize() {
+            List<Token> tokens = new ArrayList<>();
+            while (pos < input.length()) {
+                skipWhitespace();
+                if (pos >= input.length()) break;
+                char c = input.charAt(pos);
+                Token token = switch (c) {
+                    case '(' -> advance(TokenType.LPAREN, "(");
+                    case ')' -> advance(TokenType.RPAREN, ")");
+                    case '&' -> matchPair('&', TokenType.AND);
+                    case '|' -> matchPair('|', TokenType.OR);
+                    case '>' -> matchOpt('=', TokenType.GE, TokenType.GT);
+                    case '<' -> matchOpt('=', TokenType.LE, TokenType.LT);
+                    case '!' -> matchOpt('=', TokenType.NE, null);
+                    case '=' -> matchOpt('=', TokenType.EQ, null);
+                    case '"' -> readString('"');
+                    case '\'' -> readString('\'');
+                    default -> {
+                        if (Character.isDigit(c)) yield readNumber();
+                        if (Character.isLetter(c) || c == '_') yield readIdent();
+                        throw new RuntimeException("unexpected '" + c + "' at " + pos);
+                    }
+                };
+                tokens.add(token);
+            }
+            tokens.add(new Token(TokenType.EOF, ""));
+            return tokens;
+        }
+
+        private void skipWhitespace() {
+            while (pos < input.length() && Character.isWhitespace(input.charAt(pos))) pos++;
+        }
+
+        private Token advance(TokenType type, String text) {
+            pos += text.length();
+            return new Token(type, text);
+        }
+
+        private Token matchPair(char expected, TokenType type) {
+            if (pos + 1 < input.length() && input.charAt(pos + 1) == expected) {
+                pos += 2;
+                char c = input.charAt(pos - 2);
+                return new Token(type, "" + c + expected);
+            }
+            throw new RuntimeException("expected '" + expected + "' at " + pos);
+        }
+
+        private Token matchOpt(char maybe, TokenType yes, TokenType no) {
+            if (pos + 1 < input.length() && input.charAt(pos + 1) == maybe) {
+                pos += 2;
+                char c = input.charAt(pos - 2);
+                return new Token(yes, "" + c + maybe);
+            }
+            if (no != null) return advance(no, String.valueOf(input.charAt(pos)));
+            throw new RuntimeException("unexpected '" + input.charAt(pos) + "' at " + pos);
+        }
+
+        private Token readString(char quote) {
+            pos++;
+            StringBuilder sb = new StringBuilder();
+            while (pos < input.length() && input.charAt(pos) != quote) {
+                if (input.charAt(pos) == '\\') {
+                    if (pos + 1 >= input.length()) throw new RuntimeException("unterminated string");
+                    char next = input.charAt(pos + 1);
+                    sb.append(switch (next) {
+                        case 'n' -> '\n';
+                        case 't' -> '\t';
+                        case 'r' -> '\r';
+                        case '\\', '"', '\'' -> next;
+                        default -> next;
+                    });
+                    pos += 2;
+                } else {
+                    sb.append(input.charAt(pos++));
+                }
+            }
+            if (pos >= input.length()) throw new RuntimeException("unterminated string");
+            pos++;
+            return new Token(TokenType.STRING, sb.toString());
+        }
+
+        private Token readNumber() {
+            int start = pos;
+            while (pos < input.length() && Character.isDigit(input.charAt(pos))) pos++;
+            return new Token(TokenType.NUMBER, input.substring(start, pos));
+        }
+
+        private Token readIdent() {
+            int start = pos;
+            while (pos < input.length() && (Character.isLetterOrDigit(input.charAt(pos)) || input.charAt(pos) == '_')) pos++;
+            return new Token(TokenType.IDENT, input.substring(start, pos));
+        }
+    }
+
+    private static final class Parser {
+        private final List<Token> tokens;
+        private int pos;
+
+        Parser(List<Token> tokens) {
+            this.tokens = tokens;
+            this.pos = 0;
+        }
+
+        String parse() {
+            String result = parseOr();
+            if (result == null) return null;
+            if (current().type() != TokenType.EOF) return null;
+            return result;
+        }
+
+        private Token current() { return tokens.get(pos); }
+
+        private boolean match(TokenType type) {
+            if (current().type() == type) {
+                pos++;
+                return true;
+            }
+            return false;
+        }
+
+        private String parseOr() {
+            String left = parseAnd();
+            if (left == null) return null;
+            while (match(TokenType.OR)) {
+                String right = parseAnd();
+                if (right == null) return null;
+                left = "{\"kind\":\"or\",\"operands\":[" + left + "," + right + "]}";
+            }
+            return left;
+        }
+
+        private String parseAnd() {
+            String left = parseCmp();
+            if (left == null) return null;
+            while (match(TokenType.AND)) {
+                String right = parseCmp();
+                if (right == null) return null;
+                left = "{\"kind\":\"and\",\"operands\":[" + left + "," + right + "]}";
+            }
+            return left;
+        }
+
+        private String parseCmp() {
+            String left = parsePrimary();
+            if (left == null) return null;
+            String op = switch (current().type()) {
+                case GE -> "gte";
+                case GT -> "gt";
+                case LE -> "lte";
+                case LT -> "lt";
+                case NE -> "neq";
+                case EQ -> "eq";
+                default -> null;
+            };
+            if (op != null) {
+                match(current().type());
+                String right = parsePrimary();
+                if (right == null) return null;
+                return atom(op, left, right);
+            }
+            return left;
+        }
+
+        private String parsePrimary() {
+            Token token = current();
+            return switch (token.type()) {
+                case IDENT -> {
+                    pos++;
+                    yield switch (token.text()) {
+                        case "null" -> cNull();
+                        case "true" -> cBool(true);
+                        case "false" -> cBool(false);
+                        default -> var_(token.text());
+                    };
+                }
+                case NUMBER -> {
+                    pos++;
+                    yield cInt(Long.parseLong(token.text()));
+                }
+                case STRING -> {
+                    pos++;
+                    yield cStr(token.text());
+                }
+                case LPAREN -> {
+                    pos++;
+                    String inner = parseOr();
+                    if (inner == null || !match(TokenType.RPAREN)) yield null;
+                    yield inner;
+                }
+                default -> null;
+            };
+        }
+
+        private String var_(String n) { return "{\"kind\":\"var\",\"name\":\"" + n + "\"}"; }
+        private String cNull() { return "{\"kind\":\"const\",\"value\":null,\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"}}"; }
+        private String cBool(boolean b) { return "{\"kind\":\"const\",\"value\":" + b + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Bool\"}}"; }
+        private String cInt(long v) { return "{\"kind\":\"const\",\"value\":" + v + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}"; }
+        private String cStr(String s) { return "{\"kind\":\"const\",\"value\":\"" + esc(s) + "\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}"; }
+        private String atom(String name, String... args) {
+            StringBuilder sb = new StringBuilder("{\"kind\":\"atomic\",\"name\":\"" + name + "\",\"args\":[");
+            for (int i = 0; i < args.length; i++) {
+                if (i > 0) sb.append(",");
+                sb.append(args[i]);
+            }
+            sb.append("]}");
+            return sb.toString();
+        }
+    }
+
+    private static String esc(String s) {
+        return s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/implementations/java/provekit-lift-java-integration-tests/pom.xml
+++ b/implementations/java/provekit-lift-java-integration-tests/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
         <dependency>
             <groupId>com.provekit</groupId>
+            <artifactId>provekit-lift-java-provekit-native</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.provekit</groupId>
             <artifactId>provekit-lift-java-jml</artifactId>
             <version>0.1.0</version>
         </dependency>

--- a/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/CrossDomainContractEquivalenceTest.java
+++ b/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/CrossDomainContractEquivalenceTest.java
@@ -9,6 +9,7 @@ import com.provekit.lift.bean.BeanValidationExtractor;
 import com.provekit.lift.jml.JmlExtractor;
 import com.provekit.lift.springweb.SpringWebExtractor;
 import com.provekit.lift.cofoja.CofojaExtractor;
+import com.provekit.lift.provekitnative.ProvekitNativeExtractor;
 
 import java.util.*;
 
@@ -65,17 +66,30 @@ public class CrossDomainContractEquivalenceTest {
             }
             """;
 
-        // Lift all three
+        // ProvekIt-native surface (@Requires)
+        String provekitNativeSource = """
+            import com.provekit.contract.Requires;
+            public class ProvekitNativeService {
+                @Requires("name != null")
+                public String greet(String name) {
+                    return "Hello " + name;
+                }
+            }
+            """;
+
+        // Lift all domains
         String beanIr = lift(new BeanValidationExtractor(), beanSource);
         String jmlIr = lift(new JmlExtractor(), jmlSource);
         String springIr = lift(new SpringWebExtractor(), springSource);
         String cofojaIr = lift(new CofojaExtractor(), cofojaSource);
+        String provekitNativeIr = lift(new ProvekitNativeExtractor(), provekitNativeSource);
 
-        // All three domains express the same non-null constraint.
+        // All domains express the same non-null constraint.
         // They MUST produce byte-for-byte identical IR.
         assertEquals(beanIr, jmlIr, "JML and Bean Validation IR must be identical");
         assertEquals(beanIr, springIr, "Spring Web and Bean Validation IR must be identical");
         assertEquals(beanIr, cofojaIr, "Cofoja and Bean Validation IR must be identical");
+        assertEquals(beanIr, provekitNativeIr, "ProvekIt-native and Bean Validation IR must be identical");
     }
 
     @Test
@@ -112,14 +126,92 @@ public class CrossDomainContractEquivalenceTest {
             }
             """;
 
+        // ProvekIt-native surface
+        String provekitNativeSource = """
+            import com.provekit.contract.Requires;
+            public class ScoreService {
+                @Requires("score >= 0 && score <= 100")
+                public int setScore(int score) {
+                    return score;
+                }
+            }
+            """;
+
         String beanIr = lift(new BeanValidationExtractor(), beanSource);
         String jmlIr = lift(new JmlExtractor(), jmlSource);
         String cofojaIr = lift(new CofojaExtractor(), cofojaSource);
+        String provekitNativeIr = lift(new ProvekitNativeExtractor(), provekitNativeSource);
 
         // Both constrain 'score' to the same numeric range.
         // They MUST produce byte-for-byte identical IR.
         assertEquals(beanIr, jmlIr, "JML and Bean Validation IR must be identical");
         assertEquals(beanIr, cofojaIr, "Cofoja and Bean Validation IR must be identical");
+        assertEquals(beanIr, provekitNativeIr, "ProvekIt-native and Bean Validation IR must be identical");
+    }
+
+    @Test
+    public void nativeAndCofojaAnnotationsDoNotCrossLift() {
+        String cofojaSource = """
+            import com.google.java.contract.Requires;
+            public class CofojaService {
+                @Requires("name != null")
+                public String greet(String name) {
+                    return "Hello " + name;
+                }
+            }
+            """;
+
+        String nativeSource = """
+            import com.provekit.contract.Requires;
+            public class ProvekitNativeService {
+                @Requires("name != null")
+                public String greet(String name) {
+                    return "Hello " + name;
+                }
+            }
+            """;
+
+        String unimportedSimpleNameSource = """
+            public class AmbiguousService {
+                @Requires("name != null")
+                public String greet(String name) {
+                    return "Hello " + name;
+                }
+            }
+            """;
+
+        assertEquals(1, extract(new CofojaExtractor(), cofojaSource).size());
+        assertEquals(0, extract(new ProvekitNativeExtractor(), cofojaSource).size());
+        assertEquals(1, extract(new ProvekitNativeExtractor(), nativeSource).size());
+        assertEquals(0, extract(new CofojaExtractor(), nativeSource).size());
+        assertEquals(0, extract(new CofojaExtractor(), unimportedSimpleNameSource).size());
+        assertEquals(0, extract(new ProvekitNativeExtractor(), unimportedSimpleNameSource).size());
+    }
+
+    @Test
+    public void fullyQualifiedNativeAndCofojaAnnotationsAreRecognized() {
+        String cofojaSource = """
+            public class CofojaService {
+                @com.google.java.contract.Requires("name != null")
+                public String greet(String name) {
+                    return "Hello " + name;
+                }
+            }
+            """;
+
+        String nativeSource = """
+            public class ProvekitNativeService {
+                @com.provekit.contract.Requires("name != null")
+                public String greet(String name) {
+                    return "Hello " + name;
+                }
+            }
+            """;
+
+        assertEquals(1, extract(new CofojaExtractor(), cofojaSource).size());
+        assertEquals(0, extract(new ProvekitNativeExtractor(), cofojaSource).size());
+        assertEquals(1, extract(new ProvekitNativeExtractor(), nativeSource).size());
+        assertEquals(0, extract(new CofojaExtractor(), nativeSource).size());
     }
 
     @Test
@@ -146,11 +238,7 @@ public class CrossDomainContractEquivalenceTest {
     }
 
     private String lift(Extractor extractor, String source) {
-        ParseResult<CompilationUnit> result = new JavaParser().parse(source);
-        assertTrue(result.isSuccessful() && result.getResult().isPresent(),
-            "Failed to parse: " + result.getProblems());
-        CompilationUnit cu = result.getResult().get();
-        List<ContractDecl> decls = extractor.extract(cu, source);
+        List<ContractDecl> decls = extract(extractor, source);
         assertFalse(decls.isEmpty(), "Extractor should find at least one contract");
 
         StringBuilder sb = new StringBuilder("[");
@@ -160,5 +248,13 @@ public class CrossDomainContractEquivalenceTest {
         }
         sb.append("]");
         return sb.toString();
+    }
+
+    private List<ContractDecl> extract(Extractor extractor, String source) {
+        ParseResult<CompilationUnit> result = new JavaParser().parse(source);
+        assertTrue(result.isSuccessful() && result.getResult().isPresent(),
+            "Failed to parse: " + result.getProblems());
+        CompilationUnit cu = result.getResult().get();
+        return extractor.extract(cu, source);
     }
 }

--- a/implementations/java/provekit-lift-java-jml/src/main/java/com/provekit/lift/jml/JmlExtractor.java
+++ b/implementations/java/provekit-lift-java-jml/src/main/java/com/provekit/lift/jml/JmlExtractor.java
@@ -6,323 +6,54 @@ import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.provekit.lift.*;
 
-/**
- * JML extractor that parses common JML expressions into canonical IR.
- *
- * The critical requirement: JML expressions that encode the same runtime
- * constraint as other annotation families MUST produce byte-for-byte
- * identical IR. For example:
- *
- *   //@ requires name != null
- *
- * must produce the exact same JSON as Bean Validation's @NotNull:
- *
- *   {"kind":"atomic","name":"neq","args":[
- *     {"kind":"var","name":"name"},
- *     {"kind":"const","value":null,"sort":{"kind":"primitive","name":"Ref"}}
- *   ]}
- */
 public class JmlExtractor implements Extractor {
     private static final Pattern REQUIRES = Pattern.compile("//@\\s*requires\\s+(.+)");
-    private static final Pattern ENSURES  = Pattern.compile("//@\\s*ensures\\s+(.+)");
-    private static final Pattern INVARIANT= Pattern.compile("//@\\s*invariant\\s+(.+)");
+    private static final Pattern ENSURES = Pattern.compile("//@\\s*ensures\\s+(.+)");
+    private static final Pattern INVARIANT = Pattern.compile("//@\\s*invariant\\s+(.+)");
 
     public String name() { return "jml"; }
 
     public List<ContractDecl> extract(CompilationUnit cu, String rawSource) {
         List<ContractDecl> out = new ArrayList<>();
         String[] lines = rawSource.split("\n");
-        Map<Integer,List<String>> pres = new HashMap<>(), posts = new HashMap<>(), invs = new HashMap<>();
+        Map<Integer, List<String>> pres = new HashMap<>(), posts = new HashMap<>(), invs = new HashMap<>();
 
-        for (int i=0;i<lines.length;i++) {
+        for (int i = 0; i < lines.length; i++) {
             String line = lines[i];
             Matcher m;
-            if ((m=REQUIRES.matcher(line)).find())  pres.computeIfAbsent(i,k->new ArrayList<>()).add(m.group(1));
-            if ((m=ENSURES .matcher(line)).find())  posts.computeIfAbsent(i,k->new ArrayList<>()).add(m.group(1));
-            if ((m=INVARIANT.matcher(line)).find()) invs.computeIfAbsent(i,k->new ArrayList<>()).add(m.group(1));
+            if ((m = REQUIRES.matcher(line)).find()) pres.computeIfAbsent(i, k -> new ArrayList<>()).add(m.group(1));
+            if ((m = ENSURES.matcher(line)).find()) posts.computeIfAbsent(i, k -> new ArrayList<>()).add(m.group(1));
+            if ((m = INVARIANT.matcher(line)).find()) invs.computeIfAbsent(i, k -> new ArrayList<>()).add(m.group(1));
         }
 
         for (TypeDeclaration<?> type : cu.getTypes()) {
             for (BodyDeclaration<?> member : type.getMembers()) {
                 if (member instanceof MethodDeclaration method) {
-                    int line = method.getBegin().map(p->p.line).orElse(0);
+                    int line = method.getBegin().map(p -> p.line).orElse(0);
                     String symbol = method.getNameAsString();
-                    List<String> p = gather(line,pres), po = gather(line,posts), inv = gather(line,invs);
-                    if (!p.isEmpty()||!po.isEmpty()||!inv.isEmpty()) out.add(new ContractDecl(symbol,p,po,inv));
+                    List<String> p = gather(line, pres), po = gather(line, posts), inv = gather(line, invs);
+                    if (!p.isEmpty() || !po.isEmpty() || !inv.isEmpty()) {
+                        out.add(new ContractDecl(symbol, p, po, inv));
+                    }
                 }
             }
         }
         return out;
     }
 
-    private List<String> gather(int methodLine, Map<Integer,List<String>> map) {
-        List<String> r = new ArrayList<>();
-        for (int i=methodLine-1;i>=Math.max(0,methodLine-20);i--) {
+    private List<String> gather(int methodLine, Map<Integer, List<String>> map) {
+        List<String> result = new ArrayList<>();
+        for (int i = methodLine - 1; i >= Math.max(0, methodLine - 20); i--) {
             if (map.containsKey(i)) {
-                for (String e : map.get(i)) r.add(jmlToIr(e));
+                for (String expr : map.get(i)) result.add(jmlToIr(expr));
                 break;
             }
         }
-        return r;
+        return result;
     }
 
-    /**
-     * Parse a JML expression and emit canonical IR.
-     *
-     * Uses a hand-written tokenizer + recursive-descent parser (no regex
-     * gymnastics on the expression itself). Anything the parser cannot
-     * handle falls back to a jml_predicate atom for backward compatibility.
-     */
     private String jmlToIr(String expr) {
-        String e = expr.trim().replace("\\result","result");
-        try {
-            List<JmlTokenizer.Token> tokens = new JmlTokenizer(e).tokenize();
-            String parsed = new JmlExprParser(tokens).parse();
-            if (parsed != null) return parsed;
-        } catch (Exception ex) {
-            // Fallback to opaque predicate
-        }
-        return "{\"kind\":\"atomic\",\"name\":\"jml_predicate\",\"args\":[{\"kind\":\"const\",\"value\":\""+esc(e)+"\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}]}";
-    }
-
-    private String esc(String s) { return s.replace("\\","\\\\").replace("\"","\\\""); }
-
-    // ======================== Tokenizer ========================
-
-    /** Simple character-scanning tokenizer for JML boolean expressions. */
-    static final class JmlTokenizer {
-        enum Type {
-            EOF, IDENT, NUMBER, STRING,
-            GE, LE, NE, EQ, GT, LT,
-            AND, OR,
-            LPAREN, RPAREN
-        }
-
-        record Token(Type type, String text) {}
-
-        private final String input;
-        private int pos;
-
-        JmlTokenizer(String input) { this.input = input; this.pos = 0; }
-
-        List<Token> tokenize() {
-            List<Token> tokens = new ArrayList<>();
-            while (pos < input.length()) {
-                skipWhitespace();
-                if (pos >= input.length()) break;
-                char c = input.charAt(pos);
-                Token t = switch (c) {
-                    case '(' -> advance(Type.LPAREN, "(");
-                    case ')' -> advance(Type.RPAREN, ")");
-                    case '&' -> matchPair('&', Type.AND);
-                    case '|' -> matchPair('|', Type.OR);
-                    case '>' -> matchOpt('=', Type.GE, Type.GT);
-                    case '<' -> matchOpt('=', Type.LE, Type.LT);
-                    case '!' -> matchOpt('=', Type.NE, null);
-                    case '=' -> matchOpt('=', Type.EQ, null);
-                    case '"' -> readString('"');
-                    case '\'' -> readString('\'');
-                    default -> {
-                        if (Character.isDigit(c)) yield readNumber();
-                        if (Character.isLetter(c) || c == '_') yield readIdent();
-                        throw new RuntimeException("Unexpected character '" + c + "' at position " + pos);
-                    }
-                };
-                tokens.add(t);
-            }
-            tokens.add(new Token(Type.EOF, ""));
-            return tokens;
-        }
-
-        private void skipWhitespace() {
-            while (pos < input.length() && Character.isWhitespace(input.charAt(pos))) pos++;
-        }
-
-        private Token advance(Type type, String text) {
-            pos += text.length();
-            return new Token(type, text);
-        }
-
-        private Token matchPair(char expected, Type type) {
-            if (pos + 1 < input.length() && input.charAt(pos + 1) == expected) {
-                pos += 2;
-                return new Token(type, String.valueOf(expected) + expected);
-            }
-            throw new RuntimeException("Expected '" + expected + "' at position " + pos);
-        }
-
-        private Token matchOpt(char maybe, Type yesType, Type noType) {
-            if (pos + 1 < input.length() && input.charAt(pos + 1) == maybe) {
-                pos += 2;
-                char c = input.charAt(pos - 2);
-                return new Token(yesType, "" + c + maybe);
-            }
-            if (noType != null) {
-                return advance(noType, String.valueOf(input.charAt(pos)));
-            }
-            throw new RuntimeException("Unexpected '" + input.charAt(pos) + "' at position " + pos);
-        }
-
-        private Token readString(char quote) {
-            pos++; // consume opening quote
-            StringBuilder sb = new StringBuilder();
-            while (pos < input.length() && input.charAt(pos) != quote) {
-                if (input.charAt(pos) == '\\') {
-                    if (pos + 1 >= input.length()) throw new RuntimeException("Unterminated string");
-                    char next = input.charAt(pos + 1);
-                    sb.append(switch (next) {
-                        case 'n' -> '\n';
-                        case 't' -> '\t';
-                        case 'r' -> '\r';
-                        case '\\', '"', '\'' -> next;
-                        default -> next;
-                    });
-                    pos += 2;
-                } else {
-                    sb.append(input.charAt(pos++));
-                }
-            }
-            if (pos >= input.length()) throw new RuntimeException("Unterminated string");
-            pos++; // consume closing quote
-            return new Token(Type.STRING, sb.toString());
-        }
-
-        private Token readNumber() {
-            int start = pos;
-            while (pos < input.length() && Character.isDigit(input.charAt(pos))) pos++;
-            return new Token(Type.NUMBER, input.substring(start, pos));
-        }
-
-        private Token readIdent() {
-            int start = pos;
-            while (pos < input.length() && (Character.isLetterOrDigit(input.charAt(pos)) || input.charAt(pos) == '_')) pos++;
-            return new Token(Type.IDENT, input.substring(start, pos));
-        }
-    }
-
-    // ======================== Parser ========================
-
-    /** Recursive-descent parser that emits canonical IR JSON. */
-    static final class JmlExprParser {
-        private final List<JmlTokenizer.Token> tokens;
-        private int pos;
-
-        JmlExprParser(List<JmlTokenizer.Token> tokens) { this.tokens = tokens; this.pos = 0; }
-
-        /** Parse the token stream into an IR JSON string, or null if it cannot be parsed. */
-        String parse() {
-            String result = parseOr();
-            if (result == null) return null;
-            if (current().type() != JmlTokenizer.Type.EOF) return null;
-            return result;
-        }
-
-        private JmlTokenizer.Token current() { return tokens.get(pos); }
-
-        private boolean match(JmlTokenizer.Type type) {
-            if (current().type() == type) { pos++; return true; }
-            return false;
-        }
-
-        private String parseOr() {
-            String left = parseAnd();
-            if (left == null) return null;
-            while (match(JmlTokenizer.Type.OR)) {
-                String right = parseAnd();
-                if (right == null) return null;
-                left = "{\"kind\":\"or\",\"operands\":[" + left + "," + right + "]}";
-            }
-            return left;
-        }
-
-        private String parseAnd() {
-            String left = parseCmp();
-            if (left == null) return null;
-            while (match(JmlTokenizer.Type.AND)) {
-                String right = parseCmp();
-                if (right == null) return null;
-                left = "{\"kind\":\"and\",\"operands\":[" + left + "," + right + "]}";
-            }
-            return left;
-        }
-
-        private String parseCmp() {
-            String left = parsePrimary();
-            if (left == null) return null;
-
-            String opName = switch (current().type()) {
-                case GE -> "gte";
-                case GT -> "gt";
-                case LE -> "lte";
-                case LT -> "lt";
-                case NE -> "neq";
-                case EQ -> "eq";
-                default -> null;
-            };
-
-            if (opName != null) {
-                match(current().type()); // consume operator
-                String right = parsePrimary();
-                if (right == null) return null;
-                return atom(opName, left, right);
-            }
-            return left;
-        }
-
-        private String parsePrimary() {
-            JmlTokenizer.Token t = current();
-            return switch (t.type()) {
-                case IDENT -> {
-                    consume();
-                    yield switch (t.text()) {
-                        case "null"  -> cNull();
-                        case "true"  -> cBool(true);
-                        case "false" -> cBool(false);
-                        default      -> var_(t.text());
-                    };
-                }
-                case NUMBER -> {
-                    consume();
-                    yield cInt(Long.parseLong(t.text()));
-                }
-                case STRING -> {
-                    consume();
-                    yield cStr(t.text());
-                }
-                case LPAREN -> {
-                    consume();
-                    String inner = parseOr();
-                    if (inner == null || !match(JmlTokenizer.Type.RPAREN)) yield null;
-                    yield inner;
-                }
-                default -> null;
-            };
-        }
-
-        private void consume() { pos++; }
-
-        // IR constructor helpers — emit EXACTLY the same JSON as BeanValidationExtractor
-        private String var_(String n) {
-            return "{\"kind\":\"var\",\"name\":\"" + n + "\"}";
-        }
-        private String cNull() {
-            return "{\"kind\":\"const\",\"value\":null,\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"}}";
-        }
-        private String cBool(boolean b) {
-            return "{\"kind\":\"const\",\"value\":" + b + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Bool\"}}";
-        }
-        private String cInt(long v) {
-            return "{\"kind\":\"const\",\"value\":" + v + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
-        }
-        private String cStr(String s) {
-            return "{\"kind\":\"const\",\"value\":\"" + esc(s) + "\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}";
-        }
-        private String atom(String name, String... args) {
-            StringBuilder sb = new StringBuilder("{\"kind\":\"atomic\",\"name\":\"" + name + "\",\"args\":[");
-            for (int i = 0; i < args.length; i++) { if (i > 0) sb.append(","); sb.append(args[i]); }
-            sb.append("]}");
-            return sb.toString();
-        }
-        private String esc(String s) { return s.replace("\\","\\\\").replace("\"","\\\""); }
+        String normalized = expr.trim().replace("\\result", "result");
+        return ContractExpressionParser.parseOrFallback(normalized, "jml_predicate");
     }
 }

--- a/implementations/java/provekit-lift-java-provekit-native/pom.xml
+++ b/implementations/java/provekit-lift-java-provekit-native/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.provekit</groupId>
+        <artifactId>provekit-lift-java-parent</artifactId>
+        <version>0.1.0</version>
+    </parent>
+    <artifactId>provekit-lift-java-provekit-native</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.provekit</groupId>
+            <artifactId>provekit-lift-java-core</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/implementations/java/provekit-lift-java-provekit-native/src/main/java/com/provekit/lift/provekitnative/ProvekitNativeExtractor.java
+++ b/implementations/java/provekit-lift-java-provekit-native/src/main/java/com/provekit/lift/provekitnative/ProvekitNativeExtractor.java
@@ -1,4 +1,4 @@
-package com.provekit.lift.cofoja;
+package com.provekit.lift.provekitnative;
 
 import java.util.*;
 import com.github.javaparser.ast.*;
@@ -6,12 +6,12 @@ import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.*;
 import com.provekit.lift.*;
 
-public class CofojaExtractor implements Extractor {
-    private static final String PACKAGE_NAME = "com.google.java.contract";
+public class ProvekitNativeExtractor implements Extractor {
+    private static final String PACKAGE_NAME = "com.provekit.contract";
     private static final Set<String> ANNOTATIONS = Set.of("Requires", "Ensures", "Invariant");
-    private static final Set<String> COMPETING_PACKAGES = Set.of("com.provekit.contract");
+    private static final Set<String> COMPETING_PACKAGES = Set.of("com.google.java.contract");
 
-    public String name() { return "cofoja"; }
+    public String name() { return "provekit-native"; }
 
     public List<ContractDecl> extract(CompilationUnit cu, String rawSource) {
         List<ContractDecl> out = new ArrayList<>();
@@ -56,7 +56,7 @@ public class CofojaExtractor implements Extractor {
     }
 
     private String toIr(String expr) {
-        return ContractExpressionParser.parseOrFallback(expr, "cofoja_predicate");
+        return ContractExpressionParser.parseOrFallback(expr, "provekit_native_predicate");
     }
 
     private String simpleName(String fq) {

--- a/implementations/java/provekit-lift-java-provekit-native/src/main/resources/META-INF/services/com.provekit.lift.Extractor
+++ b/implementations/java/provekit-lift-java-provekit-native/src/main/resources/META-INF/services/com.provekit.lift.Extractor
@@ -1,0 +1,1 @@
+com.provekit.lift.provekitnative.ProvekitNativeExtractor

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1607,6 +1607,7 @@ dependencies = [
  "provekit-verifier",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "tempfile",
  "thiserror",

--- a/implementations/rust/provekit-cli/Cargo.toml
+++ b/implementations/rust/provekit-cli/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = "1"
 owo-colors = "4"
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = "0.9"
 walkdir = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }

--- a/implementations/rust/provekit-cli/src/cmd_proof.rs
+++ b/implementations/rust/provekit-cli/src/cmd_proof.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `provekit proof ...` — grouped helpers for .proof artifacts.
+
+use std::path::{Path, PathBuf};
+
+use clap::{Parser, Subcommand};
+use owo_colors::OwoColorize;
+use provekit_canonicalizer::blake3_512_of;
+use provekit_verifier::cbor_decode::decode;
+use serde_json::json;
+
+use crate::{DumpArgs, HashArgs, OutputFlags, EXIT_OK, EXIT_VERIFY_FAIL};
+
+#[derive(Parser, Debug, Clone)]
+pub struct ProofArgs {
+    #[command(subcommand)]
+    pub cmd: ProofCmd,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ProofCmd {
+    /// Compute the BLAKE3-512 CID of a .proof file.
+    Hash(ProofFileArgs),
+    /// Inspect a .proof envelope and print its members.
+    Inspect(ProofFileArgs),
+    /// Check that a .proof file decodes and its filename matches its content CID.
+    Check(ProofFileArgs),
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct ProofFileArgs {
+    /// Path to a .proof file.
+    pub proof_file: PathBuf,
+    #[command(flatten)]
+    pub out: OutputFlags,
+}
+
+pub fn run(args: ProofArgs) -> u8 {
+    match args.cmd {
+        ProofCmd::Hash(a) => crate::cmd_hash::run(HashArgs {
+            file: Some(a.proof_file),
+            out: a.out,
+        }),
+        ProofCmd::Inspect(a) => crate::cmd_dump::run(DumpArgs {
+            proof_file: a.proof_file,
+            out: a.out,
+        }),
+        ProofCmd::Check(a) => check(a),
+    }
+}
+
+fn check(args: ProofFileArgs) -> u8 {
+    match check_proof_file(&args.proof_file) {
+        Ok(report) => {
+            if args.out.json {
+                let payload = json!({
+                    "path": args.proof_file.display().to_string(),
+                    "cid": report.cid,
+                    "memberCount": report.member_count,
+                    "ok": true,
+                });
+                println!("{}", serde_json::to_string_pretty(&payload).unwrap_or_default());
+            } else if !args.out.quiet {
+                println!("{}: {}", "proof".green().bold(), args.proof_file.display());
+                println!("  cid: {}", report.cid);
+                println!("  members: {}", report.member_count);
+            }
+            EXIT_OK
+        }
+        Err(e) => {
+            eprintln!("{}: {e}", "error".red().bold());
+            EXIT_VERIFY_FAIL
+        }
+    }
+}
+
+struct ProofCheckReport {
+    cid: String,
+    member_count: usize,
+}
+
+fn check_proof_file(path: &Path) -> Result<ProofCheckReport, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let cid = blake3_512_of(&bytes);
+    check_filename_cid(path, &cid)?;
+
+    let catalog = decode(&bytes).map_err(|e| format!("CBOR decode {}: {e}", path.display()))?;
+    let map = catalog
+        .as_map()
+        .ok_or_else(|| "proof envelope root is not a CBOR map".to_string())?;
+    let members = map
+        .get("members")
+        .and_then(|v| v.as_map())
+        .ok_or_else(|| "proof envelope has no `members` map".to_string())?;
+
+    Ok(ProofCheckReport {
+        cid,
+        member_count: members.len(),
+    })
+}
+
+fn check_filename_cid(path: &Path, content_cid: &str) -> Result<(), String> {
+    let filename = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| format!("proof path has no UTF-8 filename: {}", path.display()))?;
+    if !filename.ends_with(".proof") {
+        return Err(format!("proof filename must end in `.proof`: {filename}"));
+    }
+
+    let stem = filename.trim_end_matches(".proof");
+    let expected_hex = content_cid.trim_start_matches("blake3-512:");
+    let stem_hex = stem.trim_start_matches("blake3-512:");
+    if stem_hex.len() != 128 || !stem_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!(
+            "proof filename must be `<cid>.proof` or `<hex>.proof`: {filename}"
+        ));
+    }
+    if stem_hex != expected_hex {
+        return Err(format!(
+            "proof filename CID {stem_hex} does not match content CID {expected_hex}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ZERO_CID: &str = "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229";
+
+    #[test]
+    fn filename_cid_accepts_full_cid_stem() {
+        let path = PathBuf::from(format!("{ZERO_CID}.proof"));
+        check_filename_cid(&path, ZERO_CID).expect("matching filename CID");
+    }
+
+    #[test]
+    fn filename_cid_rejects_mismatch() {
+        let path = PathBuf::from(format!("{}.proof", "0".repeat(128)));
+        let err = check_filename_cid(&path, ZERO_CID).expect_err("mismatch must fail");
+        assert!(err.contains("does not match content CID"), "got: {err}");
+    }
+}

--- a/implementations/rust/provekit-cli/src/cmd_zoo.rs
+++ b/implementations/rust/provekit-cli/src/cmd_zoo.rs
@@ -1,0 +1,949 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Component, Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
+
+#[derive(Parser, Debug, Clone)]
+pub struct ZooArgs {
+    /// Specimen directory or specimen.yaml path. Defaults to bug-zoo/species.
+    pub specimen: Option<PathBuf>,
+    /// Check every species under bug-zoo/species.
+    #[arg(long)]
+    pub all: bool,
+    #[command(flatten)]
+    pub out: OutputFlags,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SpecimenManifest {
+    id: String,
+    name: String,
+    kingdom: String,
+    surface: String,
+    status: String,
+    paths: SpecimenPaths,
+    commands: SpecimenCommands,
+    predicates: Predicates,
+    exposures: Vec<Exposure>,
+    equivalence: Equivalence,
+    expectations: Expectations,
+    exposure: ExposureFiles,
+    dropper: Dropper,
+    #[serde(default)]
+    wild_sightings: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SpecimenPaths {
+    lab_library: PathBuf,
+    lab_harness: PathBuf,
+    lab_kit_rpc: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SpecimenCommands {
+    host_check: CommandSpec,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct CommandSpec {
+    cwd: PathBuf,
+    argv: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Predicates {
+    boundary: String,
+    sink: String,
+    missing_edge: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Exposure {
+    id: String,
+    surface: String,
+    harness: PathBuf,
+    kit_rpc: PathBuf,
+    lift_rpc: CommandSpec,
+    proof_ir_file: PathBuf,
+    diagnostic_file: PathBuf,
+    lossiness: Lossiness,
+}
+
+#[derive(Debug, Deserialize)]
+struct Lossiness {
+    erased: Vec<String>,
+    preserved: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Equivalence {
+    #[serde(default)]
+    required: Vec<[String; 2]>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Expectations {
+    host_compiler: String,
+    ordinary_tests: String,
+    provekit_verify: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExposureFiles {
+    sat_witness_file: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct Dropper {
+    available: bool,
+}
+
+#[derive(Debug)]
+enum ZooError {
+    Setup(String),
+    Verify(String),
+}
+
+impl fmt::Display for ZooError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ZooError::Setup(message) | ZooError::Verify(message) => f.write_str(message),
+        }
+    }
+}
+
+impl ZooError {
+    fn setup(message: impl Into<String>) -> Self {
+        ZooError::Setup(message.into())
+    }
+
+    fn verify(message: impl Into<String>) -> Self {
+        ZooError::Verify(message.into())
+    }
+}
+
+pub fn run(args: ZooArgs) -> u8 {
+    let targets = match resolve_targets(&args) {
+        Ok(targets) => targets,
+        Err(error) => {
+            eprintln!("zoo: {error}");
+            return EXIT_USER_ERROR;
+        }
+    };
+
+    let mut reports = Vec::new();
+    let mut setup_failures = Vec::new();
+    let mut verification_failures = Vec::new();
+    for specimen_dir in targets {
+        match check_specimen(&specimen_dir, args.out.quiet || args.out.json) {
+            Ok(report) => reports.push(report),
+            Err(ZooError::Setup(error)) => {
+                setup_failures.push(format!("{}: {error}", specimen_dir.display()))
+            }
+            Err(ZooError::Verify(error)) => {
+                verification_failures.push(format!("{}: {error}", specimen_dir.display()))
+            }
+        }
+    }
+    let ok = setup_failures.is_empty() && verification_failures.is_empty();
+
+    if args.out.json {
+        let errors = setup_failures
+            .iter()
+            .chain(verification_failures.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        let out = json!({
+            "ok": ok,
+            "reports": reports,
+            "errors": errors,
+            "setupErrors": setup_failures.clone(),
+            "verificationErrors": verification_failures.clone(),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).expect("zoo report serializes")
+        );
+    } else if !args.out.quiet {
+        for report in &reports {
+            println!("zoo: {} PASS", report["id"].as_str().unwrap_or("specimen"));
+        }
+        for failure in setup_failures.iter().chain(verification_failures.iter()) {
+            eprintln!("zoo: {failure}");
+        }
+    }
+
+    if ok {
+        EXIT_OK
+    } else if !setup_failures.is_empty() {
+        EXIT_USER_ERROR
+    } else {
+        EXIT_VERIFY_FAIL
+    }
+}
+
+fn resolve_targets(args: &ZooArgs) -> Result<Vec<PathBuf>, String> {
+    if args.all {
+        let root = args
+            .specimen
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("bug-zoo/species"));
+        let mut out = Vec::new();
+        for entry in
+            std::fs::read_dir(&root).map_err(|e| format!("read {}: {e}", root.display()))?
+        {
+            let entry = entry.map_err(|e| format!("read dir entry: {e}"))?;
+            let path = entry.path();
+            if path.join("specimen.yaml").exists() {
+                out.push(path);
+            }
+        }
+        out.sort();
+        return Ok(out);
+    }
+
+    let path = args.specimen.clone().unwrap_or_else(|| {
+        PathBuf::from("bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence")
+    });
+    if path.file_name().and_then(|name| name.to_str()) == Some("specimen.yaml") {
+        Ok(vec![path.parent().unwrap_or(Path::new(".")).to_path_buf()])
+    } else {
+        Ok(vec![path])
+    }
+}
+
+fn check_specimen(specimen_dir: &Path, quiet: bool) -> Result<Value, ZooError> {
+    let manifest_path = specimen_dir.join("specimen.yaml");
+    let text = std::fs::read_to_string(&manifest_path)
+        .map_err(|e| ZooError::setup(format!("read {}: {e}", manifest_path.display())))?;
+    let manifest: SpecimenManifest = serde_yaml::from_str(&text)
+        .map_err(|e| ZooError::setup(format!("parse {}: {e}", manifest_path.display())))?;
+
+    let mut errors = validate_manifest_shape(&manifest);
+    errors.extend(validate_paths(specimen_dir, &manifest));
+    if !errors.is_empty() {
+        return Err(ZooError::setup(errors.join("; ")));
+    }
+
+    run_host_check(specimen_dir, &manifest.commands.host_check).map_err(ZooError::verify)?;
+
+    let mut cids = BTreeMap::new();
+    for exposure in &manifest.exposures {
+        let lifted = invoke_lift_rpc(specimen_dir, exposure).map_err(ZooError::verify)?;
+        let expected =
+            read_json(specimen_dir.join(&exposure.proof_ir_file)).map_err(ZooError::setup)?;
+        let lifted_ir = lifted
+            .get("ir")
+            .cloned()
+            .ok_or_else(|| ZooError::verify(format!("exposure `{}` missing ir", exposure.id)))?;
+        let lifted_cid = proof_ir_cid(&lifted_ir).map_err(ZooError::verify)?;
+        let expected_cid = proof_ir_cid(&expected).map_err(ZooError::setup)?;
+        if lifted_cid != expected_cid {
+            return Err(ZooError::verify(format!(
+                "exposure `{}` ProofIR CID mismatch: lifted {lifted_cid}, expected {expected_cid}",
+                exposure.id
+            )));
+        }
+
+        let diagnostic_path = specimen_dir.join(&exposure.diagnostic_file);
+        let diag = std::fs::read_to_string(&diagnostic_path).map_err(|e| {
+            ZooError::verify(format!(
+                "read diagnostic {} for `{}`: {e}",
+                diagnostic_path.display(),
+                exposure.id
+            ))
+        })?;
+        if !diag.contains(&manifest.predicates.missing_edge) {
+            return Err(ZooError::verify(format!(
+                "diagnostic for `{}` does not mention missing edge `{}`",
+                exposure.id, manifest.predicates.missing_edge
+            )));
+        }
+
+        cids.insert(exposure.id.clone(), lifted_cid);
+    }
+
+    for [left, right] in &manifest.equivalence.required {
+        if cids.get(left) != cids.get(right) {
+            return Err(ZooError::verify(format!(
+                "equivalence failed: `{left}` CID {:?} != `{right}` CID {:?}",
+                cids.get(left),
+                cids.get(right)
+            )));
+        }
+    }
+
+    let sat_witness = read_json(specimen_dir.join(&manifest.exposure.sat_witness_file))
+        .map_err(ZooError::setup)?;
+    if !quiet {
+        println!("zoo: {} hostCheck PASS", manifest.id);
+        for (id, cid) in &cids {
+            println!("zoo: exposure {id} {cid}");
+        }
+        for [left, right] in &manifest.equivalence.required {
+            println!("zoo: equivalence {left} == {right} PASS");
+        }
+        println!(
+            "zoo: expected verify failure {} PASS",
+            manifest.predicates.missing_edge
+        );
+    }
+
+    Ok(json!({
+        "id": manifest.id,
+        "name": manifest.name,
+        "kingdom": manifest.kingdom,
+        "surface": manifest.surface,
+        "status": manifest.status,
+        "proofIrCids": cids,
+        "missingEdge": manifest.predicates.missing_edge,
+        "expectations": {
+            "hostCompiler": manifest.expectations.host_compiler,
+            "ordinaryTests": manifest.expectations.ordinary_tests,
+            "provekitVerify": manifest.expectations.provekit_verify,
+        },
+        "dropperAvailable": manifest.dropper.available,
+        "wildSightings": manifest.wild_sightings,
+        "satWitness": sat_witness,
+    }))
+}
+
+fn validate_manifest_shape(manifest: &SpecimenManifest) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    if manifest.id.trim().is_empty() {
+        errors.push("id is required".into());
+    }
+    if manifest.exposures.is_empty() {
+        errors.push("at least one exposure is required".into());
+    }
+    if manifest.predicates.boundary.trim().is_empty() {
+        errors.push("predicates.boundary is required".into());
+    }
+    if manifest.predicates.sink.trim().is_empty() {
+        errors.push("predicates.sink is required".into());
+    }
+    if manifest.predicates.missing_edge.trim().is_empty() {
+        errors.push("predicates.missingEdge is required".into());
+    }
+    if manifest.kingdom.trim().is_empty() {
+        errors.push("kingdom is required".into());
+    }
+    if manifest.surface.trim().is_empty() {
+        errors.push("surface is required".into());
+    }
+    if manifest.status.trim().is_empty() {
+        errors.push("status is required".into());
+    }
+    if manifest.commands.host_check.argv.is_empty() {
+        errors.push("commands.hostCheck.argv is required".into());
+    }
+    if manifest.expectations.host_compiler.trim().is_empty() {
+        errors.push("expectations.hostCompiler is required".into());
+    }
+    if manifest.expectations.ordinary_tests.trim().is_empty() {
+        errors.push("expectations.ordinaryTests is required".into());
+    }
+    if manifest.expectations.provekit_verify.trim().is_empty() {
+        errors.push("expectations.provekitVerify is required".into());
+    }
+
+    let mut exposure_ids = BTreeSet::new();
+    for exposure in &manifest.exposures {
+        if !exposure_ids.insert(exposure.id.clone()) {
+            errors.push(format!("duplicate exposure id `{}`", exposure.id));
+        }
+        if exposure.lift_rpc.argv.is_empty() {
+            errors.push(format!(
+                "exposure `{}` liftRpc.argv is required",
+                exposure.id
+            ));
+        }
+        if exposure.lossiness.erased.is_empty() || exposure.lossiness.preserved.is_empty() {
+            errors.push(format!(
+                "exposure `{}` must describe lossiness erased and preserved boundaries",
+                exposure.id
+            ));
+        }
+    }
+
+    for [left, right] in &manifest.equivalence.required {
+        if !exposure_ids.contains(left) {
+            errors.push(format!("equivalence references unknown exposure `{left}`"));
+        }
+        if !exposure_ids.contains(right) {
+            errors.push(format!("equivalence references unknown exposure `{right}`"));
+        }
+    }
+
+    errors
+}
+
+fn validate_paths(specimen_dir: &Path, manifest: &SpecimenManifest) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    for path in [
+        &manifest.paths.lab_library,
+        &manifest.paths.lab_harness,
+        &manifest.paths.lab_kit_rpc,
+        &manifest.exposure.sat_witness_file,
+    ] {
+        if manifest_path_escapes_specimen_root(path) {
+            errors.push(format!(
+                "invalid path `{}` escapes specimen root",
+                path.display()
+            ));
+            continue;
+        }
+        let full_path = specimen_dir.join(path);
+        if !full_path.exists() {
+            errors.push(format!("missing {}", full_path.display()));
+        }
+    }
+
+    for path in [&manifest.commands.host_check.cwd] {
+        if manifest_path_escapes_specimen_root(path) {
+            errors.push(format!(
+                "invalid path `{}` escapes specimen root",
+                path.display()
+            ));
+            continue;
+        }
+        let full_path = specimen_dir.join(path);
+        if !full_path.exists() {
+            errors.push(format!("missing {}", full_path.display()));
+        }
+    }
+
+    for exposure in &manifest.exposures {
+        for path in [
+            &exposure.harness,
+            &exposure.kit_rpc,
+            &exposure.proof_ir_file,
+            &exposure.diagnostic_file,
+            &exposure.lift_rpc.cwd,
+        ] {
+            if manifest_path_escapes_specimen_root(path) {
+                errors.push(format!(
+                    "invalid path `{}` escapes specimen root",
+                    path.display()
+                ));
+                continue;
+            }
+            let full_path = specimen_dir.join(path);
+            if !full_path.exists() {
+                errors.push(format!("missing {}", full_path.display()));
+            }
+        }
+    }
+
+    errors
+}
+
+fn run_host_check(specimen_dir: &Path, command: &CommandSpec) -> Result<(), String> {
+    run_command(specimen_dir, command).map(|_| ())
+}
+
+fn run_command(specimen_dir: &Path, command: &CommandSpec) -> Result<String, String> {
+    if command.argv.is_empty() {
+        return Err("empty argv".into());
+    }
+    if manifest_path_escapes_specimen_root(&command.cwd) {
+        return Err(format!(
+            "invalid path `{}` escapes specimen root",
+            command.cwd.display()
+        ));
+    }
+
+    let cwd = specimen_dir.join(&command.cwd);
+    let output = Command::new(&command.argv[0])
+        .args(&command.argv[1..])
+        .current_dir(&cwd)
+        .output()
+        .map_err(|e| format!("spawn {:?} in {}: {e}", command.argv, cwd.display()))?;
+    if !output.status.success() {
+        return Err(format!(
+            "command {:?} failed in {}\nstdout:\n{}\nstderr:\n{}",
+            command.argv,
+            cwd.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn read_json(path: PathBuf) -> Result<Value, String> {
+    let text =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    serde_json::from_str(&text).map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+fn invoke_lift_rpc(specimen_dir: &Path, exposure: &Exposure) -> Result<Value, String> {
+    if exposure.lift_rpc.argv.is_empty() {
+        return Err(format!(
+            "exposure `{}` liftRpc.argv is required",
+            exposure.id
+        ));
+    }
+    if manifest_path_escapes_specimen_root(&exposure.lift_rpc.cwd)
+        || manifest_path_escapes_specimen_root(&exposure.harness)
+    {
+        return Err(format!(
+            "exposure `{}` contains a path that escapes specimen root",
+            exposure.id
+        ));
+    }
+
+    let cwd = specimen_dir.join(&exposure.lift_rpc.cwd);
+    let harness = specimen_dir.join(&exposure.harness);
+    let harness_root = harness.canonicalize().unwrap_or(harness);
+    let harness_root = harness_root.to_string_lossy().to_string();
+    let mut cmd = Command::new(&exposure.lift_rpc.argv[0]);
+    cmd.args(&exposure.lift_rpc.argv[1..])
+        .current_dir(&cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        format!(
+            "spawn lift RPC for `{}` in {}: {e}",
+            exposure.id,
+            cwd.display()
+        )
+    })?;
+    let mut stdin = match child.stdin.take() {
+        Some(stdin) => stdin,
+        None => {
+            cleanup_rpc_child(&mut child, None, false);
+            return Err("lifter has no stdin".into());
+        }
+    };
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            cleanup_rpc_child(&mut child, Some(stdin), false);
+            return Err("lifter has no stdout".into());
+        }
+    };
+    let mut reader = BufReader::new(stdout);
+
+    let exchange_result =
+        invoke_lift_rpc_exchange(&mut stdin, &mut reader, &harness_root, exposure);
+    drop(reader);
+    cleanup_rpc_child(&mut child, Some(stdin), exchange_result.is_ok());
+    exchange_result
+}
+
+fn invoke_lift_rpc_exchange(
+    stdin: &mut ChildStdin,
+    reader: &mut impl BufRead,
+    harness_root: &str,
+    exposure: &Exposure,
+) -> Result<Value, String> {
+    let init_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "client": {"name": "provekit-zoo", "version": env!("CARGO_PKG_VERSION")},
+            "protocol_version": "provekit-lift/1",
+            "workspace_root": harness_root,
+            "config_path": ".provekit/config.toml",
+        },
+    });
+    writeln!(stdin, "{init_req}").map_err(|e| format!("write initialize: {e}"))?;
+    let _ = read_response(reader, 1)?;
+
+    let lift_req = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "lift",
+        "params": {
+            "surface": exposure.surface,
+            "workspace_root": harness_root,
+            "source_paths": [harness_root],
+            "options": {"layer": "all"},
+        },
+    });
+    writeln!(stdin, "{lift_req}").map_err(|e| format!("write lift: {e}"))?;
+    let lift_resp = read_response(reader, 2)?;
+
+    match lift_resp.get("kind").and_then(|value| value.as_str()) {
+        Some("ir-document") => Ok(lift_resp),
+        other => Err(format!(
+            "exposure `{}` returned unsupported lift kind {:?}",
+            exposure.id, other
+        )),
+    }
+}
+
+fn cleanup_rpc_child(child: &mut Child, stdin: Option<ChildStdin>, send_shutdown: bool) {
+    if let Some(mut stdin) = stdin {
+        if send_shutdown {
+            let shutdown_req = json!({"jsonrpc": "2.0", "id": 3, "method": "shutdown"});
+            let _ = writeln!(stdin, "{shutdown_req}");
+        }
+        drop(stdin);
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) if Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(25));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+        }
+    }
+}
+
+fn read_response(reader: &mut impl BufRead, id: i64) -> Result<Value, String> {
+    let mut line = String::new();
+    let n = reader
+        .read_line(&mut line)
+        .map_err(|e| format!("read RPC response: {e}"))?;
+    if n == 0 {
+        return Err("plugin closed stdout before responding".into());
+    }
+    let v: Value = serde_json::from_str(line.trim())
+        .map_err(|e| format!("parse JSON-RPC response: {e}\nraw: {line}"))?;
+    if v.get("id").and_then(|value| value.as_i64()) != Some(id) {
+        return Err(format!("response id mismatch: expected {id}, got {v:?}"));
+    }
+    if let Some(error) = v.get("error") {
+        return Err(format!("plugin returned error: {error}"));
+    }
+    v.get("result")
+        .cloned()
+        .ok_or_else(|| "response missing result".into())
+}
+
+fn proof_ir_cid(value: &Value) -> Result<String, String> {
+    let canonical = json_to_cvalue(value)?;
+    let bytes = provekit_canonicalizer::encode_jcs(&canonical).into_bytes();
+    Ok(provekit_canonicalizer::blake3_512_of(&bytes))
+}
+
+fn json_to_cvalue(j: &Value) -> Result<std::sync::Arc<provekit_canonicalizer::Value>, String> {
+    use provekit_canonicalizer::Value as CValue;
+
+    match j {
+        Value::Null => Ok(CValue::null()),
+        Value::Bool(value) => Ok(CValue::boolean(*value)),
+        Value::Number(number) => number
+            .as_i64()
+            .map(CValue::integer)
+            .ok_or_else(|| format!("ProofIR JSON number `{number}` is not a supported integer")),
+        Value::String(value) => Ok(CValue::string(value.clone())),
+        Value::Array(items) => items
+            .iter()
+            .map(json_to_cvalue)
+            .collect::<Result<Vec<_>, _>>()
+            .map(CValue::array),
+        Value::Object(map) => map
+            .iter()
+            .map(|(key, value)| Ok((key.clone(), json_to_cvalue(value)?)))
+            .collect::<Result<Vec<_>, String>>()
+            .map(CValue::object),
+    }
+}
+
+fn manifest_path_escapes_specimen_root(path: &Path) -> bool {
+    path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    fn valid_manifest() -> SpecimenManifest {
+        SpecimenManifest {
+            id: "BZ-SHAPE-005".into(),
+            name: "x".into(),
+            kingdom: "shape".into(),
+            surface: "java".into(),
+            status: "lab".into(),
+            paths: SpecimenPaths {
+                lab_library: "lab/library".into(),
+                lab_harness: "lab/harness".into(),
+                lab_kit_rpc: "lab/kit-rpc".into(),
+            },
+            commands: SpecimenCommands {
+                host_check: CommandSpec {
+                    cwd: "lab/harness".into(),
+                    argv: vec!["./run.sh".into()],
+                },
+            },
+            predicates: Predicates {
+                boundary: "maybe_null(name)".into(),
+                sink: "non_null(name)".into(),
+                missing_edge: "maybe_null(name) => non_null(name)".into(),
+            },
+            exposures: vec![Exposure {
+                id: "spring-web".into(),
+                surface: "java-spring-web".into(),
+                harness: "exposed/spring-web/harness".into(),
+                kit_rpc: "exposed/spring-web/kit-rpc".into(),
+                lift_rpc: CommandSpec {
+                    cwd: "exposed/spring-web/kit-rpc".into(),
+                    argv: vec!["./run-java-lifter.sh".into()],
+                },
+                proof_ir_file: "exposed/spring-web/expected.proofir.json".into(),
+                diagnostic_file: "exposed/spring-web/expected-diagnostic.txt".into(),
+                lossiness: Lossiness {
+                    erased: vec!["Spring binding".into()],
+                    preserved: vec!["precondition neq(name, null)".into()],
+                },
+            }],
+            equivalence: Equivalence { required: vec![] },
+            expectations: Expectations {
+                host_compiler: "pass".into(),
+                ordinary_tests: "pass".into(),
+                provekit_verify: "fail".into(),
+            },
+            exposure: ExposureFiles {
+                sat_witness_file: "exposed/sat-witness.json".into(),
+            },
+            dropper: Dropper { available: false },
+            wild_sightings: vec![],
+        }
+    }
+
+    fn create_valid_paths(specimen_dir: &Path, manifest: &SpecimenManifest) {
+        for path in [
+            &manifest.paths.lab_library,
+            &manifest.paths.lab_harness,
+            &manifest.paths.lab_kit_rpc,
+            &manifest.exposures[0].harness,
+            &manifest.exposures[0].kit_rpc,
+        ] {
+            fs::create_dir_all(specimen_dir.join(path)).expect("create directory");
+        }
+
+        for path in [
+            &manifest.exposure.sat_witness_file,
+            &manifest.exposures[0].proof_ir_file,
+            &manifest.exposures[0].diagnostic_file,
+        ] {
+            let path = specimen_dir.join(path);
+            fs::create_dir_all(path.parent().expect("fixture path has parent"))
+                .expect("create file parent");
+            fs::write(path, "").expect("create file");
+        }
+    }
+
+    #[test]
+    fn parses_manifest_with_exposures_and_equivalence() {
+        let raw = r#"
+id: BZ-SHAPE-005
+name: Java Null Boundary Equivalence
+kingdom: shape
+surface: java
+status: lab
+paths:
+  labLibrary: lab/library
+  labHarness: lab/harness
+  labKitRpc: lab/kit-rpc
+commands:
+  hostCheck:
+    cwd: lab/harness
+    argv: ["./run.sh"]
+predicates:
+  boundary: maybe_null(name)
+  sink: non_null(name)
+  missingEdge: maybe_null(name) => non_null(name)
+exposures:
+  - id: provekit-native
+    surface: java-provekit-native
+    harness: exposed/provekit-native/harness
+    kitRpc: exposed/provekit-native/kit-rpc
+    liftRpc:
+      cwd: exposed/provekit-native/kit-rpc
+      argv: ["./run-java-lifter.sh"]
+    proofIrFile: exposed/provekit-native/expected.proofir.json
+    diagnosticFile: exposed/provekit-native/expected-diagnostic.txt
+    lossiness:
+      erased: ["Java body"]
+      preserved: ["precondition neq(name, null)"]
+  - id: spring-web
+    surface: java-spring-web
+    harness: exposed/spring-web/harness
+    kitRpc: exposed/spring-web/kit-rpc
+    liftRpc:
+      cwd: exposed/spring-web/kit-rpc
+      argv: ["./run-java-lifter.sh"]
+    proofIrFile: exposed/spring-web/expected.proofir.json
+    diagnosticFile: exposed/spring-web/expected-diagnostic.txt
+    lossiness:
+      erased: ["Spring binding"]
+      preserved: ["precondition neq(name, null)"]
+equivalence:
+  required:
+    - [provekit-native, spring-web]
+expectations:
+  hostCompiler: pass
+  ordinaryTests: pass
+  provekitVerify: fail
+exposure:
+  satWitnessFile: exposed/sat-witness.json
+dropper:
+  available: false
+wildSightings: []
+"#;
+        let manifest: SpecimenManifest = serde_yaml::from_str(raw).expect("parse manifest");
+        assert_eq!(manifest.id, "BZ-SHAPE-005");
+        assert_eq!(manifest.exposures.len(), 2);
+        assert_eq!(
+            manifest.equivalence.required[0],
+            ["provekit-native", "spring-web"]
+        );
+    }
+
+    #[test]
+    fn validation_rejects_missing_lossiness() {
+        let mut manifest = valid_manifest();
+        manifest.exposures[0].lossiness.erased.clear();
+
+        let errors = validate_manifest_shape(&manifest);
+        assert!(errors.iter().any(|e| e.contains("lossiness")));
+    }
+
+    #[test]
+    fn validation_rejects_duplicate_exposure_ids() {
+        let mut manifest = valid_manifest();
+        manifest.exposures.push(Exposure {
+            id: "spring-web".into(),
+            surface: "java-provekit-native".into(),
+            harness: "exposed/provekit-native/harness".into(),
+            kit_rpc: "exposed/provekit-native/kit-rpc".into(),
+            lift_rpc: CommandSpec {
+                cwd: "exposed/provekit-native/kit-rpc".into(),
+                argv: vec!["./run-java-lifter.sh".into()],
+            },
+            proof_ir_file: "exposed/provekit-native/expected.proofir.json".into(),
+            diagnostic_file: "exposed/provekit-native/expected-diagnostic.txt".into(),
+            lossiness: Lossiness {
+                erased: vec!["Java body".into()],
+                preserved: vec!["precondition neq(name, null)".into()],
+            },
+        });
+
+        let errors = validate_manifest_shape(&manifest);
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("duplicate exposure id `spring-web`")));
+    }
+
+    #[test]
+    fn validation_rejects_unknown_equivalence_references() {
+        let mut manifest = valid_manifest();
+        manifest.equivalence.required = vec![["spring-web".into(), "missing".into()]];
+
+        let errors = validate_manifest_shape(&manifest);
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("equivalence references unknown exposure `missing`")));
+    }
+
+    #[test]
+    fn validation_rejects_empty_command_argv() {
+        let mut manifest = valid_manifest();
+        manifest.commands.host_check.argv.clear();
+        manifest.exposures[0].lift_rpc.argv.clear();
+
+        let errors = validate_manifest_shape(&manifest);
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("commands.hostCheck.argv is required")));
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("exposure `spring-web` liftRpc.argv is required")));
+    }
+
+    #[test]
+    fn path_validation_rejects_escape_paths() {
+        let specimen = tempdir().expect("create specimen root");
+        let mut manifest = valid_manifest();
+        manifest.paths.lab_library = "../outside".into();
+        manifest.exposures[0].proof_ir_file = "/tmp/expected.proofir.json".into();
+
+        let errors = validate_paths(specimen.path(), &manifest);
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("invalid path `../outside` escapes specimen root")));
+        assert!(errors.iter().any(|error| {
+            error.contains("invalid path `/tmp/expected.proofir.json` escapes specimen root")
+        }));
+    }
+
+    #[test]
+    fn path_validation_reports_missing_files() {
+        let specimen = tempdir().expect("create specimen root");
+        let manifest = valid_manifest();
+        create_valid_paths(specimen.path(), &manifest);
+        fs::remove_file(specimen.path().join(&manifest.exposure.sat_witness_file))
+            .expect("remove sat witness");
+        fs::remove_file(specimen.path().join(&manifest.exposures[0].proof_ir_file))
+            .expect("remove proof ir");
+
+        let errors = validate_paths(specimen.path(), &manifest);
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("sat-witness.json")));
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("expected.proofir.json")));
+    }
+
+    #[test]
+    fn missing_specimen_manifest_returns_user_error() {
+        let specimen = tempdir().expect("create specimen root");
+        let code = run(ZooArgs {
+            specimen: Some(specimen.path().to_path_buf()),
+            all: false,
+            out: OutputFlags {
+                json: true,
+                quiet: true,
+            },
+        });
+
+        assert_eq!(code, EXIT_USER_ERROR);
+    }
+}

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -29,11 +29,13 @@ mod cmd_lift;
 mod cmd_link;
 mod cmd_mint;
 mod cmd_must;
+mod cmd_proof;
 mod cmd_prove;
 mod cmd_search;
 mod cmd_verify_protocol;
 mod cmd_version;
 mod cmd_witness;
+mod cmd_zoo;
 mod project_config;
 mod prompts;
 mod protocol;
@@ -75,6 +77,8 @@ pub struct OutputFlags {
 enum Cmd {
     /// Run the six-stage verifier: load proofs, enumerate callsites, solve obligations, report.
     Prove(ProveArgs),
+    /// Work with .proof artifacts: hash, inspect, check conformance.
+    Proof(cmd_proof::ProofArgs),
     /// Same as `prove`. Reserved for a future split.
     Verify(ProveArgs),
     /// Look up a formula by content. Parses an IR-JSON formula file, hashes it, reports the CID.
@@ -113,6 +117,8 @@ enum Cmd {
     /// Linker pass: derive bridges from (contracts ∪ call-edges), emit LinkBundle.
     /// Per spec protocol/specs/2026-05-03-bridge-linkage-protocol.md R2-R5.
     Link(LinkArgs),
+    /// Run Bug Zoo specimens: host check, lift exposures, compare boundary ProofIR.
+    Zoo(cmd_zoo::ZooArgs),
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -275,6 +281,7 @@ fn main() -> ExitCode {
     let cli = Cli::parse();
     let code = match cli.cmd {
         Cmd::Prove(a) | Cmd::Verify(a) => cmd_prove::run(a),
+        Cmd::Proof(a) => cmd_proof::run(a),
         Cmd::Ask(a) => cmd_ask::run(a),
         Cmd::Search(a) => cmd_search::run(a),
         Cmd::Implicate(a) | Cmd::Imp(a) => cmd_implicate::run(a),
@@ -291,6 +298,7 @@ fn main() -> ExitCode {
         Cmd::VerifyProtocol(a) => cmd_verify_protocol::run(a),
         Cmd::Version(a) => cmd_version::run(a),
         Cmd::Link(a) => cmd_link::run(a),
+        Cmd::Zoo(a) => cmd_zoo::run(a),
     };
     ExitCode::from(code)
 }

--- a/implementations/rust/provekit-cli/tests/zoo_smoke.rs
+++ b/implementations/rust/provekit-cli/tests/zoo_smoke.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn provekit_bin() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_provekit") {
+        return PathBuf::from(path);
+    }
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let workspace = PathBuf::from(manifest_dir).parent().unwrap().to_path_buf();
+    let release = workspace.join("target").join("release").join("provekit");
+    let debug = workspace.join("target").join("debug").join("provekit");
+    if release.exists() {
+        release
+    } else {
+        debug
+    }
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn command_succeeds(name: &str, arg: &str, path: Option<&OsString>) -> bool {
+    let mut command = Command::new(name);
+    command.arg(arg);
+    if let Some(path) = path {
+        command.env("PATH", path);
+    }
+    command
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+fn java_preflight_path() -> Result<OsString, String> {
+    if !command_succeeds("mvn", "--version", None) {
+        return Err("mvn is not available on PATH".into());
+    }
+
+    let mut paths = vec![
+        PathBuf::from("/usr/local/opt/openjdk/bin"),
+        PathBuf::from("/opt/homebrew/opt/openjdk/bin"),
+    ];
+    if let Some(current_path) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&current_path));
+    }
+    let path = std::env::join_paths(paths).expect("test PATH entries must be joinable");
+
+    if !command_succeeds("java", "-version", Some(&path)) {
+        return Err("java is not available on PATH or Homebrew OpenJDK fallback paths".into());
+    }
+    if !command_succeeds("javac", "-version", Some(&path)) {
+        return Err("javac is not available on PATH or Homebrew OpenJDK fallback paths".into());
+    }
+
+    Ok(path)
+}
+
+#[test]
+fn java_null_boundary_specimen_checks() {
+    let path = match java_preflight_path() {
+        Ok(path) => path,
+        Err(reason) => {
+            eprintln!("zoo smoke: skipping Java/Maven-backed specimen test: {reason}");
+            return;
+        }
+    };
+
+    let root = repo_root();
+    let specimen = root.join("bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence");
+    let out = Command::new(provekit_bin())
+        .arg("zoo")
+        .arg(&specimen)
+        .arg("--json")
+        .env("PATH", path)
+        .current_dir(&root)
+        .output()
+        .expect("spawn provekit zoo");
+
+    assert!(
+        out.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout must be strict JSON only");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["errors"].as_array().map(Vec::is_empty), Some(true));
+    assert_eq!(
+        json["setupErrors"].as_array().map(Vec::is_empty),
+        Some(true)
+    );
+    assert_eq!(
+        json["verificationErrors"].as_array().map(Vec::is_empty),
+        Some(true)
+    );
+
+    let reports = json["reports"]
+        .as_array()
+        .expect("reports must be an array");
+    assert_eq!(reports.len(), 1, "expected one specimen report");
+    let report = &reports[0];
+    assert_eq!(report["missingEdge"], "maybe_null(name) => non_null(name)");
+
+    let native_cid = report["proofIrCids"]["provekit-native"]
+        .as_str()
+        .expect("provekit-native CID must be a string");
+    let spring_cid = report["proofIrCids"]["spring-web"]
+        .as_str()
+        .expect("spring-web CID must be a string");
+    assert!(native_cid.starts_with("blake3-512:"));
+    assert_eq!(native_cid, spring_cid);
+}


### PR DESCRIPTION
## What changed

This PR adds the first executable Bug Zoo slice:

- Documents the key ProofIR lemma: ProofIR may be lossy because it is universal over contract boundaries, not host-language implementation detail.
- Adds paper 09, `Lossy Boundary Compression: Why ProofIR Is Universal Because It Forgets`.
- Adds `bug-zoo/` with the first live species, `BZ-SHAPE-005-java-null-boundary-equivalence`.
- Adds a Java ProvekIt-native lifter surface and shared Java contract expression parsing so ProvekIt-native, Spring Web, JML, and Cofoja surfaces can converge on canonical ProofIR predicates without copied parsers.
- Adds `provekit zoo`, a Rust CLI runner that validates specimen manifests, runs host checks, invokes specimen-owned lifter RPC launchers, compares canonical ProofIR CIDs, checks the expected missing edge, and emits strict JSON output.
- Adds a Rust smoke test that runs the actual `provekit zoo` command against the Java specimen when Maven/JDK are available.

## Why

The zoo is meant to prove that bug species are executable objects, not static advisory prose. The first specimen demonstrates the core claim: ordinary code passes its host checks, two different contract surfaces lift to the same ProofIR boundary, and the missing edge becomes reproducible and content-addressed:

```text
maybe_null(name) => non_null(name)
```

This is exposed, not patched. The historical fix is not the oracle; the protocol catches the missing obligation.

## Validation

Passed locally:

- `mvn -f implementations/java/pom.xml -pl provekit-lift-java-integration-tests -am test -Dtest=CrossDomainContractEquivalenceTest`
- `mvn -f implementations/java/pom.xml -pl provekit-lift-java-core,provekit-lift-java-provekit-native,provekit-lift-java-spring-web,provekit-lift-java-integration-tests -am test`
- `cd implementations/rust && cargo test -p provekit-cli cmd_zoo::tests`
- `cd implementations/rust && cargo test -p provekit-cli --test zoo_smoke`
- `cd implementations/rust && cargo run -p provekit-cli -- zoo ../../bug-zoo/species/BZ-SHAPE-005-java-null-boundary-equivalence --json`

Final JSON check returned `ok: true`; the `provekit-native` and `spring-web` ProofIR CIDs were identical:

```text
blake3-512:0d611d8478a205ff040e7d0bcf6c21b12051340ecc5f00c3953af632b23fc01e069b4ad8a8699869163e135b9fde85792eba6acc54cd75cb3d3cc6a40a99ded4
```

## Notes

The working tree still contains unrelated local changes outside this PR scope. This branch stages only the Bug Zoo/ProofIR slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `provekit proof` and `provekit zoo` CLI subcommands for contract verification and cross-framework boundary comparison
  * Introduced Bug Zoo framework enabling equivalent contract boundary verification across different implementations (initial Java null-boundary specimen)
  * Added support for ProvekIt-native contract annotation extraction

* **Documentation**
  * New whitepaper on lossy boundary compression and ProofIR universality
  * Added Bug Zoo design specification and implementation guidance
  * Enhanced README clarifying canonical projection and boundary contract terminology

* **Tests**
  * Added integration tests for cross-domain contract equivalence verification
  * Added smoke test for Bug Zoo specimen workflow validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->