### PR TITLE
Add Protocol Switchyard walkthrough

### DIFF
--- a/menagerie/protocol-switchyard/README.md
+++ b/menagerie/protocol-switchyard/README.md
@@ -71,6 +71,19 @@ The runner exits 0 and prints the four CIDs above plus the paths to the
 catalog, policy, verifier, body, and witness JSON it produced under
 `$TMPDIR`. Pass `--json` for a structured report.
 
+## Walkthrough
+
+A numbered, CLI-first tour lives under `walkthrough/`. The tour scripts
+mint the migration edge piece by piece (specs, catalogs, witness,
+verifier check); the break scripts perturb one rail at a time and show
+which check refuses the chain. See
+[`walkthrough/README.md`](walkthrough/README.md) for the script index
+and the rail-by-rail failure-mode table.
+
+```sh
+./menagerie/protocol-switchyard/walkthrough/00-start-here.sh
+```
+
 ## See also
 
 - `docs/papers/10-after-protocol-specs-how-protocols-actually-evolve.md`,

--- a/menagerie/protocol-switchyard/walkthrough/00-start-here.sh
+++ b/menagerie/protocol-switchyard/walkthrough/00-start-here.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+section "Protocol Switchyard Walkthrough"
+say "This is a CLI-first tour of the Protocol Switchyard exhibit."
+say "Paper 10 says: protocol versions are roots, migrations are witnessed edges, and compatibility is a checked route, not a release-note promise."
+
+explain_then_pause "check tools and prepare local binaries" <<'TEXT'
+What ProvekIt is doing here:
+This first script does not mint anything yet. It establishes the execution surface for the rest of the exhibit. Every later step runs through the same primitives a user would run: provekit hash, provekit protocol evolve, provekit protocol check-evolution, and the protocol-switchyard runner. The script verifies the local toolchain and prepares the local binaries.
+
+Value ProvekIt adds:
+The walkthrough does not hide behind cargo invocations or checked-in JSON fixtures. After binaries are prepared, every numbered tour script writes its own catalogs, policy, and verifier into a temp dir, then invokes ProvekIt by name. Break scripts mutate copies under temp dirs. The exhibit on disk is read-only.
+
+What to look for:
+After the prompt the script reports the toolchain and prepares any stale binaries. Later scripts should not show binary preparation again unless the source under implementations/rust or this exhibit changed.
+TEXT
+
+section "Tool Check"
+need_cmd cargo
+need_jq
+need_cmd python3
+say "cargo, jq, and python3 are available."
+say "Repo root: $REPO_ROOT"
+say "Exhibit:   $EXHIBIT_ROOT"
+
+section "Binary Prep"
+say "The walkthrough builds local binaries once, then invokes the protocol tools by name."
+ensure_walkthrough_bins
+say "provekit and provekit-protocol-switchyard are on the walkthrough PATH."
+
+section "Tour Map"
+say "01-show-v1-profile.sh         display the v1 prose specs"
+say "02-mint-v1-catalog.sh         hash v1 specs and emit fromCatalogCid"
+say "03-show-v2-profile.sh         display v2 specs and what changed"
+say "04-mint-v2-catalog.sh         hash v2 specs and emit toCatalogCid"
+say "05-mint-migration-witness.sh  invoke provekit protocol evolve, show all four CIDs"
+say "06-verify-witness.sh          invoke provekit protocol check-evolution"
+say "10-break-spec-bytes.sh        tamper with v2 spec, show changed-spec CID rail fires"
+say "11-break-policy-mode.sh       declare migration-required against extension-only policy"
+say "12-break-input-closure.sh     drop a required CID from inputCids"
+say "13-break-evidence-cid.sh      tamper with catalog-diff bytes after the body was minted"
+say "20-run-whole-exhibit.sh       invoke the runner end-to-end"
+
+section "Rule"
+say "The exhibit on disk is read-only."
+say "Every tour or break script writes JSON into a temp directory and never mutates the spec files in profiles/http."
+
+analysis_with_receipts <<'TEXT'
+The receipts here are environmental. The tour proves paper 10 by minting a witnessed edge between two catalog roots that name spec-document CIDs, then checks that edge with the same verifier. The break scripts prove the rails by perturbing one input at a time and showing which check refuses the chain.
+TEXT
+
+next_script "01-show-v1-profile.sh"

--- a/menagerie/protocol-switchyard/walkthrough/01-show-v1-profile.sh
+++ b/menagerie/protocol-switchyard/walkthrough/01-show-v1-profile.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+section "Show v1 Profile"
+explain_then_pause "show the v1 obligations" <<'TEXT'
+What ProvekIt is doing here:
+The v1 profile names two boundary obligations as prose:
+  1. request-smuggling-refusal: the parser refuses messages with ambiguous Content-Length / Transfer-Encoding framing;
+  2. content-length-transfer-encoding: the parser determines body length from a single, ordered source.
+
+These are the obligations the v1 profile carries. Their bytes will become property CIDs in the v1 catalog, which will become the fromCatalogCid for the migration edge.
+
+Value ProvekIt adds:
+ProvekIt does not parse the prose. It content-addresses it. The bytes of each spec file are the obligation. If the bytes drift, the obligation has drifted, and the catalog CID drifts with it. Section 03 shows how v2 strengthens the same two obligations.
+TEXT
+
+section "v1 request-smuggling-refusal.md"
+show_text_file "$V1_SMUGGLING_SPEC"
+
+section "v1 content-length-transfer-encoding.md"
+show_text_file "$V1_FRAMING_SPEC"
+
+analysis_with_receipts <<'TEXT'
+No CIDs yet. These are the obligation bytes the v1 catalog points at. The next script hashes them and shows the resulting fromCatalogCid.
+TEXT
+
+next_script "02-mint-v1-catalog.sh"

