### PR TITLE
[codex] Add Java production WP lift implications

### DIFF
--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/ImplicationDecl.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/ImplicationDecl.java
@@ -1,0 +1,49 @@
+package com.provekit.lift;
+
+public class ImplicationDecl {
+    public final String name;
+    public final String antecedent;
+    public final String consequent;
+    public final String antecedentSlot;
+    public final String consequentSlot;
+    public final String prover;
+    public final String proofWitness;
+
+    public ImplicationDecl(
+            String name,
+            String antecedent,
+            String consequent,
+            String antecedentSlot,
+            String consequentSlot,
+            String prover,
+            String proofWitness) {
+        this.name = name;
+        this.antecedent = antecedent;
+        this.consequent = consequent;
+        this.antecedentSlot = antecedentSlot;
+        this.consequentSlot = consequentSlot;
+        this.prover = prover;
+        this.proofWitness = proofWitness;
+    }
+
+    public String toJson() {
+        return "{"
+            + "\"name\":\"" + esc(name) + "\","
+            + "\"antecedent\":\"" + esc(antecedent) + "\","
+            + "\"consequent\":\"" + esc(consequent) + "\","
+            + "\"antecedentSlot\":\"" + esc(antecedentSlot) + "\","
+            + "\"consequentSlot\":\"" + esc(consequentSlot) + "\","
+            + "\"prover\":\"" + esc(prover) + "\","
+            + "\"proofWitness\":\"" + esc(proofWitness) + "\""
+            + "}";
+    }
+
+    private static String esc(String s) {
+        return s
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t");
+    }
+}

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/LiftHandler.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/LiftHandler.java
@@ -32,6 +32,7 @@ public class LiftHandler {
     public String parseSource(String path, String source) {
         List<ContractDecl> decls = new ArrayList<>();
         List<CallEdgeDecl> callEdges = new ArrayList<>();
+        List<ImplicationDecl> implications = new ArrayList<>();
 
         ParseResult<CompilationUnit> result = new JavaParser().parse(source);
         if (result.isSuccessful() && result.getResult().isPresent()) {
@@ -39,6 +40,9 @@ public class LiftHandler {
             for (Extractor ex : extractors) {
                 decls.addAll(ex.extract(cu, source));
             }
+            ProductionWalk.Result productionWalk = ProductionWalk.lift(cu, sourceFileName(path));
+            decls.addAll(productionWalk.declarations());
+            implications.addAll(productionWalk.implications());
             decls = mergeDeclsBySymbol(decls);
             Map<String, String> contractIndex = buildContractIndex(decls);
             callEdges.addAll(JniResolver.resolve(cu, path, contractIndex));
@@ -56,6 +60,11 @@ public class LiftHandler {
             if (i > 0) sb.append(",");
             sb.append(callEdges.get(i).toJson());
         }
+        sb.append("],\"implications\":[");
+        for (int i = 0; i < implications.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(implications.get(i).toJson());
+        }
         sb.append("],\"warnings\":[]}");
         return sb.toString();
     }
@@ -63,11 +72,12 @@ public class LiftHandler {
     public String lift(String workspace, String surface) {
         List<ContractDecl> decls = new ArrayList<>();
         List<CallEdgeDecl> callEdges = new ArrayList<>();
+        List<ImplicationDecl> implications = new ArrayList<>();
         Path root = Paths.get(workspace);
         try {
             Files.walk(root)
                 .filter(p -> p.toString().endsWith(".java"))
-                .forEach(p -> scanFile(p, decls, callEdges));
+                .forEach(p -> scanFile(p, decls, callEdges, implications));
         } catch (IOException e) {
             System.err.println("Walk error: " + e.getMessage());
         }
@@ -83,11 +93,20 @@ public class LiftHandler {
             if (i > 0) ir.append(",");
             ir.append(callEdges.get(i).toJson());
         }
+        ir.append("],\"implications\":[");
+        for (int i = 0; i < implications.size(); i++) {
+            if (i > 0) ir.append(",");
+            ir.append(implications.get(i).toJson());
+        }
         ir.append("],\"diagnostics\":[]}");
         return ir.toString();
     }
 
-    private void scanFile(Path path, List<ContractDecl> decls, List<CallEdgeDecl> callEdges) {
+    private void scanFile(
+            Path path,
+            List<ContractDecl> decls,
+            List<CallEdgeDecl> callEdges,
+            List<ImplicationDecl> implications) {
         try {
             String source = Files.readString(path);
             ParseResult<CompilationUnit> result = new JavaParser().parse(source);
@@ -97,6 +116,9 @@ public class LiftHandler {
             for (Extractor ex : extractors) {
                 fileDecls.addAll(ex.extract(cu, source));
             }
+            ProductionWalk.Result productionWalk = ProductionWalk.lift(cu, path.getFileName().toString());
+            fileDecls.addAll(productionWalk.declarations());
+            implications.addAll(productionWalk.implications());
             decls.addAll(mergeDeclsBySymbol(fileDecls));
 
             // Build contract index from accumulated decls so far (including this file).
@@ -111,6 +133,12 @@ public class LiftHandler {
         } catch (IOException e) {
             System.err.println("Parse error " + path + ": " + e.getMessage());
         }
+    }
+
+    private static String sourceFileName(String path) {
+        Path file = Paths.get(path);
+        Path name = file.getFileName();
+        return name == null ? path : name.toString();
     }
 
     private static List<ContractDecl> mergeDeclsBySymbol(List<ContractDecl> decls) {

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/ProductionWalk.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/ProductionWalk.java
@@ -1,0 +1,515 @@
+package com.provekit.lift;
+
+import java.util.*;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.*;
+
+public final class ProductionWalk {
+    private ProductionWalk() {}
+
+    public record Result(List<ContractDecl> declarations, List<ImplicationDecl> implications) {}
+
+    private record FunctionPrecondition(String name, List<String> formals, String precondition) {}
+
+    private record CallsiteHit(
+            MethodCallExpr call,
+            int stmtIndex,
+            List<String> conditions,
+            List<Statement> precedingInnerStmts) {}
+
+    private record Binding(String name, String term) {}
+
+    public static Result lift(CompilationUnit cu, String sourceFile) {
+        List<MethodDeclaration> methods = cu.findAll(MethodDeclaration.class);
+        Map<String, FunctionPrecondition> callees = new LinkedHashMap<>();
+        for (MethodDeclaration method : methods) {
+            if (isTestMethod(method)) continue;
+            liftFunctionPrecondition(method).ifPresent(pre -> callees.putIfAbsent(pre.name(), pre));
+        }
+
+        List<ContractDecl> declarations = new ArrayList<>();
+        List<ImplicationDecl> implications = new ArrayList<>();
+        Set<String> usedNames = new LinkedHashSet<>();
+        for (MethodDeclaration caller : methods) {
+            if (isTestMethod(caller) || caller.getBody().isEmpty()) continue;
+            for (FunctionPrecondition callee : callees.values()) {
+                if (callee.name().equals(caller.getNameAsString())) continue;
+                emitWalksForCallee(caller, callee, sourceFile, declarations, implications, usedNames);
+            }
+        }
+        return new Result(declarations, implications);
+    }
+
+    private static Optional<FunctionPrecondition> liftFunctionPrecondition(MethodDeclaration method) {
+        if (method.getBody().isEmpty()) return Optional.empty();
+        List<String> atoms = new ArrayList<>();
+        for (Statement stmt : method.getBody().get().getStatements()) {
+            stmtPreconditionContribution(stmt).ifPresent(atoms::add);
+        }
+        if (atoms.isEmpty()) return Optional.empty();
+        String precondition = atoms.size() == 1 ? atoms.get(0) : and(atoms);
+        List<String> formals = method.getParameters()
+            .stream()
+            .map(p -> p.getNameAsString())
+            .toList();
+        return Optional.of(new FunctionPrecondition(method.getNameAsString(), formals, precondition));
+    }
+
+    private static Optional<String> stmtPreconditionContribution(Statement stmt) {
+        if (stmt instanceof AssertStmt assertStmt) {
+            return liftFormula(assertStmt.getCheck());
+        }
+        if (stmt instanceof IfStmt ifStmt
+                && ifStmt.getElseStmt().isEmpty()
+                && statementOnlyThrows(ifStmt.getThenStmt())) {
+            return liftNegatedFormula(ifStmt.getCondition());
+        }
+        return Optional.empty();
+    }
+
+    private static boolean statementOnlyThrows(Statement stmt) {
+        if (stmt instanceof ThrowStmt) return true;
+        if (stmt instanceof BlockStmt block) {
+            return block.getStatements().size() == 1
+                && block.getStatement(0) instanceof ThrowStmt;
+        }
+        return false;
+    }
+
+    private static void emitWalksForCallee(
+            MethodDeclaration caller,
+            FunctionPrecondition callee,
+            String sourceFile,
+            List<ContractDecl> declarations,
+            List<ImplicationDecl> implications,
+            Set<String> usedNames) {
+        for (CallsiteHit hit : findCallsites(caller, callee.name())) {
+            if (callee.formals().size() != hit.call().getArguments().size()) continue;
+
+            String wp = callee.precondition();
+            for (int i = 0; i < callee.formals().size(); i++) {
+                wp = substituteVar(wp, callee.formals().get(i), termFromExpr(hit.call().getArgument(i)));
+            }
+
+            if (!hit.conditions().isEmpty()) {
+                String premise = hit.conditions().size() == 1 ? hit.conditions().get(0) : and(hit.conditions());
+                wp = implies(premise, wp);
+            }
+
+            Optional<String> base = callsiteBase(callee.name(), sourceFile, hit.call());
+            if (base.isEmpty()) continue;
+            appendEdge(
+                declarations,
+                implications,
+                usedNames,
+                base.get() + "::callsite",
+                wp,
+                wp,
+                caller.getNameAsString(),
+                callee.name()
+            );
+            String previousWp = wp;
+
+            for (Statement stmt : hit.precedingInnerStmts()) {
+                for (Binding binding : bindingsFromStmt(stmt)) {
+                    String nextWp = substituteVar(previousWp, binding.name(), binding.term());
+                    appendEdge(
+                        declarations,
+                        implications,
+                        usedNames,
+                        base.get() + "::let:" + binding.name(),
+                        nextWp,
+                        previousWp,
+                        caller.getNameAsString(),
+                        callee.name()
+                    );
+                    previousWp = nextWp;
+                }
+            }
+
+            List<Statement> stmts = caller.getBody().get().getStatements();
+            for (int i = hit.stmtIndex() - 1; i >= 0; i--) {
+                for (Binding binding : bindingsFromStmt(stmts.get(i))) {
+                    String nextWp = substituteVar(previousWp, binding.name(), binding.term());
+                    appendEdge(
+                        declarations,
+                        implications,
+                        usedNames,
+                        base.get() + "::let:" + binding.name(),
+                        nextWp,
+                        previousWp,
+                        caller.getNameAsString(),
+                        callee.name()
+                    );
+                    previousWp = nextWp;
+                }
+            }
+
+            appendEdge(
+                declarations,
+                implications,
+                usedNames,
+                base.get() + "::entry",
+                previousWp,
+                previousWp,
+                caller.getNameAsString(),
+                callee.name()
+            );
+        }
+    }
+
+    private static void appendEdge(
+            List<ContractDecl> declarations,
+            List<ImplicationDecl> implications,
+            Set<String> usedNames,
+            String rawName,
+            String pre,
+            String post,
+            String caller,
+            String callee) {
+        String name = uniqueName(rawName, usedNames);
+        declarations.add(new ContractDecl(name, List.of(pre), List.of(post)));
+        implications.add(new ImplicationDecl(
+            name + "::pre-implies-post",
+            name,
+            name,
+            "pre",
+            "post",
+            "java-wp-walk",
+            caller + "->" + callee
+        ));
+    }
+
+    private static List<CallsiteHit> findCallsites(MethodDeclaration caller, String calleeName) {
+        if (caller.getBody().isEmpty()) return List.of();
+        List<CallsiteHit> hits = new ArrayList<>();
+        List<Statement> stmts = caller.getBody().get().getStatements();
+        for (int i = 0; i < stmts.size(); i++) {
+            walkStmtForCallsites(stmts.get(i), i, calleeName, new ArrayList<>(), new ArrayList<>(), hits);
+        }
+        return hits;
+    }
+
+    private static void walkStmtForCallsites(
+            Statement stmt,
+            int stmtIndex,
+            String calleeName,
+            List<String> conditions,
+            List<Statement> innerStmts,
+            List<CallsiteHit> hits) {
+        if (stmt instanceof IfStmt ifStmt) {
+            Optional<String> lifted = liftFormula(ifStmt.getCondition());
+            lifted.ifPresent(conditions::add);
+            walkStmtForCallsites(ifStmt.getThenStmt(), stmtIndex, calleeName, conditions, innerStmts, hits);
+            if (lifted.isPresent()) {
+                conditions.remove(conditions.size() - 1);
+                conditions.add(negateFormula(lifted.get()));
+            }
+            ifStmt.getElseStmt().ifPresent(elseStmt ->
+                walkStmtForCallsites(elseStmt, stmtIndex, calleeName, conditions, innerStmts, hits));
+            if (lifted.isPresent()) conditions.remove(conditions.size() - 1);
+            return;
+        }
+        if (stmt instanceof BlockStmt block) {
+            walkBlockForCallsites(block.getStatements(), stmtIndex, calleeName, conditions, innerStmts, hits);
+            return;
+        }
+        for (MethodCallExpr call : stmt.findAll(MethodCallExpr.class)) {
+            if (call.getNameAsString().equals(calleeName)) {
+                hits.add(new CallsiteHit(
+                    call,
+                    stmtIndex,
+                    new ArrayList<>(conditions),
+                    new ArrayList<>(innerStmts)
+                ));
+            }
+        }
+    }
+
+    private static void walkBlockForCallsites(
+            List<Statement> stmts,
+            int stmtIndex,
+            String calleeName,
+            List<String> conditions,
+            List<Statement> innerStmts,
+            List<CallsiteHit> hits) {
+        for (int i = 0; i < stmts.size(); i++) {
+            List<Statement> branchPreceding = new ArrayList<>();
+            for (int j = i - 1; j >= 0; j--) {
+                branchPreceding.add(stmts.get(j));
+            }
+            branchPreceding.addAll(innerStmts);
+            walkStmtForCallsites(stmts.get(i), stmtIndex, calleeName, conditions, branchPreceding, hits);
+        }
+    }
+
+    private static List<Binding> bindingsFromStmt(Statement stmt) {
+        if (!stmt.isExpressionStmt()) return List.of();
+        Expression expr = stmt.asExpressionStmt().getExpression();
+        List<Binding> bindings = new ArrayList<>();
+        if (expr instanceof VariableDeclarationExpr decl) {
+            for (var variable : decl.getVariables()) {
+                variable.getInitializer().ifPresent(init ->
+                    bindings.add(new Binding(variable.getNameAsString(), termFromExpr(init))));
+            }
+            return bindings;
+        }
+        if (expr instanceof AssignExpr assign
+                && assign.getOperator() == AssignExpr.Operator.ASSIGN
+                && assign.getTarget() instanceof NameExpr name) {
+            return List.of(new Binding(name.getNameAsString(), termFromExpr(assign.getValue())));
+        }
+        return List.of();
+    }
+
+    private static Optional<String> liftFormula(Expression expr) {
+        expr = unwrap(expr);
+        if (expr instanceof BinaryExpr binary) {
+            Optional<String> op = binaryFormulaOp(binary.getOperator());
+            if (op.isPresent()) {
+                return Optional.of(atom(op.get(), termFromExpr(binary.getLeft()), termFromExpr(binary.getRight())));
+            }
+            if (binary.getOperator() == BinaryExpr.Operator.AND) {
+                Optional<String> left = liftFormula(binary.getLeft());
+                Optional<String> right = liftFormula(binary.getRight());
+                if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+                return Optional.of(and(List.of(left.get(), right.get())));
+            }
+            if (binary.getOperator() == BinaryExpr.Operator.OR) {
+                Optional<String> left = liftFormula(binary.getLeft());
+                Optional<String> right = liftFormula(binary.getRight());
+                if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+                return Optional.of(or(List.of(left.get(), right.get())));
+            }
+        }
+        if (expr instanceof UnaryExpr unary && unary.getOperator() == UnaryExpr.Operator.LOGICAL_COMPLEMENT) {
+            return liftFormula(unary.getExpression()).map(ProductionWalk::negateFormula);
+        }
+        return Optional.of(atom("eq", termFromExpr(expr), cBool(true)));
+    }
+
+    private static Optional<String> liftNegatedFormula(Expression expr) {
+        expr = unwrap(expr);
+        if (expr instanceof BinaryExpr binary) {
+            Optional<String> op = inverseFormulaOp(binary.getOperator());
+            if (op.isPresent()) {
+                return Optional.of(atom(op.get(), termFromExpr(binary.getLeft()), termFromExpr(binary.getRight())));
+            }
+        }
+        return liftFormula(expr).map(ProductionWalk::negateFormula);
+    }
+
+    private static String termFromExpr(Expression expr) {
+        expr = unwrap(expr);
+        if (expr instanceof NameExpr name) {
+            return var(name.getNameAsString());
+        }
+        if (expr instanceof IntegerLiteralExpr intLit) {
+            return cInt(intLit.asNumber().longValue());
+        }
+        if (expr instanceof LongLiteralExpr longLit) {
+            return cInt(longLit.asNumber().longValue());
+        }
+        if (expr instanceof StringLiteralExpr strLit) {
+            return cStr(strLit.getValue());
+        }
+        if (expr instanceof BooleanLiteralExpr boolLit) {
+            return cBool(boolLit.getValue());
+        }
+        if (expr instanceof NullLiteralExpr) {
+            return cNull();
+        }
+        if (expr instanceof UnaryExpr unary
+                && unary.getOperator() == UnaryExpr.Operator.MINUS
+                && unary.getExpression() instanceof IntegerLiteralExpr intLit) {
+            return cInt(-intLit.asNumber().longValue());
+        }
+        if (expr instanceof MethodCallExpr call) {
+            List<String> args = new ArrayList<>();
+            if (call.getScope().isPresent()) {
+                args.add(termFromExpr(call.getScope().get()));
+            }
+            for (Expression arg : call.getArguments()) {
+                args.add(termFromExpr(arg));
+            }
+            return ctor(call.getNameAsString(), args);
+        }
+        if (expr instanceof BinaryExpr binary) {
+            Optional<String> op = binaryTermOp(binary.getOperator());
+            if (op.isPresent()) {
+                return ctor(op.get(), List.of(termFromExpr(binary.getLeft()), termFromExpr(binary.getRight())));
+            }
+        }
+        if (expr instanceof FieldAccessExpr field) {
+            return ctor("field", List.of(termFromExpr(field.getScope()), cStr(field.getNameAsString())));
+        }
+        return var("<expr:" + expr + ">");
+    }
+
+    private static String substituteVar(String formula, String varName, String replacement) {
+        return formula.replace(var(varName), replacement);
+    }
+
+    private static Optional<String> callsiteBase(String callee, String sourceFile, MethodCallExpr call) {
+        return call.getRange().map(range ->
+            callee + "@" + sourceFile + ":" + range.begin.line + ":" + range.begin.column);
+    }
+
+    private static String uniqueName(String name, Set<String> usedNames) {
+        if (usedNames.add(name)) return name;
+        int i = 1;
+        while (!usedNames.add(name + "::" + i)) {
+            i++;
+        }
+        return name + "::" + i;
+    }
+
+    private static boolean isTestMethod(MethodDeclaration method) {
+        for (AnnotationExpr ann : method.getAnnotations()) {
+            String name = ann.getNameAsString();
+            if (name.equals("Test")
+                    || name.equals("RepeatedTest")
+                    || name.equals("ParameterizedTest")
+                    || name.endsWith(".Test")
+                    || name.endsWith(".ParameterizedTest")) {
+                return true;
+            }
+        }
+        return method.getNameAsString().startsWith("test");
+    }
+
+    private static Expression unwrap(Expression expr) {
+        while (expr instanceof EnclosedExpr enclosed) {
+            expr = enclosed.getInner();
+        }
+        return expr;
+    }
+
+    private static Optional<String> binaryFormulaOp(BinaryExpr.Operator op) {
+        return switch (op) {
+            case EQUALS -> Optional.of("eq");
+            case NOT_EQUALS -> Optional.of("neq");
+            case GREATER -> Optional.of("gt");
+            case GREATER_EQUALS -> Optional.of("gte");
+            case LESS -> Optional.of("lt");
+            case LESS_EQUALS -> Optional.of("lte");
+            default -> Optional.empty();
+        };
+    }
+
+    private static Optional<String> inverseFormulaOp(BinaryExpr.Operator op) {
+        return switch (op) {
+            case EQUALS -> Optional.of("neq");
+            case NOT_EQUALS -> Optional.of("eq");
+            case GREATER -> Optional.of("lte");
+            case GREATER_EQUALS -> Optional.of("lt");
+            case LESS -> Optional.of("gte");
+            case LESS_EQUALS -> Optional.of("gt");
+            default -> Optional.empty();
+        };
+    }
+
+    private static Optional<String> binaryTermOp(BinaryExpr.Operator op) {
+        return switch (op) {
+            case PLUS -> Optional.of("+");
+            case MINUS -> Optional.of("-");
+            case MULTIPLY -> Optional.of("*");
+            case DIVIDE -> Optional.of("/");
+            case REMAINDER -> Optional.of("%");
+            default -> Optional.empty();
+        };
+    }
+
+    private static String negateFormula(String formula) {
+        return not(formula);
+    }
+
+    private static String var(String name) {
+        return "{\"kind\":\"var\",\"name\":\"" + esc(name) + "\"}";
+    }
+
+    private static String cInt(long value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
+    }
+
+    private static String cStr(String value) {
+        return "{\"kind\":\"const\",\"value\":\"" + esc(value)
+            + "\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}";
+    }
+
+    private static String cBool(boolean value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Bool\"}}";
+    }
+
+    private static String cNull() {
+        return "{\"kind\":\"const\",\"value\":null,\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"}}";
+    }
+
+    private static String ctor(String name, List<String> args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"ctor\",\"name\":\"")
+            .append(esc(name))
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args.get(i));
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String atom(String name, String... args) {
+        return atom(name, Arrays.asList(args));
+    }
+
+    private static String atom(String name, List<String> args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"atomic\",\"name\":\"")
+            .append(esc(name))
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args.get(i));
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String and(List<String> operands) {
+        return connective("and", operands);
+    }
+
+    private static String or(List<String> operands) {
+        return connective("or", operands);
+    }
+
+    private static String not(String operand) {
+        return connective("not", List.of(operand));
+    }
+
+    private static String implies(String antecedent, String consequent) {
+        return connective("implies", List.of(antecedent, consequent));
+    }
+
+    private static String connective(String kind, List<String> operands) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"")
+            .append(kind)
+            .append("\",\"operands\":[");
+        for (int i = 0; i < operands.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(operands.get(i));
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String esc(String s) {
+        return s
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t");
+    }
+}

--- a/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/ProductionWalkTest.java
+++ b/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/ProductionWalkTest.java
@@ -1,0 +1,122 @@
+package com.provekit.lift;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.CompilationUnit;
+
+public class ProductionWalkTest {
+    @Test
+    public void walkSubstitutesAssignmentBackToFunctionEntry() {
+        String source = """
+            public class App {
+                static int checked(int x) {
+                    if (x < 10) {
+                        throw new IllegalArgumentException("x must be >= 10");
+                    }
+                    return x;
+                }
+
+                static int composedOk() {
+                    int y = 42;
+                    return checked(y);
+                }
+            }
+            """;
+
+        ProductionWalk.Result result = lift(source);
+
+        assertEquals(3, result.declarations().size(), "callsite, let, and entry edges");
+        assertEquals(3, result.implications().size(), "one implication per edge");
+        assertTrue(result.implications().stream().allMatch(i -> i.prover.equals("java-wp-walk")));
+        assertTrue(result.implications().stream().allMatch(i -> i.antecedentSlot.equals("pre")));
+        assertTrue(result.implications().stream().allMatch(i -> i.consequentSlot.equals("post")));
+
+        ContractDecl letEdge = find(result.declarations(), "::let:y");
+        assertTrue(letEdge.symbol.startsWith("checked@App.java:"));
+        assertEquals(List.of(atom("gte", cInt(42), cInt(10))), letEdge.preconditions);
+        assertEquals(List.of(atom("gte", var("y"), cInt(10))), letEdge.postconditions);
+
+        ContractDecl entryEdge = find(result.declarations(), "::entry");
+        assertEquals(letEdge.preconditions, entryEdge.preconditions);
+        assertEquals(letEdge.preconditions, entryEdge.postconditions);
+    }
+
+    @Test
+    public void ifGuardBecomesCallsitePremise() {
+        String source = """
+            public class App {
+                static int checked(int x) {
+                    if (x < 10) {
+                        throw new IllegalArgumentException();
+                    }
+                    return x;
+                }
+
+                static int guarded(int input) {
+                    if (input >= 10) {
+                        return checked(input);
+                    }
+                    return 0;
+                }
+            }
+            """;
+
+        ProductionWalk.Result result = lift(source);
+
+        ContractDecl callsite = find(result.declarations(), "::callsite");
+        String expected = implies(
+            atom("gte", var("input"), cInt(10)),
+            atom("gte", var("input"), cInt(10))
+        );
+        assertEquals(List.of(expected), callsite.preconditions);
+        assertEquals(List.of(expected), callsite.postconditions);
+    }
+
+    private static ProductionWalk.Result lift(String source) {
+        ParseResult<CompilationUnit> result = new JavaParser().parse(source);
+        assertTrue(result.isSuccessful() && result.getResult().isPresent(),
+            "Failed to parse: " + result.getProblems());
+        return ProductionWalk.lift(result.getResult().get(), "App.java");
+    }
+
+    private static ContractDecl find(List<ContractDecl> decls, String suffix) {
+        return decls.stream()
+            .filter(d -> d.symbol.endsWith(suffix))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("missing edge suffix " + suffix + ": " + decls));
+    }
+
+    private static String var(String name) {
+        return "{\"kind\":\"var\",\"name\":\"" + name + "\"}";
+    }
+
+    private static String cInt(long value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
+    }
+
+    private static String atom(String name, String... args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"atomic\",\"name\":\"")
+            .append(name)
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args[i]);
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String implies(String antecedent, String consequent) {
+        return "{\"kind\":\"implies\",\"operands\":["
+            + antecedent
+            + ","
+            + consequent
+            + "]}";
+    }
+}

--- a/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/JUnitExtractorTest.java
+++ b/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/JUnitExtractorTest.java
@@ -26,14 +26,11 @@ public class JUnitExtractorTest {
             }
             """;
 
-        String json = liftOne(source).toJson();
+        ContractDecl decl = liftOne(source);
+        String json = decl.toJson();
 
-        assertEquals(
-            "{\"kind\":\"contract\",\"symbol\":\"parseFortyTwo::0\",\"invariant\":"
-                + atom("eq", ctor("parseInt", cStr("42")), cInt(42))
-                + "}",
-            json
-        );
+        assertTrue(decl.symbol.startsWith("parseInt@ParseTest.java:"), decl.symbol);
+        assertEquals(List.of(atom("eq", ctor("parseInt", cStr("42")), cInt(42))), decl.invariants);
         assertFalse(json.contains("parseInt\",\"args\":[{\"kind\":\"const\",\"value\":\"43\""),
             "A point assertion for parseInt(\"42\") must not mint a contract for parseInt(\"43\")");
         assertFalse(json.contains("\"symbol\":\"parseInt\""),
@@ -55,18 +52,10 @@ public class JUnitExtractorTest {
             }
             """;
 
-        String actual0 = var("actual$0");
-        String expectedInvariant = implies(
-            atom("eq", actual0, ctor("parseInt", cStr("42"))),
-            atom("eq", actual0, cInt(42))
-        );
+        ContractDecl decl = liftOne(source);
 
-        assertEquals(
-            "{\"kind\":\"contract\",\"symbol\":\"parseFortyTwo::0\",\"invariant\":"
-                + expectedInvariant
-                + "}",
-            liftOne(source).toJson()
-        );
+        assertTrue(decl.symbol.startsWith("parseInt@ParseTest.java:"), decl.symbol);
+        assertEquals(List.of(atom("eq", ctor("parseInt", cStr("42")), cInt(42))), decl.invariants);
     }
 
     @Test
@@ -86,21 +75,11 @@ public class JUnitExtractorTest {
             """;
 
         String actual0 = var("actual$0");
-        String actual1 = var("actual$1");
-        String expectedInvariant = implies(
-            and(
-                atom("eq", actual0, ctor("parseInt", cStr("42"))),
-                atom("eq", actual1, ctor("normalize", actual0))
-            ),
-            atom("eq", actual1, cInt(42))
-        );
+        String expectedInvariant = atom("eq", ctor("normalize", actual0), cInt(42));
+        ContractDecl decl = liftOne(source);
 
-        assertEquals(
-            "{\"kind\":\"contract\",\"symbol\":\"normalized::0\",\"invariant\":"
-                + expectedInvariant
-                + "}",
-            liftOne(source).toJson()
-        );
+        assertTrue(decl.symbol.startsWith("normalize@ParseTest.java:"), decl.symbol);
+        assertEquals(List.of(expectedInvariant), decl.invariants);
     }
 
     @Test
@@ -124,26 +103,18 @@ public class JUnitExtractorTest {
             """;
 
         String guard = atom("eq", var("radix"), cInt(10));
-        String actual0 = var("actual$0");
-        String actual1 = var("actual$1");
-        String thenScope = and(
-            guard,
-            atom("eq", actual0, ctor("parseInt", cStr("42")))
-        );
-        String elseScope = and(
-            not(guard),
-            atom("eq", actual1, ctor("parseHex", cStr("2a")))
-        );
-        String expectedInvariant = and(
-            implies(thenScope, atom("eq", actual0, cInt(42))),
-            implies(elseScope, atom("eq", actual1, cInt(42)))
+        List<ContractDecl> decls = lift(source);
+
+        ContractDecl parseInt = findByPrefix(decls, "parseInt@ParseTest.java:");
+        assertEquals(
+            List.of(implies(guard, atom("eq", ctor("parseInt", cStr("42")), cInt(42)))),
+            parseInt.invariants
         );
 
+        ContractDecl parseHex = findByPrefix(decls, "parseHex@ParseTest.java:");
         assertEquals(
-            "{\"kind\":\"contract\",\"symbol\":\"parsesBothRadices::0\",\"invariant\":"
-                + expectedInvariant
-                + "}",
-            liftOne(source).toJson()
+            List.of(implies(not(guard), atom("eq", ctor("parseHex", cStr("2a")), cInt(42)))),
+            parseHex.invariants
         );
     }
 
@@ -168,24 +139,18 @@ public class JUnitExtractorTest {
             """;
 
         String guard = atom("junit_branch_condition", cStr("radixes[0] == 10"));
-        String actual0 = var("actual$0");
-        String actual1 = var("actual$1");
-        String expectedInvariant = and(
-            implies(
-                and(guard, atom("eq", actual0, ctor("parseInt", cStr("42")))),
-                atom("eq", actual0, cInt(42))
-            ),
-            implies(
-                and(not(guard), atom("eq", actual1, ctor("parseHex", cStr("2a")))),
-                atom("eq", actual1, cInt(42))
-            )
+        List<ContractDecl> decls = lift(source);
+
+        ContractDecl parseInt = findByPrefix(decls, "parseInt@ParseTest.java:");
+        assertEquals(
+            List.of(implies(guard, atom("eq", ctor("parseInt", cStr("42")), cInt(42)))),
+            parseInt.invariants
         );
 
+        ContractDecl parseHex = findByPrefix(decls, "parseHex@ParseTest.java:");
         assertEquals(
-            "{\"kind\":\"contract\",\"symbol\":\"parsesBothRadices::0\",\"invariant\":"
-                + expectedInvariant
-                + "}",
-            liftOne(source).toJson()
+            List.of(implies(not(guard), atom("eq", ctor("parseHex", cStr("2a")), cInt(42)))),
+            parseHex.invariants
         );
     }
 
@@ -193,6 +158,13 @@ public class JUnitExtractorTest {
         List<ContractDecl> decls = lift(source);
         assertEquals(1, decls.size(), "Expected exactly one lifted assertion");
         return decls.get(0);
+    }
+
+    private ContractDecl findByPrefix(List<ContractDecl> decls, String prefix) {
+        return decls.stream()
+            .filter(d -> d.symbol.startsWith(prefix))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("missing symbol prefix " + prefix + ": " + decls));
     }
 
     private List<ContractDecl> lift(String source) {

--- a/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/JavaProductionWalkIntegrationTest.java
+++ b/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/JavaProductionWalkIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.provekit.lift;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class JavaProductionWalkIntegrationTest {
+    @Test
+    public void liftShowsProductionComposesButJUnitContractsConflict() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.*;
+
+            public class App {
+                static int checked(int x) {
+                    if (x < 10) {
+                        throw new IllegalArgumentException("x must be >= 10");
+                    }
+                    return x;
+                }
+
+                static int composedOk() {
+                    int y = 42;
+                    return checked(y);
+                }
+
+                @Test
+                void checkedReturns42() {
+                    int actual = checked(42);
+                    assertEquals(42, actual);
+                }
+
+                @Test
+                void checkedDoesNotReturn42() {
+                    int actual = checked(42);
+                    assertNotEquals(42, actual);
+                }
+            }
+            """;
+
+        String response = new LiftHandler().parseSource("/tmp/App.java", source);
+
+        assertTrue(response.contains("\"implications\":["), response);
+        assertTrue(response.contains("\"prover\":\"java-wp-walk\""), response);
+        assertTrue(response.contains("\"symbol\":\"checked@App.java:"), response);
+        assertTrue(response.contains("::callsite\""), response);
+        assertTrue(response.contains("::let:y\""), response);
+        assertTrue(response.contains("::entry\""), response);
+        assertTrue(response.contains("\"precondition\":{\"kind\":\"atomic\",\"name\":\"gte\",\"args\":["
+            + cInt(42)
+            + ","
+            + cInt(10)
+            + "]}"), response);
+
+        assertTrue(response.contains("\"invariant\":{\"kind\":\"atomic\",\"name\":\"eq\""), response);
+        assertTrue(response.contains("\"invariant\":{\"kind\":\"atomic\",\"name\":\"neq\""), response);
+        assertFalse(response.contains("checkedReturns42"), response);
+        assertFalse(response.contains("checkedDoesNotReturn42"), response);
+        assertEquals(5, countOccurrences(response, "\"symbol\":\"checked@App.java:"), response);
+        assertEquals(3, countOccurrences(response, "\"prover\":\"java-wp-walk\""), response);
+    }
+
+    private static String cInt(long value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.indexOf(needle, index)) >= 0) {
+            count++;
+            index += needle.length();
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary

Adds Java production weakest-precondition lifting so production callsites can emit pre/post edge contracts and `java-wp-walk` implications, matching the Python/C direction.

The Java lifter now includes production composition output alongside JUnit-described contracts. The integration fixture shows two real JUnit tests describing conflicting `eq` / `neq` contracts while the production callsite walks `checked(y)` back through `let:y` to function entry.

## Validation

- `mvn -q test` from `implementations/java`
- `mvn -q package -DskipTests` from `implementations/java`
- Manual `provekit lift` RPC smoke against a temp Java project: returned `ir-document`, 5 contracts, 3 `java-wp-walk` implications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added implication declaration modeling to Java source code analysis.
  * Enhanced analysis output to include implications data alongside contract information.
  * Introduced production walk analysis for modeling method behavior and call patterns.
  * Extended workspace scanning to accumulate and track implications across files.

* **Tests**
  * Added test suite validating implication extraction and production analysis functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/536)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->