### PR TITLE
fix(ir-compiler): clear clippy 1.95 doc_lazy_continuation in manifest.rs

### DIFF
--- a/implementations/rust/provekit-ir-compiler/src/manifest.rs
+++ b/implementations/rust/provekit-ir-compiler/src/manifest.rs
@@ -68,6 +68,7 @@ pub fn default_root() -> Option<PathBuf> {
 /// - `key = "string"`
 /// - `key = ["a", "b"]`
 /// - `# comment` lines
+///
 /// Anything else is silently ignored.
 pub fn parse(body: &str) -> Option<Manifest> {
     let mut name = None;


### PR DESCRIPTION
## Summary

The `parse` doc comment in `implementations/rust/provekit-ir-compiler/src/manifest.rs` placed a trailing prose line immediately after a bullet list, which clippy 1.95 flags as a lazy list-continuation (`doc_lazy_continuation`), turning `cargo clippy -- -D warnings` red on `provekit-ir-compiler` and every crate that depends on it (`provekit-ir-compiler-x86-64`, `provekit-ir-compiler-wasm`, the prover compilers). This inserts a blank doc line so the trailing prose is its own paragraph. Pre-existing on main; surfaced by clippy 1.95. Same shape as #557.

After the change, `cargo clippy -p provekit-ir-compiler -- -D warnings`, `cargo clippy -p provekit-ir-compiler-x86-64 -- -D warnings`, and `cargo clippy -p provekit-ir-compiler-wasm -- -D warnings` are all clean.

## Test plan

- [ ] `cargo clippy -p provekit-ir-compiler -- -D warnings` clean
- [ ] `cargo clippy -p provekit-ir-compiler-x86-64 -- -D warnings` and `cargo clippy -p provekit-ir-compiler-wasm -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)