--- a/menagerie/protocol-switchyard/walkthrough/02-mint-v1-catalog.sh
+++ b/menagerie/protocol-switchyard/walkthrough/02-mint-v1-catalog.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+need_jq
+
+tmp="$(tmp_dir)"
+v1_catalog="$tmp/from-catalog.json"
+v1_smug_cid="$(hash_spec "$V1_SMUGGLING_SPEC")"
+v1_fram_cid="$(hash_spec "$V1_FRAMING_SPEC")"
+write_v1_catalog "$v1_catalog"
+
+section "Mint v1 Catalog"
+explain_then_pause "hash v1 specs and assemble the v1 catalog" <<'TEXT'
+What ProvekIt is doing here:
+The v1 catalog names the obligations by content. The walkthrough computes blake3-512 over the raw bytes of each v1 spec, drops those CIDs into a `properties` map keyed by obligation name, then serializes the catalog JSON. The CID of the catalog itself is JCS-canonicalized blake3-512 of that serialization, computed by the CLI when it consumes the catalog.
+
+Value ProvekIt adds:
+The catalog is now an addressable artifact. Two parties cannot disagree about what v1 means without disagreeing about the CIDs. The fromCatalogCid will be the source of the migration edge in script 05.
+TEXT
+
+section "Spec CIDs"
+say "request-smuggling-refusal       = $v1_smug_cid"
+say "content-length-transfer-encoding = $v1_fram_cid"
+
+section "v1 Catalog JSON"
+show_json_file "$v1_catalog"
+highlight_raw_line "$v1_catalog" '"version": "v1.0.0"' "v1 carries the v1.0.0 version label."
+highlight_raw_line "$v1_catalog" "$v1_smug_cid" "request-smuggling-refusal binds the obligation to its content CID."
+highlight_raw_line "$v1_catalog" "$v1_fram_cid" "content-length-transfer-encoding binds the same way."
+
+section "v1 Catalog CID"
+v1_catalog_cid="$(hash_spec "$v1_catalog")"
+say "raw blake3-512 of catalog file: $v1_catalog_cid"
+say "(Note: the CLI uses JCS-canonical blake3-512, so the on-the-wire fromCatalogCid in script 05 will differ from this raw-byte CID.)"
+
+analysis_with_receipts <<'TEXT'
+The two property CIDs receipt the obligation bytes. The catalog JSON receipt names those CIDs in a key-sorted properties map. Script 05 will feed this catalog to the CLI and emit the canonical fromCatalogCid that the migration edge uses.
+TEXT
+
+next_script "03-show-v2-profile.sh"

--- a/menagerie/protocol-switchyard/walkthrough/03-show-v2-profile.sh
+++ b/menagerie/protocol-switchyard/walkthrough/03-show-v2-profile.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+section "Show v2 Profile"
+explain_then_pause "show the v2 obligations and what changed" <<'TEXT'
+What ProvekIt is doing here:
+The v2 profile keeps the same two obligation keys but strengthens them. The framing rule closes more cases unconditionally; the smuggling refusal grows new reason codes. Same names, different bytes.
+
+Value ProvekIt adds:
+Because each obligation is content-addressed, "strengthened the obligation" is not a release-note adjective. It is a CID change at the property layer that flows up into a different catalog CID. v1 conformance witnesses do not transfer to v2 by name, by signer, or by version label. They transfer only if the property CIDs they witness still appear in the new catalog.
+TEXT
+
+section "v2 request-smuggling-refusal.md"
+show_text_file "$V2_SMUGGLING_SPEC"
+
+section "v2 content-length-transfer-encoding.md"
+show_text_file "$V2_FRAMING_SPEC"
+
+section "Diff Against v1 (request-smuggling-refusal)"
+diff -u --label "v1/request-smuggling-refusal.md" --label "v2/request-smuggling-refusal.md" \
+  "$V1_SMUGGLING_SPEC" "$V2_SMUGGLING_SPEC" || true
+
+section "Diff Against v1 (content-length-transfer-encoding)"
+diff -u --label "v1/content-length-transfer-encoding.md" --label "v2/content-length-transfer-encoding.md" \
+  "$V1_FRAMING_SPEC" "$V2_FRAMING_SPEC" || true
+
+analysis_with_receipts <<'TEXT'
+Both obligations are strengthened, not replaced. Both keys carry the same names in v2 as in v1. That is exactly what `extension-only` means in the policy: same rail set, stricter enforcement on each rail.
+TEXT
+
+next_script "04-mint-v2-catalog.sh"

--- a/menagerie/protocol-switchyard/walkthrough/04-mint-v2-catalog.sh
+++ b/menagerie/protocol-switchyard/walkthrough/04-mint-v2-catalog.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+need_jq
+
+tmp="$(tmp_dir)"
+v2_catalog="$tmp/to-catalog.json"
+v2_smug_cid="$(hash_spec "$V2_SMUGGLING_SPEC")"
+v2_fram_cid="$(hash_spec "$V2_FRAMING_SPEC")"
+v1_smug_cid="$(hash_spec "$V1_SMUGGLING_SPEC")"
+v1_fram_cid="$(hash_spec "$V1_FRAMING_SPEC")"
+write_v2_catalog "$v2_catalog"
+
+section "Mint v2 Catalog"
+explain_then_pause "hash v2 specs and assemble the v2 catalog" <<'TEXT'
+What ProvekIt is doing here:
+Same shape as the v1 catalog, but the property CIDs come from the v2 spec bytes. The catalog also carries the v1.0.1 version label. That label is policy-checked: under `extension-only` with no cross-kit semantic obligation, the policy says a patch bump is allowed.
+
+Value ProvekIt adds:
+The change is locally observable. The v1 property CIDs and the v2 property CIDs are right here, side by side. A consumer can compare them without reading prose.
+TEXT
+
+section "Property CIDs Side by Side"
+printf '  %-35s %s\n' "key" "v1                              v2"
+printf '  %-35s %s -> %s\n' "request-smuggling-refusal" "$v1_smug_cid" "$v2_smug_cid"
+printf '  %-35s %s -> %s\n' "content-length-transfer-encoding" "$v1_fram_cid" "$v2_fram_cid"
+
+section "v2 Catalog JSON"
+show_json_file "$v2_catalog"
+highlight_raw_line "$v2_catalog" '"version": "v1.0.1"' "v2 carries the v1.0.1 patch label."
+highlight_raw_line "$v2_catalog" "$v2_smug_cid" "v2 request-smuggling-refusal CID matches the v2 spec bytes."
+highlight_raw_line "$v2_catalog" "$v2_fram_cid" "v2 content-length-transfer-encoding CID matches the v2 spec bytes."
+
+analysis_with_receipts <<'TEXT'
+Two CIDs changed, none were removed, none were added. That is the on-disk fingerprint of an extension-only edge. Script 05 will mint the witnessed migration edge that names both catalogs by their canonical CIDs.
+TEXT
+
+next_script "05-mint-migration-witness.sh"

