### PR TITLE
[codex] add Java JUnit value-scope lifter

### DIFF
--- a/docs/reference/per-adapter-coverage.md
+++ b/docs/reference/per-adapter-coverage.md
@@ -171,6 +171,18 @@ The Bean Validation adapter walks `@NotNull`, `@Email`, `@Min`, `@Max`, `@Patter
 
 Both libraries express full pre/post/invariant contracts in Java. The JML adapter walks `//@ requires`, `//@ ensures`, and `//@ invariant` comment-block annotations. The Cofoja adapter walks `@Requires` and `@Ensures` annotations. Both produce contract mementos identical in shape to the Rust `contracts` adapter's output.
 
+### Java: JUnit Jupiter
+
+```java
+@Test
+void parseFortyTwo() {
+    int actual = parseInt("42");
+    assertEquals(42, actual);
+}
+```
+
+The JUnit adapter treats unit assertions as point-specific behavior witnesses, not universal function contracts. `assertEquals(expected, actual)` binds an implication over the test-local value scope: local assignments become SSA binding facts, branch joins become guarded implications, and opaque branch conditions preserve source text when the condition is outside the v0 expression subset. The example above lifts the scoped fact `actual$0 = parseInt("42") => actual$0 = 42`; it does not mint any claim about `parseInt("43")`.
+
 ### Go: `go-playground/validator`
 
 ```go

--- a/docs/reference/per-language-status.md
+++ b/docs/reference/per-language-status.md
@@ -228,6 +228,7 @@ Column meanings:
 
 **Lift adapters (shipping):**
 - `provekit-lift-java-bean-validation`: walks `@NotNull`, `@Email`, `@Min`, `@Max`, `@Pattern`, `@Size`, `@Positive`, `@Negative`, `@AssertTrue`, `@AssertFalse`, `@DecimalMin`, `@DecimalMax`, `@Digits`, `@Future`, `@Past`.
+- `provekit-lift-java-junit`: walks JUnit Jupiter test assertions and emits point-specific value-scope implications. `assertEquals(42, parseInt("42"))` lifts only the witnessed term; local assignments become SSA binding facts and branch joins become guarded implications with opaque branch-condition atoms.
 - `provekit-lift-java-jml`: walks `//@ requires`, `//@ ensures`, `//@ invariant` comment-block annotations. Uses a hand-written tokenizer + recursive-descent parser (no regex gymnastics) to produce structured IR that is byte-for-byte identical to Bean Validation for equivalent constraints.
 - `provekit-lift-java-spring-web`: walks `@RequestParam`, `@PathVariable`, `@RequestMapping`, etc.
 - `provekit-lift-java-cofoja`: walks `@Requires`, `@Ensures`, `@Invariant` annotations.

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -1,8 +1,8 @@
 # Tutorial: Java / JVM
 
-> **Status:** kit shipping in the current v1.6.2 tree. Lift adapters shipping: Bean Validation, JML, Spring Web, Cofoja, plus bindings for Spring Security, Swagger, Jackson, JPA, Hibernate. Java realizer work is active in Bug Zoo. Embedded verifier and LSP plugin planned. Verification via the Rust CLI.
+> **Status:** kit shipping in the current v1.6.2 tree. Lift adapters shipping: Bean Validation, JUnit Jupiter, JML, Spring Web, Cofoja, plus bindings for Spring Security, Swagger, Jackson, JPA, Hibernate. Java realizer work is active in Bug Zoo. Embedded verifier and LSP plugin planned. Verification via the Rust CLI.
 
-A walkthrough for Java / JVM developers. By the end you have a `.proof` catalog lifted from existing `@NotNull`, `@Email`, `@Min`, `//@ requires`, `@RequestParam` annotations (across Bean Validation, JML, Spring, and Cofoja sources, all canonicalized to the same IR).
+A walkthrough for Java / JVM developers. By the end you have a `.proof` catalog lifted from existing `@NotNull`, `@Email`, `@Min`, JUnit assertions, `//@ requires`, `@RequestParam` annotations (across Bean Validation, JUnit, JML, Spring, and Cofoja sources, all canonicalized to the same IR).
 
 ## 1. What you'll have at the end
 

