### PR TITLE
feat: Maude equational backend + CeTA termination/confluence gate

### DIFF
--- a/.provekit/config.toml
+++ b/.provekit/config.toml
@@ -36,7 +36,17 @@
 
 [solvers]
 mode = "first-wins"
-portfolio = ["z3", "cvc5", "vampire", "coq"]
+portfolio = ["maude", "z3", "cvc5", "vampire", "coq"]
+
+[solvers.maude]
+binary = "maude"
+ir_compiler = "maude"
+timeout_seconds = 30
+version = "3.x"
+ceta_gate = true
+ceta_binary = "ceta"
+termination_prover = "aprove"
+confluence_checker = "csi"
 
 [solvers.z3]
 binary = "z3"

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1681,6 +1681,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-ir-compiler-maude"
+version = "0.1.0"
+dependencies = [
+ "provekit-ir-compiler",
+ "provekit-ir-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "provekit-ir-compiler-smt-lib"
 version = "0.1.0"
 dependencies = [
@@ -1996,6 +2006,7 @@ dependencies = [
  "provekit-claim-envelope",
  "provekit-ir-compiler",
  "provekit-ir-compiler-coq",
+ "provekit-ir-compiler-maude",
  "provekit-ir-compiler-smt-lib",
  "provekit-ir-symbolic",
  "provekit-proof-envelope",

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "provekit-ir-compiler-smt-lib",
     "provekit-ir-compiler-stub",
     "provekit-ir-compiler-coq",
+    "provekit-ir-compiler-maude",
     "provekit-ir-codegen",
     "provekit-verifier",
     "provekit-self-contracts",

--- a/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // GENERATED Coq compiler
 
+#![allow(unreachable_patterns)]
+
 use provekit_ir_compiler::FreeVar;
 use provekit_ir_types::*;
 use std::collections::{BTreeMap, BTreeSet};
@@ -10,7 +12,7 @@ pub fn emit_term(term: &Term) -> String {
         Term::Var { name, .. } => name.clone(),
         Term::Const { value, sort, .. } => {
             // Coq: Function/Dependent sorts on a Const are structurally unusual but
-            // not unsound — Coq's higher-order universe permits e.g. `(fun x => x) : nat -> nat`
+            // not unsound. Coq's higher-order universe permits e.g. `(fun x => x) : nat -> nat`
             // as a constant inhabiting a function sort. `emit_const_value` ignores the sort name
             // (it only branches on the JSON value shape), so we feed it the empty string for
             // non-primitive sorts and let the value's own JSON dictate the surface form.
@@ -150,7 +152,7 @@ fn emit_sort(sort: &Sort) -> String {
         // right-associative, so a function-typed argument MUST be parenthesized to
         // preserve meaning: `(A -> B) -> C` differs from `A -> B -> C`. Soundness
         // depends on this. Issue #331; see protocol/specs/multi-solver-protocol-v2.md
-        // — Coq's portfolio seat covers higher-order, so this position is NOT opaque.
+        // Coq's portfolio seat covers higher-order, so this position is NOT opaque.
         Sort::Function { args, ret } => {
             let mut parts: Vec<String> = args.iter().map(|a| emit_sort_paren(a)).collect();
             parts.push(emit_sort_paren(ret));

--- a/implementations/rust/provekit-ir-compiler-maude/Cargo.toml
+++ b/implementations/rust/provekit-ir-compiler-maude/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "provekit-ir-compiler-maude"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "ProvekIt bundled Maude IR compiler for equational theory obligations."
+
+[lib]
+name = "provekit_ir_compiler_maude"
+path = "src/lib.rs"
+
+[[bin]]
+name = "provekit-ir-maude"
+path = "src/main.rs"
+
+[dependencies]
+provekit-ir-compiler = { path = "../provekit-ir-compiler" }
+provekit-ir-types = { path = "../provekit-ir-types" }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/implementations/rust/provekit-ir-compiler-maude/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-maude/src/lib.rs
@@ -1,0 +1,529 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Maude compiler for equational theory obligations.
+
+use std::collections::BTreeMap;
+
+use provekit_ir_compiler::{
+    Capabilities, CompileError, CompiledFormula, FreeVar, IrCompiler, OpacityManifest,
+    PROTOCOL_VERSION,
+};
+use provekit_ir_types::{IrTerm, Sort};
+use serde::Deserialize;
+use serde_json::Value as Json;
+
+pub const DIALECT: &str = "maude";
+pub const COMPILER_NAME: &str = "maude-equational-reference";
+pub const COMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaudeQueries {
+    pub lhs_reduce: String,
+    pub rhs_reduce: String,
+    pub search: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrsRule {
+    pub lhs: String,
+    pub rhs: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrsOperator {
+    pub name: String,
+    pub arity: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrsSpec {
+    pub name: String,
+    pub variables: Vec<String>,
+    pub operators: Vec<TrsOperator>,
+    pub rules: Vec<TrsRule>,
+    pub has_ac_builtin: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledMaude {
+    pub compiled: CompiledFormula,
+    pub module_name: String,
+    pub module_source: String,
+    pub queries: MaudeQueries,
+    pub trs: TrsSpec,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawObligation {
+    kind: String,
+    name: Option<String>,
+    theory: RawTheory,
+    obligation: RawEquation,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawTheory {
+    name: String,
+    #[serde(default)]
+    sorts: Vec<String>,
+    #[serde(default)]
+    subsorts: Vec<RawSubsort>,
+    #[serde(default)]
+    operators: Vec<RawOperator>,
+    #[serde(default)]
+    variables: Vec<RawVariable>,
+    #[serde(default)]
+    equations: Vec<RawEquation>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawSubsort {
+    subsort: String,
+    supersort: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawOperator {
+    name: String,
+    #[serde(default)]
+    maude: Option<String>,
+    #[serde(default)]
+    arity: Vec<String>,
+    result: String,
+    #[serde(default)]
+    attrs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawVariable {
+    name: String,
+    sort: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawEquation {
+    #[serde(default)]
+    label: Option<String>,
+    lhs: IrTerm,
+    rhs: IrTerm,
+}
+
+#[derive(Debug, Clone)]
+struct OperatorInfo {
+    source_name: String,
+    maude_name: String,
+    arity: Vec<String>,
+    result: String,
+    attrs: Vec<String>,
+}
+
+pub struct MaudeCompiler;
+
+impl MaudeCompiler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MaudeCompiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IrCompiler for MaudeCompiler {
+    fn compile(&self, ir: &Json, dialect: &str) -> Result<CompiledFormula, CompileError> {
+        if dialect != DIALECT {
+            return Err(CompileError::UnsupportedDialect(dialect.to_string()));
+        }
+        Ok(compile_artifact(ir)?.compiled)
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            name: COMPILER_NAME.to_string(),
+            version: COMPILER_VERSION.to_string(),
+            protocol_version: PROTOCOL_VERSION.to_string(),
+            dialects: vec![DIALECT.to_string()],
+            supported_sorts: vec!["equational_theory".to_string()],
+            supported_predicates: vec!["equational_theory".to_string()],
+        }
+    }
+}
+
+pub fn emit(ir: &Json) -> Result<String, String> {
+    let artifact = compile_artifact(ir).map_err(|e| e.to_string())?;
+    Ok(format!(
+        "{}{}",
+        artifact.compiled.preamble, artifact.compiled.body
+    ))
+}
+
+pub fn compile_artifact(ir: &Json) -> Result<CompiledMaude, CompileError> {
+    let raw: RawObligation =
+        serde_json::from_value(ir.clone()).map_err(|e| CompileError::MalformedIr(e.to_string()))?;
+    validate_root(&raw)?;
+
+    let module_name = module_name(&raw.theory.name)?;
+    let operators = operators_by_name(&raw.theory.operators)?;
+    let module_source = render_module(&module_name, &raw.theory, &operators)?;
+    let lhs = render_term(&raw.obligation.lhs, &operators)?;
+    let rhs = render_term(&raw.obligation.rhs, &operators)?;
+    let queries = MaudeQueries {
+        lhs_reduce: format!("red in {module_name} : {lhs} ."),
+        rhs_reduce: format!("red in {module_name} : {rhs} ."),
+        search: format!("search in {module_name} : {lhs} =>* {rhs} ."),
+    };
+    let mut body = String::new();
+    body.push('\n');
+    body.push_str(&queries.lhs_reduce);
+    body.push('\n');
+    body.push_str(&queries.rhs_reduce);
+    body.push('\n');
+    body.push_str(&queries.search);
+    body.push('\n');
+
+    let free_vars = raw
+        .theory
+        .variables
+        .iter()
+        .map(|v| FreeVar {
+            name: v.name.clone(),
+            sort: v.sort.clone(),
+        })
+        .collect();
+    let trs = trs_spec(&module_name, &raw.theory, &operators)?;
+
+    Ok(CompiledMaude {
+        compiled: CompiledFormula {
+            preamble: module_source.clone(),
+            body,
+            free_vars,
+            opacity_manifest: OpacityManifest {
+                protocol_version: "ir-compiler-protocol/2".to_string(),
+                compiler: DIALECT.to_string(),
+                compiler_version: COMPILER_VERSION.to_string(),
+                opacities: vec![],
+            },
+        },
+        module_name,
+        module_source,
+        queries,
+        trs,
+    })
+}
+
+fn validate_root(raw: &RawObligation) -> Result<(), CompileError> {
+    let accepted =
+        raw.kind == "equational_theory" || raw.name.as_deref() == Some("equational_theory");
+    if !accepted {
+        return Err(CompileError::UnsupportedPredicate(
+            raw.name.clone().unwrap_or_else(|| raw.kind.clone()),
+        ));
+    }
+    Ok(())
+}
+
+fn operators_by_name(ops: &[RawOperator]) -> Result<BTreeMap<String, OperatorInfo>, CompileError> {
+    let mut out = BTreeMap::new();
+    for op in ops {
+        validate_token(&op.name, "operator name")?;
+        if let Some(maude) = &op.maude {
+            validate_surface(maude, "maude operator")?;
+        }
+        for sort in op.arity.iter().chain(std::iter::once(&op.result)) {
+            validate_token(sort, "operator sort")?;
+        }
+        for attr in &op.attrs {
+            validate_attr(attr)?;
+        }
+        let previous = out.insert(
+            op.name.clone(),
+            OperatorInfo {
+                source_name: op.name.clone(),
+                maude_name: op.maude.clone().unwrap_or_else(|| op.name.clone()),
+                arity: op.arity.clone(),
+                result: op.result.clone(),
+                attrs: op.attrs.clone(),
+            },
+        );
+        if previous.is_some() {
+            return Err(CompileError::MalformedIr(format!(
+                "duplicate operator {}",
+                op.name
+            )));
+        }
+    }
+    Ok(out)
+}
+
+fn module_name(name: &str) -> Result<String, CompileError> {
+    if name.trim().is_empty() {
+        return Err(CompileError::MalformedIr("empty theory name".to_string()));
+    }
+    let mut out = String::new();
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_uppercase());
+        } else if matches!(ch, '-' | '_' | ':' | '.') {
+            out.push('-');
+        }
+    }
+    if out.is_empty() {
+        return Err(CompileError::MalformedIr(
+            "theory name has no Maude-safe characters".to_string(),
+        ));
+    }
+    Ok(out)
+}
+
+fn render_module(
+    module_name: &str,
+    theory: &RawTheory,
+    operators: &BTreeMap<String, OperatorInfo>,
+) -> Result<String, CompileError> {
+    let mut out = String::new();
+    out.push_str(&format!("fmod {module_name} is\n"));
+    for sort in &theory.sorts {
+        validate_token(sort, "sort")?;
+        out.push_str(&format!("  sort {sort} .\n"));
+    }
+    for subsort in &theory.subsorts {
+        validate_token(&subsort.subsort, "subsort")?;
+        validate_token(&subsort.supersort, "supersort")?;
+        out.push_str(&format!(
+            "  subsort {} < {} .\n",
+            subsort.subsort, subsort.supersort
+        ));
+    }
+    for op in &theory.operators {
+        let info = operators.get(&op.name).expect("operator map is complete");
+        out.push_str("  op ");
+        out.push_str(&info.maude_name);
+        out.push_str(" :");
+        for arg in &info.arity {
+            out.push(' ');
+            out.push_str(arg);
+        }
+        out.push_str(" -> ");
+        out.push_str(&info.result);
+        if !info.attrs.is_empty() {
+            out.push_str(" [");
+            out.push_str(&info.attrs.join(" "));
+            out.push(']');
+        }
+        out.push_str(" .\n");
+    }
+    if !theory.variables.is_empty() {
+        for variable in &theory.variables {
+            validate_token(&variable.name, "variable")?;
+            validate_token(&variable.sort, "variable sort")?;
+        }
+        let mut grouped: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        for variable in &theory.variables {
+            grouped
+                .entry(variable.sort.as_str())
+                .or_default()
+                .push(variable.name.as_str());
+        }
+        for (sort, names) in grouped {
+            let keyword = if names.len() == 1 { "var" } else { "vars" };
+            out.push_str(&format!("  {keyword} {} : {sort} .\n", names.join(" ")));
+        }
+    }
+    for equation in &theory.equations {
+        let lhs = render_term(&equation.lhs, operators)?;
+        let rhs = render_term(&equation.rhs, operators)?;
+        if let Some(label) = &equation.label {
+            validate_token(label, "equation label")?;
+        }
+        out.push_str(&format!("  eq {lhs} = {rhs} .\n"));
+    }
+    out.push_str("endfm\n");
+    Ok(out)
+}
+
+fn trs_spec(
+    module_name: &str,
+    theory: &RawTheory,
+    operators: &BTreeMap<String, OperatorInfo>,
+) -> Result<TrsSpec, CompileError> {
+    let mut trs_ops = Vec::new();
+    let mut has_ac_builtin = false;
+    for op in operators.values() {
+        if op.attrs.iter().any(|a| a == "assoc" || a == "comm") {
+            has_ac_builtin = true;
+        }
+        trs_ops.push(TrsOperator {
+            name: op.source_name.clone(),
+            arity: op.arity.len(),
+        });
+    }
+    let variables = theory.variables.iter().map(|v| v.name.clone()).collect();
+    let mut rules = Vec::new();
+    for equation in &theory.equations {
+        rules.push(TrsRule {
+            lhs: render_term_prefix(&equation.lhs)?,
+            rhs: render_term_prefix(&equation.rhs)?,
+        });
+    }
+    Ok(TrsSpec {
+        name: module_name.to_string(),
+        variables,
+        operators: trs_ops,
+        rules,
+        has_ac_builtin,
+    })
+}
+
+fn render_term(
+    term: &IrTerm,
+    operators: &BTreeMap<String, OperatorInfo>,
+) -> Result<String, CompileError> {
+    match term {
+        IrTerm::Var { name } => {
+            validate_token(name, "variable")?;
+            Ok(name.clone())
+        }
+        IrTerm::Const { value, sort } => render_const(value, sort),
+        IrTerm::Ctor { name, args } => {
+            validate_token(name, "constructor")?;
+            let rendered_args: Result<Vec<_>, _> =
+                args.iter().map(|arg| render_term(arg, operators)).collect();
+            let rendered_args = rendered_args?;
+            let Some(op) = operators.get(name) else {
+                return Err(CompileError::MalformedIr(format!(
+                    "term uses undeclared operator {name}",
+                )));
+            };
+            if op.arity.len() != rendered_args.len() {
+                return Err(CompileError::MalformedIr(format!(
+                    "operator {name} expects {} args, got {}",
+                    op.arity.len(),
+                    rendered_args.len()
+                )));
+            }
+            Ok(render_operator_term(&op.maude_name, &rendered_args))
+        }
+        IrTerm::Lambda { .. } => Err(CompileError::UnsupportedPredicate(
+            "lambda term in equational_theory".to_string(),
+        )),
+        IrTerm::Let { .. } => Err(CompileError::UnsupportedPredicate(
+            "let term in equational_theory".to_string(),
+        )),
+    }
+}
+
+fn render_term_prefix(term: &IrTerm) -> Result<String, CompileError> {
+    match term {
+        IrTerm::Var { name } => {
+            validate_token(name, "variable")?;
+            Ok(name.clone())
+        }
+        IrTerm::Const { value, sort } => render_const(value, sort),
+        IrTerm::Ctor { name, args } => {
+            validate_token(name, "constructor")?;
+            if args.is_empty() {
+                return Ok(name.clone());
+            }
+            let args: Result<Vec<_>, _> = args.iter().map(render_term_prefix).collect();
+            Ok(format!("{}({})", name, args?.join(",")))
+        }
+        IrTerm::Lambda { .. } => Err(CompileError::UnsupportedPredicate(
+            "lambda term in equational_theory".to_string(),
+        )),
+        IrTerm::Let { .. } => Err(CompileError::UnsupportedPredicate(
+            "let term in equational_theory".to_string(),
+        )),
+    }
+}
+
+fn render_operator_term(maude_name: &str, args: &[String]) -> String {
+    if args.is_empty() {
+        return maude_name.to_string();
+    }
+    if args.len() == 2 && maude_name.starts_with('_') && maude_name.ends_with('_') {
+        let middle = maude_name.trim_matches('_');
+        if !middle.is_empty() && !middle.contains('_') {
+            return format!("({} {} {})", args[0], middle, args[1]);
+        }
+    }
+    format!("{}({})", maude_name, args.join(", "))
+}
+
+fn render_const(value: &Json, sort: &Sort) -> Result<String, CompileError> {
+    match value {
+        Json::Number(n) => Ok(n.to_string()),
+        Json::Bool(b) => Ok(if *b { "true" } else { "false" }.to_string()),
+        Json::String(s) => match sort {
+            Sort::Primitive { name } if name == "String" => Ok(format!("{s:?}")),
+            _ => {
+                validate_token(s, "constant")?;
+                Ok(s.clone())
+            }
+        },
+        _ => Err(CompileError::MalformedIr(
+            "unsupported const value in equational_theory".to_string(),
+        )),
+    }
+}
+
+fn validate_token(value: &str, what: &str) -> Result<(), CompileError> {
+    let ok = !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '\'' | '?'));
+    if ok {
+        Ok(())
+    } else {
+        Err(CompileError::MalformedIr(format!(
+            "{what} is not Maude-safe: {value:?}",
+        )))
+    }
+}
+
+fn validate_surface(value: &str, what: &str) -> Result<(), CompileError> {
+    let ok = !value.is_empty()
+        && value.chars().all(|ch| {
+            ch.is_ascii_alphanumeric()
+                || matches!(
+                    ch,
+                    '_' | '+' | '*' | '-' | '/' | '<' | '>' | '=' | '\'' | '?' | ':' | '~'
+                )
+        });
+    if ok {
+        Ok(())
+    } else {
+        Err(CompileError::MalformedIr(format!(
+            "{what} is not Maude-safe: {value:?}",
+        )))
+    }
+}
+
+fn validate_attr(attr: &str) -> Result<(), CompileError> {
+    match attr {
+        "assoc" | "comm" | "idem" | "id:" | "left-id:" | "right-id:" | "ctor" => Ok(()),
+        _ => validate_token(attr, "operator attr"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rejects_non_equational_root() {
+        let ir = json!({
+            "kind": "atomic",
+            "name": "=",
+            "theory": {"name": "bad", "sorts": [], "operators": [], "equations": []},
+            "obligation": {
+                "lhs": {"kind": "const", "value": 0, "sort": {"kind": "primitive", "name": "Int"}},
+                "rhs": {"kind": "const", "value": 0, "sort": {"kind": "primitive", "name": "Int"}}
+            }
+        });
+        let err = compile_artifact(&ir).unwrap_err();
+        assert!(matches!(err, CompileError::UnsupportedPredicate(_)));
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-maude/src/main.rs
+++ b/implementations/rust/provekit-ir-compiler-maude/src/main.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binary entry point for provekit-ir-maude.
+
+use std::io::{self, Read};
+
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_maude::{MaudeCompiler, DIALECT};
+use serde_json::Value as Json;
+
+fn main() {
+    let mut input = String::new();
+    if let Err(e) = io::stdin().read_to_string(&mut input) {
+        eprintln!("Error reading stdin: {e}");
+        std::process::exit(1);
+    }
+
+    let ir: Json = match serde_json::from_str(&input) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error parsing JSON: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let compiler = MaudeCompiler::new();
+    let result = match compiler.compile(&ir, DIALECT) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Error compiling IR to Maude: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    print!("{}{}", result.preamble, result.body);
+}

--- a/implementations/rust/provekit-ir-compiler-maude/tests/byte_for_byte.rs
+++ b/implementations/rust/provekit-ir-compiler-maude/tests/byte_for_byte.rs
@@ -1,0 +1,167 @@
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_maude::{emit, MaudeCompiler, DIALECT};
+use serde_json::{json, Value as Json};
+
+fn nat_obligation() -> Json {
+    json!({
+        "kind": "atomic",
+        "name": "equational_theory",
+        "theory": {
+            "name": "provekit-nat",
+            "sorts": ["Nat"],
+            "operators": [
+                {"name": "zero", "arity": [], "result": "Nat"},
+                {"name": "s", "arity": ["Nat"], "result": "Nat"},
+                {"name": "plus", "arity": ["Nat", "Nat"], "result": "Nat"}
+            ],
+            "variables": [
+                {"name": "N", "sort": "Nat"},
+                {"name": "M", "sort": "Nat"}
+            ],
+            "equations": [
+                {
+                    "label": "plus-zero-left",
+                    "lhs": {"kind": "ctor", "name": "plus", "args": [
+                        {"kind": "ctor", "name": "zero", "args": []},
+                        {"kind": "var", "name": "N"}
+                    ]},
+                    "rhs": {"kind": "var", "name": "N"}
+                },
+                {
+                    "label": "plus-s-left",
+                    "lhs": {"kind": "ctor", "name": "plus", "args": [
+                        {"kind": "ctor", "name": "s", "args": [
+                            {"kind": "var", "name": "N"}
+                        ]},
+                        {"kind": "var", "name": "M"}
+                    ]},
+                    "rhs": {"kind": "ctor", "name": "s", "args": [
+                        {"kind": "ctor", "name": "plus", "args": [
+                            {"kind": "var", "name": "N"},
+                            {"kind": "var", "name": "M"}
+                        ]}
+                    ]}
+                }
+            ]
+        },
+        "obligation": {
+            "lhs": {"kind": "ctor", "name": "plus", "args": [
+                {"kind": "ctor", "name": "s", "args": [
+                    {"kind": "ctor", "name": "zero", "args": []}
+                ]},
+                {"kind": "ctor", "name": "s", "args": [
+                    {"kind": "ctor", "name": "zero", "args": []}
+                ]}
+            ]},
+            "rhs": {"kind": "ctor", "name": "s", "args": [
+                {"kind": "ctor", "name": "s", "args": [
+                    {"kind": "ctor", "name": "zero", "args": []}
+                ]}
+            ]}
+        }
+    })
+}
+
+fn ac_obligation() -> Json {
+    json!({
+        "kind": "atomic",
+        "name": "equational_theory",
+        "theory": {
+            "name": "provekit-ac",
+            "sorts": ["Elt"],
+            "operators": [
+                {"name": "a", "arity": [], "result": "Elt"},
+                {"name": "b", "arity": [], "result": "Elt"},
+                {"name": "c", "arity": [], "result": "Elt"},
+                {"name": "d", "arity": [], "result": "Elt"},
+                {"name": "plus", "maude": "_+_", "arity": ["Elt", "Elt"], "result": "Elt", "attrs": ["assoc", "comm"]}
+            ],
+            "equations": []
+        },
+        "obligation": {
+            "lhs": {"kind": "ctor", "name": "plus", "args": [
+                {"kind": "ctor", "name": "plus", "args": [
+                    {"kind": "ctor", "name": "plus", "args": [
+                        {"kind": "ctor", "name": "a", "args": []},
+                        {"kind": "ctor", "name": "b", "args": []}
+                    ]},
+                    {"kind": "ctor", "name": "c", "args": []}
+                ]},
+                {"kind": "ctor", "name": "d", "args": []}
+            ]},
+            "rhs": {"kind": "ctor", "name": "plus", "args": [
+                {"kind": "ctor", "name": "a", "args": []},
+                {"kind": "ctor", "name": "plus", "args": [
+                    {"kind": "ctor", "name": "b", "args": []},
+                    {"kind": "ctor", "name": "plus", "args": [
+                        {"kind": "ctor", "name": "c", "args": []},
+                        {"kind": "ctor", "name": "d", "args": []}
+                    ]}
+                ]}
+            ]}
+        }
+    })
+}
+
+#[test]
+fn nat_lowering_is_byte_for_byte_stable() {
+    let expected = "\
+fmod PROVEKIT-NAT is
+  sort Nat .
+  op zero : -> Nat .
+  op s : Nat -> Nat .
+  op plus : Nat Nat -> Nat .
+  vars N M : Nat .
+  eq plus(zero, N) = N .
+  eq plus(s(N), M) = s(plus(N, M)) .
+endfm
+
+red in PROVEKIT-NAT : plus(s(zero), s(zero)) .
+red in PROVEKIT-NAT : s(s(zero)) .
+search in PROVEKIT-NAT : plus(s(zero), s(zero)) =>* s(s(zero)) .
+";
+    assert_eq!(emit(&nat_obligation()).unwrap(), expected);
+}
+
+#[test]
+fn ac_builtin_lowering_is_byte_for_byte_stable() {
+    let expected = "\
+fmod PROVEKIT-AC is
+  sort Elt .
+  op a : -> Elt .
+  op b : -> Elt .
+  op c : -> Elt .
+  op d : -> Elt .
+  op _+_ : Elt Elt -> Elt [assoc comm] .
+endfm
+
+red in PROVEKIT-AC : (((a + b) + c) + d) .
+red in PROVEKIT-AC : (a + (b + (c + d))) .
+search in PROVEKIT-AC : (((a + b) + c) + d) =>* (a + (b + (c + d))) .
+";
+    assert_eq!(emit(&ac_obligation()).unwrap(), expected);
+}
+
+#[test]
+fn trait_output_preamble_plus_body_equals_emit() {
+    let compiler = MaudeCompiler::new();
+    for ir in [nat_obligation(), ac_obligation()] {
+        let parts = compiler.compile(&ir, DIALECT).unwrap();
+        let combined = format!("{}{}", parts.preamble, parts.body);
+        assert_eq!(combined, emit(&ir).unwrap());
+    }
+}
+
+#[test]
+fn capabilities_are_equational_only() {
+    let compiler = MaudeCompiler::new();
+    let caps = compiler.capabilities();
+    assert_eq!(caps.dialects, vec![DIALECT.to_string()]);
+    assert_eq!(
+        caps.supported_predicates,
+        vec!["equational_theory".to_string()]
+    );
+    assert!(caps
+        .supported_sorts
+        .contains(&"equational_theory".to_string()));
+}

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // GENERATED SMT-LIB v2.6 compiler
 
+#![allow(unused_imports, unused_mut, unreachable_patterns)]
+
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_ir_compiler::{CompiledFormula, FreeVar, OpacityEntry, OpacityManifest};
 use provekit_ir_types::*;
@@ -579,7 +581,7 @@ pub fn compile_formula(formula: &Formula) -> CompiledFormula {
         opacities,
     };
 
-    // Check whether the formula references Outlives — if so, inject the
+    // Check whether the formula references Outlives. If so, inject the
     // kernel axioms (per protocol/specs/2026-05-05-outlives-kernel-axioms.md §2).
     let has_outlives = has_outlives_predicate(formula);
     let mut preamble = String::new();
@@ -588,11 +590,11 @@ pub fn compile_formula(formula: &Formula) -> CompiledFormula {
         // Declare the Region sort and Outlives predicate.
         preamble.push_str("(declare-sort Region 0)\n");
         preamble.push_str("(declare-fun Outlives (Region Region) Bool)\n");
-        // Kernel axiom 1: reflexivity — Outlives(r, r) always holds.
+        // Kernel axiom 1: reflexivity. Outlives(r, r) always holds.
         preamble.push_str("(assert (forall ((r Region)) (Outlives r r)))\n");
-        // Kernel axiom 2: transitivity — Outlives(r1, r2) ∧ Outlives(r2, r3) → Outlives(r1, r3).
+        // Kernel axiom 2: transitivity. Outlives(r1, r2) and Outlives(r2, r3) imply Outlives(r1, r3).
         preamble.push_str("(assert (forall ((r1 Region) (r2 Region) (r3 Region)) (=> (and (Outlives r1 r2) (Outlives r2 r3)) (Outlives r1 r3))))\n");
-        // Kernel axiom 3: 'static top element — Outlives('static, r) for every region r.
+        // Kernel axiom 3: 'static top element. Outlives('static, r) for every region r.
         // 'static outlives every region per spec §2.3 (corrected in commit 655ab84).
         preamble.push_str("(declare-fun static_region () Region)\n");
         preamble.push_str("(assert (forall ((r Region)) (Outlives static_region r)))\n");

--- a/implementations/rust/provekit-verifier/Cargo.toml
+++ b/implementations/rust/provekit-verifier/Cargo.toml
@@ -13,6 +13,7 @@ provekit-walk = { path = "../provekit-walk" }
 provekit-ir-compiler-smt-lib = { path = "../provekit-ir-compiler-smt-lib" }
 provekit-ir-compiler = { path = "../provekit-ir-compiler" }
 provekit-ir-compiler-coq = { path = "../provekit-ir-compiler-coq" }
+provekit-ir-compiler-maude = { path = "../provekit-ir-compiler-maude" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 walkdir = { workspace = true }

--- a/implementations/rust/provekit-verifier/src/solvers/ceta.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/ceta.rs
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CeTA certificate gate for Maude reduce results.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use provekit_canonicalizer::blake3_512_of;
+use provekit_ir_compiler_maude::TrsSpec;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CetaDecision {
+    Accepted,
+    Rejected,
+}
+
+#[derive(Debug, Clone)]
+pub struct CetaGateConfig {
+    pub enabled: bool,
+    pub ceta_binary: String,
+    pub termination_prover: String,
+    pub confluence_checker: String,
+    pub timeout: Option<Duration>,
+}
+
+impl Default for CetaGateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ceta_binary: "ceta".to_string(),
+            termination_prover: "aprove".to_string(),
+            confluence_checker: "csi".to_string(),
+            timeout: Some(Duration::from_secs(60)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CetaGateReceipt {
+    pub termination_cert_cid: Option<String>,
+    pub confluence_cert_cid: Option<String>,
+    pub ceta_accepted: bool,
+    pub bypassed: bool,
+    pub error: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CetaGateResult {
+    pub receipt: CetaGateReceipt,
+    pub stdout: String,
+    pub timed_out: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CommandCapture {
+    pub status_success: bool,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub timed_out: bool,
+}
+
+pub struct CetaGate {
+    config: CetaGateConfig,
+}
+
+impl CetaGate {
+    pub fn new(config: CetaGateConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn check(&self, trs: &TrsSpec) -> CetaGateResult {
+        if trs.rules.is_empty() {
+            return CetaGateResult {
+                receipt: CetaGateReceipt {
+                    termination_cert_cid: None,
+                    confluence_cert_cid: None,
+                    ceta_accepted: true,
+                    bypassed: true,
+                    error: "no user equations require a TRS gate".to_string(),
+                },
+                stdout: String::new(),
+                timed_out: false,
+            };
+        }
+        if !self.config.enabled {
+            return CetaGateResult {
+                receipt: CetaGateReceipt {
+                    termination_cert_cid: None,
+                    confluence_cert_cid: None,
+                    ceta_accepted: false,
+                    bypassed: false,
+                    error: "ceta gate disabled".to_string(),
+                },
+                stdout: String::new(),
+                timed_out: false,
+            };
+        }
+        self.run_external_gate(trs)
+    }
+
+    fn run_external_gate(&self, trs: &TrsSpec) -> CetaGateResult {
+        let started = Instant::now();
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "provekit-ceta-{}-{}",
+            std::process::id(),
+            started.elapsed().as_nanos()
+        ));
+        if let Err(e) = fs::create_dir_all(&tmp_dir) {
+            return gate_error(format!("ceta: create temp dir: {e}"), false);
+        }
+
+        let trs_file = tmp_dir.join("system.trs");
+        let trs_body = emit_wst(trs);
+        if let Err(e) = fs::write(&trs_file, trs_body) {
+            let _ = fs::remove_dir_all(&tmp_dir);
+            return gate_error(format!("ceta: write TRS input: {e}"), false);
+        }
+
+        let term = run_command_capture(
+            &self.config.termination_prover,
+            &[trs_file.to_string_lossy().as_ref()],
+            self.config.timeout,
+        );
+        let term = match term {
+            Ok(c) if c.status_success => c,
+            Ok(c) => {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return gate_error(command_error("termination prover", &c), c.timed_out);
+            }
+            Err(e) => {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return gate_error(format!("termination prover: {e}"), false);
+            }
+        };
+        let term_cert = tmp_dir.join("termination.cpf");
+        if let Err(e) = fs::write(&term_cert, &term.stdout) {
+            let _ = fs::remove_dir_all(&tmp_dir);
+            return gate_error(format!("ceta: write termination certificate: {e}"), false);
+        }
+
+        let conf = run_command_capture(
+            &self.config.confluence_checker,
+            &[trs_file.to_string_lossy().as_ref()],
+            self.config.timeout,
+        );
+        let conf = match conf {
+            Ok(c) if c.status_success => c,
+            Ok(c) => {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return gate_error(command_error("confluence checker", &c), c.timed_out);
+            }
+            Err(e) => {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return gate_error(format!("confluence checker: {e}"), false);
+            }
+        };
+        let conf_cert = tmp_dir.join("confluence.cpf");
+        if let Err(e) = fs::write(&conf_cert, &conf.stdout) {
+            let _ = fs::remove_dir_all(&tmp_dir);
+            return gate_error(format!("ceta: write confluence certificate: {e}"), false);
+        }
+
+        let term_check = verify_with_ceta(&self.config, &term_cert);
+        let conf_check = verify_with_ceta(&self.config, &conf_cert);
+        let mut stdout = String::new();
+        let term_ok = match term_check {
+            Ok((decision, out, timed_out)) => {
+                stdout.push_str(&out);
+                decision == CetaDecision::Accepted && !timed_out
+            }
+            Err(e) => {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return gate_error(e, false);
+            }
+        };
+        let conf_ok = match conf_check {
+            Ok((decision, out, timed_out)) => {
+                stdout.push_str(&out);
+                decision == CetaDecision::Accepted && !timed_out
+            }
+            Err(e) => {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return gate_error(e, false);
+            }
+        };
+
+        let receipt = CetaGateReceipt {
+            termination_cert_cid: Some(blake3_512_of(&term.stdout)),
+            confluence_cert_cid: Some(blake3_512_of(&conf.stdout)),
+            ceta_accepted: term_ok && conf_ok,
+            bypassed: false,
+            error: if term_ok && conf_ok {
+                String::new()
+            } else {
+                "ceta rejected at least one certificate".to_string()
+            },
+        };
+        let timed_out = term.timed_out || conf.timed_out;
+        let _ = fs::remove_dir_all(&tmp_dir);
+        CetaGateResult {
+            receipt,
+            stdout,
+            timed_out,
+        }
+    }
+}
+
+pub fn parse_ceta_output(stdout: &str) -> Result<CetaDecision, String> {
+    let lower = stdout.to_ascii_lowercase();
+    if lower.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed == "yes"
+            || trimmed == "accepted"
+            || trimmed.contains("certificate accepted")
+            || trimmed.contains("proof accepted")
+    }) {
+        return Ok(CetaDecision::Accepted);
+    }
+    if lower.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed == "no"
+            || trimmed == "rejected"
+            || trimmed.contains("invalid")
+            || trimmed.contains("error")
+            || trimmed.contains("failed")
+    }) {
+        return Ok(CetaDecision::Rejected);
+    }
+    Ok(CetaDecision::Rejected)
+}
+
+pub fn emit_wst(trs: &TrsSpec) -> String {
+    let mut out = String::new();
+    out.push_str("(VAR");
+    for variable in &trs.variables {
+        out.push(' ');
+        out.push_str(variable);
+    }
+    out.push_str(")\n(RULES\n");
+    for rule in &trs.rules {
+        out.push_str("  ");
+        out.push_str(&rule.lhs);
+        out.push_str(" -> ");
+        out.push_str(&rule.rhs);
+        out.push('\n');
+    }
+    out.push_str(")\n");
+    out
+}
+
+pub fn run_command_capture(
+    binary: &str,
+    args: &[&str],
+    timeout: Option<Duration>,
+) -> Result<CommandCapture, String> {
+    let started = Instant::now();
+    let mut command = Command::new(binary);
+    command.args(args);
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("spawn {binary}: {e}"))?;
+
+    let timed_out;
+    if let Some(to) = timeout {
+        let deadline = started + to;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    timed_out = false;
+                    break;
+                }
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Ok(CommandCapture {
+                            status_success: false,
+                            stdout: Vec::new(),
+                            stderr: format!("timeout after {}s", to.as_secs().max(1)).into_bytes(),
+                            timed_out: true,
+                        });
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(e) => return Err(format!("wait {binary}: {e}")),
+            }
+        }
+    } else {
+        timed_out = false;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("wait {binary}: {e}"))?;
+    Ok(CommandCapture {
+        status_success: output.status.success(),
+        stdout: output.stdout,
+        stderr: output.stderr,
+        timed_out,
+    })
+}
+
+fn verify_with_ceta(
+    config: &CetaGateConfig,
+    cert_path: &Path,
+) -> Result<(CetaDecision, String, bool), String> {
+    let cert = cert_path.to_string_lossy();
+    let capture = run_command_capture(&config.ceta_binary, &[cert.as_ref()], config.timeout)?;
+    let mut out = String::from_utf8_lossy(&capture.stdout).to_string();
+    out.push_str(&String::from_utf8_lossy(&capture.stderr));
+    Ok((parse_ceta_output(&out)?, out, capture.timed_out))
+}
+
+fn gate_error(error: String, timed_out: bool) -> CetaGateResult {
+    CetaGateResult {
+        receipt: CetaGateReceipt {
+            termination_cert_cid: None,
+            confluence_cert_cid: None,
+            ceta_accepted: false,
+            bypassed: false,
+            error,
+        },
+        stdout: String::new(),
+        timed_out,
+    }
+}
+
+fn command_error(label: &str, capture: &CommandCapture) -> String {
+    let stderr = String::from_utf8_lossy(&capture.stderr);
+    let stdout = String::from_utf8_lossy(&capture.stdout);
+    format!("{label} failed: {stderr}{stdout}")
+}

--- a/implementations/rust/provekit-verifier/src/solvers/config.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/config.rs
@@ -6,7 +6,7 @@
 //   [solvers]
 //   default = "z3"                            # OR
 //   chain = ["z3", "cvc5"]                    # OR
-//   portfolio = ["z3", "cvc5", "bitwuzla"]    # OR
+//   portfolio = ["maude", "z3", "cvc5", "bitwuzla"]    # OR
 //   mode = "first-wins"  or  "consensus"
 //
 //   [solvers.z3]
@@ -14,6 +14,14 @@
 //   ir_compiler = "smt-lib-v2.6"
 //   timeout_seconds = 5
 //   flags = ["-T:5"]
+//
+//   [solvers.maude]
+//   binary = "maude"
+//   ir_compiler = "maude"
+//   ceta_gate = true
+//   ceta_binary = "ceta"
+//   termination_prover = "aprove"
+//   confluence_checker = "csi"
 //
 //   [solvers.dispatch]
 //   "strings" = "cvc5"
@@ -47,6 +55,19 @@ pub struct SolverConfig {
     pub timeout_seconds: Option<u64>,
     #[serde(default)]
     pub flags: Vec<String>,
+    /// Enables the certified termination and confluence gate used by
+    /// Maude before a reduce-based equality can be trusted.
+    #[serde(default)]
+    pub ceta_gate: bool,
+    /// Path to the CeTA checker binary.
+    #[serde(default = "default_ceta_binary")]
+    pub ceta_binary: String,
+    /// Path to a termination prover that emits a CPF certificate.
+    #[serde(default = "default_termination_prover")]
+    pub termination_prover: String,
+    /// Path to a confluence checker that emits a CPF certificate.
+    #[serde(default = "default_confluence_checker")]
+    pub confluence_checker: String,
     /// Optional version pin to surface in the report and in minted
     /// implication-memento `body.prover` strings. Defaults to `0`.
     #[serde(default = "default_version")]
@@ -58,6 +79,15 @@ fn default_ir_compiler() -> String {
 }
 fn default_version() -> String {
     "0".into()
+}
+fn default_ceta_binary() -> String {
+    "ceta".into()
+}
+fn default_termination_prover() -> String {
+    "aprove".into()
+}
+fn default_confluence_checker() -> String {
+    "csi".into()
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
@@ -75,6 +105,8 @@ impl Default for PortfolioMode {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct DispatchConfig {
+    #[serde(rename = "equational-theory", default)]
+    pub equational_theory: Option<String>,
     #[serde(default)]
     pub strings: Option<String>,
     #[serde(default)]

--- a/implementations/rust/provekit-verifier/src/solvers/dispatch.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/dispatch.rs
@@ -29,6 +29,7 @@ use crate::solvers::DispatchConfig;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FormulaTheory {
+    EquationalTheory,
     Strings,
     Bitvectors,
     LinearArithmetic,
@@ -38,6 +39,7 @@ pub enum FormulaTheory {
 impl FormulaTheory {
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::EquationalTheory => "equational-theory",
             Self::Strings => "strings",
             Self::Bitvectors => "bitvectors",
             Self::LinearArithmetic => "linear-arithmetic",
@@ -74,6 +76,10 @@ fn walk(v: &Json, theory: &mut FormulaTheory) {
     match v {
         Json::Object(map) => {
             if let Some(name) = map.get("name").and_then(|v| v.as_str()) {
+                if name == "equational_theory" {
+                    *theory = FormulaTheory::EquationalTheory;
+                    return;
+                }
                 if STRING_OPS.contains(&name) {
                     *theory = FormulaTheory::Strings;
                     return;
@@ -109,7 +115,10 @@ fn walk(v: &Json, theory: &mut FormulaTheory) {
                 }
             }
             for (_, child) in map {
-                if *theory == FormulaTheory::Strings {
+                if matches!(
+                    *theory,
+                    FormulaTheory::EquationalTheory | FormulaTheory::Strings
+                ) {
                     return;
                 }
                 walk(child, theory);
@@ -117,7 +126,10 @@ fn walk(v: &Json, theory: &mut FormulaTheory) {
         }
         Json::Array(arr) => {
             for child in arr {
-                if *theory == FormulaTheory::Strings {
+                if matches!(
+                    *theory,
+                    FormulaTheory::EquationalTheory | FormulaTheory::Strings
+                ) {
                     return;
                 }
                 walk(child, theory);
@@ -133,6 +145,7 @@ fn walk(v: &Json, theory: &mut FormulaTheory) {
 pub fn dispatch_for_formula<'a>(formula: &Json, dispatch: &'a DispatchConfig) -> Option<&'a str> {
     let t = classify(formula);
     let by_theory = match t {
+        FormulaTheory::EquationalTheory => dispatch.equational_theory.as_deref(),
         FormulaTheory::Strings => dispatch.strings.as_deref(),
         FormulaTheory::Bitvectors => dispatch.bitvectors.as_deref(),
         FormulaTheory::LinearArithmetic => dispatch.linear_arithmetic.as_deref(),
@@ -190,6 +203,7 @@ mod tests {
     #[test]
     fn dispatch_picks_solver() {
         let d = DispatchConfig {
+            equational_theory: Some("maude".into()),
             strings: Some("cvc5".into()),
             bitvectors: Some("bitwuzla".into()),
             linear_arithmetic: Some("z3".into()),

--- a/implementations/rust/provekit-verifier/src/solvers/maude.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/maude.rs
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Maude subprocess solver for equational theory obligations.
+
+use std::fs;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
+use provekit_ir_compiler_maude::{compile_artifact, MaudeQueries, DIALECT};
+use serde::Serialize;
+use serde_json::Value as Json;
+
+use crate::solvers::ceta::{run_command_capture, CetaGate, CetaGateConfig, CetaGateReceipt};
+use crate::solvers::{SolveResult, Solver};
+use crate::types::ObligationVerdict;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaudeDecision {
+    ReduceEqual,
+    SearchSolution,
+    NoMatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedMaudeOutput {
+    pub normal_forms: Vec<String>,
+    pub decision: MaudeDecision,
+}
+
+#[derive(Debug, Serialize)]
+struct MaudeVerdictReceipt {
+    maude_version: String,
+    module_cid: String,
+    queries: MaudeQueriesReceipt,
+    normal_forms: Vec<String>,
+    decision: MaudeDecision,
+    verdict: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MaudeQueriesReceipt {
+    lhs_reduce: String,
+    rhs_reduce: String,
+    search: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MaudeReceipt {
+    maude_verdict: MaudeVerdictReceipt,
+    ceta_gate: CetaGateReceipt,
+}
+
+#[derive(Debug)]
+pub struct MaudeSubprocessSolver {
+    name: String,
+    version: String,
+    binary: String,
+    timeout: Option<Duration>,
+    ceta_config: CetaGateConfig,
+}
+
+impl MaudeSubprocessSolver {
+    pub fn new(
+        name: impl Into<String>,
+        binary: impl Into<String>,
+        version: impl Into<String>,
+        timeout: Option<Duration>,
+        ceta_config: CetaGateConfig,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+            binary: binary.into(),
+            timeout,
+            ceta_config,
+        }
+    }
+}
+
+impl Solver for MaudeSubprocessSolver {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+
+    fn ir_compiler(&self) -> &str {
+        DIALECT
+    }
+
+    fn solve(&self, input: &str) -> SolveResult {
+        let started = Instant::now();
+        let ir: Json = match serde_json::from_str(input) {
+            Ok(j) => j,
+            Err(e) => {
+                return unknown_result(
+                    &self.name,
+                    &self.version,
+                    started,
+                    false,
+                    format!("maude: failed to parse IR-JSON: {e}"),
+                    String::new(),
+                );
+            }
+        };
+
+        let artifact = match compile_artifact(&ir) {
+            Ok(a) => a,
+            Err(e) => {
+                return unknown_result(
+                    &self.name,
+                    &self.version,
+                    started,
+                    false,
+                    format!("maude: compilation error: {e}"),
+                    String::new(),
+                );
+            }
+        };
+
+        let full_source = format!("{}{}", artifact.compiled.preamble, artifact.compiled.body);
+        let module_cid = module_cid(&full_source);
+        let maude_version =
+            read_maude_version(&self.binary).unwrap_or_else(|_| self.version.clone());
+        let ceta_gate = CetaGate::new(self.ceta_config.clone());
+
+        let maude_source = full_source.clone();
+        let maude_binary = self.binary.clone();
+        let maude_timeout = self.timeout;
+        let trs = artifact.trs.clone();
+        let (maude_run, ceta_result) = std::thread::scope(|scope| {
+            let maude_handle =
+                scope.spawn(|| run_maude_file(&maude_binary, &maude_source, maude_timeout));
+            let ceta_handle = scope.spawn(|| ceta_gate.check(&trs));
+            let maude_run = maude_handle
+                .join()
+                .unwrap_or_else(|_| Err("maude worker panicked".to_string()));
+            let ceta_result =
+                ceta_handle
+                    .join()
+                    .unwrap_or_else(|_| crate::solvers::ceta::CetaGateResult {
+                        receipt: CetaGateReceipt {
+                            termination_cert_cid: None,
+                            confluence_cert_cid: None,
+                            ceta_accepted: false,
+                            bypassed: false,
+                            error: "ceta worker panicked".to_string(),
+                        },
+                        stdout: String::new(),
+                        timed_out: false,
+                    });
+            (maude_run, ceta_result)
+        });
+
+        let capture = match maude_run {
+            Ok(c) if c.status_success => c,
+            Ok(c) => {
+                let receipt = build_receipt(
+                    &maude_version,
+                    &module_cid,
+                    &artifact.queries,
+                    Vec::new(),
+                    MaudeDecision::NoMatch,
+                    ObligationVerdict::Undecidable,
+                    ceta_result.receipt,
+                );
+                return unknown_result(
+                    &self.name,
+                    &self.version,
+                    started,
+                    c.timed_out,
+                    format!("maude failed: {}", String::from_utf8_lossy(&c.stderr)),
+                    receipt,
+                );
+            }
+            Err(e) => {
+                let receipt = build_receipt(
+                    &maude_version,
+                    &module_cid,
+                    &artifact.queries,
+                    Vec::new(),
+                    MaudeDecision::NoMatch,
+                    ObligationVerdict::Undecidable,
+                    ceta_result.receipt,
+                );
+                return unknown_result(&self.name, &self.version, started, false, e, receipt);
+            }
+        };
+
+        let mut stdout = String::from_utf8_lossy(&capture.stdout).to_string();
+        stdout.push_str(&String::from_utf8_lossy(&capture.stderr));
+        let parsed = match parse_maude_output(&stdout) {
+            Ok(p) => p,
+            Err(e) => {
+                let receipt = build_receipt(
+                    &maude_version,
+                    &module_cid,
+                    &artifact.queries,
+                    Vec::new(),
+                    MaudeDecision::NoMatch,
+                    ObligationVerdict::Undecidable,
+                    ceta_result.receipt,
+                );
+                return unknown_result(&self.name, &self.version, started, false, e, receipt);
+            }
+        };
+
+        let verdict = match parsed.decision {
+            MaudeDecision::SearchSolution => ObligationVerdict::Discharged,
+            MaudeDecision::ReduceEqual if ceta_result.receipt.ceta_accepted => {
+                ObligationVerdict::Discharged
+            }
+            MaudeDecision::ReduceEqual | MaudeDecision::NoMatch => ObligationVerdict::Undecidable,
+        };
+        let error = match (parsed.decision, verdict) {
+            (MaudeDecision::ReduceEqual, ObligationVerdict::Undecidable) => {
+                "maude reduce result discarded because ceta gate did not accept".to_string()
+            }
+            (MaudeDecision::NoMatch, _) => "maude returned no entailment witness".to_string(),
+            _ => String::new(),
+        };
+        let receipt = build_receipt(
+            &maude_version,
+            &module_cid,
+            &artifact.queries,
+            parsed.normal_forms,
+            parsed.decision,
+            verdict,
+            ceta_result.receipt,
+        );
+
+        SolveResult {
+            verdict,
+            solver_name: self.name.clone(),
+            solver_version: self.version.clone(),
+            error,
+            solver_stdout: receipt,
+            wall_clock: started.elapsed(),
+            timed_out: capture.timed_out || ceta_result.timed_out,
+        }
+    }
+}
+
+pub fn parse_maude_output(stdout: &str) -> Result<ParsedMaudeOutput, String> {
+    let mut normal_forms = Vec::new();
+    let mut saw_solution = false;
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("result ") {
+            if let Some((_, normal)) = rest.split_once(':') {
+                normal_forms.push(normal.trim().to_string());
+            }
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.starts_with("solution ") || lower == "solution" {
+            saw_solution = true;
+        }
+    }
+    if normal_forms.len() >= 2 && normal_forms[0] == normal_forms[1] {
+        return Ok(ParsedMaudeOutput {
+            normal_forms,
+            decision: MaudeDecision::ReduceEqual,
+        });
+    }
+    if saw_solution {
+        return Ok(ParsedMaudeOutput {
+            normal_forms,
+            decision: MaudeDecision::SearchSolution,
+        });
+    }
+    Ok(ParsedMaudeOutput {
+        normal_forms,
+        decision: MaudeDecision::NoMatch,
+    })
+}
+
+fn run_maude_file(
+    binary: &str,
+    source: &str,
+    timeout: Option<Duration>,
+) -> Result<crate::solvers::ceta::CommandCapture, String> {
+    let started = Instant::now();
+    let tmp_dir = std::env::temp_dir().join(format!(
+        "provekit-maude-{}-{}",
+        std::process::id(),
+        started.elapsed().as_nanos()
+    ));
+    fs::create_dir_all(&tmp_dir).map_err(|e| format!("maude: create temp dir: {e}"))?;
+    let path = tmp_dir.join("obligation.maude");
+    fs::write(&path, source).map_err(|e| format!("maude: write module file: {e}"))?;
+    let path_str = path.to_string_lossy();
+    let result = run_command_capture(binary, &[path_str.as_ref()], timeout);
+    let _ = fs::remove_dir_all(&tmp_dir);
+    result
+}
+
+fn read_maude_version(binary: &str) -> Result<String, String> {
+    let output = Command::new(binary)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("maude --version: {e}"))?;
+    let mut text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() {
+        text = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    }
+    if text.is_empty() {
+        Err("maude --version returned no output".to_string())
+    } else {
+        Ok(text)
+    }
+}
+
+fn module_cid(source: &str) -> String {
+    let value = Value::string(source.to_string());
+    let canonical = encode_jcs(&value);
+    blake3_512_of(canonical.as_bytes())
+}
+
+fn build_receipt(
+    maude_version: &str,
+    module_cid: &str,
+    queries: &MaudeQueries,
+    normal_forms: Vec<String>,
+    decision: MaudeDecision,
+    verdict: ObligationVerdict,
+    ceta_gate: CetaGateReceipt,
+) -> String {
+    let receipt = MaudeReceipt {
+        maude_verdict: MaudeVerdictReceipt {
+            maude_version: maude_version.to_string(),
+            module_cid: module_cid.to_string(),
+            queries: MaudeQueriesReceipt {
+                lhs_reduce: queries.lhs_reduce.clone(),
+                rhs_reduce: queries.rhs_reduce.clone(),
+                search: queries.search.clone(),
+            },
+            normal_forms,
+            decision,
+            verdict: verdict.as_str().to_string(),
+        },
+        ceta_gate,
+    };
+    serde_json::to_string(&receipt).unwrap_or_else(|e| format!(r#"{{"receipt_error":"{e}"}}"#))
+}
+
+fn unknown_result(
+    name: &str,
+    version: &str,
+    started: Instant,
+    timed_out: bool,
+    error: String,
+    solver_stdout: String,
+) -> SolveResult {
+    SolveResult {
+        verdict: ObligationVerdict::Undecidable,
+        solver_name: name.to_string(),
+        solver_version: version.to_string(),
+        error,
+        solver_stdout,
+        wall_clock: started.elapsed(),
+        timed_out,
+    }
+}

--- a/implementations/rust/provekit-verifier/src/solvers/mod.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/mod.rs
@@ -29,9 +29,11 @@
 //   * Dispatch                    - inspect the formula and pick the
 //                                   matching solver for that fragment.
 
+pub mod ceta;
 pub mod config;
 pub mod coq;
 pub mod dispatch;
+pub mod maude;
 pub mod plan;
 pub mod registry;
 pub mod stub;
@@ -77,9 +79,11 @@ pub trait Solver: Send + Sync {
 /// shared, cheaply-clonable handles.
 pub type SolverHandle = Arc<dyn Solver>;
 
+pub use ceta::{CetaGate, CetaGateConfig};
 pub use config::{DispatchConfig, PortfolioMode, SolverConfig, SolverPlan, SolversConfig};
 pub use coq::CoqSubprocessSolver;
 pub use dispatch::dispatch_for_formula;
+pub use maude::MaudeSubprocessSolver;
 pub use plan::{run_plan, SolverInvocation};
 pub use stub::StubSolver;
 pub use subprocess::SubprocessSolver;

--- a/implementations/rust/provekit-verifier/src/solvers/plan.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/plan.rs
@@ -43,12 +43,14 @@ pub fn run_plan(
     formula: Option<&Json>,
 ) -> (ObligationVerdict, String, Vec<SolverInvocation>) {
     match plan {
-        SolverPlan::Single(name) => single(name, registry, smt_script),
-        SolverPlan::Chain(names) => chain(names, registry, smt_script),
-        SolverPlan::Portfolio { names, mode } => portfolio(names, *mode, registry, smt_script),
+        SolverPlan::Single(name) => single(name, registry, smt_script, formula),
+        SolverPlan::Chain(names) => chain(names, registry, smt_script, formula),
+        SolverPlan::Portfolio { names, mode } => {
+            portfolio(names, *mode, registry, smt_script, formula)
+        }
         SolverPlan::Dispatch(d) => match formula {
             Some(f) => match dispatch_for_formula(f, d) {
-                Some(n) => single(n, registry, smt_script),
+                Some(n) => single(n, registry, smt_script, formula),
                 None => (
                     ObligationVerdict::Undecidable,
                     "dispatch: no matching solver and no default".into(),
@@ -74,10 +76,12 @@ fn single(
     name: &str,
     registry: &Registry,
     smt: &str,
+    formula: Option<&Json>,
 ) -> (ObligationVerdict, String, Vec<SolverInvocation>) {
     match lookup(name, registry) {
         Ok(s) => {
-            let r = s.solve(smt);
+            let input = solver_input(s.as_ref(), smt, formula);
+            let r = s.solve(&input);
             let verdict = r.verdict;
             let reason = reason_for(&r);
             let inv = SolverInvocation {
@@ -94,13 +98,15 @@ fn chain(
     names: &[String],
     registry: &Registry,
     smt: &str,
+    formula: Option<&Json>,
 ) -> (ObligationVerdict, String, Vec<SolverInvocation>) {
     let mut history: Vec<SolverInvocation> = vec![];
     let mut last_reason = String::new();
     for (idx, n) in names.iter().enumerate() {
         match lookup(n, registry) {
             Ok(s) => {
-                let r = s.solve(smt);
+                let input = solver_input(s.as_ref(), smt, formula);
+                let r = s.solve(&input);
                 let definitive = matches!(
                     r.verdict,
                     ObligationVerdict::Discharged | ObligationVerdict::Unsatisfied
@@ -152,6 +158,7 @@ fn portfolio(
     mode: PortfolioMode,
     registry: &Registry,
     smt: &str,
+    formula: Option<&Json>,
 ) -> (ObligationVerdict, String, Vec<SolverInvocation>) {
     // Resolve handles up front; surface lookup misses as Undecidable.
     let mut handles: Vec<&Arc<dyn Solver>> = vec![];
@@ -170,7 +177,13 @@ fn portfolio(
     // remaining solvers continue until natural completion or timeout.
     // The plan-execution semantics (first definitive verdict wins) is
     // still honored by the post-collection sort.
-    let results: Vec<SolveResult> = handles.par_iter().map(|s| s.solve(smt)).collect();
+    let results: Vec<SolveResult> = handles
+        .par_iter()
+        .map(|s| {
+            let input = solver_input(s.as_ref(), smt, formula);
+            s.solve(&input)
+        })
+        .collect();
 
     match mode {
         PortfolioMode::FirstWins => {
@@ -309,6 +322,16 @@ fn reason_for(r: &SolveResult) -> String {
     }
 }
 
+fn solver_input(solver: &dyn Solver, smt: &str, formula: Option<&Json>) -> String {
+    if solver.ir_compiler() == "smt-lib-v2.6" {
+        smt.to_string()
+    } else {
+        formula
+            .map(Json::to_string)
+            .unwrap_or_else(|| smt.to_string())
+    }
+}
+
 /// Helper for the runner's per-solver telemetry aggregator. Held in
 /// an `Arc<Mutex<...>>` so the rayon callsite fan-out can append from
 /// any worker thread.
@@ -430,6 +453,7 @@ mod tests {
             Arc::new(StubSolver::new("cvc5", ObligationVerdict::Unsatisfied)) as SolverHandle,
         );
         let plan = SolverPlan::Dispatch(crate::solvers::DispatchConfig {
+            equational_theory: None,
             strings: Some("cvc5".into()),
             bitvectors: None,
             linear_arithmetic: Some("z3".into()),
@@ -449,6 +473,7 @@ mod tests {
             Arc::new(StubSolver::new("z3", ObligationVerdict::Discharged)) as SolverHandle,
         );
         let plan = SolverPlan::Dispatch(crate::solvers::DispatchConfig {
+            equational_theory: None,
             strings: None,
             bitvectors: None,
             linear_arithmetic: None,

--- a/implementations/rust/provekit-verifier/src/solvers/registry.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/registry.rs
@@ -10,6 +10,10 @@
 //                            it reads IR-JSON, compiles to Coq via
 //                            `CoqCompiler`, and runs `coqc` on the
 //                            generated `.v` file.
+//   * MaudeSubprocessSolver - when `ir_compiler = "maude"`.
+//                            It compiles equational theory obligations
+//                            and trusts reduce only when the CeTA gate
+//                            accepts termination and confluence.
 //   * SubprocessSolver     - default. Generic SMT-LIB v2.6 driver
 //                            (Z3, cvc5, bitwuzla, MathSAT, ...).
 //
@@ -28,9 +32,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use provekit_ir_compiler_coq::DIALECT as COQ_DIALECT;
+use provekit_ir_compiler_maude::DIALECT as MAUDE_DIALECT;
 
 use crate::solvers::{
-    CoqSubprocessSolver, SolverConfig, SolverHandle, SolversConfig, StubSolver, SubprocessSolver,
+    CetaGateConfig, CoqSubprocessSolver, MaudeSubprocessSolver, SolverConfig, SolverHandle,
+    SolversConfig, StubSolver, SubprocessSolver,
 };
 
 pub fn build(cfg: &SolversConfig) -> HashMap<String, SolverHandle> {
@@ -50,6 +56,10 @@ fn is_coq_compiler(ir_compiler: &str) -> bool {
     ir_compiler == "coq" || ir_compiler == COQ_DIALECT
 }
 
+fn is_maude_compiler(ir_compiler: &str) -> bool {
+    ir_compiler == "maude" || ir_compiler == MAUDE_DIALECT
+}
+
 fn build_one(name: &str, sc: &SolverConfig) -> SolverHandle {
     if let Some(stub) = StubSolver::from_binary(name, &sc.binary) {
         return Arc::new(stub) as SolverHandle;
@@ -66,6 +76,21 @@ fn build_one(name: &str, sc: &SolverConfig) -> SolverHandle {
             bin,
             sc.version.clone(),
             timeout,
+        )) as SolverHandle;
+    }
+    if is_maude_compiler(&sc.ir_compiler) {
+        return Arc::new(MaudeSubprocessSolver::new(
+            name,
+            bin,
+            sc.version.clone(),
+            timeout,
+            CetaGateConfig {
+                enabled: sc.ceta_gate,
+                ceta_binary: sc.ceta_binary.clone(),
+                termination_prover: sc.termination_prover.clone(),
+                confluence_checker: sc.confluence_checker.clone(),
+                timeout,
+            },
         )) as SolverHandle;
     }
     Arc::new(SubprocessSolver::new(
@@ -199,8 +224,8 @@ ir_compiler = "coq"
         let c = SolversConfig::from_toml(&body).expect("config parses");
         let r = build(&c);
 
-        // All four seats register.
-        for name in ["z3", "cvc5", "vampire", "coq"] {
+        // All five seats register.
+        for name in ["z3", "cvc5", "vampire", "coq", "maude"] {
             assert!(r.contains_key(name), "{name} seat missing from registry");
         }
 
@@ -225,6 +250,8 @@ ir_compiler = "coq"
         // above.
         let coq = r.get("coq").unwrap();
         assert_eq!(coq.ir_compiler(), "coq");
+        let maude = r.get("maude").unwrap();
+        assert_eq!(maude.ir_compiler(), "maude");
     }
 
     #[test]

--- a/implementations/rust/provekit-verifier/tests/maude_ceta.rs
+++ b/implementations/rust/provekit-verifier/tests/maude_ceta.rs
@@ -1,0 +1,82 @@
+use provekit_verifier::solvers::ceta::{parse_ceta_output, CetaDecision};
+use provekit_verifier::solvers::maude::{parse_maude_output, MaudeDecision};
+
+#[test]
+fn maude_parser_accepts_equal_reduce_normal_forms() {
+    let stdout = "\
+reduce in PROVEKIT-NAT : plus(s(zero), s(zero)) .
+result Nat: s(s(zero))
+reduce in PROVEKIT-NAT : s(s(zero)) .
+result Nat: s(s(zero))
+search in PROVEKIT-NAT : plus(s(zero), s(zero)) =>* s(s(zero)) .
+No solution.
+";
+    let parsed = parse_maude_output(stdout).unwrap();
+    assert_eq!(parsed.normal_forms, vec!["s(s(zero))", "s(s(zero))"]);
+    assert_eq!(parsed.decision, MaudeDecision::ReduceEqual);
+}
+
+#[test]
+fn maude_parser_accepts_search_solution() {
+    let stdout = "\
+reduce in M : lhs .
+result Elt: lhs
+reduce in M : rhs .
+result Elt: rhs
+search in M : lhs =>* rhs .
+Solution 1
+state: rhs
+";
+    let parsed = parse_maude_output(stdout).unwrap();
+    assert_eq!(parsed.decision, MaudeDecision::SearchSolution);
+}
+
+#[test]
+fn maude_parser_returns_unknown_for_no_match() {
+    let stdout = "\
+reduce in M : lhs .
+result Elt: lhs
+reduce in M : rhs .
+result Elt: rhs
+search in M : lhs =>* rhs .
+No solution.
+";
+    let parsed = parse_maude_output(stdout).unwrap();
+    assert_eq!(parsed.decision, MaudeDecision::NoMatch);
+}
+
+#[test]
+fn ceta_parser_accepts_only_certified_success() {
+    assert_eq!(parse_ceta_output("YES\n").unwrap(), CetaDecision::Accepted);
+    assert_eq!(
+        parse_ceta_output("Certificate accepted\n").unwrap(),
+        CetaDecision::Accepted
+    );
+    assert_eq!(parse_ceta_output("NO\n").unwrap(), CetaDecision::Rejected);
+    assert_eq!(
+        parse_ceta_output("error: invalid certificate\n").unwrap(),
+        CetaDecision::Rejected
+    );
+}
+
+#[test]
+fn non_confluent_gate_rejection_discards_reduce() {
+    let maude_stdout = "\
+reduce in BAD : a .
+result Elt: c
+reduce in BAD : b .
+result Elt: c
+search in BAD : a =>* b .
+No solution.
+";
+    let maude = parse_maude_output(maude_stdout).unwrap();
+    assert_eq!(maude.decision, MaudeDecision::ReduceEqual);
+    let ceta = parse_ceta_output("NO\n").unwrap();
+    assert_eq!(ceta, CetaDecision::Rejected);
+}
+
+#[test]
+#[ignore = "requires maude, termination provers, confluence checker, and ceta on PATH"]
+fn binary_dependent_maude_and_ceta_gate_smoke() {
+    panic!("enable locally after installing the Maude and CeTA portfolio tools");
+}

--- a/protocol/specs/2026-05-10-equational-portfolio-extension.md
+++ b/protocol/specs/2026-05-10-equational-portfolio-extension.md
@@ -1,0 +1,159 @@
+# Equational Portfolio Extension
+
+**Status:** v0.1.0 implementation spec
+**Date:** 2026-05-10
+**Owner:** verifier crate and IR compiler crates
+
+## 1. Scope
+
+This extension adds a Maude backend to the prove portfolio for obligations whose compiler-declared coverage is exactly `equational_theory`.
+
+The IR remains solver-neutral. The Maude compiler is the authority for this coverage class. The verifier remains the authority for composing Maude with the rest of the portfolio, including the CeTA gate that controls when Maude normal-form equality can be trusted.
+
+References:
+
+- Multi-Solver Protocol v2, section 1: compiler authority over sound coverage.
+- Language Signature Protocol, section 1.2: `EquationMemento`.
+- Language Signature Protocol, section 2: homomorphism obligations include target-theory entailment.
+- Language Signature Protocol, section 6: morphism composition factors through discharged obligations.
+- Paper 13, Lemma 7: equational reasoning by catalog equations.
+- Paper 13, Lemma 8: finitely presented algebraic languages are substrate-presentable.
+
+## 2. Coverage Declaration
+
+The Maude compiler declares support for:
+
+```
+equational_theory
+```
+
+It does not declare support for dependent types, higher-order terms, induction over infinite domains, arithmetic beyond equations supplied by the caller, or general first-order logic. Inputs outside `equational_theory` are rejected rather than silently compiled.
+
+## 3. Lowering
+
+An equational obligation is an IR-JSON object with:
+
+- `kind = "atomic"` and `name = "equational_theory"`, or `kind = "equational_theory"`.
+- `theory`: a finite presentation with sorts, optional subsorts, operators, variables, and equations.
+- `obligation`: a pair `{ lhs, rhs }`.
+
+The compiler emits one Maude functional module:
+
+```
+fmod <NAME> is
+  sort <SORT> .
+  op <OP> : <ARGS> -> <RESULT> .
+  vars <VARS> : <SORT> .
+  eq <LHS> = <RHS> .
+endfm
+```
+
+The module is followed by three queries:
+
+```
+red in <NAME> : <lhs> .
+red in <NAME> : <rhs> .
+search in <NAME> : <lhs> =>* <rhs> .
+```
+
+The two `red` queries compare canonical normal forms. The `search` query is a positive reachability witness. The compiler output is deterministic for byte-for-byte testing.
+
+## 4. Verdict Semantics
+
+The Maude adapter parses the solver output as follows:
+
+- If the two `red` queries produce syntactically equal normal forms, Maude has a reduce witness.
+- If `search` reports a solution, Maude has a search witness.
+- If neither condition holds, the Maude verdict is `Unknown`, represented by the existing verifier verdict `Undecidable`.
+- If Maude errors or times out, the verdict is `Undecidable`.
+
+The `search` witness is always positive evidence for entailment and does not need the CeTA gate.
+
+The `reduce` witness is trusted only when the CeTA gate accepts the equation set as terminating and confluent. Without that gate, normal forms might be non-unique or might not exist, so equal or unequal reduce results are not enough to decide the obligation.
+
+## 5. AC-Builtin Handling
+
+Maude operator attributes such as `assoc` and `comm` are emitted as native Maude operator attributes:
+
+```
+op _+_ : Elt Elt -> Elt [assoc comm] .
+```
+
+Equations that are handled solely by Maude builtin AC matching are not emitted to the TRS gate. The gate applies to user equations read left-to-right as rewrite rules. This keeps pure AC operator declarations from being rejected as non-terminating rewrite systems.
+
+## 6. CeTA Gate
+
+For every user equation `lhs = rhs`, the gate reads the equation left-to-right as a TRS rule:
+
+```
+lhs -> rhs
+```
+
+The gate flow is:
+
+1. Emit the TRS in WST format for the termination prover and confluence checker.
+2. Run a termination prover such as AProVE, Wanda, or TTT2 to produce a CPF certificate.
+3. Run a confluence checker such as CSI, or AProVE in confluence mode, to produce a CPF certificate.
+4. Verify both certificates with CeTA.
+5. Accept the Maude `reduce` witness only if both CeTA checks accept.
+
+If any prover, checker, certificate write, CeTA check, or timeout fails, the `reduce` witness is discarded. The portfolio then treats the Maude result as `Undecidable` unless the `search` witness already discharged the obligation. Chain and portfolio modes can then fall through to Vampire, Coq, or another configured solver.
+
+## 7. Receipt Shape
+
+The Maude adapter records a two-part receipt in `solver_stdout`:
+
+```json
+{
+  "maude_verdict": {
+    "maude_version": "Maude 3.5.1",
+    "module_cid": "blake3-512:...",
+    "queries": {
+      "lhs_reduce": "red in M : lhs .",
+      "rhs_reduce": "red in M : rhs .",
+      "search": "search in M : lhs =>* rhs ."
+    },
+    "normal_forms": ["nf_lhs", "nf_rhs"],
+    "decision": "reduce_equal",
+    "verdict": "discharged"
+  },
+  "ceta_gate": {
+    "termination_cert_cid": "blake3-512:...",
+    "confluence_cert_cid": "blake3-512:...",
+    "ceta_accepted": true,
+    "bypassed": false,
+    "error": ""
+  }
+}
+```
+
+The module CID is `BLAKE3-512(JCS(<lowered module source as a JSON string>))` using `provekit-canonicalizer`. Certificate CIDs are `BLAKE3-512` over the certificate bytes using the same canonicalizer hash helper.
+
+## 8. Dispatch
+
+Configurations may place `maude` in any existing plan shape:
+
+```toml
+[solvers]
+mode = "first-wins"
+portfolio = ["maude", "z3", "cvc5", "vampire", "coq"]
+
+[solvers.maude]
+binary = "maude"
+ir_compiler = "maude"
+ceta_gate = true
+ceta_binary = "ceta"
+termination_prover = "aprove"
+confluence_checker = "csi"
+timeout_seconds = 30
+```
+
+Dispatch mode may route equational obligations directly:
+
+```toml
+[solvers.dispatch]
+"equational-theory" = "maude"
+default = "z3"
+```
+
+The verifier passes raw IR-JSON to non-SMT compilers and SMT-LIB to SMT compilers. This preserves the current solver trait while letting Maude and Coq compile from the original formula.

--- a/tools/portfolio/maude-ceta-install.md
+++ b/tools/portfolio/maude-ceta-install.md
@@ -1,0 +1,156 @@
+# Maude and CeTA Portfolio Tool Install
+
+This appendix pins a Debian-based image setup for the Maude equational backend and the certified termination and confluence gate. It does not modify any Dockerfile.
+
+Pinned versions:
+
+- Debian: bookworm
+- Maude: 3.5.1
+- Java: Eclipse Temurin 25 JRE
+- AProVE: `master_2026_02_15`
+- CeTA: 2.46
+- CSI: 1.2.7
+- Wanda: 0.6.1
+- TTT2 alternate: 1.26
+
+Install base packages:
+
+```sh
+set -eux
+apt-get update
+apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  gpg \
+  unzip \
+  xz-utils \
+  tar \
+  bash \
+  coreutils
+rm -rf /var/lib/apt/lists/*
+install -d /opt/provekit-tools/bin
+```
+
+Install Java 25 for AProVE:
+
+```sh
+set -eux
+install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public \
+  | gpg --dearmor -o /etc/apt/keyrings/adoptium.gpg
+echo "deb [signed-by=/etc/apt/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb bookworm main" \
+  > /etc/apt/sources.list.d/adoptium.list
+apt-get update
+apt-get install -y --no-install-recommends temurin-25-jre
+rm -rf /var/lib/apt/lists/*
+java -version
+```
+
+Install Maude 3.5.1:
+
+```sh
+set -eux
+install -d /opt/provekit-tools/maude-3.5.1
+curl -fL \
+  -o /tmp/maude-3.5.1-linux-x86_64.zip \
+  https://github.com/maude-lang/Maude/releases/download/Maude3.5.1/Maude-3.5.1-linux-x86_64.zip
+unzip -q /tmp/maude-3.5.1-linux-x86_64.zip -d /opt/provekit-tools/maude-3.5.1
+ln -sf /opt/provekit-tools/maude-3.5.1/maude.linux64 /opt/provekit-tools/bin/maude
+/opt/provekit-tools/bin/maude --version
+```
+
+Install AProVE `master_2026_02_15`:
+
+```sh
+set -eux
+install -d /opt/provekit-tools/aprove-master_2026_02_15
+curl -fL \
+  -o /opt/provekit-tools/aprove-master_2026_02_15/aprove.jar \
+  https://github.com/aprove-developers/aprove-releases/releases/download/master_2026_02_15/aprove.jar
+cat >/opt/provekit-tools/bin/aprove <<'SH'
+#!/usr/bin/env sh
+exec java -jar /opt/provekit-tools/aprove-master_2026_02_15/aprove.jar "$@"
+SH
+chmod +x /opt/provekit-tools/bin/aprove
+/opt/provekit-tools/bin/aprove -h >/tmp/aprove-help.txt || true
+```
+
+Install CeTA 2.46:
+
+```sh
+set -eux
+install -d /opt/provekit-tools/ceta-2.46
+curl -fL \
+  -o /tmp/ceta-2.46-linux-x86_64.tar.gz \
+  https://cl-informatik.uibk.ac.at/software/ceta/downloads/ceta-2.46-linux-x86_64.tar.gz
+tar -xzf /tmp/ceta-2.46-linux-x86_64.tar.gz -C /opt/provekit-tools/ceta-2.46 --strip-components=1
+ln -sf /opt/provekit-tools/ceta-2.46/ceta /opt/provekit-tools/bin/ceta
+/opt/provekit-tools/bin/ceta --help >/tmp/ceta-help.txt || true
+```
+
+Install CSI 1.2.7:
+
+```sh
+set -eux
+install -d /opt/provekit-tools/csi-1.2.7
+curl -fL \
+  -o /tmp/csi-1.2.7-linux-x86_64.tar.gz \
+  https://cl-informatik.uibk.ac.at/software/csi/downloads/csi-1.2.7-linux-x86_64.tar.gz
+tar -xzf /tmp/csi-1.2.7-linux-x86_64.tar.gz -C /opt/provekit-tools/csi-1.2.7 --strip-components=1
+ln -sf /opt/provekit-tools/csi-1.2.7/csi /opt/provekit-tools/bin/csi
+/opt/provekit-tools/bin/csi --help >/tmp/csi-help.txt || true
+```
+
+Install Wanda 0.6.1 as an alternate termination prover:
+
+```sh
+set -eux
+install -d /opt/provekit-tools/wanda-0.6.1
+curl -fL \
+  -o /tmp/wanda-0.6.1-linux-x86_64.tar.gz \
+  https://github.com/hezzel/wanda/releases/download/v0.6.1/wanda-0.6.1-linux-x86_64.tar.gz
+tar -xzf /tmp/wanda-0.6.1-linux-x86_64.tar.gz -C /opt/provekit-tools/wanda-0.6.1 --strip-components=1
+ln -sf /opt/provekit-tools/wanda-0.6.1/wanda /opt/provekit-tools/bin/wanda
+/opt/provekit-tools/bin/wanda --help >/tmp/wanda-help.txt || true
+```
+
+Install TTT2 1.26 as an alternate termination prover:
+
+```sh
+set -eux
+install -d /opt/provekit-tools/ttt2-1.26
+curl -fL \
+  -o /tmp/ttt2-1.26-linux-x86_64.tar.gz \
+  https://cl-informatik.uibk.ac.at/software/ttt2/downloads/ttt2-1.26-linux-x86_64.tar.gz
+tar -xzf /tmp/ttt2-1.26-linux-x86_64.tar.gz -C /opt/provekit-tools/ttt2-1.26 --strip-components=1
+ln -sf /opt/provekit-tools/ttt2-1.26/ttt2 /opt/provekit-tools/bin/ttt2
+/opt/provekit-tools/bin/ttt2 --help >/tmp/ttt2-help.txt || true
+```
+
+Expose the tools:
+
+```sh
+set -eux
+echo 'export PATH=/opt/provekit-tools/bin:$PATH' >/etc/profile.d/provekit-portfolio-tools.sh
+export PATH=/opt/provekit-tools/bin:$PATH
+maude --version
+aprove -h >/tmp/aprove-help.txt || true
+ceta --help >/tmp/ceta-help.txt || true
+csi --help >/tmp/csi-help.txt || true
+wanda --help >/tmp/wanda-help.txt || true
+ttt2 --help >/tmp/ttt2-help.txt || true
+```
+
+Recommended ProvekIt solver config:
+
+```toml
+[solvers.maude]
+binary = "/opt/provekit-tools/bin/maude"
+ir_compiler = "maude"
+timeout_seconds = 30
+version = "3.5.1"
+ceta_gate = true
+ceta_binary = "/opt/provekit-tools/bin/ceta"
+termination_prover = "/opt/provekit-tools/bin/aprove"
+confluence_checker = "/opt/provekit-tools/bin/csi"
+```


### PR DESCRIPTION
## Summary

Adds a dedicated equational-reasoning backend to the prove portfolio, behind the multi-solver protocol.

- **`provekit-ir-compiler-maude`** (new crate, parallel to the Coq compiler): lowers an `IrFormula` that is an equational-theory entailment (an LSP `EquationMemento` set as the theory + an obligation equation) to a Maude functional module plus `reduce` and `search` queries. Byte-deterministic output; declares coverage for `equational_theory` opacity positions only.
- **`solvers/maude.rs`**: invokes `maude`, parses output. Equal normal forms or a `search` path => `Discharged`; otherwise `Unknown` (Maude is complete only for confluent + terminating theories).
- **`solvers/ceta.rs`** (the gate): a Maude `reduce`-verdict is trusted only if a termination prover (AProVE/Wanda/TTT2) plus a confluence checker (CSI/AProVE) produce a certificate that **CeTA** (the Coq-extracted certified checker) accepts. CeTA rejects or any prover times out => the `reduce` verdict is discarded and the portfolio falls through to vampire/coq. The discharge receipt is two-part: `{ maude_verdict, ceta_gate: { termination_cert_cid, confluence_cert_cid, ceta_accepted } }`. CeTA certificate bytes are content-addressed.
- Registered in the portfolio (`config`/`dispatch`/`registry`/`plan`/`mod`); `.provekit/config.toml` updated.
- Spec doc `protocol/specs/2026-05-10-equational-portfolio-extension.md`; install appendix `tools/portfolio/maude-ceta-install.md` (the Dockerfile is not modified here).

Verification (local): `cargo build -p provekit-ir-compiler-maude -p provekit-verifier` clean; `cargo test -p provekit-ir-compiler-maude` 5 pass; `cargo test -p provekit-verifier --test maude_ceta` 5 pass + 1 ignored (binary-dependent); full `cargo test -p provekit-verifier` 152 pass + 1 ignored; `cargo clippy -p provekit-ir-compiler-maude -- -D warnings` clean.

Note for review: this branch also strips em-dashes from comments and adds `#![allow(unreachable_patterns)]` in `provekit-ir-compiler-{coq,smt-lib}/src/generated.rs`. Those are GENERATED files; the proper fix for the em-dashes belongs in the codegen source, and the `allow` may or may not be load-bearing for clippy 1.95. Reviewer's call whether to keep here or split.

## Test plan

- [ ] `cargo test -p provekit-ir-compiler-maude` and `cargo test -p provekit-verifier` green
- [ ] `cargo clippy -p provekit-ir-compiler-maude -- -D warnings` clean
- [ ] With `maude`/`aprove`/`ceta` installed: a confluent+terminating example reduces and the CeTA gate certifies; a non-confluent example is rejected and the verdict discarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)