### PR TITLE
[codex] Bootstrap attestations from live kit artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,10 @@ jobs:
           cache: maven
 
       # ---------------------------------------------------------------
-      # System-level deps: b3sum (PHP BLAKE3), openssl, nlohmann-json, libblake3 (Ruby FFI),
-      # libyaml (Ruby psych/bundler runtime). Run BEFORE setup-ruby so
-      # the bundler-cache step has libblake3 and libyaml already on the
-      # host when it resolves and builds native gems.
+      # System-level deps: PHP CLI + b3sum (PHP kit), openssl, nlohmann-json,
+      # libblake3 (Ruby FFI), libyaml (Ruby psych/bundler runtime). Run
+      # BEFORE setup-ruby so the bundler-cache step has libblake3 and libyaml
+      # already on the host when it resolves and builds native gems.
       #
       # cpp BLAKE3 is vendored at tools/blake3-vendored/; the Ruby kit's
       # FFI binding to libblake3 needs the system package because no
@@ -162,8 +162,10 @@ jobs:
             libyaml-dev \
             maven \
             nlohmann-json3-dev \
+            php-cli \
             unzip \
             z3
+          php -m | grep -q '^sodium$'
 
       - name: Install Vampire (upstream GitHub release)
         # Vampire joins the default solver portfolio per
@@ -467,6 +469,15 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
+
+      - name: Install PHP deps (php)
+        if: matrix.kit == 'php'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+            b3sum \
+            php-cli
+          php -m | grep -q '^sodium$'
 
       - name: "prove-${{ matrix.kit }}"
         run: make prove-${{ matrix.kit }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,27 +210,12 @@ jobs:
         # regression risk. ziglang.org keeps every release indefinitely.
         # Refresh this URL only when the kit's std API requirements change.
         #
-        # mlugg/setup-zig@v1 was tried in PR #245 and 404/503'd across
-        # every mirror; curl from ziglang.org is the simplest path that
-        # actually works.
-        run: |
-          set -euxo pipefail
-          ZIG_URL="https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
-          for attempt in 1 2 3 4 5; do
-            echo "Downloading Zig 0.16.0 (attempt ${attempt}/5)"
-            rm -f /tmp/zig.tar.xz
-            if curl -fsSL --connect-timeout 30 --max-time 180 --speed-limit 102400 --speed-time 60 "$ZIG_URL" -o /tmp/zig.tar.xz; then
-              break
-            fi
-            if [ "$attempt" -eq 5 ]; then
-              exit 1
-            fi
-            sleep $((attempt * 10))
-          done
-          sudo mkdir -p /usr/local/zig
-          sudo tar -xf /tmp/zig.tar.xz -C /usr/local/zig --strip-components=1
-          sudo ln -sf /usr/local/zig/zig /usr/local/bin/zig
-          zig version
+        # Direct ziglang.org downloads are intentionally not bandwidth-
+        # guaranteed. setup-zig v2 uses the Zig community mirror list and
+        # verifies tarball signatures while keeping the compiler version pinned.
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       # ---------------------------------------------------------------
       # The gate.
@@ -479,24 +464,9 @@ jobs:
 
       - name: Install Zig (zig)
         if: matrix.kit == 'zig'
-        run: |
-          set -euxo pipefail
-          ZIG_URL="https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
-          for attempt in 1 2 3 4 5; do
-            echo "Downloading Zig 0.16.0 (attempt ${attempt}/5)"
-            rm -f /tmp/zig.tar.xz
-            if curl -fsSL --connect-timeout 30 --max-time 180 --speed-limit 102400 --speed-time 60 "$ZIG_URL" -o /tmp/zig.tar.xz; then
-              break
-            fi
-            if [ "$attempt" -eq 5 ]; then
-              exit 1
-            fi
-            sleep $((attempt * 10))
-          done
-          sudo mkdir -p /usr/local/zig
-          sudo tar -xf /tmp/zig.tar.xz -C /usr/local/zig --strip-components=1
-          sudo ln -sf /usr/local/zig/zig /usr/local/bin/zig
-          zig version
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: "prove-${{ matrix.kit }}"
         run: make prove-${{ matrix.kit }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,16 @@ jobs:
         run: |
           set -euxo pipefail
           ZIG_URL="https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
-          curl -fsSL "$ZIG_URL" -o /tmp/zig.tar.xz
+          for attempt in 1 2 3 4 5; do
+            rm -f /tmp/zig.tar.xz
+            if curl -fsSL --connect-timeout 30 "$ZIG_URL" -o /tmp/zig.tar.xz; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
           sudo mkdir -p /usr/local/zig
           sudo tar -xf /tmp/zig.tar.xz -C /usr/local/zig --strip-components=1
           sudo ln -sf /usr/local/zig/zig /usr/local/bin/zig
@@ -472,7 +481,16 @@ jobs:
         run: |
           set -euxo pipefail
           ZIG_URL="https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
-          curl -fsSL "$ZIG_URL" -o /tmp/zig.tar.xz
+          for attempt in 1 2 3 4 5; do
+            rm -f /tmp/zig.tar.xz
+            if curl -fsSL --connect-timeout 30 "$ZIG_URL" -o /tmp/zig.tar.xz; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
           sudo mkdir -p /usr/local/zig
           sudo tar -xf /tmp/zig.tar.xz -C /usr/local/zig --strip-components=1
           sudo ln -sf /usr/local/zig/zig /usr/local/bin/zig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,9 @@ jobs:
           set -euxo pipefail
           ZIG_URL="https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
           for attempt in 1 2 3 4 5; do
+            echo "Downloading Zig 0.16.0 (attempt ${attempt}/5)"
             rm -f /tmp/zig.tar.xz
-            if curl -fsSL --connect-timeout 30 "$ZIG_URL" -o /tmp/zig.tar.xz; then
+            if curl -fsSL --connect-timeout 30 --max-time 180 --speed-limit 102400 --speed-time 60 "$ZIG_URL" -o /tmp/zig.tar.xz; then
               break
             fi
             if [ "$attempt" -eq 5 ]; then
@@ -482,8 +483,9 @@ jobs:
           set -euxo pipefail
           ZIG_URL="https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
           for attempt in 1 2 3 4 5; do
+            echo "Downloading Zig 0.16.0 (attempt ${attempt}/5)"
             rm -f /tmp/zig.tar.xz
-            if curl -fsSL --connect-timeout 30 "$ZIG_URL" -o /tmp/zig.tar.xz; then
+            if curl -fsSL --connect-timeout 30 --max-time 180 --speed-limit 102400 --speed-time 60 "$ZIG_URL" -o /tmp/zig.tar.xz; then
               break
             fi
             if [ "$attempt" -eq 5 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends \
             build-essential \
+            libsodium-dev \
             libssl-dev
 
       - name: Set up Java (java)
@@ -455,6 +456,12 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+
+      - name: Install Java deps (java)
+        if: matrix.kit == 'java'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends maven
 
       - name: Install Ruby (ruby)
         if: matrix.kit == 'ruby'

--- a/.provekit/self-contracts-attestations/c.json
+++ b/.provekit/self-contracts-attestations/c.json
@@ -2,9 +2,9 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "c",
-  "cid": "blake3-512:f2723a762dd5d6ed5c16a4d3ba75cd39d4a63bbc021d018a22764bbfe5d74ae23d58820ed76f77e3fc8718df9d8f91fafb20437a0330c252817550c35ecd0aed",
+  "cid": "blake3-512:3c4e8fc8880e3e62c2c859447640ba3c4ef7be52bfa3ba15d91f7bf99e144e5c3e68d4d10afd38b828ff0781eaaf642b9a7389f94f1de916b60a5350f2722c83",
   "contractSetCid": "blake3-512:50d08f4df4f8e16073d70a168292f3b3850aa557030a2a9ae65892aaac2b0e889204fa2cf602f4074ea85680aed37490fcbdc2ff73aa87c162fba16e57f40577",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:yzErSKm2b/2gToUnxAFYkxsLuup3qpKPBxX938tOLZxiOFpDR49R16Napzxcyumxl2xmAcrTgIijGTlH+wbyBA=="
+  "signature": "ed25519:BbgKzdDavPflAO25G2PCkIORjXb+AW275WbvcfTagFyUteq/ER5Q6PuQW2k4FvkcCshMc82/cX8xn5+LmRRJAg=="
 }

--- a/.provekit/self-contracts-attestations/cpp.json
+++ b/.provekit/self-contracts-attestations/cpp.json
@@ -4,7 +4,7 @@
   "lang": "cpp",
   "cid": "blake3-512:5a37fd2eddcc72aa8325c81bd235feb5cc0bee14f35653b76100a2d2e8c25994da2425974a503321d111a687b00df2886c11f5c7769d4db5af0e21c5290ddbc8",
   "contractSetCid": "blake3-512:0e17f718740e9e22b0897d1f7c2ee42a61b65b0d65379024465b38441e232c25b28eb8bf8a425a8770b68614a95510fd84e5ff23b5b028751ae9acb0ffe62d5e",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:PcpQPHbAi1sjO32LEzsUk8KVqjUp7hTqjBQ6NTG4ZwP+mr+iaXGubcL6SD7YwH7Q+cpSF8AG+aDuIWh5X2NvBg=="
+  "signature": "ed25519:ovJTkHrc+dV295XsoFPARtDPwiRlbf1MxBxOxEx1UCCOSvPnufpV/wx4yKroyEQ60XB+22oftqeewref2VG9Ag=="
 }

--- a/.provekit/self-contracts-attestations/csharp.json
+++ b/.provekit/self-contracts-attestations/csharp.json
@@ -4,7 +4,7 @@
   "lang": "csharp",
   "cid": "blake3-512:227a492f2ad50e8149443a616c94ccc6f1fc3ee6e65d7c8c0597b58b334714fe0c728cb9c7cf79434fe59fcd9d788c0a34ae089975774c462f1083dd453c359f",
   "contractSetCid": "blake3-512:ed7f1eb7bba9da19e6a27d531d7692f0c57121c3733119b9905d793a9dc0220d3e0ce03675df7ba57c905bc4d997289b97c8d80accec1dc606fd3b314b0ad7bf",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:hNxmVfOY+2P3UmtR3Dkbiy6Jo4nMiJcIMkJ88W8HO0E3cM8s8C+eWoh6YqPFv0xz5TTxhOdUZhl3wcakpu/tDQ=="
+  "signature": "ed25519:pan53EfGzJm9lz6R8m9yZAi5ndQQPh9z3anuesrYxzOtiwHGKa+K1VAuozBhA6KTVZwchaTny08/0N+ov+RbAg=="
 }

--- a/.provekit/self-contracts-attestations/go.json
+++ b/.provekit/self-contracts-attestations/go.json
@@ -4,7 +4,7 @@
   "lang": "go",
   "cid": "blake3-512:2cb536119bb99c4b7c24bc455672e0863b3b5392fabfc92c6db01828854ca6cb7f20a33d0c7b2f9415a7957fd844dcfe06dc668765d3ccbb08808cf08e9f92eb",
   "contractSetCid": "blake3-512:e23649f383162398556a508c2e69e035d6d231bfaf6e8926ced547fb19ddd9c65779f39fe31d85519c957bc40afa432c9be468eadfa5aac77f74f5de8c56324c",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:2QRap+bghkPM6R4MbkkZb+7nZmv7NEpqAPAuWYnk1ozJ5bDee5kGfe5Nd9N/71VrPEmcQfg4MIBPq9dC4zi2CA=="
+  "signature": "ed25519:EOa/hi83MZOMh+4Nht9csij6mhJY8hDdrlM4UA1ubJwOkkkzAtZHWRgbyEcJ0XHBMKGDdFrCAOx3Q+OZqzeWCg=="
 }

--- a/.provekit/self-contracts-attestations/java.json
+++ b/.provekit/self-contracts-attestations/java.json
@@ -4,7 +4,7 @@
   "lang": "java",
   "cid": "blake3-512:93dd048300ce9db0454fae4dd9639deca7d200de2edc005672213aec492e75c95c342ad174e3850e8ec31cfe09403c8f772fafff778254ea246367648b3a0e39",
   "contractSetCid": "blake3-512:a22c97362e15faf1e848eeb7d668ba50eba8cfb851a72465f2cccb0ca9e12af198ec14cc0e65453a18b1e40bbd17497f8975b6e3625bbf2b6b31e6ca6aacb6e3",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:J5U3R5hsrkAsJZrqNNNRFvHuzjVhGFbuHyN/WqRyF2xWlfArqXZF2R6rkaT/pZrA6pM5XjsTGK6GZJ2f1c6dBg=="
+  "signature": "ed25519:Lth14ZYM/WcmhG2gXdEe0i6qXg1Ez+Tqw/8GCZIDuIJibAFf1b4IJ7b3kbPSRFqZBW23+hBHhc03U529r8fhBA=="
 }

--- a/.provekit/self-contracts-attestations/php.json
+++ b/.provekit/self-contracts-attestations/php.json
@@ -2,9 +2,9 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "php",
-  "cid": "blake3-512:16a8af822854fa6f4f1306b9f5e43030e21ccb901bea13f2cedb1a28a881c63e6daabbc4e93af472346c954759739f84debb8da174e6fda62e91319cb7dca555",
-  "contractSetCid": "blake3-512:385e617be25516099e61118179fbb200967093448b85629f1cb5b8966dfcc06244cfcb9f59315780114fee7c9c415fcd1465fc8e85e8141d59f6b44a2df4a262",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "cid": "blake3-512:a415e42af24f248a4b34043f0358f3c62fdcc810812e2d8ff0feddc79c6c13f97a6ba5e5113548628e8fbdc65a678393657789a0141a76df13a81e67f3d11241",
+  "contractSetCid": "blake3-512:b15a63b9a56ec19be67bf71ee58969e82a24a5507484e51a137362d0f2e00fe4f406980948a7c3018e463e75b9341815275a29a51273adb512ee4f291351ddf5",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:EmN1HwUmPHK7c9jxVFUgbp6bTyjycqnol42119oIjBsLlMGA4J582WTvaBzi4Rj1bCFvut9m7NNrtvxWHMFuCw=="
+  "signature": "ed25519:/Lhi0+LonMMgieNZ/Ew1RVZrGf2Mi7TAkjs0dRkUAdDcOjJCwHyrEX0yMSvcwaAtTk7MhwkaSo4aPBFN4eX2CQ=="
 }

--- a/.provekit/self-contracts-attestations/python.json
+++ b/.provekit/self-contracts-attestations/python.json
@@ -4,7 +4,7 @@
   "lang": "python",
   "cid": "blake3-512:64c8ddf3a7ef02c6d12665866e1c2483b59009830a5f27cee869b123d5ece63cccb7dc8d62002383f348b15cd866857de0c6a053dd2fc02e3d9356bd3295b0a4",
   "contractSetCid": "blake3-512:b1de941756d0a3b352ca79ebed8b75644b7c782c3afe4163273220384125ec100457d5e969a921b7ceb277e329a24c5a4ea21ffd54963b51c1756befdb1793dc",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:IsW7B356VvsRLOQH9bggRPx/lagQQ5tyAoEm0d3mth0ecmzQjofGhnZY+ZByVs6QJhpwSnBEew86B9vtyGqlBw=="
+  "signature": "ed25519:zMhMd1kuYlNzqh8L0Uz737xkhs1aFYOfK8f4qd7RYW8+i0AsfBUugBe/U346ZuYE3y0R7qt4r1PM/GTq84ktBg=="
 }

--- a/.provekit/self-contracts-attestations/ruby.json
+++ b/.provekit/self-contracts-attestations/ruby.json
@@ -4,7 +4,7 @@
   "lang": "ruby",
   "cid": "blake3-512:6358ad54d0535d87be144d765127b7dcdde7fa6d807e27b8d85f4d3549609cd7fb573a711e7668152339753398c68dbb5e23dc2e0083ca5e7dc2c00e439d69da",
   "contractSetCid": "blake3-512:961be80d8a5ae8f3d8255462fc1845d5b45f30c0b4412c9d8b354078d63096ba363b6ae0dea4f2e35141213dc5c6b855156f434b5620a345bfbc20725bee00ff",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:gxKNFdrGsu4WXuIQuGwt7kOPevUrDH9STT2ZKz11J/Y9pkDD0vfYzZfY5RIyk9KcP5n0/vbPYSYTiAKuvW0GAg=="
+  "signature": "ed25519:1iayt6PHSkUK+2B9WW99wfvdBnBXTxH63nvyWFvooyo5JSw1IojEUMhYexIwamBgCdQ4sfQhLnVPPR5n5JlrBg=="
 }

--- a/.provekit/self-contracts-attestations/rust.json
+++ b/.provekit/self-contracts-attestations/rust.json
@@ -4,7 +4,7 @@
   "lang": "rust",
   "cid": "blake3-512:60df6322388ff7d9ccd1b9ee9d6457fdfe89a51b3d2d73a34daa0131f65c80543331832eb88920fe514ebb799bc655808f152d36274542ac9879c862a33f3a92",
   "contractSetCid": "blake3-512:8f4bcc3c3e748ae303f8c8da80245f291e803eb2d241224c75c7ac470631e4dee7ff2e0ff59af571db3d506485c115acaddfd91e4e4315eb04ee37c035ddbc69",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:XQhbaHNNhD9hCbkfmtnVZsUZz0pd7CSLuG1qCM8Rq2FF51qUZSpXh5Wg2DVGWYeD1ZHH9D2m0HKIlN9U57U4CA=="
+  "signature": "ed25519:LWmBAekUP3oiEXnJHRttR6VAQfc034VtYc3jWDRaXld7HfQEFv9sX9/xV4IrhmX0tO8Zo+AYFmL7rjkaEtY6Dw=="
 }

