### PR TITLE
[codex] load mint paths from disk

### DIFF
--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -36,7 +36,7 @@ pub use traits::{
 };
 pub use types::{
     Attestation, Boundary, Cid, CidError, Contract, Dialect, DomainClaim, DomainKind, Formula,
-    Input, Path, PathAlgebra, PathError, Refutation, Term, Truth, Verdict, VerdictCoercionError,
-    Witness,
+    Input, Path, PathAlgebra, PathDocument, PathDocumentError, PathError, PathInputBinding,
+    PathInputMaterial, Refutation, Term, Truth, Verdict, VerdictCoercionError, Witness,
 };
 pub use verbs::{cross_compile, link, prove, realize, transform, verify};

--- a/implementations/rust/libprovekit/src/core/types.rs
+++ b/implementations/rust/libprovekit/src/core/types.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_ir_types::{IrFormula, IrTerm, LetBinding, Sort};
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 
@@ -20,8 +20,7 @@ use super::traits::Canonical;
 /// `Cid` is the algebra's address type. It has no internal structure beyond
 /// the hash algorithm tag and hex digest; any semantic meaning comes from the
 /// catalog entry found by `resolve`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Cid(String);
 
 impl Cid {
@@ -56,6 +55,25 @@ impl Cid {
 impl fmt::Display for Cid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+impl Serialize for Cid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Cid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(de::Error::custom)
     }
 }
 
