### PR TITLE
walk-c: two-armed if/else WP propagation

### DIFF
--- a/implementations/c/provekit-walk-c/Makefile
+++ b/implementations/c/provekit-walk-c/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -Wall -Wextra -Wpedantic -std=c11 -I../provekit-lift-core/include -g
 LLVM_CONFIG ?= $(shell command -v llvm-config 2>/dev/null || command -v /usr/local/opt/llvm/bin/llvm-config 2>/dev/null || command -v /usr/local/opt/llvm@21/bin/llvm-config 2>/dev/null)
 
 BIN = provekit-walk-c
-SRC = src/main.c src/walk.c src/wp.c src/lift.c src/contract.c ../provekit-lift-core/src/core.c ../provekit-lift-core/src/parser.c ../provekit-lift-core/src/compile_context.c
+SRC = src/main.c src/walk.c src/wp.c src/lift.c src/contract.c src/conditional.c ../provekit-lift-core/src/core.c ../provekit-lift-core/src/parser.c ../provekit-lift-core/src/compile_context.c
 TEST_SH = tests/integration.sh
 
 ifneq ($(strip $(LLVM_CONFIG)),)

--- a/implementations/c/provekit-walk-c/src/conditional.c
+++ b/implementations/c/provekit-walk-c/src/conditional.c
@@ -1,0 +1,431 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "walk_c.h"
+
+#ifdef PK_C_ENABLE_CLANG_AST
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    CXCursor items[8];
+    unsigned len;
+} CursorList;
+
+typedef struct {
+    CXCursor target;
+    int found;
+} ContainsCtx;
+
+typedef struct {
+    CXCursor target;
+    CXCursor child;
+    int found;
+} ChildCtx;
+
+typedef struct {
+    pk_c_walk_formula *cond;
+    char *branch;
+    size_t join_stmt_index;
+    int line;
+    int column;
+} ConditionalFrame;
+
+typedef struct {
+    ConditionalFrame *items;
+    size_t len;
+    size_t cap;
+} FrameVec;
+
+typedef struct {
+    char *name;
+    pk_c_walk_term *term;
+} Assignment;
+
+static enum CXChildVisitResult collect_children(CXCursor cursor, CXCursor parent, CXClientData data) {
+    CursorList *list = (CursorList *)data;
+
+    (void)parent;
+    if (list->len < sizeof(list->items) / sizeof(list->items[0])) {
+        list->items[list->len++] = cursor;
+    }
+    return CXChildVisit_Continue;
+}
+
+static enum CXChildVisitResult contains_visitor(CXCursor cursor, CXCursor parent, CXClientData data) {
+    ContainsCtx *ctx = (ContainsCtx *)data;
+
+    (void)parent;
+    if (clang_equalCursors(cursor, ctx->target)) {
+        ctx->found = 1;
+        return CXChildVisit_Break;
+    }
+    return CXChildVisit_Recurse;
+}
+
+static int cursor_contains(CXCursor root, CXCursor target) {
+    ContainsCtx ctx = {target, 0};
+
+    if (clang_equalCursors(root, target)) {
+        return 1;
+    }
+    (void)clang_visitChildren(root, contains_visitor, &ctx);
+    return ctx.found;
+}
+
+static enum CXChildVisitResult containing_child_visitor(CXCursor cursor, CXCursor parent, CXClientData data) {
+    ChildCtx *ctx = (ChildCtx *)data;
+
+    (void)parent;
+    if (cursor_contains(cursor, ctx->target)) {
+        ctx->child = cursor;
+        ctx->found = 1;
+        return CXChildVisit_Break;
+    }
+    return CXChildVisit_Continue;
+}
+
+static int find_containing_child(CXCursor root, CXCursor target, CXCursor *child_out) {
+    ChildCtx ctx;
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.target = target;
+    (void)clang_visitChildren(root, containing_child_visitor, &ctx);
+    if (!ctx.found) {
+        return 0;
+    }
+    *child_out = ctx.child;
+    return 1;
+}
+
+static void frame_vec_free(FrameVec *vec) {
+    if (vec == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < vec->len; i++) {
+        pk_c_walk_formula_free(vec->items[i].cond);
+        free(vec->items[i].branch);
+    }
+    free(vec->items);
+    memset(vec, 0, sizeof(*vec));
+}
+
+static int frame_vec_append(
+    FrameVec *vec,
+    pk_c_walk_formula *cond,
+    const char *branch,
+    size_t join_stmt_index,
+    int line,
+    int column
+) {
+    ConditionalFrame *items;
+    size_t cap;
+
+    if (cond == NULL) {
+        return 0;
+    }
+    if (vec->len == vec->cap) {
+        cap = vec->cap == 0 ? 4 : vec->cap * 2;
+        if (cap < vec->cap) {
+            pk_c_walk_formula_free(cond);
+            return -1;
+        }
+        items = realloc(vec->items, cap * sizeof(*items));
+        if (items == NULL) {
+            pk_c_walk_formula_free(cond);
+            return -1;
+        }
+        vec->items = items;
+        vec->cap = cap;
+    }
+    vec->items[vec->len].cond = cond;
+    vec->items[vec->len].branch = pk_c_walk_copy(branch);
+    vec->items[vec->len].join_stmt_index = join_stmt_index;
+    vec->items[vec->len].line = line;
+    vec->items[vec->len].column = column;
+    if (vec->items[vec->len].branch == NULL) {
+        pk_c_walk_formula_free(cond);
+        memset(&vec->items[vec->len], 0, sizeof(vec->items[vec->len]));
+        return -1;
+    }
+    vec->len++;
+    return 0;
+}
+
+static int append_if_frame(
+    FrameVec *frames,
+    CXCursor if_cursor,
+    CXCursor cond_cursor,
+    const char *branch,
+    int negate,
+    size_t stmt_index
+) {
+    pk_c_walk_formula *cond = pk_c_walk_lift_condition(cond_cursor);
+    int line = 0;
+    int column = 0;
+
+    if (negate) {
+        cond = pk_c_walk_formula_negate_take(cond);
+    }
+    pk_c_walk_locus(if_cursor, &line, &column);
+    return frame_vec_append(frames, cond, branch, stmt_index, line, column);
+}
+
+static int collect_frames(CXCursor root, CXCursor target, FrameVec *frames, size_t stmt_index) {
+    CursorList list = {{0}, 0};
+    CXCursor child;
+
+    if (!cursor_contains(root, target)) {
+        return 0;
+    }
+    if (clang_getCursorKind(root) == CXCursor_IfStmt) {
+        (void)clang_visitChildren(root, collect_children, &list);
+        if (list.len >= 2 && cursor_contains(list.items[1], target)) {
+            if (append_if_frame(frames, root, list.items[0], "then", 0, stmt_index) != 0) {
+                return -1;
+            }
+            return collect_frames(list.items[1], target, frames, stmt_index);
+        }
+        if (list.len >= 3 && cursor_contains(list.items[2], target)) {
+            if (append_if_frame(frames, root, list.items[0], "else", 1, stmt_index) != 0) {
+                return -1;
+            }
+            return collect_frames(list.items[2], target, frames, stmt_index);
+        }
+    }
+    if (find_containing_child(root, target, &child)) {
+        return collect_frames(child, target, frames, stmt_index);
+    }
+    return 0;
+}
+
+int pk_c_walk_apply_call_context(
+    CXCursor top_stmt,
+    CXCursor call_cursor,
+    pk_c_walk_formula **wp,
+    pk_c_walk_chain *chain,
+    size_t stmt_index
+) {
+    FrameVec frames = {0};
+    int rc = 0;
+
+    if (collect_frames(top_stmt, call_cursor, &frames, stmt_index) != 0) {
+        frame_vec_free(&frames);
+        return -1;
+    }
+    for (size_t i = frames.len; i > 0; i--) {
+        ConditionalFrame *frame = &frames.items[i - 1];
+        pk_c_walk_formula *cond = pk_c_walk_formula_clone(frame->cond);
+        pk_c_walk_formula *next;
+
+        if (cond == NULL) {
+            rc = -1;
+            break;
+        }
+        next = pk_c_walk_formula_implies_take(cond, *wp);
+        *wp = NULL;
+        if (next == NULL) {
+            rc = -1;
+            break;
+        }
+        *wp = next;
+        if (pk_c_walk_chain_add_conditional_arm_arrival(
+                chain,
+                frame->branch,
+                stmt_index,
+                frame->join_stmt_index,
+                frame->line,
+                frame->column,
+                frame->cond,
+                *wp) != 0) {
+            rc = -1;
+            break;
+        }
+    }
+    frame_vec_free(&frames);
+    return rc;
+}
+
+static int single_stmt(CXCursor cursor, CXCursor *stmt_out) {
+    CursorList list = {{0}, 0};
+
+    if (clang_getCursorKind(cursor) != CXCursor_CompoundStmt) {
+        *stmt_out = cursor;
+        return 1;
+    }
+    (void)clang_visitChildren(cursor, collect_children, &list);
+    if (list.len != 1) {
+        return 0;
+    }
+    *stmt_out = list.items[0];
+    return 1;
+}
+
+static int source_has_plain_assignment(CXCursor cursor) {
+    char *source = pk_c_walk_cursor_source(cursor);
+    int found = 0;
+
+    if (source == NULL) {
+        return 0;
+    }
+    for (char *p = source; *p != '\0'; p++) {
+        char prev = p == source ? '\0' : p[-1];
+        char next = p[1];
+
+        if (*p == '=' && prev != '=' && prev != '!' && prev != '<' && prev != '>' && next != '=') {
+            found = 1;
+            break;
+        }
+    }
+    free(source);
+    return found;
+}
+
+static int lift_assignment(CXCursor cursor, Assignment *assignment) {
+    CursorList list = {{0}, 0};
+
+    memset(assignment, 0, sizeof(*assignment));
+    if (clang_getCursorKind(cursor) != CXCursor_BinaryOperator || !source_has_plain_assignment(cursor)) {
+        return 0;
+    }
+    (void)clang_visitChildren(cursor, collect_children, &list);
+    if (list.len < 2) {
+        return 0;
+    }
+    assignment->name = pk_c_walk_cursor_source(list.items[0]);
+    assignment->term = pk_c_walk_lift_term(list.items[1]);
+    if (assignment->name == NULL || assignment->term == NULL) {
+        free(assignment->name);
+        pk_c_walk_term_free(assignment->term);
+        memset(assignment, 0, sizeof(*assignment));
+        return -1;
+    }
+    return 1;
+}
+
+static void assignment_free(Assignment *assignment) {
+    if (assignment == NULL) {
+        return;
+    }
+    free(assignment->name);
+    pk_c_walk_term_free(assignment->term);
+    memset(assignment, 0, sizeof(*assignment));
+}
+
+static int apply_two_armed_assignments(
+    CXCursor if_cursor,
+    CXCursor cond_cursor,
+    CXCursor then_cursor,
+    CXCursor else_cursor,
+    pk_c_walk_formula **wp,
+    pk_c_walk_chain *chain,
+    size_t stmt_index
+) {
+    CXCursor then_stmt;
+    CXCursor else_stmt;
+    Assignment then_assignment;
+    Assignment else_assignment;
+    pk_c_walk_formula *condition = NULL;
+    pk_c_walk_formula *then_wp = NULL;
+    pk_c_walk_formula *else_wp = NULL;
+    pk_c_walk_formula *then_cond = NULL;
+    pk_c_walk_formula *else_cond = NULL;
+    pk_c_walk_formula *then_impl = NULL;
+    pk_c_walk_formula *else_impl = NULL;
+    pk_c_walk_formula *next = NULL;
+    int line = 0;
+    int column = 0;
+    int rc = -1;
+    int then_lifted;
+    int else_lifted;
+
+    memset(&then_assignment, 0, sizeof(then_assignment));
+    memset(&else_assignment, 0, sizeof(else_assignment));
+    if (!single_stmt(then_cursor, &then_stmt) || !single_stmt(else_cursor, &else_stmt)) {
+        return 0;
+    }
+    then_lifted = lift_assignment(then_stmt, &then_assignment);
+    else_lifted = lift_assignment(else_stmt, &else_assignment);
+    if (then_lifted < 0 || else_lifted < 0) {
+        goto done;
+    }
+    if (then_lifted == 0 || else_lifted == 0 ||
+        strcmp(then_assignment.name, else_assignment.name) != 0) {
+        rc = 0;
+        goto done;
+    }
+    condition = pk_c_walk_lift_condition(cond_cursor);
+    if (condition == NULL) {
+        rc = 0;
+        goto done;
+    }
+    then_wp = pk_c_walk_substitute_formula(*wp, then_assignment.name, then_assignment.term);
+    else_wp = pk_c_walk_substitute_formula(*wp, else_assignment.name, else_assignment.term);
+    then_cond = pk_c_walk_formula_clone(condition);
+    else_cond = pk_c_walk_formula_negate_take(pk_c_walk_formula_clone(condition));
+    if (then_wp == NULL || else_wp == NULL || then_cond == NULL || else_cond == NULL) {
+        goto done;
+    }
+    pk_c_walk_locus(if_cursor, &line, &column);
+    if (pk_c_walk_chain_add_conditional_arm_arrival(
+            chain, "then", stmt_index, stmt_index, line, column, then_cond, then_wp) != 0 ||
+        pk_c_walk_chain_add_conditional_arm_arrival(
+            chain, "else", stmt_index, stmt_index, line, column, else_cond, else_wp) != 0) {
+        goto done;
+    }
+    then_impl = pk_c_walk_formula_implies_take(then_cond, then_wp);
+    then_cond = NULL;
+    then_wp = NULL;
+    if (then_impl == NULL) {
+        goto done;
+    }
+    else_impl = pk_c_walk_formula_implies_take(else_cond, else_wp);
+    else_cond = NULL;
+    else_wp = NULL;
+    if (else_impl == NULL) {
+        goto done;
+    }
+    next = pk_c_walk_formula_and_take(then_impl, else_impl);
+    then_impl = NULL;
+    else_impl = NULL;
+    if (next == NULL) {
+        goto done;
+    }
+    pk_c_walk_formula_free(*wp);
+    *wp = next;
+    next = NULL;
+    rc = 0;
+
+done:
+    assignment_free(&then_assignment);
+    assignment_free(&else_assignment);
+    pk_c_walk_formula_free(condition);
+    pk_c_walk_formula_free(then_wp);
+    pk_c_walk_formula_free(else_wp);
+    pk_c_walk_formula_free(then_cond);
+    pk_c_walk_formula_free(else_cond);
+    pk_c_walk_formula_free(then_impl);
+    pk_c_walk_formula_free(else_impl);
+    pk_c_walk_formula_free(next);
+    return rc;
+}
+
+int pk_c_walk_apply_two_armed_if_stmt(
+    CXCursor stmt,
+    pk_c_walk_formula **wp,
+    pk_c_walk_chain *chain,
+    size_t stmt_index
+) {
+    CursorList list = {{0}, 0};
+
+    if (clang_getCursorKind(stmt) != CXCursor_IfStmt) {
+        return 0;
+    }
+    (void)clang_visitChildren(stmt, collect_children, &list);
+    if (list.len < 3) {
+        return 0;
+    }
+    return apply_two_armed_assignments(stmt, list.items[0], list.items[1], list.items[2], wp, chain, stmt_index);
+}
+
+#endif

