### PR TITLE
feat: provekit-ir-compiler-jvm-bytecode - ORP v0.2 compile mode (term -> JVM bytecode)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1682,6 +1682,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-ir-compiler-jvm-bytecode"
+version = "0.1.0"
+dependencies = [
+ "provekit-ir-compiler",
+ "provekit-ir-types",
+ "serde_json",
+]
+
+[[package]]
 name = "provekit-ir-compiler-lean"
 version = "0.1.0"
 dependencies = [

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "provekit-ir-compiler-coq",
     "provekit-ir-compiler-x86-64",
     "provekit-ir-compiler-wasm",
+    "provekit-ir-compiler-jvm-bytecode",
     "provekit-ir-compiler-maude",
     "provekit-ir-compiler-lean",
     "provekit-ir-codegen",

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/Cargo.toml
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "provekit-ir-compiler-jvm-bytecode"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "ProvekIt: JVM bytecode compiler for ProofIR terms."
+
+[dependencies]
+provekit-ir-compiler = { path = "../provekit-ir-compiler" }
+provekit-ir-types = { path = "../provekit-ir-types" }
+serde_json.workspace = true
+
+[[bin]]
+name = "provekit-ir-jvm-bytecode"
+path = "src/main.rs"
+
+[lib]
+name = "provekit_ir_compiler_jvm_bytecode"
+path = "src/lib.rs"

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/README.md
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/README.md
@@ -1,0 +1,124 @@
+# provekit-ir-compiler-jvm-bytecode
+
+`provekit-ir-compiler-jvm-bytecode` is an ORP v0.2 `compile` mode realizer for
+the ProofIR term stratum. It is an executable-target rung of the ProvekIt
+realizer family and is dual to `provekit-ir-compiler-coq`: Coq lowers into a
+prover-facing artifact, while this crate lowers ProofIR terms into runnable JVM
+bytecode.
+
+The emitted artifact is deterministic Jasmin text. Jasmin is used as the stable
+surface for JVM bytecode in this crate. A future backend can replace it with a
+direct `.class` writer without changing the algebra mapping.
+
+The JVM is a stack machine, so the realization homomorphism encodes the usual
+push-operands-then-op convention: lower each operand left to right, then emit
+the target instruction or branch shape.
+
+## CLI
+
+```sh
+cat ../../menagerie/c11-language-signature/example/foo.term.json | cargo run -p provekit-ir-compiler-jvm-bytecode --bin provekit-ir-jvm-bytecode
+```
+
+The binary reads a ProofIR term JSON document from stdin and writes a Jasmin
+`.j` source to stdout.
+
+## Core Subset
+
+This crate hand-maps the current core subset:
+
+| ProofIR operation | JVM Jasmin realization |
+| --- | --- |
+| `seq(a,b,...)` | emit each statement in order |
+| `if(c,t,e)` statement | `c`, `ifeq`, `t`, optional `goto`, `e`, end label |
+| `if(c,t,e)` expression | `c`, `ifeq`, expression branch, `goto`, expression branch |
+| `while(c,b)` | loop label, `c`, `ifeq`, `b`, `goto` loop label |
+| `return(e)` | `e`, `ireturn` |
+| `call(f,args...)` | args left to right, `invokestatic Class/f(II...)I` |
+| `break`, `continue` | `goto` to the active loop labels |
+| `skip` | no instructions |
+| variable | `iload` from a deterministic local slot |
+| integer or bool literal | `iconst`, `bipush`, `sipush`, or `ldc` |
+| `eq`, `lt`, `le` | `if_icmpeq`, `if_icmplt`, `if_icmple`, normalized to 0 or 1 |
+| `add`, `sub`, `mul`, `neg` | `iadd`, `isub`, `imul`, `ineg` |
+| `and`, `or`, `not` | branch shapes normalized to 0 or 1 |
+| `deref(p)` | `getstatic Class/memory [I`, `p`, `iaload` |
+| `assign(x,v)` | `v`, `istore` for a local variable |
+| `assign(p,v)` | `getstatic Class/memory [I`, `p`, `v`, `iastore` |
+
+The core subset is hand-mapped. The full operation set is
+mint-more-realizations, not new machinery: add an operation-CID table entry,
+its lowering, and the corresponding morphism discharge receipt.
+
+## Determinism
+
+Output is byte-deterministic. Parameter slots and local slots are assigned in
+sorted order, labels are minted monotonically, class and method names are
+derived deterministically, and `.limit stack` is computed during emission.
+
+The `byte_for_byte` test compiles the `foo` term twice and checks both outputs
+against `tests/fixtures/foo.expected.j`.
+
+## ORP v0.2 Role
+
+ORP v0.2 defines:
+
+```text
+compile : Term * Target -> ConcreteCode | Refusal
+```
+
+This crate implements that mode for target `jvm-bytecode` through the Jasmin
+surface syntax. It compiles only terms, not contracts. The term is already the
+implementation at the operation-CID level, so the compiler is a deterministic
+algebra-to-target morphism rather than synthesis from a boundary obligation.
+
+The round-trip story follows the protocol and papers 13 and 14:
+
+1. Lift any source language into a ProofIR term and contract projection.
+2. Compile the term to JVM bytecode through this realizer.
+3. Lift the emitted JVM bytecode back to ProofIR with a JVM lifter.
+4. Compare the projected contracts through accepted receipts.
+
+When the source lifter and this compile realizer are discharged
+homomorphisms, their composition preserves the contract. The same lifted term
+can also be compiled by `javac` from source and cross-checked at the lifted
+contract level.
+
+References:
+
+- `protocol/specs/2026-05-10-realizer-protocol-v2.md`
+- `docs/papers/13-after-grammars-programming-languages-as-content-addressed-algebras.md`
+- `docs/papers/14-after-trust-the-universal-correctness-bundle.md`
+
+## Refusal Behavior
+
+Unsupported operations fail closed with `CompileError::UnsupportedPredicate`.
+Malformed term shapes fail with `CompileError::MalformedIr`. Unsupported
+constant sorts fail with `CompileError::UnsupportedSort`. The compiler does not
+emit opaque placeholders and does not silently reinterpret operations outside
+the mapped subset.
+
+## Smoke Test
+
+The non-ignored smoke test compiles `tests/fixtures/foo.term.json` to the
+checked-in Jasmin fixture. An ignored test can assemble and run the result when
+`jasmin` or `krak2`, `javac`, and `java` are installed. It checks:
+
+```text
+foo(0) = -22
+foo(42) = 42
+```
+
+If the external toolchain is unavailable, the ignored test self-skips.
+
+## Follow-up Work
+
+- Add mappings for the full C11 operation catalog.
+- Replace the static int-memory model with a typed JVM reference model.
+- Add a deterministic direct `.class` writer and constant-pool builder.
+- Track reference types and object layouts instead of only the i32 core.
+- Add optimization passes once the morphism receipt covers them.
+- Mint the `LanguageMorphismMemento` and attach a
+  `MorphismDischargeReceipt`.
+
+Sign-off: T Savo

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/specs/algebra_to_jvm.spec.json
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/specs/algebra_to_jvm.spec.json
@@ -1,0 +1,137 @@
+{
+  "kind": "LanguageMorphismMemento",
+  "schemaVersion": "draft-0.2",
+  "name": "provekit-ir-term-algebra-to-jvm-bytecode-core",
+  "status": "draft-not-minted",
+  "mode": "compile",
+  "source": {
+    "kind": "ProofIRTermSignature",
+    "termStratum": true,
+    "language": "c:c11",
+    "languageSignature": "menagerie/c11-language-signature/specs/language_signature_c11.spec.json",
+    "signatureCid": "blake3-512:c942ba70e4b701e139a46590116f5cdc16ab41db277e80e54c01f23e4a7cf6241d4431c60473409cb3f0b61ce27f593071c1c224291f04c61aa04b4773764945",
+    "termEnvelopeKind": "c11-algebra-term",
+    "operationCatalog": "menagerie/c11-language-signature/catalog/algorithms"
+  },
+  "target": {
+    "kind": "JvmBytecodeTargetSignature",
+    "descriptor": "jvm/bytecode/jasmin-i32-core",
+    "artifactKind": "source-file",
+    "mediaType": "text/vnd.jasmin",
+    "evaluationModel": "stack-machine",
+    "valueLanes": [
+      "i32"
+    ],
+    "memory": "private static int array for the minimal deref and store model"
+  },
+  "realizer": {
+    "crate": "provekit-ir-compiler-jvm-bytecode",
+    "binary": "provekit-ir-jvm-bytecode",
+    "compiler": "jvm-bytecode-jasmin-core",
+    "dialect": "jvm-jasmin",
+    "determinism": "byte-equal term JSON and target descriptor produce byte-equal Jasmin text"
+  },
+  "operationMapping": [
+    {
+      "source": "seq(a,b,...)",
+      "target": "emit a; emit b; ...",
+      "obligation": "target sequencing preserves the source statement order"
+    },
+    {
+      "source": "if(c,t,e)",
+      "target": "emit c; ifeq L_else; emit t; goto L_end when needed; L_else: emit e; L_end:",
+      "obligation": "JVM branch selection matches the source conditional"
+    },
+    {
+      "source": "while(c,b)",
+      "target": "L_top: emit c; ifeq L_done; emit b; goto L_top; L_done:",
+      "obligation": "loop entry, exit, break, and continue preserve source control flow"
+    },
+    {
+      "source": "return(e)",
+      "target": "emit e; ireturn",
+      "obligation": "the function result is the lowered value of e"
+    },
+    {
+      "source": "call(f,args...)",
+      "target": "emit args left to right; invokestatic Class/f(II...)I",
+      "obligation": "callee and argument order match the source term"
+    },
+    {
+      "source": "break(c?)",
+      "target": "emit c; ifne L_done, or goto L_done",
+      "obligation": "branch target is the nearest enclosing while exit"
+    },
+    {
+      "source": "continue(c?)",
+      "target": "emit c; ifne L_top, or goto L_top",
+      "obligation": "branch target is the nearest enclosing while loop head"
+    },
+    {
+      "source": "skip",
+      "target": "no instructions",
+      "obligation": "skip leaves the stack and store unchanged"
+    },
+    {
+      "source": "var x",
+      "target": "iload slot(x)",
+      "obligation": "local slot x denotes the same term variable"
+    },
+    {
+      "source": "const n",
+      "target": "iconst, bipush, sipush, or ldc",
+      "obligation": "the target constant is byte-identical in the accepted i32 lane"
+    },
+    {
+      "source": "eq, lt, le",
+      "target": "if_icmpeq, if_icmplt, if_icmple normalized to 0 or 1",
+      "obligation": "integer comparison results use the accepted JVM int boolean encoding"
+    },
+    {
+      "source": "add, sub, mul, neg",
+      "target": "iadd, isub, imul, ineg",
+      "obligation": "integer arithmetic agrees with the accepted i32 JVM semantics"
+    },
+    {
+      "source": "and, or, not",
+      "target": "branch shapes normalized to 0 or 1",
+      "obligation": "boolean operations preserve the source truth convention"
+    },
+    {
+      "source": "deref(p)",
+      "target": "getstatic Class/memory [I; emit p; iaload",
+      "obligation": "load reads the same address in the accepted minimal memory model"
+    },
+    {
+      "source": "assign(x,v)",
+      "target": "emit v; istore slot(x)",
+      "obligation": "local assignment updates the same variable binding"
+    },
+    {
+      "source": "assign(p,v)",
+      "target": "getstatic Class/memory [I; emit p; emit v; iastore",
+      "obligation": "store writes the same address in the accepted minimal memory model"
+    }
+  ],
+  "homomorphismObligation": {
+    "operationPreservation": "compile(apply(op,args)) = target_apply(image(op), map(compile,args)) for every mapped operation",
+    "equationPreservation": "for each source equation in the accepted C11 signature, the emitted JVM behavior entails the compiled equation under the target semantics",
+    "contractRoundTrip": "contract(lift_jvm_bytecode(compile(t))) = repr_jvm_bytecode(contract(t)) after accepted lifter and morphism receipts",
+    "dischargeStatus": "draft only, no MorphismDischargeReceipt minted in this crate"
+  },
+  "refusalPolicy": {
+    "unsupportedOperations": "return Refusal via compile_error.unsupported_predicate",
+    "malformedTerms": "return Refusal via compile_error.malformed_ir",
+    "unsupportedSorts": "return Refusal via compile_error.unsupported_sort",
+    "unsupportedInvariants": "refuse non-unit while invariant payloads until invariant discharge is represented"
+  },
+  "deferred": [
+    "full C11 operation catalog",
+    "direct class-file writer and deterministic constant-pool construction",
+    "typed JVM references and object layouts",
+    "complete memory model",
+    "optimization passes with receipt coverage",
+    "minting and MorphismDischargeReceipt"
+  ],
+  "signOff": "T Savo"
+}

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/src/generated.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Draft operation table for the hand-mapped core subset. The full
+// operation set is mint-more-realizations, not new machinery: each
+// added operation gets a table entry, lowering rule, and receipt.
+
+pub const CORE_OPERATION_SUBSET: &[&str] = &[
+    "seq", "if", "while", "return", "call", "break", "continue", "skip", "eq", "lt", "le", "add",
+    "sub", "mul", "neg", "and", "or", "not", "deref", "assign",
+];
+
+pub const ALGEBRA_TO_JVM_TABLE: &[(&str, &str)] = &[
+    ("seq(a,b,...)", "emit each statement in order"),
+    (
+        "if(c,t,e) statement",
+        "emit c; ifeq L_else; emit t; goto L_end when t falls through; L_else: emit e; L_end:",
+    ),
+    (
+        "if(c,t,e) expression",
+        "emit c; ifeq L_else; emit t; goto L_end; L_else: emit e; L_end:",
+    ),
+    (
+        "while(c,b)",
+        "L_top: emit c; ifeq L_done; emit b; goto L_top; L_done:",
+    ),
+    ("return(e)", "emit e; ireturn"),
+    (
+        "call(f,args...)",
+        "emit args left to right; invokestatic Class/f(II...)I",
+    ),
+    ("break", "goto the active loop done label"),
+    ("continue", "goto the active loop top label"),
+    ("skip", "emit no instructions"),
+    ("var x", "iload slot(x)"),
+    ("const n", "iconst, bipush, sipush, or ldc"),
+    (
+        "eq(a,b)",
+        "emit a; emit b; if_icmpeq L_true; iconst_0; goto L_end; L_true: iconst_1; L_end:",
+    ),
+    ("lt(a,b)", "same shape with if_icmplt"),
+    ("le(a,b)", "same shape with if_icmple"),
+    ("add(a,b)", "emit a; emit b; iadd"),
+    ("sub(a,b)", "emit a; emit b; isub"),
+    ("mul(a,b)", "emit a; emit b; imul"),
+    ("neg(a)", "emit a; ineg"),
+    ("and(a,b)", "short-circuit to 0 or 1 with ifeq"),
+    ("or(a,b)", "short-circuit to 0 or 1 with ifne"),
+    (
+        "not(a)",
+        "emit a; ifeq L_true; iconst_0; goto L_end; L_true: iconst_1; L_end:",
+    ),
+    (
+        "deref(p)",
+        "getstatic Class/memory [I; emit p; iaload in the minimal int-memory model",
+    ),
+    ("assign(x,v)", "emit v; istore slot(x) for local variables"),
+    (
+        "assign(p,v)",
+        "getstatic Class/memory [I; emit p; emit v; iastore otherwise",
+    ),
+];

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/src/lib.rs
@@ -1,0 +1,992 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-ir-compiler-jvm-bytecode: ORP v0.2 compile-mode realizer for
+// the ProofIR term stratum. It lowers the core C11 operation-CID term
+// subset to deterministic Jasmin text for JVM bytecode.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use provekit_ir_compiler::{
+    Capabilities, CompileError, CompiledFormula, IrCompiler, OpacityManifest, PROTOCOL_VERSION,
+};
+use serde_json::Value as Json;
+
+mod generated;
+
+pub use generated::{ALGEBRA_TO_JVM_TABLE, CORE_OPERATION_SUBSET};
+
+pub const DIALECT: &str = "jvm-jasmin";
+pub const COMPILER_NAME: &str = "jvm-bytecode-jasmin-core";
+pub const COMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const MEMORY_CELLS: i32 = 1024;
+
+pub trait TermCompiler {
+    fn compile_term_json(&self, ir: &Json) -> Result<String, CompileError>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct JvmBytecodeCompiler;
+
+#[derive(Default)]
+struct VarSets {
+    reads: BTreeSet<String>,
+    assigned_locals: BTreeSet<String>,
+}
+
+#[derive(Clone)]
+struct LoopLabels {
+    continue_label: String,
+    break_label: String,
+}
+
+#[derive(Default)]
+struct StackState {
+    depth: i32,
+    max_depth: i32,
+}
+
+impl StackState {
+    fn apply(&mut self, delta: i32) {
+        self.depth += delta;
+        debug_assert!(self.depth >= 0);
+        if self.depth > self.max_depth {
+            self.max_depth = self.depth;
+        }
+    }
+
+    fn set_depth(&mut self, depth: i32) {
+        debug_assert!(depth >= 0);
+        self.depth = depth;
+        if self.depth > self.max_depth {
+            self.max_depth = self.depth;
+        }
+    }
+
+    fn depth(&self) -> i32 {
+        self.depth
+    }
+
+    fn limit(&self) -> i32 {
+        self.max_depth.max(1)
+    }
+}
+
+struct Lowerer {
+    class_name: String,
+    method_name: String,
+    locals: BTreeMap<String, u16>,
+    uses_memory: bool,
+    lines: Vec<String>,
+    label_counter: usize,
+    loop_stack: Vec<LoopLabels>,
+    stack: StackState,
+}
+
+impl JvmBytecodeCompiler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl TermCompiler for JvmBytecodeCompiler {
+    fn compile_term_json(&self, ir: &Json) -> Result<String, CompileError> {
+        compile_jasmin(ir)
+    }
+}
+
+impl IrCompiler for JvmBytecodeCompiler {
+    fn compile(&self, ir: &Json, dialect: &str) -> Result<CompiledFormula, CompileError> {
+        if dialect != DIALECT {
+            return Err(CompileError::UnsupportedDialect(dialect.to_string()));
+        }
+        Ok(CompiledFormula {
+            preamble: String::new(),
+            body: self.compile_term_json(ir)?,
+            free_vars: Vec::new(),
+            opacity_manifest: OpacityManifest {
+                protocol_version: "ir-compiler-protocol/2".to_string(),
+                compiler: DIALECT.to_string(),
+                compiler_version: COMPILER_VERSION.to_string(),
+                opacities: Vec::new(),
+            },
+        })
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            name: COMPILER_NAME.to_string(),
+            version: COMPILER_VERSION.to_string(),
+            protocol_version: PROTOCOL_VERSION.to_string(),
+            dialects: vec![DIALECT.to_string()],
+            supported_sorts: vec!["Int".to_string(), "Bool".to_string(), "Addr".to_string()],
+            supported_predicates: CORE_OPERATION_SUBSET
+                .iter()
+                .map(|op| (*op).to_string())
+                .collect(),
+        }
+    }
+}
+
+pub fn compile_jasmin(ir: &Json) -> Result<String, CompileError> {
+    let term = root_term(ir)?;
+    let method_name = function_name(ir);
+    let class_name = class_name(ir, &method_name);
+
+    let mut vars = VarSets::default();
+    collect_vars(term, &mut vars)?;
+    let mut locals = BTreeMap::new();
+    for name in vars.reads {
+        let slot = u16::try_from(locals.len())
+            .map_err(|_| unsupported("too many JVM local slots in core subset"))?;
+        locals.insert(name, slot);
+    }
+    for name in vars.assigned_locals {
+        if !locals.contains_key(&name) {
+            let slot = u16::try_from(locals.len())
+                .map_err(|_| unsupported("too many JVM local slots in core subset"))?;
+            locals.insert(name, slot);
+        }
+    }
+
+    let uses_memory = needs_memory(term)?;
+    let mut lowerer = Lowerer::new(class_name, method_name, locals, uses_memory);
+    lowerer.compile_function(term)
+}
+
+impl Lowerer {
+    fn new(
+        class_name: String,
+        method_name: String,
+        locals: BTreeMap<String, u16>,
+        uses_memory: bool,
+    ) -> Self {
+        Self {
+            class_name,
+            method_name,
+            locals,
+            uses_memory,
+            lines: Vec::new(),
+            label_counter: 0,
+            loop_stack: Vec::new(),
+            stack: StackState::default(),
+        }
+    }
+
+    fn compile_function(&mut self, term: &Json) -> Result<String, CompileError> {
+        if is_statement_term(term) {
+            self.emit_stmt(term)?;
+            if stmt_falls_through(term) {
+                self.emit_int_const(0);
+                self.inst("ireturn", -1);
+            }
+        } else {
+            self.emit_expr(term)?;
+            self.inst("ireturn", -1);
+        }
+
+        let body = std::mem::take(&mut self.lines);
+        let stack_limit = self.stack.limit();
+        let locals_limit = self.locals.len();
+        let descriptor = method_descriptor(self.locals.len());
+
+        let mut out = Vec::new();
+        out.push(format!(".class public {}", self.class_name));
+        out.push(".super java/lang/Object".to_string());
+        out.push(String::new());
+        if self.uses_memory {
+            out.push(".field private static memory [I".to_string());
+            out.push(String::new());
+            out.extend(self.clinit_lines());
+            out.push(String::new());
+        }
+        out.push(format!(
+            ".method public static {}{}",
+            self.method_name, descriptor
+        ));
+        out.push(format!("  .limit stack {stack_limit}"));
+        out.push(format!("  .limit locals {locals_limit}"));
+        out.extend(body);
+        out.push(".end method".to_string());
+        out.push(String::new());
+        Ok(out.join("\n"))
+    }
+
+    fn clinit_lines(&self) -> Vec<String> {
+        vec![
+            ".method static <clinit>()V".to_string(),
+            "  .limit stack 1".to_string(),
+            "  .limit locals 0".to_string(),
+            format!("  sipush {MEMORY_CELLS}"),
+            "  newarray int".to_string(),
+            format!("  putstatic {}/memory [I", self.class_name),
+            "  return".to_string(),
+            ".end method".to_string(),
+        ]
+    }
+
+    fn emit_stmt(&mut self, term: &Json) -> Result<(), CompileError> {
+        match term_kind(term)? {
+            "unit" => Ok(()),
+            "op" => match op_name(term)? {
+                "seq" => {
+                    for arg in op_args(term)? {
+                        self.emit_stmt(arg)?;
+                        if !stmt_falls_through(arg) {
+                            break;
+                        }
+                    }
+                    Ok(())
+                }
+                "if" => self.emit_if_stmt(term),
+                "while" => self.emit_while(term),
+                "return" => {
+                    let args = op_args(term)?;
+                    expect_arity("return", args, 1)?;
+                    self.emit_expr(&args[0])?;
+                    self.inst("ireturn", -1);
+                    Ok(())
+                }
+                "call" => {
+                    self.emit_expr(term)?;
+                    self.inst("pop", -1);
+                    Ok(())
+                }
+                "break" => self.emit_loop_branch("break", op_args(term)?),
+                "continue" => self.emit_loop_branch("continue", op_args(term)?),
+                "skip" => {
+                    expect_skip_args(op_args(term)?)?;
+                    Ok(())
+                }
+                "assign" => self.emit_assign_stmt(term),
+                name if is_expr_op(name) => {
+                    self.emit_expr(term)?;
+                    self.inst("pop", -1);
+                    Ok(())
+                }
+                name => Err(unsupported_operation(name)),
+            },
+            "var" | "const" => {
+                self.emit_expr(term)?;
+                self.inst("pop", -1);
+                Ok(())
+            }
+            other => Err(malformed(format!("unknown statement kind: {other}"))),
+        }
+    }
+
+    fn emit_expr(&mut self, term: &Json) -> Result<(), CompileError> {
+        match term_kind(term)? {
+            "var" => {
+                let slot = self.local_slot(var_name(term)?)?;
+                self.inst(&format!("iload {slot}"), 1);
+                Ok(())
+            }
+            "const" => {
+                self.emit_int_const(const_i32(term)?);
+                Ok(())
+            }
+            "op" => match op_name(term)? {
+                "eq" => self.emit_compare(term, "if_icmpeq"),
+                "lt" => self.emit_compare(term, "if_icmplt"),
+                "le" => self.emit_compare(term, "if_icmple"),
+                "add" => self.emit_binary_arith(term, "iadd"),
+                "sub" => self.emit_binary_arith(term, "isub"),
+                "mul" => self.emit_binary_arith(term, "imul"),
+                "neg" => {
+                    let args = op_args(term)?;
+                    expect_arity("neg", args, 1)?;
+                    self.emit_expr(&args[0])?;
+                    self.inst("ineg", 0);
+                    Ok(())
+                }
+                "and" => self.emit_and(term),
+                "or" => self.emit_or(term),
+                "not" => self.emit_not(term),
+                "deref" => self.emit_deref(term),
+                "call" => self.emit_call(term),
+                "if" => self.emit_if_expr(term),
+                "assign" => self.emit_assign_expr(term),
+                name => Err(unsupported_operation(name)),
+            },
+            "unit" => Err(malformed("unit has no JVM int expression value")),
+            other => Err(malformed(format!("unknown expression kind: {other}"))),
+        }
+    }
+
+    fn emit_if_stmt(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity("if", args, 3)?;
+        let base_depth = self.stack.depth();
+
+        self.emit_expr(&args[0])?;
+        let else_label = self.fresh_label("else");
+        let end_label = self.fresh_label("end");
+        self.inst(&format!("ifeq {else_label}"), -1);
+        self.stack.set_depth(base_depth);
+        self.emit_stmt(&args[1])?;
+        if stmt_falls_through(&args[1]) {
+            self.inst(&format!("goto {end_label}"), 0);
+        }
+        self.stack.set_depth(base_depth);
+        self.label(&else_label);
+        self.emit_stmt(&args[2])?;
+        self.stack.set_depth(base_depth);
+        self.label(&end_label);
+        Ok(())
+    }
+
+    fn emit_if_expr(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity("if", args, 3)?;
+        if is_statement_term(&args[1]) || is_statement_term(&args[2]) {
+            return Err(malformed("if expression branches must be expression terms"));
+        }
+        let base_depth = self.stack.depth();
+
+        self.emit_expr(&args[0])?;
+        let else_label = self.fresh_label("else");
+        let end_label = self.fresh_label("end");
+        self.inst(&format!("ifeq {else_label}"), -1);
+        self.stack.set_depth(base_depth);
+        self.emit_expr(&args[1])?;
+        self.inst(&format!("goto {end_label}"), 0);
+        self.stack.set_depth(base_depth);
+        self.label(&else_label);
+        self.emit_expr(&args[2])?;
+        self.stack.set_depth(base_depth + 1);
+        self.label(&end_label);
+        Ok(())
+    }
+
+    fn emit_while(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        if args.len() < 2 {
+            return Err(malformed("while expects at least 2 arguments"));
+        }
+        if let Some(invariant) = term.get("invariant").or_else(|| args.get(2)) {
+            if !is_unit(invariant) {
+                return Err(unsupported("unsupported while invariant shape"));
+            }
+        }
+
+        let top_label = self.fresh_label("loop");
+        let done_label = self.fresh_label("done");
+        let base_depth = self.stack.depth();
+        self.label(&top_label);
+        self.stack.set_depth(base_depth);
+        self.emit_expr(&args[0])?;
+        self.inst(&format!("ifeq {done_label}"), -1);
+        self.stack.set_depth(base_depth);
+        self.loop_stack.push(LoopLabels {
+            continue_label: top_label.clone(),
+            break_label: done_label.clone(),
+        });
+        self.emit_stmt(&args[1])?;
+        self.loop_stack.pop();
+        if stmt_falls_through(&args[1]) {
+            self.inst(&format!("goto {top_label}"), 0);
+        }
+        self.stack.set_depth(base_depth);
+        self.label(&done_label);
+        Ok(())
+    }
+
+    fn emit_loop_branch(&mut self, op: &str, args: &[Json]) -> Result<(), CompileError> {
+        if args.len() > 1 {
+            return Err(malformed(format!("{op} expects zero or one argument")));
+        }
+        let labels = self
+            .loop_stack
+            .last()
+            .ok_or_else(|| malformed(format!("{op} outside while")))?
+            .clone();
+        let target = if op == "break" {
+            labels.break_label
+        } else {
+            labels.continue_label
+        };
+        let base_depth = self.stack.depth();
+        if let Some(condition) = args.first() {
+            self.emit_expr(condition)?;
+            self.inst(&format!("ifne {target}"), -1);
+            self.stack.set_depth(base_depth);
+        } else {
+            self.inst(&format!("goto {target}"), 0);
+            self.stack.set_depth(base_depth);
+        }
+        Ok(())
+    }
+
+    fn emit_binary_arith(&mut self, term: &Json, inst: &str) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity(op_name(term)?, args, 2)?;
+        self.emit_expr(&args[0])?;
+        self.emit_expr(&args[1])?;
+        self.inst(inst, -1);
+        Ok(())
+    }
+
+    fn emit_compare(&mut self, term: &Json, branch: &str) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity(op_name(term)?, args, 2)?;
+        let true_label = self.fresh_label("true");
+        let end_label = self.fresh_label("end");
+        let base_depth = self.stack.depth();
+        self.emit_expr(&args[0])?;
+        self.emit_expr(&args[1])?;
+        self.inst(&format!("{branch} {true_label}"), -2);
+        self.stack.set_depth(base_depth);
+        self.emit_int_const(0);
+        self.inst(&format!("goto {end_label}"), 0);
+        self.stack.set_depth(base_depth);
+        self.label(&true_label);
+        self.emit_int_const(1);
+        self.stack.set_depth(base_depth + 1);
+        self.label(&end_label);
+        Ok(())
+    }
+
+    fn emit_and(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity("and", args, 2)?;
+        let false_label = self.fresh_label("false");
+        let end_label = self.fresh_label("end");
+        let base_depth = self.stack.depth();
+        self.emit_expr(&args[0])?;
+        self.inst(&format!("ifeq {false_label}"), -1);
+        self.stack.set_depth(base_depth);
+        self.emit_expr(&args[1])?;
+        self.inst(&format!("ifeq {false_label}"), -1);
+        self.stack.set_depth(base_depth);
+        self.emit_int_const(1);
+        self.inst(&format!("goto {end_label}"), 0);
+        self.stack.set_depth(base_depth);
+        self.label(&false_label);
+        self.emit_int_const(0);
+        self.stack.set_depth(base_depth + 1);
+        self.label(&end_label);
+        Ok(())
+    }
+
+    fn emit_or(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity("or", args, 2)?;
+        let true_label = self.fresh_label("true");
+        let end_label = self.fresh_label("end");
+        let base_depth = self.stack.depth();
+        self.emit_expr(&args[0])?;
+        self.inst(&format!("ifne {true_label}"), -1);
+        self.stack.set_depth(base_depth);
+        self.emit_expr(&args[1])?;
+        self.inst(&format!("ifne {true_label}"), -1);
+        self.stack.set_depth(base_depth);
+        self.emit_int_const(0);
+        self.inst(&format!("goto {end_label}"), 0);
+        self.stack.set_depth(base_depth);
+        self.label(&true_label);
+        self.emit_int_const(1);
+        self.stack.set_depth(base_depth + 1);
+        self.label(&end_label);
+        Ok(())
+    }
+
+    fn emit_not(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity("not", args, 1)?;
+        let true_label = self.fresh_label("true");
+        let end_label = self.fresh_label("end");
+        let base_depth = self.stack.depth();
+        self.emit_expr(&args[0])?;
+        self.inst(&format!("ifeq {true_label}"), -1);
+        self.stack.set_depth(base_depth);
+        self.emit_int_const(0);
+        self.inst(&format!("goto {end_label}"), 0);
+        self.stack.set_depth(base_depth);
+        self.label(&true_label);
+        self.emit_int_const(1);
+        self.stack.set_depth(base_depth + 1);
+        self.label(&end_label);
+        Ok(())
+    }
+
+    fn emit_deref(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity("deref", args, 1)?;
+        self.inst(&format!("getstatic {}/memory [I", self.class_name), 1);
+        self.emit_expr(&args[0])?;
+        self.inst("iaload", -1);
+        Ok(())
+    }
+
+    fn emit_call(&mut self, term: &Json) -> Result<(), CompileError> {
+        let (callee, call_args) = call_parts(term)?;
+        for arg in &call_args {
+            self.emit_expr(arg)?;
+        }
+        let descriptor = method_descriptor(call_args.len());
+        let delta = 1_i32
+            - i32::try_from(call_args.len())
+                .map_err(|_| unsupported("too many JVM call arguments"))?;
+        self.inst(
+            &format!("invokestatic {}/{callee}{descriptor}", self.class_name),
+            delta,
+        );
+        Ok(())
+    }
+
+    fn emit_assign_stmt(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity("assign", args, 2)?;
+        if term_kind(&args[0])? == "var" {
+            self.emit_expr(&args[1])?;
+            let slot = self.local_slot(var_name(&args[0])?)?;
+            self.inst(&format!("istore {slot}"), -1);
+            return Ok(());
+        }
+
+        let address = store_address_term(&args[0])?;
+        self.inst(&format!("getstatic {}/memory [I", self.class_name), 1);
+        self.emit_expr(address)?;
+        self.emit_expr(&args[1])?;
+        self.inst("iastore", -3);
+        Ok(())
+    }
+
+    fn emit_assign_expr(&mut self, term: &Json) -> Result<(), CompileError> {
+        let args = op_args(term)?;
+        expect_arity("assign", args, 2)?;
+        if term_kind(&args[0])? == "var" {
+            self.emit_expr(&args[1])?;
+            self.inst("dup", 1);
+            let slot = self.local_slot(var_name(&args[0])?)?;
+            self.inst(&format!("istore {slot}"), -1);
+            return Ok(());
+        }
+
+        let address = store_address_term(&args[0])?;
+        self.inst(&format!("getstatic {}/memory [I", self.class_name), 1);
+        self.emit_expr(address)?;
+        self.emit_expr(&args[1])?;
+        self.inst("dup_x2", 1);
+        self.inst("iastore", -3);
+        Ok(())
+    }
+
+    fn emit_int_const(&mut self, value: i32) {
+        match value {
+            -1 => self.inst("iconst_m1", 1),
+            0..=5 => self.inst(&format!("iconst_{value}"), 1),
+            -128..=127 => self.inst(&format!("bipush {value}"), 1),
+            -32768..=32767 => self.inst(&format!("sipush {value}"), 1),
+            _ => self.inst(&format!("ldc {value}"), 1),
+        }
+    }
+
+    fn local_slot(&self, name: &str) -> Result<u16, CompileError> {
+        self.locals
+            .get(name)
+            .copied()
+            .ok_or_else(|| malformed(format!("unknown local variable {name}")))
+    }
+
+    fn fresh_label(&mut self, kind: &str) -> String {
+        let label = format!("L_{kind}_{}", self.label_counter);
+        self.label_counter += 1;
+        label
+    }
+
+    fn label(&mut self, name: &str) {
+        self.lines.push(format!("{name}:"));
+    }
+
+    fn inst(&mut self, text: &str, delta: i32) {
+        self.lines.push(format!("  {text}"));
+        self.stack.apply(delta);
+    }
+}
+
+fn root_term(ir: &Json) -> Result<&Json, CompileError> {
+    match ir.get("kind").and_then(Json::as_str) {
+        Some("c11-algebra-term") => ir
+            .get("term")
+            .ok_or_else(|| malformed("c11 algebra term envelope missing term")),
+        _ => Ok(ir),
+    }
+}
+
+fn function_name(ir: &Json) -> String {
+    for key in ["function", "function_name", "fn_name", "name"] {
+        if let Some(name) = ir.get(key).and_then(Json::as_str) {
+            return sanitize_jvm_identifier(name, "proofir_term");
+        }
+    }
+    if let Some(source) = ir.get("source").and_then(Json::as_str) {
+        if let Some(stem) = Path::new(source).file_stem().and_then(|stem| stem.to_str()) {
+            return sanitize_jvm_identifier(stem, "proofir_term");
+        }
+    }
+    "proofir_term".to_string()
+}
+
+fn class_name(ir: &Json, method_name: &str) -> String {
+    for key in ["class", "class_name"] {
+        if let Some(name) = ir.get(key).and_then(Json::as_str) {
+            return upper_class_name(&sanitize_jvm_identifier(name, "ProofIrTerm"));
+        }
+    }
+    upper_class_name(method_name)
+}
+
+fn upper_class_name(name: &str) -> String {
+    let mut out = String::new();
+    let mut make_upper = true;
+    for ch in name.chars() {
+        if ch == '_' {
+            make_upper = true;
+            continue;
+        }
+        if make_upper {
+            out.push(ch.to_ascii_uppercase());
+            make_upper = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    if out.is_empty() || out.as_bytes()[0].is_ascii_digit() {
+        "ProofIrTerm".to_string()
+    } else {
+        out
+    }
+}
+
+fn sanitize_jvm_identifier(raw: &str, fallback: &str) -> String {
+    let mut out = String::new();
+    for (index, ch) in raw.chars().enumerate() {
+        let valid = ch.is_ascii_alphanumeric() || ch == '_' || ch == '$';
+        if valid && !(index == 0 && ch.is_ascii_digit()) {
+            out.push(ch);
+        } else if valid {
+            out.push('_');
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        fallback.to_string()
+    } else {
+        out
+    }
+}
+
+fn method_descriptor(param_count: usize) -> String {
+    let mut descriptor = String::from("(");
+    for _ in 0..param_count {
+        descriptor.push('I');
+    }
+    descriptor.push_str(")I");
+    descriptor
+}
+
+fn collect_vars(term: &Json, vars: &mut VarSets) -> Result<(), CompileError> {
+    match term_kind(term)? {
+        "var" => {
+            vars.reads.insert(var_name(term)?.to_string());
+            Ok(())
+        }
+        "const" | "unit" => Ok(()),
+        "ctor" => {
+            if let Some(args) = term.get("args").and_then(Json::as_array) {
+                for arg in args {
+                    collect_vars(arg, vars)?;
+                }
+            }
+            Ok(())
+        }
+        "op" => {
+            let name = op_name(term)?;
+            let args = op_args(term)?;
+            if name == "call" {
+                for arg in call_arguments(args)? {
+                    collect_vars(arg, vars)?;
+                }
+                return Ok(());
+            }
+            if name == "assign" {
+                expect_arity("assign", args, 2)?;
+                if term_kind(&args[0])? == "var" {
+                    vars.assigned_locals.insert(var_name(&args[0])?.to_string());
+                    collect_vars(&args[1], vars)?;
+                    return Ok(());
+                }
+            }
+            for arg in args {
+                collect_vars(arg, vars)?;
+            }
+            Ok(())
+        }
+        other => Err(malformed(format!("unknown term kind: {other}"))),
+    }
+}
+
+fn needs_memory(term: &Json) -> Result<bool, CompileError> {
+    match term_kind(term)? {
+        "op" => {
+            let name = op_name(term)?;
+            let args = op_args(term)?;
+            if name == "deref" {
+                return Ok(true);
+            }
+            if name == "assign" {
+                expect_arity("assign", args, 2)?;
+                if term_kind(&args[0])? != "var" {
+                    return Ok(true);
+                }
+            }
+            for arg in args {
+                if needs_memory(arg)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        "ctor" => {
+            if let Some(args) = term.get("args").and_then(Json::as_array) {
+                for arg in args {
+                    if needs_memory(arg)? {
+                        return Ok(true);
+                    }
+                }
+            }
+            Ok(false)
+        }
+        "var" | "const" | "unit" => Ok(false),
+        other => Err(malformed(format!("unknown term kind: {other}"))),
+    }
+}
+
+fn call_parts(term: &Json) -> Result<(String, Vec<&Json>), CompileError> {
+    let args = op_args(term)?;
+    if args.is_empty() {
+        return Err(malformed("call expects a callee"));
+    }
+    let callee = match term_kind(&args[0])? {
+        "var" => sanitize_jvm_identifier(var_name(&args[0])?, "callee"),
+        "const" => args[0]
+            .get("value")
+            .and_then(Json::as_str)
+            .map(|name| sanitize_jvm_identifier(name, "callee"))
+            .ok_or_else(|| malformed("call callee const must be a string"))?,
+        "ctor" => args[0]
+            .get("name")
+            .and_then(Json::as_str)
+            .map(|name| sanitize_jvm_identifier(name, "callee"))
+            .ok_or_else(|| malformed("call callee ctor missing name"))?,
+        other => return Err(malformed(format!("unsupported callee kind {other}"))),
+    };
+    Ok((callee, call_arguments(args)?))
+}
+
+fn call_arguments(args: &[Json]) -> Result<Vec<&Json>, CompileError> {
+    match args {
+        [_callee] => Ok(Vec::new()),
+        [_callee, maybe_list] if term_kind(maybe_list)? == "ctor" => Ok(maybe_list
+            .get("args")
+            .and_then(Json::as_array)
+            .map(|items| items.iter().collect())
+            .unwrap_or_default()),
+        [_callee, maybe_unit] if is_unit(maybe_unit) => Ok(Vec::new()),
+        [_callee, rest @ ..] => Ok(rest.iter().collect()),
+        [] => Err(malformed("call expects a callee")),
+    }
+}
+
+fn store_address_term(target: &Json) -> Result<&Json, CompileError> {
+    if term_kind(target)? == "op" && op_name(target)? == "deref" {
+        let args = op_args(target)?;
+        expect_arity("deref", args, 1)?;
+        Ok(&args[0])
+    } else {
+        Ok(target)
+    }
+}
+
+fn is_statement_term(term: &Json) -> bool {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("unit") => true,
+        Some("op") => match term.get("name").and_then(Json::as_str) {
+            Some("if") => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_some_and(|args| {
+                    args.len() == 3 && (is_statement_term(&args[1]) || is_statement_term(&args[2]))
+                }),
+            Some(name) => is_statement_op(name),
+            None => false,
+        },
+        _ => false,
+    }
+}
+
+fn is_statement_op(name: &str) -> bool {
+    matches!(
+        name,
+        "seq" | "while" | "return" | "break" | "continue" | "skip" | "assign"
+    )
+}
+
+fn is_expr_op(name: &str) -> bool {
+    matches!(
+        name,
+        "eq" | "lt"
+            | "le"
+            | "add"
+            | "sub"
+            | "mul"
+            | "neg"
+            | "and"
+            | "or"
+            | "not"
+            | "deref"
+            | "call"
+            | "if"
+    )
+}
+
+fn stmt_falls_through(term: &Json) -> bool {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("op") => match term.get("name").and_then(Json::as_str).unwrap_or_default() {
+            "return" => false,
+            "break" | "continue" => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_some_and(|args| !args.is_empty()),
+            "seq" => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_none_or(|args| args.last().is_none_or(stmt_falls_through)),
+            "if" => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_none_or(|args| {
+                    args.get(1).is_none_or(stmt_falls_through)
+                        || args.get(2).is_none_or(stmt_falls_through)
+                }),
+            _ => true,
+        },
+        _ => true,
+    }
+}
+
+fn term_kind(term: &Json) -> Result<&str, CompileError> {
+    term.get("kind")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("term missing kind"))
+}
+
+fn op_name(term: &Json) -> Result<&str, CompileError> {
+    term.get("name")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("op missing name"))
+}
+
+fn op_args(term: &Json) -> Result<&[Json], CompileError> {
+    term.get("args")
+        .and_then(Json::as_array)
+        .map(Vec::as_slice)
+        .ok_or_else(|| malformed("op missing args"))
+}
+
+fn var_name(term: &Json) -> Result<&str, CompileError> {
+    term.get("name")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("var missing name"))
+}
+
+fn const_i32(term: &Json) -> Result<i32, CompileError> {
+    let value = term
+        .get("value")
+        .ok_or_else(|| malformed("const missing value"))?;
+    if let Some(i) = value.as_i64() {
+        return i32::try_from(i).map_err(|_| malformed(format!("const out of i32 range: {i}")));
+    }
+    if let Some(u) = value.as_u64() {
+        return i32::try_from(u).map_err(|_| malformed(format!("const out of i32 range: {u}")));
+    }
+    if let Some(b) = value.as_bool() {
+        return Ok(i32::from(b));
+    }
+    Err(CompileError::UnsupportedSort(
+        "JVM core subset supports only i32 integer and bool constants".to_string(),
+    ))
+}
+
+fn is_unit(term: &Json) -> bool {
+    term.get("kind").and_then(Json::as_str) == Some("unit")
+        || (term.get("kind").and_then(Json::as_str) == Some("op")
+            && term.get("name").and_then(Json::as_str) == Some("skip"))
+}
+
+fn expect_skip_args(args: &[Json]) -> Result<(), CompileError> {
+    match args {
+        [] => Ok(()),
+        [arg] if is_unit(arg) => Ok(()),
+        _ => Err(malformed(format!(
+            "skip expects zero args, got {}",
+            args.len()
+        ))),
+    }
+}
+
+fn expect_arity(name: &str, args: &[Json], arity: usize) -> Result<(), CompileError> {
+    if args.len() == arity {
+        Ok(())
+    } else {
+        Err(malformed(format!(
+            "{name} expects {arity} args, got {}",
+            args.len()
+        )))
+    }
+}
+
+fn malformed(message: impl Into<String>) -> CompileError {
+    CompileError::MalformedIr(message.into())
+}
+
+fn unsupported(message: impl Into<String>) -> CompileError {
+    CompileError::UnsupportedPredicate(message.into())
+}
+
+fn unsupported_operation(name: &str) -> CompileError {
+    CompileError::UnsupportedPredicate(format!("unsupported operation {name}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_class_name_uses_source_stem() {
+        let ir = json!({
+            "kind": "c11-algebra-term",
+            "source": "path/to/foo.c",
+            "term": {"kind": "op", "name": "return", "args": [{"kind": "const", "value": 1}]}
+        });
+
+        let jasmin = compile_jasmin(&ir).expect("compile");
+
+        assert!(jasmin.contains(".class public Foo\n"));
+        assert!(jasmin.contains(".method public static foo()I\n"));
+    }
+
+    #[test]
+    fn capabilities_include_core_ops() {
+        let caps = JvmBytecodeCompiler::new().capabilities();
+        for op in CORE_OPERATION_SUBSET {
+            assert!(caps.supported_predicates.iter().any(|item| item == op));
+        }
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/src/main.rs
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/src/main.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{self, Read};
+
+use provekit_ir_compiler_jvm_bytecode::compile_jasmin;
+use serde_json::Value as Json;
+
+fn main() {
+    let mut input = String::new();
+    if let Err(e) = io::stdin().read_to_string(&mut input) {
+        eprintln!("Error reading stdin: {e}");
+        std::process::exit(1);
+    }
+
+    let ir: Json = match serde_json::from_str(&input) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error parsing JSON: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    match compile_jasmin(&ir) {
+        Ok(jasmin) => print!("{jasmin}"),
+        Err(e) => {
+            eprintln!("Error compiling IR to JVM bytecode: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/tests/byte_for_byte.rs
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/tests/byte_for_byte.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Byte-for-byte regression checks for the Jasmin JVM realizer.
+
+use provekit_ir_compiler_jvm_bytecode::{compile_jasmin, JvmBytecodeCompiler, TermCompiler};
+use serde_json::Value as Json;
+
+#[test]
+fn foo_fixture_is_byte_stable() {
+    let input: Json =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("foo term json parses");
+    let expected = include_str!("fixtures/foo.expected.j");
+
+    let first = compile_jasmin(&input).expect("compile foo once");
+    let second = compile_jasmin(&input).expect("compile foo twice");
+
+    assert_eq!(first, second);
+    assert_eq!(first, expected);
+}
+
+#[test]
+fn trait_output_is_byte_stable() {
+    let input: Json =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("foo term json parses");
+    let compiler = JvmBytecodeCompiler::new();
+
+    let first = compiler
+        .compile_term_json(&input)
+        .expect("compile foo once");
+    let second = compiler
+        .compile_term_json(&input)
+        .expect("compile foo twice");
+
+    assert_eq!(first, second);
+}

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/tests/fixtures/foo.expected.j
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/tests/fixtures/foo.expected.j
@@ -1,0 +1,23 @@
+.class public Foo
+.super java/lang/Object
+
+.method public static foo(I)I
+  .limit stack 2
+  .limit locals 1
+  iload 0
+  iconst_0
+  if_icmpeq L_true_0
+  iconst_0
+  goto L_end_1
+L_true_0:
+  iconst_1
+L_end_1:
+  ifeq L_else_2
+  bipush 22
+  ineg
+  ireturn
+L_else_2:
+L_end_3:
+  iload 0
+  ireturn
+.end method

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/tests/fixtures/foo.term.json
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/tests/fixtures/foo.term.json
@@ -1,0 +1,78 @@
+{
+  "kind": "c11-algebra-term",
+  "signature_cid": "blake3-512:c942ba70e4b701e139a46590116f5cdc16ab41db277e80e54c01f23e4a7cf6241d4431c60473409cb3f0b61ce27f593071c1c224291f04c61aa04b4773764945",
+  "source": "foo.c",
+  "term_surface": "seq(if(eq(x, 0), return(neg(22)), skip), return(x))",
+  "term": {
+    "kind": "op",
+    "name": "seq",
+    "args": [
+      {
+        "kind": "op",
+        "name": "if",
+        "args": [
+          {
+            "kind": "op",
+            "name": "eq",
+            "args": [
+              {
+                "kind": "var",
+                "name": "x"
+              },
+              {
+                "kind": "const",
+                "value": 0,
+                "sort": {
+                  "kind": "ctor",
+                  "name": "Int",
+                  "args": []
+                }
+              }
+            ]
+          },
+          {
+            "kind": "op",
+            "name": "return",
+            "args": [
+              {
+                "kind": "op",
+                "name": "neg",
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": 22,
+                    "sort": {
+                      "kind": "ctor",
+                      "name": "Int",
+                      "args": []
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "op",
+            "name": "skip",
+            "args": [
+              {
+                "kind": "unit"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "op",
+        "name": "return",
+        "args": [
+          {
+            "kind": "var",
+            "name": "x"
+          }
+        ]
+      }
+    ]
+  },
+  "wp_value_note": "The branch-sensitive WP value is recorded in foo.expected-wp-contract.json. The current c-collectors-defensive lifter emits the same branch-sensitive contract in foo.contract.json."
+}

--- a/implementations/rust/provekit-ir-compiler-jvm-bytecode/tests/smoke.rs
+++ b/implementations/rust/provekit-ir-compiler-jvm-bytecode/tests/smoke.rs
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_jvm_bytecode::{
+    compile_jasmin, JvmBytecodeCompiler, TermCompiler, DIALECT,
+};
+use serde_json::json;
+use serde_json::Value as Json;
+
+#[test]
+fn compiles_foo_term_to_checked_fixture() {
+    let input: Json =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("foo term json parses");
+    let expected = include_str!("fixtures/foo.expected.j");
+
+    let jasmin = compile_jasmin(&input).expect("compile foo term");
+
+    assert_eq!(jasmin, expected);
+}
+
+#[test]
+fn lowers_arithmetic_and_comparison_ops() {
+    let input = json!({
+        "kind": "c11-algebra-term",
+        "source": "ops.c",
+        "term": {
+            "kind": "op",
+            "name": "return",
+            "args": [{
+                "kind": "op",
+                "name": "and",
+                "args": [
+                    {
+                        "kind": "op",
+                        "name": "eq",
+                        "args": [
+                            {
+                                "kind": "op",
+                                "name": "add",
+                                "args": [
+                                    {"kind": "const", "value": 40, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                                    {"kind": "const", "value": 2, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                                ]
+                            },
+                            {"kind": "const", "value": 42, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                        ]
+                    },
+                    {
+                        "kind": "op",
+                        "name": "le",
+                        "args": [
+                            {"kind": "const", "value": 1, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                            {"kind": "const", "value": 2, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                        ]
+                    }
+                ]
+            }]
+        }
+    });
+
+    let jasmin = compile_jasmin(&input).expect("compile op term");
+
+    assert!(jasmin.contains("iadd"));
+    assert!(jasmin.contains("if_icmpeq"));
+    assert!(jasmin.contains("if_icmple"));
+    assert!(jasmin.contains("ifeq"));
+}
+
+#[test]
+fn lowers_memory_ops_with_static_int_memory() {
+    let input = json!({
+        "kind": "c11-algebra-term",
+        "source": "mem.c",
+        "term": {
+            "kind": "op",
+            "name": "seq",
+            "args": [
+                {
+                    "kind": "op",
+                    "name": "assign",
+                    "args": [
+                        {"kind": "const", "value": 0, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                        {"kind": "const", "value": 7, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                    ]
+                },
+                {
+                    "kind": "op",
+                    "name": "return",
+                    "args": [{
+                        "kind": "op",
+                        "name": "deref",
+                        "args": [
+                            {"kind": "const", "value": 0, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                        ]
+                    }]
+                }
+            ]
+        }
+    });
+
+    let jasmin = compile_jasmin(&input).expect("compile memory term");
+
+    assert!(jasmin.contains(".field private static memory [I"));
+    assert!(jasmin.contains("iastore"));
+    assert!(jasmin.contains("iaload"));
+}
+
+#[test]
+fn refuses_unknown_operations() {
+    let input = json!({
+        "kind": "c11-algebra-term",
+        "source": "bad.c",
+        "term": {"kind": "op", "name": "switch", "args": []}
+    });
+
+    let err = compile_jasmin(&input).expect_err("switch is outside the core subset");
+    assert!(err.to_string().contains("unsupported operation switch"));
+}
+
+#[test]
+fn implements_ir_compiler_trait_for_jasmin() {
+    let input: Json =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("foo term json parses");
+    let compiler = JvmBytecodeCompiler::new();
+
+    let compiled = compiler
+        .compile(&input, DIALECT)
+        .expect("compile through trait");
+
+    assert_eq!(compiled.preamble, "");
+    assert_eq!(compiled.body, include_str!("fixtures/foo.expected.j"));
+}
+
+#[ignore = "requires jasmin or krak2 plus javac and java"]
+#[test]
+fn assembles_and_runs_foo_when_toolchain_is_available() {
+    if Command::new("javac").arg("-version").output().is_err()
+        || Command::new("java").arg("-version").output().is_err()
+    {
+        eprintln!("javac or java unavailable, skipping runtime smoke");
+        return;
+    }
+
+    let input: Json =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("foo term json parses");
+    let jasmin = JvmBytecodeCompiler::new()
+        .compile_term_json(&input)
+        .expect("foo term compiles");
+
+    let dir = std::env::temp_dir().join(format!(
+        "provekit-ir-compiler-jvm-bytecode-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let jasmin_path = dir.join("Foo.j");
+    let harness_path = dir.join("Harness.java");
+
+    fs::write(&jasmin_path, jasmin).expect("write jasmin");
+    fs::write(
+        &harness_path,
+        "public class Harness {\n  public static void main(String[] args) {\n    if (Foo.foo(0) != -22) { System.exit(1); }\n    if (Foo.foo(42) != 42) { System.exit(2); }\n  }\n}\n",
+    )
+    .expect("write harness");
+
+    if !assemble_jasmin(&jasmin_path, &dir) {
+        eprintln!("jasmin or krak2 unavailable, skipping runtime smoke");
+        let _ = fs::remove_dir_all(&dir);
+        return;
+    }
+
+    let javac = Command::new("javac")
+        .arg("-classpath")
+        .arg(&dir)
+        .arg("-d")
+        .arg(&dir)
+        .arg(&harness_path)
+        .status()
+        .expect("run javac");
+    assert!(javac.success(), "javac failed with {javac}");
+
+    let run = Command::new("java")
+        .arg("-cp")
+        .arg(&dir)
+        .arg("Harness")
+        .status()
+        .expect("run harness");
+
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(run.success(), "harness failed with {run}");
+}
+
+fn assemble_jasmin(jasmin_path: &Path, out_dir: &Path) -> bool {
+    if let Ok(status) = Command::new("jasmin")
+        .arg("-d")
+        .arg(out_dir)
+        .arg(jasmin_path)
+        .status()
+    {
+        if status.success() {
+            return true;
+        }
+    }
+
+    if let Ok(status) = Command::new("krak2")
+        .arg("asm")
+        .arg(jasmin_path)
+        .arg("-out")
+        .arg(out_dir)
+        .status()
+    {
+        return status.success();
+    }
+
+    false
+}


### PR DESCRIPTION
## Summary

`implementations/rust/provekit-ir-compiler-jvm-bytecode/` -- the JVM-bytecode executable-target rung of the realizer family, dual to `provekit-ir-compiler-coq` (a realizer-to-a-prover). Implements ORP v0.2 `compile` mode: lowers a ProofIR term (AST over operation-CIDs, `foo.term.json` format) to Jasmin assembler text (a `.class` with a `static foo(I)I` method). Stack machine, so the realization homomorphism encodes push-operands-then-op.

- Covers a core operation subset: `seq`, `if`, `while`, `return`, `call`, `break`, `continue`, `skip`, `eq`, `lt`, `le`, `add`, `sub`, `mul`, `neg`, `and`, `or`, `not`, variable loads, int/bool literals, `deref`, `assign` (`deref` + non-local `assign` use a minimal private static int-array memory model). Computes `.limit stack` / `.limit locals`. Refuses on unhandled operations.
- Binary `provekit-ir-jvm-bytecode`: reads a term JSON from stdin, emits Jasmin to stdout. Byte-deterministic (`tests/byte_for_byte.rs`).
- Smoke test on `foo`'s term: emits Jasmin computing `ite(x==0, -22, x)` (the runtime-run test self-skips without `jasmin`/`krak2`).
- Draft `algebra -> jvm-bytecode` `LanguageMorphismMemento` spec at `specs/algebra_to_jvm.spec.json`. Not minted (follow-up).
- `cargo build -p provekit-ir-compiler-jvm-bytecode`, `cargo test -p provekit-ir-compiler-jvm-bytecode` (5 smoke + byte tests, 1 ignored), `cargo clippy -p provekit-ir-compiler-jvm-bytecode --no-deps -- -D warnings` all clean.

Deferred: full operation catalog, a direct `.class` writer + constant pool, reference types, optimization, minting the morphism receipt.

## Test plan

- [ ] `cargo build -p provekit-ir-compiler-jvm-bytecode`, `cargo test -p provekit-ir-compiler-jvm-bytecode`, `cargo clippy -p provekit-ir-compiler-jvm-bytecode --no-deps -- -D warnings`
- [ ] With `jasmin`/`krak2` + a JVM: assemble + run `foo`'s emitted Jasmin; `foo(0) == -22`, `foo(42) == 42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)