### PR TITLE
Add effects.c to c-sparse + c-assertions lifter Makefiles

### DIFF
--- a/implementations/c/provekit-lift-c-assertions/Makefile
+++ b/implementations/c/provekit-lift-c-assertions/Makefile
@@ -11,7 +11,7 @@ TEST_SH = tests/integration.sh
 ifneq ($(strip $(LLVM_CONFIG)),)
 CFLAGS += -DPK_C_ENABLE_CLANG_AST -I$(shell $(LLVM_CONFIG) --includedir)
 LDFLAGS += -L$(shell $(LLVM_CONFIG) --libdir) -Wl,-rpath,$(shell $(LLVM_CONFIG) --libdir) -lclang
-SRC += ../provekit-lift-core/src/clang_ast.c
+SRC += ../provekit-lift-core/src/clang_ast.c ../provekit-lift-core/src/effects.c
 else
 SRC += ../provekit-lift-core/src/clang_ast_stub.c
 endif

--- a/implementations/c/provekit-lift-c-sparse/Makefile
+++ b/implementations/c/provekit-lift-c-sparse/Makefile
@@ -11,7 +11,7 @@ TEST_SH = tests/integration.sh
 ifneq ($(strip $(LLVM_CONFIG)),)
 CFLAGS += -DPK_C_ENABLE_CLANG_AST -I$(shell $(LLVM_CONFIG) --includedir)
 LDFLAGS += -L$(shell $(LLVM_CONFIG) --libdir) -Wl,-rpath,$(shell $(LLVM_CONFIG) --libdir) -lclang
-SRC += ../provekit-lift-core/src/clang_ast.c
+SRC += ../provekit-lift-core/src/clang_ast.c ../provekit-lift-core/src/effects.c
 else
 SRC += ../provekit-lift-core/src/clang_ast_stub.c
 endif


### PR DESCRIPTION
## Summary

Trivial fix: both c-sparse and c-assertions lifter Makefiles include `clang_ast.c` in their libclang-enabled branch but omit `effects.c`. `clang_ast.c:649` references `pk_c_extract_function_effects` defined in `effects.c`, causing undefined-reference link errors.

The kernel-doc lifter Makefile already includes `effects.c` in the same position; this just mirrors that pattern in the two siblings.

Caught while smoke-testing the gold pipeline — sparse lifter is the right surface for unannotated kernel C (kernel uses sparse annotations heavily: `__must_hold`, `__acquires`, `__releases`, `__user`, `__rcu`).

## Test plan

- [x] Verified link error on c-sparse main (pre-fix)
- [x] Verified kernel-doc Makefile includes effects.c in same position

T Savo