### PR TITLE
chore: align effect sort-keys, add csharp-source to KNOWN_SURFACES, fix Swift unparseable-sig refusal

### DIFF
--- a/implementations/go/provekit-lift-go/types.go
+++ b/implementations/go/provekit-lift-go/types.go
@@ -206,7 +206,7 @@ func effectSortKey(e Effect) string {
 	case "panics":
 		return "4:panics"
 	case "unresolved_call":
-		return "5:unresolved_call:" + e.Name
+		return "5:unresolved:" + e.Name
 	case "opaque_loop":
 		return "6:opaque_loop:" + e.LoopCid
 	default:

--- a/implementations/ruby/lib/provekit/lift/ruby_source.rb
+++ b/implementations/ruby/lib/provekit/lift/ruby_source.rb
@@ -702,7 +702,7 @@ module Provekit
           when "panics"
             "4:panics"
           when "unresolved_call"
-            "5:unresolved_call:#{effect["name"]}"
+            "5:unresolved:#{effect["name"]}"
           when "opaque_loop"
             "6:opaque_loop:#{effect["loopCid"]}"
           else

--- a/implementations/rust/provekit-cli/src/project_config.rs
+++ b/implementations/rust/provekit-cli/src/project_config.rs
@@ -220,6 +220,7 @@ pub const KNOWN_SURFACES: &[&str] = &[
     "java-jml",
     "jvm-bytecode",
     "csharp",
+    "csharp-source",
     "cpp-26-contracts",
     "cpp-boost-contract",
     "clr-bytecode",

--- a/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceIR.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceIR.swift
@@ -293,7 +293,7 @@ enum SwiftEffect: Hashable {
         case .io: return "2:io"
         case .unsafe: return "3:unsafe"
         case .panics: return "4:panics"
-        case .unresolvedCall(let name): return "5:unresolved_call:\(name)"
+        case .unresolvedCall(let name): return "5:unresolved:\(name)"
         case .opaqueLoop(let loopCid): return "6:opaque_loop:\(loopCid)"
         }
     }

--- a/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceLifter.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceLifter.swift
@@ -15,6 +15,7 @@ public enum SwiftSourceLifter {
         collector.walk(sourceFile)
 
         var result = SwiftSourceLiftResult()
+        result.refusals.append(contentsOf: collector.collectorRefusals)
         var acceptedBodyTerms: [JcsCanonical] = []
         var contracts: [JcsCanonical] = []
 
@@ -143,6 +144,7 @@ private final class SwiftDefinitionCollector: SyntaxVisitor {
     private var converter: SourceLocationConverter?
 
     var functions: [SwiftFunctionInfo] = []
+    var collectorRefusals: [JcsCanonical] = []
     var globalVars: Set<String> = []
     var staticVars: Set<String> = []
 
@@ -220,10 +222,26 @@ private final class SwiftDefinitionCollector: SyntaxVisitor {
     }
 
     override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-        guard let info = try? functionInfo(for: node) else {
-            return .skipChildren
+        do {
+            let info = try functionInfo(for: node)
+            functions.append(info)
+        } catch let unsupported as UnsupportedSwiftSyntax {
+            let bestEffortName = node.name.text
+            collectorRefusals.append(SwiftSourceIR.refusal(
+                kind: unsupported.kind,
+                function: bestEffortName,
+                line: unsupported.line,
+                reason: unsupported.reason
+            ))
+        } catch {
+            let line: Int? = converter.map { node.startLocation(converter: $0).line }
+            collectorRefusals.append(SwiftSourceIR.refusal(
+                kind: "unparseable-function-signature",
+                function: node.name.text,
+                line: line,
+                reason: String(describing: error)
+            ))
         }
-        functions.append(info)
         return .skipChildren
     }
 
@@ -399,7 +417,7 @@ private final class SwiftFunctionEmitter {
             }
             if let throwStmt = stmt.as(ThrowStmtSyntax.self) {
                 effects.add(.panics)
-                let expr = try throwStmt.expression.map(expression) ?? SwiftSourceIR.unitConst()
+                let expr = try expression(throwStmt.expression)
                 return SwiftSourceIR.ctor("swift:throw", [expr])
             }
             throw unsupported(stmt, reason: "unhandled statement kind: \(type(of: stmt))")

--- a/implementations/swift/Tests/ProvekitLiftSwiftSourceTests/SwiftSourceLifterTests.swift
+++ b/implementations/swift/Tests/ProvekitLiftSwiftSourceTests/SwiftSourceLifterTests.swift
@@ -74,6 +74,45 @@ final class SwiftSourceLifterTests: XCTestCase {
         XCTAssertFalse(try canonicalString(result.refusals).contains("swift:skip"))
     }
 
+    func testRefusesUnparseableFunctionSignatureNotSilentlyDropped() throws {
+        // Functions whose signatures fail validateSignature must produce a
+        // Refusal, not be silently omitted from the output.
+        let source = """
+        func good(_ x: Int) -> Int {
+            return x + 1
+        }
+
+        func generic<T>(_ x: T) -> T {
+            return x
+        }
+
+        func asyncFunc(_ x: Int) async -> Int {
+            return x
+        }
+        """
+
+        let result = SwiftSourceLifter.liftSource(source, path: "Sig.swift")
+
+        // The good function produces a contract; the two unsupported ones produce refusals.
+        let contractNames = result.ir.compactMap { SwiftSourceIR.fnName(of: $0) }
+        XCTAssertTrue(contractNames.contains { $0.contains(".good(_:)(Int)->Int") },
+                      "good function must be lifted: \(contractNames)")
+
+        // Each unsupported function must yield a refusal, not be invisible.
+        XCTAssertGreaterThanOrEqual(result.refusals.count, 2,
+            "generic and async functions must produce refusals, got \(result.refusals.count)")
+
+        // Refusals must carry the function name (best-effort) and a reason.
+        for refusal in result.refusals {
+            let obj = try JSONObject(refusal)
+            XCTAssertNotNil(obj["kind"],   "refusal must have a kind")
+            XCTAssertNotNil(obj["reason"], "refusal must have a reason")
+        }
+
+        XCTAssertFalse(try canonicalString(result.refusals).contains("swift:unknown"))
+        XCTAssertFalse(try canonicalString(result.refusals).contains("swift:skip"))
+    }
+
     func testEffectsAreSortedAndLoopCidIsBlake3512() throws {
         let source = """
         func total(_ limit: Int) -> Int {

--- a/implementations/typescript/src/lift/typescript-source/index.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.ts
@@ -614,7 +614,7 @@ function effectSortKey(effect: TypeScriptSourceEffect): string {
     case "writes": return `1:writes:${effect.target}`;
     case "io": return "2:io";
     case "panics": return "4:panics";
-    case "unresolved_call": return `5:unresolved_call:${effect.name}`;
+    case "unresolved_call": return `5:unresolved:${effect.name}`;
     case "opaque_loop": return `6:opaque_loop:${effect.loopCid}`;
   }
 }


### PR DESCRIPTION
## Summary

Three targeted cleanup fixes from deep reviews on the merged source lift kits. All changes are CID-neutral: no wire `kind` strings, op-specs, or `.proof` pins were touched.

**1. Align effect sort-key strings to Rust canonical (Go, TS, Ruby, Swift)**

Go, TypeScript, Ruby, and Swift were emitting `"5:unresolved_call:"` as the internal sort key for `UnresolvedCall` effects. The Rust canonical (`libprovekit Effect::sort_key`) uses `"5:unresolved:"`. Zig and C# sort by integer rank (already correct); Python was already correct. This is purely cosmetic -- the wire `kind` in the emitted JSON contract stays `"unresolved_call"` -- but it makes cross-language effect-set ordering byte-consistent with the Rust peer.

**2. Add `"csharp-source"` to `KNOWN_SURFACES` in `provekit-cli`**

PR #590 added `"csharp"` but the C# source lifter's authoring surface is `"csharp-source"` (matches `implementations/csharp/.provekit/lift/csharp-source/`). Every other `<lang>-source` lifter added its `<lang>-source` entry; this closes the gap. `cargo test -p provekit-cli` passes including `known_lists_include_anchor_entries`.

**3. Swift: emit `Refusal` for unparseable function signatures + fix pre-existing build error**

`SwiftDefinitionCollector.visit(FunctionDeclSyntax)` used `try? functionInfo(for:)` and silently returned `.skipChildren` on failure, which would invisibly drop functions whose signatures couldn't be parsed. Changed to a `do/catch` block that emits a `Refusal` (kind: `"unparseable-function-signature"`) before skipping -- mirrors the body-level refusal pattern already in `liftSource`. New test: `testRefusesUnparseableFunctionSignatureNotSilentlyDropped` (generic + async functions produce refusals; valid sibling function is still lifted).

Boy-scout fix in the same file: `ThrowStmtSyntax.expression` is non-optional in the pinned `swift-syntax` version; the old `.map(expression) ?? unitConst()` call was a pre-existing build error. Replaced with `try expression(throwStmt.expression)`.

`swift build` passes locally. `swift test` requires XCTest which is unavailable in the local toolchain; CI's `Cross-language conformance gate (macOS swift)` verifies.

## Deferred (noted from deep reviews -- too ripply for a cleanup PR)

- `op_call` / `op_send` (etc.) op-spec `args` slot is `{"shape":{"kind":"set"}}` despite order-significant positional args -- fixing it changes the op-CID for `<lang>:call` across every lifter (copied from #590's C# `op_call`), which changes every contract using a call; needs CICP-witness regen across all kits -- its own careful PR.
- `test-ruby` / `test-php` / etc. not wired into `make test-all` / `make ci` -- consistent with pre-existing kits; separate decision.
- PHP `provekit-lift-php-source` (with `PhpSourceCompiler.php` + `php:assign` expression-position case) -- the kit is not yet merged into `main` at the base of this branch (`86ef2f1f`); it lives on `codex/php-source-lift-kit`. The PHP item from the review will apply as a follow-up once that branch merges.
- The compile-RPC verbatim-bytes fast-path behavior in production -- correct as-is; a doc note when there's appetite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added C# source language support

* **Bug Fixes**
  * Improved Swift code parsing with comprehensive error reporting for unsupported function signatures instead of silently dropping them

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/602)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->