### PR TITLE
mint: accept function-contract wire kind alongside legacy contract

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -402,18 +402,20 @@ fn mint_from_ir_document(
 
     for decl in ir {
         let kind = decl.get("kind").and_then(|v| v.as_str()).unwrap_or("");
-        if kind != "contract" {
+        if kind != "contract" && kind != "function-contract" {
             continue;
         }
 
         let name = decl
             .get("name")
             .or_else(|| decl.get("symbol"))
+            .or_else(|| decl.get("fn_name"))
             .and_then(|v| v.as_str())
             .unwrap_or("unnamed")
             .to_string();
         let out_binding = decl
             .get("outBinding")
+            .or_else(|| decl.get("out_binding"))
             .and_then(|v| v.as_str())
             .unwrap_or("out")
             .to_string();


### PR DESCRIPTION
cmd_mint.rs only accepted kind: contract (legacy ContractDecl shape) and silently skipped the canonical WireFunctionContractMemento shape (kind: function-contract) that every modern lifter emits. Result: every mint against a modern lifter reported 'no contracts to mint' even with real contracts in the lift response. This patch accepts both kinds and adds fn_name/out_binding fallbacks for the function-contract field naming. Verified end-to-end on menagerie/checked-c-demo: mint emits a real .proof with catalog CID + contractSetCid + signed attestation. T Savo