### PR TITLE
rust-tests: attach contracts to callee callsite

### DIFF
--- a/implementations/rust/provekit-lift-rust-tests/Cargo.toml
+++ b/implementations/rust/provekit-lift-rust-tests/Cargo.toml
@@ -9,7 +9,7 @@ description = "ProvekIt lift adapter: walk #[test] / #[tokio::test] functions an
 [dependencies]
 provekit-ir-symbolic = { path = "../provekit-ir-symbolic" }
 syn = { workspace = true }
-proc-macro2 = { workspace = true }
+proc-macro2 = { workspace = true, features = ["span-locations"] }
 quote = { workspace = true }
 
 [dev-dependencies]

--- a/implementations/rust/provekit-lift-rust-tests/README.md
+++ b/implementations/rust/provekit-lift-rust-tests/README.md
@@ -9,25 +9,28 @@ Lift unit tests as point-specific behavior witnesses.
 ## What it does
 
 Walks the `syn` AST of a Rust source file looking for `#[test]` and
-`#[tokio::test]` functions. Inside each function body, every assertion macro
-invocation (`assert_eq!`, `assert_ne!`, `assert!`, `assert_matches!`) becomes
-its own `ContractDecl` whose `inv` field is the lifted atomic predicate.
+`#[tokio::test]` functions. Inside each function body, assertion macros
+(`assert_eq!`, `assert_ne!`, `assert!`, `assert_matches!`) become
+`ContractDecl`s only when the asserted value can be tied to a producer
+callsite. Let-bound observations such as `let r = foo(5); assert_eq!(r, 10);`
+are attached to the `foo(5)` callsite and substitute the binding into the
+lifted formula.
 
-Naming: `<test_function_name>::<assertion_index>` (zero-indexed, in source
-order). Three asserts in one test produce three contracts.
+Naming: `<callee>@<file>:<line>:<col>`. Multi-call assertions produce one
+contract per callsite. Assertions with no identifiable callsite skip with a
+warning.
 
-## v0 grammar (whitelist)
+## v0.5 grammar (whitelist)
 
-For each side of an assertion expression we accept:
+For assertion expressions we accept identifiers, integer/string/byte-string/bool
+literals, paths, calls, method calls, references, casts, parens, arrays,
+tuples, `vec![]`, and supported binary/unary operand shapes. Calls are lifted
+as constructors in the formula; method calls use the same one-level UFCS
+flattening as the adapter code.
 
-- identifier (lifted to `Var`)
-- integer literal (lifted to `Const(Int)`)
-- string literal (lifted to `Const(String)`)
-- single-arg call (lifted to `Ctor` with one arg)
-
-Anything else (method calls, field access, indexing, multi-arg non-ctor
-calls, arithmetic in the test body, randomness, filesystem ops) is SKIPPED
-with a warning. Honest skips beat polluted lattices.
+Anything outside the whitelist, or any liftable assertion with no identifiable
+producer callsite, is SKIPPED with a warning. Honest skips beat polluted
+lattices.
 
 `assert_matches!` is recognized only when the pattern is `Ok(<lit>)` /
 `Err(<lit>)` / `Some(<lit>)` / `None` / a single bare ctor over literals;

--- a/implementations/rust/provekit-lift-rust-tests/src/layer2.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/layer2.rs
@@ -33,7 +33,7 @@
 //           assert_palindrome("racecar");
 //           assert_palindrome("level");
 //       }
-//   Lift to: ONE memento per call site, body = the helper's lifted
+//   Lift to: ONE memento per helper call site, body = the helper's lifted
 //   assertion with the formal parameter substituted by the literal
 //   argument at the call. Helper is defined IN THE SAME `syn::File`.
 //   Helpers with multiple statements, multiple params, or non-liftable
@@ -46,7 +46,7 @@
 //           assert_<...>;
 //           ...
 //       }
-//   Lift to: ONE memento, body = and_(...) of all liftable atoms.
+//   Lift to: ONE memento per assertion producer callsite.
 //   When ANY top-level statement is not a liftable assert (let, side-
 //   effecting call, branching), the whole pattern SKIPS , Layer 0 will
 //   then see each assert independently. We deliberately require every
@@ -65,10 +65,10 @@
 //   - Pattern 1 wraps with `Formula::Quantifier { name: <loop var ident> }`
 //     (NOT the kit's `_xN` placeholder) so the canonical IR is stable
 //     across runs.
-//   - Pattern 2 contract names: "<test>::call::<i>" zero-indexed in
-//     source order. Same call expression in two tests dedups at mint.
-//   - Pattern 3 contract name: just "<test>" (no ::N suffix). Marks the
-//     test as conjunctively characterized.
+//   - Pattern 2 contract names use the helper callsite:
+//     "<helper>@<file>:<line>:<col>".
+//   - Pattern 3 contract names use each assertion producer callsite:
+//     "<callee>@<file>:<line>:<col>".
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -79,9 +79,10 @@ use provekit_ir_symbolic::{
 };
 
 use crate::{
-    is_assertion_macro_pub, lift_assertion_macro_pub, path_to_string_pub, translate_term_pub,
-    LiftWarning,
+    callsite_contract_name_pub, is_assertion_macro_pub, lift_assertion_macro_at_callsites_pub,
+    lift_assertion_macro_pub, path_to_string_pub, translate_term_pub, BoundCall, LiftWarning,
 };
