### PR TITLE
docs(launch): v1.6.3 release notes + og-image draft

### DIFF
--- a/docs/launch/og-image-v1.6.3.md
+++ b/docs/launch/og-image-v1.6.3.md
@@ -1,0 +1,55 @@
+# GitHub social preview / og-image: text content
+
+Draft text content for a designed social preview image (1280×640 GitHub default; 1280×640 og:image meta). Image asset itself is design work; this file stages the words.
+
+## Recommended (tight, declarative)
+
+```
+ProvekIt
+Prove k(I) = t
+
+Locally verifiable proofchains for any transformation.
+A blockchain carries state transitions.
+A proofchain carries formal proofs.
+
+provekit.io · github.com/TSavo/provekit
+```
+
+Visual cut: lead with `k(I) = t` typeset large; supra-omnia-rectum quote optional in serif italic below as accent; cypherpunk lineage suggested via small monospace footer.
+
+## Alternative: substrate-focused
+
+```
+ProvekIt
+The substrate beneath every modern correctness claim.
+
+Compiler, lifter, verifier, schema, repair tool: every transformation
+gets a signed, content-addressed, locally verifiable proofchain.
+
+Polyglot. Federated. Jurisdiction-neutral. No consensus required.
+```
+
+## Alternative: paper-corpus emphasis
+
+```
+ProvekIt
+11 papers. Six runnable exhibits. One claim:
+
+         k(I) = t
+
+A blockchain carries state transitions.
+A proofchain carries formal proofs.
+```
+
+## Image-design notes (for whoever builds the asset)
+
+- Background: dark, near-black; technical, not "tech-marketing." Avoid generic AI-substrate visual clichés (glowing nodes, abstract networks).
+- Lead glyph: `k(I) = t` set in a serif math face (Computer Modern, Latin Modern, or Iowan) at 60-80% of the canvas height. The equation IS the brand mark.
+- Wordmark: "ProvekIt" with the literal lowercase k / capital It rendered at slightly different weight to make "Prove It" pop. Don't use Title Case ("Provekit") under any rendering.
+- Optional: micro-typography of one historical CID (e.g., the v1.6.3 catalog CID `dd0cc798...`) running along an edge as a fingerprint detail. Cypherpunk register, not dataviz-flourish.
+- No emoji, no badges, no "AI-powered" framing.
+- Test small: GitHub social previews render at ~640×320 in unfurls. The equation must be legible at that size.
+
+## Copy length sanity
+
+GitHub social previews fit roughly 80-120 chars of legible text per line at this canvas. Don't over-pack. The image is a signpost, not a landing page.

