### PR TITLE
Clarify Supply Chain Rails honesty boundary

### DIFF
--- a/.provekit/ci/accepted/rust/blake3-512:38b6c43e524f7c6010f3e7f6d5ff24fff60dde4af9d9d256829b6bde8ac6cf61f575473e14d7be75fd7b6996cc01ac8b274d60aef912d023ad1ec354b71db5cc.job-result.json
+++ b/.provekit/ci/accepted/rust/blake3-512:38b6c43e524f7c6010f3e7f6d5ff24fff60dde4af9d9d256829b6bde8ac6cf61f575473e14d7be75fd7b6996cc01ac8b274d60aef912d023ad1ec354b71db5cc.job-result.json
@@ -1,0 +1,25 @@
+{
+  "kind": "CIJobResultBodyClaim",
+  "schemaVersion": "1",
+  "jobKey": "provekit/ci/rust",
+  "blastRadiusCid": "blake3-512:38b6c43e524f7c6010f3e7f6d5ff24fff60dde4af9d9d256829b6bde8ac6cf61f575473e14d7be75fd7b6996cc01ac8b274d60aef912d023ad1ec354b71db5cc",
+  "result": "pass",
+  "outputCid": "blake3-512:55d0787ef83e66792bfac4b1c9dcef3bd992b0bdd2c9dcda6ba251afa992eb637fe7f146bed4a810b78965ce9c2f2bd2d4cec71c1ecd19e113e1def88318e3f2",
+  "logCid": "blake3-512:068feafb94fc4c4670824b37766220787d8fd1204fae7701714f2ca3579acec6e61cd20958a251f0f28bb99ea9ed7ba51c5b1b4c1c8417dd5c57a7c19b180e94",
+  "startedAt": "2026-05-07T00:00:00Z",
+  "finishedAt": "2026-05-07T00:00:00Z",
+  "runnerIdentityCid": "blake3-512:ea57d5bb564e290c3cd6fa3e5355e411d279c37be83cd4085d856b6c1210ce27ea65012d9810b1d343aeddd9ddfffd4542991107a3c7cc5121447ac4722ccd4b",
+  "policyCid": "blake3-512:430f7ae604144abb9810c0ee83dedce757cd12ce1bb3457051c7c94fcccfc237ccb7a909fe471290367bf9649129bdb76d63a392e28f59dad74b5417612e5668",
+  "inputCids": [
+    "blake3-512:068feafb94fc4c4670824b37766220787d8fd1204fae7701714f2ca3579acec6e61cd20958a251f0f28bb99ea9ed7ba51c5b1b4c1c8417dd5c57a7c19b180e94",
+    "blake3-512:38b6c43e524f7c6010f3e7f6d5ff24fff60dde4af9d9d256829b6bde8ac6cf61f575473e14d7be75fd7b6996cc01ac8b274d60aef912d023ad1ec354b71db5cc",
+    "blake3-512:430f7ae604144abb9810c0ee83dedce757cd12ce1bb3457051c7c94fcccfc237ccb7a909fe471290367bf9649129bdb76d63a392e28f59dad74b5417612e5668",
+    "blake3-512:55d0787ef83e66792bfac4b1c9dcef3bd992b0bdd2c9dcda6ba251afa992eb637fe7f146bed4a810b78965ce9c2f2bd2d4cec71c1ecd19e113e1def88318e3f2",
+    "blake3-512:ea57d5bb564e290c3cd6fa3e5355e411d279c37be83cd4085d856b6c1210ce27ea65012d9810b1d343aeddd9ddfffd4542991107a3c7cc5121447ac4722ccd4b"
+  ],
+  "producer": {
+    "kind": "ci-runner",
+    "name": "provekit-ci",
+    "version": "checked-in"
+  }
+}

