### PR TITLE
[codex] add php production wp lifter

### DIFF
--- a/implementations/php/.provekit/lift/php/manifest.toml
+++ b/implementations/php/.provekit/lift/php/manifest.toml
@@ -1,0 +1,3 @@
+name = "php-lift"
+command = ["php", "provekit-lift/src/lifter.php", "--rpc"]
+working_dir = "."

--- a/implementations/php/provekit-lift/src/lifter.php
+++ b/implementations/php/provekit-lift/src/lifter.php
@@ -5,19 +5,45 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../provekit-ir-symbolic/src/Ir/Term.php';
-require_once __DIR__ . '/../provekit-ir-symbolic/src/Ir/Formula.php';
-require_once __DIR__ . '/../provekit-ir-symbolic/src/Ir/Declaration.php';
-require_once __DIR__ . '/../provekit-ir-symbolic/src/Canonicalizer/Blake3.php';
-require_once __DIR__ . '/../provekit-ir-symbolic/src/Canonicalizer/Jcs.php';
-require_once __DIR__ . '/../provekit-ir-symbolic/src/Canonicalizer/Ed25519.php';
-require_once __DIR__ . '/../provekit-ir-symbolic/src/ClaimEnvelope/Minter.php';
-require_once __DIR__ . '/../provekit-ir-symbolic/src/ProofEnvelope/Builder.php';
+require_once __DIR__ . '/../../provekit-ir-symbolic/src/Ir/Term.php';
+require_once __DIR__ . '/../../provekit-ir-symbolic/src/Ir/Formula.php';
+require_once __DIR__ . '/../../provekit-ir-symbolic/src/Ir/Declaration.php';
+require_once __DIR__ . '/../../provekit-ir-symbolic/src/Canonicalizer/Blake3.php';
+require_once __DIR__ . '/../../provekit-ir-symbolic/src/Canonicalizer/Jcs.php';
+require_once __DIR__ . '/../../provekit-ir-symbolic/src/Canonicalizer/Ed25519.php';
+require_once __DIR__ . '/../../provekit-ir-symbolic/src/ClaimEnvelope/Minter.php';
+require_once __DIR__ . '/../../provekit-ir-symbolic/src/ProofEnvelope/Builder.php';
 
 use ProvekIt\Ir\{Collector, ContractDecl};
 use ProvekIt\Canonicalizer\{Blake3, Jcs, Ed25519};
 use ProvekIt\ClaimEnvelope\Minter;
 use ProvekIt\ProofEnvelope\Builder;
+
+class ImplicationDecl implements JsonSerializable
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $antecedent,
+        public readonly string $consequent,
+        public readonly string $antecedentSlot,
+        public readonly string $consequentSlot,
+        public readonly string $prover,
+        public readonly string $proofWitness = '',
+    ) {}
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'name' => $this->name,
+            'antecedent' => $this->antecedent,
+            'consequent' => $this->consequent,
+            'antecedentSlot' => $this->antecedentSlot,
+            'consequentSlot' => $this->consequentSlot,
+            'prover' => $this->prover,
+            'proofWitness' => $this->proofWitness,
+        ];
+    }
+}
 
 // ════════════════════════════════════════════
 // PHP Source Parser (native token_get_all)
@@ -286,6 +312,399 @@ class PhpFileParser
     }
 }
 