--- a/implementations/java/README.md
+++ b/implementations/java/README.md
@@ -13,6 +13,7 @@ A `@NotNull` in Jakarta Bean Validation, a `//@ requires x != null` in JML, and 
 ```
 provekit-lift-java-core              (facade — RPC, walking, IR emission)
 ├── provekit-lift-java-bean-validation   (@NotNull, @Email, @Min, @Size...)
+├── provekit-lift-java-junit             (assertEquals, local value-scope lemmas)
 ├── provekit-lift-java-jml               (//@ requires, //@ ensures)
 ├── provekit-lift-java-cofoja            (@Requires, @Ensures)
 ├── provekit-lift-java-spring-web        (@GetMapping, @RequestParam, @ResponseStatus)
@@ -30,6 +31,7 @@ You install the core + whichever bindings match the annotation libraries you use
 | Binding JAR | Annotation Library | What gets lifted |
 |---|---|---|
 | `provekit-lift-java-bean-validation` | Jakarta Bean Validation | `@NotNull`, `@NotEmpty`, `@NotBlank`, `@Email`, `@Min`, `@Max`, `@Size`, `@Pattern`, `@Positive`, `@Negative`, `@PositiveOrZero`, `@NegativeOrZero`, `@AssertTrue`, `@AssertFalse`, `@DecimalMin`, `@DecimalMax`, `@Digits`, `@Future`, `@Past` |
+| `provekit-lift-java-junit` | JUnit Jupiter | `@Test` / `@ParameterizedTest` methods with `assertEquals`, `assertNotEquals`, `assertTrue`, `assertFalse`; assertions bind implications over the test-local value scope, including SSA assignment steps and guarded branch joins |
 | `provekit-lift-java-jml` | JML (Java Modeling Language) | `//@ requires <expr>`, `//@ ensures <expr>`, `//@ invariant <expr>` |
 | `provekit-lift-java-cofoja` | Cofoja (Contracts for Java) | `@Requires("<expr>")`, `@Ensures("<expr>")`, `@Invariant("<expr>")` |
 | `provekit-lift-java-spring-web` | Spring Web / Spring MVC | `@RequestMapping`, `@GetMapping`, `@PostMapping`, `@PutMapping`, `@DeleteMapping`, `@PatchMapping`, `@RequestParam`, `@PathVariable`, `@RequestBody`, `@RequestHeader`, `@ResponseStatus` |
@@ -114,10 +116,10 @@ The core discovers bindings via `ServiceLoader`. No config needed.
 name = "java"
 version = "1.0.0"
 protocol_version = "provekit-lift/1"
-command = ["java", "-cp", "provekit-lift-java-core-0.1.0-shaded.jar:provekit-lift-java-bean-validation-0.1.0.jar:provekit-lift-java-spring-web-0.1.0.jar", "com.provekit.lift.Main", "--rpc"]
+command = ["java", "-cp", "provekit-lift-java-core-0.1.0-shaded.jar:provekit-lift-java-bean-validation-0.1.0.jar:provekit-lift-java-junit-0.1.0.jar:provekit-lift-java-spring-web-0.1.0.jar", "com.provekit.lift.Main", "--rpc"]
 
 [capabilities]
