### PR TITLE
fix(driver): emit run-dir-relative paths in cross-language-port artifacts for byte-stability

### DIFF
--- a/menagerie/cross-language-port/artifacts/classify/csharp/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/classify/csharp/transport-report.json
@@ -2,7 +2,7 @@
   "function": "classify",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-morphism-for-op operation `c11:and` has no discharged morphism into the concept hub",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/classify.c",
+  "source_file": "menagerie/cross-language-port/classify.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "csharp"

--- a/menagerie/cross-language-port/artifacts/classify/go/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/classify/go/transport-report.json
@@ -2,7 +2,7 @@
   "function": "classify",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-morphism-for-op operation `c11:and` has no discharged morphism into the concept hub",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/classify.c",
+  "source_file": "menagerie/cross-language-port/classify.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "go"

--- a/menagerie/cross-language-port/artifacts/classify/java/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/classify/java/transport-report.json
@@ -2,7 +2,7 @@
   "function": "classify",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-morphism-for-op operation `c11:and` has no discharged morphism into the concept hub",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/classify.c",
+  "source_file": "menagerie/cross-language-port/classify.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "java"

--- a/menagerie/cross-language-port/artifacts/classify/php/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/classify/php/transport-report.json
@@ -2,7 +2,7 @@
   "function": "classify",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-morphism-for-op operation `c11:and` has no discharged morphism into the concept hub",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/classify.c",
+  "source_file": "menagerie/cross-language-port/classify.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "php"

--- a/menagerie/cross-language-port/artifacts/classify/python/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/classify/python/transport-report.json
@@ -2,7 +2,7 @@
   "function": "classify",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-morphism-for-op operation `c11:and` has no discharged morphism into the concept hub",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/classify.c",
+  "source_file": "menagerie/cross-language-port/classify.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "python"

--- a/menagerie/cross-language-port/artifacts/classify/ruby/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/classify/ruby/transport-report.json
@@ -2,7 +2,7 @@
   "function": "classify",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-morphism-for-op operation `c11:and` has no discharged morphism into the concept hub",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/classify.c",
+  "source_file": "menagerie/cross-language-port/classify.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "ruby"

--- a/menagerie/cross-language-port/artifacts/classify/rust/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/classify/rust/transport-report.json
@@ -2,7 +2,7 @@
   "function": "classify",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-morphism-for-op operation `c11:and` has no discharged morphism into the concept hub",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/classify.c",
+  "source_file": "menagerie/cross-language-port/classify.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "rust"

--- a/menagerie/cross-language-port/artifacts/classify/typescript/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/classify/typescript/transport-report.json
@@ -2,7 +2,7 @@
   "function": "classify",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-morphism-for-op operation `c11:and` has no discharged morphism into the concept hub",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/classify.c",
+  "source_file": "menagerie/cross-language-port/classify.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "typescript"

--- a/menagerie/cross-language-port/artifacts/classify/zig/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/classify/zig/transport-report.json
@@ -2,7 +2,7 @@
   "function": "classify",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-morphism-for-op operation `c11:and` has no discharged morphism into the concept hub",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/classify.c",
+  "source_file": "menagerie/cross-language-port/classify.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "zig"

--- a/menagerie/cross-language-port/artifacts/foo/csharp/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/foo/csharp/transport-report.json
@@ -2,7 +2,7 @@
   "function": "foo",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:return`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/foo.c",
+  "source_file": "menagerie/cross-language-port/foo.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "csharp"

--- a/menagerie/cross-language-port/artifacts/foo/go/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/foo/go/transport-report.json
@@ -2,7 +2,7 @@
   "function": "foo",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:seq`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/foo.c",
+  "source_file": "menagerie/cross-language-port/foo.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "go"

--- a/menagerie/cross-language-port/artifacts/foo/java/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/foo/java/transport-report.json
@@ -2,7 +2,7 @@
   "function": "foo",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:conditional`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/foo.c",
+  "source_file": "menagerie/cross-language-port/foo.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "java"

--- a/menagerie/cross-language-port/artifacts/foo/php/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/foo/php/transport-report.json
@@ -2,7 +2,7 @@
   "function": "foo",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:conditional`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/foo.c",
+  "source_file": "menagerie/cross-language-port/foo.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "php"

--- a/menagerie/cross-language-port/artifacts/foo/python/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/foo/python/transport-report.json
@@ -2,7 +2,7 @@
   "function": "foo",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:eq`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/foo.c",
+  "source_file": "menagerie/cross-language-port/foo.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "python"

--- a/menagerie/cross-language-port/artifacts/foo/ruby/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/foo/ruby/transport-report.json
@@ -2,7 +2,7 @@
   "function": "foo",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:eq`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/foo.c",