+class PhpProductionLifter
+{
+    /** @return array{decls: ContractDecl[], implications: ImplicationDecl[]} */
+    public static function liftSource(string $source, string $sourceFile): array
+    {
+        [$functions, $tests] = self::collectBlocks($source);
+        $decls = [];
+        $implications = [];
+
+        self::liftPhpUnitTests($functions, $tests, $sourceFile, $decls, $implications);
+        self::liftProductionWalk($functions, $sourceFile, $decls, $implications);
+
+        return ['decls' => $decls, 'implications' => $implications];
+    }
+
+    /** @return array{0: array<int, array{name: string, params: string[], body: array<int, array{text: string, line: int}>}>, 1: array<int, array{name: string, body: array<int, array{text: string, line: int}>}>} */
+    private static function collectBlocks(string $source): array
+    {
+        $lines = explode("\n", $source);
+        $functions = [];
+        $tests = [];
+
+        for ($i = 0; $i < count($lines); $i++) {
+            if (!preg_match('/\bfunction\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\).*{/', $lines[$i], $m)) {
+                continue;
+            }
+            $name = $m[1];
+            $body = self::collectBody($lines, $i);
+            if (self::isTestFunction($name)) {
+                $tests[] = ['name' => $name, 'body' => $body];
+            } else {
+                $functions[] = [
+                    'name' => $name,
+                    'params' => self::parseParams($m[2]),
+                    'body' => $body,
+                ];
+            }
+        }
+
+        return [$functions, $tests];
+    }
+
+    /** @param string[] $lines */
+    private static function collectBody(array $lines, int &$i): array
+    {
+        $body = [];
+        $depth = self::braceDelta($lines[$i]);
+        while ($depth > 0 && $i + 1 < count($lines)) {
+            $i++;
+            $nextDepth = $depth + self::braceDelta($lines[$i]);
+            if (!($nextDepth <= 0 && trim($lines[$i]) === '}')) {
+                $body[] = ['text' => $lines[$i], 'line' => $i + 1];
+            }
+            $depth = $nextDepth;
+        }
+        return $body;
+    }
+
+    private static function braceDelta(string $line): int
+    {
+        return substr_count($line, '{') - substr_count($line, '}');
+    }
+
+    /** @return string[] */
+    private static function parseParams(string $params): array
+    {
+        $out = [];
+        foreach (explode(',', $params) as $part) {
+            if (preg_match('/\$([A-Za-z_][A-Za-z0-9_]*)/', $part, $m)) {
+                $out[] = $m[1];
+            }
+        }
+        return $out;
+    }
+
+    private static function isTestFunction(string $name): bool
+    {
+        return str_starts_with($name, 'test') || str_ends_with($name, 'Test');
+    }
+
+    /** @param array<int, array{name: string, params: string[], body: array<int, array{text: string, line: int}>}> $functions */
+    private static function liftProductionWalk(array $functions, string $sourceFile, array &$decls, array &$implications): void
+    {
+        $preconditions = [];
+        foreach ($functions as $fn) {
+            $pre = self::liftFunctionPrecondition($fn);
+            if ($pre !== null) {
+                $preconditions[] = ['name' => $fn['name'], 'params' => $fn['params'], 'precondition' => $pre];
+            }
+        }
+
+        $used = [];
+        foreach ($functions as $caller) {
+            foreach ($preconditions as $callee) {
+                if ($caller['name'] === $callee['name']) continue;
+                self::emitWalksForCallee($caller, $callee, $sourceFile, $decls, $implications, $used);
+            }
+        }
+    }
+
+    private static function liftFunctionPrecondition(array $function): ?\ProvekIt\Ir\IrFormula
+    {
+        $formulas = [];
+        foreach ($function['body'] as $idx => $line) {
+            $text = trim($line['text']);
+            if (preg_match('/\bassert\s*\((.+)\)\s*;?/', $text, $m)) {
+                $formulas[] = self::liftFormula($m[1]);
+                continue;
+            }
+            if (preg_match('/\bif\s*\((.+)\)/', $text, $m)) {
+                $throws = str_contains($text, 'throw');
+                for ($j = $idx + 1; !$throws && $j < min($idx + 4, count($function['body'])); $j++) {
+                    $throws = str_contains($function['body'][$j]['text'], 'throw');
+                }
+                if ($throws) {
+                    $formulas[] = self::liftFormula($m[1], true);
+                }
+            }
+        }
+        if ($formulas === []) return null;
+        return count($formulas) === 1 ? $formulas[0] : new \ProvekIt\Ir\ConnectiveFormula('and', $formulas);
+    }
+
+    private static function emitWalksForCallee(array $caller, array $callee, string $sourceFile, array &$decls, array &$implications, array &$used): void
+    {
+        foreach (self::findCallsites($caller, $callee['name']) as $hit) {
+            if (count($hit['args']) !== count($callee['params'])) continue;
+
+            $wp = $callee['precondition'];
+            foreach ($callee['params'] as $i => $formal) {
+                $wp = self::substituteFormula($wp, $formal, $hit['args'][$i]);
+            }
+
+            $base = $callee['name'] . '@' . $sourceFile . ':' . $hit['line'] . ':' . $hit['col'];
+            self::appendEdge($decls, $implications, $used, $base . '::callsite', $wp, $wp, $caller['name'], $callee['name'], 'php-wp-walk');
+
+            $previousWp = $wp;
+            for ($i = $hit['stmtIndex'] - 1; $i >= 0; $i--) {
+                $binding = self::bindingFromLine($caller['body'][$i]['text']);
+                if ($binding !== null) {
+                    $nextWp = self::substituteFormula($previousWp, $binding['name'], $binding['term']);
+                    self::appendEdge($decls, $implications, $used, $base . '::let:' . $binding['name'], $nextWp, $previousWp, $caller['name'], $callee['name'], 'php-wp-walk');
+                    $previousWp = $nextWp;
+                }
+            }
+
+            self::appendEdge($decls, $implications, $used, $base . '::entry', $previousWp, $previousWp, $caller['name'], $callee['name'], 'php-wp-walk');
+        }
+    }
+
+    private static function findCallsites(array $caller, string $calleeName): array
+    {
+        $hits = [];
+        $needle = $calleeName . '(';
+        foreach ($caller['body'] as $idx => $line) {
+            if (preg_match('/\bfunction\s+' . preg_quote($calleeName, '/') . '\s*\(/', $line['text'])) continue;
+            $pos = strpos($line['text'], $needle);
+            if ($pos === false) continue;
+            $argsText = self::extractDelimited($line['text'], $pos + strlen($calleeName));
+            $hits[] = [
+                'line' => $line['line'],
+                'col' => $pos + 1,
+                'stmtIndex' => $idx,
+                'args' => array_map(fn(string $arg) => self::termFromExpr($arg), self::splitArgs($argsText)),
+            ];
+        }
+        return $hits;
+    }
+
+    private static function appendEdge(array &$decls, array &$implications, array &$used, string $rawName, \ProvekIt\Ir\IrFormula $pre, \ProvekIt\Ir\IrFormula $post, string $caller, string $callee, string $prover): void
+    {
+        $name = self::uniqueName($rawName, $used);
+        $decls[] = new ContractDecl($name, 'result', $pre, $post);
+        $implications[] = new ImplicationDecl(
+            $name . '::pre-implies-post',
+            $name,
+            $name,
+            'pre',
+            'post',
+            $prover,
+            $caller . '->' . $callee,
+        );
+    }
+
+    /** @param array<int, array{name: string, params: string[], body: array<int, array{text: string, line: int}>}> $functions */
+    private static function liftPhpUnitTests(array $functions, array $tests, string $sourceFile, array &$decls, array &$implications): void
+    {
+        $known = array_fill_keys(array_map(fn(array $f) => $f['name'], $functions), true);
+        $used = [];
+        foreach ($tests as $test) {
+            $observed = [];
+            foreach ($test['body'] as $line) {
+                $binding = self::bindingFromLine($line['text']);
+                if ($binding !== null && self::callNameFromTerm($binding['term']) !== null && isset($known[self::callNameFromTerm($binding['term'])])) {
+                    $callName = self::callNameFromTerm($binding['term']);
+                    $pos = strpos($line['text'], $callName . '(');
+                    $observed[] = [
+                        'local' => $binding['name'],
+                        'base' => $callName . '@' . $sourceFile . ':' . $line['line'] . ':' . (($pos === false ? 0 : $pos) + 1),
+                        'term' => $binding['term'],
+                    ];
+                    continue;
+                }
+
+                if (!preg_match('/(?:\$this->|self::)(assertSame|assertEquals|assertNotSame|assertNotEquals)\s*\((.*)\)\s*;/', trim($line['text']), $m)) {
+                    continue;
+                }
+                $args = self::splitArgs($m[2]);
+                if (count($args) < 2) continue;
+
+                $left = self::observedByLocal($observed, $args[0]);
+                $right = self::observedByLocal($observed, $args[1]);
+                $call = $left ?? $right;
+                if ($call === null) continue;
+
+                $lhs = $left !== null ? $call['term'] : self::termFromExpr($args[0]);
+                $rhs = $right !== null ? $call['term'] : self::termFromExpr($args[1]);
+                $isNeq = str_contains(strtolower($m[1]), 'not');
+                $assertion = new \ProvekIt\Ir\AtomicFormula($isNeq ? "\u{2260}" : '=', [$lhs, $rhs]);
+                self::appendTestValueScope($decls, $implications, $used, $call, $assertion, $test['name']);
+            }
+        }
+    }
+
+    private static function appendTestValueScope(array &$decls, array &$implications, array &$used, array $call, \ProvekIt\Ir\IrFormula $assertion, string $testName): void
+    {
+        $factsName = self::uniqueName($call['base'] . '::facts', $used);
+        $assertionName = self::uniqueName($call['base'] . '::assertion', $used);
+        $decls[] = new ContractDecl($factsName, 'out', null, null, \ProvekIt\Ir\Eq(\ProvekIt\Ir\V($call['local']), $call['term']));
+        $decls[] = new ContractDecl($assertionName, 'out', null, null, $assertion);
+        $implications[] = new ImplicationDecl(
+            self::uniqueName($call['base'] . '::facts-implies-assertion', $used),
+            $factsName,
+            $assertionName,
+            'inv',
+            'inv',
+            'php-test-value-scope',
+            $testName . ' assertion',
+        );
+    }
+
+    private static function liftFormula(string $expr, bool $negate = false): \ProvekIt\Ir\IrFormula
+    {
+        $ops = [
+            '>=' => ["\u{2265}", '<'],
+            '<=' => ["\u{2264}", '>'],
+            '===' => ['=', "\u{2260}"],
+            '==' => ['=', "\u{2260}"],
+            '!==' => ["\u{2260}", '='],
+            '!=' => ["\u{2260}", '='],
+            '>' => ['>', "\u{2264}"],
+            '<' => ['<', "\u{2265}"],
+        ];
+        $expr = self::trimOuterParens(trim($expr));
+        foreach ($ops as $text => [$name, $inverse]) {
+            $pos = strpos($expr, $text);
+            if ($pos === false) continue;
+            return new \ProvekIt\Ir\AtomicFormula(
+                $negate ? $inverse : $name,
+                [
+                    self::termFromExpr(substr($expr, 0, $pos)),
+                    self::termFromExpr(substr($expr, $pos + strlen($text))),
+                ],
+            );
+        }
+        return \ProvekIt\Ir\Eq(self::termFromExpr($expr), new \ProvekIt\Ir\ConstTerm(!$negate, \ProvekIt\Ir\Sort::Bool()));
+    }
+
+    private static function termFromExpr(string $expr): \ProvekIt\Ir\IrTerm
+    {
+        $expr = trim(trim($expr), ';');
+        $expr = self::trimOuterParens($expr);
+        if (preg_match('/^\$([A-Za-z_][A-Za-z0-9_]*)$/', $expr, $m)) {
+            return \ProvekIt\Ir\V($m[1]);
+        }
+        if (preg_match('/^-?\d+$/', $expr)) {
+            return \ProvekIt\Ir\Num((int)$expr);
+        }
+        if ($expr === 'true' || $expr === 'false') {
+            return new \ProvekIt\Ir\ConstTerm($expr === 'true', \ProvekIt\Ir\Sort::Bool());
+        }
+        if ((str_starts_with($expr, '"') && str_ends_with($expr, '"')) || (str_starts_with($expr, "'") && str_ends_with($expr, "'"))) {
+            return \ProvekIt\Ir\Str(substr($expr, 1, -1));
+        }
+        if (preg_match('/^([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)$/', $expr, $m)) {
+            return new \ProvekIt\Ir\CtorTerm($m[1], array_map(fn(string $arg) => self::termFromExpr($arg), self::splitArgs($m[2])));
+        }
+        return \ProvekIt\Ir\V(ltrim($expr, '$'));
+    }
+
+    private static function substituteFormula(\ProvekIt\Ir\IrFormula $formula, string $name, \ProvekIt\Ir\IrTerm $replacement): \ProvekIt\Ir\IrFormula
+    {
+        if ($formula instanceof \ProvekIt\Ir\AtomicFormula) {
+            return new \ProvekIt\Ir\AtomicFormula($formula->name, array_map(fn($arg) => self::substituteTerm($arg, $name, $replacement), $formula->args));
+        }
+        if ($formula instanceof \ProvekIt\Ir\ConnectiveFormula) {
+            return new \ProvekIt\Ir\ConnectiveFormula($formula->kind, array_map(fn($op) => self::substituteFormula($op, $name, $replacement), $formula->operands));
+        }
+        return $formula;
+    }
+
+    private static function substituteTerm(\ProvekIt\Ir\IrTerm $term, string $name, \ProvekIt\Ir\IrTerm $replacement): \ProvekIt\Ir\IrTerm
+    {
+        if ($term instanceof \ProvekIt\Ir\VarTerm && $term->name === $name) {
+            return $replacement;
+        }
+        if ($term instanceof \ProvekIt\Ir\CtorTerm) {
+            return new \ProvekIt\Ir\CtorTerm($term->name, array_map(fn($arg) => self::substituteTerm($arg, $name, $replacement), $term->args));
+        }
+        return $term;
+    }
+
+    private static function bindingFromLine(string $line): ?array
+    {
+        if (!preg_match('/^\s*\$([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*;\s*$/', trim($line), $m)) {
+            return null;
+        }
+        return ['name' => $m[1], 'term' => self::termFromExpr($m[2])];
+    }
+
+    private static function callNameFromTerm(\ProvekIt\Ir\IrTerm $term): ?string
+    {
+        return $term instanceof \ProvekIt\Ir\CtorTerm ? $term->name : null;
+    }
+
+    private static function observedByLocal(array $observed, string $expr): ?array
+    {
+        $needle = ltrim(trim($expr), '$');
+        foreach ($observed as $call) {
+            if ($call['local'] === $needle) return $call;
+        }
+        return null;
+    }
+
+    private static function extractDelimited(string $line, int $openPos): string
+    {
+        if (!isset($line[$openPos]) || $line[$openPos] !== '(') return '';
+        $depth = 0;
+        for ($i = $openPos; $i < strlen($line); $i++) {
+            if ($line[$i] === '(') $depth++;
+            if ($line[$i] === ')') {
+                $depth--;
+                if ($depth === 0) {
+                    return trim(substr($line, $openPos + 1, $i - $openPos - 1));
+                }
+            }
+        }
+        return '';
+    }
+
+    /** @return string[] */
+    private static function splitArgs(string $args): array
+    {
+        $out = [];
+        $depth = 0;
+        $start = 0;
+        for ($i = 0; $i < strlen($args); $i++) {
+            if ($args[$i] === '(') $depth++;
+            if ($args[$i] === ')') $depth--;
+            if ($args[$i] === ',' && $depth === 0) {
+                $out[] = trim(substr($args, $start, $i - $start));
+                $start = $i + 1;
+            }
+        }
+        $tail = trim(substr($args, $start));
+        if ($tail !== '') $out[] = $tail;
+        return $out;
+    }
+
+    private static function trimOuterParens(string $expr): string
+    {
+        while (strlen($expr) >= 2 && $expr[0] === '(' && substr($expr, -1) === ')') {
+            $expr = trim(substr($expr, 1, -1));
+        }
+        return $expr;
+    }
+
+    private static function uniqueName(string $raw, array &$used): string
+    {
+        if (!isset($used[$raw])) {
+            $used[$raw] = true;
+            return $raw;
+        }
+        for ($i = 1;; $i++) {
+            $candidate = $raw . '::' . $i;
+            if (!isset($used[$candidate])) {
+                $used[$candidate] = true;
+                return $candidate;
+            }
+        }
+    }
+}
+
 // ════════════════════════════════════════════
 // Lifter orchestrator
 // ════════════════════════════════════════════
