### PR TITLE
Fix recovered C call-edge false positives

### DIFF
--- a/.provekit/ci/accepted/c/blake3-512:310b0784be7efeedbd97efa3c53e8a97ff3e3f86d52f436abc3acb1b78b70b9060a60c25aac7c0090418fb4f333522e5bf96a04fe1439d1b24fdfa917ab91647.job-result.json
+++ b/.provekit/ci/accepted/c/blake3-512:310b0784be7efeedbd97efa3c53e8a97ff3e3f86d52f436abc3acb1b78b70b9060a60c25aac7c0090418fb4f333522e5bf96a04fe1439d1b24fdfa917ab91647.job-result.json
@@ -1,0 +1,25 @@
+{
+  "kind": "CIJobResultBodyClaim",
+  "schemaVersion": "1",
+  "jobKey": "provekit/ci/c",
+  "blastRadiusCid": "blake3-512:310b0784be7efeedbd97efa3c53e8a97ff3e3f86d52f436abc3acb1b78b70b9060a60c25aac7c0090418fb4f333522e5bf96a04fe1439d1b24fdfa917ab91647",
+  "result": "pass",
+  "outputCid": "blake3-512:5b0b9fde2c6ff798ff2ed50449d0b1c976019cd8c740ec95209471fe171de8df4412270b8779ec47f5e9602ad57e871597b5c1b059aaf1ec78a75884a66c2214",
+  "logCid": "blake3-512:f58212b5bee86cc694e1e096016ca98ec787d2ac86af6dc9b97dba88c9139d8ac997852eeea6dc9bd12a7d8ed8d94cc9ae502d6a5f2b449bd29e73578045cc4b",
+  "startedAt": "2026-05-07T00:00:00Z",
+  "finishedAt": "2026-05-07T00:00:00Z",
+  "runnerIdentityCid": "blake3-512:ea57d5bb564e290c3cd6fa3e5355e411d279c37be83cd4085d856b6c1210ce27ea65012d9810b1d343aeddd9ddfffd4542991107a3c7cc5121447ac4722ccd4b",
+  "policyCid": "blake3-512:430f7ae604144abb9810c0ee83dedce757cd12ce1bb3457051c7c94fcccfc237ccb7a909fe471290367bf9649129bdb76d63a392e28f59dad74b5417612e5668",
+  "inputCids": [
+    "blake3-512:310b0784be7efeedbd97efa3c53e8a97ff3e3f86d52f436abc3acb1b78b70b9060a60c25aac7c0090418fb4f333522e5bf96a04fe1439d1b24fdfa917ab91647",
+    "blake3-512:430f7ae604144abb9810c0ee83dedce757cd12ce1bb3457051c7c94fcccfc237ccb7a909fe471290367bf9649129bdb76d63a392e28f59dad74b5417612e5668",
+    "blake3-512:5b0b9fde2c6ff798ff2ed50449d0b1c976019cd8c740ec95209471fe171de8df4412270b8779ec47f5e9602ad57e871597b5c1b059aaf1ec78a75884a66c2214",
+    "blake3-512:ea57d5bb564e290c3cd6fa3e5355e411d279c37be83cd4085d856b6c1210ce27ea65012d9810b1d343aeddd9ddfffd4542991107a3c7cc5121447ac4722ccd4b",
+    "blake3-512:f58212b5bee86cc694e1e096016ca98ec787d2ac86af6dc9b97dba88c9139d8ac997852eeea6dc9bd12a7d8ed8d94cc9ae502d6a5f2b449bd29e73578045cc4b"
+  ],
+  "producer": {
+    "kind": "ci-runner",
+    "name": "provekit-ci",
+    "version": "checked-in"
+  }
+}

--- a/implementations/c/provekit-lift-c-kernel-doc/tests/fixtures/recovery_call.c
+++ b/implementations/c/provekit-lift-c-kernel-doc/tests/fixtures/recovery_call.c
@@ -9,14 +9,29 @@
 
 extern void target_inplace_set();
 extern void target_callback_set();
