### PR TITLE
Make CICP witness checks advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,14 +433,23 @@ jobs:
 
       - name: Validate checked-in CICP reuse witnesses
         run: |
-          set -euo pipefail
+          set -uo pipefail
           cargo build --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli
+          set +e
           implementations/rust/target/release/provekit ci accept \
             --repo . \
             --all-kits \
             --clean \
             --check \
-            --json
+            --json \
+            2> .provekit/ci-accept-check.err
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            cat .provekit/ci-accept-check.err >&2
+            echo "::warning::CICP accepted witnesses are stale; this advisory smoke does not gate CI."
+            exit 0
+          fi
 
   # ---------------------------------------------------------------------------
   # Per-kit conformance gate: provekit prove --kit=<kit>
@@ -754,7 +763,13 @@ jobs:
 
   cicp-refresh:
     name: CICP PR witness refresh
-    if: always() && !cancelled() && github.event_name == 'pull_request'
+    if: >-
+      always() &&
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.prove-linux.result == 'success' &&
+      needs.prove-swift.result == 'success'
     runs-on: [self-hosted, Linux, X64, vault]
     timeout-minutes: 15
     needs:
@@ -765,24 +780,6 @@ jobs:
       actions: read
 
     steps:
-      - name: Refuse fork PRs
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          echo "CICP PR witness refresh only supports same-repo pull requests." >&2
-          exit 1
-
-      - name: Require prove jobs to pass
-        run: |
-          set -euo pipefail
-          if [ "${{ needs.prove-linux.result }}" != "success" ]; then
-            echo "prove-linux did not pass: ${{ needs.prove-linux.result }}" >&2
-            exit 1
-          fi
-          if [ "${{ needs.prove-swift.result }}" != "success" ]; then
-            echo "prove-swift did not pass: ${{ needs.prove-swift.result }}" >&2
-            exit 1
-          fi
-
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
@@ -880,5 +877,4 @@ jobs:
           git commit -m "Refresh CICP accepted witnesses"
           token="$(cat "$token_file")"
           git push "https://x-access-token:${token}@github.com/${GH_REPOSITORY}.git" "HEAD:${PR_HEAD_REF}"
-          echo "Pushed refreshed CICP accepted witnesses; the new PR head must run CI."
-          exit 1
+          echo "Pushed refreshed CICP accepted witnesses; the new PR head will run CI."

--- a/implementations/rust/provekit-cli/tests/ci_check.rs
+++ b/implementations/rust/provekit-cli/tests/ci_check.rs
@@ -336,6 +336,13 @@ fn github_ci_refreshes_stale_cicp_witnesses_on_same_repo_prs() {
             && smoke_if.contains("github.ref == 'refs/heads/main'"),
         "stale checked-in witness smoke must be a main-only check, not a PR precondition: {smoke_if}"
     );
+    let smoke_text = serde_yaml::to_string(smoke).expect("serialize smoke job");
+    assert!(
+        smoke_text.contains("::warning::CICP accepted witnesses are stale")
+            && smoke_text.contains("does not gate CI")
+            && smoke_text.contains("exit 0"),
+        "checked-in witness smoke must be advisory and must not fail CI on stale witnesses:\n{smoke_text}"
+    );
 
     let refresh = jobs
         .get(serde_yaml::Value::String("cicp-refresh".into()))
@@ -346,14 +353,19 @@ fn github_ci_refreshes_stale_cicp_witnesses_on_same_repo_prs() {
         "refresh job must run only for PRs:\n{refresh_text}"
     );
     assert!(
+        refresh_text.contains("github.event.pull_request.head.repo.full_name == github.repository")
+            && refresh_text.contains("needs.prove-linux.result == 'success'")
+            && refresh_text.contains("needs.prove-swift.result == 'success'"),
+        "refresh job must skip unsupported or already-failing PRs instead of adding another failing gate:\n{refresh_text}"
+    );
+    assert!(
         refresh_text.contains("!cancelled()"),
         "refresh job must not run after a superseded workflow has been cancelled:\n{refresh_text}"
     );
     assert!(
-        refresh_text.contains("github.event.pull_request.head.repo.full_name != github.repository")
-            && refresh_text.contains("CICP PR witness refresh only supports same-repo pull requests")
-            && refresh_text.contains("exit 1"),
-        "refresh job must fail closed for fork PRs:\n{refresh_text}"
+        !refresh_text.contains("CICP PR witness refresh only supports same-repo pull requests")
+            && !refresh_text.contains("Refuse fork PRs"),
+        "refresh job must not fail fork PRs; unsupported refreshes should be skipped by the job guard:\n{refresh_text}"
     );
     assert!(
         refresh_text.contains("prove-linux") && refresh_text.contains("prove-swift"),
@@ -379,6 +391,11 @@ fn github_ci_refreshes_stale_cicp_witnesses_on_same_repo_prs() {
             && refresh_text.contains("Vault-rendered GitHub token file is not readable")
             && refresh_text.contains("tr -d"),
         "refresh job must handle root-owned Vault token mounts by staging a readable token copy before pushing:\n{refresh_text}"
+    );
+    assert!(
+        refresh_text.contains("Pushed refreshed CICP accepted witnesses; the new PR head will run CI.")
+            && !refresh_text.contains("Pushed refreshed CICP accepted witnesses; the new PR head must run CI."),
+        "refresh job should push missing witnesses without intentionally failing the old workflow run:\n{refresh_text}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Make the main-branch CICP checked-in reuse smoke report stale witnesses as a warning instead of failing CI.
- Skip PR witness refresh for forks or already-failing prove jobs instead of adding a CICP failure on top.
- Let refresh commits push without intentionally failing the old workflow run.

## Test Plan
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test ci_check
- git diff --check HEAD~1..HEAD