### PR TITLE
feat: algebraic minter (AMP/LSP mementos) + provekit mint CLI

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "provekit-ir-types",
  "provekit-lift",
  "provekit-linker",
+ "provekit-mint-amp",
  "provekit-proof-envelope",
  "provekit-self-contracts",
  "provekit-verifier",
@@ -1928,6 +1929,20 @@ version = "0.1.0"
 dependencies = [
  "inventory",
  "provekit-ir-symbolic",
+]
+
+[[package]]
+name = "provekit-mint-amp"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "hex",
+ "libprovekit",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "provekit-canonicalizer",
+    "provekit-mint-amp",
     "provekit-proof-envelope",
     "provekit-claim-envelope",
     "provekit-ir-symbolic",

--- a/implementations/rust/provekit-cli/Cargo.toml
+++ b/implementations/rust/provekit-cli/Cargo.toml
@@ -20,6 +20,7 @@ provekit-verifier = { path = "../provekit-verifier" }
 provekit-agent = { path = "../provekit-agent" }
 provekit-lift = { path = "../provekit-lift" }
 provekit-linker = { path = "../provekit-linker" }
+provekit-mint-amp = { path = "../provekit-mint-amp" }
 provekit-self-contracts = { path = "../provekit-self-contracts" }
 libprovekit = { path = "../libprovekit" }
 provekit-ir-types = { path = "../provekit-ir-types" }

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -45,7 +45,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use base64::Engine;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use owo_colors::OwoColorize;
 use serde_json::{json, Value};
 
@@ -54,6 +54,7 @@ use provekit_claim_envelope::{
     compute_contract_set_cid, contract_cid, mint_authority, mint_contract, mint_implication,
     Authoring, MintAuthorityArgs, MintContractArgs, MintImplicationArgs,
 };
