### PR TITLE
[codex] python lifter: add production wp walk

### DIFF
--- a/implementations/python/provekit-lift-py-tests/README.md
+++ b/implementations/python/provekit-lift-py-tests/README.md
@@ -1,10 +1,10 @@
 # provekit-lift-py-tests
 
-Layer 2 structural lift adapter for Python tests (pytest + unittest). Walks
-the `ast` of a source file, recognizes four structural patterns Layer 0
-cannot, and emits canonical IR mementos with content-addressed BLAKE3-512
-hashes that are byte-identical to the Rust, TypeScript, and C++
-canonicalizers.
+Layer 2 structural lift adapter for Python tests (pytest + unittest), plus a
+production-side WP walker for Python callsite composition. It walks the `ast`
+of a source file, recognizes structural test patterns Layer 0 cannot, and
+emits canonical IR mementos with content-addressed BLAKE3-512 hashes that are
+byte-identical to the Rust, TypeScript, and C++ canonicalizers.
 
 ## Patterns
 
@@ -22,9 +22,24 @@ canonicalizers.
 4. **`@pytest.mark.parametrize` over a literal arg list.** Each row is
    substituted into the body, then folded to `and(...)`. Memento name:
    `<test>::parametrize::<param-names>`.
+5. **Callsite value-scope facts plus implications.** Local assignments and
+   simple `if/else` branches around pytest/unittest assertions become
+   callsite-owned contracts named `<callee>@<file>:<line>:<col>::facts`
+   and `<callee>@<file>:<line>:<col>::assertion`, plus an implication
+   from facts to assertion. Tests describe these contracts; they do not own
+   the emitted contract identity.
 
 Out of scope: `hypothesis` (Layer 1 already), `pytest.raises`, fixtures,
 parametrize over factories, multi-stmt loop bodies.
+
+## Production WP walk
+
+The production walker mirrors `provekit-walk` for Rust. It lifts callee
+preconditions from defensive source patterns such as `if cond: raise ...` and
+`assert cond`, substitutes actual arguments at each production callsite, then
+walks backward through in-scope assignments with `wp(x := e, P) = P[e/x]`.
+Each arrival is emitted as a callsite-owned contract edge with `pre` and
+`post` slots plus a `python-wp-walk` implication from `pre` to `post`.
 
 ## Dispatch model
 

--- a/implementations/python/provekit-lift-py-tests/pyproject.toml
+++ b/implementations/python/provekit-lift-py-tests/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "provekit-lift-py-tests"
 version = "0.1.0"
-description = "ProvekIt: Layer 2 structural lift adapter for Python pytest/unittest. Bounded loops, helper inlining, multi-assertion characterization, and parametrize as forall over the parameter set."
+description = "ProvekIt: Python pytest/unittest structural lifts plus production callsite WP walking."
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.8"
@@ -21,6 +21,7 @@ test = ["pytest>=7"]
 
 [project.scripts]
 provekit-lsp-python = "provekit_lift_py_tests.lsp:main"
+provekit-lift-python = "provekit_lift_py_tests.lsp:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/__init__.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/__init__.py
@@ -1,21 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# provekit-lift-py-tests : Layer 2 structural lift adapter for Python tests.
+# provekit-lift-py-tests : Python structural lift adapter.
 #
 # Layer 2 sits ABOVE Layer 0 (mechanical assert recognition; the future
 # Python Layer 0 will be analogous to the Rust one) and BELOW the
-# eventual Layer 3 LLM lift. It recognizes four structural patterns over
-# pytest/unittest test syntax that Layer 0 cannot, and emits canonical
-# IR mementos with content-addressed BLAKE3-512 hashes.
+# eventual Layer 3 LLM lift. It recognizes five structural patterns over
+# pytest/unittest test syntax that Layer 0 cannot. The production walker
+# mirrors Rust `provekit-walk`: callee preconditions are propagated
+# backward from Python production callsites to function entry as WP edges.
 #
 # Patterns:
 #   1. Bounded ``for`` loop -> forall-implies.
 #   2. Helper function inlined at each call site.
 #   3. Multi-assertion characterization conjunction.
 #   4. ``@pytest.mark.parametrize`` over a literal list -> enumerated and-conjunction.
+#   5. Callsite value-scope facts plus implication edges from tests.
 #
 # Out of scope for v0: ``hypothesis`` (Layer 1 already), ``pytest.raises``,