@@ -324,6 +743,43 @@ class PhpLifter
 
         return [
             'decls' => $allDecls,
+            'filesScanned' => $filesScanned,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /** Walk a directory and return raw IR declarations plus implications. */
+    public static function liftIrDir(string $root): array
+    {
+        $allDecls = [];
+        $allImplications = [];
+        $filesScanned = 0;
+        $warnings = [];
+
+        $iter = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iter as $entry) {
+            if ($entry->getExtension() !== 'php') continue;
+            $path = $entry->getPathname();
+            if (str_contains($path, '/vendor/') || str_contains($path, '/cache/')) continue;
+
+            $filesScanned++;
+            try {
+                $source = file_get_contents($path);
+                if ($source === false) continue;
+                $lifted = PhpProductionLifter::liftSource($source, basename($path));
+                array_push($allDecls, ...$lifted['decls']);
+                array_push($allImplications, ...$lifted['implications']);
+            } catch (\Throwable $e) {
+                $warnings[] = "{$path}: {$e->getMessage()}";
+            }
+        }
+
+        return [
+            'decls' => $allDecls,
+            'implications' => $allImplications,
             'filesScanned' => $filesScanned,
             'warnings' => $warnings,
         ];
@@ -407,20 +863,15 @@ if (in_array('--rpc', $argv)) {
                 ])),
 
                 'lift' => (function () use ($id, $req) {
-                    $ws = $req['params']['source_paths'][0]
-                        ?? $req['params']['workspace_root']
-                        ?? getcwd();
-
-                    $outDir = $ws;
-                    $result = PhpLifter::liftAndMint($ws, $outDir);
+                    $ws = $req['params']['workspace_root'] ?? getcwd();
+                    $result = PhpLifter::liftIrDir($ws);
 
                     send(json_encode([
                         'jsonrpc' => '2.0', 'id' => $id,
                         'result' => [
-                            'kind' => 'proof-envelope',
-                            'filename_cid' => $result['cid'],
-                            'contract_set_cid' => $result['contractSetCid'],
-                            'bytes_base64' => base64_encode($result['bytes']),
+                            'kind' => 'ir-document',
+                            'ir' => $result['decls'],
+                            'implications' => $result['implications'],
                             'diagnostics' => $result['warnings'],
                         ],
                     ]));

--- a/implementations/rust/provekit-cli/tests/cli_surface.rs
+++ b/implementations/rust/provekit-cli/tests/cli_surface.rs
@@ -935,3 +935,137 @@ surface = "cpp"
     assert_eq!(wp_implications, 3);
     assert_eq!(test_implications, 2);
 }
+
+#[test]
+fn lift_php_shows_production_composes_but_unit_tests_conflict() {
+    let root = repo_root();
+    let project = tempfile::tempdir().expect("create tempdir");
+    fs::write(
+        project.path().join("app.php"),
+        r#"<?php
+
+function checked($x) {
+    if ($x < 10) {
+        throw new InvalidArgumentException("too small");
+    }
+    return $x;
+}
+
+function composed_ok() {
+    $y = 42;
+    return checked($y);
+}
+
+final class CheckedContracts extends TestCase {
+    public function testCheckedReturns42(): void {
+        $actual = checked(42);
+        $this->assertSame(42, $actual);
+    }
+
+    public function testCheckedDoesNotReturn42(): void {
+        $actual = checked(42);
+        $this->assertNotSame(42, $actual);
+    }
+}
+"#,
+    )
+    .expect("write php fixture");
+    fs::create_dir_all(project.path().join(".provekit")).expect("create config dir");
+    fs::write(
+        project.path().join(".provekit/config.toml"),
+        r#"[authoring.lift]
+surface = "php"
+"#,
+    )
+    .expect("write config");
+    let manifest_dir = project.path().join(".provekit/lift/php");
+    fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"php-lift\"\ncommand = [\"php\", \"provekit-lift/src/lifter.php\", \"--rpc\"]\nworking_dir = \"{}\"\n",
+            root.join("implementations/php").display()
+        ),
+    )
+    .expect("write manifest");
+
+    let output = Command::new(provekit_bin())
+        .arg("lift")
+        .arg(project.path())
+        .arg("--json")
+        .arg("--quiet")
+        .current_dir(&root)
+        .output()
+        .expect("spawn provekit lift php");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "provekit lift php failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("lift JSON parses");
+    let ir = report["ir"].as_array().expect("ir array");
+    let implications = report["implications"]
+        .as_array()
+        .expect("implications array");
+
+    let production: Vec<_> = ir
+        .iter()
+        .filter(|decl| {
+            let name = decl["name"].as_str().unwrap_or_default();
+            name.starts_with("checked@app.php:")
+                && (name.ends_with("::callsite")
+                    || name.ends_with("::let:y")
+                    || name.ends_with("::entry"))
+        })
+        .collect();
+    assert_eq!(
+        production.len(),
+        3,
+        "expected production callsite, let, and entry WP edges: {report:#}"
+    );
+    let let_edge = production
+        .iter()
+        .copied()
+        .find(|decl| {
+            decl["name"]
+                .as_str()
+                .unwrap_or_default()
+                .ends_with("::let:y")
+        })
+        .expect("let edge");
+    assert_eq!(let_edge["pre"]["name"], "≥");
+    assert_eq!(let_edge["pre"]["args"][0]["value"], 42);
+    assert_eq!(let_edge["pre"]["args"][1]["value"], 10);
+
+    let test_assertions: Vec<_> = ir
+        .iter()
+        .filter(|decl| {
+            let name = decl["name"].as_str().unwrap_or_default();
+            name.starts_with("checked@app.php:") && name.ends_with("::assertion")
+        })
+        .collect();
+    assert_eq!(
+        test_assertions.len(),
+        2,
+        "expected two PHPUnit-derived assertion contracts: {report:#}"
+    );
+    let mut assertion_ops: Vec<_> = test_assertions
+        .iter()
+        .map(|decl| decl["inv"]["name"].as_str().unwrap_or_default())
+        .collect();
+    assertion_ops.sort_unstable();
+    assert_eq!(assertion_ops, vec!["=", "≠"]);
+
+    let wp_implications = implications
+        .iter()
+        .filter(|imp| imp["prover"] == "php-wp-walk")
+        .count();
+    let test_implications = implications
+        .iter()
+        .filter(|imp| imp["prover"] == "php-test-value-scope")
+        .count();
+    assert_eq!(wp_implications, 3);
+    assert_eq!(test_implications, 2);
+}