--- a/implementations/c/provekit-walk-c/src/contract.c
+++ b/implementations/c/provekit-walk-c/src/contract.c
@@ -124,10 +124,12 @@ static int append_formula(ContractBuf *b, const pk_c_walk_formula *formula) {
 
 static int append_arrival(ContractBuf *b, const pk_c_walk_arrival *arrival) {
     char idx[32];
+    char join_idx[32];
     char line[32];
     char col[32];
 
     (void)snprintf(idx, sizeof(idx), "%zu", arrival->stmt_index);
+    (void)snprintf(join_idx, sizeof(join_idx), "%zu", arrival->join_stmt_index);
     (void)snprintf(line, sizeof(line), "%d", arrival->line);
     (void)snprintf(col, sizeof(col), "%d", arrival->column);
     if (buf_append(b, "{\"column\":") != 0 ||
@@ -139,8 +141,21 @@ static int append_arrival(ContractBuf *b, const pk_c_walk_arrival *arrival) {
         buf_append(b, ",\"name\":") != 0 ||
         buf_append_quoted(b, arrival->name) != 0 ||
         buf_append(b, ",\"stmt_index\":") != 0 ||
-        buf_append(b, idx) != 0 ||
-        buf_append(b, ",\"wp\":") != 0 ||
+        buf_append(b, idx) != 0) {
+        return -1;
+    }
+    if (strcmp(arrival->kind, "ConditionalArm") == 0) {
+        if (arrival->branch == NULL || arrival->cond == NULL ||
+            buf_append(b, ",\"branch\":") != 0 ||
+            buf_append_quoted(b, arrival->branch) != 0 ||
+            buf_append(b, ",\"cond\":") != 0 ||
+            append_formula(b, arrival->cond) != 0 ||
+            buf_append(b, ",\"join_stmt_index\":") != 0 ||
+            buf_append(b, join_idx) != 0) {
+            return -1;
+        }
+    }
+    if (buf_append(b, ",\"wp\":") != 0 ||
         append_formula(b, arrival->wp) != 0 ||
         buf_append_char(b, '}') != 0) {
         return -1;

--- a/implementations/c/provekit-walk-c/src/lift.c
+++ b/implementations/c/provekit-walk-c/src/lift.c
@@ -185,7 +185,9 @@ static enum CXChildVisitResult exits_visitor(CXCursor cursor, CXCursor parent, C
     if (kind == CXCursor_CallExpr) {
         char *callee = pk_c_walk_call_callee(cursor);
 
-        if (callee != NULL && (strcmp(callee, "BUG") == 0 || strcmp(callee, "panic") == 0)) {
+        if (callee != NULL && (strcmp(callee, "BUG") == 0 ||
+            strcmp(callee, "panic") == 0 ||
+            strcmp(callee, "__builtin_trap") == 0)) {
             ctx->exits = 1;
             free(callee);
             return CXChildVisit_Break;
@@ -202,6 +204,17 @@ static int stmt_exits(CXCursor cursor) {
         clang_getCursorKind(cursor) == CXCursor_GotoStmt ||
         clang_getCursorKind(cursor) == CXCursor_BreakStmt) {
         return 1;
+    }
+    if (clang_getCursorKind(cursor) == CXCursor_CallExpr) {
+        char *callee = pk_c_walk_call_callee(cursor);
+        int exits = callee != NULL && (strcmp(callee, "BUG") == 0 ||
+            strcmp(callee, "panic") == 0 ||
+            strcmp(callee, "__builtin_trap") == 0);
+
+        free(callee);
+        if (exits) {
+            return 1;
+        }
     }
     (void)clang_visitChildren(cursor, exits_visitor, &ctx);
     return ctx.exits;

--- a/implementations/c/provekit-walk-c/src/walk.c
+++ b/implementations/c/provekit-walk-c/src/walk.c
@@ -364,10 +364,17 @@ static int process_call(CallVisitCtx *ctx, CXCursor call_cursor) {
         free(callee_name);
         return -1;
     }
+    if (pk_c_walk_apply_call_context(ctx->stmts[ctx->stmt_index], call_cursor, &wp, &chain, ctx->stmt_index) != 0) {
+        pk_c_walk_chain_free(&chain);
+        pk_c_walk_formula_free(wp);
+        free(callee_name);
+        return -1;
+    }
     for (size_t pos = ctx->stmt_index; pos > 0; pos--) {
         CXCursor prev = ctx->stmts[pos - 1];
 
         if (apply_decl_stmt(prev, &wp, &chain, pos - 1) != 0 ||
+            pk_c_walk_apply_two_armed_if_stmt(prev, &wp, &chain, pos - 1) != 0 ||
             apply_guard_stmt(prev, &wp) != 0) {
             pk_c_walk_chain_free(&chain);
             pk_c_walk_formula_free(wp);

--- a/implementations/c/provekit-walk-c/src/walk_c.h
+++ b/implementations/c/provekit-walk-c/src/walk_c.h
@@ -47,9 +47,12 @@ struct pk_c_walk_formula {
 typedef struct {
     char *kind;
     char *name;
+    char *branch;
     size_t stmt_index;
+    size_t join_stmt_index;
     int line;
     int column;
+    pk_c_walk_formula *cond;
     pk_c_walk_formula *wp;
 } pk_c_walk_arrival;
 
@@ -79,6 +82,7 @@ pk_c_walk_formula *pk_c_walk_formula_true(void);
 pk_c_walk_formula *pk_c_walk_formula_atomic_take(const char *name, pk_c_walk_term **args, size_t n_args);
 pk_c_walk_formula *pk_c_walk_formula_and_take(pk_c_walk_formula *lhs, pk_c_walk_formula *rhs);
 pk_c_walk_formula *pk_c_walk_formula_or_take(pk_c_walk_formula *lhs, pk_c_walk_formula *rhs);
+pk_c_walk_formula *pk_c_walk_formula_implies_take(pk_c_walk_formula *lhs, pk_c_walk_formula *rhs);
 pk_c_walk_formula *pk_c_walk_formula_not_take(pk_c_walk_formula *inner);
 pk_c_walk_formula *pk_c_walk_formula_negate_take(pk_c_walk_formula *formula);
 pk_c_walk_formula *pk_c_walk_formula_clone(const pk_c_walk_formula *formula);
@@ -102,6 +106,15 @@ int pk_c_walk_chain_add_arrival(
     int line,
     int column,
     const pk_c_walk_formula *wp);
+int pk_c_walk_chain_add_conditional_arm_arrival(
+    pk_c_walk_chain *chain,
+    const char *branch,
+    size_t stmt_index,
+    size_t join_stmt_index,
+    int line,
+    int column,
+    const pk_c_walk_formula *cond,
+    const pk_c_walk_formula *wp);
 
 #ifdef PK_C_ENABLE_CLANG_AST
 char *pk_c_walk_cursor_source(CXCursor cursor);
@@ -114,6 +127,17 @@ char **pk_c_walk_lift_formals(CXCursor function_cursor, size_t *len_out);
 void pk_c_walk_lift_string_list_free(char **items, size_t len);
 void pk_c_walk_locus(CXCursor cursor, int *line, int *column);
 int pk_c_walk_emit_chain_contract(pk_c_lift_result *result, const pk_c_walk_chain *chain);
+int pk_c_walk_apply_call_context(
+    CXCursor top_stmt,
+    CXCursor call_cursor,
+    pk_c_walk_formula **wp,
+    pk_c_walk_chain *chain,
+    size_t stmt_index);
+int pk_c_walk_apply_two_armed_if_stmt(
+    CXCursor stmt,
+    pk_c_walk_formula **wp,
+    pk_c_walk_chain *chain,
+    size_t stmt_index);
 #endif
 
 pk_c_lift_result *pk_c_walk_lift_source(const char *path, const char *source);

--- a/implementations/c/provekit-walk-c/src/wp.c
+++ b/implementations/c/provekit-walk-c/src/wp.c
@@ -306,6 +306,10 @@ pk_c_walk_formula *pk_c_walk_formula_or_take(pk_c_walk_formula *lhs, pk_c_walk_f
     return formula_binary_take(PK_C_WALK_FORMULA_OR, lhs, rhs);
 }
 
+pk_c_walk_formula *pk_c_walk_formula_implies_take(pk_c_walk_formula *lhs, pk_c_walk_formula *rhs) {
+    return formula_binary_take(PK_C_WALK_FORMULA_IMPLIES, lhs, rhs);
+}
+
 pk_c_walk_formula *pk_c_walk_formula_not_take(pk_c_walk_formula *inner) {
     pk_c_walk_formula *formula = formula_new(PK_C_WALK_FORMULA_NOT);
 
@@ -946,10 +950,41 @@ void pk_c_walk_chain_free(pk_c_walk_chain *chain) {
     for (size_t i = 0; i < chain->n_arrivals; i++) {
         free(chain->arrivals[i].kind);
         free(chain->arrivals[i].name);
+        free(chain->arrivals[i].branch);
+        pk_c_walk_formula_free(chain->arrivals[i].cond);
         pk_c_walk_formula_free(chain->arrivals[i].wp);
     }
     free(chain->arrivals);
     memset(chain, 0, sizeof(*chain));
+}
+
+static pk_c_walk_arrival *chain_append_slot(pk_c_walk_chain *chain) {
+    pk_c_walk_arrival *items;
+    size_t cap;
+
+    if (chain->n_arrivals == chain->cap_arrivals) {
+        cap = chain->cap_arrivals == 0 ? 4 : chain->cap_arrivals * 2;
+        if (cap < chain->cap_arrivals) {
+            return NULL;
+        }
+        items = realloc(chain->arrivals, cap * sizeof(*items));
+        if (items == NULL) {
+            return NULL;
+        }
+        chain->arrivals = items;
+        chain->cap_arrivals = cap;
+    }
+    memset(&chain->arrivals[chain->n_arrivals], 0, sizeof(chain->arrivals[chain->n_arrivals]));
+    return &chain->arrivals[chain->n_arrivals];
+}
+
+static void arrival_clear(pk_c_walk_arrival *arrival) {
+    free(arrival->kind);
+    free(arrival->name);
+    free(arrival->branch);
+    pk_c_walk_formula_free(arrival->cond);
+    pk_c_walk_formula_free(arrival->wp);
+    memset(arrival, 0, sizeof(*arrival));
 }
 
 int pk_c_walk_chain_add_arrival(
@@ -961,34 +996,52 @@ int pk_c_walk_chain_add_arrival(
     int column,
     const pk_c_walk_formula *wp
 ) {
-    pk_c_walk_arrival *items;
-    size_t cap;
+    pk_c_walk_arrival *arrival = chain_append_slot(chain);
 
-    if (chain->n_arrivals == chain->cap_arrivals) {
-        cap = chain->cap_arrivals == 0 ? 4 : chain->cap_arrivals * 2;
-        if (cap < chain->cap_arrivals) {
-            return -1;
-        }
-        items = realloc(chain->arrivals, cap * sizeof(*items));
-        if (items == NULL) {
-            return -1;
-        }
-        chain->arrivals = items;
-        chain->cap_arrivals = cap;
+    if (arrival == NULL) {
+        return -1;
     }
-    chain->arrivals[chain->n_arrivals].kind = pk_c_walk_copy(kind);
-    chain->arrivals[chain->n_arrivals].name = pk_c_walk_copy(name == NULL ? "" : name);
-    chain->arrivals[chain->n_arrivals].stmt_index = stmt_index;
-    chain->arrivals[chain->n_arrivals].line = line;
-    chain->arrivals[chain->n_arrivals].column = column;
-    chain->arrivals[chain->n_arrivals].wp = pk_c_walk_formula_clone(wp);
-    if (chain->arrivals[chain->n_arrivals].kind == NULL ||
-        chain->arrivals[chain->n_arrivals].name == NULL ||
-        chain->arrivals[chain->n_arrivals].wp == NULL) {
-        free(chain->arrivals[chain->n_arrivals].kind);
-        free(chain->arrivals[chain->n_arrivals].name);
-        pk_c_walk_formula_free(chain->arrivals[chain->n_arrivals].wp);
-        memset(&chain->arrivals[chain->n_arrivals], 0, sizeof(chain->arrivals[chain->n_arrivals]));
+    arrival->kind = pk_c_walk_copy(kind);
+    arrival->name = pk_c_walk_copy(name == NULL ? "" : name);
+    arrival->stmt_index = stmt_index;
+    arrival->line = line;
+    arrival->column = column;
+    arrival->wp = pk_c_walk_formula_clone(wp);
+    if (arrival->kind == NULL || arrival->name == NULL || arrival->wp == NULL) {
+        arrival_clear(arrival);
+        return -1;
+    }
+    chain->n_arrivals++;
+    return 0;
+}
+
+int pk_c_walk_chain_add_conditional_arm_arrival(
+    pk_c_walk_chain *chain,
+    const char *branch,
+    size_t stmt_index,
+    size_t join_stmt_index,
+    int line,
+    int column,
+    const pk_c_walk_formula *cond,
+    const pk_c_walk_formula *wp
+) {
+    pk_c_walk_arrival *arrival = chain_append_slot(chain);
+
+    if (arrival == NULL) {
+        return -1;
+    }
+    arrival->kind = pk_c_walk_copy("ConditionalArm");
+    arrival->name = pk_c_walk_copy(branch == NULL ? "" : branch);
+    arrival->branch = pk_c_walk_copy(branch == NULL ? "" : branch);
+    arrival->stmt_index = stmt_index;
+    arrival->join_stmt_index = join_stmt_index;
+    arrival->line = line;
+    arrival->column = column;
+    arrival->cond = pk_c_walk_formula_clone(cond);
+    arrival->wp = pk_c_walk_formula_clone(wp);
+    if (arrival->kind == NULL || arrival->name == NULL || arrival->branch == NULL ||
+        arrival->cond == NULL || arrival->wp == NULL) {
+        arrival_clear(arrival);
         return -1;
     }
     chain->n_arrivals++;

--- a/implementations/c/provekit-walk-c/tests/fixtures/two_armed_if.c
+++ b/implementations/c/provekit-walk-c/tests/fixtures/two_armed_if.c
@@ -1,0 +1,12 @@
+#define BUG_ON(c) do { if (c) __builtin_trap(); } while (0)
+int helper_a(int x) { BUG_ON(x < 0); return x; }
+int helper_b(int x) { BUG_ON(x > 100); return x; }
+int two_armed(int x) {
+    int r;
+    if (x > 50) {
+        r = helper_a(x);
+    } else {
+        r = helper_b(x);
+    }
+    return r;
+}

--- a/implementations/c/provekit-walk-c/tests/integration.sh
+++ b/implementations/c/provekit-walk-c/tests/integration.sh
@@ -7,6 +7,7 @@ BIN="$SCRIPT_DIR/../provekit-walk-c"
 FIXTURE="$SCRIPT_DIR/fixtures/wp_basic.c"
 CHECKED_FIXTURE="$SCRIPT_DIR/fixtures/checked_demo.c"
 OPAQUE_BUG_ON_FIXTURE="$SCRIPT_DIR/fixtures/checked_demo_opaque_bug_on.c"
+TWO_ARMED_FIXTURE="$SCRIPT_DIR/fixtures/two_armed_if.c"
 
 if [ ! -x "$BIN" ]; then
     echo "FAIL: binary not found: $BIN" >&2
@@ -25,6 +26,11 @@ fi
 
 if [ ! -f "$OPAQUE_BUG_ON_FIXTURE" ]; then
     echo "FAIL: fixture not found: $OPAQUE_BUG_ON_FIXTURE" >&2
+    exit 1
+fi
+
+if [ ! -f "$TWO_ARMED_FIXTURE" ]; then
+    echo "FAIL: fixture not found: $TWO_ARMED_FIXTURE" >&2
     exit 1
 fi
 
@@ -203,4 +209,74 @@ if len(args) != 2 or args[0].get("kind") != "const" or args[0].get("value") != 4
     raise SystemExit(f"FAIL: {label} FunctionEntry WP should be 42 ≥ 10, got {entry_wp}")
 
 print("opaque-bug-on-chain", " -> ".join(f"{a['kind']}@{a.get('line', 0)}:{a.get('column', 0)}" for a in arrivals))
+PY
+
+TWO_ARMED_RESPONSES="$(
+    {
+        printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+        printf '{"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":'
+        printf '"%s"' "$SCRIPT_DIR/fixtures"
+        printf ',"source_paths":["two_armed_if.c"],"surface":"c-walk","parse_backend":"clang_ast"}}\n'
+        printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"shutdown"}'
+    } | "$BIN" --rpc
+)"
+
+TWO_ARMED_RESPONSES_JSON="$TWO_ARMED_RESPONSES" python3 - <<'PY'
+import json
+import os
+
+responses = [json.loads(line) for line in os.environ["TWO_ARMED_RESPONSES_JSON"].splitlines() if line.strip()]
+lift = next((r for r in responses if r.get("id") == 2), None)
+if lift is None:
+    raise SystemExit("FAIL: two_armed_if lift response missing")
+
+decls = lift["result"]["declarations"]
+chains = [
+    d for d in decls
+    if d.get("kind") == "function-contract"
+    and d.get("evidence", {}).get("kind") == "wp-walk-chain"
+    and d.get("evidence", {}).get("caller") == "two_armed"
+]
+
+def has_atom(formula, name, lhs, rhs):
+    if formula.get("kind") == "atomic" and formula.get("name") == name:
+        args = formula.get("args", [])
+        return (
+            len(args) == 2
+            and args[0].get("kind") == lhs[0]
+            and args[0].get(lhs[1]) == lhs[2]
+            and args[1].get("kind") == rhs[0]
+            and args[1].get(rhs[1]) == rhs[2]
+        )
+    return any(has_atom(op, name, lhs, rhs) for op in formula.get("operands", []))
+
+def find_chain(callee, branch, guard_name):
+    matches = [c for c in chains if c.get("evidence", {}).get("callee") == callee]
+    if not matches:
+        raise SystemExit(f"FAIL: no two_armed -> {callee} wp-walk-chain emitted")
+    chain = matches[0]
+    arrivals = chain["evidence"].get("arrivals", [])
+    arm = next((a for a in arrivals if a.get("kind") == "ConditionalArm"), None)
+    if arm is None:
+        raise SystemExit(f"FAIL: {callee} chain missing ConditionalArm arrival")
+    if arm.get("branch") != branch:
+        raise SystemExit(f"FAIL: {callee} ConditionalArm branch should be {branch}, got {arm.get('branch')}")
+    if not has_atom(arm.get("cond", {}), guard_name, ("var", "name", "x"), ("const", "value", 50)):
+        raise SystemExit(f"FAIL: {callee} ConditionalArm cond missing x {guard_name} 50: {arm.get('cond')}")
+    entry = next((a for a in arrivals if a.get("kind") == "FunctionEntry"), None)
+    if entry is None:
+        raise SystemExit(f"FAIL: {callee} FunctionEntry arrival missing")
+    entry_wp = entry.get("wp", {})
+    if entry_wp.get("kind") == "atomic" and entry_wp.get("name") == "true":
+        raise SystemExit(f"FAIL: {callee} FunctionEntry WP is trivial true")
+    if not has_atom(entry_wp, guard_name, ("var", "name", "x"), ("const", "value", 50)):
+        raise SystemExit(f"FAIL: {callee} FunctionEntry WP missing guard x {guard_name} 50: {entry_wp}")
+    if chain.get("post") != arrivals[0].get("wp"):
+        raise SystemExit(f"FAIL: {callee} chain post must match callsite WP")
+    if chain.get("pre") != entry.get("wp"):
+        raise SystemExit(f"FAIL: {callee} chain pre must match function entry WP")
+    print(f"two-armed-{callee}-chain", " -> ".join(f"{a['kind']}@{a.get('line', 0)}:{a.get('column', 0)}" for a in arrivals))
+
+find_chain("helper_a", "then", ">")
+find_chain("helper_b", "else", "≤")
 PY


### PR DESCRIPTION
Extends walk-c's backward WP for general two-armed conditionals. Each arm contributes a guarded fact to the join. Sample chains on fixture: (x > 50) -> (x >= 0) on the then arm, (x <= 50) -> (x <= 100) on the else arm. RED before fix, GREEN after. T Savo