### PR TITLE
feat: Lean 4 + mathlib portfolio backend

### DIFF
--- a/.provekit/config.toml
+++ b/.provekit/config.toml
@@ -12,6 +12,7 @@
 # Closes:
 #   - #251 (cvc5 in default portfolio)
 #   - #252 Tier 1 (Vampire in default portfolio via SMT-LIB-v2.6)
+#   - Lean 4 plus mathlib as the dependent type and category theory seat
 #
 # Mode: first-wins
 # -----------------
@@ -20,7 +21,7 @@
 # Undecidable, the post-collection sort skips it, and the first
 # definitive verdict from an installed solver authors the result.
 # This keeps single-solver developer environments (z3 only) working
-# byte-for-byte, while CI (which installs all four) exercises the full
+# byte-for-byte, while CI (which installs all available solvers) exercises the full
 # portfolio. `coverage_required` (v2 §7) is intentionally unset; we do
 # not opt into the v2 ConsensusCoverage rule from this PR. That gate
 # can land later when the OpacityManifest types are wired through.
@@ -29,14 +30,15 @@
 # ----------------
 # `smt-lib-v2.6` routes to `SubprocessSolver` (generic SMT-LIB-v2.6
 # subprocess); `coq` routes to `CoqSubprocessSolver` (per
-# `registry::is_coq_compiler`). The v2 spec text uses `gallina` for
+# `registry::is_coq_compiler`); `lean` routes to `LeanSubprocessSolver`.
+# The v2 spec text uses `gallina` for
 # Coq's IR-compiler tag, but the existing
 # `provekit_ir_compiler_coq::DIALECT` constant is `"coq"`, so we match
 # the implementation rather than the spec example.
 
 [solvers]
 mode = "first-wins"
-portfolio = ["maude", "z3", "cvc5", "vampire", "coq"]
+portfolio = ["maude", "z3", "cvc5", "vampire", "coq", "lean"]
 
 [solvers.maude]
 binary = "maude"
@@ -87,3 +89,10 @@ binary = "coqc"
 ir_compiler = "coq"
 timeout_seconds = 60
 version = "8.x"