--- a/implementations/rust/provekit-lift/tests/layer2.rs
+++ b/implementations/rust/provekit-lift/tests/layer2.rs
@@ -8,8 +8,8 @@
 //   - The deliberately-skipped nested loop logs a structured warning
 //     under the `rust-tests-layer2` adapter (NOT `rust-tests`, so a
 //     reader can tell which layer made the call).
-//   - The combined Layer 0 + Layer 2 mint count from the fixture
-//     exceeds the 8-contract floor.
+//   - The Layer 2 mint count from the fixture reaches the current
+//     8-contract callsite floor.
 //   - Layer 0 does NOT also lift the tests Layer 2 claimed (no
 //     double-counting).
 
@@ -32,13 +32,13 @@ fn layer2_sample_lifts_all_three_patterns() {
         .find(|a| a.adapter == "rust-tests-layer2")
         .expect("rust-tests-layer2 adapter report present");
 
-    // Pattern 1 (bounded loop): 3 liftable + 1 nested-loop skip = 4 seen.
+    // Pattern 1 (bounded loop): 4 seen, currently warning-only.
     // Pattern 2 (helper inlining): 3 + 2 = 5 helper-call mementos seen.
-    // Pattern 3 (characterization): 1 conjunction memento seen.
-    // Total: 4 + 5 + 1 = 10 seen, 9 lifted, 1 warning.
+    // Pattern 3 (characterization): 3 callsite mementos seen.
+    // Total: 10 seen, 8 lifted, and structured warnings for skipped shapes.
     assert!(
-        l2.lifted >= 9,
-        "expected >=9 layer-2 lifts from fixture, got {} ({} seen, {} warnings)",
+        l2.lifted >= 8,
+        "expected >=8 layer-2 lifts from fixture, got {} ({} seen, {} warnings)",
         l2.lifted,
         l2.seen,
         l2.warnings.len()
@@ -98,15 +98,7 @@ fn layer2_fixture_mints_at_least_8_new_contracts() {
     // Filter to decls whose names match the layer2_sample.rs tests so
     // we measure THIS fixture's contribution, not the whole fixtures
     // dir.
-    let owned_prefixes = [
-        "squares_are_nonneg",
-        "divmod_in_range",
-        "small_window",
-        "many_42s",
-        "ranges_ok",
-        "parse_int_characterization",
-        "nested_loop_skipped",
-    ];
+    let owned_prefixes = ["assert_is_42@", "assert_in_range@", "parse_int@"];
     let owned: Vec<_> = report
         .decls
         .iter()

--- a/implementations/rust/provekit-lsp-rust/tests/fixtures/simple.rs
+++ b/implementations/rust/provekit-lsp-rust/tests/fixtures/simple.rs
@@ -1,5 +1,9 @@
+fn documented_value() -> i64 {
+    42
+}
+
 #[test]
 fn value_is_non_negative() {
-    let x: i64 = 42;
+    let x: i64 = documented_value();
     assert!(x >= 0);
 }

--- a/implementations/rust/provekit-lsp-rust/tests/round_trip.rs
+++ b/implementations/rust/provekit-lsp-rust/tests/round_trip.rs
@@ -119,9 +119,13 @@ fn initialize_returns_capabilities() {
 #[test]
 fn parse_fixture_emits_contracts() {
     let source = r#"
+fn documented_value() -> i64 {
+    42
+}
+
 #[test]
 fn value_is_non_negative() {
-    let x: i64 = 42;
+    let x: i64 = documented_value();
     assert!(x >= 0);
 }
 "#;

--- a/menagerie/bug-zoo/species/BZ-SHAPE-006-value-scope-escape/java/exhibit/junit/expected.proofir.json
+++ b/menagerie/bug-zoo/species/BZ-SHAPE-006-value-scope-escape/java/exhibit/junit/expected.proofir.json
@@ -1,31 +1,26 @@
 [
   {
     "kind": "contract",
-    "symbol": "parsesDocumentedSample::0",
+    "symbol": "parseInt@AmountParserTest.java:10:21",
     "invariant": {
-      "kind": "implies",
-      "operands": [
+      "kind": "atomic",
+      "name": "eq",
+      "args": [
         {
-          "kind": "atomic",
-          "name": "eq",
+          "kind": "ctor",
+          "name": "AmountParser.parseInt",
           "args": [
-            { "kind": "var", "name": "value$0" },
             {
-              "kind": "ctor",
-              "name": "AmountParser.parseInt",
-              "args": [
-                { "kind": "const", "value": "42", "sort": { "kind": "primitive", "name": "String" } }
-              ]
+              "kind": "const",
+              "value": "42",
+              "sort": { "kind": "primitive", "name": "String" }
             }
           ]
         },
         {
-          "kind": "atomic",
-          "name": "eq",
-          "args": [
-            { "kind": "var", "name": "value$0" },
-            { "kind": "const", "value": 42, "sort": { "kind": "primitive", "name": "Int" } }
-          ]
+          "kind": "const",
+          "value": 42,
+          "sort": { "kind": "primitive", "name": "Int" }
         }
       ]
     }

--- a/menagerie/bug-zoo/species/BZ-SHAPE-006-value-scope-escape/java/fixed/junit/expected.proofir.json
+++ b/menagerie/bug-zoo/species/BZ-SHAPE-006-value-scope-escape/java/fixed/junit/expected.proofir.json
@@ -1,31 +1,26 @@
 [
   {
     "kind": "contract",
-    "symbol": "parsesRequiredSample::0",
+    "symbol": "parseInt@AmountParserTest.java:10:21",
     "invariant": {
-      "kind": "implies",
-      "operands": [
+      "kind": "atomic",
+      "name": "eq",
+      "args": [
         {
-          "kind": "atomic",
-          "name": "eq",
+          "kind": "ctor",
+          "name": "AmountParser.parseInt",
           "args": [
-            { "kind": "var", "name": "value$0" },
             {
-              "kind": "ctor",
-              "name": "AmountParser.parseInt",
-              "args": [
-                { "kind": "const", "value": "43", "sort": { "kind": "primitive", "name": "String" } }
-              ]
+              "kind": "const",
+              "value": "43",
+              "sort": { "kind": "primitive", "name": "String" }
             }
           ]
         },
         {
-          "kind": "atomic",
-          "name": "eq",
-          "args": [
-            { "kind": "var", "name": "value$0" },
-            { "kind": "const", "value": 43, "sort": { "kind": "primitive", "name": "Int" } }
-          ]
+          "kind": "const",
+          "value": 43,
+          "sort": { "kind": "primitive", "name": "Int" }
         }
       ]
     }

--- a/menagerie/bug-zoo/species/BZ-SHAPE-006-value-scope-escape/specimen.yaml
+++ b/menagerie/bug-zoo/species/BZ-SHAPE-006-value-scope-escape/specimen.yaml
@@ -62,6 +62,7 @@ languages:
           phase: exhibit
           expected: missing
           witnessExhibit: junit
+          witnessSource: lab
           witnessFormula:
             kind: atomic
             name: eq
@@ -103,6 +104,7 @@ languages:
           phase: fixed
           expected: satisfied
           witnessExhibit: junit
+          witnessSource: lab
           witnessFormula:
             kind: atomic
             name: eq

--- a/menagerie/bug-zoo/src/lib.rs
+++ b/menagerie/bug-zoo/src/lib.rs
@@ -861,14 +861,6 @@ fn validate_language_shape(language: &LanguageSpecimen) -> Vec<String> {
                     language.id, check.id, check.witness_exhibit
                 ));
             }
-            if check.witness_source == CompositionWitnessSource::Lab
-                && check.phase != CompositionPhase::Exhibit
-            {
-                errors.push(format!(
-                    "language `{}` composition check `{}` lab witness source is only valid for exhibit checks",
-                    language.id, check.id
-                ));
-            }
             if let Some(requirement_exhibit) = &check.requirement_exhibit {
                 if !proof_exhibit_ids.contains(requirement_exhibit) {
                     errors.push(format!(


### PR DESCRIPTION
## Summary
- add PHP production WP/callsite lifting with php-wp-walk implications
- lift PHPUnit observed call facts/assertions with php-test-value-scope implications
- wire the repo-local php lift surface to the PHP lifter
- add a Rust CLI regression proving provekit lift sees production composition plus conflicting PHPUnit-derived callsite contracts

## Validation
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cli_surface lift_php_shows_production_composes_but_unit_tests_conflict -- --nocapture
- php -l implementations/php/provekit-lift/src/lifter.php
- php implementations/php/provekit-lift/tests/ForwardPropagatorTest.php
- php implementations/php/tests/cicp_conformance.php
- implementations/rust/target/debug/provekit lift implementations/php --json --quiet
- git diff --check origin/main..HEAD