--- a/docs/launch/release-notes-v1.6.3.md
+++ b/docs/launch/release-notes-v1.6.3.md
@@ -1,0 +1,83 @@
+# ProvekIt v1.6.3: Protocol Evolution
+
+**Catalog CID:** `blake3-512:dd0cc79889ee67d2594f5cfa20a191bafed15196fb2c5036f85deced7cd976055ae93825edebc10812b6fcf3c6ccf274fbc1137f32705aa0dc5938dc5825e31d`
+
+**Version label:** `v1.6.3-2026-05-09`
+
+**PEP migration witness:** v1.6.2 to v1.6.3 minted via Protocol Evolution Protocol. Witness CID and `ProtocolEvolutionBodyClaim` resolvable from the catalog graph.
+
+## Verify this release
+
+```sh
+cargo run --release \
+  --manifest-path tools/recompute-spec-cids/Cargo.toml -- --verify
+```
+
+Exit 0 iff every spec hashes to the value the catalog declares. The protocol verifies its own authority. Trust nothing else.
+
+## What's new since v1.6.2
+
+### Protocol surface
+
+- **Protocol Evolution Protocol (PEP).** New extension protocol formalizes how protocol versions evolve. Each version is a signed content-addressed root; each migration is a witnessed edge with `ProtocolEvolutionBodyClaim` + `TruthDischargeWitness`. The `provekit protocol evolve` and `provekit protocol check-evolution` CLI verbs make migration first-class.
+- **Content-Addressed CI Protocol.** Every CI gate becomes a typed claim root with explicit closure. Branch protection can require typed evidence, not just "checks passed."
+- **PEP dogfood evolution checker.** The protocol uses its own evolution protocol to evolve. The v1.6.2 to v1.6.3 bump itself is a witnessed PEP migration; the dogfood is testable.
+- **Conformance catalog-pinned across kits.** Per-kit conformance gates now resolve through the protocol catalog rather than per-language hand-pinning. One source of truth.
+
+### Lifter family expansion
+
+C lifter family extended (sparse contract lifter, assertions contract lifter, libclang AST backend, kernel compile context resolver). Java JUnit value-scope lifter shipped. Rust + C LSP forward-propagation floor in production. Polyglot bug-zoo verified across Java, TypeScript, C#, Go, and Rust.
+
+### Menagerie
+
+Six runnable destinations (was three at v1.6.2 cut):
+
+| Destination | Status | Paper |
+|---|---|---|
+| bug-zoo | runnable | 07, 09 |
+| supply-chain-rails | runnable | 06 |
+| bridgeworks | runnable | 04 |
+| protocol-switchyard | runnable (new at v1.6.3) | 10 |
+| hashbound-mainline | planned | n/a |
+| change-station | planned | 11 |
+
+`protocol-switchyard` ships with a numbered walkthrough + four break scripts that prove which rail fires when each artifact is perturbed.
+
+### Documentation
+
+- **11-paper After-X arc** complete (Whitepaper, Bluepaper, Substrate-not-Blockchain, Vertical Stack, Witness Pluralism, After Reputation, After Verification, After Types, Lossy Boundary Compression, After Protocol Specs, After Commits).
+- Papers index now cross-links each paper to its runnable menagerie counterpart.
+- Menagerie toolchain prerequisites surfaced in `menagerie/README.md` + `menagerie/scripts/check-prereqs.sh` for cold-start visitors.
+
+### Architectural clarifications
+
+- Paper 03 §4: Turing-completeness gives sufficiency, not uniqueness. The substrate's universality at this layer is empirical, not a theorem about the design space.
+- Paper 11 §8: CI bootstrap inherits the lifter's correctness. Refusal receipts catch known unknowns; lifter defects are unknown unknowns. The Bug Zoo loop is the falsifiability gate.
+
+## Verify chain (historical catalogs)
+
+```
+v1.4.0  blake3-512:b0f2030d56c2fddf...
+v1.4.1  blake3-512:dc2f42ff8a4a6628... (bluepaper freeze, May 3)
+v1.5.0  blake3-512:540e8c1f5f7fea88...
+v1.6.0  blake3-512:ce04a4053498...     (FloatSort + RegionSort)
+v1.6.1  blake3-512:fa1fbf90b7f0...
+v1.6.2  blake3-512:52bdb2be4b38...
+v1.6.3  blake3-512:dd0cc79889ee...     <- this release
+```
+
+Each step is a witnessed PEP migration edge. The chain itself is the authority.
+
+## First principle
+
+*Supra omnia, rectum.* (T)
+
+---
+
+**Tagging command (when ready to ship):**
+
+```sh
+git tag -s v1.6.3 -m "ProvekIt v1.6.3: protocol catalog dd0cc79889ee..."
+git push origin v1.6.3
+gh release create v1.6.3 --notes-file .staged/release-notes-v1.6.3.md
+```


### PR DESCRIPTION
## Summary

Lands two staged drafts into `docs/launch/` so they survive worktree cleanup and the v1.6.3 release notes are reachable from a permalink ahead of the release tag.

- `docs/launch/release-notes-v1.6.3.md`: full release notes for v1.6.3 (Protocol Evolution Protocol, Content-Addressed CI Protocol, menagerie expansion to six destinations, 11-paper After-X arc complete, catalog CID `dd0cc798...`).
- `docs/launch/og-image-v1.6.3.md`: text-content draft for the social preview / og:image asset (three copy variants + image-design notes for whoever builds the asset). Image asset itself remains design work.

Em-dashes from the staged source files were normalized to ASCII (colons, parens, "n/a") per repo convention. No other content changes.

The release tag will follow this PR.

## Test plan

- [ ] PR diff touches only `docs/launch/`
- [ ] No em-dashes or en-dashes anywhere in the two new files
- [ ] Files render correctly on GitHub preview