-authoring_surfaces = ["java-bean-validation", "java-jml", "java-cofoja", "java-spring-web", "java-spring-security", "java-swagger", "java-jackson", "java-jpa", "java-hibernate"]
+authoring_surfaces = ["java-bean-validation", "java-junit", "java-jml", "java-cofoja", "java-spring-web", "java-spring-security", "java-swagger", "java-jackson", "java-jpa", "java-hibernate"]
 ir_version = "v1.1.0"
 ```
 

--- a/implementations/java/pom.xml
+++ b/implementations/java/pom.xml
@@ -22,6 +22,7 @@
         <module>provekit-lift-java-core</module>
         <module>provekit-lift-java-bean-validation</module>
         <module>provekit-lift-java-provekit-native</module>
+        <module>provekit-lift-java-junit</module>
         <module>provekit-lift-java-jml</module>
         <module>provekit-lift-java-cofoja</module>
         <module>provekit-lift-java-spring-web</module>

--- a/implementations/java/provekit-lift-java-integration-tests/pom.xml
+++ b/implementations/java/provekit-lift-java-integration-tests/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
         <dependency>
             <groupId>com.provekit</groupId>
+            <artifactId>provekit-lift-java-junit</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.provekit</groupId>
             <artifactId>provekit-lift-java-jml</artifactId>
             <version>0.1.0</version>
         </dependency>

--- a/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/JUnitExtractorTest.java
+++ b/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/JUnitExtractorTest.java
@@ -1,0 +1,261 @@
+package com.provekit.lift;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.CompilationUnit;
+import com.provekit.lift.junit.JUnitExtractor;
+
+import java.util.List;
+
+public class JUnitExtractorTest {
+
+    @Test
+    public void directAssertEqualsLiftsOnlyTheWitnessedCallTerm() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
+            public class ParseTest {
+                @Test
+                void parseFortyTwo() {
+                    assertEquals(42, parseInt("42"));
+                }
+            }
+            """;
+
+        String json = liftOne(source).toJson();
+
+        assertEquals(
+            "{\"kind\":\"contract\",\"symbol\":\"parseFortyTwo::0\",\"invariant\":"
+                + atom("eq", ctor("parseInt", cStr("42")), cInt(42))
+                + "}",
+            json
+        );
+        assertFalse(json.contains("parseInt\",\"args\":[{\"kind\":\"const\",\"value\":\"43\""),
+            "A point assertion for parseInt(\"42\") must not mint a contract for parseInt(\"43\")");
+        assertFalse(json.contains("\"symbol\":\"parseInt\""),
+            "A point assertion must not become a universal function contract");
+    }
+
+    @Test
+    public void assignedActualBindsAssertionThroughValueScopeImplication() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
+            public class ParseTest {
+                @Test
+                void parseFortyTwo() {
+                    int actual = parseInt("42");
+                    assertEquals(42, actual);
+                }
+            }
+            """;
+
+        String actual0 = var("actual$0");
+        String expectedInvariant = implies(
+            atom("eq", actual0, ctor("parseInt", cStr("42"))),
+            atom("eq", actual0, cInt(42))
+        );
+
+        assertEquals(
+            "{\"kind\":\"contract\",\"symbol\":\"parseFortyTwo::0\",\"invariant\":"
+                + expectedInvariant
+                + "}",
+            liftOne(source).toJson()
+        );
+    }
+
+    @Test
+    public void reassignmentBindsAssertionThroughSsaStepLemmas() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
+            public class ParseTest {
+                @Test
+                void normalized() {
+                    int actual = parseInt("42");
+                    actual = normalize(actual);
+                    assertEquals(42, actual);
+                }
+            }
+            """;
+
+        String actual0 = var("actual$0");
+        String actual1 = var("actual$1");
+        String expectedInvariant = implies(
+            and(
+                atom("eq", actual0, ctor("parseInt", cStr("42"))),
+                atom("eq", actual1, ctor("normalize", actual0))
+            ),
+            atom("eq", actual1, cInt(42))
+        );
+
+        assertEquals(
+            "{\"kind\":\"contract\",\"symbol\":\"normalized::0\",\"invariant\":"
+                + expectedInvariant
+                + "}",
+            liftOne(source).toJson()
+        );
+    }
+
+    @Test
+    public void branchJoinExpandsAssertionAcrossGuardedValueScopes() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import org.junit.jupiter.api.Assertions;
+
+            public class ParseTest {
+                @Test
+                void parsesBothRadices() {
+                    int actual;
+                    if (radix == 10) {
+                        actual = parseInt("42");
+                    } else {
+                        actual = parseHex("2a");
+                    }
+                    Assertions.assertEquals(42, actual);
+                }
+            }
+            """;
+
+        String guard = atom("eq", var("radix"), cInt(10));
+        String actual0 = var("actual$0");
+        String actual1 = var("actual$1");
+        String thenScope = and(
+            guard,
+            atom("eq", actual0, ctor("parseInt", cStr("42")))
+        );
+        String elseScope = and(
+            not(guard),
+            atom("eq", actual1, ctor("parseHex", cStr("2a")))
+        );
+        String expectedInvariant = and(
+            implies(thenScope, atom("eq", actual0, cInt(42))),
+            implies(elseScope, atom("eq", actual1, cInt(42)))
+        );
+
+        assertEquals(
+            "{\"kind\":\"contract\",\"symbol\":\"parsesBothRadices::0\",\"invariant\":"
+                + expectedInvariant
+                + "}",
+            liftOne(source).toJson()
+        );
+    }
+
+    @Test
+    public void unliftableBranchConditionFallsBackToOpaqueGuard() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import org.junit.jupiter.api.Assertions;
+
+            public class ParseTest {
+                @Test
+                void parsesBothRadices() {
+                    int actual;
+                    if (radixes[0] == 10) {
+                        actual = parseInt("42");
+                    } else {
+                        actual = parseHex("2a");
+                    }
+                    Assertions.assertEquals(42, actual);
+                }
+            }
+            """;
+
+        String guard = atom("junit_branch_condition", cStr("radixes[0] == 10"));
+        String actual0 = var("actual$0");
+        String actual1 = var("actual$1");
+        String expectedInvariant = and(
+            implies(
+                and(guard, atom("eq", actual0, ctor("parseInt", cStr("42")))),
+                atom("eq", actual0, cInt(42))
+            ),
+            implies(
+                and(not(guard), atom("eq", actual1, ctor("parseHex", cStr("2a")))),
+                atom("eq", actual1, cInt(42))
+            )
+        );
+
+        assertEquals(
+            "{\"kind\":\"contract\",\"symbol\":\"parsesBothRadices::0\",\"invariant\":"
+                + expectedInvariant
+                + "}",
+            liftOne(source).toJson()
+        );
+    }
+
+    private ContractDecl liftOne(String source) {
+        List<ContractDecl> decls = lift(source);
+        assertEquals(1, decls.size(), "Expected exactly one lifted assertion");
+        return decls.get(0);
+    }
+
+    private List<ContractDecl> lift(String source) {
+        ParseResult<CompilationUnit> result = new JavaParser().parse(source);
+        assertTrue(result.isSuccessful() && result.getResult().isPresent(),
+            "Failed to parse: " + result.getProblems());
+        return new JUnitExtractor().extract(result.getResult().get(), source);
+    }
+
+    private static String var(String name) {
+        return "{\"kind\":\"var\",\"name\":\"" + name + "\"}";
+    }
+
+    private static String cInt(long value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
+    }
+
+    private static String cStr(String value) {
+        return "{\"kind\":\"const\",\"value\":\"" + value
+            + "\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}";
+    }
+
+    private static String ctor(String name, String... args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"ctor\",\"name\":\"")
+            .append(name)
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args[i]);
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String atom(String name, String... args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"atomic\",\"name\":\"")
+            .append(name)
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args[i]);
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String and(String... operands) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"and\",\"operands\":[");
+        for (int i = 0; i < operands.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(operands[i]);
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String not(String operand) {
+        return "{\"kind\":\"not\",\"operands\":[" + operand + "]}";
+    }
+
+    private static String implies(String antecedent, String consequent) {
+        return "{\"kind\":\"implies\",\"operands\":["
+            + antecedent
+            + ","
+            + consequent
+            + "]}";
+    }
+}

--- a/implementations/java/provekit-lift-java-junit/pom.xml
+++ b/implementations/java/provekit-lift-java-junit/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.provekit</groupId>
+        <artifactId>provekit-lift-java-parent</artifactId>
+        <version>0.1.0</version>
+    </parent>
+    <artifactId>provekit-lift-java-junit</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.provekit</groupId>
+            <artifactId>provekit-lift-java-core</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/implementations/java/provekit-lift-java-junit/src/main/java/com/provekit/lift/junit/JUnitExtractor.java
+++ b/implementations/java/provekit-lift-java-junit/src/main/java/com/provekit/lift/junit/JUnitExtractor.java
@@ -1,0 +1,517 @@
+package com.provekit.lift.junit;
+
+import java.util.*;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.IfStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import com.provekit.lift.AnnotationSupport;
+import com.provekit.lift.ContractDecl;
+import com.provekit.lift.Extractor;
+
+public class JUnitExtractor implements Extractor {
+    private static final Set<String> JUPITER_TESTS = Set.of("Test", "RepeatedTest");
+    private static final Set<String> JUPITER_PARAM_TESTS = Set.of("ParameterizedTest");
+    private static final Set<String> ASSERTIONS = Set.of(
+        "assertEquals", "assertNotEquals", "assertTrue", "assertFalse"
+    );
+
+    public String name() { return "junit"; }
+
+    public List<ContractDecl> extract(CompilationUnit cu, String rawSource) {
+        List<ContractDecl> out = new ArrayList<>();
+        for (TypeDeclaration<?> type : cu.getTypes()) {
+            for (BodyDeclaration<?> member : type.getMembers()) {
+                if (member instanceof MethodDeclaration method && isJUnitTest(cu, method)) {
+                    extractMethod(cu, method, out);
+                }
+            }
+        }
+        return out;
+    }
+
+    private boolean isJUnitTest(CompilationUnit cu, MethodDeclaration method) {
+        for (AnnotationExpr ann : method.getAnnotations()) {
+            if (AnnotationSupport.belongsToFamily(
+                    cu, ann, "org.junit.jupiter.api", JUPITER_TESTS, Set.of())) {
+                return true;
+            }
+            if (AnnotationSupport.belongsToFamily(
+                    cu, ann, "org.junit.jupiter.params", JUPITER_PARAM_TESTS, Set.of())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void extractMethod(CompilationUnit cu, MethodDeclaration method, List<ContractDecl> out) {
+        if (method.getBody().isEmpty()) return;
+
+        Map<String, Integer> versions = new LinkedHashMap<>();
+        List<ValueScope> scopes = List.of(new ValueScope());
+        int assertionIndex = 0;
+
+        for (Statement stmt : method.getBody().get().getStatements()) {
+            Optional<String> assertion = liftAssertion(cu, stmt, scopes);
+            if (assertion.isPresent()) {
+                out.add(new ContractDecl(
+                    method.getNameAsString() + "::" + assertionIndex,
+                    List.of(),
+                    List.of(),
+                    List.of(assertion.get())
+                ));
+                assertionIndex++;
+                continue;
+            }
+            scopes = applyStatement(stmt, scopes, versions);
+        }
+    }
+
+    private Optional<String> liftAssertion(
+            CompilationUnit cu,
+            Statement stmt,
+            List<ValueScope> scopes) {
+        if (!stmt.isExpressionStmt()) return Optional.empty();
+        Expression expr = stmt.asExpressionStmt().getExpression();
+        if (!(expr instanceof MethodCallExpr call)) return Optional.empty();
+        if (!isJUnitAssertion(cu, call)) return Optional.empty();
+
+        String name = call.getNameAsString();
+        List<String> scoped = new ArrayList<>();
+        for (ValueScope scope : scopes) {
+            Optional<String> consequent = switch (name) {
+                case "assertEquals" -> liftBinaryAssertion(call, scope, "eq");
+                case "assertNotEquals" -> liftBinaryAssertion(call, scope, "neq");
+                case "assertTrue" -> liftTruthAssertion(call, scope, true);
+                case "assertFalse" -> liftTruthAssertion(call, scope, false);
+                default -> Optional.empty();
+            };
+            if (consequent.isEmpty()) return Optional.empty();
+            scoped.add(scope.wrap(consequent.get()));
+        }
+        if (scoped.isEmpty()) return Optional.empty();
+        return Optional.of(scoped.size() == 1 ? scoped.get(0) : and(scoped));
+    }
+
+    private Optional<String> liftBinaryAssertion(MethodCallExpr call, ValueScope scope, String op) {
+        if (call.getArguments().size() < 2) return Optional.empty();
+        if (call.getArguments().size() > 2 && !(call.getArgument(2) instanceof StringLiteralExpr)) {
+            return Optional.empty();
+        }
+        Optional<String> expected = liftTerm(call.getArgument(0), scope);
+        Optional<String> actual = liftTerm(call.getArgument(1), scope);
+        if (expected.isEmpty() || actual.isEmpty()) return Optional.empty();
+        return Optional.of(atom(op, actual.get(), expected.get()));
+    }
+
+    private Optional<String> liftTruthAssertion(MethodCallExpr call, ValueScope scope, boolean expected) {
+        if (call.getArguments().size() != 1) return Optional.empty();
+        Optional<String> formula = liftFormula(call.getArgument(0), scope);
+        if (formula.isEmpty()) return Optional.empty();
+        return Optional.of(expected ? formula.get() : not(formula.get()));
+    }
+
+    private boolean isJUnitAssertion(CompilationUnit cu, MethodCallExpr call) {
+        String name = call.getNameAsString();
+        if (!ASSERTIONS.contains(name)) return false;
+
+        if (call.getScope().isEmpty()) {
+            return hasStaticAssertionsImport(cu, name);
+        }
+
+        String scope = call.getScope().get().toString();
+        if (scope.equals("Assertions") || scope.equals("org.junit.jupiter.api.Assertions")) {
+            return true;
+        }
+        return scope.endsWith(".Assertions") && scope.contains("junit");
+    }
+
+    private boolean hasStaticAssertionsImport(CompilationUnit cu, String assertionName) {
+        for (ImportDeclaration importDecl : cu.getImports()) {
+            if (!importDecl.isStatic()) continue;
+            String imported = importDecl.getNameAsString();
+            if (importDecl.isAsterisk() && imported.equals("org.junit.jupiter.api.Assertions")) {
+                return true;
+            }
+            if (!importDecl.isAsterisk()
+                    && imported.equals("org.junit.jupiter.api.Assertions." + assertionName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<ValueScope> applyStatement(
+            Statement stmt,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        if (stmt.isBlockStmt()) {
+            return applyBlock(stmt.asBlockStmt(), scopes, versions);
+        }
+        if (stmt.isIfStmt()) {
+            return applyIf(stmt.asIfStmt(), scopes, versions);
+        }
+        if (!stmt.isExpressionStmt()) {
+            return scopes;
+        }
+
+        Expression expr = stmt.asExpressionStmt().getExpression();
+        if (expr instanceof VariableDeclarationExpr decl) {
+            return applyVariableDeclaration(decl, scopes, versions);
+        }
+        if (expr instanceof AssignExpr assign && assign.getOperator() == AssignExpr.Operator.ASSIGN) {
+            return applyAssignment(assign, scopes, versions);
+        }
+        return scopes;
+    }
+
+    private List<ValueScope> applyBlock(
+            BlockStmt block,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        List<ValueScope> current = scopes;
+        for (Statement child : block.getStatements()) {
+            current = applyStatement(child, current, versions);
+        }
+        return current;
+    }
+
+    private List<ValueScope> applyIf(
+            IfStmt stmt,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        List<ValueScope> out = new ArrayList<>();
+
+        for (ValueScope scope : scopes) {
+            String guard = liftFormula(stmt.getCondition(), scope)
+                .orElseGet(() -> opaqueBranchCondition(stmt.getCondition()));
+            ValueScope thenScope = scope.copy();
+            thenScope.facts.add(guard);
+            out.addAll(applyStatement(stmt.getThenStmt(), List.of(thenScope), versions));
+
+            ValueScope elseScope = scope.copy();
+            elseScope.facts.add(not(guard));
+            if (stmt.getElseStmt().isPresent()) {
+                out.addAll(applyStatement(stmt.getElseStmt().get(), List.of(elseScope), versions));
+            } else {
+                out.add(elseScope);
+            }
+        }
+
+        return out;
+    }
+
+    private List<ValueScope> applyVariableDeclaration(
+            VariableDeclarationExpr decl,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        List<ValueScope> out = new ArrayList<>();
+        for (ValueScope scope : scopes) {
+            ValueScope next = scope.copy();
+            for (VariableDeclarator varDecl : decl.getVariables()) {
+                String name = varDecl.getNameAsString();
+                next.locals.add(name);
+                if (varDecl.getInitializer().isPresent()) {
+                    bind(next, name, varDecl.getInitializer().get(), versions);
+                } else {
+                    next.current.remove(name);
+                }
+            }
+            out.add(next);
+        }
+        return out;
+    }
+
+    private List<ValueScope> applyAssignment(
+            AssignExpr assign,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        if (!(assign.getTarget() instanceof NameExpr target)) return scopes;
+
+        List<ValueScope> out = new ArrayList<>();
+        for (ValueScope scope : scopes) {
+            ValueScope next = scope.copy();
+            bind(next, target.getNameAsString(), assign.getValue(), versions);
+            out.add(next);
+        }
+        return out;
+    }
+
+    private void bind(
+            ValueScope scope,
+            String name,
+            Expression expr,
+            Map<String, Integer> versions) {
+        scope.locals.add(name);
+        Optional<String> lifted = liftTerm(expr, scope);
+        if (lifted.isEmpty()) {
+            scope.current.remove(name);
+            return;
+        }
+
+        int version = versions.getOrDefault(name, 0);
+        versions.put(name, version + 1);
+        String ssaName = name + "$" + version;
+        String ssaVar = var(ssaName);
+        scope.current.put(name, ssaVar);
+        scope.facts.add(atom("eq", ssaVar, lifted.get()));
+    }
+
+    private Optional<String> liftFormula(Expression expr, ValueScope scope) {
+        if (expr instanceof EnclosedExpr enclosed) return liftFormula(enclosed.getInner(), scope);
+        if (expr instanceof BinaryExpr binary) {
+            Optional<String> op = binaryFormulaOp(binary.getOperator());
+            if (op.isPresent()) {
+                Optional<String> left = liftTerm(binary.getLeft(), scope);
+                Optional<String> right = liftTerm(binary.getRight(), scope);
+                if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+                return Optional.of(atom(op.get(), left.get(), right.get()));
+            }
+            if (binary.getOperator() == BinaryExpr.Operator.AND) {
+                Optional<String> left = liftFormula(binary.getLeft(), scope);
+                Optional<String> right = liftFormula(binary.getRight(), scope);
+                if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+                return Optional.of(and(List.of(left.get(), right.get())));
+            }
+            if (binary.getOperator() == BinaryExpr.Operator.OR) {
+                Optional<String> left = liftFormula(binary.getLeft(), scope);
+                Optional<String> right = liftFormula(binary.getRight(), scope);
+                if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+                return Optional.of(or(List.of(left.get(), right.get())));
+            }
+        }
+        Optional<String> term = liftTerm(expr, scope);
+        return term.map(t -> atom("eq", t, cBool(true)));
+    }
+
+    private Optional<String> liftTerm(Expression expr, ValueScope scope) {
+        if (expr instanceof EnclosedExpr enclosed) return liftTerm(enclosed.getInner(), scope);
+        if (expr instanceof NameExpr name) {
+            String simple = name.getNameAsString();
+            if (scope.locals.contains(simple)) {
+                return Optional.ofNullable(scope.current.get(simple));
+            }
+            return Optional.of(var(simple));
+        }
+        if (expr instanceof IntegerLiteralExpr intLit) {
+            return Optional.of(cInt(intLit.asNumber().longValue()));
+        }
+        if (expr instanceof LongLiteralExpr longLit) {
+            return Optional.of(cInt(longLit.asNumber().longValue()));
+        }
+        if (expr instanceof StringLiteralExpr strLit) {
+            return Optional.of(cStr(strLit.getValue()));
+        }
+        if (expr instanceof BooleanLiteralExpr boolLit) {
+            return Optional.of(cBool(boolLit.getValue()));
+        }
+        if (expr instanceof NullLiteralExpr) {
+            return Optional.of(cNull());
+        }
+        if (expr instanceof UnaryExpr unary
+                && unary.getOperator() == UnaryExpr.Operator.MINUS
+                && unary.getExpression() instanceof IntegerLiteralExpr intLit) {
+            return Optional.of(cInt(-intLit.asNumber().longValue()));
+        }
+        if (expr instanceof MethodCallExpr call) {
+            return liftMethodCallTerm(call, scope);
+        }
+        if (expr instanceof FieldAccessExpr field) {
+            return Optional.of(ctor(field.toString()));
+        }
+        if (expr instanceof BinaryExpr binary) {
+            Optional<String> op = binaryTermOp(binary.getOperator());
+            if (op.isEmpty()) return Optional.empty();
+            Optional<String> left = liftTerm(binary.getLeft(), scope);
+            Optional<String> right = liftTerm(binary.getRight(), scope);
+            if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+            return Optional.of(ctor(op.get(), left.get(), right.get()));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> liftMethodCallTerm(MethodCallExpr call, ValueScope scope) {
+        List<String> args = new ArrayList<>();
+        String name = call.getNameAsString();
+
+        if (call.getScope().isPresent()) {
+            Expression recv = call.getScope().get();
+            if (recv instanceof NameExpr nameExpr && startsUppercase(nameExpr.getNameAsString())) {
+                name = nameExpr.getNameAsString() + "." + name;
+            } else if (recv instanceof FieldAccessExpr fieldAccess) {
+                name = fieldAccess.toString() + "." + name;
+            } else {
+                Optional<String> recvTerm = liftTerm(recv, scope);
+                if (recvTerm.isEmpty()) return Optional.empty();
+                args.add(recvTerm.get());
+            }
+        }
+
+        for (Expression arg : call.getArguments()) {
+            Optional<String> lifted = liftTerm(arg, scope);
+            if (lifted.isEmpty()) return Optional.empty();
+            args.add(lifted.get());
+        }
+        return Optional.of(ctor(name, args));
+    }
+
+    private Optional<String> binaryFormulaOp(BinaryExpr.Operator op) {
+        return switch (op) {
+            case EQUALS -> Optional.of("eq");
+            case NOT_EQUALS -> Optional.of("neq");
+            case GREATER -> Optional.of("gt");
+            case GREATER_EQUALS -> Optional.of("gte");
+            case LESS -> Optional.of("lt");
+            case LESS_EQUALS -> Optional.of("lte");
+            default -> Optional.empty();
+        };
+    }
+
+    private Optional<String> binaryTermOp(BinaryExpr.Operator op) {
+        return switch (op) {
+            case PLUS -> Optional.of("+");
+            case MINUS -> Optional.of("-");
+            case MULTIPLY -> Optional.of("*");
+            case DIVIDE -> Optional.of("/");
+            case REMAINDER -> Optional.of("%");
+            default -> Optional.empty();
+        };
+    }
+
+    private String opaqueBranchCondition(Expression expr) {
+        return atom("junit_branch_condition", cStr(expr.toString()));
+    }
+
+    private boolean startsUppercase(String s) {
+        return !s.isEmpty() && Character.isUpperCase(s.charAt(0));
+    }
+
+    private static final class ValueScope {
+        final Map<String, String> current;
+        final Set<String> locals;
+        final List<String> facts;
+
+        ValueScope() {
+            this(new LinkedHashMap<>(), new LinkedHashSet<>(), new ArrayList<>());
+        }
+
+        private ValueScope(Map<String, String> current, Set<String> locals, List<String> facts) {
+            this.current = current;
+            this.locals = locals;
+            this.facts = facts;
+        }
+
+        ValueScope copy() {
+            return new ValueScope(
+                new LinkedHashMap<>(current),
+                new LinkedHashSet<>(locals),
+                new ArrayList<>(facts)
+            );
+        }
+
+        String wrap(String consequent) {
+            if (facts.isEmpty()) return consequent;
+            return implies(facts.size() == 1 ? facts.get(0) : and(facts), consequent);
+        }
+    }
+
+    private static String var(String name) {
+        return "{\"kind\":\"var\",\"name\":\"" + esc(name) + "\"}";
+    }
+
+    private static String cInt(long value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
+    }
+
+    private static String cStr(String value) {
+        return "{\"kind\":\"const\",\"value\":\"" + esc(value)
+            + "\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}";
+    }
+
+    private static String cBool(boolean value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Bool\"}}";
+    }
+
+    private static String cNull() {
+        return "{\"kind\":\"const\",\"value\":null,\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"}}";
+    }
+
+    private static String ctor(String name, String... args) {
+        return ctor(name, Arrays.asList(args));
+    }
+
+    private static String ctor(String name, List<String> args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"ctor\",\"name\":\"")
+            .append(esc(name))
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args.get(i));
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String atom(String name, String... args) {
+        return atom(name, Arrays.asList(args));
+    }
+
+    private static String atom(String name, List<String> args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"atomic\",\"name\":\"")
+            .append(esc(name))
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args.get(i));
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String and(List<String> operands) {
+        return connective("and", operands);
+    }
+
+    private static String and(String... operands) {
+        return connective("and", Arrays.asList(operands));
+    }
+
+    private static String or(List<String> operands) {
+        return connective("or", operands);
+    }
+
+    private static String not(String operand) {
+        return connective("not", List.of(operand));
+    }
+
+    private static String implies(String antecedent, String consequent) {
+        return connective("implies", List.of(antecedent, consequent));
+    }
+
+    private static String connective(String kind, List<String> operands) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"")
+            .append(kind)
+            .append("\",\"operands\":[");
+        for (int i = 0; i < operands.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(operands.get(i));
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String esc(String s) {
+        return s
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t");
+    }
+}

--- a/implementations/java/provekit-lift-java-junit/src/main/resources/META-INF/services/com.provekit.lift.Extractor
+++ b/implementations/java/provekit-lift-java-junit/src/main/resources/META-INF/services/com.provekit.lift.Extractor
@@ -1,0 +1,1 @@
+com.provekit.lift.junit.JUnitExtractor


### PR DESCRIPTION
## Summary
- Add `provekit-lift-java-junit` as a ServiceLoader-backed Java lifter module.
- Lift JUnit Jupiter assertions as point-specific value-scope witnesses, including local assignment SSA and branch joins.
- Document Java JUnit adapter coverage/status.

## Why
JUnit assertions witness behavior at the asserted value scope. `assertEquals(42, parseInt("42"))` should produce a contract for that call/value, not a universal `parseInt` contract and not a claim about `parseInt("43")`.

## Stack
- Stacked on #483 (`codex/baseline-index-v162`).

## Validation
- `mvn -q -f implementations/java/pom.xml test`
- `git diff --cached --check`
- `git show --check --stat --oneline --no-renames HEAD`