--- a/.provekit/self-contracts-attestations/ts.json
+++ b/.provekit/self-contracts-attestations/ts.json
@@ -4,7 +4,7 @@
   "lang": "ts",
   "cid": "blake3-512:c3ec9665f68dc49f5ce76cb0be8a71a743c25ae2a328b5fce9eef9d541fc74d2d4605f7f71ca4b9100216340767a000859d472d3b952f7cca5aecba3debbfca7",
   "contractSetCid": "blake3-512:5a45314fdfb0fa1357a78a3f5c22e794fcbc10d3e649c39989710887eb742a6610861b9ab5c9e941ab01bc4357f5671a61c9d8a1d431dff8da3b6280a66d0d6a",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:nJemNd4R7c8nHrHf5k0t9xIKccxmippGO2+PrqjLB1oMPHGwLpvs5zu7IUu9CTwgmQEgjlM/1Bdgasi9FmJmDw=="
+  "signature": "ed25519:MjyRLAw991ZJeeUytO75R04JbyXTTf2roO+7xt2bkmqrs0uNFyZVgGq7DZZRgQodWisamHGuVJjYMwEtWTa8Bw=="
 }

--- a/.provekit/self-contracts-attestations/zig.json
+++ b/.provekit/self-contracts-attestations/zig.json
@@ -2,9 +2,9 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "zig",
-  "cid": "blake3-512:891887b2bdbefe6ff9bcb95dda6fca02711a58cac2b3cabac29b79ee0c47373ad223bc33ea98be141596d6943ffde64aba37865c9a08658c3cee71d27f822308",
+  "cid": "blake3-512:cfb964f44883e53c4dffbd92767ccffa5d07bf27c755a73cfb8a13f0faff60caa4b59f3939bfc6e4ca7b1935684133289e959d2eab1de79e0d22099f5e1c2cea",
   "contractSetCid": "blake3-512:405ff171d26342acab133240baeac8774de95f66d03d4748ca9254233e1e143be6a8d2322319da73942650589bf54b2f3ac8875e6e3a34f5cd3699cad20e93e3",
-  "declaredAt": "2026-05-03T18:00:00Z",
+  "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:E/ofRVqAxD5HWOJpVV9Gd/b74cNz+ebyt5xSsBG2HzJTQm3tzytKLz/VsY+NOTQL4o5KwR75rtTEJN56wlEWCA=="
+  "signature": "ed25519:Z3e5PdvB248s04ZKztTsKWGo8b07MVo1N588wy3sI73nwNzP6mCFN1F8V1ewbgR4WgiM/EjTd0dJnmICwBI7BA=="
 }

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ build-java-self-contracts:
 .PHONY: build-ruby
 build-ruby:
 	cd implementations/ruby/ext/provekit_blake3 && $(RUBY) extconf.rb && $(MAKE)
-	cd implementations/ruby && $(RUBY) -Ilib -e 'require "provekit"; abort unless Provekit::Blake3.hex("provekit").start_with?("blake3-512:")'
+	cd implementations/ruby && $(RUBY) -S bundle exec $(RUBY) -Ilib -e 'require "provekit"; abort unless Provekit::Blake3.hex("provekit").start_with?("blake3-512:")'
 
 .PHONY: build-swift
 build-swift:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # ProvekIt — top-level orchestrator
 #
-# Six-language polyglot. Each language owns its native build tool;
+# Twelve-kit polyglot. TypeScript is the center surface, but every kit
+# owns its native build tool;
 # this Makefile is glue, not a build system. `make ci` runs the same
 # gate the GitHub Actions workflow runs (Linux x86_64: Rust/Go/C++/TS/C#/Python).
 # Swift is macOS-only; use `make build-swift`, `make test-swift`, `make mint-swift`
@@ -8,9 +9,10 @@
 #
 # Mainline targets:
 #   make help        — print this help
-#   make ci          — full conformance gate (catalog + protocol + 10 mints + tests)
-#   make conformance — catalog + protocol + 10 mint CIDs + self-contract tests
-#   make all-mint    — run all 10 mint commands; print CIDs (Linux/CI subset)
+#   make ci          — full conformance gate (catalog + protocol + live mints + tests)
+#   make conformance — catalog + protocol + live mint CIDs + self-contract tests
+#   make all-mint    — run all 10 Linux/CI mint commands; print CIDs
+#   make bootstrap-self-contracts — re-sign attestations from live artifacts
 #   make test-all    — run every language-native test suite (Linux/CI subset)
 #
 # Per-language targets:
@@ -33,13 +35,11 @@
 #
 #   1. Make your code change in `implementations/<lang>/provekit-self-contracts`
 #      (or the language's analog).
-#   2. `make mint-<lang>`
-#      -> the mint target FAILS and prints the new bundle CID + contractSetCid.
-#   3. `cargo run --release --manifest-path tools/foundation-keygen/Cargo.toml \
-#         --bin sign-self-contracts -- <lang> <bundle-cid> <contract-set-cid>`
-#      -> rewrites `.provekit/self-contracts-attestations/<lang>.json` with
-#         a fresh foundation-v0 ed25519 signature over the new CID + contractSetCid.
-#   4. `git add .provekit/self-contracts-attestations/<lang>.json && git commit`
+#   2. `make bootstrap-self-contracts`
+#      -> builds the selected kit toolchains, mints verifier-loadable proof
+#         artifacts, and re-signs `.provekit/self-contracts-attestations/*.json`
+#         from the live bundle CID + contractSetCid.
+#   3. `git add .provekit/self-contracts-attestations/<lang>.json && git commit`
 #
 # The bundle (letter) does not know its own CID. The on-disk attestation
 # (envelope) names the CID and is signed externally. See
@@ -58,6 +58,8 @@ CATALOG_CID := blake3-512:ce04a40534986a95362d5f130fd3a1a667b7a157f0554f262af11e
 PROVEKIT := implementations/rust/target/release/provekit
 VERIFY_SELF_CONTRACTS := tools/foundation-keygen/target/release/verify-self-contracts
 SELF_CONTRACTS_ATTEST_DIR := .provekit/self-contracts-attestations
+CONFORMANCE_PROFILE ?= linux
+CONFORMANCE_JOBS ?= 4
 
 .PHONY: help
 help:
@@ -67,6 +69,9 @@ help:
 	@echo "  make ci             full gate (conformance + test-all) [Linux/CI: 10 peer langs]"
 	@echo "  make conformance    catalog + protocol + 10 mint CIDs + self-contract tests"
 	@echo "  make all-mint       10 mint commands (Swift excluded: macOS-only, use mint-swift)"
+	@echo "  make bootstrap-self-contracts"
+	@echo "                       re-sign attestations from live kit artifacts"
+	@echo "                       override: CONFORMANCE_PROFILE=all CONFORMANCE_JOBS=8"
 	@echo "  make test-all       language test suites (Swift excluded: macOS-only, use test-swift)"
 	@echo ""
 	@echo "Per-language build:"
@@ -496,7 +501,15 @@ conformance-region-fixture:
 .PHONY: cross-kit-conformance
 cross-kit-conformance:
 	@echo "=== Catalog-pinned cross-kit conformance fixtures ==="
-	cargo run --release --manifest-path tools/cross-kit-conformance/Cargo.toml -- --profile linux
+	cargo run --release --manifest-path tools/cross-kit-conformance/Cargo.toml -- \
+		--profile $(CONFORMANCE_PROFILE) --jobs $(CONFORMANCE_JOBS)
+
+.PHONY: bootstrap-self-contracts
+bootstrap-self-contracts:
+	@echo "=== Bootstrap self-contract attestations from live kit artifacts ==="
+	cargo run --release --manifest-path tools/cross-kit-conformance/Cargo.toml -- \
+		--profile $(CONFORMANCE_PROFILE) --jobs $(CONFORMANCE_JOBS) \
+		--bootstrap-self-contract-attestations
 
 # --- Per-language test suites ------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,14 @@ VERIFY_SELF_CONTRACTS := tools/foundation-keygen/target/release/verify-self-cont
 SELF_CONTRACTS_ATTEST_DIR := .provekit/self-contracts-attestations
 CONFORMANCE_PROFILE ?= linux
 CONFORMANCE_JOBS ?= 4
+RUBY ?= $(shell for p in /usr/local/opt/ruby/bin/ruby /opt/homebrew/opt/ruby/bin/ruby /usr/local/bin/ruby /opt/homebrew/bin/ruby; do if [ -x "$$p" ]; then echo "$$p"; exit; fi; done; command -v ruby || echo ruby)
+JAVA_HOME ?= $(shell for d in /usr/local/opt/openjdk /opt/homebrew/opt/openjdk; do if [ -x "$$d/bin/java" ]; then echo "$$d"; exit; fi; done)
+export JAVA_HOME
+ifeq ($(strip $(JAVA_HOME)),)
+export PATH := $(dir $(RUBY)):$(PATH)
+else
+export PATH := $(dir $(RUBY)):$(JAVA_HOME)/bin:$(PATH)
+endif
 
 .PHONY: help
 help:
@@ -67,15 +75,15 @@ help:
 	@echo ""
 	@echo "Mainline:"
 	@echo "  make ci             full gate (conformance + test-all) [Linux/CI: 10 peer langs]"
-	@echo "  make conformance    catalog + protocol + 10 mint CIDs + self-contract tests"
-	@echo "  make all-mint       10 mint commands (Swift excluded: macOS-only, use mint-swift)"
+	@echo "  make conformance    catalog + protocol + 11 mint CIDs + self-contract tests"
+	@echo "  make all-mint       11 mint commands (Swift excluded: macOS-only, use mint-swift)"
 	@echo "  make bootstrap-self-contracts"
 	@echo "                       re-sign attestations from live kit artifacts"
 	@echo "                       override: CONFORMANCE_PROFILE=all CONFORMANCE_JOBS=8"
 	@echo "  make test-all       language test suites (Swift excluded: macOS-only, use test-swift)"
 	@echo ""
 	@echo "Per-language build:"
-	@echo "  make build-all      build every kit (rust + cpp + go + ts + csharp + java)"
+	@echo "  make build-all      build every kit (rust + cpp + go + ts + csharp + java + ruby)"
 	@echo "  make build-rust     cargo build --release (workspace + tools)"
 	@echo "  make build-cpp      clang++ + vendored-blake3"
 	@echo "  make build-go       go build per Go module"
@@ -118,7 +126,7 @@ help:
 # with the Swift toolchain and is not run by Linux CI. Use `make build-swift`
 # directly on macOS.
 .PHONY: build-all
-build-all: build-rust build-cpp build-go build-ts build-csharp build-java
+build-all: build-rust build-cpp build-go build-ts build-csharp build-java build-ruby
 
 .PHONY: build-rust
 build-rust:
@@ -176,6 +184,11 @@ build-java-self-contracts:
 	# implementations/java/provekit-java-self-contracts/target/provekit-java-self-contracts.jar
 	# and the lift manifest spawns it with `java -jar`.
 	mvn -q -f implementations/java/pom.xml -pl provekit-java-self-contracts -am package -DskipTests
+
+.PHONY: build-ruby
+build-ruby:
+	cd implementations/ruby/ext/provekit_blake3 && $(RUBY) extconf.rb && $(MAKE)
+	cd implementations/ruby && $(RUBY) -Ilib -e 'require "provekit"; abort unless Provekit::Blake3.hex("provekit").start_with?("blake3-512:")'
 
 .PHONY: build-swift
 build-swift:
@@ -295,7 +308,7 @@ mint-python: build-rust
 		 echo "      $(PROVEKIT) mint --kit=python" && exit 1)
 
 .PHONY: mint-ruby
-mint-ruby: build-rust
+mint-ruby: build-rust build-ruby
 	@echo ">> minting ruby self-contracts"
 	@mint_out=$$($(PROVEKIT) mint --kit=ruby --quiet); \
 	cid=$$(echo "$$mint_out" | head -1); \
@@ -342,15 +355,14 @@ mint-php: build-rust
 		(echo "FAIL: php self-contracts attestation rejected; re-mint and commit:" && \
 		 echo "      $(PROVEKIT) mint --kit=php" && exit 1)
 
-# NOTE: all-mint runs 10 of 12 kits (Linux/CI subset).
-# Excluded: swift (macOS-only; use mint-swift on macOS), ruby (attestation
-# exists but CI toolchain integration pending, #234).
+# NOTE: all-mint runs 11 of 12 kits (Linux/CI subset).
+# Excluded: swift (macOS-only; use mint-swift on macOS).
 # zig and c were added after their Side A merges (#283, #272) and are included.
 # php was added after its self-contracts attestation was signed (#393).
 .PHONY: all-mint
-all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python mint-c mint-zig mint-php
+all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python mint-ruby mint-c mint-zig mint-php
 	@echo ""
-	@echo "==== all 10 core self-contract CIDs match pinned values ===="
+	@echo "==== all 11 core self-contract CIDs match pinned values ===="
 	@printf "  %-8s  %s\n" "rust"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/rust.json)"
 	@printf "  %-8s  %s\n" "go"     "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/go.json)"
 	@printf "  %-8s  %s\n" "cpp"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/cpp.json)"
@@ -358,6 +370,7 @@ all-mint: mint-rust mint-go mint-cpp mint-ts mint-csharp mint-java mint-python m
 	@printf "  %-8s  %s\n" "csharp" "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/csharp.json)"
 	@printf "  %-8s  %s\n" "java"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/java.json)"
 	@printf "  %-8s  %s\n" "python" "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/python.json)"
+	@printf "  %-8s  %s\n" "ruby"   "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/ruby.json)"
 	@printf "  %-8s  %s\n" "c"      "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/c.json)"
 	@printf "  %-8s  %s\n" "zig"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/zig.json)"
 	@printf "  %-8s  %s\n" "php"    "(envelope: $(SELF_CONTRACTS_ATTEST_DIR)/php.json)"

--- a/Makefile
+++ b/Makefile
@@ -434,7 +434,7 @@ prove-python: build-rust
 	$(PROVEKIT) prove --kit=python
 
 .PHONY: prove-ruby
-prove-ruby: build-rust
+prove-ruby: build-rust build-ruby
 	@echo ">> proving ruby lift-plugin-protocol conformance (C1-C8)"
 	$(PROVEKIT) prove --kit=ruby
 

--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ prove-zig: build-rust build-zig
 	$(PROVEKIT) prove --kit=zig
 
 .PHONY: prove-c
-prove-c: build-rust build-c
+prove-c: build-rust build-c build-c-self-contracts
 	@echo ">> proving c lift-plugin-protocol conformance (C1-C8)"
 	$(PROVEKIT) prove --kit=c
 

--- a/implementations/c/mint-c-self-contracts/src/orchestrator.c
+++ b/implementations/c/mint-c-self-contracts/src/orchestrator.c
@@ -3,11 +3,11 @@
  * Orchestrator. Drives one full author + mint + bundle pass:
  *
  *   1. Author every contract slab in c_kit_invariants.c.
- *   2. For each ContractDecl, JCS-encode the canonical contract body
- *      {name, outBinding, pre?, post?, inv?} and hash to BLAKE3-512 to
- *      get the signer-independent contentCid (member CID).
- *   3. The member bytes are those same JCS bytes; the catalog wraps
- *      them via pksc_proof_build.
+ *   2. For each ContractDecl, mint a signed layered contract memento.
+ *      The memento header carries the signer-independent contentCid
+ *      BLAKE3-512(JCS({name, outBinding, pre?, post?, inv?})).
+ *   3. The proof member key is the attestation CID
+ *      BLAKE3-512(JCS(envelope)); member bytes are the full memento.
  *   4. contractSetCid = BLAKE3-512(JCS(sorted(contentCids))) — byte-
  *      identical to other kits per spec
  *      protocol/specs/2026-05-03-contract-set-extension.md §1.
@@ -38,15 +38,6 @@
 /* ----------------------------------------------------------------------- */
 /* helpers                                                                  */
 /* ----------------------------------------------------------------------- */