+extern void target_noncall_ref();
+extern void target_parenthesized_set();
+extern void target_deref_set();
 
 void caller_with_recovery(int *req, int *sg) {
+    void (*fp)(void);
     u8 *iv;            /* undeclared typedef -> dependent-type lvalue */
     int elen, ivlen = 0;
     elen = 0;
 
+    /* Function references are not calls and must not produce callEdges. */
+    fp = target_noncall_ref;
+    (void)target_noncall_ref;
+
     /* Args without a poisoned operand: regular CallExpr. */
     target_callback_set(req, 0, sg, sg);
+
+    /* The one real call to the function-ref target must still surface. */
+    target_noncall_ref();
+
+    /* Parenthesized function designators are still direct calls. */
+    (target_parenthesized_set)(req, sg, sg, elen + ivlen, iv);
+    (*target_deref_set)(req, sg, sg, elen + ivlen, iv);
 
     /* Passing the dependent-type `iv`: libclang produces RecoveryExpr. */
     target_inplace_set(req, sg, sg, elen + ivlen, iv);

--- a/implementations/c/provekit-lift-c-kernel-doc/tests/integration.sh
+++ b/implementations/c/provekit-lift-c-kernel-doc/tests/integration.sh
@@ -283,17 +283,40 @@ else
     RECOVERY_REQUEST="{\"jsonrpc\":\"2.0\",\"id\":120,\"method\":\"parse\",\"params\":{\"path\":\"recovery_call.c\",\"parse_backend\":\"clang_ast\",\"source\":\"$RECOVERY_SOURCE\"}}"
     RECOVERY_RESPONSE=$(printf '%s\n' "$RECOVERY_REQUEST" | "$BIN" --rpc)
 
-    printf '%s\n' "$RECOVERY_RESPONSE" | grep -q '"callee_name":"target_callback_set"' || {
-        echo "FAIL: regular CallExpr target_callback_set should still be lifted in recovery fixture" >&2
+    CALLBACK_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_callback_set"' | wc -l | tr -d '[:space:]')
+    if [ "$CALLBACK_COUNT" != "1" ]; then
+        echo "FAIL: regular CallExpr target_callback_set should be lifted exactly once in recovery fixture (got $CALLBACK_COUNT)" >&2
         echo "$RECOVERY_RESPONSE" >&2
         exit 1
-    }
+    fi
 
-    printf '%s\n' "$RECOVERY_RESPONSE" | grep -q '"callee_name":"target_inplace_set"' || {
-        echo "FAIL: RecoveryExpr-wrapped call target_inplace_set must be surfaced as a callEdge (libclang wraps the call when an arg has dependent type)" >&2
+    INPLACE_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_inplace_set"' | wc -l | tr -d '[:space:]')
+    if [ "$INPLACE_COUNT" != "1" ]; then
+        echo "FAIL: RecoveryExpr-wrapped call target_inplace_set must be surfaced exactly once as a callEdge (got $INPLACE_COUNT)" >&2
         echo "$RECOVERY_RESPONSE" >&2
         exit 1
-    }
+    fi
+
+    NONCALL_REF_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_noncall_ref"' | wc -l | tr -d '[:space:]')
+    if [ "$NONCALL_REF_COUNT" != "1" ]; then
+        echo "FAIL: function references to target_noncall_ref must not be counted as calls; only the real call should surface (got $NONCALL_REF_COUNT)" >&2
+        echo "$RECOVERY_RESPONSE" >&2
+        exit 1
+    fi
+
+    PAREN_CALL_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_parenthesized_set"' | wc -l | tr -d '[:space:]')
+    if [ "$PAREN_CALL_COUNT" != "1" ]; then
+        echo "FAIL: parenthesized function designator target_parenthesized_set should be lifted exactly once (got $PAREN_CALL_COUNT)" >&2
+        echo "$RECOVERY_RESPONSE" >&2
+        exit 1
+    fi
+
+    DEREF_CALL_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_deref_set"' | wc -l | tr -d '[:space:]')
+    if [ "$DEREF_CALL_COUNT" != "1" ]; then
+        echo "FAIL: dereferenced function designator target_deref_set should be lifted exactly once (got $DEREF_CALL_COUNT)" >&2
+        echo "$RECOVERY_RESPONSE" >&2
+        exit 1
+    fi
 fi
 
 echo "provekit-lift-c-kernel-doc integration passed"

--- a/implementations/c/provekit-lift-core/src/clang_ast.c
+++ b/implementations/c/provekit-lift-core/src/clang_ast.c
@@ -251,6 +251,62 @@ static char *pk_c_clang_get_cursor_source(CXCursor cursor) {
     return out;
 }
 
+static void pk_c_clang_skip_space(const char **p) {
+    while (isspace((unsigned char)**p)) {
+        (*p)++;
+    }
+}
+
+static int pk_c_clang_match_callee_token(const char **p, const char *callee) {
+    size_t len = strlen(callee);
+
+    if (strncmp(*p, callee, len) != 0) {
+        return 0;
+    }
+    if (isalnum((unsigned char)(*p)[len]) || (*p)[len] == '_') {
+        return 0;
+    }
+    *p += len;
+    return 1;
+}
+
+static int pk_c_clang_source_starts_direct_call(CXCursor cursor, const char *callee) {
+    char *source;
+    const char *p;
+    int result = 0;
+
+    if (callee == NULL || callee[0] == '\0') {
+        return 0;
+    }
+    source = pk_c_clang_get_cursor_source(cursor);
+    if (source == NULL) {
+        return 0;
+    }
+    p = source;
+    pk_c_clang_skip_space(&p);
+    if (pk_c_clang_match_callee_token(&p, callee)) {
+        pk_c_clang_skip_space(&p);
+        result = *p == '(';
+    } else if (*p == '(') {
+        p++;
+        pk_c_clang_skip_space(&p);
+        if (*p == '*') {
+            p++;
+            pk_c_clang_skip_space(&p);
+        }
+        if (pk_c_clang_match_callee_token(&p, callee)) {
+            pk_c_clang_skip_space(&p);
+            if (*p == ')') {
+                p++;
+                pk_c_clang_skip_space(&p);
+                result = *p == '(';
+            }
+        }
+    }
+    free(source);
+    return result;
+}
+
 static const char *pk_c_clang_classify_arg_text(const char *text) {
     const char *p;
 
@@ -514,7 +570,9 @@ static enum CXChildVisitResult pk_c_clang_find_recovery_function_ref(
     }
     /* Step through transparent wrappers (ImplicitCastExpr is reported as
      * UnexposedExpr by libclang) until we hit the function reference. */
-    if (kind == CXCursor_UnexposedExpr) {
+    if (kind == CXCursor_UnexposedExpr ||
+        kind == CXCursor_ParenExpr ||
+        kind == CXCursor_UnaryOperator) {
         return CXChildVisit_Recurse;
     }
     /* Anything else as a first child means the cursor is not a recovery-
@@ -598,7 +656,8 @@ static enum CXChildVisitResult pk_c_clang_visit(CXCursor cursor, CXCursor parent
         pk_c_clang_callee_ctx fc = {0};
 
         (void)clang_visitChildren(cursor, pk_c_clang_find_recovery_function_ref, &fc);
-        if (fc.name != NULL && fc.name[0] != '\0') {
+        if (fc.name != NULL && fc.name[0] != '\0' &&
+            pk_c_clang_source_starts_direct_call(cursor, fc.name)) {
             int rc = pk_c_clang_append_call(
                 ctx->facts, ctx->path, ctx->current_function, fc.name, cursor);
 


### PR DESCRIPTION
## Summary
- narrow RecoveryExpr call-edge recovery to direct call-shaped source ranges
- add regression coverage for non-call function references plus exact call counts
- refresh the C CICP witness for the follow-up fix

## Verification
- make -C implementations/c/provekit-lift-c-kernel-doc test
- make -C implementations/c/provekit-lift-core test
- cargo build -p provekit-cli --release
- implementations/rust/target/release/provekit ci accept --repo . --all-kits --clean --check --json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of call analysis by distinguishing between actual function calls and function references.

* **Tests**
  * Extended test coverage to verify correct identification of function calls versus references.
  * Strengthened integration tests with more rigorous call-edge verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/511)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->