### PR TITLE
feat(walk-c): emit callsite actuals in Callsite arrivals

### DIFF
--- a/implementations/c/provekit-walk-c/src/contract.c
+++ b/implementations/c/provekit-walk-c/src/contract.c
@@ -155,6 +155,12 @@ static int append_arrival(ContractBuf *b, const pk_c_walk_arrival *arrival) {
             return -1;
         }
     }
+    if (strcmp(arrival->kind, "Callsite") == 0) {
+        if (buf_append(b, ",\"args\":") != 0 ||
+            buf_append(b, arrival->actuals_json == NULL ? "[]" : arrival->actuals_json) != 0) {
+            return -1;
+        }
+    }
     if (buf_append(b, ",\"wp\":") != 0 ||
         append_formula(b, arrival->wp) != 0 ||
         buf_append_char(b, '}') != 0) {

--- a/implementations/c/provekit-walk-c/src/lift.c
+++ b/implementations/c/provekit-walk-c/src/lift.c
@@ -154,6 +154,18 @@ pk_c_walk_term *pk_c_walk_lift_term(CXCursor cursor) {
     return term;
 }
 
+pk_c_walk_term *pk_c_walk_lift_term_full(CXCursor cursor) {
+    char *source = pk_c_walk_cursor_source(cursor);
+    pk_c_walk_term *term;
+
+    if (source == NULL) {
+        return NULL;
+    }
+    term = pk_c_walk_term_from_text_full(source, strlen(source));
+    free(source);
+    return term;
+}
+
 pk_c_walk_formula *pk_c_walk_lift_condition(CXCursor cursor) {
     char *source = pk_c_walk_cursor_source(cursor);
     pk_c_walk_formula *formula;

--- a/implementations/c/provekit-walk-c/src/walk.c
+++ b/implementations/c/provekit-walk-c/src/walk.c
@@ -2,6 +2,7 @@
 
 #include "walk_c.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -176,13 +177,22 @@ static char *json_buf_take(JsonBuf *buf) {
 
 static int json_buf_grow(JsonBuf *buf, size_t need) {
     size_t next = buf->cap ? buf->cap : 256;
+    size_t required;
     char *data;
 
-    while (next < buf->len + need + 1) {
-        if (next > ((size_t)-1) / 2) {
-            return -1;
+    if (buf->len > SIZE_MAX - 1 || need > SIZE_MAX - buf->len - 1) {
+        return -1;
+    }
+    required = buf->len + need + 1;
+    while (next < required) {
+        if (next > SIZE_MAX / 2) {
+            next = required;
+            break;
         }
         next *= 2;
+    }
+    if (next < required) {
+        return -1;
     }
     data = realloc(buf->data, next);
     if (data == NULL) {
@@ -191,6 +201,18 @@ static int json_buf_grow(JsonBuf *buf, size_t need) {
     buf->data = data;
     buf->cap = next;
     return 0;
+}
+
+static int json_buf_append_n(JsonBuf *buf, const char *text, size_t len);
+
+static int json_buf_append_int(JsonBuf *buf, int value) {
+    char text[32];
+    int len = snprintf(text, sizeof(text), "%d", value);
+
+    if (len < 0 || (size_t)len >= sizeof(text)) {
+        return -1;
+    }
+    return json_buf_append_n(buf, text, (size_t)len);
 }
 
 static int json_buf_append_n(JsonBuf *buf, const char *text, size_t len) {
@@ -223,6 +245,33 @@ static int json_buf_append_quoted(JsonBuf *buf, const char *text) {
         json_buf_append_char(buf, '"') == 0 ? 0 : -1;
     free(escaped);
     return rc;
+}
+
+static int json_buf_append_callsite_arg(
+    JsonBuf *buf,
+    int position,
+    const char *text,
+    const char *kind,
+    const char *type,
+    const char *term_json
+) {
+    return json_buf_append(buf, "{\"position\":") == 0 &&
+        json_buf_append_int(buf, position) == 0 &&
+        json_buf_append(buf, ",\"text\":") == 0 &&
+        json_buf_append_quoted(buf, text) == 0 &&
+        json_buf_append(buf, ",\"kind\":") == 0 &&
+        json_buf_append_quoted(buf, kind) == 0 &&
+        json_buf_append(buf, ",\"type\":") == 0 &&
+        json_buf_append_quoted(buf, type) == 0 &&
+        json_buf_append(buf, ",\"term\":") == 0 &&
+        json_buf_append(buf, term_json == NULL ? "null" : term_json) == 0 &&
+        json_buf_append_char(buf, '}') == 0 ? 0 : -1;
+}
+
+static int json_buf_append_callsite_arg_fallback(JsonBuf *buf, int position) {
+    return json_buf_append(buf, "{\"position\":") == 0 &&
+        json_buf_append_int(buf, position) == 0 &&
+        json_buf_append(buf, ",\"text\":\"\",\"kind\":\"\",\"type\":\"\",\"term\":null}") == 0 ? 0 : -1;
 }
 
 static enum CXChildVisitResult single_child_visitor(CXCursor cursor, CXCursor parent, CXClientData data) {
@@ -456,15 +505,32 @@ static char *extract_callsite_actuals(CXCursor call_cursor) {
     }
     for (int i = 0; i < n_args; i++) {
         CXCursor arg = unwrap_actual_cursor(clang_Cursor_getArgument(call_cursor, (unsigned)i));
-        char position[32];
+        JsonBuf arg_buf;
+        int arg_serialized = 0;
+        int arg_buf_live = 0;
         char *text = pk_c_walk_cursor_source(arg);
         char *kind = cx_string_copy(clang_getCursorKindSpelling(clang_getCursorKind(arg)));
         char *type = cx_string_copy(clang_getTypeSpelling(clang_getCursorType(arg)));
-        pk_c_walk_term *term = pk_c_walk_lift_term(arg);
+        pk_c_walk_term *term = pk_c_walk_lift_term_full(arg);
         char *term_json = term == NULL ? NULL : pk_c_walk_term_json(term);
 
-        if (snprintf(position, sizeof(position), "%d", i) < 0 ||
-            text == NULL || kind == NULL || type == NULL || term_json == NULL) {
+        if (json_buf_init(&arg_buf) == 0) {
+            arg_buf_live = 1;
+            if (json_buf_append_callsite_arg(&arg_buf, i, text, kind, type, term_json) == 0) {
+                arg_serialized = 1;
+            } else {
+                json_buf_free(&arg_buf);
+                arg_buf_live = 0;
+                if (json_buf_init(&arg_buf) == 0) {
+                    arg_buf_live = 1;
+                    arg_serialized = json_buf_append_callsite_arg_fallback(&arg_buf, i) == 0;
+                }
+            }
+        }
+        if (i > 0 && json_buf_append_char(&buf, ',') != 0) {
+            if (arg_buf_live) {
+                json_buf_free(&arg_buf);
+            }
             free(text);
             free(kind);
             free(type);
@@ -472,24 +538,21 @@ static char *extract_callsite_actuals(CXCursor call_cursor) {
             free(term_json);
             goto done;
         }
-        if ((i > 0 && json_buf_append_char(&buf, ',') != 0) ||
-            json_buf_append(&buf, "{\"position\":") != 0 ||
-            json_buf_append(&buf, position) != 0 ||
-            json_buf_append(&buf, ",\"text\":") != 0 ||
-            json_buf_append_quoted(&buf, text) != 0 ||
-            json_buf_append(&buf, ",\"kind\":") != 0 ||
-            json_buf_append_quoted(&buf, kind) != 0 ||
-            json_buf_append(&buf, ",\"type\":") != 0 ||
-            json_buf_append_quoted(&buf, type) != 0 ||
-            json_buf_append(&buf, ",\"term\":") != 0 ||
-            json_buf_append(&buf, term_json) != 0 ||
-            json_buf_append_char(&buf, '}') != 0) {
+        if ((arg_serialized
+                ? json_buf_append_n(&buf, arg_buf.data, arg_buf.len)
+                : json_buf_append_callsite_arg_fallback(&buf, i)) != 0) {
+            if (arg_buf_live) {
+                json_buf_free(&arg_buf);
+            }
             free(text);
             free(kind);
             free(type);
             pk_c_walk_term_free(term);
             free(term_json);
             goto done;
+        }
+        if (arg_buf_live) {
+            json_buf_free(&arg_buf);
         }
         free(text);
         free(kind);

--- a/implementations/c/provekit-walk-c/src/walk.c
+++ b/implementations/c/provekit-walk-c/src/walk.c
@@ -31,6 +31,17 @@ typedef struct {
 } CursorVec;
 
 typedef struct {
+    CXCursor cursor;
+    unsigned count;
+} SingleChildCtx;
+
+typedef struct {
+    char *data;
+    size_t len;
+    size_t cap;
+} JsonBuf;
+
+typedef struct {
     FunctionList *functions;
 } FunctionVisitCtx;
 
@@ -123,13 +134,122 @@ static int cursor_is_main_file(CXCursor cursor) {
     return clang_Location_isFromMainFile(clang_getCursorLocation(cursor)) != 0;
 }
 
-static char *cursor_name(CXCursor cursor) {
-    CXString spelling = clang_getCursorSpelling(cursor);
-    const char *cstr = clang_getCString(spelling);
+static char *cx_string_copy(CXString string) {
+    const char *cstr = clang_getCString(string);
     char *copy = pk_c_walk_copy(cstr == NULL ? "" : cstr);
 
-    clang_disposeString(spelling);
+    clang_disposeString(string);
     return copy;
+}
+
+static char *cursor_name(CXCursor cursor) {
+    return cx_string_copy(clang_getCursorSpelling(cursor));
+}
+
+static int json_buf_init(JsonBuf *buf) {
+    buf->len = 0;
+    buf->cap = 256;
+    buf->data = malloc(buf->cap);
+    if (buf->data == NULL) {
+        buf->cap = 0;
+        return -1;
+    }
+    buf->data[0] = '\0';
+    return 0;
+}
+
+static void json_buf_free(JsonBuf *buf) {
+    free(buf->data);
+    buf->data = NULL;
+    buf->len = 0;
+    buf->cap = 0;
+}
+
+static char *json_buf_take(JsonBuf *buf) {
+    char *data = buf->data;
+
+    buf->data = NULL;
+    buf->len = 0;
+    buf->cap = 0;
+    return data;
+}
+
+static int json_buf_grow(JsonBuf *buf, size_t need) {
+    size_t next = buf->cap ? buf->cap : 256;
+    char *data;
+
+    while (next < buf->len + need + 1) {
+        if (next > ((size_t)-1) / 2) {
+            return -1;
+        }
+        next *= 2;
+    }
+    data = realloc(buf->data, next);
+    if (data == NULL) {
+        return -1;
+    }
+    buf->data = data;
+    buf->cap = next;
+    return 0;
+}
+
+static int json_buf_append_n(JsonBuf *buf, const char *text, size_t len) {
+    if (json_buf_grow(buf, len) != 0) {
+        return -1;
+    }
+    memcpy(buf->data + buf->len, text, len);
+    buf->len += len;
+    buf->data[buf->len] = '\0';
+    return 0;
+}
+
+static int json_buf_append(JsonBuf *buf, const char *text) {
+    return json_buf_append_n(buf, text, strlen(text));
+}
+
+static int json_buf_append_char(JsonBuf *buf, char ch) {
+    return json_buf_append_n(buf, &ch, 1);
+}
+
+static int json_buf_append_quoted(JsonBuf *buf, const char *text) {
+    char *escaped = pk_c_lift_json_escape(text == NULL ? "" : text);
+    int rc;
+
+    if (escaped == NULL) {
+        return -1;
+    }
+    rc = json_buf_append_char(buf, '"') == 0 &&
+        json_buf_append(buf, escaped) == 0 &&
+        json_buf_append_char(buf, '"') == 0 ? 0 : -1;
+    free(escaped);
+    return rc;
+}
+
+static enum CXChildVisitResult single_child_visitor(CXCursor cursor, CXCursor parent, CXClientData data) {
+    SingleChildCtx *ctx = (SingleChildCtx *)data;
+
+    (void)parent;
+    if (ctx->count == 0) {
+        ctx->cursor = cursor;
+    }
+    ctx->count++;
+    return ctx->count > 1 ? CXChildVisit_Break : CXChildVisit_Continue;
+}
+
+static CXCursor unwrap_actual_cursor(CXCursor cursor) {
+    enum CXCursorKind kind = clang_getCursorKind(cursor);
+
+    while (kind == CXCursor_UnexposedExpr || kind == CXCursor_ParenExpr) {
+        SingleChildCtx ctx = {clang_getNullCursor(), 0};
+
+        (void)clang_visitChildren(cursor, single_child_visitor, &ctx);
+        if (ctx.count != 1 || clang_Cursor_isNull(ctx.cursor)) {
+            break;
+        }
+        cursor = ctx.cursor;
+        kind = clang_getCursorKind(cursor);
+    }
+    return cursor;
 }
 
 static enum CXChildVisitResult function_visitor(CXCursor cursor, CXCursor parent, CXClientData data) {
@@ -320,11 +440,78 @@ static int substitute_actuals(
     return 0;
 }
 
+static char *extract_callsite_actuals(CXCursor call_cursor) {
+    JsonBuf buf;
+    int n_args = clang_Cursor_getNumArguments(call_cursor);
+    char *out = NULL;
+
+    if (n_args < 0) {
+        n_args = 0;
+    }
+    if (json_buf_init(&buf) != 0) {
+        return NULL;
+    }
+    if (json_buf_append_char(&buf, '[') != 0) {
+        goto done;
+    }
+    for (int i = 0; i < n_args; i++) {
+        CXCursor arg = unwrap_actual_cursor(clang_Cursor_getArgument(call_cursor, (unsigned)i));
+        char position[32];
+        char *text = pk_c_walk_cursor_source(arg);
+        char *kind = cx_string_copy(clang_getCursorKindSpelling(clang_getCursorKind(arg)));
+        char *type = cx_string_copy(clang_getTypeSpelling(clang_getCursorType(arg)));
+        pk_c_walk_term *term = pk_c_walk_lift_term(arg);
+        char *term_json = term == NULL ? NULL : pk_c_walk_term_json(term);
+
+        if (snprintf(position, sizeof(position), "%d", i) < 0 ||
+            text == NULL || kind == NULL || type == NULL || term_json == NULL) {
+            free(text);
+            free(kind);
+            free(type);
+            pk_c_walk_term_free(term);
+            free(term_json);
+            goto done;
+        }
+        if ((i > 0 && json_buf_append_char(&buf, ',') != 0) ||
+            json_buf_append(&buf, "{\"position\":") != 0 ||
+            json_buf_append(&buf, position) != 0 ||
+            json_buf_append(&buf, ",\"text\":") != 0 ||
+            json_buf_append_quoted(&buf, text) != 0 ||
+            json_buf_append(&buf, ",\"kind\":") != 0 ||
+            json_buf_append_quoted(&buf, kind) != 0 ||
+            json_buf_append(&buf, ",\"type\":") != 0 ||
+            json_buf_append_quoted(&buf, type) != 0 ||
+            json_buf_append(&buf, ",\"term\":") != 0 ||
+            json_buf_append(&buf, term_json) != 0 ||
+            json_buf_append_char(&buf, '}') != 0) {
+            free(text);
+            free(kind);
+            free(type);
+            pk_c_walk_term_free(term);
+            free(term_json);
+            goto done;
+        }
+        free(text);
+        free(kind);
+        free(type);
+        pk_c_walk_term_free(term);
+        free(term_json);
+    }
+    if (json_buf_append_char(&buf, ']') == 0) {
+        out = json_buf_take(&buf);
+    }
+
+done:
+    json_buf_free(&buf);
+    return out;
+}
+
 static int process_call(CallVisitCtx *ctx, CXCursor call_cursor) {
     char *callee_name = pk_c_walk_call_callee(call_cursor);
     const WalkFunction *callee;
     pk_c_walk_formula *wp;
     pk_c_walk_chain chain;
+    char *actuals_json;
     int line = 0;
     int column = 0;
     int rc;
@@ -361,6 +548,12 @@ static int process_call(CallVisitCtx *ctx, CXCursor call_cursor) {
             return -1;
         }
     }
+    actuals_json = extract_callsite_actuals(call_cursor);
+    if (actuals_json == NULL) {
+        pk_c_walk_formula_free(wp);
+        free(callee_name);
+        return -1;
+    }
     pk_c_walk_chain_init(&chain);
     chain.caller_name = pk_c_walk_copy(ctx->caller->name);
     chain.callee_name = pk_c_walk_copy(callee_name);
@@ -370,15 +563,24 @@ static int process_call(CallVisitCtx *ctx, CXCursor call_cursor) {
     chain.column = column;
     if (chain.caller_name == NULL || chain.callee_name == NULL || chain.path == NULL ||
         clone_formals_into_chain(&chain, ctx->caller) != 0 ||
-        pk_c_walk_chain_add_arrival(&chain, "Callsite", callee_name, ctx->stmt_index, line, column, wp) != 0) {
+        pk_c_walk_chain_add_callsite_arrival(
+            &chain,
+            callee_name,
+            ctx->stmt_index,
+            line,
+            column,
+            actuals_json,
+            wp) != 0) {
         pk_c_walk_chain_free(&chain);
         pk_c_walk_formula_free(wp);
+        free(actuals_json);
         free(callee_name);
         return -1;
     }
     if (pk_c_walk_apply_call_context(ctx->stmts[ctx->stmt_index], call_cursor, &wp, &chain, ctx->stmt_index) != 0) {
         pk_c_walk_chain_free(&chain);
         pk_c_walk_formula_free(wp);
+        free(actuals_json);
         free(callee_name);
         return -1;
     }
@@ -390,6 +592,7 @@ static int process_call(CallVisitCtx *ctx, CXCursor call_cursor) {
             apply_guard_stmt(prev, &wp) != 0) {
             pk_c_walk_chain_free(&chain);
             pk_c_walk_formula_free(wp);
+            free(actuals_json);
             free(callee_name);
             return -1;
         }
@@ -405,11 +608,13 @@ static int process_call(CallVisitCtx *ctx, CXCursor call_cursor) {
         pk_c_walk_emit_chain_contract(ctx->result, &chain) != 0) {
         pk_c_walk_chain_free(&chain);
         pk_c_walk_formula_free(wp);
+        free(actuals_json);
         free(callee_name);
         return -1;
     }
     pk_c_walk_chain_free(&chain);
     pk_c_walk_formula_free(wp);
+    free(actuals_json);
     free(callee_name);
     return 0;
 }

--- a/implementations/c/provekit-walk-c/src/walk_c.h
+++ b/implementations/c/provekit-walk-c/src/walk_c.h
@@ -96,6 +96,7 @@ int pk_c_walk_formula_is_true(const pk_c_walk_formula *formula);
 char *pk_c_walk_formula_json(const pk_c_walk_formula *formula);
 char *pk_c_walk_term_json(const pk_c_walk_term *term);
 pk_c_walk_term *pk_c_walk_term_from_text(const char *start, size_t len);
+pk_c_walk_term *pk_c_walk_term_from_text_full(const char *start, size_t len);
 pk_c_walk_formula *pk_c_walk_formula_from_text(const char *start, size_t len);
 
 void pk_c_walk_chain_init(pk_c_walk_chain *chain);
@@ -130,6 +131,7 @@ int pk_c_walk_chain_add_conditional_arm_arrival(
 char *pk_c_walk_cursor_source(CXCursor cursor);
 char *pk_c_walk_call_callee(CXCursor cursor);
 pk_c_walk_term *pk_c_walk_lift_term(CXCursor cursor);
+pk_c_walk_term *pk_c_walk_lift_term_full(CXCursor cursor);
 pk_c_walk_formula *pk_c_walk_lift_condition(CXCursor cursor);
 pk_c_walk_formula *pk_c_walk_lift_function_pre(CXCursor function_cursor);
 pk_c_walk_formula *pk_c_walk_lift_if_exit_pre(CXCursor if_cursor);

--- a/implementations/c/provekit-walk-c/src/walk_c.h
+++ b/implementations/c/provekit-walk-c/src/walk_c.h
@@ -48,6 +48,7 @@ typedef struct {
     char *kind;
     char *name;
     char *branch;
+    char *actuals_json;
     size_t stmt_index;
     size_t join_stmt_index;
     int line;
@@ -93,6 +94,7 @@ pk_c_walk_formula *pk_c_walk_substitute_formula(
     const pk_c_walk_term *replacement);
 int pk_c_walk_formula_is_true(const pk_c_walk_formula *formula);
 char *pk_c_walk_formula_json(const pk_c_walk_formula *formula);
+char *pk_c_walk_term_json(const pk_c_walk_term *term);
 pk_c_walk_term *pk_c_walk_term_from_text(const char *start, size_t len);
 pk_c_walk_formula *pk_c_walk_formula_from_text(const char *start, size_t len);
 
@@ -105,6 +107,14 @@ int pk_c_walk_chain_add_arrival(
     size_t stmt_index,
     int line,
     int column,
+    const pk_c_walk_formula *wp);
+int pk_c_walk_chain_add_callsite_arrival(
+    pk_c_walk_chain *chain,
+    const char *name,
+    size_t stmt_index,
+    int line,
+    int column,
+    const char *actuals_json,
     const pk_c_walk_formula *wp);
 int pk_c_walk_chain_add_conditional_arm_arrival(
     pk_c_walk_chain *chain,

--- a/implementations/c/provekit-walk-c/src/wp.c
+++ b/implementations/c/provekit-walk-c/src/wp.c
@@ -562,6 +562,20 @@ static int term_json_into(WpBuf *b, const pk_c_walk_term *term) {
     return buf_append(b, "]}");
 }
 
+char *pk_c_walk_term_json(const pk_c_walk_term *term) {
+    WpBuf b;
+    char *out = NULL;
+
+    if (buf_init(&b) != 0) {
+        return NULL;
+    }
+    if (term_json_into(&b, term) == 0) {
+        out = buf_take(&b);
+    }
+    buf_free(&b);
+    return out;
+}
+
 static int formula_json_into(WpBuf *b, const pk_c_walk_formula *formula) {
     const char *kind;
 
@@ -951,6 +965,7 @@ void pk_c_walk_chain_free(pk_c_walk_chain *chain) {
         free(chain->arrivals[i].kind);
         free(chain->arrivals[i].name);
         free(chain->arrivals[i].branch);
+        free(chain->arrivals[i].actuals_json);
         pk_c_walk_formula_free(chain->arrivals[i].cond);
         pk_c_walk_formula_free(chain->arrivals[i].wp);
     }
@@ -982,18 +997,20 @@ static void arrival_clear(pk_c_walk_arrival *arrival) {
     free(arrival->kind);
     free(arrival->name);
     free(arrival->branch);
+    free(arrival->actuals_json);
     pk_c_walk_formula_free(arrival->cond);
     pk_c_walk_formula_free(arrival->wp);
     memset(arrival, 0, sizeof(*arrival));
 }
 
-int pk_c_walk_chain_add_arrival(
+static int chain_add_arrival_with_actuals(
     pk_c_walk_chain *chain,
     const char *kind,
     const char *name,
     size_t stmt_index,
     int line,
     int column,
+    const char *actuals_json,
     const pk_c_walk_formula *wp
 ) {
     pk_c_walk_arrival *arrival = chain_append_slot(chain);
@@ -1006,13 +1023,50 @@ int pk_c_walk_chain_add_arrival(
     arrival->stmt_index = stmt_index;
     arrival->line = line;
     arrival->column = column;
+    if (actuals_json != NULL) {
+        arrival->actuals_json = pk_c_walk_copy(actuals_json);
+    }
     arrival->wp = pk_c_walk_formula_clone(wp);
-    if (arrival->kind == NULL || arrival->name == NULL || arrival->wp == NULL) {
+    if (arrival->kind == NULL || arrival->name == NULL ||
+        (actuals_json != NULL && arrival->actuals_json == NULL) ||
+        arrival->wp == NULL) {
         arrival_clear(arrival);
         return -1;
     }
     chain->n_arrivals++;
     return 0;
+}
+
+int pk_c_walk_chain_add_arrival(
+    pk_c_walk_chain *chain,
+    const char *kind,
+    const char *name,
+    size_t stmt_index,
+    int line,
+    int column,
+    const pk_c_walk_formula *wp
+) {
+    return chain_add_arrival_with_actuals(chain, kind, name, stmt_index, line, column, NULL, wp);
+}
+
+int pk_c_walk_chain_add_callsite_arrival(
+    pk_c_walk_chain *chain,
+    const char *name,
+    size_t stmt_index,
+    int line,
+    int column,
+    const char *actuals_json,
+    const pk_c_walk_formula *wp
+) {
+    return chain_add_arrival_with_actuals(
+        chain,
+        "Callsite",
+        name,
+        stmt_index,
+        line,
+        column,
+        actuals_json == NULL ? "[]" : actuals_json,
+        wp);
 }
 
 int pk_c_walk_chain_add_conditional_arm_arrival(

--- a/implementations/c/provekit-walk-c/src/wp.c
+++ b/implementations/c/provekit-walk-c/src/wp.c
@@ -942,6 +942,21 @@ pk_c_walk_term *pk_c_walk_term_from_text(const char *start, size_t len) {
     return parse_term_expr(&parser);
 }
 
+pk_c_walk_term *pk_c_walk_term_from_text_full(const char *start, size_t len) {
+    WpParser parser = {start, start + len};
+    pk_c_walk_term *term = parse_term_expr(&parser);
+
+    if (term == NULL) {
+        return NULL;
+    }
+    parser_skip_ws(&parser);
+    if (parser.p != parser.end) {
+        pk_c_walk_term_free(term);
+        return NULL;
+    }
+    return term;
+}
+
 pk_c_walk_formula *pk_c_walk_formula_from_text(const char *start, size_t len) {
     WpParser parser = {start, start + len};
 

--- a/implementations/c/provekit-walk-c/tests/fixtures/callsite_actuals.c
+++ b/implementations/c/provekit-walk-c/tests/fixtures/callsite_actuals.c
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#define BUG() do { return -1; } while (0)
+
+int actuals_callee(int literal, int ref, int expr) {
+    if (literal < 0) {
+        BUG();
+    }
+    if (ref < 0) {
+        BUG();
+    }
+    if (expr < 0) {
+        BUG();
+    }
+    return literal + ref + expr;
+}
+
+int actuals_caller(int input) {
+    return actuals_callee(7, input, input + 1);
+}

--- a/implementations/c/provekit-walk-c/tests/fixtures/callsite_actuals.c
+++ b/implementations/c/provekit-walk-c/tests/fixtures/callsite_actuals.c
@@ -2,6 +2,10 @@
 
 #define BUG() do { return -1; } while (0)
 
+struct foo {
+    int x;
+};
+
 int actuals_callee(int literal, int ref, int expr) {
     if (literal < 0) {
         BUG();
@@ -17,4 +21,32 @@ int actuals_callee(int literal, int ref, int expr) {
 
 int actuals_caller(int input) {
     return actuals_callee(7, input, input + 1);
+}
+
+int actuals_single_callee(int value) {
+    return value;
+}
+
+int actuals_mixed_callee(int ref, int expr) {
+    return ref + expr;
+}
+
+struct foo actuals_struct_callee(struct foo value) {
+    return value;
+}
+
+int actuals_ternary_caller(int cond, int x, int y) {
+    return actuals_single_callee(cond ? x : y);
+}
+
+int actuals_comma_caller(int x, int y) {
+    return actuals_single_callee((x, y));
+}
+
+struct foo actuals_compound_literal_caller(void) {
+    return actuals_struct_callee((struct foo){.x = 1});
+}
+
+int actuals_mixed_caller(int cond, int x, int y, int z) {
+    return actuals_mixed_callee(x, cond ? y : z);
 }

--- a/implementations/c/provekit-walk-c/tests/integration.sh
+++ b/implementations/c/provekit-walk-c/tests/integration.sh
@@ -10,6 +10,7 @@ OPAQUE_BUG_ON_FIXTURE="$SCRIPT_DIR/fixtures/checked_demo_opaque_bug_on.c"
 TWO_ARMED_FIXTURE="$SCRIPT_DIR/fixtures/two_armed_if.c"
 CALL_STATEMENT_FIXTURE="$SCRIPT_DIR/fixtures/call_statement.c"
 HANDLED_GUARD_FIXTURE="$SCRIPT_DIR/fixtures/handled_guard.c"
+ACTUALS_FIXTURE="$SCRIPT_DIR/fixtures/callsite_actuals.c"
 
 if [ ! -x "$BIN" ]; then
     echo "FAIL: binary not found: $BIN" >&2
@@ -43,6 +44,11 @@ fi
 
 if [ ! -f "$HANDLED_GUARD_FIXTURE" ]; then
     echo "FAIL: fixture not found: $HANDLED_GUARD_FIXTURE" >&2
+    exit 1
+fi
+
+if [ ! -f "$ACTUALS_FIXTURE" ]; then
+    echo "FAIL: fixture not found: $ACTUALS_FIXTURE" >&2
     exit 1
 fi
 
@@ -384,4 +390,90 @@ if not is_true(entry.get("wp", {})):
 if not is_true(chain.get("pre", {})):
     raise SystemExit(f"FAIL: handled null guard chain pre should be true, got {chain.get('pre')}")
 print("handled-guard-chain", " -> ".join(f"{a['kind']}@{a.get('line', 0)}:{a.get('column', 0)}" for a in arrivals))
+PY
+
+ACTUALS_RESPONSES="$(
+    {
+        printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+        printf '{"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":'
+        printf '"%s"' "$SCRIPT_DIR/fixtures"
+        printf ',"source_paths":["callsite_actuals.c"],"surface":"c-walk","parse_backend":"clang_ast"}}\n'
+        printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"shutdown"}'
+    } | "$BIN" --rpc
+)"
+
+ACTUALS_RESPONSES_AGAIN="$(
+    {
+        printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+        printf '{"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":'
+        printf '"%s"' "$SCRIPT_DIR/fixtures"
+        printf ',"source_paths":["callsite_actuals.c"],"surface":"c-walk","parse_backend":"clang_ast"}}\n'
+        printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"shutdown"}'
+    } | "$BIN" --rpc
+)"
+
+ACTUALS_RESPONSES_JSON="$ACTUALS_RESPONSES" ACTUALS_RESPONSES_AGAIN_JSON="$ACTUALS_RESPONSES_AGAIN" python3 - <<'PY'
+import json
+import os
+
+def callsite_arrival(blob):
+    responses = [json.loads(line) for line in blob.splitlines() if line.strip()]
+    lift = next((r for r in responses if r.get("id") == 2), None)
+    if lift is None:
+        raise SystemExit("FAIL: callsite_actuals lift response missing")
+
+    chains = [
+        d for d in lift["result"]["declarations"]
+        if d.get("kind") == "function-contract"
+        and d.get("evidence", {}).get("kind") == "wp-walk-chain"
+        and d.get("evidence", {}).get("caller") == "actuals_caller"
+        and d.get("evidence", {}).get("callee") == "actuals_callee"
+    ]
+    if not chains:
+        raise SystemExit("FAIL: no actuals_caller -> actuals_callee wp-walk-chain emitted")
+
+    arrivals = chains[0]["evidence"].get("arrivals", [])
+    callsites = [a for a in arrivals if a.get("kind") == "Callsite"]
+    if not callsites:
+        raise SystemExit("FAIL: callsite_actuals chain missing Callsite arrival")
+    for arrival in callsites:
+        if "args" not in arrival:
+            raise SystemExit(f"FAIL: Callsite arrival missing args field: {arrival}")
+        if not isinstance(arrival["args"], list):
+            raise SystemExit(f"FAIL: Callsite arrival args must be an array: {arrival['args']!r}")
+    return callsites[0]
+
+arrival = callsite_arrival(os.environ["ACTUALS_RESPONSES_JSON"])
+again = callsite_arrival(os.environ["ACTUALS_RESPONSES_AGAIN_JSON"])
+args = arrival["args"]
+
+positions = [arg.get("position") for arg in args]
+if positions != list(range(len(args))):
+    raise SystemExit(f"FAIL: callsite args positions must be contiguous from 0, got {positions}")
+if len(args) != 3:
+    raise SystemExit(f"FAIL: expected three callsite args, got {len(args)}: {args}")
+
+texts = [arg.get("text") for arg in args]
+if texts != ["7", "input", "input+1"]:
+    raise SystemExit(f"FAIL: unexpected callsite arg texts: {texts}")
+
+kinds = [arg.get("kind") for arg in args]
+if kinds[0] != "IntegerLiteral" or kinds[1] != "DeclRefExpr" or kinds[2] != "BinaryOperator":
+    raise SystemExit(f"FAIL: expected literal/ref/binop cursor kinds, got {kinds}")
+
+types = [arg.get("type") for arg in args]
+if types != ["int", "int", "int"]:
+    raise SystemExit(f"FAIL: expected int arg types, got {types}")
+
+for arg in args:
+    term = arg.get("term")
+    if not isinstance(term, dict):
+        raise SystemExit(f"FAIL: callsite arg missing IR term object: {arg}")
+    if term.get("kind") not in {"const", "var", "ctor"}:
+        raise SystemExit(f"FAIL: callsite arg term has unexpected shape: {term}")
+
+if arrival != again:
+    raise SystemExit(f"FAIL: callsite arrival changed across identical runs: {arrival} != {again}")
+
+print("callsite-actuals", ",".join(f"{a['position']}:{a['kind']}:{a['text']}" for a in args))
 PY

--- a/implementations/c/provekit-walk-c/tests/integration.sh
+++ b/implementations/c/provekit-walk-c/tests/integration.sh
@@ -416,7 +416,7 @@ ACTUALS_RESPONSES_JSON="$ACTUALS_RESPONSES" ACTUALS_RESPONSES_AGAIN_JSON="$ACTUA
 import json
 import os
 
-def callsite_arrival(blob):
+def callsite_arrival(blob, caller="actuals_caller", callee="actuals_callee"):
     responses = [json.loads(line) for line in blob.splitlines() if line.strip()]
     lift = next((r for r in responses if r.get("id") == 2), None)
     if lift is None:
@@ -426,16 +426,16 @@ def callsite_arrival(blob):
         d for d in lift["result"]["declarations"]
         if d.get("kind") == "function-contract"
         and d.get("evidence", {}).get("kind") == "wp-walk-chain"
-        and d.get("evidence", {}).get("caller") == "actuals_caller"
-        and d.get("evidence", {}).get("callee") == "actuals_callee"
+        and d.get("evidence", {}).get("caller") == caller
+        and d.get("evidence", {}).get("callee") == callee
     ]
     if not chains:
-        raise SystemExit("FAIL: no actuals_caller -> actuals_callee wp-walk-chain emitted")
+        raise SystemExit(f"FAIL: no {caller} -> {callee} wp-walk-chain emitted")
 
     arrivals = chains[0]["evidence"].get("arrivals", [])
     callsites = [a for a in arrivals if a.get("kind") == "Callsite"]
     if not callsites:
-        raise SystemExit("FAIL: callsite_actuals chain missing Callsite arrival")
+        raise SystemExit(f"FAIL: {caller} -> {callee} chain missing Callsite arrival")
     for arrival in callsites:
         if "args" not in arrival:
             raise SystemExit(f"FAIL: Callsite arrival missing args field: {arrival}")
@@ -474,6 +474,61 @@ for arg in args:
 
 if arrival != again:
     raise SystemExit(f"FAIL: callsite arrival changed across identical runs: {arrival} != {again}")
+
+def require_single_arg(caller, callee, expected_text):
+    arrival = callsite_arrival(os.environ["ACTUALS_RESPONSES_JSON"], caller, callee)
+    args = arrival["args"]
+    if len(args) != 1:
+        raise SystemExit(f"FAIL: {caller} expected one callsite arg, got {len(args)}: {args}")
+    arg = args[0]
+    if arg.get("position") != 0:
+        raise SystemExit(f"FAIL: {caller} arg position should be 0, got {arg}")
+    if arg.get("text") != expected_text:
+        raise SystemExit(f"FAIL: {caller} arg text should be {expected_text!r}, got {arg.get('text')!r}")
+    if "term" not in arg:
+        raise SystemExit(f"FAIL: {caller} arg missing nullable term field: {arg}")
+    return arg
+
+def reject_truncated_prefix(arg, forbidden_term, label):
+    term = arg.get("term")
+    if term == forbidden_term:
+        raise SystemExit(f"FAIL: {label} arg term is a truncated prefix parse: {arg}")
+    if term is not None and not isinstance(term, dict):
+        raise SystemExit(f"FAIL: {label} arg term must be object or null: {arg}")
+
+ternary_arg = require_single_arg(
+    "actuals_ternary_caller",
+    "actuals_single_callee",
+    "cond?x:y",
+)
+reject_truncated_prefix(ternary_arg, {"kind": "var", "name": "cond"}, "ternary")
+
+comma_arg = require_single_arg(
+    "actuals_comma_caller",
+    "actuals_single_callee",
+    "x,y",
+)
+reject_truncated_prefix(comma_arg, {"kind": "var", "name": "x"}, "comma-expression")
+
+compound_arg = require_single_arg(
+    "actuals_compound_literal_caller",
+    "actuals_struct_callee",
+    "(structfoo){.x=1}",
+)
+reject_truncated_prefix(compound_arg, {"kind": "var", "name": "structfoo"}, "compound-literal")
+
+mixed = callsite_arrival(
+    os.environ["ACTUALS_RESPONSES_JSON"],
+    "actuals_mixed_caller",
+    "actuals_mixed_callee",
+)
+mixed_args = mixed["args"]
+if len(mixed_args) != 2:
+    raise SystemExit(f"FAIL: mixed callsite should keep two args, got {mixed_args}")
+if mixed_args[0].get("text") != "x" or not isinstance(mixed_args[0].get("term"), dict):
+    raise SystemExit(f"FAIL: mixed callsite should preserve liftable first arg term: {mixed_args}")
+if mixed_args[1].get("text") != "cond?y:z" or mixed_args[1].get("term") is not None:
+    raise SystemExit(f"FAIL: mixed callsite should preserve unliftable second arg with term null: {mixed_args}")
 
 print("callsite-actuals", ",".join(f"{a['position']}:{a['kind']}:{a['text']}" for a in args))
 PY


### PR DESCRIPTION
## Summary

This fills the substrate gap where `provekit-walk-c` Callsite arrivals carried no actual argument data, preventing `compose_discharge.py` from doing argument-substitution-based composition.

The Callsite arrival schema now includes `args` as an array of `args[].{position,text,kind,type,term}` objects. `position` is 0-indexed and deterministic; `kind` is the libclang cursor kind spelling; `term` is the existing walk-c IR term JSON for the actual expression.

## Tests

- Added `implementations/c/provekit-walk-c/tests/fixtures/callsite_actuals.c` with literal, variable, and binary-expression actuals.
- Extended `implementations/c/provekit-walk-c/tests/integration.sh` to assert every Callsite arrival has `args`, positions are contiguous/ascending, mixed cursor kinds serialize, terms are present, and repeated runs are deterministic.

## Substrate impact

The next substrate re-ingest will produce actuals-bearing mementos. Existing pre-#577 substrate is preserved at `~/scratch/pre577/`.

This is the prerequisite for re-running compose-discharge post-#577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Call-site arguments are now captured and serialized in JSON, including source text, types, and lifted terms for complete call context.
  * Introduced new public API functions for registering call-site arrivals with argument metadata.

* **Tests**
  * Added integration tests validating call-site argument extraction, serialization, and consistency across multiple runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/583)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->