### PR TITLE
fix(test): apply empty-set CID skip guard to rust+cpp pinned mint_kit_integration tests

### DIFF
--- a/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
+++ b/implementations/rust/provekit-cli/tests/mint_kit_integration.rs
@@ -536,7 +536,7 @@ fn kits_with_real_contracts_produce_nonempty_contract_set() {
         let lang = if *kit == "ts" { "ts" } else { kit };
         let attest = read_attestation(root, lang);
         let cset = attest["contractSetCid"].as_str().unwrap();
-        if *kit == "zig" && cset == EMPTY_SET_CID {
+        if cset == EMPTY_SET_CID {
             panic_if_empty_set_cid_in_ci(kit);
             eprintln!(
                 "kit `{kit}`: lifter binary not built locally; skipping aggregate non-empty assertion"
@@ -827,6 +827,15 @@ fn rust_kit_contract_set_cid_is_pinned_to_self_contracts_canonical() {
         .as_str()
         .expect("contractSetCid must be string");
 
+    // Skip the pinning assertion if the lifter binary isn't built: when
+    // the dispatcher hits ENOENT on spawn it returns ok=true with the
+    // empty-set CID. Panic in CI (missing binary there is a CI config bug).
+    if cset == EMPTY_SET_CID {
+        panic_if_empty_set_cid_in_ci("rust");
+        eprintln!("rust kit: mint-self-contracts binary not built locally -- skipping pinning assertion");
+        return;
+    }
+
     // Pinned value: must match the canonical self-contracts CID.
     assert_eq!(
         cset, RUST_KIT_FULL_SELF_CONTRACT_SURFACE_CID,
@@ -953,6 +962,15 @@ fn cpp_kit_contract_set_cid_is_pinned_to_self_contracts_canonical() {
     let cset = attest["contractSetCid"]
         .as_str()
         .expect("contractSetCid must be string");
+
+    // Skip the pinning assertion if the lifter binary isn't built: when
+    // the dispatcher hits ENOENT on spawn it returns ok=true with the
+    // empty-set CID. Panic in CI (missing binary there is a CI config bug).
+    if cset == EMPTY_SET_CID {
+        panic_if_empty_set_cid_in_ci("cpp");
+        eprintln!("cpp kit: mint_cpp_self_contracts binary not built locally -- skipping pinning assertion");
+        return;
+    }
 
     // Pinned value: must match the canonical self-contracts CID.
     assert_eq!(
@@ -1208,8 +1226,9 @@ fn c_kit_pins_expected_contract_set_cid() {
 
     // Skip the pinning assertion if the lifter binary isn't built: when
     // the dispatcher hits ENOENT on spawn it returns ok=true with the
-    // empty-set CID. Mirrors the cpp/swift skip pattern.
+    // empty-set CID. Panic in CI (missing binary there is a CI config bug).
     if cset == EMPTY_SET_CID {
+        panic_if_empty_set_cid_in_ci("c");
         eprintln!("c kit: lifter binary not built -- skipping pinning assertion");
         return;
     }
@@ -1263,8 +1282,9 @@ fn ruby_kit_pins_expected_contract_set_cid() {
 
     // Skip the pinning assertion if the lifter binary isn't built: when
     // the dispatcher hits ENOENT on spawn it returns ok=true with the
-    // empty-set CID. Mirrors the cpp/swift skip pattern.
+    // empty-set CID. Panic in CI (missing binary there is a CI config bug).
     if cset == EMPTY_SET_CID {
+        panic_if_empty_set_cid_in_ci("ruby");
         eprintln!("ruby kit: lifter binary not built -- skipping pinning assertion");
         return;
     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Mechanical follow-on to the diagnosis in PR #623 (`docs/audits/2026-05-12-mint-kit-integration-failures.md`).

Three tests were hitting a pinned-CID `assert_eq!` after `cmd_mint::dispatch` returned `ok=true` with the empty-set CID (`d53d18c2...`) via the ENOENT-graceful-fallback path (lifter binary absent locally):

- `kits_with_real_contracts_produce_nonempty_contract_set` — only guarded the `zig` case; generalised to guard all kits in the loop.
- `rust_kit_contract_set_cid_is_pinned_to_self_contracts_canonical` — no empty-set guard before the pinned-CID assert.
- `cpp_kit_contract_set_cid_is_pinned_to_self_contracts_canonical` — same gap.

**Pattern applied** (matches existing zig/swift tests):
```rust
if cset == EMPTY_SET_CID {
    panic_if_empty_set_cid_in_ci(kit);
    eprintln!("... binary not built locally -- skipping pinning assertion");
    return;
}
```

**Behaviour split:**
- Local (no release binary built): tests skip gracefully — `ok`.
- `CI=1` (binary absent = CI config bug): tests panic with `"<kit> kit collapsed to the empty-set CID in CI — routing or lifter regression"` — the informative signal that CI infra needs to build `./target/release/mint-self-contracts` (rust) and `./target/mint_cpp_self_contracts` (cpp).

The panic-in-CI is the next-step signal — not handled in this PR. Whoever owns CI infra should either build the binaries in CI or accept-as-known and add the kits to CI's skip list.

**Boy-scout:** `c_kit` and `ruby_kit` had the early-return skip but were missing the `panic_if_empty_set_cid_in_ci` call. Added to match zig.

## What is NOT changed

- `cmd_mint::dispatch` ENOENT-to-empty-set behaviour — deliberate local-dev UX, untouched.
- Pinned CIDs — not modified.
- Missing binaries are not added to CI — that is the follow-on.

## Test plan

- [x] `cargo test -p provekit-cli --test mint_kit_integration` — all 19 pass locally (three previously failing tests now skip gracefully).
- [x] `CI=1 cargo test ... -- rust_kit_contract_set_cid_is_pinned_to_self_contracts_canonical` — panics with expected message.
- [x] `CI=1 cargo test ... -- cpp_kit_contract_set_cid_is_pinned_to_self_contracts_canonical` — panics with expected message.
- [x] `CI=1 cargo test ... -- kits_with_real_contracts_produce_nonempty_contract_set` — panics on `rust` kit with expected message.
EOF
)