### PR TITLE
parser.c: extract n_arity from regex-matched function signature

### DIFF
--- a/implementations/c/provekit-lift-core/src/parser.c
+++ b/implementations/c/provekit-lift-core/src/parser.c
@@ -50,6 +50,50 @@ static int pk_c_parser_blank_line(const char *line) {
     return 1;
 }
 
+static int pk_c_parser_count_function_args(const char *params, const char *limit) {
+    const char *start;
+    const char *end;
+    int arity = 0;
+    int segment_has_token = 0;
+
+    if (params == NULL) {
+        return 0;
+    }
+
+    end = params;
+    while (*end != '\0' && *end != ')' && (limit == NULL || end < limit)) {
+        end++;
+    }
+    start = params;
+    while (start < end && isspace((unsigned char)*start)) {
+        start++;
+    }
+    while (end > start && isspace((unsigned char)end[-1])) {
+        end--;
+    }
+    if (start == end) {
+        return 0;
+    }
+    if ((size_t)(end - start) == strlen("void") &&
+        strncmp(start, "void", strlen("void")) == 0) {
+        return 0;
+    }
+    for (const char *p = start; p < end; p++) {
+        if (*p == ',') {
+            if (segment_has_token) {
+                arity++;
+            }
+            segment_has_token = 0;
+        } else if (!isspace((unsigned char)*p)) {
+            segment_has_token = 1;
+        }
+    }
+    if (segment_has_token) {
+        arity++;
+    }
+    return arity;
+}
+
 static int pk_c_parser_contract_annotation(const char *line, int in_block_comment) {
     const char *p = pk_c_parser_first_nonblank(line);
 
@@ -246,6 +290,7 @@ static int pk_c_parser_append_function(
     size_t name_len,
     int line,
     int column,
+    int n_arity,
     int has_contract_annotation
 ) {
     pk_c_function_fact *fact;
@@ -256,6 +301,7 @@ static int pk_c_parser_append_function(
     fact = &facts->functions[facts->n_functions];
     memset(fact, 0, sizeof(*fact));
     fact->name = pk_c_parser_copy_n(name, name_len);
+    fact->n_arity = n_arity;
     pk_c_parser_set_locus(&fact->locus, path, line, column);
     if (fact->name == NULL || fact->locus.path == NULL) {
         free(fact->name);
@@ -1052,10 +1098,14 @@ pk_c_source_facts *pk_c_parse_source(const char *path, const char *source) {
             regexec(&function_re, code_line, 2, function_match, 0) == 0 &&
             function_match[1].rm_so >= 0) {
             size_t function_index;
+            int n_arity;
 
+            body_open = strchr(code_line + function_match[0].rm_eo, '{');
+            n_arity = pk_c_parser_count_function_args(
+                code_line + function_match[0].rm_eo, body_open);
             if (pk_c_parser_append_function(facts, path, code_line + function_match[1].rm_so,
                 (size_t)(function_match[1].rm_eo - function_match[1].rm_so), line_no,
-                (int)function_match[1].rm_so + 1, pending_contract) != 0) {
+                (int)function_match[1].rm_so + 1, n_arity, pending_contract) != 0) {
                 free(code_line);
                 pk_c_source_facts_free(facts);
                 facts = NULL;
@@ -1070,7 +1120,6 @@ pk_c_source_facts *pk_c_parse_source(const char *path, const char *source) {
                 facts = NULL;
                 goto done;
             }
-            body_open = strchr(code_line + function_match[0].rm_eo, '{');
             if (body_open != NULL) {
                 facts->functions[function_index].has_body = 1;
                 if (pk_c_parser_scan_calls(facts, &call_re, path, body_open + 1, line_no,

--- a/implementations/c/provekit-lift-core/tests/test_runner.c
+++ b/implementations/c/provekit-lift-core/tests/test_runner.c
@@ -197,6 +197,32 @@ static void test_parse_functions_and_macros(void) {
     pk_c_source_facts_free(facts);
 }
 
+static void test_parse_regex_function_arity(void) {
+    const char *source =
+        "int add(int a, int b) { return a + b; }\n"
+        "int identity(int x) { return x; }\n"
+        "int zero(void) { return 0; }\n"
+        "int legacy() { return 0; }\n"
+        "int trailing(int x,) { return x; }\n";
+    pk_c_source_facts *facts = pk_c_parse_source("fixture.c", source);
+    if (!facts) {
+        fprintf(stderr, "FAIL: parse returned null\n");
+        failures++;
+        return;
+    }
+    if (facts->n_functions != 5) {
+        fprintf(stderr, "FAIL: expected 5 arity functions, got %zu\n", facts->n_functions);
+        failures++;
+    } else {
+        assert_int_eq(facts->functions[0].n_arity, 2, "add arity");
+        assert_int_eq(facts->functions[1].n_arity, 1, "identity arity");
+        assert_int_eq(facts->functions[2].n_arity, 0, "void arity");
+        assert_int_eq(facts->functions[3].n_arity, 0, "empty arity");
+        assert_int_eq(facts->functions[4].n_arity, 1, "trailing comma arity");
+    }
+    pk_c_source_facts_free(facts);
+}
+
 static void test_parse_nested_macro_arguments(void) {
     const char *source =
         "int helper(int x) { return x; }\n"
@@ -966,6 +992,7 @@ int main(void) {
     test_structured_helpers_escape_json_strings();
     test_array_growth_overflow_is_rejected();
     test_parse_functions_and_macros();
+    test_parse_regex_function_arity();
     test_parse_nested_macro_arguments();
     test_parse_same_line_function_body_call();
     test_parse_recursive_same_line_function_body_call();


### PR DESCRIPTION
## Summary

The C lifter's regex fallback at `pk_c_parser_append_function` adds function facts but never extracts arity from the matched parameter list. Result: `fact->n_arity = 0` for every function discovered via the regex path, even when the function has parameters.

Downstream effect: provekit compose refuses every chain because `formal_idx 0 >= formals.len() = 0`. The c-walker MVP (#521 / #522) hits this on every fixture, defeating the whole synthesis pipeline.

This PR fixes it.

## Changes

- New helper to count args between the parens after the function name: `void` / empty → 0, otherwise comma-separated count + 1
- `pk_c_parser_append_function` takes a new `int n_arity` parameter and sets `fact->n_arity`
- Regex caller in the line-scanner extracts the `(...)` substring before appending the fact
- Regression test in `tests/test_runner.c` locking down arity values

## Smoke

Container on battleaxe, lift `tests/fixtures/trivial.c` via c-walker (which uses the regex backend in the container's no-compile_commands.json setup):

```
add: formals=2
identity: formals=1
negate: formals=1
zero: formals=0
caller: formals=1
```

Was `formals=0` for all five before this fix.

## Test plan

- [x] `make test` in `provekit-lift-core/` — RED before fix, GREEN after
- [x] Container smoke confirms formals populated correctly under Linux libclang too

T Savo