--- a/menagerie/protocol-switchyard/walkthrough/05-mint-migration-witness.sh
+++ b/menagerie/protocol-switchyard/walkthrough/05-mint-migration-witness.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+need_jq
+
+tmp="$(tmp_dir)"
+say "Workspace: $tmp"
+
+section "Mint Migration Witness"
+explain_then_pause "invoke provekit protocol evolve" <<'TEXT'
+What ProvekIt is doing here:
+The walkthrough writes the v1 catalog, the v2 catalog, the policy, and the verifier into a temp dir, then invokes:
+
+  provekit protocol evolve --from from-catalog.json --to to-catalog.json \
+                           --policy policy.json --verifier verifier.json \
+                           --out-dir witness/ --change-class extension-only \
+                           --changed-spec request-smuggling-refusal=<path> \
+                           --changed-spec content-length-transfer-encoding=<path>
+
+The CLI canonicalizes each catalog (JCS), hashes it (blake3-512), checks each --changed-spec file's bytes against the property CID the catalog declares, builds a ProtocolCatalogDiff, fills out a ProtocolEvolutionBodyClaim with all the input CIDs in their closure, mints a TruthDischargeWitness over the body, and writes everything to disk.
+
+Value ProvekIt adds:
+The witnessed edge is the substrate primitive paper 10 talks about. fromCatalogCid and toCatalogCid are the two roots. bodyCid is the migration body. witnessCid is the truth-discharge over the body. None of those CIDs are claimed; all are recomputable from the inputs in this temp dir.
+TEXT
+
+stdout_file="$tmp/evolve.stdout"
+stderr_file="$tmp/evolve.stderr"
+
+print_provekit protocol evolve \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --out-dir "$tmp/witness" \
+  --change-class extension-only \
+  --producer protocol-switchyard-walkthrough \
+  --changed-spec "request-smuggling-refusal=$V2_SMUGGLING_SPEC" \
+  --changed-spec "content-length-transfer-encoding=$V2_FRAMING_SPEC" \
+  --json --quiet
+
+mint_evolution_into "$tmp"
+
+section "Evolve Summary JSON"
+show_json_file "$stdout_file"
+highlight_raw_line "$stdout_file" '"fromCatalogCid":' "Source root for the migration edge."
+highlight_raw_line "$stdout_file" '"toCatalogCid":' "Destination root for the migration edge."
+highlight_raw_line "$stdout_file" '"bodyCid":' "ProtocolEvolutionBodyClaim CID over both roots, the catalog diff, the policy, and the verifier."
+highlight_raw_line "$stdout_file" '"witnessCid":' "TruthDischargeWitness CID over the body."
+highlight_raw_line "$stdout_file" '"changeClass": "extension-only"' "Declared change class matches the policy's acceptedChangeClass."
+
+section "Witness Artifacts on Disk"
+ls -la "$tmp/witness"
+
+section "Witness Body Excerpt"
+show_json_file "$tmp/witness/protocol-evolution.body.json"
+
+analysis_with_receipts <<'TEXT'
+Four CIDs proved. fromCatalogCid is the JCS-canonical hash of the v1 catalog. toCatalogCid is the same for v2. bodyCid is the canonical hash of the body claim that names both roots, the catalog diff, the policy CID, the verifier CID, and the closure of input CIDs. witnessCid is the truth-discharge over the body. The migration edge is now an addressable artifact a third party can recompute.
+
+Save this temp dir path; script 06 reads from it.
+TEXT
+
+cp -R "$tmp" "$tmp.preserved" 2>/dev/null || true
+say ""
+say "PROVEKIT_SWITCHYARD_LAST_TMP=$tmp"
+printf '%s\n' "$tmp" > "${TMPDIR:-/tmp}/provekit-switchyard-last-tmp.txt"
+
+next_script "06-verify-witness.sh"

--- a/menagerie/protocol-switchyard/walkthrough/06-verify-witness.sh
+++ b/menagerie/protocol-switchyard/walkthrough/06-verify-witness.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+need_jq
+
+tmp="$(tmp_dir)"
+mint_evolution_into "$tmp"
+
+section "Verify Witness"
+explain_then_pause "invoke provekit protocol check-evolution" <<'TEXT'
+What ProvekIt is doing here:
+Verification is the same admission code path as mint, run against the on-disk artifacts:
+
+  provekit protocol check-evolution --body protocol-evolution.body.json \
+                                    --from from-catalog.json --to to-catalog.json \
+                                    --policy policy.json --verifier verifier.json \
+                                    --catalog-diff catalog-diff.json
+
+The verifier rehashes both catalogs and confirms body.fromCatalogCid and body.toCatalogCid agree. It rehashes the policy and verifier and confirms body.policyCid and body.verifierCid agree. It rehashes the catalog diff and confirms body.evidence.catalogDiffCid agrees. It then checks that the changeSet in the body matches the catalog diff arrays, that the version label rule is consistent with the change class, that the change class is the one the policy accepts, and that body.inputCids contains every CID required by the body's closure.
+
+Value ProvekIt adds:
+None of those rails depend on the producer being trustworthy. They are all locally recomputable. Anyone who can read the artifacts can run the same admission code with no shared secret.
+TEXT
+
+stdout_file="$tmp/check.stdout"
+stderr_file="$tmp/check.stderr"
+
+print_provekit protocol check-evolution \
+  --body "$tmp/witness/protocol-evolution.body.json" \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --catalog-diff "$tmp/witness/catalog-diff.json" \
+  --json --quiet
+
+run_provekit_capture "$stdout_file" "$stderr_file" \
+  protocol check-evolution \
+  --body "$tmp/witness/protocol-evolution.body.json" \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --catalog-diff "$tmp/witness/catalog-diff.json" \
+  --json --quiet
+
+section "Check JSON"
+show_json_file "$stdout_file"
+highlight_raw_line "$stdout_file" '"ok": true,' "Every admission rail returned ok."
+highlight_raw_line "$stdout_file" '"bodyCid":' "Body CID matches script 05's bodyCid receipt."
+highlight_raw_line "$stdout_file" '"changeClass": "extension-only"' "Body's declared class still matches the policy."
+highlight_raw_line "$stdout_file" '"catalogDiffCid":' "Catalog diff bytes still hash to the CID the body claims."
+
+analysis_with_receipts <<'TEXT'
+The migration edge admits. Now we need to prove the rails are not theatre. The break scripts (10, 11, 12, 13) perturb one rail at a time on a copy of this temp dir and show the verifier refuses. If even one of those breaks slipped through, the green receipt above would not be evidence; it would be polite text. They do not slip through.
+TEXT
+
+next_script "10-break-spec-bytes.sh"