-
-static char *dup_cstr(const char *s) {
-    if (!s) return NULL;
-    size_t n = strlen(s);
-    char *p = (char *)malloc(n + 1);
-    if (!p) return NULL;
-    memcpy(p, s, n + 1);
-    return p;
-}
 
 /* Deep-copy a pksc_value tree. Used because each contract decl's pre/post/inv
  * is owned by the slab; we need an independent tree to assemble into the
@@ -95,6 +86,38 @@ static int cmp_str_ptr(const void *a, const void *b) {
     const char *sa = *(const char *const *)a;
     const char *sb = *(const char *const *)b;
     return strcmp(sa, sb);
+}
+
+static int obj_set_str(pksc_value *obj, const char *key, const char *value) {
+    pksc_value *v = pksc_v_str(value);
+    if (!v) return -1;
+    if (pksc_v_obj_set(obj, key, v) != 0) {
+        pksc_value_free(v);
+        return -1;
+    }
+    return 0;
+}
+
+static int obj_set_value_copy(pksc_value *obj, const char *key, const pksc_value *value) {
+    pksc_value *copy = value_copy(value);
+    if (!copy) return -1;
+    if (pksc_v_obj_set(obj, key, copy) != 0) {
+        pksc_value_free(copy);
+        return -1;
+    }
+    return 0;
+}
+
+static char *hash_value_cid(const pksc_value *value) {
+    pksc_bytes jcs;
+    pksc_bytes_init(&jcs);
+    if (pksc_jcs_encode(&jcs, value) != 0) {
+        pksc_bytes_free(&jcs);
+        return NULL;
+    }
+    char *cid = pksc_blake3_512_cid(jcs.data, jcs.len);
+    pksc_bytes_free(&jcs);
+    return cid;
 }
 
 /* contractSetCid = BLAKE3-512(JCS(sorted([cids...]))). Returns malloc'd
@@ -179,6 +202,245 @@ fail_o_only:
     return NULL;
 }
 
+static char *contract_content_cid(const mcsc_contract *c) {
+    pksc_value *body = build_contract_body(c);
+    if (!body) return NULL;
+    char *cid = hash_value_cid(body);
+    pksc_value_free(body);
+    return cid;
+}
+
+static char *contract_formula_hash(const pksc_value *formula) {
+    return hash_value_cid(formula);
+}
+
+static char *contract_property_hash(const mcsc_contract *c) {
+    pksc_value *o = pksc_v_obj_new();
+    if (!o) return NULL;
+    if (c->pre && obj_set_value_copy(o, "pre", c->pre) != 0) goto fail;
+    if (c->post && obj_set_value_copy(o, "post", c->post) != 0) goto fail;
+    if (c->inv && obj_set_value_copy(o, "inv", c->inv) != 0) goto fail;
+    if (obj_set_str(o, "outBinding", c->out_binding) != 0) goto fail;
+    char *cid = hash_value_cid(o);
+    pksc_value_free(o);
+    return cid;
+fail:
+    pksc_value_free(o);
+    return NULL;
+}
+
+static char *contract_binding_hash(const mcsc_contract *c, const char *property_hash) {
+    pksc_value *o = pksc_v_obj_new();
+    if (!o) return NULL;
+    if (obj_set_str(o, "producerId", MCSC_PRODUCED_BY) != 0) goto fail;
+    if (obj_set_str(o, "contractName", c->name) != 0) goto fail;
+    if (obj_set_str(o, "propertyHash", property_hash) != 0) goto fail;
+    char *cid = hash_value_cid(o);
+    pksc_value_free(o);
+    return cid;
+fail:
+    pksc_value_free(o);
+    return NULL;
+}
+
+static pksc_value *build_contract_header(const mcsc_contract *c,
+                                         const char *content_cid,
+                                         const char *binding_hash,
+                                         const char *property_hash) {
+    pksc_value *header = pksc_v_obj_new();
+    if (!header) return NULL;
+    if (obj_set_str(header, "schemaVersion", "2") != 0) goto fail;
+    if (obj_set_str(header, "kind", "contract") != 0) goto fail;
+    if (obj_set_str(header, "cid", content_cid) != 0) goto fail;
+    if (obj_set_str(header, "name", c->name) != 0) goto fail;
+    if (obj_set_str(header, "outBinding", c->out_binding) != 0) goto fail;
+    if (c->pre && obj_set_value_copy(header, "pre", c->pre) != 0) goto fail;
+    if (c->post && obj_set_value_copy(header, "post", c->post) != 0) goto fail;
+    if (c->inv && obj_set_value_copy(header, "inv", c->inv) != 0) goto fail;
+    if (obj_set_str(header, "verdict", "holds") != 0) goto fail;
+    if (obj_set_str(header, "bindingHash", binding_hash) != 0) goto fail;
+    if (obj_set_str(header, "propertyHash", property_hash) != 0) goto fail;
+    pksc_value *inputs = pksc_v_arr_new();
+    if (!inputs) goto fail;
+    if (pksc_v_obj_set(header, "inputCids", inputs) != 0) {
+        pksc_value_free(inputs);
+        goto fail;
+    }
+    return header;
+fail:
+    pksc_value_free(header);
+    return NULL;
+}
+
+static pksc_value *build_contract_metadata(const mcsc_contract *c) {
+    pksc_value *metadata = pksc_v_obj_new();
+    if (!metadata) return NULL;
+
+    pksc_value *authoring = pksc_v_obj_new();
+    if (!authoring) goto fail;
+    if (obj_set_str(authoring, "producerKind", "kit-author") != 0) goto fail_authoring;
+    if (obj_set_str(authoring, "author", MCSC_PRODUCED_BY) != 0) goto fail_authoring;
+    if (obj_set_str(authoring, "note", "self-contract from c slab") != 0) goto fail_authoring;
+    if (pksc_v_obj_set(metadata, "authoring", authoring) != 0) goto fail_authoring;
+    authoring = NULL;
+
+    if (obj_set_str(metadata, "producedBy", MCSC_PRODUCED_BY) != 0) goto fail;
+    if (obj_set_str(metadata, "producedAt", MCSC_DECLARED_AT) != 0) goto fail;
+
+    if (c->pre) {
+        char *h = contract_formula_hash(c->pre);
+        if (!h) goto fail;
+        int rc = obj_set_str(metadata, "preHash", h);
+        free(h);
+        if (rc != 0) goto fail;
+    }
+    if (c->post) {
+        char *h = contract_formula_hash(c->post);
+        if (!h) goto fail;
+        int rc = obj_set_str(metadata, "postHash", h);
+        free(h);
+        if (rc != 0) goto fail;
+    }
+    if (c->inv) {
+        char *h = contract_formula_hash(c->inv);
+        if (!h) goto fail;
+        int rc = obj_set_str(metadata, "invHash", h);
+        free(h);
+        if (rc != 0) goto fail;
+    }
+    return metadata;
+
+fail_authoring:
+    pksc_value_free(authoring);
+fail:
+    pksc_value_free(metadata);
+    return NULL;
+}
+
+static char *signing_payload_jcs(const pksc_value *header, const pksc_value *metadata) {
+    pksc_value *payload = pksc_v_obj_new();
+    if (!payload) return NULL;
+    if (obj_set_value_copy(payload, "header", header) != 0) goto fail;
+    if (obj_set_value_copy(payload, "metadata", metadata) != 0) goto fail;
+    char *jcs = pksc_jcs_encode_string(payload);
+    pksc_value_free(payload);
+    return jcs;
+fail:
+    pksc_value_free(payload);
+    return NULL;
+}
+
+static int mint_contract_memento(const mcsc_contract *c,
+                                 pksc_member *member,
+                                 char **content_cid_out) {
+    memset(member, 0, sizeof(*member));
+    *content_cid_out = NULL;
+
+    char *content_cid = contract_content_cid(c);
+    if (!content_cid) return -1;
+    char *property_hash = contract_property_hash(c);
+    if (!property_hash) goto fail_content;
+    char *binding_hash = contract_binding_hash(c, property_hash);
+    if (!binding_hash) goto fail_property;
+
+    pksc_value *header = build_contract_header(c, content_cid, binding_hash, property_hash);
+    if (!header) goto fail_binding;
+    pksc_value *metadata = build_contract_metadata(c);
+    if (!metadata) goto fail_header;
+
+    char *payload = signing_payload_jcs(header, metadata);
+    if (!payload) goto fail_metadata;
+    char *sig = pksc_ed25519_sign_string(PKSC_FOUNDATION_V0_SEED,
+        (const uint8_t *)payload, strlen(payload));
+    free(payload);
+    if (!sig) goto fail_metadata;
+    char *pubkey = pksc_ed25519_pubkey_string(PKSC_FOUNDATION_V0_SEED);
+    if (!pubkey) {
+        free(sig);
+        goto fail_metadata;
+    }
+
+    pksc_value *envelope = pksc_v_obj_new();
+    if (!envelope) {
+        free(pubkey);
+        free(sig);
+        goto fail_metadata;
+    }
+    if (obj_set_str(envelope, "signer", pubkey) != 0 ||
+        obj_set_str(envelope, "declaredAt", MCSC_DECLARED_AT) != 0 ||
+        obj_set_str(envelope, "signature", sig) != 0) {
+        pksc_value_free(envelope);
+        free(pubkey);
+        free(sig);
+        goto fail_metadata;
+    }
+    free(pubkey);
+    free(sig);
+
+    char *attestation_cid = hash_value_cid(envelope);
+    if (!attestation_cid) {
+        pksc_value_free(envelope);
+        goto fail_metadata;
+    }
+
+    pksc_value *memento = pksc_v_obj_new();
+    if (!memento) {
+        free(attestation_cid);
+        pksc_value_free(envelope);
+        goto fail_metadata;
+    }
+    if (pksc_v_obj_set(memento, "envelope", envelope) != 0) {
+        free(attestation_cid);
+        pksc_value_free(envelope);
+        pksc_value_free(memento);
+        goto fail_metadata;
+    }
+    envelope = NULL;
+    if (pksc_v_obj_set(memento, "header", header) != 0) {
+        free(attestation_cid);
+        pksc_value_free(header);
+        pksc_value_free(metadata);
+        pksc_value_free(memento);
+        goto fail_binding;
+    }
+    header = NULL;
+    if (pksc_v_obj_set(memento, "metadata", metadata) != 0) {
+        free(attestation_cid);
+        pksc_value_free(metadata);
+        pksc_value_free(memento);
+        goto fail_binding;
+    }
+    metadata = NULL;
+
+    char *canonical = pksc_jcs_encode_string(memento);
+    pksc_value_free(memento);
+    if (!canonical) {
+        free(attestation_cid);
+        goto fail_binding;
+    }
+
+    member->key = attestation_cid;
+    member->bytes = (uint8_t *)canonical;
+    member->len = strlen(canonical);
+    *content_cid_out = content_cid;
+
+    free(binding_hash);
+    free(property_hash);
+    return 0;
+
+fail_metadata:
+    pksc_value_free(metadata);
+fail_header:
+    pksc_value_free(header);
+fail_binding:
+    free(binding_hash);
+fail_property:
+    free(property_hash);
+fail_content:
+    free(content_cid);
+    return -1;
+}
+
 /* Make a directory if it doesn't exist. */
 static int ensure_dir(const char *path) {
     if (!path) return 0;
@@ -241,29 +503,13 @@ int mcsc_mint_one_run(const char *out_dir, mcsc_mint_result *out) {
         mcsc_slab *s = slabs->slabs[si];
         for (size_t ci = 0; ci < s->n; ci++) {
             const mcsc_contract *c = s->contracts[ci];
-            pksc_value *body = build_contract_body(c);
-            if (!body) goto fail;
-
-            pksc_bytes jcs;
-            pksc_bytes_init(&jcs);
-            if (pksc_jcs_encode(&jcs, body) != 0) {
-                pksc_value_free(body);
-                pksc_bytes_free(&jcs);
-                goto fail;
-            }
-            pksc_value_free(body);
-
-            char *cid = pksc_blake3_512_cid(jcs.data, jcs.len);
-            if (!cid) {
-                pksc_bytes_free(&jcs);
-                goto fail;
-            }
+            char *content_cid = NULL;
+            if (mint_contract_memento(c, &members[idx], &content_cid) != 0) goto fail;
 
             /* Detect duplicate CIDs across slabs. */
             for (size_t k = 0; k < idx; k++) {
-                if (strcmp(members[k].key, cid) == 0) {
-                    free(cid);
-                    pksc_bytes_free(&jcs);
+                if (strcmp(content_cids[k], content_cid) == 0) {
+                    free(content_cid);
                     fprintf(stderr,
                             "duplicate contract CID across slabs (contract `%s`)\n",
                             c->name);
@@ -271,15 +517,7 @@ int mcsc_mint_one_run(const char *out_dir, mcsc_mint_result *out) {
                 }
             }
 
-            members[idx].key = cid; /* takes ownership */
-            /* Move ownership of jcs.data into members[idx].bytes. */
-            members[idx].bytes = jcs.data;
-            members[idx].len = jcs.len;
-            jcs.data = NULL;
-            jcs.cap = jcs.len = 0;
-
-            content_cids[idx] = dup_cstr(cid);
-            if (!content_cids[idx]) goto fail;
+            content_cids[idx] = content_cid;
             idx++;
         }
     }

--- a/implementations/php/provekit-ir-symbolic/src/ClaimEnvelope/Minter.php
+++ b/implementations/php/provekit-ir-symbolic/src/ClaimEnvelope/Minter.php
@@ -21,82 +21,94 @@ class Minter
         string $producedBy,
         string $producedAt,
     ): array {
+        $formulaValue = fn($f) => $f === null ? null : $f->jsonSerialize();
+
         // Compute property hash: BLAKE3(JCS({pre?, post?, inv?, outBinding}))
         $propObj = ['outBinding' => $decl->outBinding];
-        if ($decl->pre !== null)  $propObj['pre'] = $decl->pre;
-        if ($decl->post !== null) $propObj['post'] = $decl->post;
-        if ($decl->inv !== null)  $propObj['inv'] = $decl->inv;
+        if ($decl->pre !== null)  $propObj['pre'] = $formulaValue($decl->pre);
+        if ($decl->post !== null) $propObj['post'] = $formulaValue($decl->post);
+        if ($decl->inv !== null)  $propObj['inv'] = $formulaValue($decl->inv);
         $propHash = Blake3::cid(Jcs::encode($propObj));
 
-        // Compute binding hash: BLAKE3(JCS({name, outBinding, pre?, post?, inv?}))
-        $bindObj = ['name' => $decl->name, 'outBinding' => $decl->outBinding];
-        if ($decl->pre !== null)  $bindObj['pre'] = $decl->pre;
-        if ($decl->post !== null) $bindObj['post'] = $decl->post;
-        if ($decl->inv !== null)  $bindObj['inv'] = $decl->inv;
+        // Compute binding hash: BLAKE3(JCS({producerId, contractName, propertyHash}))
+        $bindObj = [
+            'producerId' => $producedBy,
+            'contractName' => $decl->name,
+            'propertyHash' => $propHash,
+        ];
         $bindHash = Blake3::cid(Jcs::encode($bindObj));
 
         // Content CID: BLAKE3(JCS(name + outBinding + pre/post/inv))
         $contentObj = ['name' => $decl->name, 'outBinding' => $decl->outBinding];
-        if ($decl->pre !== null)  $contentObj['pre'] = $decl->pre;
-        if ($decl->post !== null) $contentObj['post'] = $decl->post;
-        if ($decl->inv !== null)  $contentObj['inv'] = $decl->inv;
+        if ($decl->pre !== null)  $contentObj['pre'] = $formulaValue($decl->pre);
+        if ($decl->post !== null) $contentObj['post'] = $formulaValue($decl->post);
+        if ($decl->inv !== null)  $contentObj['inv'] = $formulaValue($decl->inv);
         $contentCid = Blake3::cid(Jcs::encode($contentObj));
 
         // Build header
         $header = [
             'kind' => 'contract',
-            'schema' => 'blake3-512:' . str_repeat('0', 128 + 2), // placeholder
+            'schemaVersion' => '2',
             'cid' => $contentCid,
             'name' => $decl->name,
             'outBinding' => $decl->outBinding,
-            'post' => $decl->post?->jsonSerialize(),
-            'postHash' => Blake3::cid(Jcs::encode($decl->post?->jsonSerialize())),
             'bindingHash' => $bindHash,
             'propertyHash' => $propHash,
             'inputCids' => [],
             'verdict' => 'holds',
-            'schemaVersion' => '1',
         ];
         if ($decl->pre !== null) {
-            $header['pre'] = $decl->pre->jsonSerialize();
-            $header['preHash'] = Blake3::cid(Jcs::encode($decl->pre->jsonSerialize()));
+            $header['pre'] = $formulaValue($decl->pre);
+        }
+        if ($decl->post !== null) {
+            $header['post'] = $formulaValue($decl->post);
+        }
+        if ($decl->inv !== null) {
+            $header['inv'] = $formulaValue($decl->inv);
         }
 
-        // Build envelope
+        // Metadata is signed but opaque to the substrate verifier.
+        $metadata = [
+            'authoring' => [
+                'producerKind' => 'kit-author',
+                'author' => $producedBy,
+                'note' => 'self-contract from php slab',
+            ],
+            'producedBy' => $producedBy,
+            'producedAt' => $producedAt,
+        ];
+        if ($decl->pre !== null) {
+            $metadata['preHash'] = Blake3::cid(Jcs::encode($formulaValue($decl->pre)));
+        }
+        if ($decl->post !== null) {
+            $metadata['postHash'] = Blake3::cid(Jcs::encode($formulaValue($decl->post)));
+        }
+        if ($decl->inv !== null) {
+            $metadata['invHash'] = Blake3::cid(Jcs::encode($formulaValue($decl->inv)));
+        }
+
+        // Build envelope. The signature covers JCS({header, metadata}); the
+        // member CID is BLAKE3-512(JCS(envelope-with-signature)).
         $env = [
             'signer' => 'ed25519:' . $this->signer->pubKeyBase64(),
             'declaredAt' => $producedAt,
         ];
-        $sigPayload = Jcs::encode($env) . Jcs::encode($header);
+        $sigPayload = Jcs::encode(['header' => $header, 'metadata' => $metadata]);
         $env['signature'] = 'ed25519:' . $this->signer->signBase64($sigPayload);
+        $attestationCid = Blake3::cid(Jcs::encode($env));
 
         // Full memento
         $memento = [
             'envelope' => $env,
             'header' => $header,
-            'evidence' => [
-                'kind' => 'contract',
-                'body' => [
-                    'contractName' => $decl->name,
-                    'outBinding' => $decl->outBinding,
-                    'post' => $decl->post?->jsonSerialize(),
-                    'postHash' => $header['postHash'],
-                    'producerKind' => 'lift',
-                    'lifter' => $producedBy,
-                    'evidence' => 'types',
-                ],
-            ],
+            'metadata' => $metadata,
         ];
-        if ($decl->pre !== null) {
-            $memento['evidence']['body']['pre'] = $decl->pre->jsonSerialize();
-            $memento['evidence']['body']['preHash'] = $header['preHash'];
-        }
 
         $canonical = Jcs::encode($memento);
 
         return [
             'cid' => $contentCid,
-            'envelopeCid' => Blake3::cid($canonical),
+            'envelopeCid' => $attestationCid,
             'canonicalBytes' => $canonical,
         ];
     }
@@ -189,7 +201,7 @@ class Minter
         $canonical = Jcs::encode($memento);
 
         return [
-            'cid' => Blake3::cid($canonical),
+            'cid' => Blake3::cid(Jcs::encode($env)),
             'canonicalBytes' => $canonical,
         ];
     }

--- a/implementations/php/provekit-ir-symbolic/src/ProofEnvelope/Builder.php
+++ b/implementations/php/provekit-ir-symbolic/src/ProofEnvelope/Builder.php
@@ -35,60 +35,47 @@ class Builder
         ];
     }
 
