### PR TITLE
fix(lift-php-source): handle php:assign in expression position (nested assignment round-trip)

### DIFF
--- a/implementations/php/provekit-lift-php-source/src/PhpSourceCompiler.php
+++ b/implementations/php/provekit-lift-php-source/src/PhpSourceCompiler.php
@@ -147,6 +147,7 @@ final class PhpSourceCompiler
             'php:index' => new \PhpParser\Node\Expr\ArrayDimFetch($this->exprNode($args[0]), $this->isUnit($args[1]) ? null : $this->exprNode($args[1])),
             'php:propfetch' => new \PhpParser\Node\Expr\PropertyFetch($this->exprNode($args[0]), $this->constString($args[1])),
             'php:call' => new \PhpParser\Node\Expr\FuncCall(new \PhpParser\Node\Name($this->constString($args[0])), array_map(fn(array $arg): object => new \PhpParser\Node\Arg($this->exprNode($arg)), array_slice($args, 1))),
+            'php:assign' => new \PhpParser\Node\Expr\Assign($this->targetNode($args[0]), $this->exprNode($args[1])),
             default => throw new \InvalidArgumentException('unsupported php operation in expression position: ' . $name),
         };
     }
@@ -233,6 +234,7 @@ final class PhpSourceCompiler
             'php:call' => $this->constString($args[0]) . '(' . implode(', ', array_map(fn(array $arg): string => $this->exprString($arg), array_slice($args, 1))) . ')',
             'php:not' => '!' . $this->exprString($args[0]),
             'php:neg' => '-' . $this->exprString($args[0]),
+            'php:assign' => '(' . $this->exprString($args[0]) . ' = ' . $this->exprString($args[1]) . ')',
             default => throw new \InvalidArgumentException('unsupported php operation in fallback compiler: ' . $name),
         };
     }

--- a/implementations/php/provekit-lift-php-source/tests/PhpSourceLifterTest.php
+++ b/implementations/php/provekit-lift-php-source/tests/PhpSourceLifterTest.php
@@ -228,6 +228,46 @@ function test_php_language_signature_catalog_has_required_shapes(): void
     assert_same('unevaluated', $coalesce['post']['arity_shape']['slots'][1]['evaluation'], 'nullcoalesce RHS unevaluated');
 }
 
+function test_compile_nested_assign_expression_roundtrip(): void
+{
+    // $a = $b = 1: the inner $b = 1 is php:assign in expression position (value of outer assign).
+    // The compiler must handle php:assign in exprNode(), not only in stmtNode().
+    $source = <<<'PHP'
+<?php
+function f() {
+    $a = $b = 1;
+    return $a + $b;
+}
+PHP;
+
+    $lifter = new PhpSourceLifter();
+    $first = $lifter->liftSource($source, 'src/nested_assign.php');
+    assert_same([], $first['refusals'], 'nested assign should lift without refusals');
+    $contract = contract($first['ir'], 'f');
+    $body = rhs($contract);
+
+    // The IR must contain php:assign in expression position (nested).
+    $names = ctor_names($body);
+    assert_true(in_array('php:assign', $names, true), 'body IR contains php:assign');
+
+    // Compile back to PHP source; this must not throw.
+    $compiled = (new PhpSourceCompiler())->compileBodyTerm($body, 'f', $contract['formals']);
+
+    // Re-lift the compiled source; IR must be byte-identical (round-trip).
+    $second = $lifter->liftSource($compiled, 'src/nested_assign.php');
+    assert_same([], $second['refusals'], 'compiled nested-assign body should relift');
+    $reliftedBody = rhs(contract($second['ir'], 'f'));
+    assert_same(Jcs::encode($body), Jcs::encode($reliftedBody), 'nested-assign IR round-trip canonical bytes');
+
+    // The compiled output must represent the nested assignment as an assign-expression.
+    // PhpParser emits it as "$a = $b = 1" (chained); the fallback emits "($b = 1)".
+    // Either way the compiled source must contain the nested variable assignment.
+    assert_true(
+        str_contains($compiled, '$b = 1') || str_contains($compiled, '($b = 1)'),
+        'compiled PHP contains nested assignment expression; got: ' . $compiled
+    );
+}
+
 $tests = array_filter(
     get_defined_functions()['user'],
     static fn(string $name): bool => str_starts_with($name, 'test_')


### PR DESCRIPTION
## Summary

- `PhpSourceCompiler::exprNode()` had no case for `php:assign`, causing an `InvalidArgumentException` crash when the lifter emitted a `php:assign` term in expression position — which happens for nested assignments like `$a = $b = 1` (the inner `$b = 1` is an assign-expression whose value is `1`).
- Added `php:assign` to `exprNode()` emitting `Expr\Assign(target, value)`, matching the existing `stmtNode()` handler. Also added `php:assign` to the fallback `exprString()` method, emitting `($target = $value)` with parens for correct precedence in nested contexts.
- Regression test: `function f() { $a = $b = 1; return $a + $b; }` lifted, compiled, and re-lifted — asserts byte-identical IR round-trip and that the compiled PHP contains the nested assignment expression.

## Files changed

- `implementations/php/provekit-lift-php-source/src/PhpSourceCompiler.php` — two one-line additions: `php:assign` case in `exprNode()` and `exprString()`
- `implementations/php/provekit-lift-php-source/tests/PhpSourceLifterTest.php` — `test_compile_nested_assign_expression_roundtrip()`

## Verification

```
$ composer test
CICP conformance vectors passed
ForwardPropagatorTest passed
PHP source lifter tests passed (7 tests)
```

All 7 tests pass (was 6 before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PHP assignment expressions are now supported in expression positions, enabling nested assignments such as `$a = $b = 1`. Both compilation backends now handle these expressions consistently.

* **Tests**
  * Added validation for nested assignment expression round-trip compilation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/606)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->