+
+[solvers.lean]
+binary = "lake"
+ir_compiler = "lean"
+timeout_seconds = 60
+version = "4.x"
+lake_project = "tools/portfolio/lean-mathlib"

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1682,6 +1682,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-ir-compiler-lean"
+version = "0.1.0"
+dependencies = [
+ "provekit-canonicalizer",
+ "provekit-ir-compiler",
+ "provekit-ir-types",
+ "serde_json",
+]
+
+[[package]]
 name = "provekit-ir-compiler-maude"
 version = "0.1.0"
 dependencies = [
@@ -2021,6 +2031,7 @@ dependencies = [
  "provekit-claim-envelope",
  "provekit-ir-compiler",
  "provekit-ir-compiler-coq",
+ "provekit-ir-compiler-lean",
  "provekit-ir-compiler-maude",
  "provekit-ir-compiler-smt-lib",
  "provekit-ir-symbolic",

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "provekit-ir-compiler-stub",
     "provekit-ir-compiler-coq",
     "provekit-ir-compiler-maude",
+    "provekit-ir-compiler-lean",
     "provekit-ir-codegen",
     "provekit-verifier",
     "provekit-self-contracts",

--- a/implementations/rust/provekit-ir-compiler-lean/Cargo.toml
+++ b/implementations/rust/provekit-ir-compiler-lean/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "provekit-ir-compiler-lean"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "ProvekIt: Lean 4 and mathlib IR compiler."
+
+[dependencies]
+provekit-canonicalizer = { path = "../provekit-canonicalizer" }
+provekit-ir-compiler = { path = "../provekit-ir-compiler" }
+provekit-ir-types = { path = "../provekit-ir-types" }
+serde_json.workspace = true
+
+[[bin]]
+name = "provekit-ir-lean"
+path = "src/main.rs"
+
+[lib]
+name = "provekit_ir_compiler_lean"
+path = "src/lib.rs"

--- a/implementations/rust/provekit-ir-compiler-lean/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-lean/src/lib.rs
@@ -1,0 +1,727 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lean 4 compiler for IR obligations.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use provekit_ir_compiler::{
+    Capabilities, CompileError, CompiledFormula, FreeVar, IrCompiler, OpacityEntry,
+    OpacityManifest, PROTOCOL_VERSION,
+};
+use provekit_ir_types::{Formula, Sort, Term};
+use serde_json::Value as Json;
+
+pub const DIALECT: &str = "lean";
+pub const COMPILER_NAME: &str = "lean4-mathlib-reference";
+pub const COMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const THEOREM_NAME: &str = "provekit_obligation";
+
+pub struct LeanCompiler;
+
+impl LeanCompiler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for LeanCompiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IrCompiler for LeanCompiler {
+    fn compile(&self, ir: &Json, dialect: &str) -> Result<CompiledFormula, CompileError> {
+        if dialect != DIALECT {
+            return Err(CompileError::UnsupportedDialect(dialect.to_string()));
+        }
+        compile_to_parts(ir)
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            name: COMPILER_NAME.to_string(),
+            version: COMPILER_VERSION.to_string(),
+            protocol_version: PROTOCOL_VERSION.to_string(),
+            dialects: vec![DIALECT.to_string()],
+            supported_sorts: vec![
+                "Int".to_string(),
+                "Bool".to_string(),
+                "Real".to_string(),
+                "String".to_string(),
+                "Function".to_string(),
+                "Dependent".to_string(),
+                "CategoricalStructure".to_string(),
+            ],
+            supported_predicates: vec![
+                "=".to_string(),
+                "!=".to_string(),
+                "<".to_string(),
+                "<=".to_string(),
+                ">".to_string(),
+                ">=".to_string(),
+                "and".to_string(),
+                "or".to_string(),
+                "not".to_string(),
+                "implies".to_string(),
+                "forall".to_string(),
+                "exists".to_string(),
+                "higher-order".to_string(),
+                "dependent_type".to_string(),
+                "categorical_structure".to_string(),
+                "mathlib".to_string(),
+            ],
+        }
+    }
+}
+
+fn is_term_kind(kind: &str) -> bool {
+    matches!(kind, "var" | "const" | "ctor" | "lambda" | "let")
+}
+
+pub fn emit(ir: &Json) -> Result<String, CompileError> {
+    let compiled = compile_to_parts(ir)?;
+    Ok(format!("{}{}", compiled.preamble, compiled.body))
+}
+
+pub fn compile_to_parts(ir: &Json) -> Result<CompiledFormula, CompileError> {
+    let kind = ir.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    if is_term_kind(kind) {
+        let term: Term = serde_json::from_value(ir.clone())
+            .map_err(|e| CompileError::MalformedIr(e.to_string()))?;
+        let mut ctx = EmitContext::default();
+        let expr = emit_term(&term, &mut ctx)?;
+        let mut body = String::new();
+        body.push_str(&format!(
+            "theorem {THEOREM_NAME} : ({expr}) = ({expr}) := by\n  aesop\n\n"
+        ));
+        body.push_str(&format!("#print axioms {THEOREM_NAME}\n"));
+        return Ok(CompiledFormula {
+            preamble: lean_preamble(),
+            body,
+            free_vars: vec![],
+            opacity_manifest: opacity_manifest(ctx.opacities),
+        });
+    }
+
+    let formula: Formula =
+        serde_json::from_value(ir.clone()).map_err(|e| CompileError::MalformedIr(e.to_string()))?;
+    let mut ctx = EmitContext::default();
+    collect_formula(&formula, &mut ctx, &mut BTreeMap::new())?;
+    let proposition = emit_formula(&formula, &mut ctx)?;
+    ctx.sort_opacities();
+
+    let mut binders = Vec::new();
+    for (name, ty) in &ctx.type_params {
+        binders.push(format!("({name} : {ty})"));
+    }
+    for (name, sig) in &ctx.functions {
+        binders.push(format!("({name} : {})", sig.as_lean_type()));
+    }
+    for (name, sig) in &ctx.predicates {
+        binders.push(format!("({name} : {})", sig.as_lean_type()));
+    }
+    for (name, sort) in &ctx.free_vars {
+        binders.push(format!("({name} : {sort})"));
+    }
+
+    let theorem_head = if binders.is_empty() {
+        format!("theorem {THEOREM_NAME} : {proposition} := by\n")
+    } else {
+        format!(
+            "theorem {THEOREM_NAME} {} : {proposition} := by\n",
+            binders.join(" ")
+        )
+    };
+
+    let mut body = String::new();
+    body.push_str(&theorem_head);
+    body.push_str("  aesop\n\n");
+    body.push_str(&format!("#print axioms {THEOREM_NAME}\n"));
+
+    let free_vars = ctx
+        .free_vars
+        .iter()
+        .map(|(name, sort)| FreeVar {
+            name: name.clone(),
+            sort: sort.clone(),
+        })
+        .collect();
+
+    Ok(CompiledFormula {
+        preamble: lean_preamble(),
+        body,
+        free_vars,
+        opacity_manifest: opacity_manifest(ctx.opacities),
+    })
+}
+
+fn lean_preamble() -> String {
+    "import Mathlib\n\nset_option autoImplicit false\n\n".to_string()
+}
+
+fn opacity_manifest(opacities: Vec<OpacityEntry>) -> OpacityManifest {
+    OpacityManifest {
+        protocol_version: "ir-compiler-protocol/2".to_string(),
+        compiler: DIALECT.to_string(),
+        compiler_version: COMPILER_VERSION.to_string(),
+        opacities,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LeanSignature {
+    args: Vec<String>,
+    ret: String,
+}
+
+impl LeanSignature {
+    fn as_lean_type(&self) -> String {
+        if self.args.is_empty() {
+            self.ret.clone()
+        } else {
+            let mut parts = self.args.clone();
+            parts.push(self.ret.clone());
+            parts.join(" -> ")
+        }
+    }
+}
+
+#[derive(Default)]
+struct EmitContext {
+    free_vars: BTreeMap<String, String>,
+    type_params: BTreeMap<String, String>,
+    functions: BTreeMap<String, LeanSignature>,
+    predicates: BTreeMap<String, LeanSignature>,
+    opacities: Vec<OpacityEntry>,
+}
+
+impl EmitContext {
+    fn sort_opacities(&mut self) {
+        self.opacities.sort_by(|a, b| {
+            a.position_cid
+                .cmp(&b.position_cid)
+                .then_with(|| a.reason_code.cmp(&b.reason_code))
+        });
+        self.opacities.dedup();
+    }
+}
+
+fn collect_formula(
+    formula: &Formula,
+    ctx: &mut EmitContext,
+    bound: &mut BTreeMap<String, String>,
+) -> Result<(), CompileError> {
+    match formula {
+        Formula::Atomic { name, args } => {
+            if is_builtin_atomic(name) {
+                let expected = common_atomic_sort(name, args, bound, ctx)?;
+                for arg in args {
+                    collect_term(arg, ctx, bound, expected.as_deref())?;
+                }
+            } else {
+                let predicate = lean_ident(name);
+                if !is_external_lean_name(name) {
+                    let arg_sorts = args
+                        .iter()
+                        .map(|arg| term_sort_hint(arg, bound, ctx).unwrap_or_else(|| "Int".into()))
+                        .collect();
+                    ctx.predicates.entry(predicate).or_insert(LeanSignature {
+                        args: arg_sorts,
+                        ret: "Prop".to_string(),
+                    });
+                }
+                for arg in args {
+                    collect_term(arg, ctx, bound, None)?;
+                }
+            }
+        }
+        Formula::And { operands } | Formula::Or { operands } | Formula::Implies { operands } => {
+            for operand in operands {
+                collect_formula(operand, ctx, bound)?;
+            }
+        }
+        Formula::Not { operands } => {
+            for operand in operands {
+                collect_formula(operand, ctx, bound)?;
+            }
+        }
+        Formula::Forall { name, sort, body } | Formula::Exists { name, sort, body } => {
+            let lean_sort = emit_sort(sort, ctx)?;
+            let lean_name = lean_ident(name);
+            bound.insert(lean_name.clone(), lean_sort);
+            collect_formula(body, ctx, bound)?;
+            bound.remove(&lean_name);
+        }
+        Formula::Choice {
+            var_name,
+            sort,
+            body,
+        } => {
+            let lean_sort = emit_sort(sort, ctx)?;
+            let lean_name = lean_ident(var_name);
+            bound.insert(lean_name.clone(), lean_sort);
+            collect_formula(body, ctx, bound)?;
+            bound.remove(&lean_name);
+        }
+    }
+    Ok(())
+}
+
+fn collect_term(
+    term: &Term,
+    ctx: &mut EmitContext,
+    bound: &mut BTreeMap<String, String>,
+    expected: Option<&str>,
+) -> Result<(), CompileError> {
+    match term {
+        Term::Var { name } => {
+            let lean_name = lean_ident(name);
+            if !bound.contains_key(&lean_name) {
+                ctx.free_vars
+                    .entry(lean_name)
+                    .or_insert_with(|| expected.unwrap_or("Int").to_string());
+            }
+        }
+        Term::Const { sort, .. } => {
+            let _ = emit_sort(sort, ctx)?;
+        }
+        Term::Ctor { name, args } => {
+            let lean_name = lean_ident(name);
+            let bound_function =
+                bound.contains_key(&lean_name) || ctx.free_vars.contains_key(&lean_name);
+            let arg_sorts: Vec<String> = args
+                .iter()
+                .map(|arg| term_sort_hint(arg, bound, ctx).unwrap_or_else(|| "Int".to_string()))
+                .collect();
+            if !bound_function && !is_external_lean_name(name) {
+                ctx.functions
+                    .entry(lean_name)
+                    .or_insert_with(|| LeanSignature {
+                        args: arg_sorts.clone(),
+                        ret: expected.unwrap_or("Int").to_string(),
+                    });
+            }
+            for (arg, arg_sort) in args.iter().zip(arg_sorts.iter()) {
+                collect_term(arg, ctx, bound, Some(arg_sort))?;
+            }
+        }
+        Term::Lambda {
+            param_name,
+            param_sort,
+            body,
+        } => {
+            let lean_sort = emit_sort(param_sort, ctx)?;
+            let lean_name = lean_ident(param_name);
+            bound.insert(lean_name.clone(), lean_sort);
+            collect_term(body, ctx, bound, expected)?;
+            bound.remove(&lean_name);
+        }
+        Term::Let { bindings, body } => {
+            for binding in bindings {
+                collect_term(&binding.bound_term, ctx, bound, None)?;
+                bound.insert(lean_ident(&binding.name), "Int".to_string());
+            }
+            collect_term(body, ctx, bound, expected)?;
+            for binding in bindings {
+                bound.remove(&lean_ident(&binding.name));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn emit_formula(formula: &Formula, ctx: &mut EmitContext) -> Result<String, CompileError> {
+    match formula {
+        Formula::Atomic { name, args } => emit_atomic(name, args, ctx),
+        Formula::And { operands } => {
+            if operands.is_empty() {
+                return Ok("True".to_string());
+            }
+            let parts = operands
+                .iter()
+                .map(|o| emit_formula(o, ctx))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(format!("({})", parts.join(" ∧ ")))
+        }
+        Formula::Or { operands } => {
+            if operands.is_empty() {
+                return Ok("False".to_string());
+            }
+            let parts = operands
+                .iter()
+                .map(|o| emit_formula(o, ctx))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(format!("({})", parts.join(" ∨ ")))
+        }
+        Formula::Not { operands } => {
+            let operand = exactly_one_operand("not", operands)?;
+            Ok(format!("(¬ {})", emit_formula(operand, ctx)?))
+        }
+        Formula::Implies { operands } => {
+            if operands.len() != 2 {
+                return Err(CompileError::MalformedIr(
+                    "implies expects exactly two operands".to_string(),
+                ));
+            }
+            Ok(format!(
+                "({} -> {})",
+                emit_formula(&operands[0], ctx)?,
+                emit_formula(&operands[1], ctx)?
+            ))
+        }
+        Formula::Forall { name, sort, body } => Ok(format!(
+            "∀ ({} : {}), {}",
+            lean_ident(name),
+            emit_sort(sort, ctx)?,
+            emit_formula(body, ctx)?
+        )),
+        Formula::Exists { name, sort, body } => Ok(format!(
+            "∃ ({} : {}), {}",
+            lean_ident(name),
+            emit_sort(sort, ctx)?,
+            emit_formula(body, ctx)?
+        )),
+        Formula::Choice {
+            var_name,
+            sort,
+            body,
+        } => Ok(format!(
+            "∃ ({} : {}), {}",
+            lean_ident(var_name),
+            emit_sort(sort, ctx)?,
+            emit_formula(body, ctx)?
+        )),
+    }
+}
+
+fn emit_atomic(name: &str, args: &[Term], ctx: &mut EmitContext) -> Result<String, CompileError> {
+    match lean_atomic_name(name).as_str() {
+        "True" if args.is_empty() => Ok("True".to_string()),
+        "False" if args.is_empty() => Ok("False".to_string()),
+        "=" | "≠" | "<" | "<=" | ">" | ">=" => {
+            if args.len() != 2 {
+                return Err(CompileError::MalformedIr(format!(
+                    "predicate {name} expects exactly two arguments"
+                )));
+            }
+            let lhs = emit_term(&args[0], ctx)?;
+            let rhs = emit_term(&args[1], ctx)?;
+            Ok(format!("({lhs} {} {rhs})", lean_atomic_name(name)))
+        }
+        other => {
+            let args = args
+                .iter()
+                .map(|arg| emit_term(arg, ctx))
+                .collect::<Result<Vec<_>, _>>()?;
+            if args.is_empty() {
+                Ok(other.to_string())
+            } else {
+                Ok(format!("({} {})", other, args.join(" ")))
+            }
+        }
+    }
+}
+
+fn emit_term(term: &Term, ctx: &mut EmitContext) -> Result<String, CompileError> {
+    match term {
+        Term::Var { name } => Ok(lean_ident(name)),
+        Term::Const { value, sort } => emit_const(value, sort),
+        Term::Ctor { name, args } => {
+            let name = lean_ident(name);
+            let args = args
+                .iter()
+                .map(|arg| emit_term(arg, ctx))
+                .collect::<Result<Vec<_>, _>>()?;
+            if args.is_empty() {
+                Ok(name)
+            } else {
+                Ok(format!("({} {})", name, args.join(" ")))
+            }
+        }
+        Term::Lambda {
+            param_name,
+            param_sort,
+            body,
+        } => Ok(format!(
+            "(fun ({} : {}) => {})",
+            lean_ident(param_name),
+            emit_sort(param_sort, ctx)?,
+            emit_term(body, ctx)?
+        )),
+        Term::Let { bindings, body } => {
+            let mut out = String::new();
+            for binding in bindings {
+                out.push_str(&format!(
+                    "let {} := {}; ",
+                    lean_ident(&binding.name),
+                    emit_term(&binding.bound_term, ctx)?
+                ));
+            }
+            out.push_str(&emit_term(body, ctx)?);
+            Ok(format!("({out})"))
+        }
+    }
+}
+
+fn emit_const(value: &Json, sort: &Sort) -> Result<String, CompileError> {
+    match value {
+        Json::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i < 0 {
+                    Ok(format!("({i} : {})", primitive_sort_name(sort)))
+                } else {
+                    Ok(i.to_string())
+                }
+            } else if let Some(u) = n.as_u64() {
+                Ok(u.to_string())
+            } else {
+                Ok(format!("({n} : {})", primitive_sort_name(sort)))
+            }
+        }
+        Json::Bool(b) => Ok(if *b { "true".into() } else { "false".into() }),
+        Json::String(s) => {
+            serde_json::to_string(s).map_err(|e| CompileError::Internal(e.to_string()))
+        }
+        _ => Err(CompileError::UnsupportedSort(
+            "Lean constants require number, bool, or string values".to_string(),
+        )),
+    }
+}
+
+fn emit_sort(sort: &Sort, ctx: &mut EmitContext) -> Result<String, CompileError> {
+    match sort {
+        Sort::Primitive { name } => match name.as_str() {
+            "Int" => Ok("Int".to_string()),
+            "Real" => Ok("Real".to_string()),
+            "Bool" => Ok("Bool".to_string()),
+            "String" => Ok("String".to_string()),
+            other => {
+                let lean_name = lean_ident(other);
+                ctx.type_params
+                    .entry(lean_name.clone())
+                    .or_insert_with(|| "Type".to_string());
+                Ok(lean_name)
+            }
+        },
+        Sort::Function { args, ret } => {
+            let mut parts = args
+                .iter()
+                .map(|arg| emit_sort_paren(arg, ctx))
+                .collect::<Result<Vec<_>, _>>()?;
+            parts.push(emit_sort_paren(ret, ctx)?);
+            Ok(parts.join(" -> "))
+        }
+        Sort::Dependent {
+            name,
+            index_var,
+            index_sort,
+        } => {
+            let type_name = lean_ident(name);
+            let index_sort = emit_sort(index_sort, ctx)?;
+            ctx.type_params
+                .entry(type_name.clone())
+                .or_insert_with(|| format!("{index_sort} -> Type"));
+            Ok(format!(
+                "∀ ({} : {}), {} {}",
+                lean_ident(index_var),
+                index_sort,
+                type_name,
+                lean_ident(index_var)
+            ))
+        }
+        Sort::Float { .. } => {
+            let serialized = serde_json::to_value(sort).unwrap_or(Json::Null);
+            ctx.opacities.push(OpacityEntry {
+                position_cid: position_cid_of(&serialized),
+                reason_code: "other:float_sort".to_string(),
+            });
+            Ok("Int".to_string())
+        }
+        Sort::Region { .. } => {
+            let serialized = serde_json::to_value(sort).unwrap_or(Json::Null);
+            ctx.opacities.push(OpacityEntry {
+                position_cid: position_cid_of(&serialized),
+                reason_code: "other:region_sort".to_string(),
+            });
+            Ok("Int".to_string())
+        }
+    }
+}
+
+fn emit_sort_paren(sort: &Sort, ctx: &mut EmitContext) -> Result<String, CompileError> {
+    match sort {
+        Sort::Function { .. } | Sort::Dependent { .. } => {
+            Ok(format!("({})", emit_sort(sort, ctx)?))
+        }
+        Sort::Primitive { .. } | Sort::Float { .. } | Sort::Region { .. } => emit_sort(sort, ctx),
+    }
+}
+
+fn primitive_sort_name(sort: &Sort) -> &'static str {
+    match sort {
+        Sort::Primitive { name } if name == "Real" => "Real",
+        Sort::Primitive { name } if name == "Bool" => "Bool",
+        Sort::Primitive { name } if name == "String" => "String",
+        _ => "Int",
+    }
+}
+
+fn exactly_one_operand<'a>(
+    kind: &str,
+    operands: &'a [Formula],
+) -> Result<&'a Formula, CompileError> {
+    if operands.len() == 1 {
+        Ok(&operands[0])
+    } else {
+        Err(CompileError::MalformedIr(format!(
+            "{kind} expects exactly one operand"
+        )))
+    }
+}
+
+fn common_atomic_sort(
+    name: &str,
+    args: &[Term],
+    bound: &BTreeMap<String, String>,
+    ctx: &mut EmitContext,
+) -> Result<Option<String>, CompileError> {
+    if !matches!(
+        lean_atomic_name(name).as_str(),
+        "=" | "≠" | "<" | "<=" | ">" | ">="
+    ) {
+        return Ok(None);
+    }
+    for arg in args {
+        if let Some(sort) = term_sort_hint(arg, bound, ctx) {
+            return Ok(Some(sort));
+        }
+    }
+    Ok(Some("Int".to_string()))
+}
+
+fn term_sort_hint(
+    term: &Term,
+    bound: &BTreeMap<String, String>,
+    ctx: &mut EmitContext,
+) -> Option<String> {
+    match term {
+        Term::Var { name } => {
+            let lean_name = lean_ident(name);
+            bound
+                .get(&lean_name)
+                .cloned()
+                .or_else(|| ctx.free_vars.get(&lean_name).cloned())
+        }
+        Term::Const { sort, .. } => emit_sort(sort, ctx).ok(),
+        Term::Ctor { .. } | Term::Lambda { .. } | Term::Let { .. } => None,
+    }
+}
+
+fn is_builtin_atomic(name: &str) -> bool {
+    matches!(
+        lean_atomic_name(name).as_str(),
+        "True" | "False" | "=" | "≠" | "<" | "<=" | ">" | ">="
+    )
+}
+
+fn lean_atomic_name(name: &str) -> String {
+    match name {
+        "true" => "True".to_string(),
+        "false" => "False".to_string(),
+        "eq" | "=" => "=".to_string(),
+        "ne" | "neq" | "!=" | "\u{2260}" => "≠".to_string(),
+        "lt" | "<" => "<".to_string(),
+        "lte" | "<=" | "\u{2264}" => "<=".to_string(),
+        "gt" | ">" => ">".to_string(),
+        "gte" | ">=" | "\u{2265}" => ">=".to_string(),
+        other => lean_ident(other),
+    }
+}
+
+fn is_external_lean_name(name: &str) -> bool {
+    name.contains('.') || matches!(name, "id" | "True" | "False")
+}
+
+fn lean_ident(name: &str) -> String {
+    if name.is_empty() {
+        return "x".to_string();
+    }
+    if name.contains('.') {
+        return name
+            .split('.')
+            .map(lean_ident_segment)
+            .collect::<Vec<_>>()
+            .join(".");
+    }
+    lean_ident_segment(name)
+}
+
+fn lean_ident_segment(segment: &str) -> String {
+    let mut out = String::new();
+    for (idx, ch) in segment.chars().enumerate() {
+        let ok = ch == '_' || ch.is_ascii_alphanumeric();
+        if ok && !(idx == 0 && ch.is_ascii_digit()) {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() || out == "_" {
+        "x".to_string()
+    } else {
+        match out.as_str() {
+            "theorem" | "axiom" | "def" | "fun" | "let" | "in" | "by" | "forall" | "exists" => {
+                format!("{out}_")
+            }
+            _ => out,
+        }
+    }
+}
+
+fn position_cid_of(value: &Json) -> String {
+    let canonical = encode_jcs(&to_cvalue(value));
+    blake3_512_of(canonical.as_bytes())
+}
+
+fn to_cvalue(value: &Json) -> Arc<CValue> {
+    match value {
+        Json::Null => CValue::null(),
+        Json::Bool(b) => CValue::boolean(*b),
+        Json::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CValue::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                if let Ok(i) = i64::try_from(u) {
+                    CValue::integer(i)
+                } else {
+                    CValue::string(u.to_string())
+                }
+            } else {
+                CValue::string(n.to_string())
+            }
+        }
+        Json::String(s) => CValue::string(s.clone()),
+        Json::Array(items) => CValue::array(items.iter().map(to_cvalue).collect()),
+        Json::Object(map) => CValue::object(map.iter().map(|(k, v)| (k.clone(), to_cvalue(v)))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn emit_simple_formula() {
+        let out = emit(&json!({
+            "kind": "atomic",
+            "name": "true",
+            "args": []
+        }))
+        .expect("emit");
+        assert!(out.contains("theorem provekit_obligation : True := by"));
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-lean/src/main.rs
+++ b/implementations/rust/provekit-ir-compiler-lean/src/main.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binary entry point for provekit-ir-compiler-lean.
+
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_lean::{LeanCompiler, DIALECT};
+use serde_json::Value as Json;
+use std::io::{self, Read};
+
+fn main() {
+    let mut input = String::new();
+    if let Err(error) = io::stdin().read_to_string(&mut input) {
+        eprintln!("Error reading stdin: {error}");
+        std::process::exit(1);
+    }
+
+    let ir: Json = match serde_json::from_str(&input) {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!("Error parsing JSON: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    let compiler = LeanCompiler::new();
+    let result = match compiler.compile(&ir, DIALECT) {
+        Ok(result) => result,
+        Err(error) => {
+            eprintln!("Error compiling IR to Lean: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    print!("{}{}", result.preamble, result.body);
+}

--- a/implementations/rust/provekit-ir-compiler-lean/tests/byte_for_byte.rs
+++ b/implementations/rust/provekit-ir-compiler-lean/tests/byte_for_byte.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_lean::{LeanCompiler, DIALECT};
+use serde_json::json;
+
+#[test]
+fn repeated_compiles_are_byte_identical() {
+    let ir = json!({
+        "kind": "forall",
+        "name": "f",
+        "sort": {
+            "kind": "function",
+            "args": [{"kind": "primitive", "name": "Int"}],
+            "return": {"kind": "primitive", "name": "Int"}
+        },
+        "body": {
+            "kind": "atomic",
+            "name": "=",
+            "args": [
+                {"kind": "ctor", "name": "f", "args": [{"kind": "const", "value": 1, "sort": {"kind": "primitive", "name": "Int"}}]},
+                {"kind": "ctor", "name": "f", "args": [{"kind": "const", "value": 1, "sort": {"kind": "primitive", "name": "Int"}}]}
+            ]
+        }
+    });
+
+    let compiler = LeanCompiler::new();
+    let first = compiler.compile(&ir, DIALECT).expect("first compile");
+    let second = compiler.compile(&ir, DIALECT).expect("second compile");
+    assert_eq!(first, second);
+    assert_eq!(
+        format!("{}{}", first.preamble, first.body),
+        format!("{}{}", second.preamble, second.body)
+    );
+}

--- a/implementations/rust/provekit-ir-compiler-lean/tests/fixtures/reflexivity.lean
+++ b/implementations/rust/provekit-ir-compiler-lean/tests/fixtures/reflexivity.lean
@@ -1,0 +1,8 @@
+import Mathlib
+
+set_option autoImplicit false
+
+theorem provekit_obligation : ∀ (x : Int), (x = x) := by
+  aesop
+
+#print axioms provekit_obligation

--- a/implementations/rust/provekit-ir-compiler-lean/tests/lowering.rs
+++ b/implementations/rust/provekit-ir-compiler-lean/tests/lowering.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_lean::{LeanCompiler, DIALECT};
+use serde_json::json;
+
+fn reflexivity_ir() -> serde_json::Value {
+    json!({
+        "kind": "forall",
+        "name": "x",
+        "sort": {"kind": "primitive", "name": "Int"},
+        "body": {
+            "kind": "atomic",
+            "name": "=",
+            "args": [
+                {"kind": "var", "name": "x"},
+                {"kind": "var", "name": "x"}
+            ]
+        }
+    })
+}
+
+#[test]
+fn lowers_reflexivity_fixture_byte_for_byte() {
+    let compiler = LeanCompiler::new();
+    let out = compiler
+        .compile(&reflexivity_ir(), DIALECT)
+        .expect("compile");
+    let source = format!("{}{}", out.preamble, out.body);
+    assert_eq!(
+        source,
+        include_str!("fixtures/reflexivity.lean"),
+        "Lean lowering drifted from the checked fixture"
+    );
+}
+
+#[test]
+fn declares_dependent_and_categorical_coverage() {
+    let compiler = LeanCompiler::new();
+    let caps = compiler.capabilities();
+    assert!(caps.supported_sorts.iter().any(|s| s == "Dependent"));
+    assert!(caps
+        .supported_sorts
+        .iter()
+        .any(|s| s == "CategoricalStructure"));
+    assert!(caps.supported_predicates.iter().any(|p| p == "mathlib"));
+}
+
+#[test]
+fn false_obligation_gets_checked_by_automation_without_sorry() {
+    let compiler = LeanCompiler::new();
+    let ir = json!({"kind": "atomic", "name": "false", "args": []});
+    let out = compiler.compile(&ir, DIALECT).expect("compile");
+    let source = format!("{}{}", out.preamble, out.body);
+    assert!(source.contains("theorem provekit_obligation : False := by"));
+    assert!(!source.contains("sorry"));
+}
+
+#[test]
+fn binary_emits_lean_source_from_stdin() {
+    let Some(bin) = option_env!("CARGO_BIN_EXE_provekit-ir-lean") else {
+        eprintln!("skip: provekit-ir-lean binary path not supplied by cargo");
+        return;
+    };
+    let mut child = std::process::Command::new(bin)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn provekit-ir-lean");
+    {
+        use std::io::Write;
+        let stdin = child.stdin.as_mut().expect("stdin");
+        stdin
+            .write_all(reflexivity_ir().to_string().as_bytes())
+            .expect("write ir");
+    }
+    let output = child.wait_with_output().expect("wait");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    assert_eq!(stdout, include_str!("fixtures/reflexivity.lean"));
+}

--- a/implementations/rust/provekit-verifier/Cargo.toml
+++ b/implementations/rust/provekit-verifier/Cargo.toml
@@ -14,6 +14,7 @@ provekit-ir-compiler-smt-lib = { path = "../provekit-ir-compiler-smt-lib" }
 provekit-ir-compiler = { path = "../provekit-ir-compiler" }
 provekit-ir-compiler-coq = { path = "../provekit-ir-compiler-coq" }
 provekit-ir-compiler-maude = { path = "../provekit-ir-compiler-maude" }
+provekit-ir-compiler-lean = { path = "../provekit-ir-compiler-lean" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 walkdir = { workspace = true }

--- a/implementations/rust/provekit-verifier/src/solvers/config.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/config.rs
@@ -72,6 +72,13 @@ pub struct SolverConfig {
     /// implication-memento `body.prover` strings. Defaults to `0`.
     #[serde(default = "default_version")]
     pub version: String,
+    /// Optional path to a Lake project that has Mathlib pinned and
+    /// cached. Used by the Lean adapter as its working directory.
+    #[serde(default)]
+    pub lake_project: Option<String>,
+    /// Optional elan toolchain passed as `+toolchain` to lake and lean.
+    #[serde(default)]
+    pub lean_toolchain: Option<String>,
 }
 
 fn default_ir_compiler() -> String {
@@ -113,6 +120,10 @@ pub struct DispatchConfig {
     pub bitvectors: Option<String>,
     #[serde(rename = "linear-arithmetic", default)]
     pub linear_arithmetic: Option<String>,
+    #[serde(rename = "dependent-type", default)]
+    pub dependent_type: Option<String>,
+    #[serde(rename = "categorical-structure", default)]
+    pub categorical_structure: Option<String>,
     #[serde(default)]
     pub default: Option<String>,
 }

--- a/implementations/rust/provekit-verifier/src/solvers/dispatch.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/dispatch.rs
@@ -33,6 +33,8 @@ pub enum FormulaTheory {
     Strings,
     Bitvectors,
     LinearArithmetic,
+    DependentType,
+    CategoricalStructure,
     Default,
 }
 
@@ -43,6 +45,8 @@ impl FormulaTheory {
             Self::Strings => "strings",
             Self::Bitvectors => "bitvectors",
             Self::LinearArithmetic => "linear-arithmetic",
+            Self::DependentType => "dependent-type",
+            Self::CategoricalStructure => "categorical-structure",
             Self::Default => "default",
         }
     }
@@ -64,6 +68,16 @@ const BV_OPS: &[&str] = &[
     "bvult", "bvule", "bvugt", "bvuge", "bvslt", "bvsle", "bvsgt", "bvsge",
 ];
 
+const CATEGORY_OPS: &[&str] = &[
+    "CategoryTheory.Category",
+    "CategoryTheory.Functor",
+    "CategoryTheory.NatTrans",
+    "CategoryTheory.Limits",
+    "Function.Bijective",
+    "LawvereTheory",
+    "FreeAlgebra",
+];
+
 pub fn classify(formula: &Json) -> FormulaTheory {
     let mut theory = FormulaTheory::Default;
     walk(formula, &mut theory);
@@ -78,6 +92,10 @@ fn walk(v: &Json, theory: &mut FormulaTheory) {
             if let Some(name) = map.get("name").and_then(|v| v.as_str()) {
                 if name == "equational_theory" {
                     *theory = FormulaTheory::EquationalTheory;
+                    return;
+                }
+                if CATEGORY_OPS.iter().any(|op| name.contains(op)) {
+                    *theory = FormulaTheory::CategoricalStructure;
                     return;
                 }
                 if STRING_OPS.contains(&name) {
@@ -98,6 +116,14 @@ fn walk(v: &Json, theory: &mut FormulaTheory) {
             // Detect bitvector sorts: {"kind":"primitive","name":"BitVec"} or BV<n>.
             if let Some(sort) = map.get("sort") {
                 if let Some(srt_obj) = sort.as_object() {
+                    if srt_obj
+                        .get("kind")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|kind| kind == "dependent" || kind == "function")
+                    {
+                        *theory = FormulaTheory::DependentType;
+                        return;
+                    }
                     if let Some(srt_name) = srt_obj.get("name").and_then(|v| v.as_str()) {
                         if srt_name == "String" {
                             *theory = FormulaTheory::Strings;
@@ -149,6 +175,8 @@ pub fn dispatch_for_formula<'a>(formula: &Json, dispatch: &'a DispatchConfig) ->
         FormulaTheory::Strings => dispatch.strings.as_deref(),
         FormulaTheory::Bitvectors => dispatch.bitvectors.as_deref(),
         FormulaTheory::LinearArithmetic => dispatch.linear_arithmetic.as_deref(),
+        FormulaTheory::DependentType => dispatch.dependent_type.as_deref(),
+        FormulaTheory::CategoricalStructure => dispatch.categorical_structure.as_deref(),
         FormulaTheory::Default => None,
     };
     by_theory.or(dispatch.default.as_deref())
@@ -207,6 +235,8 @@ mod tests {
             strings: Some("cvc5".into()),
             bitvectors: Some("bitwuzla".into()),
             linear_arithmetic: Some("z3".into()),
+            dependent_type: Some("lean".into()),
+            categorical_structure: Some("lean".into()),
             default: Some("z3".into()),
         };
         let f = json!({"kind":"atomic","name":"length","args":[]});
@@ -217,5 +247,45 @@ mod tests {
         assert_eq!(dispatch_for_formula(&f, &d), Some("z3"));
         let f = json!({"kind":"atomic","name":"unknown","args":[]});
         assert_eq!(dispatch_for_formula(&f, &d), Some("z3")); // via default
+    }
+
+    #[test]
+    fn dispatch_picks_lean_for_dependent_sort() {
+        let d = DispatchConfig {
+            equational_theory: None,
+            strings: None,
+            bitvectors: None,
+            linear_arithmetic: None,
+            dependent_type: Some("lean".into()),
+            categorical_structure: None,
+            default: Some("z3".into()),
+        };
+        let f = json!({
+            "kind": "forall",
+            "name": "xs",
+            "sort": {
+                "kind": "dependent",
+                "name": "Vec",
+                "indexVar": "n",
+                "indexSort": {"kind": "primitive", "name": "Int"}
+            },
+            "body": {"kind": "atomic", "name": "true", "args": []}
+        });
+        assert_eq!(dispatch_for_formula(&f, &d), Some("lean"));
+    }
+
+    #[test]
+    fn dispatch_picks_lean_for_category_theory_name() {
+        let d = DispatchConfig {
+            equational_theory: None,
+            strings: None,
+            bitvectors: None,
+            linear_arithmetic: None,
+            dependent_type: None,
+            categorical_structure: Some("lean".into()),
+            default: Some("z3".into()),
+        };
+        let f = json!({"kind":"atomic","name":"CategoryTheory.Functor.map_id","args":[]});
+        assert_eq!(dispatch_for_formula(&f, &d), Some("lean"));
     }
 }

--- a/implementations/rust/provekit-verifier/src/solvers/lean.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/lean.rs
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lean subprocess solver. Invokes `lake env lean` on a generated file.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+use provekit_canonicalizer::blake3_512_of;
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_lean::{LeanCompiler, DIALECT, THEOREM_NAME};
+use serde_json::{json, Value as Json};
+
+use crate::solvers::{SolveResult, Solver};
+use crate::types::ObligationVerdict;
+
+#[derive(Debug)]
+pub struct LeanSubprocessSolver {
+    name: String,
+    version: String,
+    binary: String,
+    timeout: Option<Duration>,
+    lake_project: Option<PathBuf>,
+    lean_toolchain: Option<String>,
+}
+
+impl LeanSubprocessSolver {
+    pub fn new(
+        name: impl Into<String>,
+        binary: impl Into<String>,
+        version: impl Into<String>,
+        timeout: Option<Duration>,
+        lake_project: Option<String>,
+        lean_toolchain: Option<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+            binary: binary.into(),
+            timeout,
+            lake_project: lake_project.map(PathBuf::from),
+            lean_toolchain,
+        }
+    }
+
+    pub fn lean_file_cid(source: &str) -> String {
+        blake3_512_of(source.as_bytes())
+    }
+
+    pub fn uses_sorry_or_sorry_ax(source: &str, output: &str) -> bool {
+        source.contains("sorry")
+            || output.contains("sorryAx")
+            || output.to_ascii_lowercase().contains("sorry")
+    }
+
+    pub fn parse_axiom_set(output: &str, theorem_name: &str) -> Vec<String> {
+        if output.contains("does not depend on any axioms") {
+            return vec![];
+        }
+        let relevant = output
+            .lines()
+            .find(|line| line.contains(theorem_name) && line.contains('['))
+            .unwrap_or(output);
+        if let (Some(start), Some(end)) = (relevant.find('['), relevant.rfind(']')) {
+            return relevant[start + 1..end]
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned)
+                .collect();
+        }
+        output
+            .lines()
+            .map(str::trim)
+            .filter(|line| {
+                !line.is_empty()
+                    && !line.contains(theorem_name)
+                    && !line.starts_with("info:")
+                    && !line.starts_with("warning:")
+            })
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    pub fn mathlib_commit_from_project(project: &Path) -> Option<String> {
+        let manifest_path = project.join("lake-manifest.json");
+        let body = std::fs::read_to_string(manifest_path).ok()?;
+        let value: Json = serde_json::from_str(&body).ok()?;
+        find_mathlib_rev(&value)
+    }
+
+    fn project_dir(&self, tmp_dir: &Path) -> PathBuf {
+        match &self.lake_project {
+            Some(path) if path.is_file() => path
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| tmp_dir.to_path_buf()),
+            Some(path) => path.clone(),
+            None => tmp_dir.to_path_buf(),
+        }
+    }
+
+    fn lean_version(&self, cwd: &Path) -> String {
+        let mut cmd = Command::new("lean");
+        if let Some(toolchain) = &self.lean_toolchain {
+            cmd.arg(format!("+{toolchain}"));
+        }
+        cmd.arg("--version");
+        cmd.current_dir(cwd);
+        match cmd.output() {
+            Ok(output) if output.status.success() => {
+                String::from_utf8_lossy(&output.stdout).trim().to_string()
+            }
+            Ok(output) => String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            Err(error) => format!("lean --version unavailable: {error}"),
+        }
+    }
+
+    fn wait_for_child(
+        &self,
+        mut child: std::process::Child,
+        started: Instant,
+    ) -> Result<(Output, bool), String> {
+        if let Some(timeout) = self.timeout {
+            let deadline = started + timeout;
+            loop {
+                match child.try_wait() {
+                    Ok(Some(_)) => {
+                        return child
+                            .wait_with_output()
+                            .map(|output| (output, false))
+                            .map_err(|error| format!("lean: wait error: {error}"));
+                    }
+                    Ok(None) => {
+                        if Instant::now() >= deadline {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                            return Err(format!(
+                                "lean: timeout after {}s",
+                                timeout.as_secs().max(1)
+                            ));
+                        }
+                        std::thread::sleep(Duration::from_millis(20));
+                    }
+                    Err(error) => return Err(format!("lean: wait error: {error}")),
+                }
+            }
+        }
+        child
+            .wait_with_output()
+            .map(|output| (output, false))
+            .map_err(|error| format!("lean: wait error: {error}"))
+    }
+}
+
+impl Solver for LeanSubprocessSolver {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+
+    fn ir_compiler(&self) -> &str {
+        DIALECT
+    }
+
+    fn solve(&self, smt: &str) -> SolveResult {
+        let started = Instant::now();
+        let ir: Json = match serde_json::from_str(smt) {
+            Ok(value) => value,
+            Err(error) => {
+                return SolveResult {
+                    verdict: ObligationVerdict::Undecidable,
+                    solver_name: self.name.clone(),
+                    solver_version: self.version.clone(),
+                    error: format!("lean: failed to parse IR-JSON: {error}"),
+                    solver_stdout: String::new(),
+                    wall_clock: started.elapsed(),
+                    timed_out: false,
+                };
+            }
+        };
+
+        let compiler = LeanCompiler::new();
+        let compiled = match compiler.compile(&ir, DIALECT) {
+            Ok(compiled) => compiled,
+            Err(error) => {
+                return SolveResult {
+                    verdict: ObligationVerdict::Undecidable,
+                    solver_name: self.name.clone(),
+                    solver_version: self.version.clone(),
+                    error: format!("lean: compilation error: {error}"),
+                    solver_stdout: String::new(),
+                    wall_clock: started.elapsed(),
+                    timed_out: false,
+                };
+            }
+        };
+
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "provekit-lean-{}-{}",
+            std::process::id(),
+            started.elapsed().as_nanos()
+        ));
+        if let Err(error) = std::fs::create_dir_all(&tmp_dir) {
+            return SolveResult {
+                verdict: ObligationVerdict::Undecidable,
+                solver_name: self.name.clone(),
+                solver_version: self.version.clone(),
+                error: format!("lean: failed to create temp dir: {error}"),
+                solver_stdout: String::new(),
+                wall_clock: started.elapsed(),
+                timed_out: false,
+            };
+        }
+
+        let lean_file = tmp_dir.join("proof.lean");
+        let source = format!("{}{}", compiled.preamble, compiled.body);
+        let file_cid = Self::lean_file_cid(&source);
+        if let Err(error) = std::fs::write(&lean_file, &source) {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            return SolveResult {
+                verdict: ObligationVerdict::Undecidable,
+                solver_name: self.name.clone(),
+                solver_version: self.version.clone(),
+                error: format!("lean: failed to write .lean file: {error}"),
+                solver_stdout: String::new(),
+                wall_clock: started.elapsed(),
+                timed_out: false,
+            };
+        }
+
+        let project_dir = self.project_dir(&tmp_dir);
+        let lean_version = self.lean_version(&project_dir);
+        let mathlib_commit = Self::mathlib_commit_from_project(&project_dir);
+
+        let mut cmd = Command::new(&self.binary);
+        if let Some(toolchain) = &self.lean_toolchain {
+            cmd.arg(format!("+{toolchain}"));
+        }
+        cmd.arg("env").arg("lean").arg(&lean_file);
+        cmd.current_dir(&project_dir);
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        let child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                let _ = std::fs::remove_dir_all(&tmp_dir);
+                return SolveResult {
+                    verdict: ObligationVerdict::Undecidable,
+                    solver_name: self.name.clone(),
+                    solver_version: self.version.clone(),
+                    error: format!("lean: spawn {}: {error}", self.binary),
+                    solver_stdout: String::new(),
+                    wall_clock: started.elapsed(),
+                    timed_out: false,
+                };
+            }
+        };
+
+        let (output, timed_out) = match self.wait_for_child(child, started) {
+            Ok(result) => result,
+            Err(error) => {
+                let _ = std::fs::remove_dir_all(&tmp_dir);
+                return SolveResult {
+                    verdict: ObligationVerdict::Undecidable,
+                    solver_name: self.name.clone(),
+                    solver_version: self.version.clone(),
+                    error,
+                    solver_stdout: String::new(),
+                    wall_clock: started.elapsed(),
+                    timed_out: true,
+                };
+            }
+        };
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let combined = format!("{stdout}{stderr}");
+        let axioms = Self::parse_axiom_set(&combined, THEOREM_NAME);
+        let uses_sorry = Self::uses_sorry_or_sorry_ax(&source, &combined);
+        let has_error = combined.contains("error:");
+        let discharged = output.status.success() && !uses_sorry && !has_error;
+        let verdict = if discharged {
+            ObligationVerdict::Discharged
+        } else {
+            ObligationVerdict::Undecidable
+        };
+
+        let receipt = json!({
+            "kind": "lean-discharge-receipt",
+            "leanVersion": lean_version,
+            "mathlibCommit": mathlib_commit,
+            "emittedFileCid": file_cid,
+            "axioms": axioms,
+            "leanStdout": stdout,
+            "leanStderr": stderr,
+        });
+        let solver_stdout = serde_json::to_string_pretty(&receipt)
+            .unwrap_or_else(|error| format!("{{\"receiptError\":\"{error}\"}}"));
+
+        SolveResult {
+            verdict,
+            solver_name: self.name.clone(),
+            solver_version: self.version.clone(),
+            error: if discharged {
+                String::new()
+            } else if uses_sorry {
+                "lean: proof uses sorry or sorryAx".to_string()
+            } else if has_error {
+                "lean: output contains errors".to_string()
+            } else {
+                format!("lake env lean exited with code {:?}", output.status.code())
+            },
+            solver_stdout,
+            wall_clock: started.elapsed(),
+            timed_out,
+        }
+    }
+}
+
+fn find_mathlib_rev(value: &Json) -> Option<String> {
+    match value {
+        Json::Object(map) => {
+            let package_name = map
+                .get("name")
+                .or_else(|| map.get("url"))
+                .and_then(Json::as_str)
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            if package_name.contains("mathlib") {
+                if let Some(rev) = map
+                    .get("rev")
+                    .or_else(|| map.get("gitRev"))
+                    .or_else(|| map.get("commit"))
+                    .and_then(Json::as_str)
+                {
+                    return Some(rev.to_string());
+                }
+            }
+            map.values().find_map(find_mathlib_rev)
+        }
+        Json::Array(items) => items.iter().find_map(find_mathlib_rev),
+        _ => None,
+    }
+}

--- a/implementations/rust/provekit-verifier/src/solvers/mod.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/mod.rs
@@ -34,6 +34,7 @@ pub mod config;
 pub mod coq;
 pub mod dispatch;
 pub mod maude;
+pub mod lean;
 pub mod plan;
 pub mod registry;
 pub mod stub;
@@ -84,6 +85,7 @@ pub use config::{DispatchConfig, PortfolioMode, SolverConfig, SolverPlan, Solver
 pub use coq::CoqSubprocessSolver;
 pub use dispatch::dispatch_for_formula;
 pub use maude::MaudeSubprocessSolver;
+pub use lean::LeanSubprocessSolver;
 pub use plan::{run_plan, SolverInvocation};
 pub use stub::StubSolver;
 pub use subprocess::SubprocessSolver;

--- a/implementations/rust/provekit-verifier/src/solvers/plan.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/plan.rs
@@ -457,6 +457,8 @@ mod tests {
             strings: Some("cvc5".into()),
             bitvectors: None,
             linear_arithmetic: Some("z3".into()),
+            dependent_type: None,
+            categorical_structure: None,
             default: Some("z3".into()),
         });
         let f = serde_json::json!({"kind":"atomic","name":"length","args":[]});
@@ -477,6 +479,8 @@ mod tests {
             strings: None,
             bitvectors: None,
             linear_arithmetic: None,
+            dependent_type: None,
+            categorical_structure: None,
             default: Some("z3".into()),
         });
         let f = serde_json::json!({"kind":"atomic","name":"unknown","args":[]});

--- a/implementations/rust/provekit-verifier/src/solvers/registry.rs
+++ b/implementations/rust/provekit-verifier/src/solvers/registry.rs
@@ -32,11 +32,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use provekit_ir_compiler_coq::DIALECT as COQ_DIALECT;
+use provekit_ir_compiler_lean::DIALECT as LEAN_DIALECT;
 use provekit_ir_compiler_maude::DIALECT as MAUDE_DIALECT;
 
 use crate::solvers::{
-    CetaGateConfig, CoqSubprocessSolver, MaudeSubprocessSolver, SolverConfig, SolverHandle,
-    SolversConfig, StubSolver, SubprocessSolver,
+    CetaGateConfig, CoqSubprocessSolver, LeanSubprocessSolver, MaudeSubprocessSolver, SolverConfig,
+    SolverHandle, SolversConfig, StubSolver, SubprocessSolver,
 };
 
 pub fn build(cfg: &SolversConfig) -> HashMap<String, SolverHandle> {
@@ -60,12 +61,18 @@ fn is_maude_compiler(ir_compiler: &str) -> bool {
     ir_compiler == "maude" || ir_compiler == MAUDE_DIALECT
 }
 
+fn is_lean_compiler(ir_compiler: &str) -> bool {
+    ir_compiler == "lean" || ir_compiler == LEAN_DIALECT
+}
+
 fn build_one(name: &str, sc: &SolverConfig) -> SolverHandle {
     if let Some(stub) = StubSolver::from_binary(name, &sc.binary) {
         return Arc::new(stub) as SolverHandle;
     }
     let timeout = sc.timeout_seconds.map(Duration::from_secs);
-    let bin = if sc.binary.is_empty() {
+    let bin = if sc.binary.is_empty() && is_lean_compiler(&sc.ir_compiler) {
+        "lake".to_string()
+    } else if sc.binary.is_empty() {
         name.to_string()
     } else {
         sc.binary.clone()
@@ -91,6 +98,16 @@ fn build_one(name: &str, sc: &SolverConfig) -> SolverHandle {
                 confluence_checker: sc.confluence_checker.clone(),
                 timeout,
             },
+        )) as SolverHandle;
+    }
+    if is_lean_compiler(&sc.ir_compiler) {
+        return Arc::new(LeanSubprocessSolver::new(
+            name,
+            bin,
+            sc.version.clone(),
+            timeout,
+            sc.lake_project.clone(),
+            sc.lean_toolchain.clone(),
         )) as SolverHandle;
     }
     Arc::new(SubprocessSolver::new(
@@ -199,12 +216,34 @@ ir_compiler = "coq"
     }
 
     #[test]
+    fn build_recognizes_lean_ir_compiler() {
+        let toml = r#"
+[solvers]
+default = "lean"
+[solvers.lean]
+binary = "lake"
+ir_compiler = "lean"
+"#;
+        let c = SolversConfig::from_toml(toml).unwrap();
+        let r = build(&c);
+        let s = r.get("lean").expect("lean registered");
+        assert_eq!(s.ir_compiler(), "lean");
+        let res = s.solve("(check-sat)");
+        assert_eq!(res.verdict, crate::types::ObligationVerdict::Undecidable);
+        assert!(
+            res.error.contains("parse IR-JSON") || res.error.contains("IR-JSON"),
+            "expected IR-JSON parse error from LeanSubprocessSolver, got: {}",
+            res.error
+        );
+    }
+
+    #[test]
     fn build_recognizes_default_workspace_portfolio() {
         // Closes #251 (cvc5) + #252 Tier 1 (Vampire).
         //
         // Reads the canonical `.provekit/config.toml` from the repo
         // root (computed from CARGO_MANIFEST_DIR) and asserts that the
-        // file parses cleanly and registers all four default-portfolio
+        // file parses cleanly and registers all five default-portfolio
         // solvers with the right ir_compiler tags. This is a
         // registry-build smoke test only: it does not spawn any solver
         // binary, so it passes even on hosts that lack
@@ -224,8 +263,8 @@ ir_compiler = "coq"
         let c = SolversConfig::from_toml(&body).expect("config parses");
         let r = build(&c);
 
-        // All five seats register.
-        for name in ["z3", "cvc5", "vampire", "coq", "maude"] {
+        // All six seats register.
+        for name in ["z3", "cvc5", "vampire", "coq", "maude", "lean"] {
             assert!(r.contains_key(name), "{name} seat missing from registry");
         }
 
@@ -252,6 +291,8 @@ ir_compiler = "coq"
         assert_eq!(coq.ir_compiler(), "coq");
         let maude = r.get("maude").unwrap();
         assert_eq!(maude.ir_compiler(), "maude");
+        let lean = r.get("lean").unwrap();
+        assert_eq!(lean.ir_compiler(), "lean");
     }
 
     #[test]

--- a/implementations/rust/provekit-verifier/tests/lean_solver.rs
+++ b/implementations/rust/provekit-verifier/tests/lean_solver.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_verifier::solvers::{
+    plan::run_plan, registry, LeanSubprocessSolver, Solver, SolverPlan, SolversConfig,
+};
+use provekit_verifier::types::ObligationVerdict;
+
+#[test]
+fn lean_file_cid_uses_provekit_canonicalizer_hash() {
+    let source = "theorem provekit_obligation : True := by trivial\n";
+    assert_eq!(
+        LeanSubprocessSolver::lean_file_cid(source),
+        provekit_canonicalizer::blake3_512_of(source.as_bytes())
+    );
+}
+
+#[test]
+fn axiom_parser_detects_sorry_ax() {
+    let output = "axioms provekit_obligation: [propext, Quot.sound, sorryAx]\n";
+    let axioms = LeanSubprocessSolver::parse_axiom_set(output, "provekit_obligation");
+    assert!(axioms.iter().any(|a| a == "sorryAx"));
+    assert!(LeanSubprocessSolver::uses_sorry_or_sorry_ax(
+        "theorem provekit_obligation : True := by trivial\n",
+        output
+    ));
+}
+
+#[test]
+fn registry_recognizes_lean_ir_compiler() {
+    let cfg = SolversConfig::from_toml(
+        r#"
+[solvers]
+default = "lean"
+
+[solvers.lean]
+binary = "lake"
+ir_compiler = "lean"
+"#,
+    )
+    .expect("parse");
+    let plan = SolverPlan::from_config(&cfg);
+    let registry = registry::build(&cfg);
+    let solver = registry.get("lean").expect("lean registered");
+    assert_eq!(solver.ir_compiler(), "lean");
+    match plan {
+        SolverPlan::Single(name) => assert_eq!(name, "lean"),
+        _ => panic!("expected single lean solver"),
+    }
+    let result = solver.solve("(check-sat)");
+    assert_eq!(result.verdict, ObligationVerdict::Undecidable);
+    assert!(result.error.contains("IR-JSON"));
+}
+
+#[test]
+fn run_plan_feeds_ir_json_to_lean_solver() {
+    let cfg = SolversConfig::from_toml(
+        r#"
+[solvers]
+default = "lean"
+
+[solvers.lean]
+binary = "/definitely/missing/lake"
+ir_compiler = "lean"
+"#,
+    )
+    .expect("parse");
+    let plan = SolverPlan::from_config(&cfg);
+    let registry = registry::build(&cfg);
+    let formula = serde_json::json!({"kind": "atomic", "name": "true", "args": []});
+    let (verdict, _reason, invocations) = run_plan(&plan, &registry, "(check-sat)", Some(&formula));
+    assert_eq!(verdict, ObligationVerdict::Undecidable);
+    let error = &invocations[0].result.error;
+    assert!(
+        error.contains("spawn") && !error.contains("parse IR-JSON"),
+        "Lean should receive formula JSON before spawning lake, got: {error}"
+    );
+}
+
+#[test]
+fn mathlib_commit_parser_reads_lake_manifest() {
+    let dir = std::env::temp_dir().join(format!(
+        "provekit-lean-manifest-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    std::fs::write(
+        dir.join("lake-manifest.json"),
+        r#"{"packages":[{"name":"mathlib","rev":"abc123"}]}"#,
+    )
+    .expect("write manifest");
+    let commit = LeanSubprocessSolver::mathlib_commit_from_project(&dir);
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(commit.as_deref(), Some("abc123"));
+}
+
+#[test]
+#[ignore = "requires lake, lean, and a local mathlib lake project"]
+fn lean_solver_discharges_reflexivity_with_local_mathlib() {
+    let project = std::env::var("PROVEKIT_LEAN_PROJECT")
+        .expect("set PROVEKIT_LEAN_PROJECT to a mathlib lake project");
+    let solver = LeanSubprocessSolver::new(
+        "lean",
+        "lake",
+        "4.x",
+        Some(std::time::Duration::from_secs(60)),
+        Some(project),
+        None,
+    );
+    let ir = serde_json::json!({
+        "kind": "forall",
+        "name": "x",
+        "sort": {"kind": "primitive", "name": "Int"},
+        "body": {
+            "kind": "atomic",
+            "name": "=",
+            "args": [
+                {"kind": "var", "name": "x"},
+                {"kind": "var", "name": "x"}
+            ]
+        }
+    });
+    let result = solver.solve(&ir.to_string());
+    assert_eq!(result.verdict, ObligationVerdict::Discharged);
+    assert!(!result.solver_stdout.contains("sorryAx"));
+}

--- a/protocol/specs/2026-05-10-lean-backend.md
+++ b/protocol/specs/2026-05-10-lean-backend.md
@@ -1,0 +1,66 @@
+# Lean 4 and mathlib Backend
+
+**Status:** implementation note
+**Date:** 2026-05-10
+**Owner:** verifier crate
+**Companion specs:** `2026-05-02-multi-solver-protocol-v2.md`, `2026-05-09-language-signature-protocol.md`
+**Companion paper:** `docs/papers/13-after-grammars-programming-languages-as-content-addressed-algebras.md`
+
+## 1. Scope
+
+The Lean backend adds a Lean 4 plus mathlib seat to the prove portfolio. It is parallel to the existing Coq seat: the IR compiler lowers an `IrFormula` to a single Lean file, and the verifier adapter asks Lean's kernel to check that file through `lake env lean`.
+
+The compiler imports `Mathlib`, states the obligation as `theorem provekit_obligation : <IR proposition>`, and supplies a tactic proof attempt using mathlib automation. The generated file also runs `#print axioms provekit_obligation` so the verifier can record the checked proof's trust base.
+
+## 2. Coverage Declaration
+
+The Lean compiler declares sound coverage for:
+
+- `dependent_type` positions expressible as Lean dependent products.
+- `categorical_structure` obligations whose Lean statement cites mathlib category theory, algebra, or free algebra facts.
+- Higher order formulas expressible as Lean function types.
+- General first order goals that Lean and mathlib automation can close.
+
+Lean's kernel remains the authority. The compiler may emit a syntactically valid scaffold, but any proof that uses `sorry` is not a discharge.
+
+## 3. Verdict Semantics
+
+The Lean solver returns `Discharged` only when all of the following hold:
+
+- `lake env lean <file.lean>` exits with status 0.
+- The emitted file contains no `sorry`.
+- The output from `#print axioms provekit_obligation` contains no `sorryAx`.
+- Lean reports no errors.
+
+Any failure, timeout, elaboration error, tactic failure, `sorry`, or `sorryAx` produces `Unknown` at the portfolio level, represented by `ObligationVerdict::Undecidable` in the Rust verifier.
+
+Standard Lean and mathlib axioms are recorded, not rejected. They are part of the receipt's trust base.
+
+## 4. Receipt Shape
+
+Each Lean invocation records a receipt with:
+
+- `leanVersion`: output from `lean --version`.
+- `mathlibCommit`: the resolved mathlib revision from `lake-manifest.json`.
+- `emittedFileCid`: `blake3-512:<hex>` over the emitted Lean file bytes, computed through `provekit-canonicalizer`.
+- `axioms`: the axiom set reported by `#print axioms provekit_obligation`.
+
+This matches the content-addressed receipt model: the proof text has a CID, the kernel version is explicit, the mathlib revision is explicit, and the axiom set is the proof's trust base.
+
+## 5. Portfolio Composition
+
+The Lean solver is registered with `ir_compiler = "lean"` and binary `lake`. In portfolio mode it runs beside z3, cvc5, Vampire, and Coq. In dispatch mode, dependent type and category theory positions may route directly to Lean through the `dependent-type` and `categorical-structure` dispatch keys.
+
+Under the multi-solver protocol v2 model, each compiler remains the authority on what it translated soundly. Lean covers dependent and categorical positions that SMT compilers report as opaque. A `sorry` proof never covers a position.
+
+## 6. LSP and Paper 13 Alignment
+
+LSP section 2 defines the homomorphism obligation for language morphisms. LSP section 6 states that discharged morphisms compose when their homomorphism obligations compose.
+
+Paper 13 supplies the categorical background:
+
+- Lemma 2, morphism composition, aligns with LSP section 6.
+- Lemma 3, initial algebra universality, aligns with mathlib's algebraic and categorical libraries.
+- Lemma 6, effect signatures as embedded Lawvere theories, aligns with mathlib category theory and algebraic structure support.
+
+The Lean backend is the portfolio seat that lets these obligations cite mathlib facts and have Lean's kernel check the resulting proof.

--- a/tools/portfolio/lean-mathlib-install.md
+++ b/tools/portfolio/lean-mathlib-install.md
@@ -1,0 +1,113 @@
+# Lean 4 and mathlib Install Appendix
+
+This appendix sets up the Lake project used by the verifier's Lean solver. It does not modify Dockerfiles.
+
+Pinned versions:
+
+- Lean toolchain: `leanprover/lean4:v4.29.1`
+- mathlib release: `v4.29.1`
+- mathlib release commit: `5e932f9`
+- Project path used by `.provekit/config.toml`: `tools/portfolio/lean-mathlib`
+
+## 1. Install elan
+
+Linux and macOS:
+
+```sh
+curl https://elan.lean-lang.org/elan-init.sh -sSf | sh
+source "$HOME/.elan/env"
+```
+
+Windows PowerShell:
+
+```powershell
+curl -O --location https://elan.lean-lang.org/elan-init.ps1
+powershell -ExecutionPolicy Bypass -f elan-init.ps1
+del elan-init.ps1
+```
+
+Install the pinned Lean toolchain:
+
+```sh
+elan toolchain install leanprover/lean4:v4.29.1
+```
+
+## 2. Create the Lake project
+
+Run these commands from the repository root:
+
+```sh
+mkdir -p tools/portfolio/lean-mathlib
+cd tools/portfolio/lean-mathlib
+printf '%s\n' 'leanprover/lean4:v4.29.1' > lean-toolchain
+cat > lakefile.lean <<'EOF'
+import Lake
+open Lake DSL
+
+package provekit_mathlib
+
+require mathlib from git
+  "https://github.com/leanprover-community/mathlib4.git" @ "5e932f9"
+
+lean_lib ProvekitMathlib
+EOF
+mkdir -p ProvekitMathlib
+printf '%s\n' 'import Mathlib' > ProvekitMathlib.lean
+```
+
+The verifier runs generated proof files with:
+
+```sh
+lake env lean /path/to/proof.lean
+```
+
+## 3. Resolve and cache mathlib
+
+Run:
+
+```sh
+lake update
+lake exe cache get
+```
+
+Do not build mathlib from source for the portfolio image. `lake exe cache get` downloads prebuilt `.olean` files and avoids a multi-hour local build.
+
+## 4. Verify the project
+
+Run:
+
+```sh
+lean --version
+lake env lean --version
+lake env lean - <<'EOF'
+import Mathlib
+
+theorem provekit_cache_smoke : True := by
+  trivial
+
+#print axioms provekit_cache_smoke
+EOF
+```
+
+Expected result: both version commands report Lean `4.29.1`, and the smoke theorem checks without `sorryAx`.
+
+## 5. Configure ProvekIt
+
+The default workspace config already contains:
+
+```toml
+[solvers.lean]
+binary = "lake"
+ir_compiler = "lean"
+timeout_seconds = 60
+version = "4.x"
+lake_project = "tools/portfolio/lean-mathlib"
+```
+
+If the Lake project lives elsewhere, set `lake_project` to that directory or to its `lakefile.lean`.
+
+To force the elan proxy to a toolchain in solver config, add:
+
+```toml
+lean_toolchain = "leanprover/lean4:v4.29.1"
+```


### PR DESCRIPTION
## Summary

Adds Lean 4 + mathlib as a prove-portfolio backend, parallel to the existing Coq backend.

- **`provekit-ir-compiler-lean`** (new crate): lowers an obligation to a Lean 4 `theorem` with the `IrFormula` as the goal, plus a mathlib-automation tactic block (or a `sorry`-flagged scaffold when no automation applies, which yields `Unknown`, never `Discharged`). Byte-deterministic output; declares coverage for `dependent_type` and `categorical_structure` opacity positions plus general higher-order goals mathlib can close.
- **`solvers/lean.rs`**: invokes `lake env lean`. Exit 0, no errors, no `sorry`/`sorryAx` in `#print axioms` => `Discharged`; otherwise `Unknown`. The discharge receipt records the Lean toolchain version, the mathlib commit (from `lake-manifest.json`), the emitted `.lean` file CID, and the `#print axioms` axiom set as the proof's trust base.
- Registered in the portfolio (`config`/`dispatch`/`registry`/`plan`/`mod`); `.provekit/config.toml` portfolio now includes `lean`.
- Spec doc `protocol/specs/2026-05-10-lean-backend.md`; install appendix `tools/portfolio/lean-mathlib-install.md` (`elan` + pinned Lean 4 + `lake exe cache get` for the prebuilt mathlib oleans; the Dockerfile is not modified here).

Why Lean and not just Coq: mathlib already contains most of the categorical machinery paper 13 references (`CategoryTheory`, `Algebra.Category`, `FreeAlgebra`), so morphism-composition functoriality and initial-algebra universality become "cite the mathlib lemma" rather than reproving in Coq from scratch.

Verification (local): `cargo build -p provekit-ir-compiler-lean -p provekit-verifier` clean; `cargo test -p provekit-ir-compiler-lean` 6 pass; `cargo test -p provekit-verifier --test lean_solver` 5 pass + 1 ignored (binary-dependent); `cargo test -p provekit-verifier --lib` 44 pass; `cargo test -p provekit-verifier --test multi_solver_modes` 12 pass; `cargo clippy -p provekit-ir-compiler-lean -- -D warnings` clean.

## Test plan

- [ ] `cargo test -p provekit-ir-compiler-lean` and `cargo test -p provekit-verifier` green
- [ ] `cargo clippy -p provekit-ir-compiler-lean -- -D warnings` clean
- [ ] With `elan` + Lean 4 + mathlib cache installed: a known mathlib theorem lowered as an obligation discharges and `#print axioms` shows no `sorryAx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)