### PR TITLE
Add provekit-lift-c-kunit lifter (PR 3 of #520 design)

### DIFF
--- a/implementations/c/provekit-lift-c-kunit/.gitignore
+++ b/implementations/c/provekit-lift-c-kunit/.gitignore
@@ -1,0 +1,1 @@
+provekit-lift-c-kunit

--- a/implementations/c/provekit-lift-c-kunit/Makefile
+++ b/implementations/c/provekit-lift-c-kunit/Makefile
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CC = cc
+CFLAGS = -Wall -Wextra -Wpedantic -std=c11 -I../provekit-lift-core/include -g
+LLVM_CONFIG ?= $(shell command -v llvm-config 2>/dev/null || command -v /usr/local/opt/llvm/bin/llvm-config 2>/dev/null || command -v /usr/local/opt/llvm@21/bin/llvm-config 2>/dev/null)
+
+UNAME_S := $(shell uname -s)
+
+BIN = provekit-lift-c-kunit
+SRC = src/main.c src/kunit.c ../provekit-lift-core/src/core.c ../provekit-lift-core/src/parser.c ../provekit-lift-core/src/compile_context.c
+TEST_SH = tests/integration.sh
+
+# Path to libprovekit's C ABI staticlib + header (CCP §6.2). Built via
+# `cargo build --release -p libprovekit` from implementations/rust.
+LIBPROVEKIT_INCLUDE := ../../rust/libprovekit/include
+LIBPROVEKIT_STATICLIB := ../../rust/target/release/liblibprovekit.a
+
+ifneq ($(strip $(LLVM_CONFIG)),)
+CFLAGS += -DPK_C_ENABLE_CLANG_AST -I$(shell $(LLVM_CONFIG) --includedir)
+LDFLAGS += -L$(shell $(LLVM_CONFIG) --libdir) -Wl,-rpath,$(shell $(LLVM_CONFIG) --libdir) -lclang
+SRC += ../provekit-lift-core/src/clang_ast.c ../provekit-lift-core/src/effects.c
+else
+SRC += ../provekit-lift-core/src/clang_ast_stub.c
+endif
+
+.PHONY: all test clean libprovekit
+
+all: $(BIN)
+
+# Build libprovekit's staticlib (lazy): only invoked when the artifact
+# is missing. Re-running cargo on every build is too expensive for the
+# inner loop; deliberate `make libprovekit` is the way to refresh.
+$(LIBPROVEKIT_STATICLIB):
+	cd ../../rust && cargo build --release -p libprovekit
+
+libprovekit:
+	cd ../../rust && cargo build --release -p libprovekit
+
+ifneq ($(strip $(LLVM_CONFIG)),)
+$(BIN): $(SRC)
+	$(CC) $(CFLAGS) -o $@ $(SRC) $(LDFLAGS)
+else
+$(BIN): $(SRC)
+	$(CC) $(CFLAGS) -o $@ $(SRC) $(LDFLAGS)
+endif
+
+test: $(BIN) $(TEST_SH)
+	@chmod +x $(TEST_SH)
+	@$(TEST_SH)
+
+clean:
+	rm -f $(BIN)

--- a/implementations/c/provekit-lift-c-kunit/compile_flags.txt
+++ b/implementations/c/provekit-lift-c-kunit/compile_flags.txt
@@ -1,0 +1,7 @@
+-std=c11
+-Wall
+-Wextra
+-Wpedantic
+-DPK_C_ENABLE_CLANG_AST
+-I../provekit-lift-core/include
+-I/usr/local/Cellar/llvm/22.1.4/include

--- a/implementations/c/provekit-lift-c-kunit/src/kunit.c
+++ b/implementations/c/provekit-lift-c-kunit/src/kunit.c
@@ -1,0 +1,1400 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "provekit/c_lift_core.h"
+
+typedef struct {
+    char *data;
+    size_t len;
+    size_t cap;
+} KBuf;
+
+typedef struct {
+    char **items;
+    size_t len;
+    size_t cap;
+} KStringSet;
+
+typedef struct {
+    char *name;
+    size_t next_index;
+} KCounter;
+
+typedef struct {
+    KCounter *items;
+    size_t len;
+    size_t cap;
+} KCounterSet;
+
+typedef struct {
+    char **items;
+    size_t len;
+    size_t cap;
+} KArgList;
+
+typedef enum {
+    KUNIT_OP_EQ,
+    KUNIT_OP_NE,
+    KUNIT_OP_TRUE,
+    KUNIT_OP_FALSE,
+    KUNIT_OP_NULL,
+    KUNIT_OP_NOT_NULL,
+    KUNIT_OP_LT,
+    KUNIT_OP_LE,
+    KUNIT_OP_GT,
+    KUNIT_OP_GE
+} KunitOp;
+
+typedef struct {
+    KunitOp op;
+    int required_args;
+} KunitMacroInfo;
+
+static char *k_copy_n(const char *src, size_t len) {
+    char *out = malloc(len + 1);
+
+    if (out == NULL) {
+        return NULL;
+    }
+    memcpy(out, src, len);
+    out[len] = '\0';
+    return out;
+}
+
+static char *k_copy(const char *src) {
+    return k_copy_n(src == NULL ? "" : src, strlen(src == NULL ? "" : src));
+}
+
+static int kbuf_init(KBuf *b) {
+    b->len = 0;
+    b->cap = 256;
+    b->data = malloc(b->cap);
+    if (b->data == NULL) {
+        b->cap = 0;
+        return -1;
+    }
+    b->data[0] = '\0';
+    return 0;
+}
+
+static void kbuf_free(KBuf *b) {
+    free(b->data);
+    b->data = NULL;
+    b->len = 0;
+    b->cap = 0;
+}
+
+static int kbuf_grow(KBuf *b, size_t need) {
+    size_t next = b->cap ? b->cap : 256;
+    char *data;
+
+    while (next < b->len + need + 1) {
+        if (next > ((size_t)-1) / 2) {
+            return -1;
+        }
+        next *= 2;
+    }
+    data = realloc(b->data, next);
+    if (data == NULL) {
+        return -1;
+    }
+    b->data = data;
+    b->cap = next;
+    return 0;
+}
+
+static int kbuf_append_n(KBuf *b, const char *s, size_t n) {
+    if (kbuf_grow(b, n) != 0) {
+        return -1;
+    }
+    memcpy(b->data + b->len, s, n);
+    b->len += n;
+    b->data[b->len] = '\0';
+    return 0;
+}
+
+static int kbuf_append(KBuf *b, const char *s) {
+    return kbuf_append_n(b, s, strlen(s));
+}
+
+static int kbuf_append_char(KBuf *b, char c) {
+    return kbuf_append_n(b, &c, 1);
+}
+
+static int kbuf_append_quoted(KBuf *b, const char *s) {
+    char *escaped = pk_c_lift_json_escape(s == NULL ? "" : s);
+    int rc;
+
+    if (escaped == NULL) {
+        return -1;
+    }
+    rc = kbuf_append_char(b, '"') == 0 &&
+        kbuf_append(b, escaped) == 0 &&
+        kbuf_append_char(b, '"') == 0 ? 0 : -1;
+    free(escaped);
+    return rc;
+}
+
+static void k_set_error(char *err, size_t err_len, const char *msg) {
+    if (err != NULL && err_len > 0) {
+        (void)snprintf(err, err_len, "%s", msg);
+    }
+}
+
+static void k_string_set_free(KStringSet *set) {
+    if (set == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < set->len; i++) {
+        free(set->items[i]);
+    }
+    free(set->items);
+    memset(set, 0, sizeof(*set));
+}
+
+static int k_string_set_contains(const KStringSet *set, const char *s) {
+    if (set == NULL || s == NULL) {
+        return 0;
+    }
+    for (size_t i = 0; i < set->len; i++) {
+        if (strcmp(set->items[i], s) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int k_string_set_add(KStringSet *set, const char *s) {
+    char **items;
+
+    if (s == NULL || s[0] == '\0' || k_string_set_contains(set, s)) {
+        return 0;
+    }
+    if (set->len >= set->cap) {
+        size_t cap = set->cap == 0 ? 8 : set->cap * 2;
+        if (cap < set->cap) {
+            return -1;
+        }
+        items = realloc(set->items, cap * sizeof(*set->items));
+        if (items == NULL) {
+            return -1;
+        }
+        set->items = items;
+        set->cap = cap;
+    }
+    set->items[set->len] = k_copy(s);
+    if (set->items[set->len] == NULL) {
+        return -1;
+    }
+    set->len++;
+    return 0;
+}
+
+static void k_counter_set_free(KCounterSet *set) {
+    if (set == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < set->len; i++) {
+        free(set->items[i].name);
+    }
+    free(set->items);
+    memset(set, 0, sizeof(*set));
+}
+
+static int k_counter_next(KCounterSet *set, const char *name, size_t *idx) {
+    KCounter *items;
+
+    if (set == NULL || name == NULL || idx == NULL) {
+        return -1;
+    }
+    for (size_t i = 0; i < set->len; i++) {
+        if (strcmp(set->items[i].name, name) == 0) {
+            *idx = set->items[i].next_index++;
+            return 0;
+        }
+    }
+    if (set->len >= set->cap) {
+        size_t cap = set->cap == 0 ? 8 : set->cap * 2;
+        if (cap < set->cap) {
+            return -1;
+        }
+        items = realloc(set->items, cap * sizeof(*set->items));
+        if (items == NULL) {
+            return -1;
+        }
+        set->items = items;
+        set->cap = cap;
+    }
+    set->items[set->len].name = k_copy(name);
+    if (set->items[set->len].name == NULL) {
+        return -1;
+    }
+    set->items[set->len].next_index = 1;
+    *idx = 0;
+    set->len++;
+    return 0;
+}
+
+static void k_arg_list_free(KArgList *args) {
+    if (args == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < args->len; i++) {
+        free(args->items[i]);
+    }
+    free(args->items);
+    memset(args, 0, sizeof(*args));
+}
+
+static int k_arg_list_push(KArgList *args, const char *start, size_t len) {
+    char **items;
+    char *copy;
+    size_t first = 0;
+    size_t last = len;
+
+    while (first < len && isspace((unsigned char)start[first])) {
+        first++;
+    }
+    while (last > first && isspace((unsigned char)start[last - 1])) {
+        last--;
+    }
+    copy = k_copy_n(start + first, last - first);
+    if (copy == NULL) {
+        return -1;
+    }
+    if (args->len >= args->cap) {
+        size_t cap = args->cap == 0 ? 4 : args->cap * 2;
+        if (cap < args->cap) {
+            free(copy);
+            return -1;
+        }
+        items = realloc(args->items, cap * sizeof(*args->items));
+        if (items == NULL) {
+            free(copy);
+            return -1;
+        }
+        args->items = items;
+        args->cap = cap;
+    }
+    args->items[args->len++] = copy;
+    return 0;
+}
+
+static int k_split_args(const char *text, KArgList *args) {
+    const char *start = text == NULL ? "" : text;
+    const char *p = start;
+    int paren = 0;
+    int bracket = 0;
+    int brace = 0;
+    char quote = '\0';
+
+    memset(args, 0, sizeof(*args));
+    for (; *p != '\0'; p++) {
+        if (quote != '\0') {
+            if (*p == '\\' && p[1] != '\0') {
+                p++;
+            } else if (*p == quote) {
+                quote = '\0';
+            }
+            continue;
+        }
+        if (*p == '"' || *p == '\'') {
+            quote = *p;
+            continue;
+        }
+        if (*p == '(') {
+            paren++;
+        } else if (*p == ')' && paren > 0) {
+            paren--;
+        } else if (*p == '[') {
+            bracket++;
+        } else if (*p == ']' && bracket > 0) {
+            bracket--;
+        } else if (*p == '{') {
+            brace++;
+        } else if (*p == '}' && brace > 0) {
+            brace--;
+        } else if (*p == ',' && paren == 0 && bracket == 0 && brace == 0) {
+            if (k_arg_list_push(args, start, (size_t)(p - start)) != 0) {
+                k_arg_list_free(args);
+                return -1;
+            }
+            start = p + 1;
+        }
+    }
+    if (start != p || args->len > 0) {
+        if (k_arg_list_push(args, start, (size_t)(p - start)) != 0) {
+            k_arg_list_free(args);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int k_is_ident_start(char c) {
+    return isalpha((unsigned char)c) || c == '_';
+}
+
+static int k_is_ident_char(char c) {
+    return isalnum((unsigned char)c) || c == '_';
+}
+
+static int k_is_identifier(const char *s) {
+    if (s == NULL || !k_is_ident_start(*s)) {
+        return 0;
+    }
+    for (s++; *s != '\0'; s++) {
+        if (!k_is_ident_char(*s)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static char *k_code_view(const char *source) {
+    char *copy = k_copy(source == NULL ? "" : source);
+    size_t i = 0;
+    int in_block = 0;
+    char quote = '\0';
+
+    if (copy == NULL) {
+        return NULL;
+    }
+    while (copy[i] != '\0') {
+        if (in_block) {
+            if (copy[i] == '*' && copy[i + 1] == '/') {
+                copy[i++] = ' ';
+                copy[i++] = ' ';
+                in_block = 0;
+            } else if (copy[i] != '\n') {
+                copy[i++] = ' ';
+            } else {
+                i++;
+            }
+            continue;
+        }
+        if (quote != '\0') {
+            if (copy[i] == '\\' && copy[i + 1] != '\0') {
+                copy[i++] = ' ';
+                if (copy[i] != '\n') {
+                    copy[i] = ' ';
+                }
+                i++;
+                continue;
+            }
+            if (copy[i] == quote) {
+                quote = '\0';
+            }
+            if (copy[i] != '\n') {
+                copy[i] = ' ';
+            }
+            i++;
+            continue;
+        }
+        if (copy[i] == '/' && copy[i + 1] == '/') {
+            while (copy[i] != '\0' && copy[i] != '\n') {
+                copy[i++] = ' ';
+            }
+            continue;
+        }
+        if (copy[i] == '/' && copy[i + 1] == '*') {
+            copy[i++] = ' ';
+            copy[i++] = ' ';
+            in_block = 1;
+            continue;
+        }
+        if (copy[i] == '"' || copy[i] == '\'') {
+            quote = copy[i];
+            copy[i++] = ' ';
+            continue;
+        }
+        i++;
+    }
+    return copy;
+}
+
+static void k_skip_ws(const char **p) {
+    while (**p != '\0' && isspace((unsigned char)**p)) {
+        (*p)++;
+    }
+}
+
+static int k_collect_kunit_cases(const char *source, KStringSet *registered) {
+    char *code = k_code_view(source);
+    const char *p;
+
+    if (code == NULL) {
+        return -1;
+    }
+    p = code;
+    while (*p != '\0') {
+        if (!k_is_ident_start(*p)) {
+            p++;
+            continue;
+        }
+        if (strncmp(p, "KUNIT_CASE", 10) == 0 && !k_is_ident_char(p[10])) {
+            char name[256];
+            size_t len = 0;
+
+            p += 10;
+            k_skip_ws(&p);
+            if (*p != '(') {
+                continue;
+            }
+            p++;
+            k_skip_ws(&p);
+            if (!k_is_ident_start(*p)) {
+                continue;
+            }
+            while (k_is_ident_char(*p) && len + 1 < sizeof(name)) {
+                name[len++] = *p++;
+            }
+            name[len] = '\0';
+            if (k_string_set_add(registered, name) != 0) {
+                free(code);
+                return -1;
+            }
+        } else {
+            p++;
+            while (k_is_ident_char(*p)) {
+                p++;
+            }
+        }
+    }
+    free(code);
+    return 0;
+}
+
+static int k_segment_has_word(const char *start, const char *end, const char *word) {
+    size_t n = strlen(word);
+
+    for (const char *p = start; p < end; p++) {
+        if ((p == start || !k_is_ident_char(p[-1])) &&
+            (size_t)(end - p) >= n &&
+            strncmp(p, word, n) == 0 &&
+            (p + n == end || !k_is_ident_char(p[n]))) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int k_source_has_kunit_signature(const char *source, const char *name) {
+    char *code = k_code_view(source);
+    const char *p;
+    size_t name_len;
+
+    if (code == NULL || name == NULL) {
+        free(code);
+        return 0;
+    }
+    name_len = strlen(name);
+    p = code;
+    while ((p = strstr(p, name)) != NULL) {
+        const char *before;
+        const char *after;
+        const char *params_start;
+        const char *params_end;
+        int depth = 1;
+
+        if ((p > code && k_is_ident_char(p[-1])) || k_is_ident_char(p[name_len])) {
+            p += name_len;
+            continue;
+        }
+        before = p;
+        while (before > code && before[-1] != ';' && before[-1] != '{' && before[-1] != '}') {
+            before--;
+        }
+        after = p + name_len;
+        while (isspace((unsigned char)*after)) {
+            after++;
+        }
+        if (*after != '(' || !k_segment_has_word(before, p, "void")) {
+            p += name_len;
+            continue;
+        }
+        params_start = after + 1;
+        params_end = params_start;
+        while (*params_end != '\0' && depth > 0) {
+            if (*params_end == '(') {
+                depth++;
+            } else if (*params_end == ')') {
+                depth--;
+                if (depth == 0) {
+                    break;
+                }
+            }
+            params_end++;
+        }
+        if (depth == 0 &&
+            k_segment_has_word(params_start, params_end, "struct") &&
+            k_segment_has_word(params_start, params_end, "kunit") &&
+            k_segment_has_word(params_start, params_end, "test") &&
+            memchr(params_start, '*', (size_t)(params_end - params_start)) != NULL) {
+            free(code);
+            return 1;
+        }
+        p += name_len;
+    }
+    free(code);
+    return 0;
+}
+
+static int k_collect_test_functions(
+    const char *source,
+    const pk_c_source_facts *facts,
+    const KStringSet *registered,
+    KStringSet *tests
+) {
+    if (facts == NULL) {
+        return 0;
+    }
+    for (size_t i = 0; i < facts->n_functions; i++) {
+        const char *name = facts->functions[i].name;
+
+        if (name == NULL || name[0] == '\0') {
+            continue;
+        }
+        if (k_string_set_contains(registered, name) ||
+            k_source_has_kunit_signature(source, name)) {
+            if (k_string_set_add(tests, name) != 0) {
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+static int k_macro_info(const char *name, KunitMacroInfo *info) {
+    const char *tail;
+
+    if (strncmp(name, "KUNIT_EXPECT_", 13) == 0) {
+        tail = name + 13;
+    } else if (strncmp(name, "KUNIT_ASSERT_", 13) == 0) {
+        tail = name + 13;
+    } else {
+        return 0;
+    }
+    if (strcmp(tail, "EQ") == 0) {
+        info->op = KUNIT_OP_EQ;
+        info->required_args = 3;
+    } else if (strcmp(tail, "NE") == 0) {
+        info->op = KUNIT_OP_NE;
+        info->required_args = 3;
+    } else if (strcmp(tail, "TRUE") == 0) {
+        info->op = KUNIT_OP_TRUE;
+        info->required_args = 2;
+    } else if (strcmp(tail, "FALSE") == 0) {
+        info->op = KUNIT_OP_FALSE;
+        info->required_args = 2;
+    } else if (strcmp(tail, "NULL") == 0) {
+        info->op = KUNIT_OP_NULL;
+        info->required_args = 2;
+    } else if (strcmp(tail, "NOT_NULL") == 0) {
+        info->op = KUNIT_OP_NOT_NULL;
+        info->required_args = 2;
+    } else if (strcmp(tail, "LT") == 0) {
+        info->op = KUNIT_OP_LT;
+        info->required_args = 3;
+    } else if (strcmp(tail, "LE") == 0) {
+        info->op = KUNIT_OP_LE;
+        info->required_args = 3;
+    } else if (strcmp(tail, "GT") == 0) {
+        info->op = KUNIT_OP_GT;
+        info->required_args = 3;
+    } else if (strcmp(tail, "GE") == 0) {
+        info->op = KUNIT_OP_GE;
+        info->required_args = 3;
+    } else {
+        return 0;
+    }
+    return 1;
+}
+
+static char *k_trim_copy(const char *s) {
+    const char *start = s == NULL ? "" : s;
+    const char *end;
+
+    while (isspace((unsigned char)*start)) {
+        start++;
+    }
+    end = start + strlen(start);
+    while (end > start && isspace((unsigned char)end[-1])) {
+        end--;
+    }
+    return k_copy_n(start, (size_t)(end - start));
+}
+
+static int k_matching_outer_parens(const char *s) {
+    size_t len = strlen(s);
+    int depth = 0;
+    char quote = '\0';
+
+    if (len < 2 || s[0] != '(' || s[len - 1] != ')') {
+        return 0;
+    }
+    for (size_t i = 0; i < len; i++) {
+        if (quote != '\0') {
+            if (s[i] == '\\' && s[i + 1] != '\0') {
+                i++;
+            } else if (s[i] == quote) {
+                quote = '\0';
+            }
+            continue;
+        }
+        if (s[i] == '"' || s[i] == '\'') {
+            quote = s[i];
+            continue;
+        }
+        if (s[i] == '(') {
+            depth++;
+        } else if (s[i] == ')') {
+            depth--;
+            if (depth == 0 && i + 1 < len) {
+                return 0;
+            }
+        }
+    }
+    return depth == 0;
+}
+
+static void k_strip_outer_parens(char *s) {
+    while (k_matching_outer_parens(s)) {
+        size_t len = strlen(s);
+        memmove(s, s + 1, len - 2);
+        s[len - 2] = '\0';
+        char *trimmed = k_trim_copy(s);
+        if (trimmed == NULL) {
+            return;
+        }
+        strcpy(s, trimmed);
+        free(trimmed);
+    }
+}
+
+static int k_parse_int_literal(const char *s, long *out) {
+    char *end = NULL;
+    long value;
+
+    if (s == NULL || s[0] == '\0') {
+        return 0;
+    }
+    value = strtol(s, &end, 10);
+    if (end == s) {
+        return 0;
+    }
+    while (*end != '\0') {
+        if (!isspace((unsigned char)*end)) {
+            return 0;
+        }
+        end++;
+    }
+    *out = value;
+    return 1;
+}
+
+static int k_append_const_int(KBuf *out, long value) {
+    char buf[64];
+
+    (void)snprintf(buf, sizeof(buf), "%ld", value);
+    return kbuf_append(out, "{\"kind\":\"const\",\"value\":") == 0 &&
+        kbuf_append(out, buf) == 0 &&
+        kbuf_append(out, ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}") == 0 ? 0 : -1;
+}
+
+static int k_append_const_bool(KBuf *out, int value) {
+    return kbuf_append(out, "{\"kind\":\"const\",\"value\":") == 0 &&
+        kbuf_append(out, value ? "true" : "false") == 0 &&
+        kbuf_append(out, ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Bool\"}}") == 0 ? 0 : -1;
+}
+
+static int k_append_const_string(KBuf *out, const char *quoted) {
+    size_t len = strlen(quoted);
+    char *inner;
+    int rc;
+
+    if (len < 2 || quoted[0] != '"' || quoted[len - 1] != '"') {
+        return -1;
+    }
+    inner = k_copy_n(quoted + 1, len - 2);
+    if (inner == NULL) {
+        return -1;
+    }
+    rc = kbuf_append(out, "{\"kind\":\"const\",\"value\":") == 0 &&
+        kbuf_append_quoted(out, inner) == 0 &&
+        kbuf_append(out, ",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}") == 0 ? 0 : -1;
+    free(inner);
+    return rc;
+}
+
+static int k_append_ctor_null(KBuf *out) {
+    return kbuf_append(out, "{\"kind\":\"ctor\",\"name\":\"NULL\",\"args\":[]}");
+}
+
+static int k_find_top_op(const char *s, const char *const *ops, size_t n_ops, size_t *pos, size_t *op_len) {
+    int paren = 0;
+    int bracket = 0;
+    int brace = 0;
+    char quote = '\0';
+    size_t len = strlen(s);
+
+    for (size_t i = len; i > 0; i--) {
+        size_t at = i - 1;
+
+        if (quote != '\0') {
+            if (s[at] == quote && (at == 0 || s[at - 1] != '\\')) {
+                quote = '\0';
+            }
+            continue;
+        }
+        if (s[at] == '"' || s[at] == '\'') {
+            quote = s[at];
+            continue;
+        }
+        if (s[at] == ')') {
+            paren++;
+            continue;
+        }
+        if (s[at] == '(' && paren > 0) {
+            paren--;
+            continue;
+        }
+        if (s[at] == ']') {
+            bracket++;
+            continue;
+        }
+        if (s[at] == '[' && bracket > 0) {
+            bracket--;
+            continue;
+        }
+        if (s[at] == '}') {
+            brace++;
+            continue;
+        }
+        if (s[at] == '{' && brace > 0) {
+            brace--;
+            continue;
+        }
+        if (paren != 0 || bracket != 0 || brace != 0) {
+            continue;
+        }
+        for (size_t j = 0; j < n_ops; j++) {
+            size_t n = strlen(ops[j]);
+
+            if (at + n <= len && strncmp(s + at, ops[j], n) == 0) {
+                if ((ops[j][0] == '-' || ops[j][0] == '+') && at == 0) {
+                    continue;
+                }
+                *pos = at;
+                *op_len = n;
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+static const char *k_term_op_name(const char *op, size_t len) {
+    if (len == 1) {
+        return op;
+    }
+    if (len == 2 && strncmp(op, "<<", 2) == 0) {
+        return "<<";
+    }
+    if (len == 2 && strncmp(op, ">>", 2) == 0) {
+        return ">>";
+    }
+    return NULL;
+}
+
+static int k_append_term_json(KBuf *out, const char *expr, char *err, size_t err_len);
+
+static int k_append_call_term(KBuf *out, const char *expr, char *err, size_t err_len) {
+    const char *open = strchr(expr, '(');
+    const char *end;
+    char *callee;
+    char *inside;
+    KArgList args;
+    int rc = -1;
+
+    if (open == NULL || expr[strlen(expr) - 1] != ')') {
+        return 0;
+    }
+    for (const char *p = expr; p < open; p++) {
+        if (!k_is_ident_char(*p)) {
+            return 0;
+        }
+    }
+    if (open == expr) {
+        return 0;
+    }
+    end = open + 1;
+    {
+        int depth = 1;
+        char quote = '\0';
+        while (*end != '\0' && depth > 0) {
+            if (quote != '\0') {
+                if (*end == '\\' && end[1] != '\0') {
+                    end++;
+                } else if (*end == quote) {
+                    quote = '\0';
+                }
+            } else if (*end == '"' || *end == '\'') {
+                quote = *end;
+            } else if (*end == '(') {
+                depth++;
+            } else if (*end == ')') {
+                depth--;
+                if (depth == 0) {
+                    break;
+                }
+            }
+            end++;
+        }
+        if (depth != 0 || end[1] != '\0') {
+            return 0;
+        }
+    }
+    callee = k_copy_n(expr, (size_t)(open - expr));
+    inside = k_copy_n(open + 1, (size_t)(end - open - 1));
+    if (callee == NULL || inside == NULL) {
+        free(callee);
+        free(inside);
+        return -1;
+    }
+    if (k_split_args(inside, &args) != 0) {
+        free(callee);
+        free(inside);
+        return -1;
+    }
+    if (kbuf_append(out, "{\"kind\":\"ctor\",\"name\":") != 0 ||
+        kbuf_append_quoted(out, callee) != 0 ||
+        kbuf_append(out, ",\"args\":[") != 0) {
+        goto cleanup;
+    }
+    for (size_t i = 0; i < args.len; i++) {
+        if (i > 0 && kbuf_append_char(out, ',') != 0) {
+            goto cleanup;
+        }
+        if (k_append_term_json(out, args.items[i], err, err_len) != 0) {
+            goto cleanup;
+        }
+    }
+    if (kbuf_append(out, "]}") != 0) {
+        goto cleanup;
+    }
+    rc = 1;
+
+cleanup:
+    k_arg_list_free(&args);
+    free(callee);
+    free(inside);
+    return rc;
+}
+
+static int k_append_term_json(KBuf *out, const char *expr, char *err, size_t err_len) {
+    static const char *const ops[] = {"|", "^", "&", "<<", ">>", "+", "-", "*", "/", "%"};
+    char *s = k_trim_copy(expr);
+    long value;
+    size_t pos;
+    size_t op_len;
+    int call_rc;
+
+    if (s == NULL) {
+        return -1;
+    }
+    k_strip_outer_parens(s);
+    if (s[0] == '\0') {
+        k_set_error(err, err_len, "empty expression");
+        free(s);
+        return -1;
+    }
+    if (s[0] == '&' && s[1] != '&') {
+        int rc = k_append_term_json(out, s + 1, err, err_len);
+        free(s);
+        return rc;
+    }
+    if (k_parse_int_literal(s, &value)) {
+        int rc = k_append_const_int(out, value);
+        free(s);
+        return rc;
+    }
+    if (s[0] == '"') {
+        int rc = k_append_const_string(out, s);
+        free(s);
+        return rc;
+    }
+    if (strcmp(s, "true") == 0) {
+        free(s);
+        return k_append_const_bool(out, 1);
+    }
+    if (strcmp(s, "false") == 0) {
+        free(s);
+        return k_append_const_bool(out, 0);
+    }
+    if (strcmp(s, "NULL") == 0) {
+        free(s);
+        return k_append_ctor_null(out);
+    }
+    call_rc = k_append_call_term(out, s, err, err_len);
+    if (call_rc != 0) {
+        free(s);
+        return call_rc == 1 ? 0 : -1;
+    }
+    if (k_find_top_op(s, ops, sizeof(ops) / sizeof(ops[0]), &pos, &op_len)) {
+        char *lhs = k_copy_n(s, pos);
+        char *rhs = k_copy(s + pos + op_len);
+        const char *name = k_term_op_name(s + pos, op_len);
+        int rc = -1;
+
+        if (lhs == NULL || rhs == NULL || name == NULL) {
+            free(lhs);
+            free(rhs);
+            free(s);
+            return -1;
+        }
+        if (kbuf_append(out, "{\"kind\":\"ctor\",\"name\":") == 0 &&
+            kbuf_append_quoted(out, name) == 0 &&
+            kbuf_append(out, ",\"args\":[") == 0 &&
+            k_append_term_json(out, lhs, err, err_len) == 0 &&
+            kbuf_append_char(out, ',') == 0 &&
+            k_append_term_json(out, rhs, err, err_len) == 0 &&
+            kbuf_append(out, "]}") == 0) {
+            rc = 0;
+        }
+        free(lhs);
+        free(rhs);
+        free(s);
+        return rc;
+    }
+    if (k_is_identifier(s)) {
+        int rc = kbuf_append(out, "{\"kind\":\"var\",\"name\":") == 0 &&
+            kbuf_append_quoted(out, s) == 0 &&
+            kbuf_append_char(out, '}') == 0 ? 0 : -1;
+        free(s);
+        return rc;
+    }
+    k_set_error(err, err_len, "expression shape not in C KUnit lift whitelist");
+    free(s);
+    return -1;
+}
+
+static int k_append_atomic2(KBuf *out, const char *name, const char *lhs, const char *rhs, char *err, size_t err_len) {
+    return kbuf_append(out, "{\"kind\":\"atomic\",\"name\":") == 0 &&
+        kbuf_append_quoted(out, name) == 0 &&
+        kbuf_append(out, ",\"args\":[") == 0 &&
+        k_append_term_json(out, lhs, err, err_len) == 0 &&
+        kbuf_append_char(out, ',') == 0 &&
+        k_append_term_json(out, rhs, err, err_len) == 0 &&
+        kbuf_append(out, "]}") == 0 ? 0 : -1;
+}
+
+static int k_append_null_atomic(KBuf *out, const char *name, const char *expr, char *err, size_t err_len) {
+    return kbuf_append(out, "{\"kind\":\"atomic\",\"name\":") == 0 &&
+        kbuf_append_quoted(out, name) == 0 &&
+        kbuf_append(out, ",\"args\":[") == 0 &&
+        k_append_term_json(out, expr, err, err_len) == 0 &&
+        kbuf_append(out, ",{\"kind\":\"ctor\",\"name\":\"NULL\",\"args\":[]}]}") == 0 ? 0 : -1;
+}
+
+static const char *k_cmp_name(const char *op, size_t len) {
+    if (len == 2 && strncmp(op, "==", 2) == 0) return "eq";
+    if (len == 2 && strncmp(op, "!=", 2) == 0) return "ne";
+    if (len == 2 && strncmp(op, "<=", 2) == 0) return "le";
+    if (len == 2 && strncmp(op, ">=", 2) == 0) return "ge";
+    if (len == 1 && op[0] == '<') return "lt";
+    if (len == 1 && op[0] == '>') return "gt";
+    return NULL;
+}
+
+static int k_find_top_comparison(const char *s, size_t *pos, size_t *op_len, const char **name) {
+    static const char *const ops[] = {"==", "!=", "<=", ">=", "<", ">"};
+    int paren = 0;
+    int bracket = 0;
+    int brace = 0;
+    char quote = '\0';
+    size_t len = strlen(s);
+
+    for (size_t i = 0; i < len; i++) {
+        if (quote != '\0') {
+            if (s[i] == '\\' && s[i + 1] != '\0') {
+                i++;
+            } else if (s[i] == quote) {
+                quote = '\0';
+            }
+            continue;
+        }
+        if (s[i] == '"' || s[i] == '\'') {
+            quote = s[i];
+            continue;
+        }
+        if (s[i] == '(') paren++;
+        else if (s[i] == ')' && paren > 0) paren--;
+        else if (s[i] == '[') bracket++;
+        else if (s[i] == ']' && bracket > 0) bracket--;
+        else if (s[i] == '{') brace++;
+        else if (s[i] == '}' && brace > 0) brace--;
+        if (paren != 0 || bracket != 0 || brace != 0) {
+            continue;
+        }
+        for (size_t j = 0; j < sizeof(ops) / sizeof(ops[0]); j++) {
+            size_t n = strlen(ops[j]);
+
+            if (i + n <= len && strncmp(s + i, ops[j], n) == 0) {
+                if ((ops[j][0] == '<' && s[i + 1] == '<') ||
+                    (ops[j][0] == '>' && s[i + 1] == '>')) {
+                    continue;
+                }
+                *pos = i;
+                *op_len = n;
+                *name = k_cmp_name(s + i, n);
+                return *name != NULL;
+            }
+        }
+    }
+    return 0;
+}
+
+static int k_append_formula_json(KBuf *out, const char *expr, char *err, size_t err_len);
+
+static int k_append_connective(KBuf *out, const char *kind, const char *lhs, const char *rhs, char *err, size_t err_len) {
+    return kbuf_append(out, "{\"kind\":") == 0 &&
+        kbuf_append_quoted(out, kind) == 0 &&
+        kbuf_append(out, ",\"operands\":[") == 0 &&
+        k_append_formula_json(out, lhs, err, err_len) == 0 &&
+        kbuf_append_char(out, ',') == 0 &&
+        k_append_formula_json(out, rhs, err, err_len) == 0 &&
+        kbuf_append(out, "]}") == 0 ? 0 : -1;
+}
+
+static int k_find_top_logic(const char *s, const char *op, size_t *pos) {
+    int paren = 0;
+    char quote = '\0';
+    size_t len = strlen(s);
+    size_t op_len = strlen(op);
+
+    for (size_t i = 0; i + op_len <= len; i++) {
+        if (quote != '\0') {
+            if (s[i] == '\\' && s[i + 1] != '\0') {
+                i++;
+            } else if (s[i] == quote) {
+                quote = '\0';
+            }
+            continue;
+        }
+        if (s[i] == '"' || s[i] == '\'') {
+            quote = s[i];
+            continue;
+        }
+        if (s[i] == '(') {
+            paren++;
+            continue;
+        }
+        if (s[i] == ')' && paren > 0) {
+            paren--;
+            continue;
+        }
+        if (paren == 0 && strncmp(s + i, op, op_len) == 0) {
+            *pos = i;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int k_append_formula_json(KBuf *out, const char *expr, char *err, size_t err_len) {
+    char *s = k_trim_copy(expr);
+    size_t pos;
+    size_t op_len;
+    const char *name;
+
+    if (s == NULL) {
+        return -1;
+    }
+    k_strip_outer_parens(s);
+    if (s[0] == '!' && s[1] != '=') {
+        int rc = kbuf_append(out, "{\"kind\":\"not\",\"operands\":[") == 0 &&
+            k_append_formula_json(out, s + 1, err, err_len) == 0 &&
+            kbuf_append(out, "]}") == 0 ? 0 : -1;
+        free(s);
+        return rc;
+    }
+    if (k_find_top_logic(s, "||", &pos)) {
+        char *lhs = k_copy_n(s, pos);
+        char *rhs = k_copy(s + pos + 2);
+        int rc = lhs != NULL && rhs != NULL
+            ? k_append_connective(out, "or", lhs, rhs, err, err_len)
+            : -1;
+        free(lhs);
+        free(rhs);
+        free(s);
+        return rc;
+    }
+    if (k_find_top_logic(s, "&&", &pos)) {
+        char *lhs = k_copy_n(s, pos);
+        char *rhs = k_copy(s + pos + 2);
+        int rc = lhs != NULL && rhs != NULL
+            ? k_append_connective(out, "and", lhs, rhs, err, err_len)
+            : -1;
+        free(lhs);
+        free(rhs);
+        free(s);
+        return rc;
+    }
+    if (k_find_top_comparison(s, &pos, &op_len, &name)) {
+        char *lhs = k_copy_n(s, pos);
+        char *rhs = k_copy(s + pos + op_len);
+        int rc = lhs != NULL && rhs != NULL
+            ? k_append_atomic2(out, name, lhs, rhs, err, err_len)
+            : -1;
+        free(lhs);
+        free(rhs);
+        free(s);
+        return rc;
+    }
+    {
+        int rc = kbuf_append(out, "{\"kind\":\"atomic\",\"name\":\"truthy\",\"args\":[") == 0 &&
+            k_append_term_json(out, s, err, err_len) == 0 &&
+            kbuf_append(out, "]}") == 0 ? 0 : -1;
+        free(s);
+        return rc;
+    }
+}
+
+static int k_build_formula(KBuf *formula, KunitOp op, const KArgList *args, char *err, size_t err_len) {
+    const char *a = args->items[1];
+    const char *b = args->len > 2 ? args->items[2] : NULL;
+
+    if (kbuf_init(formula) != 0) {
+        return -1;
+    }
+    switch (op) {
+    case KUNIT_OP_EQ:
+        return k_append_atomic2(formula, "eq", a, b, err, err_len);
+    case KUNIT_OP_NE:
+        return k_append_atomic2(formula, "ne", a, b, err, err_len);
+    case KUNIT_OP_TRUE:
+        return k_append_formula_json(formula, a, err, err_len);
+    case KUNIT_OP_FALSE:
+        return kbuf_append(formula, "{\"kind\":\"not\",\"operands\":[") == 0 &&
+            k_append_formula_json(formula, a, err, err_len) == 0 &&
+            kbuf_append(formula, "]}") == 0 ? 0 : -1;
+    case KUNIT_OP_NULL:
+        return k_append_null_atomic(formula, "eq", a, err, err_len);
+    case KUNIT_OP_NOT_NULL:
+        return k_append_null_atomic(formula, "ne", a, err, err_len);
+    case KUNIT_OP_LT:
+        return k_append_atomic2(formula, "lt", a, b, err, err_len);
+    case KUNIT_OP_LE:
+        return k_append_atomic2(formula, "le", a, b, err, err_len);
+    case KUNIT_OP_GT:
+        return k_append_atomic2(formula, "gt", a, b, err, err_len);
+    case KUNIT_OP_GE:
+        return k_append_atomic2(formula, "ge", a, b, err, err_len);
+    }
+    k_set_error(err, err_len, "unknown KUnit operation");
+    return -1;
+}
+
+static int k_build_contract(
+    KBuf *out,
+    const char *test_name,
+    size_t index,
+    const char *post,
+    const pk_c_locus *locus,
+    const char *fallback_path
+) {
+    char index_buf[64];
+
+    (void)snprintf(index_buf, sizeof(index_buf), "%zu", index);
+    if (kbuf_init(out) != 0) {
+        return -1;
+    }
+    if (kbuf_append(out, "{\"fn_name\":") != 0 ||
+        kbuf_append_char(out, '"') != 0 ||
+        kbuf_append(out, test_name) != 0 ||
+        kbuf_append(out, "::") != 0 ||
+        kbuf_append(out, index_buf) != 0 ||
+        kbuf_append(out, "\",\"kind\":\"function-contract\",") != 0 ||
+        kbuf_append(out, "\"formals\":[],\"formal_sorts\":[],") != 0 ||
+        kbuf_append(out, "\"return_sort\":{\"kind\":\"primitive\",\"name\":\"i32\"},") != 0 ||
+        kbuf_append(out, "\"pre\":{\"kind\":\"atomic\",\"name\":\"true\",\"args\":[]},") != 0 ||
+        kbuf_append(out, "\"post\":") != 0 ||
+        kbuf_append(out, post) != 0 ||
+        kbuf_append(out, ",\"effects\":{\"effects\":[]},") != 0 ||
+        kbuf_append(out, "\"locus\":{\"col\":") != 0) {
+        return -1;
+    }
+    (void)snprintf(index_buf, sizeof(index_buf), "%d", locus == NULL ? 0 : locus->column);
+    if (kbuf_append(out, index_buf) != 0 ||
+        kbuf_append(out, ",\"file\":") != 0 ||
+        kbuf_append_quoted(out, locus != NULL && locus->path != NULL ? locus->path : fallback_path) != 0 ||
+        kbuf_append(out, ",\"line\":") != 0) {
+        return -1;
+    }
+    (void)snprintf(index_buf, sizeof(index_buf), "%d", locus == NULL ? 0 : locus->line);
+    return kbuf_append(out, index_buf) == 0 &&
+        kbuf_append(out, "},\"auto_minted_mementos\":[],\"body_cid\":null}") == 0 ? 0 : -1;
+}
+
+static int k_append_core_result(pk_c_lift_result *result, const pk_c_source_facts *facts) {
+    if (facts == NULL || facts->extraction_result == NULL) {
+        return 0;
+    }
+    return pk_c_lift_result_extend(result, facts->extraction_result);
+}
+
+static int k_add_skip_opacity(
+    pk_c_lift_result *result,
+    const pk_c_macro_call_fact *call,
+    const char *reason
+) {
+    return pk_c_lift_result_add_opacity_entry(
+        result,
+        "c-kunit.unsupported-assertion",
+        call->locus.path,
+        call->locus.line,
+        call->locus.column,
+        reason,
+        "c-kunit");
+}
+
+static int k_lift_kunit_macros(
+    pk_c_lift_result *result,
+    const char *path,
+    const pk_c_source_facts *facts,
+    const KStringSet *tests
+) {
+    KCounterSet counters = {0};
+    int rc = 0;
+
+    if (facts == NULL) {
+        return 0;
+    }
+    for (size_t i = 0; i < facts->n_macro_calls; i++) {
+        const pk_c_macro_call_fact *call = &facts->macro_calls[i];
+        KunitMacroInfo info;
+        KArgList args;
+        KBuf formula;
+        KBuf contract;
+        size_t idx;
+        char err[256];
+
+        if (call->name == NULL || !k_macro_info(call->name, &info)) {
+            continue;
+        }
+        if (!k_string_set_contains(tests, call->enclosing_function)) {
+            continue;
+        }
+        if (k_counter_next(&counters, call->enclosing_function, &idx) != 0) {
+            rc = -1;
+            break;
+        }
+        if (k_split_args(call->argument_text, &args) != 0) {
+            rc = -1;
+            break;
+        }
+        if ((int)args.len < info.required_args) {
+            (void)k_add_skip_opacity(result, call, "KUnit assertion had fewer arguments than expected");
+            k_arg_list_free(&args);
+            continue;
+        }
+        err[0] = '\0';
+        if (k_build_formula(&formula, info.op, &args, err, sizeof(err)) != 0) {
+            (void)k_add_skip_opacity(
+                result,
+                call,
+                err[0] != '\0' ? err : "KUnit assertion expression could not be lifted");
+            kbuf_free(&formula);
+            k_arg_list_free(&args);
+            continue;
+        }
+        if (k_build_contract(&contract, call->enclosing_function, idx, formula.data,
+                &call->locus, path) != 0) {
+            kbuf_free(&formula);
+            k_arg_list_free(&args);
+            rc = -1;
+            break;
+        }
+        if (pk_c_lift_result_add_declaration(result, contract.data) != 0) {
+            kbuf_free(&contract);
+            kbuf_free(&formula);
+            k_arg_list_free(&args);
+            rc = -1;
+            break;
+        }
+        kbuf_free(&contract);
+        kbuf_free(&formula);
+        k_arg_list_free(&args);
+    }
+    k_counter_set_free(&counters);
+    return rc;
+}
+
+pk_c_lift_result *pk_c_kunit_lift_source_with_options(
+    const char *path,
+    const char *source,
+    const pk_c_parse_options *options
+) {
+    pk_c_lift_result *result = pk_c_lift_result_new();
+    pk_c_source_facts *core_facts;
+    pk_c_source_facts *scan_facts;
+    KStringSet registered = {0};
+    KStringSet tests = {0};
+
+    if (result == NULL) {
+        return NULL;
+    }
+    if (source == NULL) {
+        return result;
+    }
+    core_facts = pk_c_parse_source_with_options(path, source, options);
+    if (core_facts == NULL) {
+        (void)pk_c_lift_result_add_diagnostic(
+            result,
+            "{\"severity\":\"error\",\"message\":\"parse failed\"}");
+        return result;
+    }
+    if (k_append_core_result(result, core_facts) != 0) {
+        pk_c_source_facts_free(core_facts);
+        pk_c_lift_result_free(result);
+        return NULL;
+    }
+    if (options != NULL && options->backend == PK_C_PARSE_BACKEND_CLANG_AST) {
+        scan_facts = pk_c_parse_source(path, source);
+        if (scan_facts == NULL) {
+            pk_c_source_facts_free(core_facts);
+            pk_c_lift_result_free(result);
+            return NULL;
+        }
+    } else {
+        scan_facts = core_facts;
+    }
+    if (k_collect_kunit_cases(source, &registered) != 0 ||
+        k_collect_test_functions(source, scan_facts, &registered, &tests) != 0 ||
+        k_lift_kunit_macros(result, path, scan_facts, &tests) != 0) {
+        if (scan_facts != core_facts) {
+            pk_c_source_facts_free(scan_facts);
+        }
+        pk_c_source_facts_free(core_facts);
+        k_string_set_free(&registered);
+        k_string_set_free(&tests);
+        pk_c_lift_result_free(result);
+        return NULL;
+    }
+    if (scan_facts != core_facts) {
+        pk_c_source_facts_free(scan_facts);
+    }
+    pk_c_source_facts_free(core_facts);
+    k_string_set_free(&registered);
+    k_string_set_free(&tests);
+    return result;
+}
+
+pk_c_lift_result *pk_c_kunit_lift_source(const char *path, const char *source) {
+    return pk_c_kunit_lift_source_with_options(path, source, NULL);
+}

--- a/implementations/c/provekit-lift-c-kunit/src/main.c
+++ b/implementations/c/provekit-lift-c-kunit/src/main.c
@@ -1,0 +1,1423 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#define _POSIX_C_SOURCE 200809L
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "provekit/c_lift_core.h"
+
+pk_c_lift_result *pk_c_kunit_lift_source(const char *path, const char *source);
+pk_c_lift_result *pk_c_kunit_lift_source_with_options(
+    const char *path,
+    const char *source,
+    const pk_c_parse_options *options);
+
+typedef struct {
+    char *data;
+    size_t len;
+    size_t cap;
+} Buf;
+
+typedef struct {
+    char **items;
+    size_t len;
+} StringArray;
+
+static void string_array_free(StringArray *arr);
+
+typedef struct {
+    pk_c_parse_options options;
+    StringArray clang_args;
+    pk_c_compile_context *compile_context;
+    char *parse_backend;
+    char *compile_context_kind;
+    char *workspace_root;
+    char *compile_command;
+    char *target_triple;
+    int resolve_kernel_context;
+} ParseRequestOptions;
+
+typedef struct {
+    Buf ir;
+    Buf call_edges;
+    Buf diagnostics;
+    Buf opacity_report;
+    Buf refusals;
+    size_t ir_count;
+    size_t call_edge_count;
+    size_t diagnostic_count;
+    size_t opacity_count;
+    size_t refusal_count;
+    char error[512];
+} LiftAccumulator;
+
+static void buf_init(Buf *b) {
+    b->len = 0;
+    b->cap = 256;
+    b->data = malloc(b->cap);
+    if (b->data) {
+        b->data[0] = '\0';
+    } else {
+        b->cap = 0;
+    }
+}
+
+static void buf_free(Buf *b) {
+    free(b->data);
+    b->data = NULL;
+    b->len = 0;
+    b->cap = 0;
+}
+
+static int buf_grow(Buf *b, size_t need) {
+    size_t next = b->cap ? b->cap : 256;
+    char *data;
+
+    while (next < b->len + need + 1) {
+        if (next > ((size_t)-1) / 2) {
+            return -1;
+        }
+        next *= 2;
+    }
+
+    data = realloc(b->data, next);
+    if (!data) {
+        return -1;
+    }
+
+    b->data = data;
+    b->cap = next;
+    return 0;
+}
+
+static int buf_append_n(Buf *b, const char *s, size_t n) {
+    if (buf_grow(b, n) != 0) {
+        return -1;
+    }
+    memcpy(b->data + b->len, s, n);
+    b->len += n;
+    b->data[b->len] = '\0';
+    return 0;
+}
+
+static int buf_append(Buf *b, const char *s) {
+    return buf_append_n(b, s, strlen(s));
+}
+
+static int buf_append_char(Buf *b, char c) {
+    return buf_append_n(b, &c, 1);
+}
+
+static void json_escape_str(Buf *out, const char *s) {
+    (void)buf_append_char(out, '"');
+    for (const unsigned char *p = (const unsigned char *)s; p && *p; p++) {
+        switch (*p) {
+        case '"':
+            (void)buf_append(out, "\\\"");
+            break;
+        case '\\':
+            (void)buf_append(out, "\\\\");
+            break;
+        case '\n':
+            (void)buf_append(out, "\\n");
+            break;
+        case '\r':
+            (void)buf_append(out, "\\r");
+            break;
+        case '\t':
+            (void)buf_append(out, "\\t");
+            break;
+        default:
+            if (*p < 0x20) {
+                char esc[7];
+                (void)snprintf(esc, sizeof(esc), "\\u00%02x", *p);
+                (void)buf_append(out, esc);
+            } else {
+                (void)buf_append_char(out, (char)*p);
+            }
+            break;
+        }
+    }
+    (void)buf_append_char(out, '"');
+}
+
+static char *str_dup(const char *s) {
+    size_t n = strlen(s);
+    char *out = malloc(n + 1);
+    if (!out) {
+        return NULL;
+    }
+    memcpy(out, s, n + 1);
+    return out;
+}
+
+static void json_skip_ws(const char **p) {
+    while (**p == ' ' || **p == '\t' || **p == '\r' || **p == '\n') {
+        (*p)++;
+    }
+}
+
+static int json_parse_value(const char **p);
+
+static int json_hex_value(char c) {
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    return -1;
+}
+
+static int json_decode_hex4(const char *p, unsigned *out) {
+    unsigned value = 0;
+
+    for (int i = 0; i < 4; i++) {
+        int digit = json_hex_value(p[i]);
+        if (digit < 0) {
+            return -1;
+        }
+        value = (value << 4) | (unsigned)digit;
+    }
+    *out = value;
+    return 0;
+}
+
+static int json_append_utf8(char *out, size_t cap, size_t *len, unsigned codepoint) {
+    if (codepoint == 0 || codepoint > 0x10ffffu ||
+        (codepoint >= 0xd800u && codepoint <= 0xdfffu)) {
+        return -1;
+    }
+    if (codepoint < 0x80u) {
+        if (*len + 1 >= cap) {
+            return -1;
+        }
+        out[(*len)++] = (char)codepoint;
+    } else if (codepoint < 0x800u) {
+        if (*len + 2 >= cap) {
+            return -1;
+        }
+        out[(*len)++] = (char)(0xc0u | (codepoint >> 6));
+        out[(*len)++] = (char)(0x80u | (codepoint & 0x3fu));
+    } else if (codepoint < 0x10000u) {
+        if (*len + 3 >= cap) {
+            return -1;
+        }
+        out[(*len)++] = (char)(0xe0u | (codepoint >> 12));
+        out[(*len)++] = (char)(0x80u | ((codepoint >> 6) & 0x3fu));
+        out[(*len)++] = (char)(0x80u | (codepoint & 0x3fu));
+    } else {
+        if (*len + 4 >= cap) {
+            return -1;
+        }
+        out[(*len)++] = (char)(0xf0u | (codepoint >> 18));
+        out[(*len)++] = (char)(0x80u | ((codepoint >> 12) & 0x3fu));
+        out[(*len)++] = (char)(0x80u | ((codepoint >> 6) & 0x3fu));
+        out[(*len)++] = (char)(0x80u | (codepoint & 0x3fu));
+    }
+    return 0;
+}
+
+static char *decode_json_string(const char *start, const char **end_out) {
+    size_t cap = strlen(start) + 1;
+    char *out = malloc(cap);
+    size_t len = 0;
+    const char *p = start;
+
+    if (!out) {
+        return NULL;
+    }
+
+    while (*p && *p != '"') {
+        if (*p == '\\') {
+            p++;
+            switch (*p) {
+            case 'b':
+                out[len++] = '\b';
+                p++;
+                break;
+            case 'f':
+                out[len++] = '\f';
+                p++;
+                break;
+            case 'n':
+                out[len++] = '\n';
+                p++;
+                break;
+            case 'r':
+                out[len++] = '\r';
+                p++;
+                break;
+            case 't':
+                out[len++] = '\t';
+                p++;
+                break;
+            case '"':
+                out[len++] = '"';
+                p++;
+                break;
+            case '\\':
+                out[len++] = '\\';
+                p++;
+                break;
+            case '/':
+                out[len++] = '/';
+                p++;
+                break;
+            case 'u': {
+                unsigned codepoint;
+
+                p++;
+                if (json_decode_hex4(p, &codepoint) != 0) {
+                    free(out);
+                    return NULL;
+                }
+                p += 4;
+                if (codepoint >= 0xd800u && codepoint <= 0xdbffu) {
+                    unsigned low;
+
+                    if (p[0] != '\\' || p[1] != 'u' ||
+                        json_decode_hex4(p + 2, &low) != 0 ||
+                        low < 0xdc00u || low > 0xdfffu) {
+                        free(out);
+                        return NULL;
+                    }
+                    p += 6;
+                    codepoint = 0x10000u + (((codepoint - 0xd800u) << 10) |
+                        (low - 0xdc00u));
+                }
+                if (json_append_utf8(out, cap, &len, codepoint) != 0) {
+                    free(out);
+                    return NULL;
+                }
+                break;
+            }
+            case '\0':
+                out[len] = '\0';
+                if (end_out) {
+                    *end_out = p;
+                }
+                return out;
+            default:
+                free(out);
+                return NULL;
+            }
+        } else {
+            out[len++] = *p++;
+        }
+    }
+
+    out[len] = '\0';
+    if (end_out) {
+        *end_out = p;
+    }
+    return out;
+}
+
+static const char *json_find_object_value(const char *json, const char *field) {
+    const char *p = json;
+
+    json_skip_ws(&p);
+    if (*p != '{') {
+        return NULL;
+    }
+    p++;
+    json_skip_ws(&p);
+    if (*p == '}') {
+        return NULL;
+    }
+    for (;;) {
+        const char *end = NULL;
+        char *key;
+        int matched;
+
+        if (*p != '"') {
+            return NULL;
+        }
+        key = decode_json_string(p + 1, &end);
+        if (key == NULL || end == NULL || *end != '"') {
+            free(key);
+            return NULL;
+        }
+        p = end + 1;
+        json_skip_ws(&p);
+        if (*p != ':') {
+            free(key);
+            return NULL;
+        }
+        p++;
+        json_skip_ws(&p);
+        matched = strcmp(key, field) == 0;
+        free(key);
+        if (matched) {
+            return p;
+        }
+        if (!json_parse_value(&p)) {
+            return NULL;
+        }
+        json_skip_ws(&p);
+        if (*p == '}') {
+            return NULL;
+        }
+        if (*p != ',') {
+            return NULL;
+        }
+        p++;
+        json_skip_ws(&p);
+    }
+}
+
+static const char *json_find_params_value(const char *json, const char *field) {
+    const char *params = json_find_object_value(json, "params");
+
+    if (params == NULL) {
+        return NULL;
+    }
+    return json_find_object_value(params, field);
+}
+
+static char *json_extract_str(const char *json, const char *field) {
+    const char *p = json_find_object_value(json, field);
+
+    if (p == NULL || *p != '"') {
+        return NULL;
+    }
+    return decode_json_string(p + 1, NULL);
+}
+
+static char *json_extract_param_str(const char *json, const char *field) {
+    const char *p = json_find_params_value(json, field);
+
+    if (p == NULL || *p != '"') {
+        return NULL;
+    }
+    return decode_json_string(p + 1, NULL);
+}
+
+static int json_has_param_field(const char *json, const char *field) {
+    return json_find_params_value(json, field) != NULL;
+}
+
+static char *json_extract_id(const char *json) {
+    const char *p = json_find_object_value(json, "id");
+    Buf b;
+    char *out;
+
+    if (!p) {
+        return str_dup("null");
+    }
+    if (!*p) {
+        return str_dup("null");
+    }
+
+    buf_init(&b);
+    if (!b.data) {
+        return NULL;
+    }
+
+    if (*p == '"') {
+        const char *end = NULL;
+        char *decoded = decode_json_string(p + 1, &end);
+        if (!decoded) {
+            buf_free(&b);
+            return NULL;
+        }
+        json_escape_str(&b, decoded);
+        free(decoded);
+    } else {
+        while (*p && *p != ',' && *p != '}') {
+            if (buf_append_char(&b, *p) != 0) {
+                buf_free(&b);
+                return NULL;
+            }
+            p++;
+        }
+        while (b.len > 0 &&
+               (b.data[b.len - 1] == ' ' || b.data[b.len - 1] == '\t' ||
+                b.data[b.len - 1] == '\r' || b.data[b.len - 1] == '\n')) {
+            b.data[--b.len] = '\0';
+        }
+    }
+
+    out = b.data;
+    b.data = NULL;
+    buf_free(&b);
+    return out;
+}
+
+static int json_parse_string_value(const char **p) {
+    if (**p != '"') {
+        return 0;
+    }
+    (*p)++;
+
+    while (**p) {
+        unsigned char c = (unsigned char)**p;
+
+        if (c == '"') {
+            (*p)++;
+            return 1;
+        }
+        if (c < 0x20) {
+            return 0;
+        }
+        if (c == '\\') {
+            (*p)++;
+            switch (**p) {
+            case '"':
+            case '\\':
+            case '/':
+            case 'b':
+            case 'f':
+            case 'n':
+            case 'r':
+            case 't':
+                (*p)++;
+                break;
+            case 'u':
+                (*p)++;
+                for (int i = 0; i < 4; i++) {
+                    char h = **p;
+                    if (!((h >= '0' && h <= '9') || (h >= 'a' && h <= 'f') ||
+                          (h >= 'A' && h <= 'F'))) {
+                        return 0;
+                    }
+                    (*p)++;
+                }
+                break;
+            default:
+                return 0;
+            }
+        } else {
+            (*p)++;
+        }
+    }
+
+    return 0;
+}
+
+static int json_parse_literal(const char **p, const char *literal) {
+    size_t n = strlen(literal);
+    if (strncmp(*p, literal, n) != 0) {
+        return 0;
+    }
+    *p += n;
+    return 1;
+}
+
+static int json_parse_number(const char **p) {
+    const char *s = *p;
+
+    if (*s == '-') {
+        s++;
+    }
+    if (*s == '0') {
+        s++;
+    } else if (*s >= '1' && *s <= '9') {
+        do {
+            s++;
+        } while (*s >= '0' && *s <= '9');
+    } else {
+        return 0;
+    }
+
+    if (*s == '.') {
+        s++;
+        if (!(*s >= '0' && *s <= '9')) {
+            return 0;
+        }
+        do {
+            s++;
+        } while (*s >= '0' && *s <= '9');
+    }
+
+    if (*s == 'e' || *s == 'E') {
+        s++;
+        if (*s == '+' || *s == '-') {
+            s++;
+        }
+        if (!(*s >= '0' && *s <= '9')) {
+            return 0;
+        }
+        do {
+            s++;
+        } while (*s >= '0' && *s <= '9');
+    }
+
+    *p = s;
+    return 1;
+}
+
+static int json_parse_array(const char **p) {
+    if (**p != '[') {
+        return 0;
+    }
+    (*p)++;
+    json_skip_ws(p);
+
+    if (**p == ']') {
+        (*p)++;
+        return 1;
+    }
+
+    for (;;) {
+        if (!json_parse_value(p)) {
+            return 0;
+        }
+        json_skip_ws(p);
+        if (**p == ']') {
+            (*p)++;
+            return 1;
+        }
+        if (**p != ',') {
+            return 0;
+        }
+        (*p)++;
+        json_skip_ws(p);
+        if (**p == ']') {
+            return 0;
+        }
+    }
+}
+
+static int json_parse_object(const char **p) {
+    if (**p != '{') {
+        return 0;
+    }
+    (*p)++;
+    json_skip_ws(p);
+
+    if (**p == '}') {
+        (*p)++;
+        return 1;
+    }
+
+    for (;;) {
+        if (!json_parse_string_value(p)) {
+            return 0;
+        }
+        json_skip_ws(p);
+        if (**p != ':') {
+            return 0;
+        }
+        (*p)++;
+        json_skip_ws(p);
+        if (!json_parse_value(p)) {
+            return 0;
+        }
+        json_skip_ws(p);
+        if (**p == '}') {
+            (*p)++;
+            return 1;
+        }
+        if (**p != ',') {
+            return 0;
+        }
+        (*p)++;
+        json_skip_ws(p);
+        if (**p == '}') {
+            return 0;
+        }
+    }
+}
+
+static int json_parse_value(const char **p) {
+    json_skip_ws(p);
+
+    switch (**p) {
+    case '{':
+        return json_parse_object(p);
+    case '[':
+        return json_parse_array(p);
+    case '"':
+        return json_parse_string_value(p);
+    case 't':
+        return json_parse_literal(p, "true");
+    case 'f':
+        return json_parse_literal(p, "false");
+    case 'n':
+        return json_parse_literal(p, "null");
+    default:
+        if (**p == '-' || (**p >= '0' && **p <= '9')) {
+            return json_parse_number(p);
+        }
+        return 0;
+    }
+}
+
+static int validate_json_request(const char *json) {
+    const char *p = json;
+
+    json_skip_ws(&p);
+    if (!json_parse_object(&p)) {
+        return 0;
+    }
+    json_skip_ws(&p);
+    return *p == '\0';
+}
+
+static int json_extract_str_array(const char *json, const char *field, StringArray *out) {
+    const char *p;
+
+    memset(out, 0, sizeof(*out));
+    p = json_find_object_value(json, field);
+    if (!p) {
+        return 0;
+    }
+
+    if (*p != '[') {
+        string_array_free(out);
+        return -1;
+    }
+    p++;
+
+    while (*p) {
+        char *item;
+        char **next;
+
+        while (*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n' || *p == ',') {
+            p++;
+        }
+        if (*p == ']') {
+            return 0;
+        }
+        if (*p != '"') {
+            string_array_free(out);
+            return -1;
+        }
+
+        item = decode_json_string(p + 1, &p);
+        if (!item || *p != '"') {
+            free(item);
+            string_array_free(out);
+            return -1;
+        }
+        p++;
+
+        next = realloc(out->items, sizeof(char *) * (out->len + 1));
+        if (!next) {
+            free(item);
+            string_array_free(out);
+            return -1;
+        }
+        out->items = next;
+        out->items[out->len++] = item;
+    }
+
+    string_array_free(out);
+    return -1;
+}
+
+static int json_extract_param_str_array(const char *json, const char *field, StringArray *out) {
+    const char *params = json_find_object_value(json, "params");
+
+    if (params == NULL) {
+        memset(out, 0, sizeof(*out));
+        return 0;
+    }
+    return json_extract_str_array(params, field, out);
+}
+
+static void string_array_free(StringArray *arr) {
+    if (!arr) {
+        return;
+    }
+    for (size_t i = 0; i < arr->len; i++) {
+        free(arr->items[i]);
+    }
+    free(arr->items);
+    arr->items = NULL;
+    arr->len = 0;
+}
+
+static void parse_request_options_free(ParseRequestOptions *config) {
+    if (!config) {
+        return;
+    }
+    string_array_free(&config->clang_args);
+    pk_c_compile_context_free(config->compile_context);
+    free(config->parse_backend);
+    free(config->compile_context_kind);
+    free(config->workspace_root);
+    free(config->compile_command);
+    free(config->target_triple);
+    memset(config, 0, sizeof(*config));
+}
+
+static int parse_backend_from_name(const char *name, pk_c_parse_backend *backend) {
+    if (!backend) {
+        return -1;
+    }
+    *backend = PK_C_PARSE_BACKEND_AUTO;
+    if (!name || !*name || strcmp(name, "auto") == 0) {
+        return 0;
+    }
+    if (strcmp(name, "regex") == 0) {
+        *backend = PK_C_PARSE_BACKEND_REGEX;
+        return 0;
+    }
+    if (strcmp(name, "clang_ast") == 0 || strcmp(name, "libclang") == 0) {
+        *backend = PK_C_PARSE_BACKEND_CLANG_AST;
+        return 0;
+    }
+    return -1;
+}
+
+static int parse_request_options_init(
+    ParseRequestOptions *config,
+    const char *line,
+    const char *path,
+    char *error,
+    size_t error_len
+) {
+    pk_c_parse_backend backend = PK_C_PARSE_BACKEND_AUTO;
+
+    memset(config, 0, sizeof(*config));
+    config->parse_backend = json_extract_param_str(line, "parse_backend");
+    if (!config->parse_backend) {
+        config->parse_backend = json_extract_param_str(line, "parser_backend");
+    }
+    if (parse_backend_from_name(config->parse_backend, &backend) != 0) {
+        (void)snprintf(error, error_len, "parse_backend must be auto, regex, or clang_ast");
+        return -1;
+    }
+    if (json_extract_param_str_array(line, "clang_args", &config->clang_args) != 0) {
+        (void)snprintf(error, error_len, "clang_args must be an array of strings");
+        return -1;
+    }
+    config->compile_context_kind = json_extract_param_str(line, "compile_context");
+    config->workspace_root = json_extract_param_str(line, "workspace_root");
+    if (config->compile_context_kind != NULL &&
+        config->compile_context_kind[0] != '\0' &&
+        strcmp(config->compile_context_kind, "none") != 0 &&
+        strcmp(config->compile_context_kind, "kernel") != 0) {
+        (void)snprintf(error, error_len, "compile_context must be none or kernel");
+        return -1;
+    }
+    config->resolve_kernel_context = config->compile_context_kind != NULL &&
+        strcmp(config->compile_context_kind, "kernel") == 0;
+    config->compile_command = json_extract_param_str(line, "compile_command");
+    config->target_triple = json_extract_param_str(line, "target_triple");
+
+    if (config->compile_command) {
+        config->compile_context = pk_c_compile_context_from_command(path, config->compile_command);
+        if (!config->compile_context) {
+            (void)snprintf(error, error_len, "compile_command could not be parsed");
+            return -1;
+        }
+        pk_c_compile_context_configure_parse_options(
+            config->compile_context,
+            backend,
+            &config->options);
+    } else if (config->resolve_kernel_context && path != NULL) {
+        config->compile_context = pk_c_compile_context_resolve_kernel(config->workspace_root, path);
+        if (!config->compile_context) {
+            (void)snprintf(error, error_len, "kernel compile context could not be resolved");
+            return -1;
+        }
+        pk_c_compile_context_configure_parse_options(
+            config->compile_context,
+            backend,
+            &config->options);
+    } else {
+        memset(&config->options, 0, sizeof(config->options));
+        config->options.backend = backend;
+    }
+
+    if (config->clang_args.len > 0) {
+        config->options.clang_args = (const char *const *)config->clang_args.items;
+        config->options.n_clang_args = config->clang_args.len;
+    }
+    if (config->target_triple) {
+        config->options.target_triple = config->target_triple;
+    }
+    return 0;
+}
+
+static int append_request_option_opacity(
+    pk_c_lift_result *result,
+    const ParseRequestOptions *config
+) {
+    if (!config || !config->compile_context ||
+        !config->compile_context->extraction_result) {
+        return 0;
+    }
+    return pk_c_lift_result_extend(result, config->compile_context->extraction_result);
+}
+
+static void parse_request_options_apply_overrides(
+    const ParseRequestOptions *config,
+    pk_c_parse_options *options
+) {
+    if (!config || !options) {
+        return;
+    }
+    if (config->clang_args.len > 0) {
+        options->clang_args = (const char *const *)config->clang_args.items;
+        options->n_clang_args = config->clang_args.len;
+    }
+    if (config->target_triple) {
+        options->target_triple = config->target_triple;
+    }
+}
+
+static int has_suffix(const char *s, const char *suffix) {
+    size_t sl = strlen(s);
+    size_t tl = strlen(suffix);
+    return sl >= tl && strcmp(s + sl - tl, suffix) == 0;
+}
+
+static char *join_path(const char *a, const char *b) {
+    size_t al = strlen(a);
+    size_t bl = strlen(b);
+    int needs_slash = al > 0 && a[al - 1] != '/';
+    char *out = malloc(al + (needs_slash ? 1u : 0u) + bl + 1u);
+    size_t pos = al;
+
+    if (!out) {
+        return NULL;
+    }
+
+    memcpy(out, a, al);
+    if (needs_slash) {
+        out[pos++] = '/';
+    }
+    memcpy(out + pos, b, bl);
+    out[pos + bl] = '\0';
+    return out;
+}
+
+static char *resolve_source_path(const char *workspace, const char *source_path) {
+    if (!source_path || !*source_path || strcmp(source_path, ".") == 0) {
+        return str_dup(workspace);
+    }
+    if (source_path[0] == '/') {
+        return str_dup(source_path);
+    }
+    return join_path(workspace, source_path);
+}
+
+static char *read_file(const char *path) {
+    FILE *f = fopen(path, "rb");
+    long len;
+    char *data;
+
+    if (!f) {
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    len = ftell(f);
+    if (len < 0) {
+        fclose(f);
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_SET) != 0) {
+        fclose(f);
+        return NULL;
+    }
+
+    data = malloc((size_t)len + 1u);
+    if (!data) {
+        fclose(f);
+        return NULL;
+    }
+    if (fread(data, 1, (size_t)len, f) != (size_t)len) {
+        free(data);
+        fclose(f);
+        return NULL;
+    }
+    data[len] = '\0';
+    fclose(f);
+    return data;
+}
+
+static void acc_init(LiftAccumulator *acc) {
+    memset(acc, 0, sizeof(*acc));
+    buf_init(&acc->ir);
+    buf_init(&acc->call_edges);
+    buf_init(&acc->diagnostics);
+    buf_init(&acc->opacity_report);
+    buf_init(&acc->refusals);
+}
+
+static void acc_free(LiftAccumulator *acc) {
+    buf_free(&acc->ir);
+    buf_free(&acc->call_edges);
+    buf_free(&acc->diagnostics);
+    buf_free(&acc->opacity_report);
+    buf_free(&acc->refusals);
+}
+
+static int acc_append_json_array(Buf *buf, size_t *count, const pk_c_json_array *items) {
+    for (size_t i = 0; i < items->len; i++) {
+        if (*count > 0 && buf_append_char(buf, ',') != 0) {
+            return -1;
+        }
+        if (buf_append(buf, items->items[i]) != 0) {
+            return -1;
+        }
+        (*count)++;
+    }
+    return 0;
+}
+
+static int acc_append_result(LiftAccumulator *acc, pk_c_lift_result *result) {
+    return acc_append_json_array(&acc->ir, &acc->ir_count, &result->declarations) == 0 &&
+        acc_append_json_array(&acc->call_edges, &acc->call_edge_count, &result->call_edges) == 0 &&
+        acc_append_json_array(&acc->diagnostics, &acc->diagnostic_count, &result->diagnostics) == 0 &&
+        acc_append_json_array(&acc->opacity_report, &acc->opacity_count, &result->opacity_report) == 0 &&
+        acc_append_json_array(&acc->refusals, &acc->refusal_count, &result->refusals) == 0
+        ? 0
+        : -1;
+}
+
+static int lift_one_file(
+    const char *path,
+    LiftAccumulator *acc,
+    const ParseRequestOptions *config
+) {
+    char *source = read_file(path);
+    pk_c_lift_result *result;
+    pk_c_compile_context *file_context = NULL;
+    pk_c_parse_options file_options;
+    const pk_c_parse_options *options = config == NULL ? NULL : &config->options;
+
+    if (!source) {
+        (void)snprintf(acc->error,
+            sizeof(acc->error),
+            "%s: read failed: %s",
+            path,
+            strerror(errno));
+        return -1;
+    }
+
+    if (config != NULL && config->resolve_kernel_context && config->compile_context == NULL) {
+        file_context = pk_c_compile_context_resolve_kernel(config->workspace_root, path);
+        if (file_context == NULL) {
+            free(source);
+            (void)snprintf(acc->error, sizeof(acc->error), "%s: kernel compile context failed", path);
+            return -1;
+        }
+        pk_c_compile_context_configure_parse_options(
+            file_context,
+            config->options.backend,
+            &file_options);
+        parse_request_options_apply_overrides(config, &file_options);
+        options = &file_options;
+    }
+
+    result = pk_c_kunit_lift_source_with_options(path, source, options);
+    free(source);
+    if (!result) {
+        pk_c_compile_context_free(file_context);
+        (void)snprintf(acc->error, sizeof(acc->error), "%s: lift failed", path);
+        return -1;
+    }
+    if (file_context != NULL && file_context->extraction_result != NULL &&
+        pk_c_lift_result_extend(result, file_context->extraction_result) != 0) {
+        pk_c_lift_result_free(result);
+        pk_c_compile_context_free(file_context);
+        (void)snprintf(acc->error, sizeof(acc->error), "%s: context opacity failed", path);
+        return -1;
+    }
+
+    if (acc_append_result(acc, result) != 0) {
+        pk_c_lift_result_free(result);
+        pk_c_compile_context_free(file_context);
+        (void)snprintf(acc->error, sizeof(acc->error), "out of memory aggregating %s", path);
+        return -1;
+    }
+
+    pk_c_lift_result_free(result);
+    pk_c_compile_context_free(file_context);
+    return 0;
+}
+
+static int walk_path(
+    const char *path,
+    LiftAccumulator *acc,
+    const ParseRequestOptions *config
+) {
+    struct stat st;
+    DIR *dir;
+    struct dirent *entry;
+
+    if (lstat(path, &st) != 0) {
+        (void)snprintf(acc->error,
+            sizeof(acc->error),
+            "%s: stat failed: %s",
+            path,
+            strerror(errno));
+        return -1;
+    }
+
+    if (S_ISLNK(st.st_mode)) {
+        return 0;
+    }
+
+    if (S_ISREG(st.st_mode)) {
+        return has_suffix(path, ".c") ? lift_one_file(path, acc, config) : 0;
+    }
+
+    if (!S_ISDIR(st.st_mode)) {
+        return 0;
+    }
+
+    dir = opendir(path);
+    if (!dir) {
+        (void)snprintf(acc->error,
+            sizeof(acc->error),
+            "%s: opendir failed: %s",
+            path,
+            strerror(errno));
+        return -1;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        char *child;
+        int rc;
+
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+
+        child = join_path(path, entry->d_name);
+        if (!child) {
+            closedir(dir);
+            (void)snprintf(acc->error, sizeof(acc->error), "out of memory walking %s", path);
+            return -1;
+        }
+
+        rc = walk_path(child, acc, config);
+        free(child);
+        if (rc != 0) {
+            closedir(dir);
+            return rc;
+        }
+    }
+
+    closedir(dir);
+    return 0;
+}
+
+static void send_response(const char *id, const char *result_json) {
+    printf("{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":%s}\n", id ? id : "null", result_json);
+    fflush(stdout);
+}
+
+static void send_error(const char *id, int code, const char *message) {
+    Buf b;
+    char code_buf[32];
+
+    buf_init(&b);
+    if (!b.data) {
+        printf("{\"jsonrpc\":\"2.0\",\"id\":%s,\"error\":{\"code\":-32603,\"message\":\"internal error\"}}\n",
+            id ? id : "null");
+        fflush(stdout);
+        return;
+    }
+
+    (void)snprintf(code_buf, sizeof(code_buf), "%d", code);
+    (void)buf_append(&b, "{\"code\":");
+    (void)buf_append(&b, code_buf);
+    (void)buf_append(&b, ",\"message\":");
+    json_escape_str(&b, message);
+    (void)buf_append_char(&b, '}');
+
+    printf("{\"jsonrpc\":\"2.0\",\"id\":%s,\"error\":%s}\n", id ? id : "null", b.data);
+    fflush(stdout);
+    buf_free(&b);
+}
+
+static void handle_initialize(const char *id) {
+    send_response(id,
+        "{\"capabilities\":{\"authoring_surfaces\":[\"c-kunit\"],"
+        "\"emits_signed_mementos\":false,\"ir_version\":\"v1.1.0\"},"
+        "\"name\":\"c-kunit\",\"protocol_version\":\"provekit-lift/1\","
+        "\"version\":\"0.1.0\"}");
+}
+
+static void handle_parse(const char *id, const char *line) {
+    char *path = json_extract_param_str(line, "path");
+    char *source = json_extract_param_str(line, "source");
+    ParseRequestOptions parse_config;
+    char option_error[256];
+    pk_c_lift_result *result;
+    char *json;
+
+    if (!source) {
+        free(path);
+        send_error(id, -32602, "missing source");
+        return;
+    }
+
+    if (parse_request_options_init(
+        &parse_config,
+        line,
+        path ? path : "source.c",
+        option_error,
+        sizeof(option_error)) != 0) {
+        parse_request_options_free(&parse_config);
+        free(path);
+        free(source);
+        send_error(id, -32602, option_error);
+        return;
+    }
+
+    result = pk_c_kunit_lift_source_with_options(
+        path ? path : "source.c",
+        source,
+        &parse_config.options);
+    if (!result) {
+        parse_request_options_free(&parse_config);
+        free(path);
+        free(source);
+        send_error(id, -32603, "internal error");
+        return;
+    }
+    if (append_request_option_opacity(result, &parse_config) != 0) {
+        pk_c_lift_result_free(result);
+        parse_request_options_free(&parse_config);
+        free(path);
+        free(source);
+        send_error(id, -32603, "internal error");
+        return;
+    }
+
+    json = pk_c_lift_result_to_json(result);
+    if (!json) {
+        pk_c_lift_result_free(result);
+        parse_request_options_free(&parse_config);
+        free(path);
+        free(source);
+        send_error(id, -32603, "internal error");
+        return;
+    }
+
+    send_response(id, json);
+
+    free(json);
+    pk_c_lift_result_free(result);
+    parse_request_options_free(&parse_config);
+    free(path);
+    free(source);
+}
+
+static void handle_lift(const char *id, const char *line) {
+    char *workspace = json_extract_param_str(line, "workspace_root");
+    char *surface = json_extract_param_str(line, "surface");
+    StringArray source_paths;
+    ParseRequestOptions parse_config;
+    char option_error[256];
+    LiftAccumulator acc;
+    Buf result;
+
+    if (!surface) {
+        free(workspace);
+        send_error(id, -32602, "surface must be a string");
+        return;
+    }
+    if (strcmp(surface, "c-kunit") != 0) {
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, "unsupported surface");
+        return;
+    }
+
+    if (!workspace || !*workspace) {
+        free(workspace);
+        workspace = str_dup(".");
+        if (!workspace) {
+            free(surface);
+            send_error(id, -32603, "out of memory");
+            return;
+        }
+    }
+
+    if (!json_has_param_field(line, "source_paths")) {
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, "source_paths must be a non-empty array of strings");
+        return;
+    }
+
+    if (json_extract_param_str_array(line, "source_paths", &source_paths) != 0) {
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, "source_paths must be an array of strings");
+        return;
+    }
+    if (source_paths.len == 0) {
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, "source_paths must be a non-empty array of strings");
+        return;
+    }
+    for (size_t i = 0; i < source_paths.len; i++) {
+        if (!source_paths.items[i] || !*source_paths.items[i]) {
+            string_array_free(&source_paths);
+            free(surface);
+            free(workspace);
+            send_error(id, -32602, "source_paths entries must be non-empty strings");
+            return;
+        }
+    }
+
+    if (parse_request_options_init(
+        &parse_config,
+        line,
+        NULL,
+        option_error,
+        sizeof(option_error)) != 0) {
+        parse_request_options_free(&parse_config);
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32602, option_error);
+        return;
+    }
+
+    acc_init(&acc);
+    if (!acc.ir.data || !acc.call_edges.data || !acc.diagnostics.data ||
+        !acc.opacity_report.data || !acc.refusals.data) {
+        acc_free(&acc);
+        parse_request_options_free(&parse_config);
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32603, "out of memory");
+        return;
+    }
+
+    for (size_t i = 0; i < source_paths.len; i++) {
+        char *resolved = resolve_source_path(workspace, source_paths.items[i]);
+        int rc;
+
+        if (!resolved) {
+            acc_free(&acc);
+            parse_request_options_free(&parse_config);
+            string_array_free(&source_paths);
+            free(surface);
+            free(workspace);
+            send_error(id, -32603, "out of memory");
+            return;
+        }
+
+        rc = walk_path(resolved, &acc, &parse_config);
+        free(resolved);
+        if (rc != 0) {
+            send_error(id, -32603, acc.error[0] ? acc.error : "lift failed");
+            acc_free(&acc);
+            parse_request_options_free(&parse_config);
+            string_array_free(&source_paths);
+            free(surface);
+            free(workspace);
+            return;
+        }
+    }
+
+    if (parse_config.compile_context != NULL &&
+        parse_config.compile_context->extraction_result != NULL &&
+        acc_append_result(&acc, parse_config.compile_context->extraction_result) != 0) {
+        send_error(id, -32603, "out of memory aggregating compile context opacity");
+        acc_free(&acc);
+        parse_request_options_free(&parse_config);
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        return;
+    }
+
+    buf_init(&result);
+    if (!result.data ||
+        buf_append(&result, "{\"declarations\":[") != 0 ||
+        buf_append(&result, acc.ir.data ? acc.ir.data : "") != 0 ||
+        buf_append(&result, "],\"callEdges\":[") != 0 ||
+        buf_append(&result, acc.call_edges.data ? acc.call_edges.data : "") != 0 ||
+        buf_append(&result, "],\"diagnostics\":[") != 0 ||
+        buf_append(&result, acc.diagnostics.data ? acc.diagnostics.data : "") != 0 ||
+        buf_append(&result, "],\"opacityReport\":[") != 0 ||
+        buf_append(&result, acc.opacity_report.data ? acc.opacity_report.data : "") != 0 ||
+        buf_append(&result, "],\"refusals\":[") != 0 ||
+        buf_append(&result, acc.refusals.data ? acc.refusals.data : "") != 0 ||
+        buf_append(&result, "],\"ir\":[") != 0 ||
+        buf_append(&result, acc.ir.data ? acc.ir.data : "") != 0 ||
+        buf_append(&result, "],\"kind\":\"ir-document\"}") != 0) {
+        buf_free(&result);
+        acc_free(&acc);
+        parse_request_options_free(&parse_config);
+        string_array_free(&source_paths);
+        free(surface);
+        free(workspace);
+        send_error(id, -32603, "out of memory");
+        return;
+    }
+
+    send_response(id, result.data);
+
+    buf_free(&result);
+    acc_free(&acc);
+    parse_request_options_free(&parse_config);
+    string_array_free(&source_paths);
+    free(surface);
+    free(workspace);
+}
+
+int main(int argc, char **argv) {
+    char *line = NULL;
+    size_t line_cap = 0;
+
+    if (argc != 2 || strcmp(argv[1], "--rpc") != 0) {
+        fprintf(stderr, "usage: %s --rpc\n", argv[0]);
+        return 1;
+    }
+
+    while (getline(&line, &line_cap, stdin) != -1) {
+        if (!validate_json_request(line)) {
+            send_error("null", -32700, "parse error");
+            continue;
+        }
+
+        char *id = json_extract_id(line);
+        char *method = json_extract_str(line, "method");
+
+        if (!id) {
+            id = str_dup("null");
+        }
+
+        if (!method) {
+            send_error(id, -32700, "parse error: missing method");
+        } else if (strcmp(method, "initialize") == 0) {
+            handle_initialize(id);
+        } else if (strcmp(method, "parse") == 0) {
+            handle_parse(id, line);
+        } else if (strcmp(method, "lift") == 0) {
+            handle_lift(id, line);
+        } else if (strcmp(method, "shutdown") == 0) {
+            send_response(id, "null");
+            free(method);
+            free(id);
+            break;
+        } else {
+            send_error(id, -32601, "unknown method");
+        }
+
+        free(method);
+        free(id);
+    }
+
+    free(line);
+    return 0;
+}

--- a/implementations/c/provekit-lift-c-kunit/tests/fixtures/kunit_basic.c
+++ b/implementations/c/provekit-lift-c-kunit/tests/fixtures/kunit_basic.c
@@ -1,0 +1,24 @@
+struct kunit {};
+
+#define KUNIT_CASE(fn) { fn }
+
+static int add_one(int x) {
+    return x + 1;
+}
+
+static void pk_basic_test(struct kunit *test) {
+    int x = 5;
+
+    KUNIT_EXPECT_EQ(test, x, 5);
+    KUNIT_EXPECT_NE(test, add_one(1), 1);
+    KUNIT_EXPECT_TRUE(test, x > 0);
+    KUNIT_EXPECT_NOT_NULL(test, test);
+}
+
+struct kunit_case {
+    void (*run_case)(struct kunit *test);
+};
+
+static struct kunit_case pk_cases[] = {
+    KUNIT_CASE(pk_basic_test),
+};

--- a/implementations/c/provekit-lift-c-kunit/tests/integration.sh
+++ b/implementations/c/provekit-lift-c-kunit/tests/integration.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="$SCRIPT_DIR/../provekit-lift-c-kunit"
+FIXTURE="$SCRIPT_DIR/fixtures/kunit_basic.c"
+
+if [ ! -x "$BIN" ]; then
+    echo "FAIL: binary not found: $BIN" >&2
+    exit 1
+fi
+
+if [ ! -f "$FIXTURE" ]; then
+    echo "FAIL: fixture not found: $FIXTURE" >&2
+    exit 1
+fi
+
+RESPONSES="$(
+    {
+        printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+        printf '{"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":'
+        printf '"%s"' "$SCRIPT_DIR/fixtures"
+        printf ',"source_paths":["kunit_basic.c"],"surface":"c-kunit"}}\n'
+        printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"shutdown"}'
+    } | "$BIN" --rpc
+)"
+
+printf '%s\n' "$RESPONSES" | grep -q '"name":"c-kunit"' || {
+    echo "FAIL: initialize missing c-kunit name" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"protocol_version":"provekit-lift/1"' || {
+    echo "FAIL: initialize missing protocol version" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"kind":"ir-document"' || {
+    echo "FAIL: lift missing ir-document kind" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+CONTRACT_COUNT=$(printf '%s\n' "$RESPONSES" | grep -o '"fn_name":"pk_basic_test::[0-9]"' | sort -u | wc -l | tr -d ' ')
+if [ "$CONTRACT_COUNT" -ne 4 ]; then
+    echo "FAIL: expected 4 KUnit contracts, got $CONTRACT_COUNT" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+fi
+
+for name in pk_basic_test::0 pk_basic_test::1 pk_basic_test::2 pk_basic_test::3; do
+    printf '%s\n' "$RESPONSES" | grep -q "\"fn_name\":\"$name\"" || {
+        echo "FAIL: missing contract $name" >&2
+        echo "$RESPONSES" >&2
+        exit 1
+    }
+done
+
+printf '%s\n' "$RESPONSES" | grep -q '"post":{"kind":"atomic","name":"eq","args":\[{"kind":"var","name":"x"},{"kind":"const","value":5,"sort":{"kind":"primitive","name":"Int"}}\]}' || {
+    echo "FAIL: KUNIT_EXPECT_EQ(test, x, 5) did not lift to eq(x, 5)" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"post":{"kind":"atomic","name":"ne","args":\[{"kind":"ctor","name":"add_one","args":\[{"kind":"const","value":1,"sort":{"kind":"primitive","name":"Int"}}\]},{"kind":"const","value":1,"sort":{"kind":"primitive","name":"Int"}}\]}' || {
+    echo "FAIL: KUNIT_EXPECT_NE(test, add_one(1), 1) did not lift to ne(add_one(1), 1)" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"post":{"kind":"atomic","name":"gt","args":\[{"kind":"var","name":"x"},{"kind":"const","value":0,"sort":{"kind":"primitive","name":"Int"}}\]}' || {
+    echo "FAIL: KUNIT_EXPECT_TRUE(test, x > 0) did not lift to gt(x, 0)" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf '%s\n' "$RESPONSES" | grep -q '"post":{"kind":"atomic","name":"ne","args":\[{"kind":"var","name":"test"},{"kind":"ctor","name":"NULL","args":\[\]}\]}' || {
+    echo "FAIL: KUNIT_EXPECT_NOT_NULL(test, test) did not lift to ne(test, NULL)" >&2
+    echo "$RESPONSES" >&2
+    exit 1
+}
+
+printf 'provekit-lift-c-kunit integration passed: %s contracts from %s KUNIT_* macros\n' "$CONTRACT_COUNT" "$CONTRACT_COUNT"


### PR DESCRIPTION
## Summary

New C lifter that mints contracts from KUnit test bodies. **Mirror of `provekit-lift-rust-tests` for C** — test code is de facto specification, every assertion is an executable contract.

PR 3 of the C lifter family design (docs/explanation/c-lifter-family.md, merged in #520).

## What it lifts

| KUnit macro | Lifted formula |
|---|---|
| `KUNIT_EXPECT_EQ(test, a, b)` | `eq(a, b)` |
| `KUNIT_EXPECT_NE(test, a, b)` | `ne(a, b)` |
| `KUNIT_EXPECT_TRUE(test, expr)` | `expr` |
| `KUNIT_EXPECT_FALSE(test, expr)` | `not(expr)` |
| `KUNIT_EXPECT_NULL(test, p)` | `eq(p, NULL)` |
| `KUNIT_EXPECT_NOT_NULL(test, p)` | `ne(p, NULL)` |
| `KUNIT_EXPECT_LT/LE/GT/GE(test, a, b)` | `<op>(a, b)` |
| `KUNIT_ASSERT_*` | Same formulas, recorded as harder strength |

KUnit-specific wrinkle: macros take `struct kunit *test` as first arg — lifter skips it, lifts remaining args.

Test detection: `KUNIT_CASE(name)` registrations preferred, fallback to signature `void <name>(struct kunit *test)`.

Output: one ContractDecl per macro, named `<test_fn>::<index>`, following the WireFunctionContractMemento JSON shape used by the c-walker lifter.

## Smoke

Local `make test`: PASS — `provekit-lift-c-kunit integration passed: 4 contracts from 4 KUNIT_* macros`

Container on battleaxe (gold image `provekit-sweep:dev`, fresh clone of this branch): same — 4 contracts from 4 KUNIT_* macros.

## Follow-ups (not in this PR)

- The gold container's entrypoint loop has been updated to add `provekit-lift-c-kunit` to the build list (entrypoint.sh on user's Mac, scp'd to battleaxe; not in this repo)
- Real kernel KUnit test files (e.g. `lib/kunit/string-stream-test.c`) should produce contracts on production functions called by tests; that gate is for when the parser-side arity work (#524) and c-walker defensive patterns (Task B) compose with kunit contracts on chains crossing test→production

T Savo