### PR TITLE
Promote JS env lowerer receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,23 @@ jobs:
       - name: Set up Rust (stable)
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Restore Rust target dirs
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            implementations/rust/target
+            tools/cross-kit-conformance/target
+            tools/recompute-spec-cids/target
+            tools/foundation-keygen/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Cache Rust target dirs
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v4
         with:
           path: |
@@ -296,7 +312,26 @@ jobs:
         # RPC against mint-swift-self-contracts).
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Restore Rust target dirs
+        if: github.event_name == 'pull_request'
+        # Same cache shape as the Linux job; ${{ runner.os }} resolves to
+        # macOS here so the namespace is distinct (no collision with the
+        # Linux cargo cache). PRs restore only so post-job cache upload cannot
+        # turn successful verification into a timeout failure.
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            implementations/rust/target
+            tools/recompute-spec-cids/target
+            tools/foundation-keygen/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Cache Rust target dirs
+        if: github.event_name != 'pull_request'
         # Same cache shape as the Linux job; ${{ runner.os }} resolves to
         # macOS here so the namespace is distinct (no collision with the
         # Linux cargo cache). Cold-start without this is ~5-7 minutes of
@@ -363,7 +398,22 @@ jobs:
       - name: Set up Rust (stable)
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Restore Rust target dirs
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            implementations/rust/target
+            tools/recompute-spec-cids/target
+            tools/foundation-keygen/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Cache Rust target dirs
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v4
         with:
           path: |
@@ -425,7 +475,22 @@ jobs:
       - name: Set up Rust (stable)
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Restore Rust target dirs
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            implementations/rust/target
+            tools/recompute-spec-cids/target
+            tools/foundation-keygen/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Cache Rust target dirs
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v4
         with:
           path: |
@@ -602,7 +667,22 @@ jobs:
       - name: Set up Rust (stable)
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Restore Rust target dirs
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            implementations/rust/target
+            tools/recompute-spec-cids/target
+            tools/foundation-keygen/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Cache Rust target dirs
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v4
         with:
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -84,8 +84,14 @@ implementations/c/provekit-lift/bin/
 # Project-local Bridgeworks toy lifter build output.
 menagerie/bridgeworks/**/kit-rpc/target/
 
+# Project-local Supply Chain Rails toy lifter/lowerer build output.
+menagerie/supply-chain-rails/**/kit-rpc/target/
+
 # Bridgeworks walkthrough scratch/build output.
 /target/provekit-bridgeworks-*
+
+# Supply Chain Rails walkthrough scratch/build output.
+/target/provekit-supply-chain-*
 
 # C++ orchestrator binary output (rebuilt by tools/build-cpp-self-contracts.sh).
 implementations/cpp/target/