@@ -453,7 +471,7 @@ pub enum VerdictCoercionError {
 /// input, and the step names it depends on. Executing a command is still one
 /// `Kit(Input) -> DomainClaim`; `Input::Path` carries the algebra needed for
 /// that kit to compose subordinate transforms when necessary.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Path {
     /// Algebra steps available to the transform.
     pub algebra: Vec<PathAlgebra>,
@@ -563,7 +581,8 @@ impl Path {
 }
 
 /// One algebra step inside a [`Path`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PathAlgebra {
     /// Stable step name inside the path.
     pub name: String,
@@ -587,6 +606,143 @@ pub enum PathError {
     /// The dependency graph contains a cycle.
     #[error("path dependency cycle includes step `{step}`")]
     Cycle { step: String },
+}
+
+/// Stable top-level kind for serialized path documents.
+pub const PATH_DOCUMENT_KIND: &str = "provekit-path/v1";
+
+/// Serializable, language-neutral path plus the materialized input catalog it
+/// needs to execute.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PathDocument {
+    /// Wire kind/version for disk and cross-runtime transport.
+    pub kind: String,
+    /// The CID-able path algebra.
+    pub path: Path,
+    /// Materialized inputs keyed by the CIDs referenced from path steps.
+    #[serde(default)]
+    pub inputs: Vec<PathInputBinding>,
+}
+
+impl PathDocument {
+    /// Build a path document and address each materialized input.
+    pub fn from_path_and_inputs(path: Path, inputs: Vec<Input>) -> Result<Self, PathDocumentError> {
+        let mut bindings = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            bindings.push(PathInputBinding {
+                cid: super::primitives::address(&input),
+                input: PathInputMaterial::try_from_input(input)?,
+            });
+        }
+        Ok(Self {
+            kind: PATH_DOCUMENT_KIND.to_string(),
+            path,
+            inputs: bindings,
+        })
+    }
+
+    /// Validate and materialize the typed input catalog entries.
+    pub fn materialized_inputs(&self) -> Result<Vec<(Cid, Input)>, PathDocumentError> {
+        if self.kind != PATH_DOCUMENT_KIND {
+            return Err(PathDocumentError::InvalidKind {
+                expected: PATH_DOCUMENT_KIND,
+                actual: self.kind.clone(),
+            });
+        }
+
+        let mut out = Vec::with_capacity(self.inputs.len());
+        for binding in &self.inputs {
+            let input = binding.input.to_input();
+            let actual = super::primitives::address(&input);
+            if actual != binding.cid {
+                return Err(PathDocumentError::InputCidMismatch {
+                    expected: binding.cid.clone(),
+                    actual,
+                });
+            }
+            out.push((binding.cid.clone(), input));
+        }
+        Ok(out)
+    }
+}
+
+/// One materialized input entry in a [`PathDocument`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PathInputBinding {
+    /// CID referenced from `PathAlgebra.inputs`.
+    pub cid: Cid,
+    /// Materialized input value.
+    pub input: PathInputMaterial,
+}
+
+/// Disk-safe subset of [`Input`] used by path documents.
+///
+/// The first durable shape only needs command specs. Claim/truth/refutation
+/// inputs should move here once their contract representation has a stable
+/// language-neutral wire form.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum PathInputMaterial {
+    /// JSON command/spec input.
+    Spec { value: JsonValue },
+}
+
+impl PathInputMaterial {
+    fn try_from_input(input: Input) -> Result<Self, PathDocumentError> {
+        match input {
+            Input::Spec(value) => Ok(Self::Spec { value }),
+            other => Err(PathDocumentError::UnsupportedInputMaterial {
+                kind: input_kind(&other).to_string(),
+            }),
+        }
+    }
+
+    fn to_input(&self) -> Input {
+        match self {
+            Self::Spec { value } => Input::Spec(value.clone()),
+        }
+    }
+}
+
+/// Serialized path document validation errors.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PathDocumentError {
+    /// The top-level `kind` is not the current path document kind.
+    #[error("path document kind `{actual}` is not `{expected}`")]
+    InvalidKind {
+        /// Expected kind.
+        expected: &'static str,
+        /// Actual kind.
+        actual: String,
+    },
+    /// A materialized input's bytes do not address to its declared CID.
+    #[error("path input declared as `{expected}` materialized as `{actual}`")]
+    InputCidMismatch {
+        /// Declared CID.
+        expected: Cid,
+        /// Actual CID after canonicalization.
+        actual: Cid,
+    },
+    /// The input variant is not yet part of the disk-safe path catalog.
+    #[error("path documents currently support materialized spec inputs, not `{kind}`")]
+    UnsupportedInputMaterial {
+        /// Input variant name.
+        kind: String,
+    },
+}
+
+fn input_kind(input: &Input) -> &'static str {
+    match input {
+        Input::Source { .. } => "source",
+        Input::Spec(_) => "spec",
+        Input::Claim(_) => "claim",
+        Input::Truth(_) => "truth",
+        Input::Refutation(_) => "refutation",
+        Input::Term(_) => "term",
+        Input::Path(_) => "path",
+    }
 }
 
 /// Closed input universe for transforms.

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -9,10 +9,12 @@ use libprovekit::compose::{
 use libprovekit::core::{
     address, compose, link, prove, transform, verify, CKit, Cid, DomainClaim, DomainKind,
     FunctionContractDomain, HashMapCatalog, HashMapInputCatalog, Input, InputCatalog, Kit,
-    LiftPluginKit, Path, PathAlgebra, PathError, Refutation, Term, Truth, Verdict, Witness,
+    LiftPluginKit, Path, PathAlgebra, PathDocument, PathError, Refutation, Term, Truth, Verdict,
+    Witness,
 };
 use provekit_canonicalizer::Value;
 use provekit_ir_types::{IrFormula, IrTerm, Sort};
+use serde_json::json;
 
 fn any_sort() -> Sort {
     Sort::Primitive {
@@ -268,6 +270,101 @@ fn path_is_cidable_language_neutral_algebra() {
     assert_eq!(
         path.step("mint").expect("mint step").depends_on,
         vec!["lift".to_string()]
+    );
+}
+
+#[test]
+fn path_document_round_trips_with_cid_checked_materialized_inputs() {
+    let lift_input = Input::Spec(json!({
+        "surface": "rust-self-contracts",
+        "workspace_root": ".",
+        "config_path": ".provekit/config.toml",
+        "source_paths": ["."],
+        "options": {"layer": "all"}
+    }));
+    let mint_input = Input::Spec(json!({
+        "outDir": "target/provekit-path-doc",
+        "options": {"quiet": true}
+    }));
+    let lift_input_cid = address(&lift_input);
+    let mint_input_cid = address(&mint_input);
+    let path = Path {
+        algebra: vec![
+            PathAlgebra {
+                name: "lift".to_string(),
+                kit: "lift-plugin:rust-self-contracts".to_string(),
+                inputs: vec![lift_input_cid.clone()],
+                depends_on: vec![],
+            },
+            PathAlgebra {
+                name: "mint".to_string(),
+                kit: "provekit-mint".to_string(),
+                inputs: vec![mint_input_cid.clone()],
+                depends_on: vec!["lift".to_string()],
+            },
+        ],
+    };
+
+    let document = PathDocument::from_path_and_inputs(
+        path.clone(),
+        vec![lift_input.clone(), mint_input.clone()],
+    )
+    .expect("path document accepts matching inputs");
+    let encoded = serde_json::to_string_pretty(&document).expect("path document serializes");
+    let decoded: PathDocument = serde_json::from_str(&encoded).expect("path document parses");
+    let inputs = decoded
+        .materialized_inputs()
+        .expect("path document materializes checked inputs");
+
+    assert_eq!(decoded.path.cid(), path.cid());
+    assert_eq!(inputs.len(), 2);
+    assert!(inputs.iter().any(|(cid, input)| {
+        cid == &lift_input_cid
+            && matches!(input, Input::Spec(value) if value["surface"] == "rust-self-contracts")
+    }));
+    assert!(inputs.iter().any(|(cid, input)| {
+        cid == &mint_input_cid
+            && matches!(input, Input::Spec(value) if value["outDir"] == "target/provekit-path-doc")
+    }));
+    assert!(
+        !encoded.contains("\"term\""),
+        "path documents should not embed language terms: {encoded}"
+    );
+}
+
+#[test]
+fn path_document_rejects_materialized_input_cid_mismatch() {
+    let declared = Input::Spec(json!({"surface": "declared"}));
+    let actual = Input::Spec(json!({"surface": "changed"}));
+    let declared_cid = address(&declared);
+    let document = PathDocument {
+        kind: "provekit-path/v1".to_string(),
+        path: Path {
+            algebra: vec![PathAlgebra {
+                name: "lift".to_string(),
+                kit: "lift-plugin:declared".to_string(),
+                inputs: vec![declared_cid],
+                depends_on: vec![],
+            }],
+        },
+        inputs: vec![libprovekit::core::PathInputBinding {
+            cid: address(&declared),
+            input: libprovekit::core::PathInputMaterial::Spec {
+                value: match actual {
+                    Input::Spec(value) => value,
+                    _ => unreachable!(),
+                },
+            },
+        }],
+    };
+
+    let error = document
+        .materialized_inputs()
+        .expect_err("changed materialized input must not satisfy declared cid")
+        .to_string();
+    assert!(
+        error.contains("materialized as"),
+        "unexpected path document error: {error}"
     );
 }
 

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -51,8 +51,8 @@ use serde_json::{json, Value};
 
 use libprovekit::core::{
     address, Boundary, Cid, Dialect, Domain, DomainClaim, DomainKind, FunctionContractDomain,
-    HashMapInputCatalog, Input, InputCatalog, Kit, KitError, Path as CorePath, PathAlgebra, Term,
-    Verdict,
+    HashMapInputCatalog, Input, InputCatalog, Kit, KitError, Path as CorePath, PathAlgebra,
+    PathDocument, Term, Verdict,
 };
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_claim_envelope::{
@@ -155,6 +155,8 @@ struct MintKit {
 struct MintSession {
     claim: DomainClaim,
     result: DispatchResult,
+    surface: String,
+    out_dir: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -211,7 +213,8 @@ impl MintKit {
                 .map_err(KitError::Transformation)?,
         );
         let surface = required_str(&lift_request, "surface", "mint path lift step")
-            .map_err(KitError::Transformation)?;
+            .map_err(KitError::Transformation)?
+            .to_string();
         let out_dir = PathBuf::from(
             required_str(&mint_request, "outDir", "mint path mint step")
                 .map_err(KitError::Transformation)?,
@@ -224,7 +227,7 @@ impl MintKit {
 
         let session = match lift_plugin::dispatch_lift(
             &project_root,
-            surface,
+            &surface,
             LiftPluginOptions::default(),
             quiet,
         ) {
@@ -250,7 +253,12 @@ impl MintKit {
                     }),
                 };
                 let claim = mint_result_claim(input, None, &result)?;
-                return Ok(MintSession { claim, result });
+                return Ok(MintSession {
+                    claim,
+                    result,
+                    surface,
+                    out_dir,
+                });
             }
             Err(LiftPluginError::Failed(error)) => return Err(KitError::Transformation(error)),
         };
@@ -260,7 +268,12 @@ impl MintKit {
         let result = mint_lift_response(&project_root, &out_dir, quiet, lift_response)
             .map_err(KitError::Transformation)?;
         let claim = mint_result_claim(input, Some(&lift_claim), &result)?;
-        Ok(MintSession { claim, result })
+        Ok(MintSession {
+            claim,
+            result,
+            surface,
+            out_dir,
+        })
     }
 
     fn path_step_spec(&self, step: &PathAlgebra, context: &str) -> Result<Value, KitError> {
@@ -318,12 +331,37 @@ fn dispatch(
     surface: &str,
     out_dir: &Path,
     quiet: bool,
-) -> Result<DispatchResult, String> {
+) -> Result<MintSession, String> {
     let mint_input = mint_input(project_root, surface, out_dir, quiet);
-    let session = MintKit::new(mint_input.inputs)
+    MintKit::new(mint_input.inputs)
         .transform_session(&mint_input.input)
-        .map_err(|error| error.to_string())?;
-    Ok(session.result)
+        .map_err(|error| error.to_string())
+}
+
+fn dispatch_path(project_root: &Path, path_file: &Path) -> Result<MintSession, String> {
+    let path = path_under(project_root, path_file);
+    let text = std::fs::read_to_string(&path)
+        .map_err(|error| format!("read mint path document {}: {error}", path.display()))?;
+    let document: PathDocument = serde_json::from_str(&text)
+        .map_err(|error| format!("parse mint path document {}: {error}", path.display()))?;
+    let mut inputs = HashMapInputCatalog::default();
+    for (cid, input) in document
+        .materialized_inputs()
+        .map_err(|error| format!("invalid mint path document {}: {error}", path.display()))?
+    {
+        inputs.put(cid, input);
+    }
+    MintKit::new(inputs)
+        .transform_session(&Input::Path(Box::new(document.path)))
+        .map_err(|error| error.to_string())
+}
+
+fn path_under(project_root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_root.join(path)
+    }
 }
 
 fn mint_input(project_root: &Path, surface: &str, out_dir: &Path, quiet: bool) -> MintPathInput {
@@ -1141,33 +1179,47 @@ pub fn run(args: MintArgs) -> u8 {
         return EXIT_USER_ERROR;
     }
 
-    // Resolve surface: --surface > --kit derived > project config > user config.
-    let surface = if let Some(s) = args.surface {
-        s
-    } else if let Some(s) = derived_surface {
-        s
+    let project_cfg = read_project_config(&project_root);
+    let user_cfg = read_user_config();
+    let configured_path = if args.kit.is_none() && args.surface.is_none() && args.out.is_none() {
+        project_cfg
+            .path_for("mint")
+            .or_else(|| user_cfg.path_for("mint"))
     } else {
-        let project_cfg = read_project_config(&project_root);
-        let user_cfg = read_user_config();
-        match project_cfg
-            .surface_for("lift")
-            .or_else(|| user_cfg.surface_for("lift"))
-        {
-            Some(s) => s,
-            None => {
-                eprintln!(
-                    "{}: no lift surface configured. Set [authoring] surface or [authoring.lift] surface in .provekit/config.toml, or pass --surface/--kit.",
-                    "error".red().bold()
-                );
-                return EXIT_USER_ERROR;
-            }
-        }
+        None
     };
 
-    let out_dir = args.out.unwrap_or_else(|| project_root.clone());
+    let session = if let Some(path_file) = configured_path {
+        dispatch_path(&project_root, Path::new(&path_file))
+    } else {
+        // Resolve surface: --surface > --kit derived > project config > user config.
+        let surface = if let Some(s) = args.surface.clone() {
+            s
+        } else if let Some(s) = derived_surface {
+            s
+        } else {
+            match project_cfg
+                .surface_for("lift")
+                .or_else(|| user_cfg.surface_for("lift"))
+            {
+                Some(s) => s,
+                None => {
+                    eprintln!(
+                        "{}: no lift surface configured. Set [authoring] surface or [authoring.lift] surface in .provekit/config.toml, or pass --surface/--kit.",
+                        "error".red().bold()
+                    );
+                    return EXIT_USER_ERROR;
+                }
+            }
+        };
 
-    match dispatch(&project_root, &surface, &out_dir, args.flags.quiet) {
-        Ok(result) => {
+        let out_dir = args.out.clone().unwrap_or_else(|| project_root.clone());
+        dispatch(&project_root, &surface, &out_dir, args.flags.quiet)
+    };
+
+    match session {
+        Ok(session) => {
+            let result = session.result;
             let contract_set_cid = if result.contract_set_cid.is_empty() {
                 compute_contract_set_cid(vec![])
             } else {
@@ -1180,7 +1232,7 @@ pub fn run(args: MintArgs) -> u8 {
                     serde_json::to_string_pretty(&json!({
                         "ok": true,
                         "project": &project_root,
-                        "surface": &surface,
+                        "surface": &session.surface,
                         "filenameCid": &result.filename_cid,
                         "contractSetCid": &contract_set_cid,
                         "bytesWritten": result.bytes_written,
@@ -1197,12 +1249,17 @@ pub fn run(args: MintArgs) -> u8 {
                 println!("  contractSetCid:     {contract_set_cid}");
                 if result.bytes_written > 0 {
                     println!("  proof bytes:        {}", result.bytes_written);
-                    println!(
-                        "  .proof file:        {}",
-                        out_dir
-                            .join(format!("{}.proof", result.filename_cid))
-                            .display()
-                    );
+                    if let Some(proof_file) = &result.proof_file {
+                        println!("  .proof file:        {}", proof_file.display());
+                    } else {
+                        println!(
+                            "  .proof file:        {}",
+                            session
+                                .out_dir
+                                .join(format!("{}.proof", result.filename_cid))
+                                .display()
+                        );
+                    }
                 } else {
                     println!("  (no .proof written: lifter binary not found)");
                 }
@@ -1218,7 +1275,7 @@ pub fn run(args: MintArgs) -> u8 {
             // Write attestation unless suppressed.
             if !args.no_attest {
                 // Determine lang_key: use --kit derived value, else infer from surface.
-                let lang = lang_key.as_deref().unwrap_or(&surface);
+                let lang = lang_key.as_deref().unwrap_or(&session.surface);
                 if let Err(e) = write_attestation(
                     &project_root,
                     lang,

--- a/implementations/rust/provekit-cli/src/project_config.rs
+++ b/implementations/rust/provekit-cli/src/project_config.rs
@@ -50,6 +50,9 @@ pub struct ProjectConfig {
     /// e.g., an OpenAPI spec project whose .proof files are
     /// consumed alongside the main project.
     pub callees: Vec<String>,
+
+    /// Serialized command path documents, keyed by command.
+    pub path_mint: Option<String>,
 }
 
 impl ProjectConfig {
@@ -71,6 +74,13 @@ impl ProjectConfig {
             _ => &None,
         };
         per_cmd.clone().or_else(|| self.agent_default.clone())
+    }
+
+    pub fn path_for(&self, cmd: &str) -> Option<String> {
+        match cmd {
+            "mint" => self.path_mint.clone(),
+            _ => None,
+        }
     }
 }
 
@@ -141,6 +151,7 @@ fn parse_config(text: &str) -> ProjectConfig {
             (Some("verify"), "callees") => {
                 cfg.callees = parse_string_array(&val);
             }
+            (Some("paths.mint"), "file") => cfg.path_mint = Some(val),
             _ => {}
         }
     }
@@ -274,6 +285,16 @@ mod tests {
         ";
         let cfg = parse_config(raw);
         assert_eq!(cfg.surface_for("must").as_deref(), Some("kani"));
+    }
+
+    #[test]
+    fn parses_mint_path_file() {
+        let cfg = parse_config("[paths.mint]\nfile = \".provekit/paths/mint.json\"\n");
+        assert_eq!(
+            cfg.path_for("mint").as_deref(),
+            Some(".provekit/paths/mint.json")
+        );
+        assert_eq!(cfg.path_for("prove"), None);
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/tests/cli_surface.rs
+++ b/implementations/rust/provekit-cli/tests/cli_surface.rs
@@ -6,6 +6,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use libprovekit::core::{address, Input, Path as CorePath, PathAlgebra, PathDocument};
 use serde_json::json;
 
 fn provekit_bin() -> PathBuf {
@@ -318,6 +319,118 @@ done
         .as_str()
         .unwrap_or_default()
         .starts_with("blake3-512:"));
+}
+
+#[test]
+fn mint_uses_path_document_from_project_config() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let project = dir.path().join("project");
+    let manifest_dir = project.join(".provekit/lift/path-lift");
+    let path_dir = project.join(".provekit/paths");
+    let out_dir = dir.path().join("path-out");
+    fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+    fs::create_dir_all(&path_dir).expect("create path dir");
+
+    let plugin = dir.path().join("path-lift-plugin.sh");
+    write_executable(
+        &plugin,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+  if [[ "$line" == *'"method":"initialize"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"path-lift","protocol_version":"provekit-lift/1","capabilities":{}}}'
+  elif [[ "$line" == *'"method":"lift"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"kind":"ir-document","ir":[{"kind":"contract","name":"path.config.contract","outBinding":"out","post":{"kind":"atomic","name":"path_config_true","args":[]}}],"diagnostics":[]}}'
+  elif [[ "$line" == *'"method":"shutdown"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+    exit 0
+  fi
+done
+"#,
+    );
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"path-lift\"\ncommand = [\"{}\"]\n",
+            plugin.display()
+        ),
+    )
+    .expect("write manifest");
+
+    let lift_input = Input::Spec(json!({
+        "surface": "path-lift",
+        "workspace_root": project.canonicalize().unwrap_or_else(|_| project.clone()),
+        "config_path": ".provekit/config.toml",
+        "source_paths": ["."],
+        "options": {
+            "layer": "all",
+            "identifyOnly": false
+        }
+    }));
+    let mint_input = Input::Spec(json!({
+        "projectRoot": project.display().to_string(),
+        "surface": "path-lift",
+        "outDir": out_dir.display().to_string(),
+        "options": {
+            "quiet": true
+        }
+    }));
+    let lift_input_cid = address(&lift_input);
+    let mint_input_cid = address(&mint_input);
+    let path = CorePath {
+        algebra: vec![
+            PathAlgebra {
+                name: "lift".to_string(),
+                kit: "lift-plugin:path-lift".to_string(),
+                inputs: vec![lift_input_cid],
+                depends_on: vec![],
+            },
+            PathAlgebra {
+                name: "mint".to_string(),
+                kit: "provekit-mint".to_string(),
+                inputs: vec![mint_input_cid],
+                depends_on: vec!["lift".to_string()],
+            },
+        ],
+    };
+    let document = PathDocument::from_path_and_inputs(path, vec![lift_input, mint_input])
+        .expect("build path document");
+    fs::write(
+        path_dir.join("mint.json"),
+        serde_json::to_string_pretty(&document).expect("serialize path document"),
+    )
+    .expect("write path document");
+    fs::write(
+        project.join(".provekit/config.toml"),
+        "[paths.mint]\nfile = \".provekit/paths/mint.json\"\n",
+    )
+    .expect("write config");
+
+    let output = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(&project)
+        .arg("--no-attest")
+        .arg("--json")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "mint should load PathDocument from [paths.mint], not require [authoring.lift]\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("mint JSON parses");
+    assert_eq!(report["surface"], "path-lift");
+    assert_eq!(
+        report["proofFile"]
+            .as_str()
+            .map(|value| value.contains("path-out")),
+        Some(true)
+    );
+    assert_eq!(report["lift"]["kind"], "ir-document");
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Adds a serialized `PathDocument` primitive shape to `libprovekit::core`.
- Makes `Path` and `PathAlgebra` serde-compatible while keeping CIDs validated on deserialize.
- Adds CID-checked materialized path inputs so disk path documents fail closed if an input no longer hashes to its declared CID.
- Teaches `.provekit/config.toml` to load `[paths.mint] file = "..."`.
- Lets `provekit mint` execute a configured path document when no one-shot `--kit`, `--surface`, or `--out` override is supplied.
- Keeps the existing generated in-memory `lift -> mint` path as the fallback for current CLI flows.

## Why

This is the next primitive step after #579: `Path` stops being only an internal mint construction and becomes a language-neutral data shape that can live on disk and drive command composition.

## Validation

- `cargo test -p libprovekit --test core_interface`
- `cargo test -p provekit-cli mint_`
- `cargo check -p libprovekit -p provekit-cli`
- `cargo fmt --all -- --check`
- `git diff --check HEAD^ HEAD`
- `make build-all`
- `make bug-zoo`

The Rust checks still emit existing warnings from `provekit-self-contracts`, `provekit-lsp`, and `provekit-lift-openapi`; no new path-config-specific warnings were reported.