--- a/menagerie/protocol-switchyard/walkthrough/10-break-spec-bytes.sh
+++ b/menagerie/protocol-switchyard/walkthrough/10-break-spec-bytes.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+need_jq
+
+tmp="$(tmp_dir)"
+write_v1_catalog "$tmp/from-catalog.json"
+write_v2_catalog "$tmp/to-catalog.json"
+write_policy "$tmp/policy.json"
+write_verifier "$tmp/verifier.json"
+mkdir -p "$tmp/witness"
+
+tampered_spec="$tmp/v2-request-smuggling-refusal-tampered.md"
+cp "$V2_SMUGGLING_SPEC" "$tampered_spec"
+printf '\nTAMPERED LINE\n' >> "$tampered_spec"
+
+section "Break Spec Bytes"
+explain_then_pause "feed a tampered v2 spec into provekit protocol evolve" <<'TEXT'
+What ProvekIt is doing here:
+The v2 catalog says request-smuggling-refusal binds to a specific blake3-512 of the v2 spec bytes. The break script keeps the catalog unchanged and points the --changed-spec flag at a tampered copy of the spec instead. The CLI rehashes the file the flag points at, compares it to the property CID the catalog declares, and refuses the mint if they disagree.
+
+Value ProvekIt adds:
+The bridge between the catalog property layer and the spec bytes layer is the load-bearing rail. If a producer can swap spec bytes without updating the catalog, the catalog is decorative. ProvekIt refuses to mint when those layers disagree.
+
+Expected refusal: changed spec `request-smuggling-refusal` CID mismatch.
+TEXT
+
+section "Tamper Diff"
+diff -u --label "original/v2/request-smuggling-refusal.md" --label "tampered-copy/request-smuggling-refusal.md" \
+  "$V2_SMUGGLING_SPEC" "$tampered_spec" || true
+
+print_provekit protocol evolve \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --out-dir "$tmp/witness" \
+  --change-class extension-only \
+  --producer protocol-switchyard-walkthrough \
+  --changed-spec "request-smuggling-refusal=$tampered_spec" \
+  --changed-spec "content-length-transfer-encoding=$V2_FRAMING_SPEC" \
+  --json --quiet
+
+stdout_file="$tmp/evolve.stdout"
+stderr_file="$tmp/evolve.stderr"
+status=0
+set +e
+run_provekit_capture "$stdout_file" "$stderr_file" \
+  protocol evolve \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --out-dir "$tmp/witness" \
+  --change-class extension-only \
+  --producer protocol-switchyard-walkthrough \
+  --changed-spec "request-smuggling-refusal=$tampered_spec" \
+  --changed-spec "content-length-transfer-encoding=$V2_FRAMING_SPEC" \
+  --json --quiet
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+  say "Unexpected success. The tampered spec was admitted."
+  show_json_file "$stdout_file"
+  exit 1
+fi
+
+section "Refusal Evidence"
+show_text_file "$stderr_file"
+if grep -F "changed spec \`request-smuggling-refusal\` CID mismatch" "$stderr_file" >/dev/null; then
+  say "Rail fired: changed-spec CID mismatch (catalog property layer to spec bytes)."
+else
+  say "Did not see the expected rail message. stderr is above."
+  exit 1
+fi
+
+section "Repository State"
+say "The exhibit profiles/http directory was never modified."
+say "The tampered spec was a copy under: $tampered_spec"
+diff -q "$V2_SMUGGLING_SPEC" "$EXHIBIT_ROOT/profiles/http/v2/specs/request-smuggling-refusal.md" >/dev/null && say "v2 spec on disk is unchanged."
+
+analysis_with_receipts <<'TEXT'
+The mint refused. The error names the obligation key (`request-smuggling-refusal`), the CID the catalog declares, and the CID the file actually hashes to. That is the bridge edge between the catalog property layer and the spec bytes layer doing its job.
+
+Repository state is clean because the break only ever touched a copy under $TMPDIR.
+TEXT
+
+next_script "11-break-policy-mode.sh"

--- a/menagerie/protocol-switchyard/walkthrough/11-break-policy-mode.sh
+++ b/menagerie/protocol-switchyard/walkthrough/11-break-policy-mode.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+need_jq
+
+tmp="$(tmp_dir)"
+mint_evolution_into "$tmp"
+
+section "Break Policy Mode"
+explain_then_pause "rewrite body.changeClass to migration-required and recheck" <<'TEXT'
+What ProvekIt is doing here:
+The body is minted under change-class extension-only against a policy that declares acceptedChangeClass extension-only. The break script rewrites the body's changeClass to migration-required without changing the policy. The verifier then refuses on policy/body class mismatch.
+
+Value ProvekIt adds:
+A producer cannot upgrade the change class after the fact by editing one field in the body. The policy is hashed into the body via policyCid. The change class is a body field too. The verifier reads both and refuses any mismatch with the policy's acceptedChangeClass.
+
+Expected refusal: PEP admission refused: policy accepts `extension-only`, body declares `migration-required`.
+TEXT
+
+cp "$tmp/witness/protocol-evolution.body.json" "$tmp/witness/body-original.json"
+python3 - "$tmp/witness/protocol-evolution.body.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d['changeClass'] = 'migration-required'
+json.dump(d, open(p, 'w'), indent=2)
+PY
+
+section "Body Diff"
+diff -u --label "original/body.json" --label "tampered/body.json" \
+  "$tmp/witness/body-original.json" "$tmp/witness/protocol-evolution.body.json" || true
+
+print_provekit protocol check-evolution \
+  --body "$tmp/witness/protocol-evolution.body.json" \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --catalog-diff "$tmp/witness/catalog-diff.json" \
+  --json --quiet
+
+stdout_file="$tmp/check.stdout"
+stderr_file="$tmp/check.stderr"
+status=0
+set +e
+run_provekit_capture "$stdout_file" "$stderr_file" \
+  protocol check-evolution \
+  --body "$tmp/witness/protocol-evolution.body.json" \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --catalog-diff "$tmp/witness/catalog-diff.json" \
+  --json --quiet
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+  say "Unexpected success. The mismatched body was admitted."
+  show_json_file "$stdout_file"
+  exit 1
+fi
+
+section "Refusal Evidence"
+show_text_file "$stderr_file"
+if grep -F "policy accepts \`extension-only\`, body declares \`migration-required\`" "$stderr_file" >/dev/null; then
+  say "Rail fired: policy/body changeClass mismatch."
+else
+  say "Did not see the expected rail message. stderr is above."
+  exit 1
+fi
+
+section "Repository State"
+say "Only the body inside the temp witness dir was touched. The exhibit on disk is untouched."
+
+analysis_with_receipts <<'TEXT'
+The verifier refused. The error names both the policy's accepted class and the body's declared class. The mismatch is the rail.
+
+Why this matters: an extension-only edge says "no producer-side migration required for consumers." A migration-required edge says the opposite. They are different physics and the policy is the rule that picks. The body cannot lie about which physics it lives under.
+TEXT
+
+next_script "12-break-input-closure.sh"

