### PR TITLE
chore(lift-kits): sweep MERGE-WITH-NITS nits from PRs #595/#596/#598/#599/#600

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,10 +154,11 @@ jobs:
           cache: maven
 
       # ---------------------------------------------------------------
-      # System-level deps: PHP CLI + b3sum (PHP kit), openssl, nlohmann-json,
-      # libblake3 (Ruby FFI), libyaml (Ruby psych/bundler runtime). Run
-      # BEFORE setup-ruby so the bundler-cache step has libblake3 and libyaml
-      # already on the host when it resolves and builds native gems.
+      # System-level deps: PHP CLI + Composer + b3sum (PHP kit), openssl,
+      # nlohmann-json, libblake3 (Ruby FFI), libyaml (Ruby psych/bundler
+      # runtime). Run BEFORE setup-ruby so the bundler-cache step has
+      # libblake3 and libyaml already on the host when it resolves and
+      # builds native gems.
       #
       # cpp BLAKE3 is vendored at tools/blake3-vendored/; the Ruby kit's
       # FFI binding to libblake3 needs the system package because no
@@ -189,6 +190,7 @@ jobs:
             build-essential \
             clang \
             cmake \
+            composer \
             cvc5 \
             libclang-dev \
             libsodium-dev \

--- a/Makefile
+++ b/Makefile
@@ -701,7 +701,7 @@ build-zig:
 # NOTE: test-swift is intentionally excluded from test-all: it requires a
 # macOS host with the Swift toolchain. Use `make test-swift` on macOS.
 .PHONY: test-all
-test-all: test-rust test-go test-ts test-csharp test-python test-java
+test-all: test-rust test-go test-ts test-csharp test-python test-ruby test-php test-java
 	@echo ""
 	@echo "==== test-all: PASS ===="
 

--- a/implementations/php/provekit-lift-php-source/src/PhpSourceCompiler.php
+++ b/implementations/php/provekit-lift-php-source/src/PhpSourceCompiler.php
@@ -275,6 +275,7 @@ final class PhpSourceCompiler
 
     private function isUnit(array $term): bool
     {
-        return ($term['kind'] ?? null) === 'const' && !array_key_exists('value', $term) || (($term['kind'] ?? null) === 'const' && ($term['value'] ?? null) === null);
+        return ($term['kind'] ?? null) === 'const'
+            && (!array_key_exists('value', $term) || ($term['value'] ?? null) === null);
     }
 }

--- a/implementations/ruby/lib/provekit/lift/ruby_source.rb
+++ b/implementations/ruby/lib/provekit/lift/ruby_source.rb
@@ -508,7 +508,7 @@ module Provekit
         end
       end
 
-      METAPROGRAMMING_CALLS = Set.new(%w[define_method method_missing send __send__ public_send eval instance_eval class_eval module_eval]).freeze
+      METAPROGRAMMING_CALLS = Set.new(%w[define_method method_missing send __send__ public_send eval instance_eval class_eval module_eval instance_variable_get instance_variable_set const_get const_set]).freeze
 
       BINOPS = {
         :+ => "ruby:add",

--- a/implementations/rust/provekit-cli/src/project_config.rs
+++ b/implementations/rust/provekit-cli/src/project_config.rs
@@ -325,6 +325,10 @@ mod tests {
         assert!(KNOWN_SURFACES.contains(&"ts-zod"));
         assert!(KNOWN_SURFACES.contains(&"typescript-source"));
         assert!(KNOWN_SURFACES.contains(&"php-source"));
+        assert!(KNOWN_SURFACES.contains(&"ruby-source"));
+        assert!(KNOWN_SURFACES.contains(&"csharp-source"));
+        assert!(KNOWN_SURFACES.contains(&"swift-source"));
+        assert!(KNOWN_SURFACES.contains(&"zig-source"));
         assert!(KNOWN_SURFACES.contains(&"clr-bytecode"));
         assert!(KNOWN_SURFACES.contains(&"evm-bytecode"));
         assert!(KNOWN_AGENTS.contains(&"stub"));

--- a/menagerie/ruby-language-signature/specs/op_source-unit.spec.json
+++ b/menagerie/ruby-language-signature/specs/op_source-unit.spec.json
@@ -48,7 +48,8 @@
           "name": "operational_term"
         }
       ]
-    }
+    },
+    "notes": "The bytes slot carries the original UTF-8 Ruby source as a string."
   },
   "effects": {
     "effects": []

--- a/menagerie/typescript-language-signature/mint.sh
+++ b/menagerie/typescript-language-signature/mint.sh
@@ -19,19 +19,19 @@ mint_one() {
   out=$("$PROVEKIT" mint "$kind" --spec "$SPEC_DIR/$spec" --unsigned --catalog "$CATALOG_ARG")
   printf '%s\t%s\t%s\n' "$kind" "$spec" "$out" | tee -a "$CID_FILE"
 }
-for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'sort_*.spec.json' -exec basename {} \; | sort); do
+for spec in sort_any.spec.json sort_args.spec.json sort_boolean.spec.json sort_expr.spec.json sort_lvalue.spec.json sort_null.spec.json sort_number.spec.json sort_stmt.spec.json sort_string.spec.json sort_unit.spec.json; do
   mint_one sort "$spec"
 done
