### PR TITLE
Fix c-walker contracts that compose was refusing on n_arity=0 functions

### DIFF
--- a/implementations/c/provekit-lift-c-walker/compile_flags.txt
+++ b/implementations/c/provekit-lift-c-walker/compile_flags.txt
@@ -1,0 +1,7 @@
+-std=c11
+-Wall
+-Wextra
+-Wpedantic
+-DPK_C_ENABLE_CLANG_AST
+-I../provekit-lift-core/include
+-I/usr/local/Cellar/llvm/22.1.4/include

--- a/implementations/c/provekit-lift-c-walker/src/walker.c
+++ b/implementations/c/provekit-lift-c-walker/src/walker.c
@@ -165,25 +165,18 @@ static int build_trivial_contract(WBuf *b, const char *fn_name, int n_arity) {
 
     /*
      * post formula:
-     *   arity == 0: result = x0 (degenerate; compose handles 0-arity by
-     *               treating it as identity; emit result = x0 with empty formals
-     *               which is accepted by the wire decoder via serde default)
+     *   arity == 0: true (no formal to reference; emitting result = x0 here
+     *               would name a nonexistent formal and trip compose's
+     *               formal_idx >= formals.len() check on every chain)
      *   arity == 1: result = x0
      *   arity >= 2: result = Ctor("tuple", [Var(x0), ..., Var(xN-1)])
-     *
-     * The = atomic wraps both sides so find_result_equation in libprovekit
-     * can extract inner_value for substitution.
      */
-    if (wbuf_append(b, "\"post\":{\"args\":[{\"kind\":\"var\",\"name\":\"result\"},") != 0) return -1;
-    if (n_arity <= 1) {
-        /* Single formal: result = x0 (or degenerate 0-arity identity). */
-        const char *fname = (n_arity == 1) ? "x0" : "x0";
-        if (wbuf_append(b, "{\"kind\":\"var\",\"name\":") != 0) return -1;
-        if (wbuf_append_quoted(b, fname) != 0) return -1;
-        if (wbuf_append(b, "}") != 0) return -1;
+    if (n_arity == 0) {
+        if (wbuf_append(b, "\"post\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"true\"},") != 0) return -1;
+    } else if (n_arity == 1) {
+        if (wbuf_append(b, "\"post\":{\"args\":[{\"kind\":\"var\",\"name\":\"result\"},{\"kind\":\"var\",\"name\":\"x0\"}],\"kind\":\"atomic\",\"name\":\"=\"},") != 0) return -1;
     } else {
-        /* Multi-formal: result = Ctor("tuple", [Var(x0), ..., Var(xN-1)]). */
-        if (wbuf_append(b, "{\"args\":[") != 0) return -1;
+        if (wbuf_append(b, "\"post\":{\"args\":[{\"kind\":\"var\",\"name\":\"result\"},{\"args\":[") != 0) return -1;
         for (i = 0; i < n_arity; i++) {
             if (i > 0 && wbuf_append_char(b, ',') != 0) return -1;
             (void)snprintf(formal_name, sizeof(formal_name), "x%d", i);
@@ -191,11 +184,11 @@ static int build_trivial_contract(WBuf *b, const char *fn_name, int n_arity) {
             if (wbuf_append_quoted(b, formal_name) != 0) return -1;
             if (wbuf_append(b, "}") != 0) return -1;
         }
-        if (wbuf_append(b, "],\"kind\":\"ctor\",\"name\":\"tuple\"}") != 0) return -1;
+        if (wbuf_append(b, "],\"kind\":\"ctor\",\"name\":\"tuple\"}],\"kind\":\"atomic\",\"name\":\"=\"},") != 0) return -1;
     }
-    if (wbuf_append(b, "],\"kind\":\"atomic\",\"name\":\"=\"},") != 0) return -1;
 
     if (wbuf_append(b, "\"pre\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"true\"},") != 0) return -1;
+    if (wbuf_append(b, "\"effects\":{\"effects\":[]},") != 0) return -1;
     if (wbuf_append(b, "\"return_sort\":{\"kind\":\"primitive\",\"name\":\"i32\"}}") != 0) return -1;
 
     return 0;

--- a/implementations/c/provekit-lift-c-walker/tests/fixtures/trivial.c
+++ b/implementations/c/provekit-lift-c-walker/tests/fixtures/trivial.c
@@ -16,3 +16,7 @@ int negate(int x) {
 int zero(void) {
     return 0;
 }
+
+int caller(int x) {
+    return add(x, 1);
+}

--- a/implementations/c/provekit-lift-c-walker/tests/integration.sh
+++ b/implementations/c/provekit-lift-c-walker/tests/integration.sh
@@ -112,4 +112,16 @@ printf '%s\n' "$RESPONSES" | grep -q '"fn_name":"negate"' || {
     exit 1
 }
 
+printf '%s\n' "$RESPONSES" | grep -q '"fn_name":"caller"' || {
+    echo "FAIL: caller function not found in declarations" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"effects":{"effects":\[\]}' || {
+    echo "FAIL: declarations must include explicit effects:{effects:[]} field" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
 echo "provekit-lift-c-walker integration passed"


### PR DESCRIPTION
## Summary

PR #521 (the c-walker MVP) emitted contracts whose `post = result = x0` referenced a formal that didn't exist for n_arity=0 functions. compose's `formal_idx >= formals.len()` check tripped (`0 >= 0`) and refused every chain involving such a contract.

This PR fixes the contract shape:

| n_arity | Before (broken) | After |
|---|---|---|
| 0 | `post: result = x0` (refs nonexistent formal x0) | `post: true` (vacuous, composable) |
| 1 | `post: result = x0` | `post: result = x0` (unchanged, was correct) |
| ≥2 | `post: result = tuple(x0, ..., xN-1)` | unchanged |

Plus:
- Removed dead ternary `(n_arity == 1) ? "x0" : "x0"` (both branches identical)
- Added explicit `effects: {"effects":[]}` field. Wire serde defaulted to empty so compose passed by accident, but the contract was claiming purity it hadn't proven. Now the empty claim is on the record.
- `compile_flags.txt` for the lifter dir (silence recurring clangd noise on edits)
- Extended `tests/fixtures/trivial.c` with `caller(x) -> add(x, 1)` so the in-tree integration test now has a cross-function call (lets future smoke gates exercise compose end-to-end without leaving the lifter package)
- Integration script asserts the new caller fn lifts and that the explicit effects field appears

## Discovered while testing — separate (deeper) bug, not addressed here

When libclang doesn't fully parse a file (e.g. bare fixture without compile_commands.json, or kernel C with missing headers), `parser.c`'s regex fallback at `pk_c_parser_append_function` adds function facts but **never extracts arity from the matched signature** — `n_arity` is left at 0 from `memset`. Result: even `int add(int a, int b)` lifts as n_arity=0 via the regex path.

So this PR's fix means contracts are no longer **structurally broken** for n_arity=0 functions, but compose still refuses to chain them (correctly — you can't substitute a result through a function that takes no inputs). To get end-to-end compose firing on real C, parser.c needs an arity-extraction pass — proposed as a follow-up.

## Smoke

- Local Mac integration: PASS (5 fixture functions including new caller, all assertions including effects field)
- Gold container on battleaxe lift: PASS (5 declarations emitted, post=`true` for all since libclang+regex give n_arity=0 on the bare fixture as expected)

T Savo