--- a/menagerie/protocol-switchyard/walkthrough/12-break-input-closure.sh
+++ b/menagerie/protocol-switchyard/walkthrough/12-break-input-closure.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+need_jq
+
+tmp="$(tmp_dir)"
+mint_evolution_into "$tmp"
+
+section "Break Input Closure"
+explain_then_pause "drop catalogDiffCid from inputCids and recheck" <<'TEXT'
+What ProvekIt is doing here:
+The body's inputCids array must include every CID the body's closure references: fromCatalogCid, toCatalogCid, policyCid, verifierCid, changed-spec CIDs, and every CID inside the changeSet and evidence subtrees. The break script removes evidence.catalogDiffCid from inputCids and runs the verifier.
+
+Value ProvekIt adds:
+Input closure is the rail that prevents an attacker from minting a body whose evidence references CIDs that were never declared as inputs. Every CID under evidence and changeSet must also appear in inputCids. The verifier walks the body's CID graph and checks closure.
+
+Expected refusal: PEP admission refused: inputCids missing required CID `<the catalogDiffCid>`.
+TEXT
+
+cp "$tmp/witness/protocol-evolution.body.json" "$tmp/witness/body-original.json"
+python3 - "$tmp/witness/protocol-evolution.body.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+required = d['evidence']['catalogDiffCid']
+d['inputCids'] = [c for c in d['inputCids'] if c != required]
+json.dump(d, open(p, 'w'), indent=2)
+PY
+
+section "Body Diff"
+diff -u --label "original/body.json" --label "tampered/body.json" \
+  "$tmp/witness/body-original.json" "$tmp/witness/protocol-evolution.body.json" || true
+
+print_provekit protocol check-evolution \
+  --body "$tmp/witness/protocol-evolution.body.json" \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --catalog-diff "$tmp/witness/catalog-diff.json" \
+  --json --quiet
+
+stdout_file="$tmp/check.stdout"
+stderr_file="$tmp/check.stderr"
+status=0
+set +e
+run_provekit_capture "$stdout_file" "$stderr_file" \
+  protocol check-evolution \
+  --body "$tmp/witness/protocol-evolution.body.json" \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --catalog-diff "$tmp/witness/catalog-diff.json" \
+  --json --quiet
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+  say "Unexpected success. A non-closed body was admitted."
+  show_json_file "$stdout_file"
+  exit 1
+fi
+
+section "Refusal Evidence"
+show_text_file "$stderr_file"
+if grep -F "inputCids missing required CID" "$stderr_file" >/dev/null; then
+  say "Rail fired: input-closure check refused the body."
+else
+  say "Did not see the expected rail message. stderr is above."
+  exit 1
+fi
+
+section "Repository State"
+say "Only the body inside the temp witness dir was touched. The exhibit on disk is untouched."
+
+analysis_with_receipts <<'TEXT'
+The verifier refused. The error names exactly which CID was required by the body's closure but missing from inputCids.
+
+This is the rail that turns a body claim into a recomputable artifact. Anyone who can read the body knows up front the full set of bytes the claim depends on, and a verifier can refuse the moment the claim's references run outside that set.
+TEXT
+
+next_script "13-break-evidence-cid.sh"

--- a/menagerie/protocol-switchyard/walkthrough/13-break-evidence-cid.sh
+++ b/menagerie/protocol-switchyard/walkthrough/13-break-evidence-cid.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+need_jq
+
+tmp="$(tmp_dir)"
+mint_evolution_into "$tmp"
+
+section "Break Evidence CID"
+explain_then_pause "tamper with catalog-diff bytes after the body was minted" <<'TEXT'
+What ProvekIt is doing here:
+The body's evidence.catalogDiffCid pins the bytes of catalog-diff.json. The break script edits the catalog-diff file under the temp witness dir (adds a phantom unchangedSemantics entry) and asks the verifier to admit the same body against this new file.
+
+Value ProvekIt adds:
+Evidence is content-addressed. The body declared the diff bytes ahead of time; the verifier rehashes the file the verifier received; if those disagree, the file in question is not the file the body was talking about, and the admission must refuse.
+
+Expected refusal: PEP admission refused: evidence catalogDiffCid is `<body's CID>`, supplied catalog diff hashes to `<file CID>`.
+TEXT
+
+cp "$tmp/witness/catalog-diff.json" "$tmp/witness/catalog-diff-original.json"
+python3 - "$tmp/witness/catalog-diff.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d['unchangedSemantics'] = ['phantom-injected-entry'] + d['unchangedSemantics']
+json.dump(d, open(p, 'w'), indent=2)
+PY
+
+section "Catalog Diff Tamper"
+diff -u --label "original/catalog-diff.json" --label "tampered/catalog-diff.json" \
+  "$tmp/witness/catalog-diff-original.json" "$tmp/witness/catalog-diff.json" || true
+
+print_provekit protocol check-evolution \
+  --body "$tmp/witness/protocol-evolution.body.json" \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --catalog-diff "$tmp/witness/catalog-diff.json" \
+  --json --quiet
+
+stdout_file="$tmp/check.stdout"
+stderr_file="$tmp/check.stderr"
+status=0
+set +e
+run_provekit_capture "$stdout_file" "$stderr_file" \
+  protocol check-evolution \
+  --body "$tmp/witness/protocol-evolution.body.json" \
+  --from "$tmp/from-catalog.json" \
+  --to "$tmp/to-catalog.json" \
+  --policy "$tmp/policy.json" \
+  --verifier "$tmp/verifier.json" \
+  --catalog-diff "$tmp/witness/catalog-diff.json" \
+  --json --quiet
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+  say "Unexpected success. The verifier admitted a body against a tampered catalog-diff."
+  show_json_file "$stdout_file"
+  exit 1
+fi
+
+section "Refusal Evidence"
+show_text_file "$stderr_file"
+if grep -F "evidence catalogDiffCid is" "$stderr_file" >/dev/null; then
+  say "Rail fired: evidence CID does not match the supplied catalog-diff bytes."
+else
+  say "Did not see the expected rail message. stderr is above."
+  exit 1
+fi
+
+section "Repository State"
+say "Only files inside the temp witness dir were touched. The exhibit on disk is untouched."
+
+analysis_with_receipts <<'TEXT'
+The verifier refused. The error prints the CID the body claims for the catalog diff and the CID the file actually hashes to. They are two strings that must be one. They are not, so the body and the file disagree, so the admission refuses.
+
+This rail forecloses the simplest tamper: edit a downstream evidence file and hope nobody rehashes it. ProvekIt rehashes it.
+TEXT
+
+next_script "20-run-whole-exhibit.sh"

