### PR TITLE
feat: provekit-ir-compiler-c - ORP v0.2 compile mode (term -> C source)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1673,6 +1673,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-ir-compiler-c"
+version = "0.1.0"
+dependencies = [
+ "provekit-canonicalizer",
+ "provekit-ir-compiler",
+ "provekit-ir-types",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "provekit-ir-compiler-coq"
 version = "0.1.0"
 dependencies = [

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "provekit-ir-compiler-smt-lib",
     "provekit-ir-compiler-stub",
     "provekit-ir-compiler-coq",
+    "provekit-ir-compiler-c",
     "provekit-ir-compiler-x86-64",
     "provekit-ir-compiler-wasm",
     "provekit-ir-compiler-maude",

--- a/implementations/rust/provekit-ir-compiler-c/Cargo.toml
+++ b/implementations/rust/provekit-ir-compiler-c/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "provekit-ir-compiler-c"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "ProvekIt: C11 compile-mode IR term compiler."
+
+[dependencies]
+provekit-ir-compiler = { path = "../provekit-ir-compiler" }
+provekit-ir-types = { path = "../provekit-ir-types" }
+serde_json.workspace = true
+
+[dev-dependencies]
+provekit-canonicalizer = { path = "../provekit-canonicalizer" }
+tempfile = "3"
+
+[[bin]]
+name = "provekit-ir-c"
+path = "src/main.rs"
+
+[lib]
+name = "provekit_ir_compiler_c"
+path = "src/lib.rs"

--- a/implementations/rust/provekit-ir-compiler-c/README.md
+++ b/implementations/rust/provekit-ir-compiler-c/README.md
@@ -1,0 +1,133 @@
+# provekit-ir-compiler-c
+
+`provekit-ir-compiler-c` is the C executable-target rung of the ProvekIt
+realizer family. It implements ORP v0.2 `compile` mode for the ProofIR term
+stratum:
+
+```text
+compile : Term * c:c11 -> ConcreteCode | Refusal
+```
+
+The input is a ProofIR term, an AST over operation CIDs, not a contract. The
+output is complete C11 source. C is structured enough that the realization
+homomorphism is nearly transparent: most term operations lower directly to the
+matching C expression or statement form.
+
+This is dual to `provekit-ir-compiler-coq`: Coq realizes IR into prover input,
+while this crate realizes IR terms into runnable C.
+
+## CLI
+
+```sh
+cat ../../menagerie/c11-language-signature/example/foo.term.json | cargo run -p provekit-ir-compiler-c --bin provekit-ir-c
+```
+
+The binary reads a ProofIR term JSON document from stdin and writes C11 source
+to stdout.
+
+## API
+
+The crate exposes `compile_c`, `CCompiler`, and a small `TermCompiler` trait:
+
+```rust
+pub trait TermCompiler {
+    fn compile_term_json(&self, ir: &serde_json::Value) -> Result<String, CompileError>;
+}
+```
+
+`CCompiler` also implements `IrCompiler` for registry compatibility. In that
+path, the emitted C source is returned as `CompiledFormula.body`, with an empty
+preamble and no free variables.
+
+## Core Subset
+
+The current hand-mapped subset covers:
+
+```text
+seq, if, while, return, call, break, continue, skip,
+eq, lt, le, add, sub, mul, neg, and, or, not,
+variable reference, integer literal, deref, assign
+```
+
+| ProofIR operation | C11 realization |
+| --- | --- |
+| `seq(a,b)` | Emit `a` followed by `b`. |
+| `if(c,t,e)` statement | `if c { t } else { e }`. |
+| `if(c,t,e)` expression | `(c) ? (t) : (e)`. |
+| `while(c,b)` | `while c { b }`. |
+| `return(e)` | `return (e);`. |
+| `call(f,args)` | `f(args)`. |
+| `break`, `continue` | `break;` and `continue;` in a loop. |
+| `skip` | `;`. |
+| variable reference | The validated C identifier. |
+| integer or bool literal | The literal, with bools encoded as `0` or `1`. |
+| `eq`, `lt`, `le` | `==`, `<`, `<=`. |
+| `add`, `sub`, `mul`, `neg` | `+`, `-`, `*`, unary `-`. |
+| `and`, `or`, `not` | `&&`, `||`, `!`. |
+| `deref(p)` | `(*(p))`. |
+| `assign(lv,e)` | `lv = (e);` as a statement, `(lv = (e))` as an expression. |
+
+The core subset is hand-mapped. The full operation set is
+mint-more-realizations, not new machinery: add an operation-CID table entry,
+its lowering, and the corresponding morphism discharge receipt.
+
+## Byte Determinism
+
+Output is byte-deterministic for byte-equal input JSON and the same target
+descriptor. Function names are derived deterministically from the envelope or
+source file stem. Parameters follow first read order. Labels are not needed for
+the C structured subset. The `byte_for_byte` test compiles fixtures twice and
+checks exact byte equality; the smoke test checks `foo.term.json` against a
+checked-in C source fixture.
+
+## Round Trip Story
+
+ORP v0.2 treats `compile` mode as a deterministic homomorphism from the term
+algebra to target code. In LSP terms, this crate is the implementation body for
+a draft `LanguageMorphismMemento`:
+
+```text
+ProofIR C11 term algebra -> c:c11 source
+```
+
+The draft spec is in `specs/algebra_to_c.spec.json`.
+
+The intended C round trip is:
+
+```text
+contract(lift_from_c(compile_to_c(t))) = contract(t)
+```
+
+Because target C and the source term algebra share the C11 signature, the
+representation morphism is the identity for the current contract projection.
+Composing this realizer with the existing `c-collectors-defensive` lifter gives
+the clean sanity check: `c -> algebra -> c` should preserve the contract CID.
+
+The same composition also explains cross-language routes. For example,
+`lift-from-rust` followed by `compile-to-c` is cross-compiling Rust to C at the
+ProofIR term stratum while carrying the same contract through accepted receipts.
+
+References:
+
+- `protocol/specs/2026-05-10-realizer-protocol-v2.md`
+- `docs/papers/13-after-grammars-programming-languages-as-content-addressed-algebras.md`
+- `docs/papers/14-after-trust-the-universal-correctness-bundle.md`
+
+## Refusal Behavior
+
+Unsupported operations fail closed with `CompileError::UnsupportedPredicate`.
+Malformed terms fail with `CompileError::MalformedIr`. Unsupported constant
+sorts fail with `CompileError::UnsupportedSort`. The compiler does not emit
+opaque placeholders, does not silently drop invariants, and refuses unsafe C
+identifiers instead of rewriting term variables.
+
+## Follow-up Work
+
+- Add mappings for the full C11 operation catalog.
+- Carry declarations and type widths through the term envelope.
+- Add richer ABI bindings for multiple functions and external calls.
+- Mint the `algebra -> c` morphism receipt.
+- Mint the round-trip identity receipt for `lift-from-c` composed with
+  `compile-to-c`.
+
+Sign-off: T Savo

--- a/implementations/rust/provekit-ir-compiler-c/specs/algebra_to_c.spec.json
+++ b/implementations/rust/provekit-ir-compiler-c/specs/algebra_to_c.spec.json
@@ -1,0 +1,136 @@
+{
+  "kind": "LanguageMorphismMemento",
+  "schemaVersion": "draft-0.2",
+  "name": "proofir-c11-algebra-to-c11-source-core",
+  "status": "draft-not-minted",
+  "author": "T Savo",
+  "mode": "compile",
+  "source": {
+    "kind": "ProofIRTermSignature",
+    "termStratum": true,
+    "language": "c:c11",
+    "termEnvelopeKind": "c11-algebra-term",
+    "languageSignature": "menagerie/c11-language-signature/specs/language_signature_c11.spec.json",
+    "signatureCid": "blake3-512:c942ba70e4b701e139a46590116f5cdc16ab41db277e80e54c01f23e4a7cf6241d4431c60473409cb3f0b61ce27f593071c1c224291f04c61aa04b4773764945",
+    "operationCatalog": "menagerie/c11-language-signature/catalog/algorithms"
+  },
+  "target": {
+    "kind": "TargetSignature",
+    "language": "c:c11",
+    "descriptor": "c/c11/source-core",
+    "artifactKind": "source-file",
+    "mediaType": "text/x-csrc",
+    "syntax": "C11",
+    "entryShape": "single int function with int parameters"
+  },
+  "realizer": {
+    "crate": "provekit-ir-compiler-c",
+    "binary": "provekit-ir-c",
+    "compiler": "c11-source-core",
+    "dialect": "c:c11",
+    "version": "0.1.0",
+    "determinism": "byte-equal term JSON and target descriptor produce byte-equal C source"
+  },
+  "operationMapping": [
+    {
+      "source": "seq(a,b)",
+      "target": "emit a followed by b",
+      "obligation": "target sequencing preserves source statement order"
+    },
+    {
+      "source": "if(c,t,e)",
+      "target": "statement position emits if c { t } else { e }; expression position emits (c) ? (t) : (e)",
+      "obligation": "C selects the same branch as the source conditional"
+    },
+    {
+      "source": "while(c,b)",
+      "target": "while c { b }",
+      "obligation": "loop entry, exit, break, and continue preserve the source control flow"
+    },
+    {
+      "source": "return(e)",
+      "target": "return (e);",
+      "obligation": "the returned C value is the lowered value of e"
+    },
+    {
+      "source": "call(f,args)",
+      "target": "f(args)",
+      "obligation": "callee and argument order match the source term"
+    },
+    {
+      "source": "break(unit)",
+      "target": "break;",
+      "obligation": "control transfers to the nearest enclosing loop exit"
+    },
+    {
+      "source": "continue(unit)",
+      "target": "continue;",
+      "obligation": "control transfers to the nearest enclosing loop head"
+    },
+    {
+      "source": "skip(unit)",
+      "target": ";",
+      "obligation": "state is unchanged"
+    },
+    {
+      "source": "var x",
+      "target": "x",
+      "obligation": "the C identifier denotes the same term variable"
+    },
+    {
+      "source": "const n",
+      "target": "n",
+      "obligation": "the target literal denotes the same accepted integer value"
+    },
+    {
+      "source": "eq, lt, le",
+      "target": "==, <, <=",
+      "obligation": "integer comparison results agree with the C11 integer semantics selected by the source signature"
+    },
+    {
+      "source": "add, sub, mul, neg",
+      "target": "+, -, *, unary -",
+      "obligation": "integer arithmetic agrees with the accepted C11 integer subset"
+    },
+    {
+      "source": "and, or, not",
+      "target": "&&, ||, !",
+      "obligation": "truth values preserve the C zero false and nonzero true convention"
+    },
+    {
+      "source": "deref(p)",
+      "target": "(*(p))",
+      "obligation": "the read observes the same address in the accepted memory model"
+    },
+    {
+      "source": "assign(lv,e)",
+      "target": "lv = (e); in statement position, (lv = (e)) in expression position",
+      "obligation": "the write updates the same lvalue in the accepted memory model"
+    }
+  ],
+  "homomorphismObligation": {
+    "operationPreservation": "compile(apply(op,args)) = target_apply(image(op), map(compile,args)) for every mapped operation",
+    "equationPreservation": "for each source equation in the accepted C11 signature, the emitted C behavior entails the compiled equation under C11 semantics",
+    "dischargeStatus": "draft only, no MorphismDischargeReceipt minted in this crate"
+  },
+  "contractPreservation": {
+    "statement": "For any accepted term t in the core subset, contract(lift_from_c(compile_to_c(t))) = contract(t).",
+    "composition": "This morphism composes with the existing c-collectors-defensive lifter c -> algebra morphism to give a round trip whose contract is the identity.",
+    "obligation": "discharged by composition after the algebra -> c morphism receipt and the c-collectors-defensive lifter receipt are minted",
+    "followUpReceipt": "round-trip identity receipt for c -> algebra -> c"
+  },
+  "refusalPolicy": {
+    "unsupportedOperations": "return Refusal via compile_error.unsupported_predicate",
+    "malformedTerms": "return Refusal via compile_error.malformed_ir",
+    "unsupportedSorts": "return Refusal via compile_error.unsupported_sort",
+    "unsafeIdentifiers": "refuse term variables and callees that are not valid C identifiers"
+  },
+  "deferred": [
+    "full C11 operation catalog",
+    "declarations and type widths",
+    "multiple functions and translation units",
+    "minting the algebra -> c MorphismDischargeReceipt",
+    "minting the c -> algebra -> c identity receipt"
+  ],
+  "signOff": "T Savo"
+}

--- a/implementations/rust/provekit-ir-compiler-c/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-c/src/generated.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Hand-maintained operation table for the current core subset.
+// The full operation set is mint-more-realizations, not new machinery:
+// each added operation is another homomorphic table entry plus its receipt.
+
+pub const CORE_OPERATION_SUBSET: &[&str] = &[
+    "seq", "if", "while", "return", "call", "break", "continue", "skip", "eq", "lt", "le", "add",
+    "sub", "mul", "neg", "and", "or", "not", "var", "const", "deref", "assign",
+];
+
+pub const ALGEBRA_TO_C_TABLE: &[(&str, &str)] = &[
+    ("seq(a,b)", "emit a followed by b"),
+    (
+        "if(c,t,e) statement",
+        "if c { t } else { e } with structured blocks",
+    ),
+    (
+        "if(c,t,e) expression",
+        "(c) ? (t) : (e) with expression branches",
+    ),
+    ("while(c,b)", "while c { b }"),
+    ("return(e)", "return (e);"),
+    ("call(f,args)", "f(args)"),
+    ("break(unit)", "break;"),
+    ("continue(unit)", "continue;"),
+    ("skip(unit)", ";"),
+    ("var x", "x"),
+    ("const n", "n"),
+    ("eq(a,b)", "((a) == (b))"),
+    ("lt(a,b)", "((a) < (b))"),
+    ("le(a,b)", "((a) <= (b))"),
+    ("add(a,b)", "((a) + (b))"),
+    ("sub(a,b)", "((a) - (b))"),
+    ("mul(a,b)", "((a) * (b))"),
+    ("neg(a)", "(-(a))"),
+    ("and(a,b)", "((a) && (b))"),
+    ("or(a,b)", "((a) || (b))"),
+    ("not(a)", "(!(a))"),
+    ("deref(p)", "(*(p))"),
+    (
+        "assign(lv,e)",
+        "lv = (e); in statement position, (lv = (e)) in expression position",
+    ),
+];

--- a/implementations/rust/provekit-ir-compiler-c/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-c/src/lib.rs
@@ -1,0 +1,665 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ORP v0.2 compile-mode realizer for ProofIR C11 term algebra to C11 source.
+
+use std::path::Path;
+
+use provekit_ir_compiler::{
+    Capabilities, CompileError, CompiledFormula, FreeVar, IrCompiler, OpacityManifest,
+    PROTOCOL_VERSION,
+};
+use serde_json::Value as Json;
+
+mod generated;
+
+pub use generated::{ALGEBRA_TO_C_TABLE, CORE_OPERATION_SUBSET};
+
+pub const DIALECT: &str = "c:c11";
+pub const COMPILER_NAME: &str = "c11-source-core";
+pub const COMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub trait TermCompiler {
+    fn compile_term_json(&self, ir: &Json) -> Result<String, CompileError>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CCompiler;
+
+#[derive(Debug, Default)]
+struct VarSets {
+    params: Vec<String>,
+    assigned: Vec<String>,
+}
+
+struct Emitter {
+    lines: Vec<String>,
+    loop_depth: usize,
+}
+
+impl CCompiler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl TermCompiler for CCompiler {
+    fn compile_term_json(&self, ir: &Json) -> Result<String, CompileError> {
+        compile_c(ir)
+    }
+}
+
+impl IrCompiler for CCompiler {
+    fn compile(&self, ir: &Json, dialect: &str) -> Result<CompiledFormula, CompileError> {
+        if dialect != DIALECT {
+            return Err(CompileError::UnsupportedDialect(dialect.to_string()));
+        }
+
+        Ok(CompiledFormula {
+            preamble: String::new(),
+            body: compile_c(ir)?,
+            free_vars: Vec::<FreeVar>::new(),
+            opacity_manifest: OpacityManifest {
+                protocol_version: "ir-compiler-protocol/2".to_string(),
+                compiler: DIALECT.to_string(),
+                compiler_version: COMPILER_VERSION.to_string(),
+                opacities: vec![],
+            },
+        })
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            name: COMPILER_NAME.to_string(),
+            version: COMPILER_VERSION.to_string(),
+            protocol_version: PROTOCOL_VERSION.to_string(),
+            dialects: vec![DIALECT.to_string()],
+            supported_sorts: vec![
+                "Int".to_string(),
+                "Bool".to_string(),
+                "Ptr".to_string(),
+                "LValue".to_string(),
+                "Stmt".to_string(),
+                "Unit".to_string(),
+            ],
+            supported_predicates: CORE_OPERATION_SUBSET
+                .iter()
+                .map(|op| (*op).to_string())
+                .collect(),
+        }
+    }
+}
+
+pub fn compile_c(input: &Json) -> Result<String, CompileError> {
+    let term = term_payload(input)?;
+    let function_name = function_name(input);
+
+    let mut vars = VarSets::default();
+    collect_vars(term, &mut vars)?;
+
+    let params = vars.params;
+    let locals = vars
+        .assigned
+        .into_iter()
+        .filter(|name| !params.iter().any(|param| param == name))
+        .collect::<Vec<_>>();
+
+    let mut lines = Vec::new();
+    lines.push("#include <stdint.h>".to_string());
+    lines.push(String::new());
+    lines.push(format!("int {}({}) {{", function_name, param_list(&params)));
+
+    for local in &locals {
+        lines.push(format!("    int {local} = 0;"));
+    }
+
+    let mut emitter = Emitter::new();
+    if is_statement_term(term) {
+        emitter.emit_stmt(term, 1)?;
+        lines.extend(emitter.lines);
+        if !stmt_always_returns(term) {
+            lines.push("    return (0);".to_string());
+        }
+    } else {
+        let expr = emit_expr(term)?;
+        lines.push(format!("    return ({});", expr));
+    }
+
+    lines.push("}".to_string());
+    lines.push(String::new());
+    Ok(lines.join("\n"))
+}
+
+impl Emitter {
+    fn new() -> Self {
+        Self {
+            lines: Vec::new(),
+            loop_depth: 0,
+        }
+    }
+
+    fn emit_stmt(&mut self, term: &Json, indent: usize) -> Result<(), CompileError> {
+        match term_kind(term)? {
+            "unit" => {
+                self.line(indent, ";");
+                Ok(())
+            }
+            "var" | "const" => {
+                let expr = emit_expr(term)?;
+                self.line(indent, format!("({expr});"));
+                Ok(())
+            }
+            "op" => match op_name(term)? {
+                "seq" => {
+                    let args = op_args(term)?;
+                    expect_arity("seq", args, 2)?;
+                    self.emit_stmt(&args[0], indent)?;
+                    self.emit_stmt(&args[1], indent)
+                }
+                "if" => {
+                    let args = op_args(term)?;
+                    expect_arity("if", args, 3)?;
+                    let cond = emit_condition(&args[0])?;
+                    self.line(indent, format!("if {cond} {{"));
+                    self.emit_stmt(&args[1], indent + 1)?;
+                    self.line(indent, "} else {");
+                    self.emit_stmt(&args[2], indent + 1)?;
+                    self.line(indent, "}");
+                    Ok(())
+                }
+                "while" => {
+                    let args = op_args(term)?;
+                    expect_arity("while", args, 2)?;
+                    let cond = emit_condition(&args[0])?;
+                    self.line(indent, format!("while {cond} {{"));
+                    self.loop_depth += 1;
+                    let body_result = self.emit_stmt(&args[1], indent + 1);
+                    self.loop_depth -= 1;
+                    body_result?;
+                    self.line(indent, "}");
+                    Ok(())
+                }
+                "return" => {
+                    let args = op_args(term)?;
+                    expect_arity("return", args, 1)?;
+                    let expr = emit_expr(&args[0])?;
+                    self.line(indent, format!("return ({});", expr));
+                    Ok(())
+                }
+                "call" => {
+                    let expr = emit_call(term)?;
+                    self.line(indent, format!("{expr};"));
+                    Ok(())
+                }
+                "break" => {
+                    expect_unit_arg("break", op_args(term)?)?;
+                    if self.loop_depth == 0 {
+                        return Err(malformed("break outside loop"));
+                    }
+                    self.line(indent, "break;");
+                    Ok(())
+                }
+                "continue" => {
+                    expect_unit_arg("continue", op_args(term)?)?;
+                    if self.loop_depth == 0 {
+                        return Err(malformed("continue outside loop"));
+                    }
+                    self.line(indent, "continue;");
+                    Ok(())
+                }
+                "skip" => {
+                    expect_unit_arg("skip", op_args(term)?)?;
+                    self.line(indent, ";");
+                    Ok(())
+                }
+                "assign" => {
+                    let args = op_args(term)?;
+                    expect_arity("assign", args, 2)?;
+                    let target = emit_lvalue(&args[0])?;
+                    let value = emit_expr(&args[1])?;
+                    self.line(indent, format!("{target} = ({value});"));
+                    Ok(())
+                }
+                name if is_expr_op(name) => {
+                    let expr = emit_expr(term)?;
+                    self.line(indent, format!("({expr});"));
+                    Ok(())
+                }
+                name => Err(unsupported(name)),
+            },
+            other => Err(malformed(format!("unknown statement kind: {other}"))),
+        }
+    }
+
+    fn line(&mut self, indent: usize, text: impl AsRef<str>) {
+        self.lines
+            .push(format!("{}{}", "    ".repeat(indent), text.as_ref()));
+    }
+}
+
+fn emit_expr(term: &Json) -> Result<String, CompileError> {
+    match term_kind(term)? {
+        "var" => c_identifier(var_name(term)?).map(str::to_string),
+        "const" => const_literal(term),
+        "op" => {
+            let name = op_name(term)?;
+            let args = op_args(term)?;
+            match name {
+                "eq" => emit_binary(args, "=="),
+                "lt" => emit_binary(args, "<"),
+                "le" => emit_binary(args, "<="),
+                "add" => emit_binary(args, "+"),
+                "sub" => emit_binary(args, "-"),
+                "mul" => emit_binary(args, "*"),
+                "and" => emit_binary(args, "&&"),
+                "or" => emit_binary(args, "||"),
+                "neg" => {
+                    expect_arity(name, args, 1)?;
+                    Ok(format!("(-{})", operand(&emit_expr(&args[0])?)))
+                }
+                "not" => {
+                    expect_arity(name, args, 1)?;
+                    Ok(format!("(!{})", operand(&emit_expr(&args[0])?)))
+                }
+                "deref" => {
+                    expect_arity(name, args, 1)?;
+                    Ok(format!("(*{})", operand(&emit_expr(&args[0])?)))
+                }
+                "assign" => {
+                    expect_arity(name, args, 2)?;
+                    let target = emit_lvalue(&args[0])?;
+                    let value = emit_expr(&args[1])?;
+                    Ok(format!("({target} = ({value}))"))
+                }
+                "call" => emit_call(term),
+                "if" => {
+                    expect_arity(name, args, 3)?;
+                    if is_statement_term(&args[1]) || is_statement_term(&args[2]) {
+                        return Err(malformed("if expression branches must be expressions"));
+                    }
+                    let cond = emit_expr(&args[0])?;
+                    let then_branch = emit_expr(&args[1])?;
+                    let else_branch = emit_expr(&args[2])?;
+                    Ok(format!("(({cond}) ? ({then_branch}) : ({else_branch}))"))
+                }
+                name => Err(unsupported(name)),
+            }
+        }
+        "unit" => Err(malformed("unit has no expression value")),
+        other => Err(malformed(format!("unknown expression kind: {other}"))),
+    }
+}
+
+fn emit_binary(args: &[Json], op: &str) -> Result<String, CompileError> {
+    expect_arity(op, args, 2)?;
+    let lhs = emit_expr(&args[0])?;
+    let rhs = emit_expr(&args[1])?;
+    Ok(format!("({} {} {})", operand(&lhs), op, operand(&rhs)))
+}
+
+fn operand(expr: &str) -> String {
+    if expr.starts_with('(') && expr.ends_with(')') {
+        expr.to_string()
+    } else {
+        format!("({expr})")
+    }
+}
+
+fn emit_condition(term: &Json) -> Result<String, CompileError> {
+    let expr = emit_expr(term)?;
+    if expr.starts_with('(') && expr.ends_with(')') {
+        Ok(expr)
+    } else {
+        Ok(format!("({expr})"))
+    }
+}
+
+fn emit_lvalue(term: &Json) -> Result<String, CompileError> {
+    match term_kind(term)? {
+        "var" => c_identifier(var_name(term)?).map(str::to_string),
+        "op" if op_name(term)? == "deref" => {
+            let args = op_args(term)?;
+            expect_arity("deref", args, 1)?;
+            Ok(format!("*({})", emit_expr(&args[0])?))
+        }
+        _ => Err(unsupported("assign target")),
+    }
+}
+
+fn emit_call(term: &Json) -> Result<String, CompileError> {
+    let args = op_args(term)?;
+    if args.is_empty() {
+        return Err(malformed("call expects callee plus arguments"));
+    }
+    let callee = callee_name(&args[0])?;
+    let call_args = call_arguments(args)?;
+    let rendered_args = call_args
+        .iter()
+        .map(|arg| emit_expr(arg))
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    Ok(format!("{callee}({rendered_args})"))
+}
+
+fn collect_vars(term: &Json, vars: &mut VarSets) -> Result<(), CompileError> {
+    match term_kind(term)? {
+        "var" => push_unique(&mut vars.params, c_identifier(var_name(term)?)?),
+        "const" | "unit" => {}
+        "op" => {
+            let name = op_name(term)?;
+            let args = op_args(term)?;
+            if name == "call" {
+                for arg in call_arguments(args)? {
+                    collect_vars(arg, vars)?;
+                }
+                return Ok(());
+            }
+            if name == "assign" {
+                expect_arity(name, args, 2)?;
+                if term_kind(&args[0])? == "var" {
+                    push_unique(&mut vars.assigned, c_identifier(var_name(&args[0])?)?);
+                    collect_vars(&args[1], vars)?;
+                    return Ok(());
+                }
+            }
+            for arg in args {
+                collect_vars(arg, vars)?;
+            }
+        }
+        "ctor" => {
+            if let Some(args) = term.get("args").and_then(Json::as_array) {
+                for arg in args {
+                    collect_vars(arg, vars)?;
+                }
+            }
+        }
+        other => return Err(malformed(format!("unknown term kind: {other}"))),
+    }
+    Ok(())
+}
+
+fn term_payload(input: &Json) -> Result<&Json, CompileError> {
+    match input.get("kind").and_then(Json::as_str) {
+        Some("c11-algebra-term") => input
+            .get("term")
+            .ok_or_else(|| malformed("c11 algebra term envelope missing term")),
+        _ => Ok(input),
+    }
+}
+
+fn function_name(input: &Json) -> String {
+    for key in ["function", "function_name", "fn_name", "name"] {
+        if let Some(name) = input.get(key).and_then(Json::as_str) {
+            return sanitize_symbol(name);
+        }
+    }
+    if let Some(source) = input.get("source").and_then(Json::as_str) {
+        if let Some(stem) = Path::new(source).file_stem().and_then(|stem| stem.to_str()) {
+            return sanitize_symbol(stem);
+        }
+    }
+    "proofir_term".to_string()
+}
+
+fn sanitize_symbol(raw: &str) -> String {
+    let mut out = String::new();
+    for (index, ch) in raw.chars().enumerate() {
+        let valid = ch.is_ascii_alphanumeric() || ch == '_';
+        if valid && !(index == 0 && ch.is_ascii_digit()) {
+            out.push(ch);
+        } else if valid {
+            out.push('_');
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        "proofir_term".to_string()
+    } else {
+        out
+    }
+}
+
+fn param_list(params: &[String]) -> String {
+    if params.is_empty() {
+        return "void".to_string();
+    }
+    params
+        .iter()
+        .map(|name| format!("int {name}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn call_arguments(args: &[Json]) -> Result<Vec<&Json>, CompileError> {
+    match args {
+        [_callee] => Ok(Vec::new()),
+        [_callee, maybe_list] if term_kind(maybe_list)? == "ctor" => Ok(maybe_list
+            .get("args")
+            .and_then(Json::as_array)
+            .map(|items| items.iter().collect())
+            .unwrap_or_default()),
+        [_callee, maybe_unit] if is_unit(maybe_unit) => Ok(Vec::new()),
+        [_callee, rest @ ..] => Ok(rest.iter().collect()),
+        [] => Err(malformed("call expects callee plus arguments")),
+    }
+}
+
+fn callee_name(term: &Json) -> Result<String, CompileError> {
+    match term_kind(term)? {
+        "var" => c_identifier(var_name(term)?).map(str::to_string),
+        "const" => term
+            .get("value")
+            .and_then(Json::as_str)
+            .ok_or_else(|| malformed("call callee const must be a string"))
+            .and_then(|name| c_identifier(name).map(str::to_string)),
+        "ctor" => term
+            .get("name")
+            .and_then(Json::as_str)
+            .ok_or_else(|| malformed("call callee ctor missing name"))
+            .and_then(|name| c_identifier(name).map(str::to_string)),
+        other => Err(malformed(format!("unsupported callee kind {other}"))),
+    }
+}
+
+fn const_literal(term: &Json) -> Result<String, CompileError> {
+    let value = term
+        .get("value")
+        .ok_or_else(|| malformed("const missing value"))?;
+    if let Some(i) = value.as_i64() {
+        return Ok(i.to_string());
+    }
+    if let Some(u) = value.as_u64() {
+        return Ok(u.to_string());
+    }
+    if let Some(b) = value.as_bool() {
+        return Ok(i32::from(b).to_string());
+    }
+    Err(CompileError::UnsupportedSort(
+        "C11 core compiler supports only integer and bool constants".to_string(),
+    ))
+}
+
+fn is_statement_term(term: &Json) -> bool {
+    term.get("kind")
+        .and_then(Json::as_str)
+        .is_some_and(|kind| match kind {
+            "unit" => true,
+            "op" => match term.get("name").and_then(Json::as_str) {
+                Some("if") => term
+                    .get("args")
+                    .and_then(Json::as_array)
+                    .is_some_and(|args| {
+                        args.len() == 3
+                            && (is_statement_term(&args[1]) || is_statement_term(&args[2]))
+                    }),
+                Some(name) => is_statement_op(name),
+                None => false,
+            },
+            _ => false,
+        })
+}
+
+fn is_statement_op(name: &str) -> bool {
+    matches!(
+        name,
+        "seq" | "while" | "return" | "break" | "continue" | "skip" | "assign"
+    )
+}
+
+fn is_expr_op(name: &str) -> bool {
+    matches!(
+        name,
+        "eq" | "lt"
+            | "le"
+            | "add"
+            | "sub"
+            | "mul"
+            | "neg"
+            | "and"
+            | "or"
+            | "not"
+            | "deref"
+            | "call"
+            | "if"
+    )
+}
+
+fn stmt_always_returns(term: &Json) -> bool {
+    match term.get("kind").and_then(Json::as_str) {
+        Some("op") => match term.get("name").and_then(Json::as_str) {
+            Some("return") => true,
+            Some("seq") => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_some_and(|args| args.iter().any(stmt_always_returns)),
+            Some("if") => term
+                .get("args")
+                .and_then(Json::as_array)
+                .is_some_and(|args| {
+                    args.len() == 3
+                        && stmt_always_returns(&args[1])
+                        && stmt_always_returns(&args[2])
+                }),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn term_kind(term: &Json) -> Result<&str, CompileError> {
+    term.get("kind")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("term missing kind"))
+}
+
+fn op_name(term: &Json) -> Result<&str, CompileError> {
+    term.get("name")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("op missing name"))
+}
+
+fn op_args(term: &Json) -> Result<&[Json], CompileError> {
+    term.get("args")
+        .and_then(Json::as_array)
+        .map(Vec::as_slice)
+        .ok_or_else(|| malformed("op missing args array"))
+}
+
+fn var_name(term: &Json) -> Result<&str, CompileError> {
+    term.get("name")
+        .and_then(Json::as_str)
+        .ok_or_else(|| malformed("var missing name"))
+}
+
+fn expect_arity(op: &str, args: &[Json], expected: usize) -> Result<(), CompileError> {
+    if args.len() == expected {
+        Ok(())
+    } else {
+        Err(malformed(format!(
+            "{op} expects {expected} arguments, got {}",
+            args.len()
+        )))
+    }
+}
+
+fn expect_unit_arg(op: &str, args: &[Json]) -> Result<(), CompileError> {
+    match args {
+        [] => Ok(()),
+        [arg] if is_unit(arg) => Ok(()),
+        _ => Err(malformed(format!("{op} expects one unit argument"))),
+    }
+}
+
+fn is_unit(term: &Json) -> bool {
+    term.get("kind").and_then(Json::as_str) == Some("unit")
+        || (term.get("kind").and_then(Json::as_str) == Some("op")
+            && term.get("name").and_then(Json::as_str) == Some("skip"))
+}
+
+fn c_identifier(raw: &str) -> Result<&str, CompileError> {
+    let mut chars = raw.chars();
+    let Some(first) = chars.next() else {
+        return Err(malformed("empty identifier"));
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return Err(malformed(format!("unsupported C identifier: {raw}")));
+    }
+    if !chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_') {
+        return Err(malformed(format!("unsupported C identifier: {raw}")));
+    }
+    Ok(raw)
+}
+
+fn push_unique(vec: &mut Vec<String>, name: &str) {
+    if !vec.iter().any(|existing| existing == name) {
+        vec.push(name.to_string());
+    }
+}
+
+fn unsupported(name: &str) -> CompileError {
+    CompileError::UnsupportedPredicate(name.to_string())
+}
+
+fn malformed(message: impl Into<String>) -> CompileError {
+    CompileError::MalformedIr(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_function_name_uses_source_stem() {
+        let ir = json!({
+            "kind": "c11-algebra-term",
+            "source": "path/to/foo.c",
+            "term": {"kind": "op", "name": "skip", "args": [{"kind": "unit"}]}
+        });
+
+        let c_source = compile_c(&ir).expect("compile");
+
+        assert!(c_source.contains("int foo(void) {"));
+    }
+
+    #[test]
+    fn invalid_variable_names_are_refused() {
+        let ir = json!({
+            "kind": "var",
+            "name": "x-y"
+        });
+
+        let err = compile_c(&ir).expect_err("invalid identifier");
+
+        assert!(err.to_string().contains("unsupported C identifier"));
+    }
+
+    #[test]
+    fn capabilities_include_core_ops() {
+        let caps = CCompiler::new().capabilities();
+        for op in CORE_OPERATION_SUBSET {
+            assert!(caps.supported_predicates.iter().any(|item| item == op));
+        }
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-c/src/main.rs
+++ b/implementations/rust/provekit-ir-compiler-c/src/main.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binary entry point for provekit-ir-compiler-c.
+//
+// Reads ProofIR term JSON from stdin and emits C11 source to stdout.
+// Usage: cat foo.term.json | provekit-ir-c
+
+use std::io::{self, Read};
+
+use provekit_ir_compiler_c::compile_c;
+use serde_json::Value as Json;
+
+fn main() {
+    let mut input = String::new();
+    if let Err(e) = io::stdin().read_to_string(&mut input) {
+        eprintln!("Error reading stdin: {e}");
+        std::process::exit(1);
+    }
+
+    let ir: Json = match serde_json::from_str(&input) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error parsing JSON: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    match compile_c(&ir) {
+        Ok(c_source) => print!("{c_source}"),
+        Err(e) => {
+            eprintln!("Error compiling IR to C: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/implementations/rust/provekit-ir-compiler-c/tests/byte_for_byte.rs
+++ b/implementations/rust/provekit-ir-compiler-c/tests/byte_for_byte.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Byte-for-byte regression check for the C11 compiler. ORP v0.2 compile
+// mode is deterministic, so the same term and target descriptor must
+// produce the exact same C source bytes.
+
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_c::{compile_c, CCompiler, DIALECT};
+use serde_json::json;
+
+fn fixtures() -> Vec<serde_json::Value> {
+    vec![
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("foo fixture"),
+        json!({
+            "kind": "c11-algebra-term",
+            "source": "arith.c",
+            "term": {
+                "kind": "op",
+                "name": "return",
+                "args": [{
+                    "kind": "op",
+                    "name": "sub",
+                    "args": [
+                        {"kind": "var", "name": "x"},
+                        {"kind": "const", "value": 7, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                    ]
+                }]
+            }
+        }),
+        json!({
+            "kind": "c11-algebra-term",
+            "source": "bools.c",
+            "term": {
+                "kind": "op",
+                "name": "return",
+                "args": [{
+                    "kind": "op",
+                    "name": "or",
+                    "args": [
+                        {"kind": "op", "name": "eq", "args": [
+                            {"kind": "var", "name": "x"},
+                            {"kind": "const", "value": 1, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                        ]},
+                        {"kind": "op", "name": "lt", "args": [
+                            {"kind": "var", "name": "y"},
+                            {"kind": "const", "value": 9, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                        ]}
+                    ]
+                }]
+            }
+        }),
+    ]
+}
+
+#[test]
+fn emit_is_byte_deterministic() {
+    for fixture in fixtures() {
+        let first = compile_c(&fixture).expect("first emit");
+        let second = compile_c(&fixture).expect("second emit");
+        assert_eq!(first, second);
+    }
+}
+
+#[test]
+fn trait_compile_body_equals_emit_string() {
+    let compiler = CCompiler::new();
+    for fixture in fixtures() {
+        let through_trait = compiler.compile(&fixture, DIALECT).expect("compile");
+        let direct = compile_c(&fixture).expect("emit");
+        assert_eq!(through_trait.preamble, "");
+        assert_eq!(through_trait.body, direct);
+        assert_eq!(through_trait.free_vars.len(), 0);
+    }
+}
+
+#[test]
+fn trait_compile_rejects_wrong_dialect() {
+    let compiler = CCompiler::new();
+    let term = json!({"kind": "op", "name": "skip", "args": [{"kind": "unit"}]});
+    let result = compiler.compile(&term, "coq");
+    assert!(matches!(
+        result,
+        Err(provekit_ir_compiler::CompileError::UnsupportedDialect(_))
+    ));
+}

--- a/implementations/rust/provekit-ir-compiler-c/tests/fixtures/foo.expected.c
+++ b/implementations/rust/provekit-ir-compiler-c/tests/fixtures/foo.expected.c
@@ -1,0 +1,10 @@
+#include <stdint.h>
+
+int foo(int x) {
+    if ((x) == (0)) {
+        return ((-(22)));
+    } else {
+        ;
+    }
+    return (x);
+}

--- a/implementations/rust/provekit-ir-compiler-c/tests/fixtures/foo.term.json
+++ b/implementations/rust/provekit-ir-compiler-c/tests/fixtures/foo.term.json
@@ -1,0 +1,78 @@
+{
+  "kind": "c11-algebra-term",
+  "signature_cid": "blake3-512:c942ba70e4b701e139a46590116f5cdc16ab41db277e80e54c01f23e4a7cf6241d4431c60473409cb3f0b61ce27f593071c1c224291f04c61aa04b4773764945",
+  "source": "foo.c",
+  "term_surface": "seq(if(eq(x, 0), return(neg(22)), skip), return(x))",
+  "term": {
+    "kind": "op",
+    "name": "seq",
+    "args": [
+      {
+        "kind": "op",
+        "name": "if",
+        "args": [
+          {
+            "kind": "op",
+            "name": "eq",
+            "args": [
+              {
+                "kind": "var",
+                "name": "x"
+              },
+              {
+                "kind": "const",
+                "value": 0,
+                "sort": {
+                  "kind": "ctor",
+                  "name": "Int",
+                  "args": []
+                }
+              }
+            ]
+          },
+          {
+            "kind": "op",
+            "name": "return",
+            "args": [
+              {
+                "kind": "op",
+                "name": "neg",
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": 22,
+                    "sort": {
+                      "kind": "ctor",
+                      "name": "Int",
+                      "args": []
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "op",
+            "name": "skip",
+            "args": [
+              {
+                "kind": "unit"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "op",
+        "name": "return",
+        "args": [
+          {
+            "kind": "var",
+            "name": "x"
+          }
+        ]
+      }
+    ]
+  },
+  "wp_value_note": "The branch-sensitive WP value is recorded in foo.expected-wp-contract.json. The current c-collectors-defensive lifter emits the same branch-sensitive contract in foo.contract.json."
+}

--- a/implementations/rust/provekit-ir-compiler-c/tests/smoke.rs
+++ b/implementations/rust/provekit-ir-compiler-c/tests/smoke.rs
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use provekit_ir_compiler::IrCompiler;
+use provekit_ir_compiler_c::{compile_c, CCompiler, DIALECT};
+use serde_json::json;
+use serde_json::Value as Json;
+
+#[test]
+fn smoke_compiles_foo_term_byte_for_byte() {
+    let input: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("fixture json");
+    let expected = include_str!("fixtures/foo.expected.c");
+
+    let c_source = compile_c(&input).expect("foo term compiles");
+
+    assert_eq!(c_source, expected);
+}
+
+#[test]
+fn lowers_core_expression_ops() {
+    let input = json!({
+        "kind": "c11-algebra-term",
+        "source": "ops.c",
+        "term": {
+            "kind": "op",
+            "name": "return",
+            "args": [{
+                "kind": "op",
+                "name": "and",
+                "args": [
+                    {
+                        "kind": "op",
+                        "name": "eq",
+                        "args": [
+                            {
+                                "kind": "op",
+                                "name": "add",
+                                "args": [
+                                    {"kind": "const", "value": 40, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                                    {"kind": "const", "value": 2, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                                ]
+                            },
+                            {"kind": "const", "value": 42, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                        ]
+                    },
+                    {
+                        "kind": "op",
+                        "name": "not",
+                        "args": [{
+                            "kind": "op",
+                            "name": "le",
+                            "args": [
+                                {"kind": "const", "value": 9, "sort": {"kind": "ctor", "name": "Int", "args": []}},
+                                {"kind": "const", "value": 3, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                            ]
+                        }]
+                    }
+                ]
+            }]
+        }
+    });
+
+    let c_source = compile_c(&input).expect("compile op term");
+
+    assert!(c_source.contains("((40) + (2))"));
+    assert!(c_source.contains("(((40) + (2)) == (42))"));
+    assert!(c_source.contains("(!((9) <= (3)))"));
+    assert!(c_source.contains("&&"));
+}
+
+#[test]
+fn lowers_statement_if_and_expression_if_differently() {
+    let input = json!({
+        "kind": "c11-algebra-term",
+        "source": "choose.c",
+        "term": {
+            "kind": "op",
+            "name": "return",
+            "args": [{
+                "kind": "op",
+                "name": "if",
+                "args": [
+                    {"kind": "op", "name": "lt", "args": [
+                        {"kind": "var", "name": "x"},
+                        {"kind": "const", "value": 0, "sort": {"kind": "ctor", "name": "Int", "args": []}}
+                    ]},
+                    {"kind": "op", "name": "neg", "args": [{"kind": "var", "name": "x"}]},
+                    {"kind": "var", "name": "x"}
+                ]
+            }]
+        }
+    });
+
+    let c_source = compile_c(&input).expect("compile expression if");
+
+    assert!(c_source.contains("?"));
+    assert!(c_source.contains(":"));
+    assert!(!c_source.contains("if ((x) < (0)) {"));
+}
+
+#[test]
+fn refuses_unknown_operations() {
+    let input = json!({
+        "kind": "c11-algebra-term",
+        "source": "bad.c",
+        "term": {"kind": "op", "name": "switch", "args": []}
+    });
+
+    let err = compile_c(&input).expect_err("switch is outside the core subset");
+    assert!(err.to_string().contains("unsupported predicate: switch"));
+}
+
+#[test]
+fn implements_ir_compiler_trait_for_c11() {
+    let input: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("fixture json");
+    let compiler = CCompiler::new();
+
+    let compiled = compiler
+        .compile(&input, DIALECT)
+        .expect("compile through trait");
+
+    assert_eq!(compiled.preamble, "");
+    assert_eq!(compiled.body, include_str!("fixtures/foo.expected.c"));
+}
+
+#[ignore = "requires cc, gcc, or clang on PATH"]
+#[test]
+fn ignored_compiles_links_and_runs_foo_when_c_compiler_is_available() {
+    let Some(compiler) = c_compiler() else {
+        eprintln!("C compiler not available, skipping runtime smoke");
+        return;
+    };
+
+    let input: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("fixture json");
+    let c_source = compile_c(&input).expect("foo term compiles");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source_path = dir.path().join("foo.c");
+    let harness_path = dir.path().join("harness.c");
+    let bin_path = dir.path().join("harness");
+
+    fs::write(&source_path, c_source).expect("write source");
+    fs::write(
+        &harness_path,
+        r#"
+#include <stdint.h>
+
+int foo(int x);
+
+int main(void) {
+    if (foo(0) != -22) {
+        return 1;
+    }
+    if (foo(42) != 42) {
+        return 2;
+    }
+    return 0;
+}
+"#,
+    )
+    .expect("write harness");
+
+    let status = Command::new(&compiler)
+        .arg("-std=c11")
+        .arg(&source_path)
+        .arg(&harness_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .status()
+        .expect("run C compiler");
+    assert!(status.success(), "{compiler} failed with {status}");
+
+    let status = Command::new(&bin_path).status().expect("run harness");
+    assert!(status.success(), "harness failed with {status}");
+}
+
+#[ignore = "requires a prebuilt provekit-lift-c-collectors-defensive binary"]
+#[test]
+fn ignored_round_trips_foo_contract_when_c_lifter_is_available() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .expect("repo root");
+    let lifter = repo_root
+        .join("implementations/c/provekit-lift-c-collectors-defensive")
+        .join("provekit-lift-c-collectors-defensive");
+    if Command::new(&lifter).arg("--help").output().is_err() {
+        eprintln!("C lifter binary not available, skipping round-trip smoke");
+        return;
+    }
+
+    let input: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/foo.term.json")).expect("fixture json");
+    let c_source = compile_c(&input).expect("foo term compiles");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source_path = dir.path().join("foo.c");
+    fs::write(&source_path, c_source).expect("write source");
+
+    let output = Command::new(&lifter)
+        .arg(&source_path)
+        .output()
+        .expect("run C lifter");
+    assert!(output.status.success(), "C lifter failed");
+
+    let re_lifted = String::from_utf8_lossy(&output.stdout);
+    let actual_contract = extract_lifted_contract(&re_lifted).expect("lifted function contract");
+    let expected_contracts: Json = serde_json::from_str(include_str!(
+        "../../../../menagerie/c11-language-signature/example/foo.contract.json"
+    ))
+    .expect("direct foo contract fixture parses");
+    let expected_contract = expected_contracts
+        .as_array()
+        .and_then(|items| items.first())
+        .expect("direct foo contract fixture has one contract");
+
+    let actual_cid = cid_of_json(&actual_contract);
+    let expected_cid = cid_of_json(expected_contract);
+
+    assert_eq!(actual_cid, expected_cid);
+}
+
+fn c_compiler() -> Option<String> {
+    ["cc", "gcc", "clang"]
+        .into_iter()
+        .find(|cmd| Command::new(cmd).arg("--version").output().is_ok())
+        .map(str::to_string)
+}
+
+fn extract_lifted_contract(output: &str) -> Option<Json> {
+    for line in output.lines() {
+        let parsed: Json = serde_json::from_str(line).ok()?;
+        if let Some(contract) = parsed.pointer("/result/declarations/0") {
+            return Some(contract.clone());
+        }
+        if let Some(contract) = parsed.pointer("/result/ir/0") {
+            return Some(contract.clone());
+        }
+    }
+    None
+}
+
+fn cid_of_json(value: &Json) -> String {
+    let canonical = to_cvalue(value);
+    let jcs = encode_jcs(&canonical);
+    blake3_512_of(jcs.as_bytes())
+}
+
+fn to_cvalue(value: &Json) -> Arc<CValue> {
+    match value {
+        Json::Null => CValue::null(),
+        Json::Bool(value) => CValue::boolean(*value),
+        Json::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                CValue::integer(value)
+            } else if let Some(value) = value.as_u64() {
+                CValue::string(value.to_string())
+            } else if let Some(value) = value.as_f64() {
+                CValue::string(value.to_string())
+            } else {
+                CValue::null()
+            }
+        }
+        Json::String(value) => CValue::string(value.clone()),
+        Json::Array(values) => CValue::array(values.iter().map(to_cvalue).collect()),
+        Json::Object(values) => CValue::object(
+            values
+                .iter()
+                .map(|(key, value)| (key.clone(), to_cvalue(value))),
+        ),
+    }
+}


### PR DESCRIPTION
## Summary

`implementations/rust/provekit-ir-compiler-c/` -- the C executable-target rung of the realizer family. Implements ORP v0.2 `compile` mode: lowers a ProofIR term (AST over operation-CIDs, `foo.term.json` format) to a complete compilable C11 file. C is structured so the realization homomorphism is nearly transparent.

- Covers a core operation subset: `seq`, `if`, `while`, `return`, `call`, `break`, `continue`, `skip`, `eq`, `lt`, `le`, `add`, `sub`, `mul`, `neg`, `and`, `or`, `not`, variable reference, integer literal, `deref`, `assign`; tracks statement-vs-expression position (`if/else` statements vs `?:` expressions). Refuses on unhandled operations.
- Binary `provekit-ir-c`: reads a term JSON from stdin, emits C to stdout. Byte-deterministic. Smoke on `foo`'s term emits `int foo(int x) { if ((x) == (0)) { return ((-(22))); } else { ; } return (x); }`; the ignored harness test ran explicitly and verified `foo(0) == -22`, `foo(42) == 42`.
- Draft `algebra -> c:c11` `LanguageMorphismMemento` spec at `specs/algebra_to_c.spec.json`, noting it composes with the `c-collectors-defensive` lifter's `c -> algebra` morphism for a `c -> algebra -> c` round-trip whose contract should be the identity (a discharged-by-composition obligation, mint as follow-up). The smoke also wires (but currently self-skips, no lifter binary present) the round-trip CID-equality check.
- `cargo build -p provekit-ir-compiler-c`, `cargo test -p provekit-ir-compiler-c` (11 passed, 2 ignored), `cargo clippy -p provekit-ir-compiler-c --no-deps -- -D warnings` all clean.

Deferred: full operation catalog, declarations/type-widths, multi-function translation units, minting the `algebra -> c` receipt and the round-trip-identity receipt.

## Test plan

- [ ] `cargo build -p provekit-ir-compiler-c`, `cargo test -p provekit-ir-compiler-c`, `cargo clippy -p provekit-ir-compiler-c --no-deps -- -D warnings`
- [ ] With a C compiler: compile + run `foo`'s emitted C + a harness; `foo(0) == -22`, `foo(42) == 42`
- [ ] With the C lifter binary: `compile-to-c` `foo`'s term, re-lift, the re-lifted contract CID equals the term's contract CID (round-trip identity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)