+  "source_file": "menagerie/cross-language-port/foo.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "ruby"

--- a/menagerie/cross-language-port/artifacts/foo/rust/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/foo/rust/transport-report.json
@@ -1,49 +1,19 @@
 {
-  "status": "transported",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/foo.c",
-  "source_language": "c11",
-  "target_language": "rust",
-  "function": "foo",
   "artifacts": {
-    "concept_term": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/artifacts/foo/rust/concept.term.json",
-    "roundtrip_concept_term": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/artifacts/foo/rust/roundtrip.concept.term.json",
-    "rust_source": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/artifacts/foo/rust/foo.rs",
-    "rust_term": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/artifacts/foo/rust/rust.term.json",
-    "source_term": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/artifacts/foo/rust/c11.term.json",
-    "target_source": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/artifacts/foo/rust/foo.rs",
-    "target_term": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/artifacts/foo/rust/rust.term.json"
+    "concept_term": "menagerie/cross-language-port/artifacts/foo/rust/concept.term.json",
+    "roundtrip_concept_term": "menagerie/cross-language-port/artifacts/foo/rust/roundtrip.concept.term.json",
+    "rust_source": "menagerie/cross-language-port/artifacts/foo/rust/foo.rs",
+    "rust_term": "menagerie/cross-language-port/artifacts/foo/rust/rust.term.json",
+    "source_term": "menagerie/cross-language-port/artifacts/foo/rust/c11.term.json",
+    "target_source": "menagerie/cross-language-port/artifacts/foo/rust/foo.rs",
+    "target_term": "menagerie/cross-language-port/artifacts/foo/rust/rust.term.json"
   },
-  "stages": [
-    {
-      "stage": "lift",
-      "status": "ok",
-      "detail": "c11 source projected to algebra term"
-    },
-    {
-      "stage": "desugar",
-      "status": "checked",
-      "detail": "2 discharged desugaring equations are available; C11/projected Term transport did not require an IrTerm rewrite"
-    },
-    {
-      "stage": "transport-to-concept",
-      "status": "ok",
-      "detail": "c11 operations transported through discharged morphisms"
-    },
-    {
-      "stage": "transport-to-target",
-      "status": "ok",
-      "detail": "concept operations transported to rust"
-    },
-    {
-      "stage": "realize",
-      "status": "ok",
-      "detail": "emitted core-form rust source"
-    }
+  "deferred": [
+    "bytecode and asm transport through conditional-jump recovery",
+    "cosmetic re-sugaring after the core-form realizer",
+    "source lifter subprocess wiring for every non-C language in this CLI path"
   ],
-  "normalizations": [
-    "normalized c11:bop_eq to core c11:eq",
-    "folded c11:uop_neg(integer-literal) into a signed integer constant"
-  ],
+  "function": "foo",
   "morphism_receipts": [
     "morphism_c11_add_to_add=blake3-512:1546458bf93fd30d66d8cd187d400db747e8ea579824ae2853968f19db078996cc198aebc4e2106fc107253f85daed4c11dcd04c2520521a4b41b3a93a598983",
     "morphism_c11_addr_of_to_addr=blake3-512:b6548be43be33755624cff6c15230445a9251a3d3b569d978f22caf6eb8f410753653f4d50f4b43be4a5c31442fa5bf88daa04eaa58891b010ecb478d3de2290",
@@ -95,9 +65,39 @@
     "morphism_rust_skip_to_skip=blake3-512:1dd361e3f636b7ec5949a9eba487760c614bcf245f93af48bd8ded323759d9aeaf9ecce2ffebedd5ede1c2d92bef7bf18c622108b96452aea646e5aacea9e40a",
     "morphism_rust_while_to_while=blake3-512:c70edb47d70f785863aef6c97fbfae6ca600e878d128446d2573ee37deaac44400f7cd74e9fcb4aa8a2a55ac9130f4977083bef965780ad81546103b0ddacc90"
   ],
-  "deferred": [
-    "bytecode and asm transport through conditional-jump recovery",
-    "cosmetic re-sugaring after the core-form realizer",
-    "source lifter subprocess wiring for every non-C language in this CLI path"
-  ]
+  "normalizations": [
+    "normalized c11:bop_eq to core c11:eq",
+    "folded c11:uop_neg(integer-literal) into a signed integer constant"
+  ],
+  "source_file": "menagerie/cross-language-port/foo.c",
+  "source_language": "c11",
+  "stages": [
+    {
+      "detail": "c11 source projected to algebra term",
+      "stage": "lift",
+      "status": "ok"
+    },
+    {
+      "detail": "2 discharged desugaring equations are available; C11/projected Term transport did not require an IrTerm rewrite",
+      "stage": "desugar",
+      "status": "checked"
+    },
+    {
+      "detail": "c11 operations transported through discharged morphisms",
+      "stage": "transport-to-concept",
+      "status": "ok"
+    },
+    {
+      "detail": "concept operations transported to rust",
+      "stage": "transport-to-target",
+      "status": "ok"
+    },
+    {
+      "detail": "emitted core-form rust source",
+      "stage": "realize",
+      "status": "ok"
+    }
+  ],
+  "status": "transported",
+  "target_language": "rust"
 }

--- a/menagerie/cross-language-port/artifacts/foo/typescript/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/foo/typescript/transport-report.json
@@ -2,7 +2,7 @@
   "function": "foo",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:seq`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/foo.c",
+  "source_file": "menagerie/cross-language-port/foo.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "typescript"

--- a/menagerie/cross-language-port/artifacts/foo/zig/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/foo/zig/transport-report.json
@@ -2,7 +2,7 @@
   "function": "foo",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op operation `concept:return` CID mismatch: expected blake3-512:408a99b65b634b0425cb1a516151367b39ede0edd92a909dc239372fbd36e37023c45384447fe716e89396ac9828887bde8ce278ffa9a4f95ccacf28689ef6db, got blake3-512:57981a2c7d25fd2afe840d6d30e503b6c04b98e5c909457dee1083f852fa746e0addb62c00b0d39e951193ce2a1fe75e36f7728625d53224f3a9adee3b690607",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/foo.c",
+  "source_file": "menagerie/cross-language-port/foo.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "zig"

--- a/menagerie/cross-language-port/artifacts/sum_to/csharp/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/sum_to/csharp/transport-report.json
@@ -2,7 +2,7 @@
   "function": "sum_to",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:decl`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/sum_to.c",
+  "source_file": "menagerie/cross-language-port/sum_to.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "csharp"

--- a/menagerie/cross-language-port/artifacts/sum_to/go/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/sum_to/go/transport-report.json
@@ -2,7 +2,7 @@
   "function": "sum_to",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:seq`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/sum_to.c",
+  "source_file": "menagerie/cross-language-port/sum_to.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "go"

--- a/menagerie/cross-language-port/artifacts/sum_to/java/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/sum_to/java/transport-report.json
@@ -2,7 +2,7 @@
   "function": "sum_to",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:assign`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/sum_to.c",
+  "source_file": "menagerie/cross-language-port/sum_to.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "java"

--- a/menagerie/cross-language-port/artifacts/sum_to/php/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/sum_to/php/transport-report.json
@@ -2,7 +2,7 @@
   "function": "sum_to",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:decl`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/sum_to.c",
+  "source_file": "menagerie/cross-language-port/sum_to.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "php"

--- a/menagerie/cross-language-port/artifacts/sum_to/python/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/sum_to/python/transport-report.json
@@ -2,7 +2,7 @@
   "function": "sum_to",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:decl`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/sum_to.c",
+  "source_file": "menagerie/cross-language-port/sum_to.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "python"

--- a/menagerie/cross-language-port/artifacts/sum_to/ruby/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/sum_to/ruby/transport-report.json
@@ -2,7 +2,7 @@
   "function": "sum_to",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:decl`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/sum_to.c",
+  "source_file": "menagerie/cross-language-port/sum_to.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "ruby"

--- a/menagerie/cross-language-port/artifacts/sum_to/rust/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/sum_to/rust/transport-report.json
@@ -2,7 +2,7 @@
   "function": "sum_to",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:decl`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/sum_to.c",
+  "source_file": "menagerie/cross-language-port/sum_to.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "rust"

--- a/menagerie/cross-language-port/artifacts/sum_to/typescript/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/sum_to/typescript/transport-report.json
@@ -2,7 +2,7 @@
   "function": "sum_to",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op missing discharged morphism for operation `concept:seq`",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/sum_to.c",
+  "source_file": "menagerie/cross-language-port/sum_to.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "typescript"

--- a/menagerie/cross-language-port/artifacts/sum_to/zig/transport-report.json
+++ b/menagerie/cross-language-port/artifacts/sum_to/zig/transport-report.json
@@ -2,7 +2,7 @@
   "function": "sum_to",
   "note": "Precise extension request: the concept hub catalog has no discharged morphism covering the refused operation for this target language; see transport-gaps.md for the structural reason.",
   "refusal": "refusal: transport-time:no-target-morphism-for-op operation `concept:return` CID mismatch: expected blake3-512:408a99b65b634b0425cb1a516151367b39ede0edd92a909dc239372fbd36e37023c45384447fe716e89396ac9828887bde8ce278ffa9a4f95ccacf28689ef6db, got blake3-512:57981a2c7d25fd2afe840d6d30e503b6c04b98e5c909457dee1083f852fa746e0addb62c00b0d39e951193ce2a1fe75e36f7728625d53224f3a9adee3b690607",
-  "source_file": "/Users/tsavo/provekit-worktrees/pk-java-typed-sorts/menagerie/cross-language-port/sum_to.c",
+  "source_file": "menagerie/cross-language-port/sum_to.c",
   "source_language": "c11",
   "status": "refusal",
   "target_language": "zig"

--- a/menagerie/cross-language-port/driver.sh
+++ b/menagerie/cross-language-port/driver.sh
@@ -45,11 +45,30 @@ report = {
 }
 json.dump(report, open(sys.argv[5], 'w', encoding='utf-8'), indent=2, sort_keys=True)
 open(sys.argv[5], 'a', encoding='utf-8').write('\n')
-" "$refusal_msg" "$src" "$target" "$fn" "$dir/transport-report.json"
+" "$refusal_msg" "menagerie/cross-language-port/$fn.c" "$target" "$fn" "$dir/transport-report.json"
       printf '%s -> %s: refusal recorded (%s)\n' "$fn" "$target" "$refusal_msg"
       continue
     fi
     rm -f "$refusal_tmp"
+    python3 - "$dir/transport-report.json" "$ROOT" <<'RELATIVIZE_PY'
+import json, sys
+from pathlib import Path
+report_path = Path(sys.argv[1])
+root = Path(sys.argv[2]).resolve()
+report = json.load(open(report_path, encoding='utf-8'))
+def rel(value):
+    try:
+        p = Path(value).resolve()
+        return str(p.relative_to(root))
+    except (ValueError, TypeError):
+        return value
+if 'source_file' in report:
+    report['source_file'] = rel(report['source_file'])
+if 'artifacts' in report and isinstance(report['artifacts'], dict):
+    report['artifacts'] = {k: rel(v) for k, v in sorted(report['artifacts'].items())}
+json.dump(report, open(report_path, 'w', encoding='utf-8'), indent=2, sort_keys=True)
+open(report_path, 'a', encoding='utf-8').write('\n')
+RELATIVIZE_PY
     cmp "$dir/concept.term.json" "$dir/roundtrip.concept.term.json"
     test -s "$dir/$fn.$ext"
     printf '%s -> %s: roundtrip concept artifact ok\n' "$fn" "$target"


### PR DESCRIPTION
## Summary

- `provekit transport` CLI uses `fs::canonicalize()` on the source file and emits absolute `out_dir` paths into `transport-report.json` -- driver had no control over this.
- Refusal path in driver was passing `$src` (absolute) as `source_file` to inline Python.
- Fix: post-process each successful `transport-report.json` with a Python heredoc that relativizes `source_file` and all `artifacts.*` values against the repo root (`menagerie/cross-language-port/...` prefix). Refusal path now supplies a repo-root-relative literal.

## Two-run byte-identical proof

Run from `pk-64/` vs `pk-64/implementations/`: `diff -ruN` between snapshots produced empty output. The only bytes that differ across CWDs are in `refusal` message text (the CLI's own error string when it can't locate the repo root from outside the tree) -- never in path fields.

## Test plan

- [x] `bash menagerie/cross-language-port/driver.sh` from repo root: 27 refusals recorded + `foo -> rust` roundtrip ok
- [x] Run from `implementations/` subdir: byte-identical artifacts (`diff -ruN` empty)
- [x] `source_file` in `foo/rust/transport-report.json`: `menagerie/cross-language-port/foo.c` (repo-root-relative)
- [x] `artifacts.*` values: all `menagerie/cross-language-port/artifacts/foo/rust/...`
- [x] Refusal `source_file`: `menagerie/cross-language-port/foo.c`
- [x] `bash menagerie/concept-shapes/mint.sh`: clean (3 tests OK, no new dirtied files from this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)