### PR TITLE
feat(ts): add TypeScript source lift kit (self-hosted) + ts-language-signature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,8 @@ help:
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  make clean          remove build artifacts"
+	@echo "  make mint-typescript-language-signature"
+	@echo "                       mint the draft TypeScript source language-signature catalog"
 	@echo ""
 	@echo "Pinned CIDs (catalog v1.6.2):"
 	@echo "  catalog: $(CATALOG_CID)"
@@ -510,6 +512,10 @@ catalog-verify:
 .PHONY: c11-cursorkind-check
 c11-cursorkind-check:
 	python3 tools/generate-c11-from-cursorkind.py --check
+
+.PHONY: mint-typescript-language-signature
+mint-typescript-language-signature:
+	menagerie/typescript-language-signature/mint.sh
 
 .PHONY: protocol-verify
 protocol-verify: build-rust

--- a/implementations/rust/provekit-cli/src/project_config.rs
+++ b/implementations/rust/provekit-cli/src/project_config.rs
@@ -205,6 +205,7 @@ pub const KNOWN_SURFACES: &[&str] = &[
     "rust-proptest",
     "rust-quickcheck",
     "ts-zod",
+    "typescript-source",
     "ts-class-validator",
     "ts-fast-check",
     "ts-jsdoc",
@@ -312,6 +313,7 @@ mod tests {
     fn known_lists_include_anchor_entries() {
         assert!(KNOWN_SURFACES.contains(&"default"));
         assert!(KNOWN_SURFACES.contains(&"ts-zod"));
+        assert!(KNOWN_SURFACES.contains(&"typescript-source"));
         assert!(KNOWN_SURFACES.contains(&"clr-bytecode"));
         assert!(KNOWN_AGENTS.contains(&"stub"));
         assert!(KNOWN_AGENTS.contains(&"claude-code"));

--- a/implementations/typescript/.provekit/lift/typescript-source/manifest.toml
+++ b/implementations/typescript/.provekit/lift/typescript-source/manifest.toml
@@ -1,0 +1,10 @@
+name = "typescript-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+command = ["npx", "tsx", "src/lift/typescript-source/bin.ts", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["typescript-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/typescript/src/lift/typescript-source/bin.ts
+++ b/implementations/typescript/src/lift/typescript-source/bin.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import readline from "node:readline";
+
+import {
+  compileTypeScriptSourceIr,
+  liftTypeScriptSourcePaths,
+  type FunctionContractMemento,
+} from "./index.js";
+
+const DIALECT = "typescript-source";
+const VERSION = "0.1.0-draft";
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: unknown;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+export function main(argv: string[] = process.argv.slice(2)): void {
+  if (!argv.includes("--rpc")) {
+    process.stderr.write("usage: provekit-lift-typescript-source --rpc\n");
+    process.exit(1);
+  }
+  runRpcMode();
+}
+
+function runRpcMode(): void {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
+  rl.on("line", (line) => {
+    if (line.trim() === "") return;
+    let request: JsonRpcRequest;
+    try {
+      request = JSON.parse(line) as JsonRpcRequest;
+    } catch (error) {
+      write(errorResponse(null, -32700, `PARSE_ERROR: ${(error as Error).message}`));
+      return;
+    }
+    try {
+      const response = dispatch(request);
+      if (response) write(response);
+    } catch (error) {
+      write(errorResponse(request.id ?? null, -32603, (error as Error).message));
+    }
+  });
+}
+
+function dispatch(request: JsonRpcRequest): Record<string, unknown> | null {
+  switch (request.method) {
+    case "initialize":
+      return success(request.id, {
+        name: "provekit-lift-typescript-source",
+        version: VERSION,
+        protocol_version: "provekit-lift/1",
+        capabilities: {
+          authoring_surfaces: [DIALECT],
+          ir_version: "v1.1.0",
+          emits_signed_mementos: false,
+        },
+      });
+    case "lift":
+      return liftRpc(request);
+    case "compile":
+      return compileRpc(request);
+    case "shutdown":
+      return success(request.id, null);
+    default:
+      return errorResponse(request.id ?? null, -32601, `METHOD_NOT_FOUND: ${request.method ?? ""}`);
+  }
+}
+
+function liftRpc(request: JsonRpcRequest): Record<string, unknown> {
+  const params = request.params ?? {};
+  const surface = typeof params.surface === "string" ? params.surface : DIALECT;
+  if (surface !== DIALECT) {
+    return errorResponse(request.id ?? null, 1003, `SURFACE_NOT_SUPPORTED: ${surface}`);
+  }
+  const sourcePaths = Array.isArray(params.source_paths)
+    ? params.source_paths.filter((path): path is string => typeof path === "string")
+    : [];
+  if (sourcePaths.length === 0) {
+    return errorResponse(request.id ?? null, -32602, "source_paths must be a non-empty array of strings");
+  }
+  const workspaceRoot = typeof params.workspace_root === "string" ? params.workspace_root : ".";
+  const result = liftTypeScriptSourcePaths(workspaceRoot, sourcePaths);
+  return success(request.id, {
+    kind: "ir-document",
+    ir: result.declarations,
+    callEdges: [],
+    diagnostics: result.diagnostics,
+    opacityReport: result.opacityReport,
+    refusals: result.refusals,
+  });
+}
+
+function compileRpc(request: JsonRpcRequest): Record<string, unknown> {
+  const params = request.params ?? {};
+  const ir = params.ir;
+  if (!Array.isArray(ir)) {
+    return errorResponse(request.id ?? null, -32602, "ir must be an array of function-contract mementos");
+  }
+  const body = compileTypeScriptSourceIr(ir as FunctionContractMemento[]);
+  return success(request.id, { kind: "compiled-formula", body });
+}
+
+function success(id: unknown, result: unknown): Record<string, unknown> {
+  return { jsonrpc: "2.0", id: id ?? null, result };
+}
+
+function errorResponse(id: unknown, code: number, message: string): Record<string, unknown> {
+  return { jsonrpc: "2.0", id: id ?? null, error: { code, message } };
+}
+
+function write(value: Record<string, unknown>): void {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+main();

--- a/implementations/typescript/src/lift/typescript-source/index.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.test.ts
@@ -3,8 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { canonicalJsonString } from "../../claimEnvelope/canonicalize.js";
+import { canonicalEncode, canonicalJsonString } from "../../claimEnvelope/canonicalize.js";
+import { computeCid } from "../../canonicalizer/hash.js";
 import {
+  compileTypeScriptSourceBodyIr,
   compileTypeScriptSourceIr,
   functionContractCid,
   liftTypeScriptSourcePaths,
@@ -17,6 +19,10 @@ function tempDir(prefix = "provekit-ts-source-"): string {
 
 function rhs(contract: Record<string, any>): any {
   return contract.post.args[1];
+}
+
+function canonicalCid(value: unknown): string {
+  return computeCid(canonicalEncode(value));
 }
 
 describe("typescript-source lifter", () => {
@@ -115,16 +121,45 @@ describe("typescript-source lifter", () => {
     expect(canonicalJsonString(result)).not.toContain("ts:skip");
   });
 
-  it("round-trips lift(compile(lift(src))) with byte-identical canonical IR", () => {
-    const first = liftTypeScriptSourceText(
-      "function add(x: number, y: number): number { return x + y; }\n",
-      "src/roundtrip.ts",
+  it("emits distinct refusal reasons for unsupported function shapes", () => {
+    const result = liftTypeScriptSourceText(
+      `
+      declare function dec(...args: any[]): any;
+      async function asyncFn(x: number): Promise<number> { return x; }
+      function* generatorFn(x: number): Iterable<number> { yield x; }
+      function genericFn<T>(x: number): number { return x; }
+      function restFn(...xs: number[]): number { return 1; }
+      function defaultFn(x: number = 1): number { return x; }
+      function destructuredFn({ x }: { x: number }): number { return x; }
+      class C {
+        @dec
+        decoratedMethod(x: number): number { return x; }
+      }
+      `,
+      "src/refuse-shapes.ts",
     );
+
+    expect(result.declarations).toEqual([]);
+    expect(new Map(result.refusals.map((refusal) => [refusal.function, refusal.reason]))).toEqual(new Map([
+      ["src/refuse-shapes.ts:asyncFn", "async function not supported"],
+      ["src/refuse-shapes.ts:generatorFn", "generator function not supported"],
+      ["src/refuse-shapes.ts:genericFn", "generic type parameters not supported"],
+      ["src/refuse-shapes.ts:restFn", "rest parameters not supported"],
+      ["src/refuse-shapes.ts:defaultFn", "default parameters not supported"],
+      ["src/refuse-shapes.ts:destructuredFn", "destructured parameters not supported"],
+      ["src/refuse-shapes.ts:C.decoratedMethod", "decorated function not supported"],
+    ]));
+  });
+
+  it("preserves source-unit raw bytes for lift(compile(lift(src))) round-trips", () => {
+    const source = "function add(x: number, y: number): number { return x + y; }\n";
+    const first = liftTypeScriptSourceText(source, "src/roundtrip.ts");
     expect(first.refusals).toEqual([]);
 
     const compiled = compileTypeScriptSourceIr(first.declarations);
     const second = liftTypeScriptSourceText(compiled, "src/roundtrip.ts");
 
+    expect(compiled).toBe(source);
     expect(second.refusals).toEqual([]);
     expect(canonicalJsonString(second.declarations)).toBe(
       canonicalJsonString(first.declarations),
@@ -132,6 +167,30 @@ describe("typescript-source lifter", () => {
     expect(second.declarations.map(functionContractCid)).toEqual(
       first.declarations.map(functionContractCid),
     );
+  });
+
+  it("round-trips a bare body term through the AST printer with byte-identical canonical IR", () => {
+    const first = liftTypeScriptSourceText(
+      "function f(x: number, y: number): number { return x + y; }\n",
+      "src/body-roundtrip.ts",
+    );
+    expect(first.refusals).toEqual([]);
+
+    const firstContract = first.declarations.find((decl) => decl.fnName === "src/body-roundtrip.ts:f")!;
+    const originalBodyTerm = rhs(firstContract);
+    const compiled = compileTypeScriptSourceBodyIr(originalBodyTerm, {
+      functionName: "f",
+      formals: firstContract.formals,
+      formalSorts: firstContract.formalSorts,
+      returnSort: firstContract.returnSort,
+    });
+    const second = liftTypeScriptSourceText(compiled, "src/body-roundtrip.ts");
+
+    expect(second.refusals).toEqual([]);
+    const secondContract = second.declarations.find((decl) => decl.fnName === "src/body-roundtrip.ts:f")!;
+    const reliftedBodyTerm = rhs(secondContract);
+    expect([...canonicalEncode(reliftedBodyTerm)]).toEqual([...canonicalEncode(originalBodyTerm)]);
+    expect(canonicalCid(reliftedBodyTerm)).toBe(canonicalCid(originalBodyTerm));
   });
 
   it("rejects source paths that escape the workspace root", () => {

--- a/implementations/typescript/src/lift/typescript-source/index.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { canonicalJsonString } from "../../claimEnvelope/canonicalize.js";
+import {
+  compileTypeScriptSourceIr,
+  functionContractCid,
+  liftTypeScriptSourcePaths,
+  liftTypeScriptSourceText,
+} from "./index.js";
+
+function tempDir(prefix = "provekit-ts-source-"): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function rhs(contract: Record<string, any>): any {
+  return contract.post.args[1];
+}
+
+describe("typescript-source lifter", () => {
+  it("lifts function declarations into ts:-namespaced function-contracts wrapped by source-unit", () => {
+    const result = liftTypeScriptSourceText(
+      "export function add(x: number, y: number): number { return x + y; }\n",
+      "src/math.ts",
+    );
+
+    expect(result.refusals).toEqual([]);
+    expect(result.declarations).toHaveLength(2);
+
+    const sourceUnit = result.declarations[0]!;
+    expect(sourceUnit.kind).toBe("function-contract");
+    expect(sourceUnit.fnName).toBe("src/math.ts:<source-unit>");
+    expect(rhs(sourceUnit).name).toBe("ts:source-unit");
+    expect(rhs(sourceUnit).args[1].name).toBe("ts:seq");
+
+    const add = result.declarations[1]!;
+    expect(add.fnName).toBe("src/math.ts:add");
+    expect(add.formals).toEqual(["x", "y"]);
+    expect(add.formalSorts).toEqual([
+      { kind: "primitive", name: "Number" },
+      { kind: "primitive", name: "Number" },
+    ]);
+    expect(add.returnSort).toEqual({ kind: "primitive", name: "Number" });
+    expect(rhs(add)).toMatchObject({ kind: "ctor", name: "ts:add" });
+    expect(functionContractCid(add)).toMatch(/^blake3-512:[0-9a-f]{128}$/);
+  });
+
+  it("qualifies class and namespace methods so distinct definitions do not collide", () => {
+    const result = liftTypeScriptSourceText(
+      `
+      namespace N {
+        export class A { m(x: number): number { return x + 1; } }
+        export class B { m(x: number): number { return x + 2; } }
+      }
+      `,
+      "src/classes.ts",
+    );
+
+    expect(result.refusals).toEqual([]);
+    expect(result.declarations.map((d) => d.fnName)).toEqual([
+      "src/classes.ts:<source-unit>",
+      "src/classes.ts:N.A.m",
+      "src/classes.ts:N.B.m",
+    ]);
+  });
+
+  it("emits canonical Effect wire shapes sorted like the Rust Effect::sort_key", () => {
+    const result = liftTypeScriptSourceText(
+      `
+      let counter = 0;
+      function tick(x: number): number {
+        counter = counter + x;
+        console.log(counter);
+        while (x > 0) {
+          x = x - 1;
+        }
+        missing(counter);
+        if (x < 0) { throw "negative"; }
+        return counter;
+      }
+      `,
+      "src/effects.ts",
+    );
+
+    expect(result.refusals).toEqual([]);
+    const tick = result.declarations.find((d) => d.fnName === "src/effects.ts:tick")!;
+    expect(tick.effects).toEqual([
+      { kind: "reads", target: "src/effects.ts:counter" },
+      { kind: "writes", target: "src/effects.ts:counter" },
+      { kind: "io" },
+      { kind: "panics" },
+      { kind: "unresolved_call", name: "missing" },
+      { kind: "opaque_loop", loopCid: expect.stringMatching(/^blake3-512:[0-9a-f]{128}$/) },
+    ]);
+  });
+
+  it("refuses unsupported syntax instead of emitting unknown or skip fallbacks", () => {
+    const result = liftTypeScriptSourceText(
+      "const f = (x: number): number => x + 1;\n",
+      "src/refuse.ts",
+    );
+
+    expect(result.declarations).toEqual([]);
+    expect(result.refusals).toEqual([
+      {
+        kind: "ArrowFunction",
+        function: "f",
+        line: 1,
+        reason: expect.stringContaining("arrow functions"),
+      },
+    ]);
+    expect(canonicalJsonString(result)).not.toContain("ts:unknown");
+    expect(canonicalJsonString(result)).not.toContain("ts:skip");
+  });
+
+  it("round-trips lift(compile(lift(src))) with byte-identical canonical IR", () => {
+    const first = liftTypeScriptSourceText(
+      "function add(x: number, y: number): number { return x + y; }\n",
+      "src/roundtrip.ts",
+    );
+    expect(first.refusals).toEqual([]);
+
+    const compiled = compileTypeScriptSourceIr(first.declarations);
+    const second = liftTypeScriptSourceText(compiled, "src/roundtrip.ts");
+
+    expect(second.refusals).toEqual([]);
+    expect(canonicalJsonString(second.declarations)).toBe(
+      canonicalJsonString(first.declarations),
+    );
+    expect(second.declarations.map(functionContractCid)).toEqual(
+      first.declarations.map(functionContractCid),
+    );
+  });
+
+  it("rejects source paths that escape the workspace root", () => {
+    const td = tempDir();
+    writeFileSync(join(td, "ok.ts"), "function ok(): number { return 1; }\n");
+
+    const result = liftTypeScriptSourcePaths(td, ["../escape.ts"]);
+
+    expect(result.declarations).toEqual([]);
+    expect(result.refusals[0]).toMatchObject({
+      kind: "path-traversal",
+      function: null,
+      line: null,
+    });
+  });
+});

--- a/implementations/typescript/src/lift/typescript-source/index.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.ts
@@ -181,6 +181,41 @@ export function compileTypeScriptSourceIr(
     if (decl.fnName.endsWith(":<source-unit>")) continue;
     statements.push(compileFunctionContract(decl));
   }
+  return printStatements(statements);
+}
+
+export interface TypeScriptSourceBodyCompileOptions {
+  functionName?: string;
+  formals?: readonly string[];
+  formalSorts?: readonly Sort[];
+  returnSort?: Sort;
+}
+
+export function compileTypeScriptSourceBodyIr(
+  bodyTerm: IrTerm,
+  options: TypeScriptSourceBodyCompileOptions = {},
+): string {
+  const formals = [...(options.formals ?? freeVariableNames(bodyTerm))];
+  const formalSorts = formals.map((_, index) => options.formalSorts?.[index] ?? primitiveSort("Any"));
+  const functionName = options.functionName ?? "lifted";
+  const contract: FunctionContractMemento = {
+    schemaVersion: "1",
+    kind: "function-contract",
+    fnName: `roundtrip.ts:${functionName}`,
+    formals,
+    formalSorts,
+    returnSort: options.returnSort ?? primitiveSort("Any"),
+    pre: TRUE_FORMULA,
+    post: eqFormula(RETURN_VALUE, bodyTerm),
+    bodyCid: null,
+    effects: [],
+    locus: { file: "roundtrip.ts", line: 1, col: 1 },
+    autoMintedMementos: [],
+  };
+  return printStatements([compileFunctionContract(contract)]);
+}
+
+function printStatements(statements: ts.Statement[]): string {
   const sourceFile = ts.factory.updateSourceFile(
     ts.createSourceFile("roundtrip.ts", "", ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS),
     statements,
@@ -284,8 +319,9 @@ function liftFunctionLike(
   const qualifiedName = [...prefix, shortName].join(".");
   const fnName = `${fileContext.modulePath}:${qualifiedName}`;
 
-  if (hasUnsupportedFunctionShape(node)) {
-    addRefusal(fileContext, node, fnName, "async, generator, decorated, generic, rest, default, or destructured functions are not handled");
+  const unsupportedShapeReason = unsupportedFunctionShapeReason(node);
+  if (unsupportedShapeReason) {
+    addRefusal(fileContext, node, fnName, unsupportedShapeReason);
     return;
   }
 
@@ -655,15 +691,32 @@ function sourceUnitContract(sourceText: string, context: FileLiftContext, lifted
   };
 }
 
-function hasUnsupportedFunctionShape(node: ts.FunctionDeclaration | ts.MethodDeclaration): boolean {
+function unsupportedFunctionShapeReason(node: ts.FunctionDeclaration | ts.MethodDeclaration): string | null {
   const decorators = ts.canHaveDecorators(node) ? ts.getDecorators(node) : undefined;
-  return Boolean(
-    node.asteriskToken ||
-    node.typeParameters?.length ||
-    decorators?.length ||
-    node.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ||
-    node.parameters.some((p) => p.dotDotDotToken || p.initializer || !ts.isIdentifier(p.name)),
-  );
+  if (node.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword)) {
+    return "async function not supported";
+  }
+  if (node.asteriskToken) {
+    return "generator function not supported";
+  }
+  if (decorators?.length) {
+    return "decorated function not supported";
+  }
+  if (node.typeParameters?.length) {
+    return "generic type parameters not supported";
+  }
+  for (const param of node.parameters) {
+    if (param.dotDotDotToken) {
+      return "rest parameters not supported";
+    }
+    if (param.initializer) {
+      return "default parameters not supported";
+    }
+    if (!ts.isIdentifier(param.name)) {
+      return "destructured parameters not supported";
+    }
+  }
+  return null;
 }
 
 function parameterName(param: ts.ParameterDeclaration): string {
@@ -772,6 +825,46 @@ function isCtor(term: IrTerm | undefined, name: string): boolean {
 function termArgs(term: IrTerm): IrTerm[] {
   if (term.kind !== "ctor") throw new Error(`expected ctor term, got ${term.kind}`);
   return term.args;
+}
+
+function freeVariableNames(term: IrTerm): string[] {
+  const names = new Set<string>();
+  const visit = (current: IrTerm, bound: Set<string>): void => {
+    if (current.kind === "var") {
+      if (current.name !== RETURN_VALUE.name && !bound.has(current.name)) names.add(current.name);
+      return;
+    }
+    if (current.kind === "const") return;
+    if (current.kind === "lambda") {
+      visit(current.body, new Set([...bound, current.paramName]));
+      return;
+    }
+    if (current.kind === "let") {
+      const letBound = new Set(bound);
+      for (const binding of current.bindings) {
+        visit(binding.boundTerm, letBound);
+        letBound.add(binding.name);
+      }
+      visit(current.body, letBound);
+      return;
+    }
+    if (current.name === "ts:seq") {
+      const seqBound = new Set(bound);
+      for (const arg of current.args) {
+        if (isCtor(arg, "ts:decl")) {
+          visit(termArgs(arg)[1] ?? unitConst(), seqBound);
+          const declared = stringValue(termArgs(arg)[0], "");
+          if (declared) seqBound.add(declared);
+        } else {
+          visit(arg, seqBound);
+        }
+      }
+      return;
+    }
+    for (const arg of current.args) visit(arg, bound);
+  };
+  visit(term, new Set());
+  return [...names];
 }
 
 function seqTerm(args: IrTerm[]): IrTerm {

--- a/implementations/typescript/src/lift/typescript-source/index.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.ts
@@ -1,0 +1,1027 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import ts from "typescript";
+
+import { canonicalJsonString } from "../../claimEnvelope/canonicalize.js";
+import { computeCid } from "../../canonicalizer/hash.js";
+import type { IrFormula, IrTerm, Sort } from "../../ir/formulas.js";
+
+export type TypeScriptSourceEffect =
+  | { kind: "reads"; target: string }
+  | { kind: "writes"; target: string }
+  | { kind: "io" }
+  | { kind: "panics" }
+  | { kind: "unresolved_call"; name: string }
+  | { kind: "opaque_loop"; loopCid: string };
+
+export interface TypeScriptSourceRefusal {
+  kind: string;
+  function: string | null;
+  line: number | null;
+  reason: string;
+}
+
+export interface TypeScriptSourceDiagnostic {
+  severity: "warning" | "error";
+  message: string;
+}
+
+export interface FunctionContractMemento {
+  schemaVersion: "1";
+  kind: "function-contract";
+  fnName: string;
+  formals: string[];
+  formalSorts: Sort[];
+  returnSort: Sort;
+  pre: IrFormula;
+  post: IrFormula;
+  bodyCid: string | null;
+  effects: TypeScriptSourceEffect[];
+  locus: { file: string; line: number; col: number };
+  autoMintedMementos: unknown[];
+}
+
+export interface TypeScriptSourceLiftResult {
+  declarations: FunctionContractMemento[];
+  diagnostics: TypeScriptSourceDiagnostic[];
+  opacityReport: unknown[];
+  refusals: TypeScriptSourceRefusal[];
+}
+
+interface LiftedFunction {
+  contract: FunctionContractMemento;
+  bodyTerm: IrTerm;
+}
+
+interface FileLiftContext {
+  modulePath: string;
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+  moduleVars: Set<string>;
+  knownCallables: Set<string>;
+  refusals: TypeScriptSourceRefusal[];
+}
+
+interface FunctionContext extends FileLiftContext {
+  functionName: string;
+  locals: Set<string>;
+  effects: Map<string, TypeScriptSourceEffect>;
+}
+
+class UnsupportedSyntaxError extends Error {
+  constructor(
+    public readonly node: ts.Node,
+    message: string,
+  ) {
+    super(message);
+    this.name = "UnsupportedSyntaxError";
+  }
+}
+
+const TRUE_FORMULA: IrFormula = { kind: "atomic", name: "true", args: [] };
+const RETURN_VALUE: IrTerm = { kind: "var", name: "return_value" };
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "target",
+  "out",
+  ".next",
+  ".turbo",
+  ".vite",
+  "coverage",
+]);
+const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"]);
+
+export function liftTypeScriptSourceText(
+  sourceText: string,
+  fileName = "input.ts",
+): TypeScriptSourceLiftResult {
+  const modulePath = normalizePath(fileName);
+  const { program, sourceFile } = createProgramFromText(sourceText, modulePath);
+  return liftSourceFile(sourceFile, program.getTypeChecker(), modulePath);
+}
+
+export function liftTypeScriptSourcePaths(
+  workspaceRoot: string,
+  sourcePaths: string[],
+): TypeScriptSourceLiftResult {
+  const root = resolve(workspaceRoot);
+  const diagnostics: TypeScriptSourceDiagnostic[] = [];
+  const refusals: TypeScriptSourceRefusal[] = [];
+  const files: string[] = [];
+
+  for (const sourcePath of sourcePaths) {
+    const fullPath = resolve(root, sourcePath);
+    if (!isInsideRoot(root, fullPath)) {
+      diagnostics.push({ severity: "error", message: `path traversal rejected: ${sourcePath}` });
+      refusals.push({
+        kind: "path-traversal",
+        function: null,
+        line: null,
+        reason: `path '${sourcePath}' escapes workspace root '${root}'`,
+      });
+      continue;
+    }
+    if (!existsSync(fullPath)) {
+      diagnostics.push({ severity: "warning", message: `path not found: ${fullPath}` });
+      continue;
+    }
+    const st = statSync(fullPath);
+    if (st.isDirectory()) {
+      files.push(...enumerateSourceFiles(fullPath));
+    } else if (st.isFile() && isSourceFile(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+
+  if (files.length === 0) {
+    return { declarations: [], diagnostics, opacityReport: [], refusals };
+  }
+
+  const program = ts.createProgram(files, compilerOptions());
+  const checker = program.getTypeChecker();
+  const declarations: FunctionContractMemento[] = [];
+  for (const file of files.sort()) {
+    const sourceFile = program.getSourceFile(file);
+    if (!sourceFile) {
+      diagnostics.push({ severity: "error", message: `program did not load ${file}` });
+      continue;
+    }
+    const modulePath = normalizePath(relative(root, file));
+    const lifted = liftSourceFile(sourceFile, checker, modulePath);
+    declarations.push(...lifted.declarations);
+    diagnostics.push(...lifted.diagnostics);
+    refusals.push(...lifted.refusals);
+  }
+  return { declarations, diagnostics, opacityReport: [], refusals };
+}
+
+export function functionContractCid(contract: FunctionContractMemento): string {
+  return cidOfValue(contract);
+}
+
+export function compileTypeScriptSourceIr(
+  declarations: readonly FunctionContractMemento[],
+): string {
+  const sourceUnit = declarations.find((d) => d.fnName.endsWith(":<source-unit>"));
+  if (sourceUnit) {
+    const term = postRhs(sourceUnit);
+    if (isCtor(term, "ts:source-unit")) {
+      const bytes = termArgs(term)[0];
+      if (bytes && bytes.kind === "const" && typeof bytes.value === "string") {
+        return bytes.value;
+      }
+    }
+  }
+
+  const statements: ts.Statement[] = [];
+  for (const decl of declarations) {
+    if (decl.fnName.endsWith(":<source-unit>")) continue;
+    statements.push(compileFunctionContract(decl));
+  }
+  const sourceFile = ts.factory.updateSourceFile(
+    ts.createSourceFile("roundtrip.ts", "", ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS),
+    statements,
+  );
+  return ts.createPrinter({ newLine: ts.NewLineKind.LineFeed }).printFile(sourceFile);
+}
+
+function liftSourceFile(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+  modulePath: string,
+): TypeScriptSourceLiftResult {
+  const refusals: TypeScriptSourceRefusal[] = [];
+  const context: FileLiftContext = {
+    modulePath,
+    sourceFile,
+    checker,
+    moduleVars: collectModuleVariables(sourceFile),
+    knownCallables: collectKnownCallables(sourceFile),
+    refusals,
+  };
+  const lifted: LiftedFunction[] = [];
+  processStatements(sourceFile.statements, [], context, lifted);
+
+  const declarations = lifted.map((item) => item.contract);
+  if (lifted.length > 0) {
+    declarations.unshift(sourceUnitContract(sourceFile.getFullText(), context, lifted));
+  }
+
+  return { declarations, diagnostics: [], opacityReport: [], refusals };
+}
+
+function processStatements(
+  statements: ts.NodeArray<ts.Statement>,
+  prefix: string[],
+  context: FileLiftContext,
+  lifted: LiftedFunction[],
+): void {
+  for (const stmt of statements) {
+    if (ts.isFunctionDeclaration(stmt)) {
+      if (stmt.body) liftFunctionLike(stmt, stmt.name, stmt.body, prefix, context, lifted);
+      continue;
+    }
+    if (ts.isClassDeclaration(stmt)) {
+      if (!stmt.name) {
+        addRefusal(context, stmt, null, "anonymous classes are not handled");
+        continue;
+      }
+      for (const member of stmt.members) {
+        if (ts.isMethodDeclaration(member)) {
+          const name = methodNameText(member.name);
+          if (name && member.body) {
+            liftFunctionLike(member, member.name, member.body, [...prefix, stmt.name.text], context, lifted);
+          } else {
+            addRefusal(context, member, null, "computed or bodyless methods are not handled");
+          }
+        } else if (!ts.isPropertyDeclaration(member) && !ts.isConstructorDeclaration(member)) {
+          addRefusal(context, member, `${stmt.name.text}.<member>`, `class member ${syntaxKindName(member)} is not handled`);
+        }
+      }
+      continue;
+    }
+    if (ts.isModuleDeclaration(stmt)) {
+      const name = moduleNameText(stmt.name);
+      if (stmt.body && ts.isModuleBlock(stmt.body)) {
+        processStatements(stmt.body.statements, [...prefix, name], context, lifted);
+      } else {
+        addRefusal(context, stmt, name, "non-block namespace/module declarations are not handled");
+      }
+      continue;
+    }
+    if (ts.isVariableStatement(stmt)) {
+      refuseArrowVariables(stmt, context);
+      continue;
+    }
+    if (
+      ts.isImportDeclaration(stmt) ||
+      ts.isExportDeclaration(stmt) ||
+      ts.isInterfaceDeclaration(stmt) ||
+      ts.isTypeAliasDeclaration(stmt)
+    ) {
+      continue;
+    }
+    addRefusal(context, stmt, null, `top-level ${syntaxKindName(stmt)} is not handled`);
+  }
+}
+
+function liftFunctionLike(
+  node: ts.FunctionDeclaration | ts.MethodDeclaration,
+  nameNode: ts.PropertyName | ts.Identifier | undefined,
+  body: ts.Block,
+  prefix: string[],
+  fileContext: FileLiftContext,
+  lifted: LiftedFunction[],
+): void {
+  const shortName = nameNode ? nameFromPropertyName(nameNode) : null;
+  if (!shortName) {
+    addRefusal(fileContext, node, null, "anonymous or computed function names are not handled");
+    return;
+  }
+  const qualifiedName = [...prefix, shortName].join(".");
+  const fnName = `${fileContext.modulePath}:${qualifiedName}`;
+
+  if (hasUnsupportedFunctionShape(node)) {
+    addRefusal(fileContext, node, fnName, "async, generator, decorated, generic, rest, default, or destructured functions are not handled");
+    return;
+  }
+
+  try {
+    const formals = node.parameters.map((param) => parameterName(param));
+    const formalSorts = node.parameters.map((param) => sortFromTypeNode(param.type, fileContext.checker, param));
+    const returnSort = sortFromTypeNode(node.type, fileContext.checker, node);
+    const locals = new Set<string>(formals);
+    const functionContext: FunctionContext = {
+      ...fileContext,
+      functionName: fnName,
+      locals,
+      effects: new Map(),
+    };
+    collectLocalDeclarations(body, locals);
+    const bodyTerm = emitBlock(body, functionContext);
+    const postTerm = singleReturnExpression(body)
+      ? emitExpression(singleReturnExpression(body)!, functionContext)
+      : bodyTerm;
+    const line = lineOf(fileContext.sourceFile, node);
+    const contract: FunctionContractMemento = {
+      schemaVersion: "1",
+      kind: "function-contract",
+      fnName,
+      formals,
+      formalSorts,
+      returnSort,
+      pre: TRUE_FORMULA,
+      post: eqFormula(RETURN_VALUE, postTerm),
+      bodyCid: null,
+      effects: sortEffects([...functionContext.effects.values()]),
+      locus: { file: fileContext.modulePath, line, col: 1 },
+      autoMintedMementos: [],
+    };
+    lifted.push({ contract, bodyTerm: postTerm });
+  } catch (error) {
+    if (error instanceof UnsupportedSyntaxError) {
+      addRefusal(fileContext, error.node, fnName, error.message);
+    } else {
+      addRefusal(fileContext, node, fnName, (error as Error).message);
+    }
+  }
+}
+
+function emitBlock(block: ts.Block, context: FunctionContext): IrTerm {
+  const terms = block.statements.map((stmt) => emitStatement(stmt, context));
+  if (terms.length === 0) {
+    throw new UnsupportedSyntaxError(block, "empty function bodies are not handled");
+  }
+  return seqTerm(terms);
+}
+
+function emitStatement(stmt: ts.Statement, context: FunctionContext): IrTerm {
+  if (ts.isBlock(stmt)) return emitBlock(stmt, context);
+  if (ts.isReturnStatement(stmt)) {
+    return ctor("ts:return", stmt.expression ? emitExpression(stmt.expression, context) : unitConst());
+  }
+  if (ts.isVariableStatement(stmt)) {
+    const terms: IrTerm[] = [];
+    for (const declaration of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name)) {
+        throw new UnsupportedSyntaxError(declaration.name, "destructuring variable declarations are not handled");
+      }
+      if (declaration.initializer && ts.isArrowFunction(declaration.initializer)) {
+        throw new UnsupportedSyntaxError(declaration.initializer, "arrow functions are not handled");
+      }
+      context.locals.add(declaration.name.text);
+      terms.push(ctor("ts:decl", stringConst(declaration.name.text), declaration.initializer ? emitExpression(declaration.initializer, context) : unitConst()));
+    }
+    return seqTerm(terms);
+  }
+  if (ts.isExpressionStatement(stmt)) return emitExpression(stmt.expression, context);
+  if (ts.isIfStatement(stmt)) {
+    const thenTerm = emitStatement(stmt.thenStatement, context);
+    const elseTerm = stmt.elseStatement ? emitStatement(stmt.elseStatement, context) : seqTerm([]);
+    return ctor("ts:if", emitExpression(stmt.expression, context), thenTerm, elseTerm);
+  }
+  if (ts.isWhileStatement(stmt)) {
+    const loopTerm = ctor("ts:while", emitExpression(stmt.expression, context), emitStatement(stmt.statement, context));
+    addEffect(context, { kind: "opaque_loop", loopCid: cidOfValue(loopTerm) });
+    return loopTerm;
+  }
+  if (ts.isForStatement(stmt)) {
+    const init = stmt.initializer ? emitForInitializer(stmt.initializer, context) : seqTerm([]);
+    const cond = stmt.condition ? emitExpression(stmt.condition, context) : boolConst(true);
+    const update = stmt.incrementor ? emitExpression(stmt.incrementor, context) : seqTerm([]);
+    const loopTerm = ctor("ts:for", init, cond, update, emitStatement(stmt.statement, context));
+    addEffect(context, { kind: "opaque_loop", loopCid: cidOfValue(loopTerm) });
+    return loopTerm;
+  }
+  if (ts.isThrowStatement(stmt)) {
+    addEffect(context, { kind: "panics" });
+    return ctor("ts:throw", stmt.expression ? emitExpression(stmt.expression, context) : unitConst());
+  }
+  if (ts.isBreakStatement(stmt)) return ctor("ts:break", unitConst());
+  if (ts.isContinueStatement(stmt)) return ctor("ts:continue", unitConst());
+  throw new UnsupportedSyntaxError(stmt, `statement kind ${syntaxKindName(stmt)} is not handled`);
+}
+
+function emitForInitializer(init: ts.ForInitializer, context: FunctionContext): IrTerm {
+  if (ts.isVariableDeclarationList(init)) {
+    const terms: IrTerm[] = [];
+    for (const declaration of init.declarations) {
+      if (!ts.isIdentifier(declaration.name)) {
+        throw new UnsupportedSyntaxError(declaration.name, "destructuring for initializers are not handled");
+      }
+      context.locals.add(declaration.name.text);
+      terms.push(ctor("ts:decl", stringConst(declaration.name.text), declaration.initializer ? emitExpression(declaration.initializer, context) : unitConst()));
+    }
+    return seqTerm(terms);
+  }
+  return emitExpression(init, context);
+}
+
+function emitExpression(expr: ts.Expression, context: FunctionContext): IrTerm {
+  if (ts.isParenthesizedExpression(expr)) return emitExpression(expr.expression, context);
+  if (ts.isNumericLiteral(expr)) return numberConst(Number(expr.text));
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) return stringConst(expr.text);
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return boolConst(true);
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) return boolConst(false);
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return nullConst();
+  if (ts.isIdentifier(expr)) {
+    if (context.moduleVars.has(expr.text) && !context.locals.has(expr.text)) {
+      addEffect(context, { kind: "reads", target: moduleCell(context, expr.text) });
+    }
+    return { kind: "var", name: expr.text };
+  }
+  if (expr.kind === ts.SyntaxKind.ThisKeyword) return { kind: "var", name: "this" };
+  if (ts.isBinaryExpression(expr)) return emitBinaryExpression(expr, context);
+  if (ts.isPrefixUnaryExpression(expr)) return emitPrefixExpression(expr, context);
+  if (ts.isPostfixUnaryExpression(expr)) return emitPostfixExpression(expr, context);
+  if (ts.isConditionalExpression(expr)) {
+    return ctor("ts:ite", emitExpression(expr.condition, context), emitExpression(expr.whenTrue, context), emitExpression(expr.whenFalse, context));
+  }
+  if (ts.isCallExpression(expr)) return emitCallExpression(expr, context);
+  if (ts.isTypeOfExpression(expr)) return ctor("ts:typeof", emitExpression(expr.expression, context));
+  if (ts.isPropertyAccessExpression(expr)) {
+    if (expr.questionDotToken) {
+      throw new UnsupportedSyntaxError(expr, "optional chaining is not handled");
+    }
+    return ctor("ts:member", emitExpression(expr.expression, context), stringConst(expr.name.text));
+  }
+  if (ts.isElementAccessExpression(expr)) {
+    if (expr.questionDotToken) {
+      throw new UnsupportedSyntaxError(expr, "optional chaining is not handled");
+    }
+    return ctor("ts:index", emitExpression(expr.expression, context), emitExpression(expr.argumentExpression, context));
+  }
+  if (ts.isNewExpression(expr)) {
+    const args = expr.arguments ? expr.arguments.map((arg) => emitExpression(arg, context)) : [];
+    return ctor("ts:new", emitExpression(expr.expression, context), argsTerm(args));
+  }
+  if (ts.isTemplateExpression(expr)) {
+    throw new UnsupportedSyntaxError(expr, "template literals are not handled");
+  }
+  if (ts.isAsExpression(expr) || ts.isTypeAssertionExpression(expr) || ts.isSatisfiesExpression(expr)) {
+    throw new UnsupportedSyntaxError(expr, "type assertions and satisfies expressions are not handled");
+  }
+  if (ts.isAwaitExpression(expr)) {
+    throw new UnsupportedSyntaxError(expr, "await expressions are not handled");
+  }
+  if (ts.isArrowFunction(expr) || ts.isFunctionExpression(expr)) {
+    throw new UnsupportedSyntaxError(expr, "function expressions are not handled");
+  }
+  throw new UnsupportedSyntaxError(expr, `expression kind ${syntaxKindName(expr)} is not handled`);
+}
+
+function emitBinaryExpression(expr: ts.BinaryExpression, context: FunctionContext): IrTerm {
+  if (expr.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+    const value = emitExpression(expr.right, context);
+    addWriteEffectForTarget(expr.left, context);
+    return ctor("ts:assign", emitLValue(expr.left, context), value);
+  }
+
+  const op = binaryOperatorName(expr.operatorToken.kind);
+  if (!op) {
+    throw new UnsupportedSyntaxError(expr.operatorToken, `binary operator ${syntaxKindName(expr.operatorToken)} is not handled`);
+  }
+  return ctor(op, emitExpression(expr.left, context), emitExpression(expr.right, context));
+}
+
+function emitPrefixExpression(expr: ts.PrefixUnaryExpression, context: FunctionContext): IrTerm {
+  const operand = emitExpression(expr.operand, context);
+  switch (expr.operator) {
+    case ts.SyntaxKind.ExclamationToken:
+      return ctor("ts:not", operand);
+    case ts.SyntaxKind.MinusToken:
+      return ctor("ts:neg", operand);
+    case ts.SyntaxKind.PlusToken:
+      return ctor("ts:pos", operand);
+    case ts.SyntaxKind.TildeToken:
+      return ctor("ts:bitnot", operand);
+    case ts.SyntaxKind.PlusPlusToken:
+      addWriteEffectForTarget(expr.operand, context);
+      return ctor("ts:preinc", emitLValue(expr.operand, context));
+    case ts.SyntaxKind.MinusMinusToken:
+      addWriteEffectForTarget(expr.operand, context);
+      return ctor("ts:predec", emitLValue(expr.operand, context));
+    default:
+      throw new UnsupportedSyntaxError(expr, `prefix operator ${syntaxKindName(expr)} is not handled`);
+  }
+}
+
+function emitPostfixExpression(expr: ts.PostfixUnaryExpression, context: FunctionContext): IrTerm {
+  addWriteEffectForTarget(expr.operand, context);
+  switch (expr.operator) {
+    case ts.SyntaxKind.PlusPlusToken:
+      return ctor("ts:postinc", emitLValue(expr.operand, context));
+    case ts.SyntaxKind.MinusMinusToken:
+      return ctor("ts:postdec", emitLValue(expr.operand, context));
+    default:
+      throw new UnsupportedSyntaxError(expr, `postfix operator ${syntaxKindName(expr)} is not handled`);
+  }
+}
+
+function emitCallExpression(expr: ts.CallExpression, context: FunctionContext): IrTerm {
+  if (expr.questionDotToken) {
+    throw new UnsupportedSyntaxError(expr, "optional calls are not handled");
+  }
+  const calleeName = calleeText(expr.expression);
+  for (const arg of expr.arguments) {
+    if (ts.isSpreadElement(arg)) {
+      throw new UnsupportedSyntaxError(arg, "spread call arguments are not handled");
+    }
+  }
+  const args = expr.arguments.map((arg) => emitExpression(arg, context));
+  if (isIoCallee(calleeName)) {
+    addEffect(context, { kind: "io" });
+  } else if (calleeName && !context.knownCallables.has(calleeName)) {
+    addEffect(context, { kind: "unresolved_call", name: calleeName });
+  }
+  return ctor("ts:call", emitExpression(expr.expression, context), argsTerm(args));
+}
+
+function emitLValue(expr: ts.Expression, context: FunctionContext): IrTerm {
+  if (ts.isIdentifier(expr)) return { kind: "var", name: expr.text };
+  if (ts.isPropertyAccessExpression(expr)) return ctor("ts:member", emitExpression(expr.expression, context), stringConst(expr.name.text));
+  if (ts.isElementAccessExpression(expr)) return ctor("ts:index", emitExpression(expr.expression, context), emitExpression(expr.argumentExpression, context));
+  throw new UnsupportedSyntaxError(expr, `assignment target ${syntaxKindName(expr)} is not handled`);
+}
+
+function binaryOperatorName(kind: ts.SyntaxKind): string | null {
+  switch (kind) {
+    case ts.SyntaxKind.PlusToken: return "ts:add";
+    case ts.SyntaxKind.MinusToken: return "ts:sub";
+    case ts.SyntaxKind.AsteriskToken: return "ts:mul";
+    case ts.SyntaxKind.SlashToken: return "ts:div";
+    case ts.SyntaxKind.PercentToken: return "ts:mod";
+    case ts.SyntaxKind.EqualsEqualsToken:
+    case ts.SyntaxKind.EqualsEqualsEqualsToken: return "ts:eq";
+    case ts.SyntaxKind.ExclamationEqualsToken:
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken: return "ts:ne";
+    case ts.SyntaxKind.LessThanToken: return "ts:lt";
+    case ts.SyntaxKind.LessThanEqualsToken: return "ts:le";
+    case ts.SyntaxKind.GreaterThanToken: return "ts:gt";
+    case ts.SyntaxKind.GreaterThanEqualsToken: return "ts:ge";
+    case ts.SyntaxKind.AmpersandAmpersandToken: return "ts:and";
+    case ts.SyntaxKind.BarBarToken: return "ts:or";
+    case ts.SyntaxKind.QuestionQuestionToken: return "ts:nullish";
+    case ts.SyntaxKind.AmpersandToken: return "ts:bitand";
+    case ts.SyntaxKind.BarToken: return "ts:bitor";
+    case ts.SyntaxKind.CaretToken: return "ts:bitxor";
+    case ts.SyntaxKind.LessThanLessThanToken: return "ts:shl";
+    case ts.SyntaxKind.GreaterThanGreaterThanToken: return "ts:shr";
+    case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken: return "ts:ushr";
+    default: return null;
+  }
+}
+
+function addWriteEffectForTarget(expr: ts.Expression, context: FunctionContext): void {
+  const root = rootIdentifier(expr);
+  if (root && context.moduleVars.has(root) && !context.locals.has(root)) {
+    addEffect(context, { kind: "writes", target: moduleCell(context, root) });
+  } else if (!root && (ts.isPropertyAccessExpression(expr) || ts.isElementAccessExpression(expr))) {
+    addEffect(context, { kind: "writes", target: normalizeWhitespace(expr.getText(context.sourceFile)) });
+  }
+}
+
+function addEffect(context: FunctionContext, effect: TypeScriptSourceEffect): void {
+  context.effects.set(effectSortKey(effect), effect);
+}
+
+function sortEffects(effects: TypeScriptSourceEffect[]): TypeScriptSourceEffect[] {
+  return effects.sort((a, b) => effectSortKey(a).localeCompare(effectSortKey(b)));
+}
+
+function effectSortKey(effect: TypeScriptSourceEffect): string {
+  switch (effect.kind) {
+    case "reads": return `0:reads:${effect.target}`;
+    case "writes": return `1:writes:${effect.target}`;
+    case "io": return "2:io";
+    case "panics": return "4:panics";
+    case "unresolved_call": return `5:unresolved_call:${effect.name}`;
+    case "opaque_loop": return `6:opaque_loop:${effect.loopCid}`;
+  }
+}
+
+function collectModuleVariables(sourceFile: ts.SourceFile): Set<string> {
+  const vars = new Set<string>();
+  const visitStatements = (statements: ts.NodeArray<ts.Statement>): void => {
+    for (const stmt of statements) {
+      if (ts.isVariableStatement(stmt)) {
+        for (const decl of stmt.declarationList.declarations) {
+          if (ts.isIdentifier(decl.name)) vars.add(decl.name.text);
+        }
+      } else if (ts.isModuleDeclaration(stmt) && stmt.body && ts.isModuleBlock(stmt.body)) {
+        visitStatements(stmt.body.statements);
+      }
+    }
+  };
+  visitStatements(sourceFile.statements);
+  return vars;
+}
+
+function collectKnownCallables(sourceFile: ts.SourceFile): Set<string> {
+  const callables = new Set<string>();
+  const visitStatements = (statements: ts.NodeArray<ts.Statement>): void => {
+    for (const stmt of statements) {
+      if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body) callables.add(stmt.name.text);
+      if (ts.isClassDeclaration(stmt)) {
+        for (const member of stmt.members) {
+          if (ts.isMethodDeclaration(member)) {
+            const name = methodNameText(member.name);
+            if (name) callables.add(name);
+          }
+        }
+      }
+      if (ts.isModuleDeclaration(stmt) && stmt.body && ts.isModuleBlock(stmt.body)) visitStatements(stmt.body.statements);
+    }
+  };
+  visitStatements(sourceFile.statements);
+  return callables;
+}
+
+function collectLocalDeclarations(node: ts.Node, locals: Set<string>): void {
+  const visit = (child: ts.Node): void => {
+    if (ts.isVariableDeclaration(child) && ts.isIdentifier(child.name)) locals.add(child.name.text);
+    if (ts.isFunctionLike(child) && child !== node) return;
+    ts.forEachChild(child, visit);
+  };
+  ts.forEachChild(node, visit);
+}
+
+function refuseArrowVariables(stmt: ts.VariableStatement, context: FileLiftContext): void {
+  for (const decl of stmt.declarationList.declarations) {
+    if (decl.initializer && ts.isArrowFunction(decl.initializer)) {
+      const name = ts.isIdentifier(decl.name) ? decl.name.text : null;
+      addRefusal(context, decl.initializer, name, "arrow functions are not handled by the typescript-source lifter");
+    }
+  }
+}
+
+function sourceUnitContract(sourceText: string, context: FileLiftContext, lifted: LiftedFunction[]): FunctionContractMemento {
+  return {
+    schemaVersion: "1",
+    kind: "function-contract",
+    fnName: `${context.modulePath}:<source-unit>`,
+    formals: [],
+    formalSorts: [],
+    returnSort: primitiveSort("Unit"),
+    pre: TRUE_FORMULA,
+    post: eqFormula(RETURN_VALUE, ctor("ts:source-unit", stringConst(sourceText), seqTerm(lifted.map((f) => f.bodyTerm)))),
+    bodyCid: null,
+    effects: [],
+    locus: { file: context.modulePath, line: 1, col: 1 },
+    autoMintedMementos: [],
+  };
+}
+
+function hasUnsupportedFunctionShape(node: ts.FunctionDeclaration | ts.MethodDeclaration): boolean {
+  const decorators = ts.canHaveDecorators(node) ? ts.getDecorators(node) : undefined;
+  return Boolean(
+    node.asteriskToken ||
+    node.typeParameters?.length ||
+    decorators?.length ||
+    node.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ||
+    node.parameters.some((p) => p.dotDotDotToken || p.initializer || !ts.isIdentifier(p.name)),
+  );
+}
+
+function parameterName(param: ts.ParameterDeclaration): string {
+  if (!ts.isIdentifier(param.name)) {
+    throw new UnsupportedSyntaxError(param.name, "destructuring parameters are not handled");
+  }
+  return param.name.text;
+}
+
+function sortFromTypeNode(node: ts.TypeNode | undefined, checker: ts.TypeChecker, at: ts.Node): Sort {
+  if (!node) {
+    const type = checker.getTypeAtLocation(at);
+    const text = checker.typeToString(type);
+    return sortFromTypeText(text, at);
+  }
+  return sortFromTypeText(node.getText(), node);
+}
+
+function sortFromTypeText(typeText: string, node: ts.Node): Sort {
+  switch (typeText.trim()) {
+    case "number": return primitiveSort("Number");
+    case "boolean": return primitiveSort("Boolean");
+    case "string": return primitiveSort("String");
+    case "void": return primitiveSort("Unit");
+    case "any": return primitiveSort("Any");
+    case "unknown": return primitiveSort("Unknown");
+    default:
+      throw new UnsupportedSyntaxError(node, `type ${typeText} is not in the handled basic TypeScript slice`);
+  }
+}
+
+function singleReturnExpression(block: ts.Block): ts.Expression | null {
+  if (block.statements.length !== 1) return null;
+  const only = block.statements[0]!;
+  return ts.isReturnStatement(only) && only.expression ? only.expression : null;
+}
+
+function moduleCell(context: FileLiftContext, name: string): string {
+  return `${context.modulePath}:${name}`;
+}
+
+function rootIdentifier(expr: ts.Expression): string | null {
+  if (ts.isIdentifier(expr)) return expr.text;
+  if (ts.isPropertyAccessExpression(expr)) return rootIdentifier(expr.expression);
+  if (ts.isElementAccessExpression(expr)) return rootIdentifier(expr.expression);
+  return null;
+}
+
+function calleeText(expr: ts.Expression): string | null {
+  if (ts.isIdentifier(expr)) return expr.text;
+  if (ts.isPropertyAccessExpression(expr)) {
+    const left = calleeText(expr.expression);
+    return left ? `${left}.${expr.name.text}` : expr.name.text;
+  }
+  return null;
+}
+
+function isIoCallee(callee: string | null): boolean {
+  if (!callee) return false;
+  return callee === "fetch" || callee.startsWith("console.") || callee === "fs" || callee.startsWith("fs.") || callee.startsWith("net.") || callee.startsWith("http.") || callee.startsWith("https.");
+}
+
+function addRefusal(
+  context: FileLiftContext,
+  node: ts.Node,
+  functionName: string | null,
+  reason: string,
+): void {
+  context.refusals.push({
+    kind: syntaxKindName(node),
+    function: functionName,
+    line: lineOf(context.sourceFile, node),
+    reason,
+  });
+}
+
+function lineOf(sourceFile: ts.SourceFile, node: ts.Node): number {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+function syntaxKindName(node: ts.Node): string {
+  return ts.SyntaxKind[node.kind] ?? String(node.kind);
+}
+
+function nameFromPropertyName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  return null;
+}
+
+function methodNameText(name: ts.PropertyName): string | null {
+  return nameFromPropertyName(name);
+}
+
+function moduleNameText(name: ts.ModuleName): string {
+  return name.text;
+}
+
+function ctor(name: string, ...args: IrTerm[]): IrTerm {
+  return { kind: "ctor", name, args };
+}
+
+function isCtor(term: IrTerm | undefined, name: string): boolean {
+  return term?.kind === "ctor" && term.name === name;
+}
+
+function termArgs(term: IrTerm): IrTerm[] {
+  if (term.kind !== "ctor") throw new Error(`expected ctor term, got ${term.kind}`);
+  return term.args;
+}
+
+function seqTerm(args: IrTerm[]): IrTerm {
+  return ctor("ts:seq", ...args);
+}
+
+function argsTerm(args: IrTerm[]): IrTerm {
+  return ctor("ts:args", ...args);
+}
+
+function primitiveSort(name: string): Sort {
+  return { kind: "primitive", name };
+}
+
+function numberConst(value: number): IrTerm {
+  return { kind: "const", value, sort: primitiveSort("Number") };
+}
+
+function boolConst(value: boolean): IrTerm {
+  return { kind: "const", value, sort: primitiveSort("Boolean") };
+}
+
+function stringConst(value: string): IrTerm {
+  return { kind: "const", value, sort: primitiveSort("String") };
+}
+
+function nullConst(): IrTerm {
+  return { kind: "const", value: null, sort: primitiveSort("Null") };
+}
+
+function unitConst(): IrTerm {
+  return { kind: "const", value: null, sort: primitiveSort("Unit") };
+}
+
+function eqFormula(lhs: IrTerm, rhs: IrTerm): IrFormula {
+  return { kind: "atomic", name: "=", args: [lhs, rhs] };
+}
+
+function postRhs(contract: FunctionContractMemento): IrTerm {
+  const post = contract.post;
+  if (post.kind === "atomic" && post.name === "=" && post.args.length === 2) return post.args[1]!;
+  throw new Error(`contract ${contract.fnName} does not have a return_value equality postcondition`);
+}
+
+function cidOfValue(value: unknown): string {
+  return computeCid(Buffer.from(canonicalJsonString(value), "utf8"));
+}
+
+function createProgramFromText(sourceText: string, fileName: string): { program: ts.Program; sourceFile: ts.SourceFile } {
+  const sourceFile = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.ES2022, true, scriptKind(fileName));
+  const options = compilerOptions();
+  const host = ts.createCompilerHost(options, true);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  const normalizedFileName = normalizePath(fileName);
+  host.getSourceFile = (requested, languageVersion, onError, shouldCreateNewSourceFile) => {
+    if (normalizePath(requested) === normalizedFileName) return sourceFile;
+    return originalGetSourceFile(requested, languageVersion, onError, shouldCreateNewSourceFile);
+  };
+  host.readFile = (requested) => normalizePath(requested) === normalizedFileName ? sourceText : readFileIfExists(requested);
+  host.fileExists = (requested) => normalizePath(requested) === normalizedFileName || existsSync(requested);
+  const program = ts.createProgram([fileName], options, host);
+  return { program, sourceFile };
+}
+
+function compilerOptions(): ts.CompilerOptions {
+  return {
+    allowJs: true,
+    checkJs: false,
+    module: ts.ModuleKind.CommonJS,
+    noResolve: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2022,
+  };
+}
+
+function readFileIfExists(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function enumerateSourceFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const path = resolve(dir, entry);
+      const st = statSync(path);
+      if (st.isDirectory()) {
+        if (!SKIP_DIRS.has(entry) && !entry.startsWith(".")) walk(path);
+      } else if (st.isFile() && isSourceFile(path)) {
+        out.push(path);
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+function isSourceFile(path: string): boolean {
+  if (path.endsWith(".d.ts")) return false;
+  const lower = path.toLowerCase();
+  return [...SOURCE_EXTS].some((ext) => lower.endsWith(ext));
+}
+
+function scriptKind(fileName: string): ts.ScriptKind {
+  if (fileName.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (fileName.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  if (fileName.endsWith(".js")) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function isInsideRoot(root: string, fullPath: string): boolean {
+  const rel = relative(root, fullPath);
+  return rel === "" || (!rel.startsWith("..") && !resolve(rel).startsWith("/.."));
+}
+
+function compileFunctionContract(decl: FunctionContractMemento): ts.FunctionDeclaration {
+  const name = sanitizeIdentifier(decl.fnName.split(":").pop()?.split(".").pop() || "lifted");
+  const parameters = decl.formals.map((formal, index) => ts.factory.createParameterDeclaration(
+    undefined,
+    undefined,
+    sanitizeIdentifier(formal),
+    undefined,
+    typeNodeForSort(decl.formalSorts[index]),
+  ));
+  return ts.factory.createFunctionDeclaration(
+    undefined,
+    undefined,
+    name,
+    undefined,
+    parameters,
+    typeNodeForSort(decl.returnSort),
+    ts.factory.createBlock(emitStatementsFromTerm(postRhs(decl)), true),
+  );
+}
+
+function emitStatementsFromTerm(term: IrTerm): ts.Statement[] {
+  if (isCtor(term, "ts:seq")) return termArgs(term).flatMap(emitStatementsFromTerm);
+  if (isCtor(term, "ts:return")) {
+    const args = termArgs(term);
+    return [ts.factory.createReturnStatement(args[0] ? expressionFromTerm(args[0]) : undefined)];
+  }
+  if (isCtor(term, "ts:decl")) {
+    const args = termArgs(term);
+    const name = stringValue(args[0], "tmp");
+    return [ts.factory.createVariableStatement(undefined, ts.factory.createVariableDeclarationList([
+      ts.factory.createVariableDeclaration(sanitizeIdentifier(name), undefined, undefined, expressionFromTerm(args[1])),
+    ], ts.NodeFlags.Let))];
+  }
+  if (isCtor(term, "ts:assign")) return [ts.factory.createExpressionStatement(expressionFromTerm(term))];
+  if (isCtor(term, "ts:throw")) return [ts.factory.createThrowStatement(expressionFromTerm(termArgs(term)[0]))];
+  if (isCtor(term, "ts:if")) {
+    const args = termArgs(term);
+    return [ts.factory.createIfStatement(
+      expressionFromTerm(args[0]),
+      ts.factory.createBlock(emitStatementsFromTerm(args[1] ?? seqTerm([])), true),
+      ts.factory.createBlock(emitStatementsFromTerm(args[2] ?? seqTerm([])), true),
+    )];
+  }
+  if (isCtor(term, "ts:while")) {
+    const args = termArgs(term);
+    return [ts.factory.createWhileStatement(
+      expressionFromTerm(args[0]),
+      ts.factory.createBlock(emitStatementsFromTerm(args[1] ?? seqTerm([])), true),
+    )];
+  }
+  return [ts.factory.createReturnStatement(expressionFromTerm(term))];
+}
+
+function expressionFromTerm(term: IrTerm | undefined): ts.Expression {
+  if (!term) return ts.factory.createVoidZero();
+  if (term.kind === "const") {
+    if (typeof term.value === "number") return ts.factory.createNumericLiteral(String(term.value));
+    if (typeof term.value === "boolean") return term.value ? ts.factory.createTrue() : ts.factory.createFalse();
+    if (typeof term.value === "string") return ts.factory.createStringLiteral(term.value);
+    return ts.factory.createNull();
+  }
+  if (term.kind === "var") return ts.factory.createIdentifier(sanitizeIdentifier(term.name));
+  if (term.kind !== "ctor") throw new Error(`cannot compile term kind ${term.kind}`);
+  const args = term.args;
+  const binary = binaryTokenForCtor(term.name);
+  if (binary !== null) return ts.factory.createBinaryExpression(expressionFromTerm(args[0]), binary, expressionFromTerm(args[1]));
+  switch (term.name) {
+    case "ts:not": return ts.factory.createPrefixUnaryExpression(ts.SyntaxKind.ExclamationToken, expressionFromTerm(args[0]));
+    case "ts:neg": return ts.factory.createPrefixUnaryExpression(ts.SyntaxKind.MinusToken, expressionFromTerm(args[0]));
+    case "ts:pos": return ts.factory.createPrefixUnaryExpression(ts.SyntaxKind.PlusToken, expressionFromTerm(args[0]));
+    case "ts:bitnot": return ts.factory.createPrefixUnaryExpression(ts.SyntaxKind.TildeToken, expressionFromTerm(args[0]));
+    case "ts:typeof": return ts.factory.createTypeOfExpression(expressionFromTerm(args[0]));
+    case "ts:ite": return ts.factory.createConditionalExpression(expressionFromTerm(args[0]), ts.factory.createToken(ts.SyntaxKind.QuestionToken), expressionFromTerm(args[1]), ts.factory.createToken(ts.SyntaxKind.ColonToken), expressionFromTerm(args[2]));
+    case "ts:assign": return ts.factory.createAssignment(expressionFromTerm(args[0]), expressionFromTerm(args[1]));
+    case "ts:member": return ts.factory.createPropertyAccessExpression(expressionFromTerm(args[0]), stringValue(args[1], "field"));
+    case "ts:index": return ts.factory.createElementAccessExpression(expressionFromTerm(args[0]), expressionFromTerm(args[1]));
+    case "ts:call": return ts.factory.createCallExpression(expressionFromTerm(args[0]), undefined, args[1] && isCtor(args[1], "ts:args") ? termArgs(args[1]).map(expressionFromTerm) : []);
+    case "ts:new": return ts.factory.createNewExpression(expressionFromTerm(args[0]), undefined, args[1] && isCtor(args[1], "ts:args") ? termArgs(args[1]).map(expressionFromTerm) : []);
+    default: throw new Error(`cannot compile operation ${term.name}`);
+  }
+}
+
+function binaryTokenForCtor(name: string): ts.BinaryOperator | null {
+  switch (name) {
+    case "ts:add": return ts.SyntaxKind.PlusToken;
+    case "ts:sub": return ts.SyntaxKind.MinusToken;
+    case "ts:mul": return ts.SyntaxKind.AsteriskToken;
+    case "ts:div": return ts.SyntaxKind.SlashToken;
+    case "ts:mod": return ts.SyntaxKind.PercentToken;
+    case "ts:eq": return ts.SyntaxKind.EqualsEqualsEqualsToken;
+    case "ts:ne": return ts.SyntaxKind.ExclamationEqualsEqualsToken;
+    case "ts:lt": return ts.SyntaxKind.LessThanToken;
+    case "ts:le": return ts.SyntaxKind.LessThanEqualsToken;
+    case "ts:gt": return ts.SyntaxKind.GreaterThanToken;
+    case "ts:ge": return ts.SyntaxKind.GreaterThanEqualsToken;
+    case "ts:and": return ts.SyntaxKind.AmpersandAmpersandToken;
+    case "ts:or": return ts.SyntaxKind.BarBarToken;
+    case "ts:nullish": return ts.SyntaxKind.QuestionQuestionToken;
+    case "ts:bitand": return ts.SyntaxKind.AmpersandToken;
+    case "ts:bitor": return ts.SyntaxKind.BarToken;
+    case "ts:bitxor": return ts.SyntaxKind.CaretToken;
+    case "ts:shl": return ts.SyntaxKind.LessThanLessThanToken;
+    case "ts:shr": return ts.SyntaxKind.GreaterThanGreaterThanToken;
+    case "ts:ushr": return ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken;
+    default: return null;
+  }
+}
+
+function stringValue(term: IrTerm | undefined, fallback: string): string {
+  return term && term.kind === "const" && typeof term.value === "string" ? term.value : fallback;
+}
+
+function typeNodeForSort(sort: Sort | undefined): ts.TypeNode {
+  const name = sort?.kind === "primitive" ? sort.name : "Any";
+  switch (name) {
+    case "Number": return ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+    case "Boolean": return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
+    case "String": return ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+    case "Unit": return ts.factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword);
+    default: return ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+  }
+}
+
+function sanitizeIdentifier(name: string): string {
+  const sanitized = name.replace(/[^A-Za-z0-9_$]/g, "_");
+  return /^[A-Za-z_$]/.test(sanitized) ? sanitized : `_${sanitized}`;
+}

--- a/menagerie/manifest.yaml
+++ b/menagerie/manifest.yaml
@@ -29,6 +29,11 @@ destinations:
       witnessCid). Aspirational: no grammar-conformance execution against the
       prose specs, no implementation conformance witness, no separate
       compatibility-invariant or bridge-checker witnesses yet.
+  - id: typescript-language-signature
+    path: typescript-language-signature
+    runnable: true
+    claim: TypeScript source AST operation algebra for ts:-namespaced function-contract mementos
+    command: menagerie/typescript-language-signature/mint.sh
   - id: change-station
     path: change-station
     runnable: planned

--- a/menagerie/manifest.yaml
+++ b/menagerie/manifest.yaml
@@ -29,11 +29,6 @@ destinations:
       witnessCid). Aspirational: no grammar-conformance execution against the
       prose specs, no implementation conformance witness, no separate
       compatibility-invariant or bridge-checker witnesses yet.
-  - id: typescript-language-signature
-    path: typescript-language-signature
-    runnable: true
-    claim: TypeScript source AST operation algebra for ts:-namespaced function-contract mementos
-    command: menagerie/typescript-language-signature/mint.sh
   - id: change-station
     path: change-station
     runnable: planned

--- a/menagerie/typescript-language-signature/README.md
+++ b/menagerie/typescript-language-signature/README.md
@@ -1,0 +1,5 @@
+# TypeScript Source Language Signature
+
+Draft source-language operation algebra for the ProvekIt TypeScript source lifter. Operation CIDs are intentionally namespaced with `ts:` and describe TypeScript/JavaScript source AST constructs, not cross-language semantic equality.
+
+Version: `0.1.0-draft`.

--- a/menagerie/typescript-language-signature/mint.sh
+++ b/menagerie/typescript-language-signature/mint.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+BASE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+ROOT="$(CDPATH= cd -- "$BASE/../.." && pwd)"
+RUST_DIR="$ROOT/implementations/rust"
+PROVEKIT="$RUST_DIR/target/debug/provekit"
+SPEC_DIR="$BASE/specs"
+CATALOG_REAL="$BASE/catalog"
+CATALOG_ARG="$BASE/dev/../catalog"
+CID_FILE="$BASE/cids.tsv"
+COMPONENT_FILE="$BASE/component-cids.json"
+mkdir -p "$BASE/dev"
+rm -rf "$CATALOG_REAL"
+cargo build --manifest-path "$RUST_DIR/Cargo.toml" -p provekit-cli -p provekit-ir-compiler-maude
+: > "$CID_FILE"
+mint_one() {
+  kind="$1"
+  spec="$2"
+  out=$("$PROVEKIT" mint "$kind" --spec "$SPEC_DIR/$spec" --unsigned --catalog "$CATALOG_ARG")
+  printf '%s\t%s\t%s\n' "$kind" "$spec" "$out" | tee -a "$CID_FILE"
+}
+for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'sort_*.spec.json' -exec basename {} \; | sort); do
+  mint_one sort "$spec"
+done
+for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'op_*.spec.json' -exec basename {} \; | sort); do
+  mint_one algorithm "$spec"
+done
+for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'eff_*.spec.json' -exec basename {} \; | sort); do
+  mint_one algorithm "$spec"
+done
+for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'eq_*.spec.json' -exec basename {} \; | sort); do
+  mint_one equation "$spec"
+done
+for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'effsig_*.spec.json' -exec basename {} \; | sort); do
+  mint_one effect-signature "$spec"
+done
+mint_one language-signature language_signature_typescript.spec.json
+python3 - "$CID_FILE" "$COMPONENT_FILE" <<'PY'
+import json
+import sys
+from pathlib import Path
+rows = []
+for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+    if not line.strip():
+        continue
+    parts = line.split("\t")
+    if len(parts) != 4:
+        raise SystemExit(f"bad cids.tsv row: {line}")
+    kind, spec, cid, path = parts
+    rows.append({"kind": kind, "spec": spec, "cid": cid, "path": path})
+Path(sys.argv[2]).write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
+PY

--- a/menagerie/typescript-language-signature/specs/eff_io.spec.json
+++ b/menagerie/typescript-language-signature/specs/eff_io.spec.json
@@ -1,0 +1,37 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:effect:io",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "formal_sorts": [],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Unit",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "io-effect",
+    "arity": [],
+    "result": "Unit",
+    "wp": "record IO or network interaction",
+    "arity_shape": {
+      "kind": "positional",
+      "arity": 0
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Io"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/eff_opaque_loop.spec.json
+++ b/menagerie/typescript-language-signature/specs/eff_opaque_loop.spec.json
@@ -1,0 +1,51 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:effect:opaque-loop",
+  "version": "0.1.0-draft",
+  "formals": [
+    "loopCid"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "String",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Unit",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "opaque-loop-effect",
+    "arity": [
+      "String"
+    ],
+    "result": "Unit",
+    "wp": "record an opaque loop keyed by its lifted sub-IR CID",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "loopCid"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Loop"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/eff_panic.spec.json
+++ b/menagerie/typescript-language-signature/specs/eff_panic.spec.json
@@ -1,0 +1,37 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:effect:panic",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "formal_sorts": [],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Unit",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "panic-effect",
+    "arity": [],
+    "result": "Unit",
+    "wp": "record throw/panic behavior",
+    "arity_shape": {
+      "kind": "positional",
+      "arity": 0
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Panic"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/eff_read.spec.json
+++ b/menagerie/typescript-language-signature/specs/eff_read.spec.json
@@ -1,0 +1,51 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:effect:read",
+  "version": "0.1.0-draft",
+  "formals": [
+    "target"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "String",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Unit",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "read-effect",
+    "arity": [
+      "String"
+    ],
+    "result": "Unit",
+    "wp": "record a read from target state cell",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "target"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Read"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/eff_unresolved_call.spec.json
+++ b/menagerie/typescript-language-signature/specs/eff_unresolved_call.spec.json
@@ -1,0 +1,51 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:effect:unresolved-call",
+  "version": "0.1.0-draft",
+  "formals": [
+    "name"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "String",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Unit",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "unresolved-call-effect",
+    "arity": [
+      "String"
+    ],
+    "result": "Unit",
+    "wp": "record a call whose callee contract is not available",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "name"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Call"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/eff_write.spec.json
+++ b/menagerie/typescript-language-signature/specs/eff_write.spec.json
@@ -1,0 +1,51 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:effect:write",
+  "version": "0.1.0-draft",
+  "formals": [
+    "target"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "String",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Unit",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "write-effect",
+    "arity": [
+      "String"
+    ],
+    "result": "Unit",
+    "wp": "record a write to target state cell",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "target"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Write"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/effsig_call.spec.json
+++ b/menagerie/typescript-language-signature/specs/effsig_call.spec.json
@@ -1,0 +1,15 @@
+{
+  "kind": "effect_signature",
+  "fn_name": "ts:effect-signature:call",
+  "version": "0.1.0-draft",
+  "sorts": [
+    "sort_string.spec.json",
+    "sort_unit.spec.json"
+  ],
+  "operations": [
+    "eff_unresolved_call.spec.json"
+  ],
+  "equations": [],
+  "effect_signatures": [],
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/effsig_io.spec.json
+++ b/menagerie/typescript-language-signature/specs/effsig_io.spec.json
@@ -1,0 +1,15 @@
+{
+  "kind": "effect_signature",
+  "fn_name": "ts:effect-signature:io",
+  "version": "0.1.0-draft",
+  "sorts": [
+    "sort_string.spec.json",
+    "sort_unit.spec.json"
+  ],
+  "operations": [
+    "eff_io.spec.json"
+  ],
+  "equations": [],
+  "effect_signatures": [],
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/effsig_loop.spec.json
+++ b/menagerie/typescript-language-signature/specs/effsig_loop.spec.json
@@ -1,0 +1,15 @@
+{
+  "kind": "effect_signature",
+  "fn_name": "ts:effect-signature:loop",
+  "version": "0.1.0-draft",
+  "sorts": [
+    "sort_string.spec.json",
+    "sort_unit.spec.json"
+  ],
+  "operations": [
+    "eff_opaque_loop.spec.json"
+  ],
+  "equations": [],
+  "effect_signatures": [],
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/effsig_panic.spec.json
+++ b/menagerie/typescript-language-signature/specs/effsig_panic.spec.json
@@ -1,0 +1,15 @@
+{
+  "kind": "effect_signature",
+  "fn_name": "ts:effect-signature:panic",
+  "version": "0.1.0-draft",
+  "sorts": [
+    "sort_string.spec.json",
+    "sort_unit.spec.json"
+  ],
+  "operations": [
+    "eff_panic.spec.json"
+  ],
+  "equations": [],
+  "effect_signatures": [],
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/effsig_read.spec.json
+++ b/menagerie/typescript-language-signature/specs/effsig_read.spec.json
@@ -1,0 +1,15 @@
+{
+  "kind": "effect_signature",
+  "fn_name": "ts:effect-signature:read",
+  "version": "0.1.0-draft",
+  "sorts": [
+    "sort_string.spec.json",
+    "sort_unit.spec.json"
+  ],
+  "operations": [
+    "eff_read.spec.json"
+  ],
+  "equations": [],
+  "effect_signatures": [],
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/effsig_write.spec.json
+++ b/menagerie/typescript-language-signature/specs/effsig_write.spec.json
@@ -1,0 +1,15 @@
+{
+  "kind": "effect_signature",
+  "fn_name": "ts:effect-signature:write",
+  "version": "0.1.0-draft",
+  "sorts": [
+    "sort_string.spec.json",
+    "sort_unit.spec.json"
+  ],
+  "operations": [
+    "eff_write.spec.json"
+  ],
+  "equations": [],
+  "effect_signatures": [],
+  "locus": "menagerie/typescript-language-signature/README.md#effects"
+}

--- a/menagerie/typescript-language-signature/specs/eq_seq_assoc.spec.json
+++ b/menagerie/typescript-language-signature/specs/eq_seq_assoc.spec.json
@@ -1,0 +1,72 @@
+{
+  "kind": "equation",
+  "fn_name": "ts:seq-assoc",
+  "version": "0.1.0-draft",
+  "formals": [
+    "a",
+    "b",
+    "c"
+  ],
+  "formal_sorts": [
+    "sort_stmt.spec.json",
+    "sort_stmt.spec.json",
+    "sort_stmt.spec.json"
+  ],
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "equation",
+    "lhs": {
+      "kind": "op",
+      "name": "ts:seq",
+      "args": [
+        {
+          "kind": "op",
+          "name": "ts:seq",
+          "args": [
+            {
+              "kind": "var",
+              "name": "a"
+            },
+            {
+              "kind": "var",
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "kind": "var",
+          "name": "c"
+        }
+      ]
+    },
+    "rhs": {
+      "kind": "op",
+      "name": "ts:seq",
+      "args": [
+        {
+          "kind": "var",
+          "name": "a"
+        },
+        {
+          "kind": "op",
+          "name": "ts:seq",
+          "args": [
+            {
+              "kind": "var",
+              "name": "b"
+            },
+            {
+              "kind": "var",
+              "name": "c"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#equations"
+}

--- a/menagerie/typescript-language-signature/specs/eq_seq_empty_left.spec.json
+++ b/menagerie/typescript-language-signature/specs/eq_seq_empty_left.spec.json
@@ -1,0 +1,39 @@
+{
+  "kind": "equation",
+  "fn_name": "ts:seq-empty-left",
+  "version": "0.1.0-draft",
+  "formals": [
+    "a"
+  ],
+  "formal_sorts": [
+    "sort_stmt.spec.json"
+  ],
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "equation",
+    "lhs": {
+      "kind": "op",
+      "name": "ts:seq",
+      "args": [
+        {
+          "kind": "op",
+          "name": "ts:seq",
+          "args": []
+        },
+        {
+          "kind": "var",
+          "name": "a"
+        }
+      ]
+    },
+    "rhs": {
+      "kind": "var",
+      "name": "a"
+    }
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#equations"
+}

--- a/menagerie/typescript-language-signature/specs/eq_seq_empty_right.spec.json
+++ b/menagerie/typescript-language-signature/specs/eq_seq_empty_right.spec.json
@@ -1,0 +1,39 @@
+{
+  "kind": "equation",
+  "fn_name": "ts:seq-empty-right",
+  "version": "0.1.0-draft",
+  "formals": [
+    "a"
+  ],
+  "formal_sorts": [
+    "sort_stmt.spec.json"
+  ],
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "equation",
+    "lhs": {
+      "kind": "op",
+      "name": "ts:seq",
+      "args": [
+        {
+          "kind": "var",
+          "name": "a"
+        },
+        {
+          "kind": "op",
+          "name": "ts:seq",
+          "args": []
+        }
+      ]
+    },
+    "rhs": {
+      "kind": "var",
+      "name": "a"
+    }
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#equations"
+}

--- a/menagerie/typescript-language-signature/specs/language_signature_typescript.spec.json
+++ b/menagerie/typescript-language-signature/specs/language_signature_typescript.spec.json
@@ -1,0 +1,571 @@
+{
+  "kind": "language_signature",
+  "fn_name": "typescript",
+  "version": "0.1.0-draft",
+  "sorts": [
+    "sort_number.spec.json",
+    "sort_boolean.spec.json",
+    "sort_string.spec.json",
+    "sort_null.spec.json",
+    "sort_any.spec.json",
+    "sort_unit.spec.json",
+    "sort_expr.spec.json",
+    "sort_stmt.spec.json",
+    "sort_args.spec.json",
+    "sort_lvalue.spec.json"
+  ],
+  "operations": [
+    "op_add.spec.json",
+    "op_and.spec.json",
+    "op_args.spec.json",
+    "op_assign.spec.json",
+    "op_bitand.spec.json",
+    "op_bitnot.spec.json",
+    "op_bitor.spec.json",
+    "op_bitxor.spec.json",
+    "op_break.spec.json",
+    "op_call.spec.json",
+    "op_continue.spec.json",
+    "op_decl.spec.json",
+    "op_div.spec.json",
+    "op_eq.spec.json",
+    "op_for.spec.json",
+    "op_ge.spec.json",
+    "op_gt.spec.json",
+    "op_if.spec.json",
+    "op_index.spec.json",
+    "op_ite.spec.json",
+    "op_le.spec.json",
+    "op_lt.spec.json",
+    "op_member.spec.json",
+    "op_mod.spec.json",
+    "op_mul.spec.json",
+    "op_ne.spec.json",
+    "op_neg.spec.json",
+    "op_new.spec.json",
+    "op_not.spec.json",
+    "op_nullish.spec.json",
+    "op_or.spec.json",
+    "op_pos.spec.json",
+    "op_postdec.spec.json",
+    "op_postinc.spec.json",
+    "op_predec.spec.json",
+    "op_preinc.spec.json",
+    "op_return.spec.json",
+    "op_seq.spec.json",
+    "op_shl.spec.json",
+    "op_shr.spec.json",
+    "op_source-unit.spec.json",
+    "op_sub.spec.json",
+    "op_throw.spec.json",
+    "op_typeof.spec.json",
+    "op_ushr.spec.json",
+    "op_while.spec.json"
+  ],
+  "equations": [
+    "eq_seq_assoc.spec.json",
+    "eq_seq_empty_left.spec.json",
+    "eq_seq_empty_right.spec.json"
+  ],
+  "effects": [
+    "eff_io.spec.json",
+    "eff_opaque_loop.spec.json",
+    "eff_panic.spec.json",
+    "eff_read.spec.json",
+    "eff_unresolved_call.spec.json",
+    "eff_write.spec.json"
+  ],
+  "effect_signatures": [
+    "effsig_call.spec.json",
+    "effsig_io.spec.json",
+    "effsig_loop.spec.json",
+    "effsig_panic.spec.json",
+    "effsig_read.spec.json",
+    "effsig_write.spec.json"
+  ],
+  "arity_shapes": {
+    "ts:add": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:and": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs",
+          "evaluation": "unevaluated"
+        }
+      ]
+    },
+    "ts:args": {
+      "kind": "positional",
+      "variadic": true
+    },
+    "ts:assign": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "target"
+        },
+        {
+          "name": "value"
+        }
+      ]
+    },
+    "ts:bitand": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:bitnot": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    },
+    "ts:bitor": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:bitxor": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:break": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "unit"
+        }
+      ]
+    },
+    "ts:call": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "callee"
+        },
+        {
+          "name": "args",
+          "shape": {
+            "kind": "set"
+          }
+        }
+      ]
+    },
+    "ts:continue": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "unit"
+        }
+      ]
+    },
+    "ts:decl": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "name"
+        },
+        {
+          "name": "initializer"
+        }
+      ]
+    },
+    "ts:div": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:eq": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:for": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "init"
+        },
+        {
+          "name": "cond"
+        },
+        {
+          "name": "update"
+        },
+        {
+          "name": "body",
+          "evaluation": "unevaluated"
+        }
+      ]
+    },
+    "ts:ge": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:gt": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:if": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "cond"
+        },
+        {
+          "name": "then_branch",
+          "evaluation": "unevaluated"
+        },
+        {
+          "name": "else_branch",
+          "evaluation": "unevaluated"
+        }
+      ]
+    },
+    "ts:index": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "object"
+        },
+        {
+          "name": "index"
+        }
+      ]
+    },
+    "ts:ite": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "cond"
+        },
+        {
+          "name": "then_expr",
+          "evaluation": "unevaluated"
+        },
+        {
+          "name": "else_expr",
+          "evaluation": "unevaluated"
+        }
+      ]
+    },
+    "ts:le": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:lt": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:member": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "object"
+        },
+        {
+          "name": "property"
+        }
+      ]
+    },
+    "ts:mod": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:mul": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:ne": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:neg": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    },
+    "ts:new": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "constructor"
+        },
+        {
+          "name": "args",
+          "shape": {
+            "kind": "set"
+          }
+        }
+      ]
+    },
+    "ts:not": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    },
+    "ts:nullish": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs",
+          "evaluation": "unevaluated"
+        }
+      ]
+    },
+    "ts:or": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs",
+          "evaluation": "unevaluated"
+        }
+      ]
+    },
+    "ts:pos": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    },
+    "ts:postdec": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    },
+    "ts:postinc": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    },
+    "ts:predec": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    },
+    "ts:preinc": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    },
+    "ts:return": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "value"
+        }
+      ]
+    },
+    "ts:seq": {
+      "kind": "positional",
+      "variadic": true
+    },
+    "ts:shl": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:shr": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:source-unit": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "bytes",
+          "evaluation": "unevaluated",
+          "slot_sort": "literal"
+        },
+        {
+          "name": "operational_term"
+        }
+      ]
+    },
+    "ts:sub": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:throw": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "value"
+        }
+      ]
+    },
+    "ts:typeof": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    },
+    "ts:ushr": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    },
+    "ts:while": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "cond"
+        },
+        {
+          "name": "body",
+          "evaluation": "unevaluated"
+        }
+      ]
+    }
+  },
+  "locus": "menagerie/typescript-language-signature/README.md"
+}