--- a/implementations/rust/provekit-linkerd/tests/multi_kit.rs
+++ b/implementations/rust/provekit-linkerd/tests/multi_kit.rs
@@ -119,15 +119,103 @@ fn shutdown(sock: &PathBuf) {
 
 /// Check if a binary is available on PATH.
 fn binary_on_path(name: &str) -> bool {
+    binary_path(name).is_some()
+}
+
+fn binary_path(name: &str) -> Option<PathBuf> {
     if let Ok(path_var) = std::env::var("PATH") {
         for dir in path_var.split(':') {
             let candidate = PathBuf::from(dir).join(name);
             if candidate.is_file() {
-                return true;
+                return Some(candidate);
             }
         }
     }
-    false
+    None
+}
+
+fn rpc_binary_accepts_initialize(name: &str, args: &[&str]) -> Result<PathBuf, String> {
+    let path = binary_path(name).ok_or_else(|| format!("{name} not on PATH"))?;
+
+    let mut child = Command::new(&path)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("spawn {}: {e}", path.display()))?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| format!("{} did not expose stdin", path.display()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| format!("{} did not expose stdout", path.display()))?;
+
+    let init_req = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}
+    });
+    let init_line = serde_json::to_string(&init_req).unwrap() + "\n";
+    if let Err(e) = stdin.write_all(init_line.as_bytes()) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(format!("write initialize to {}: {e}", path.display()));
+    }
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let read = reader.read_line(&mut line);
+        let _ = tx.send((read, line));
+    });
+
+    let (read, line) = match rx.recv_timeout(Duration::from_secs(3)) {
+        Ok(result) => result,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!("{} did not answer initialize", path.display()));
+        }
+    };
+
+    match read {
+        Ok(0) => {
+            let _ = child.wait();
+            return Err(format!(
+                "{} exited before initialize response",
+                path.display()
+            ));
+        }
+        Ok(_) => {}
+        Err(e) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!("read initialize from {}: {e}", path.display()));
+        }
+    }
+
+    if !line.contains("\"result\"") {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(format!(
+            "{} returned unexpected initialize response: {}",
+            path.display(),
+            line.trim()
+        ));
+    }
+
+    let shutdown_req = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "shutdown", "params": {}
+    });
+    let shutdown_line = serde_json::to_string(&shutdown_req).unwrap() + "\n";
+    let _ = stdin.write_all(shutdown_line.as_bytes());
+    drop(stdin);
+    let _ = child.wait();
+
+    Ok(path)
 }
 
 // -------------------------------------------------------------------