--- a/menagerie/protocol-switchyard/walkthrough/20-run-whole-exhibit.sh
+++ b/menagerie/protocol-switchyard/walkthrough/20-run-whole-exhibit.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+need_jq
+
+section "Run Whole Exhibit"
+explain_then_pause "invoke the protocol-switchyard runner end-to-end" <<'TEXT'
+What ProvekIt is doing here:
+The runner is the integrated form of scripts 02 through 06. It writes catalogs, policy, and verifier into its own temp dir, shells through `provekit protocol evolve`, and prints the four load-bearing CIDs.
+
+Value ProvekIt adds:
+The runner is the answer to "what does an end-to-end integrator look like for paper 10?" The numbered tour scripts show the same primitives one piece at a time; the runner shows the pieces composing.
+TEXT
+
+stdout_file="$(tmp_dir)/runner.stdout"
+stderr_file="$stdout_file.stderr"
+
+print_switchyard --all --json
+run_switchyard_capture "$stdout_file" "$stderr_file" --all --json
+
+section "Runner JSON"
+show_json_file "$stdout_file"
+highlight_raw_line "$stdout_file" '"from_catalog_cid":' "Same root paper 10 names as the source root."
+highlight_raw_line "$stdout_file" '"to_catalog_cid":' "Same root paper 10 names as the destination root."
+highlight_raw_line "$stdout_file" '"body_cid":' "Migration body CID (paper 10 section 6)."
+highlight_raw_line "$stdout_file" '"witness_cid":' "TruthDischargeWitness CID over the body."
+
+analysis_with_receipts <<'TEXT'
+End-to-end pass. The runner's CIDs come from the same canonicalization the tour scripts used, so the visitor can rerun script 05 and get the same fromCatalogCid and toCatalogCid the runner just emitted. The break scripts already proved each rail refuses tampering one input at a time. The runner shows the green case integrated.
+TEXT
+
+say ""
+say "Walkthrough complete."

--- a/menagerie/protocol-switchyard/walkthrough/README.md
+++ b/menagerie/protocol-switchyard/walkthrough/README.md
@@ -1,0 +1,89 @@
+# Protocol Switchyard Walkthrough
+
+A CLI-first tour of the Protocol Switchyard exhibit (paper 10). The
+walkthrough mints a witnessed migration edge between two HTTP profile
+catalog roots, then perturbs one rail at a time and shows the verifier
+refuse.
+
+Run the walkthrough in order:
+
+```sh
+./00-start-here.sh
+./01-show-v1-profile.sh
+./02-mint-v1-catalog.sh
+./03-show-v2-profile.sh
+./04-mint-v2-catalog.sh
+./05-mint-migration-witness.sh
+./06-verify-witness.sh
+./10-break-spec-bytes.sh
+./11-break-policy-mode.sh
+./12-break-input-closure.sh
+./13-break-evidence-cid.sh
+./20-run-whole-exhibit.sh
+```
+
+Each script writes its inputs into a fresh temp directory under
+`$TMPDIR`. The exhibit on disk under `profiles/http/` is read-only.
+Break scripts mutate copies under `$TMPDIR`; the repository state never
+needs restoration.
+
+## Tour
+
+| Script | What it shows | Receipts |
+| --- | --- | --- |
+| `00-start-here.sh` | Orientation; tool check; binary prep | local `provekit` and `provekit-protocol-switchyard` binaries are ready |
+| `01-show-v1-profile.sh` | The two v1 obligation specs as bytes | raw spec text under `profiles/http/v1/specs/` |
+| `02-mint-v1-catalog.sh` | Hash v1 specs into property CIDs and assemble the v1 catalog | `request-smuggling-refusal` and `content-length-transfer-encoding` CIDs, v1 catalog JSON |
+| `03-show-v2-profile.sh` | The two v2 obligation specs and the diff against v1 | unified diff per obligation |
+| `04-mint-v2-catalog.sh` | Hash v2 specs and assemble the v2 catalog | side-by-side property CIDs, v2 catalog JSON |
+| `05-mint-migration-witness.sh` | Invoke `provekit protocol evolve` | `fromCatalogCid`, `toCatalogCid`, `bodyCid`, `witnessCid`, on-disk witness artifacts |
+| `06-verify-witness.sh` | Invoke `provekit protocol check-evolution` against the minted witness | `ok: true`, body and catalog-diff CIDs match |
+
+Maps to paper 10 sections 4 through 6: profiles carry obligations,
+catalogs name those obligations by content CID, migration edges are
+witnessed bodies that name two catalog roots plus a closure of evidence.
+
+## Break Rails
+
+Each break script perturbs exactly one input and runs the verifier.
+The script exits non-zero only if the verifier refused with the rail
+the perturbation targets. A break that "succeeds" silently is itself
+a bug.
+
+| Script | Rail perturbed | Failure mode |
+| --- | --- | --- |
+| `10-break-spec-bytes.sh` | catalog property layer to spec bytes | `provekit protocol evolve` refuses with `changed spec ` `request-smuggling-refusal` ` CID mismatch` because the file the `--changed-spec` flag points at hashes to a different CID than the catalog declares |
+| `11-break-policy-mode.sh` | policy / body change-class agreement | `provekit protocol check-evolution` refuses with `policy accepts ` `extension-only` `, body declares ` `migration-required` after the body's `changeClass` field is rewritten |
+| `12-break-input-closure.sh` | input closure of the body | verifier refuses with `inputCids missing required CID <catalogDiffCid>` after that CID is dropped from the body's `inputCids` array |
+| `13-break-evidence-cid.sh` | evidence CID to evidence bytes | verifier refuses with `evidence catalogDiffCid is <X>, supplied catalog diff hashes to <Y>` after the catalog-diff bytes are tampered with under the witness dir |
+
+Maps to paper 10 section 6's admission predicate: each rail is one
+content-addressed bridge edge, and the verifier refuses the chain at
+exactly the edge that broke.
+
+## Integrator
+
+| Script | What it shows |
+| --- | --- |
+| `20-run-whole-exhibit.sh` | The integrated runner (`cargo run -- --all`) emits the same four CIDs the tour produces piece by piece |
+
+## Voice
+
+Every script answers:
+
+- What is ProvekIt doing here?
+- What value does ProvekIt add?
+- Which receipt proves the claim or refuses the chain?
+
+The visitor's takeaway:
+
+```text
+Protocol versions are catalog roots.
+Migrations are witnessed edges.
+Compatibility is a checked route, not a release-note promise.
+```
+
+The break scripts prove the rails are not theatre. If the change-class
+field, the input closure, the evidence-CID chain, or the spec-bytes
+binding can be edited without consequence, then the green case at
+script 06 is decorative. None of those edits go through.