--- a/docs/superpowers/plans/2026-05-09-js-env-lowerer-evidence.md
+++ b/docs/superpowers/plans/2026-05-09-js-env-lowerer-evidence.md
@@ -1,0 +1,286 @@
+# JavaScript Env Lowerer Evidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote the Supply Chain Rails JavaScript lowerer from token scanning to an AST-backed `runtime.no-env-secret-read` evidence/refusal engine with content-addressed receipts.
+
+**Architecture:** Keep the lowerer as the exhibit-local Rust JSON-RPC kit, but split JavaScript analysis into explicit parse, scan, and receipt steps. Use a real JavaScript parser, fail closed on parse/unsupported dynamic surfaces, and preserve ProvekIt's `lower -> witness/refusal -> .proof` flow.
+
+**Tech Stack:** Rust 2021, `tree-sitter`, `tree-sitter-javascript`, `serde_json`, existing ProvekIt lower JSON-RPC protocol, existing Supply Chain Rails smoke tests.
+
+---
+
+### Task 1: Add Red Tests For Env Receipts
+
+**Files:**
+- Modify: `menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-js-lowerer.rs`
+- Test: `menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-js-lowerer.rs`
+
+- [ ] **Step 1: Write failing unit tests in the lowerer file**
+
+Add a `#[cfg(test)] mod tests` with helpers that call a pure `analyze_runtime_no_env_secret_read("index.js", source)` function. The tests must assert:
+
+```rust
+#[test]
+fn runtime_no_env_accepts_source_without_env_reads() {
+    let result = analyze_runtime_no_env_secret_read(
+        "index.js",
+        "export function parseJson(input) { return JSON.parse(input); }\n",
+    )
+    .expect("analysis succeeds");
+    assert!(result.findings.is_empty());
+    assert!(result.unsupported.is_empty());
+}
+
+#[test]
+fn runtime_no_env_rejects_direct_process_env_read_with_span() {
+    let result = analyze_runtime_no_env_secret_read(
+        "index.js",
+        "export function parseJson(input) {\n  return process.env.SAFE_JSON_TOKEN || input;\n}\n",
+    )
+    .expect("analysis succeeds");
+    assert_eq!(result.findings[0].reason_code, "env-secret-read");
+    assert_eq!(result.findings[0].expression, "process.env.SAFE_JSON_TOKEN");
+    assert_eq!(result.findings[0].span.line_start, 2);
+}
+
+#[test]
+fn runtime_no_env_rejects_aliased_env_read() {
+    let result = analyze_runtime_no_env_secret_read(
+        "index.js",
+        "const env = process.env;\nexport function parseJson(input) { return env.SAFE_JSON_TOKEN || input; }\n",
+    )
+    .expect("analysis succeeds");
+    assert_eq!(result.findings[0].reason_code, "env-secret-read");
+    assert_eq!(result.findings[0].expression, "env.SAFE_JSON_TOKEN");
+}
+
+#[test]
+fn runtime_no_env_fails_closed_on_dynamic_process_env_read() {
+    let result = analyze_runtime_no_env_secret_read(
+        "index.js",
+        "const key = 'env';\nexport function parseJson(input) { return process[key].SAFE_JSON_TOKEN || input; }\n",
+    )
+    .expect("analysis succeeds");
+    assert_eq!(result.unsupported[0].reason_code, "dynamic-env-access");
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run: `cargo test --manifest-path menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml runtime_no_env -- --nocapture`
+
+Expected: compile failure because `analyze_runtime_no_env_secret_read` and the analysis structs do not exist.
+
+### Task 2: Implement AST Analysis
+
+**Files:**
+- Modify: `menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml`
+- Modify: `menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-js-lowerer.rs`
+
+- [ ] **Step 1: Add parser dependencies**
+
+Add to the kit RPC manifest:
+
+```toml
+tree-sitter = "0.24"
+tree-sitter-javascript = "0.23"
+```
+
+- [ ] **Step 2: Implement analysis data structures**
+
+Add:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SourceSpan {
+    line_start: usize,
+    column_start: usize,
+    line_end: usize,
+    column_end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EnvFinding {
+    reason_code: &'static str,
+    expression: String,
+    span: SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UnsupportedSurface {
+    reason_code: &'static str,
+    expression: String,
+    span: SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeNoEnvAnalysis {
+    findings: Vec<EnvFinding>,
+    unsupported: Vec<UnsupportedSurface>,
+}
+```
+
+- [ ] **Step 3: Parse and walk JavaScript AST**
+
+Implement `analyze_runtime_no_env_secret_read(artifact, source)` using `tree_sitter::Parser`, `tree_sitter_javascript::LANGUAGE`, and a node walk. The walker must:
+
+```rust
+// direct read
+process.env
+process.env.SAFE_JSON_TOKEN
+
+// alias declaration
+const env = process.env
+let env = process.env
+var env = process.env
+
+// alias read
+env.SAFE_JSON_TOKEN
+
+// fail-closed dynamic surfaces
+process["env"]
+process[key]
+require(...)
+import(...)
+```
+
+- [ ] **Step 4: Run focused tests and verify they pass**
+
+Run: `cargo test --manifest-path menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml runtime_no_env -- --nocapture`
+
+Expected: all `runtime_no_env_*` tests pass.
+
+### Task 3: Emit Receipt Fields From Analysis
+
+**Files:**
+- Modify: `menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-js-lowerer.rs`
+- Test: `menagerie/supply-chain-rails/tests/smoke.rs`
+
+- [ ] **Step 1: Add failing CLI-level smoke assertions**
+
+Extend the existing Supply Chain Rails smoke test to assert the lower result exposes:
+
+```rust
+assert_eq!(
+    report["redRails"]["witness"]["reasonCode"],
+    "env-secret-read"
+);
+assert!(report["redRails"]["witness"]["evidenceCid"]
+    .as_str()
+    .expect("evidenceCid")
+    .starts_with("blake3-512:"));
+assert_eq!(
+    report["redRails"]["witness"]["unsupportedSemantics"],
+    serde_json::json!([])
+);
+```
+
+- [ ] **Step 2: Run the smoke test and verify it fails**
+
+Run: `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-supply-chain-rails --test smoke all_exhibits_show_conventional_green_then_provekit_red -- --nocapture`
+
+Expected: failure because `redRails.witness.evidenceCid` or `unsupportedSemantics` is not surfaced yet.
+
+- [ ] **Step 3: Wire analysis into `realize`**
+
+For `runtime.no-env-secret-read`, replace token scanning with AST analysis and emit evidence containing:
+
+```json
+{
+  "kind": "javascript-runtime-no-env-evidence",
+  "contract": "runtime.no-env-secret-read",
+  "contractCid": "<cid over proofIr>",
+  "artifact": "index.js",
+  "artifactCid": "<cid over source bytes>",
+  "lowerer": {"name":"supply-chain-js-lowerer","version":"0.2.0"},
+  "mode": "witness",
+  "findings": [],
+  "unsupportedSemantics": [],
+  "sourceSpans": []
+}
+```
+
+Rejected output must include `reasonCode`, `evidenceCid`, `findings`, `unsupportedSemantics`, and `sourceSpans`.
+
+- [ ] **Step 4: Run focused smoke and lowerer tests**
+
+Run:
+
+```bash
+cargo test --manifest-path menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml runtime_no_env -- --nocapture
+cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-supply-chain-rails --test smoke all_exhibits_show_conventional_green_then_provekit_red -- --nocapture
+```
+
+Expected: both pass.
+
+### Task 4: Update Walkthrough Receipts
+
+**Files:**
+- Modify: `menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/04-preserve-contracts-fail-witness.sh`
+- Modify: `menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/README.md`
+- Modify: `menagerie/supply-chain-rails/README.md`
+
+- [ ] **Step 1: Highlight raw evidence receipt lines**
+
+Update `04-preserve-contracts-fail-witness.sh` to highlight:
+
+```bash
+highlight_raw_line "$lower_json" '"evidenceCid":' "The refusal evidence is content-addressed."
+highlight_raw_line "$lower_json" '"sourceSpans":' "The lowerer points at the source span that contradicts the preserved contract."
+highlight_raw_line "$lower_json" '"unsupportedSemantics": []' "The failure is a concrete counterexample, not an unsupported-language escape hatch."
+```
+
+- [ ] **Step 2: Update honesty language**
+
+Change docs from “toy-shaped JS lowerer” to “AST-backed for `runtime.no-env-secret-read`, still limited to the documented coverage envelope.”
+
+- [ ] **Step 3: Run script syntax checks**
+
+Run: `bash -n menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/04-preserve-contracts-fail-witness.sh`
+
+Expected: exit 0.
+
+### Task 5: Final Verification And PR
+
+**Files:**
+- Modify: `.provekit/ci/accepted/**` only if `provekit ci accept --check` reports a stale checked-in witness.
+
+- [ ] **Step 1: Run formatting**
+
+Run:
+
+```bash
+cargo fmt --manifest-path menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml --check
+cargo fmt --manifest-path implementations/rust/Cargo.toml --package provekit-supply-chain-rails --check
+```
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --manifest-path menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml runtime_no_env -- --nocapture
+cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-supply-chain-rails --test smoke -- --nocapture
+```
+
+- [ ] **Step 3: Run checked-in CICP gate**
+
+Run: `implementations/rust/target/release/provekit ci accept --all-kits --clean --check --out .provekit/ci/accepted`
+
+Expected: verifies existing accepted witnesses, or reports the exact missing witness to refresh.
+
+- [ ] **Step 4: Run diff hygiene**
+
+Run: `git diff --check`
+
+- [ ] **Step 5: Commit and PR**
+
+Commit message:
+
+```bash
+git commit -m "Promote JS env lowerer receipts"
+```
+
+Open a non-draft PR and cite #499.
+

--- a/docs/superpowers/plans/2026-05-09-js-env-lowerer-evidence.md
+++ b/docs/superpowers/plans/2026-05-09-js-env-lowerer-evidence.md
@@ -283,4 +283,3 @@ git commit -m "Promote JS env lowerer receipts"
 ```
 
 Open a non-draft PR and cite #499.