-for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'op_*.spec.json' -exec basename {} \; | sort); do
+for spec in op_add.spec.json op_and.spec.json op_args.spec.json op_assign.spec.json op_bitand.spec.json op_bitnot.spec.json op_bitor.spec.json op_bitxor.spec.json op_break.spec.json op_call.spec.json op_continue.spec.json op_decl.spec.json op_div.spec.json op_eq.spec.json op_for.spec.json op_ge.spec.json op_gt.spec.json op_if.spec.json op_index.spec.json op_ite.spec.json op_le.spec.json op_lt.spec.json op_member.spec.json op_mod.spec.json op_mul.spec.json op_ne.spec.json op_neg.spec.json op_new.spec.json op_not.spec.json op_nullish.spec.json op_or.spec.json op_pos.spec.json op_postdec.spec.json op_postinc.spec.json op_predec.spec.json op_preinc.spec.json op_return.spec.json op_seq.spec.json op_shl.spec.json op_shr.spec.json op_source-unit.spec.json op_sub.spec.json op_throw.spec.json op_typeof.spec.json op_ushr.spec.json op_while.spec.json; do
   mint_one algorithm "$spec"
 done
-for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'eff_*.spec.json' -exec basename {} \; | sort); do
+for spec in eff_io.spec.json eff_opaque_loop.spec.json eff_panic.spec.json eff_read.spec.json eff_unresolved_call.spec.json eff_write.spec.json; do
   mint_one algorithm "$spec"
 done
-for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'eq_*.spec.json' -exec basename {} \; | sort); do
+for spec in eq_and_to_ite_desugar.spec.json eq_or_to_ite_desugar.spec.json eq_seq_assoc.spec.json eq_seq_empty_left.spec.json eq_seq_empty_right.spec.json; do
   mint_one equation "$spec"
 done
-for spec in $(find "$SPEC_DIR" -maxdepth 1 -name 'effsig_*.spec.json' -exec basename {} \; | sort); do
+for spec in effsig_call.spec.json effsig_io.spec.json effsig_loop.spec.json effsig_panic.spec.json effsig_read.spec.json effsig_write.spec.json; do
   mint_one effect-signature "$spec"
 done
 mint_one language-signature language_signature_typescript.spec.json


### PR DESCRIPTION
## Summary

Sweeps the accumulated nits from 5 PRs that were merged with MERGE-WITH-NITS verdicts. All are pure cleanup -- no design changes, no substrate touches.

## Per-kit nits closed

**rust/provekit-cli** (all PRs):
- Extend `known_lists_include_anchor_entries` test to assert `ruby-source`, `csharp-source`, `swift-source`, `zig-source` are all present in `KNOWN_SURFACES`. They were in the array; the regression test didn't cover them. Surfaces without anchor assertions are invisible to future refactors.

**Makefile** (PR #598 nit #2 -- boy-scout):
- Wire `test-ruby` and `test-php` into `test-all`. These are first-class polyglot kits; their absence from `test-all` means `make ci` silently skips them. Swift stays intentionally excluded (macOS-only, documented).

**typescript-language-signature/mint.sh** (PR #595 nit #3):
- Replace 5 `find` invocations with explicit enumeration, matching the `c11-language-signature` and `rust-language-signature` pattern. Removes portability footgun; makes the spec list visible in the script.

**ruby/ruby_source.rb** (PR #598 nit #4):
- Add `instance_variable_get`, `instance_variable_set`, `const_get`, `const_set` to `METAPROGRAMMING_CALLS`. These are the same class of runtime-reflective call as the existing entries. They fall through to `unresolved_call` (sound but loose); the denylist tightens refusal discipline.

**php/PhpSourceCompiler.php** (PR #600 nit #2):
- Simplify `isUnit()` from a precedence-reliant double-condition to a single clear form: `kind === 'const' && (!array_key_exists || value === null)`. Semantically identical; readable.

## Already swept (verified empty cherry-picks from origin/codex/lift-kit-nits-cleanup)

- Effect sort-key alignment: `5:unresolved_call:` -> `5:unresolved:` (ruby + swift) -- already on main
- `csharp-source` backfill in `KNOWN_SURFACES` -- already on main
- Swift: emit `Refusal` for unparseable function signatures + `ThrowStmt` API fix -- already on main

## Items flagged as bugs (carved out, not fixed here)

- PR #596 nit #1: Zig string literal not unescaped on lift -- CIDs misrepresent runtime string value. Substrate-affecting. Needs its own task.
- PR #596 nit #2: Zig compile surface narrower than lift surface (`for`/`break`/`continue` produce broken Zig). Needs its own task.
- PR #600 nit #3: PHP nested assign (`$a=$b=1`) -- lifter emits, PrettyPrinter compiler throws. Lifter/compiler asymmetry. Needs its own task.
- PR #595 nit #1: TS round-trip test is tautological (doesn't drive real compile path). Test bug. Needs its own task.

## Test plan

- [x] `cargo test -p provekit-cli --bin provekit -- project_config` -- 7 passed
- [x] `cargo test -p libprovekit -p provekit-cli --test transport_cli` -- 8 passed
- [ ] CI conformance gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)