--- a/menagerie/protocol-switchyard/walkthrough/common.sh
+++ b/menagerie/protocol-switchyard/walkthrough/common.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+EXHIBIT_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../../.." && pwd)"
+WALKTHROUGH_TARGET_DIR="${PROVEKIT_SWITCHYARD_WALKTHROUGH_TARGET_DIR:-$REPO_ROOT/target/provekit-switchyard-walkthrough-bin}"
+WALKTHROUGH_BIN_DIR="$WALKTHROUGH_TARGET_DIR/debug"
+PROVEKIT_BIN="$WALKTHROUGH_BIN_DIR/provekit"
+SWITCHYARD_BIN="$WALKTHROUGH_BIN_DIR/provekit-protocol-switchyard"
+
+V1_SMUGGLING_SPEC="$EXHIBIT_ROOT/profiles/http/v1/specs/request-smuggling-refusal.md"
+V1_FRAMING_SPEC="$EXHIBIT_ROOT/profiles/http/v1/specs/content-length-transfer-encoding.md"
+V2_SMUGGLING_SPEC="$EXHIBIT_ROOT/profiles/http/v2/specs/request-smuggling-refusal.md"
+V2_FRAMING_SPEC="$EXHIBIT_ROOT/profiles/http/v2/specs/content-length-transfer-encoding.md"
+
+PROTOCOL_NAME="protocol-switchyard-http"
+FROM_VERSION="v1.0.0"
+TO_VERSION="v1.0.1"
+DECLARED_AT="2026-05-09T00:00:00Z"
+
+export CARGO_TERM_COLOR=never
+export NO_COLOR=1
+export PATH="$WALKTHROUGH_BIN_DIR:$PATH"
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+say() {
+  printf '%s\n' "$1"
+}
+
+pause_for_user() {
+  local action="${1:-continue}"
+  if [ "${PROVEKIT_SWITCHYARD_WALKTHROUGH_NO_PAUSE:-}" = "1" ] || [ ! -t 0 ]; then
+    return
+  fi
+  printf '\nPress Enter to %s...' "$action"
+  IFS= read -r _
+  printf '\n'
+}
+
+explain_then_pause() {
+  local action="${1:-continue}"
+  section "What This Means"
+  cat
+  pause_for_user "$action"
+}
+
+analysis_with_receipts() {
+  section "Human Analysis With Receipts"
+  cat
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$1" >&2
+    exit 2
+  fi
+}
+
+need_jq() {
+  need_cmd jq
+}
+
+tmp_dir() {
+  mktemp -d "${TMPDIR:-/tmp}/provekit-switchyard-walkthrough.XXXXXX"
+}
+
+show_json_file() {
+  local path="$1"
+  awk '{ printf "  %6d: %s\n", NR, $0 }' "$path"
+}
+
+show_text_file() {
+  local path="$1"
+  awk '{ printf "  %6d: %s\n", NR, $0 }' "$path"
+}
+
+highlight_raw_line() {
+  local path="$1"
+  local pattern="$2"
+  local comment="$3"
+  local found=0
+  local line text
+
+  while IFS=: read -r line text; do
+    found=1
+    printf '  %6d: %s\n' "$line" "$text"
+  done < <(grep -n -F "$pattern" "$path" || true)
+  if [ "$found" -eq 0 ]; then
+    say "  missing raw line matching: $pattern"
+    return 1
+  fi
+  say "  comment: $comment"
+}
+
+print_provekit() {
+  printf '$ provekit'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
+print_switchyard() {
+  printf '$ provekit-protocol-switchyard'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
+source_newer_than_binary() {
+  local binary="$1"
+  local source="$2"
+  if [ -d "$source" ]; then
+    /usr/bin/find "$source" \
+      \( -path '*/target' -o -path '*/.git' \) -prune -o \
+      -type f \( -name '*.rs' -o -name 'Cargo.toml' -o -name 'Cargo.lock' \) \
+      -newer "$binary" -print -quit | grep -q .
+    return
+  fi
+  [ -f "$source" ] && [ "$source" -nt "$binary" ]
+}
+
+binary_needs_build() {
+  local binary="$1"
+  shift
+  if [ "${PROVEKIT_SWITCHYARD_FORCE_REBUILD:-}" = "1" ] || [ ! -x "$binary" ]; then
+    return 0
+  fi
+  local source
+  for source in "$@"; do
+    if source_newer_than_binary "$binary" "$source"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+build_cargo_binary_if_needed() {
+  local manifest="$1"
+  local bin_name="$2"
+  local binary="$3"
+  shift 3
+  if binary_needs_build "$binary" "$@"; then
+    say "Preparing local binary: $bin_name" >&2
+    local log_dir log
+    log_dir="$(tmp_dir)"
+    log="$log_dir/build-$bin_name.log"
+    if ! cargo build --quiet --manifest-path "$manifest" --target-dir "$WALKTHROUGH_TARGET_DIR" --bin "$bin_name" >"$log" 2>&1; then
+      cat "$log" >&2
+      return 1
+    fi
+    rm -rf "$log_dir"
+  fi
+}
+
+ensure_walkthrough_bins() {
+  if [ "${PROVEKIT_SWITCHYARD_WALKTHROUGH_BINS_READY:-}" = "$WALKTHROUGH_TARGET_DIR" ]; then
+    return
+  fi
+  need_cmd cargo
+  mkdir -p "$WALKTHROUGH_TARGET_DIR"
+  build_cargo_binary_if_needed \
+    "$REPO_ROOT/implementations/rust/provekit-cli/Cargo.toml" \
+    "provekit" \
+    "$PROVEKIT_BIN" \
+    "$REPO_ROOT/implementations/rust/provekit-cli/src" \
+    "$REPO_ROOT/implementations/rust/provekit-cli/Cargo.toml" \
+    "$REPO_ROOT/implementations/rust/Cargo.toml" \
+    "$REPO_ROOT/implementations/rust/Cargo.lock"
+  build_cargo_binary_if_needed \
+    "$REPO_ROOT/menagerie/protocol-switchyard/Cargo.toml" \
+    "provekit-protocol-switchyard" \
+    "$SWITCHYARD_BIN" \
+    "$REPO_ROOT/menagerie/protocol-switchyard/src" \
+    "$REPO_ROOT/menagerie/protocol-switchyard/Cargo.toml" \
+    "$REPO_ROOT/implementations/rust/Cargo.toml" \
+    "$REPO_ROOT/implementations/rust/Cargo.lock"
+  export PROVEKIT_SWITCHYARD_WALKTHROUGH_BINS_READY="$WALKTHROUGH_TARGET_DIR"
+}
+
+run_provekit_capture() {
+  local stdout_file="$1"
+  local stderr_file="$2"
+  shift 2
+  ensure_walkthrough_bins
+  (cd "$REPO_ROOT" && "$PROVEKIT_BIN" "$@" >"$stdout_file" 2>"$stderr_file")
+}
+
+run_switchyard_capture() {
+  local stdout_file="$1"
+  local stderr_file="$2"
+  shift 2
+  ensure_walkthrough_bins
+  (cd "$REPO_ROOT" && "$SWITCHYARD_BIN" "$@" >"$stdout_file" 2>"$stderr_file")
+}
+
+hash_spec() {
+  local path="$1"
+  ensure_walkthrough_bins
+  "$PROVEKIT_BIN" hash "$path" 2>/dev/null | tail -1
+}
+
+write_v1_catalog() {
+  local out="$1"
+  local v1_smug_cid v1_fram_cid
+  v1_smug_cid="$(hash_spec "$V1_SMUGGLING_SPEC")"
+  v1_fram_cid="$(hash_spec "$V1_FRAMING_SPEC")"
+  cat > "$out" <<JSON
+{
+  "kind": "catalog",
+  "name": "$PROTOCOL_NAME",
+  "version": "$FROM_VERSION",
+  "algorithms": {
+    "hash": ["blake3-512"],
+    "signature": ["ed25519"],
+    "pubkey": ["ed25519"]
+  },
+  "properties": {
+    "content-length-transfer-encoding": "$v1_fram_cid",
+    "request-smuggling-refusal": "$v1_smug_cid"
+  },
+  "declaredAt": "$DECLARED_AT"
+}
+JSON
+}
+
+write_v2_catalog() {
+  local out="$1"
+  local v2_smug_cid v2_fram_cid
+  v2_smug_cid="$(hash_spec "$V2_SMUGGLING_SPEC")"
+  v2_fram_cid="$(hash_spec "$V2_FRAMING_SPEC")"
+  cat > "$out" <<JSON
+{
+  "kind": "catalog",
+  "name": "$PROTOCOL_NAME",
+  "version": "$TO_VERSION",
+  "algorithms": {
+    "hash": ["blake3-512"],
+    "signature": ["ed25519"],
+    "pubkey": ["ed25519"]
+  },
+  "properties": {
+    "content-length-transfer-encoding": "$v2_fram_cid",
+    "request-smuggling-refusal": "$v2_smug_cid"
+  },
+  "declaredAt": "$DECLARED_AT"
+}
+JSON
+}
+
+write_policy() {
+  local out="$1"
+  cat > "$out" <<'JSON'
+{
+  "kind": "ProtocolEvolutionPolicy",
+  "schemaVersion": "1",
+  "name": "protocol-switchyard-http-v1-to-v2",
+  "acceptedChangeClass": "extension-only",
+  "versionLabelRule": {
+    "extensionOnlyWithoutCrossKitSemanticObligation": "patch"
+  },
+  "requiredChecks": [
+    "from catalog CID recomputes from from-catalog.json",
+    "to catalog CID recomputes from to-catalog.json",
+    "modified properties are content-addressed by spec file bytes",
+    "no core substrate property is changed",
+    "change class is extension-only"
+  ],
+  "nonGoals": [
+    "execute grammar conformance against the prose specs",
+    "mint an implementation conformance witness for any HTTP server",
+    "claim that v2 conformance implies bug-for-bug compatibility with any deployed HTTP stack"
+  ]
+}
+JSON
+}
+
+write_verifier() {
+  local out="$1"
+  cat > "$out" <<'JSON'
+{
+  "kind": "ProtocolEvolutionVerifier",
+  "schemaVersion": "1",
+  "name": "protocol-switchyard-http-verifier",
+  "version": "0.1.0",
+  "acceptedTools": [
+    {
+      "name": "blake3-512 of spec bytes",
+      "command": "cargo run --manifest-path menagerie/protocol-switchyard/Cargo.toml -- --all",
+      "purpose": "Recompute property CIDs by hashing the spec files in this exhibit."
+    }
+  ],
+  "acceptedManualAssertions": [
+    "v2 strengthens the v1 framing-ambiguity refusal by closing additional boundary cases.",
+    "v1 conformance witnesses do not imply v2 conformance.",
+    "this exhibit demonstrates the witnessed-edge shape, not implementation conformance."
+  ]
+}
+JSON
+}
+
+mint_evolution_into() {
+  local work_dir="$1"
+  local from_path="$work_dir/from-catalog.json"
+  local to_path="$work_dir/to-catalog.json"
+  local policy_path="$work_dir/policy.json"
+  local verifier_path="$work_dir/verifier.json"
+  local witness_dir="$work_dir/witness"
+  local stdout_file="$work_dir/evolve.stdout"
+  local stderr_file="$work_dir/evolve.stderr"
+
+  write_v1_catalog "$from_path"
+  write_v2_catalog "$to_path"
+  write_policy "$policy_path"
+  write_verifier "$verifier_path"
+  mkdir -p "$witness_dir"
+
+  run_provekit_capture "$stdout_file" "$stderr_file" \
+    protocol evolve \
+    --from "$from_path" \
+    --to "$to_path" \
+    --policy "$policy_path" \
+    --verifier "$verifier_path" \
+    --out-dir "$witness_dir" \
+    --change-class extension-only \
+    --producer protocol-switchyard-walkthrough \
+    --changed-spec "request-smuggling-refusal=$V2_SMUGGLING_SPEC" \
+    --changed-spec "content-length-transfer-encoding=$V2_FRAMING_SPEC" \
+    --json --quiet
+}
+
+next_script() {
+  local next="$1"
+  section "Next"
+  say "Run: $SCRIPT_DIR/$next"
+}


### PR DESCRIPTION
## Summary

Stacked PR on top of #506 (the Protocol Switchyard MVP). Adds the walkthrough/ directory the MVP was missing, mirroring the bridgeworks/supply-chain-rails pattern.

- Numbered tour scripts (00-06) walk the visitor through the v1->v2 HTTP profile migration piece-by-piece: show specs, hash to property CIDs, assemble v1/v2 catalogs, mint the witnessed edge via `provekit protocol evolve`, verify via `provekit protocol check-evolution`.
- Four break scripts (10-13) perturb one rail at a time and show which check refuses the chain. Rails: changed-spec CID binding, policy/body changeClass agreement, body input closure, evidence-CID to evidence-bytes binding.
- Integrator script (20) invokes the existing runner end-to-end.

The exhibit on disk under profiles/http stays read-only. Every script writes its inputs into a fresh $TMPDIR; break scripts mutate copies. No restoration logic needed (matches both reference exhibits).

## Test plan

- [x] `bash 00-start-here.sh` exits 0
- [x] Tour scripts 01-06 each exit 0 in sequence
- [x] Each break script exits 0 (rail fired); exits non-zero only if the rail did not fire
- [x] After break runs, `git status menagerie/protocol-switchyard/profiles/` is clean
- [x] `cargo run --manifest-path menagerie/protocol-switchyard/Cargo.toml -- --all` still passes
- [x] `cargo build --release --manifest-path menagerie/protocol-switchyard/Cargo.toml` clean
- [x] No em-dashes / en-dashes in any walkthrough file

Bases on `codex/protocol-switchyard-mvp`, not main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive CLI walkthrough tour demonstrating protocol evolution capabilities through sequential numbered steps.
  * Includes verification scenarios and failure demonstrations to validate system behavior under different conditions.

* **Documentation**
  * Added comprehensive walkthrough guide explaining each tour step, expected outputs, and system validation checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/508)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->