-    /**
-     * Simplified deterministic CBOR catalog encoding.
-     * Real implementation would use a proper CBOR library;
-     * this hand-rolled version produces correct structure for verification.
-     */
     private function encodeCatalog(string $name, string $version, array $members, string $declaredAt): string
     {
-        // CBOR map with deterministic integer keys
-        $map = [];
-
-        // Key 0: kind = "catalog"
-        $map[0] = $this->cborString('catalog');
-
-        // Key 1: name
-        $map[1] = $this->cborString($name . '@provekit/lift');
-
-        // Key 2: signer
-        $map[2] = $this->cborString(Blake3::cid($this->signer->pubKeyHex()));
-
-        // Key 3: members (CBOR map)
-        $membersCbor = chr(0xa0 | count($members)); // map header
+        ksort($members, SORT_STRING);
+        $memberPairs = [];
         foreach ($members as $cid => $bytes) {
-            $membersCbor .= $this->cborString($cid);
-            $membersCbor .= $this->cborBytes($bytes);
+            $memberPairs[$cid] = $this->cborBytes($bytes);
         }
-        $map[3] = $membersCbor;
+        $membersCbor = $this->cborMap($memberPairs);
 
-        // Key 4: version
-        $map[4] = $this->cborString($version);
+        $signer = 'ed25519:' . $this->signer->pubKeyBase64();
+        $signerCid = Blake3::cid($signer);
 
-        // Key 5: signature (sign canonical data)
-        $map[5] = $this->cborString(
-            'ed25519:' . $this->signer->signBase64($membersCbor)
-        );
+        $unsignedPairs = [
+            'kind' => $this->cborString('catalog'),
+            'name' => $this->cborString($name),
+            'version' => $this->cborString($version),
+            'members' => $membersCbor,
+            'signer' => $this->cborString($signerCid),
+            'declaredAt' => $this->cborString($declaredAt),
+        ];
+        $unsigned = $this->cborMap($unsignedPairs);
+        $signature = $this->signer->sign($unsigned);
 
-        // Key 6: declaredAt
-        $map[6] = $this->cborString($declaredAt);
-
-        // Deterministic: sort keys before encoding
-        ksort($map);
-        $buf = chr(0xa0 | count($map));
-        foreach ($map as $k => $v) {
-            $buf .= $this->cborInt($k) . $v;
-        }
-
-        return $buf;
+        $signedPairs = $unsignedPairs;
+        $signedPairs['signature'] = $this->cborBytes($signature);
+        return $this->cborMap($signedPairs);
     }
 
-    private function cborInt(int $n): string
+    private function cborMap(array $pairs): string
     {
-        if ($n <= 23) return chr($n);
-        if ($n <= 0xFF) return chr(0x18) . chr($n);
-        if ($n <= 0xFFFF) return chr(0x19) . pack('n', $n);
-        throw new \RuntimeException("int too large for hand-rolled CBOR");
+        $encoded = [];
+        foreach ($pairs as $key => $valueCbor) {
+            $encoded[$this->cborString((string)$key)] = $valueCbor;
+        }
+        ksort($encoded, SORT_STRING);
+
+        $buf = $this->cborHead(5, count($encoded));
+        foreach ($encoded as $keyCbor => $valueCbor) {
+            $buf .= $keyCbor . $valueCbor;
+        }
+        return $buf;
     }
 
     private function cborString(string $s): string

--- a/implementations/php/provekit-lift/src/lifter.php
+++ b/implementations/php/provekit-lift/src/lifter.php
@@ -345,7 +345,7 @@ class PhpLifter
 
         foreach ($lifted['decls'] as $decl) {
             $minted = $minter->mintContract($decl, $producedBy, $producedAt);
-            $members[$minted['cid']] = $minted['canonicalBytes'];
+            $members[$minted['envelopeCid']] = $minted['canonicalBytes'];
             $contractCids[$decl->name] = $minted['cid'];
         }
 

--- a/implementations/php/provekit-self-contracts/cmd/mint-php-self-contracts/main.php
+++ b/implementations/php/provekit-self-contracts/cmd/mint-php-self-contracts/main.php
@@ -46,7 +46,7 @@ function mintAll(string $outDir): array
 
         foreach ($finished['contracts'] as $contract) {
             $minted = $minter->mintContract($contract, PRODUCED_BY, DECLARED_AT);
-            $members[$minted['cid']] = $minted['canonicalBytes'];
+            $members[$minted['envelopeCid']] = $minted['canonicalBytes'];
             $contractCids[$contract->name] = $minted['cid'];
         }
     }

--- a/implementations/ruby/ext/provekit_blake3/extconf.rb
+++ b/implementations/ruby/ext/provekit_blake3/extconf.rb
@@ -8,7 +8,6 @@ require "fileutils"
 dir_config("blake3")
 
 $CFLAGS << " -std=c11"