+use syn::spanned::Spanned;
 
 /// Output of a Layer 2 pass over a `syn::File`. Carries the same
 /// shape as Layer 0's `AdapterOutput` so the dispatcher can fold it
@@ -383,8 +384,9 @@ fn classify_for_loop(
         }
     };
 
-    let inner_formula = match lift_assertion_macro_pub(&mac) {
-        Ok(f) => f,
+    let bindings: BTreeMap<String, BoundCall> = BTreeMap::new();
+    let parts = match lift_assertion_macro_at_callsites_pub(&mac, source_path, &bindings) {
+        Ok(parts) => parts,
         Err(e) => {
             out.bounded_loop_skipped += 1;
             out.warnings.push(LiftWarning {
@@ -396,34 +398,35 @@ fn classify_for_loop(
         }
     };
 
-    // Build forall x:Int. (lo <= x AND x </<= hi) -> inner.
-    let var_term = make_var(var_name.clone());
-    let lower = gte(var_term.clone(), lo_term);
-    let upper = if inclusive {
-        lte(var_term.clone(), hi_term)
-    } else {
-        lt(var_term.clone(), hi_term)
-    };
-    let antecedent = and_(vec![lower, upper]);
-    let body_formula = connective_("implies", vec![antecedent, inner_formula]);
+    for part in parts {
+        let var_term = make_var(var_name.clone());
+        let lower = gte(var_term.clone(), lo_term.clone());
+        let upper = if inclusive {
+            lte(var_term.clone(), hi_term.clone())
+        } else {
+            lt(var_term.clone(), hi_term.clone())
+        };
+        let antecedent = and_(vec![lower, upper]);
+        let body_formula = connective_("implies", vec![antecedent, part.formula]);
 
-    let quantified = Rc::new(Formula::Quantifier {
-        kind: "forall".into(),
-        name: var_name,
-        sort: Int(),
-        body: body_formula,
-    });
+        let quantified = Rc::new(Formula::Quantifier {
+            kind: "forall".into(),
+            name: var_name.clone(),
+            sort: Int(),
+            body: body_formula,
+        });
 
-    out.decls.push(ContractDecl {
-        name: test_name.to_string(),
-        pre: None,
-        post: None,
-        inv: Some(quantified),
-        out_binding: "out".into(),
-        evidence: None,
-    });
-    out.lifted += 1;
-    out.bounded_loop_lifted += 1;
+        out.decls.push(ContractDecl {
+            name: part.name,
+            pre: None,
+            post: None,
+            inv: Some(quantified),
+            out_binding: "out".into(),
+            evidence: None,
+        });
+        out.lifted += 1;
+        out.bounded_loop_lifted += 1;
+    }
 }
 
 fn has_nested_for_loop(stmt: &syn::Stmt) -> bool {
@@ -499,6 +502,7 @@ struct HelperCall {
     helper_name: String,
     /// The single argument expression at the call site.
     arg: syn::Expr,
+    span: proc_macro2::Span,
 }
 
 /// If every top-level statement is a call to a known helper, return the
@@ -535,6 +539,7 @@ fn collect_helper_calls(
         calls.push(HelperCall {
             helper_name: callee,
             arg,
+            span: call.span(),
         });
     }
     Some(calls)
@@ -549,9 +554,9 @@ fn classify_helper_inlining(
 ) {
     out.claimed_tests.insert(test_name.to_string());
 
-    for (i, call) in calls.iter().enumerate() {
+    for call in calls {
         out.seen += 1;
-        let memento_name = format!("{test_name}::call::{i}");
+        let memento_name = callsite_contract_name_pub(&call.helper_name, source_path, call.span);
         let helper = helpers
             .get(&call.helper_name)
             .expect("helper presence verified by collect_helper_calls");
@@ -736,15 +741,16 @@ fn classify_characterization(
     out.claimed_tests.insert(test_name.to_string());
     out.seen += 1;
 
-    let mut atoms: Vec<Rc<Formula>> = Vec::new();
+    let bindings: BTreeMap<String, BoundCall> = BTreeMap::new();
+    let mut parts = Vec::new();
     let mut skipped_atoms: Vec<String> = Vec::new();
     for (i, m) in macs.iter().enumerate() {
-        match lift_assertion_macro_pub(m) {
-            Ok(f) => atoms.push(f),
+        match lift_assertion_macro_at_callsites_pub(m, source_path, &bindings) {
+            Ok(mut lifted) => parts.append(&mut lifted),
             Err(e) => skipped_atoms.push(format!("#{i}: {e}")),
         }
     }
-    if atoms.len() < 2 {
+    if parts.len() < 2 {
         // Not enough liftable atoms to call this a characterization.
         // Drop the claim so Layer 0 can still try the individual asserts.
         out.claimed_tests.remove(test_name);
@@ -754,31 +760,32 @@ fn classify_characterization(
             item_name: test_name.into(),
             reason: format!(
                 "layer2 characterization: only {} of {} asserts were liftable; releasing to layer 0",
-                atoms.len(),
+                parts.len(),
                 macs.len()
             ),
         });
         return;
     }
 
-    let body = and_(atoms);
-    out.decls.push(ContractDecl {
-        name: test_name.to_string(),
-        pre: None,
-        post: None,
-        inv: Some(body),
-        out_binding: "out".into(),
-        evidence: None,
-    });
-    out.lifted += 1;
-    out.characterization_lifted += 1;
+    for part in parts {
+        out.decls.push(ContractDecl {
+            name: part.name,
+            pre: None,
+            post: None,
+            inv: Some(part.formula),
+            out_binding: "out".into(),
+            evidence: None,
+        });
+        out.lifted += 1;
+        out.characterization_lifted += 1;
+    }
 
     if !skipped_atoms.is_empty() {
         out.warnings.push(LiftWarning {
             source_path: source_path.into(),
             item_name: test_name.into(),
             reason: format!(
-                "layer2 characterization: {} atoms skipped from conjunction: {}",
+                "layer2 characterization: {} atoms skipped from callsite lift: {}",
                 skipped_atoms.len(),
                 skipped_atoms.join("; ")
             ),
@@ -798,13 +805,32 @@ mod tests {
         syn::parse_file(src).unwrap()
     }
 
+    fn assert_callsite_name(name: &str, callee: &str) {
+        let prefix = format!("{callee}@t.rs:");
+        assert!(
+            name.starts_with(&prefix),
+            "expected `{name}` to start with `{prefix}`"
+        );
+        let rest = &name[prefix.len()..];
+        let parts: Vec<_> = rest.split(':').collect();
+        assert_eq!(parts.len(), 2, "expected <line>:<col>, got `{rest}`");
+        assert!(parts[0].parse::<usize>().unwrap() > 0);
+        parts[1].parse::<usize>().unwrap();
+        assert!(
+            !name.starts_with("squares_are_nonneg")
+                && !name.starts_with("palindromes")
+                && !name.starts_with("three_facts"),
+            "old test-owned name leaked: {name}"
+        );
+    }
+
     #[test]
     fn pattern1_bounded_loop_lifts_to_forall_implies() {
         let src = r#"
             #[test]
             fn squares_are_nonneg() {
                 for x in 0..100 {
-                    assert!(x >= 0);
+                    assert!(square(x) >= 0);
                 }
             }
         "#;
@@ -813,6 +839,7 @@ mod tests {
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
         assert_eq!(out.bounded_loop_lifted, 1);
         assert!(out.claimed_tests.contains("squares_are_nonneg"));
+        assert_callsite_name(&out.decls[0].name, "square");
         let inv = out.decls[0].inv.as_ref().unwrap();
         match &**inv {
             Formula::Quantifier { kind, name, .. } => {
@@ -829,13 +856,14 @@ mod tests {
             #[test]
             fn inclusive() {
                 for x in 0..=10 {
-                    assert!(x >= 0);
+                    assert!(bounded(x) >= 0);
                 }
             }
         "#;
         let f = parse(src);
         let out = lift_file_layer2(&f, "t.rs");
         assert_eq!(out.lifted, 1);
+        assert_callsite_name(&out.decls[0].name, "bounded");
     }
 
     #[test]
@@ -892,12 +920,14 @@ mod tests {
         assert_eq!(out.lifted, 2, "warnings: {:?}", out.warnings);
         assert_eq!(out.helper_inlined_lifted, 2);
         let names: Vec<_> = out.decls.iter().map(|d| d.name.as_str()).collect();
-        assert!(names.contains(&"palindromes::call::0"));
-        assert!(names.contains(&"palindromes::call::1"));
+        assert_eq!(names.len(), 2);
+        for name in names {
+            assert_callsite_name(name, "assert_palindrome");
+        }
     }
 
     #[test]
-    fn pattern3_characterization_lifts_to_conjunction() {
+    fn pattern3_characterization_lifts_per_callsite() {
         let src = r#"
             #[test]
             fn three_facts() {
@@ -908,15 +938,12 @@ mod tests {
         "#;
         let f = parse(src);
         let out = lift_file_layer2(&f, "t.rs");
-        assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
-        assert_eq!(out.characterization_lifted, 1);
-        let inv = out.decls[0].inv.as_ref().unwrap();
-        match &**inv {
-            Formula::Connective { kind, operands } => {
-                assert_eq!(kind, "and");
-                assert_eq!(operands.len(), 3);
-            }
-            _ => panic!("expected and"),
+        assert_eq!(out.lifted, 3, "warnings: {:?}", out.warnings);
+        assert_eq!(out.characterization_lifted, 3);
+        let names: Vec<_> = out.decls.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names.len(), 3);
+        for name in names {
+            assert_callsite_name(name, "f");
         }
     }
 

--- a/implementations/rust/provekit-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/lib.rs
@@ -3,9 +3,9 @@
 // provekit-lift-rust-tests
 //
 // Walks the syn AST of a Rust source file looking for `#[test]` and
-// `#[tokio::test]` functions. For each, scans the function body for
-// assertion-macro invocations and lifts EACH assertion to its own
-// content-addressed ContractDecl.
+// `#[tokio::test]` functions. For each assertion macro, identifies the
+// producer callsite for the asserted value and lifts one content-addressed
+// ContractDecl per callsite.
 //
 // THE FRAMING:
 //
@@ -57,24 +57,25 @@
 // JCS invariants operationally enforced but un-lifted. v0.5 admits the
 // idiomatic "compose a constructor, call a function, compare" shape.
 //
-// Naming convention: contract name = "<test_function_name>::<index>",
-// where index counts assertion-macro statements zero-indexed in source
-// order. The semantics: each assertion is independently a witness; if
-// the file later splits an assert into two, the new one mints a fresh
-// CID without invalidating the others.
+// Naming convention: contract name = "<callee>@<file>:<line>:<col>",
+// where the locus is the call expression that produced the asserted value.
+// Let-bound observations substitute the latest visible `let name = <call>`
+// binding into the lifted formula before emission. Assertions with no
+// identifiable producer callsite skip with a LiftWarning.
 //
 // Each lifted ContractDecl has:
-//   - name           = "<test_fn>::<i>"
+//   - name           = "<callee>@<file>:<line>:<col>"
 //   - inv            = the lifted atomic Formula (closed; no foralls)
 //   - pre/post       = None
 //   - out_binding    = "out" (unused; provided for ContractDecl shape parity)
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use provekit_ir_symbolic::{
     eq, gt, gte, lt, lte, make_var, ne, num, str_const, ContractDecl, Formula, Term,
 };
+use syn::spanned::Spanned;
 
 pub mod layer2;
 pub use layer2::{lift_file_layer2, Layer2Output};
@@ -101,6 +102,35 @@ pub(crate) fn path_to_string_pub(p: &syn::Path) -> String {
 
 pub(crate) fn translate_term_pub(expr: &syn::Expr) -> Result<Rc<Term>, String> {
     translate_term(expr)
+}
+
+pub(crate) fn lift_assertion_macro_at_callsites_pub(
+    mac: &syn::Macro,
+    source_path: &str,
+    bindings: &BTreeMap<String, BoundCall>,
+) -> Result<Vec<LiftedCallsiteAssertion>, String> {
+    lift_assertion_macro_at_callsites(mac, source_path, bindings)
+}
+
+pub(crate) fn callsite_contract_name_pub(
+    callee: &str,
+    source_path: &str,
+    span: proc_macro2::Span,
+) -> String {
+    callsite_contract_name(callee, source_path, span)
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BoundCall {
+    pub(crate) callee: String,
+    pub(crate) span: proc_macro2::Span,
+    pub(crate) term: Rc<Term>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LiftedCallsiteAssertion {
+    pub(crate) name: String,
+    pub(crate) formula: Rc<Formula>,
 }
 
 #[derive(Debug, Clone)]
@@ -190,11 +220,10 @@ fn has_test_attr(attrs: &[syn::Attribute]) -> bool {
 
 fn visit_test_fn(f: &syn::ItemFn, source_path: &str, out: &mut AdapterOutput) {
     let test_name = f.sig.ident.to_string();
-    // Walk every statement in the body. Each macro statement that is
-    // an assertion macro increments the assertion index, regardless
-    // of whether it lifts cleanly.
-    let mut idx: usize = 0;
+    let mut bindings: BTreeMap<String, BoundCall> = BTreeMap::new();
     for stmt in &f.block.stmts {
+        update_call_bindings_from_stmt(stmt, &mut bindings);
+
         let mac_opt = match stmt {
             syn::Stmt::Macro(sm) => Some(&sm.mac),
             syn::Stmt::Expr(syn::Expr::Macro(em), _) => Some(&em.mac),
@@ -205,27 +234,356 @@ fn visit_test_fn(f: &syn::ItemFn, source_path: &str, out: &mut AdapterOutput) {
             continue;
         }
         out.seen += 1;
-        let memento_name = format!("{test_name}::{idx}");
-        idx += 1;
-        match lift_assertion_macro(mac) {
-            Ok(formula) => {
-                out.decls.push(ContractDecl {
-                    name: memento_name,
-                    pre: None,
-                    post: None,
-                    inv: Some(formula),
-                    out_binding: "out".into(),
-                    evidence: None,
-                });
-                out.lifted += 1;
+        match lift_assertion_macro_at_callsites(mac, source_path, &bindings) {
+            Ok(parts) => {
+                for part in parts {
+                    out.decls.push(ContractDecl {
+                        name: part.name,
+                        pre: None,
+                        post: None,
+                        inv: Some(part.formula),
+                        out_binding: "out".into(),
+                        evidence: None,
+                    });
+                    out.lifted += 1;
+                }
             }
             Err(reason) => {
                 out.warnings.push(LiftWarning {
                     source_path: source_path.into(),
-                    item_name: memento_name,
+                    item_name: test_name.clone(),
                     reason,
                 });
             }
+        }
+    }
+}
+
+fn update_call_bindings_from_stmt(stmt: &syn::Stmt, bindings: &mut BTreeMap<String, BoundCall>) {
+    let syn::Stmt::Local(local) = stmt else {
+        return;
+    };
+
+    let mut bound_names = Vec::new();
+    collect_pat_idents(&local.pat, &mut bound_names);
+    for name in &bound_names {
+        bindings.remove(name);
+    }
+
+    if bound_names.len() != 1 {
+        return;
+    }
+    let Some(init) = &local.init else {
+        return;
+    };
+    if let Some(call) = bound_call_from_expr(&init.expr) {
+        bindings.insert(bound_names.remove(0), call);
+    }
+}
+
+fn collect_pat_idents(pat: &syn::Pat, out: &mut Vec<String>) {
+    match pat {
+        syn::Pat::Ident(p) => out.push(p.ident.to_string()),
+        syn::Pat::Type(p) => collect_pat_idents(&p.pat, out),
+        syn::Pat::Reference(p) => collect_pat_idents(&p.pat, out),
+        syn::Pat::Paren(p) => collect_pat_idents(&p.pat, out),
+        syn::Pat::Tuple(p) => {
+            for elem in &p.elems {
+                collect_pat_idents(elem, out);
+            }
+        }
+        syn::Pat::TupleStruct(p) => {
+            for elem in &p.elems {
+                collect_pat_idents(elem, out);
+            }
+        }
+        syn::Pat::Struct(p) => {
+            for field in &p.fields {
+                collect_pat_idents(&field.pat, out);
+            }
+        }
+        syn::Pat::Slice(p) => {
+            for elem in &p.elems {
+                collect_pat_idents(elem, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn bound_call_from_expr(expr: &syn::Expr) -> Option<BoundCall> {
+    match expr {
+        syn::Expr::Call(c) => {
+            let syn::Expr::Path(p) = &*c.func else {
+                return None;
+            };
+            Some(BoundCall {
+                callee: path_final_segment(&p.path)?,
+                span: c.span(),
+                term: translate_term(expr).ok()?,
+            })
+        }
+        syn::Expr::MethodCall(mc) => Some(BoundCall {
+            callee: mc.method.to_string(),
+            span: mc.span(),
+            term: translate_term(expr).ok()?,
+        }),
+        syn::Expr::Paren(p) => bound_call_from_expr(&p.expr),
+        syn::Expr::Reference(r) => bound_call_from_expr(&r.expr),
+        syn::Expr::Cast(c) => bound_call_from_expr(&c.expr),
+        _ => None,
+    }
+}
+
+#[derive(Clone)]
+struct AssertionCallsite {
+    callee: String,
+    span: proc_macro2::Span,
+}
+
+fn lift_assertion_macro_at_callsites(
+    mac: &syn::Macro,
+    source_path: &str,
+    bindings: &BTreeMap<String, BoundCall>,
+) -> Result<Vec<LiftedCallsiteAssertion>, String> {
+    let formula = lift_assertion_macro(mac)?;
+    let exprs = assertion_observed_exprs(mac)?;
+    let mut callsites = Vec::new();
+    let mut substitutions: BTreeMap<String, Rc<Term>> = BTreeMap::new();
+    for expr in &exprs {
+        collect_expr_callsites(expr, bindings, &mut callsites, &mut substitutions);
+    }
+    if callsites.is_empty() {
+        return Err("assertion has no identifiable callsite".into());
+    }
+
+    let formula = subst_vars_in_formula(&formula, &substitutions);
+    let mut seen_names = BTreeSet::new();
+    let mut out = Vec::new();
+    for callsite in callsites {
+        let name = callsite_contract_name(&callsite.callee, source_path, callsite.span);
+        if seen_names.insert(name.clone()) {
+            out.push(LiftedCallsiteAssertion {
+                name,
+                formula: formula.clone(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+fn assertion_observed_exprs(mac: &syn::Macro) -> Result<Vec<syn::Expr>, String> {
+    let path = path_to_string(&mac.path);
+    match path.as_str() {
+        "assert_eq" => {
+            let pair: TwoExprs =
+                syn::parse2(mac.tokens.clone()).map_err(|e| format!("assert_eq: parse: {e}"))?;
+            Ok(vec![pair.a, pair.b])
+        }
+        "assert_ne" => {
+            let pair: TwoExprs =
+                syn::parse2(mac.tokens.clone()).map_err(|e| format!("assert_ne: parse: {e}"))?;
+            Ok(vec![pair.a, pair.b])
+        }
+        "assert" => {
+            let one: OneExpr =
+                syn::parse2(mac.tokens.clone()).map_err(|e| format!("assert: parse: {e}"))?;
+            Ok(vec![one.a])
+        }
+        "assert_matches" => {
+            let pair: ScrutineePattern = syn::parse2(mac.tokens.clone())
+                .map_err(|e| format!("assert_matches: parse: {e}"))?;
+            Ok(vec![pair.scrutinee])
+        }
+        other => Err(format!("not an assertion macro: {other}")),
+    }
+}
+
+fn collect_expr_callsites(
+    expr: &syn::Expr,
+    bindings: &BTreeMap<String, BoundCall>,
+    out: &mut Vec<AssertionCallsite>,
+    substitutions: &mut BTreeMap<String, Rc<Term>>,
+) {
+    match expr {
+        syn::Expr::Call(c) => {
+            if let syn::Expr::Path(p) = &*c.func {
+                if let Some(callee) = path_final_segment(&p.path) {
+                    out.push(AssertionCallsite {
+                        callee,
+                        span: c.span(),
+                    });
+                }
+            }
+        }
+        syn::Expr::MethodCall(mc) => out.push(AssertionCallsite {
+            callee: mc.method.to_string(),
+            span: mc.span(),
+        }),
+        syn::Expr::Path(p) => {
+            if let Some(id) = p.path.get_ident() {
+                if let Some(binding) = bindings.get(&id.to_string()) {
+                    out.push(AssertionCallsite {
+                        callee: binding.callee.clone(),
+                        span: binding.span,
+                    });
+                    substitutions.insert(id.to_string(), binding.term.clone());
+                }
+            }
+        }
+        syn::Expr::Binary(b) => {
+            collect_expr_callsites(&b.left, bindings, out, substitutions);
+            collect_expr_callsites(&b.right, bindings, out, substitutions);
+        }
+        syn::Expr::Paren(p) => collect_expr_callsites(&p.expr, bindings, out, substitutions),
+        syn::Expr::Reference(r) => collect_expr_callsites(&r.expr, bindings, out, substitutions),
+        syn::Expr::Cast(c) => collect_expr_callsites(&c.expr, bindings, out, substitutions),
+        syn::Expr::Tuple(t) => {
+            for elem in &t.elems {
+                collect_expr_callsites(elem, bindings, out, substitutions);
+            }
+        }
+        syn::Expr::Array(a) => {
+            for elem in &a.elems {
+                collect_expr_callsites(elem, bindings, out, substitutions);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn callsite_contract_name(callee: &str, source_path: &str, span: proc_macro2::Span) -> String {
+    let start = span.start();
+    format!("{callee}@{source_path}:{}:{}", start.line, start.column)
+}
+
+fn path_final_segment(path: &syn::Path) -> Option<String> {
+    path.segments.last().map(|seg| seg.ident.to_string())
+}
+
+fn subst_vars_in_formula(
+    f: &Rc<Formula>,
+    substitutions: &BTreeMap<String, Rc<Term>>,
+) -> Rc<Formula> {
+    if substitutions.is_empty() {
+        return f.clone();
+    }
+    match &**f {
+        Formula::Atomic { name, args } => {
+            let new_args: Vec<Rc<Term>> = args
+                .iter()
+                .map(|a| subst_vars_in_term(a, substitutions))
+                .collect();
+            Rc::new(Formula::Atomic {
+                name: name.clone(),
+                args: new_args,
+            })
+        }
+        Formula::Connective { kind, operands } => {
+            let new_ops: Vec<Rc<Formula>> = operands
+                .iter()
+                .map(|o| subst_vars_in_formula(o, substitutions))
+                .collect();
+            Rc::new(Formula::Connective {
+                kind: kind.clone(),
+                operands: new_ops,
+            })
+        }
+        Formula::Quantifier {
+            kind,
+            name,
+            sort,
+            body,
+        } => {
+            if substitutions.contains_key(name) {
+                f.clone()
+            } else {
+                Rc::new(Formula::Quantifier {
+                    kind: kind.clone(),
+                    name: name.clone(),
+                    sort: sort.clone(),
+                    body: subst_vars_in_formula(body, substitutions),
+                })
+            }
+        }
+        Formula::Choice {
+            var_name,
+            sort,
+            body,
+        } => {
+            if substitutions.contains_key(var_name) {
+                f.clone()
+            } else {
+                Rc::new(Formula::Choice {
+                    var_name: var_name.clone(),
+                    sort: sort.clone(),
+                    body: subst_vars_in_formula(body, substitutions),
+                })
+            }
+        }
+    }
+}
+
+fn subst_vars_in_term(t: &Rc<Term>, substitutions: &BTreeMap<String, Rc<Term>>) -> Rc<Term> {
+    match &**t {
+        Term::Var { name } => substitutions
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| t.clone()),
+        Term::Const { .. } => t.clone(),
+        Term::Ctor { name, args } => {
+            let new_args: Vec<Rc<Term>> = args
+                .iter()
+                .map(|a| subst_vars_in_term(a, substitutions))
+                .collect();
+            Rc::new(Term::Ctor {
+                name: name.clone(),
+                args: new_args,
+            })
+        }
+        Term::Lambda {
+            param_name,
+            param_sort,
+            body,
+        } => {
+            if substitutions.contains_key(param_name) {
+                t.clone()
+            } else {
+                Rc::new(Term::Lambda {
+                    param_name: param_name.clone(),
+                    param_sort: param_sort.clone(),
+                    body: subst_vars_in_term(body, substitutions),
+                })
+            }
+        }
+        Term::Let { bindings, body } => {
+            let mut new_bindings = Vec::new();
+            let mut shadowed = false;
+            for b in bindings {
+                if !shadowed {
+                    new_bindings.push(provekit_ir_symbolic::LetBinding {
+                        name: b.name.clone(),
+                        bound_term: subst_vars_in_term(&b.bound_term, substitutions),
+                    });
+                    if substitutions.contains_key(&b.name) {
+                        shadowed = true;
+                    }
+                } else {
+                    new_bindings.push(provekit_ir_symbolic::LetBinding {
+                        name: b.name.clone(),
+                        bound_term: b.bound_term.clone(),
+                    });
+                }
+            }
+            let new_body = if shadowed {
+                body.clone()
+            } else {
+                subst_vars_in_term(body, substitutions)
+            };
+            Rc::new(Term::Let {
+                bindings: new_bindings,
+                body: new_body,
+            })
         }
     }
 }
@@ -655,6 +1013,23 @@ mod tests {
         syn::parse_file(src).unwrap()
     }
 
+    fn assert_callsite_name(name: &str, callee: &str) {
+        let prefix = format!("{callee}@t.rs:");
+        assert!(
+            name.starts_with(&prefix),
+            "expected `{name}` to start with `{prefix}`"
+        );
+        let rest = &name[prefix.len()..];
+        let parts: Vec<_> = rest.split(':').collect();
+        assert_eq!(parts.len(), 2, "expected <line>:<col>, got `{rest}`");
+        assert!(parts[0].parse::<usize>().unwrap() > 0);
+        parts[1].parse::<usize>().unwrap();
+        assert!(
+            !name.starts_with("parse_int_42::") && !name.starts_with("three_facts::"),
+            "old test-owned name leaked: {name}"
+        );
+    }
+
     #[test]
     fn lifts_simple_assert_eq() {
         let src = r#"
@@ -666,7 +1041,7 @@ mod tests {
         let f = parse(src);
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
-        assert_eq!(out.decls[0].name, "parse_int_42::0");
+        assert_callsite_name(&out.decls[0].name, "parse_int");
         assert!(out.decls[0].inv.is_some());
     }
 
@@ -684,10 +1059,10 @@ mod tests {
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 3, "warnings: {:?}", out.warnings);
         let names: Vec<_> = out.decls.iter().map(|d| d.name.as_str()).collect();
-        assert_eq!(
-            names,
-            vec!["three_facts::0", "three_facts::1", "three_facts::2"]
-        );
+        assert_eq!(names.len(), 3);
+        for name in names {
+            assert_callsite_name(name, "f");
+        }
     }
 
     #[test]
@@ -695,12 +1070,60 @@ mod tests {
         let src = r#"
             #[test]
             fn nonneg_one() {
-                assert!(some_value > 0);
+                assert!(some_value() > 0);
             }
         "#;
         let f = parse(src);
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+        assert_callsite_name(&out.decls[0].name, "some_value");
+    }
+
+    #[test]
+    fn let_bound_call_attaches_to_bound_callsite() {
+        let src = r#"
+            #[test]
+            fn test_foo() {
+                let r = foo(5);
+                assert_eq!(r, 10);
+            }
+        "#;
+        let f = parse(src);
+        let out = lift_file(&f, "t.rs");
+        assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+        assert_callsite_name(&out.decls[0].name, "foo");
+        let inv = out.decls[0].inv.as_ref().expect("inv");
+        let lhs = match &**inv {
+            Formula::Atomic { name, args } if name == "=" && args.len() == 2 => args[0].clone(),
+            other => panic!("expected atomic =, got {other:?}"),
+        };
+        match &*lhs {
+            Term::Ctor { name, args } => {
+                assert_eq!(name, "foo");
+                assert_eq!(args.len(), 1);
+            }
+            other => panic!("expected let binding to substitute to foo call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skips_literal_assertion_without_callsite() {
+        let src = r#"
+            #[test]
+            fn literal_fact() {
+                assert_eq!(1, 1);
+            }
+        "#;
+        let f = parse(src);
+        let out = lift_file(&f, "t.rs");
+        assert_eq!(out.seen, 1);
+        assert_eq!(out.lifted, 0);
+        assert_eq!(out.warnings.len(), 1);
+        assert!(
+            out.warnings[0].reason.contains("callsite"),
+            "warning should explain no callsite: {:?}",
+            out.warnings[0]
+        );
     }
 
     #[test]
@@ -714,6 +1137,7 @@ mod tests {
         let f = parse(src);
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+        assert_callsite_name(&out.decls[0].name, "g");
     }
 
     #[test]
@@ -729,6 +1153,7 @@ mod tests {
         let f = parse(src);
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+        assert_callsite_name(&out.decls[0].name, "len");
         // Inspect the IR: the LHS should be Ctor("len", [str_const("foo")]).
         let inv = out.decls[0].inv.as_ref().expect("inv");
         let lhs = match &**inv {
@@ -835,7 +1260,7 @@ mod tests {
         "#;
         let f = parse(src);
         let out = lift_file(&f, "t.rs");
-        assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+        assert_eq!(out.lifted, 2, "warnings: {:?}", out.warnings);
     }
 
     #[test]
@@ -849,7 +1274,7 @@ mod tests {
         "#;
         let f = parse(src);
         let out = lift_file(&f, "t.rs");
-        assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+        assert_eq!(out.lifted, 2, "warnings: {:?}", out.warnings);
     }
 
     #[test]

--- a/implementations/rust/provekit-lift-rust-tests/tests/round_trip.rs
+++ b/implementations/rust/provekit-lift-rust-tests/tests/round_trip.rs
@@ -2,8 +2,8 @@
 //
 // Integration test: end-to-end fixture lift -> mint -> .proof file ->
 // verifier load. Asserts:
-//   - 4 simple `assert_eq!` lifted
-//   - 1 `assert!` with binop lifted
+//   - 4 simple `assert_eq!` callsites lifted
+//   - 1 no-call `assert!` with binop skips honestly
 //   - 1 deliberately-skipped `format!()` macro operand produces a warning
 //     (v0.5 widened the operand whitelist to include method calls; the
 //      negative shape moved to format!-style operand-position macros)
@@ -43,7 +43,7 @@ fn neg_one_negates() {{
     assert_eq!(neg(1), -1);
 }}
 
-// 1 assert! with a binop body.
+// 1 assert! with no callsite.
 #[test]
 fn count_positive() {{
     assert!(count > 0);
@@ -61,7 +61,7 @@ fn skipped_format_macro() {{
 }
 
 #[test]
-fn fixture_lifts_5_skips_1_and_round_trips_through_verifier() {
+fn fixture_lifts_4_skips_2_and_round_trips_through_verifier() {
     // Per-test temp dir.
     let base = std::env::temp_dir();
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -97,16 +97,23 @@ fn fixture_lifts_5_skips_1_and_round_trips_through_verifier() {
         "expected 6 assertion candidates seen across the fixture"
     );
     assert_eq!(
-        rt.lifted, 5,
-        "expected 5 lifted (4 assert_eq! + 1 assert!), warnings: {:?}",
+        rt.lifted, 4,
+        "expected 4 lifted callsite assertions, warnings: {:?}",
         rt.warnings
     );
     assert_eq!(
         rt.warnings.len(),
-        1,
-        "expected exactly 1 honest skip (the format! macro assertion)"
+        2,
+        "expected exactly 2 honest skips (no callsite + format! macro)"
     );
-    assert!(rt.warnings[0].item_name.starts_with("skipped_format_macro"));
+    assert!(rt
+        .warnings
+        .iter()
+        .any(|w| w.item_name == "count_positive" && w.reason.contains("callsite")));
+    assert!(rt
+        .warnings
+        .iter()
+        .any(|w| w.item_name == "skipped_format_macro" && w.reason.contains("format")));
 
     // .proof filename = `<cid>.proof`.
     assert!(proof_path.exists(), "proof file should exist on disk");
@@ -130,10 +137,10 @@ fn fixture_lifts_5_skips_1_and_round_trips_through_verifier() {
         "verifier should have zero load errors, got {:?}",
         pool.load_errors
     );
-    // Each lifted assert is a unique-named contract -> one member each.
+    // Each lifted callsite assertion is a unique-named contract -> one member each.
     assert_eq!(
-        minted.member_count, 5,
-        "expected 5 distinct mementos (one per lifted assertion)"
+        minted.member_count, 4,
+        "expected 4 distinct mementos (one per lifted callsite assertion)"
     );
 
     println!("FIXTURE_PROOF_CID={}", minted.cid);


### PR DESCRIPTION
Same structural fix as c-kunit. Contracts now named <callee>@<file>:<line>:<col> attached to the producer callsite, not <test_fn>::<index> attached to the test method. Local: cargo test -p provekit-lift-rust-tests --release: 25 unit + 1 integration pass (was 12/13 RED). T Savo