### PR TITLE
fix(proof-envelope): clear clippy 1.95 doc_lazy_continuation in proof.rs

### DIFF
--- a/implementations/rust/provekit-proof-envelope/src/proof.rs
+++ b/implementations/rust/provekit-proof-envelope/src/proof.rs
@@ -42,11 +42,12 @@ pub struct ProofEnvelopeInput {
     pub members: BTreeMap<String, Vec<u8>>,
     /// Identity carried into the envelope's `signer` field. Two valid
     /// shapes per the memento-envelope grammar:
-    ///   1. `blake3-512:<hex>` — CID resolving to a pubkey memento
+    ///   1. `blake3-512:<hex>` - CID resolving to a pubkey memento
     ///      (canonical, used by `.proof` catalogs)
-    ///   2. `ed25519:<base64-pubkey>` — inline self-identifying form
+    ///   2. `ed25519:<base64-pubkey>` - inline self-identifying form
     ///      (used by memento envelopes that don't pin a separate
     ///      pubkey memento, e.g. fixtures and standalone declarations)
+    ///
     /// The struct field name is preserved for backwards compatibility;
     /// either form is accepted by the wire format.
     pub signer_cid: String,


### PR DESCRIPTION
## Summary

The `signer_cid` doc comment in `implementations/rust/provekit-proof-envelope/src/proof.rs` placed two trailing prose lines immediately after a numbered list, which clippy 1.95 flags as a lazy list-continuation (`doc_lazy_continuation`), turning `cargo clippy -- -D warnings` red across every crate that depends on `provekit-proof-envelope`. This inserts a blank doc line so the trailing prose is its own paragraph, and swaps the two em-dashes in that comment for hyphens (project no-em-dash rule). Pre-existing on main; surfaced by clippy 1.95.

`cargo clippy -p provekit-proof-envelope -- -D warnings` is clean after the change. (Note: PR #548's Maude/CeTA branch separately hand-edited the `provekit-ir-compiler-{coq,smt-lib}/src/generated.rs` files to strip em-dashes + add `#![allow(unreachable_patterns)]`; moving that fix to the codegen source is a remaining follow-up.)

## Test plan

- [ ] `cargo clippy -p provekit-proof-envelope -- -D warnings` clean
- [ ] `cargo build -p provekit-proof-envelope`

🤖 Generated with [Claude Code](https://claude.com/claude-code)