@@ -343,13 +431,16 @@ pub fn abs_value(x: i64) -> i64 {
 ///   - No JSON-RPC error is returned.
 #[test]
 fn test4_java_kit_dispatch() {
-    if !binary_on_path("provekit-lsp-java") {
-        println!(
-            "SKIP test4_java_kit_dispatch: provekit-lsp-java not on PATH. \
-             Install via: cd implementations/java/provekit-lift-java-core && \
-             mvn package -q && cp target/appassembler/bin/provekit-lsp-java ~/.local/bin/"
-        );
-        return;
+    match rpc_binary_accepts_initialize("provekit-lsp-java", &["--rpc"]) {
+        Ok(_) => {}
+        Err(reason) => {
+            println!(
+                "SKIP test4_java_kit_dispatch: provekit-lsp-java is not usable ({reason}). \
+                 Install via: cd implementations/java/provekit-lift-java-core && \
+                 mvn package -q && cp target/appassembler/bin/provekit-lsp-java ~/.local/bin/"
+            );
+            return;
+        }
     }
 
     let sock = unique_sock_path("t4");

--- a/menagerie/supply-chain-rails/README.md
+++ b/menagerie/supply-chain-rails/README.md
@@ -3,28 +3,57 @@
 Supply Chain Rails is the Menagerie destination for proof-carrying
 artifact admission.
 
-Its core claim is stronger than artifact authentication:
+Its core claim is narrower and stronger than artifact authentication:
 
 ```text
-an authentic compatible-looking release cannot silently betray its contracts
+an authentic conventional-green release can still fail contract admission
 ```
 
 A package maintainer may still sign a bad release. The package name may be
 right. The registry may be right. The tarball hash may match. A real
 `slsa-verifier` VSA check and a real `in-toto-verify` pipeline check may be
-green. That only proves the package's provenance and process predicates.
+green. That proves useful provenance and process predicates, not the preserved
+behavioral contract the consumer relies on.
 
-That is the problem statement:
+That is the precise problem statement:
 
 ```text
-SLSA does not catch it.
-in-toto does not catch it.
-ProvekIt does.
+SLSA VSA verifies the tarball's declared provenance/process summary.
+This in-toto layout verifies the packaging step and product digest.
+ProvekIt rejects admission when a preserved contract cannot lower into evidence.
 ```
 
 The exhibit should not caricature SLSA or in-toto as broken. Their receipts are
 allowed to be valid. They simply discharge different predicates than the one the
 consumer needs for safe admission.
+
+## Honesty Boundary
+
+This exhibit is npm-shaped, not a complete model of the npm ecosystem. The
+artifact is a real `npm pack` tarball, and ProvekIt invokes real
+`slsa-verifier` and `in-toto-verify` binaries. The registry, maintainer keys,
+and attestations are repository-owned fixtures so the receipt chain is
+reproducible.
+
+That means the exhibit does not claim that ProvekIt currently models every npm
+attack surface. It does not model full npm dependency resolution, lifecycle
+script semantics, registry provenance, package aliases, bundled dependency
+behavior, or every possible in-toto layout. The npm lifter maps enough package
+rails to carry the contract admission story, and the JavaScript lowerer
+demonstrates the ORP move for this contract. They are not general-purpose npm
+or JavaScript verifiers yet.
+
+The path to remove those caveats is tracked in:
+
+- [#498](https://github.com/TSavo/provekit/issues/498): make the npm inspector
+  a complete package semantic model.
+- [#499](https://github.com/TSavo/provekit/issues/499): promote the JavaScript
+  lowerer from exhibit-specific ORP to a general JavaScript evidence engine.
+
+Until those land, the claim is conditional and receipt-shaped: for this
+package-shaped release, this contract set, these accepted lowerers, and this
+admission policy, conventional receipts stay green while ProvekIt rejects the
+release on the rail whose contract evidence fails.
 
 The private signing keys under `authenticated-betrayal/packages/*/attestations`
 are repository-owned fixtures. They are intentionally checked in so the native
@@ -47,16 +76,17 @@ green-red, not red-green:
 
 ```text
 safe-json 1.4.1 -> safe-json 1.4.2
-ordinary supply-chain receipts: green
+conventional receipt rails: green
 ProvekIt admission receipt: red
 ```
 
 `1.4.1` is admitted because its package identity, binary identity, contract set,
 lowered witnesses, and CI input closure compose. `1.4.2` is published by the
-same legitimate maintainer with ordinary provenance green, but it introduces a
+same fixture maintainer with conventional provenance green, but it introduces a
 forbidden behavior.
 
-The walkthrough must first show the problem as a package manager sees it:
+The walkthrough must first show the problem as conventional package receipts
+see it:
 
 ```text
 right name, right maintainer, right version shape, right provenance, right build
@@ -70,7 +100,7 @@ authentic artifact, inadmissible contract graph
 
 The attacker then has only visible choices:
 
-| Choice | Conventional supply-chain result | ProvekIt receipt |
+| Choice | Conventional receipt result | ProvekIt receipt |
 | --- | --- | --- |
 | Keep the old contract set and lie about behavior | green | ORP lowerer refuses or emits a counterexample instead of a witness `.proof` |
 | Weaken the contract set to match the new behavior | green | `oldSet subset newSet` fails for the claimed compatible update |
@@ -98,9 +128,10 @@ The exhibit is specified as receipts, not as a whitepaper:
   defines the CLI-first tour and the proof artifacts each step must show.
 
 The poisoned npm package tarball is the artifact under test. It is not the
-proof. The proof is the receipt chain that shows conventional green, then the
-specific ProvekIt rail that turns red. PyPI/PIP can get a sibling exhibit later;
-this one is npm all the way down.
+proof. The proof is the receipt chain that shows conventional green for the
+fixture's package-shaped rails, then the specific ProvekIt rail that turns red.
+PyPI/PIP can get a sibling exhibit later; this one is npm-shaped all the way
+down.
 
 The npm lifter does not author behavioral contracts from package metadata. It
 maps package rails, then delegates the contract surface to the existing

--- a/menagerie/supply-chain-rails/authenticated-betrayal/specimen.yaml
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/specimen.yaml
@@ -1,9 +1,16 @@
 id: SCR-SHAPE-001
 name: Authenticated Betrayal
 status: implemented
-claim: SLSA does not catch it; in-toto does not catch it; ProvekIt does
+claim: conventional SLSA and in-toto receipts stay green while ProvekIt rejects admission for an undischargeable preserved contract
 walkthroughShape: conventional-green-then-provekit-red
 toolRule: every central receipt is emitted or inspected by provekit
+truthBoundary:
+  ecosystem: npm-shaped fixture, not a complete npm registry or installer model
+  nativeReceipts: real slsa-verifier and in-toto-verify over repository-owned fixture attestations
+  provekitClaim: admission is rejected only for declared contracts under accepted lowerers and policy
+  followUps:
+    - https://github.com/TSavo/provekit/issues/498
+    - https://github.com/TSavo/provekit/issues/499
 
 package:
   name: safe-json
@@ -15,7 +22,7 @@ package:
 ordinarySupplyChainSignals:
   expected: green
   receiptSource: provekit package inspect
-  conclusion: conventional receipts validate but do not ask whether preserved behavior still holds
+  conclusion: conventional receipts validate the fixture provenance and packaging predicates but do not ask whether preserved behavior still holds
   receipts:
     - package name resolves to safe-json
     - maintainer signature is green

--- a/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/00-start-here.sh
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/00-start-here.sh
@@ -5,17 +5,19 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
 section "Start Here"
 explain_then_pause "start the exhibit" <<'TEXT'
-This exhibit is about an npm package that looks normal to ordinary supply-chain checks. The package name is right, the maintainer story is right, the tarball hash is right, `slsa-verifier verify-vsa` accepts the signed SLSA verification summary, and `in-toto-verify` accepts the signed packaging layout and link. That is the point: those systems can prove useful provenance and process facts without proving the package still satisfies the contract its consumers rely on.
+This exhibit is about an npm-shaped package release that looks normal to the conventional receipts this fixture provides. The package name is right, the maintainer story is right, the tarball hash is right, `slsa-verifier verify-vsa` accepts the signed SLSA verification summary, and `in-toto-verify` accepts the signed packaging layout and link. That is the point: those systems can prove useful provenance and process facts without proving the package still satisfies the contract its consumers rely on.
 
-ProvekIt adds a different admission question. It asks whether the release extends the previous contract set, whether each preserved contract can be lowered into evidence, whether the observed bytes match the admitted binary CID, whether CI evidence applies to this exact input closure, and whether policy still admits the signer and witness classes. The package manager sees one artifact. ProvekIt sees a vector of rails.
+ProvekIt adds a different admission question. It asks whether the release extends the previous contract set, whether each preserved contract can be lowered into evidence, whether the observed bytes match the admitted binary CID, whether CI evidence applies to this exact input closure, and whether policy still admits the signer and witness classes. The conventional receipt view sees one artifact. ProvekIt sees a vector of rails.
+
+The honesty boundary matters. This is not a complete npm registry or installer model. The tarball is real and the native receipt tools are real, but the registry, maintainer keys, and attestations are fixtures. The claim being proven is about contract admission for this declared contract set under this policy, not about every possible npm attack.
 
 The first package is safe-json@1.4.1, a tiny JSON boundary helper with believable contracts: deterministic parsing, no network effect, no install side effect, and no runtime secret environment read. The second package is safe-json@1.4.2, signed by the same maintainer, but it reads SAFE_JSON_TOKEN on a rare telemetry-shaped input path.
 TEXT
 
-section "Claim"
-say "SLSA does not catch it."
-say "in-toto does not catch it."
-say "ProvekIt does."
+section "Precise Claim"
+say "SLSA accepts the signed VSA for this tarball digest; it does not prove runtime.no-env-secret-read."
+say "This in-toto layout accepts the packaging step; it does not prove runtime.no-env-secret-read."
+say "ProvekIt rejects admission when the preserved contract cannot lower into accepted evidence."
 
 analysis_with_receipts <<'TEXT'
 No command has run yet. The receipt standard for the rest of the walkthrough is simple: every material line comes from provekit output, and every human claim is tied back to a raw line from that output.

--- a/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/03-show-conventional-green.sh
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/03-show-conventional-green.sh
@@ -8,14 +8,14 @@ inspect_json="$tmp/conventional-green.json"
 inspect_stderr="$tmp/conventional-green.stderr"
 
 section "Show Conventional Green"
-explain_then_pause "inspect safe-json 1.4.2 as a package manager would" <<'TEXT'
-Now the exhibit changes the package behavior. safe-json@1.4.2 is still the right package, right version shape, right tarball metadata, and right maintainer story. The conventional receipts are deliberately green. This is not a strawman failure where metadata is obviously broken.
+explain_then_pause "inspect safe-json 1.4.2 through conventional receipt rails" <<'TEXT'
+Now the exhibit changes the package behavior. safe-json@1.4.2 is still the right package, right version shape, right tarball metadata, and right maintainer story inside this fixture. The conventional receipts are deliberately green. This is not a strawman failure where metadata is obviously broken.
 
 ProvekIt value starts with refusing to overclaim. The package inspection receipt is not stamping labels. It invokes `slsa-verifier verify-vsa` against a signed SLSA Verification Summary Attestation for the tarball digest, and it invokes `in-toto-verify` against a signed root layout plus the packaging link. Those tools go green, and ProvekIt records their commands and receipt paths.
 
 That still is not admission. SLSA says a verifier accepted the subject digest at a declared level. in-toto says the packaging step produced `package.tgz` from the declared materials under the authorized functionary key. Neither receipt says the JavaScript runtime preserves `runtime.no-env-secret-read`.
 
-What to look for: the package is a real npm tarball, SLSA and in-toto name their actual tools, both receipts are green, and admission.status remains not-decided.
+What to look for: the package is a real npm tarball, SLSA and in-toto name their actual tools, both receipts are green, the registry authority is explicitly fixture-shaped, and admission.status remains not-decided.
 TEXT
 
 print_provekit package inspect "menagerie/supply-chain-rails/authenticated-betrayal/packages/safe-json-1.4.2-lie" --json --quiet
@@ -24,6 +24,7 @@ run_provekit_capture "$inspect_json" "$inspect_stderr" package inspect "menageri
 section "Conventional Green JSON"
 show_json_file "$inspect_json"
 highlight_raw_line "$inspect_json" '"format": "npm-pack-tarball"' "The artifact is a real npm pack tarball, not a text placeholder."
+highlight_raw_line "$inspect_json" '"registry": "fixture:npm"' "The registry authority is a fixture, not a live npm registry claim."
 highlight_raw_line "$inspect_json" '"tool": "slsa-verifier"' "The SLSA rail came from the installed SLSA verifier."
 highlight_raw_line "$inspect_json" '"predicateType": "https://slsa.dev/verification_summary/v1"' "The SLSA receipt is a signed Verification Summary Attestation."
 highlight_raw_line "$inspect_json" '"tool": "in-toto-verify"' "The in-toto rail came from the installed in-toto verifier."
@@ -32,7 +33,7 @@ highlight_raw_line "$inspect_json" '"sbomContents": {' "The SBOM-style contents 
 highlight_raw_line "$inspect_json" '"status": "not-decided"' "ProvekIt does not confuse provenance with contract admission."
 
 analysis_with_receipts <<'TEXT'
-These lines prove the setup. The release can be authentic and conventional-green while still not being admitted. SLSA and in-toto are not mocked here: ProvekIt invoked their installed verifiers and preserved the exact receipt shape in the package inspection output.
+These lines prove the setup. The release can be authentic under the fixture authority and conventional-green while still not being admitted. SLSA and in-toto are not mocked here: ProvekIt invoked their installed verifiers and preserved the exact receipt shape in the package inspection output.
 
 That gap is exactly where ProvekIt adds value: the maintainer can claim the old contract, but the claim has to lower into evidence.
 TEXT

--- a/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/08-run-whole-exhibit.sh
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/08-run-whole-exhibit.sh
@@ -11,7 +11,7 @@ section "Run Whole Exhibit"
 explain_then_pause "run the rail matrix" <<'TEXT'
 The final step runs the exhibit runner. This is not a separate proof engine. The runner shells through provekit for package inspection, lift, lower, mint, version compatibility, binary verification, and policy admission. Its job is orchestration and checking that the receipts compose into the promised green-red story.
 
-The important thing to see is the shape of the final matrix. Ordinary supply-chain receipts are green. ProvekIt then rejects on witness, contract-set, binary, and CI input-closure rails, each with its own receipt field.
+The important thing to see is the shape of the final matrix. Conventional fixture receipts are green. ProvekIt then rejects on witness, contract-set, binary, and CI input-closure rails, each with its own receipt field.
 
 What to look for: the final report says ok true for the exhibit, conventional receipts green, and red rails named with specific reasons.
 TEXT
@@ -31,7 +31,7 @@ highlight_raw_line "$runner_json" '"reason": "binaryCid mismatch"' "The substitu
 highlight_raw_line "$runner_json" '"reason": "inputClosureCid mismatch"' "The stale-CI path trips the closure rail."
 
 analysis_with_receipts <<'TEXT'
-This is the exhibit claim with receipts. The package has green conventional supply-chain evidence, but ProvekIt refuses admission when the release betrays a preserved contract, weakens the contract set, substitutes bytes, or reuses stale CI evidence.
+This is the exhibit claim with receipts. The package has green conventional fixture evidence, but ProvekIt refuses admission when the release betrays a preserved contract, weakens the contract set, substitutes bytes, or reuses stale CI evidence.
 
 The proof is not a poisoned tarball. The proof is the receipt chain showing exactly which claim stayed green and exactly which rail went red.
 TEXT

--- a/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/README.md
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/README.md
@@ -26,13 +26,27 @@ Each script follows the Bridgeworks cadence:
 The exhibit proves this claim with receipts:
 
 ```text
-SLSA does not catch it.
-in-toto does not catch it.
-ProvekIt does.
+SLSA VSA verifies the tarball's declared provenance/process summary.
+This in-toto layout verifies the packaging step and product digest.
+ProvekIt rejects admission when a preserved contract cannot lower into evidence.
 ```
 
-The npm package is `safe-json`, a small believable JSON boundary helper. The
-baseline `1.4.1` release has four contracts:
+This is deliberately not a claim that the fixture is the whole npm ecosystem.
+The package is npm-shaped and the tarball is real, but the registry,
+maintainer keys, and attestations are repository-owned fixtures. The native
+receipt tools are real; the authority path is fixture authority. The visitor
+should see the gap between valid conventional receipts and contract admission,
+not infer that every npm or JavaScript supply-chain attack is already modeled.
+
+Two gaps are tracked explicitly before this can claim full coverage:
+
+- [#498](https://github.com/TSavo/provekit/issues/498): make the npm inspector
+  a complete package semantic model.
+- [#499](https://github.com/TSavo/provekit/issues/499): promote the JavaScript
+  lowerer from exhibit-specific ORP to a general JavaScript evidence engine.
+
+The npm-shaped package is `safe-json`, a small believable JSON boundary helper.
+The baseline `1.4.1` release has four contracts:
 
 - `parse.deterministic`
 - `parse.no-network-effect`
@@ -64,7 +78,7 @@ CID, and package input-closure CID. ProvekIt invokes `slsa-verifier verify-vsa`
 and `in-toto-verify`; the walkthrough does not call those tools directly.
 
 Those receipts are intentionally green. They are useful context, but they do
-not decide admission. ProvekIt admission goes red on one of the rails:
+not decide admission. ProvekIt admission goes red on one of the contract rails:
 
 | Script | Rail | Receipt |
 | --- | --- | --- |
@@ -81,7 +95,7 @@ not decide admission. ProvekIt admission goes red on one of the rails:
 Every script answers:
 
 - What is ProvekIt doing here?
-- What value does ProvekIt add beyond package-manager or provenance checks?
+- What value does ProvekIt add beyond the package-shaped provenance checks shown here?
 - Which receipt proves or rejects the initial claim?
 
 The important sentence for the visitor:

--- a/menagerie/supply-chain-rails/src/lib.rs
+++ b/menagerie/supply-chain-rails/src/lib.rs
@@ -29,7 +29,7 @@ pub struct OutputFlags {
     name = "provekit-supply-chain-rails",
     version,
     about = "Run Supply Chain Rails package-admission exhibits.",
-    long_about = "Supply Chain Rails demonstrates that ordinary supply-chain receipts can stay green while ProvekIt rejects an authentic package release on contract, witness, binary, or CI rails."
+    long_about = "Supply Chain Rails demonstrates that conventional package receipts can stay green while ProvekIt rejects a package-shaped release on contract, witness, binary, or CI rails."
 )]
 pub struct SupplyChainRailsArgs {
     /// Exhibit directory or specimen.yaml path. Defaults to menagerie/supply-chain-rails/authenticated-betrayal.
@@ -327,7 +327,7 @@ fn check_specimen(specimen_dir: &Path) -> Result<Value, SupplyChainRailsError> {
     Ok(json!({
         "id": "SCR-SHAPE-001",
         "name": "Authenticated Betrayal",
-        "claim": "SLSA does not catch it; in-toto does not catch it; ProvekIt does",
+        "claim": "conventional SLSA and in-toto receipts stay green while ProvekIt rejects admission for an undischargeable preserved contract",
         "baseline": {
             "package": baseline_inspect["package"],
             "minted": baseline_mint["ok"],

--- a/tools/cross-kit-conformance/src/lib.rs
+++ b/tools/cross-kit-conformance/src/lib.rs
@@ -540,6 +540,13 @@ fn self_contract_bootstrap_targets(profile: Profile) -> Vec<&'static str> {
     targets
 }
 
+fn bootstrap_timeout_for_target(target: &str) -> Duration {
+    match target {
+        "build-swift" => Duration::from_secs(1800),
+        _ => Duration::from_secs(900),
+    }
+}
+
 fn attestation_path(lang: &str) -> PathBuf {
     repo_root()
         .join(".provekit/self-contracts-attestations")
@@ -777,7 +784,7 @@ fn bootstrap_self_contract_toolchains(profile: Profile) -> Result<()> {
     for target in self_contract_bootstrap_targets(profile) {
         println!("  bootstrap: make {target}");
         let cmd = vec!["make".to_string(), target.to_string()];
-        let proc = run_cmd(&cmd, &repo_root(), Duration::from_secs(900));
+        let proc = run_cmd(&cmd, &repo_root(), bootstrap_timeout_for_target(target));
         if proc.code != 0 {
             return Err(command_error(&cmd, &proc));
         }
@@ -1922,16 +1929,26 @@ public class PkJavaConformance {{
 fn swift_emit_cid(name: &str) -> Result<String> {
     let root = repo_root();
     command_stdout(
-        &[
-            "swift".into(),
-            "run".into(),
-            "conformance".into(),
-            "--fixture".into(),
-            name.into(),
-        ],
+        &swift_fixture_cmd(name),
         &root.join("implementations/swift"),
         Duration::from_secs(180),
     )
+}
+
+fn swift_conformance_cmd(args: &[&str]) -> Vec<String> {
+    let mut cmd = vec![
+        "swift".to_string(),
+        "run".to_string(),
+        "-c".to_string(),
+        "release".to_string(),
+        "conformance".to_string(),
+    ];
+    cmd.extend(args.iter().map(|arg| arg.to_string()));
+    cmd
+}
+
+fn swift_fixture_cmd(name: &str) -> Vec<String> {
+    swift_conformance_cmd(&["--fixture", name])
 }
 
 fn linux_direct_adapters() -> Vec<DirectAdapter> {
@@ -2075,7 +2092,7 @@ fn swift_native_checks() -> Vec<NativeCheck> {
     vec![NativeCheck {
         kit: "swift",
         name: "swift conformance runner CID checks",
-        cmd: vec!["swift".into(), "run".into(), "conformance".into()],
+        cmd: swift_conformance_cmd(&[]),
         cwd: root.join("implementations/swift"),
         timeout: Duration::from_secs(300),
     }]
@@ -2636,6 +2653,35 @@ mod tests {
         let targets = self_contract_bootstrap_targets(Profile::Linux);
         assert!(targets.contains(&"build-rust"));
         assert!(targets.contains(&"build-ruby"));
+    }
+
+    #[test]
+    fn swift_profile_uses_release_runner_and_extended_bootstrap_timeout() {
+        let native = swift_native_checks()
+            .into_iter()
+            .next()
+            .expect("swift native check");
+
+        assert_eq!(
+            bootstrap_timeout_for_target("build-swift"),
+            Duration::from_secs(1800)
+        );
+        assert_eq!(
+            native.cmd,
+            vec!["swift", "run", "-c", "release", "conformance"]
+        );
+        assert_eq!(
+            swift_fixture_cmd("eq_atomic"),
+            vec![
+                "swift",
+                "run",
+                "-c",
+                "release",
+                "conformance",
+                "--fixture",
+                "eq_atomic"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Tightens the Supply Chain Rails claim from broad "SLSA/in-toto do not catch it" language to a receipt-shaped admission claim.
- Adds an explicit honesty boundary for npm-shaped fixture authority, real native receipt tools, and the current npm/JS coverage limits.
- Links the remaining 100% coverage work to #498 and #499, and updates the walkthrough language plus runner claim string to match.
- Hardens the optional Java kit dispatch test so stale or unusable self-hosted runner launchers skip explicitly instead of failing Rust tests before `test-java` can rebuild the Java kit.
- Refreshes the Rust CICP accepted witness for the new Rust input-closure CID.
- Uses the release Swift conformance harness and extends the Swift bootstrap window so macOS does not spend the direct adapter timeout on cold debug or dependency builds.

## Verification
- `bash -n menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/00-start-here.sh menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/03-show-conventional-green.sh menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/08-run-whole-exhibit.sh`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-supply-chain-rails --test smoke -- --nocapture`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit -- --nocapture`
- `cargo fmt --manifest-path implementations/rust/Cargo.toml --package provekit-linkerd --check`
- `cargo test --release --manifest-path tools/cross-kit-conformance/Cargo.toml swift_profile_uses_release_runner_and_extended_bootstrap_timeout -- --nocapture`
- `cargo test --release --manifest-path tools/cross-kit-conformance/Cargo.toml`
- `cargo fmt --manifest-path tools/cross-kit-conformance/Cargo.toml --check`
- `cargo run --release --manifest-path tools/cross-kit-conformance/Cargo.toml -- --profile swift --jobs 4`
- `implementations/rust/target/release/provekit ci accept --all-kits --clean --check --out .provekit/ci/accepted`
- `git diff --check`
