### PR TITLE
walk-c: lift opaque BUG_ON(cond) macro calls as if-then-fail-fast

### DIFF
--- a/implementations/c/provekit-walk-c/src/lift.c
+++ b/implementations/c/provekit-walk-c/src/lift.c
@@ -253,6 +253,13 @@ static enum CXChildVisitResult pre_visitor(CXCursor cursor, CXCursor parent, CXC
                 free(callee);
                 return CXChildVisit_Break;
             }
+        } else if (callee != NULL && strcmp(callee, "BUG_ON") == 0 && clang_Cursor_getNumArguments(cursor) == 1) {
+            CXCursor arg = clang_Cursor_getArgument(cursor, 0);
+
+            if (add_pre(ctx, pk_c_walk_formula_negate_take(pk_c_walk_lift_condition(arg))) != 0) {
+                free(callee);
+                return CXChildVisit_Break;
+            }
         }
         free(callee);
     }

--- a/implementations/c/provekit-walk-c/tests/fixtures/checked_demo.c
+++ b/implementations/c/provekit-walk-c/tests/fixtures/checked_demo.c
@@ -1,0 +1,9 @@
+#define BUG_ON(x) do { if (x) return -1; } while (0)
+int checked(int x) {
+    BUG_ON(x < 10);
+    return x;
+}
+int composed_ok(void) {
+    int y = 42;
+    return checked(y);
+}

--- a/implementations/c/provekit-walk-c/tests/fixtures/checked_demo_opaque_bug_on.c
+++ b/implementations/c/provekit-walk-c/tests/fixtures/checked_demo_opaque_bug_on.c
@@ -1,0 +1,9 @@
+void BUG_ON(int);
+int checked(int x) {
+    BUG_ON(x < 10);
+    return x;
+}
+int composed_ok(void) {
+    int y = 42;
+    return checked(y);
+}

--- a/implementations/c/provekit-walk-c/tests/integration.sh
+++ b/implementations/c/provekit-walk-c/tests/integration.sh
@@ -5,6 +5,8 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BIN="$SCRIPT_DIR/../provekit-walk-c"
 FIXTURE="$SCRIPT_DIR/fixtures/wp_basic.c"
+CHECKED_FIXTURE="$SCRIPT_DIR/fixtures/checked_demo.c"
+OPAQUE_BUG_ON_FIXTURE="$SCRIPT_DIR/fixtures/checked_demo_opaque_bug_on.c"
 
 if [ ! -x "$BIN" ]; then
     echo "FAIL: binary not found: $BIN" >&2
@@ -13,6 +15,16 @@ fi
 
 if [ ! -f "$FIXTURE" ]; then
     echo "FAIL: fixture not found: $FIXTURE" >&2
+    exit 1
+fi
+
+if [ ! -f "$CHECKED_FIXTURE" ]; then
+    echo "FAIL: fixture not found: $CHECKED_FIXTURE" >&2
+    exit 1
+fi
+
+if [ ! -f "$OPAQUE_BUG_ON_FIXTURE" ]; then
+    echo "FAIL: fixture not found: $OPAQUE_BUG_ON_FIXTURE" >&2
     exit 1
 fi
 
@@ -78,4 +90,117 @@ if chain.get("pre") != entry.get("wp"):
     raise SystemExit("FAIL: chain pre must match function entry WP")
 
 print("sample-chain", " -> ".join(f"{a['kind']}@{a.get('line', 0)}:{a.get('column', 0)}" for a in arrivals))