+use provekit_mint_amp as algebraic_mint;
 use provekit_proof_envelope::{
     build_proof_envelope, ed25519_pubkey_string, ed25519_sign_string, Ed25519Seed,
     ProofEnvelopeInput,
@@ -822,6 +823,8 @@ fn find_attestation_dir(start: &Path) -> Result<PathBuf, String> {
 
 #[derive(Parser, Debug, Clone)]
 pub struct MintArgs {
+    #[command(subcommand)]
+    pub command: Option<MintCommand>,
     /// Project root containing `.provekit/config.toml`. Defaults to current dir.
     #[arg(long)]
     pub project: Option<PathBuf>,
@@ -843,7 +846,34 @@ pub struct MintArgs {
     pub flags: OutputFlags,
 }
 
+#[derive(Subcommand, Debug, Clone)]
+pub enum MintCommand {
+    Algorithm(AlgebraicMintArgs),
+    Binding(AlgebraicMintArgs),
+    Sort(AlgebraicMintArgs),
+    Equation(AlgebraicMintArgs),
+    EffectSignature(AlgebraicMintArgs),
+    LanguageSignature(AlgebraicMintArgs),
+    LanguageMorphism(AlgebraicMintArgs),
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct AlgebraicMintArgs {
+    #[arg(long)]
+    pub spec: PathBuf,
+    #[arg(long)]
+    pub signer: Option<PathBuf>,
+    #[arg(long)]
+    pub unsigned: bool,
+    #[arg(long)]
+    pub catalog: PathBuf,
+}
+
 pub fn run(args: MintArgs) -> u8 {
+    if let Some(command) = args.command {
+        return run_algebraic_mint(command);
+    }
+
     // Resolve (project_root, surface, lang_key) from --kit or --project.
     let (project_root, derived_surface, lang_key) = if let Some(kit) = &args.kit {
         match resolve_kit(kit) {
@@ -970,6 +1000,116 @@ pub fn run(args: MintArgs) -> u8 {
             EXIT_VERIFY_FAIL
         }
     }
+}
+
+fn run_algebraic_mint(command: MintCommand) -> u8 {
+    let result = match command {
+        MintCommand::Algorithm(args) => {
+            let signer = signer_from_args(&args);
+            signer.and_then(|signer| {
+                let catalog = algebraic_mint::Catalog::new(args.catalog.clone())?;
+                let spec = algebraic_mint::AlgorithmSpec::from_path(&args.spec)?;
+                algebraic_mint::mint_algorithm(spec, &signer, &catalog)
+            })
+        }
+        MintCommand::Binding(args) => {
+            let signer = signer_from_args(&args);
+            signer.and_then(|signer| {
+                let catalog = algebraic_mint::Catalog::new(args.catalog.clone())?;
+                let spec = algebraic_mint::BindingSpec::from_path(&args.spec)?;
+                algebraic_mint::mint_binding(spec, &signer, &catalog)
+            })
+        }
+        MintCommand::Sort(args) => {
+            let signer = signer_from_args(&args);
+            signer.and_then(|signer| {
+                let catalog = algebraic_mint::Catalog::new(args.catalog.clone())?;
+                let spec = algebraic_mint::SortSpec::from_path(&args.spec)?;
+                algebraic_mint::mint_sort(spec, &signer, &catalog)
+            })
+        }
+        MintCommand::Equation(args) => {
+            let signer = signer_from_args(&args);
+            signer.and_then(|signer| {
+                let catalog = algebraic_mint::Catalog::new(args.catalog.clone())?;
+                let spec = algebraic_mint::EquationSpec::from_path(&args.spec)?;
+                algebraic_mint::mint_equation(spec, &signer, &catalog)
+            })
+        }
+        MintCommand::EffectSignature(args) => {
+            let signer = signer_from_args(&args);
+            signer.and_then(|signer| {
+                let catalog = algebraic_mint::Catalog::new(args.catalog.clone())?;
+                let spec = algebraic_mint::EffectSignatureSpec::from_path(&args.spec)?;
+                algebraic_mint::mint_effect_signature(spec, &signer, &catalog)
+            })
+        }
+        MintCommand::LanguageSignature(args) => {
+            let signer = signer_from_args(&args);
+            signer.and_then(|signer| {
+                let catalog = algebraic_mint::Catalog::new(args.catalog.clone())?;
+                let spec = algebraic_mint::LanguageSignatureSpec::from_path(&args.spec)?;
+                algebraic_mint::mint_language_signature(spec, &signer, &catalog)
+            })
+        }
+        MintCommand::LanguageMorphism(args) => {
+            let signer = signer_from_args(&args);
+            signer.and_then(|signer| {
+                let catalog = algebraic_mint::Catalog::new(args.catalog.clone())?;
+                let spec = algebraic_mint::LanguageMorphismSpec::from_path(&args.spec)?;
+                algebraic_mint::mint_language_morphism(spec, &signer, &catalog)
+            })
+        }
+    };
+
+    match result {
+        Ok(minted) => {
+            println!("{}\t{}", minted.cid, minted.path.display());
+            EXIT_OK
+        }
+        Err(error) => {
+            print_algebraic_error(&error);
+            EXIT_USER_ERROR
+        }
+    }
+}
+
+fn signer_from_args(args: &AlgebraicMintArgs) -> algebraic_mint::Result<algebraic_mint::Signer> {
+    if args.unsigned && args.signer.is_some() {
+        return Err(algebraic_mint::MintError::Signer(
+            "`--unsigned` cannot be combined with `--signer`".into(),
+        ));
+    }
+    if args.unsigned {
+        return Ok(algebraic_mint::Signer::from_unsigned_test_only());
+    }
+    let signer_path = args.signer.as_ref().ok_or_else(|| {
+        algebraic_mint::MintError::Signer(
+            "missing `--signer PATH` unless `--unsigned` is set".into(),
+        )
+    })?;
+    algebraic_mint::Signer::from_pem_path(signer_path)
+}
+
+fn print_algebraic_error(error: &algebraic_mint::MintError) {
+    let kind = match error {
+        algebraic_mint::MintError::Validation(_) => "validation",
+        algebraic_mint::MintError::Catalog(_) => "catalog",
+        algebraic_mint::MintError::Signer(_) => "signer",
+        algebraic_mint::MintError::Canonical(_) => "canonical",
+        algebraic_mint::MintError::Io { .. } => "io",
+        algebraic_mint::MintError::Json { .. } => "json",
+    };
+    eprintln!(
+        "{}",
+        serde_json::to_string(&json!({
+            "error": {
+                "kind": kind,
+                "message": error.to_string()
+            }
+        }))
+        .expect("serialize algebraic mint error")
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/implementations/rust/provekit-mint-amp/Cargo.toml
+++ b/implementations/rust/provekit-mint-amp/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "provekit-mint-amp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "AMP and LSP algebraic memento minter."
+
+[dependencies]
+base64 = { workspace = true }
+ed25519-dalek = { workspace = true }
+hex = { workspace = true }
+libprovekit = { path = "../libprovekit" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/implementations/rust/provekit-mint-amp/README.md
+++ b/implementations/rust/provekit-mint-amp/README.md
@@ -1,0 +1,43 @@
+# provekit-mint-amp
+
+`provekit-mint-amp` mints AMP and LSP algebraic mementos into a content-addressed catalog. It accepts small JSON specs for algorithm, binding, sort, equation, effect signature, language signature, and language morphism claims, resolves nested spec references to CIDs, canonicalizes with the workspace JCS and BLAKE3-512 helpers, signs the canonical payload bytes with Ed25519, writes the signed envelope, and updates `index.json`.
+
+## CLI Examples
+
+Mint a `SortMemento` with the unsigned development signer into an explicit test catalog:
+
+```sh
+provekit mint sort \
+  --spec implementations/rust/provekit-mint-amp/tests/fixtures/sort_c_int.spec.json \
+  --unsigned \
+  --catalog /tmp/provekit-minter-test-catalog
+```
+
+Mint an `EquationMemento` that references the sort spec. The minter resolves the sort spec path recursively and stores the sort CID in `formal_sorts`.
+
+```sh
+provekit mint equation \
+  --spec implementations/rust/provekit-mint-amp/tests/fixtures/equation_c_branch_identity.spec.json \
+  --unsigned \
+  --catalog /tmp/provekit-minter-test-catalog
+```
+
+Mint a `LanguageSignatureMemento` that references sorts, operations, equations, and effect signatures. Any referenced spec paths are minted first.
+
+```sh
+provekit mint language-signature \
+  --spec implementations/rust/provekit-mint-amp/tests/fixtures/language_signature_c_c11.spec.json \
+  --unsigned \
+  --catalog /tmp/provekit-minter-test-catalog
+```
+
+Production catalog minting should use `--signer PATH`, where `PATH` contains an Ed25519 private key in PEM, raw hex, or base64 form. The unsigned signer is restricted to catalog roots whose path explicitly marks them as test or dev.
+
+## Specs
+
+The wire shapes follow the draft AMP and LSP specs:
+
+- `protocol/specs/2026-05-09-algorithm-memento-protocol.md`
+- `protocol/specs/2026-05-09-language-signature-protocol.md`
+
+CCP composition is not needed for these minting paths. If a future minter needs composition, it should use `libprovekit::compose` rather than reimplementing the CCP algebra.

--- a/implementations/rust/provekit-mint-amp/src/catalog.rs
+++ b/implementations/rust/provekit-mint-amp/src/catalog.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::{canonical_jcs, MintError, Result, Signer};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Kind {
+    Algorithm,
+    Binding,
+    Sort,
+    Equation,
+    EffectSignature,
+    LanguageSignature,
+    LanguageMorphism,
+}
+
+impl Kind {
+    pub fn directory(self) -> &'static str {
+        match self {
+            Kind::Algorithm => "algorithms",
+            Kind::Binding => "bindings",
+            Kind::Sort => "sorts",
+            Kind::Equation => "equations",
+            Kind::EffectSignature => "signatures",
+            Kind::LanguageSignature => "signatures",
+            Kind::LanguageMorphism => "morphisms",
+        }
+    }
+}
+
+impl std::fmt::Display for Kind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Kind::Algorithm => "algorithm",
+            Kind::Binding => "binding",
+            Kind::Sort => "sort",
+            Kind::Equation => "equation",
+            Kind::EffectSignature => "effect_signature",
+            Kind::LanguageSignature => "language_signature",
+            Kind::LanguageMorphism => "language_morphism",
+        };
+        f.write_str(s)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Catalog {
+    pub root: PathBuf,
+    pub index: CatalogIndex,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogIndex {
+    pub schema_version: String,
+    #[serde(default)]
+    pub entries: BTreeMap<String, CatalogEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogEntry {
+    pub cid: String,
+    pub kind: Kind,
+    pub name: String,
+    pub path: PathBuf,
+}
+
+impl Default for CatalogIndex {
+    fn default() -> Self {
+        Self {
+            schema_version: "provekit-algebraic-catalog-index/1".into(),
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+impl Catalog {
+    pub fn new(root: PathBuf) -> Result<Catalog> {
+        std::fs::create_dir_all(&root).map_err(|source| MintError::Io {
+            path: root.clone(),
+            source,
+        })?;
+        for dir in [
+            "algorithms",
+            "bindings",
+            "signatures",
+            "morphisms",
+            "sorts",
+            "equations",
+        ] {
+            let path = root.join(dir);
+            std::fs::create_dir_all(&path).map_err(|source| MintError::Io { path, source })?;
+        }
+        let index = load_index(&root)?;
+        if !root.join("index.json").exists() {
+            save_index(&root, &index)?;
+        }
+        Ok(Catalog { root, index })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn write_memento(
+        &mut self,
+        kind: Kind,
+        name: &str,
+        payload: &Value,
+        cid: &str,
+    ) -> Result<PathBuf> {
+        let signature = Value::Null;
+        let path = write_envelope(
+            &self.root,
+            &mut self.index,
+            kind,
+            name,
+            payload,
+            cid,
+            signature,
+        )?;
+        save_index(&self.root, &self.index)?;
+        Ok(path)
+    }
+
+    pub fn write_signed_memento(
+        &self,
+        kind: Kind,
+        name: &str,
+        payload: &Value,
+        cid: &str,
+        signer: &Signer,
+    ) -> Result<PathBuf> {
+        let canonical = canonical_jcs(payload)?;
+        let signature = json!({
+            "alg": "ed25519",
+            "key_id": signer.key_id(),
+            "sig_b64": signer.sign_b64(canonical.as_bytes()),
+        });
+        let mut index = load_index(&self.root)?;
+        let path = write_envelope(&self.root, &mut index, kind, name, payload, cid, signature)?;
+        save_index(&self.root, &index)?;
+        Ok(path)
+    }
+
+    pub fn read_by_cid(&self, cid: &str) -> Result<Value> {
+        let index = load_index(&self.root)?;
+        let path = if let Some(entry) = index.entries.get(cid) {
+            self.root.join(&entry.path)
+        } else {
+            find_cid_path(&self.root, cid)?.ok_or_else(|| {
+                MintError::Catalog(format!("CID `{cid}` is not present in catalog index"))
+            })?
+        };
+        read_envelope_payload(&path, cid)
+    }
+}
+
+fn write_envelope(
+    root: &Path,
+    index: &mut CatalogIndex,
+    kind: Kind,
+    name: &str,
+    payload: &Value,
+    cid: &str,
+    signature: Value,
+) -> Result<PathBuf> {
+    let relative = index
+        .entries
+        .get(cid)
+        .map(|entry| entry.path.clone())
+        .unwrap_or_else(|| {
+            PathBuf::from(kind.directory()).join(format!("{}.{}.json", sanitize_name(name), cid))
+        });
+    let path = root.join(&relative);
+
+    if path.exists() {
+        let existing = read_envelope(&path)?;
+        if existing.get("cid").and_then(Value::as_str) == Some(cid)
+            && existing.get("memento") == Some(payload)
+        {
+            index
+                .entries
+                .entry(cid.to_string())
+                .or_insert(CatalogEntry {
+                    cid: cid.to_string(),
+                    kind,
+                    name: name.to_string(),
+                    path: relative,
+                });
+            return Ok(path);
+        }
+        return Err(MintError::Catalog(format!(
+            "CID collision for `{cid}` at {}",
+            path.display()
+        )));
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| MintError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let envelope = json!({
+        "memento": payload,
+        "cid": cid,
+        "signature": signature,
+    });
+    let bytes = serde_json::to_vec_pretty(&envelope).map_err(|source| MintError::Json {
+        path: path.clone(),
+        source,
+    })?;
+    std::fs::write(&path, bytes).map_err(|source| MintError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    index.entries.insert(
+        cid.to_string(),
+        CatalogEntry {
+            cid: cid.to_string(),
+            kind,
+            name: name.to_string(),
+            path: relative,
+        },
+    );
+    Ok(path)
+}
+
+fn read_envelope_payload(path: &Path, cid: &str) -> Result<Value> {
+    let envelope = read_envelope(path)?;
+    if envelope.get("cid").and_then(Value::as_str) != Some(cid) {
+        return Err(MintError::Catalog(format!(
+            "catalog entry {} does not contain CID `{cid}`",
+            path.display()
+        )));
+    }
+    envelope
+        .get("memento")
+        .cloned()
+        .ok_or_else(|| MintError::Catalog(format!("missing memento in {}", path.display())))
+}
+
+fn read_envelope(path: &Path) -> Result<Value> {
+    let bytes = std::fs::read(path).map_err(|source| MintError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_slice(&bytes).map_err(|source| MintError::Json {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn load_index(root: &Path) -> Result<CatalogIndex> {
+    let path = root.join("index.json");
+    if !path.exists() {
+        return Ok(CatalogIndex::default());
+    }
+    let bytes = std::fs::read(&path).map_err(|source| MintError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    serde_json::from_slice(&bytes).map_err(|source| MintError::Json { path, source })
+}
+
+fn save_index(root: &Path, index: &CatalogIndex) -> Result<()> {
+    let path = root.join("index.json");
+    let bytes = serde_json::to_vec_pretty(index).map_err(|source| MintError::Json {
+        path: path.clone(),
+        source,
+    })?;
+    std::fs::write(&path, bytes).map_err(|source| MintError::Io { path, source })
+}
+
+fn find_cid_path(root: &Path, cid: &str) -> Result<Option<PathBuf>> {
+    for dir in [
+        "algorithms",
+        "bindings",
+        "signatures",
+        "morphisms",
+        "sorts",
+        "equations",
+    ] {
+        let dir_path = root.join(dir);
+        if !dir_path.exists() {
+            continue;
+        }
+        for entry in std::fs::read_dir(&dir_path).map_err(|source| MintError::Io {
+            path: dir_path.clone(),
+            source,
+        })? {
+            let entry = entry.map_err(|source| MintError::Io {
+                path: dir_path.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.contains(cid))
+                .unwrap_or(false)
+            {
+                return Ok(Some(path));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn sanitize_name(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            '/' | '\\' | ' ' | '\t' | '\n' | '\r' => '_',
+            _ => c,
+        })
+        .collect()
+}

--- a/implementations/rust/provekit-mint-amp/src/lib.rs
+++ b/implementations/rust/provekit-mint-amp/src/lib.rs
@@ -1,0 +1,764 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod catalog;
+pub mod signer;
+mod spec;
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+pub use catalog::{Catalog, CatalogEntry, CatalogIndex, Kind};
+pub use signer::Signer;
+pub use spec::{
+    AlgorithmSpec, BindingSpec, EffectSignatureSpec, EquationSpec, LanguageMorphismSpec,
+    LanguageSignatureSpec, SortSpec,
+};
+
+pub type Result<T> = std::result::Result<T, MintError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum MintError {
+    #[error("validation error: {0}")]
+    Validation(String),
+    #[error("catalog error: {0}")]
+    Catalog(String),
+    #[error("signer error: {0}")]
+    Signer(String),
+    #[error("canonicalization error: {0}")]
+    Canonical(String),
+    #[error("I/O error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("JSON error at {path}: {source}")]
+    Json {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct MintedMemento {
+    pub cid: String,
+    pub path: PathBuf,
+    pub payload: Value,
+}
+
+pub fn canonical_jcs(value: &Value) -> Result<String> {
+    libprovekit::canonical::json_jcs(value).map_err(|e| MintError::Canonical(e.to_string()))
+}
+
+pub fn canonical_cid(value: &Value) -> Result<String> {
+    libprovekit::canonical::json_cid(value).map_err(|e| MintError::Canonical(e.to_string()))
+}
+
+pub fn mint_algorithm(
+    spec: AlgorithmSpec,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<MintedMemento> {
+    let payload = algorithm_payload(&spec)?;
+    write_signed(
+        Kind::Algorithm,
+        &required_string(&spec.raw, "fn_name")?,
+        payload,
+        signer,
+        catalog,
+    )
+}
+
+pub fn mint_binding(
+    spec: BindingSpec,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<MintedMemento> {
+    let algorithm_cid = match optional_reference(&spec.raw, "algorithm", &spec, signer, catalog)? {
+        Some(cid) => cid,
+        None => first_input_cid(&spec.raw, &spec, signer, catalog).ok_or_else(|| {
+            MintError::Validation(
+                "BindingMemento requires `algorithm` or a non-empty `input_cids` array".into(),
+            )
+        })??,
+    };
+    let payload = binding_payload(&spec, algorithm_cid, signer, catalog)?;
+    write_signed(
+        Kind::Binding,
+        &required_string(&spec.raw, "fn_name")?,
+        payload,
+        signer,
+        catalog,
+    )
+}
+
+pub fn mint_sort(spec: SortSpec, signer: &Signer, catalog: &Catalog) -> Result<MintedMemento> {
+    let payload = sort_payload(&spec)?;
+    write_signed(
+        Kind::Sort,
+        &required_string(&spec.raw, "fn_name")?,
+        payload,
+        signer,
+        catalog,
+    )
+}
+
+pub fn mint_equation(
+    spec: EquationSpec,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<MintedMemento> {
+    let payload = equation_payload(&spec, signer, catalog)?;
+    write_signed(
+        Kind::Equation,
+        &required_string(&spec.raw, "fn_name")?,
+        payload,
+        signer,
+        catalog,
+    )
+}
+
+pub fn mint_effect_signature(
+    spec: EffectSignatureSpec,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<MintedMemento> {
+    let payload = language_signature_payload(
+        &spec,
+        "EffectSignatureMemento",
+        "LSP",
+        "EffectSignature",
+        true,
+        signer,
+        catalog,
+    )?;
+    write_signed(
+        Kind::EffectSignature,
+        &required_string(&spec.raw, "fn_name")?,
+        payload,
+        signer,
+        catalog,
+    )
+}
+
+pub fn mint_language_signature(
+    spec: LanguageSignatureSpec,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<MintedMemento> {
+    let payload = language_signature_payload(
+        &spec,
+        "LanguageSignatureMemento",
+        "LSP",
+        "LanguageSignature",
+        false,
+        signer,
+        catalog,
+    )?;
+    write_signed(
+        Kind::LanguageSignature,
+        &required_string(&spec.raw, "fn_name")?,
+        payload,
+        signer,
+        catalog,
+    )
+}
+
+pub fn mint_language_morphism(
+    spec: LanguageMorphismSpec,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<MintedMemento> {
+    let payload = language_morphism_payload(&spec, signer, catalog)?;
+    write_signed(
+        Kind::LanguageMorphism,
+        &required_string(&spec.raw, "fn_name")?,
+        payload,
+        signer,
+        catalog,
+    )
+}
+
+fn write_signed(
+    kind: Kind,
+    name: &str,
+    payload: Value,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<MintedMemento> {
+    signer.ensure_catalog_allowed(catalog.root())?;
+    let cid = canonical_cid(&payload)?;
+    let path = catalog.write_signed_memento(kind, name, &payload, &cid, signer)?;
+    Ok(MintedMemento { cid, path, payload })
+}
+
+fn algorithm_payload(spec: &AlgorithmSpec) -> Result<Value> {
+    validate_kind(spec.raw(), &["algorithm", "AlgorithmMemento"])?;
+    validate_contract_fields(spec.raw(), true, true, true, true)?;
+    validate_formal_lengths(spec.raw())?;
+    let mut payload = base_contract_payload("AMP", "AlgorithmMemento", spec.raw())?;
+    payload["auto_minted_mementos"] = json!([]);
+    Ok(payload)
+}
+
+fn binding_payload(
+    spec: &BindingSpec,
+    algorithm_cid: String,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<Value> {
+    validate_kind(
+        spec.raw(),
+        &["binding", "BindingMemento", "BindingClaimMemento"],
+    )?;
+    validate_contract_fields(spec.raw(), true, true, true, true)?;
+    validate_formal_lengths(spec.raw())?;
+    require_cid_field(spec.raw(), "body_cid")?;
+
+    let mut payload = base_contract_payload("AMP", "BindingMemento", spec.raw())?;
+    payload["language"] = optional_string(spec.raw(), "language")
+        .map(Value::String)
+        .unwrap_or(Value::Null);
+    payload["algorithm_cid"] = Value::String(algorithm_cid.clone());
+    payload["input_cids"] = Value::Array(input_cids_with(spec, algorithm_cid, signer, catalog)?);
+    payload["post"] = resolve_embedded_refs(
+        required_value(spec.raw(), "post")?,
+        spec.base_dir(),
+        signer,
+        catalog,
+    )?;
+    payload["discharge_status"] = Value::String("pending".into());
+    payload["auto_minted_mementos"] = json!([]);
+    Ok(payload)
+}
+
+fn sort_payload(spec: &SortSpec) -> Result<Value> {
+    validate_kind(spec.raw(), &["sort", "SortMemento"])?;
+    require_string(spec.raw(), "fn_name")?;
+    required_value(spec.raw(), "return_sort")?;
+    required_value(spec.raw(), "post")?;
+    let mut payload = base_contract_payload("LSP", "SortMemento", spec.raw())?;
+    if !payload_has_key(&payload, "formal_sorts") {
+        payload["formal_sorts"] = json!([]);
+    }
+    Ok(payload)
+}
+
+fn equation_payload(spec: &EquationSpec, signer: &Signer, catalog: &Catalog) -> Result<Value> {
+    validate_kind(spec.raw(), &["equation", "EquationMemento"])?;
+    require_string(spec.raw(), "fn_name")?;
+    required_array(spec.raw(), "formals")?;
+    required_array(spec.raw(), "formal_sorts")?;
+    required_value(spec.raw(), "post")?;
+    validate_formal_lengths(spec.raw())?;
+
+    let mut payload = base_contract_payload("LSP", "EquationMemento", spec.raw())?;
+    payload["formal_sorts"] = Value::Array(resolve_reference_array(
+        spec,
+        "formal_sorts",
+        signer,
+        catalog,
+        Some(Kind::Sort),
+    )?);
+    payload["return_sort"] = spec
+        .raw()
+        .get("return_sort")
+        .cloned()
+        .unwrap_or_else(|| json!({"kind": "primitive", "name": "Bool"}));
+    payload["effects"] = json!({"effects": []});
+    Ok(payload)
+}
+
+fn language_signature_payload<S: JsonSpec>(
+    spec: &S,
+    kind: &str,
+    protocol: &str,
+    return_name: &str,
+    require_empty_effects: bool,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<Value> {
+    let accepted = if require_empty_effects {
+        vec!["effect_signature", "EffectSignatureMemento"]
+    } else {
+        vec!["language_signature", "LanguageSignatureMemento"]
+    };
+    validate_kind(spec.raw(), &accepted)?;
+    require_string(spec.raw(), "fn_name")?;
+    for field in ["sorts", "operations", "equations", "effect_signatures"] {
+        required_array(spec.raw(), field)?;
+    }
+    if require_empty_effects && !required_array(spec.raw(), "effect_signatures")?.is_empty() {
+        return Err(MintError::Validation(
+            "EffectSignatureMemento requires an empty `effect_signatures` array".into(),
+        ));
+    }
+
+    let sorts = resolve_reference_array(spec, "sorts", signer, catalog, Some(Kind::Sort))?;
+    let operations =
+        resolve_reference_array(spec, "operations", signer, catalog, Some(Kind::Algorithm))?;
+    let equations =
+        resolve_reference_array(spec, "equations", signer, catalog, Some(Kind::Equation))?;
+    let effect_signatures = resolve_reference_array(
+        spec,
+        "effect_signatures",
+        signer,
+        catalog,
+        Some(Kind::EffectSignature),
+    )?;
+
+    let mut payload = base_static_payload(protocol, kind, spec.raw());
+    payload["return_sort"] = spec
+        .raw()
+        .get("return_sort")
+        .cloned()
+        .unwrap_or_else(|| json!({"kind": "ctor", "name": return_name, "args": []}));
+    payload["post"] = json!({
+        "sorts": sorts,
+        "operations": operations,
+        "equations": equations,
+        "effect_signatures": effect_signatures,
+    });
+    if let Some(body_cid) = optional_string(spec.raw(), "body_cid") {
+        validate_cid(&body_cid, "body_cid")?;
+        payload["body_cid"] = Value::String(body_cid);
+    }
+    Ok(payload)
+}
+
+fn language_morphism_payload(
+    spec: &LanguageMorphismSpec,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<Value> {
+    validate_kind(
+        spec.raw(),
+        &["language_morphism", "LanguageMorphismMemento"],
+    )?;
+    require_string(spec.raw(), "fn_name")?;
+    require_string(spec.raw(), "source_signature")?;
+    require_string(spec.raw(), "target_signature")?;
+    required_value(spec.raw(), "post")?;
+    require_cid_field(spec.raw(), "body_cid")?;
+
+    let source_cid = required_reference(
+        spec.raw(),
+        "source_signature",
+        spec,
+        signer,
+        catalog,
+        Some(Kind::LanguageSignature),
+    )?;
+    let target_cid = required_reference(
+        spec.raw(),
+        "target_signature",
+        spec,
+        signer,
+        catalog,
+        Some(Kind::LanguageSignature),
+    )?;
+
+    let mut payload = base_contract_payload("LSP", "LanguageMorphismMemento", spec.raw())?;
+    payload["formals"] = spec
+        .raw()
+        .get("formals")
+        .cloned()
+        .unwrap_or_else(|| json!(["source_term"]));
+    payload["formal_sorts"] = spec
+        .raw()
+        .get("formal_sorts")
+        .cloned()
+        .unwrap_or_else(|| json!([{"kind": "TermInLanguage", "signature_cid": source_cid}]));
+    payload["return_sort"] = spec
+        .raw()
+        .get("return_sort")
+        .cloned()
+        .unwrap_or_else(|| json!({"kind": "TermInLanguage", "signature_cid": target_cid}));
+    payload["source_signature_cid"] = Value::String(source_cid.clone());
+    payload["target_signature_cid"] = Value::String(target_cid.clone());
+    payload["input_cids"] = json!([source_cid, target_cid]);
+    payload["post"] = resolve_embedded_refs(
+        required_value(spec.raw(), "post")?,
+        spec.base_dir(),
+        signer,
+        catalog,
+    )?;
+    payload["discharge_status"] = Value::String("pending".into());
+    Ok(payload)
+}
+
+fn base_contract_payload(protocol: &str, kind: &str, raw: &Value) -> Result<Value> {
+    let mut payload = base_static_payload(protocol, kind, raw);
+    payload["formals"] = raw.get("formals").cloned().unwrap_or_else(|| json!([]));
+    payload["formal_sorts"] = raw
+        .get("formal_sorts")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+    payload["return_sort"] = raw
+        .get("return_sort")
+        .cloned()
+        .unwrap_or_else(|| json!({"kind": "primitive", "name": "Bool"}));
+    payload["pre"] = raw.get("pre").cloned().unwrap_or_else(true_formula);
+    payload["post"] = raw
+        .get("post")
+        .cloned()
+        .ok_or_else(|| MintError::Validation("missing required field `post`".into()))?;
+    payload["effects"] = raw.get("effects").cloned().unwrap_or_else(empty_effects);
+    if let Some(locus) = raw.get("locus") {
+        payload["locus"] = locus.clone();
+    }
+    if let Some(body_cid) = optional_string(raw, "body_cid") {
+        validate_cid(&body_cid, "body_cid")?;
+        payload["body_cid"] = Value::String(body_cid);
+    }
+    if let Some(input_cids) = raw.get("input_cids") {
+        payload["input_cids"] = input_cids.clone();
+    }
+    if let Some(refines) = raw.get("refines") {
+        payload["refines"] = refines.clone();
+    }
+    Ok(payload)
+}
+
+fn base_static_payload(protocol: &str, kind: &str, raw: &Value) -> Value {
+    json!({
+        "schema_version": "1",
+        "protocol": protocol,
+        "kind": kind,
+        "fn_name": raw.get("fn_name").cloned().unwrap_or(Value::Null),
+        "formals": [],
+        "formal_sorts": [],
+        "pre": true_formula(),
+        "post": Value::Null,
+        "effects": empty_effects(),
+        "auto_minted_mementos": [],
+    })
+}
+
+fn validate_contract_fields(
+    raw: &Value,
+    formals: bool,
+    formal_sorts: bool,
+    return_sort: bool,
+    pre_post: bool,
+) -> Result<()> {
+    require_string(raw, "fn_name")?;
+    if formals {
+        required_array(raw, "formals")?;
+    }
+    if formal_sorts {
+        required_array(raw, "formal_sorts")?;
+    }
+    if return_sort {
+        required_value(raw, "return_sort")?;
+    }
+    if pre_post {
+        required_value(raw, "pre")?;
+        required_value(raw, "post")?;
+    }
+    Ok(())
+}
+
+fn validate_formal_lengths(raw: &Value) -> Result<()> {
+    let formals = raw.get("formals").and_then(Value::as_array);
+    let formal_sorts = raw.get("formal_sorts").and_then(Value::as_array);
+    if let (Some(formals), Some(formal_sorts)) = (formals, formal_sorts) {
+        if formals.len() != formal_sorts.len() {
+            return Err(MintError::Validation(format!(
+                "`formals` length {} does not match `formal_sorts` length {}",
+                formals.len(),
+                formal_sorts.len()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_kind(raw: &Value, accepted: &[&str]) -> Result<()> {
+    let Some(kind) = raw.get("kind").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    if accepted.contains(&kind) {
+        Ok(())
+    } else {
+        Err(MintError::Validation(format!(
+            "spec kind `{kind}` is not one of {}",
+            accepted.join(", ")
+        )))
+    }
+}
+
+fn require_string(raw: &Value, field: &str) -> Result<()> {
+    required_string(raw, field).map(|_| ())
+}
+
+fn required_string(raw: &Value, field: &str) -> Result<String> {
+    raw.get(field)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| MintError::Validation(format!("missing required string field `{field}`")))
+}
+
+fn optional_string(raw: &Value, field: &str) -> Option<String> {
+    raw.get(field).and_then(Value::as_str).map(str::to_string)
+}
+
+fn required_array<'a>(raw: &'a Value, field: &str) -> Result<&'a Vec<Value>> {
+    raw.get(field)
+        .and_then(Value::as_array)
+        .ok_or_else(|| MintError::Validation(format!("missing required array field `{field}`")))
+}
+
+fn required_value<'a>(raw: &'a Value, field: &str) -> Result<&'a Value> {
+    raw.get(field)
+        .ok_or_else(|| MintError::Validation(format!("missing required field `{field}`")))
+}
+
+fn payload_has_key(payload: &Value, key: &str) -> bool {
+    payload
+        .as_object()
+        .map(|obj| obj.contains_key(key))
+        .unwrap_or(false)
+}
+
+fn require_cid_field(raw: &Value, field: &str) -> Result<()> {
+    let value = required_string(raw, field)?;
+    validate_cid(&value, field)
+}
+
+fn validate_cid(value: &str, field: &str) -> Result<()> {
+    if libprovekit::canonical::is_blake3_512_cid(value) {
+        Ok(())
+    } else {
+        Err(MintError::Validation(format!(
+            "`{field}` must be a blake3-512 CID"
+        )))
+    }
+}
+
+fn first_input_cid<S: JsonSpec>(
+    raw: &Value,
+    spec: &S,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Option<Result<String>> {
+    raw.get("input_cids")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first())
+        .map(|item| resolve_reference_value(item, spec.base_dir(), signer, catalog, None))
+}
+
+fn input_cids_with<S: JsonSpec>(
+    spec: &S,
+    required_cid: String,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<Vec<Value>> {
+    let mut out = vec![Value::String(required_cid.clone())];
+    if let Some(items) = spec.raw().get("input_cids").and_then(Value::as_array) {
+        for item in items {
+            let cid = resolve_reference_value(item, spec.base_dir(), signer, catalog, None)?;
+            if cid != required_cid && !out.iter().any(|v| v.as_str() == Some(cid.as_str())) {
+                out.push(Value::String(cid));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn optional_reference<S: JsonSpec>(
+    raw: &Value,
+    field: &str,
+    spec: &S,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<Option<String>> {
+    raw.get(field)
+        .map(|value| resolve_reference_value(value, spec.base_dir(), signer, catalog, None))
+        .transpose()
+}
+
+fn required_reference<S: JsonSpec>(
+    raw: &Value,
+    field: &str,
+    spec: &S,
+    signer: &Signer,
+    catalog: &Catalog,
+    expected: Option<Kind>,
+) -> Result<String> {
+    resolve_reference_value(
+        required_value(raw, field)?,
+        spec.base_dir(),
+        signer,
+        catalog,
+        expected,
+    )
+}
+
+fn resolve_reference_array<S: JsonSpec>(
+    spec: &S,
+    field: &str,
+    signer: &Signer,
+    catalog: &Catalog,
+    expected: Option<Kind>,
+) -> Result<Vec<Value>> {
+    let items = required_array(spec.raw(), field)?;
+    let mut out = Vec::with_capacity(items.len());
+    for item in items {
+        out.push(Value::String(resolve_reference_value(
+            item,
+            spec.base_dir(),
+            signer,
+            catalog,
+            expected,
+        )?));
+    }
+    Ok(out)
+}
+
+fn resolve_embedded_refs(
+    value: &Value,
+    base_dir: Option<&Path>,
+    signer: &Signer,
+    catalog: &Catalog,
+) -> Result<Value> {
+    match value {
+        Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(resolve_embedded_refs(item, base_dir, signer, catalog)?);
+            }
+            Ok(Value::Array(out))
+        }
+        Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (key, item) in map {
+                out.insert(
+                    key.clone(),
+                    resolve_embedded_refs(item, base_dir, signer, catalog)?,
+                );
+            }
+            Ok(Value::Object(out))
+        }
+        Value::String(s) if looks_like_json_path(s) => {
+            let path = resolve_path(base_dir, s);
+            if path.exists() {
+                Ok(Value::String(mint_spec_path(&path, signer, catalog, None)?))
+            } else {
+                Ok(value.clone())
+            }
+        }
+        _ => Ok(value.clone()),
+    }
+}
+
+fn resolve_reference_value(
+    value: &Value,
+    base_dir: Option<&Path>,
+    signer: &Signer,
+    catalog: &Catalog,
+    expected: Option<Kind>,
+) -> Result<String> {
+    let s = value
+        .as_str()
+        .ok_or_else(|| MintError::Validation("CID reference must be a string".into()))?;
+    if libprovekit::canonical::is_blake3_512_cid(s) {
+        return Ok(s.to_string());
+    }
+    let path = resolve_path(base_dir, s);
+    if !path.exists() {
+        return Err(MintError::Validation(format!(
+            "reference `{s}` is neither a CID nor an existing spec path"
+        )));
+    }
+    mint_spec_path(&path, signer, catalog, expected)
+}
+
+fn mint_spec_path(
+    path: &Path,
+    signer: &Signer,
+    catalog: &Catalog,
+    expected: Option<Kind>,
+) -> Result<String> {
+    let raw = read_json(path)?;
+    let kind = kind_from_spec(&raw).ok_or_else(|| {
+        MintError::Validation(format!(
+            "referenced spec {} is missing `kind`",
+            path.display()
+        ))
+    })?;
+    if let Some(expected) = expected {
+        if kind != expected {
+            return Err(MintError::Validation(format!(
+                "referenced spec {} has kind `{kind}`, expected `{expected}`",
+                path.display()
+            )));
+        }
+    }
+    let cid = match kind {
+        Kind::Algorithm => mint_algorithm(AlgorithmSpec::from_path(path)?, signer, catalog)?.cid,
+        Kind::Binding => mint_binding(BindingSpec::from_path(path)?, signer, catalog)?.cid,
+        Kind::Sort => mint_sort(SortSpec::from_path(path)?, signer, catalog)?.cid,
+        Kind::Equation => mint_equation(EquationSpec::from_path(path)?, signer, catalog)?.cid,
+        Kind::EffectSignature => {
+            mint_effect_signature(EffectSignatureSpec::from_path(path)?, signer, catalog)?.cid
+        }
+        Kind::LanguageSignature => {
+            mint_language_signature(LanguageSignatureSpec::from_path(path)?, signer, catalog)?.cid
+        }
+        Kind::LanguageMorphism => {
+            mint_language_morphism(LanguageMorphismSpec::from_path(path)?, signer, catalog)?.cid
+        }
+    };
+    Ok(cid)
+}
+
+fn kind_from_spec(raw: &Value) -> Option<Kind> {
+    match raw.get("kind").and_then(Value::as_str)? {
+        "algorithm" | "AlgorithmMemento" => Some(Kind::Algorithm),
+        "binding" | "BindingMemento" | "BindingClaimMemento" => Some(Kind::Binding),
+        "sort" | "SortMemento" => Some(Kind::Sort),
+        "equation" | "EquationMemento" => Some(Kind::Equation),
+        "effect_signature" | "EffectSignatureMemento" => Some(Kind::EffectSignature),
+        "language_signature" | "LanguageSignatureMemento" => Some(Kind::LanguageSignature),
+        "language_morphism" | "LanguageMorphismMemento" => Some(Kind::LanguageMorphism),
+        _ => None,
+    }
+}
+
+fn resolve_path(base_dir: Option<&Path>, raw: &str) -> PathBuf {
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        base_dir.unwrap_or_else(|| Path::new(".")).join(path)
+    }
+}
+
+fn looks_like_json_path(value: &str) -> bool {
+    value.ends_with(".json") || value.ends_with(".spec.json") || value.contains('/')
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let bytes = std::fs::read(path).map_err(|source| MintError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_slice(&bytes).map_err(|source| MintError::Json {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn true_formula() -> Value {
+    json!({"kind": "atomic", "name": "true", "args": []})
+}
+
+fn empty_effects() -> Value {
+    json!({"effects": []})
+}
+
+pub trait JsonSpec {
+    fn raw(&self) -> &Value;
+    fn base_dir(&self) -> Option<&Path>;
+}

--- a/implementations/rust/provekit-mint-amp/src/signer.rs
+++ b/implementations/rust/provekit-mint-amp/src/signer.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Component, Path};
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use ed25519_dalek::{Signature, Signer as _, SigningKey, VerifyingKey};
+
+use crate::{MintError, Result};
+
+#[derive(Debug, Clone)]
+pub struct Signer {
+    key: SigningKey,
+    key_id: String,
+    unsigned_test_only: bool,
+}
+
+impl Signer {
+    pub fn from_pem_path(path: &Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path).map_err(|source| MintError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let private = parse_private_key_text(&text)?;
+        let key = signing_key_from_private_bytes(&private)?;
+        Ok(Self::from_key(key, false, None))
+    }
+
+    pub fn from_unsigned_test_only() -> Self {
+        Self::from_key(
+            SigningKey::from_bytes(&[0xFA; 32]),
+            true,
+            Some("UNSIGNED_DEV_ONLY".into()),
+        )
+    }
+
+    pub fn from_test_seed(seed: [u8; 32]) -> Self {
+        Self::from_key(SigningKey::from_bytes(&seed), false, None)
+    }
+
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.key.verifying_key()
+    }
+
+    pub fn sign_b64(&self, message: &[u8]) -> String {
+        let signature: Signature = self.key.sign(message);
+        B64.encode(signature.to_bytes())
+    }
+
+    pub fn ensure_catalog_allowed(&self, root: &Path) -> Result<()> {
+        if !self.unsigned_test_only {
+            return Ok(());
+        }
+        if is_explicit_test_catalog(root) {
+            Ok(())
+        } else {
+            Err(MintError::Signer(format!(
+                "unsigned test signer refuses catalog root {}",
+                root.display()
+            )))
+        }
+    }
+
+    fn from_key(key: SigningKey, unsigned_test_only: bool, key_id: Option<String>) -> Self {
+        let key_id = key_id.unwrap_or_else(|| {
+            let public = key.verifying_key().to_bytes();
+            format!("ed25519:{}", B64.encode(public))
+        });
+        Self {
+            key,
+            key_id,
+            unsigned_test_only,
+        }
+    }
+}
+
+fn parse_private_key_text(text: &str) -> Result<Vec<u8>> {
+    let trimmed = text.trim();
+    if let Some(b64) = trimmed.strip_prefix("ed25519:") {
+        return B64
+            .decode(b64.trim())
+            .map_err(|e| MintError::Signer(format!("decode ed25519 private key: {e}")));
+    }
+    if looks_like_hex(trimmed) {
+        return hex::decode(trimmed)
+            .map_err(|e| MintError::Signer(format!("decode hex private key: {e}")));
+    }
+    if trimmed.contains("-----BEGIN") {
+        let mut body = String::new();
+        for line in trimmed.lines() {
+            let line = line.trim();
+            if line.starts_with("-----") || line.contains(':') || line.is_empty() {
+                continue;
+            }
+            body.push_str(line);
+        }
+        return B64
+            .decode(body)
+            .map_err(|e| MintError::Signer(format!("decode PEM private key: {e}")));
+    }
+    B64.decode(trimmed)
+        .map_err(|e| MintError::Signer(format!("decode private key: {e}")))
+}
+
+fn signing_key_from_private_bytes(bytes: &[u8]) -> Result<SigningKey> {
+    let seed: [u8; 32] = if bytes.len() == 32 {
+        bytes
+            .try_into()
+            .map_err(|_| MintError::Signer("invalid 32 byte Ed25519 seed".into()))?
+    } else if bytes.len() == 64 {
+        bytes[0..32]
+            .try_into()
+            .map_err(|_| MintError::Signer("invalid 64 byte Ed25519 private key".into()))?
+    } else if bytes.len() >= 48 && bytes.windows(3).any(|w| w == [0x2b, 0x65, 0x70]) {
+        bytes[bytes.len() - 32..]
+            .try_into()
+            .map_err(|_| MintError::Signer("invalid PKCS8 Ed25519 private key".into()))?
+    } else {
+        return Err(MintError::Signer(format!(
+            "unsupported Ed25519 private key length {}",
+            bytes.len()
+        )));
+    };
+    Ok(SigningKey::from_bytes(&seed))
+}
+
+fn looks_like_hex(value: &str) -> bool {
+    (value.len() == 64 || value.len() == 128) && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn is_explicit_test_catalog(root: &Path) -> bool {
+    let path_text = root.to_string_lossy().to_ascii_lowercase();
+    if path_text.contains("protocol/algorithm-catalog")
+        || path_text.contains("protocol/language-catalog")
+        || path_text.contains("production")
+    {
+        return false;
+    }
+    root.components().any(|component| match component {
+        Component::Normal(part) => {
+            let part = part.to_string_lossy().to_ascii_lowercase();
+            part.contains("test") || part.contains("dev")
+        }
+        _ => false,
+    })
+}

--- a/implementations/rust/provekit-mint-amp/src/spec.rs
+++ b/implementations/rust/provekit-mint-amp/src/spec.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+
+use crate::{JsonSpec, MintError, Result};
+
+macro_rules! spec_type {
+    ($name:ident) => {
+        #[derive(Debug, Clone)]
+        pub struct $name {
+            pub(crate) raw: Value,
+            pub(crate) source_dir: Option<PathBuf>,
+        }
+
+        impl $name {
+            pub fn from_path(path: &Path) -> Result<Self> {
+                let bytes = std::fs::read(path).map_err(|source| MintError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+                let raw: Value =
+                    serde_json::from_slice(&bytes).map_err(|source| MintError::Json {
+                        path: path.to_path_buf(),
+                        source,
+                    })?;
+                Ok(Self {
+                    raw,
+                    source_dir: path.parent().map(Path::to_path_buf),
+                })
+            }
+
+            pub fn from_json_str(input: &str) -> Result<Self> {
+                let raw: Value = serde_json::from_str(input).map_err(|source| MintError::Json {
+                    path: PathBuf::from("<inline>"),
+                    source,
+                })?;
+                Ok(Self {
+                    raw,
+                    source_dir: None,
+                })
+            }
+
+            pub fn from_value(raw: Value) -> Self {
+                Self {
+                    raw,
+                    source_dir: None,
+                }
+            }
+
+            pub fn raw(&self) -> &Value {
+                &self.raw
+            }
+        }
+
+        impl JsonSpec for $name {
+            fn raw(&self) -> &Value {
+                &self.raw
+            }
+
+            fn base_dir(&self) -> Option<&Path> {
+                self.source_dir.as_deref()
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                self.raw.serialize(serializer)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let raw = Value::deserialize(deserializer)?;
+                Ok(Self {
+                    raw,
+                    source_dir: None,
+                })
+            }
+        }
+    };
+}
+
+spec_type!(AlgorithmSpec);
+spec_type!(BindingSpec);
+spec_type!(SortSpec);
+spec_type!(EquationSpec);
+spec_type!(EffectSignatureSpec);
+spec_type!(LanguageSignatureSpec);
+spec_type!(LanguageMorphismSpec);

--- a/implementations/rust/provekit-mint-amp/tests/cid_collision_refused.rs
+++ b/implementations/rust/provekit-mint-amp/tests/cid_collision_refused.rs
@@ -1,0 +1,37 @@
+mod common;
+
+use serde_json::json;
+
+use provekit_mint_amp::{Kind, Result};
+
+#[test]
+fn existing_cid_with_different_payload_is_refused() -> Result<()> {
+    let (_dir, mut catalog) = common::test_catalog("collision").expect("catalog");
+    let payload = json!({
+        "schema_version": "1",
+        "kind": "SortMemento",
+        "fn_name": "collision"
+    });
+
+    let path = catalog.write_memento(Kind::Sort, "collision", &payload, "blake3-512:1234")?;
+    std::fs::write(
+        &path,
+        serde_json::to_vec_pretty(&json!({
+            "memento": {"tampered": true},
+            "cid": "blake3-512:1234",
+            "signature": null
+        }))
+        .expect("serialize tampered envelope"),
+    )
+    .expect("tamper file");
+
+    let err = catalog
+        .write_memento(Kind::Sort, "collision", &payload, "blake3-512:1234")
+        .expect_err("tampered existing CID should fail");
+
+    assert!(
+        err.to_string().contains("CID collision"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}

--- a/implementations/rust/provekit-mint-amp/tests/common.rs
+++ b/implementations/rust/provekit-mint-amp/tests/common.rs
@@ -1,0 +1,25 @@
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+use provekit_mint_amp::{Catalog, Result, Signer};
+
+pub fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+pub fn test_catalog(prefix: &str) -> Result<(tempfile::TempDir, Catalog)> {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("provekit-minter-test-{prefix}-"))
+        .tempdir()
+        .expect("tempdir");
+    let catalog = Catalog::new(dir.path().join("catalog-test"))?;
+    Ok((dir, catalog))
+}
+
+pub fn signer() -> Signer {
+    Signer::from_test_seed([0x34; 32])
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/algorithm_branch_on_nonzero.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/algorithm_branch_on_nonzero.spec.json
@@ -1,0 +1,35 @@
+{
+  "kind": "algorithm",
+  "fn_name": "branch-on-nonzero",
+  "formals": ["ast_pattern", "context"],
+  "formal_sorts": [
+    {"kind": "ctor", "name": "ASTPattern", "args": []},
+    {"kind": "ctor", "name": "Context", "args": []}
+  ],
+  "return_sort": {"kind": "ctor", "name": "IrFormula", "args": []},
+  "pre": {
+    "kind": "atomic",
+    "name": "matches",
+    "args": [
+      {"kind": "var", "name": "ast_pattern"},
+      {"kind": "ctor", "name": "BranchOnNonzero", "args": []}
+    ]
+  },
+  "post": {
+    "kind": "atomic",
+    "name": "=",
+    "args": [
+      {"kind": "var", "name": "result"},
+      {
+        "kind": "ctor",
+        "name": "Implies",
+        "args": [
+          {"kind": "var", "name": "condition"},
+          {"kind": "var", "name": "then_formula"}
+        ]
+      }
+    ]
+  },
+  "effects": {"effects": []},
+  "locus": "docs/papers/12-after-languages-how-proofir-represents-every-language.md#branch-on-nonzero"
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/binding_c_branch_on_nonzero.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/binding_c_branch_on_nonzero.spec.json
@@ -1,0 +1,25 @@
+{
+  "kind": "binding",
+  "fn_name": "branch-on-nonzero:c-libclang:0.1.0",
+  "algorithm": "algorithm_branch_on_nonzero.spec.json",
+  "language": "c",
+  "formals": ["language_ast_input", "context"],
+  "formal_sorts": [
+    {"kind": "ctor", "name": "LanguageAST_c", "args": []},
+    {"kind": "ctor", "name": "Context", "args": []}
+  ],
+  "return_sort": {"kind": "ctor", "name": "IrFormula", "args": []},
+  "pre": {
+    "kind": "atomic",
+    "name": "c_if_condition_nonzero",
+    "args": [{"kind": "var", "name": "language_ast_input"}]
+  },
+  "post": {
+    "kind": "refines",
+    "algorithm": "algorithm_branch_on_nonzero.spec.json",
+    "projection": "c-ast-to-ast-pattern"
+  },
+  "effects": {"effects": []},
+  "locus": "implementations/c/provekit-lift-c/src/branch_on_nonzero.c:1:1",
+  "body_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/binding_python_branch_on_nonzero.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/binding_python_branch_on_nonzero.spec.json
@@ -1,0 +1,25 @@
+{
+  "kind": "binding",
+  "fn_name": "branch-on-nonzero:python-ast:0.1.0",
+  "algorithm": "algorithm_branch_on_nonzero.spec.json",
+  "language": "python",
+  "formals": ["language_ast_input", "context"],
+  "formal_sorts": [
+    {"kind": "ctor", "name": "LanguageAST_python", "args": []},
+    {"kind": "ctor", "name": "Context", "args": []}
+  ],
+  "return_sort": {"kind": "ctor", "name": "IrFormula", "args": []},
+  "pre": {
+    "kind": "atomic",
+    "name": "python_if_truthy",
+    "args": [{"kind": "var", "name": "language_ast_input"}]
+  },
+  "post": {
+    "kind": "refines",
+    "algorithm": "algorithm_branch_on_nonzero.spec.json",
+    "projection": "python-ast-to-ast-pattern"
+  },
+  "effects": {"effects": []},
+  "locus": "implementations/python/provekit_lift/branch_on_nonzero.py:1:1",
+  "body_cid": "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/effect_signature_c_control.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/effect_signature_c_control.spec.json
@@ -1,0 +1,9 @@
+{
+  "kind": "effect_signature",
+  "fn_name": "c:control-effects:c11",
+  "sorts": ["sort_c_bool.spec.json"],
+  "operations": [],
+  "equations": [],
+  "effect_signatures": [],
+  "body_cid": "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/equation_c_branch_identity.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/equation_c_branch_identity.spec.json
@@ -1,0 +1,12 @@
+{
+  "kind": "equation",
+  "fn_name": "c:branch-on-nonzero-identity",
+  "formals": ["x"],
+  "formal_sorts": ["sort_c_int.spec.json"],
+  "pre": {"kind": "atomic", "name": "true", "args": []},
+  "post": {
+    "kind": "equation",
+    "lhs": {"kind": "op", "name": "branch_on_nonzero", "args": [{"kind": "var", "name": "x"}]},
+    "rhs": {"kind": "op", "name": "branch_on_nonzero", "args": [{"kind": "var", "name": "x"}]}
+  }
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/language_signature_c_c11.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/language_signature_c_c11.spec.json
@@ -1,0 +1,9 @@
+{
+  "kind": "language_signature",
+  "fn_name": "c:c11",
+  "sorts": ["sort_c_int.spec.json", "sort_c_bool.spec.json"],
+  "operations": ["algorithm_branch_on_nonzero.spec.json"],
+  "equations": ["equation_c_branch_identity.spec.json"],
+  "effect_signatures": ["effect_signature_c_control.spec.json"],
+  "body_cid": "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/language_signature_llvm_ir.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/language_signature_llvm_ir.spec.json
@@ -1,0 +1,9 @@
+{
+  "kind": "language_signature",
+  "fn_name": "llvm-ir:18",
+  "sorts": ["sort_c_int.spec.json", "sort_c_bool.spec.json"],
+  "operations": [],
+  "equations": [],
+  "effect_signatures": [],
+  "body_cid": "blake3-512:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/morphism_c_to_llvm_ir.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/morphism_c_to_llvm_ir.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "language_morphism",
+  "fn_name": "c-to-llvm-ir:clang-18",
+  "source_signature": "language_signature_c_c11.spec.json",
+  "target_signature": "language_signature_llvm_ir.spec.json",
+  "formals": ["source_term"],
+  "pre": {"kind": "atomic", "name": "true", "args": []},
+  "post": {
+    "kind": "homomorphism-obligation",
+    "source": "language_signature_c_c11.spec.json",
+    "target": "language_signature_llvm_ir.spec.json",
+    "operation_mapping": {}
+  },
+  "effects": {"effects": []},
+  "body_cid": "blake3-512:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/sort_c_bool.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/sort_c_bool.spec.json
@@ -1,0 +1,14 @@
+{
+  "kind": "sort",
+  "fn_name": "c:bool",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "C truth value",
+    "values": ["false", "true"]
+  }
+}

--- a/implementations/rust/provekit-mint-amp/tests/fixtures/sort_c_int.spec.json
+++ b/implementations/rust/provekit-mint-amp/tests/fixtures/sort_c_int.spec.json
@@ -1,0 +1,15 @@
+{
+  "kind": "sort",
+  "fn_name": "c:int",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "C signed int",
+    "width": 32,
+    "semantics": "implementation-defined-overflow"
+  }
+}

--- a/implementations/rust/provekit-mint-amp/tests/mint_then_read_round_trips.rs
+++ b/implementations/rust/provekit-mint-amp/tests/mint_then_read_round_trips.rs
@@ -1,0 +1,74 @@
+mod common;
+
+use provekit_mint_amp::{
+    mint_algorithm, mint_binding, mint_effect_signature, mint_equation, mint_language_morphism,
+    mint_language_signature, mint_sort, AlgorithmSpec, BindingSpec, EffectSignatureSpec,
+    EquationSpec, LanguageMorphismSpec, LanguageSignatureSpec, SortSpec,
+};
+
+#[test]
+fn mint_each_kind_then_read_payload_by_cid() {
+    let (_dir, catalog) = common::test_catalog("roundtrip").expect("catalog");
+    let signer = common::signer();
+
+    let minted = [
+        mint_sort(
+            SortSpec::from_path(&common::fixture("sort_c_int.spec.json")).expect("sort spec"),
+            &signer,
+            &catalog,
+        )
+        .expect("mint sort"),
+        mint_equation(
+            EquationSpec::from_path(&common::fixture("equation_c_branch_identity.spec.json"))
+                .expect("equation spec"),
+            &signer,
+            &catalog,
+        )
+        .expect("mint equation"),
+        mint_algorithm(
+            AlgorithmSpec::from_path(&common::fixture("algorithm_branch_on_nonzero.spec.json"))
+                .expect("algorithm spec"),
+            &signer,
+            &catalog,
+        )
+        .expect("mint algorithm"),
+        mint_binding(
+            BindingSpec::from_path(&common::fixture("binding_c_branch_on_nonzero.spec.json"))
+                .expect("binding spec"),
+            &signer,
+            &catalog,
+        )
+        .expect("mint binding"),
+        mint_effect_signature(
+            EffectSignatureSpec::from_path(&common::fixture(
+                "effect_signature_c_control.spec.json",
+            ))
+            .expect("effect signature spec"),
+            &signer,
+            &catalog,
+        )
+        .expect("mint effect signature"),
+        mint_language_signature(
+            LanguageSignatureSpec::from_path(&common::fixture(
+                "language_signature_c_c11.spec.json",
+            ))
+            .expect("language signature spec"),
+            &signer,
+            &catalog,
+        )
+        .expect("mint language signature"),
+        mint_language_morphism(
+            LanguageMorphismSpec::from_path(&common::fixture("morphism_c_to_llvm_ir.spec.json"))
+                .expect("morphism spec"),
+            &signer,
+            &catalog,
+        )
+        .expect("mint morphism"),
+    ];
+
+    for memento in minted {
+        let stored = catalog.read_by_cid(&memento.cid).expect("read by cid");
+        assert_eq!(stored, memento.payload);
+        assert!(memento.path.exists(), "memento path should exist");
+    }
+}

--- a/implementations/rust/provekit-mint-amp/tests/same_spec_yields_same_cid.rs
+++ b/implementations/rust/provekit-mint-amp/tests/same_spec_yields_same_cid.rs
@@ -1,0 +1,31 @@
+mod common;
+
+use provekit_mint_amp::{mint_sort, SortSpec};
+
+#[test]
+fn object_key_order_does_not_change_cid() {
+    let (_dir, catalog) = common::test_catalog("determinism").expect("catalog");
+    let signer = common::signer();
+
+    let spec_a = SortSpec::from_path(&common::fixture("sort_c_int.spec.json")).expect("spec a");
+    let spec_b = SortSpec::from_json_str(
+        r#"{
+          "post": {
+            "semantics": "implementation-defined-overflow",
+            "width": 32,
+            "name": "C signed int",
+            "kind": "sort-description"
+          },
+          "return_sort": {"name": "*", "kind": "kind"},
+          "formals": [],
+          "fn_name": "c:int",
+          "kind": "sort"
+        }"#,
+    )
+    .expect("spec b");
+
+    let minted_a = mint_sort(spec_a, &signer, &catalog).expect("mint a");
+    let minted_b = mint_sort(spec_b, &signer, &catalog).expect("mint b");
+
+    assert_eq!(minted_a.cid, minted_b.cid);
+}

--- a/implementations/rust/provekit-mint-amp/tests/signature_roundtrips.rs
+++ b/implementations/rust/provekit-mint-amp/tests/signature_roundtrips.rs
@@ -1,0 +1,34 @@
+mod common;
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use ed25519_dalek::{Signature, Verifier};
+
+use provekit_mint_amp::{canonical_jcs, mint_sort, SortSpec};
+
+#[test]
+fn signature_verifies_against_canonical_payload_bytes() {
+    let (_dir, catalog) = common::test_catalog("signature").expect("catalog");
+    let signer = common::signer();
+    let minted = mint_sort(
+        SortSpec::from_path(&common::fixture("sort_c_bool.spec.json")).expect("sort spec"),
+        &signer,
+        &catalog,
+    )
+    .expect("mint sort");
+
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&minted.path).expect("read envelope"))
+            .expect("parse envelope");
+    let sig_b64 = envelope["signature"]["sig_b64"]
+        .as_str()
+        .expect("signature string");
+    let sig_bytes = B64.decode(sig_b64).expect("decode signature");
+    let sig_array: [u8; 64] = sig_bytes.try_into().expect("signature length");
+    let signature = Signature::from_bytes(&sig_array);
+    let canonical = canonical_jcs(&minted.payload).expect("canonical payload");
+
+    signer
+        .verifying_key()
+        .verify(canonical.as_bytes(), &signature)
+        .expect("signature verifies");
+}

--- a/implementations/rust/provekit-mint-amp/tests/unsigned_refuses_production_path.rs
+++ b/implementations/rust/provekit-mint-amp/tests/unsigned_refuses_production_path.rs
@@ -1,0 +1,28 @@
+use provekit_mint_amp::{mint_sort, Catalog, Signer, SortSpec};
+
+#[test]
+fn unsigned_signer_refuses_non_test_catalog_root() {
+    let dir = tempfile::Builder::new()
+        .prefix("provekit-production-catalog-")
+        .tempdir()
+        .expect("tempdir");
+    let catalog = Catalog::new(dir.path().join("catalog")).expect("catalog");
+    let signer = Signer::from_unsigned_test_only();
+    let spec = SortSpec::from_json_str(
+        r#"{
+          "kind": "sort",
+          "fn_name": "production-check",
+          "formals": [],
+          "return_sort": {"kind": "kind", "name": "*"},
+          "post": {"kind": "sort-description", "name": "production check"}
+        }"#,
+    )
+    .expect("spec");
+
+    let err = mint_sort(spec, &signer, &catalog).expect_err("unsigned should refuse");
+
+    assert!(
+        err.to_string().contains("unsigned test signer"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

New `provekit-mint-amp` crate plus `provekit mint` CLI subcommands that mint the seven AMP/LSP memento kinds into the catalog: `AlgorithmMemento`, `BindingMemento`, `SortMemento`, `EquationMemento`, `EffectSignatureMemento`, `LanguageSignatureMemento`, `LanguageMorphismMemento`.

- CIDs via `provekit-canonicalizer` (BLAKE3-512 of JCS canonical bytes).
- Ed25519 signing: foundation v0 key via `--signer PATH`, or `--unsigned` dev mode which refuses to write to non-test catalog roots.
- Catalog write per AMP §3 / LSP §3 layout; refuses to overwrite an existing CID.
- Internal CID-reference resolution (a `LanguageSignatureMemento` can cite `SortMemento`/`AlgorithmMemento`/`EquationMemento` CIDs, or paths the minter resolves recursively).
- Mementos minted with `discharge_status: "pending"`; discharge (homomorphism/refinement obligations) is a separate step using the existing prove portfolio.

5 integration tests (round-trip read by CID, deterministic CID across orderings, CID-collision refused, signature round-trips, unsigned refuses production path), fixtures, README. `cargo build`, `cargo test -p provekit-mint-amp` (5 pass), `cargo clippy -p provekit-mint-amp -- -D warnings` all clean locally. Companion specs: AMP/LSP (already on main via #544).

## Test plan

- [ ] `cargo test -p provekit-mint-amp` green
- [ ] `cargo clippy -p provekit-mint-amp -- -D warnings` clean
- [ ] `provekit mint sort --spec <fixture> --unsigned --catalog /tmp/c` prints `<cid>\t<path>` and round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)