### PR TITLE
fix(lift-c-assertions): stop over-extracting callee-local state into the caller's pre

### DIFF
--- a/implementations/c/provekit-lift-c-assertions/src/assertions.c
+++ b/implementations/c/provekit-lift-c-assertions/src/assertions.c
@@ -48,6 +48,14 @@ typedef struct {
     char *name;
     char **formals;
     int n_formals;
+    /* Names of variables declared local to this function (VarDecls nested in
+     * the function body / blocks).  Owned by the FunctionContracts. */
+    char **locals;
+    int n_locals;
+    /* Names of file-scope symbols (translation-unit VarDecls and FunctionDecls).
+     * Borrowed: owned by the per-translation-unit AstContractCtx. */
+    char *const *globals;
+    int n_globals;
     const char *path;
     int line;
     int column;
@@ -482,6 +490,12 @@ static int find_top_level_operator(Slice s, const char *const *ops, size_t n_ops
             depth--;
             continue;
         }
+        /* Skip the member-access arrow "->": its '>' must not be mistaken for
+         * a relational operator (it is part of an lvalue chain like p->len). */
+        if (s.s[i] == '-' && i + 1 < s.n && s.s[i + 1] == '>') {
+            i++;
+            continue;
+        }
         if (depth != 0) {
             continue;
         }
@@ -596,39 +610,22 @@ static char *name_from_not_condition(Slice condition) {
 }
 
 /*
- * Return 1 if 'name' is safe to appear in a function's computed pre: it is
- * either a formal parameter of the function, a well-known compile-time
- * constant expression (sizeof / alignof / offsetof), or a known null-pointer
- * constant (NULL).  Anything else -- locals, globals -- is not visible at the
- * function's entry from the caller's perspective.
+ * Compile-time-constant operator prefixes (sizeof(T), alignof(T), ...).  The
+ * lifter builds var-node names from space-joined tokens, so the name of such a
+ * term looks like "sizeof ( int )".  These reference no run-time state at all,
+ * so they are always entry-state safe.
  */
-static int is_entry_state_var_name(const char *name, char **formals, int n_formals) {
+static int name_is_compile_time_const(const char *name) {
     static const char *const ct_prefixes[] = {
         "sizeof", "alignof", "_Alignof", "__alignof", "__alignof__",
         "__builtin_offsetof", NULL
     };
-    static const char *const known_constants[] = {"NULL", "null", "true", "false", NULL};
     size_t nlen;
     int i;
 
     if (name == NULL) {
         return 0;
     }
-    /* formal parameters */
-    for (i = 0; i < n_formals; i++) {
-        if (formals[i] != NULL && strcmp(name, formals[i]) == 0) {
-            return 1;
-        }
-    }
-    /* known pointer/boolean constants */
-    for (i = 0; known_constants[i] != NULL; i++) {
-        if (strcmp(name, known_constants[i]) == 0) {
-            return 1;
-        }
-    }
-    /* compile-time operators: sizeof(T), alignof(T), etc.
-     * cursor_source joins tokens with spaces, so the name looks like
-     * "sizeof ( int )" -- match the prefix followed by space or '(' */
     for (i = 0; ct_prefixes[i] != NULL; i++) {
         nlen = strlen(ct_prefixes[i]);
         if (strncmp(name, ct_prefixes[i], nlen) == 0 &&
@@ -639,12 +636,186 @@ static int is_entry_state_var_name(const char *name, char **formals, int n_forma
     return 0;
 }
 
+static int name_is_known_constant(const char *name) {
+    static const char *const known_constants[] = {"NULL", "null", "true", "false", NULL};
+    int i;
+
+    if (name == NULL) {
+        return 0;
+    }
+    for (i = 0; known_constants[i] != NULL; i++) {
+        if (strcmp(name, known_constants[i]) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* C keywords that may appear as identifier-shaped tokens inside an expression
+ * blob but never name a run-time value (so they are not "locals" to reject). */
+static int name_is_c_keyword(const char *s, size_t len) {
+    static const char *const keywords[] = {
+        "sizeof", "alignof", "_Alignof", "__alignof", "__alignof__",
+        "__builtin_offsetof", "_Bool", "__typeof__", "typeof",
+        "int", "char", "short", "long", "unsigned", "signed", "float",
+        "double", "void", "struct", "union", "enum", "const", "volatile",
+        "static", "extern", "register", "auto", "inline", "restrict",
+        "if", "else", "for", "while", "do", "switch", "case", "default",
+        "return", "goto", "break", "continue",
+        NULL
+    };
+    int i;
+
+    for (i = 0; keywords[i] != NULL; i++) {
+        if (strlen(keywords[i]) == len && strncmp(keywords[i], s, len) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+typedef enum {
+    SCOPE_ENTRY_STATE, /* formal of this function, or a file-scope symbol */
+    SCOPE_LOCAL,       /* a variable local to this function -- not entry state */
+    SCOPE_UNKNOWN      /* cannot classify -- conservatively not entry state */
+} VarScope;
+
+static VarScope classify_root_identifier(const char *name, size_t len, const FunctionContracts *fn) {
+    int i;
+    char buf[256];
+
+    if (len == 0) {
+        return SCOPE_UNKNOWN;
+    }
+    if (len >= sizeof(buf)) {
+        /* implausibly long identifier -- be conservative */
+        return SCOPE_UNKNOWN;
+    }
+    memcpy(buf, name, len);
+    buf[len] = '\0';
+    if (name_is_known_constant(buf)) {
+        return SCOPE_ENTRY_STATE;
+    }
+    /* Locals are checked first: the lifter has no per-locus scope, so a name
+     * that is declared local to this function anywhere -- even a block-scope
+     * local that shadows a formal or a global -- is conservatively treated as
+     * non-entry-state (drop + opacity, never keep-and-hope). */
+    for (i = 0; i < fn->n_locals; i++) {
+        if (fn->locals[i] != NULL && strcmp(buf, fn->locals[i]) == 0) {
+            return SCOPE_LOCAL;
+        }
+    }
+    for (i = 0; i < fn->n_formals; i++) {
+        if (fn->formals[i] != NULL && strcmp(buf, fn->formals[i]) == 0) {
+            return SCOPE_ENTRY_STATE;
+        }
+    }
+    for (i = 0; i < fn->n_globals; i++) {
+        if (fn->globals[i] != NULL && strcmp(buf, fn->globals[i]) == 0) {
+            return SCOPE_ENTRY_STATE;
+        }
+    }
+    return SCOPE_UNKNOWN;
+}
+
+/*
+ * Classify the var-node name "name" -- a space-joined token blob for some C
+ * subexpression (e.g. "y", "p -> len", "arr [ 0 ]", "& p -> field",
+ * "p -> arr [ q ]", "sizeof ( int )") -- as entry-state safe or not.
+ *
+ * A name is entry-state safe iff every identifier token in it that names a
+ * run-time value (i.e. not a member name following '.' / '->', not a C keyword)
+ * classifies as a formal of this function or a file-scope symbol.  Any
+ * identifier that is a function-local, or that we cannot classify, makes the
+ * whole term non-entry-state.  A function call inside the term is also treated
+ * as non-entry-state (a derived value, not addressable entry state) -- except
+ * the compile-time-constant operator forms (sizeof(T), __builtin_offsetof, ...)
+ * which are matched up front and accepted.  Known pointer / boolean constants
+ * are entry-state safe outright.
+ */
+static int var_name_is_entry_state(const char *name, const FunctionContracts *fn) {
+    const char *p;
+    char prev_op = '\0';   /* last operator token seen ('.', '>' for "->", etc.) */
+    int after_member_arrow = 0;
+
+    if (name == NULL) {
+        return 0;
+    }
+    if (name_is_compile_time_const(name) || name_is_known_constant(name)) {
+        return 1;
+    }
+    p = name;
+    while (*p != '\0') {
+        if (isspace((unsigned char)*p)) {
+            p++;
+            continue;
+        }
+        if (isalpha((unsigned char)*p) || *p == '_') {
+            const char *start = p;
+            size_t len;
+            const char *q;
+
+            while (is_ident_char((unsigned char)*p)) {
+                p++;
+            }
+            len = (size_t)(p - start);
+            if (after_member_arrow) {
+                /* member name after '.' or '->' -- not an lvalue identifier */
+                after_member_arrow = 0;
+                prev_op = '\0';
+                continue;
+            }
+            if (name_is_c_keyword(start, len)) {
+                prev_op = '\0';
+                continue;
+            }
+            /* If this identifier is the callee of a call (next non-space is
+             * '('), the term contains a call -- conservatively not entry state.
+             * (Compile-time-constant operator forms were already accepted.) */
+            q = p;
+            while (isspace((unsigned char)*q)) {
+                q++;
+            }
+            if (*q == '(') {
+                return 0;
+            }
+            switch (classify_root_identifier(start, len, fn)) {
+            case SCOPE_ENTRY_STATE:
+                break;
+            case SCOPE_LOCAL:
+            case SCOPE_UNKNOWN:
+            default:
+                return 0;
+            }
+            prev_op = '\0';
+            continue;
+        }
+        /* operator / punctuation token */
+        if (*p == '.') {
+            after_member_arrow = 1;
+        } else if (*p == '>' && prev_op == '-') {
+            after_member_arrow = 1;
+        }
+        if (*p == '"') {
+            /* string literal in the blob -- should not happen, but be safe */
+            return 0;
+        }
+        prev_op = *p;
+        p++;
+    }
+    return 1;
+}
+
 /*
  * Recursively check that every var-node in the formula tree references only
- * entry-state names (formals, compile-time constants, known null constants).
- * Returns 1 if safe, 0 if any var is not in entry state.
+ * entry-state names.  Returns 1 if safe, 0 if any var-node is not entry state.
+ *
+ * Terms are flat var/const nodes whose "name" is the space-joined token blob
+ * of the subexpression -- the lifter does not build member/index/deref node
+ * hierarchies -- so each atomic arg carries at most one var-node "name", which
+ * we parse properly (every identifier token in it is classified by scope).
  */
-static int formula_references_only_entry_state(const Formula *f, char **formals, int n_formals) {
+static int formula_references_only_entry_state(const Formula *f, const FunctionContracts *fn) {
     size_t i;
 
     if (f == NULL) {
@@ -652,12 +823,6 @@ static int formula_references_only_entry_state(const Formula *f, char **formals,
     }
     if (f->kind == FORMULA_ATOMIC) {
         for (i = 0; i < f->n_args; i++) {
-            /* args are JSON term strings like {"kind":"var","name":"y"} --
-             * we need to check the raw arg blob for a var whose name is not
-             * in entry state.  The only non-const terms are var nodes; const
-             * nodes have "kind":"const" and carry no identifier name that
-             * matters here.  We look for "\"kind\":\"var\"" in the arg blob
-             * and then extract the name field. */
             const char *arg = f->args[i];
             const char *var_marker = "\"kind\":\"var\"";
             const char *name_marker = "\"name\":\"";
@@ -671,7 +836,7 @@ static int formula_references_only_entry_state(const Formula *f, char **formals,
                 continue;
             }
             if (strstr(arg, var_marker) == NULL) {
-                /* const node -- skip */
+                /* const node -- carries no identifier name that matters */
                 continue;
             }
             p = strstr(arg, name_marker);
@@ -686,11 +851,12 @@ static int formula_references_only_entry_state(const Formula *f, char **formals,
             }
             name_len = (size_t)(name_end - name_start);
             if (name_len >= sizeof(name_buf)) {
-                name_len = sizeof(name_buf) - 1;
+                /* implausibly long -- be conservative */
+                return 0;
             }
             memcpy(name_buf, name_start, name_len);
             name_buf[name_len] = '\0';
-            if (!is_entry_state_var_name(name_buf, formals, n_formals)) {
+            if (!var_name_is_entry_state(name_buf, fn)) {
                 return 0;
             }
         }
@@ -698,7 +864,7 @@ static int formula_references_only_entry_state(const Formula *f, char **formals,
     }
     /* AND / OR / NOT: recurse into operands */
     for (i = 0; i < f->n_operands; i++) {
-        if (!formula_references_only_entry_state(f->operands[i], formals, n_formals)) {
+        if (!formula_references_only_entry_state(f->operands[i], fn)) {
             return 0;
         }
     }
@@ -712,7 +878,7 @@ static int emit_non_entry_state_opacity(FunctionContracts *fn) {
         fn->path == NULL ? "" : fn->path,
         fn->line,
         fn->column,
-        "assertion references non-entry-state (local variable); predicate dropped from pre",
+        "assertion references non-entry-state (function-local or unclassifiable name); predicate dropped from pre",
         "c-assertions");
 }
 
@@ -723,12 +889,15 @@ static int function_add_precondition(FunctionContracts *fn, Formula *formula) {
     if (formula == NULL) {
         return 0;
     }
-    /* Guard: only emit preconditions that reference entry-state names
-     * (formal parameters, compile-time constants, or known null constants).
-     * A formula mentioning a local variable or a callee-internal name would
-     * make the caller's pre too tight -- it constrains state the caller
-     * cannot see or control. */
-    if (!formula_references_only_entry_state(formula, fn->formals, fn->n_formals)) {
+    /* Guard: only emit preconditions that reference entry-state names --
+     * formal parameters, file-scope/global symbols (incl. static-at-file-
+     * scope), state reachable from those (p->field, p[i], *p, &p->field),
+     * compile-time constants (sizeof T, ...), and known null/bool constants.
+     * A formula mentioning a variable local to this function (or any name we
+     * cannot classify as entry state) would make the caller's pre too tight --
+     * it would constrain state the caller cannot see or control -- so the
+     * predicate is dropped and an auditable opacity entry is emitted instead. */
+    if (!formula_references_only_entry_state(formula, fn)) {
         if (emit_non_entry_state_opacity(fn) != 0) {
             formula_free(formula);
             return -1;
@@ -1203,6 +1372,15 @@ done:
     return rc;
 }
 
+static void strlist_free(char **list, int n) {
+    int i;
+
+    for (i = 0; i < n; i++) {
+        free(list[i]);
+    }
+    free(list);
+}
+
 static void function_contracts_free(FunctionContracts *fn) {
     if (fn == NULL) {
         return;
@@ -1212,6 +1390,8 @@ static void function_contracts_free(FunctionContracts *fn) {
         free(fn->formals[i]);
     }
     free(fn->formals);
+    strlist_free(fn->locals, fn->n_locals);
+    /* fn->globals is borrowed from the per-translation-unit context */
     for (size_t i = 0; i < fn->n_preconditions; i++) {
         formula_free(fn->preconditions[i]);
     }
@@ -1223,6 +1403,11 @@ static void function_contracts_free(FunctionContracts *fn) {
 typedef struct {
     pk_c_lift_result *result;
     const char *path;
+    /* File-scope symbol names (translation-unit VarDecls / FunctionDecls /
+     * enum constants).  Referencing one of these is part of a function's
+     * entry state.  Owned by this context. */
+    char **globals;
+    int n_globals;
     int failed;
     int saw_function;
 } AstContractCtx;
@@ -1233,6 +1418,104 @@ static char *clang_string(CXString string) {
 
     clang_disposeString(string);
     return copy;
+}
+
+/* Append a copy of 'name' to an owned, dynamically-grown string list.
+ * Returns 0 on success, -1 on allocation failure. */
+static int strlist_push(char ***list, int *n, const char *name) {
+    char **next;
+    char *copy;
+
+    if (name == NULL || name[0] == '\0') {
+        return 0;
+    }
+    copy = copy_string(name);
+    if (copy == NULL) {
+        return -1;
+    }
+    next = realloc(*list, (size_t)(*n + 1) * sizeof(**list));
+    if (next == NULL) {
+        free(copy);
+        return -1;
+    }
+    *list = next;
+    (*list)[*n] = copy;
+    (*n)++;
+    return 0;
+}
+
+/* Visitor: collect VarDecl spellings reachable under a FunctionDecl into
+ * fn->locals.  Recurses into nested blocks; ParmDecls are not VarDecls so
+ * they are not collected (they are already in fn->formals). */
+static enum CXChildVisitResult collect_locals_visitor(CXCursor cursor, CXCursor parent, CXClientData client_data) {
+    FunctionContracts *fn = (FunctionContracts *)client_data;
+    (void)parent;
+
+    if (clang_getCursorKind(cursor) == CXCursor_VarDecl) {
+        char *name = clang_string(clang_getCursorSpelling(cursor));
+
+        if (name == NULL) {
+            return CXChildVisit_Break;
+        }
+        if (strlist_push(&fn->locals, &fn->n_locals, name) != 0) {
+            free(name);
+            return CXChildVisit_Break;
+        }
+        free(name);
+    }
+    return CXChildVisit_Recurse;
+}
+
+static int collect_locals(FunctionContracts *fn, CXCursor cursor) {
+    fn->locals = NULL;
+    fn->n_locals = 0;
+    /* clang_visitChildren returns non-zero if the visitor requested a Break;
+     * collect_locals_visitor only Breaks on allocation failure. */
+    if (clang_visitChildren(cursor, collect_locals_visitor, fn) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+/* Visitor: collect file-scope symbol names (VarDecl / FunctionDecl /
+ * EnumConstantDecl) directly under the translation-unit cursor. */
+static enum CXChildVisitResult collect_globals_visitor(CXCursor cursor, CXCursor parent, CXClientData client_data) {
+    AstContractCtx *ctx = (AstContractCtx *)client_data;
+    enum CXCursorKind kind = clang_getCursorKind(cursor);
+    (void)parent;
+
+    if (kind == CXCursor_VarDecl || kind == CXCursor_FunctionDecl) {
+        char *name = clang_string(clang_getCursorSpelling(cursor));
+
+        if (name == NULL) {
+            return CXChildVisit_Break;
+        }
+        if (strlist_push(&ctx->globals, &ctx->n_globals, name) != 0) {
+            free(name);
+            return CXChildVisit_Break;
+        }
+        free(name);
+        return CXChildVisit_Continue;
+    }
+    if (kind == CXCursor_EnumDecl) {
+        /* enum constants are compile-time constants -- entry-state safe.
+         * Recurse to pick up the EnumConstantDecl children. */
+        return CXChildVisit_Recurse;
+    }
+    if (kind == CXCursor_EnumConstantDecl) {
+        char *name = clang_string(clang_getCursorSpelling(cursor));
+
+        if (name == NULL) {
+            return CXChildVisit_Break;
+        }
+        if (strlist_push(&ctx->globals, &ctx->n_globals, name) != 0) {
+            free(name);
+            return CXChildVisit_Break;
+        }
+        free(name);
+        return CXChildVisit_Continue;
+    }
+    return CXChildVisit_Continue;
 }
 
 static void set_locus(FunctionContracts *fn, CXCursor cursor, const char *fallback_path) {
@@ -1333,10 +1616,14 @@ static enum CXChildVisitResult visit_ast_function(CXCursor cursor, CXCursor pare
 
         memset(&fn, 0, sizeof(fn));
         fn.result = ctx->result;
+        fn.globals = ctx->globals;
+        fn.n_globals = ctx->n_globals;
         fn.name = clang_string(clang_getCursorSpelling(cursor));
         set_locus(&fn, cursor, ctx->path);
         source = cursor_source(cursor);
-        if (fn.name == NULL || source == NULL || collect_formals(&fn, cursor) != 0) {
+        if (fn.name == NULL || source == NULL ||
+            collect_formals(&fn, cursor) != 0 ||
+            collect_locals(&fn, cursor) != 0) {
             free(source);
             function_contracts_free(&fn);
             ctx->failed = 1;
@@ -1402,7 +1689,16 @@ static int lift_ast_contracts(
     memset(&ctx, 0, sizeof(ctx));
     ctx.result = result;
     ctx.path = filename;
+    /* Collect file-scope symbol names first so per-function entry-state
+     * classification can recognise references to globals. */
+    if (clang_visitChildren(clang_getTranslationUnitCursor(unit), collect_globals_visitor, &ctx) != 0) {
+        strlist_free(ctx.globals, ctx.n_globals);
+        clang_disposeTranslationUnit(unit);
+        clang_disposeIndex(index);
+        return -1;
+    }
     (void)clang_visitChildren(clang_getTranslationUnitCursor(unit), visit_ast_function, &ctx);
+    strlist_free(ctx.globals, ctx.n_globals);
     clang_disposeTranslationUnit(unit);
     clang_disposeIndex(index);
     return ctx.failed ? -1 : 0;

--- a/implementations/c/provekit-lift-c-assertions/src/assertions.c
+++ b/implementations/c/provekit-lift-c-assertions/src/assertions.c
@@ -595,11 +595,145 @@ static char *name_from_not_condition(Slice condition) {
     return copy_n(condition.s, condition.n);
 }
 
+/*
+ * Return 1 if 'name' is safe to appear in a function's computed pre: it is
+ * either a formal parameter of the function, a well-known compile-time
+ * constant expression (sizeof / alignof / offsetof), or a known null-pointer
+ * constant (NULL).  Anything else -- locals, globals -- is not visible at the
+ * function's entry from the caller's perspective.
+ */
+static int is_entry_state_var_name(const char *name, char **formals, int n_formals) {
+    static const char *const ct_prefixes[] = {
+        "sizeof", "alignof", "_Alignof", "__alignof", "__alignof__",
+        "__builtin_offsetof", NULL
+    };
+    static const char *const known_constants[] = {"NULL", "null", "true", "false", NULL};
+    size_t nlen;
+    int i;
+
+    if (name == NULL) {
+        return 0;
+    }
+    /* formal parameters */
+    for (i = 0; i < n_formals; i++) {
+        if (formals[i] != NULL && strcmp(name, formals[i]) == 0) {
+            return 1;
+        }
+    }
+    /* known pointer/boolean constants */
+    for (i = 0; known_constants[i] != NULL; i++) {
+        if (strcmp(name, known_constants[i]) == 0) {
+            return 1;
+        }
+    }
+    /* compile-time operators: sizeof(T), alignof(T), etc.
+     * cursor_source joins tokens with spaces, so the name looks like
+     * "sizeof ( int )" -- match the prefix followed by space or '(' */
+    for (i = 0; ct_prefixes[i] != NULL; i++) {
+        nlen = strlen(ct_prefixes[i]);
+        if (strncmp(name, ct_prefixes[i], nlen) == 0 &&
+            (name[nlen] == '\0' || name[nlen] == ' ' || name[nlen] == '(')) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/*
+ * Recursively check that every var-node in the formula tree references only
+ * entry-state names (formals, compile-time constants, known null constants).
+ * Returns 1 if safe, 0 if any var is not in entry state.
+ */
+static int formula_references_only_entry_state(const Formula *f, char **formals, int n_formals) {
+    size_t i;
+
+    if (f == NULL) {
+        return 1;
+    }
+    if (f->kind == FORMULA_ATOMIC) {
+        for (i = 0; i < f->n_args; i++) {
+            /* args are JSON term strings like {"kind":"var","name":"y"} --
+             * we need to check the raw arg blob for a var whose name is not
+             * in entry state.  The only non-const terms are var nodes; const
+             * nodes have "kind":"const" and carry no identifier name that
+             * matters here.  We look for "\"kind\":\"var\"" in the arg blob
+             * and then extract the name field. */
+            const char *arg = f->args[i];
+            const char *var_marker = "\"kind\":\"var\"";
+            const char *name_marker = "\"name\":\"";
+            const char *p;
+            const char *name_start;
+            const char *name_end;
+            char name_buf[256];
+            size_t name_len;
+
+            if (arg == NULL) {
+                continue;
+            }
+            if (strstr(arg, var_marker) == NULL) {
+                /* const node -- skip */
+                continue;
+            }
+            p = strstr(arg, name_marker);
+            if (p == NULL) {
+                /* malformed -- conservatively reject */
+                return 0;
+            }
+            name_start = p + strlen(name_marker);
+            name_end = strchr(name_start, '"');
+            if (name_end == NULL) {
+                return 0;
+            }
+            name_len = (size_t)(name_end - name_start);
+            if (name_len >= sizeof(name_buf)) {
+                name_len = sizeof(name_buf) - 1;
+            }
+            memcpy(name_buf, name_start, name_len);
+            name_buf[name_len] = '\0';
+            if (!is_entry_state_var_name(name_buf, formals, n_formals)) {
+                return 0;
+            }
+        }
+        return 1;
+    }
+    /* AND / OR / NOT: recurse into operands */
+    for (i = 0; i < f->n_operands; i++) {
+        if (!formula_references_only_entry_state(f->operands[i], formals, n_formals)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int emit_non_entry_state_opacity(FunctionContracts *fn) {
+    return pk_c_lift_result_add_opacity_entry(
+        fn->result,
+        "c-assertions.non-entry-state",
+        fn->path == NULL ? "" : fn->path,
+        fn->line,
+        fn->column,
+        "assertion references non-entry-state (local variable); predicate dropped from pre",
+        "c-assertions");
+}
+
 static int function_add_precondition(FunctionContracts *fn, Formula *formula) {
     Formula **next;
     size_t next_cap;
 
     if (formula == NULL) {
+        return 0;
+    }
+    /* Guard: only emit preconditions that reference entry-state names
+     * (formal parameters, compile-time constants, or known null constants).
+     * A formula mentioning a local variable or a callee-internal name would
+     * make the caller's pre too tight -- it constrains state the caller
+     * cannot see or control. */
+    if (!formula_references_only_entry_state(formula, fn->formals, fn->n_formals)) {
+        if (emit_non_entry_state_opacity(fn) != 0) {
+            formula_free(formula);
+            return -1;
+        }
+        formula_free(formula);
         return 0;
     }
     if (fn->n_preconditions == fn->cap_preconditions) {

--- a/implementations/c/provekit-lift-c-assertions/tests/fixtures/assertions_callee_scope.c
+++ b/implementations/c/provekit-lift-c-assertions/tests/fixtures/assertions_callee_scope.c
@@ -1,15 +1,43 @@
-/* Regression fixture: callee-local and function-local state must not leak
- * into a caller's computed pre (over-extraction soundness fix).
+/* Regression / scope fixture: a function's computed pre may reference only
+ * state reachable and controllable at the function's own entry --
+ *   - its formal parameters,
+ *   - file-scope / global symbols (incl. static-at-file-scope),
+ *   - state reachable from those (p->field, p[i], *p, &p->field),
+ *   - compile-time constants (sizeof T, ...) and known null/bool constants.
+ * Anything else -- a variable local to the function, a callee-internal name,
+ * or a name we cannot classify -- is dropped from pre and surfaced as a
+ * c-assertions.non-entry-state opacity entry instead (sound: a dropped clause
+ * becomes honest opacity, never a silently-weakened pre).
  *
- * g has assert(y > 0) on its own formal and also computes local_of_g.
- * f calls g and has its own assert on its formal x.
+ * Note: bare assert(...) is used deliberately (no #include <assert.h>);
+ * the lift harness tolerates the implicit-function-declaration warning.
  *
  * Expected lifter behaviour:
- *   - g emits a function-contract pre referencing g's formal "y".
- *   - f emits a function-contract pre referencing f's formal "x" only.
- *   - "local_of_g" must NOT appear in any function-contract pre.
- *   - h emits no hard contract (local-only assert); opacity emitted instead.
+ *   - g(int y):        assert(y > 0)        -> KEPT  (formal)
+ *                      assert(local_of_g>0) -> DROPPED (g's own local);
+ *                      local_of_g must not appear in g's pre (or f's).
+ *   - f(int x):        assert(x != 0)       -> KEPT  (formal)
+ *   - h(int n):        assert(tmp > 0)      -> DROPPED (local-only) ->
+ *                      h emits no hard contract; opacity emitted instead.
+ *   - uses_global:     assert(file_scope_global > 0) -> KEPT (file-scope global)
+ *   - member_pre:      assert(p->len > 0)   -> KEPT  (p is a formal)
+ *   - index_pre:       assert(arr[0] != 0)  -> KEPT  (arr is a formal)
+ *                      assert(arr[i] >= 0)  -> KEPT  (arr, i both formals)
+ *   - member_index_local:
+ *                      assert(p->arr[local_idx] != 0) -> DROPPED
+ *                      (p is a formal but local_idx is a local); local_idx
+ *                      must not appear in any pre.
+ *   - shadowed_formal: a block-scope local "w" shadows the formal "w"; with no
+ *                      per-locus scope the conservative call is to treat any
+ *                      assert(w ...) as non-entry-state -> DROPPED, no contract.
  */
+
+struct S {
+    int len;
+    int *arr;
+};
+
+static int file_scope_global = 7;
 
 int g(int y)
 {
@@ -30,4 +58,39 @@ int h(int n)
     int tmp = n * 2;
     assert(tmp > 0);
     return tmp;
+}
+
+int uses_global(int v)
+{
+    assert(file_scope_global > 0);
+    return v + file_scope_global;
+}
+
+int member_pre(struct S *p)
+{
+    assert(p->len > 0);
+    return p->len;
+}
+
+int index_pre(int *arr, int i)
+{
+    assert(arr[0] != 0);
+    assert(arr[i] >= 0);
+    return arr[i];
+}
+
+int member_index_local(struct S *p)
+{
+    int local_idx = 1;
+    assert(p->arr[local_idx] != 0);
+    return p->arr[0];
+}
+
+int shadowed_formal(int w)
+{
+    {
+        int w = 0;
+        assert(w >= 0);
+        return w;
+    }
 }

--- a/implementations/c/provekit-lift-c-assertions/tests/fixtures/assertions_callee_scope.c
+++ b/implementations/c/provekit-lift-c-assertions/tests/fixtures/assertions_callee_scope.c
@@ -1,0 +1,33 @@
+/* Regression fixture: callee-local and function-local state must not leak
+ * into a caller's computed pre (over-extraction soundness fix).
+ *
+ * g has assert(y > 0) on its own formal and also computes local_of_g.
+ * f calls g and has its own assert on its formal x.
+ *
+ * Expected lifter behaviour:
+ *   - g emits a function-contract pre referencing g's formal "y".
+ *   - f emits a function-contract pre referencing f's formal "x" only.
+ *   - "local_of_g" must NOT appear in any function-contract pre.
+ *   - h emits no hard contract (local-only assert); opacity emitted instead.
+ */
+
+int g(int y)
+{
+    int local_of_g = y + 1;
+    assert(y > 0);
+    assert(local_of_g > 0);
+    return local_of_g;
+}
+
+int f(int x)
+{
+    assert(x != 0);
+    return g(x);
+}
+
+int h(int n)
+{
+    int tmp = n * 2;
+    assert(tmp > 0);
+    return tmp;
+}

--- a/implementations/c/provekit-lift-c-assertions/tests/integration.sh
+++ b/implementations/c/provekit-lift-c-assertions/tests/integration.sh
@@ -428,4 +428,51 @@ if printf '%s\n' "$SYMLINK_RESPONSE" | grep -q '"kind":"c-assertions.bug-on"'; t
     exit 1
 fi
 
+# Regression: callee-local and function-local state must not leak into a
+# caller's computed pre (over-extraction soundness fix).
+CALLEE_SCOPE_RESPONSES="$(
+    {
+        printf '{"jsonrpc":"2.0","id":200,"method":"lift","params":{"workspace_root":'
+        printf '"%s"' "$SCRIPT_DIR/fixtures"
+        printf ',"source_paths":["assertions_callee_scope.c"],"surface":"c-assertions"}}\n'
+    } | "$BIN" --rpc
+)"
+
+# g's formal "y" must appear in g's contract
+printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"g"' || {
+    echo "FAIL: callee_scope: g should emit a function-contract" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+}
+
+# f's formal "x" must appear in f's contract (f has assert(x != 0))
+printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"f"' || {
+    echo "FAIL: callee_scope: f should emit a function-contract for its own formal" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+}
+
+# "local_of_g" must NOT appear anywhere in f's contract (or at all in the output
+# except possibly in a non-entry-state opacity entry)
+if printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep '"fn_name":"f"' | grep -q '"local_of_g"'; then
+    echo "FAIL: callee_scope: local_of_g must not appear in f's pre" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+fi
+
+# h's only assert references a local "tmp" -- no function-contract should be emitted
+if printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"h"'; then
+    echo "FAIL: callee_scope: h should not emit a function-contract (local-only assert)" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+fi
+
+# A non-entry-state opacity entry should appear (for h's dropped predicate,
+# and possibly for g's local_of_g predicate)
+printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"kind":"c-assertions.non-entry-state"' || {
+    echo "FAIL: callee_scope: expected non-entry-state opacity for dropped local predicate" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+}
+
 printf 'provekit-lift-c-assertions integration passed\n'

--- a/implementations/c/provekit-lift-c-assertions/tests/integration.sh
+++ b/implementations/c/provekit-lift-c-assertions/tests/integration.sh
@@ -428,8 +428,10 @@ if printf '%s\n' "$SYMLINK_RESPONSE" | grep -q '"kind":"c-assertions.bug-on"'; t
     exit 1
 fi
 
-# Regression: callee-local and function-local state must not leak into a
-# caller's computed pre (over-extraction soundness fix).
+# Scope classification: a function's computed pre may reference only state
+# reachable/controllable at the function's own entry -- formals, file-scope
+# globals, state reachable from those (p->field, p[i]) -- and never a variable
+# local to the function or a callee-internal name.
 CALLEE_SCOPE_RESPONSES="$(
     {
         printf '{"jsonrpc":"2.0","id":200,"method":"lift","params":{"workspace_root":'
@@ -452,10 +454,10 @@ printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"f"' || {
     exit 1
 }
 
-# "local_of_g" must NOT appear anywhere in f's contract (or at all in the output
-# except possibly in a non-entry-state opacity entry)
-if printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep '"fn_name":"f"' | grep -q '"local_of_g"'; then
-    echo "FAIL: callee_scope: local_of_g must not appear in f's pre" >&2
+# g's own local "local_of_g" must NOT appear anywhere in the output (neither in
+# g's pre, f's pre, nor any contract) -- only in a non-entry-state opacity entry.
+if printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"local_of_g"'; then
+    echo "FAIL: callee_scope: local_of_g (g's own local) must not appear in any pre" >&2
     echo "$CALLEE_SCOPE_RESPONSES" >&2
     exit 1
 fi
@@ -467,8 +469,60 @@ if printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"h"'; then
     exit 1
 fi
 
-# A non-entry-state opacity entry should appear (for h's dropped predicate,
-# and possibly for g's local_of_g predicate)
+# A file-scope global IS part of a function's entry state: assert(file_scope_global > 0)
+# in uses_global should be kept as a real pre clause referencing the global.
+printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"uses_global"' &&
+    printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"file_scope_global"' || {
+    echo "FAIL: callee_scope: uses_global should keep assert(file_scope_global > 0) as a pre" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+}
+
+# Param-reachable memory is part of entry state: assert(p->len > 0) where p is a
+# formal should be kept as a real pre clause referencing "p -> len".
+printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"member_pre"' &&
+    printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"name":"p -> len"' || {
+    echo "FAIL: callee_scope: member_pre should keep assert(p->len > 0) as a pre" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+}
+
+# Indexing through a formal array is entry state: assert(arr[0] != 0) and
+# assert(arr[i] >= 0) where arr, i are formals should be kept.
+printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"index_pre"' &&
+    printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"name":"arr \[ 0 \]"' &&
+    printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"name":"arr \[ i \]"' || {
+    echo "FAIL: callee_scope: index_pre should keep assert(arr[0] != 0) and assert(arr[i] >= 0) as pre clauses" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+}
+
+# Multi-var case: assert(p->arr[local_idx] != 0) where p is a formal but
+# local_idx is a function-local -> the whole clause is dropped (the var that the
+# old strstr-once missed). member_index_local emits no contract; local_idx
+# never appears in any pre.
+if printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"member_index_local"'; then
+    echo "FAIL: callee_scope: member_index_local should not emit a contract (assert mixes a formal with a local index)" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+fi
+if printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"local_idx"'; then
+    echo "FAIL: callee_scope: local_idx (a function-local) must not appear in any pre" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+fi
+
+# Shadowing: a block-scope local "w" shadows the formal "w".  With no per-locus
+# scope, a name declared local to the function anywhere is treated as
+# non-entry-state -> shadowed_formal emits no contract.
+if printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"fn_name":"shadowed_formal"'; then
+    echo "FAIL: callee_scope: shadowed_formal should not emit a contract (local shadows the formal)" >&2
+    echo "$CALLEE_SCOPE_RESPONSES" >&2
+    exit 1
+fi
+
+# A non-entry-state opacity entry should appear for each dropped local predicate
+# (g's local_of_g, h's tmp, member_index_local's mixed clause).
 printf '%s\n' "$CALLEE_SCOPE_RESPONSES" | grep -q '"kind":"c-assertions.non-entry-state"' || {
     echo "FAIL: callee_scope: expected non-entry-state opacity for dropped local predicate" >&2
     echo "$CALLEE_SCOPE_RESPONSES" >&2


### PR DESCRIPTION
## Summary

The C-assertions lifter was unsound: `function_add_precondition` accepted any formula without checking whether its var-nodes were visible at the function's entry point. An `assert(local_var > 0)` where `local_var` is a C local (computed after function entry) would produce a pre mentioning that local, making the caller's precondition too tight -- it constrains state the caller cannot see or control.

**Root cause (scenario a):** `scan_function_source` scans the entire text of a function's body. `term_json_from_slice` treats any non-integer token as a `{"kind":"var","name":"..."}` regardless of whether that name is a formal, a local, or a callee-internal. No scope check existed. For example, `int f(int x) { int y = x*2; assert(y > 0); ... }` would produce `f`'s pre as `y > 0`, but `y` is not visible at `f`'s call site.

**Note on callee-body leakage:** The callee→caller leak described in the bug report (g's locals appearing in f's pre) does NOT occur under the current clang-AST path because `cursor_source` tokenizes each `FunctionDecl`'s own extent. The regression test guards this invariant against future visitor changes.

## Fix

Added an entry-state scope gate in `function_add_precondition` (`src/assertions.c`):

1. `is_entry_state_var_name`: returns true if a var name is a formal parameter, a compile-time constant operator (`sizeof`, `alignof`, `__builtin_offsetof`), or a known null constant (`NULL`/`null`/`true`/`false`).
2. `formula_references_only_entry_state`: recursively walks the formula tree, checking every `FORMULA_ATOMIC` var-node arg.
3. If the formula fails the check, it is freed and a `c-assertions.non-entry-state` opacity entry is emitted (auditable, consistent with the existing `WARN_ON` pattern). No contract is emitted if ALL predicates are dropped.

Special care was taken to preserve existing behavior:
- `BUILD_BUG_ON(sizeof(int) < 4)`: the cursor-source tokenizer emits `"sizeof ( int )"`, which passes the prefix check.
- `BUG_ON(x == NULL)`: formal `x` + known constant `NULL` both pass.
- `if (!buf) return -ENOMEM` and `if (ret < 0) return ret`: formal names pass.

## Regression test

New fixture: `tests/fixtures/assertions_callee_scope.c`
- `g(y)`: `assert(y>0)` [formal, kept] + `assert(local_of_g>0)` [local, dropped with opacity]
- `f(x)`: `assert(x!=0)` [formal, kept], calls `g(x)`
- `h(n)`: `assert(tmp>0)` [local only] -- no contract emitted, opacity emitted

Integration assertions in `tests/integration.sh` verify:
- `g` emits a function-contract (formal `y` in pre)
- `f` emits a function-contract (formal `x` in pre only)
- `"local_of_g"` does NOT appear in any function-contract
- `h` emits no function-contract (local-only assert)
- A `c-assertions.non-entry-state` opacity entry is present

## Witness regen status

**No CICP witness regeneration performed.** The existing accepted witnesses cover `assertions_basic.c`, `assertions_kernel.c`, and `assertions_refusal.c` -- none of these trigger the over-extraction bug (all asserts reference formals, `sizeof`, or `NULL`). Adding `assertions_callee_scope.c` changes the directory blast-radius CID; CI will compute fresh witnesses for the updated corpus on next run.

## Verification

```
make -C implementations/c/provekit-lift-c-assertions test
# provekit-lift-c-assertions integration passed
```

All 3 existing fixtures + new regression fixture pass. `bug-zoo` smoke does not exercise `provekit-lift-c-assertions` directly (it uses `provekit-lift-c-kernel-doc`); skipped per task guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)