-$DEFLIBPATH = []
 
 # Vendored BLAKE3 root.
 #

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -66,8 +66,8 @@ use crate::{EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
 const FOUNDATION_V0_SEED: Ed25519Seed = [0x42u8; 32];
 
 /// Pinned `declaredAt` for self-contracts attestations minted under the
-/// unified pipeline. Matches v1.4.1 catalog declared_at for consistency.
-const SELF_CONTRACTS_DECLARED_AT: &str = "2026-05-03T18:00:00Z";
+/// unified pipeline. Matches the v1.6.0 catalog declared_at for consistency.
+const SELF_CONTRACTS_DECLARED_AT: &str = "2026-05-05T18:00:00Z";
 
 
 /// Canonical mapping from `--kit=<name>` to (project_subdir, lift_surface, lang_key).
@@ -854,6 +854,7 @@ mod tests {
         assert_eq!(a["schemaVersion"].as_str(), Some("1"));
         assert_eq!(a["kind"].as_str(), Some("self-contracts-attestation"));
         assert_eq!(a["lang"].as_str(), Some("rust"));
+        assert_eq!(a["declaredAt"].as_str(), Some("2026-05-05T18:00:00Z"));
         assert!(a["signature"].as_str().unwrap().starts_with("ed25519:"));
         assert!(a["signer"].as_str().unwrap().starts_with("ed25519:"));
     }

--- a/implementations/swift/Package.swift
+++ b/implementations/swift/Package.swift
@@ -126,7 +126,7 @@ let package = Package(
         ),
         .executableTarget(
             name: "MintSwiftSelfContracts",
-            dependencies: ["Provekit"]
+            dependencies: ["Provekit", "ProvekitCrypto"]
         ),
         // LSPTests: standalone integration test runner (no XCTest/Testing dep needed).
         // `swift run test-swift-lsp` returns exit 0 on pass, non-zero on fail.

--- a/implementations/swift/Sources/MintSwiftSelfContracts/RPC.swift
+++ b/implementations/swift/Sources/MintSwiftSelfContracts/RPC.swift
@@ -24,6 +24,7 @@
 
 import Foundation
 import Provekit
+import ProvekitCrypto
 
 // MARK: - RPC entry point
 
@@ -87,38 +88,24 @@ private func handleInitialize(id: Any?) {
 
 private func handleLift(id: Any?) {
     // Walk the slab (the `allContracts` array authored in main.swift) and
-    // emit a proof-envelope. The contractSetCid is the canonical
-    // BLAKE3-512(JCS(sorted(contractCids))) per
+    // emit a real signed-CBOR .proof bundle. The contractSetCid is the
+    // canonical BLAKE3-512(JCS(sorted(contractCids))) per
     // protocol/specs/2026-05-03-contract-set-extension.md §1, byte-identical
-    // to what the rust/go/cpp/ts kits produce for the same contracts.
-    //
-    // The .proof bundle format proper (CBOR + signed catalog memento) is
-    // Phase 3 deferred for the swift kit; this RPC emits a minimal
-    // JCS-JSON catalog whose filename_cid is the BLAKE3-512 of those
-    // bytes. This satisfies the rust dispatcher's `proof-envelope`
-    // contract (kind, filename_cid non-empty, bytes_base64 decodable) and
-    // produces a content-meaningful CID that changes when the slab changes,
-    // satisfying acceptance gate #2 of issue #211.
+    // to what the Rust verifier re-derives from the loaded member mementos.
+    let minted: SwiftSelfContractProof
+    do {
+        minted = try mintSwiftSelfContractProof(contracts: swiftSelfContracts())
+    } catch {
+        writeError(id: id, code: -32000, message: "LIFT_FAILED: \(error)")
+        return
+    }
 
-    let contracts = swiftSelfContracts()
-    let cids = contracts.map { contractContentCid($0) }
-    let setCid = computeContractSetCid(cids)
-
-    // Build the (Phase-3-deferred) catalog body. JCS-encoded; the file's
-    // filename CID is BLAKE3-512 of these bytes.
-    let catalogJcs = encodeSwiftCatalog(name: "@provekit/swift-self-contracts",
-                                        version: "1.0.0",
-                                        contracts: contracts,
-                                        contractCids: cids)
-    let catalogBytes = Data(catalogJcs.utf8)
-    let filenameCid = Blake3.hex(catalogBytes)
-
-    let b64 = catalogBytes.base64EncodedString()
+    let b64 = minted.bytes.base64EncodedString()
 
     let result: [String: Any] = [
         "kind": "proof-envelope",
-        "filename_cid": filenameCid,
-        "contract_set_cid": setCid,
+        "filename_cid": minted.filenameCid,
+        "contract_set_cid": minted.contractSetCid,
         "bytes_base64": b64,
         "diagnostics": [],
     ]
@@ -141,7 +128,7 @@ func contractContentCid(_ d: Declaration) -> String {
     guard case let .contract(name, outBinding, pre, post, inv) = d else {
         // Bridges aren't part of the swift self-contracts slab today;
         // if one shows up we'd fall back to encoding the full declaration.
-        return Blake3.hex(Data(Jcs.encode(Jcs.declToValue(d)).utf8))
+        return ProvekitCrypto.Blake3.hex(Data(Jcs.encode(Jcs.declToValue(d)).utf8))
     }
     var pairs: [(String, JcsValue)] = [
         ("name", .string(name)),
@@ -157,7 +144,7 @@ func contractContentCid(_ d: Declaration) -> String {
         pairs.append(("inv", Jcs.formulaToValue(inv)))
     }
     let jcs = Jcs.encode(.object(pairs))
-    return Blake3.hex(Data(jcs.utf8))
+    return ProvekitCrypto.Blake3.hex(Data(jcs.utf8))
 }
 
 /// Compute the contract set CID per spec `2026-05-03-contract-set-extension.md` §1:
@@ -169,43 +156,107 @@ func computeContractSetCid(_ cids: [String]) -> String {
     let sorted = cids.sorted()
     let arr: [JcsValue] = sorted.map { .string($0) }
     let jcs = Jcs.encode(.array(arr))
-    return Blake3.hex(Data(jcs.utf8))
+    return ProvekitCrypto.Blake3.hex(Data(jcs.utf8))
 }
 
-/// Build a minimal JCS-canonical catalog body. The filename_cid of the
-/// emitted .proof bundle is BLAKE3-512 of these bytes. NOT byte-equivalent
-/// to the rust/go/cpp/ts CBOR-signed catalog format; that's Phase 3 work
-/// (per the existing comment in MintSwiftSelfContracts/main.swift line 208).
-///
-/// Body shape:
-///   {
-///     contracts: <jcs declarations array>,
-///     contractCids: [<sorted contract content CIDs>],
-///     declaredAt: <ISO-8601>,
-///     kind: "swift-self-contracts-catalog-phase3-pending",
-///     name: <catalog name>,
-///     version: <catalog version>
-///   }
-///
-/// The presence of `contractCids` and `contracts` makes the bytes change
-/// when ANY contract field changes, satisfying issue #211 acceptance gate #2
-/// ("Bundle CID is content-meaningful").
-func encodeSwiftCatalog(name: String,
-                        version: String,
-                        contracts: [Declaration],
-                        contractCids: [String]) -> String {
-    let declsValue: JcsValue = .array(contracts.map(Jcs.declToValue))
-    let cidsValue: JcsValue = .array(contractCids.sorted().map { .string($0) })
-    let declaredAt = "2026-05-03T18:00:00Z"
-    let body: JcsValue = .object([
-        ("contractCids", cidsValue),
-        ("contracts", declsValue),
-        ("declaredAt", .string(declaredAt)),
-        ("kind", .string("swift-self-contracts-catalog-phase3-pending")),
-        ("name", .string(name)),
-        ("version", .string(version)),
-    ])
-    return Jcs.encode(body)
+private struct SwiftSelfContractProof {
+    let bytes: Data
+    let filenameCid: String
+    let contractSetCid: String
+}
+
+private enum SwiftSelfContractMintError: Error, CustomStringConvertible {
+    case nonIntegerNumber(String)
+    case noContractMembers
+
+    var description: String {
+        switch self {
+        case .nonIntegerNumber(let n):
+            return "self-contract formula contains non-integer JCS number: \(n)"
+        case .noContractMembers:
+            return "swift self-contract slab produced no contract members"
+        }
+    }
+}
+
+private let swiftSelfContractCatalogName = "@provekit/swift-self-contracts"
+private let swiftSelfContractCatalogVersion = "1.0.0"
+private let swiftSelfContractProducedBy = "swift-self-contracts@1.0.0"
+private let swiftSelfContractDeclaredAt = "2026-05-03T18:00:00Z"
+
+private func mintSwiftSelfContractProof(contracts: [Declaration]) throws -> SwiftSelfContractProof {
+    let minter = ClaimMinter(signerSeed: Ed25519.foundationV0Seed)
+    var members: [(String, Data)] = []
+    var contractCids: [String] = []
+
+    for declaration in contracts {
+        guard case let .contract(name, outBinding, pre, post, inv) = declaration else {
+            continue
+        }
+
+        let args = ContractMintArgs(
+            contractName: name,
+            pre: try pre.map { try formulaCanonical($0) },
+            post: try post.map { try formulaCanonical($0) },
+            inv: try inv.map { try formulaCanonical($0) },
+            outBinding: outBinding,
+            producedBy: swiftSelfContractProducedBy,
+            producedAt: swiftSelfContractDeclaredAt,
+            inputCids: [],
+            authoring: .kitAuthor(author: swiftSelfContractProducedBy, note: nil)
+        )
+
+        contractCids.append(contractCid(fromArgs: args))
+        let memento = try minter.mintContract(args)
+        members.append((memento.cid, memento.canonicalBytes))
+    }
+
+    if members.isEmpty {
+        throw SwiftSelfContractMintError.noContractMembers
+    }
+
+    let signerPubkey = Ed25519.publicKeyString(fromSeed: Ed25519.foundationV0Seed)
+    let signerCid = ProvekitCrypto.Blake3.hex(Data(signerPubkey.utf8))
+    let envelope = ProofEnvelopeBuilder.build(ProofEnvelopeInput(
+        name: swiftSelfContractCatalogName,
+        version: swiftSelfContractCatalogVersion,
+        members: members,
+        signerCid: signerCid,
+        signerSeed: Ed25519.foundationV0Seed,
+        declaredAt: swiftSelfContractDeclaredAt
+    ))
+
+    return SwiftSelfContractProof(
+        bytes: envelope.bytes,
+        filenameCid: envelope.filenameCid,
+        contractSetCid: ProvekitCrypto.computeContractSetCid(contractCids)
+    )
+}
+
+private func formulaCanonical(_ formula: Formula) throws -> JcsCanonical {
+    return try jcsCanonical(from: Jcs.formulaToValue(formula))
+}
+
+private func jcsCanonical(from value: JcsValue) throws -> JcsCanonical {
+    switch value {
+    case .string(let s):
+        return .string(s)
+    case .number(let n):
+        guard let i = Int64(n) else {
+            throw SwiftSelfContractMintError.nonIntegerNumber(n)
+        }
+        return .int(i)
+    case .bool(let b):
+        return .bool(b)
+    case .null:
+        return .null
+    case .array(let values):
+        return .array(try values.map { try jcsCanonical(from: $0) })
+    case .object(let pairs):
+        return .object(try pairs.map { (key, nested) in
+            (key, try jcsCanonical(from: nested))
+        })
+    }
 }
 
 // MARK: - JSON-RPC writers

--- a/implementations/swift/Sources/MintSwiftSelfContracts/main.swift
+++ b/implementations/swift/Sources/MintSwiftSelfContracts/main.swift
@@ -49,10 +49,7 @@ let allContracts = swiftSelfContracts()
 let cids = allContracts.map { contractContentCid($0) }
 let contractSetCid = computeContractSetCid(cids)
 
-// The full signed-CBOR proof bundle is Phase 3 work for the swift kit;
-// the human-mode CID is a placeholder. The `--rpc` mode emits a real
-// content-meaningful filename_cid (see RPC.swift > handleLift).
-let bundleCidPlaceholder = "swift-kit-bundle:phase-3-deferred"
-
-print("catalog CID: \(bundleCidPlaceholder)")
+// Human mode is a lightweight inspection path. The `--rpc` mode mints the
+// real signed-CBOR proof artifact used by `provekit mint --kit=swift`.
+print("catalog CID: swift-kit-bundle:rpc-mode")
 print("contractSetCid: \(contractSetCid)")

--- a/implementations/zig/mint-zig-self-contracts/build.zig
+++ b/implementations/zig/mint-zig-self-contracts/build.zig
@@ -17,6 +17,7 @@
 // Module imports:
 //   provekit-ir                — IR types + JCS + BLAKE3 helper
 //   provekit-proof-envelope-zig — buildProofEnvelope + sign helpers
+//   provekit-self-contracts    — native layered memento minting
 
 const std = @import("std");
 
@@ -39,6 +40,12 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    const provekit_self_contracts = b.createModule(.{
+        .root_source_file = b.path("../provekit-self-contracts/src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
@@ -46,6 +53,7 @@ pub fn build(b: *std.Build) void {
         .imports = &.{
             .{ .name = "provekit-ir", .module = provekit_ir },
             .{ .name = "provekit-proof-envelope-zig", .module = provekit_proof_envelope },
+            .{ .name = "provekit-self-contracts", .module = provekit_self_contracts },
         },
     });
 

--- a/implementations/zig/mint-zig-self-contracts/src/main.zig
+++ b/implementations/zig/mint-zig-self-contracts/src/main.zig
@@ -134,7 +134,7 @@ fn handleInitialize(w: *std.Io.Writer, id_raw: []const u8) !void {
             "\"capabilities\":{{" ++
             "\"authoring_surfaces\":[\"zig-self-contracts\"]," ++
             "\"ir_version\":\"v1.1.0\"," ++
-            "\"emits_signed_mementos\":false}}}}}}\n",
+            "\"emits_signed_mementos\":true}}}}}}\n",
         .{id_raw},
     );
 }

--- a/implementations/zig/mint-zig-self-contracts/src/mint.zig
+++ b/implementations/zig/mint-zig-self-contracts/src/mint.zig
@@ -8,28 +8,26 @@
 //      content CID:
 //        contractCid = blake3-512(JCS({name, outBinding, pre?, post?, inv?}))
 //   3. Computes contractSetCid = blake3-512(JCS(<sorted contractCids>)).
-//   4. Builds a `.proof` catalog envelope using the just-landed Side B
-//      crypto substrate (provekit-proof-envelope-zig). Member set is
-//      empty in this tier-3 bootstrap because zig has no claim-envelope
-//      analog yet (no signed-memento minting). The contractSetCid is
-//      content-meaningful regardless.
+//   4. Mints each contract as a signed layered memento using the native
+//      Zig claim-envelope substrate, then bundles those mementos into a
+//      `.proof` catalog envelope.
 //   5. Emits the .proof bytes + filename CID + contractSetCid to caller.
 //
 // Cross-kit anchor: the contractSetCid for the same authored contracts
 // is signer-independent across all kits per spec #94 §1. The .proof
-// filename CID depends on the empty member set + name + version +
+// filename CID depends on the signed memento set + name + version +
 // declaredAt + signer; it is byte-deterministic across runs but is NOT
-// expected to match other kits (those bundle real signed mementos).
-//
-// Followups (out of scope for #213):
-//   * Port claim-envelope to zig (mint signed mementos).
-//   * Add closed-loop bridge declaration.
+// expected to match other kits.
 
 const std = @import("std");
 const provekit = @import("provekit-ir");
 const proof_env = @import("provekit-proof-envelope-zig");
+const sc = @import("provekit-self-contracts");
 
 const slab = @import("slab.zig");
+const ScValue = sc.jcs.Value;
+const ObjectBuilder = sc.jcs.ObjectBuilder;
+const ArrayBuilder = sc.jcs.ArrayBuilder;
 
 pub const PRODUCED_BY: []const u8 = "@provekit/zig-self-contracts@1.0";
 pub const DECLARED_AT: []const u8 = "2026-04-30T18:00:00.000Z";
@@ -171,6 +169,112 @@ fn computeContractSetCid(
 }
 
 // ---------------------------------------------------------------------------
+// IR -> provekit-self-contracts JCS Value conversion.
+// ---------------------------------------------------------------------------
+
+fn sortToValue(alloc: std.mem.Allocator, sort: provekit.Sort) !*ScValue {
+    var b = ObjectBuilder.init(alloc);
+    switch (sort) {
+        .primitive => |name| {
+            try b.add("kind", try ScValue.newString(alloc, "primitive"));
+            try b.add("name", try ScValue.newString(alloc, name));
+        },
+        .function => |f| {
+            var args = ArrayBuilder.init(alloc);
+            for (f.args) |arg| try args.append(try sortToValue(alloc, arg.*));
+            try b.add("args", try args.finish());
+            try b.add("kind", try ScValue.newString(alloc, "function"));
+            try b.add("return", try sortToValue(alloc, f.return_.*));
+        },
+        .dependent => |d| {
+            try b.add("indexSort", try sortToValue(alloc, d.index_sort.*));
+            try b.add("indexVar", try ScValue.newString(alloc, d.index_var));
+            try b.add("kind", try ScValue.newString(alloc, "dependent"));
+            try b.add("name", try ScValue.newString(alloc, d.name));
+        },
+        .region => |r| {
+            try b.add("kind", try ScValue.newString(alloc, "region"));
+            try b.add("name", try ScValue.newString(alloc, r.name));
+        },
+    }
+    return b.finish();
+}
+
+fn constValueToValue(alloc: std.mem.Allocator, value: provekit.Term.ConstValue) !*ScValue {
+    return switch (value) {
+        .int => |n| ScValue.newInt(alloc, n),
+        .string => |s| ScValue.newString(alloc, s),
+        .bool => |b| ScValue.newBool(alloc, b),
+        .null_void => ScValue.newNull(alloc),
+    };
+}
+
+fn termToValue(alloc: std.mem.Allocator, term: provekit.Term) !*ScValue {
+    var b = ObjectBuilder.init(alloc);
+    switch (term) {
+        .var_term => |t| {
+            try b.add("kind", try ScValue.newString(alloc, "var"));
+            try b.add("name", try ScValue.newString(alloc, t.name));
+        },
+        .const_term => |t| {
+            try b.add("kind", try ScValue.newString(alloc, "const"));
+            try b.add("sort", try sortToValue(alloc, t.sort));
+            try b.add("value", try constValueToValue(alloc, t.value));
+        },
+        .ctor_term => |t| {
+            var args = ArrayBuilder.init(alloc);
+            for (t.args) |arg| try args.append(try termToValue(alloc, arg));
+            try b.add("args", try args.finish());
+            try b.add("kind", try ScValue.newString(alloc, "ctor"));
+            try b.add("name", try ScValue.newString(alloc, t.name));
+        },
+    }
+    return b.finish();
+}
+
+fn connectiveKindName(kind: provekit.Formula.ConnectiveKind) []const u8 {
+    return switch (kind) {
+        .@"and" => "and",
+        .@"or" => "or",
+        .not => "not",
+        .implies => "implies",
+    };
+}
+
+fn quantifierKindName(kind: provekit.Formula.QuantifierKind) []const u8 {
+    return switch (kind) {
+        .forall => "forall",
+        .exists => "exists",
+    };
+}
+
+fn formulaToValue(alloc: std.mem.Allocator, formula: provekit.Formula) !*ScValue {
+    var b = ObjectBuilder.init(alloc);
+    switch (formula) {
+        .atomic => |f| {
+            var args = ArrayBuilder.init(alloc);
+            for (f.args) |arg| try args.append(try termToValue(alloc, arg));
+            try b.add("args", try args.finish());
+            try b.add("kind", try ScValue.newString(alloc, "atomic"));
+            try b.add("name", try ScValue.newString(alloc, f.name));
+        },
+        .connective => |f| {
+            var operands = ArrayBuilder.init(alloc);
+            for (f.operands) |operand| try operands.append(try formulaToValue(alloc, operand));
+            try b.add("kind", try ScValue.newString(alloc, connectiveKindName(f.kind)));
+            try b.add("operands", try operands.finish());
+        },
+        .quantifier => |f| {
+            try b.add("body", try formulaToValue(alloc, f.body.*));
+            try b.add("kind", try ScValue.newString(alloc, quantifierKindName(f.kind)));
+            try b.add("name", try ScValue.newString(alloc, f.name));
+            try b.add("sort", try sortToValue(alloc, f.sort));
+        },
+    }
+    return b.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Public entry point.
 // ---------------------------------------------------------------------------
 
@@ -178,11 +282,20 @@ pub fn mintSelfProof(alloc: std.mem.Allocator) !MintResult {
     var authoring = try slab.authorAll(alloc);
     defer authoring.deinit();
 
-    // 1. Compute every contract's content CID.
+    // 1. Mint every contract as a real signed memento and collect its
+    // signer-independent content CID for contractSetCid.
     var cids_list: std.ArrayList([]u8) = .empty;
     defer {
         for (cids_list.items) |c| alloc.free(c);
         cids_list.deinit(alloc);
+    }
+    var members_list: std.ArrayList(proof_env.Member) = .empty;
+    defer {
+        for (members_list.items) |m| {
+            alloc.free(m.cid);
+            alloc.free(m.bytes);
+        }
+        members_list.deinit(alloc);
     }
     var per_source: std.ArrayList(LabeledCount) = .empty;
     errdefer {
@@ -196,8 +309,29 @@ pub fn mintSelfProof(alloc: std.mem.Allocator) !MintResult {
         try per_source.append(alloc, .{ .label = label_dup, .count = s.contracts.len });
         for (s.contracts) |d| {
             const c = d.contract;
-            const cid = try contractContentCid(alloc, c);
-            try cids_list.append(alloc, cid);
+            var minted = try sc.claim_envelope.mintContract(alloc, .{
+                .contract_name = c.name,
+                .pre = if (c.pre) |pre| try formulaToValue(alloc, pre) else null,
+                .post = if (c.post) |post| try formulaToValue(alloc, post) else null,
+                .inv = if (c.inv) |inv| try formulaToValue(alloc, inv) else null,
+                .out_binding = c.out_binding,
+                .produced_by = PRODUCED_BY,
+                .produced_at = DECLARED_AT,
+                .input_cids = &.{},
+                .authoring = .{ .kit_author = .{
+                    .author = PRODUCED_BY,
+                    .note = "self-contract from zig slab",
+                } },
+                .signer_seed = sc.foundation.SEED,
+            });
+            var minted_transferred = false;
+            errdefer if (!minted_transferred) minted.deinit(alloc);
+            try cids_list.append(alloc, minted.contract_cid);
+            try members_list.append(alloc, .{
+                .cid = minted.cid,
+                .bytes = minted.canonical_bytes,
+            });
+            minted_transferred = true;
         }
         total += s.contracts.len;
     }
@@ -211,9 +345,7 @@ pub fn mintSelfProof(alloc: std.mem.Allocator) !MintResult {
     const contract_set_cid = try computeContractSetCid(alloc, cids_view.items);
     errdefer alloc.free(contract_set_cid);
 
-    // 3. Build the .proof envelope. Members map is empty in this Tier-3
-    //    bootstrap (no claim-envelope substrate yet); the contractSetCid
-    //    above is the cross-kit content-meaningful anchor.
+    // 3. Build the .proof envelope from the kit-emitted mementos.
     const signer_pubkey = try proof_env.sign.pubkeyString(alloc, proof_env.FOUNDATION_V0_SEED);
     defer alloc.free(signer_pubkey);
     const signer_cid = try proof_env.blake3_512_of(alloc, signer_pubkey);
@@ -222,7 +354,7 @@ pub fn mintSelfProof(alloc: std.mem.Allocator) !MintResult {
     const built = try proof_env.buildProofEnvelope(alloc, .{
         .name = CATALOG_NAME,
         .version = CATALOG_VERSION,
-        .members = &.{},
+        .members = members_list.items,
         .signer_cid = signer_cid,
         .declared_at = DECLARED_AT,
         .signer_seed = proof_env.FOUNDATION_V0_SEED,
@@ -255,6 +387,7 @@ test "mintSelfProof produces a content-meaningful contractSetCid" {
     try testing.expect(std.mem.startsWith(u8, r.filename_cid, "blake3-512:"));
     try testing.expect(r.total_contracts > 0);
     try testing.expect(r.proof_bytes.len > 0);
+    try testing.expect(r.proof_bytes.len > 1024);
 }
 
 test "mintSelfProof is byte-deterministic" {

--- a/tools/cross-kit-conformance/Cargo.lock
+++ b/tools/cross-kit-conformance/Cargo.lock
@@ -100,8 +100,8 @@ name = "cross-kit-conformance"
 version = "0.1.0"
 dependencies = [
  "provekit-canonicalizer",
- "provekit-claim-envelope",
  "provekit-self-contracts",
+ "provekit-verifier",
  "serde",
  "serde_json",
  "toml",

--- a/tools/cross-kit-conformance/Cargo.toml
+++ b/tools/cross-kit-conformance/Cargo.toml
@@ -11,8 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 provekit-canonicalizer = { path = "../../implementations/rust/provekit-canonicalizer" }
-provekit-claim-envelope = { path = "../../implementations/rust/provekit-claim-envelope" }
 provekit-self-contracts = { path = "../../implementations/rust/provekit-self-contracts" }
+provekit-verifier = { path = "../../implementations/rust/provekit-verifier" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 toml = "0.8"

--- a/tools/cross-kit-conformance/src/lib.rs
+++ b/tools/cross-kit-conformance/src/lib.rs
@@ -1,11 +1,10 @@
-use provekit_canonicalizer::blake3_512_of;
-use provekit_claim_envelope::{
-    mint_bridge_v14, BridgeTargetV14, MintBridgeV14Args, MintedEnvelope,
-};
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use serde::Deserialize;
+use serde_json::Value as JsonValue;
 use std::collections::{HashSet, VecDeque};
 use std::ffi::OsString;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -31,7 +30,6 @@ const EMPTY_CONTRACT_SET_CID: &str = concat!(
     "d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab",
     "09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229"
 );
-const PROTOCOL_BRIDGE_DECLARED_AT: &str = "2026-05-06T00:00:00.000Z";
 
 const CORE_FIXTURES: &[&str] = &[
     "eq_atomic",
@@ -77,7 +75,9 @@ struct FixtureToml {
 struct KitSelfContractAttestation {
     kit: String,
     attestation_lang: String,
+    bundle_cid: String,
     contract_set_cid: String,
+    path: PathBuf,
 }
 
 #[derive(Debug, Deserialize)]
@@ -95,6 +95,7 @@ struct SelfContractAttestationJson {
 struct RunConfig {
     profile: Profile,
     jobs: usize,
+    bootstrap_self_contract_attestations: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -193,6 +194,38 @@ struct NativeCheckResult {
 }
 
 type OrderedJob<T> = Box<dyn FnOnce() -> T + Send + 'static>;
+
+#[derive(Debug, Clone, Copy)]
+struct SelfContractProducer {
+    kit: &'static str,
+    attestation_lang: &'static str,
+    mint_kit_alias: &'static str,
+}
+
+#[derive(Debug)]
+struct MintStdoutArtifact {
+    bundle_cid: String,
+    contract_set_cid: String,
+}
+
+#[derive(Debug)]
+struct LiveSelfContractArtifact {
+    kit: &'static str,
+    attestation_lang: &'static str,
+    bundle_cid: String,
+    contract_set_cid: String,
+    proof_bytes_len: usize,
+    proof_member_count: usize,
+    proof_contract_count: usize,
+}
+
+#[derive(Debug)]
+struct LiveProofArtifactValidation {
+    proof_bytes_len: usize,
+    proof_member_count: usize,
+    proof_contract_count: usize,
+    derived_contract_set_cid: String,
+}
 
 #[derive(Debug)]
 struct TempDir {
@@ -300,40 +333,64 @@ fn run_cmd_env(
         }
     };
 
+    let stdout_reader = child.stdout.take().map(spawn_output_reader);
+    let stderr_reader = child.stderr.take().map(spawn_output_reader);
     let started = Instant::now();
     loop {
         match child.try_wait() {
-            Ok(Some(_)) => {
-                let output = child.wait_with_output().expect("completed child output");
+            Ok(Some(status)) => {
                 return ProcResult {
-                    code: output.status.code().unwrap_or(1),
-                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                    code: status.code().unwrap_or(1),
+                    stdout: String::from_utf8_lossy(&join_output_reader(stdout_reader)).to_string(),
+                    stderr: String::from_utf8_lossy(&join_output_reader(stderr_reader)).to_string(),
                 };
             }
             Ok(None) => {
                 if started.elapsed() >= timeout {
                     let _ = child.kill();
-                    let output = child.wait_with_output().expect("killed child output");
-                    let mut stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                    let _ = child.wait();
+                    let stdout = join_output_reader(stdout_reader);
+                    let mut stderr =
+                        String::from_utf8_lossy(&join_output_reader(stderr_reader)).to_string();
                     stderr.push_str(&format!("\ntimeout after {}s", timeout.as_secs()));
                     return ProcResult {
                         code: -1,
-                        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                        stdout: String::from_utf8_lossy(&stdout).to_string(),
                         stderr,
                     };
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
                 return ProcResult {
                     code: 1,
-                    stdout: String::new(),
-                    stderr: e.to_string(),
-                }
+                    stdout: String::from_utf8_lossy(&join_output_reader(stdout_reader)).to_string(),
+                    stderr: format!(
+                        "{}\n{}",
+                        e,
+                        String::from_utf8_lossy(&join_output_reader(stderr_reader))
+                    ),
+                };
             }
         }
     }
+}
+
+fn spawn_output_reader<R>(mut pipe: R) -> thread::JoinHandle<Vec<u8>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let _ = pipe.read_to_end(&mut bytes);
+        bytes
+    })
+}
+
+fn join_output_reader(handle: Option<thread::JoinHandle<Vec<u8>>>) -> Vec<u8> {
+    handle.and_then(|h| h.join().ok()).unwrap_or_default()
 }
 
 fn command_stdout(cmd: &[String], cwd: &Path, timeout: Duration) -> Result<String> {
@@ -384,13 +441,63 @@ fn attestation_lang_for_kit(kit: &str) -> &str {
     }
 }
 
+fn self_contract_producer_for(kit: &'static str) -> SelfContractProducer {
+    match kit {
+        "typescript" => SelfContractProducer {
+            kit,
+            attestation_lang: "ts",
+            mint_kit_alias: "ts",
+        },
+        other => SelfContractProducer {
+            kit,
+            attestation_lang: other,
+            mint_kit_alias: other,
+        },
+    }
+}
+
+fn self_contract_producers(profile: Profile) -> Vec<SelfContractProducer> {
+    profile
+        .required_kits()
+        .into_iter()
+        .map(self_contract_producer_for)
+        .collect()
+}
+
+fn self_contract_bootstrap_targets(profile: Profile) -> Vec<&'static str> {
+    let mut targets = vec!["build-rust"];
+    for producer in self_contract_producers(profile) {
+        let target = match producer.kit {
+            "go" => Some("build-go"),
+            "cpp" => Some("build-cpp"),
+            "typescript" => Some("build-ts"),
+            "csharp" => Some("build-csharp"),
+            "java" => Some("build-java-self-contracts"),
+            "c" => Some("build-c-self-contracts"),
+            "zig" => Some("build-zig"),
+            "swift" => Some("build-swift"),
+            _ => None,
+        };
+        if let Some(target) = target {
+            if !targets.contains(&target) {
+                targets.push(target);
+            }
+        }
+    }
+    targets
+}
+
+fn attestation_path(lang: &str) -> PathBuf {
+    repo_root()
+        .join(".provekit/self-contracts-attestations")
+        .join(format!("{lang}.json"))
+}
+
 fn load_self_contract_attestations(profile: Profile) -> Result<Vec<KitSelfContractAttestation>> {
     let mut out = Vec::new();
     for kit in profile.required_kits() {
         let attestation_lang = attestation_lang_for_kit(kit);
-        let path = repo_root()
-            .join(".provekit/self-contracts-attestations")
-            .join(format!("{attestation_lang}.json"));
+        let path = attestation_path(attestation_lang);
         let raw = fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
         let parsed: SelfContractAttestationJson =
             serde_json::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))?;
@@ -439,91 +546,294 @@ fn load_self_contract_attestations(profile: Profile) -> Result<Vec<KitSelfContra
         out.push(KitSelfContractAttestation {
             kit: kit.to_string(),
             attestation_lang: attestation_lang.to_string(),
+            bundle_cid: parsed.cid,
             contract_set_cid: parsed.contract_set_cid,
+            path,
         });
     }
     Ok(out)
 }
 
-fn mint_protocol_contract_bridge(
-    attestation: &KitSelfContractAttestation,
-) -> Result<MintedEnvelope> {
-    if !cid_is_well_formed(&attestation.contract_set_cid) {
+fn parse_mint_stdout(stdout: &str) -> Result<MintStdoutArtifact> {
+    let bundle_cid = stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("blake3-512:"))
+        .ok_or_else(|| "mint output missing live bundle CID".to_string())?
+        .to_string();
+    if !cid_is_well_formed(&bundle_cid) {
+        return Err(format!("mint output bundle CID is malformed: {bundle_cid}"));
+    }
+
+    let contract_set_cid = stdout
+        .lines()
+        .map(str::trim)
+        .find_map(|line| line.strip_prefix("contractSetCid:").map(str::trim))
+        .ok_or_else(|| "mint output missing contractSetCid".to_string())?
+        .to_string();
+    if !cid_is_well_formed(&contract_set_cid) {
         return Err(format!(
-            "{} self-contract set CID is malformed: {}",
-            attestation.kit, attestation.contract_set_cid
+            "mint output contractSetCid is malformed: {contract_set_cid}"
         ));
     }
-    let args = MintBridgeV14Args {
-        name: format!(
-            "{}-self-contracts-implements-provekit-protocol",
-            attestation.attestation_lang
-        ),
-        source_symbol: "self_contracts".into(),
-        source_layer: format!("{}-self-contracts", attestation.attestation_lang),
-        source_contract_cid: attestation.contract_set_cid.clone(),
-        target: BridgeTargetV14::ContractSet {
-            cid: EXPECTED_PROTOCOL_CONTRACT_SET_CID.into(),
-        },
-        target_witness_cid: None,
-        target_binary_cid: None,
-        target_layer: Some("provekit-protocol-contracts".into()),
-        target_contract_set_cid: None,
-        produced_by: Some("cross-kit-conformance@0.1".into()),
-        produced_at: Some(PROTOCOL_BRIDGE_DECLARED_AT.into()),
-        declared_at: PROTOCOL_BRIDGE_DECLARED_AT.into(),
-        signer_seed: [0x42; 32],
-    };
-    Ok(mint_bridge_v14(&args))
+
+    Ok(MintStdoutArtifact {
+        bundle_cid,
+        contract_set_cid,
+    })
 }
 
-fn assert_protocol_bridge_targets_protocol_set(
-    canonical_bytes: &[u8],
-    attestation: &KitSelfContractAttestation,
-) -> Result<()> {
-    let raw = std::str::from_utf8(canonical_bytes)
-        .map_err(|e| format!("bridge bytes are not UTF-8: {e}"))?;
-    if raw.contains("pending-") || raw.contains("deferred:") || raw.contains("null") {
-        return Err("protocol bridge contains a placeholder or null".to_string());
+fn provekit_bin() -> PathBuf {
+    repo_root().join("implementations/rust/target/release/provekit")
+}
+
+fn json_to_cvalue(j: &JsonValue) -> Arc<CValue> {
+    match j {
+        JsonValue::Null => CValue::null(),
+        JsonValue::Bool(b) => CValue::boolean(*b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CValue::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                CValue::integer(u as i64)
+            } else {
+                CValue::integer(0)
+            }
+        }
+        JsonValue::String(s) => CValue::string(s.clone()),
+        JsonValue::Array(items) => CValue::array(items.iter().map(json_to_cvalue).collect()),
+        JsonValue::Object(map) => CValue::object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), json_to_cvalue(v)))
+                .collect::<Vec<_>>(),
+        ),
+    }
+}
+
+fn compute_contract_set_cid(mut contract_cids: Vec<String>) -> String {
+    contract_cids.sort();
+    let values = contract_cids
+        .into_iter()
+        .map(CValue::string)
+        .collect::<Vec<_>>();
+    let jcs = encode_jcs(&CValue::array(values));
+    blake3_512_of(jcs.as_bytes())
+}
+
+fn contract_content_cid_from_memento(envelope: &JsonValue) -> Result<String> {
+    let body = provekit_verifier::types::memento_body(envelope)
+        .ok_or_else(|| "contract memento has no body/header".to_string())?;
+    let name = body
+        .get("name")
+        .or_else(|| body.get("contractName"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "contract memento missing name/contractName".to_string())?;
+    let out_binding = body
+        .get("outBinding")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "contract memento missing string outBinding".to_string())?;
+
+    let mut entries = vec![
+        ("name".to_string(), CValue::string(name.to_string())),
+        (
+            "outBinding".to_string(),
+            CValue::string(out_binding.to_string()),
+        ),
+    ];
+    for key in ["pre", "post", "inv"] {
+        if let Some(value) = body.get(key) {
+            entries.push((key.to_string(), json_to_cvalue(value)));
+        }
     }
 
-    let bridge: serde_json::Value =
-        serde_json::from_slice(canonical_bytes).map_err(|e| format!("parse bridge JCS: {e}"))?;
-    let header = bridge
-        .get("header")
-        .and_then(|v| v.as_object())
-        .ok_or_else(|| "bridge header missing or not an object".to_string())?;
-    if header.get("kind").and_then(|v| v.as_str()) != Some("bridge") {
-        return Err("bridge header.kind must be bridge".to_string());
+    let derived = blake3_512_of(encode_jcs(&CValue::object(entries)).as_bytes());
+    if let Some(header_cid) = body.get("cid").and_then(|v| v.as_str()) {
+        if header_cid != derived {
+            return Err(format!(
+                "contract content CID drift:\n  got:  {derived}\n  want: {header_cid}"
+            ));
+        }
     }
-    if header.get("sourceContractCid").and_then(|v| v.as_str())
-        != Some(attestation.contract_set_cid.as_str())
-    {
+    Ok(derived)
+}
+
+fn contract_content_cids_from_pool(pool: &provekit_verifier::MementoPool) -> Result<Vec<String>> {
+    let mut cids = Vec::new();
+    for (memento_cid, envelope) in &pool.mementos {
+        if provekit_verifier::types::memento_kind(envelope) == Some("contract") {
+            let cid = contract_content_cid_from_memento(envelope)
+                .map_err(|e| format!("contract member {memento_cid}: {e}"))?;
+            cids.push(cid);
+        }
+    }
+    Ok(cids)
+}
+
+fn validate_live_proof_artifact(
+    kit: &str,
+    artifact_dir: &Path,
+    bundle_cid: &str,
+) -> Result<LiveProofArtifactValidation> {
+    let proof_path = artifact_dir.join(format!("{bundle_cid}.proof"));
+    let bytes = fs::read(&proof_path).map_err(|e| format!("read {}: {e}", proof_path.display()))?;
+    if bytes.is_empty() {
+        return Err(format!("{kit} proof artifact is empty"));
+    }
+    let recomputed = blake3_512_of(&bytes);
+    if recomputed != bundle_cid {
         return Err(format!(
-            "{} bridge sourceContractCid does not match self contractSetCid",
-            attestation.kit
+            "{kit} proof artifact CID drift:\n  got:  {recomputed}\n  want: {bundle_cid}"
         ));
     }
-    let expected_source_layer = format!("{}-self-contracts", attestation.attestation_lang);
-    if header.get("sourceLayer").and_then(|v| v.as_str()) != Some(expected_source_layer.as_str()) {
+
+    let pool = provekit_verifier::load_all_proofs::run(artifact_dir);
+    if !pool.load_errors.is_empty() {
+        let details = pool
+            .load_errors
+            .iter()
+            .map(|e| format!("{}: {}", e.proof_path, e.reason))
+            .collect::<Vec<_>>()
+            .join("\n  ");
         return Err(format!(
-            "{} bridge sourceLayer does not name the kit self-contracts layer",
-            attestation.kit
+            "{kit} proof artifact has load errors:\n  {details}"
         ));
     }
-    let target = header
-        .get("target")
-        .and_then(|v| v.as_object())
-        .ok_or_else(|| "bridge header.target missing or not an object".to_string())?;
-    if target.get("kind").and_then(|v| v.as_str()) != Some("contractSet") {
-        return Err("bridge target.kind must be contractSet".to_string());
+
+    let members = pool
+        .bundle_members
+        .get(bundle_cid)
+        .ok_or_else(|| format!("{kit} proof artifact did not load bundle {bundle_cid}"))?;
+    if members.is_empty() {
+        return Err(format!("{kit} proof artifact loaded with zero members"));
     }
-    if target.get("cid").and_then(|v| v.as_str()) != Some(EXPECTED_PROTOCOL_CONTRACT_SET_CID) {
+
+    let contract_cids = contract_content_cids_from_pool(&pool)?;
+    if contract_cids.is_empty() {
+        return Err(format!("{kit} proof artifact has no contract mementos"));
+    }
+    let derived_contract_set_cid = compute_contract_set_cid(contract_cids.clone());
+
+    Ok(LiveProofArtifactValidation {
+        proof_bytes_len: bytes.len(),
+        proof_member_count: members.len(),
+        proof_contract_count: contract_cids.len(),
+        derived_contract_set_cid,
+    })
+}
+
+fn bootstrap_self_contract_toolchains(profile: Profile) -> Result<()> {
+    for target in self_contract_bootstrap_targets(profile) {
+        println!("  bootstrap: make {target}");
+        let cmd = vec!["make".to_string(), target.to_string()];
+        let proc = run_cmd(&cmd, &repo_root(), Duration::from_secs(900));
+        if proc.code != 0 {
+            return Err(command_error(&cmd, &proc));
+        }
+    }
+    Ok(())
+}
+
+fn mint_live_self_contract_artifact(
+    producer: SelfContractProducer,
+) -> Result<LiveSelfContractArtifact> {
+    let tmp = TempDir::new(&format!(
+        "pk_{}_self_contract_bootstrap",
+        producer.attestation_lang
+    ))?;
+    let cmd = vec![
+        provekit_bin().display().to_string(),
+        "mint".to_string(),
+        "--kit".to_string(),
+        producer.mint_kit_alias.to_string(),
+        "--quiet".to_string(),
+        "--no-attest".to_string(),
+        "--out".to_string(),
+        tmp.path().display().to_string(),
+    ];
+    let proc = run_cmd(&cmd, &repo_root(), Duration::from_secs(600));
+    if proc.code != 0 {
+        return Err(command_error(&cmd, &proc));
+    }
+
+    let parsed = parse_mint_stdout(&proc.stdout)?;
+    if parsed.contract_set_cid == EMPTY_CONTRACT_SET_CID {
+        return Err("live mint produced the empty self-contract set".to_string());
+    }
+
+    let proof = validate_live_proof_artifact(producer.kit, tmp.path(), &parsed.bundle_cid)?;
+    if proof.derived_contract_set_cid != parsed.contract_set_cid {
         return Err(format!(
-            "{} bridge target.cid does not match pinned protocolContractSetCid",
-            attestation.kit
+            "{} proof artifact contractSetCid drift:\n  got:  {}\n  want: {}",
+            producer.kit, proof.derived_contract_set_cid, parsed.contract_set_cid
         ));
     }
+
+    Ok(LiveSelfContractArtifact {
+        kit: producer.kit,
+        attestation_lang: producer.attestation_lang,
+        bundle_cid: parsed.bundle_cid,
+        contract_set_cid: parsed.contract_set_cid,
+        proof_bytes_len: proof.proof_bytes_len,
+        proof_member_count: proof.proof_member_count,
+        proof_contract_count: proof.proof_contract_count,
+    })
+}
+
+fn verify_self_contract_attestation(
+    attestation: &KitSelfContractAttestation,
+    observed_contract_set_cid: &str,
+) -> Result<()> {
+    let verifier = repo_root().join("tools/foundation-keygen/target/release/verify-self-contracts");
+    let cmd = vec![
+        verifier.display().to_string(),
+        attestation.path.display().to_string(),
+        observed_contract_set_cid.to_string(),
+    ];
+    let proc = run_cmd(&cmd, &repo_root(), Duration::from_secs(30));
+    if proc.code != 0 {
+        return Err(command_error(&cmd, &proc));
+    }
+    Ok(())
+}
+
+fn sign_self_contract_attestation(artifact: &LiveSelfContractArtifact) -> Result<()> {
+    let signer = repo_root().join("tools/foundation-keygen/target/release/sign-self-contracts");
+    let cmd = vec![
+        signer.display().to_string(),
+        artifact.attestation_lang.to_string(),
+        artifact.bundle_cid.clone(),
+        artifact.contract_set_cid.clone(),
+    ];
+    let proc = run_cmd(&cmd, &repo_root(), Duration::from_secs(30));
+    if proc.code != 0 {
+        return Err(command_error(&cmd, &proc));
+    }
+    Ok(())
+}
+
+fn assert_live_artifact_matches_attestation(
+    artifact: &LiveSelfContractArtifact,
+    attestation: &KitSelfContractAttestation,
+) -> Result<()> {
+    if artifact.attestation_lang != attestation.attestation_lang {
+        return Err(format!(
+            "{} live artifact lang={} but attestation lang={}",
+            artifact.kit, artifact.attestation_lang, attestation.attestation_lang
+        ));
+    }
+    if artifact.bundle_cid != attestation.bundle_cid {
+        return Err(format!(
+            "{} live bundle CID does not match pinned attestation CID:\n  got:  {}\n  want: {}",
+            artifact.kit, artifact.bundle_cid, attestation.bundle_cid
+        ));
+    }
+    if artifact.contract_set_cid != attestation.contract_set_cid {
+        return Err(format!(
+            "{} live contractSetCid does not match pinned attestation:\n  got:  {}\n  want: {}",
+            artifact.kit, artifact.contract_set_cid, attestation.contract_set_cid
+        ));
+    }
+    verify_self_contract_attestation(attestation, &artifact.contract_set_cid)?;
     Ok(())
 }
 
@@ -1957,8 +2267,12 @@ fn run_native_checks(checks: &[NativeCheck], jobs: usize) -> usize {
     failures
 }
 
-fn run_protocol_contract_gate(profile: Profile) -> Result<usize> {
-    println!("\nProtocol Contract Bridge Gate");
+fn run_protocol_contract_gate(
+    profile: Profile,
+    jobs: usize,
+    bootstrap_self_contract_attestations: bool,
+) -> Result<usize> {
+    println!("\nProtocol Contract Bootstrap Gate");
     let got = protocol_contract_set_cid()?;
     if got != EXPECTED_PROTOCOL_CONTRACT_SET_CID {
         return Err(format!(
@@ -1967,15 +2281,56 @@ fn run_protocol_contract_gate(profile: Profile) -> Result<usize> {
     }
     println!("  protocolContractSetCid: {got}");
 
+    bootstrap_self_contract_toolchains(profile)?;
+
+    let producers = self_contract_producers(profile);
+    let mint_jobs: Vec<OrderedJob<(SelfContractProducer, Result<LiveSelfContractArtifact>)>> =
+        producers
+            .into_iter()
+            .map(|producer| {
+                Box::new(move || {
+                    let result = mint_live_self_contract_artifact(producer);
+                    (producer, result)
+                })
+                    as OrderedJob<(SelfContractProducer, Result<LiveSelfContractArtifact>)>
+            })
+            .collect();
+
     let mut failures = 0;
-    for attestation in load_self_contract_attestations(profile)? {
-        match mint_protocol_contract_bridge(&attestation).and_then(|bridge| {
-            assert_protocol_bridge_targets_protocol_set(&bridge.canonical_bytes, &attestation)
+    let minted = run_ordered_jobs(mint_jobs, jobs);
+
+    if bootstrap_self_contract_attestations {
+        println!("  bootstrapping self-contract attestations from live kit artifacts");
+        for (_, result) in &minted {
+            if let Ok(artifact) = result {
+                if let Err(e) = sign_self_contract_attestation(artifact) {
+                    failures += 1;
+                    println!(
+                        "  FAIL {:<10} attestation bootstrap failed: {e}",
+                        artifact.kit
+                    );
+                }
+            }
+        }
+    }
+
+    let attestations = load_self_contract_attestations(profile)?;
+    for (producer, result) in minted {
+        let attestation = attestations
+            .iter()
+            .find(|a| a.attestation_lang == producer.attestation_lang)
+            .ok_or_else(|| format!("missing attestation for {}", producer.attestation_lang))?;
+        match result.and_then(|artifact| {
+            assert_live_artifact_matches_attestation(&artifact, attestation)?;
+            Ok(artifact)
         }) {
-            Ok(()) => {
+            Ok(artifact) => {
                 println!(
-                    "  PASS {:<10} selfContractSetCid -> protocolContractSetCid",
-                    attestation.kit
+                    "  PASS {:<10} live proof {} bytes, {} members, {} contracts; selfContractSetCid pinned",
+                    attestation.kit,
+                    artifact.proof_bytes_len,
+                    artifact.proof_member_count,
+                    artifact.proof_contract_count
                 );
             }
             Err(e) => {
@@ -1991,11 +2346,15 @@ fn print_help() {
     println!(
         "cross-kit-conformance\n\
          \n\
-         Usage: cross-kit-conformance [--profile linux|swift|all] [--jobs N]\n\
+         Usage: cross-kit-conformance [--profile linux|swift|all] [--jobs N] [--bootstrap-self-contract-attestations]\n\
          \n\
          The Rust harness validates catalog-pinned fixture CIDs. Adapters may\n\
          produce any representation internally; the conformance boundary is\n\
          the protocol CID.\n\
+         \n\
+         --bootstrap-self-contract-attestations re-signs the pinned\n\
+         .provekit/self-contracts-attestations/*.json files from live,\n\
+         verifier-loadable kit-emitted proof artifacts before checking them.\n\
          \n\
          --jobs N runs selected kit/check jobs concurrently. The default is\n\
          bounded to 4 so local and CI output stay usable."
@@ -2010,6 +2369,7 @@ where
     let mut config = RunConfig {
         profile: Profile::default_for_host(),
         jobs: default_jobs(),
+        bootstrap_self_contract_attestations: false,
     };
     let mut args = args.into_iter().map(Into::into).skip(1);
     while let Some(arg) = args.next() {
@@ -2031,6 +2391,9 @@ where
                     return Err("--jobs must be greater than zero".to_string());
                 }
                 config.jobs = jobs;
+            }
+            "--bootstrap-self-contract-attestations" | "--update-self-contract-attestations" => {
+                config.bootstrap_self_contract_attestations = true;
             }
             "-h" | "--help" => {
                 print_help();
@@ -2071,8 +2434,11 @@ fn run(config: RunConfig) -> Result<usize> {
     }
     assert_profile_inventory(profile, &direct, &native)?;
 
-    let failures = run_protocol_contract_gate(profile)?
-        + run_direct_adapters(&direct, &fixtures, config.jobs)
+    let failures = run_protocol_contract_gate(
+        profile,
+        config.jobs,
+        config.bootstrap_self_contract_attestations,
+    )? + run_direct_adapters(&direct, &fixtures, config.jobs)
         + run_native_checks(&native, config.jobs);
     println!("\nResult");
     if failures == 0 {
@@ -2170,10 +2536,18 @@ mod tests {
 
     #[test]
     fn jobs_argument_parses_and_rejects_zero() {
-        let config = parse_config(["cross-kit-conformance", "--profile", "linux", "--jobs", "3"])
-            .expect("parse config");
+        let config = parse_config([
+            "cross-kit-conformance",
+            "--profile",
+            "linux",
+            "--jobs",
+            "3",
+            "--bootstrap-self-contract-attestations",
+        ])
+        .expect("parse config");
         assert_eq!(config.profile, Profile::Linux);
         assert_eq!(config.jobs, 3);
+        assert!(config.bootstrap_self_contract_attestations);
 
         let err = parse_config(["cross-kit-conformance", "--jobs", "0"])
             .expect_err("zero jobs must be rejected");
@@ -2195,22 +2569,84 @@ mod tests {
     }
 
     #[test]
+    fn run_cmd_drains_large_child_stderr() {
+        let cmd = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "i=0; while [ $i -lt 20000 ]; do echo noisy >&2; i=$((i+1)); done; echo done"
+                .to_string(),
+        ];
+        let result = run_cmd(&cmd, &repo_root(), Duration::from_secs(10));
+        assert_eq!(result.code, 0, "stderr: {}", tail(&result.stderr, 400));
+        assert!(result.stdout.contains("done"));
+        assert!(
+            result.stderr.len() > 16 * 1024,
+            "test must exceed a small pipe buffer"
+        );
+    }
+
+    #[test]
+    fn self_contract_bootstrap_covers_linux_profile_with_real_mint_emitters() {
+        let producers = self_contract_producers(Profile::Linux);
+        let kits: Vec<_> = producers.iter().map(|producer| producer.kit).collect();
+        assert_eq!(kits, Profile::Linux.required_kits());
+        assert!(producers
+            .iter()
+            .all(|producer| !producer.mint_kit_alias.is_empty()));
+        assert!(self_contract_bootstrap_targets(Profile::Linux).contains(&"build-rust"));
+    }
+
+    #[test]
+    fn mint_stdout_requires_bundle_and_contract_set_cids() {
+        let artifact = parse_mint_stdout(
+            "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\ncontractSetCid: blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+        )
+        .expect("parse full mint output");
+        assert_eq!(artifact.bundle_cid.len(), 139);
+        assert_eq!(artifact.contract_set_cid.len(), 139);
+
+        let err = parse_mint_stdout(
+            "contractSetCid: blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+        )
+        .expect_err("bundle cid is required");
+        assert!(err.contains("bundle CID"), "got: {err}");
+    }
+
+    #[test]
+    fn live_proof_validation_rejects_hash_correct_garbage() {
+        let tmp = TempDir::new("pk_garbage_proof").expect("tempdir");
+        let bytes = b"not a proof envelope";
+        let cid = blake3_512_of(bytes);
+        fs::write(tmp.path().join(format!("{cid}.proof")), bytes).expect("write garbage proof");
+
+        let err = validate_live_proof_artifact("rust", tmp.path(), &cid)
+            .expect_err("hash-correct garbage proof must be rejected");
+        assert!(err.contains("load errors"), "got: {err}");
+    }
+
+    #[test]
     fn protocol_contract_set_cid_is_pinned_to_rust_source() {
         let got = protocol_contract_set_cid().expect("derive protocol contract set CID");
         assert_eq!(got, EXPECTED_PROTOCOL_CONTRACT_SET_CID);
     }
 
     #[test]
-    fn protocol_contract_bridges_target_pinned_contract_set() {
+    fn self_contract_attestations_pin_non_empty_live_artifact_cids() {
         let attestations =
             load_self_contract_attestations(Profile::Linux).expect("load linux attestations");
         assert_eq!(attestations.len(), 11);
 
         for attestation in attestations {
-            let bridge = mint_protocol_contract_bridge(&attestation)
-                .expect("mint protocol contract-set bridge");
-            assert_protocol_bridge_targets_protocol_set(&bridge.canonical_bytes, &attestation)
-                .expect("bridge targets pinned protocol contract set");
+            assert!(
+                cid_is_well_formed(&attestation.bundle_cid),
+                "{} bundle cid is malformed",
+                attestation.kit
+            );
+            assert_ne!(
+                attestation.contract_set_cid, EMPTY_CONTRACT_SET_CID,
+                "{} self-contract set is empty",
+                attestation.kit
+            );
         }
     }
 }

--- a/tools/cross-kit-conformance/src/lib.rs
+++ b/tools/cross-kit-conformance/src/lib.rs
@@ -75,7 +75,6 @@ struct FixtureToml {
 struct KitSelfContractAttestation {
     kit: String,
     attestation_lang: String,
-    bundle_cid: String,
     contract_set_cid: String,
     path: PathBuf,
 }
@@ -605,7 +604,6 @@ fn load_self_contract_attestations(profile: Profile) -> Result<Vec<KitSelfContra
         out.push(KitSelfContractAttestation {
             kit: kit.to_string(),
             attestation_lang: attestation_lang.to_string(),
-            bundle_cid: parsed.cid,
             contract_set_cid: parsed.contract_set_cid,
             path,
         });
@@ -880,18 +878,16 @@ fn assert_live_artifact_matches_attestation(
             artifact.kit, artifact.attestation_lang, attestation.attestation_lang
         ));
     }
-    if artifact.bundle_cid != attestation.bundle_cid {
-        return Err(format!(
-            "{} live bundle CID does not match pinned attestation CID:\n  got:  {}\n  want: {}",
-            artifact.kit, artifact.bundle_cid, attestation.bundle_cid
-        ));
-    }
     if artifact.contract_set_cid != attestation.contract_set_cid {
         return Err(format!(
             "{} live contractSetCid does not match pinned attestation:\n  got:  {}\n  want: {}",
             artifact.kit, artifact.contract_set_cid, attestation.contract_set_cid
         ));
     }
+    // Bundle CIDs are representation CIDs and are signed for provenance, but
+    // spec #94 makes contractSetCid the trust comparison. The verifier below
+    // validates the pinned attestation signature and compares that signed
+    // contractSetCid with the freshly-minted artifact.
     verify_self_contract_attestation(attestation, &artifact.contract_set_cid)?;
     Ok(())
 }
@@ -2734,17 +2730,12 @@ mod tests {
     }
 
     #[test]
-    fn self_contract_attestations_pin_non_empty_live_artifact_cids() {
+    fn self_contract_attestations_pin_non_empty_contract_set_cids() {
         let attestations =
             load_self_contract_attestations(Profile::Linux).expect("load linux attestations");
         assert_eq!(attestations.len(), 11);
 
         for attestation in attestations {
-            assert!(
-                cid_is_well_formed(&attestation.bundle_cid),
-                "{} bundle cid is malformed",
-                attestation.kit
-            );
             assert_ne!(
                 attestation.contract_set_cid, EMPTY_CONTRACT_SET_CID,
                 "{} self-contract set is empty",

--- a/tools/cross-kit-conformance/src/lib.rs
+++ b/tools/cross-kit-conformance/src/lib.rs
@@ -318,6 +318,18 @@ fn run_cmd_env(
         .current_dir(cwd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    if !envs.iter().any(|(key, _)| *key == "PATH") {
+        let current_path = std::env::var_os("PATH");
+        command.env(
+            "PATH",
+            prepend_unique_path_dirs(current_path.as_ref(), &runtime_bin_dir_candidates()),
+        );
+    }
+    if !envs.iter().any(|(key, _)| *key == "JAVA_HOME") {
+        if let Some(java_home) = detect_java_home() {
+            command.env("JAVA_HOME", java_home);
+        }
+    }
     for (key, value) in envs {
         command.env(key, value);
     }
@@ -376,6 +388,44 @@ fn run_cmd_env(
             }
         }
     }
+}
+
+fn runtime_bin_dir_candidates() -> Vec<PathBuf> {
+    [
+        "/usr/local/opt/ruby/bin",
+        "/opt/homebrew/opt/ruby/bin",
+        "/usr/local/opt/openjdk/bin",
+        "/opt/homebrew/opt/openjdk/bin",
+    ]
+    .into_iter()
+    .map(PathBuf::from)
+    .filter(|p| p.is_dir())
+    .collect()
+}
+
+fn detect_java_home() -> Option<PathBuf> {
+    ["/usr/local/opt/openjdk", "/opt/homebrew/opt/openjdk"]
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|home| home.join("bin/java").is_file())
+}
+
+fn prepend_unique_path_dirs(base: Option<&OsString>, dirs: &[PathBuf]) -> OsString {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for dir in dirs {
+        if seen.insert(dir.clone()) {
+            out.push(dir.clone());
+        }
+    }
+    if let Some(base) = base {
+        for dir in std::env::split_paths(base) {
+            if seen.insert(dir.clone()) {
+                out.push(dir);
+            }
+        }
+    }
+    std::env::join_paths(out).unwrap_or_else(|_| base.cloned().unwrap_or_default())
 }
 
 fn spawn_output_reader<R>(mut pipe: R) -> thread::JoinHandle<Vec<u8>>
@@ -473,6 +523,7 @@ fn self_contract_bootstrap_targets(profile: Profile) -> Vec<&'static str> {
             "typescript" => Some("build-ts"),
             "csharp" => Some("build-csharp"),
             "java" => Some("build-java-self-contracts"),
+            "ruby" => Some("build-ruby"),
             "c" => Some("build-c-self-contracts"),
             "zig" => Some("build-zig"),
             "swift" => Some("build-swift"),
@@ -2593,7 +2644,47 @@ mod tests {
         assert!(producers
             .iter()
             .all(|producer| !producer.mint_kit_alias.is_empty()));
-        assert!(self_contract_bootstrap_targets(Profile::Linux).contains(&"build-rust"));
+        let targets = self_contract_bootstrap_targets(Profile::Linux);
+        assert!(targets.contains(&"build-rust"));
+        assert!(targets.contains(&"build-ruby"));
+    }
+
+    #[test]
+    fn conformance_path_prefers_homebrew_runtime_bins_before_usr_bin() {
+        let base = OsString::from(
+            "/usr/bin:/bin:/usr/local/opt/ruby/bin:/usr/local/opt/openjdk/bin:/usr/local/bin",
+        );
+        let got = prepend_unique_path_dirs(
+            Some(&base),
+            &[
+                PathBuf::from("/usr/local/opt/ruby/bin"),
+                PathBuf::from("/usr/local/opt/openjdk/bin"),
+            ],
+        );
+        let parts: Vec<_> = std::env::split_paths(&got).collect();
+
+        let ruby_pos = parts
+            .iter()
+            .position(|p| p == Path::new("/usr/local/opt/ruby/bin"))
+            .expect("ruby bin present");
+        let java_pos = parts
+            .iter()
+            .position(|p| p == Path::new("/usr/local/opt/openjdk/bin"))
+            .expect("openjdk bin present");
+        let usr_pos = parts
+            .iter()
+            .position(|p| p == Path::new("/usr/bin"))
+            .expect("/usr/bin present");
+
+        assert!(ruby_pos < usr_pos, "ruby bin must outrank /usr/bin");
+        assert!(java_pos < usr_pos, "openjdk bin must outrank /usr/bin");
+        assert_eq!(
+            parts
+                .iter()
+                .filter(|p| p == &&PathBuf::from("/usr/local/opt/ruby/bin"))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/tools/cross-kit-conformance/src/lib.rs
+++ b/tools/cross-kit-conformance/src/lib.rs
@@ -403,6 +403,14 @@ fn runtime_bin_dir_candidates() -> Vec<PathBuf> {
     .collect()
 }
 
+fn ruby_bundle_exec_cmd(args: &[&str]) -> Vec<String> {
+    ["ruby", "-S", "bundle", "exec", "ruby"]
+        .into_iter()
+        .chain(args.iter().copied())
+        .map(String::from)
+        .collect()
+}
+
 fn detect_java_home() -> Option<PathBuf> {
     ["/usr/local/opt/openjdk", "/opt/homebrew/opt/openjdk"]
         .into_iter()
@@ -1717,13 +1725,7 @@ else
 end
 "#;
     command_stdout(
-        &[
-            "ruby".into(),
-            "-Ilib".into(),
-            "-e".into(),
-            code.into(),
-            name.into(),
-        ],
+        &ruby_bundle_exec_cmd(&["-Ilib", "-e", code, name]),
         &root.join("implementations/ruby"),
         Duration::from_secs(60),
     )
@@ -2040,12 +2042,7 @@ fn linux_native_checks() -> Vec<NativeCheck> {
         NativeCheck {
             kit: "ruby",
             name: "ruby bridge_v1_4 fixture CID",
-            cmd: vec![
-                "ruby".into(),
-                "-Ilib".into(),
-                "-Itest".into(),
-                "test/test_bridge_v14.rb".into(),
-            ],
+            cmd: ruby_bundle_exec_cmd(&["-Ilib", "-Itest", "test/test_bridge_v14.rb"]),
             cwd: root.join("implementations/ruby"),
             timeout: Duration::from_secs(120),
         },
@@ -2685,6 +2682,21 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn ruby_fixture_commands_run_under_bundler() {
+        let cmd = ruby_bundle_exec_cmd(&["-Ilib", "-e", "puts :ok"]);
+        assert_eq!(
+            cmd,
+            vec!["ruby", "-S", "bundle", "exec", "ruby", "-Ilib", "-e", "puts :ok"]
+        );
+
+        let native = linux_native_checks()
+            .into_iter()
+            .find(|check| check.kit == "ruby")
+            .expect("ruby native check");
+        assert_eq!(&native.cmd[..5], ["ruby", "-S", "bundle", "exec", "ruby"]);
     }
 
     #[test]

--- a/tools/foundation-keygen/src/bin/sign_self_contracts.rs
+++ b/tools/foundation-keygen/src/bin/sign_self_contracts.rs
@@ -30,7 +30,7 @@ use std::process::ExitCode;
 
 use foundation_keygen::{
     build_signed_self_contracts_attestation, self_contracts_attestation_path_for,
-    FOUNDATION_V0_SEED, SELF_CONTRACTS_DECLARED_AT_V1_3_1, SELF_CONTRACTS_LANGS,
+    FOUNDATION_V0_SEED, SELF_CONTRACTS_DECLARED_AT_V1_6_0, SELF_CONTRACTS_LANGS,
 };
 
 fn validate_cid(cid: &str, name: &str) -> Result<(), String> {
@@ -53,9 +53,12 @@ fn validate_cid(cid: &str, name: &str) -> Result<(), String> {
 
 fn run() -> Result<(), String> {
     let mut args = std::env::args().skip(1);
-    let lang = args
-        .next()
-        .ok_or_else(|| "missing <lang> argument (rust|go|cpp|ts|csharp)".to_string())?;
+    let lang = args.next().ok_or_else(|| {
+        format!(
+            "missing <lang> argument; expected one of {:?}",
+            SELF_CONTRACTS_LANGS
+        )
+    })?;
     let cid = args
         .next()
         .ok_or_else(|| "missing <bundle-cid> argument (blake3-512:<128 hex>)".to_string())?;
@@ -83,7 +86,7 @@ fn run() -> Result<(), String> {
         &lang,
         &cid,
         &contract_set_cid,
-        SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+        SELF_CONTRACTS_DECLARED_AT_V1_6_0,
     )?;
 
     let out_path = self_contracts_attestation_path_for(&lang);
@@ -100,7 +103,7 @@ fn run() -> Result<(), String> {
     println!("lang:              {}", lang);
     println!("cid:               {}", cid);
     println!("contractSetCid:    {}", contract_set_cid);
-    println!("declaredAt:        {}", SELF_CONTRACTS_DECLARED_AT_V1_3_1);
+    println!("declaredAt:        {}", SELF_CONTRACTS_DECLARED_AT_V1_6_0);
     println!("signer:            {}", attestation["signer"]);
     println!("signature:         {}", attestation["signature"]);
     println!();

--- a/tools/foundation-keygen/src/lib.rs
+++ b/tools/foundation-keygen/src/lib.rs
@@ -126,23 +126,23 @@ pub fn self_contracts_attestation_path_for(lang: &str) -> PathBuf {
         .join(format!("{lang}.json"))
 }
 
-/// Pinned `declaredAt` for self-contracts attestations under the v0
-/// foundation key. One constant per protocol-catalog version because
-/// the attestation is bound to a catalog CID; bumping protocol versions
-/// regenerates the attestation. CID drift between catalog versions does
-/// not move this timestamp, so re-signing the same bundle CID under the
-/// same protocol version produces byte-identical output. v1 of the
-/// foundation key may use signing-time clocks; this is a v0 invariant.
+/// Historical pinned `declaredAt` for self-contracts attestations from
+/// the v1.3.1 catalog cut.
 pub const SELF_CONTRACTS_DECLARED_AT_V1_3_1: &str = "2026-05-02T17:00:00Z";
+
+/// Current pinned `declaredAt` for self-contracts attestations under the
+/// v0 foundation key. Self-contract attestations are regenerated as part
+/// of the protocol bootstrap for the current catalog cut, not with a live
+/// clock, so re-running the same bootstrap remains byte-identical.
+pub const SELF_CONTRACTS_DECLARED_AT_V1_6_0: &str = V1_6_0_DECLARED_AT;
 
 /// Recognized peer identifiers for self-contracts attestations.
 /// Kept in sync with the Makefile's `mint-<lang>` targets.
-/// All 11 peer kits use the same letter-envelope attestation shape;
+/// All 12 peer kits use the same letter-envelope attestation shape;
 /// the source tree no longer carries machine-local truth about its own
 /// bytes for any kit.
 pub const SELF_CONTRACTS_LANGS: &[&str] = &[
-    "rust", "go", "cpp", "ts", "csharp",
-    "swift", "java", "python", "ruby", "zig", "c",
+    "rust", "go", "cpp", "ts", "csharp", "swift", "java", "python", "ruby", "zig", "c", "php",
 ];
 
 /// Build the signed message body for a self-contracts attestation
@@ -186,7 +186,8 @@ pub fn build_signed_self_contracts_attestation(
         ));
     }
     let signer_pubkey = ed25519_pubkey_string(seed);
-    let message = build_self_contracts_message(lang, cid, contract_set_cid, declared_at, &signer_pubkey);
+    let message =
+        build_self_contracts_message(lang, cid, contract_set_cid, declared_at, &signer_pubkey);
     let bytes = attestation_signing_bytes(&message)?;
     let signature = ed25519_sign_string(seed, &bytes);
     Ok(json!({
@@ -257,9 +258,8 @@ pub fn verify_signed_self_contracts_attestation(
             .map(|s| s.to_string())
             .ok_or_else(|| format!("self-contracts attestation missing string field `{k}`"))
     };
-    let get_str_opt = |k: &str| -> Option<String> {
-        obj.get(k).and_then(|v| v.as_str()).map(|s| s.to_string())
-    };
+    let get_str_opt =
+        |k: &str| -> Option<String> { obj.get(k).and_then(|v| v.as_str()).map(|s| s.to_string()) };
 
     let schema_version = get_str("schemaVersion")?;
     let kind = get_str("kind")?;
@@ -295,7 +295,10 @@ pub fn verify_signed_self_contracts_attestation(
         ),
         ("lang".to_string(), Value::string(lang)),
         ("cid".to_string(), Value::string(claimed_bundle_cid.clone())),
-        ("contractSetCid".to_string(), Value::string(claimed_contract_set_cid.clone())),
+        (
+            "contractSetCid".to_string(),
+            Value::string(claimed_contract_set_cid.clone()),
+        ),
         ("declaredAt".to_string(), Value::string(declared_at)),
         ("signer".to_string(), Value::string(signer.clone())),
     ];
@@ -331,10 +334,10 @@ fn repo_root() -> PathBuf {
 /// Compute the catalog CID via the same JCS-then-BLAKE3-512 path used
 /// by `tools/recompute-spec-cids/` and the CLI's `verify-protocol`.
 pub fn compute_catalog_cid_from_path(path: &Path) -> Result<String, String> {
-    let text = std::fs::read_to_string(path)
-        .map_err(|e| format!("read {}: {}", path.display(), e))?;
-    let json: JsonValue = serde_json::from_str(&text)
-        .map_err(|e| format!("parse catalog json: {}", e))?;
+    let text =
+        std::fs::read_to_string(path).map_err(|e| format!("read {}: {}", path.display(), e))?;
+    let json: JsonValue =
+        serde_json::from_str(&text).map_err(|e| format!("parse catalog json: {}", e))?;
     let canon = json_to_value(&json)?;
     let jcs = encode_jcs(&canon);
     Ok(blake3_512_of(jcs.as_bytes()))
@@ -345,9 +348,7 @@ fn json_to_value(j: &JsonValue) -> Result<Arc<Value>, String> {
         JsonValue::Null => Value::null(),
         JsonValue::Bool(b) => Value::boolean(*b),
         JsonValue::Number(n) => {
-            let i = n
-                .as_i64()
-                .ok_or_else(|| format!("non-i64 number: {}", n))?;
+            let i = n.as_i64().ok_or_else(|| format!("non-i64 number: {}", n))?;
             Value::integer(i)
         }
         JsonValue::String(s) => Value::string(s.clone()),
@@ -474,7 +475,7 @@ mod tests {
             "rust",
             cid,
             FAKE_CONTRACT_SET_CID,
-            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            SELF_CONTRACTS_DECLARED_AT_V1_6_0,
         )
         .unwrap();
         let b = build_signed_self_contracts_attestation(
@@ -482,7 +483,7 @@ mod tests {
             "rust",
             cid,
             FAKE_CONTRACT_SET_CID,
-            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            SELF_CONTRACTS_DECLARED_AT_V1_6_0,
         )
         .unwrap();
         assert_eq!(a, b);
@@ -496,7 +497,7 @@ mod tests {
             "perl",
             cid,
             FAKE_CONTRACT_SET_CID,
-            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            SELF_CONTRACTS_DECLARED_AT_V1_6_0,
         )
         .unwrap_err();
         assert!(err.contains("unknown lang"));
@@ -512,13 +513,12 @@ mod tests {
             "go",
             cid,
             FAKE_CONTRACT_SET_CID,
-            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            SELF_CONTRACTS_DECLARED_AT_V1_6_0,
         )
         .unwrap();
         let bytes = serde_json::to_vec(&attestation).unwrap();
-        let verdict = verify_signed_self_contracts_attestation(
-            &bytes, &pk, FAKE_CONTRACT_SET_CID,
-        ).unwrap();
+        let verdict =
+            verify_signed_self_contracts_attestation(&bytes, &pk, FAKE_CONTRACT_SET_CID).unwrap();
         assert!(verdict.signer_matches);
         assert!(verdict.signature_ok);
         assert!(verdict.contract_set_cid_matches);
@@ -536,14 +536,13 @@ mod tests {
             "cpp",
             cid,
             FAKE_CONTRACT_SET_CID,
-            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            SELF_CONTRACTS_DECLARED_AT_V1_6_0,
         )
         .unwrap();
         let bytes = serde_json::to_vec(&attestation).unwrap();
         let drifted_set_cid = "blake3-512:cafe0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-        let verdict = verify_signed_self_contracts_attestation(
-            &bytes, &pk, drifted_set_cid,
-        ).unwrap();
+        let verdict =
+            verify_signed_self_contracts_attestation(&bytes, &pk, drifted_set_cid).unwrap();
         assert!(verdict.signer_matches, "signer untouched");
         assert!(verdict.signature_ok, "signature still verifies");
         assert!(!verdict.contract_set_cid_matches, "contractSetCid drifted");
@@ -556,7 +555,7 @@ mod tests {
         // NOT a failure. Same contracts, different bundle bytes (different envelope
         // timestamps) must still pass when contractSetCid matches.
         let bundle_cid = "blake3-512:beef00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-        let different_bundle_cid = "blake3-512:face0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        let _different_bundle_cid = "blake3-512:face0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
         let pk = ed25519_pubkey_string(&FOUNDATION_V0_SEED);
         // Attest with one bundle CID...
         let attestation = build_signed_self_contracts_attestation(
@@ -564,22 +563,24 @@ mod tests {
             "rust",
             bundle_cid,
             FAKE_CONTRACT_SET_CID,
-            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            SELF_CONTRACTS_DECLARED_AT_V1_6_0,
         )
         .unwrap();
         // ...and verify against a different bundle CID (same contractSetCid).
         // verify_signed_self_contracts_attestation takes contractSetCid, not bundle CID.
         // So we only check contractSetCid. Bundle drift is invisible to the verifier.
         let bytes = serde_json::to_vec(&attestation).unwrap();
-        let verdict = verify_signed_self_contracts_attestation(
-            &bytes, &pk, FAKE_CONTRACT_SET_CID,
-        ).unwrap();
+        let verdict =
+            verify_signed_self_contracts_attestation(&bytes, &pk, FAKE_CONTRACT_SET_CID).unwrap();
         assert!(verdict.signer_matches);
         assert!(verdict.signature_ok);
         assert!(verdict.contract_set_cid_matches);
         // The bundle CID in the attestation is `bundle_cid` but the observed
         // bundle is `different_bundle_cid`; this does NOT affect verdict.ok().
-        assert!(verdict.ok(), "same contractSetCid = pass, bundle CID drift is irrelevant");
+        assert!(
+            verdict.ok(),
+            "same contractSetCid = pass, bundle CID drift is irrelevant"
+        );
         // confirmed: claimed_bundle_cid is the one we signed with
         assert_eq!(verdict.claimed_bundle_cid, bundle_cid);
     }
@@ -593,16 +594,22 @@ mod tests {
             "kind": "self-contracts-attestation",
             "lang": "rust",
             "cid": "blake3-512:beef00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-            "declaredAt": SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            "declaredAt": SELF_CONTRACTS_DECLARED_AT_V1_6_0,
             "signer": "ed25519:fake",
             "signature": "ed25519:fake",
         }))
         .unwrap();
-        let err = verify_signed_self_contracts_attestation(
-            &bytes, "ed25519:fake", FAKE_CONTRACT_SET_CID,
-        ).unwrap_err();
-        assert!(err.contains("contractSetCid"), "error should mention the missing field: {err}");
-        assert!(err.contains("spec #94"), "error should reference the spec: {err}");
+        let err =
+            verify_signed_self_contracts_attestation(&bytes, "ed25519:fake", FAKE_CONTRACT_SET_CID)
+                .unwrap_err();
+        assert!(
+            err.contains("contractSetCid"),
+            "error should mention the missing field: {err}"
+        );
+        assert!(
+            err.contains("spec #94"),
+            "error should reference the spec: {err}"
+        );
     }
 
     #[test]
@@ -614,14 +621,14 @@ mod tests {
             "lang": "rust",
             "cid": "blake3-512:beef00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "contractSetCid": FAKE_CONTRACT_SET_CID,
-            "declaredAt": SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            "declaredAt": SELF_CONTRACTS_DECLARED_AT_V1_6_0,
             "signer": "ed25519:fake",
             "signature": "ed25519:fake",
         }))
         .unwrap();
-        let err = verify_signed_self_contracts_attestation(
-            &bytes, "ed25519:fake", FAKE_CONTRACT_SET_CID,
-        ).unwrap_err();
+        let err =
+            verify_signed_self_contracts_attestation(&bytes, "ed25519:fake", FAKE_CONTRACT_SET_CID)
+                .unwrap_err();
         assert!(err.contains("kind"));
     }
 
@@ -637,13 +644,12 @@ mod tests {
             "ts",
             cid,
             FAKE_CONTRACT_SET_CID,
-            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            SELF_CONTRACTS_DECLARED_AT_V1_6_0,
         )
         .unwrap();
         let bytes = serde_json::to_vec(&attestation).unwrap();
-        let verdict = verify_signed_self_contracts_attestation(
-            &bytes, &pk, FAKE_CONTRACT_SET_CID,
-        ).unwrap();
+        let verdict =
+            verify_signed_self_contracts_attestation(&bytes, &pk, FAKE_CONTRACT_SET_CID).unwrap();
         assert!(verdict.signer_matches);
         assert!(verdict.signature_ok);
         assert!(verdict.contract_set_cid_matches);
@@ -662,13 +668,12 @@ mod tests {
             "csharp",
             cid,
             FAKE_CONTRACT_SET_CID,
-            SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            SELF_CONTRACTS_DECLARED_AT_V1_6_0,
         )
         .unwrap();
         let bytes = serde_json::to_vec(&attestation).unwrap();
-        let verdict = verify_signed_self_contracts_attestation(
-            &bytes, &pk, FAKE_CONTRACT_SET_CID,
-        ).unwrap();
+        let verdict =
+            verify_signed_self_contracts_attestation(&bytes, &pk, FAKE_CONTRACT_SET_CID).unwrap();
         assert!(verdict.signer_matches);
         assert!(verdict.signature_ok);
         assert!(verdict.contract_set_cid_matches);
@@ -676,13 +681,16 @@ mod tests {
     }
 
     #[test]
-    fn self_contracts_lang_set_is_eleven_peers() {
+    fn self_contracts_lang_set_is_twelve_peers() {
         // Guard the canonical kit suite. Adding or removing a peer is
         // a deliberate act; this test forces an explicit edit.
         // java/python/ruby/zig/c added in feat(cli): unify mint pipeline.
         assert_eq!(
             SELF_CONTRACTS_LANGS,
-            &["rust", "go", "cpp", "ts", "csharp", "swift", "java", "python", "ruby", "zig", "c"]
+            &[
+                "rust", "go", "cpp", "ts", "csharp", "swift", "java", "python", "ruby", "zig", "c",
+                "php"
+            ]
         );
     }
 
@@ -703,6 +711,7 @@ mod tests {
             V1_5_0_DECLARED_AT,
             V1_6_0_DECLARED_AT,
             SELF_CONTRACTS_DECLARED_AT_V1_3_1,
+            SELF_CONTRACTS_DECLARED_AT_V1_6_0,
         ];
         for ts in &pinned {
             // Must match ISO-8601 UTC shape: YYYY-MM-DDTHH:MM:SSZ (exactly 20 bytes)


### PR DESCRIPTION
## Summary

- make the cross-kit conformance gate require real kit-emitted self-contract proof artifacts, verifier-load them, recompute content CIDs, and bootstrap attestations from live bundle CID plus contractSetCid
- add `make bootstrap-self-contracts` as the automated attestation regeneration lane with profile/job controls
- fix C, PHP, and Zig self-contract emitters so their proof bundles contain real signed layered mementos
- discover local Homebrew Ruby/OpenJDK runtimes before macOS `/usr/bin` shims, build Ruby native BLAKE3 extension, and include Ruby in the Linux-profile bootstrap/all-mint lane
- pin mint-side self-contract attestations to the v1.6.0 declaredAt timestamp so `make mint-*` does not drift backward from bootstrap output

## Verification

- `git diff --check`
- `cargo test --manifest-path tools/cross-kit-conformance/Cargo.toml`
- `cargo test --release --manifest-path tools/foundation-keygen/Cargo.toml`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli build_signed_attestation_has_required_fields`
- `make build-c-self-contracts`
- `make build-zig`
- PHP lint on touched PHP files
- `make build-ruby`
- `make mint-ruby`
- `make bootstrap-self-contracts`

`make bootstrap-self-contracts` now passes locally: all 11 Linux-profile kits emit verifier-loadable live proof artifacts, and Ruby/Java direct plus native checks pass using the discovered local runtimes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ruby language support to self-contracts system and build toolchain.
  * Enhanced Java toolchain auto-detection and setup.

* **Chores**
  * Updated CI workflow to use Zig 0.16.0 and improved toolchain installation.
  * Regenerated self-contracts attestations across all languages with updated timestamps and signatures.
  * Improved PHP dependency verification and Ruby extension build configuration.
  * Updated build system targets and cross-kit conformance tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->