### PR TITLE
Add C kernel-doc lifter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ build-c:
 	$(MAKE) -C implementations/c/provekit-lift all
 	$(MAKE) -C implementations/c/provekit-lift-core all
 	$(MAKE) -C implementations/c/provekit-lift-c-sparse all
+	$(MAKE) -C implementations/c/provekit-lift-c-kernel-doc all
 	$(MAKE) -C implementations/c/provekit-lift-c-assertions all
 	$(MAKE) -C implementations/c/provekit-lsp-c all
 	$(MAKE) -C implementations/c/provekit-self-contracts lib
@@ -570,6 +571,7 @@ test-c: build-c
 	$(MAKE) -C implementations/c/provekit-lift test
 	$(MAKE) -C implementations/c/provekit-lift-core test
 	$(MAKE) -C implementations/c/provekit-lift-c-sparse test
+	$(MAKE) -C implementations/c/provekit-lift-c-kernel-doc test
 	$(MAKE) -C implementations/c/provekit-lift-c-assertions test
 	$(MAKE) -C implementations/c/provekit-lift-composition test
 	$(MAKE) -C implementations/c/provekit-lsp-c test

--- a/implementations/c/.provekit/lift/c-kernel-doc/manifest.toml
+++ b/implementations/c/.provekit/lift/c-kernel-doc/manifest.toml
@@ -1,0 +1,10 @@
+name = "c-kernel-doc"
+version = "0.1.0"
+protocol_version = "provekit-lift/1"
+command = ["./provekit-lift-c-kernel-doc/provekit-lift-c-kernel-doc", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["c-kernel-doc"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/c/provekit-lift-c-kernel-doc/Makefile
+++ b/implementations/c/provekit-lift-c-kernel-doc/Makefile
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CC = cc
+CFLAGS = -Wall -Wextra -Wpedantic -std=c11 -I../provekit-lift-core/include -g
+LLVM_CONFIG ?= $(shell command -v llvm-config 2>/dev/null || command -v /usr/local/opt/llvm/bin/llvm-config 2>/dev/null || command -v /usr/local/opt/llvm@21/bin/llvm-config 2>/dev/null)
+
+BIN = provekit-lift-c-kernel-doc
+SRC = src/main.c src/kernel_doc.c ../provekit-lift-core/src/core.c ../provekit-lift-core/src/parser.c ../provekit-lift-core/src/compile_context.c
+TEST_SH = tests/integration.sh
+
+ifneq ($(strip $(LLVM_CONFIG)),)
+CFLAGS += -DPK_C_ENABLE_CLANG_AST -I$(shell $(LLVM_CONFIG) --includedir)
+LDFLAGS += -L$(shell $(LLVM_CONFIG) --libdir) -Wl,-rpath,$(shell $(LLVM_CONFIG) --libdir) -lclang
+SRC += ../provekit-lift-core/src/clang_ast.c
+else
+SRC += ../provekit-lift-core/src/clang_ast_stub.c
+endif
+
+.PHONY: all test clean
+
+all: $(BIN)
+
+$(BIN): $(SRC)
+	$(CC) $(CFLAGS) -o $@ $(SRC) $(LDFLAGS)
+
+test: $(BIN) $(TEST_SH)
+	@chmod +x $(TEST_SH)
+	@$(TEST_SH)
+
+clean:
+	rm -f $(BIN)

--- a/implementations/c/provekit-lift-c-kernel-doc/src/kernel_doc.c
+++ b/implementations/c/provekit-lift-c-kernel-doc/src/kernel_doc.c
@@ -1,0 +1,600 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "provekit/c_lift_core.h"
+
+typedef struct {
+    char **items;
+    size_t len;
+    size_t cap;
+} LineArray;
+
+static char *copy_n(const char *src, size_t len) {
+    char *out = malloc(len + 1);
+
+    if (!out) {
+        return NULL;
+    }
+    memcpy(out, src, len);
+    out[len] = '\0';
+    return out;
+}
+
+static char *copy_str(const char *src) {
+    return copy_n(src == NULL ? "" : src, strlen(src == NULL ? "" : src));
+}
+
+static char *json_escape_fragment(const char *src) {
+    size_t len = 0;
+    char *out;
+    char *p;
+
+    if (src == NULL) {
+        src = "";
+    }
+    for (const unsigned char *s = (const unsigned char *)src; *s != '\0'; s++) {
+        size_t add;
+
+        if (*s == '"' || *s == '\\') {
+            add = 2;
+        } else if (*s < 0x20) {
+            add = 6;
+        } else {
+            add = 1;
+        }
+        if (add > ((size_t)-1) - len) {
+            return NULL;
+        }
+        len += add;
+    }
+    out = malloc(len + 1);
+    if (out == NULL) {
+        return NULL;
+    }
+    p = out;
+    for (const unsigned char *s = (const unsigned char *)src; *s != '\0'; s++) {
+        switch (*s) {
+        case '"':
+            *p++ = '\\';
+            *p++ = '"';
+            break;
+        case '\\':
+            *p++ = '\\';
+            *p++ = '\\';
+            break;
+        case '\n':
+            *p++ = '\\';
+            *p++ = 'n';
+            break;
+        case '\r':
+            *p++ = '\\';
+            *p++ = 'r';
+            break;
+        case '\t':
+            *p++ = '\\';
+            *p++ = 't';
+            break;
+        default:
+            if (*s < 0x20) {
+                (void)snprintf(p, 7, "\\u%04x", *s);
+                p += 6;
+            } else {
+                *p++ = (char)*s;
+            }
+            break;
+        }
+    }
+    *p = '\0';
+    return out;
+}
+
+static char *trim_copy(const char *src) {
+    const char *start = src == NULL ? "" : src;
+    const char *end;
+
+    while (*start != '\0' && isspace((unsigned char)*start)) {
+        start++;
+    }
+    end = start + strlen(start);
+    while (end > start && isspace((unsigned char)end[-1])) {
+        end--;
+    }
+    return copy_n(start, (size_t)(end - start));
+}
+
+static int line_array_push(LineArray *lines, char *line) {
+    char **items;
+    size_t cap;
+
+    if (lines->len >= lines->cap) {
+        cap = lines->cap == 0 ? 16 : lines->cap * 2;
+        if (cap < lines->cap) {
+            free(line);
+            return -1;
+        }
+        items = realloc(lines->items, cap * sizeof(*lines->items));
+        if (items == NULL) {
+            free(line);
+            return -1;
+        }
+        lines->items = items;
+        lines->cap = cap;
+    }
+    lines->items[lines->len++] = line;
+    return 0;
+}
+
+static void line_array_free(LineArray *lines) {
+    if (lines == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < lines->len; i++) {
+        free(lines->items[i]);
+    }
+    free(lines->items);
+    lines->items = NULL;
+    lines->len = 0;
+    lines->cap = 0;
+}
+
+static int split_lines(const char *source, LineArray *lines) {
+    const char *p = source == NULL ? "" : source;
+
+    while (*p != '\0') {
+        const char *start = p;
+
+        while (*p != '\0' && *p != '\n') {
+            p++;
+        }
+        if (line_array_push(lines, copy_n(start, (size_t)(p - start))) != 0) {
+            return -1;
+        }
+        if (*p == '\n') {
+            p++;
+        }
+    }
+    return 0;
+}
+
+static const char *first_nonblank(const char *line) {
+    const char *p = line == NULL ? "" : line;
+
+    while (*p != '\0' && isspace((unsigned char)*p)) {
+        p++;
+    }
+    return p;
+}
+
+static int is_blank(const char *line) {
+    return *first_nonblank(line) == '\0';
+}
+
+static int has_prefix(const char *s, const char *prefix) {
+    return strncmp(s, prefix, strlen(prefix)) == 0;
+}
+
+static char lower_ascii(char c) {
+    return (char)tolower((unsigned char)c);
+}
+
+static int contains_ci(const char *haystack, const char *needle) {
+    size_t needle_len = strlen(needle);
+
+    if (needle_len == 0) {
+        return 1;
+    }
+    for (const char *h = haystack == NULL ? "" : haystack; *h != '\0'; h++) {
+        size_t i;
+
+        for (i = 0; i < needle_len; i++) {
+            if (h[i] == '\0' || lower_ascii(h[i]) != lower_ascii(needle[i])) {
+                break;
+            }
+        }
+        if (i == needle_len) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int append_core_result(pk_c_lift_result *result, const pk_c_source_facts *facts) {
+    if (facts == NULL || facts->extraction_result == NULL) {
+        return 0;
+    }
+    return pk_c_lift_result_extend(result, facts->extraction_result);
+}
+
+static int add_contract(
+    pk_c_lift_result *result,
+    const char *name,
+    const char *function_name,
+    const char *binding_name
+) {
+    char *escaped_name = json_escape_fragment(name);
+    char *escaped_function = json_escape_fragment(function_name);
+    char *escaped_binding = json_escape_fragment(binding_name);
+    char *json;
+    int written;
+    int rc;
+
+    if (escaped_name == NULL || escaped_function == NULL || escaped_binding == NULL) {
+        free(escaped_name);
+        free(escaped_function);
+        free(escaped_binding);
+        return -1;
+    }
+
+    written = snprintf(NULL,
+        0,
+        "{\"function\":\"%s\",\"kind\":\"contract\",\"name\":\"%s\","
+        "\"outBinding\":\"out\",\"post\":{\"args\":[{\"kind\":\"var\",\"name\":\"%s\"}],"
+        "\"kind\":\"atomic\",\"name\":\"%s\"}}",
+        escaped_function,
+        escaped_name,
+        escaped_binding,
+        escaped_name);
+    if (written < 0) {
+        free(escaped_name);
+        free(escaped_function);
+        free(escaped_binding);
+        return -1;
+    }
+    json = malloc((size_t)written + 1);
+    if (json == NULL) {
+        free(escaped_name);
+        free(escaped_function);
+        free(escaped_binding);
+        return -1;
+    }
+    (void)snprintf(json,
+        (size_t)written + 1,
+        "{\"function\":\"%s\",\"kind\":\"contract\",\"name\":\"%s\","
+        "\"outBinding\":\"out\",\"post\":{\"args\":[{\"kind\":\"var\",\"name\":\"%s\"}],"
+        "\"kind\":\"atomic\",\"name\":\"%s\"}}",
+        escaped_function,
+        escaped_name,
+        escaped_binding,
+        escaped_name);
+
+    rc = pk_c_lift_result_add_declaration(result, json);
+    free(json);
+    free(escaped_name);
+    free(escaped_function);
+    free(escaped_binding);
+    return rc;
+}
+
+static int add_diagnostic(
+    pk_c_lift_result *result,
+    const char *kind,
+    const char *path,
+    int line,
+    const char *message
+) {
+    char *escaped_kind = json_escape_fragment(kind);
+    char *escaped_path = json_escape_fragment(path);
+    char *escaped_message = json_escape_fragment(message);
+    char *json;
+    int written;
+    int rc;
+
+    if (escaped_kind == NULL || escaped_path == NULL || escaped_message == NULL) {
+        free(escaped_kind);
+        free(escaped_path);
+        free(escaped_message);
+        return -1;
+    }
+    written = snprintf(NULL,
+        0,
+        "{\"kind\":\"%s\",\"locus\":{\"column\":1,\"line\":%d,\"path\":\"%s\"},"
+        "\"message\":\"%s\",\"severity\":\"warning\"}",
+        escaped_kind,
+        line,
+        escaped_path,
+        escaped_message);
+    if (written < 0) {
+        free(escaped_kind);
+        free(escaped_path);
+        free(escaped_message);
+        return -1;
+    }
+    json = malloc((size_t)written + 1);
+    if (json == NULL) {
+        free(escaped_kind);
+        free(escaped_path);
+        free(escaped_message);
+        return -1;
+    }
+    (void)snprintf(json,
+        (size_t)written + 1,
+        "{\"kind\":\"%s\",\"locus\":{\"column\":1,\"line\":%d,\"path\":\"%s\"},"
+        "\"message\":\"%s\",\"severity\":\"warning\"}",
+        escaped_kind,
+        line,
+        escaped_path,
+        escaped_message);
+    rc = pk_c_lift_result_add_diagnostic(result, json);
+    free(json);
+    free(escaped_kind);
+    free(escaped_path);
+    free(escaped_message);
+    return rc;
+}
+
+static char *clean_doc_line(const char *line) {
+    char *work = copy_str(line);
+    char *start;
+    char *end_marker;
+    char *trimmed;
+
+    if (work == NULL) {
+        return NULL;
+    }
+    start = strstr(work, "/**");
+    if (start != NULL) {
+        memmove(work, start + 3, strlen(start + 3) + 1);
+    }
+    end_marker = strstr(work, "*/");
+    if (end_marker != NULL) {
+        *end_marker = '\0';
+    }
+    start = (char *)first_nonblank(work);
+    if (*start == '*') {
+        start++;
+        if (*start == ' ') {
+            start++;
+        }
+    }
+    trimmed = trim_copy(start);
+    free(work);
+    return trimmed;
+}
+
+static char *extract_function_name(const char *line) {
+    const char *open = strchr(line == NULL ? "" : line, '(');
+    const char *end;
+    const char *start;
+
+    if (open == NULL) {
+        return NULL;
+    }
+    end = open;
+    while (end > line && isspace((unsigned char)end[-1])) {
+        end--;
+    }
+    start = end;
+    while (start > line &&
+        (isalnum((unsigned char)start[-1]) || start[-1] == '_')) {
+        start--;
+    }
+    if (start == end) {
+        return NULL;
+    }
+    return copy_n(start, (size_t)(end - start));
+}
+
+static char *extract_doc_param(const char *doc_line) {
+    const char *p = doc_line;
+    const char *start;
+
+    if (p == NULL || *p != '@') {
+        return NULL;
+    }
+    p++;
+    start = p;
+    while (*p != '\0' && *p != ':' && !isspace((unsigned char)*p)) {
+        p++;
+    }
+    if (p == start) {
+        return NULL;
+    }
+    return copy_n(start, (size_t)(p - start));
+}
+
+static char *extract_must_hold_lock(const char *doc_line) {
+    const char *held;
+    const char *end;
+    const char *start;
+
+    held = strstr(doc_line == NULL ? "" : doc_line, " held");
+    if (held == NULL) {
+        return copy_str("lock");
+    }
+    end = held;
+    while (end > doc_line && isspace((unsigned char)end[-1])) {
+        end--;
+    }
+    start = end;
+    while (start > doc_line &&
+        (isalnum((unsigned char)start[-1]) || start[-1] == '_')) {
+        start--;
+    }
+    if (start == end) {
+        return copy_str("lock");
+    }
+    return copy_n(start, (size_t)(end - start));
+}
+
+static int process_doc_comment(
+    pk_c_lift_result *result,
+    const LineArray *lines,
+    size_t start,
+    size_t end,
+    const char *path
+) {
+    size_t attach = end + 1;
+    char *function_name = NULL;
+
+    while (attach < lines->len && is_blank(lines->items[attach])) {
+        attach++;
+    }
+    if (attach >= lines->len) {
+        return add_diagnostic(result,
+            "c-kernel-doc.unattached-comment",
+            path,
+            (int)start + 1,
+            "kernel-doc comment is not followed by a function declaration");
+    }
+    if (*first_nonblank(lines->items[attach]) == '#') {
+        return pk_c_lift_result_add_opacity_entry(result,
+            "c-kernel-doc.conditional-attachment",
+            path,
+            (int)start + 1,
+            1,
+            "kernel-doc comment is separated from the declaration by a preprocessor directive",
+            "c-kernel-doc");
+    }
+
+    function_name = extract_function_name(lines->items[attach]);
+    if (function_name == NULL) {
+        return add_diagnostic(result,
+            "c-kernel-doc.unattached-comment",
+            path,
+            (int)start + 1,
+            "kernel-doc comment is not attached to a recognizable function declaration");
+    }
+
+    for (size_t i = start; i <= end; i++) {
+        char *doc = clean_doc_line(lines->items[i]);
+        int rc = 0;
+
+        if (doc == NULL) {
+            free(function_name);
+            return -1;
+        }
+
+        if (doc[0] == '@') {
+            char *param = extract_doc_param(doc);
+
+            if (param != NULL && contains_ci(doc, "must not be null")) {
+                rc = add_contract(result,
+                    "c-kernel-doc.param.nonnull",
+                    function_name,
+                    param);
+            } else if (param != NULL && contains_ci(doc, "must be positive")) {
+                rc = add_contract(result,
+                    "c-kernel-doc.param.positive",
+                    function_name,
+                    param);
+            }
+            free(param);
+        } else if (has_prefix(doc, "Context:") && contains_ci(doc, "held")) {
+            char *lock = extract_must_hold_lock(doc);
+
+            if (lock == NULL) {
+                rc = -1;
+            } else {
+                rc = add_contract(result,
+                    "c-kernel-doc.context.must-hold",
+                    function_name,
+                    lock);
+                free(lock);
+            }
+        } else if (has_prefix(doc, "Return:")) {
+            if (contains_ci(doc, "negative errno")) {
+                rc = add_contract(result,
+                    "c-kernel-doc.return.negative-errno",
+                    function_name,
+                    function_name);
+            } else if (contains_ci(doc, "owns") && contains_ci(doc, "release")) {
+                rc = pk_c_lift_result_add_refusal_entry(result,
+                    "c-kernel-doc.unsupported-return-ownership",
+                    path,
+                    (int)i + 1,
+                    1,
+                    "c-kernel-doc",
+                    "kernel-doc return ownership language is recognized but not modeled by this lifter");
+            }
+        }
+        free(doc);
+        if (rc != 0) {
+            free(function_name);
+            return -1;
+        }
+    }
+
+    free(function_name);
+    return 0;
+}
+
+static int scan_kernel_doc(pk_c_lift_result *result, const char *path, const char *source) {
+    LineArray lines = {0};
+    int rc = 0;
+
+    if (split_lines(source, &lines) != 0) {
+        line_array_free(&lines);
+        return -1;
+    }
+
+    for (size_t i = 0; i < lines.len; i++) {
+        const char *first = first_nonblank(lines.items[i]);
+
+        if (!has_prefix(first, "/**")) {
+            continue;
+        }
+
+        size_t end = i;
+        while (end < lines.len && strstr(lines.items[end], "*/") == NULL) {
+            end++;
+        }
+        if (end >= lines.len) {
+            rc = add_diagnostic(result,
+                "c-kernel-doc.unclosed-comment",
+                path,
+                (int)i + 1,
+                "kernel-doc comment is not closed");
+            break;
+        }
+        rc = process_doc_comment(result, &lines, i, end, path);
+        if (rc != 0) {
+            break;
+        }
+        i = end;
+    }
+
+    line_array_free(&lines);
+    return rc;
+}
+
+pk_c_lift_result *pk_c_kernel_doc_lift_source_with_options(
+    const char *path,
+    const char *source,
+    const pk_c_parse_options *options
+) {
+    pk_c_lift_result *result = pk_c_lift_result_new();
+    pk_c_source_facts *facts;
+
+    if (!result) {
+        return NULL;
+    }
+    if (!source) {
+        return result;
+    }
+
+    facts = pk_c_parse_source_with_options(path, source, options);
+    if (facts == NULL) {
+        (void)pk_c_lift_result_add_diagnostic(
+            result,
+            "{\"message\":\"parse failed\",\"severity\":\"error\"}");
+        return result;
+    }
+    if (append_core_result(result, facts) != 0) {
+        pk_c_source_facts_free(facts);
+        pk_c_lift_result_free(result);
+        return NULL;
+    }
+    pk_c_source_facts_free(facts);
+
+    if (scan_kernel_doc(result, path == NULL ? "" : path, source) != 0) {
+        pk_c_lift_result_free(result);
+        return NULL;
+    }
+    return result;
+}
+
+pk_c_lift_result *pk_c_kernel_doc_lift_source(const char *path, const char *source) {
+    return pk_c_kernel_doc_lift_source_with_options(path, source, NULL);
+}

--- a/implementations/c/provekit-lift-c-kernel-doc/src/main.c
+++ b/implementations/c/provekit-lift-c-kernel-doc/src/main.c
@@ -1,0 +1,1422 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "provekit/c_lift_core.h"
+
+pk_c_lift_result *pk_c_kernel_doc_lift_source(const char *path, const char *source);
+pk_c_lift_result *pk_c_kernel_doc_lift_source_with_options(
+    const char *path,
+    const char *source,
+    const pk_c_parse_options *options);
+
+typedef struct {
+    char *data;
+    size_t len;
+    size_t cap;
+} Buf;
+
+typedef struct {
+    char **items;
+    size_t len;
+} StringArray;
+
+static void string_array_free(StringArray *arr);
+
+typedef struct {
+    pk_c_parse_options options;
+    StringArray clang_args;
+    pk_c_compile_context *compile_context;
+    char *parse_backend;
+    char *compile_context_kind;
+    char *workspace_root;
+    char *compile_command;
+    char *target_triple;
+    int resolve_kernel_context;
+} ParseRequestOptions;
+
+typedef struct {
+    Buf ir;
+    Buf call_edges;
+    Buf diagnostics;
+    Buf opacity_report;
+    Buf refusals;
+    size_t ir_count;
+    size_t call_edge_count;
+    size_t diagnostic_count;
+    size_t opacity_count;
+    size_t refusal_count;
+    char error[512];
+} LiftAccumulator;
+
+static void buf_init(Buf *b) {
+    b->len = 0;
+    b->cap = 256;
+    b->data = malloc(b->cap);
+    if (b->data) {
+        b->data[0] = '\0';
+    } else {
+        b->cap = 0;
+    }
+}
+
+static void buf_free(Buf *b) {
+    free(b->data);
+    b->data = NULL;
+    b->len = 0;
+    b->cap = 0;
+}
+
+static int buf_grow(Buf *b, size_t need) {
+    size_t next = b->cap ? b->cap : 256;
+    char *data;
+
+    while (next < b->len + need + 1) {
+        if (next > ((size_t)-1) / 2) {
+            return -1;
+        }
+        next *= 2;
+    }
+
+    data = realloc(b->data, next);
+    if (!data) {
+        return -1;
+    }
+
+    b->data = data;
+    b->cap = next;
+    return 0;
+}
+
+static int buf_append_n(Buf *b, const char *s, size_t n) {
+    if (buf_grow(b, n) != 0) {
+        return -1;
+    }
+    memcpy(b->data + b->len, s, n);
+    b->len += n;
+    b->data[b->len] = '\0';
+    return 0;
+}
+
+static int buf_append(Buf *b, const char *s) {
+    return buf_append_n(b, s, strlen(s));
+}
+
+static int buf_append_char(Buf *b, char c) {
+    return buf_append_n(b, &c, 1);
+}
+
+static void json_escape_str(Buf *out, const char *s) {
+    (void)buf_append_char(out, '"');
+    for (const unsigned char *p = (const unsigned char *)s; p && *p; p++) {
+        switch (*p) {
+        case '"':
+            (void)buf_append(out, "\\\"");
+            break;
+        case '\\':
+            (void)buf_append(out, "\\\\");
+            break;
+        case '\n':
+            (void)buf_append(out, "\\n");
+            break;
+        case '\r':
+            (void)buf_append(out, "\\r");
+            break;
+        case '\t':
+            (void)buf_append(out, "\\t");
+            break;
+        default:
+            if (*p < 0x20) {
+                char esc[7];
+                (void)snprintf(esc, sizeof(esc), "\\u00%02x", *p);
+                (void)buf_append(out, esc);
+            } else {
+                (void)buf_append_char(out, (char)*p);
+            }
+            break;
+        }
+    }
+    (void)buf_append_char(out, '"');
+}
+
+static char *str_dup(const char *s) {
+    size_t n = strlen(s);
+    char *out = malloc(n + 1);
+    if (!out) {
+        return NULL;
+    }
+    memcpy(out, s, n + 1);
+    return out;
+}
+
+static void json_skip_ws(const char **p) {
+    while (**p == ' ' || **p == '\t' || **p == '\r' || **p == '\n') {
+        (*p)++;
+    }
+}
+
+static int json_parse_value(const char **p);
+
+static int json_hex_value(char c) {
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    return -1;
+}
+
+static int json_decode_hex4(const char *p, unsigned *out) {
+    unsigned value = 0;
+
+    for (int i = 0; i < 4; i++) {
+        int digit = json_hex_value(p[i]);
+        if (digit < 0) {
+            return -1;
+        }
+        value = (value << 4) | (unsigned)digit;
+    }
+    *out = value;
+    return 0;
+}
+
+static int json_append_utf8(char *out, size_t cap, size_t *len, unsigned codepoint) {
+    if (codepoint == 0 || codepoint > 0x10ffffu ||
+        (codepoint >= 0xd800u && codepoint <= 0xdfffu)) {
+        return -1;
+    }
+    if (codepoint < 0x80u) {
+        if (*len + 1 >= cap) {
+            return -1;
+        }
+        out[(*len)++] = (char)codepoint;
+    } else if (codepoint < 0x800u) {
+        if (*len + 2 >= cap) {
+            return -1;
+        }
+        out[(*len)++] = (char)(0xc0u | (codepoint >> 6));
+        out[(*len)++] = (char)(0x80u | (codepoint & 0x3fu));
+    } else if (codepoint < 0x10000u) {
+        if (*len + 3 >= cap) {
+            return -1;
+        }
+        out[(*len)++] = (char)(0xe0u | (codepoint >> 12));
+        out[(*len)++] = (char)(0x80u | ((codepoint >> 6) & 0x3fu));
+        out[(*len)++] = (char)(0x80u | (codepoint & 0x3fu));
+    } else {
+        if (*len + 4 >= cap) {
+            return -1;
+        }
+        out[(*len)++] = (char)(0xf0u | (codepoint >> 18));
+        out[(*len)++] = (char)(0x80u | ((codepoint >> 12) & 0x3fu));
+        out[(*len)++] = (char)(0x80u | ((codepoint >> 6) & 0x3fu));
+        out[(*len)++] = (char)(0x80u | (codepoint & 0x3fu));
+    }
+    return 0;
+}
+
+static char *decode_json_string(const char *start, const char **end_out) {
+    size_t cap = strlen(start) + 1;
+    char *out = malloc(cap);
+    size_t len = 0;
+    const char *p = start;
+
+    if (!out) {
+        return NULL;
+    }
+
+    while (*p && *p != '"') {
+        if (*p == '\\') {
+            p++;
+            switch (*p) {
+            case 'b':
+                out[len++] = '\b';
+                p++;
+                break;
+            case 'f':
+                out[len++] = '\f';
+                p++;
+                break;
+            case 'n':
+                out[len++] = '\n';
+                p++;
+                break;
+            case 'r':
+                out[len++] = '\r';
+                p++;
+                break;
+            case 't':
+                out[len++] = '\t';
+                p++;
+                break;
+            case '"':
+                out[len++] = '"';
+                p++;
+                break;
+            case '\\':
+                out[len++] = '\\';
+                p++;
+                break;
+            case '/':
+                out[len++] = '/';
+                p++;
+                break;
+            case 'u': {
+                unsigned codepoint;
+
+                p++;
+                if (json_decode_hex4(p, &codepoint) != 0) {
+                    free(out);
+                    return NULL;
+                }
+                p += 4;
+                if (codepoint >= 0xd800u && codepoint <= 0xdbffu) {
+                    unsigned low;
+
+                    if (p[0] != '\\' || p[1] != 'u' ||
+                        json_decode_hex4(p + 2, &low) != 0 ||
+                        low < 0xdc00u || low > 0xdfffu) {
+                        free(out);
+                        return NULL;
+                    }
+                    p += 6;
+                    codepoint = 0x10000u + (((codepoint - 0xd800u) << 10) |
+                        (low - 0xdc00u));
+                }
+                if (json_append_utf8(out, cap, &len, codepoint) != 0) {
+                    free(out);
+                    return NULL;
+                }
+                break;
+            }
+            case '\0':
+                out[len] = '\0';
+                if (end_out) {
+                    *end_out = p;
+                }
+                return out;
+            default:
+                free(out);
+                return NULL;
+            }
+        } else {
+            out[len++] = *p++;
+        }
+    }
+
+    out[len] = '\0';
+    if (end_out) {
+        *end_out = p;
+    }
+    return out;
+}
+
+static const char *json_find_object_value(const char *json, const char *field) {
+    const char *p = json;
+
+    json_skip_ws(&p);
+    if (*p != '{') {
+        return NULL;
+    }
+    p++;
+    json_skip_ws(&p);
+    if (*p == '}') {
+        return NULL;
+    }
+    for (;;) {
+        const char *end = NULL;
+        char *key;
+        int matched;
+
+        if (*p != '"') {
+            return NULL;
+        }
+        key = decode_json_string(p + 1, &end);
+        if (key == NULL || end == NULL || *end != '"') {
+            free(key);
+            return NULL;
+        }
+        p = end + 1;
+        json_skip_ws(&p);
+        if (*p != ':') {
+            free(key);
+            return NULL;
+        }
+        p++;
+        json_skip_ws(&p);
+        matched = strcmp(key, field) == 0;
+        free(key);
+        if (matched) {
+            return p;
+        }
+        if (!json_parse_value(&p)) {
+            return NULL;
+        }
+        json_skip_ws(&p);
+        if (*p == '}') {
+            return NULL;
+        }
+        if (*p != ',') {
+            return NULL;
+        }
+        p++;
+        json_skip_ws(&p);
+    }
+}
+
+static const char *json_find_params_value(const char *json, const char *field) {
+    const char *params = json_find_object_value(json, "params");
+
+    if (params == NULL) {
+        return NULL;
+    }
+    return json_find_object_value(params, field);
+}
+
+static char *json_extract_str(const char *json, const char *field) {
+    const char *p = json_find_object_value(json, field);
+
+    if (p == NULL || *p != '"') {
+        return NULL;
+    }
+    return decode_json_string(p + 1, NULL);
+}
+
+static char *json_extract_param_str(const char *json, const char *field) {
+    const char *p = json_find_params_value(json, field);
+
+    if (p == NULL || *p != '"') {
+        return NULL;
+    }
+    return decode_json_string(p + 1, NULL);
+}
+
+static int json_has_param_field(const char *json, const char *field) {
+    return json_find_params_value(json, field) != NULL;
+}
+
+static char *json_extract_id(const char *json) {
+    const char *p = json_find_object_value(json, "id");
+    Buf b;
+    char *out;
+
+    if (!p) {
+        return str_dup("null");
+    }
+    if (!*p) {
+        return str_dup("null");
+    }
+
+    buf_init(&b);
+    if (!b.data) {
+        return NULL;
+    }
+
+    if (*p == '"') {
+        const char *end = NULL;
+        char *decoded = decode_json_string(p + 1, &end);
+        if (!decoded) {
+            buf_free(&b);
+            return NULL;
+        }
+        json_escape_str(&b, decoded);
+        free(decoded);
+    } else {
+        while (*p && *p != ',' && *p != '}') {
+            if (buf_append_char(&b, *p) != 0) {
+                buf_free(&b);
+                return NULL;
+            }
+            p++;
+        }
+        while (b.len > 0 &&
+               (b.data[b.len - 1] == ' ' || b.data[b.len - 1] == '\t' ||
+                b.data[b.len - 1] == '\r' || b.data[b.len - 1] == '\n')) {
+            b.data[--b.len] = '\0';
+        }
+    }
+
+    out = b.data;
+    b.data = NULL;
+    buf_free(&b);
+    return out;
+}
+
+static int json_parse_string_value(const char **p) {
+    if (**p != '"') {
+        return 0;
+    }
+    (*p)++;
+
+    while (**p) {
+        unsigned char c = (unsigned char)**p;
+
+        if (c == '"') {
+            (*p)++;
+            return 1;
+        }
+        if (c < 0x20) {
+            return 0;
+        }
+        if (c == '\\') {
+            (*p)++;
+            switch (**p) {
+            case '"':
+            case '\\':
+            case '/':
+            case 'b':
+            case 'f':
+            case 'n':
+            case 'r':
+            case 't':
+                (*p)++;
+                break;
+            case 'u':
+                (*p)++;
+                for (int i = 0; i < 4; i++) {
+                    char h = **p;
+                    if (!((h >= '0' && h <= '9') || (h >= 'a' && h <= 'f') ||
+                          (h >= 'A' && h <= 'F'))) {
+                        return 0;
+                    }
+                    (*p)++;
+                }
+                break;
+            default:
+                return 0;
+            }
+        } else {
+            (*p)++;
+        }
+    }
+
+    return 0;
+}
+
+static int json_parse_literal(const char **p, const char *literal) {
+    size_t n = strlen(literal);
+    if (strncmp(*p, literal, n) != 0) {
+        return 0;
+    }
+    *p += n;
+    return 1;
+}
+
+static int json_parse_number(const char **p) {
+    const char *s = *p;
+
+    if (*s == '-') {
+        s++;
+    }
+    if (*s == '0') {
+        s++;
+    } else if (*s >= '1' && *s <= '9') {
+        do {
+            s++;
+        } while (*s >= '0' && *s <= '9');
+    } else {
+        return 0;
+    }
+
+    if (*s == '.') {
+        s++;
+        if (!(*s >= '0' && *s <= '9')) {
+            return 0;
+        }
+        do {
+            s++;
+        } while (*s >= '0' && *s <= '9');
+    }
+
+    if (*s == 'e' || *s == 'E') {
+        s++;
+        if (*s == '+' || *s == '-') {
+            s++;
+        }
+        if (!(*s >= '0' && *s <= '9')) {
+            return 0;
+        }
+        do {
+            s++;
+        } while (*s >= '0' && *s <= '9');
+    }
+
+    *p = s;
+    return 1;
+}
+
+static int json_parse_array(const char **p) {
+    if (**p != '[') {
+        return 0;
+    }
+    (*p)++;
+    json_skip_ws(p);
+
+    if (**p == ']') {
+        (*p)++;
+        return 1;
+    }
+
+    for (;;) {
+        if (!json_parse_value(p)) {
+            return 0;
+        }
+        json_skip_ws(p);
+        if (**p == ']') {
+            (*p)++;
+            return 1;
+        }
+        if (**p != ',') {
+            return 0;
+        }
+        (*p)++;
+        json_skip_ws(p);
+        if (**p == ']') {
+            return 0;
+        }
+    }
+}
+
+static int json_parse_object(const char **p) {
+    if (**p != '{') {
+        return 0;
+    }
+    (*p)++;
+    json_skip_ws(p);
+
+    if (**p == '}') {
+        (*p)++;
+        return 1;
+    }
+
+    for (;;) {
+        if (!json_parse_string_value(p)) {
+            return 0;
+        }
+        json_skip_ws(p);
+        if (**p != ':') {
+            return 0;
+        }
+        (*p)++;
+        json_skip_ws(p);
+        if (!json_parse_value(p)) {
+            return 0;
+        }
+        json_skip_ws(p);
+        if (**p == '}') {
+            (*p)++;
+            return 1;
+        }
+        if (**p != ',') {
+            return 0;
+        }
+        (*p)++;
+        json_skip_ws(p);
+        if (**p == '}') {
+            return 0;
+        }
+    }
+}
+
+static int json_parse_value(const char **p) {
+    json_skip_ws(p);
+
+    switch (**p) {
+    case '{':
+        return json_parse_object(p);
+    case '[':
+        return json_parse_array(p);
+    case '"':
+        return json_parse_string_value(p);
+    case 't':
+        return json_parse_literal(p, "true");
+    case 'f':
+        return json_parse_literal(p, "false");
+    case 'n':
+        return json_parse_literal(p, "null");
+    default:
+        if (**p == '-' || (**p >= '0' && **p <= '9')) {
+            return json_parse_number(p);
+        }
+        return 0;
+    }
+}
+
+static int validate_json_request(const char *json) {
+    const char *p = json;
+
+    json_skip_ws(&p);
+    if (!json_parse_object(&p)) {
+        return 0;
+    }
+    json_skip_ws(&p);
+    return *p == '\0';
+}
+
+static int json_extract_str_array(const char *json, const char *field, StringArray *out) {
+    const char *p;
+
+    memset(out, 0, sizeof(*out));
+    p = json_find_object_value(json, field);
+    if (!p) {
+        return 0;
+    }
+
+    if (*p != '[') {
+        string_array_free(out);
+        return -1;
+    }
+    p++;
+
+    while (*p) {
+        char *item;
+        char **next;
+
+        while (*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n' || *p == ',') {
+            p++;
+        }
+        if (*p == ']') {
+            return 0;
+        }
+        if (*p != '"') {
+            string_array_free(out);
+            return -1;
+        }
+
+        item = decode_json_string(p + 1, &p);
+        if (!item || *p != '"') {
+            free(item);
+            string_array_free(out);
+            return -1;
+        }
+        p++;
+
+        next = realloc(out->items, sizeof(char *) * (out->len + 1));
+        if (!next) {
+            free(item);
+            string_array_free(out);
+            return -1;
+        }
+        out->items = next;
+        out->items[out->len++] = item;
+    }
+
+    string_array_free(out);
+    return -1;
+}
+
+static int json_extract_param_str_array(const char *json, const char *field, StringArray *out) {
+    const char *params = json_find_object_value(json, "params");
+
+    if (params == NULL) {
+        memset(out, 0, sizeof(*out));
+        return 0;
+    }
+    return json_extract_str_array(params, field, out);
+}
+
+static void string_array_free(StringArray *arr) {
+    if (!arr) {
+        return;
+    }
+    for (size_t i = 0; i < arr->len; i++) {
+        free(arr->items[i]);
+    }
+    free(arr->items);
+    arr->items = NULL;
+    arr->len = 0;
+}
+
+static void parse_request_options_free(ParseRequestOptions *config) {
+    if (!config) {
+        return;
+    }
+    string_array_free(&config->clang_args);
+    pk_c_compile_context_free(config->compile_context);
+    free(config->parse_backend);
+    free(config->compile_context_kind);
+    free(config->workspace_root);
+    free(config->compile_command);
+    free(config->target_triple);
+    memset(config, 0, sizeof(*config));
+}
+
+static int parse_backend_from_name(const char *name, pk_c_parse_backend *backend) {
+    if (!backend) {
+        return -1;
+    }
+    *backend = PK_C_PARSE_BACKEND_AUTO;
+    if (!name || !*name || strcmp(name, "auto") == 0) {
+        return 0;
+    }
+    if (strcmp(name, "regex") == 0) {
+        *backend = PK_C_PARSE_BACKEND_REGEX;
+        return 0;
+    }
+    if (strcmp(name, "clang_ast") == 0 || strcmp(name, "libclang") == 0) {
+        *backend = PK_C_PARSE_BACKEND_CLANG_AST;
+        return 0;
+    }
+    return -1;
+}
+
+static int parse_request_options_init(
+    ParseRequestOptions *config,
+    const char *line,
+    const char *path,
+    char *error,
+    size_t error_len
+) {
+    pk_c_parse_backend backend = PK_C_PARSE_BACKEND_AUTO;
+
+    memset(config, 0, sizeof(*config));
+    config->parse_backend = json_extract_param_str(line, "parse_backend");
+    if (!config->parse_backend) {
+        config->parse_backend = json_extract_param_str(line, "parser_backend");
+    }
+    if (parse_backend_from_name(config->parse_backend, &backend) != 0) {
+        (void)snprintf(error, error_len, "parse_backend must be auto, regex, or clang_ast");
+        return -1;
+    }
+    if (json_extract_param_str_array(line, "clang_args", &config->clang_args) != 0) {
+        (void)snprintf(error, error_len, "clang_args must be an array of strings");
+        return -1;
+    }
+    config->compile_context_kind = json_extract_param_str(line, "compile_context");
+    config->workspace_root = json_extract_param_str(line, "workspace_root");
+    if (config->compile_context_kind != NULL &&
+        config->compile_context_kind[0] != '\0' &&
+        strcmp(config->compile_context_kind, "none") != 0 &&
+        strcmp(config->compile_context_kind, "kernel") != 0) {
+        (void)snprintf(error, error_len, "compile_context must be none or kernel");
+        return -1;
+    }
+    config->resolve_kernel_context = config->compile_context_kind != NULL &&
+        strcmp(config->compile_context_kind, "kernel") == 0;
+    config->compile_command = json_extract_param_str(line, "compile_command");
+    config->target_triple = json_extract_param_str(line, "target_triple");
+
+    if (config->compile_command) {
+        config->compile_context = pk_c_compile_context_from_command(path, config->compile_command);
+        if (!config->compile_context) {
+            (void)snprintf(error, error_len, "compile_command could not be parsed");
+            return -1;
+        }
+        pk_c_compile_context_configure_parse_options(
+            config->compile_context,
+            backend,
+            &config->options);
+    } else if (config->resolve_kernel_context && path != NULL) {
+        config->compile_context = pk_c_compile_context_resolve_kernel(config->workspace_root, path);
+        if (!config->compile_context) {
+            (void)snprintf(error, error_len, "kernel compile context could not be resolved");
+            return -1;
+        }
+        pk_c_compile_context_configure_parse_options(
+            config->compile_context,
+            backend,
+            &config->options);
+    } else {
+        memset(&config->options, 0, sizeof(config->options));
+        config->options.backend = backend;
+    }
+
+    if (config->clang_args.len > 0) {
+        config->options.clang_args = (const char *const *)config->clang_args.items;
+        config->options.n_clang_args = config->clang_args.len;
+    }
+    if (config->target_triple) {
+        config->options.target_triple = config->target_triple;
+    }
+    return 0;
+}
+
+static int append_request_option_opacity(
+    pk_c_lift_result *result,
+    const ParseRequestOptions *config
+) {
+    if (!config || !config->compile_context ||
+        !config->compile_context->extraction_result) {
+        return 0;
+    }
+    return pk_c_lift_result_extend(result, config->compile_context->extraction_result);
+}
+
+static void parse_request_options_apply_overrides(
+    const ParseRequestOptions *config,
+    pk_c_parse_options *options
+) {
+    if (!config || !options) {
+        return;
+    }
+    if (config->clang_args.len > 0) {
+        options->clang_args = (const char *const *)config->clang_args.items;
+        options->n_clang_args = config->clang_args.len;
+    }
+    if (config->target_triple) {
+        options->target_triple = config->target_triple;
+    }
+}
+
+static int has_suffix(const char *s, const char *suffix) {
+    size_t sl = strlen(s);
+    size_t tl = strlen(suffix);
+    return sl >= tl && strcmp(s + sl - tl, suffix) == 0;
+}
+
+static char *join_path(const char *a, const char *b) {
+    size_t al = strlen(a);
+    size_t bl = strlen(b);
+    int needs_slash = al > 0 && a[al - 1] != '/';
+    char *out = malloc(al + (needs_slash ? 1u : 0u) + bl + 1u);
+    size_t pos = al;
+
+    if (!out) {
+        return NULL;
+    }
+
+    memcpy(out, a, al);
+    if (needs_slash) {
+        out[pos++] = '/';
+    }
+    memcpy(out + pos, b, bl);
+    out[pos + bl] = '\0';
+    return out;
+}
+
+static char *resolve_source_path(const char *workspace, const char *source_path) {
+    if (!source_path || !*source_path || strcmp(source_path, ".") == 0) {
+        return str_dup(workspace);
+    }
+    if (source_path[0] == '/') {
+        return str_dup(source_path);
+    }
+    return join_path(workspace, source_path);
+}
+
+static char *read_file(const char *path) {
+    FILE *f = fopen(path, "rb");
+    long len;
+    char *data;
+
+    if (!f) {
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    len = ftell(f);
+    if (len < 0) {
+        fclose(f);
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_SET) != 0) {
+        fclose(f);
+        return NULL;
+    }
+
+    data = malloc((size_t)len + 1u);
+    if (!data) {
+        fclose(f);
+        return NULL;
+    }
+    if (fread(data, 1, (size_t)len, f) != (size_t)len) {
+        free(data);
+        fclose(f);
+        return NULL;
+    }
+    data[len] = '\0';
+    fclose(f);
+    return data;
+}
+
+static void acc_init(LiftAccumulator *acc) {
+    memset(acc, 0, sizeof(*acc));
+    buf_init(&acc->ir);
+    buf_init(&acc->call_edges);
+    buf_init(&acc->diagnostics);
+    buf_init(&acc->opacity_report);
+    buf_init(&acc->refusals);
+}
+
+static void acc_free(LiftAccumulator *acc) {
+    buf_free(&acc->ir);
+    buf_free(&acc->call_edges);
+    buf_free(&acc->diagnostics);
+    buf_free(&acc->opacity_report);
+    buf_free(&acc->refusals);
+}
+
+static int acc_append_json_array(Buf *buf, size_t *count, const pk_c_json_array *items) {
+    for (size_t i = 0; i < items->len; i++) {
+        if (*count > 0 && buf_append_char(buf, ',') != 0) {
+            return -1;
+        }
+        if (buf_append(buf, items->items[i]) != 0) {
+            return -1;
+        }
+        (*count)++;
+    }
+    return 0;
+}
+
+static int acc_append_result(LiftAccumulator *acc, pk_c_lift_result *result) {
+    return acc_append_json_array(&acc->ir, &acc->ir_count, &result->declarations) == 0 &&
+        acc_append_json_array(&acc->call_edges, &acc->call_edge_count, &result->call_edges) == 0 &&
+        acc_append_json_array(&acc->diagnostics, &acc->diagnostic_count, &result->diagnostics) == 0 &&
+        acc_append_json_array(&acc->opacity_report, &acc->opacity_count, &result->opacity_report) == 0 &&
+        acc_append_json_array(&acc->refusals, &acc->refusal_count, &result->refusals) == 0
+        ? 0
+        : -1;
+}
+
+static int lift_one_file(
+    const char *path,
+    LiftAccumulator *acc,
+    const ParseRequestOptions *config
+) {
+    char *source = read_file(path);
+    pk_c_lift_result *result;
+    pk_c_compile_context *file_context = NULL;
+    pk_c_parse_options file_options;
+    const pk_c_parse_options *options = config == NULL ? NULL : &config->options;
+
+    if (!source) {
+        (void)snprintf(acc->error,
+            sizeof(acc->error),
+            "%s: read failed: %s",
+            path,
+            strerror(errno));
+        return -1;
+    }
+
+    if (config != NULL && config->resolve_kernel_context && config->compile_context == NULL) {
+        file_context = pk_c_compile_context_resolve_kernel(config->workspace_root, path);
+        if (file_context == NULL) {
+            free(source);
+            (void)snprintf(acc->error, sizeof(acc->error), "%s: kernel compile context failed", path);
+            return -1;
+        }
+        pk_c_compile_context_configure_parse_options(
+            file_context,
+            config->options.backend,
+            &file_options);
+        parse_request_options_apply_overrides(config, &file_options);
+        options = &file_options;
+    }
+
+    result = pk_c_kernel_doc_lift_source_with_options(path, source, options);
+    free(source);
+    if (!result) {
+        pk_c_compile_context_free(file_context);
+        (void)snprintf(acc->error, sizeof(acc->error), "%s: lift failed", path);
+        return -1;
+    }
+    if (file_context != NULL && file_context->extraction_result != NULL &&
+        pk_c_lift_result_extend(result, file_context->extraction_result) != 0) {
+        pk_c_lift_result_free(result);
+        pk_c_compile_context_free(file_context);
+        (void)snprintf(acc->error, sizeof(acc->error), "%s: context opacity failed", path);
+        return -1;
+    }
+
+    if (acc_append_result(acc, result) != 0) {
+        pk_c_lift_result_free(result);
+        pk_c_compile_context_free(file_context);
+        (void)snprintf(acc->error, sizeof(acc->error), "out of memory aggregating %s", path);
+        return -1;
+    }
+
+    pk_c_lift_result_free(result);
+    pk_c_compile_context_free(file_context);
+    return 0;
+}
+
+static int walk_path(
+    const char *path,
+    LiftAccumulator *acc,
+    const ParseRequestOptions *config
+) {
+    struct stat st;
+    DIR *dir;
+    struct dirent *entry;
+
+    if (lstat(path, &st) != 0) {
+        (void)snprintf(acc->error,
+            sizeof(acc->error),
+            "%s: stat failed: %s",
+            path,
+            strerror(errno));
+        return -1;
+    }
+
+    if (S_ISLNK(st.st_mode)) {
+        return 0;
+    }
+
+    if (S_ISREG(st.st_mode)) {
+        return has_suffix(path, ".c") ? lift_one_file(path, acc, config) : 0;
+    }
+
+    if (!S_ISDIR(st.st_mode)) {
+        return 0;
+    }
+
+    dir = opendir(path);
+    if (!dir) {
+        (void)snprintf(acc->error,
+            sizeof(acc->error),
+            "%s: opendir failed: %s",
+            path,
+            strerror(errno));
+        return -1;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        char *child;
+        int rc;
+
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+
+        child = join_path(path, entry->d_name);
+        if (!child) {
+            closedir(dir);
+            (void)snprintf(acc->error, sizeof(acc->error), "out of memory walking %s", path);
+            return -1;
+        }
+
+        rc = walk_path(child, acc, config);
+        free(child);
+        if (rc != 0) {
+            closedir(dir);
+            return rc;
+        }
+    }
+
+    closedir(dir);
+    return 0;
+}
+
+static void send_response(const char *id, const char *result_json) {
+    printf("{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":%s}\n", id ? id : "null", result_json);
+    fflush(stdout);
+}
+
+static void send_error(const char *id, int code, const char *message) {
+    Buf b;
+    char code_buf[32];
+
+    buf_init(&b);
+    if (!b.data) {
+        printf("{\"jsonrpc\":\"2.0\",\"id\":%s,\"error\":{\"code\":-32603,\"message\":\"internal error\"}}\n",
+            id ? id : "null");
+        fflush(stdout);
+        return;
+    }
+
+    (void)snprintf(code_buf, sizeof(code_buf), "%d", code);
+    (void)buf_append(&b, "{\"code\":");
+    (void)buf_append(&b, code_buf);
+    (void)buf_append(&b, ",\"message\":");
+    json_escape_str(&b, message);
+    (void)buf_append_char(&b, '}');
+
+    printf("{\"jsonrpc\":\"2.0\",\"id\":%s,\"error\":%s}\n", id ? id : "null", b.data);
+    fflush(stdout);
+    buf_free(&b);
+}
+
+static void handle_initialize(const char *id) {
+    send_response(id,
+        "{\"capabilities\":{\"authoring_surfaces\":[\"c-kernel-doc\"],"
+        "\"emits_signed_mementos\":false,\"ir_version\":\"v1.1.0\"},"
+        "\"name\":\"c-kernel-doc\",\"protocol_version\":\"provekit-lift/1\","
+        "\"version\":\"0.1.0\"}");
+}
+
+static void handle_parse(const char *id, const char *line) {
+    char *path = json_extract_param_str(line, "path");
+    char *source = json_extract_param_str(line, "source");
+    ParseRequestOptions parse_config;
+    char option_error[256];
+    pk_c_lift_result *result;
+    char *json;
+
+    if (!source) {
+        free(path);
+        send_error(id, -32602, "missing source");
+        return;
+    }
+
+    if (parse_request_options_init(
+        &parse_config,
+        line,
+        path ? path : "source.c",
+        option_error,
+        sizeof(option_error)) != 0) {
+        parse_request_options_free(&parse_config);
+        free(path);
+        free(source);
+        send_error(id, -32602, option_error);
+        return;
+    }
+
+    result = pk_c_kernel_doc_lift_source_with_options(
+        path ? path : "source.c",
+        source,
+        &parse_config.options);
+    if (!result) {
+        parse_request_options_free(&parse_config);
+        free(path);
+        free(source);
+        send_error(id, -32603, "internal error");
+        return;
+    }
+    if (append_request_option_opacity(result, &parse_config) != 0) {
+        pk_c_lift_result_free(result);
+        parse_request_options_free(&parse_config);
+        free(path);
+        free(source);
+        send_error(id, -32603, "internal error");
+        return;
+    }
+
+    json = pk_c_lift_result_to_json(result);
+    if (!json) {
+        pk_c_lift_result_free(result);
+        parse_request_options_free(&parse_config);
+        free(path);
+        free(source);
+        send_error(id, -32603, "internal error");
+        return;
+    }
+
+    send_response(id, json);
+
+    free(json);
+    pk_c_lift_result_free(result);
+    parse_request_options_free(&parse_config);
+    free(path);
+    free(source);
+}
+
+static void handle_lift(const char *id, const char *line) {
+    char *workspace = json_extract_param_str(line, "workspace_root");
+    char *surface = json_extract_param_str(line, "surface");
+    StringArray source_paths;
+    ParseRequestOptions parse_config;
+    char option_error[256];
+    LiftAccumulator acc;
+    Buf result;
+
+    if (!surface) {
+        free(workspace);
+        send_error(id, -32602, "surface must be a string");
+        return;
+    }
+    if (strcmp(surface, "c-kernel-doc") != 0) {
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, "unsupported surface");
+        return;
+    }
+
+    if (!workspace || !*workspace) {
+        free(workspace);
+        workspace = str_dup(".");
+        if (!workspace) {
+            free(surface);
+            send_error(id, -32603, "out of memory");
+            return;
+        }
+    }
+
+    if (!json_has_param_field(line, "source_paths")) {
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, "source_paths must be a non-empty array of strings");
+        return;
+    }
+
+    if (json_extract_param_str_array(line, "source_paths", &source_paths) != 0) {
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, "source_paths must be an array of strings");
+        return;
+    }
+    if (source_paths.len == 0) {
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, "source_paths must be a non-empty array of strings");
+        return;
+    }
+    for (size_t i = 0; i < source_paths.len; i++) {
+        if (!source_paths.items[i] || !*source_paths.items[i]) {
+            string_array_free(&source_paths);
+            free(surface);
+            free(workspace);
+            send_error(id, -32602, "source_paths entries must be non-empty strings");
+            return;
+        }
+    }
+
+    if (parse_request_options_init(
+        &parse_config,
+        line,
+        NULL,
+        option_error,
+        sizeof(option_error)) != 0) {
+        parse_request_options_free(&parse_config);
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, option_error);
+        return;
+    }
+
+    acc_init(&acc);
+    if (!acc.ir.data || !acc.call_edges.data || !acc.diagnostics.data ||
+        !acc.opacity_report.data || !acc.refusals.data) {
+        acc_free(&acc);
+        parse_request_options_free(&parse_config);
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32603, "out of memory");
+        return;
+    }
+
+    for (size_t i = 0; i < source_paths.len; i++) {
+        char *resolved = resolve_source_path(workspace, source_paths.items[i]);
+        int rc;
+
+        if (!resolved) {
+            acc_free(&acc);
+            parse_request_options_free(&parse_config);
+            string_array_free(&source_paths);
+            free(surface);
+            free(workspace);
+            send_error(id, -32603, "out of memory");
+            return;
+        }
+
+        rc = walk_path(resolved, &acc, &parse_config);
+        free(resolved);
+        if (rc != 0) {
+            send_error(id, -32603, acc.error[0] ? acc.error : "lift failed");
+            acc_free(&acc);
+            parse_request_options_free(&parse_config);
+            string_array_free(&source_paths);
+            free(surface);
+            free(workspace);
+            return;
+        }
+    }
+
+    if (parse_config.compile_context != NULL &&
+        parse_config.compile_context->extraction_result != NULL &&
+        acc_append_result(&acc, parse_config.compile_context->extraction_result) != 0) {
+        send_error(id, -32603, "out of memory aggregating compile context opacity");
+        acc_free(&acc);
+        parse_request_options_free(&parse_config);
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        return;
+    }
+
+    buf_init(&result);
+    if (!result.data ||
+        buf_append(&result, "{\"declarations\":[") != 0 ||
+        buf_append(&result, acc.ir.data ? acc.ir.data : "") != 0 ||
+        buf_append(&result, "],\"callEdges\":[") != 0 ||
+        buf_append(&result, acc.call_edges.data ? acc.call_edges.data : "") != 0 ||
+        buf_append(&result, "],\"diagnostics\":[") != 0 ||
+        buf_append(&result, acc.diagnostics.data ? acc.diagnostics.data : "") != 0 ||
+        buf_append(&result, "],\"opacityReport\":[") != 0 ||
+        buf_append(&result, acc.opacity_report.data ? acc.opacity_report.data : "") != 0 ||
+        buf_append(&result, "],\"refusals\":[") != 0 ||
+        buf_append(&result, acc.refusals.data ? acc.refusals.data : "") != 0 ||
+        buf_append(&result, "],\"ir\":[") != 0 ||
+        buf_append(&result, acc.ir.data ? acc.ir.data : "") != 0 ||
+        buf_append(&result, "],\"kind\":\"ir-document\"}") != 0) {
+        buf_free(&result);
+        acc_free(&acc);
+        parse_request_options_free(&parse_config);
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32603, "out of memory");
+        return;
+    }
+
+    send_response(id, result.data);
+
+    buf_free(&result);
+    acc_free(&acc);
+    parse_request_options_free(&parse_config);
+    string_array_free(&source_paths);
+    free(surface);
+    free(workspace);
+}
+
+int main(int argc, char **argv) {
+    char *line = NULL;
+    size_t line_cap = 0;
+
+    if (argc != 2 || strcmp(argv[1], "--rpc") != 0) {
+        fprintf(stderr, "usage: %s --rpc\n", argv[0]);
+        return 1;
+    }
+
+    while (getline(&line, &line_cap, stdin) != -1) {
+        if (!validate_json_request(line)) {
+            send_error("null", -32700, "parse error");
+            continue;
+        }
+
+        char *id = json_extract_id(line);
+        char *method = json_extract_str(line, "method");
+
+        if (!id) {
+            id = str_dup("null");
+        }
+
+        if (!method) {
+            send_error(id, -32700, "parse error: missing method");
+        } else if (strcmp(method, "initialize") == 0) {
+            handle_initialize(id);
+        } else if (strcmp(method, "parse") == 0) {
+            handle_parse(id, line);
+        } else if (strcmp(method, "lift") == 0) {
+            handle_lift(id, line);
+        } else if (strcmp(method, "shutdown") == 0) {
+            send_response(id, "null");
+            free(method);
+            free(id);
+            break;
+        } else {
+            send_error(id, -32601, "unknown method");
+        }
+
+        free(method);
+        free(id);
+    }
+
+    free(line);
+    return 0;
+}

