### PR TITLE
fix(lift-go): typed operand sorts in go-language-signature op specs

### DIFF
--- a/menagerie/go-language-signature/specs/go_language_signature.spec.json
+++ b/menagerie/go-language-signature/specs/go_language_signature.spec.json
@@ -76,11 +76,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -89,11 +89,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -102,11 +102,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -115,11 +115,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -128,11 +128,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -141,11 +141,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -154,11 +154,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -167,11 +167,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -180,11 +180,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -193,11 +193,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -206,11 +206,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -256,11 +256,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -269,11 +269,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -282,11 +282,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -295,11 +295,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -308,11 +308,11 @@
       "slots": [
         {
           "name": "lhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         },
         {
           "name": "rhs",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -321,7 +321,7 @@
       "slots": [
         {
           "name": "value",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },
@@ -330,7 +330,7 @@
       "slots": [
         {
           "name": "value",
-          "slot_sort": "Term"
+          "slot_sort": "Int"
         }
       ]
     },

--- a/menagerie/go-language-signature/specs/op_add.spec.json
+++ b/menagerie/go-language-signature/specs/op_add.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:add",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
-    "wp": "integer/floating/string addition or concatenation as typed by Go",
+    "result": "Int",
+    "wp": "integer addition",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_bitand.spec.json
+++ b/menagerie/go-language-signature/specs/op_bitand.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:bitand",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
+    "result": "Int",
     "wp": "bitwise and",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_bitnot.spec.json
+++ b/menagerie/go-language-signature/specs/op_bitnot.spec.json
@@ -7,13 +7,13 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -25,16 +25,15 @@
     "kind": "operation-contract",
     "operator": "go:bitnot",
     "arity": [
-      "Term"
+      "Int"
     ],
-    "result": "Term",
+    "result": "Int",
     "wp": "bitwise complement",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "value",
-          "slot_sort": "Term"
+          "name": "value"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_bitor.spec.json
+++ b/menagerie/go-language-signature/specs/op_bitor.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:bitor",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
+    "result": "Int",
     "wp": "bitwise or",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_bitxor.spec.json
+++ b/menagerie/go-language-signature/specs/op_bitxor.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:bitxor",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
+    "result": "Int",
     "wp": "bitwise xor",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_div.spec.json
+++ b/menagerie/go-language-signature/specs/op_div.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:div",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
-    "wp": "division",
+    "result": "Int",
+    "wp": "integer division",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_eq.spec.json
+++ b/menagerie/go-language-signature/specs/op_eq.spec.json
@@ -8,12 +8,12 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:eq",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
     "result": "Bool",
-    "wp": "Go equality comparison",
+    "wp": "integer equality comparison",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_ge.spec.json
+++ b/menagerie/go-language-signature/specs/op_ge.spec.json
@@ -8,12 +8,12 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:ge",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
     "result": "Bool",
-    "wp": "greater-than-or-equal comparison",
+    "wp": "integer greater-than-or-equal comparison",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_gt.spec.json
+++ b/menagerie/go-language-signature/specs/op_gt.spec.json
@@ -8,12 +8,12 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:gt",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
     "result": "Bool",
-    "wp": "greater-than comparison",
+    "wp": "integer greater-than comparison",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_le.spec.json
+++ b/menagerie/go-language-signature/specs/op_le.spec.json
@@ -8,12 +8,12 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:le",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
     "result": "Bool",
-    "wp": "less-than-or-equal comparison",
+    "wp": "integer less-than-or-equal comparison",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_lt.spec.json
+++ b/menagerie/go-language-signature/specs/op_lt.spec.json
@@ -8,12 +8,12 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:lt",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
     "result": "Bool",
-    "wp": "less-than comparison",
+    "wp": "integer less-than comparison",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_mod.spec.json
+++ b/menagerie/go-language-signature/specs/op_mod.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:mod",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
-    "wp": "remainder",
+    "result": "Int",
+    "wp": "integer remainder",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_mul.spec.json
+++ b/menagerie/go-language-signature/specs/op_mul.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:mul",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
-    "wp": "multiplication",
+    "result": "Int",
+    "wp": "integer multiplication",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_ne.spec.json
+++ b/menagerie/go-language-signature/specs/op_ne.spec.json
@@ -8,12 +8,12 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:ne",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
     "result": "Bool",
-    "wp": "Go inequality comparison",
+    "wp": "integer inequality comparison",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_neg.spec.json
+++ b/menagerie/go-language-signature/specs/op_neg.spec.json
@@ -7,13 +7,13 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -25,16 +25,15 @@
     "kind": "operation-contract",
     "operator": "go:neg",
     "arity": [
-      "Term"
+      "Int"
     ],
-    "result": "Term",
-    "wp": "numeric negation",
+    "result": "Int",
+    "wp": "integer arithmetic negation",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "value",
-          "slot_sort": "Term"
+          "name": "value"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_shl.spec.json
+++ b/menagerie/go-language-signature/specs/op_shl.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:shl",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
-    "wp": "left shift",
+    "result": "Int",
+    "wp": "integer left shift",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_shr.spec.json
+++ b/menagerie/go-language-signature/specs/op_shr.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:shr",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
-    "wp": "right shift",
+    "result": "Int",
+    "wp": "integer right shift",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }

--- a/menagerie/go-language-signature/specs/op_sub.spec.json
+++ b/menagerie/go-language-signature/specs/op_sub.spec.json
@@ -8,18 +8,18 @@
   "formal_sorts": [
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     },
     {
       "kind": "ctor",
-      "name": "Term",
+      "name": "Int",
       "args": []
     }
   ],
   "return_sort": {
     "kind": "ctor",
-    "name": "Term",
+    "name": "Int",
     "args": []
   },
   "pre": {
@@ -31,21 +31,19 @@
     "kind": "operation-contract",
     "operator": "go:sub",
     "arity": [
-      "Term",
-      "Term"
+      "Int",
+      "Int"
     ],
-    "result": "Term",
-    "wp": "subtraction",
+    "result": "Int",
+    "wp": "integer subtraction",
     "arity_shape": {
       "kind": "named",
       "slots": [
         {
-          "name": "lhs",
-          "slot_sort": "Term"
+          "name": "lhs"
         },
         {
-          "name": "rhs",
-          "slot_sort": "Term"
+          "name": "rhs"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- **The problem**: Every op spec in `menagerie/go-language-signature/specs/` declared catch-all `{"kind":"ctor","name":"Term","args":[]}` for `formal_sorts`/`return_sort`/`arity`/`result`. The cross-language transport refinement check requires a language's op specs to *refine* the concept hub op — `go:add` needs `[Int,Int]→Int` to match `concept:add`, not `[Term,Term]→Term`. Result was "formal sort mismatch: got `[Term,Term]` want `[Int,Int]`" on every arithmetic/comparison/bitwise op.

- **The fix**: Updated 18 op spec files in `menagerie/go-language-signature/specs/` to use typed sorts matching the C11 convention exactly (`{"kind":"ctor","name":"Int","args":[]}`, `{"kind":"ctor","name":"Bool","args":[]}`). Also updated `arity_shapes` in `go_language_signature.spec.json` to match. No Go lifter source code was changed — the lifter already wires `go/types` (`types.Config{}.Check` + `types.Info{Types}`); the issue was only in the static spec files.

- **What got typed (18 ops)**:
  - Arithmetic binary `Int→Int→Int`: `add`, `sub`, `mul`, `div`, `mod`
  - Bitwise binary `Int→Int→Int`: `bitand`, `bitor`, `bitxor`, `shl`, `shr`
  - Unary numeric `Int→Int`: `neg`, `bitnot`
  - Comparison `Int→Int→Bool`: `eq`, `ne`, `lt`, `le`, `gt`, `ge`
  - (`and`/`or`/`not` were already typed `Bool` in prior work — left as-is)

- **Left as Term** (genuine transport gaps — polymorphic, control-flow, or address ops): `assign`, `decl`, `seq`, `skip`, `call`, `index`, `member`, `deref`, `addr`, `incdec`, `if`, `for`, `range`, `return`, `source_unit`

- **go-language-signature CID**: will regenerate when the signature is minted (no catalog exists yet for the go sig — nothing pinned, expected consequence of discovery-phase edit)

- **Verification**: `make test-go` — all pass: `provekit-ir-symbolic`, `provekit-self-contracts`, `provekit-lift-go-tests`, `provekit-lift-go`

## Test plan

- [x] `make test-go` passes (all 4 Go packages)
- [x] No `"Term"` remaining in any of the 18 updated op spec `formal_sorts`/`return_sort`/`arity`/`result` fields
- [x] `go_language_signature.spec.json` `arity_shapes` updated to match
- [x] C11 convention followed: no `slot_sort` in `arity_shape.slots` for homogeneous Int/Bool ops
- [x] No other language specs, lifter source, CI pins, or self-contracts touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)