### PR TITLE
feat: provekit-ir-compiler-wasm - ORP v0.2 compile mode (term -> WASM WAT)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1721,6 +1721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-ir-compiler-wasm"
+version = "0.1.0"
+dependencies = [
+ "provekit-ir-compiler",
+ "provekit-ir-types",
+ "serde_json",
+]
+
+[[package]]
 name = "provekit-ir-compiler-x86-64"
 version = "0.1.0"
 dependencies = [

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "provekit-ir-compiler-stub",
     "provekit-ir-compiler-coq",
     "provekit-ir-compiler-x86-64",
+    "provekit-ir-compiler-wasm",
     "provekit-ir-compiler-maude",
     "provekit-ir-compiler-lean",
     "provekit-ir-codegen",

--- a/implementations/rust/provekit-ir-compiler-wasm/Cargo.toml
+++ b/implementations/rust/provekit-ir-compiler-wasm/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "provekit-ir-compiler-wasm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "ProvekIt: WASM WAT compiler for ProofIR terms."
+
+[dependencies]
+provekit-ir-compiler = { path = "../provekit-ir-compiler" }
+provekit-ir-types = { path = "../provekit-ir-types" }
+serde_json.workspace = true
+
+[dev-dependencies]
+provekit-ir-compiler = { path = "../provekit-ir-compiler" }
+
+[[bin]]
+name = "provekit-ir-wasm"
+path = "src/main.rs"
+
+[lib]
+name = "provekit_ir_compiler_wasm"
+path = "src/lib.rs"

--- a/implementations/rust/provekit-ir-compiler-wasm/README.md
+++ b/implementations/rust/provekit-ir-compiler-wasm/README.md
@@ -1,0 +1,100 @@
+# provekit-ir-compiler-wasm
+
+`provekit-ir-compiler-wasm` is an ORP v0.2 `compile`-mode realizer for the
+ProofIR term stratum. It is the executable-target dual of
+`provekit-ir-compiler-coq`: Coq emits prover input for contracts, while this
+crate emits runnable WebAssembly text for terms.
+
+The target is WebAssembly WAT. WebAssembly is a stack machine, so the
+realization homomorphism uses the usual push-operands-then-op convention:
+compile each argument left to right, then emit the target instruction.
+
+## CLI
+
+```sh
+cat ../../menagerie/c11-language-signature/example/foo.term.json | cargo run -p provekit-ir-compiler-wasm --bin provekit-ir-wasm
+```
+
+The binary reads a ProofIR term JSON document from stdin and writes a WAT
+module to stdout.
+
+## Core Subset
+
+This crate hand-maps the current core subset:
+
+| ProofIR operation | WAT realization |
+| --- | --- |
+| `seq(a,b,...)` | emit each statement in order, dropping expression values in statement position |
+| `if(c,t,e)` statement | `c`, `if`, `t`, `else`, `e`, `end` |
+| `if(c,t,e)` expression | `c`, `if (result i32)`, `t`, `else`, `e`, `end` |
+| `while(c,b)` | `block`, `loop`, `c`, `i32.eqz`, `br_if`, `b`, `br`, `end`, `end` |
+| `return(e)` | `e`, `return` |
+| `call(f,args...)` | args left to right, `call $f` |
+| `break`, `continue` | `br` or `br_if` to the active loop labels |
+| `skip` | no instructions |
+| variable | `local.get` |
+| integer or bool literal | `i32.const` |
+| `eq`, `lt`, `le` | `i32.eq`, `i32.lt_s`, `i32.le_s` |
+| `add`, `sub`, `mul`, `neg` | `i32.add`, `i32.sub`, `i32.mul`, `0 x i32.sub` |
+| `and`, `or`, `not` | `i32.and`, `i32.or`, `i32.eqz` |
+| `deref(p)` | `p`, `i32.load` with exported memory |
+| `assign(x,v)` | `v`, `local.set $x` for local variables |
+| `assign(p,v)` | `p`, `v`, `i32.store` otherwise |
+
+The core subset is hand-mapped. The full operation set is
+mint-more-realizations, not new machinery: add an operation-CID table entry,
+its lowering, and the corresponding morphism discharge receipt.
+
+## Determinism
+
+WAT output is byte-deterministic. Function parameters, local declarations, and
+module sections are emitted in sorted, stable order. The `byte_for_byte` test
+compiles the `foo` term twice and checks both outputs against
+`fixtures/foo.wat`.
+
+## ORP v0.2 Role
+
+ORP v0.2 defines:
+
+```text
+compile : Term * Target -> ConcreteCode | Refusal
+```
+
+This crate implements that mode for target `wasm-wat`. It compiles only terms,
+not contracts. The term is already the implementation at the operation-CID
+level, so the compiler is a deterministic algebra-to-target morphism rather
+than synthesis from a boundary obligation.
+
+The round-trip story follows the protocol and papers 13 and 14:
+
+1. Lift source code into a ProofIR term and contract projection.
+2. Compile the term to WASM through this realizer.
+3. Lift the emitted WASM back to ProofIR with a WASM lifter.
+4. Compare the projected contracts through the accepted receipts.
+
+When both lifter and compiler are discharged homomorphisms, their composition
+preserves the contract. The shipped WASM can also be cross-checked against the
+WASM emitted by a native toolchain for the same source.
+
+References:
+
+- `protocol/specs/2026-05-10-realizer-protocol-v2.md`
+- `docs/papers/13-after-grammars-programming-languages-as-content-addressed-algebras.md`
+- `docs/papers/14-after-trust-the-universal-correctness-bundle.md`
+
+## Refusal Behavior
+
+Unsupported operations fail closed with a compile error. The compiler does not
+emit opaque placeholders and does not silently reinterpret operations outside
+the mapped subset.
+
+## Follow-up Work
+
+- Add mappings for the full C11 operation catalog.
+- Carry integer width through variables and operations for complete i64 typed
+  lowering.
+- Expand the memory model beyond a single exported MVP memory.
+- Add component model exports and imports.
+- Mint the draft `LanguageMorphismMemento` once the proof receipts are ready.
+
+Sign-off: T Savo

--- a/implementations/rust/provekit-ir-compiler-wasm/fixtures/foo.wat
+++ b/implementations/rust/provekit-ir-compiler-wasm/fixtures/foo.wat
@@ -1,0 +1,16 @@
+(module
+  (func $foo (export "foo") (param $x i32) (result i32)
+    local.get $x
+    i32.const 0
+    i32.eq
+    if
+      i32.const 0
+      i32.const 22
+      i32.sub
+      return
+    else
+    end
+    local.get $x
+    return
+  )
+)

--- a/implementations/rust/provekit-ir-compiler-wasm/specs/algebra_to_wasm.spec.json
+++ b/implementations/rust/provekit-ir-compiler-wasm/specs/algebra_to_wasm.spec.json
@@ -1,0 +1,131 @@
+{
+  "kind": "LanguageMorphismMemento",
+  "schemaVersion": "draft-0.2",
+  "name": "provekit-ir-term-algebra-to-wasm-wat-core",
+  "status": "draft-not-minted",
+  "mode": "compile",
+  "source": {
+    "kind": "ProofIRTermSignature",
+    "termStratum": true,
+    "languageSignature": "menagerie/c11-language-signature/specs/language_signature_c11.spec.json",
+    "signatureCid": "blake3-512:c942ba70e4b701e139a46590116f5cdc16ab41db277e80e54c01f23e4a7cf6241d4431c60473409cb3f0b61ce27f593071c1c224291f04c61aa04b4773764945",
+    "operationCatalog": "menagerie/c11-language-signature/catalog/algorithms"
+  },
+  "target": {
+    "kind": "WasmWatTargetSignature",
+    "descriptor": "wasm/wat/mvp-i32-core",
+    "artifactKind": "source-file",
+    "mediaType": "text/vnd.wasm.wat",
+    "evaluationModel": "stack-machine",
+    "valueLanes": [
+      "i32"
+    ],
+    "memory": "single exported MVP memory when deref or store is used"
+  },
+  "realizer": {
+    "crate": "provekit-ir-compiler-wasm",
+    "binary": "provekit-ir-wasm",
+    "compiler": "wasm-wat-reference",
+    "dialect": "wasm-wat"
+  },
+  "operationMapping": [
+    {
+      "source": "seq(a,b,...)",
+      "target": "emit a; emit b; ...; drop expression results in statement position",
+      "obligation": "target sequencing preserves the source statement order"
+    },
+    {
+      "source": "if(c,t,e)",
+      "target": "emit c; if or if (result i32); emit t; else; emit e; end",
+      "obligation": "WASM selects the same branch as the source conditional"
+    },
+    {
+      "source": "while(c,b)",
+      "target": "block breakN; loop continueN; emit c; i32.eqz; br_if breakN; emit b; br continueN; end; end",
+      "obligation": "loop entry, exit, break, and continue preserve the source control flow"
+    },
+    {
+      "source": "return(e)",
+      "target": "emit e; return",
+      "obligation": "the function result is the lowered value of e"
+    },
+    {
+      "source": "call(f,args...)",
+      "target": "emit args left to right; call $f",
+      "obligation": "callee and argument order match the source term"
+    },
+    {
+      "source": "break(c?)",
+      "target": "emit c; br_if breakN, or br breakN",
+      "obligation": "branch target is the nearest enclosing while exit"
+    },
+    {
+      "source": "continue(c?)",
+      "target": "emit c; br_if continueN, or br continueN",
+      "obligation": "branch target is the nearest enclosing while loop head"
+    },
+    {
+      "source": "skip",
+      "target": "no instructions",
+      "obligation": "skip leaves the stack and store unchanged"
+    },
+    {
+      "source": "var x",
+      "target": "local.get $x",
+      "obligation": "local x denotes the same term variable"
+    },
+    {
+      "source": "const n",
+      "target": "i32.const n",
+      "obligation": "the target constant is byte-identical in the accepted i32 lane"
+    },
+    {
+      "source": "eq, lt, le",
+      "target": "i32.eq, i32.lt_s, i32.le_s",
+      "obligation": "integer comparison results are encoded as WASM i32 booleans"
+    },
+    {
+      "source": "add, sub, mul, neg",
+      "target": "i32.add, i32.sub, i32.mul, i32.const 0 plus i32.sub",
+      "obligation": "integer arithmetic agrees with the accepted MVP i32 semantics"
+    },
+    {
+      "source": "and, or, not",
+      "target": "i32.and, i32.or, i32.eqz",
+      "obligation": "boolean values use the 0 false, nonzero true WASM convention"
+    },
+    {
+      "source": "deref(p)",
+      "target": "emit p; i32.load",
+      "obligation": "load reads the same address in the accepted memory model"
+    },
+    {
+      "source": "assign(x,v)",
+      "target": "emit v; local.set $x",
+      "obligation": "local assignment updates the same variable binding"
+    },
+    {
+      "source": "assign(p,v)",
+      "target": "emit p; emit v; i32.store",
+      "obligation": "store writes the same address in the accepted memory model"
+    }
+  ],
+  "homomorphismObligation": {
+    "operationPreservation": "compile(apply(op,args)) = target_apply(image(op), map(compile,args)) for every mapped operation",
+    "equationPreservation": "for each source equation in the accepted C11 signature, the emitted WAT behavior entails the compiled equation under the target semantics",
+    "contractRoundTrip": "contract(lift_wasm(compile(t))) = repr_wasm(contract(t)) after accepted lifter and morphism receipts"
+  },
+  "refusalPolicy": {
+    "unsupportedOperations": "return Refusal via compile_error.unsupported_predicate",
+    "malformedTerms": "return Refusal via compile_error.malformed_ir",
+    "unsupportedSorts": "return Refusal via compile_error.unsupported_sort"
+  },
+  "deferred": [
+    "full C11 operation catalog",
+    "typed i64 lowering for variables and operation results",
+    "complete memory model",
+    "component model imports and exports",
+    "minting and MorphismDischargeReceipt"
+  ],
+  "signOff": "T Savo"
+}

--- a/implementations/rust/provekit-ir-compiler-wasm/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-wasm/src/generated.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Draft operation table for the hand-mapped core subset. This is kept in a
+// separate module to mirror the generated-table shape used by sibling
+// compilers while the full catalog-backed emitter remains future work.
+
+pub const ALGEBRA_TO_WASM_TABLE: &[(&str, &str)] = &[
+    (
+        "seq(a,b,...)",
+        "emit each statement in order; drop expression results in statement position",
+    ),
+    (
+        "if(c,t,e) statement",
+        "emit c; if; emit t; else; emit e; end",
+    ),
+    (
+        "if(c,t,e) expression",
+        "emit c; if (result i32); emit t; else; emit e; end",
+    ),
+    (
+        "while(c,b)",
+        "block break; loop continue; emit c; i32.eqz; br_if break; emit b; br continue; end; end",
+    ),
+    ("return(e)", "emit e; return"),
+    ("call(f,args...)", "emit args left to right; call $f"),
+    ("break()", "br $breakN"),
+    ("break(c)", "emit c; br_if $breakN"),
+    ("continue()", "br $continueN"),
+    ("continue(c)", "emit c; br_if $continueN"),
+    ("skip", "emit no instructions"),
+    ("var x", "local.get $x"),
+    ("const n", "i32.const n"),
+    ("eq(a,b)", "emit a; emit b; i32.eq"),
+    ("lt(a,b)", "emit a; emit b; i32.lt_s"),
+    ("le(a,b)", "emit a; emit b; i32.le_s"),
+    ("add(a,b)", "emit a; emit b; i32.add"),
+    ("sub(a,b)", "emit a; emit b; i32.sub"),
+    ("mul(a,b)", "emit a; emit b; i32.mul"),
+    ("neg(a)", "i32.const 0; emit a; i32.sub"),
+    ("and(a,b)", "emit a; emit b; i32.and"),
+    ("or(a,b)", "emit a; emit b; i32.or"),
+    ("not(a)", "emit a; i32.eqz"),
+    ("deref(p)", "emit p; i32.load"),
+    (
+        "assign(x,v)",
+        "emit v; local.set $x when x is a local variable",
+    ),
+    ("assign(p,v)", "emit p; emit v; i32.store otherwise"),
+];

--- a/implementations/rust/provekit-ir-compiler-wasm/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-wasm/src/lib.rs
@@ -1,0 +1,697 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-ir-compiler-wasm: ORP v0.2 compile-mode realizer for the
+// ProofIR term stratum. It lowers the core C11 operation-CID term subset
+// to WebAssembly WAT text. The full operation set is mint-more-realizations,
+// not new machinery: each added operation is another homomorphic table entry
+// plus its proof or receipt.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use provekit_ir_compiler::{
+    Capabilities, CompileError, CompiledFormula, IrCompiler, OpacityManifest, PROTOCOL_VERSION,
+};
+use serde_json::Value as Json;
+
+mod generated;
+
+pub use generated::ALGEBRA_TO_WASM_TABLE;
+
+pub const DIALECT: &str = "wasm-wat";
+pub const COMPILER_NAME: &str = "wasm-wat-reference";
+pub const COMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub struct WasmCompiler;
+
+#[derive(Default)]
+struct VarSets {
+    reads: BTreeSet<String>,
+    assigned_locals: BTreeSet<String>,
+}
+
+#[derive(Clone)]
+struct LoopLabels {
+    break_label: String,
+    continue_label: String,
+}
+
+struct EmitContext {
+    lines: Vec<String>,
+    loop_stack: Vec<LoopLabels>,
+    next_loop: usize,
+}
+
+impl EmitContext {
+    fn new() -> Self {
+        Self {
+            lines: Vec::new(),
+            loop_stack: Vec::new(),
+            next_loop: 0,
+        }
+    }
+
+    fn line(&mut self, indent: usize, text: impl AsRef<str>) {
+        let mut line = String::with_capacity(indent * 2 + text.as_ref().len());
+        line.push_str(&"  ".repeat(indent));
+        line.push_str(text.as_ref());
+        self.lines.push(line);
+    }
+
+    fn loop_labels(&self, op: &str) -> Result<&LoopLabels, CompileError> {
+        self.loop_stack
+            .last()
+            .ok_or_else(|| malformed(format!("{op} outside while")))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WasmModule {
+    pub wat: String,
+}
+
+impl WasmCompiler {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn compile_term(&self, input: &Json) -> Result<String, CompileError> {
+        compile_wat(input)
+    }
+}
+
+impl Default for WasmCompiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn compile_wat(input: &Json) -> Result<String, CompileError> {
+    let term = term_payload(input)?;
+    let function_name = function_name(input)?;
+
+    let mut vars = VarSets::default();
+    collect_vars(term, &mut vars)?;
+    let params = vars.reads;
+    let locals = vars
+        .assigned_locals
+        .difference(&params)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let needs_memory = needs_memory(term)?;
+
+    let mut body = EmitContext::new();
+    if is_statement_term(term) {
+        emit_stmt(term, &mut body, 2)?;
+        if !stmt_always_returns(term) {
+            body.line(2, "i32.const 0");
+        }
+    } else {
+        emit_expr(term, &mut body, 2)?;
+    }
+
+    let mut lines = Vec::new();
+    lines.push("(module".to_string());
+    if needs_memory {
+        lines.push("  (memory (export \"memory\") 1)".to_string());
+    }
+    lines.push(func_header(&function_name, &params));
+    for local in &locals {
+        lines.push(format!("    (local ${local} i32)"));
+    }
+    lines.extend(body.lines);
+    lines.push("  )".to_string());
+    lines.push(")".to_string());
+    lines.push(String::new());
+
+    Ok(lines.join("\n"))
+}
+
+impl IrCompiler for WasmCompiler {
+    fn compile(&self, ir: &Json, dialect: &str) -> Result<CompiledFormula, CompileError> {
+        if dialect != DIALECT {
+            return Err(CompileError::UnsupportedDialect(dialect.to_string()));
+        }
+
+        Ok(CompiledFormula {
+            preamble: String::new(),
+            body: compile_wat(ir)?,
+            free_vars: Vec::new(),
+            opacity_manifest: OpacityManifest {
+                protocol_version: "ir-compiler-protocol/2".to_string(),
+                compiler: DIALECT.to_string(),
+                compiler_version: COMPILER_VERSION.to_string(),
+                opacities: Vec::new(),
+            },
+        })
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            name: COMPILER_NAME.to_string(),
+            version: COMPILER_VERSION.to_string(),
+            protocol_version: PROTOCOL_VERSION.to_string(),
+            dialects: vec![DIALECT.to_string()],
+            supported_sorts: vec!["Int".to_string(), "Bool".to_string(), "Addr".to_string()],
+            supported_predicates: vec![
+                "seq".to_string(),
+                "if".to_string(),
+                "while".to_string(),
+                "return".to_string(),
+                "call".to_string(),
+                "break".to_string(),
+                "continue".to_string(),
+                "skip".to_string(),
+                "eq".to_string(),
+                "lt".to_string(),
+                "le".to_string(),
+                "add".to_string(),
+                "sub".to_string(),
+                "mul".to_string(),
+                "neg".to_string(),
+                "and".to_string(),
+                "or".to_string(),
+                "not".to_string(),
+                "deref".to_string(),
+                "assign".to_string(),
+            ],
+        }
+    }
+}
+
+fn term_payload(input: &Json) -> Result<&Json, CompileError> {
+    match input.get("kind").and_then(Json::as_str) {
+        Some("c11-algebra-term") => input
+            .get("term")
+            .ok_or_else(|| malformed("c11-algebra-term missing term")),
+        _ => Ok(input),
+    }
+}
+
+fn function_name(input: &Json) -> Result<String, CompileError> {
+    let raw = input
+        .get("function")
+        .or_else(|| input.get("name"))
+        .and_then(Json::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            input
+                .get("source")
+                .and_then(Json::as_str)
+                .and_then(|source| Path::new(source).file_stem())
+                .and_then(|stem| stem.to_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "main".to_string());
+    sanitize_identifier(&raw)
+}
+
+fn func_header(function_name: &str, params: &BTreeSet<String>) -> String {
+    let mut header = format!("  (func ${function_name} (export \"{function_name}\")");
+    for param in params {
+        header.push_str(&format!(" (param ${param} i32)"));
+    }
+    header.push_str(" (result i32)");
+    header
+}
+
+fn collect_vars(term: &Json, vars: &mut VarSets) -> Result<(), CompileError> {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("var") => {
+            let name = name_field(term)?;
+            vars.reads.insert(sanitize_identifier(name)?);
+            Ok(())
+        }
+        Some("const") | Some("unit") => Ok(()),
+        Some("op") => {
+            let name = name_field(term)?;
+            let args = args_field(term)?;
+            if name == "call" {
+                for arg in args.iter().skip(1) {
+                    collect_vars(arg, vars)?;
+                }
+                return Ok(());
+            }
+            if name == "assign" {
+                expect_arity(name, args, 2)?;
+                if let Some(target) = local_assign_target(&args[0])? {
+                    vars.assigned_locals.insert(target);
+                    collect_vars(&args[1], vars)?;
+                    return Ok(());
+                }
+            }
+            for arg in args {
+                collect_vars(arg, vars)?;
+            }
+            Ok(())
+        }
+        Some(other) => Err(malformed(format!("unknown term kind: {other}"))),
+        None => Err(malformed("term missing kind")),
+    }
+}
+
+fn needs_memory(term: &Json) -> Result<bool, CompileError> {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("op") => {
+            let name = name_field(term)?;
+            let args = args_field(term)?;
+            if name == "deref" {
+                return Ok(true);
+            }
+            if name == "assign" {
+                expect_arity(name, args, 2)?;
+                if local_assign_target(&args[0])?.is_none() {
+                    return Ok(true);
+                }
+            }
+            args.iter().try_fold(false, |seen, arg| {
+                Ok::<_, CompileError>(seen || needs_memory(arg)?)
+            })
+        }
+        Some("var" | "const" | "unit") => Ok(false),
+        Some(other) => Err(malformed(format!("unknown term kind: {other}"))),
+        None => Err(malformed("term missing kind")),
+    }
+}
+
+fn emit_stmt(term: &Json, ctx: &mut EmitContext, indent: usize) -> Result<(), CompileError> {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("unit") => Ok(()),
+        Some("op") => {
+            let name = name_field(term)?;
+            let args = args_field(term)?;
+            match name {
+                "seq" => {
+                    for arg in args {
+                        emit_stmt(arg, ctx, indent)?;
+                    }
+                    Ok(())
+                }
+                "if" => {
+                    expect_arity(name, args, 3)?;
+                    emit_expr(&args[0], ctx, indent)?;
+                    ctx.line(indent, "if");
+                    emit_stmt(&args[1], ctx, indent + 1)?;
+                    ctx.line(indent, "else");
+                    emit_stmt(&args[2], ctx, indent + 1)?;
+                    ctx.line(indent, "end");
+                    Ok(())
+                }
+                "while" => {
+                    expect_arity(name, args, 2)?;
+                    let loop_id = ctx.next_loop;
+                    ctx.next_loop += 1;
+                    let labels = LoopLabels {
+                        break_label: format!("break{loop_id}"),
+                        continue_label: format!("continue{loop_id}"),
+                    };
+                    ctx.line(indent, format!("block ${}", labels.break_label));
+                    ctx.line(indent + 1, format!("loop ${}", labels.continue_label));
+                    ctx.loop_stack.push(labels);
+                    emit_expr(&args[0], ctx, indent + 2)?;
+                    let active = ctx
+                        .loop_stack
+                        .last()
+                        .ok_or_else(|| malformed("missing active loop"))?
+                        .clone();
+                    ctx.line(indent + 2, "i32.eqz");
+                    ctx.line(indent + 2, format!("br_if ${}", active.break_label));
+                    emit_stmt(&args[1], ctx, indent + 2)?;
+                    ctx.line(indent + 2, format!("br ${}", active.continue_label));
+                    ctx.loop_stack.pop();
+                    ctx.line(indent + 1, "end");
+                    ctx.line(indent, "end");
+                    Ok(())
+                }
+                "return" => {
+                    expect_arity(name, args, 1)?;
+                    emit_expr(&args[0], ctx, indent)?;
+                    ctx.line(indent, "return");
+                    Ok(())
+                }
+                "break" => emit_branch("break", args, ctx, indent),
+                "continue" => emit_branch("continue", args, ctx, indent),
+                "skip" => Ok(()),
+                "assign" => emit_assign(args, ctx, indent),
+                _ if is_expr_op(name) => {
+                    emit_expr(term, ctx, indent)?;
+                    ctx.line(indent, "drop");
+                    Ok(())
+                }
+                _ => Err(unsupported(name)),
+            }
+        }
+        Some("var" | "const") => {
+            emit_expr(term, ctx, indent)?;
+            ctx.line(indent, "drop");
+            Ok(())
+        }
+        Some(other) => Err(malformed(format!("unknown statement kind: {other}"))),
+        None => Err(malformed("statement missing kind")),
+    }
+}
+
+fn emit_expr(term: &Json, ctx: &mut EmitContext, indent: usize) -> Result<(), CompileError> {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("var") => {
+            let name = sanitize_identifier(name_field(term)?)?;
+            ctx.line(indent, format!("local.get ${name}"));
+            Ok(())
+        }
+        Some("const") => {
+            let value = const_i32(term)?;
+            ctx.line(indent, format!("i32.const {value}"));
+            Ok(())
+        }
+        Some("op") => {
+            let name = name_field(term)?;
+            let args = args_field(term)?;
+            match name {
+                "eq" => emit_binary(args, ctx, indent, "i32.eq"),
+                "lt" => emit_binary(args, ctx, indent, "i32.lt_s"),
+                "le" => emit_binary(args, ctx, indent, "i32.le_s"),
+                "add" => emit_binary(args, ctx, indent, "i32.add"),
+                "sub" => emit_binary(args, ctx, indent, "i32.sub"),
+                "mul" => emit_binary(args, ctx, indent, "i32.mul"),
+                "and" => emit_binary(args, ctx, indent, "i32.and"),
+                "or" => emit_binary(args, ctx, indent, "i32.or"),
+                "neg" => {
+                    expect_arity(name, args, 1)?;
+                    ctx.line(indent, "i32.const 0");
+                    emit_expr(&args[0], ctx, indent)?;
+                    ctx.line(indent, "i32.sub");
+                    Ok(())
+                }
+                "not" => {
+                    expect_arity(name, args, 1)?;
+                    emit_expr(&args[0], ctx, indent)?;
+                    ctx.line(indent, "i32.eqz");
+                    Ok(())
+                }
+                "deref" => {
+                    expect_arity(name, args, 1)?;
+                    emit_expr(&args[0], ctx, indent)?;
+                    ctx.line(indent, "i32.load");
+                    Ok(())
+                }
+                "call" => {
+                    let (callee, call_args) = call_parts(term)?;
+                    for arg in call_args {
+                        emit_expr(arg, ctx, indent)?;
+                    }
+                    ctx.line(indent, format!("call ${callee}"));
+                    Ok(())
+                }
+                "if" => {
+                    expect_arity(name, args, 3)?;
+                    if is_statement_term(&args[1]) || is_statement_term(&args[2]) {
+                        return Err(malformed("if expression branches must be expression terms"));
+                    }
+                    emit_expr(&args[0], ctx, indent)?;
+                    ctx.line(indent, "if (result i32)");
+                    emit_expr(&args[1], ctx, indent + 1)?;
+                    ctx.line(indent, "else");
+                    emit_expr(&args[2], ctx, indent + 1)?;
+                    ctx.line(indent, "end");
+                    Ok(())
+                }
+                _ => Err(unsupported(name)),
+            }
+        }
+        Some("unit") => Err(malformed("unit has no i32 expression value")),
+        Some(other) => Err(malformed(format!("unknown expression kind: {other}"))),
+        None => Err(malformed("expression missing kind")),
+    }
+}
+
+fn emit_binary(
+    args: &[Json],
+    ctx: &mut EmitContext,
+    indent: usize,
+    op: &str,
+) -> Result<(), CompileError> {
+    expect_arity(op, args, 2)?;
+    emit_expr(&args[0], ctx, indent)?;
+    emit_expr(&args[1], ctx, indent)?;
+    ctx.line(indent, op);
+    Ok(())
+}
+
+fn emit_assign(args: &[Json], ctx: &mut EmitContext, indent: usize) -> Result<(), CompileError> {
+    expect_arity("assign", args, 2)?;
+    if let Some(target) = local_assign_target(&args[0])? {
+        emit_expr(&args[1], ctx, indent)?;
+        ctx.line(indent, format!("local.set ${target}"));
+        return Ok(());
+    }
+
+    let address = store_address_term(&args[0])?;
+    emit_expr(address, ctx, indent)?;
+    emit_expr(&args[1], ctx, indent)?;
+    ctx.line(indent, "i32.store");
+    Ok(())
+}
+
+fn emit_branch(
+    op: &str,
+    args: &[Json],
+    ctx: &mut EmitContext,
+    indent: usize,
+) -> Result<(), CompileError> {
+    if args.len() > 1 {
+        return Err(malformed(format!("{op} expects zero or one argument")));
+    }
+    let labels = ctx.loop_labels(op)?.clone();
+    let target = if op == "break" {
+        labels.break_label
+    } else {
+        labels.continue_label
+    };
+    if let Some(condition) = args.first() {
+        emit_expr(condition, ctx, indent)?;
+        ctx.line(indent, format!("br_if ${target}"));
+    } else {
+        ctx.line(indent, format!("br ${target}"));
+    }
+    Ok(())
+}
+
+fn is_statement_term(term: &Json) -> bool {
+    term.get("kind")
+        .and_then(Json::as_str)
+        .is_some_and(|kind| match kind {
+            "unit" => true,
+            "op" => match term.get("name").and_then(Json::as_str) {
+                Some("if") => term
+                    .get("args")
+                    .and_then(Json::as_array)
+                    .is_some_and(|args| {
+                        args.len() == 3
+                            && (is_statement_term(&args[1]) || is_statement_term(&args[2]))
+                    }),
+                Some(name) => is_statement_op(name),
+                None => false,
+            },
+            _ => false,
+        })
+}
+
+fn is_statement_op(name: &str) -> bool {
+    matches!(
+        name,
+        "seq" | "while" | "return" | "break" | "continue" | "skip" | "assign"
+    )
+}
+
+fn is_expr_op(name: &str) -> bool {
+    matches!(
+        name,
+        "eq" | "lt"
+            | "le"
+            | "add"
+            | "sub"
+            | "mul"
+            | "neg"
+            | "and"
+            | "or"
+            | "not"
+            | "deref"
+            | "call"
+            | "if"
+    )
+}
+
+fn stmt_always_returns(term: &Json) -> bool {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("op") => match term.get("name").and_then(Json::as_str) {
+            Some("return") => true,
+            Some("seq") => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_some_and(|args| args.iter().any(stmt_always_returns)),
+            Some("if") => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_some_and(|args| {
+                    args.len() == 3
+                        && stmt_always_returns(&args[1])
+                        && stmt_always_returns(&args[2])
+                }),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn call_parts(term: &Json) -> Result<(String, &[Json]), CompileError> {
+    let args = args_field(term)?;
+    if args.is_empty() {
+        return Err(malformed("call expects callee plus zero or more arguments"));
+    }
+    let callee = match args[0].get("kind").and_then(Json::as_str) {
+        Some("var") => name_field(&args[0])?,
+        Some("const") => args[0]
+            .get("value")
+            .and_then(Json::as_str)
+            .ok_or_else(|| malformed("call callee const must be a string"))?,
+        _ => {
+            return Err(malformed(
+                "call callee must be a var or string const in this subset",
+            ))
+        }
+    };
+    Ok((sanitize_identifier(callee)?, &args[1..]))
+}
+
+fn store_address_term(target: &Json) -> Result<&Json, CompileError> {
+    if target.get("kind").and_then(Json::as_str) == Some("op")
+        && target.get("name").and_then(Json::as_str) == Some("deref")
+    {
+        let args = args_field(target)?;
+        expect_arity("deref", args, 1)?;
+        Ok(&args[0])
+    } else {
+        Ok(target)
+    }
+}
+
+fn local_assign_target(target: &Json) -> Result<Option<String>, CompileError> {
+    if target.get("kind").and_then(Json::as_str) == Some("var") {
+        Ok(Some(sanitize_identifier(name_field(target)?)?))
+    } else {
+        Ok(None)
+    }
+}
+
+fn const_i32(term: &Json) -> Result<i32, CompileError> {
+    let value = term
+        .get("value")
+        .ok_or_else(|| malformed("const missing value"))?;
+    if let Some(i) = value.as_i64() {
+        return i32::try_from(i).map_err(|_| malformed(format!("const out of i32 range: {i}")));
+    }
+    if let Some(u) = value.as_u64() {
+        return i32::try_from(u).map_err(|_| malformed(format!("const out of i32 range: {u}")));
+    }
+    if let Some(b) = value.as_bool() {
+        return Ok(i32::from(b));
+    }
+    Err(CompileError::UnsupportedSort(
+        "WASM MVP subset supports only i32 integer and bool constants".to_string(),
+    ))
+}
+
+fn args_field(term: &Json) -> Result<&[Json], CompileError> {
+    term.get("args")
+        .and_then(Json::as_array)
+        .map(Vec::as_slice)
+        .ok_or_else(|| malformed("op missing args array"))
+}
+
+fn name_field(term: &Json) -> Result<&str, CompileError> {
+    term.get("name")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("term missing name"))
+}
+
+fn expect_arity(op: &str, args: &[Json], expected: usize) -> Result<(), CompileError> {
+    if args.len() == expected {
+        Ok(())
+    } else {
+        Err(malformed(format!(
+            "{op} expects {expected} arguments, got {}",
+            args.len()
+        )))
+    }
+}
+
+fn sanitize_identifier(raw: &str) -> Result<String, CompileError> {
+    if raw.is_empty() {
+        return Err(malformed("empty identifier"));
+    }
+    if raw
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | '$'))
+    {
+        Ok(raw.to_string())
+    } else {
+        Err(malformed(format!("unsupported identifier: {raw}")))
+    }
+}
+
+fn unsupported(name: &str) -> CompileError {
+    CompileError::UnsupportedPredicate(name.to_string())
+}
+
+fn malformed(message: impl Into<String>) -> CompileError {
+    CompileError::MalformedIr(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn top_level_expression_leaves_i32_result() {
+        let input = json!({
+            "function": "expr",
+            "kind": "op",
+            "name": "add",
+            "args": [
+                {"kind": "const", "value": 1, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                {"kind": "const", "value": 2, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+            ]
+        });
+
+        let wat = compile_wat(&input).unwrap();
+
+        assert!(wat.contains("i32.add"));
+        assert!(!wat.contains("drop"));
+    }
+
+    #[test]
+    fn local_assignment_uses_local_set() {
+        let input = json!({
+            "function": "locals",
+            "kind": "op",
+            "name": "seq",
+            "args": [
+                {
+                    "kind": "op",
+                    "name": "assign",
+                    "args": [
+                        {"kind": "var", "name": "x"},
+                        {"kind": "const", "value": 1, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                    ]
+                },
+                {"kind": "op", "name": "return", "args": [{"kind": "var", "name": "x"}]}
+            ]
+        });
+
+        let wat = compile_wat(&input).unwrap();
+
+        assert!(wat.contains("local.set $x"));
+        assert!(wat.contains("(param $x i32)"));
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-wasm/src/main.rs
+++ b/implementations/rust/provekit-ir-compiler-wasm/src/main.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binary entry point for provekit-ir-compiler-wasm.
+//
+// Reads ProofIR term JSON from stdin and emits WebAssembly WAT to stdout.
+// Usage: cat foo.term.json | provekit-ir-wasm
+
+use std::io::{self, Read};
+
+use provekit_ir_compiler_wasm::compile_wat;
+use serde_json::Value as Json;
+
+fn main() {
+    let mut input = String::new();
+    if let Err(e) = io::stdin().read_to_string(&mut input) {
+        eprintln!("Error reading stdin: {e}");
+        std::process::exit(1);
+    }
+
+    let ir: Json = match serde_json::from_str(&input) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error parsing JSON: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    match compile_wat(&ir) {
+        Ok(wat) => print!("{wat}"),
+        Err(e) => {
+            eprintln!("Error compiling IR to WAT: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-wasm/tests/byte_for_byte.rs
+++ b/implementations/rust/provekit-ir-compiler-wasm/tests/byte_for_byte.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Byte-for-byte regression check for the WAT compiler. The realizer is
+// deterministic, so compiling the same term twice must return the exact
+// same bytes, and the fixture captures the public surface for foo.
+
+use serde_json::Value as Json;
+
+use provekit_ir_compiler_wasm::{compile_wat, WasmCompiler};
+
+#[test]
+fn foo_fixture_is_byte_stable() {
+    let input: Json = serde_json::from_str(include_str!(
+        "../../../../menagerie/c11-language-signature/example/foo.term.json"
+    ))
+    .expect("foo term json parses");
+    let expected = include_str!("../fixtures/foo.wat");
+
+    let first = compile_wat(&input).expect("compile foo once");
+    let second = compile_wat(&input).expect("compile foo twice");
+
+    assert_eq!(first, second);
+    assert_eq!(first, expected);
+}
+
+#[test]
+fn trait_output_is_byte_stable() {
+    let input: Json = serde_json::from_str(include_str!(
+        "../../../../menagerie/c11-language-signature/example/foo.term.json"
+    ))
+    .expect("foo term json parses");
+    let compiler = WasmCompiler::new();
+
+    let first = compiler.compile_term(&input).expect("compile foo once");
+    let second = compiler.compile_term(&input).expect("compile foo twice");
+
+    assert_eq!(first, second);
+}

--- a/implementations/rust/provekit-ir-compiler-wasm/tests/smoke.rs
+++ b/implementations/rust/provekit-ir-compiler-wasm/tests/smoke.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+use std::process::Command;
+
+use serde_json::json;
+use serde_json::Value as Json;
+
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_wasm::{compile_wat, WasmCompiler, DIALECT};
+
+#[test]
+fn compiles_foo_term_to_checked_fixture() {
+    let input: Json = serde_json::from_str(include_str!(
+        "../../../../menagerie/c11-language-signature/example/foo.term.json"
+    ))
+    .expect("foo term json parses");
+    let expected = include_str!("../fixtures/foo.wat");
+
+    let wat = compile_wat(&input).expect("compile foo term");
+
+    assert_eq!(wat, expected);
+}
+
+#[test]
+fn lowers_arithmetic_and_comparison_ops() {
+    let input = json!({
+        "kind": "c11-algebra-term",
+        "source": "ops.c",
+        "term": {
+            "kind": "op",
+            "name": "return",
+            "args": [{
+                "kind": "op",
+                "name": "and",
+                "args": [
+                    {
+                        "kind": "op",
+                        "name": "eq",
+                        "args": [
+                            {
+                                "kind": "op",
+                                "name": "add",
+                                "args": [
+                                    {"kind": "const", "value": 40, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                                    {"kind": "const", "value": 2, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                                ]
+                            },
+                            {"kind": "const", "value": 42, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                        ]
+                    },
+                    {
+                        "kind": "op",
+                        "name": "lt",
+                        "args": [
+                            {"kind": "const", "value": 1, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                            {"kind": "const", "value": 2, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                        ]
+                    }
+                ]
+            }]
+        }
+    });
+
+    let wat = compile_wat(&input).expect("compile op term");
+
+    assert!(wat.contains("i32.add"));
+    assert!(wat.contains("i32.eq"));
+    assert!(wat.contains("i32.lt_s"));
+    assert!(wat.contains("i32.and"));
+}
+
+#[test]
+fn lowers_memory_ops_with_exported_memory() {
+    let input = json!({
+        "kind": "c11-algebra-term",
+        "source": "mem.c",
+        "term": {
+            "kind": "op",
+            "name": "seq",
+            "args": [
+                {
+                    "kind": "op",
+                    "name": "assign",
+                    "args": [
+                        {"kind": "const", "value": 0, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                        {"kind": "const", "value": 7, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                    ]
+                },
+                {
+                    "kind": "op",
+                    "name": "return",
+                    "args": [{
+                        "kind": "op",
+                        "name": "deref",
+                        "args": [
+                            {"kind": "const", "value": 0, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                        ]
+                    }]
+                }
+            ]
+        }
+    });
+
+    let wat = compile_wat(&input).expect("compile memory term");
+
+    assert!(wat.contains("(memory (export \"memory\") 1)"));
+    assert!(wat.contains("i32.store"));
+    assert!(wat.contains("i32.load"));
+}
+
+#[test]
+fn refuses_unknown_operations() {
+    let input = json!({
+        "kind": "c11-algebra-term",
+        "source": "bad.c",
+        "term": {"kind": "op", "name": "switch", "args": []}
+    });
+
+    let err = compile_wat(&input).expect_err("switch is outside the core subset");
+    assert!(err.to_string().contains("unsupported predicate: switch"));
+}
+
+#[test]
+fn implements_ir_compiler_trait_for_wat() {
+    let input: Json = serde_json::from_str(include_str!(
+        "../../../../menagerie/c11-language-signature/example/foo.term.json"
+    ))
+    .expect("foo term json parses");
+    let compiler = WasmCompiler::new();
+
+    let compiled = compiler
+        .compile(&input, DIALECT)
+        .expect("compile through trait");
+
+    assert_eq!(compiled.preamble, "");
+    assert_eq!(compiled.body, include_str!("../fixtures/foo.wat"));
+}
+
+#[ignore]
+#[test]
+fn runs_foo_with_wasmtime_when_available() {
+    if Command::new("wasmtime").arg("--version").output().is_err() {
+        eprintln!("wasmtime not available, skipping runtime smoke");
+        return;
+    }
+
+    let input: Json = serde_json::from_str(include_str!(
+        "../../../../menagerie/c11-language-signature/example/foo.term.json"
+    ))
+    .expect("foo term json parses");
+    let wat = compile_wat(&input).expect("compile foo term");
+    let path = std::env::temp_dir().join(format!(
+        "provekit-ir-compiler-wasm-foo-{}.wat",
+        std::process::id()
+    ));
+
+    {
+        let mut file = std::fs::File::create(&path).expect("create temp wat");
+        file.write_all(wat.as_bytes()).expect("write temp wat");
+    }
+
+    let zero = Command::new("wasmtime")
+        .arg("--invoke")
+        .arg("foo")
+        .arg(&path)
+        .arg("0")
+        .output()
+        .expect("run wasmtime foo 0");
+    let forty_two = Command::new("wasmtime")
+        .arg("--invoke")
+        .arg("foo")
+        .arg(&path)
+        .arg("42")
+        .output()
+        .expect("run wasmtime foo 42");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert!(zero.status.success(), "foo(0) failed");
+    assert!(forty_two.status.success(), "foo(42) failed");
+    assert_eq!(String::from_utf8_lossy(&zero.stdout).trim(), "-22");
+    assert_eq!(String::from_utf8_lossy(&forty_two.stdout).trim(), "42");
+}


### PR DESCRIPTION
## Summary

`implementations/rust/provekit-ir-compiler-wasm/` -- the WASM executable-target rung of the realizer family. Implements ORP v0.2 `compile` mode: lowers a ProofIR term (AST over operation-CIDs) to a WASM module in WAT text. Target is a stack machine, so the realization homomorphism encodes the push-operands-then-op convention.

- Covers a core operation subset: `seq`, `if`, `while`, `return`, `call`, `break`, `continue`, `skip`, `eq`, `lt`, `le`, `add`, `sub`, `mul`, `neg`, `and`, `or`, `not`, variables (locals), i32 integer/bool constants, `deref` (`i32.load` + exported memory), `assign` (`local.set` or `i32.store`). Refuses on unhandled operations.
- Binary `provekit-ir-wasm`: reads a term JSON from stdin, emits WAT to stdout.
- Byte-deterministic emission. Smoke test on `foo`'s term: emits a `(func $foo (param $x i32) (result i32) ...)` computing `ite(x==0, -22, x)` (the runtime-run test self-skips without `wasmtime`/`wasm-tools`/`wat2wasm`).
- Draft `algebra -> wasm` `LanguageMorphismMemento` spec at `specs/algebra_to_wasm.spec.json`. Not minted (follow-up).
- `cargo build -p provekit-ir-compiler-wasm`, `cargo test -p provekit-ir-compiler-wasm` (9 pass, 1 ignored), `cargo clippy -p provekit-ir-compiler-wasm --no-deps -- -D warnings` all clean for the new crate. (Note: the full `cargo clippy -p provekit-ir-compiler-wasm -- -D warnings` is blocked by the same pre-existing lint in `provekit-ir-compiler/src/manifest.rs:71` -- a follow-up, not introduced here.)

Deferred: full C11 catalog coverage, typed i64 lowering, complete memory model, component model imports/exports, minted morphism receipt.

## Test plan

- [ ] `cargo build -p provekit-ir-compiler-wasm`, `cargo test -p provekit-ir-compiler-wasm`, `cargo clippy -p provekit-ir-compiler-wasm --no-deps -- -D warnings`
- [ ] With `wasmtime` or `wat2wasm` available: run `foo`'s emitted WAT; `foo(0) == -22`, `foo(42) == 42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)