### PR TITLE
Document menagerie toolchain prerequisites

### DIFF
--- a/menagerie/README.md
+++ b/menagerie/README.md
@@ -16,6 +16,35 @@ same boundary. The rest of the Menagerie names the other routes through the
 substrate: long implication chains, supply-chain admission, domain bridges,
 protocol migrations, and proof-carrying changes.
 
+## Prerequisites
+
+The runnable exhibits drive real foreign toolchains. The Rust runner shells out
+to per-language harness scripts (`./run.sh`) which call `pnpm`, `tsc`, `tsx`,
+`javac`, `java`, `mvn`, `dotnet`, `go`, and `jq`. A cold-start visitor missing
+any of these will see the exhibit fail with `command not found` from inside
+pnpm, Maven, or a harness shell.
+
+Before running an exhibit, run `bash menagerie/scripts/check-prereqs.sh` to
+verify the toolchain. The script probes each tool with `command -v`, prints a
+PASS/MISSING table, and exits non-zero with a list of the missing tools.
+
+| Tool | Why it is needed | macOS (Homebrew) | Linux (apt or generic) |
+|---|---|---|---|
+| `cargo` (Rust) | Drives `cargo run --manifest-path menagerie/<exhibit>/Cargo.toml`; implicit if you reached this README via cargo. | `brew install rustup-init && rustup-init` | `curl https://sh.rustup.rs -sSf \| sh` |
+| `node` | Hosts `pnpm` and `tsx` for the TypeScript harnesses. | `brew install node` | `apt install nodejs` (or use `nvm`) |
+| `pnpm` | Runs `pnpm exec tsc` and `pnpm exec tsx` in the TypeScript bug-zoo harnesses. | `brew install pnpm` | `npm install -g pnpm` (or `corepack enable && corepack prepare pnpm@latest --activate`) |
+| `java`, `javac` (JDK 17+) | Compiles and runs the Java bug-zoo lab harnesses and lifter jars. | `brew install openjdk` (link with `sudo ln -sfn $(brew --prefix)/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk`) | `apt install default-jdk` |
+| `mvn` (Maven) | Builds the `provekit-lift-java-*` jars used by the Java kit-rpc lifters. | `brew install maven` | `apt install maven` |
+| `dotnet` (.NET SDK 8+) | Builds and runs the C# bug-zoo harnesses and `Provekit.BugZoo` lifters. | `brew install --cask dotnet-sdk` | `apt install dotnet-sdk-8.0` (or follow Microsoft's package feed) |
+| `go` | Runs the Go side of the BZ-SHAPE-007 polyglot link harness. | `brew install go` | `apt install golang` |
+| `jq` | Filters JSON in the supply-chain-rails and bridgeworks walkthroughs. | `brew install jq` | `apt install jq` |
+
+The bridgeworks walkthrough scripts also use `cc` and `make` for the C lowerer.
+These ship with macOS Command Line Tools and most Linux distributions; install
+with `xcode-select --install` on macOS or `apt install build-essential` on
+Debian-derived Linux. They are not required by `cargo run --manifest-path
+menagerie/bridgeworks/Cargo.toml -- --all`; only by the walkthrough.
+
 ## Destinations
 
 | Destination | Claim | Status |