-# fixtures, parametrize over factories, nested loops, conditional bodies.
+# fixtures, parametrize over factories, nested loops.
 
 from .canonicalizer import (
     BLAKE3_512_PREFIX,
@@ -67,7 +69,7 @@ from .ir import (
     term_to_value,
 )
 from .decorators import contract, ContractViolation, collect_module
-from .layer2 import LiftWarning, Layer2Output, lift_file_layer2
+from .layer2 import ImplicationDecl, LiftWarning, Layer2Output, lift_file_layer2
 from .proof_envelope import ProofEnvelopeInput, envelope_body_to_value
 from .claim_envelope import (
     Authoring,
@@ -92,6 +94,7 @@ from .verifier import (
     HandshakeReport,
     VerifierNotFoundError,
 )
+from .walk import ProductionWalkOutput, lift_production_walk
 
 __all__ = [
     "Authoring",
@@ -112,11 +115,13 @@ __all__ = [
     "EvidenceTerm",
     "HandshakeReport",
     "Int",
+    "ImplicationDecl",
     "LAYERED_SCHEMA_VERSION",
     "Layer2Output",
     "LiftWarning",
     "Locus",
     "ProofEnvelopeInput",
+    "ProductionWalkOutput",
     "Real",
     "Signer",
     "Sort",
@@ -149,6 +154,7 @@ __all__ = [
     "implies",
     "jcs_hash",
     "lift_file_layer2",
+    "lift_production_walk",
     "locus_to_value",
     "lt",
     "lte",

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
@@ -4,7 +4,7 @@
 #
 # Layer 2 sits ABOVE the (future) Python Layer 0 ("mechanical assert
 # recognition") and below the eventual Layer 3 LLM lift. It walks the
-# Python AST of a source file and recognizes four structural patterns:
+# Python AST of a source file and recognizes five structural patterns:
 #
 #   PATTERN 1 - bounded for loop as universal quantifier
 #       def test_x():
@@ -45,6 +45,16 @@
 #   Lift to: ONE memento, body = and-conjunction over each row substitution.
 #   Memento name: ``<test>::parametrize::<param-names>``.
 #
+#   PATTERN 5 - callsite value-scope facts plus implications
+#       def test_parse():
+#           actual = parse_int("42")
+#           assert actual == 42
+#   Lift to: two callsite-owned contracts,
+#       ``parse_int@<file>:<line>:<col>::facts`` and
+#       ``parse_int@<file>:<line>:<col>::assertion``,
+#   plus an implication edge from facts to assertion. The test is evidence
+#   describing the callsite contract; it does not own the contract name.
+#
 # CLAIM SET:
 #   ``lift_file_layer2`` returns a ``claimed_tests`` set: each test name
 #   Layer 2 took ownership of. The dispatcher passes that set to Layer 0
@@ -55,6 +65,7 @@
 from __future__ import annotations
 
 import ast
+import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
@@ -62,7 +73,6 @@ from .ir import (
     ContractDecl,
     Formula,
     Int,
-    Sort,
     Term,
     and_,
     atomic,
@@ -77,6 +87,7 @@ from .ir import (
     lte,
     make_var,
     ne,
+    not_,
     num,
     str_const,
     subst_var_in_formula,
@@ -110,6 +121,20 @@ class Layer2Output:
     characterization_skipped: int = 0
     parametrize_lifted: int = 0
     parametrize_skipped: int = 0
+    value_scope_lifted: int = 0
+    value_scope_skipped: int = 0
+    implications: List["ImplicationDecl"] = field(default_factory=list)
+
+
+@dataclass
+class ImplicationDecl:
+    name: str
+    antecedent: str
+    consequent: str
+    antecedent_slot: str = "inv"
+    consequent_slot: str = "inv"
+    prover: str = "python-test-value-scope"
+    proof_witness: str = ""
 
 
 @dataclass
@@ -117,6 +142,27 @@ class _HelperDef:
     """A function with one typed param + a single liftable assertion."""
     param_name: str
     assertion: ast.stmt  # the single body statement
+
+
+@dataclass
+class _CallOrigin:
+    callee: str
+    lineno: int
+    col: int
+
+
+@dataclass
+class _ValueScope:
+    current: Dict[str, Term] = field(default_factory=dict)
+    origins: Dict[str, _CallOrigin] = field(default_factory=dict)
+    facts: List[Formula] = field(default_factory=list)
+
+    def copy(self) -> "_ValueScope":
+        return _ValueScope(
+            current=dict(self.current),
+            origins=dict(self.origins),
+            facts=list(self.facts),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -278,6 +324,9 @@ def _classify_and_lift(
             break
     if all_asserts and len(asserts) >= 2:
         _classify_characterization(asserts, test_name, source_path, out)
+        return
+
+    if _classify_value_scope(body, test_name, source_path, out):
         return
 
     # No Layer 2 pattern claimed it. Leave for Layer 0.
@@ -933,3 +982,462 @@ def _classify_parametrize(
     out.decls.append(ContractDecl(name=memento_name, inv=folded))
     out.lifted += 1
     out.parametrize_lifted += 1
+
+
+# ---------------------------------------------------------------------------
+# PATTERN 5: callsite-scoped value facts from tests
+# ---------------------------------------------------------------------------
+
+
+def _classify_value_scope(
+    body: Sequence[ast.stmt],
+    test_name: str,
+    source_path: str,
+    out: Layer2Output,
+) -> bool:
+    scopes: List[_ValueScope] = [_ValueScope()]
+    versions: Dict[str, int] = {}
+    decls: List[ContractDecl] = []
+    implications: List[ImplicationDecl] = []
+    used_names: Set[str] = set()
+    assertion_index = 0
+
+    for stmt in body:
+        if _is_assertion_stmt(stmt):
+            made = _emit_value_scope_assertion(
+                stmt,
+                scopes,
+                test_name,
+                assertion_index,
+                source_path,
+                decls,
+                implications,
+                used_names,
+            )
+            assertion_index += 1
+            if made:
+                continue
+            if not decls:
+                return False
+            continue
+
+        next_scopes = _apply_value_scope_statement(stmt, scopes, versions)
+        if next_scopes is None:
+            return False
+        scopes = next_scopes
+
+    if not implications:
+        return False
+
+    out.claimed_tests.add(test_name)
+    out.seen += 1
+    out.decls.extend(decls)
+    out.implications.extend(implications)
+    out.lifted += len(decls)
+    out.value_scope_lifted += 1
+    return True
+
+
+def _apply_value_scope_statement(
+    stmt: ast.stmt,
+    scopes: List[_ValueScope],
+    versions: Dict[str, int],
+) -> Optional[List[_ValueScope]]:
+    if isinstance(stmt, ast.Assign):
+        if len(stmt.targets) != 1 or not isinstance(stmt.targets[0], ast.Name):
+            return None
+        return _apply_value_scope_binding(stmt.targets[0].id, stmt.value, scopes, versions)
+
+    if isinstance(stmt, ast.AnnAssign):
+        if stmt.value is None or not isinstance(stmt.target, ast.Name):
+            return None
+        return _apply_value_scope_binding(stmt.target.id, stmt.value, scopes, versions)
+
+    if isinstance(stmt, ast.If):
+        return _apply_value_scope_if(stmt, scopes, versions)
+
+    if isinstance(stmt, ast.Pass):
+        return scopes
+
+    return None
+
+
+def _apply_value_scope_if(
+    stmt: ast.If,
+    scopes: List[_ValueScope],
+    versions: Dict[str, int],
+) -> Optional[List[_ValueScope]]:
+    out: List[_ValueScope] = []
+    for scope in scopes:
+        guard = _lift_branch_guard(stmt.test, scope)
+
+        then_scope = scope.copy()
+        then_scope.facts.append(guard)
+        then_scopes = _apply_value_scope_block(stmt.body, [then_scope], versions)
+        if then_scopes is None:
+            return None
+        out.extend(then_scopes)
+
+        else_scope = scope.copy()
+        else_scope.facts.append(not_(guard))
+        else_scopes = _apply_value_scope_block(stmt.orelse, [else_scope], versions)
+        if else_scopes is None:
+            return None
+        out.extend(else_scopes or [else_scope])
+
+    return out
+
+
+def _apply_value_scope_block(
+    stmts: Sequence[ast.stmt],
+    scopes: List[_ValueScope],
+    versions: Dict[str, int],
+) -> Optional[List[_ValueScope]]:
+    current = scopes
+    for stmt in stmts:
+        if _is_assertion_stmt(stmt):
+            return None
+        next_scopes = _apply_value_scope_statement(stmt, current, versions)
+        if next_scopes is None:
+            return None
+        current = next_scopes
+    return current
+
+
+def _apply_value_scope_binding(
+    name: str,
+    value: ast.expr,
+    scopes: List[_ValueScope],
+    versions: Dict[str, int],
+) -> List[_ValueScope]:
+    out: List[_ValueScope] = []
+    for scope in scopes:
+        next_scope = scope.copy()
+        try:
+            rhs = _translate_term_scoped(value, scope)
+        except ValueError:
+            next_scope.current.pop(name, None)
+            next_scope.origins.pop(name, None)
+            out.append(next_scope)
+            continue
+
+        version = versions.get(name, 0)
+        versions[name] = version + 1
+        ssa_name = f"{name}${version}"
+        ssa = make_var(ssa_name)
+        next_scope.current[name] = ssa
+        origin = _call_origin_from_expr(value)
+        if origin is not None:
+            next_scope.origins[name] = origin
+        else:
+            next_scope.origins.pop(name, None)
+        next_scope.facts.append(eq(ssa, rhs))
+        out.append(next_scope)
+    return out
+
+
+def _emit_value_scope_assertion(
+    stmt: ast.stmt,
+    scopes: List[_ValueScope],
+    test_name: str,
+    assertion_index: int,
+    source_path: str,
+    decls: List[ContractDecl],
+    implications: List[ImplicationDecl],
+    used_names: Set[str],
+) -> int:
+    made = 0
+    for scope in scopes:
+        context = _assertion_callsite_context(stmt, scope)
+        if context is None:
+            continue
+        origins, facts, assertion = context
+
+        for origin in origins:
+            base = _callsite_contract_base(origin, source_path)
+            facts_name = _unique_contract_name(f"{base}::facts", used_names)
+            assertion_name = _unique_contract_name(f"{base}::assertion", used_names)
+            implication_name = _unique_contract_name(
+                f"{base}::facts-implies-assertion", used_names
+            )
+            fact_formula = facts[0] if len(facts) == 1 else and_(facts)
+            decls.append(ContractDecl(name=facts_name, inv=fact_formula))
+            decls.append(ContractDecl(name=assertion_name, inv=assertion))
+            implications.append(
+                ImplicationDecl(
+                    name=implication_name,
+                    antecedent=facts_name,
+                    consequent=assertion_name,
+                    proof_witness=f"{test_name} assertion {assertion_index}",
+                )
+            )
+            made += 1
+    return made
+
+
+def _assertion_callsite_context(
+    stmt: ast.stmt,
+    scope: _ValueScope,
+) -> Optional[Tuple[List[_CallOrigin], List[Formula], Formula]]:
+    direct_calls = _collect_assertion_calls(stmt)
+    call_vars: Dict[Tuple[int, int], Term] = {}
+    for call in direct_calls:
+        origin = _call_origin_from_expr(call)
+        if origin is not None:
+            call_vars[_call_key(call)] = make_var(_call_result_var_name(origin))
+
+    transient_facts: List[Formula] = []
+    direct_origins: List[_CallOrigin] = []
+    for call in direct_calls:
+        origin = _call_origin_from_expr(call)
+        if origin is None:
+            continue
+        try:
+            rhs = _translate_call_rhs(call, scope, call_vars)
+        except ValueError:
+            continue
+        var_term = call_vars[_call_key(call)]
+        transient_facts.append(eq(var_term, rhs))
+        direct_origins.append(origin)
+
+    origins = _unique_origins(_origins_for_assertion(stmt, scope) + direct_origins)
+    if not origins:
+        return None
+
+    facts = scope.facts + transient_facts
+    if not facts:
+        return None
+
+    try:
+        assertion = _lift_assertion_stmt_scoped(stmt, scope, call_vars)
+    except ValueError:
+        return None
+
+    return origins, facts, assertion
+
+
+def _unique_contract_name(name: str, used_names: Set[str]) -> str:
+    if name not in used_names:
+        used_names.add(name)
+        return name
+    i = 1
+    while f"{name}::{i}" in used_names:
+        i += 1
+    unique = f"{name}::{i}"
+    used_names.add(unique)
+    return unique
+
+
+def _callsite_contract_base(origin: _CallOrigin, source_path: str) -> str:
+    file_name = os.path.basename(source_path) or source_path or "<unknown>"
+    return f"{origin.callee}@{file_name}:{origin.lineno}:{origin.col}"
+
+
+def _call_result_var_name(origin: _CallOrigin) -> str:
+    return f"{origin.callee}$call${origin.lineno}${origin.col}"
+
+
+def _call_key(call: ast.Call) -> Tuple[int, int]:
+    return (getattr(call, "lineno", 0), getattr(call, "col_offset", 0))
+
+
+def _call_origin_from_expr(node: ast.expr) -> Optional[_CallOrigin]:
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and not node.keywords
+    ):
+        return _CallOrigin(
+            callee=node.func.id,
+            lineno=getattr(node, "lineno", 0),
+            col=getattr(node, "col_offset", 0),
+        )
+    return None
+
+
+def _assertion_value_exprs(stmt: ast.stmt) -> List[ast.expr]:
+    exprs: List[ast.expr] = []
+    if isinstance(stmt, ast.Assert):
+        exprs.append(stmt.test)
+    elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+        name = _attr_method_name(stmt.value.func)
+        if name in _UNITTEST_BINARY_PREDICATES:
+            exprs.extend(stmt.value.args[:2])
+        elif name in ("assertTrue", "assertFalse") and stmt.value.args:
+            exprs.append(stmt.value.args[0])
+    return exprs
+
+
+def _collect_assertion_calls(stmt: ast.stmt) -> List[ast.Call]:
+    calls: List[ast.Call] = []
+    seen: Set[Tuple[int, int]] = set()
+    for expr in _assertion_value_exprs(stmt):
+        for node in ast.walk(expr):
+            if not isinstance(node, ast.Call):
+                continue
+            if _call_origin_from_expr(node) is None:
+                continue
+            key = _call_key(node)
+            if key in seen:
+                continue
+            seen.add(key)
+            calls.append(node)
+    return sorted(calls, key=_call_key)
+
+
+def _origins_for_assertion(stmt: ast.stmt, scope: _ValueScope) -> List[_CallOrigin]:
+    origins: List[_CallOrigin] = []
+    for expr in _assertion_value_exprs(stmt):
+        for node in ast.walk(expr):
+            if isinstance(node, ast.Name) and node.id in scope.origins:
+                origins.append(scope.origins[node.id])
+    return _unique_origins(origins)
+
+
+def _unique_origins(origins: List[_CallOrigin]) -> List[_CallOrigin]:
+    out: List[_CallOrigin] = []
+    seen: Set[Tuple[str, int, int]] = set()
+    for origin in origins:
+        key = (origin.callee, origin.lineno, origin.col)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(origin)
+    return out
+
+
+def _translate_call_rhs(
+    call: ast.Call,
+    scope: _ValueScope,
+    call_vars: Dict[Tuple[int, int], Term],
+) -> Term:
+    if not isinstance(call.func, ast.Name):
+        raise ValueError("call target must be a simple name")
+    if call.keywords:
+        raise ValueError("call with kwargs is not liftable")
+    return ctor(
+        call.func.id,
+        [_translate_term_scoped(arg, scope, call_vars) for arg in call.args],
+    )
+
+
+def _lift_branch_guard(node: ast.expr, scope: _ValueScope) -> Formula:
+    try:
+        return _translate_bool_expr_scoped(node, scope)
+    except ValueError:
+        return atomic("python_branch_condition", [str_const(_unparse(node))])
+
+
+def _lift_assertion_stmt_scoped(
+    stmt: ast.stmt,
+    scope: _ValueScope,
+    call_vars: Optional[Dict[Tuple[int, int], Term]] = None,
+) -> Formula:
+    if isinstance(stmt, ast.Assert):
+        return _translate_bool_expr_scoped(stmt.test, scope, call_vars)
+    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+        call = stmt.value
+        name = _attr_method_name(call.func)
+        if name in _UNITTEST_BINARY_PREDICATES:
+            if len(call.args) < 2:
+                raise ValueError(f"{name} expects at least 2 positional args")
+            l = _translate_term_scoped(call.args[0], scope, call_vars)
+            r = _translate_term_scoped(call.args[1], scope, call_vars)
+            return atomic(_UNITTEST_BINARY_PREDICATES[name], [l, r])
+        if name == "assertTrue":
+            if len(call.args) < 1:
+                raise ValueError("assertTrue expects 1 positional arg")
+            return _translate_bool_expr_scoped(call.args[0], scope, call_vars)
+        if name == "assertFalse":
+            if len(call.args) < 1:
+                raise ValueError("assertFalse expects 1 positional arg")
+            return not_(_translate_bool_expr_scoped(call.args[0], scope, call_vars))
+    raise ValueError("statement is not a value-scope assertion")
+
+
+def _translate_bool_expr_scoped(
+    node: ast.expr,
+    scope: _ValueScope,
+    call_vars: Optional[Dict[Tuple[int, int], Term]] = None,
+) -> Formula:
+    if isinstance(node, ast.Compare):
+        if len(node.ops) != 1 or len(node.comparators) != 1:
+            raise ValueError("only single comparisons are liftable")
+        sym = _COMPARE_OP_MAP.get(type(node.ops[0]))
+        if sym is None:
+            raise ValueError(f"unsupported comparison op: {type(node.ops[0]).__name__}")
+        return atomic(
+            sym,
+            [
+                _translate_term_scoped(node.left, scope, call_vars),
+                _translate_term_scoped(node.comparators[0], scope, call_vars),
+            ],
+        )
+    if isinstance(node, ast.BoolOp):
+        operands = [
+            _translate_bool_expr_scoped(v, scope, call_vars) for v in node.values
+        ]
+        if isinstance(node.op, ast.And):
+            return and_(operands)
+        if isinstance(node.op, ast.Or):
+            return connective("or", operands)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return not_(_translate_bool_expr_scoped(node.operand, scope, call_vars))
+    term = _translate_term_scoped(node, scope, call_vars)
+    return eq(term, bool_const(True))
+
+
+def _translate_term_scoped(
+    node: ast.expr,
+    scope: _ValueScope,
+    call_vars: Optional[Dict[Tuple[int, int], Term]] = None,
+) -> Term:
+    call_vars = call_vars or {}
+    if isinstance(node, ast.Name):
+        if node.id in scope.current:
+            return scope.current[node.id]
+        return _translate_term(node)
+    if isinstance(node, ast.Constant):
+        return _translate_term(node)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return _translate_term(node)
+    if isinstance(node, ast.Call):
+        if not isinstance(node.func, ast.Name):
+            raise ValueError("call target must be a simple name")
+        if node.keywords:
+            raise ValueError("call with kwargs is not liftable")
+        key = _call_key(node)
+        if key in call_vars:
+            return call_vars[key]
+        return ctor(
+            node.func.id,
+            [_translate_term_scoped(arg, scope, call_vars) for arg in node.args],
+        )
+    if isinstance(node, ast.BinOp):
+        op = _BINOP_TERM_NAMES.get(type(node.op))
+        if op is None:
+            raise ValueError("unsupported binary operator")
+        return ctor(
+            op,
+            [
+                _translate_term_scoped(node.left, scope, call_vars),
+                _translate_term_scoped(node.right, scope, call_vars),
+            ],
+        )
+    raise ValueError("expression shape not in value-scope lift whitelist")
+
+
+_BINOP_TERM_NAMES = {
+    ast.Add: "+",
+    ast.Sub: "-",
+    ast.Mult: "*",
+    ast.Div: "/",
+    ast.Mod: "%",
+}
+
+
+def _unparse(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)  # type: ignore[attr-defined]
+    except Exception:
+        return node.__class__.__name__

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import traceback
 from dataclasses import dataclass, field
@@ -28,6 +29,7 @@ from .ir import (
 )
 from .canonicalizer import encode_jcs, jcs_hash
 from .layer2 import lift_file_layer2
+from .walk import lift_production_walk
 from .decorators import collect_module
 from .lift.pydantic import lift_pydantic_model
 from .cpython_ctypes_resolver import resolve_ctypes_calls
@@ -73,6 +75,74 @@ def handle_initialize(msg_id: Any) -> None:
     )
 
 
+def _implications_to_json(layer2) -> List[Dict[str, Any]]:
+    return [
+        {
+            "name": implication.name,
+            "antecedent": implication.antecedent,
+            "consequent": implication.consequent,
+            "antecedentSlot": implication.antecedent_slot,
+            "consequentSlot": implication.consequent_slot,
+            "prover": implication.prover,
+            "proofWitness": implication.proof_witness,
+        }
+        for implication in layer2.implications
+    ]
+
+
+def _lift_source(path: str, source: str) -> Dict[str, Any]:
+    decls: List[Any] = []
+
+    # Layer 2: pytest/unittest structural lift.
+    layer2 = lift_file_layer2(source, path)
+    decls.extend(layer2.decls)
+
+    # Production walk: lift callee preconditions and mint callsite WP edges.
+    production_walk = lift_production_walk(source, path)
+    decls.extend(production_walk.decls)
+
+    # Try to load the source as a module to collect @provekit.contract
+    # decorators. This only works when the source is importable; for
+    # standalone files we skip this path.
+    # TODO: use importlib.util to load from source string.
+
+    # Pydantic lift: if the file defines BaseModel subclasses, walk them.
+    # We do this by exec-ing the source in a clean namespace and
+    # inspecting for pydantic models. Only done when pydantic is available.
+    try:
+        pydantic_decls = _try_lift_pydantic(source)
+        decls.extend(pydantic_decls)
+    except Exception:
+        pass
+
+    # Build contract index for call-edge resolution.
+    # Maps function/contract name -> contractCid (blake3-512 hash of JCS).
+    contract_index: Dict[str, str] = {}
+    for d in decls:
+        if isinstance(d, ContractDecl):
+            cid = jcs_hash(contract_decl_to_value(d))
+            contract_index[d.name] = cid
+
+    # Emit ctypes call-edge stream per spec #114 R1.
+    ctypes_result = resolve_ctypes_calls(source, path, contract_index)
+    call_edges = ctypes_result.call_edges
+    call_edges_value = call_edges_to_value(call_edges)
+    call_edges_array = json.loads(encode_jcs(call_edges_value))
+
+    declarations_array: List[Any] = []
+    if decls:
+        value = declarations_to_value(decls)
+        declarations_array = json.loads(encode_jcs(value))
+
+    return {
+        "decls": decls,
+        "declarations": declarations_array,
+        "callEdges": call_edges_array,
+        "warnings": [w.__dict__ for w in layer2.warnings + production_walk.warnings],
+        "implications": _implications_to_json(layer2) + _implications_to_json(production_walk),
+    }
+
+
 def handle_parse(msg_id: Any, params: dict) -> None:
     path = params.get("path", "")
     source = params.get("source", "")
@@ -92,75 +162,99 @@ def handle_parse(msg_id: Any, params: dict) -> None:
         return
 
     try:
+        lifted = _lift_source(path, source)
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "declarations": lifted["declarations"],
+                    "callEdges": lifted["callEdges"],
+                    "warnings": lifted["warnings"],
+                    "implications": lifted["implications"],
+                },
+            }
+        )
+
+    except Exception as e:
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {
+                    "code": -32603,
+                    "message": str(e),
+                    "data": traceback.format_exc(),
+                },
+            }
+        )
+
+
+def _iter_python_files(workspace_root: str, source_paths: List[Any]) -> List[str]:
+    root = os.path.abspath(workspace_root or ".")
+    paths = source_paths or ["."]
+    out: List[str] = []
+    for source_path in paths:
+        raw = str(source_path)
+        path = raw if os.path.isabs(raw) else os.path.join(root, raw)
+        if os.path.isfile(path):
+            if path.endswith(".py"):
+                out.append(path)
+            continue
+        if not os.path.isdir(path):
+            continue
+        for dirpath, dirnames, filenames in os.walk(path):
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in {".git", ".venv", "venv", "__pycache__", ".mypy_cache", ".pytest_cache"}
+            ]
+            for filename in filenames:
+                if filename.endswith(".py"):
+                    out.append(os.path.join(dirpath, filename))
+    return sorted(set(out))
+
+
+def handle_lift(msg_id: Any, params: dict) -> None:
+    workspace_root = str(params.get("workspace_root", "."))
+    source_paths = params.get("source_paths", ["."])
+
+    try:
         decls: List[Any] = []
+        warnings: List[Any] = []
+        implications: List[Any] = []
+        for path in _iter_python_files(workspace_root, source_paths):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    source = f.read()
+            except OSError as e:
+                warnings.append({
+                    "source_path": path,
+                    "item_name": "<file>",
+                    "reason": f"read failed: {e}",
+                })
+                continue
+            lifted = _lift_source(path, source)
+            decls.extend(lifted["decls"])
+            warnings.extend(lifted["warnings"])
+            implications.extend(lifted["implications"])
 
-        # Layer 2: pytest/unittest structural lift.
-        layer2 = lift_file_layer2(source, path)
-        decls.extend(layer2.decls)
-
-        # Try to load the source as a module to collect @provekit.contract
-        # decorators. This only works when the source is importable; for
-        # standalone files we skip this path.
-        # TODO: use importlib.util to load from source string.
-
-        # Pydantic lift: if the file defines BaseModel subclasses, walk them.
-        # We do this by exec-ing the source in a clean namespace and
-        # inspecting for pydantic models. Only done when pydantic is available.
-        try:
-            pydantic_decls = _try_lift_pydantic(source)
-            decls.extend(pydantic_decls)
-        except Exception:
-            pass
-
-        # Build contract index for call-edge resolution.
-        # Maps function/contract name -> contractCid (blake3-512 hash of JCS).
-        contract_index: Dict[str, str] = {}
-        for d in decls:
-            if isinstance(d, ContractDecl):
-                cid = jcs_hash(contract_decl_to_value(d))
-                contract_index[d.name] = cid
-
-        # Emit ctypes call-edge stream per spec #114 R1.
-        ctypes_result = resolve_ctypes_calls(source, path, contract_index)
-        call_edges = ctypes_result.call_edges
-        call_edges_value = call_edges_to_value(call_edges)
-        # encode_jcs returns a str; parse it back to a native list so the
-        # outer json.dumps embeds it as a JSON array, not a JSON-encoded string.
-        call_edges_array = json.loads(encode_jcs(call_edges_value))
-
-        if not decls:
-            _send(
-                {
-                    "jsonrpc": "2.0",
-                    "id": msg_id,
-                    "result": {
-                        "declarations": [],
-                        "callEdges": call_edges_array,
-                        "warnings": [],
-                    },
-                }
-            )
-            return
-
-        # Emit canonical IR JSON; parse JCS string to native list so
-        # json.dumps emits an array, not a JSON-encoded string.
-        value = declarations_to_value(decls)
-        declarations_array = json.loads(encode_jcs(value))
-
-        warnings = [w.__dict__ for w in layer2.warnings]
+        ir: List[Any] = []
+        if decls:
+            ir = json.loads(encode_jcs(declarations_to_value(decls)))
 
         _send(
             {
                 "jsonrpc": "2.0",
                 "id": msg_id,
                 "result": {
-                    "declarations": declarations_array,
-                    "callEdges": call_edges_array,
+                    "kind": "ir-document",
+                    "ir": ir,
+                    "implications": implications,
+                    "diagnostics": [],
                     "warnings": warnings,
                 },
             }
         )
-
     except Exception as e:
         _send(
             {
@@ -222,6 +316,8 @@ def main() -> None:
             handle_initialize(msg_id)
         elif method == "parse":
             handle_parse(msg_id, params)
+        elif method == "lift":
+            handle_lift(msg_id, params)
         elif method == "shutdown":
             handle_shutdown(msg_id)
         else:

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/walk.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/walk.py
@@ -1,0 +1,512 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Production-side WP walker for Python.
+#
+# This mirrors the Rust `provekit-walk` MVP shape:
+#   1. lift a callee's implicit precondition from defensive source patterns;
+#   2. substitute actual arguments at each production callsite;
+#   3. walk backward through in-scope assignments using wp(x := e, P) = P[e/x];
+#   4. emit each arrival as a pre/post edge plus an implication declaration.
+
+from __future__ import annotations
+
+import ast
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+from .ir import (
+    ContractDecl,
+    Formula,
+    Term,
+    and_,
+    atomic,
+    bool_const,
+    connective,
+    ctor,
+    eq,
+    gt,
+    gte,
+    lt,
+    lte,
+    make_var,
+    ne,
+    not_,
+    num,
+    or_,
+    str_const,
+    subst_var_in_formula,
+)
+from .layer2 import ImplicationDecl, LiftWarning
+
+
+@dataclass
+class ProductionWalkOutput:
+    decls: List[ContractDecl] = field(default_factory=list)
+    implications: List[ImplicationDecl] = field(default_factory=list)
+    warnings: List[LiftWarning] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _FunctionPrecondition:
+    name: str
+    formals: List[str]
+    precondition: Formula
+
+
+@dataclass(frozen=True)
+class _Binding:
+    name: str
+    term: Term
+    lineno: int
+    col: int
+
+
+@dataclass(frozen=True)
+class _CallsiteHit:
+    callee: str
+    args: List[ast.expr]
+    lineno: int
+    col: int
+    stmt_index: int
+    conditions: List[Formula]
+    preceding_inner_stmts: List[ast.stmt]
+
+
+_COMPARE_OP_MAP = {
+    ast.Eq: "=",
+    ast.NotEq: "≠",
+    ast.Lt: "<",
+    ast.LtE: "≤",
+    ast.Gt: ">",
+    ast.GtE: "≥",
+    ast.Is: "=",
+    ast.IsNot: "≠",
+}
+
+_BINOP_TERM_NAMES = {
+    ast.Add: "+",
+    ast.Sub: "-",
+    ast.Mult: "*",
+    ast.Div: "/",
+    ast.FloorDiv: "//",
+    ast.Mod: "%",
+    ast.Pow: "**",
+}
+
+
+def lift_production_walk(source: str, source_path: str) -> ProductionWalkOutput:
+    out = ProductionWalkOutput()
+    try:
+        tree = ast.parse(source, filename=source_path)
+    except SyntaxError as e:
+        out.warnings.append(
+            LiftWarning(source_path, "<file>", f"python-wp-walk: failed to parse source: {e}")
+        )
+        return out
+
+    functions = _top_level_functions(tree)
+    callees = {
+        name: pre
+        for name, fn in functions.items()
+        if (pre := _lift_function_precondition(fn)) is not None
+    }
+    used_names: Set[str] = set()
+
+    for caller in functions.values():
+        if _is_test_function(caller.name):
+            continue
+        for callee in callees.values():
+            if callee.name == caller.name:
+                continue
+            _emit_walks_for_callee(caller, callee, source_path, out, used_names)
+
+    return out
+
+
+def _top_level_functions(tree: ast.Module) -> Dict[str, ast.FunctionDef]:
+    out: Dict[str, ast.FunctionDef] = {}
+    for item in tree.body:
+        if isinstance(item, ast.FunctionDef):
+            out[item.name] = item
+    return out
+
+
+def _is_test_function(name: str) -> bool:
+    return name.startswith("test_") or name.endswith("_test")
+
+
+def _lift_function_precondition(fn: ast.FunctionDef) -> Optional[_FunctionPrecondition]:
+    atoms: List[Formula] = []
+    for stmt in fn.body:
+        contribution = _stmt_precondition_contribution(stmt)
+        if contribution is not None:
+            atoms.append(contribution)
+    if not atoms:
+        return None
+    precondition = atoms[0] if len(atoms) == 1 else and_(atoms)
+    return _FunctionPrecondition(
+        name=fn.name,
+        formals=[arg.arg for arg in fn.args.args],
+        precondition=precondition,
+    )
+
+
+def _stmt_precondition_contribution(stmt: ast.stmt) -> Optional[Formula]:
+    if isinstance(stmt, ast.Assert):
+        try:
+            return _lift_predicate(stmt.test)
+        except ValueError:
+            return None
+    if isinstance(stmt, ast.If) and not stmt.orelse and _block_only_raises(stmt.body):
+        try:
+            return _negate_formula(_lift_predicate(stmt.test))
+        except ValueError:
+            return None
+    return None
+
+
+def _block_only_raises(stmts: Sequence[ast.stmt]) -> bool:
+    return len(stmts) == 1 and isinstance(stmts[0], ast.Raise)
+
+
+def _emit_walks_for_callee(
+    caller: ast.FunctionDef,
+    callee: _FunctionPrecondition,
+    source_path: str,
+    out: ProductionWalkOutput,
+    used_names: Set[str],
+) -> None:
+    for hit in _find_callsites(caller, callee.name):
+        if len(callee.formals) != len(hit.args):
+            out.warnings.append(
+                LiftWarning(
+                    source_path,
+                    caller.name,
+                    f"python-wp-walk: arity mismatch at {caller.name}->{callee.name} "
+                    f"(formals={len(callee.formals)}, actuals={len(hit.args)})",
+                )
+            )
+            continue
+
+        try:
+            wp = callee.precondition
+            for formal, actual in zip(callee.formals, hit.args):
+                wp = subst_var_in_formula(wp, formal, _term_from_expr(actual))
+        except ValueError as e:
+            out.warnings.append(
+                LiftWarning(
+                    source_path,
+                    caller.name,
+                    f"python-wp-walk: callsite actual not liftable for {callee.name}: {e}",
+                )
+            )
+            continue
+
+        if hit.conditions:
+            premise = hit.conditions[0] if len(hit.conditions) == 1 else and_(hit.conditions)
+            wp = connective("implies", [premise, wp])
+
+        base = _callsite_base(callee.name, source_path, hit.lineno, hit.col)
+        _append_edge(out, used_names, f"{base}::callsite", wp, wp, caller.name, callee.name)
+        previous_wp = wp
+
+        for stmt in hit.preceding_inner_stmts:
+            for binding in _bindings_from_stmt(stmt):
+                next_wp = subst_var_in_formula(previous_wp, binding.name, binding.term)
+                _append_edge(
+                    out,
+                    used_names,
+                    f"{base}::let:{binding.name}",
+                    next_wp,
+                    previous_wp,
+                    caller.name,
+                    callee.name,
+                )
+                previous_wp = next_wp
+
+        for stmt in reversed(caller.body[: hit.stmt_index]):
+            for binding in _bindings_from_stmt(stmt):
+                next_wp = subst_var_in_formula(previous_wp, binding.name, binding.term)
+                _append_edge(
+                    out,
+                    used_names,
+                    f"{base}::let:{binding.name}",
+                    next_wp,
+                    previous_wp,
+                    caller.name,
+                    callee.name,
+                )
+                previous_wp = next_wp
+
+        _append_edge(out, used_names, f"{base}::entry", previous_wp, previous_wp, caller.name, callee.name)
+
+
+def _append_edge(
+    out: ProductionWalkOutput,
+    used_names: Set[str],
+    raw_name: str,
+    pre: Formula,
+    post: Formula,
+    caller_name: str,
+    callee_name: str,
+) -> None:
+    name = _unique_name(raw_name, used_names)
+    out.decls.append(ContractDecl(name=name, pre=pre, post=post, out_binding="result"))
+    out.implications.append(
+        ImplicationDecl(
+            name=f"{name}::pre-implies-post",
+            antecedent=name,
+            consequent=name,
+            antecedent_slot="pre",
+            consequent_slot="post",
+            prover="python-wp-walk",
+            proof_witness=f"{caller_name}->{callee_name}",
+        )
+    )
+
+
+def _find_callsites(caller: ast.FunctionDef, callee_name: str) -> List[_CallsiteHit]:
+    hits: List[_CallsiteHit] = []
+    for idx, stmt in enumerate(caller.body):
+        _walk_stmt_for_callsites(
+            stmt,
+            idx,
+            callee_name,
+            conditions=[],
+            inner_stmts=[],
+            hits=hits,
+        )
+    return hits
+
+
+def _walk_stmt_for_callsites(
+    stmt: ast.stmt,
+    stmt_index: int,
+    callee_name: str,
+    conditions: List[Formula],
+    inner_stmts: List[ast.stmt],
+    hits: List[_CallsiteHit],
+) -> None:
+    if isinstance(stmt, (ast.Assign, ast.AnnAssign, ast.Expr, ast.Return)):
+        expr = _stmt_expr(stmt)
+        if expr is not None:
+            _walk_expr_for_callsites(expr, stmt_index, callee_name, conditions, inner_stmts, hits)
+        return
+
+    if isinstance(stmt, ast.If):
+        lifted = _try_lift_predicate(stmt.test)
+        if lifted is not None:
+            conditions.append(lifted)
+        _walk_block_for_callsites(stmt.body, stmt_index, callee_name, conditions, inner_stmts, hits)
+        if lifted is not None:
+            conditions.pop()
+
+        if lifted is not None:
+            conditions.append(_negate_formula(lifted))
+        _walk_block_for_callsites(stmt.orelse, stmt_index, callee_name, conditions, inner_stmts, hits)
+        if lifted is not None:
+            conditions.pop()
+        return
+
+    for child in ast.iter_child_nodes(stmt):
+        if isinstance(child, ast.expr):
+            _walk_expr_for_callsites(child, stmt_index, callee_name, conditions, inner_stmts, hits)
+
+
+def _walk_block_for_callsites(
+    stmts: Sequence[ast.stmt],
+    stmt_index: int,
+    callee_name: str,
+    conditions: List[Formula],
+    inner_stmts: List[ast.stmt],
+    hits: List[_CallsiteHit],
+) -> None:
+    for branch_idx, stmt in enumerate(stmts):
+        branch_preceding = list(reversed(stmts[:branch_idx])) + list(inner_stmts)
+        _walk_stmt_for_callsites(
+            stmt,
+            stmt_index,
+            callee_name,
+            conditions,
+            branch_preceding,
+            hits,
+        )
+
+
+def _walk_expr_for_callsites(
+    expr: ast.expr,
+    stmt_index: int,
+    callee_name: str,
+    conditions: List[Formula],
+    inner_stmts: List[ast.stmt],
+    hits: List[_CallsiteHit],
+) -> None:
+    if isinstance(expr, ast.Call):
+        if isinstance(expr.func, ast.Name) and expr.func.id == callee_name and not expr.keywords:
+            hits.append(
+                _CallsiteHit(
+                    callee=callee_name,
+                    args=list(expr.args),
+                    lineno=getattr(expr, "lineno", 0),
+                    col=getattr(expr, "col_offset", 0),
+                    stmt_index=stmt_index,
+                    conditions=list(conditions),
+                    preceding_inner_stmts=list(inner_stmts),
+                )
+            )
+        for arg in expr.args:
+            _walk_expr_for_callsites(arg, stmt_index, callee_name, conditions, inner_stmts, hits)
+        return
+
+    for child in ast.iter_child_nodes(expr):
+        if isinstance(child, ast.expr):
+            _walk_expr_for_callsites(child, stmt_index, callee_name, conditions, inner_stmts, hits)
+
+
+def _stmt_expr(stmt: ast.stmt) -> Optional[ast.expr]:
+    if isinstance(stmt, ast.Assign):
+        return stmt.value
+    if isinstance(stmt, ast.AnnAssign):
+        return stmt.value
+    if isinstance(stmt, ast.Expr):
+        return stmt.value
+    if isinstance(stmt, ast.Return):
+        return stmt.value
+    return None
+
+
+def _bindings_from_stmt(stmt: ast.stmt) -> List[_Binding]:
+    if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+        return [
+            _Binding(
+                stmt.targets[0].id,
+                _term_from_expr(stmt.value),
+                getattr(stmt, "lineno", 0),
+                getattr(stmt, "col_offset", 0),
+            )
+        ]
+    if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name) and stmt.value is not None:
+        return [
+            _Binding(
+                stmt.target.id,
+                _term_from_expr(stmt.value),
+                getattr(stmt, "lineno", 0),
+                getattr(stmt, "col_offset", 0),
+            )
+        ]
+    return []
+
+
+def _try_lift_predicate(node: ast.expr) -> Optional[Formula]:
+    try:
+        return _lift_predicate(node)
+    except ValueError:
+        return None
+
+
+def _lift_predicate(node: ast.expr) -> Formula:
+    if isinstance(node, ast.Compare):
+        if len(node.ops) != 1 or len(node.comparators) != 1:
+            raise ValueError("only single comparisons are liftable")
+        sym = _COMPARE_OP_MAP.get(type(node.ops[0]))
+        if sym is None:
+            raise ValueError(f"unsupported comparison op: {type(node.ops[0]).__name__}")
+        return atomic(sym, [_term_from_expr(node.left), _term_from_expr(node.comparators[0])])
+    if isinstance(node, ast.BoolOp):
+        operands = [_lift_predicate(value) for value in node.values]
+        if isinstance(node.op, ast.And):
+            return and_(operands)
+        if isinstance(node.op, ast.Or):
+            return or_(operands)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return _negate_formula(_lift_predicate(node.operand))
+    return eq(_term_from_expr(node), bool_const(True))
+
+
+def _term_from_expr(node: ast.expr) -> Term:
+    if isinstance(node, ast.Name):
+        if node.id == "True":
+            return bool_const(True)
+        if node.id == "False":
+            return bool_const(False)
+        if node.id == "None":
+            return ctor("None", [])
+        return make_var(node.id)
+    if isinstance(node, ast.Constant):
+        value = node.value
+        if isinstance(value, bool):
+            return bool_const(value)
+        if isinstance(value, int):
+            return num(value)
+        if isinstance(value, str):
+            return str_const(value)
+        if value is None:
+            return ctor("None", [])
+        return _placeholder_term(node)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        if isinstance(node.operand, ast.Constant) and isinstance(node.operand.value, int):
+            return num(-node.operand.value)
+        return ctor("neg", [_term_from_expr(node.operand)])
+    if isinstance(node, ast.BinOp):
+        name = _BINOP_TERM_NAMES.get(type(node.op))
+        if name is None:
+            return _placeholder_term(node)
+        return ctor(name, [_term_from_expr(node.left), _term_from_expr(node.right)])
+    if isinstance(node, ast.Call):
+        if not isinstance(node.func, ast.Name) or node.keywords:
+            return _placeholder_term(node)
+        return ctor(node.func.id, [_term_from_expr(arg) for arg in node.args])
+    if isinstance(node, ast.Attribute):
+        return ctor("field", [_term_from_expr(node.value), str_const(node.attr)])
+    if isinstance(node, ast.Subscript):
+        return ctor("index", [_term_from_expr(node.value), _term_from_expr(node.slice)])
+    return _placeholder_term(node)
+
+
+def _negate_formula(formula: Formula) -> Formula:
+    if _is_atomic(formula, "<"):
+        return gte(formula.args[0], formula.args[1])  # type: ignore[attr-defined]
+    if _is_atomic(formula, "≤"):
+        return gt(formula.args[0], formula.args[1])  # type: ignore[attr-defined]
+    if _is_atomic(formula, ">"):
+        return lte(formula.args[0], formula.args[1])  # type: ignore[attr-defined]
+    if _is_atomic(formula, "≥"):
+        return lt(formula.args[0], formula.args[1])  # type: ignore[attr-defined]
+    if _is_atomic(formula, "="):
+        return ne(formula.args[0], formula.args[1])  # type: ignore[attr-defined]
+    if _is_atomic(formula, "≠"):
+        return eq(formula.args[0], formula.args[1])  # type: ignore[attr-defined]
+    return not_(formula)
+
+
+def _is_atomic(formula: Formula, name: str) -> bool:
+    return getattr(formula, "name", None) == name and hasattr(formula, "args")
+
+
+def _callsite_base(callee: str, source_path: str, lineno: int, col: int) -> str:
+    file_name = os.path.basename(source_path) or source_path or "<unknown>"
+    return f"{callee}@{file_name}:{lineno}:{col}"
+
+
+def _placeholder_term(node: ast.AST) -> Term:
+    return make_var(f"<expr:{_unparse(node)}>")
+
+
+def _unique_name(name: str, used_names: Set[str]) -> str:
+    if name not in used_names:
+        used_names.add(name)
+        return name
+    i = 1
+    while f"{name}::{i}" in used_names:
+        i += 1
+    unique = f"{name}::{i}"
+    used_names.add(unique)
+    return unique
+
+
+def _unparse(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)  # type: ignore[attr-defined]
+    except Exception:
+        return node.__class__.__name__

--- a/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
@@ -7,8 +7,12 @@ import textwrap
 from provekit_lift_py_tests import lift_file_layer2
 from provekit_lift_py_tests.ir import (
     _Atomic,
+    _ConstInt,
+    _ConstStr,
     _Connective,
+    _Ctor,
     _Quantifier,
+    _Var,
 )
 
 
@@ -231,13 +235,131 @@ def test_pattern4_parametrize_skips_non_literal_row():
     assert any("parametrize" in w.reason for w in out.warnings)
 
 
+# --- Pattern 5: value-scope assertions -----------------------------------
+
+
+def test_pattern5_local_assignment_scopes_pytest_assertion():
+    out = _lift("""
+        def test_parse_value_scope():
+            actual = parse_int("42")
+            assert actual == 42
+    """)
+    assert out.lifted == 2, f"warnings: {out.warnings}"
+    assert out.value_scope_lifted == 1
+    assert "test_parse_value_scope" in out.claimed_tests
+    by_name = {d.name: d for d in out.decls}
+    assert len(by_name) == 2
+    assert all(name.startswith("parse_int@t.py:") for name in by_name)
+    assert all("test_parse_value_scope" not in name for name in by_name)
+    callsite_name = next(name for name in by_name if name.endswith("::facts"))
+    assertion_name = next(name for name in by_name if name.endswith("::assertion"))
+    assert len(out.implications) == 1
+    assert out.implications[0].name.startswith("parse_int@t.py:")
+    assert "test_parse_value_scope" not in out.implications[0].name
+    assert out.implications[0].antecedent == callsite_name
+    assert out.implications[0].consequent == assertion_name
+
+    fact = by_name[callsite_name].inv
+    consequent = by_name[assertion_name].inv
+
+    assert isinstance(fact, _Atomic)
+    assert fact.name == "="
+    assert isinstance(fact.args[0], _Var)
+    assert fact.args[0].name == "actual$0"
+    assert isinstance(fact.args[1], _Ctor)
+    assert fact.args[1].name == "parse_int"
+    assert isinstance(fact.args[1].args[0], _ConstStr)
+    assert fact.args[1].args[0].value == "42"
+
+    assert isinstance(consequent, _Atomic)
+    assert consequent.name == "="
+    assert isinstance(consequent.args[0], _Var)
+    assert consequent.args[0].name == "actual$0"
+    assert isinstance(consequent.args[1], _ConstInt)
+    assert consequent.args[1].value == 42
+
+
+def test_pattern5_if_else_scopes_assertion_to_each_branch():
+    out = _lift("""
+        def test_branch_value_scope(raw):
+            if raw == "42":
+                actual = parse_int(raw)
+            else:
+                actual = parse_int("0")
+            assert actual >= 0
+    """)
+    assert out.value_scope_lifted == 1, f"warnings: {out.warnings}"
+    names = {d.name for d in out.decls}
+    assert len(names) == 4
+    assert all(name.startswith("parse_int@t.py:") for name in names)
+    assert all("test_branch_value_scope" not in name for name in names)
+    assert len([name for name in names if name.endswith("::facts")]) == 2
+    assert len([name for name in names if name.endswith("::assertion")]) == 2
+    assert len(out.implications) == 2
+    for d in out.decls:
+        assert d.inv is not None
+        if d.name.endswith("::facts"):
+            assert isinstance(d.inv, _Connective)
+            assert d.inv.kind == "and"
+        if d.name.endswith("::assertion"):
+            assert isinstance(d.inv, _Atomic)
+            assert d.inv.name == "≥"
+
+
+def test_pattern5_local_assignment_scopes_unittest_assertion():
+    out = _lift("""
+        import unittest
+
+        class TestParser(unittest.TestCase):
+            def test_parse_value_scope(self):
+                actual = parse_int("42")
+                self.assertEqual(actual, 42)
+    """)
+    assert out.value_scope_lifted == 1, f"warnings: {out.warnings}"
+    names = {d.name for d in out.decls}
+    assert len(names) == 2
+    assert all(name.startswith("parse_int@t.py:") for name in names)
+    assert all("test_parse_value_scope" not in name for name in names)
+    assert len(out.implications) == 1
+
+
+def test_pattern5_direct_call_assertion_lifts_to_callsite_contracts():
+    out = _lift("""
+        def test_direct_parse():
+            assert parse_int("42") == 42
+    """)
+    assert out.value_scope_lifted == 1, f"warnings: {out.warnings}"
+    assert "test_direct_parse" in out.claimed_tests
+    names = {d.name for d in out.decls}
+    assert len(names) == 2
+    assert all(name.startswith("parse_int@t.py:") for name in names)
+    assert all("test_direct_parse" not in name for name in names)
+    assert len([name for name in names if name.endswith("::facts")]) == 1
+    assert len([name for name in names if name.endswith("::assertion")]) == 1
+    assert len(out.implications) == 1
+
+
+def test_pattern5_mints_every_callsite_implication_in_one_assertion():
+    out = _lift("""
+        def test_two_calls():
+            assert parse_int("42") == parse_int("042")
+    """)
+    assert out.value_scope_lifted == 1, f"warnings: {out.warnings}"
+    names = {d.name for d in out.decls}
+    assert len([name for name in names if name.endswith("::facts")]) == 2
+    assert len([name for name in names if name.endswith("::assertion")]) == 2
+    assert len(out.implications) == 2
+    assert all(imp.antecedent.endswith("::facts") for imp in out.implications)
+    assert all(imp.consequent.endswith("::assertion") for imp in out.implications)
+
+
 # --- No pattern fires ----------------------------------------------------
 
 
-def test_single_assert_test_falls_through_to_layer0():
+def test_single_literal_assert_test_falls_through_to_layer0():
     out = _lift("""
         def test_one():
-            assert f(1) == 1
+            assert 1 == 1
     """)
     assert out.lifted == 0
     assert not out.claimed_tests

--- a/implementations/python/provekit-lift-py-tests/tests/test_walk.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_walk.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import textwrap
+
+from provekit_lift_py_tests.ir import _Atomic, _Connective, _ConstInt, _Var
+from provekit_lift_py_tests.lsp import _lift_source
+from provekit_lift_py_tests.walk import lift_production_walk
+
+
+def _lift(src: str):
+    return lift_production_walk(textwrap.dedent(src), "app.py")
+
+
+def _edge(out, suffix: str):
+    matches = [d for d in out.decls if d.name.endswith(suffix)]
+    assert len(matches) == 1, f"expected one {suffix} edge, got {[d.name for d in out.decls]}"
+    return matches[0]
+
+
+def test_walk_substitutes_assignment_back_to_function_entry():
+    out = _lift(
+        """
+        def f(x):
+            if x < 10:
+                raise ValueError("x must be >= 10")
+            return x * 2
+
+        def caller():
+            y = 42
+            result = f(y)
+            return result
+        """
+    )
+
+    assert len(out.implications) == 3, f"warnings: {out.warnings}"
+    assert all(imp.prover == "python-wp-walk" for imp in out.implications)
+    assert all(imp.antecedent_slot == "pre" for imp in out.implications)
+    assert all(imp.consequent_slot == "post" for imp in out.implications)
+
+    let_edge = _edge(out, "::let:y")
+    assert let_edge.name.startswith("f@app.py:")
+
+    pre = let_edge.pre
+    post = let_edge.post
+    assert isinstance(pre, _Atomic)
+    assert pre.name == "≥"
+    assert isinstance(pre.args[0], _ConstInt)
+    assert pre.args[0].value == 42
+    assert isinstance(pre.args[1], _ConstInt)
+    assert pre.args[1].value == 10
+
+    assert isinstance(post, _Atomic)
+    assert post.name == "≥"
+    assert isinstance(post.args[0], _Var)
+    assert post.args[0].name == "y"
+    assert isinstance(post.args[1], _ConstInt)
+    assert post.args[1].value == 10
+
+    entry_edge = _edge(out, "::entry")
+    assert entry_edge.pre == pre
+
+
+def test_walk_if_guard_becomes_callsite_premise():
+    out = _lift(
+        """
+        def f(x):
+            if x < 10:
+                raise ValueError("x must be >= 10")
+            return x
+
+        def guarded_caller(input):
+            if input >= 10:
+                return f(input)
+            return 0
+        """
+    )
+
+    callsite = _edge(out, "::callsite")
+    assert isinstance(callsite.pre, _Connective)
+    assert callsite.pre.kind == "implies"
+    assert len(callsite.pre.operands) == 2
+    for operand in callsite.pre.operands:
+        assert isinstance(operand, _Atomic)
+        assert operand.name == "≥"
+        assert isinstance(operand.args[0], _Var)
+        assert operand.args[0].name == "input"
+        assert isinstance(operand.args[1], _ConstInt)
+        assert operand.args[1].value == 10
+
+
+def test_walk_emits_one_callsite_chain_per_production_call():
+    out = _lift(
+        """
+        def f(x):
+            assert x >= 10
+            return x
+
+        def g(x):
+            if x == 0:
+                raise ValueError("zero")
+            return x
+
+        def caller():
+            a = 12
+            b = 3
+            left = f(a)
+            right = g(b)
+            return left + right
+        """
+    )
+
+    names = [d.name for d in out.decls]
+    assert len([name for name in names if name.startswith("f@app.py:")]) == 4
+    assert len([name for name in names if name.startswith("g@app.py:")]) == 5
+    assert len(out.implications) == 9
+
+
+def test_lsp_lift_source_includes_production_walk_edges_and_implications():
+    lifted = _lift_source(
+        "app.py",
+        textwrap.dedent(
+            """
+            def f(x):
+                if x < 10:
+                    raise ValueError("x must be >= 10")
+                return x
+
+            def caller():
+                y = 42
+                return f(y)
+            """
+        ),
+    )
+
+    names = [decl["name"] for decl in lifted["declarations"]]
+    implications = [
+        imp for imp in lifted["implications"] if imp["prover"] == "python-wp-walk"
+    ]
+    assert any(name.endswith("::callsite") for name in names)
+    assert any(name.endswith("::let:y") for name in names)
+    assert any(name.endswith("::entry") for name in names)
+    assert len(implications) == 3
+    assert all(imp["antecedentSlot"] == "pre" for imp in implications)
+    assert all(imp["consequentSlot"] == "post" for imp in implications)
+
+
+def test_lsp_lift_source_shows_production_composes_while_tests_conflict():
+    lifted = _lift_source(
+        "app.py",
+        textwrap.dedent(
+            """
+            import unittest
+
+            def checked(x):
+                if x < 10:
+                    raise ValueError("x must be >= 10")
+                return x
+
+            def composed_ok():
+                y = 42
+                return checked(y)
+
+            class CheckedContracts(unittest.TestCase):
+                def test_checked_returns_42(self):
+                    actual = checked(42)
+                    self.assertEqual(actual, 42)
+
+                def test_checked_does_not_return_42(self):
+                    actual = checked(42)
+                    self.assertNotEqual(actual, 42)
+            """
+        ),
+    )
+
+    contracts = lifted["declarations"]
+    names = [decl["name"] for decl in contracts]
+
+    production = [
+        decl
+        for decl in contracts
+        if decl["name"].startswith("checked@app.py:")
+        and any(decl["name"].endswith(suffix) for suffix in ["::callsite", "::let:y", "::entry"])
+    ]
+    assert len(production) == 3
+    let_edge = next(decl for decl in production if decl["name"].endswith("::let:y"))
+    assert let_edge["pre"]["name"] == "≥"
+    assert let_edge["pre"]["args"][0]["value"] == 42
+    assert let_edge["pre"]["args"][1]["value"] == 10
+
+    test_assertions = [
+        decl
+        for decl in contracts
+        if decl["name"].startswith("checked@app.py:")
+        and decl["name"].endswith("::assertion")
+    ]
+    assert len(test_assertions) == 2
+    assertion_ops = sorted(decl["inv"]["name"] for decl in test_assertions)
+    assert assertion_ops == ["=", "≠"]
+    for test_name in ["test_checked_returns_42", "test_checked_does_not_return_42"]:
+        assert all(test_name not in name for name in names)
+
+    wp_implications = [
+        imp for imp in lifted["implications"] if imp["prover"] == "python-wp-walk"
+    ]
+    test_implications = [
+        imp for imp in lifted["implications"] if imp["prover"] == "python-test-value-scope"
+    ]
+    assert len(wp_implications) == 3
+    assert len(test_implications) == 2

--- a/implementations/rust/provekit-cli/tests/cli_surface.rs
+++ b/implementations/rust/provekit-cli/tests/cli_surface.rs
@@ -319,3 +319,346 @@ done
         .unwrap_or_default()
         .starts_with("blake3-512:"));
 }
+
+#[test]
+fn lift_python_emits_contracts_and_callsite_implications() {
+    let root = repo_root();
+    let project = tempfile::tempdir().expect("create tempdir");
+    fs::write(
+        project.path().join("test_parser.py"),
+        r#"
+def parse_int(raw):
+    return int(raw)
+
+def test_parse_value_scope():
+    actual = parse_int("42")
+    assert actual == 42
+
+def test_direct_parse():
+    assert parse_int("42") == 42
+
+def test_two_callsites():
+    assert parse_int("42") == parse_int("042")
+"#,
+    )
+    .expect("write python fixture");
+    fs::create_dir_all(project.path().join(".provekit")).expect("create config dir");
+    fs::write(
+        project.path().join(".provekit/config.toml"),
+        r#"[authoring.lift]
+surface = "python"
+"#,
+    )
+    .expect("write config");
+    let manifest_dir = project.path().join(".provekit/lift/python");
+    fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+    let python_src = root.join("implementations/python/provekit-lift-py-tests/src");
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"python-lift\"\ncommand = [\"env\", \"PYTHONPATH={}\", \"python3\", \"-m\", \"provekit_lift_py_tests.lsp\"]\nworking_dir = \".\"\n",
+            python_src.display()
+        ),
+    )
+    .expect("write manifest");
+
+    let output = Command::new(provekit_bin())
+        .arg("lift")
+        .arg(project.path())
+        .arg("--json")
+        .arg("--quiet")
+        .current_dir(&root)
+        .output()
+        .expect("spawn provekit lift python");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "provekit lift python failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("lift JSON parses");
+    assert_eq!(report["kind"], "ir-document");
+    let ir = report["ir"].as_array().expect("ir array");
+    let implications = report["implications"]
+        .as_array()
+        .expect("implications array");
+    assert_eq!(
+        ir.len(),
+        8,
+        "expected callsite fact + assertion contracts: {report:#}"
+    );
+    assert_eq!(
+        implications.len(),
+        4,
+        "expected one implication per lifted callsite: {report:#}"
+    );
+    let names: Vec<_> = ir
+        .iter()
+        .map(|decl| decl["name"].as_str().unwrap_or_default())
+        .collect();
+    assert!(names.iter().all(|name| name.starts_with("parse_int@")));
+    for test_name in [
+        "test_parse_value_scope",
+        "test_direct_parse",
+        "test_two_callsites",
+    ] {
+        assert!(names.iter().all(|name| !name.contains(test_name)));
+    }
+    assert_eq!(
+        names
+            .iter()
+            .filter(|name| name.ends_with("::facts"))
+            .count(),
+        4
+    );
+    assert_eq!(
+        names
+            .iter()
+            .filter(|name| name.ends_with("::assertion"))
+            .count(),
+        4
+    );
+    for implication in implications {
+        let antecedent = implication["antecedent"].as_str().unwrap_or_default();
+        let consequent = implication["consequent"].as_str().unwrap_or_default();
+        assert!(antecedent.ends_with("::facts"));
+        assert!(consequent.ends_with("::assertion"));
+        assert!(names.contains(&antecedent));
+        assert!(names.contains(&consequent));
+    }
+}
+
+#[test]
+fn lift_python_emits_production_wp_callsite_implications() {
+    let root = repo_root();
+    let project = tempfile::tempdir().expect("create tempdir");
+    fs::write(
+        project.path().join("app.py"),
+        r#"
+def f(x):
+    if x < 10:
+        raise ValueError("x must be >= 10")
+    return x
+
+def caller():
+    y = 42
+    return f(y)
+"#,
+    )
+    .expect("write python fixture");
+    fs::create_dir_all(project.path().join(".provekit")).expect("create config dir");
+    fs::write(
+        project.path().join(".provekit/config.toml"),
+        r#"[authoring.lift]
+surface = "python"
+"#,
+    )
+    .expect("write config");
+    let manifest_dir = project.path().join(".provekit/lift/python");
+    fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+    let python_src = root.join("implementations/python/provekit-lift-py-tests/src");
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"python-lift\"\ncommand = [\"env\", \"PYTHONPATH={}\", \"python3\", \"-m\", \"provekit_lift_py_tests.lsp\"]\nworking_dir = \".\"\n",
+            python_src.display()
+        ),
+    )
+    .expect("write manifest");
+
+    let output = Command::new(provekit_bin())
+        .arg("lift")
+        .arg(project.path())
+        .arg("--json")
+        .arg("--quiet")
+        .current_dir(&root)
+        .output()
+        .expect("spawn provekit lift python");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "provekit lift python failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("lift JSON parses");
+    assert_eq!(report["kind"], "ir-document");
+    let ir = report["ir"].as_array().expect("ir array");
+    let implications = report["implications"]
+        .as_array()
+        .expect("implications array");
+    assert_eq!(
+        ir.len(),
+        3,
+        "expected callsite, let, and entry WP edges: {report:#}"
+    );
+    assert_eq!(
+        implications.len(),
+        3,
+        "expected one pre->post implication per WP edge: {report:#}"
+    );
+
+    let names: Vec<_> = ir
+        .iter()
+        .map(|decl| decl["name"].as_str().unwrap_or_default())
+        .collect();
+    assert!(names.iter().all(|name| name.starts_with("f@app.py:")));
+    assert!(names.iter().any(|name| name.ends_with("::callsite")));
+    assert!(names.iter().any(|name| name.ends_with("::let:y")));
+    assert!(names.iter().any(|name| name.ends_with("::entry")));
+
+    let let_edge = ir
+        .iter()
+        .find(|decl| {
+            decl["name"]
+                .as_str()
+                .unwrap_or_default()
+                .ends_with("::let:y")
+        })
+        .expect("let edge");
+    assert_eq!(let_edge["pre"]["name"], "≥");
+    assert_eq!(let_edge["pre"]["args"][0]["value"], 42);
+    assert_eq!(let_edge["post"]["name"], "≥");
+    assert_eq!(let_edge["post"]["args"][0]["name"], "y");
+
+    for implication in implications {
+        let antecedent = implication["antecedent"].as_str().unwrap_or_default();
+        let consequent = implication["consequent"].as_str().unwrap_or_default();
+        assert_eq!(antecedent, consequent);
+        assert!(names.contains(&antecedent));
+        assert_eq!(implication["antecedentSlot"], "pre");
+        assert_eq!(implication["consequentSlot"], "post");
+        assert_eq!(implication["prover"], "python-wp-walk");
+    }
+}
+
+#[test]
+fn lift_python_shows_production_composes_but_unittest_contracts_conflict() {
+    let root = repo_root();
+    let project = tempfile::tempdir().expect("create tempdir");
+    fs::write(
+        project.path().join("app.py"),
+        r#"
+import unittest
+
+def checked(x):
+    if x < 10:
+        raise ValueError("x must be >= 10")
+    return x
+
+def composed_ok():
+    y = 42
+    return checked(y)
+
+class CheckedContracts(unittest.TestCase):
+    def test_checked_returns_42(self):
+        actual = checked(42)
+        self.assertEqual(actual, 42)
+
+    def test_checked_does_not_return_42(self):
+        actual = checked(42)
+        self.assertNotEqual(actual, 42)
+"#,
+    )
+    .expect("write python fixture");
+    fs::create_dir_all(project.path().join(".provekit")).expect("create config dir");
+    fs::write(
+        project.path().join(".provekit/config.toml"),
+        r#"[authoring.lift]
+surface = "python"
+"#,
+    )
+    .expect("write config");
+    let manifest_dir = project.path().join(".provekit/lift/python");
+    fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+    let python_src = root.join("implementations/python/provekit-lift-py-tests/src");
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"python-lift\"\ncommand = [\"env\", \"PYTHONPATH={}\", \"python3\", \"-m\", \"provekit_lift_py_tests.lsp\"]\nworking_dir = \".\"\n",
+            python_src.display()
+        ),
+    )
+    .expect("write manifest");
+
+    let output = Command::new(provekit_bin())
+        .arg("lift")
+        .arg(project.path())
+        .arg("--json")
+        .arg("--quiet")
+        .current_dir(&root)
+        .output()
+        .expect("spawn provekit lift python");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "provekit lift python failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("lift JSON parses");
+    let ir = report["ir"].as_array().expect("ir array");
+    let implications = report["implications"]
+        .as_array()
+        .expect("implications array");
+
+    let production: Vec<_> = ir
+        .iter()
+        .filter(|decl| {
+            let name = decl["name"].as_str().unwrap_or_default();
+            name.starts_with("checked@app.py:")
+                && (name.ends_with("::callsite")
+                    || name.ends_with("::let:y")
+                    || name.ends_with("::entry"))
+        })
+        .collect();
+    assert_eq!(
+        production.len(),
+        3,
+        "expected production callsite, let, and entry WP edges: {report:#}"
+    );
+    let let_edge = production
+        .iter()
+        .copied()
+        .find(|decl| {
+            decl["name"]
+                .as_str()
+                .unwrap_or_default()
+                .ends_with("::let:y")
+        })
+        .expect("let edge");
+    assert_eq!(let_edge["pre"]["name"], "≥");
+    assert_eq!(let_edge["pre"]["args"][0]["value"], 42);
+    assert_eq!(let_edge["pre"]["args"][1]["value"], 10);
+
+    let test_assertions: Vec<_> = ir
+        .iter()
+        .filter(|decl| {
+            let name = decl["name"].as_str().unwrap_or_default();
+            name.starts_with("checked@app.py:") && name.ends_with("::assertion")
+        })
+        .collect();
+    assert_eq!(
+        test_assertions.len(),
+        2,
+        "expected two unittest-derived assertion contracts: {report:#}"
+    );
+    let mut assertion_ops: Vec<_> = test_assertions
+        .iter()
+        .map(|decl| decl["inv"]["name"].as_str().unwrap_or_default())
+        .collect();
+    assertion_ops.sort_unstable();
+    assert_eq!(assertion_ops, vec!["=", "≠"]);
+
+    let wp_implications = implications
+        .iter()
+        .filter(|imp| imp["prover"] == "python-wp-walk")
+        .count();
+    let test_implications = implications
+        .iter()
+        .filter(|imp| imp["prover"] == "python-test-value-scope")
+        .count();
+    assert_eq!(wp_implications, 3);
+    assert_eq!(test_implications, 2);
+}


### PR DESCRIPTION
## Summary
- add a Python production WP walker that lifts callee preconditions, substitutes production callsite actuals, walks backward through assignments, and emits pre/post implication edges
- align Python test-derived callsite contracts with the callee@file:line:col identity used by the newer callsite work
- wire production walk output into the Python lift plugin and add Rust CLI acceptance coverage, including a real unittest fixture where production composes but two unit tests describe conflicting callee behavior

## Verification
- python3 -m pytest implementations/python/provekit-lift-py-tests/tests -q
- rustfmt --check implementations/rust/provekit-cli/tests/cli_surface.rs
- git diff --check
- cargo test --manifest-path implementations/rust/provekit-cli/Cargo.toml --test cli_surface -- --nocapture