--- a/menagerie/typescript-language-signature/specs/op_add.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_add.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:add",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "add",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator +",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_and.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_and.spec.json
@@ -1,0 +1,57 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:and",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "and",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "short-circuit logical conjunction",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs",
+          "evaluation": "unevaluated"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_args.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_args.spec.json
@@ -1,0 +1,42 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:args",
+  "version": "0.1.0-draft",
+  "formals": [
+    "items"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Args",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "args",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Args",
+    "wp": "ordered argument list; variadic positional term args preserve source order",
+    "arity_shape": {
+      "kind": "positional",
+      "variadic": true
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_assign.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_assign.spec.json
@@ -1,0 +1,61 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:assign",
+  "version": "0.1.0-draft",
+  "formals": [
+    "target",
+    "value"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "LValue",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "assign",
+    "arity": [
+      "LValue",
+      "Expr"
+    ],
+    "result": "Stmt",
+    "wp": "store value into target and update state",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "target"
+        },
+        {
+          "name": "value"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Write"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_bitand.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_bitand.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:bitand",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "bitand",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator &",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_bitnot.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_bitnot.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:bitnot",
+  "version": "0.1.0-draft",
+  "formals": [
+    "operand"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "bitnot",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript unary operator ~",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_bitor.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_bitor.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:bitor",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "bitor",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator |",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_bitxor.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_bitxor.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:bitxor",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "bitxor",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator ^",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_break.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_break.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:break",
+  "version": "0.1.0-draft",
+  "formals": [
+    "unit"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Unit",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "break",
+    "arity": [
+      "Unit"
+    ],
+    "result": "Stmt",
+    "wp": "break from enclosing loop/switch",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "unit"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_call.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_call.spec.json
@@ -1,0 +1,64 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:call",
+  "version": "0.1.0-draft",
+  "formals": [
+    "callee",
+    "args"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Args",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "call",
+    "arity": [
+      "Expr",
+      "Args"
+    ],
+    "result": "Expr",
+    "wp": "call callee with ordered arguments",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "callee"
+        },
+        {
+          "name": "args",
+          "shape": {
+            "kind": "set"
+          }
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Call"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_continue.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_continue.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:continue",
+  "version": "0.1.0-draft",
+  "formals": [
+    "unit"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Unit",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "continue",
+    "arity": [
+      "Unit"
+    ],
+    "result": "Stmt",
+    "wp": "continue enclosing loop",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "unit"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_decl.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_decl.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:decl",
+  "version": "0.1.0-draft",
+  "formals": [
+    "name",
+    "initializer"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "String",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "decl",
+    "arity": [
+      "String",
+      "Expr"
+    ],
+    "result": "Stmt",
+    "wp": "introduce a local binding with initializer",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "name"
+        },
+        {
+          "name": "initializer"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_div.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_div.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:div",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "div",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator /",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_eq.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_eq.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:eq",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "eq",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator ==/===",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_for.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_for.spec.json
@@ -1,0 +1,82 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:for",
+  "version": "0.1.0-draft",
+  "formals": [
+    "init",
+    "cond",
+    "update",
+    "body"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Stmt",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Stmt",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Stmt",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "for",
+    "arity": [
+      "Stmt",
+      "Expr",
+      "Stmt",
+      "Stmt"
+    ],
+    "result": "Stmt",
+    "wp": "for loop; opaque until a loop invariant memento is supplied",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "init"
+        },
+        {
+          "name": "cond"
+        },
+        {
+          "name": "update"
+        },
+        {
+          "name": "body",
+          "evaluation": "unevaluated"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Loop"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_ge.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_ge.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:ge",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "ge",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator >=",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_gt.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_gt.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:gt",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "gt",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator >",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_if.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_if.spec.json
@@ -1,0 +1,68 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:if",
+  "version": "0.1.0-draft",
+  "formals": [
+    "cond",
+    "then_branch",
+    "else_branch"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Stmt",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Stmt",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "if",
+    "arity": [
+      "Expr",
+      "Stmt",
+      "Stmt"
+    ],
+    "result": "Stmt",
+    "wp": "conditional statement with branch-local effects",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "cond"
+        },
+        {
+          "name": "then_branch",
+          "evaluation": "unevaluated"
+        },
+        {
+          "name": "else_branch",
+          "evaluation": "unevaluated"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_index.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_index.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:index",
+  "version": "0.1.0-draft",
+  "formals": [
+    "object",
+    "index"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "LValue",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "index",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "LValue",
+    "wp": "element access x[i]",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "object"
+        },
+        {
+          "name": "index"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_ite.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_ite.spec.json
@@ -1,0 +1,68 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:ite",
+  "version": "0.1.0-draft",
+  "formals": [
+    "cond",
+    "then_expr",
+    "else_expr"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "ite",
+    "arity": [
+      "Expr",
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "conditional expression cond ? then_expr : else_expr",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "cond"
+        },
+        {
+          "name": "then_expr",
+          "evaluation": "unevaluated"
+        },
+        {
+          "name": "else_expr",
+          "evaluation": "unevaluated"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_le.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_le.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:le",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "le",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator <=",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_lt.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_lt.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:lt",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "lt",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator <",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_member.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_member.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:member",
+  "version": "0.1.0-draft",
+  "formals": [
+    "object",
+    "property"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "String",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "LValue",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "member",
+    "arity": [
+      "Expr",
+      "String"
+    ],
+    "result": "LValue",
+    "wp": "property/member access x.f",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "object"
+        },
+        {
+          "name": "property"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_mod.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_mod.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:mod",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "mod",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator %",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_mul.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_mul.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:mul",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "mul",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator *",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_ne.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_ne.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:ne",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "ne",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator !=/!==",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_neg.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_neg.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:neg",
+  "version": "0.1.0-draft",
+  "formals": [
+    "operand"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "neg",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript unary operator -",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_new.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_new.spec.json
@@ -1,0 +1,59 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:new",
+  "version": "0.1.0-draft",
+  "formals": [
+    "constructor",
+    "args"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Args",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "new",
+    "arity": [
+      "Expr",
+      "Args"
+    ],
+    "result": "Expr",
+    "wp": "construct a new object with ordered arguments",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "constructor"
+        },
+        {
+          "name": "args",
+          "shape": {
+            "kind": "set"
+          }
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_not.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_not.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:not",
+  "version": "0.1.0-draft",
+  "formals": [
+    "operand"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "not",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript unary operator !",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_nullish.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_nullish.spec.json
@@ -1,0 +1,57 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:nullish",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "nullish",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "short-circuit nullish coalescing",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs",
+          "evaluation": "unevaluated"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_or.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_or.spec.json
@@ -1,0 +1,57 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:or",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "or",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "short-circuit logical disjunction",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs",
+          "evaluation": "unevaluated"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_pos.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_pos.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:pos",
+  "version": "0.1.0-draft",
+  "formals": [
+    "operand"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "pos",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript unary operator +",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_postdec.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_postdec.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:postdec",
+  "version": "0.1.0-draft",
+  "formals": [
+    "operand"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "postdec",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript unary operator x--",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_postinc.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_postinc.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:postinc",
+  "version": "0.1.0-draft",
+  "formals": [
+    "operand"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "postinc",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript unary operator x++",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_predec.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_predec.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:predec",
+  "version": "0.1.0-draft",
+  "formals": [
+    "operand"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "predec",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript unary operator --x",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_preinc.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_preinc.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:preinc",
+  "version": "0.1.0-draft",
+  "formals": [
+    "operand"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "preinc",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript unary operator ++x",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_return.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_return.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:return",
+  "version": "0.1.0-draft",
+  "formals": [
+    "value"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "return",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Stmt",
+    "wp": "return value from the current function",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "value"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_seq.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_seq.spec.json
@@ -1,0 +1,42 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:seq",
+  "version": "0.1.0-draft",
+  "formals": [
+    "items"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Stmt",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "seq",
+    "arity": [
+      "Stmt"
+    ],
+    "result": "Stmt",
+    "wp": "ordered statement sequence; variadic positional term args are evaluated in order",
+    "arity_shape": {
+      "kind": "positional",
+      "variadic": true
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_shl.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_shl.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:shl",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "shl",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator <<",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_shr.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_shr.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:shr",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "shr",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator >>",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_source-unit.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_source-unit.spec.json
@@ -1,0 +1,58 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:source-unit",
+  "version": "0.1.0-draft",
+  "formals": [
+    "bytes",
+    "operational_term"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "String",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Stmt",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "source-unit",
+    "arity": [
+      "String",
+      "Stmt"
+    ],
+    "result": "Stmt",
+    "wp": "lossless TypeScript source wrapper; source bytes are recoverable and operational_term is the lifted program",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "bytes",
+          "evaluation": "unevaluated",
+          "slot_sort": "literal"
+        },
+        {
+          "name": "operational_term"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_sub.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_sub.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:sub",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "sub",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator -",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_throw.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_throw.spec.json
@@ -1,0 +1,51 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:throw",
+  "version": "0.1.0-draft",
+  "formals": [
+    "value"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "throw",
+    "arity": [
+      "Expr"
+    ],
+    "result": "Stmt",
+    "wp": "throw value; may panic/raise under the contract precondition",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "value"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Panic"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_typeof.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_typeof.spec.json
@@ -1,0 +1,46 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:typeof",
+  "version": "0.1.0-draft",
+  "formals": [
+    "operand"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "String",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "typeof",
+    "arity": [
+      "Expr"
+    ],
+    "result": "String",
+    "wp": "TypeScript unary operator typeof",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "operand"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_ushr.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_ushr.spec.json
@@ -1,0 +1,56 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:ushr",
+  "version": "0.1.0-draft",
+  "formals": [
+    "lhs",
+    "rhs"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Expr",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "ushr",
+    "arity": [
+      "Expr",
+      "Expr"
+    ],
+    "result": "Expr",
+    "wp": "TypeScript binary operator >>>",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "lhs"
+        },
+        {
+          "name": "rhs"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": []
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/op_while.spec.json
+++ b/menagerie/typescript-language-signature/specs/op_while.spec.json
@@ -1,0 +1,62 @@
+{
+  "kind": "algorithm",
+  "fn_name": "ts:while",
+  "version": "0.1.0-draft",
+  "formals": [
+    "cond",
+    "body"
+  ],
+  "formal_sorts": [
+    {
+      "kind": "ctor",
+      "name": "Expr",
+      "args": []
+    },
+    {
+      "kind": "ctor",
+      "name": "Stmt",
+      "args": []
+    }
+  ],
+  "return_sort": {
+    "kind": "ctor",
+    "name": "Stmt",
+    "args": []
+  },
+  "pre": {
+    "kind": "atomic",
+    "name": "true",
+    "args": []
+  },
+  "post": {
+    "kind": "operation-contract",
+    "operator": "while",
+    "arity": [
+      "Expr",
+      "Stmt"
+    ],
+    "result": "Stmt",
+    "wp": "while loop; opaque until a loop invariant memento is supplied",
+    "arity_shape": {
+      "kind": "named",
+      "slots": [
+        {
+          "name": "cond"
+        },
+        {
+          "name": "body",
+          "evaluation": "unevaluated"
+        }
+      ]
+    }
+  },
+  "effects": {
+    "effects": [
+      {
+        "kind": "effect-signature",
+        "name": "Loop"
+      }
+    ]
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#operations"
+}

--- a/menagerie/typescript-language-signature/specs/sort_any.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_any.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:Any",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "Any",
+    "description": "TypeScript any/unknown escape sort for compiler fallback only."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}

--- a/menagerie/typescript-language-signature/specs/sort_args.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_args.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:Args",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "Args",
+    "description": "Ordered call/new argument list."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}

--- a/menagerie/typescript-language-signature/specs/sort_boolean.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_boolean.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:Boolean",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "Boolean",
+    "description": "TypeScript boolean values in the handled source-lift slice."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}

--- a/menagerie/typescript-language-signature/specs/sort_expr.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_expr.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:Expr",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "Expr",
+    "description": "TypeScript source expression term."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}

--- a/menagerie/typescript-language-signature/specs/sort_lvalue.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_lvalue.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:LValue",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "LValue",
+    "description": "Assignable TypeScript target."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}

--- a/menagerie/typescript-language-signature/specs/sort_null.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_null.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:Null",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "Null",
+    "description": "JavaScript null literal."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}

--- a/menagerie/typescript-language-signature/specs/sort_number.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_number.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:Number",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "Number",
+    "description": "TypeScript number values in the handled source-lift slice."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}

--- a/menagerie/typescript-language-signature/specs/sort_stmt.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_stmt.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:Stmt",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "Stmt",
+    "description": "TypeScript source statement term."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}

--- a/menagerie/typescript-language-signature/specs/sort_string.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_string.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:String",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "String",
+    "description": "TypeScript string values and lossless source bytes."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}

--- a/menagerie/typescript-language-signature/specs/sort_unit.spec.json
+++ b/menagerie/typescript-language-signature/specs/sort_unit.spec.json
@@ -1,0 +1,16 @@
+{
+  "kind": "sort",
+  "fn_name": "ts:Unit",
+  "version": "0.1.0-draft",
+  "formals": [],
+  "return_sort": {
+    "kind": "kind",
+    "name": "*"
+  },
+  "post": {
+    "kind": "sort-description",
+    "name": "Unit",
+    "description": "Statement/unit result."
+  },
+  "locus": "menagerie/typescript-language-signature/README.md#sorts"
+}


### PR DESCRIPTION
Self-hosted TypeScript source-language lift kit + `menagerie/ts-language-signature/`. Mirrors PR #590 (the C# source lifter).

- TypeScript lifter via the TypeScript compiler API → `function-contract` mementos over `ts:`-namespaced ops
- per-file `ts:source-unit` lossless wrapper; round-trip `compile` + a `lift(compile(lift(src)))` test
- `arity_shape` on every op spec; `Refusal`s (not fakes) for unhandled syntax; effects on the canonical `Effect` wire shapes, sorted
- new `ts-source` lift surface (existing `ts` kit surface manifest untouched — the lesson from #590); `version 0.1.0-draft`
- vitest 6/6 + full suite 785 tests pass; tsc --noEmit pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)