### PR TITLE
[codex] Make docs honest about current gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,17 @@
 # ProvekIt — cross-language conformance gate
 #
-# Runs the same gate as `make ci` on every push and PR. Source of truth
-# for "do the kits derive the catalog-pinned protocol CIDs on Linux x86_64
-# today" — answer is committed to the repo, not asserted.
+# Runs the Linux `make ci` gate on every push and PR, then adds macOS Swift
+# and per-kit verifier jobs. Source of truth for "do the kits derive the
+# catalog-pinned protocol CIDs today" is committed to the repo, not asserted.
 #
 # Languages exercised:
 #   Rust 1.x stable, Go 1.22, .NET 10 (preview), Node 22 + pnpm 10,
 #   Python 3.12, Java 21 (Temurin) + Maven, clang/clang++ via apt,
 #   C, C++, Zig, PHP, Ruby, and Swift in the macOS job.
 #
-# The Makefile is the contract. CI installs toolchains then calls `make`
-# targets so local dev and CI run the same code path. If you can run
-# `make ci` locally, this workflow runs the same thing.
+# The Makefile is the local contract. CI installs toolchains, calls `make`
+# targets for the Linux profile, then runs the extra platform/profile jobs that
+# are not part of the default local aggregate.
 
 name: CI
 
@@ -247,7 +247,7 @@ jobs:
     # plus an OpenSSL libcrypto dep wired through Homebrew prefixes). This
     # job exercises `make mint-swift` end-to-end on a macOS runner so the
     # swift kit's pinned contractSetCid is verified on every PR alongside
-    # the Linux 10/12 set, advancing the gate to 11/12.
+    # the Linux 11/12 set, advancing the gate to 12/12.
     #
     # Scope (kept lean to manage macOS runner minutes):
     #   - install rust (swift toolchain ships pre-installed on the
@@ -264,7 +264,7 @@ jobs:
     # the Linux job's contract; replicating them here doubles cost
     # without adding signal. The cross-kit byte-equivalence claim is
     # already protected by the Linux gate's pinned CIDs for the other
-    # 10 kits, and JCS+BLAKE3 is architecture-independent.
+    # 11 kits, and JCS+BLAKE3 is architecture-independent.
     name: Cross-language conformance gate (macOS swift)
     # Self-hosted Mac runner registered on the architect's machine
     # (label `macOS`, X64). Closes #305 — moves the swift jobs off

--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,18 @@
 #
 # Twelve-kit polyglot. TypeScript is the center surface, but every kit
 # owns its native build tool;
-# this Makefile is glue, not a build system. `make ci` runs the same
-# gate the GitHub Actions workflow runs (Linux x86_64: Rust/Go/C++/TS/C#/Python).
+# this Makefile is glue, not a build system. `make ci` runs the Linux-profile
+# gate used by the main GitHub Actions job.
 # Swift is macOS-only; use `make build-swift`, `make test-swift`, `make mint-swift`
 # directly on a macOS host — those targets are excluded from the CI aggregates.
 #
 # Mainline targets:
 #   make help        — print this help
-#   make ci          — full conformance gate (catalog + protocol + live mints + tests)
+#   make ci          — Linux-profile gate (catalog + protocol + live mints + tests)
 #   make conformance — catalog + protocol + live mint CIDs + self-contract tests
-#   make all-mint    — run all 10 Linux/CI mint commands; print CIDs
+#   make all-mint    — run all 11 Linux-profile mint commands; print CIDs
 #   make bootstrap-self-contracts — re-sign attestations from live artifacts
-#   make test-all    — run every language-native test suite (Linux/CI subset)
+#   make test-all    — run the Linux native test aggregate
 #
 # Per-language targets:
 #   make build-rust  — cargo build --release for workspace + tools
@@ -21,9 +21,10 @@
 #   make test-rust / test-go / test-ts / test-csharp / test-python
 #
 # Determinism:
-#   make ci is the contract. If it's green, every peer's self-contracts
-#   round-trip to its pinned CID, the v1.6.2 catalog hash matches, and
-#   every native test suite passes. Anything else is decoration.
+#   make ci is the local Linux-profile contract. If it's green, the non-Swift
+#   self-contracts round-trip to their pinned CIDs, the v1.6.2 catalog hash
+#   matches, and the Linux native test aggregate passes. The GitHub workflow
+#   adds macOS Swift and per-kit verifier jobs.
 
 .DEFAULT_GOAL := help
 
