### PR TITLE
[codex] align LSP baseline index model

### DIFF
--- a/bug-zoo/tests/smoke.rs
+++ b/bug-zoo/tests/smoke.rs
@@ -52,10 +52,28 @@ fn csharp_discover_cli_finds_null_boundary_with_language_lifter() {
         "bug-zoo/species/BZ-SHAPE-007-csharp-null-boundary-equivalence/exposed/linq-where/harness",
     );
 
+    let build = Command::new("dotnet")
+        .arg("build")
+        .arg(&project)
+        .arg("--nologo")
+        .arg("--verbosity")
+        .arg("quiet")
+        .current_dir(&root)
+        .output()
+        .expect("build csharp discover cli");
+
+    let build_stdout = String::from_utf8_lossy(&build.stdout);
+    let build_stderr = String::from_utf8_lossy(&build.stderr);
+    assert!(
+        build.status.success(),
+        "csharp discover build failed\nstdout:\n{build_stdout}\nstderr:\n{build_stderr}"
+    );
+
     let output = Command::new("dotnet")
         .arg("run")
         .arg("--project")
         .arg(project)
+        .arg("--no-build")
         .arg("--no-restore")
         .arg("--")
         .arg("discover")

--- a/docs/lsp/callsite-resolution-v1.md
+++ b/docs/lsp/callsite-resolution-v1.md
@@ -1,0 +1,134 @@
+# Callsite Resolution v1
+
+This document defines how an LSP forward propagator resolves a source callsite to a callee precondition under the current v1.6.2 content-addressed baseline model.
+
+## Decision
+
+The normative lookup surface is a content-addressed LSP callsite index artifact.
+
+The identity is `baseline_index_cid`, computed from the index artifact bytes. Consumers verify the index against the baseline catalog before using it. The model does not define any filename-derived lookup surface.
+
+## Resolution Pipeline
+
+The LSP plugin performs two separate steps:
+
+1. Resolve the source call expression to a per-language canonical callee identifier.
+2. Look up that identifier in the verified baseline index to find candidate contracts.
+
+The index is keyed by canonical callee identifier, not by `file:line:character`. Source location remains diagnostic metadata, but it is not the baseline lookup key.
+
+## Index Artifact Shape
+
+The index artifact is JSON using JCS-compatible objects and arrays. Its CID is:
+
+```
+baseline_index_cid = "blake3-512:" || hex(BLAKE3-512(JCS(index_artifact)))
+```
+
+Required shape:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "provekit.lsp.callsite_index",
+  "language": "rust",
+  "protocol_catalog_cid": "blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f",
+  "baseline_catalog_cid": "blake3-512:...",
+  "baseline_contract_set_cid": "blake3-512:...",
+  "entries": {
+    "std::string::String::len": [
+      {
+        "contract_name": "rust_std_string_len_returns_usize",
+        "member_cid": "blake3-512:...",
+        "contract_cid": "blake3-512:...",
+        "attestation_cid": "blake3-512:...",
+        "pre_cid": "blake3-512:...",
+        "post_cid": "blake3-512:...",
+        "signer": "ed25519:...",
+        "signer_role": "foundation-baseline",
+        "declared_at": "2026-05-03T18:00:00Z"
+      }
+    ]
+  }
+}
+```
+
+`member_cid` identifies the member bytes inside the baseline catalog. `contract_cid` identifies the contract content. `attestation_cid` identifies the signer-specific attestation. These fields are intentionally distinct.
+
+`pre_cid` and `post_cid` identify canonical formulas. If a contract has no precondition or no postcondition, the corresponding field is omitted.
+
+## Producing the Index
+
+An index producer:
+
+1. Verifies the baseline `.proof` artifact CID.
+2. Verifies every member CID listed by the baseline catalog.
+3. Decodes contract members.
+4. Recomputes each `contract_cid` from the `ContractDecl` content.
+5. Extracts each member's canonical callee identifier, contract name, optional precondition, optional postcondition, signer, signer role, and declared timestamp.
+6. Groups entries by canonical callee identifier.
+7. Emits the index artifact and records its `baseline_index_cid`.
+
+The index can be published as a standalone content-addressed artifact, embedded as signed metadata, or materialized as a local cache. All three forms are equivalent only after the consumer recomputes and verifies the same `baseline_index_cid`.
+
+## Verifying the Index
+
+An LSP consumer MUST verify an index before lookup:
+
+1. Recompute `baseline_index_cid` from the index artifact bytes.
+2. Check `protocol_catalog_cid` equals the active protocol catalog.
+3. Check `baseline_catalog_cid` equals the verified baseline catalog artifact.
+4. Recompute the index from the baseline catalog members and compare it to the supplied artifact.
+5. Reject entries whose `contract_cid`, formula CIDs, signer, or signer role do not match the verified baseline member.
+
+If any step fails, the supplied index is discarded. The plugin MAY rebuild a local index from the verified baseline catalog instead of failing the whole LSP session.
+
+## Multi-Signer Resolution
+
+When several trusted catalogs provide contracts for the same callee identifier, the resolver applies policy before order:
+
+1. Keep only entries whose signer is trusted for the callee scope.
+2. Prefer an explicit workspace signer pin over role defaults.
+3. Prefer `language-steward`, then `foundation-baseline`, then `community` when policy permits role fallback.
+4. If multiple entries still tie, choose the newest `declared_at`.
+5. If timestamps tie, choose lexicographically by `attestation_cid` for deterministic behavior.
+
+The selected entry's `signer` and `signer_role` are copied into the diagnostic payload. The role is never inferred from the filename.
+
+## Per-Language Canonical Identifiers
+
+| Kit | Format | Example |
+|---|---|---|
+| Rust | Rust full path | `std::vec::Vec::push` |
+| Go | Package symbol | `fmt.Println`, `strings.HasPrefix` |
+| TypeScript | ECMAScript receiver path | `Array.prototype.push`, `String.prototype.startsWith` |
+| Java | Fully qualified member | `java.util.ArrayList.add` |
+| C# | Fully qualified member | `System.Collections.Generic.List.Add` |
+| Python | Module or builtin path | `builtins.len`, `os.path.join` |
+| Ruby | Class member syntax | `String#length`, `Array#push` |
+| PHP | Leading-backslash global function | `\\strlen`, `\\preg_match` |
+| C | Link symbol | `strlen`, `memcpy` |
+| C++ | Qualified symbol | `std::vector::push_back` |
+| Swift | Type member | `String.count`, `Array.append` |
+| Zig | Module path | `std.mem.copy` |
+
+If a host language parser cannot resolve a dynamic call to one of these forms, the forward propagator uses `top` for that path and suppresses `implication-failed`.
+
+## Performance
+
+The hot lookup path MUST complete within 5ms for 100 callsites on a warm LSP session. Verification and index construction may happen during initialization or cache refresh; they are not part of the hot lookup budget.
+
+The in-memory cache key is:
+
+```
+(protocol_catalog_cid, baseline_catalog_cid, baseline_index_cid)
+```
+
+Changing any member of that tuple invalidates the cache.
+
+## Issue Map
+
+- [#308](https://github.com/TSavo/provekit/issues/308): parent epic.
+- [#312](https://github.com/TSavo/provekit/issues/312): original callsite-resolution ticket.
+- [#478](https://github.com/TSavo/provekit/issues/478): v1.6.2 rebaseline ticket.
+- [#313](https://github.com/TSavo/provekit/issues/313), [#314](https://github.com/TSavo/provekit/issues/314), and [#324](https://github.com/TSavo/provekit/issues/324): representative per-kit forward propagators.

--- a/docs/lsp/diagnostic-shape-v1.md
+++ b/docs/lsp/diagnostic-shape-v1.md
@@ -1,0 +1,142 @@
+# LSP Diagnostic Shape v1
+
+This document defines the cross-kit diagnostic shape for the forward-propagation precondition check.
+
+The check is:
+
+```
+current_post implies callee_pre
+```
+
+When the verifier rejects that implication, the LSP plugin emits one `implication-failed` diagnostic at the callsite.
+
+## Scope
+
+This shape is for precondition failures found by the thin forward-propagation loop in [forward-propagation-floor-v1.md](forward-propagation-floor-v1.md). It is not the shape for parse errors, missing CIDs, signature failures, protocol catalog mismatches, or unresolved baseline artifacts.
+
+Those failures use the stable ProvekIt diagnostic codes in [../reference/error-codes.md](../reference/error-codes.md).
+
+## Constants
+
+Forward-propagation precondition failures always use:
+
+| Field | Value |
+|---|---|
+| `severity` | `1` |
+| `source` | `"provekit"` |
+| `code` | `"implication-failed"` |
+
+Severity `1` is the LSP Error severity.
+
+## CID Model
+
+The diagnostic MUST preserve the v1.6.2 CID separation:
+
+| Field | Meaning |
+|---|---|
+| `protocol_catalog_cid` | The active protocol catalog CID. For the current tree this is v1.6.2. |
+| `baseline_catalog_cid` | The CID of the verified `.proof` baseline catalog artifact used for lookup. This is the artifact CID, not a friendly filename. |
+| `baseline_contract_set_cid` | The signer-independent content set CID for the baseline contracts, when present or derivable. |
+| `baseline_index_cid` | The CID of the LSP callsite index artifact described in [callsite-resolution-v1.md](callsite-resolution-v1.md). |
+| `callee_contract_cid` | The content-only CID of the callee `ContractDecl`. It is independent of signer state. |
+| `callee_attestation_cid` | The signer-specific CID of the memento or member that attests to the callee contract. |
+| `callee_pre_cid` | The CID of the canonical precondition formula used for this implication query. |
+| `callee_post_cid` | The CID of the canonical postcondition formula, if the callee contract has one. |
+| `current_post_cid` | The CID of the accumulated caller post at the callsite. |
+
+Implementations MUST NOT put an attestation CID in a field named `contract_cid`. Bridges, lookup entries, and diagnostics use `contractCid` semantics for contract identity and `attestationCid` semantics only for signer-specific evidence.
+
+## Diagnostic Payload
+
+The LSP diagnostic object is:
+
+```json
+{
+  "range": {
+    "start": { "line": 41, "character": 12 },
+    "end": { "line": 41, "character": 24 }
+  },
+  "severity": 1,
+  "source": "provekit",
+  "code": "implication-failed",
+  "message": "callee precondition not established at this callsite",
+  "data": {
+    "schema_version": 1,
+    "kind": "provekit.lsp.implication_failed",
+    "callee": "std::option::Option::unwrap",
+    "callee_contract_cid": "blake3-512:...",
+    "callee_attestation_cid": "blake3-512:...",
+    "callee_pre_cid": "blake3-512:...",
+    "callee_post_cid": "blake3-512:...",
+    "current_post_cid": "blake3-512:...",
+    "missing_conjuncts": [
+      "receiver is Some"
+    ],
+    "signer": "ed25519:...",
+    "signer_role": "foundation-baseline",
+    "baseline_catalog_cid": "blake3-512:...",
+    "baseline_contract_set_cid": "blake3-512:...",
+    "baseline_index_cid": "blake3-512:...",
+    "protocol_catalog_cid": "blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f"
+  }
+}
+```
+
+`range` is the source range of the call expression or callee token. Lines and characters are zero-indexed per LSP.
+
+`callee` uses the per-language canonical identifier format from [callsite-resolution-v1.md](callsite-resolution-v1.md).
+
+`missing_conjuncts` is a display list derived from the failed verifier explanation. It is not a trust root. The trust roots are the CIDs plus the verified signer data.
+
+## Emission Rules
+
+An LSP plugin emits this diagnostic only when all of the following hold:
+
+1. The callee resolves to at least one trusted baseline entry.
+2. The selected entry has a precondition formula.
+3. The accumulated caller post is not `top`.
+4. The verifier rejects `current_post implies callee_pre`.
+
+If the accumulated post is `top`, the plugin suppresses this diagnostic. The floor spec treats `top` as a loss of precision, not as a user-visible contract violation.
+
+If lookup, verification, or trust-policy evaluation fails before the implication query can run, the plugin emits a more specific ProvekIt diagnostic code instead of `implication-failed`.
+
+## Hover Content
+
+On hover over the diagnostic range, the editor SHOULD show:
+
+- The callee's full precondition and postcondition in human-readable form.
+- The signer identity and signer role actually used for this diagnostic.
+- The baseline catalog CID and baseline index CID used for lookup.
+- The current accumulated post at the callsite.
+- A diff-style listing of which precondition conjuncts were not established.
+
+The hover MAY shorten CIDs for display, but the full CIDs MUST remain available in diagnostic `data`.
+
+## Quick Fixes
+
+At v1.0.0 floor, an editor MAY offer one quick fix per missing conjunct:
+
+| Field | Value |
+|---|---|
+| `kind` | `"quickfix"` |
+| `title` | `"Add guard: <human-readable conjunct>"` |
+
+The edit content is per-kit because guard syntax is host-language-specific. The quick fix MUST NOT change the diagnostic `data` shape.
+
+## Cross-Kit Consistency
+
+The JSON shape, constants, CID fields, and `missing_conjuncts` field are identical across kits.
+
+The only per-kit variance is:
+
+- The `callee` identifier format.
+- The human-readable message text after the required core meaning.
+- The quick-fix edit content.
+
+## Issue Map
+
+- [#308](https://github.com/TSavo/provekit/issues/308): parent epic.
+- [#311](https://github.com/TSavo/provekit/issues/311): original diagnostic-shape lock ticket.
+- [#478](https://github.com/TSavo/provekit/issues/478): v1.6.2 baseline and index rebaseline ticket.
+- [#313](https://github.com/TSavo/provekit/issues/313), [#314](https://github.com/TSavo/provekit/issues/314), and [#324](https://github.com/TSavo/provekit/issues/324): representative per-kit forward propagators.

--- a/docs/lsp/forward-propagation-floor-v1.md
+++ b/docs/lsp/forward-propagation-floor-v1.md
@@ -7,8 +7,8 @@ This document defines the scope for the LSP forward-propagator implementation ac
 - **Variable assignment posts**: `let x = expr` accumulates a post `typeof(x)` or the callee's post for the assigned callee
 - **Sequential flow**: posts accumulate left-to-right in a basic block
 - **If/else branch merge**: uses G3 disjunction (per #256) to merge the two branch posts
-- **Function call posts**: when the callee has a known post in the seed catalog, that post is added to the accumulated post
-- **Callsite pre-check**: for callsites with a known callee pre (from seed catalog via #312 index), emit a verifier query `current_post implies callee_pre`; failed implication produces a diagnostic per #311
+- **Function call posts**: when the callee has a known post in a verified baseline index, that post is added to the accumulated post
+- **Callsite pre-check**: for callsites with a known callee pre, emit a verifier query `current_post implies callee_pre`; failed implication produces a diagnostic per [diagnostic-shape-v1.md](diagnostic-shape-v1.md)
 - **`top` fallback**: any construct not in this list maps the propagator's post to `top` for the current scope
 
 ## OUT of scope (defer to v1.1+)
@@ -28,25 +28,39 @@ When the propagator cannot track a post precisely, it uses `top` (the weakest po
 
 Every per-kit issue (#313-#324) must implement exactly this scope. Deviating from the IN/OUT lists requires a new floor spec version, not a per-kit exception.
 
-## Diagnostic shape (per #311)
+## Diagnostic Shape
 
-Diagnostics follow the LSP protocol:
+Diagnostics follow [diagnostic-shape-v1.md](diagnostic-shape-v1.md).
 
-```json
-{
-  "range": { "start": { "line": N, "character": M }, "end": { "line": N, "character": M + L } },
-  "severity": 1,
-  "code": "implication-failed",
-  "source": "provekit",
-  "message": "current_post implies callee_pre: failed"
-}
-```
+The diagnostic payload MUST carry the v1.6.2 identifiers that let a user or tool replay the decision:
 
-## Callsite resolution index format (per #312)
+- `protocol_catalog_cid`
+- `baseline_catalog_cid`
+- `baseline_index_cid`
+- `callee_contract_cid`
+- `callee_pre_cid`
+- `current_post_cid`
+- `signer` and `signer_role`
 
-The seed catalog provides a callsite index mapping:
+The plugin MUST suppress `implication-failed` when the accumulated post is `top`.
 
-- Key: `file:line:character` (canonical callsite identifier)
-- Value: `{ callee: "path/to/function", pre: Post, post: Post }`
+## Callsite Resolution
 
-Example: `Array.prototype.push`, `String.prototype.startsWith` (globalThis prefix format for JS/TS).
+Callsite resolution follows [callsite-resolution-v1.md](callsite-resolution-v1.md).
+
+The current model has two steps:
+
+1. Resolve a source call expression to the kit's canonical callee identifier.
+2. Look up that identifier in a verified, content-addressed baseline index.
+
+The index is keyed by callee identifier, not by `file:line:character`. Source location is diagnostic metadata only.
+
+The normative index identity is `baseline_index_cid`. The v1.6.2 LSP baseline index model does not define any filename-derived lookup surface.
+
+## Issue Cross-Links
+
+- [#308](https://github.com/TSavo/provekit/issues/308): parent forward-propagation epic.
+- [#311](https://github.com/TSavo/provekit/issues/311): diagnostic shape.
+- [#312](https://github.com/TSavo/provekit/issues/312): callsite resolution.
+- [#313](https://github.com/TSavo/provekit/issues/313), [#314](https://github.com/TSavo/provekit/issues/314), and [#324](https://github.com/TSavo/provekit/issues/324): representative per-kit implementation issues that should reference these docs.
+- [#478](https://github.com/TSavo/provekit/issues/478): v1.6.2 rebaseline for this doc family.


### PR DESCRIPTION
## Summary

- Add `docs/lsp/diagnostic-shape-v1.md` for the forward-propagation `implication-failed` diagnostic payload.
- Add `docs/lsp/callsite-resolution-v1.md` for the v1.6.2 content-addressed baseline index model.
- Update `docs/lsp/forward-propagation-floor-v1.md` to point at the new docs and remove stale seed-catalog and filename-derived lookup assumptions.

## Notes

The callsite resolution model is `baseline_index_cid` only. It does not define a `.proof.idx` compatibility path or any filename-derived lookup surface.

Closes #478.

## Validation

- `git diff --check origin/main..HEAD`
- ASCII scan over touched LSP docs
- `rg` scan for stale `.idx`, compatibility, backwards-compat, and sidecar wording under `docs/lsp`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced C# build verification in smoke tests with explicit pre-execution build step.

* **Documentation**
  * Added LSP specification for callsite resolution with baseline index verification.
  * Added LSP specification for diagnostic shape and payload structure.
  * Updated LSP forward-propagation specification with baseline index references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->