+PY
+
+CHECKED_RESPONSES="$(
+    {
+        printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+        printf '{"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":'
+        printf '"%s"' "$SCRIPT_DIR/fixtures"
+        printf ',"source_paths":["checked_demo.c"],"surface":"c-walk","parse_backend":"clang_ast"}}\n'
+        printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"shutdown"}'
+    } | "$BIN" --rpc
+)"
+
+CHECKED_RESPONSES_JSON="$CHECKED_RESPONSES" python3 - <<'PY'
+import json
+import os
+
+responses = [json.loads(line) for line in os.environ["CHECKED_RESPONSES_JSON"].splitlines() if line.strip()]
+lift = next((r for r in responses if r.get("id") == 2), None)
+if lift is None:
+    raise SystemExit("FAIL: checked_demo lift response missing")
+
+decls = lift["result"]["declarations"]
+chains = [
+    d for d in decls
+    if d.get("kind") == "function-contract"
+    and d.get("evidence", {}).get("kind") == "wp-walk-chain"
+    and d.get("evidence", {}).get("caller") == "composed_ok"
+    and d.get("evidence", {}).get("callee") == "checked"
+]
+if not chains:
+    raise SystemExit("FAIL: no checked_demo composed_ok -> checked wp-walk-chain emitted")
+
+chain = chains[0]
+arrivals = chain["evidence"].get("arrivals", [])
+if len(arrivals) < 3:
+    raise SystemExit(f"FAIL: checked_demo expected >=3 arrivals, got {len(arrivals)}")
+
+kinds = [a.get("kind") for a in arrivals[:3]]
+if kinds != ["Callsite", "LetBinding", "FunctionEntry"]:
+    raise SystemExit(f"FAIL: checked_demo first three arrivals wrong: {kinds}")
+
+binding = arrivals[1]
+if binding.get("name") != "y":
+    raise SystemExit(f"FAIL: checked_demo LetBinding should be y, got {binding.get('name')}")
+
+entry = next((a for a in arrivals if a.get("kind") == "FunctionEntry"), None)
+if entry is None:
+    raise SystemExit("FAIL: checked_demo FunctionEntry arrival missing")
+
+entry_wp = entry.get("wp", {})
+if entry_wp.get("kind") == "atomic" and entry_wp.get("name") == "true":
+    raise SystemExit("FAIL: checked_demo FunctionEntry WP is trivial true")
+
+if entry_wp.get("kind") != "atomic" or entry_wp.get("name") != "≥":
+    raise SystemExit(f"FAIL: checked_demo FunctionEntry WP should be ≥ atom, got {entry_wp}")
+args = entry_wp.get("args", [])
+if len(args) != 2 or args[0].get("kind") != "const" or args[0].get("value") != 42 or args[1].get("kind") != "const" or args[1].get("value") != 10:
+    raise SystemExit(f"FAIL: checked_demo FunctionEntry WP should be 42 ≥ 10, got {entry_wp}")
+
+if chain.get("post") != arrivals[0].get("wp"):
+    raise SystemExit("FAIL: checked_demo chain post must match callsite WP")
+if chain.get("pre") != entry.get("wp"):
+    raise SystemExit("FAIL: checked_demo chain pre must match function entry WP")
+
+print("checked-demo-chain", " -> ".join(f"{a['kind']}@{a.get('line', 0)}:{a.get('column', 0)}" for a in arrivals))
+PY
+
+OPAQUE_RESPONSES="$(
+    {
+        printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+        printf '{"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":'
+        printf '"%s"' "$SCRIPT_DIR/fixtures"
+        printf ',"source_paths":["checked_demo_opaque_bug_on.c"],"surface":"c-walk","parse_backend":"clang_ast"}}\n'
+        printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"shutdown"}'
+    } | "$BIN" --rpc
+)"
+
+CHECKED_RESPONSES_JSON="$OPAQUE_RESPONSES" CHECKED_LABEL="opaque BUG_ON" python3 - <<'PY'
+import json
+import os
+
+label = os.environ["CHECKED_LABEL"]
+responses = [json.loads(line) for line in os.environ["CHECKED_RESPONSES_JSON"].splitlines() if line.strip()]
+lift = next((r for r in responses if r.get("id") == 2), None)
+if lift is None:
+    raise SystemExit(f"FAIL: {label} lift response missing")
+
+decls = lift["result"]["declarations"]
+chains = [
+    d for d in decls
+    if d.get("kind") == "function-contract"
+    and d.get("evidence", {}).get("kind") == "wp-walk-chain"
+    and d.get("evidence", {}).get("caller") == "composed_ok"
+    and d.get("evidence", {}).get("callee") == "checked"
+]
+if not chains:
+    raise SystemExit(f"FAIL: no {label} composed_ok -> checked wp-walk-chain emitted")
+
+arrivals = chains[0]["evidence"].get("arrivals", [])
+if len(arrivals) < 3:
+    raise SystemExit(f"FAIL: {label} expected >=3 arrivals, got {len(arrivals)}")
+
+entry = next((a for a in arrivals if a.get("kind") == "FunctionEntry"), None)
+if entry is None:
+    raise SystemExit(f"FAIL: {label} FunctionEntry arrival missing")
+entry_wp = entry.get("wp", {})
+if entry_wp.get("kind") != "atomic" or entry_wp.get("name") != "≥":
+    raise SystemExit(f"FAIL: {label} FunctionEntry WP should be ≥ atom, got {entry_wp}")
+args = entry_wp.get("args", [])
+if len(args) != 2 or args[0].get("kind") != "const" or args[0].get("value") != 42 or args[1].get("kind") != "const" or args[1].get("value") != 10:
+    raise SystemExit(f"FAIL: {label} FunctionEntry WP should be 42 ≥ 10, got {entry_wp}")
+
+print("opaque-bug-on-chain", " -> ".join(f"{a['kind']}@{a.get('line', 0)}:{a.get('column', 0)}" for a in arrivals))
 PY


### PR DESCRIPTION
Fixes the production-callsite chain emission gap surfaced by the menagerie/checked-c-demo. When BUG_ON reaches libclang as an opaque CallExpr (macro NOT expanded), walk-c's lift.c never extracted checked's pre, walk.c suppressed chains for trivial preconditions, and the chain emission fell silent. Patch: lift.c treats direct BUG_ON(cond) like the expanded defensive guard. New fixtures: checked_demo.c + checked_demo_opaque_bug_on.c. RED→GREEN: integration passes with both chains emitted. T Savo