@@ -74,7 +75,7 @@ help:
 	@echo "ProvekIt — top-level orchestrator"
 	@echo ""
 	@echo "Mainline:"
-	@echo "  make ci             full gate (conformance + test-all) [Linux/CI: 10 peer langs]"
+	@echo "  make ci             Linux-profile gate (conformance + test-all)"
 	@echo "  make conformance    catalog + protocol + 11 mint CIDs + self-contract tests"
 	@echo "  make all-mint       11 mint commands (Swift excluded: macOS-only, use mint-swift)"
 	@echo "  make bug-zoo        replay executable bug specimens through source-routed CLI"

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ For more entry points (per-language tutorials, IDE integration, publishing a `.p
 
 - **Protocol catalog**: v1.6.2 (patch over v1.6.1; catalogs the Content-Addressed CI Protocol as an extension-only protocol)
 - **Catalog CID**: `blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f`
-- **Canonical implementation**: Rust (`cargo install provekit`)
+- **Canonical implementation**: Rust, built from this repository with `cargo install --path implementations/rust/provekit-cli`
 - **Conforming implementations**: Rust, TypeScript, Python, Java, C#, Ruby, Zig, Go, C++, Swift, C, PHP. Coverage varies; see [docs/reference/per-language-status.md](docs/reference/per-language-status.md).
 - **Protocol evolution**: PEP dogfoods catalog transitions as signed, content-addressed body-claims under `protocol/evolution/v1.6.1/` and `protocol/evolution/v1.6.2/`.
 - **Content-addressed CI**: CICP binds CI results to exact source, protocol catalog, kit/toolchain, config, and accepted witness inputs. Reuse is allowed only when that closure is byte-identical.
-- **Bug Zoo**: the self-contained `bug-zoo/` runner checks lab, exhibit, fixed, and wild specimen states; fixed pairs are accepted only after the same surface re-lifts or re-links to a clean boundary receipt.
+- **Bug Zoo**: the self-contained `bug-zoo/` runner checks lab, exhibit, fixed, link, equivalence, and composition receipts for checked-in specimens. Wild sightings are metadata only until real upstream specimens are pinned and wired into the runner.
 - **Conformance gate**: catalog CIDs, proof-protocol fixtures, CICP vectors, self-contract attestations, and per-kit tests must agree before CI is green.
 
 The protocol is content-addressed end to end. Each version's canonical name is its own catalog hash. Anyone with the spec bytes can verify that label locally. No central party decides what a version means; the bytes do.
@@ -137,7 +137,8 @@ lifecycle:
   through the same surface to yield the green `provekit prove` or
   `provekit link` signal.
 - `wild/`: optional real upstream sightings pinned by advisory, commit, path,
-  and evidence.
+  and evidence. No checked-in wild specimens are executed today; current
+  `wildSightings` entries are reported as metadata.
 
 In shorthand:
 
@@ -220,7 +221,7 @@ For other host languages, see the polyglot-stack tutorial above. The Rust CLI is
 
 ## Building from source
 
-If you are working on ProvekIt itself (kit, lift adapter, prover backend, spec change), see [docs/contributing/build.md](docs/contributing/build.md) for the polyglot Make targets, system dependencies, and per-implementation build commands. The conformance gate (`make ci`) enforces byte-determinism across every implementation.
+If you are working on ProvekIt itself (kit, lift adapter, prover backend, spec change), see [docs/contributing/build.md](docs/contributing/build.md) for the polyglot Make targets, system dependencies, and per-implementation build commands. The default `make ci` gate covers the Linux conformance profile plus the Linux native test aggregate; the full GitHub workflow adds macOS Swift and per-kit verifier jobs.
 
 ## License
 

--- a/bug-zoo/README.md
+++ b/bug-zoo/README.md
@@ -57,7 +57,9 @@ Each species can carry four states:
   no `.provekit` config and no lifter/prover workflow.
 - `exhibit/`: the same bug species with one or more native contract surfaces; ProvekIt lifts the surface and reports the missing edge.
 - `fixed/`: the paired exhibit source with the boundary closed; ProvekIt lifts the same surface and reports clean.
-- `wild/`: real OSS specimens pinned by advisory, commit, affected path, and evidence.
+- `wild/`: optional real OSS sightings pinned by advisory, commit, affected
+  path, and evidence. The current runner reports `wildSightings` metadata but
+  does not execute wild specimens yet.
 
 ## Organization
 

--- a/docs/contributing/build.md
+++ b/docs/contributing/build.md
@@ -1,20 +1,20 @@
 # Building ProvekIt from source
 
-ProvekIt is a multi-language polyglot. The main implementations today: Rust, Go, C++, TypeScript, C#, Python, Java, Ruby, Zig, Swift, C, PHP. The cross-language conformance gate runs the same way locally and in CI: every peer mints its own self-contracts under the foundation key, and every minted catalog must match the pinned content-addressed CID before the build is green.
+ProvekIt is a multi-language polyglot. The main implementations today: Rust, Go, C++, TypeScript, C#, Python, Java, Ruby, Zig, Swift, C, PHP. The default local conformance gate uses the Linux profile: every non-Swift peer mints its own self-contracts under the foundation key, and every minted catalog must match the pinned content-addressed CID before that local gate is green. Swift is checked by the macOS profile in CI.
 
-The contract is the top-level [`Makefile`](../../Makefile). If `make ci` is green, the protocol is byte-deterministic across every peer on the host and every native test suite passes. The CI workflow at [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) runs the same `make ci` on `ubuntu-latest`.
+The contract is the top-level [`Makefile`](../../Makefile). If `make ci` is green, the Linux profile's self-contracts, catalog hash, proof-protocol fixtures, CICP vectors, and Linux native test aggregate passed on that host. The CI workflow at [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) runs that Linux path and adds macOS Swift plus per-kit `provekit prove --kit=<kit>` verifier jobs.
 
 ## Make targets
 
 ```sh
 make help          # available targets
-make ci            # full gate (conformance + every language's tests)
+make ci            # Linux-profile gate (conformance + Linux native test aggregate)
 make conformance   # catalog + protocol + N mints match pinned CIDs
 make all-mint      # run all mint commands; print CIDs
-make test-all      # run all language-native test suites
+make test-all      # run the Linux native test aggregate
 provekit ci ...    # CICP supply-chain admission and result witnesses
 cargo run --manifest-path bug-zoo/Cargo.toml -- --all
-                   # Bug Zoo specimen/exposure/dropper checks
+                   # Bug Zoo lab/exhibit/fixed/link/composition checks
 make clean         # remove all build artifacts
 ```
 
@@ -87,7 +87,7 @@ Additional protocol/tooling checks now run in CI:
 - **Proof protocol conformance.** `.proof` fixtures under `protocol/conformance/proof-protocol/` are checked by `provekit proof`.
 - **CICP vector conformance.** Every language library that emits CICP bodies must derive the same golden-vector CIDs in `protocol/conformance/cicp/`.
 - **CICP supply-chain admission.** The GitHub workflow computes kit blast radii, tries reuse only against checked-in accepted witnesses, and uploads candidate result witnesses for review when reuse is refused.
-- **Bug Zoo.** `cargo run --manifest-path bug-zoo/Cargo.toml -- --all` verifies exposed ProofIR equivalence, scoped proof receipts, polyglot link-bundle receipts, and fixed-pair closure for checked-in specimens.
+- **Bug Zoo.** `cargo run --manifest-path bug-zoo/Cargo.toml -- --all` verifies exhibit ProofIR equivalence, scoped proof receipts, polyglot link-bundle receipts, and fixed-pair closure for checked-in specimens.
 
 If you are adding a new implementation, see [porting-to-a-new-language.md](porting-to-a-new-language.md) for how the conformance harness picks up your kit.
 

--- a/docs/explanation/landing.md
+++ b/docs/explanation/landing.md
@@ -3,14 +3,14 @@
 Modern dependency stacks, protocol stacks, and CI supply chains are deep. ProvekIt collapses their load-bearing claims to content-addressed evidence.
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 cd your-rust-crate
 cargo provekit-lift
 provekit prove
 ```
 
-Three commands. Sixty-four bytes of comparison per call site. One CPU instruction per discharge.
+Install once; then three commands. Sixty-four bytes of comparison per call site. One CPU instruction per discharge.
 
 ## What it does
 

--- a/docs/explanation/pitch.md
+++ b/docs/explanation/pitch.md
@@ -53,7 +53,7 @@ This is what the term "constraint-driven development" names. Software ages backw
 ## Install path
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 cd your-rust-crate
 cargo provekit-lift

--- a/docs/explanation/product.md
+++ b/docs/explanation/product.md
@@ -80,12 +80,12 @@ ProvekIt is not a coding-agent guardrail or an LLM proof harness. The protocol d
 
 ## Adoption surfaces
 
-ProvekIt ships through three install paths.
+ProvekIt has three adoption paths.
 
 **1. Library author publishes a `.proof` alongside their crate.**
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 cd my-crate
 cargo provekit-lift   # walks proptest! and #[contracts::ensures] annotations
                       # emits target/.proof

--- a/docs/how-to/bug-zoo.md
+++ b/docs/how-to/bug-zoo.md
@@ -50,7 +50,9 @@ Each species can carry four states:
 - `lab/`: ordinary host-language code and checks. These should pass, because the bug is latent under the host's normal surface. No `.provekit` project is configured here.
 - `exhibit/`: one or more source surfaces lift into ProofIR or link into a LinkBundle and expose the missing edge with a red CLI signal.
 - `fixed/`: paired source surfaces close the edge and re-run through the same ProofIR or LinkBundle path with a green CLI signal.
-- `wild/`: real upstream sightings pinned by advisory, commit, path, and evidence.
+- `wild/`: optional real upstream sightings pinned by advisory, commit, path,
+  and evidence. Today this is metadata: the runner reports `wildSightings`, but
+  no checked-in `wild/` specimens are executed.
 
 ## Run It
 

--- a/docs/papers/01-whitepaper.md
+++ b/docs/papers/01-whitepaper.md
@@ -80,7 +80,14 @@ The cypherpunk thesis from the 1990s mailing lists was that cryptographic primit
 
 ## Install path
 
-The Rust kit is the reference. It is `cargo install`-able once the workspace publishes:
+> **Current status:** this early paper describes the intended published package
+> and agent surface. The current repo is build-from-source; use
+> `cargo install --path implementations/rust/provekit-cli` from the repository
+> root and see [../reference/protocol-extensions.md](../reference/protocol-extensions.md)
+> for the current CLI surface.
+
+The Rust kit is the reference. Once the workspace publishes, the intended shape
+is:
 
 ```sh
 cargo install provekit-cli

--- a/docs/quickstart-extender.md
+++ b/docs/quickstart-extender.md
@@ -53,17 +53,17 @@ The top-level Makefile orchestrates the full build:
 # Build the Rust workspace (CLI, LSP server, linker daemon, tools)
 make build-rust
 
-# Run the full conformance gate
+# Run the Linux-profile conformance gate
 make conformance
 
-# Run all language-native test suites
+# Run the Linux native test aggregate
 make test-all
 
 # Run both
 make ci
 ```
 
-`make ci` is the gate. If it is green, every peer's self-contracts round-trip to pinned CIDs, the catalog hash matches, and every native test suite passes.
+`make ci` is the local Linux-profile gate. If it is green, the Linux profile's self-contracts round-trip to pinned CIDs, the catalog hash matches, and the Linux native test aggregate passes. The full GitHub workflow adds the macOS Swift profile and per-kit verifier jobs.
 
 Per-language builds for non-Rust kits:
 
@@ -318,15 +318,17 @@ examples/
 
 ## How CI works
 
-CI runs `make ci` on `ubuntu-latest`. The gate has two parts:
+CI runs `make ci` for the Linux profile, then runs additional macOS Swift and per-kit verifier jobs. The local Linux gate has two parts:
 
-**`make conformance`**: four checks in sequence.
+**`make conformance`**: six checks in sequence.
 1. `catalog-verify`: recomputes all spec CIDs from spec bytes and confirms they match `protocol/specs/2026-04-30-protocol-catalog.json`. Fails on any drift.
 2. `protocol-verify`: runs `provekit verify-protocol --signed`, which checks that the local binary's declared catalog CID is signed by the foundation key.
-3. `all-mint`: runs the five per-kit mint commands (rust, go, cpp, ts, csharp). Each mints the kit's self-contracts bundle, computes the `contractSetCid`, and verifies it against the signed attestation envelope in `.provekit/self-contracts-attestations/<lang>.json`. Fails if the contractSetCid has drifted from the signed value.
+3. `all-mint`: runs the Linux-profile per-kit mint commands. Each mints the kit's self-contracts bundle, computes the `contractSetCid`, and verifies it against the signed attestation envelope in `.provekit/self-contracts-attestations/<lang>.json`. Fails if the contractSetCid has drifted from the signed value.
 4. `test-self-contracts`: runs the Rust kit's catalog-format unit tests (19 tests covering R1-R15 of the protocol catalog format spec). Fails if any format invariant regresses.
+5. `conformance-region-fixture`: checks the RegionSort fixture coverage.
+6. `cross-kit-conformance`: runs the profile-aware cross-kit conformance harness.
 
-**`make test-all`**: runs every language-native test suite in sequence.
+**`make test-all`**: runs the Linux native test aggregate in sequence.
 
 To debug a `mint-<lang>` failure: the Makefile prints the new `cid` and `contractSetCid` when the attestation check fails. If you changed self-contracts intentionally, follow the bump dance printed in the error message (the `sign-self-contracts` tool call). If the drift is unintentional, look for a change in the kit's source that altered the lifted contracts.
 

--- a/docs/reference/per-language-status.md
+++ b/docs/reference/per-language-status.md
@@ -128,7 +128,7 @@ Column meanings:
 
 **Embedded verifier:** Yes. `provekit_verifier::run(project_root)` returns a `HandshakeReport` synchronously.
 
-**CLI:** `provekit` is the canonical shipping CLI for protocol v1.6.2. Subcommands include `prove`, `proof`, `protocol`, `ci`, `verify`, `verify-protocol`, `version`, `init`, `mint`, `lift`, `dump`, `hash`, `ask`, `search`, and `implicate`. Bug Zoo is repo-owned machinery under `bug-zoo/`, not a public `provekit` subcommand. Distributed via `cargo install provekit` once published, or `cargo install --path implementations/rust/provekit-cli` from source.
+**CLI:** `provekit` is the canonical Rust CLI for protocol v1.6.2. Subcommands include `prove`, `proof`, `protocol`, `ci`, `verify`, `verify-protocol`, `version`, `init`, `mint`, `lift`, `dump`, `hash`, `ask`, `search`, and `implicate`. Bug Zoo is repo-owned machinery under `bug-zoo/`, not a public `provekit` subcommand. Distributed from source today with `cargo install --path implementations/rust/provekit-cli`; crates.io publishing remains future work.
 
 ## TypeScript
 

--- a/docs/tutorials/c.md
+++ b/docs/tutorials/c.md
@@ -20,7 +20,7 @@ In v1.2: a `.proof` lifted from `assert.h` macros (partial coverage; `assert` di
 ## 3. Install
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
 cd implementations/c && make

--- a/docs/tutorials/cpp.md
+++ b/docs/tutorials/cpp.md
@@ -21,7 +21,7 @@ In v1.1: a `.proof` file authored directly through the C++ kit (header-only IR l
 ## 3. Install
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
 cd implementations/cpp && make

--- a/docs/tutorials/csharp.md
+++ b/docs/tutorials/csharp.md
@@ -19,11 +19,10 @@ A walkthrough for C# developers. By the end you have a `.proof` catalog lifted f
 ## 3. Install
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
 cd implementations/csharp && dotnet build
-dotnet tool install --global Provekit.Cli
 ```
 
 The C# kit ships as `Provekit.IR`, `Provekit.Canonicalizer`, `Provekit.SelfContracts`, `Provekit.ClaimEnvelope`, `Provekit.ProofEnvelope`, `Provekit.Verifier`.

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -19,7 +19,7 @@ In v1.1: a `.proof` file authored directly through the Go kit's IR API.
 ## 3. Install
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
 cd implementations/go && go build ./...

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -21,7 +21,7 @@ A walkthrough for Java / JVM developers. By the end you have a `.proof` catalog 
 
 ```bash
 # the canonical verifier (Rust CLI)
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
 # the Java kit (multi-module Maven, ServiceLoader-discovered)

--- a/docs/tutorials/python.md
+++ b/docs/tutorials/python.md
@@ -21,14 +21,17 @@ A walkthrough for Python developers. By the end you have a `.proof` catalog lift
 
 ```bash
 # the canonical verifier (Rust CLI)
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
-# the Python kit
-pip install provekit
+# the in-tree Python lift tests / adapter harness
+cd implementations/python/provekit-lift-py-tests
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -e .
 ```
 
-The Python kit lives at [implementations/python/](../../implementations/python/). The canonicalizer is pure Python and byte-identical to the Rust canonicalizer for all conformance tests.
+The Python kit lives at [implementations/python/](../../implementations/python/). There is no PyPI package in the current source-built distribution. The canonicalizer is pure Python and byte-identical to the Rust canonicalizer for all conformance tests.
 
 ## 4. Lift your first contract
 

--- a/docs/tutorials/ruby.md
+++ b/docs/tutorials/ruby.md
@@ -19,13 +19,13 @@ A walkthrough for Ruby developers. By the end you have a `.proof` catalog lifted
 ## 3. Install
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
-gem install provekit
+cd implementations/ruby && bundle install
 ```
 
-The Ruby kit lives at [implementations/ruby/](../../implementations/ruby/).
+The Ruby kit lives at [implementations/ruby/](../../implementations/ruby/). There is no RubyGems package in the current source-built distribution.
 
 ## 4. Lift your first contract
 

--- a/docs/tutorials/rust.md
+++ b/docs/tutorials/rust.md
@@ -8,10 +8,12 @@ For the current end-user quickstart (get a red squiggle in 10 minutes):
 
 > [docs/quickstart-end-user.md](../quickstart-end-user.md)
 
-For the current extender quickstart (write a new kit lifter or protocol spec):
+## Step 1: install the source-built CLI
+
+From the repository root:
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 ```
 
 The installed binary is `provekit`. It is the canonical Rust implementation for protocol v1.6.2; alternative implementations in other languages conform to the same catalog CID.
@@ -122,7 +124,7 @@ provekit search --consequent some-formula.json
 
 ## Troubleshooting
 
-**`provekit verify-protocol` exits with code 1.** The local install's spec bytes do not hash to the expected catalog CID. Either the install is corrupted (re-run `cargo install provekit`) or the binary was built against a different protocol version (check `provekit version`).
+**`provekit verify-protocol` exits with code 1.** The local install's spec bytes do not hash to the expected catalog CID. Either the install is corrupted (re-run `cargo install --path implementations/rust/provekit-cli`) or the binary was built against a different protocol version (check `provekit version`).
 
 **`cargo provekit-lift` reports zero mementos.** No lift adapter recognized any annotations in the workspace. Today's shipping adapters cover `proptest!` blocks and `#[contracts::requires]` / `#[contracts::ensures]` macros; if your crate uses a different annotation library, the adapter is on the v1.2 roadmap (see [per-adapter-coverage.md](../reference/per-adapter-coverage.md)).
 

--- a/docs/tutorials/swift.md
+++ b/docs/tutorials/swift.md
@@ -19,7 +19,7 @@ In a later release: a `.proof` file lifted from Swift property wrappers and macr
 ## 3. Install
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
 cd implementations/swift && swift build

--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -20,14 +20,14 @@ A walkthrough for TypeScript developers. By the end you have a `.proof` catalog 
 
 ```bash
 # the canonical verifier (Rust CLI)
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
-# the TypeScript kit
-pnpm add @provekit/kit @provekit/lift-zod @provekit/lift-class-validator @provekit/lift-fast-check
+# the in-tree TypeScript kit
+cd implementations/typescript && pnpm install --frozen-lockfile
 ```
 
-Package names are placeholder; actual names will be confirmed when the v1.1 npm publish lands. See [implementations/typescript/](../../implementations/typescript/) for the in-tree workspace.
+Registry package names are not published yet. See [implementations/typescript/](../../implementations/typescript/) for the in-tree workspace.
 
 ## 4. Lift your first contract
 

--- a/docs/tutorials/zig.md
+++ b/docs/tutorials/zig.md
@@ -19,7 +19,7 @@ A walkthrough for Zig developers. Zig has no native attribute syntax, so the lif
 ## 3. Install
 
 ```bash
-cargo install provekit
+cargo install --path implementations/rust/provekit-cli
 provekit verify-protocol
 
 cd implementations/zig && zig build


### PR DESCRIPTION
## Summary

- Correct the public install story to use the source-built Rust CLI path and remove unpublished registry install snippets from current tutorials.
- Narrow Bug Zoo docs so `wild/` is described as metadata only until real upstream specimens are executable.
- Clarify that local `make ci` is the Linux-profile gate, while full CI adds macOS Swift and per-kit verifier jobs.
- Mark the first whitepaper install section as an early/future sketch instead of current CLI instructions.

## Validation

- `make help`
- `git diff --check`
- targeted `rg` check for stale install/conformance/wild overclaims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions across tutorials to build the CLI from source via the repository path.
  * Updated protocol status to v1.6.2 and clarified CI coverage across Linux and macOS profiles.
  * Expanded documentation on conformance gates, Bug Zoo specimen states, and CI workflow behavior.
  * Clarified that wild Bug Zoo specimens are tracked as metadata but not currently executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->