### PR TITLE
feat: provekit-ir-compiler-x86-64 - ORP v0.2 compile mode (term -> x86-64 SysV asm)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1721,6 +1721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-ir-compiler-x86-64"
+version = "0.1.0"
+dependencies = [
+ "provekit-ir-compiler",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "provekit-ir-symbolic"
 version = "0.1.0"
 dependencies = [

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "provekit-ir-compiler-smt-lib",
     "provekit-ir-compiler-stub",
     "provekit-ir-compiler-coq",
+    "provekit-ir-compiler-x86-64",
     "provekit-ir-compiler-maude",
     "provekit-ir-compiler-lean",
     "provekit-ir-codegen",

--- a/implementations/rust/provekit-ir-compiler-x86-64/Cargo.toml
+++ b/implementations/rust/provekit-ir-compiler-x86-64/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "provekit-ir-compiler-x86-64"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "ProvekIt: x86-64 SysV compile-mode IR term compiler."
+
+[dependencies]
+provekit-ir-compiler = { path = "../provekit-ir-compiler" }
+serde_json.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
+
+[[bin]]
+name = "provekit-ir-x86-64"
+path = "src/main.rs"
+
+[lib]
+name = "provekit_ir_compiler_x86_64"
+path = "src/lib.rs"

--- a/implementations/rust/provekit-ir-compiler-x86-64/README.md
+++ b/implementations/rust/provekit-ir-compiler-x86-64/README.md
@@ -1,0 +1,115 @@
+# provekit-ir-compiler-x86-64
+
+`provekit-ir-compiler-x86-64` is the x86-64 executable target rung of the ProvekIt realizer family. It implements ORP v0.2 `compile` mode for the term stratum:
+
+```text
+compile : Term * x86-64:sysv -> ConcreteCode | Refusal
+```
+
+The input is a ProofIR term, an AST over operation CIDs, not a contract. The output is Intel syntax x86-64 SysV assembly that can be passed to `gcc` or `as`.
+
+This is the executable-target dual of `provekit-ir-compiler-coq`: Coq realizes IR into proof source, while this crate realizes IR terms into runnable code.
+
+## API
+
+The existing `IrCompiler` trait in `provekit-ir-compiler` is shaped around formula compilation, so this crate provides a small `TermCompiler` trait:
+
+```rust
+pub trait TermCompiler {
+    fn compile_term_json(&self, ir: &serde_json::Value) -> Result<String, CompileError>;
+}
+```
+
+`X8664Compiler` also implements `IrCompiler` for registry compatibility. In that path, the emitted assembly is returned as `CompiledFormula.body`, with an empty preamble and no free variables.
+
+The binary is `provekit-ir-x86-64`:
+
+```sh
+cat tests/fixtures/foo.term.json | provekit-ir-x86-64 > foo.s
+gcc harness.c foo.s -o harness
+```
+
+## Core Subset
+
+The current hand-mapped subset covers:
+
+```text
+seq, if, while, return, call, break, continue, skip,
+eq, lt, le, add, sub, mul, neg, and, or, not,
+variable reference, integer literal, deref, assign
+```
+
+The mapping is intentionally direct:
+
+| ProofIR operation | x86-64 realization |
+| --- | --- |
+| `seq(a, b)` | Emit `a` followed by `b`. |
+| `if(c, a, b)` | Compile `c` to `eax`, `cmp eax, 0`, branch with `je`. |
+| `while(c, b)` | Loop head label, condition compare, exit branch, body, back edge. |
+| `return(e)` | Compile `e` to `eax`, then `ret`. |
+| `call(f, args)` | SysV integer argument registers, stack alignment, direct `call`. |
+| `break` | Jump to the innermost loop exit label. |
+| `continue` | Jump to the innermost loop head label. |
+| `skip` | Emit no instruction. |
+| `eq`, `lt`, `le` | `cmp` plus `sete`, `setl`, or `setle`, then `movzx`. |
+| `add`, `sub`, `mul`, `neg` | `add`, `sub`, `imul`, `neg`. |
+| `and`, `or`, `not` | Normalize to zero or one, then `and`, `or`, or `sete`. |
+| `var`, `const` | First-occurrence SysV argument register or integer immediate. |
+| `deref` | Load `DWORD PTR [address]`. |
+| `assign` | Store into a variable register or `DWORD PTR [address]`. |
+
+The core subset is hand mapped. The full operation set is mint-more-realizations, not new machinery.
+
+## Refusal Behavior
+
+Unsupported operations return a refusal through `CompileError`; the compiler does not emit partial assembly or an opaque placeholder. Non-integer constants, too many integer parameters for the current core ABI slice, unsupported call targets, unsupported assignment targets, and nontrivial loop invariant payloads are refused.
+
+`while` lowers only when the term has no invariant payload or carries the unit shape. A real invariant memento needs a discharge path before it can be compiled without silently dropping an obligation.
+
+## Byte Determinism
+
+Output is byte deterministic for byte-equal input JSON and the same target descriptor. Labels are allocated in traversal order. Variables are assigned to SysV integer argument registers by first occurrence order. The `tests/byte_for_byte.rs` test keeps this invariant explicit.
+
+## Round Trip Story
+
+ORP v0.2 treats `compile` mode as a deterministic homomorphism from the term algebra to target code. In LSP terms, this crate is the implementation body for a draft `LanguageMorphismMemento`:
+
+```text
+ProofIR C11 term algebra -> x86-64:sysv assembly
+```
+
+The draft spec is in `specs/algebra_to_x86_64.spec.json`.
+
+The intended theorem is:
+
+```text
+contract(lift_x86_64(compile_x86_64(t))) = contract(t)
+```
+
+When composed with a C lifter, this gives the round trip:
+
+```text
+lift C function -> ProofIR term -> compile to x86-64 -> lift x86-64
+```
+
+The lifted result should carry the same contract, modulo accepted representation morphisms. Comparing `lift(native-compiler-x86)` with `lift(compile-to-x86)` is also a differential miscompile detector: disagreement points to either a compiler bug, a lifter bug, or a missing morphism discharge.
+
+This is the ORP v0.2 term-stratum story from `protocol/specs/2026-05-10-realizer-protocol-v2.md`, aligned with papers 13 and 14 on languages as content-addressed algebras and portable correctness bundles.
+
+## Verification
+
+From `implementations/rust`:
+
+```sh
+cargo build -p provekit-ir-compiler-x86-64
+cargo test -p provekit-ir-compiler-x86-64
+cargo clippy -p provekit-ir-compiler-x86-64 -- -D warnings
+```
+
+The smoke fixture lowers `tests/fixtures/foo.term.json` to `tests/fixtures/foo.expected.s`. The ignored test assembles that assembly with `gcc` and runs a harness that checks `foo(0) == -22` and `foo(42) == 42`.
+
+## Follow Up
+
+The next steps are the full C11 operation set, a real register allocator, a stack-frame model for local variables, richer type widths, optimized instruction selection, minted morphism receipts, and automatic realization table generation from accepted operation mementos.
+
+T Savo

--- a/implementations/rust/provekit-ir-compiler-x86-64/specs/algebra_to_x86_64.spec.json
+++ b/implementations/rust/provekit-ir-compiler-x86-64/specs/algebra_to_x86_64.spec.json
@@ -1,0 +1,174 @@
+{
+  "schemaVersion": "language-morphism-draft-v0.1.0",
+  "kind": "LanguageMorphismMemento",
+  "status": "draft",
+  "name": "proofir-c11-algebra-to-x86-64-sysv-core",
+  "author": "T Savo",
+  "mode": "compile",
+  "source": {
+    "kind": "ProofIRTermSignature",
+    "language": "c:c11",
+    "signatureCid": "blake3-512:c942ba70e4b701e139a46590116f5cdc16ab41db277e80e54c01f23e4a7cf6241d4431c60473409cb3f0b61ce27f593071c1c224291f04c61aa04b4773764945",
+    "termEnvelopeKind": "c11-algebra-term",
+    "operationSet": "menagerie/c11-language-signature/catalog/algorithms"
+  },
+  "target": {
+    "kind": "TargetSignature",
+    "language": "x86-64:sysv",
+    "artifactKind": "assembly-source",
+    "mediaType": "text/x-asm",
+    "syntax": "intel",
+    "abi": "System V AMD64 integer subset",
+    "targetSignatureSpec": "../../provekit-lift-asm-x86-64/specs/x86_64_sysv_signature.spec.json"
+  },
+  "compiler": {
+    "crate": "provekit-ir-compiler-x86-64",
+    "binary": "provekit-ir-x86-64",
+    "version": "0.1.0",
+    "determinism": "byte-equal term JSON and target descriptor produce byte-equal assembly"
+  },
+  "operationRealizations": [
+    {
+      "sourceOperation": "seq",
+      "targetRealization": "emit first statement followed by second statement",
+      "x86Instructions": []
+    },
+    {
+      "sourceOperation": "if",
+      "targetRealization": "compile condition to eax, compare against zero, branch to else label with je",
+      "x86Instructions": ["cmp", "je", "jmp"]
+    },
+    {
+      "sourceOperation": "while",
+      "targetRealization": "emit loop head label, condition compare, exit branch, body, and back edge",
+      "x86Instructions": ["cmp", "je", "jmp"],
+      "refusal": "nontrivial invariant payloads are refused until invariant discharge is represented"
+    },
+    {
+      "sourceOperation": "return",
+      "targetRealization": "compile expression to eax and ret",
+      "x86Instructions": ["mov", "ret"]
+    },
+    {
+      "sourceOperation": "call",
+      "targetRealization": "compile up to six integer arguments into rdi, rsi, rdx, rcx, r8, r9 with SysV stack alignment, then call",
+      "x86Instructions": ["mov", "push", "pop", "sub", "call", "add"]
+    },
+    {
+      "sourceOperation": "break",
+      "targetRealization": "jump to the innermost loop exit label",
+      "x86Instructions": ["jmp"]
+    },
+    {
+      "sourceOperation": "continue",
+      "targetRealization": "jump to the innermost loop head label",
+      "x86Instructions": ["jmp"]
+    },
+    {
+      "sourceOperation": "skip",
+      "targetRealization": "emit no instruction",
+      "x86Instructions": []
+    },
+    {
+      "sourceOperation": "eq",
+      "targetRealization": "cmp operands and set al with sete, then zero extend to eax",
+      "x86Instructions": ["cmp", "sete", "movzx"]
+    },
+    {
+      "sourceOperation": "lt",
+      "targetRealization": "cmp operands and set al with setl, then zero extend to eax",
+      "x86Instructions": ["cmp", "setl", "movzx"]
+    },
+    {
+      "sourceOperation": "le",
+      "targetRealization": "cmp operands and set al with setle, then zero extend to eax",
+      "x86Instructions": ["cmp", "setle", "movzx"]
+    },
+    {
+      "sourceOperation": "add",
+      "targetRealization": "compile lhs to eax, rhs to ecx, add eax, ecx",
+      "x86Instructions": ["push", "pop", "add"]
+    },
+    {
+      "sourceOperation": "sub",
+      "targetRealization": "compile lhs to eax, rhs to ecx, sub eax, ecx",
+      "x86Instructions": ["push", "pop", "sub"]
+    },
+    {
+      "sourceOperation": "mul",
+      "targetRealization": "compile lhs to eax, rhs to ecx, imul eax, ecx",
+      "x86Instructions": ["push", "pop", "imul"]
+    },
+    {
+      "sourceOperation": "neg",
+      "targetRealization": "compile operand to eax and neg eax",
+      "x86Instructions": ["neg"]
+    },
+    {
+      "sourceOperation": "and",
+      "targetRealization": "normalize operands to zero or one and emit and eax, ecx",
+      "x86Instructions": ["cmp", "setne", "movzx", "and"]
+    },
+    {
+      "sourceOperation": "or",
+      "targetRealization": "normalize operands to zero or one and emit or eax, ecx",
+      "x86Instructions": ["cmp", "setne", "movzx", "or"]
+    },
+    {
+      "sourceOperation": "not",
+      "targetRealization": "compare operand against zero and emit sete",
+      "x86Instructions": ["cmp", "sete", "movzx"]
+    },
+    {
+      "sourceOperation": "var",
+      "targetRealization": "read the deterministic SysV integer argument register assigned by first occurrence order",
+      "x86Instructions": ["mov"]
+    },
+    {
+      "sourceOperation": "const",
+      "targetRealization": "move integer literal into eax",
+      "x86Instructions": ["mov"]
+    },
+    {
+      "sourceOperation": "deref",
+      "targetRealization": "compile address to rax and load DWORD PTR [rax] into eax",
+      "x86Instructions": ["mov"]
+    },
+    {
+      "sourceOperation": "assign",
+      "targetRealization": "store eax into an assigned variable register or DWORD PTR [address]",
+      "x86Instructions": ["mov"]
+    }
+  ],
+  "homomorphismObligation": {
+    "statement": "For every supported source operation op, compile(apply(op, args)) equals target_apply(image(op), compile(args)) under the x86-64:sysv operational semantics.",
+    "equations": [
+      "seq-assoc",
+      "seq-skip-left",
+      "seq-skip-right",
+      "if-true",
+      "if-false",
+      "if-idemp",
+      "while-false",
+      "not-not",
+      "and-true",
+      "and-false",
+      "or-true",
+      "or-false"
+    ],
+    "dischargeStatus": "draft only, no MorphismDischargeReceipt minted in this crate"
+  },
+  "contractPreservation": {
+    "statement": "For any accepted term t in the core subset, contract(lift_x86_64_sysv(compile_x86_64_sysv(t))) equals repr_x86_64_sysv(contract(t)).",
+    "composition": "A C lifter receipt plus this compile morphism receipt plus the x86-64 lifter receipt gives the ORP v0.2 round trip theorem."
+  },
+  "refusalPolicy": {
+    "unsupportedOperations": "return a refusal through CompileError rather than emit opaque or partial assembly",
+    "unsupportedSorts": "non-integer constants and non-core target shapes are refused",
+    "loops": "loop invariant payloads outside the unit or absent shape are refused"
+  },
+  "notes": [
+    "This is a draft spec artifact. It is not signed or minted in this crate.",
+    "The core subset is hand mapped. The full operation set is mint-more-realizations, not new machinery."
+  ]
+}

--- a/implementations/rust/provekit-ir-compiler-x86-64/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-x86-64/src/generated.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Hand-maintained operation table for the current core subset. The full
+// C11 operation set should mint more realization rows, not new machinery.
+
+pub const CORE_OPERATION_SUBSET: &[&str] = &[
+    "seq", "if", "while", "return", "call", "break", "continue", "skip", "eq", "lt", "le", "add",
+    "sub", "mul", "neg", "and", "or", "not", "deref", "assign",
+];
+
+pub const LANGUAGE_MORPHISM_TABLE: &[(&str, &str)] = &[
+    ("seq(a, b)", "emit a followed by b"),
+    (
+        "if(c, a, b)",
+        "compile c to eax, cmp eax, 0, branch with je",
+    ),
+    (
+        "while(c, b)",
+        "loop label, condition compare, exit branch, body, back edge",
+    ),
+    ("return(e)", "compile e to eax, ret"),
+    (
+        "call(f, args)",
+        "SysV integer argument registers, call f, result in eax",
+    ),
+    ("break", "jump to innermost loop exit label"),
+    ("continue", "jump to innermost loop head label"),
+    ("skip", "emit no instruction"),
+    ("eq(a, b)", "cmp a, b followed by sete"),
+    ("lt(a, b)", "cmp a, b followed by setl"),
+    ("le(a, b)", "cmp a, b followed by setle"),
+    ("add(a, b)", "add eax, ecx"),
+    ("sub(a, b)", "sub eax, ecx"),
+    ("mul(a, b)", "imul eax, ecx"),
+    ("neg(a)", "neg eax"),
+    ("and(a, b)", "normalize to 0 or 1, and eax, ecx"),
+    ("or(a, b)", "normalize to 0 or 1, or eax, ecx"),
+    ("not(a)", "cmp eax, 0 followed by sete"),
+    ("var(x)", "move from assigned SysV argument register"),
+    ("const(i)", "mov eax, immediate"),
+    ("deref(p)", "load DWORD PTR [address]"),
+    (
+        "assign(x, e)",
+        "compile e and store into x or DWORD PTR [address]",
+    ),
+];

--- a/implementations/rust/provekit-ir-compiler-x86-64/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-x86-64/src/lib.rs
@@ -1,0 +1,692 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ORP v0.2 compile-mode realizer for ProofIR terms targeting x86-64 SysV.
+
+use std::path::Path;
+
+use provekit_ir_compiler::{
+    Capabilities, CompileError, CompiledFormula, FreeVar, IrCompiler, OpacityManifest,
+    PROTOCOL_VERSION,
+};
+use serde_json::Value as Json;
+
+mod generated;
+
+pub use generated::{CORE_OPERATION_SUBSET, LANGUAGE_MORPHISM_TABLE};
+
+pub const DIALECT: &str = "x86-64:sysv";
+pub const COMPILER_NAME: &str = "x86-64-sysv-core";
+pub const COMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const ARG_REGS_32: [&str; 6] = ["edi", "esi", "edx", "ecx", "r8d", "r9d"];
+const ARG_REGS_64: [&str; 6] = ["rdi", "rsi", "rdx", "rcx", "r8", "r9"];
+
+pub trait TermCompiler {
+    fn compile_term_json(&self, ir: &Json) -> Result<String, CompileError>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct X8664Compiler;
+
+impl X8664Compiler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl TermCompiler for X8664Compiler {
+    fn compile_term_json(&self, ir: &Json) -> Result<String, CompileError> {
+        let term = root_term(ir)?;
+        let function = function_name(ir);
+        let mut vars = Vec::new();
+        collect_vars(term, &mut vars);
+        if vars.len() > ARG_REGS_32.len() {
+            return Err(CompileError::UnsupportedPredicate(format!(
+                "x86-64 core compiler supports at most {} integer arguments",
+                ARG_REGS_32.len()
+            )));
+        }
+
+        let mut lowerer = Lowerer::new(function, vars);
+        lowerer.compile_function(term)
+    }
+}
+
+impl IrCompiler for X8664Compiler {
+    fn compile(&self, ir: &Json, dialect: &str) -> Result<CompiledFormula, CompileError> {
+        if dialect != DIALECT {
+            return Err(CompileError::UnsupportedDialect(dialect.to_string()));
+        }
+        let body = self.compile_term_json(ir)?;
+        Ok(CompiledFormula {
+            preamble: String::new(),
+            body,
+            free_vars: Vec::<FreeVar>::new(),
+            opacity_manifest: OpacityManifest {
+                protocol_version: "ir-compiler-protocol/2".to_string(),
+                compiler: DIALECT.to_string(),
+                compiler_version: COMPILER_VERSION.to_string(),
+                opacities: vec![],
+            },
+        })
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            name: COMPILER_NAME.to_string(),
+            version: COMPILER_VERSION.to_string(),
+            protocol_version: PROTOCOL_VERSION.to_string(),
+            dialects: vec![DIALECT.to_string()],
+            supported_sorts: vec![
+                "Int".to_string(),
+                "Bool".to_string(),
+                "Ptr".to_string(),
+                "LValue".to_string(),
+                "Stmt".to_string(),
+                "Unit".to_string(),
+            ],
+            supported_predicates: CORE_OPERATION_SUBSET
+                .iter()
+                .map(|op| (*op).to_string())
+                .collect(),
+        }
+    }
+}
+
+pub fn emit(ir: &Json) -> Result<String, CompileError> {
+    X8664Compiler::new().compile_term_json(ir)
+}
+
+#[derive(Debug, Clone)]
+struct LoopLabels {
+    continue_label: String,
+    break_label: String,
+}
+
+struct Lowerer {
+    function: String,
+    vars: Vec<String>,
+    out: String,
+    label_counter: usize,
+    stack_slots: usize,
+    loop_stack: Vec<LoopLabels>,
+}
+
+impl Lowerer {
+    fn new(function: String, vars: Vec<String>) -> Self {
+        Self {
+            function,
+            vars,
+            out: String::new(),
+            label_counter: 0,
+            stack_slots: 0,
+            loop_stack: Vec::new(),
+        }
+    }
+
+    fn compile_function(&mut self, term: &Json) -> Result<String, CompileError> {
+        self.out.push_str(".intel_syntax noprefix\n");
+        self.out.push_str(".text\n");
+        self.out.push_str(&format!(".globl {}\n", self.function));
+        self.out
+            .push_str(&format!(".type {}, @function\n", self.function));
+        self.out.push_str(&format!("{}:\n", self.function));
+        self.compile_stmt(term)?;
+        if stmt_falls_through(term) {
+            self.inst("xor", "eax, eax");
+            self.inst0("ret");
+        }
+        self.out
+            .push_str(&format!(".size {}, .-{}\n", self.function, self.function));
+        self.out
+            .push_str(".section .note.GNU-stack,\"\",@progbits\n");
+        Ok(std::mem::take(&mut self.out))
+    }
+
+    fn compile_stmt(&mut self, term: &Json) -> Result<(), CompileError> {
+        match term_kind(term)? {
+            "unit" => Ok(()),
+            "op" => match op_name(term)? {
+                "seq" => {
+                    let args = op_args(term)?;
+                    expect_arity("seq", args, 2)?;
+                    self.compile_stmt(&args[0])?;
+                    if stmt_falls_through(&args[0]) {
+                        self.compile_stmt(&args[1])?;
+                    }
+                    Ok(())
+                }
+                "if" => {
+                    let args = op_args(term)?;
+                    expect_arity("if", args, 3)?;
+                    let else_label = self.fresh_label("else");
+                    let end_label = self.fresh_label("end");
+                    self.compile_expr(&args[0])?;
+                    self.inst("cmp", "eax, 0");
+                    self.inst("je", &else_label);
+                    self.compile_stmt(&args[1])?;
+                    if stmt_falls_through(&args[1]) {
+                        self.inst("jmp", &end_label);
+                    }
+                    self.label(&else_label);
+                    self.compile_stmt(&args[2])?;
+                    self.label(&end_label);
+                    Ok(())
+                }
+                "while" => {
+                    let args = op_args(term)?;
+                    if args.len() < 2 {
+                        return Err(malformed("while expects at least 2 args"));
+                    }
+                    if let Some(invariant) = term.get("invariant").or_else(|| args.get(2)) {
+                        if !is_unit(invariant) {
+                            return Err(CompileError::UnsupportedPredicate(
+                                "unsupported while invariant shape".to_string(),
+                            ));
+                        }
+                    }
+
+                    let head_label = self.fresh_label("loop");
+                    let end_label = self.fresh_label("end");
+                    self.label(&head_label);
+                    self.compile_expr(&args[0])?;
+                    self.inst("cmp", "eax, 0");
+                    self.inst("je", &end_label);
+                    self.loop_stack.push(LoopLabels {
+                        continue_label: head_label.clone(),
+                        break_label: end_label.clone(),
+                    });
+                    self.compile_stmt(&args[1])?;
+                    self.loop_stack.pop();
+                    if stmt_falls_through(&args[1]) {
+                        self.inst("jmp", &head_label);
+                    }
+                    self.label(&end_label);
+                    Ok(())
+                }
+                "return" => {
+                    let args = op_args(term)?;
+                    expect_arity("return", args, 1)?;
+                    self.compile_expr(&args[0])?;
+                    self.inst0("ret");
+                    Ok(())
+                }
+                "call" => {
+                    self.compile_call(term)?;
+                    Ok(())
+                }
+                "break" => {
+                    let break_label = self
+                        .loop_stack
+                        .last()
+                        .ok_or_else(|| malformed("break outside loop"))?
+                        .break_label
+                        .clone();
+                    self.inst("jmp", &break_label);
+                    Ok(())
+                }
+                "continue" => {
+                    let continue_label = self
+                        .loop_stack
+                        .last()
+                        .ok_or_else(|| malformed("continue outside loop"))?
+                        .continue_label
+                        .clone();
+                    self.inst("jmp", &continue_label);
+                    Ok(())
+                }
+                "skip" => Ok(()),
+                "assign" => self.compile_assign(term),
+                name => Err(unsupported_operation(name)),
+            },
+            _ => {
+                self.compile_expr(term)?;
+                Ok(())
+            }
+        }
+    }
+
+    fn compile_expr(&mut self, term: &Json) -> Result<(), CompileError> {
+        match term_kind(term)? {
+            "var" => {
+                let name = var_name(term)?;
+                let index = self.var_index(name)?;
+                self.inst("mov", &format!("eax, {}", ARG_REGS_32[index]));
+                Ok(())
+            }
+            "const" => {
+                let value = int_value(term)?;
+                self.inst("mov", &format!("eax, {value}"));
+                Ok(())
+            }
+            "op" => match op_name(term)? {
+                "add" => self.compile_binary_arith(term, "add"),
+                "sub" => self.compile_binary_arith(term, "sub"),
+                "mul" => self.compile_binary_arith(term, "imul"),
+                "neg" => {
+                    let args = op_args(term)?;
+                    expect_arity("neg", args, 1)?;
+                    self.compile_expr(&args[0])?;
+                    self.inst0("neg     eax");
+                    Ok(())
+                }
+                "eq" => self.compile_compare(term, "sete"),
+                "lt" => self.compile_compare(term, "setl"),
+                "le" => self.compile_compare(term, "setle"),
+                "and" => self.compile_logical_binary(term, "and"),
+                "or" => self.compile_logical_binary(term, "or"),
+                "not" => {
+                    let args = op_args(term)?;
+                    expect_arity("not", args, 1)?;
+                    self.compile_expr(&args[0])?;
+                    self.inst("cmp", "eax, 0");
+                    self.inst("sete", "al");
+                    self.inst("movzx", "eax, al");
+                    Ok(())
+                }
+                "deref" => {
+                    let args = op_args(term)?;
+                    expect_arity("deref", args, 1)?;
+                    self.compile_address(&args[0])?;
+                    self.inst("mov", "eax, DWORD PTR [rax]");
+                    Ok(())
+                }
+                "call" => self.compile_call(term),
+                "assign" => self.compile_assign(term),
+                name => Err(unsupported_operation(name)),
+            },
+            other => Err(malformed(format!("unsupported expression kind {other}"))),
+        }
+    }
+
+    fn compile_binary_arith(&mut self, term: &Json, mnemonic: &str) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity(op_name(term)?, args, 2)?;
+        self.compile_expr(&args[0])?;
+        self.push_rax();
+        self.compile_expr(&args[1])?;
+        self.inst("mov", "ecx, eax");
+        self.pop_to("rax");
+        self.inst(mnemonic, "eax, ecx");
+        Ok(())
+    }
+
+    fn compile_compare(&mut self, term: &Json, setcc: &str) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity(op_name(term)?, args, 2)?;
+        self.compile_expr(&args[0])?;
+        if term_kind(&args[1])? == "const" {
+            let value = int_value(&args[1])?;
+            self.inst("cmp", &format!("eax, {value}"));
+        } else {
+            self.push_rax();
+            self.compile_expr(&args[1])?;
+            self.inst("mov", "ecx, eax");
+            self.pop_to("rax");
+            self.inst("cmp", "eax, ecx");
+        }
+        self.inst(setcc, "al");
+        self.inst("movzx", "eax, al");
+        Ok(())
+    }
+
+    fn compile_logical_binary(&mut self, term: &Json, mnemonic: &str) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity(op_name(term)?, args, 2)?;
+        self.compile_expr(&args[0])?;
+        self.inst("cmp", "eax, 0");
+        self.inst("setne", "al");
+        self.inst("movzx", "eax, al");
+        self.push_rax();
+        self.compile_expr(&args[1])?;
+        self.inst("cmp", "eax, 0");
+        self.inst("setne", "al");
+        self.inst("movzx", "eax, al");
+        self.inst("mov", "ecx, eax");
+        self.pop_to("rax");
+        self.inst(mnemonic, "eax, ecx");
+        Ok(())
+    }
+
+    fn compile_assign(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity("assign", args, 2)?;
+        let target = &args[0];
+        let value = &args[1];
+        if term_kind(target)? == "var" {
+            self.compile_expr(value)?;
+            let index = self.var_index(var_name(target)?)?;
+            self.inst("mov", &format!("{}, eax", ARG_REGS_32[index]));
+            return Ok(());
+        }
+
+        if term_kind(target)? == "op" && op_name(target)? == "deref" {
+            let target_args = op_args(target)?;
+            expect_arity("deref", target_args, 1)?;
+            self.compile_expr(value)?;
+            self.push_rax();
+            self.compile_address(&target_args[0])?;
+            self.inst("mov", "rdx, rax");
+            self.pop_to("rax");
+            self.inst("mov", "DWORD PTR [rdx], eax");
+            return Ok(());
+        }
+
+        Err(CompileError::UnsupportedPredicate(
+            "unsupported assign target".to_string(),
+        ))
+    }
+
+    fn compile_address(&mut self, term: &Json) -> Result<(), CompileError> {
+        match term_kind(term)? {
+            "var" => {
+                let index = self.var_index(var_name(term)?)?;
+                self.inst("mov", &format!("rax, {}", ARG_REGS_64[index]));
+                Ok(())
+            }
+            "const" => {
+                let value = int_value(term)?;
+                self.inst("mov", &format!("rax, {value}"));
+                Ok(())
+            }
+            "op" if op_name(term)? == "deref" => {
+                let args = op_args(term)?;
+                expect_arity("deref", args, 1)?;
+                self.compile_address(&args[0])
+            }
+            "op" => {
+                self.compile_expr(term)?;
+                self.inst0("movsxd  rax, eax");
+                Ok(())
+            }
+            other => Err(malformed(format!("unsupported address kind {other}"))),
+        }
+    }
+
+    fn compile_call(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        if args.is_empty() {
+            return Err(malformed("call expects a callee"));
+        }
+        let callee = callee_name(&args[0])?;
+        let call_args = call_arguments(args)?;
+        if call_args.len() > ARG_REGS_64.len() {
+            return Err(CompileError::UnsupportedPredicate(format!(
+                "x86-64 SysV core call supports at most {} integer arguments",
+                ARG_REGS_64.len()
+            )));
+        }
+
+        for arg in &call_args {
+            self.compile_expr(arg)?;
+            self.push_rax();
+        }
+        for (index, _) in call_args.iter().enumerate().rev() {
+            self.pop_to(ARG_REGS_64[index]);
+        }
+
+        let needs_alignment_pad = self.stack_slots.is_multiple_of(2);
+        if needs_alignment_pad {
+            self.inst("sub", "rsp, 8");
+            self.stack_slots += 1;
+        }
+        self.inst("call", &callee);
+        if needs_alignment_pad {
+            self.inst("add", "rsp, 8");
+            self.stack_slots -= 1;
+        }
+        Ok(())
+    }
+
+    fn var_index(&self, name: &str) -> Result<usize, CompileError> {
+        self.vars
+            .iter()
+            .position(|var| var == name)
+            .ok_or_else(|| malformed(format!("unknown variable {name}")))
+    }
+
+    fn fresh_label(&mut self, kind: &str) -> String {
+        let label = format!(".L_{kind}_{}", self.label_counter);
+        self.label_counter += 1;
+        label
+    }
+
+    fn label(&mut self, name: &str) {
+        self.out.push_str(name);
+        self.out.push_str(":\n");
+    }
+
+    fn inst(&mut self, mnemonic: &str, operands: &str) {
+        self.out
+            .push_str(&format!("    {mnemonic:<7} {operands}\n"));
+    }
+
+    fn inst0(&mut self, text: &str) {
+        self.out.push_str("    ");
+        self.out.push_str(text);
+        self.out.push('\n');
+    }
+
+    fn push_rax(&mut self) {
+        self.inst0("push    rax");
+        self.stack_slots += 1;
+    }
+
+    fn pop_to(&mut self, register: &str) {
+        self.inst0(&format!("pop     {register}"));
+        self.stack_slots -= 1;
+    }
+}
+
+fn root_term(ir: &Json) -> Result<&Json, CompileError> {
+    match ir.get("kind").and_then(Json::as_str) {
+        Some("c11-algebra-term") => ir
+            .get("term")
+            .ok_or_else(|| malformed("c11 algebra term envelope missing term")),
+        _ => Ok(ir),
+    }
+}
+
+fn function_name(ir: &Json) -> String {
+    for key in ["function", "function_name", "fn_name"] {
+        if let Some(name) = ir.get(key).and_then(Json::as_str) {
+            return sanitize_symbol(name);
+        }
+    }
+    if let Some(source) = ir.get("source").and_then(Json::as_str) {
+        if let Some(stem) = Path::new(source).file_stem().and_then(|stem| stem.to_str()) {
+            return sanitize_symbol(stem);
+        }
+    }
+    "proofir_term".to_string()
+}
+
+fn sanitize_symbol(name: &str) -> String {
+    let mut out = String::new();
+    for (index, ch) in name.chars().enumerate() {
+        let valid = ch.is_ascii_alphanumeric() || ch == '_';
+        if valid && !(index == 0 && ch.is_ascii_digit()) {
+            out.push(ch);
+        } else if valid {
+            out.push('_');
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        "proofir_term".to_string()
+    } else {
+        out
+    }
+}
+
+fn collect_vars(term: &Json, vars: &mut Vec<String>) {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("var") => {
+            if let Some(name) = term.get("name").and_then(Json::as_str) {
+                push_unique(vars, name);
+            }
+        }
+        Some("op") if term.get("name").and_then(Json::as_str) == Some("call") => {
+            if let Some(args) = term.get("args").and_then(Json::as_array) {
+                if let Ok(call_args) = call_arguments(args) {
+                    for arg in call_args {
+                        collect_vars(arg, vars);
+                    }
+                }
+            }
+        }
+        Some("op") | Some("ctor") => {
+            if let Some(args) = term.get("args").and_then(Json::as_array) {
+                for arg in args {
+                    collect_vars(arg, vars);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_unique(vars: &mut Vec<String>, name: &str) {
+    if !vars.iter().any(|existing| existing == name) {
+        vars.push(name.to_string());
+    }
+}
+
+fn call_arguments(args: &[Json]) -> Result<Vec<&Json>, CompileError> {
+    match args {
+        [_callee] => Ok(Vec::new()),
+        [_callee, maybe_list] if term_kind(maybe_list)? == "ctor" => Ok(maybe_list
+            .get("args")
+            .and_then(Json::as_array)
+            .map(|items| items.iter().collect())
+            .unwrap_or_default()),
+        [_callee, maybe_unit] if is_unit(maybe_unit) => Ok(Vec::new()),
+        [_callee, rest @ ..] => Ok(rest.iter().collect()),
+        [] => Err(malformed("call expects a callee")),
+    }
+}
+
+fn callee_name(term: &Json) -> Result<String, CompileError> {
+    match term_kind(term)? {
+        "var" => Ok(sanitize_symbol(var_name(term)?)),
+        "const" => term
+            .get("value")
+            .and_then(Json::as_str)
+            .map(sanitize_symbol)
+            .ok_or_else(|| malformed("call callee const must be a string")),
+        "ctor" => term
+            .get("name")
+            .and_then(Json::as_str)
+            .map(sanitize_symbol)
+            .ok_or_else(|| malformed("call callee ctor missing name")),
+        other => Err(malformed(format!("unsupported callee kind {other}"))),
+    }
+}
+
+fn stmt_falls_through(term: &Json) -> bool {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("op") => match term.get("name").and_then(Json::as_str).unwrap_or_default() {
+            "return" | "break" | "continue" => false,
+            "seq" => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_none_or(|args| args.last().is_none_or(stmt_falls_through)),
+            "if" => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_none_or(|args| {
+                    args.get(1).is_none_or(stmt_falls_through)
+                        || args.get(2).is_none_or(stmt_falls_through)
+                }),
+            _ => true,
+        },
+        _ => true,
+    }
+}
+
+fn term_kind(term: &Json) -> Result<&str, CompileError> {
+    term.get("kind")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("term missing kind"))
+}
+
+fn op_name(term: &Json) -> Result<&str, CompileError> {
+    term.get("name")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("op missing name"))
+}
+
+fn op_args(term: &Json) -> Result<&[Json], CompileError> {
+    term.get("args")
+        .and_then(Json::as_array)
+        .map(Vec::as_slice)
+        .ok_or_else(|| malformed("op missing args"))
+}
+
+fn var_name(term: &Json) -> Result<&str, CompileError> {
+    term.get("name")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("var missing name"))
+}
+
+fn int_value(term: &Json) -> Result<i64, CompileError> {
+    term.get("value")
+        .and_then(Json::as_i64)
+        .ok_or_else(|| CompileError::UnsupportedSort("only integer constants are supported".into()))
+}
+
+fn is_unit(term: &Json) -> bool {
+    term.get("kind").and_then(Json::as_str) == Some("unit")
+        || (term.get("kind").and_then(Json::as_str) == Some("op")
+            && term.get("name").and_then(Json::as_str) == Some("skip"))
+}
+
+fn expect_arity(name: &str, args: &[Json], arity: usize) -> Result<(), CompileError> {
+    if args.len() == arity {
+        Ok(())
+    } else {
+        Err(malformed(format!(
+            "{name} expects {arity} args, got {}",
+            args.len()
+        )))
+    }
+}
+
+fn malformed(message: impl Into<String>) -> CompileError {
+    CompileError::MalformedIr(message.into())
+}
+
+fn unsupported_operation(name: &str) -> CompileError {
+    CompileError::UnsupportedPredicate(format!("unsupported operation {name}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_function_name_uses_source_stem() {
+        let ir = json!({
+            "kind": "c11-algebra-term",
+            "source": "path/to/foo.c",
+            "term": {"kind": "op", "name": "skip", "args": [{"kind": "unit"}]}
+        });
+
+        let asm = X8664Compiler::new()
+            .compile_term_json(&ir)
+            .expect("compile");
+
+        assert!(asm.contains(".globl foo\n"));
+    }
+
+    #[test]
+    fn capabilities_include_core_ops() {
+        let caps = X8664Compiler::new().capabilities();
+        for op in CORE_OPERATION_SUBSET {
+            assert!(caps.supported_predicates.iter().any(|item| item == op));
+        }
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-x86-64/src/main.rs
+++ b/implementations/rust/provekit-ir-compiler-x86-64/src/main.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binary entry point for provekit-ir-compiler-x86-64.
+//
+// Reads ProofIR term JSON from stdin and emits x86-64 SysV assembly.
+
+use provekit_ir_compiler_x86_64::{TermCompiler, X8664Compiler};
+use serde_json::Value as Json;
+use std::io::{self, Read, Write};
+
+fn main() {
+    let mut input = String::new();
+    if let Err(error) = io::stdin().read_to_string(&mut input) {
+        eprintln!("Error reading stdin: {error}");
+        std::process::exit(1);
+    }
+
+    let ir: Json = match serde_json::from_str(&input) {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!("Error parsing JSON: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    let compiler = X8664Compiler::new();
+    let asm = match compiler.compile_term_json(&ir) {
+        Ok(asm) => asm,
+        Err(error) => {
+            eprintln!("Error compiling IR to x86-64: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(error) = io::stdout().write_all(asm.as_bytes()) {
+        eprintln!("Error writing assembly: {error}");
+        std::process::exit(1);
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-x86-64/tests/byte_for_byte.rs
+++ b/implementations/rust/provekit-ir-compiler-x86-64/tests/byte_for_byte.rs
@@ -1,0 +1,71 @@
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_x86_64::{emit, X8664Compiler, DIALECT};
+use serde_json::json;
+
+fn fixtures() -> Vec<serde_json::Value> {
+    vec![
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("foo fixture"),
+        json!({
+            "kind": "op",
+            "name": "return",
+            "args": [{
+                "kind": "op",
+                "name": "sub",
+                "args": [
+                    {"kind": "var", "name": "x"},
+                    {"kind": "const", "value": 7, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                ]
+            }]
+        }),
+        json!({
+            "kind": "op",
+            "name": "return",
+            "args": [{
+                "kind": "op",
+                "name": "or",
+                "args": [
+                    {"kind": "op", "name": "eq", "args": [
+                        {"kind": "var", "name": "x"},
+                        {"kind": "const", "value": 1, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                    ]},
+                    {"kind": "op", "name": "lt", "args": [
+                        {"kind": "var", "name": "y"},
+                        {"kind": "const", "value": 9, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                    ]}
+                ]
+            }]
+        }),
+    ]
+}
+
+#[test]
+fn emit_is_byte_deterministic() {
+    for fixture in fixtures() {
+        let first = emit(&fixture).expect("first emit");
+        let second = emit(&fixture).expect("second emit");
+        assert_eq!(first, second);
+    }
+}
+
+#[test]
+fn trait_compile_body_equals_emit_string() {
+    let compiler = X8664Compiler::new();
+    for fixture in fixtures() {
+        let through_trait = compiler.compile(&fixture, DIALECT).expect("compile");
+        let direct = emit(&fixture).expect("emit");
+        assert_eq!(through_trait.preamble, "");
+        assert_eq!(through_trait.body, direct);
+        assert_eq!(through_trait.free_vars.len(), 0);
+    }
+}
+
+#[test]
+fn trait_compile_rejects_wrong_dialect() {
+    let compiler = X8664Compiler::new();
+    let term = json!({"kind": "op", "name": "skip", "args": [{"kind": "unit"}]});
+    let result = compiler.compile(&term, "coq");
+    assert!(matches!(
+        result,
+        Err(provekit_ir_compiler::CompileError::UnsupportedDialect(_))
+    ));
+}

--- a/implementations/rust/provekit-ir-compiler-x86-64/tests/fixtures/foo.expected.s
+++ b/implementations/rust/provekit-ir-compiler-x86-64/tests/fixtures/foo.expected.s
@@ -1,0 +1,20 @@
+.intel_syntax noprefix
+.text
+.globl foo
+.type foo, @function
+foo:
+    mov     eax, edi
+    cmp     eax, 0
+    sete    al
+    movzx   eax, al
+    cmp     eax, 0
+    je      .L_else_0
+    mov     eax, 22
+    neg     eax
+    ret
+.L_else_0:
+.L_end_1:
+    mov     eax, edi
+    ret
+.size foo, .-foo
+.section .note.GNU-stack,"",@progbits

--- a/implementations/rust/provekit-ir-compiler-x86-64/tests/fixtures/foo.term.json
+++ b/implementations/rust/provekit-ir-compiler-x86-64/tests/fixtures/foo.term.json
@@ -1,0 +1,78 @@
+{
+  "kind": "c11-algebra-term",
+  "signature_cid": "blake3-512:c942ba70e4b701e139a46590116f5cdc16ab41db277e80e54c01f23e4a7cf6241d4431c60473409cb3f0b61ce27f593071c1c224291f04c61aa04b4773764945",
+  "source": "foo.c",
+  "term_surface": "seq(if(eq(x, 0), return(neg(22)), skip), return(x))",
+  "term": {
+    "kind": "op",
+    "name": "seq",
+    "args": [
+      {
+        "kind": "op",
+        "name": "if",
+        "args": [
+          {
+            "kind": "op",
+            "name": "eq",
+            "args": [
+              {
+                "kind": "var",
+                "name": "x"
+              },
+              {
+                "kind": "const",
+                "value": 0,
+                "sort": {
+                  "kind": "ctor",
+                  "name": "Int",
+                  "args": []
+                }
+              }
+            ]
+          },
+          {
+            "kind": "op",
+            "name": "return",
+            "args": [
+              {
+                "kind": "op",
+                "name": "neg",
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": 22,
+                    "sort": {
+                      "kind": "ctor",
+                      "name": "Int",
+                      "args": []
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "op",
+            "name": "skip",
+            "args": [
+              {
+                "kind": "unit"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "op",
+        "name": "return",
+        "args": [
+          {
+            "kind": "var",
+            "name": "x"
+          }
+        ]
+      }
+    ]
+  },
+  "wp_value_note": "The branch-sensitive WP value is recorded in foo.expected-wp-contract.json. The current c-collectors-defensive lifter emits the same branch-sensitive contract in foo.contract.json."
+}

--- a/implementations/rust/provekit-ir-compiler-x86-64/tests/smoke.rs
+++ b/implementations/rust/provekit-ir-compiler-x86-64/tests/smoke.rs
@@ -1,0 +1,122 @@
+use std::fs;
+use std::process::Command;
+
+use provekit_ir_compiler_x86_64::{TermCompiler, X8664Compiler};
+use serde_json::json;
+
+#[test]
+fn smoke_compiles_foo_term_byte_for_byte() {
+    let input: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("fixture json");
+    let expected = include_str!("fixtures/foo.expected.s");
+
+    let asm = X8664Compiler::new()
+        .compile_term_json(&input)
+        .expect("foo term compiles");
+
+    assert_eq!(asm, expected);
+}
+
+#[test]
+fn lowers_arithmetic_and_comparison_ops() {
+    let compiler = X8664Compiler::new();
+    let term = json!({
+        "kind": "op",
+        "name": "return",
+        "args": [{
+            "kind": "op",
+            "name": "add",
+            "args": [
+                {"kind": "var", "name": "x"},
+                {
+                    "kind": "op",
+                    "name": "mul",
+                    "args": [
+                        {"kind": "const", "value": 2, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                        {"kind": "const", "value": 3, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                    ]
+                }
+            ]
+        }]
+    });
+
+    let asm = compiler.compile_term_json(&term).expect("term compiles");
+
+    assert!(asm.contains("imul    eax, ecx"));
+    assert!(asm.contains("add     eax, ecx"));
+    assert!(asm.contains("ret\n"));
+}
+
+#[test]
+fn refuses_unknown_operations() {
+    let compiler = X8664Compiler::new();
+    let term = json!({"kind": "op", "name": "switch", "args": []});
+
+    let err = compiler
+        .compile_term_json(&term)
+        .expect_err("switch is not core");
+
+    assert!(err.to_string().contains("unsupported operation switch"));
+}
+
+#[ignore = "requires GNU/Linux gcc or compatible x86-64 SysV assembler and runner"]
+#[test]
+fn ignored_assembles_and_runs_foo() {
+    if !has_linux_gcc() {
+        eprintln!("skipping: gcc is not a GNU/Linux x86-64 SysV toolchain");
+        return;
+    }
+
+    let input: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("fixture json");
+    let asm = X8664Compiler::new()
+        .compile_term_json(&input)
+        .expect("foo term compiles");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let asm_path = dir.path().join("foo.s");
+    let harness_path = dir.path().join("harness.c");
+    let bin_path = dir.path().join("harness");
+
+    fs::write(&asm_path, asm).expect("write asm");
+    fs::write(
+        &harness_path,
+        r#"
+int foo(int x);
+
+int main(void) {
+    if (foo(0) != -22) {
+        return 1;
+    }
+    if (foo(42) != 42) {
+        return 2;
+    }
+    return 0;
+}
+"#,
+    )
+    .expect("write harness");
+
+    let status = Command::new("gcc")
+        .arg(&harness_path)
+        .arg(&asm_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .status()
+        .expect("run gcc");
+    assert!(status.success(), "gcc failed with {status}");
+
+    let status = Command::new(&bin_path).status().expect("run harness");
+    assert!(status.success(), "harness failed with {status}");
+}
+
+fn has_linux_gcc() -> bool {
+    let Ok(output) = Command::new("gcc").arg("-dumpmachine").output() else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let machine = String::from_utf8_lossy(&output.stdout);
+    machine.contains("linux") && (machine.contains("x86_64") || machine.contains("amd64"))
+}


### PR DESCRIPTION
## Summary

`implementations/rust/provekit-ir-compiler-x86-64/` -- the x86-64 executable-target rung of the realizer family, dual to `provekit-ir-compiler-coq` (which is a realizer-to-a-prover); this one is a realizer-to-runnable-code. Implements ORP v0.2 `compile` mode: lowers a ProofIR term (AST over operation-CIDs, the `foo.term.json` format) to x86-64 SysV assembly (Intel syntax).

- Covers a core operation subset: `seq`, `if`, `while`, `return`, `call`, `break`, `continue`, `skip`, `eq`, `lt`, `le`, `add`, `sub`, `mul`, `neg`, `and`, `or`, `not`, variable reference, integer literal, `deref`, `assign`. Refuses on unhandled operations rather than miscompiling.
- Binary `provekit-ir-x86-64`: reads a term JSON from stdin, emits asm to stdout.
- Byte-deterministic emission (`tests/byte_for_byte.rs`). Smoke test on `foo`'s term: emits asm that computes `ite(x==0, -22, x)` (the harness-run test self-skips on a non-GNU/Linux-x86-64 toolchain).
- Draft `algebra -> x86-64:sysv` `LanguageMorphismMemento` spec at `specs/algebra_to_x86_64.spec.json` (the per-operation realization mapping, the homomorphism obligation, the contract-preservation statement, the refusal policy). Not minted (follow-up).
- `cargo build -p provekit-ir-compiler-x86-64`, `cargo test -p provekit-ir-compiler-x86-64` (8 pass, 1 ignored), `cargo clippy -p provekit-ir-compiler-x86-64 --no-deps -- -D warnings` all clean for the new crate. (Note: the full `cargo clippy -p provekit-ir-compiler-x86-64 -- -D warnings` is blocked by a pre-existing lint in `provekit-ir-compiler/src/manifest.rs:71` -- a separate follow-up, not introduced here.)

Deferred: full C11 operation coverage, real register allocation, stack-frame locals, richer widths, optimization, minted morphism receipts.

## Test plan

- [ ] `cargo build -p provekit-ir-compiler-x86-64`, `cargo test -p provekit-ir-compiler-x86-64`, `cargo clippy -p provekit-ir-compiler-x86-64 --no-deps -- -D warnings`
- [ ] On a GNU/Linux x86-64 host: assemble `foo`'s emitted asm + a harness; `foo(0) == -22`, `foo(42) == 42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)