--- a/implementations/c/provekit-lift-c-kernel-doc/tests/fixtures/kernel_doc_basic.c
+++ b/implementations/c/provekit-lift-c-kernel-doc/tests/fixtures/kernel_doc_basic.c
@@ -1,0 +1,10 @@
+/**
+ * copy_to_user_buffer - copy bytes to a user buffer
+ * @buf: destination buffer. Must not be NULL.
+ * @len: byte count. Must be positive.
+ * Context: Must be called with io_lock held.
+ * Return: 0 on success or negative errno on failure.
+ */
+int copy_to_user_buffer(char *buf, int len) {
+    return len < 0 ? -22 : 0;
+}

--- a/implementations/c/provekit-lift-c-kernel-doc/tests/integration.sh
+++ b/implementations/c/provekit-lift-c-kernel-doc/tests/integration.sh
@@ -1,0 +1,205 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="$SCRIPT_DIR/../provekit-lift-c-kernel-doc"
+FIXTURE="$SCRIPT_DIR/fixtures/kernel_doc_basic.c"
+
+if [ ! -x "$BIN" ]; then
+    echo "FAIL: binary not found: $BIN" >&2
+    exit 1
+fi
+
+SOURCE=$(sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' "$FIXTURE" | tr -d '\n' | sed 's/\\n$//')
+
+RESPONSES="$(
+    {
+        printf '%s\n' '{"jsonrpc":"2.0","id":17,"method":"initialize","params":{}}'
+        printf '{"jsonrpc":"2.0","id":42,"method":"lift","params":{"workspace_root":'
+        printf '"%s"' "$SCRIPT_DIR/fixtures"
+        printf ',"source_paths":["kernel_doc_basic.c"],"surface":"c-kernel-doc"}}\n'
+        printf '%s\n' '{"jsonrpc":"2.0","id":77,"method":"shutdown"}'
+    } | "$BIN" --rpc
+)"
+
+printf '%s\n' "$RESPONSES" | grep -q '"id":17' || {
+    echo "FAIL: initialize did not echo id 17" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"name":"c-kernel-doc"' || {
+    echo "FAIL: initialize missing c-kernel-doc name" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"protocol_version":"provekit-lift/1"' || {
+    echo "FAIL: initialize missing protocol version" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"id":42' || {
+    echo "FAIL: lift did not echo id 42" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"kind":"ir-document"' || {
+    echo "FAIL: lift missing ir-document kind" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"name":"c-kernel-doc.context.must-hold"' || {
+    echo "FAIL: lift missing Context must-hold contract" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"name":"c-kernel-doc.return.negative-errno"' || {
+    echo "FAIL: lift missing Return negative errno contract" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"name":"c-kernel-doc.param.nonnull"' || {
+    echo "FAIL: lift missing parameter nonnull contract" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"name":"buf"' || {
+    echo "FAIL: lift missing buf parameter binding" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"name":"c-kernel-doc.param.positive"' || {
+    echo "FAIL: lift missing parameter positive contract" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"name":"len"' || {
+    echo "FAIL: lift missing len parameter binding" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"diagnostics":\[\]' || {
+    echo "FAIL: valid fixture should have empty diagnostics" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"opacityReport":\[\]' || {
+    echo "FAIL: valid fixture should have empty opacity report" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"refusals":\[\]' || {
+    echo "FAIL: valid fixture should have empty refusals" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+BAD_SURFACE_RESPONSES="$(
+    {
+        printf '{"jsonrpc":"2.0","id":43,"method":"lift","params":{"workspace_root":'
+        printf '"%s"' "$SCRIPT_DIR/fixtures"
+        printf ',"source_paths":["kernel_doc_basic.c"],"surface":"c-sparse"}}\n'
+    } | "$BIN" --rpc
+)"
+
+printf '%s\n' "$BAD_SURFACE_RESPONSES" | grep -q '"message":"unsupported surface"' || {
+    echo "FAIL: c-kernel-doc should reject other C-family surfaces" >&2
+    echo "$BAD_SURFACE_RESPONSES" >&2
+    exit 1
+}
+
+REQUEST="{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"parse\",\"params\":{\"path\":\"kernel_doc_basic.c\",\"source\":\"$SOURCE\"}}"
+RESPONSE=$(printf '%s\n' "$REQUEST" | "$BIN" --rpc)
+
+printf '%s\n' "$RESPONSE" | grep -q '"id":99' || {
+    echo "FAIL: parse did not echo id 99" >&2
+    echo "$RESPONSE" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSE" | grep -q '"name":"c-kernel-doc.context.must-hold"' || {
+    echo "FAIL: parse missing Context must-hold contract" >&2
+    echo "$RESPONSE" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSE" | grep -q '"name":"io_lock"' || {
+    echo "FAIL: parse missing context lock binding" >&2
+    echo "$RESPONSE" >&2
+    exit 1
+}
+
+AST_REQUEST="{\"jsonrpc\":\"2.0\",\"id\":98,\"method\":\"parse\",\"params\":{\"path\":\"kernel_doc_basic.c\",\"parse_backend\":\"clang_ast\",\"source\":\"$SOURCE\"}}"
+AST_RESPONSE=$(printf '%s\n' "$AST_REQUEST" | "$BIN" --rpc)
+
+printf '%s\n' "$AST_RESPONSE" | grep -q '"name":"c-kernel-doc.return.negative-errno"' || {
+    echo "FAIL: clang_ast parse should preserve kernel-doc return contract" >&2
+    echo "$AST_RESPONSE" >&2
+    exit 1
+}
+
+KERNEL_CONTEXT_REQUEST="$(
+    printf '{"jsonrpc":"2.0","id":97,"method":"parse","params":{"workspace_root":'
+    printf '"%s"' "$SCRIPT_DIR/fixtures"
+    printf ',"path":"kernel/missing.c","compile_context":"kernel","source":"%s"}}' "$SOURCE"
+)"
+KERNEL_CONTEXT_RESPONSE=$(printf '%s\n' "$KERNEL_CONTEXT_REQUEST" | "$BIN" --rpc)
+
+printf '%s\n' "$KERNEL_CONTEXT_RESPONSE" | grep -q '"kind":"kernel-compile-context-missing"' || {
+    echo "FAIL: kernel compile context resolver opacity should flow through kernel-doc RPC" >&2
+    echo "$KERNEL_CONTEXT_RESPONSE" >&2
+    exit 1
+}
+
+MALFORMED_REQUEST='{"jsonrpc":"2.0","id":100,"method":"parse","params":{"path":"malformed.c","source":"/**\n * orphan - malformed kernel doc\n * @p: Must not be NULL.\n */\nint unrelated;\n"}}'
+MALFORMED_RESPONSE=$(printf '%s\n' "$MALFORMED_REQUEST" | "$BIN" --rpc)
+
+printf '%s\n' "$MALFORMED_RESPONSE" | grep -q '"kind":"c-kernel-doc.unattached-comment"' || {
+    echo "FAIL: unattached kernel-doc should emit diagnostic" >&2
+    echo "$MALFORMED_RESPONSE" >&2
+    exit 1
+}
+
+OPAQUE_REQUEST='{"jsonrpc":"2.0","id":101,"method":"parse","params":{"path":"conditional.c","source":"/**\n * maybe_run - conditional attachment\n * Return: 0 on success or negative errno on failure.\n */\n#ifdef CONFIG_FOO\nint maybe_run(void) { return 0; }\n#endif\n"}}'
+OPAQUE_RESPONSE=$(printf '%s\n' "$OPAQUE_REQUEST" | "$BIN" --rpc)
+
+printf '%s\n' "$OPAQUE_RESPONSE" | grep -q '"kind":"c-kernel-doc.conditional-attachment"' || {
+    echo "FAIL: preprocessor-separated kernel-doc should emit attachment opacity" >&2
+    echo "$OPAQUE_RESPONSE" >&2
+    exit 1
+}
+
+REFUSAL_REQUEST='{"jsonrpc":"2.0","id":102,"method":"parse","params":{"path":"ownership.c","source":"/**\n * acquire_ref - get a reference\n * Return: caller owns a reference and must release it.\n */\nvoid *acquire_ref(void) { return 0; }\n"}}'
+REFUSAL_RESPONSE=$(printf '%s\n' "$REFUSAL_REQUEST" | "$BIN" --rpc)
+
+printf '%s\n' "$REFUSAL_RESPONSE" | grep -q '"kind":"c-kernel-doc.unsupported-return-ownership"' || {
+    echo "FAIL: ownership return language should emit refusal" >&2
+    echo "$REFUSAL_RESPONSE" >&2
+    exit 1
+}
+
+printf '%s\n' "$REFUSAL_RESPONSE" | grep -q '"refusals":\[' || {
+    echo "FAIL: ownership refusal should stay in refusals stream" >&2
+    echo "$REFUSAL_RESPONSE" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"id":77' || {
+    echo "FAIL: shutdown did not echo id 77" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+echo "provekit-lift-c-kernel-doc integration passed"


### PR DESCRIPTION
## Summary
- add standalone `c-kernel-doc` C-family lifter with its own lift manifest and C aggregate wiring
- lift initial kernel-doc `Context:`, `Return:`, and parameter phrases into owned declarations
- keep visibility and semantic boundaries explicit via diagnostics, opacity, and refusals

## Test Plan
- `make test-c`
- `implementations/rust/target/release/provekit ci accept --repo . --all-kits --clean --check --json`
