### PR TITLE
Paper 11 §8: name lifter trust delegation in CI bootstrap

### DIFF
--- a/docs/papers/11-after-commits-proof-carrying-change.md
+++ b/docs/papers/11-after-commits-proof-carrying-change.md
@@ -620,6 +620,8 @@ commitCid + CI-signed proof binding
 
 That is enough to make protected branches semantic today.
 
+The bootstrap inherits the lifter's correctness. A `CommitProofBinding` signed by CI binds whatever the lifter produced over the tree, including its bugs. Refusal receipts catch known unknowns by design; lifter defects are unknown unknowns and cannot refuse themselves. The empirical answer is the Bug Zoo loop: lifter regressions surface as missing rediscovery edges, and a lifter that fails to recover known historical obligations is wrong, not refining. The bootstrap does not eliminate trust in the lifter. It makes that trust explicit, named by lifter CID and profile, and policy-checkable. A consumer that does not trust a particular lifter can refuse bindings produced by it, and a repository that wants stronger guarantees can require multiple lifters to converge before the binding is admitted.
+
 Branch protection can evolve from:
 
 ```text


### PR DESCRIPTION
## Summary

- §8 already concedes that CI signs the `CommitProofBinding` before native commit-object support exists. It does not say what that delegation costs: every binding inherits whatever the lifter produced, including its bugs.
- Refusal receipts (§6) handle known unknowns by design. Lifter defects are unknown unknowns and cannot refuse themselves. The Bug Zoo loop (paper 09 §10) is the empirical falsifiability gate: a lifter that fails to recover known historical obligations is wrong, not refining.
- One paragraph added after "That is enough to make protected branches semantic today." and before the branch-protection-evolution list, so the list reads as the operational mechanism for the trust property just named. Frames the lifter trust as explicit and policy-checkable rather than implicit centralization.

## Test plan

- [ ] Markdown parses cleanly
- [ ] §8 reads end-to-end with the new paragraph in flow
- [ ] No em-dashes or en-dashes
- [ ] Echoes paper 09 §10's "Bug Zoo" naming (not "menagerie") to match corpus convention
- [ ] Does not duplicate §12's "lifter wrong" counterargument; new paragraph is bootstrap-specific (CI-signed binding inherits lifter), §12 stays revocation-focused