-

--- a/menagerie/supply-chain-rails/README.md
+++ b/menagerie/supply-chain-rails/README.md
@@ -39,16 +39,18 @@ That means the exhibit does not claim that ProvekIt currently models every npm
 attack surface. It does not model full npm dependency resolution, lifecycle
 script semantics, registry provenance, package aliases, bundled dependency
 behavior, or every possible in-toto layout. The npm lifter maps enough package
-rails to carry the contract admission story, and the JavaScript lowerer
-demonstrates the ORP move for this contract. They are not general-purpose npm
-or JavaScript verifiers yet.
+rails to carry the contract admission story. The JavaScript lowerer now parses
+JavaScript and emits AST-backed evidence for `runtime.no-env-secret-read`,
+including refusal spans and unsupported-semantics receipts. It is still not a
+general-purpose JavaScript verifier beyond that documented coverage envelope.
 
 The path to remove those caveats is tracked in:
 
 - [#498](https://github.com/TSavo/provekit/issues/498): make the npm inspector
   a complete package semantic model.
 - [#499](https://github.com/TSavo/provekit/issues/499): promote the JavaScript
-  lowerer from exhibit-specific ORP to a general JavaScript evidence engine.
+  lowerer beyond the current `runtime.no-env-secret-read` envelope into a
+  general JavaScript evidence engine.
 
 Until those land, the claim is conditional and receipt-shaped: for this
 package-shaped release, this contract set, these accepted lowerers, and this

--- a/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.lock
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +400,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +564,8 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
+ "tree-sitter",
+ "tree-sitter-javascript",
 ]
 
 [[package]]
@@ -563,6 +609,35 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tree-sitter"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "typenum"

--- a/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml
@@ -12,6 +12,8 @@ provekit-claim-envelope = { path = "../../../../implementations/rust/provekit-cl
 serde_json = "1"
 sha2 = "0.10"
 tar = "0.4"
+tree-sitter = "0.24"
+tree-sitter-javascript = "0.23"
 
 [workspace]
 

--- a/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-js-lowerer.rs
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-js-lowerer.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeSet;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use serde_json::{json, Value};
+use tree_sitter::{Node, Parser};
 
 fn main() {
     let args = std::env::args().collect::<Vec<_>>();
@@ -98,6 +102,10 @@ fn realize(project: &Path, plan: &Value) -> Result<Value, String> {
         .map_err(|e| format!("read {}: {e}", artifact_path.display()))?;
     let artifact_cid = blake3_512(source.as_bytes());
 
+    if contract == "runtime.no-env-secret-read" {
+        return realize_runtime_no_env(contract, artifact, &source, &artifact_cid, plan);
+    }
+
     if let Some(message) = refusal_for(contract, artifact, &source) {
         let evidence = json!({
             "kind": "static-js-witness-refusal",
@@ -179,6 +187,423 @@ fn realize(project: &Path, plan: &Value) -> Result<Value, String> {
     }))
 }
 
+fn realize_runtime_no_env(
+    contract: &str,
+    artifact: &str,
+    source: &str,
+    artifact_cid: &str,
+    plan: &Value,
+) -> Result<Value, String> {
+    let analysis = analyze_runtime_no_env_secret_read(artifact, source)?;
+    let policy_cid = plan
+        .get("policyCid")
+        .and_then(Value::as_str)
+        .unwrap_or("builtin:supply-chain-rails/npm-safe-json@0.1");
+    let proof_ir = plan
+        .pointer("/obligation/proofIr")
+        .cloned()
+        .unwrap_or_else(|| json!({"kind": "atomic", "name": contract, "args": []}));
+    let contract_cid = jcs_cid(&proof_ir);
+    let findings = findings_json(&analysis.findings);
+    let unsupported = unsupported_json(&analysis.unsupported);
+    let source_spans = source_spans_json(&analysis);
+    let lowerer = json!({"name": "supply-chain-js-lowerer", "version": "0.2.0"});
+    let evidence = json!({
+        "kind": "javascript-runtime-no-env-evidence",
+        "contract": contract,
+        "contractCid": contract_cid,
+        "artifact": artifact,
+        "artifactCid": artifact_cid,
+        "lowerer": lowerer,
+        "mode": "witness",
+        "findings": findings,
+        "unsupportedSemantics": unsupported,
+        "sourceSpans": source_spans,
+    });
+    let evidence_cid = jcs_cid(&evidence);
+    let claim_body = json!({
+        "claimKind": "npm-package-contract-witness",
+        "contract": contract,
+        "contractCid": contract_cid,
+        "subjectCids": [artifact_cid],
+        "policyCid": policy_cid
+    });
+
+    let common = json!({
+        "kind": "ORPLowerResult",
+        "claimKind": "npm-package-contract-witness",
+        "policyCid": policy_cid,
+        "verifierCid": "builtin:supply-chain-rails/js-static-lowerer@0.2",
+        "claimBody": claim_body,
+        "evidence": evidence,
+        "evidenceCid": evidence_cid,
+        "inputCids": [artifact_cid, contract_cid],
+        "producedAt": "2026-05-08T00:00:00Z"
+    });
+
+    if let Some(finding) = analysis.findings.first() {
+        let message = format!(
+            "counterexample: {} at {}:{} violates {contract}",
+            finding.expression, finding.span.line_start, finding.span.column_start
+        );
+        return Ok(merge_output(
+            common,
+            json!({
+                "status": "rejected",
+                "reasonCode": finding.reason_code,
+                "message": message,
+                "error": message,
+                "findings": findings,
+                "unsupportedSemantics": unsupported,
+                "sourceSpans": source_spans,
+                "realizer": lowerer,
+                "observedArtifactCids": [artifact_cid],
+                "witnessArtifact": {
+                    "language": "javascript-ast-analysis",
+                    "source": format!("parse({artifact}) => reject when AST contradicts preserved contract {contract}")
+                }
+            }),
+        ));
+    }
+
+    if let Some(unsupported_surface) = analysis.unsupported.first() {
+        let message = format!(
+            "unsupported JavaScript semantics: {} at {}:{}",
+            unsupported_surface.reason_code,
+            unsupported_surface.span.line_start,
+            unsupported_surface.span.column_start
+        );
+        return Ok(merge_output(
+            common,
+            json!({
+                "status": "rejected",
+                "reasonCode": unsupported_surface.reason_code,
+                "message": message,
+                "error": message,
+                "findings": findings,
+                "unsupportedSemantics": unsupported,
+                "sourceSpans": source_spans,
+                "realizer": lowerer,
+                "observedArtifactCids": [artifact_cid],
+                "witnessArtifact": {
+                    "language": "javascript-ast-analysis",
+                    "source": format!("parse({artifact}) => fail closed for unsupported JavaScript while lowering {contract}")
+                }
+            }),
+        ));
+    }
+
+    Ok(merge_output(
+        common,
+        json!({
+            "status": "witnessed",
+            "message": format!("accepted witness for {contract}"),
+            "findings": findings,
+            "unsupportedSemantics": unsupported,
+            "sourceSpans": source_spans,
+            "realizer": lowerer,
+            "observedArtifactCids": [artifact_cid],
+            "witnessArtifact": {
+                "language": "javascript-ast-analysis",
+                "source": format!("parse({artifact}) => accepted contract {contract}; no AST env reads matched")
+            }
+        }),
+    ))
+}
+
+fn merge_output(mut base: Value, mut output: Value) -> Value {
+    let evidence_cid = base
+        .get("evidenceCid")
+        .cloned()
+        .unwrap_or_else(|| Value::Null);
+    if let Some(output_obj) = output.as_object_mut() {
+        output_obj.insert("evidenceCid".to_string(), evidence_cid);
+    }
+    if let Some(base_obj) = base.as_object_mut() {
+        base_obj.insert("output".to_string(), output);
+    }
+    base
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SourceSpan {
+    line_start: usize,
+    column_start: usize,
+    line_end: usize,
+    column_end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EnvFinding {
+    reason_code: &'static str,
+    expression: String,
+    span: SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UnsupportedSurface {
+    reason_code: &'static str,
+    expression: String,
+    span: SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeNoEnvAnalysis {
+    findings: Vec<EnvFinding>,
+    unsupported: Vec<UnsupportedSurface>,
+}
+
+fn analyze_runtime_no_env_secret_read(
+    _artifact: &str,
+    source: &str,
+) -> Result<RuntimeNoEnvAnalysis, String> {
+    let mut parser = Parser::new();
+    let language = tree_sitter_javascript::LANGUAGE.into();
+    parser
+        .set_language(&language)
+        .map_err(|e| format!("initialize JavaScript parser: {e}"))?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or_else(|| "parse JavaScript source".to_string())?;
+    let root = tree.root_node();
+    let source_bytes = source.as_bytes();
+
+    let mut aliases = BTreeSet::new();
+    collect_env_aliases(root, source_bytes, &mut aliases);
+
+    let mut analysis = RuntimeNoEnvAnalysis {
+        findings: Vec::new(),
+        unsupported: Vec::new(),
+    };
+    if root.has_error() {
+        analysis.unsupported.push(UnsupportedSurface {
+            reason_code: "parse-error",
+            expression: "<parse-error>".to_string(),
+            span: span_for(root),
+        });
+    }
+    scan_env_reads(root, source_bytes, &aliases, &mut analysis);
+    Ok(analysis)
+}
+
+fn collect_env_aliases(node: Node<'_>, source: &[u8], aliases: &mut BTreeSet<String>) {
+    if node.kind() == "variable_declarator" {
+        if let (Some(name), Some(value)) = (
+            node.child_by_field_name("name"),
+            node.child_by_field_name("value"),
+        ) {
+            let name_text = node_text(name, source);
+            let value_text = compact_js_text(&node_text(value, source));
+            if name.kind() == "identifier" && value_text == "process.env" {
+                aliases.insert(name_text);
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_env_aliases(child, source, aliases);
+    }
+}
+
+fn scan_env_reads(
+    node: Node<'_>,
+    source: &[u8],
+    aliases: &BTreeSet<String>,
+    analysis: &mut RuntimeNoEnvAnalysis,
+) {
+    let text = node_text(node, source);
+    let compact = compact_js_text(&text);
+    match node.kind() {
+        "member_expression" => {
+            if is_process_env_member(&compact)
+                && !is_env_alias_initializer(node, source, aliases)
+                && !is_nested_process_env_prefix(node, source)
+            {
+                push_finding(
+                    analysis,
+                    EnvFinding {
+                        reason_code: "env-secret-read",
+                        expression: text.clone(),
+                        span: span_for(node),
+                    },
+                );
+            }
+            for alias in aliases {
+                if compact.starts_with(&format!("{alias}.")) {
+                    push_finding(
+                        analysis,
+                        EnvFinding {
+                            reason_code: "env-secret-read",
+                            expression: text.clone(),
+                            span: span_for(node),
+                        },
+                    );
+                }
+            }
+        }
+        "subscript_expression" => {
+            if compact.starts_with("process[") {
+                push_unsupported(
+                    analysis,
+                    UnsupportedSurface {
+                        reason_code: "dynamic-env-access",
+                        expression: text,
+                        span: span_for(node),
+                    },
+                );
+            }
+        }
+        "call_expression" => {
+            if compact.starts_with("require(") || compact.starts_with("import(") {
+                push_unsupported(
+                    analysis,
+                    UnsupportedSurface {
+                        reason_code: "unresolved-module-call",
+                        expression: text,
+                        span: span_for(node),
+                    },
+                );
+            }
+        }
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        scan_env_reads(child, source, aliases, analysis);
+    }
+}
+
+fn is_process_env_member(compact: &str) -> bool {
+    compact == "process.env" || compact.starts_with("process.env.")
+}
+
+fn is_nested_process_env_prefix(node: Node<'_>, source: &[u8]) -> bool {
+    if compact_js_text(&node_text(node, source)) != "process.env" {
+        return false;
+    }
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    parent.kind() == "member_expression"
+        && is_process_env_member(&compact_js_text(&node_text(parent, source)))
+}
+
+fn is_env_alias_initializer(node: Node<'_>, source: &[u8], aliases: &BTreeSet<String>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    if parent.kind() != "variable_declarator" {
+        return false;
+    }
+    let Some(name) = parent.child_by_field_name("name") else {
+        return false;
+    };
+    let Some(value) = parent.child_by_field_name("value") else {
+        return false;
+    };
+    aliases.contains(&node_text(name, source)) && value.id() == node.id()
+}
+
+fn push_finding(analysis: &mut RuntimeNoEnvAnalysis, finding: EnvFinding) {
+    if !analysis.findings.iter().any(|existing| {
+        existing.reason_code == finding.reason_code
+            && existing.expression == finding.expression
+            && existing.span == finding.span
+    }) {
+        analysis.findings.push(finding);
+    }
+}
+
+fn push_unsupported(analysis: &mut RuntimeNoEnvAnalysis, unsupported: UnsupportedSurface) {
+    if !analysis.unsupported.iter().any(|existing| {
+        existing.reason_code == unsupported.reason_code
+            && existing.expression == unsupported.expression
+            && existing.span == unsupported.span
+    }) {
+        analysis.unsupported.push(unsupported);
+    }
+}
+
+fn node_text(node: Node<'_>, source: &[u8]) -> String {
+    node.utf8_text(source)
+        .unwrap_or("<invalid-utf8>")
+        .trim()
+        .to_string()
+}
+
+fn compact_js_text(text: &str) -> String {
+    text.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+fn span_for(node: Node<'_>) -> SourceSpan {
+    let start = node.start_position();
+    let end = node.end_position();
+    SourceSpan {
+        line_start: start.row + 1,
+        column_start: start.column + 1,
+        line_end: end.row + 1,
+        column_end: end.column + 1,
+    }
+}
+
+fn findings_json(findings: &[EnvFinding]) -> Value {
+    Value::Array(
+        findings
+            .iter()
+            .map(|finding| {
+                json!({
+                    "reasonCode": finding.reason_code,
+                    "expression": finding.expression,
+                    "span": span_json(&finding.span),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn unsupported_json(unsupported: &[UnsupportedSurface]) -> Value {
+    Value::Array(
+        unsupported
+            .iter()
+            .map(|surface| {
+                json!({
+                    "reasonCode": surface.reason_code,
+                    "expression": surface.expression,
+                    "span": span_json(&surface.span),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn source_spans_json(analysis: &RuntimeNoEnvAnalysis) -> Value {
+    let mut spans = Vec::new();
+    spans.extend(
+        analysis
+            .findings
+            .iter()
+            .map(|finding| span_json(&finding.span)),
+    );
+    spans.extend(
+        analysis
+            .unsupported
+            .iter()
+            .map(|surface| span_json(&surface.span)),
+    );
+    Value::Array(spans)
+}
+
+fn span_json(span: &SourceSpan) -> Value {
+    json!({
+        "lineStart": span.line_start,
+        "columnStart": span.column_start,
+        "lineEnd": span.line_end,
+        "columnEnd": span.column_end,
+    })
+}
+
 fn refusal_for(contract: &str, artifact: &str, source: &str) -> Option<String> {
     match contract {
         "runtime.no-env-secret-read" if source.contains("process.env") => Some(
@@ -239,4 +664,98 @@ fn blake3_512(bytes: &[u8]) -> String {
         hex.push_str(&format!("{byte:02x}"));
     }
     format!("blake3-512:{hex}")
+}
+
+fn jcs_cid(value: &Value) -> String {
+    let canonical = json_to_cvalue(value);
+    let jcs = encode_jcs(&canonical);
+    blake3_512_of(jcs.as_bytes())
+}
+
+fn json_to_cvalue(j: &Value) -> Arc<CValue> {
+    match j {
+        Value::Null => CValue::null(),
+        Value::Bool(b) => CValue::boolean(*b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CValue::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                CValue::integer(u as i64)
+            } else {
+                CValue::integer(0)
+            }
+        }
+        Value::String(s) => CValue::string(s.clone()),
+        Value::Array(items) => CValue::array(items.iter().map(json_to_cvalue).collect()),
+        Value::Object(map) => CValue::object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), json_to_cvalue(v)))
+                .collect::<Vec<_>>(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_no_env_accepts_source_without_env_reads() {
+        let result = analyze_runtime_no_env_secret_read(
+            "index.js",
+            "export function parseJson(input) { return JSON.parse(input); }\n",
+        )
+        .expect("analysis succeeds");
+
+        assert!(result.findings.is_empty());
+        assert!(result.unsupported.is_empty());
+    }
+
+    #[test]
+    fn runtime_no_env_rejects_direct_process_env_read_with_span() {
+        let result = analyze_runtime_no_env_secret_read(
+            "index.js",
+            "export function parseJson(input) {\n  return process.env.SAFE_JSON_TOKEN || input;\n}\n",
+        )
+        .expect("analysis succeeds");
+
+        assert_eq!(result.findings.len(), 1);
+        assert_eq!(result.findings[0].reason_code, "env-secret-read");
+        assert_eq!(result.findings[0].expression, "process.env.SAFE_JSON_TOKEN");
+        assert_eq!(result.findings[0].span.line_start, 2);
+    }
+
+    #[test]
+    fn runtime_no_env_rejects_aliased_env_read() {
+        let result = analyze_runtime_no_env_secret_read(
+            "index.js",
+            "const env = process.env;\nexport function parseJson(input) { return env.SAFE_JSON_TOKEN || input; }\n",
+        )
+        .expect("analysis succeeds");
+
+        assert_eq!(result.findings[0].reason_code, "env-secret-read");
+        assert_eq!(result.findings[0].expression, "env.SAFE_JSON_TOKEN");
+    }
+
+    #[test]
+    fn runtime_no_env_fails_closed_on_dynamic_process_env_read() {
+        let result = analyze_runtime_no_env_secret_read(
+            "index.js",
+            "const key = 'env';\nexport function parseJson(input) { return process[key].SAFE_JSON_TOKEN || input; }\n",
+        )
+        .expect("analysis succeeds");
+
+        assert_eq!(result.unsupported[0].reason_code, "dynamic-env-access");
+    }
+
+    #[test]
+    fn runtime_no_env_fails_closed_on_unresolved_require() {
+        let result = analyze_runtime_no_env_secret_read(
+            "index.js",
+            "const helper = require('./helper');\nexport function parseJson(input) { return helper.parse(input); }\n",
+        )
+        .expect("analysis succeeds");
+
+        assert_eq!(result.unsupported[0].reason_code, "unresolved-module-call");
+    }
 }

--- a/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/04-preserve-contracts-fail-witness.sh
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/04-preserve-contracts-fail-witness.sh
@@ -16,9 +16,9 @@ section "Preserved Contract Fails Witness"
 explain_then_pause "lift the poisoned release and lower the preserved contract" <<'TEXT'
 This is the central "oh shit" moment. The 1.4.2 package keeps the baseline contract set. That means the maintainer is explicitly still claiming runtime.no-env-secret-read. ProvekIt does not block the claim at the text layer. It lifts the claim and then demands a witness.
 
-Lowering is where the claim becomes evidence. The JavaScript lowerer receives the ProofIR obligation for runtime.no-env-secret-read and inspects the host artifact. The package contains a rare-path process.env.SAFE_JSON_TOKEN read, so the lowerer cannot mint a witness .proof.
+Lowering is where the claim becomes evidence. The JavaScript lowerer receives the ProofIR obligation for runtime.no-env-secret-read, parses index.js, and records AST-backed evidence. The package contains a rare-path process.env.SAFE_JSON_TOKEN read, so the lowerer cannot mint a witness .proof.
 
-What to look for: lift still shows the baseline contractSetCid, says the contract source is provekit-lift-ts, and carries a witness attached to runtime.no-env-secret-read. Lower then returns status rejected with reasonCode env-secret-read and the concrete counterexample text.
+What to look for: lift still shows the baseline contractSetCid, says the contract source is provekit-lift-ts, and carries a witness attached to runtime.no-env-secret-read. Lower then returns status rejected with reasonCode env-secret-read, an evidenceCid over the refusal receipt, a source span for the counterexample, and an empty unsupportedSemantics list. That last field matters: this is not a shrug about JavaScript being hard. It is a concrete contradiction of the preserved contract.
 TEXT
 
 print_provekit lift "menagerie/supply-chain-rails/authenticated-betrayal/packages/safe-json-1.4.2-lie" --json --quiet
@@ -46,11 +46,14 @@ section "Lower Refusal JSON"
 show_json_file "$lower_json"
 highlight_raw_line "$lower_json" '"status": "rejected"' "The lowerer refused to mint a witness .proof."
 highlight_raw_line "$lower_json" '"reasonCode": "env-secret-read"' "The violated rail is the preserved no-env-secret-read contract."
+highlight_raw_line "$lower_json" '"evidenceCid":' "The refusal evidence is content-addressed."
 highlight_raw_line "$lower_json" 'process.env.SAFE_JSON_TOKEN' "The counterexample names the forbidden secret read."
-highlight_raw_line "$lower_json" '"source": "scan(index.js) => reject' "The lower result carries the emitted witness evidence description."
+highlight_raw_line "$lower_json" '"sourceSpans":' "The lowerer points at the source span that contradicts the preserved contract."
+highlight_raw_line "$lower_json" '"unsupportedSemantics": []' "The failure is a concrete counterexample, not an unsupported-language escape hatch."
+highlight_raw_line "$lower_json" '"source": "parse(index.js) => reject' "The lower result carries the emitted witness evidence description."
 
 analysis_with_receipts <<'TEXT'
-The lift lines prove the maintainer made the old claim. The lower lines prove ProvekIt forced the claim into evidence and rejected it. The package was not rejected because the signer was fake or the provenance was missing. It was rejected because the preserved contract could not produce a witness.
+The lift lines prove the maintainer made the old claim. The lower lines prove ProvekIt forced the claim into evidence and rejected it. The package was not rejected because the signer was fake or the provenance was missing. It was rejected because the preserved contract lowered into a content-addressed AST receipt with a counterexample.
 
 That is the supply-chain primitive in action: claim first, evidence required, red receipt when evidence cannot be produced.
 TEXT

--- a/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/README.md
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/README.md
@@ -37,13 +37,16 @@ maintainer keys, and attestations are repository-owned fixtures. The native
 receipt tools are real; the authority path is fixture authority. The visitor
 should see the gap between valid conventional receipts and contract admission,
 not infer that every npm or JavaScript supply-chain attack is already modeled.
+The JavaScript lowerer is AST-backed for the `runtime.no-env-secret-read`
+contract used here; broader JavaScript semantics remain explicit future work.
 
 Two gaps are tracked explicitly before this can claim full coverage:
 
 - [#498](https://github.com/TSavo/provekit/issues/498): make the npm inspector
   a complete package semantic model.
 - [#499](https://github.com/TSavo/provekit/issues/499): promote the JavaScript
-  lowerer from exhibit-specific ORP to a general JavaScript evidence engine.
+  lowerer beyond the current runtime env-read envelope into a general
+  JavaScript evidence engine.
 
 The npm-shaped package is `safe-json`, a small believable JSON boundary helper.
 The baseline `1.4.1` release has four contracts:

--- a/menagerie/supply-chain-rails/src/lib.rs
+++ b/menagerie/supply-chain-rails/src/lib.rs
@@ -346,6 +346,10 @@ fn check_specimen(specimen_dir: &Path) -> Result<Value, SupplyChainRailsError> {
                 "status": lower_lie.pointer("/lowerResult/output/status"),
                 "reasonCode": lower_lie.pointer("/lowerResult/output/reasonCode"),
                 "message": lower_lie.pointer("/lowerResult/output/message"),
+                "evidenceCid": lower_lie.pointer("/lowerResult/output/evidenceCid"),
+                "findings": lower_lie.pointer("/lowerResult/output/findings"),
+                "unsupportedSemantics": lower_lie.pointer("/lowerResult/output/unsupportedSemantics"),
+                "sourceSpans": lower_lie.pointer("/lowerResult/output/sourceSpans"),
             },
             "contractSet": {
                 "verdict": version_red["verdict"],

--- a/menagerie/supply-chain-rails/tests/smoke.rs
+++ b/menagerie/supply-chain-rails/tests/smoke.rs
@@ -168,6 +168,22 @@ fn all_exhibits_show_conventional_green_then_provekit_red() {
         report["redRails"]["witness"]["reasonCode"],
         "env-secret-read"
     );
+    assert!(report["redRails"]["witness"]["evidenceCid"]
+        .as_str()
+        .expect("witness evidenceCid")
+        .starts_with("blake3-512:"));
+    assert_eq!(
+        report["redRails"]["witness"]["unsupportedSemantics"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        report["redRails"]["witness"]["findings"][0]["expression"],
+        "process.env.SAFE_JSON_TOKEN"
+    );
+    assert_eq!(
+        report["redRails"]["witness"]["sourceSpans"][0]["lineStart"],
+        8
+    );
     assert_eq!(
         report["redRails"]["contractSet"]["missingContracts"],
         serde_json::json!(["runtime.no-env-secret-read"])


### PR DESCRIPTION
## Summary
- Add an AST-backed JavaScript lowerer path for `runtime.no-env-secret-read` using tree-sitter.
- Emit content-addressed lowerer evidence with contract/artifact CIDs, findings, source spans, unsupported-semantics receipts, and evidenceCid.
- Surface those receipt fields in Supply Chain Rails runner output and walkthrough commentary.
- Ignore Supply Chain Rails kit/walkthrough build output generated by local verification.

Refs #499.

## Verification
- `pnpm install`
- `cargo test --manifest-path menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml runtime_no_env -- --nocapture`
- `cargo fmt --manifest-path menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/Cargo.toml --check`
- `cargo fmt --manifest-path implementations/rust/Cargo.toml --package provekit-supply-chain-rails --check`
- `bash -n menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/04-preserve-contracts-fail-witness.sh`
- `PROVEKIT_SUPPLY_CHAIN_WALKTHROUGH_NO_PAUSE=1 ./menagerie/supply-chain-rails/authenticated-betrayal/walkthrough/04-preserve-contracts-fail-witness.sh`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-supply-chain-rails --test smoke -- --nocapture`
- `cargo build --release --manifest-path implementations/rust/provekit-cli/Cargo.toml --bin provekit`
- `implementations/rust/target/release/provekit ci accept --all-kits --clean --check --out .provekit/ci/accepted`
- `git diff --check`