--- a/menagerie/scripts/check-prereqs.sh
+++ b/menagerie/scripts/check-prereqs.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Probe the host toolchain for the runnable Menagerie exhibits.
+# Exits 0 when every required tool resolves on PATH; non-zero otherwise.
+
+set -u
+
+REQUIRED=(
+  "cargo:Rust runner for cargo run --manifest-path menagerie/<exhibit>/Cargo.toml"
+  "node:Required by pnpm and tsx for TypeScript bug-zoo harnesses"
+  "pnpm:Drives pnpm exec tsc/tsx in TypeScript bug-zoo harnesses"
+  "java:Runs compiled Java bug-zoo harnesses and lifters"
+  "javac:Compiles Java bug-zoo lab harnesses"
+  "mvn:Builds the Java kit-rpc lifter jars (provekit-lift-java-*)"
+  "dotnet:Builds and runs the C# bug-zoo harnesses and lifters"
+  "go:Runs the Go side of the BZ-SHAPE-007 polyglot link harness"
+  "jq:Used by supply-chain-rails and bridgeworks walkthroughs"
+)
+
+OPTIONAL=(
+  "cc:Only the bridgeworks walkthrough (C lowerer); not needed for cargo run --all"
+  "make:Only the bridgeworks walkthrough; not needed for cargo run --all"
+)
+
+probe() {
+  local name="$1"
+  if command -v "$name" >/dev/null 2>&1; then
+    printf '  PASS    %-8s %s\n' "$name" "$(command -v "$name")"
+    return 0
+  else
+    printf '  MISSING %-8s (not on PATH)\n' "$name"
+    return 1
+  fi
+}
+
+missing=()
+echo "Required toolchain (cold-start visitors hit these first):"
+for entry in "${REQUIRED[@]}"; do
+  name="${entry%%:*}"
+  reason="${entry#*:}"
+  if ! probe "$name"; then
+    missing+=("$name ($reason)")
+  fi
+done
+
+echo
+echo "Optional toolchain (walkthrough-only):"
+for entry in "${OPTIONAL[@]}"; do
+  name="${entry%%:*}"
+  probe "$name" >/dev/null
+  if command -v "$name" >/dev/null 2>&1; then
+    printf '  PASS    %-8s %s\n' "$name" "$(command -v "$name")"
+  else
+    reason="${entry#*:}"
+    printf '  ABSENT  %-8s %s\n' "$name" "$reason"
+  fi
+done
+
+echo
+if [ "${#missing[@]}" -eq 0 ]; then
+  echo "All required tools resolve on PATH."
+  exit 0
+fi
+
+echo "Missing required tools:"
+for item in "${missing[@]}"; do
+  echo "  - $item"
+done
+echo
+echo "See menagerie/README.md (Prerequisites) for install hints."
+exit 1


### PR DESCRIPTION
## Summary
- Adds a Prerequisites section to `menagerie/README.md` listing the foreign toolchains the runnable exhibits actually shell out to, with one-line install hints for macOS (Homebrew) and Linux (apt/generic).
- Adds `menagerie/scripts/check-prereqs.sh`: probes each tool with `command -v`, prints a PASS/MISSING table, exits 0 when all required tools resolve and non-zero with a missing list otherwise.
- Cold-start visitors who run `cargo run --manifest-path menagerie/bug-zoo/Cargo.toml -- --all` (or the supply-chain-rails or bridgeworks equivalent) currently hit `tsx`/`tsc`/`javac`/`mvn`/`dotnet` not-found errors from inside pnpm or harness shells. The README did not surface this.

## Toolchain probed and why
- `cargo` (Rust runner)
- `node`, `pnpm` (TypeScript bug-zoo harnesses use `pnpm exec tsc`/`tsx`)
- `java`, `javac` (Java lab harnesses)
- `mvn` (Maven, builds `provekit-lift-java-*` jars used by Java kit-rpc lifters)
- `dotnet` (.NET SDK for C# bug-zoo harnesses and lifters)
- `go` (Go side of BZ-SHAPE-007 polyglot link harness)
- `jq` (supply-chain-rails and bridgeworks walkthroughs)
- `cc`, `make` are reported as optional/walkthrough-only (bridgeworks C lowerer); not required by `cargo run -- --all`.

## Constraints honored
- No changes to `bug-zoo` or `supply-chain-rails` runner behavior. Skip-on-missing remains a separate decision.
- Touched only `menagerie/README.md` and the new `menagerie/scripts/check-prereqs.sh`.
- No em-dashes or en-dashes.
- `bash`-portable (uses `command -v`, basic arrays, no zsh-only syntax).

## Test plan
- [x] `bash menagerie/scripts/check-prereqs.sh` exits 0 on a host with all tools (verified on this dev machine; full PASS table).
- [x] `PATH=/usr/bin:/bin bash menagerie/scripts/check-prereqs.sh` exits 1 and lists the missing tools (verified).
- [x] No em-dashes/en-dashes in the diff (`grep -P '[\x{2013}\x{2014}]'` returns nothing).
- [ ] Reviewer: confirm the install hints match your distro's package names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)