### PR TITLE
[codex] Harden local CICP accept workflow

### DIFF
--- a/.provekit/ci/accepted/rust/blake3-512:baadce3e4cb15b6f23d2accdf5c24647f336039dd42cc21de95f7bd0392cd5d5af162c48aab5b9e4c70ace0cca985ddf2a14accce1c91d010a8f23ad465e3367.job-result.json
+++ b/.provekit/ci/accepted/rust/blake3-512:baadce3e4cb15b6f23d2accdf5c24647f336039dd42cc21de95f7bd0392cd5d5af162c48aab5b9e4c70ace0cca985ddf2a14accce1c91d010a8f23ad465e3367.job-result.json
@@ -1,0 +1,25 @@
+{
+  "kind": "CIJobResultBodyClaim",
+  "schemaVersion": "1",
+  "jobKey": "provekit/ci/rust",
+  "blastRadiusCid": "blake3-512:baadce3e4cb15b6f23d2accdf5c24647f336039dd42cc21de95f7bd0392cd5d5af162c48aab5b9e4c70ace0cca985ddf2a14accce1c91d010a8f23ad465e3367",
+  "result": "pass",
+  "outputCid": "blake3-512:9c9115ccf873c654715de527579d6e9a4ec9b9cc8ac291904aa7fa6afdc24a0699bcb7469cd434dfb1bd9e7e9d78f4a5232d356d49e1ef342e1d49ed032c8471",
+  "logCid": "blake3-512:caf239cacc085d5190c0107e315e0abe3738aac10773855dc332a16ca4730d0f63f5f358d4ec797c52d9037f3e248ae6921a12e9e1d8b577200d6ec6accf7eee",
+  "startedAt": "2026-05-07T00:00:00Z",
+  "finishedAt": "2026-05-07T00:00:00Z",
+  "runnerIdentityCid": "blake3-512:ea57d5bb564e290c3cd6fa3e5355e411d279c37be83cd4085d856b6c1210ce27ea65012d9810b1d343aeddd9ddfffd4542991107a3c7cc5121447ac4722ccd4b",
+  "policyCid": "blake3-512:430f7ae604144abb9810c0ee83dedce757cd12ce1bb3457051c7c94fcccfc237ccb7a909fe471290367bf9649129bdb76d63a392e28f59dad74b5417612e5668",
+  "inputCids": [
+    "blake3-512:430f7ae604144abb9810c0ee83dedce757cd12ce1bb3457051c7c94fcccfc237ccb7a909fe471290367bf9649129bdb76d63a392e28f59dad74b5417612e5668",
+    "blake3-512:9c9115ccf873c654715de527579d6e9a4ec9b9cc8ac291904aa7fa6afdc24a0699bcb7469cd434dfb1bd9e7e9d78f4a5232d356d49e1ef342e1d49ed032c8471",
+    "blake3-512:baadce3e4cb15b6f23d2accdf5c24647f336039dd42cc21de95f7bd0392cd5d5af162c48aab5b9e4c70ace0cca985ddf2a14accce1c91d010a8f23ad465e3367",
+    "blake3-512:caf239cacc085d5190c0107e315e0abe3738aac10773855dc332a16ca4730d0f63f5f358d4ec797c52d9037f3e248ae6921a12e9e1d8b577200d6ec6accf7eee",
+    "blake3-512:ea57d5bb564e290c3cd6fa3e5355e411d279c37be83cd4085d856b6c1210ce27ea65012d9810b1d343aeddd9ddfffd4542991107a3c7cc5121447ac4722ccd4b"
+  ],
+  "producer": {
+    "kind": "ci-runner",
+    "name": "provekit-ci",
+    "version": "checked-in"
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@
 #   make conformance — catalog + protocol + live mint CIDs + self-contract tests
 #   make all-mint    — run all 11 Linux-profile mint commands; print CIDs
 #   make bootstrap-self-contracts — re-sign attestations from live artifacts
+#   make ci-accept-check — rebuild release CLI, then validate CICP accepted witnesses
+#   make ci-accept-refresh — rebuild release CLI, then refresh CICP accepted witnesses
 #   make test-all    — run the Linux native test aggregate
 #
 # Per-language targets:
@@ -59,6 +61,7 @@ CATALOG_CID := blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114
 PROVEKIT := implementations/rust/target/release/provekit
 VERIFY_SELF_CONTRACTS := tools/foundation-keygen/target/release/verify-self-contracts
 SELF_CONTRACTS_ATTEST_DIR := .provekit/self-contracts-attestations
+CICP_ACCEPTED_DIR ?= .provekit/ci/accepted
 CONFORMANCE_PROFILE ?= linux
 CONFORMANCE_JOBS ?= 4
 RUBY ?= $(shell for p in /usr/local/opt/ruby/bin/ruby /opt/homebrew/opt/ruby/bin/ruby /usr/local/bin/ruby /opt/homebrew/bin/ruby; do if [ -x "$$p" ]; then echo "$$p"; exit; fi; done; command -v ruby || echo ruby)
@@ -76,6 +79,10 @@ help:
 	@echo ""
 	@echo "Mainline:"
 	@echo "  make ci             Linux-profile gate (conformance + test-all)"
+	@echo "  make ci-accept-check"
+	@echo "                       rebuild release provekit, then validate CICP accepted witnesses"
+	@echo "  make ci-accept-refresh"
+	@echo "                       rebuild release provekit, then refresh CICP accepted witnesses"
 	@echo "  make conformance    catalog + protocol + 11 mint CIDs + self-contract tests"
 	@echo "  make all-mint       11 mint commands (Swift excluded: macOS-only, use mint-swift)"
 	@echo "  make bug-zoo        replay executable bug specimens through source-routed CLI"
@@ -129,6 +136,28 @@ help:
 # directly on macOS.
 .PHONY: build-all
 build-all: build-rust build-cpp build-go build-ts build-csharp build-java build-ruby
+
+.PHONY: ci-accept-check
+ci-accept-check: build-rust
+	@echo ">> validating CICP accepted witnesses with freshly built release provekit"
+	$(PROVEKIT) ci accept \
+		--repo . \
+		--all-kits \
+		--clean \
+		--check \
+		--out $(CICP_ACCEPTED_DIR) \
+		--json
+
+.PHONY: ci-accept-refresh
+ci-accept-refresh: build-rust
+	@echo ">> refreshing CICP accepted witnesses with freshly built release provekit"
+	$(PROVEKIT) ci accept \
+		--repo . \
+		--all-kits \
+		--clean \
+		--assume-pass \
+		--out $(CICP_ACCEPTED_DIR) \
+		--json
 
 .PHONY: build-rust
 build-rust:

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -46,7 +46,7 @@ Bumping the catalog CID is a coordinated activity:
 6. **Update `provekit verify-protocol`** in the Rust CLI to expect the new catalog CID.
 7. **Update conformance fixtures** if the canonical input/output bytes changed.
 8. **Emit or check the PEP transition** with `provekit protocol evolve` or `provekit protocol check-evolution`.
-9. **Update CICP accepted witnesses** only after reviewing candidate job-result witnesses as supply-chain artifacts.
+9. **Update CICP accepted witnesses** only after reviewing candidate job-result witnesses as supply-chain artifacts. Use `make ci-accept-refresh`, then `make ci-accept-check`, so the local flow rebuilds the release CLI before touching `.provekit/ci/accepted`.
 10. **Run `make ci`** to verify the whole stack.
 11. **Tag the release** in git.
 12. **Publish packages** in dependency order: protocol catalog first, then kits, then lift adapters, then tooling.

--- a/docs/how-to/content-addressed-ci.md
+++ b/docs/how-to/content-addressed-ci.md
@@ -76,6 +76,20 @@ provekit ci result \
   --result pass
 ```
 
+Validate the checked-in accepted witness store using the same release-built
+CLI shape as CI:
+
+```sh
+make ci-accept-check
+```
+
+Refresh the checked-in accepted store after the relevant prove jobs have been
+reviewed and accepted:
+
+```sh
+make ci-accept-refresh
+```
+
 ## CI Workflow Shape
 
 The GitHub workflow does three things around each prove job:

--- a/implementations/rust/provekit-cli/src/cmd_ci.rs
+++ b/implementations/rust/provekit-cli/src/cmd_ci.rs
@@ -1288,8 +1288,15 @@ fn run_git(
 }
 
 fn stale_accept_error(args: &CiAcceptArgs, missing: &[(String, String, PathBuf)]) -> String {
-    let mut message =
-        String::from("CICP accepted witnesses are stale.\n\nRun:\n  provekit ci accept");
+    let mut message = String::from(
+        "CICP accepted witnesses are stale.\n\n\
+         Run from the repository root with a freshly built release CLI:\n\
+           make ci-accept-refresh\n\n\
+         To validate after refresh:\n\
+           make ci-accept-check\n\n\
+         Exact CLI equivalent for this invocation:\n\
+           provekit ci accept",
+    );
     if args.all_kits {
         message.push_str(" --all-kits");
     } else if let Some(kit) = &args.kit {

--- a/implementations/rust/provekit-cli/tests/ci_check.rs
+++ b/implementations/rust/provekit-cli/tests/ci_check.rs
@@ -430,8 +430,12 @@ fn ci_accept_check_reports_missing_witnesses_without_writing() {
         "stderr={stderr}"
     );
     assert!(
-        stderr.contains("provekit ci accept"),
-        "stderr should include a repair command\nstderr={stderr}"
+        stderr.contains("make ci-accept-refresh"),
+        "stderr should point at the release-built repair target\nstderr={stderr}"
+    );
+    assert!(
+        stderr.contains("make ci-accept-check"),
+        "stderr should point at the release-built validation target\nstderr={stderr}"
     );
     assert!(
         !accepted_dir.exists(),


### PR DESCRIPTION
## Summary

- add `make ci-accept-check` and `make ci-accept-refresh` so local accepted-witness validation and refresh always rebuild and run the release `provekit` binary
- point stale CICP accepted-witness errors at those Make targets while preserving the exact equivalent CLI invocation
- document the release-built local flow in the CICP how-to and release process

## Why

The local accepted-witness path was easy to misuse by accidentally running a stale debug CLI or an ad hoc command. The new Make targets make the intended path explicit: rebuild release `provekit`, then validate or refresh `.provekit/ci/accepted`.

## Verification

- `cargo test --manifest-path implementations/rust/provekit-cli/Cargo.toml --test ci_check -- --nocapture`
- `make ci-accept-check`
- `cargo fmt --manifest-path implementations/rust/Cargo.toml --all -- --check`
- `git diff --check`
