### PR TITLE
feat(abstraction-layer): ConceptAbstractionMemento + RealizationDesugaringMemento schemas + fixtures (PR 1/N)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1619,6 +1619,7 @@ dependencies = [
  "hex",
  "provekit-canonicalizer",
  "provekit-proof-envelope",
+ "serde",
  "serde_json",
  "thiserror",
 ]

--- a/implementations/rust/provekit-claim-envelope/Cargo.toml
+++ b/implementations/rust/provekit-claim-envelope/Cargo.toml
@@ -12,5 +12,6 @@ provekit-proof-envelope = { path = "../provekit-proof-envelope" }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+serde = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }

--- a/implementations/rust/provekit-claim-envelope/tests/abstraction_layer_cid_pin.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/abstraction_layer_cid_pin.rs
@@ -16,14 +16,14 @@
 //     (B) concept:double-dispatch   -- ConceptAbstractionMemento
 //     (C) concept:double-dispatch->c11:2d-fn-ptr-table   -- RealizationDesugaringMemento
 //     (D) concept:double-dispatch->jvm:visitor-pattern   -- RealizationDesugaringMemento
-//     (E) concept:double-dispatch->ruby:case-respond_to  -- RealizationDesugaringMemento
+//     (E) concept:double-dispatch->ruby:case-type-tuple  -- RealizationDesugaringMemento
 //
 //   2. Round-trip parity: emit -> re-parse -> re-emit -> byte-identical JCS.
 //
 //   3. Projection-distance law held by the three RealizationDesugaringMementos:
-//      C (c11) carries both structural_divergence AND domain_narrowing (heavy).
-//      D (java) carries structural_divergence, less domain_narrowing (mid).
-//      E (ruby) carries only structural_divergence (near-zero).
+//      C (c11) carries structural_divergence + domain_narrowing + ub_introduction (heavy).
+//      D (java) carries structural_divergence + domain_narrowing (mid; visitor accept/visit).
+//      E (ruby) carries only structural_divergence (near-zero; case-match ≈ contract).
 //
 // To update pinned CIDs after a deliberate schema change:
 //   1. Remove the assertion and run the test to see the printed CID.
@@ -143,12 +143,26 @@ fn double_dispatch_jcs_round_trip() {
 // (C) RealizationDesugaringMemento: double-dispatch -> c11
 // ================================================================
 //
-// Heavy structural_divergence + domain_narrowing (C is the unforgiving end).
+// Heavy structural_divergence + domain_narrowing + ub_introduction (C is the unforgiving end).
+//
+// The rhs encodes the full 2D void*-table dispatch:
+//   ((fn_ptr)table[tag(receiver)][tag(secondary)])(receiver, secondary, args)
+// Steps: concept:member -> concept:index (dim 1) -> concept:index (dim 2)
+//        -> concept:cast (void* -> fn-ptr) -> concept:call
+//
+// Loss-record (3 distinct atomic claims, heaviest end of the bracket):
+//   structural_divergence: open_coded_vtable_replaces_single_op (2 index + 1 cast)
+//   domain_narrowing:      requires_static_2d_dispatch_table
+//   ub_introduction:       out_of_range_tag_is_ub
+//
+// JCS key order is alphabetical within each object (RFC 8785 §3.2.3).
+// TODO: re-sort the "Locked JCS key order" CDDL comments to match actual
+// canonicalizer output (alphabetical), not struct declaration order.
 
-const DD_C11_CANONICAL: &str = r#"{"direction":"left-to-right","effects":[],"fn_name":"concept:double-dispatch->c11:2d-fn-ptr-table","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"formals":["receiver","secondary","method_name","args"],"kind":"equation","loss_record":{"domain_narrowing":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"}],"kind":"atomic","name":"requires_static_2d_dispatch_table"},"structural_divergence":{"args":[],"kind":"atomic","name":"true"}},"post":{"lhs":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"},{"name":"method_name","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"concept:double-dispatch"},"rhs":{"args":[{"args":[{"args":[{"args":[{"kind":"ctor","name":"concept:member","args":[{"name":"receiver","kind":"var"},{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"dispatch_tbl"}]}],"kind":"ctor","name":"concept:index","args":[{"kind":"ctor","name":"concept:tag-of","args":[{"name":"receiver","kind":"var"}]}]}],"kind":"ctor","name":"concept:index","args":[{"kind":"ctor","name":"concept:tag-of","args":[{"name":"secondary","kind":"var"}]}]}],"kind":"atomic","name":"concept:call"}],"kind":"atomic","name":"concept:call"}},"pre":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"}],"kind":"atomic","name":"static_dispatch_table"},"role":"abstraction-realization","target_lang":"c11"}"#;
+const DD_C11_CANONICAL: &str = r#"{"direction":"left-to-right","effects":[],"fn_name":"concept:double-dispatch->c11:2d-fn-ptr-table","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"formals":["receiver","secondary","method_name","args"],"kind":"equation","loss_record":{"domain_narrowing":{"args":[{"kind":"var","name":"receiver"},{"kind":"var","name":"secondary"}],"kind":"atomic","name":"requires_static_2d_dispatch_table"},"structural_divergence":{"args":[{"args":[{"kind":"var","name":"receiver"}],"kind":"ctor","name":"concept:index"},{"args":[{"kind":"var","name":"secondary"}],"kind":"ctor","name":"concept:index"},{"args":[],"kind":"ctor","name":"concept:cast"}],"kind":"atomic","name":"open_coded_vtable_replaces_single_op"},"ub_introduction":{"args":[{"kind":"var","name":"receiver"},{"kind":"var","name":"secondary"}],"kind":"atomic","name":"out_of_range_tag_is_ub"}},"post":{"lhs":{"args":[{"kind":"var","name":"receiver"},{"kind":"var","name":"secondary"},{"kind":"var","name":"method_name"},{"kind":"var","name":"args"}],"kind":"atomic","name":"concept:double-dispatch"},"rhs":{"args":[{"args":[{"args":[{"args":[{"args":[{"kind":"var","name":"receiver"},{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"dispatch_tbl"}],"kind":"ctor","name":"concept:member"},{"args":[{"kind":"var","name":"receiver"}],"kind":"ctor","name":"concept:tag-of"}],"kind":"ctor","name":"concept:index"},{"args":[{"kind":"var","name":"secondary"}],"kind":"ctor","name":"concept:tag-of"}],"kind":"ctor","name":"concept:index"},{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"fn_ptr_2d"}],"kind":"ctor","name":"concept:cast"},{"kind":"var","name":"receiver"},{"kind":"var","name":"secondary"},{"kind":"var","name":"args"}],"kind":"atomic","name":"concept:call"}},"pre":{"args":[{"kind":"var","name":"receiver"},{"kind":"var","name":"secondary"}],"kind":"atomic","name":"static_dispatch_table"},"role":"abstraction-realization","target_lang":"c11"}"#;
 
 const DD_C11_CID: &str =
-    "blake3-512:081b7f07196d75c4a3796953113d73b3d8b4603ab3ffe1993015bb5cd09a33727122567876855875e62f4196d8c28e997e295bfc96f6b7a37462df4782bbb8a0";
+    "blake3-512:35932da2302a9ca08c4c1ccadc1ee04995b91a0ce005977a2804181a59c786fe90794bf0e2de561a871d8d40e1da6c525b1cf0a3b8517dd8dafc92227e6796f0";
 
 #[test]
 fn dd_c11_cid_stable() {
@@ -166,12 +180,21 @@ fn dd_c11_jcs_round_trip() {
 // (D) RealizationDesugaringMemento: double-dispatch -> java
 // ================================================================
 //
-// Mid structural_divergence, minimal domain_narrowing (Java is the middle).
+// Mid structural_divergence + domain_narrowing (Java is the middle of the bracket).
+//
+// The rhs encodes the visitor pattern: two sequential itab-method calls.
+//   receiver.accept(secondary)     -- dispatches on receiver's type
+//   secondary.visit_receiver_type(receiver, args)  -- dispatches on secondary's type
+// This is a concept:seq of TWO concept:itab-method ctors, not a single invokeinterface.
+//
+// Loss-record (2 distinct atomic claims, mid bracket):
+//   structural_divergence: visitor_accept_visit_indirection (2 itab-method nodes)
+//   domain_narrowing:      visitable_set_fixed_at_declaration
 
-const DD_JAVA_CANONICAL: &str = r#"{"direction":"left-to-right","effects":[],"fn_name":"concept:double-dispatch->jvm:visitor-pattern","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"formals":["receiver","secondary","method_name","args"],"kind":"equation","loss_record":{"structural_divergence":{"args":[],"kind":"atomic","name":"visitor_pattern_indirection"}},"post":{"lhs":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"},{"name":"method_name","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"concept:double-dispatch"},"rhs":{"args":[{"name":"receiver","kind":"var"},{"name":"method_name","kind":"var"},{"name":"secondary","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"jvm:invokeinterface"}},"role":"abstraction-realization","target_lang":"java"}"#;
+const DD_JAVA_CANONICAL: &str = r#"{"direction":"left-to-right","effects":[],"fn_name":"concept:double-dispatch->jvm:visitor-pattern","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"formals":["receiver","secondary","method_name","args"],"kind":"equation","loss_record":{"domain_narrowing":{"args":[{"kind":"var","name":"receiver"},{"kind":"var","name":"secondary"}],"kind":"atomic","name":"visitable_set_fixed_at_declaration"},"structural_divergence":{"args":[{"args":[{"kind":"var","name":"receiver"}],"kind":"ctor","name":"concept:itab-method"},{"args":[{"kind":"var","name":"secondary"}],"kind":"ctor","name":"concept:itab-method"}],"kind":"atomic","name":"visitor_accept_visit_indirection"}},"post":{"lhs":{"args":[{"kind":"var","name":"receiver"},{"kind":"var","name":"secondary"},{"kind":"var","name":"method_name"},{"kind":"var","name":"args"}],"kind":"atomic","name":"concept:double-dispatch"},"rhs":{"args":[{"args":[{"kind":"var","name":"receiver"},{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"accept"},{"kind":"var","name":"secondary"}],"kind":"ctor","name":"concept:itab-method"},{"args":[{"kind":"var","name":"secondary"},{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"visit_receiver_type"},{"kind":"var","name":"receiver"},{"kind":"var","name":"args"}],"kind":"ctor","name":"concept:itab-method"}],"kind":"atomic","name":"concept:seq"}},"role":"abstraction-realization","target_lang":"java"}"#;
 
 const DD_JAVA_CID: &str =
-    "blake3-512:8ea85ecdc492a2c31a9fc2f36626935eb0cf1f7290c1f16c999ba23b2a802e68278c5aa8f019fc56f2ea7e3ab0dcfc3b96c85d9e794d1c77f107c1d8713b0b5c";
+    "blake3-512:a024327ba96392f6b070b3e88b8638cc8318e98c946c46cbaca5a849359a0e9eeffd4e3d81f307e4d1f613f076a903211945226db3bed499b12a7da07ccedf1f";
 
 #[test]
 fn dd_java_cid_stable() {
@@ -189,12 +212,26 @@ fn dd_java_jcs_round_trip() {
 // (E) RealizationDesugaringMemento: double-dispatch -> ruby
 // ================================================================
 //
-// Near-zero structural_divergence only (Ruby is the loose end).
+// Near-zero structural_divergence only (Ruby is the loose end of the bracket).
+//
+// The rhs encodes a case-match over the type tuple, preserving the
+// implication structure of the abstraction's contract:
+//   case [type(receiver), type(secondary)]
+//   when [X, Y] then method_name(receiver, secondary, args)
+//   else raise TypeError
+//
+// This is a concept:match over concept:pair(type-of(receiver), type-of(secondary))
+// with a concept:match-arm and a concept:raise fallthrough.
+// The realization ≈ the contract -- Ruby just writes out the guarded dispatch directly.
+//
+// Loss-record (1 atomic claim, loosest end):
+//   structural_divergence: case_fallthrough_narrows_open_dispatch
+//     (Ruby's open dispatch domain is narrowed by the case fallthrough to TypeError)
 
-const DD_RUBY_CANONICAL: &str = r#"{"direction":"left-to-right","effects":[],"fn_name":"concept:double-dispatch->ruby:case-respond_to","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"formals":["receiver","secondary","method_name","args"],"kind":"equation","loss_record":{"structural_divergence":{"args":[],"kind":"atomic","name":"guarded_case_chain"}},"post":{"lhs":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"},{"name":"method_name","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"concept:double-dispatch"},"rhs":{"args":[{"name":"receiver","kind":"var"},{"name":"method_name","kind":"var"},{"name":"secondary","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"ruby:public_send"}},"role":"abstraction-realization","target_lang":"ruby"}"#;
+const DD_RUBY_CANONICAL: &str = r#"{"direction":"left-to-right","effects":[],"fn_name":"concept:double-dispatch->ruby:case-type-tuple","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"formals":["receiver","secondary","method_name","args"],"kind":"equation","loss_record":{"structural_divergence":{"args":[{"args":[],"kind":"ctor","name":"concept:raise"}],"kind":"atomic","name":"case_fallthrough_narrows_open_dispatch"}},"post":{"lhs":{"args":[{"kind":"var","name":"receiver"},{"kind":"var","name":"secondary"},{"kind":"var","name":"method_name"},{"kind":"var","name":"args"}],"kind":"atomic","name":"concept:double-dispatch"},"rhs":{"args":[{"args":[{"args":[{"kind":"var","name":"receiver"}],"kind":"ctor","name":"concept:type-of"},{"args":[{"kind":"var","name":"secondary"}],"kind":"ctor","name":"concept:type-of"}],"kind":"ctor","name":"concept:pair"},{"args":[{"args":[{"args":[{"kind":"var","name":"receiver"}],"kind":"ctor","name":"concept:tag-of"},{"args":[{"kind":"var","name":"secondary"}],"kind":"ctor","name":"concept:tag-of"}],"kind":"ctor","name":"concept:pair"},{"args":[{"kind":"var","name":"method_name"},{"kind":"var","name":"receiver"},{"kind":"var","name":"secondary"},{"kind":"var","name":"args"}],"kind":"ctor","name":"concept:call"}],"kind":"ctor","name":"concept:match-arm"},{"args":[{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"TypeError"}],"kind":"ctor","name":"concept:raise"}],"kind":"atomic","name":"concept:match"}},"role":"abstraction-realization","target_lang":"ruby"}"#;
 
 const DD_RUBY_CID: &str =
-    "blake3-512:730a633f0e59e0393261ac911be375821cf86a1c49a61fc3135a1cf01720d2e9ba1e339beca4dac2c67e04a3ffc5695305291b8f101c0b7484178e2a0a66b81c";
+    "blake3-512:5f6e90c1f3a832ddd97ad624522a001d0a90091ca796d75cf7a1dccd819a5b12ec0181bf8297653204ed226259ba6acaf48633586dd403ce30ae258260af319f";
 
 #[test]
 fn dd_ruby_cid_stable() {
@@ -213,65 +250,112 @@ fn dd_ruby_jcs_round_trip() {
 // ================================================================
 //
 // The three double-dispatch realizations demonstrate the C-far/Java-mid/Ruby-near
-// projection-distance law from spec §3.0:
+// projection-distance law from spec §3.0. This is a NON-TRIVIAL assertion:
+// the test compares real structural content (loss-record dimension count and
+// structural_divergence formula complexity), not merely presence/absence.
 //
-//   C:    structural_divergence + domain_narrowing  (heavy)
-//   Java: structural_divergence only                (mid; visitor pattern indirection)
-//   Ruby: structural_divergence only, lighter       (near-zero; native send)
+// Law:
+//   C:    3 loss dimensions (structural_divergence + domain_narrowing + ub_introduction)
+//         structural_divergence has 3 args (open_coded_vtable: 2 index + 1 cast nodes)
+//   Java: 2 loss dimensions (structural_divergence + domain_narrowing)
+//         structural_divergence has 2 args (2 itab-method nodes for accept/visit)
+//   Ruby: 1 loss dimension (structural_divergence only)
+//         structural_divergence has 1 arg (1 raise node for fallthrough)
 //
-// This test reads the canonical JSON for each and asserts the expected
-// loss-record shape matches the spec's characterization.
+// Strict ordering: C-dims > Java-dims > Ruby-dims and C-sd-args > Java-sd-args > Ruby-sd-args
+
+/// Count the elements of a JSON array (returns 0 for non-arrays).
+fn array_len(v: &Json) -> usize {
+    v.as_array().map(|a| a.len()).unwrap_or(0)
+}
+
+/// Count loss-record dimensions (number of top-level keys in loss_record object).
+fn loss_record_dim_count(canonical: &str) -> usize {
+    let j: Json = serde_json::from_str(canonical).expect("parse");
+    let lr = j.pointer("/loss_record").expect("loss_record present");
+    lr.as_object().map(|m| m.len()).unwrap_or(0)
+}
+
+/// Count the args array of the structural_divergence formula.
+fn sd_arg_count(canonical: &str) -> usize {
+    let j: Json = serde_json::from_str(canonical).expect("parse");
+    let sd = j.pointer("/loss_record/structural_divergence").expect("structural_divergence present");
+    array_len(sd.pointer("/args").unwrap_or(&Json::Null))
+}
 
 #[test]
-fn projection_distance_law_c_has_structural_and_domain_narrowing() {
-    let j: Json = serde_json::from_str(DD_C11_CANONICAL).expect("parse dd->c11");
-    let lr = j.pointer("/loss_record").expect("loss_record present");
+fn projection_distance_law_dimension_counts_strict_ordering() {
+    let c_dims  = loss_record_dim_count(DD_C11_CANONICAL);
+    let j_dims  = loss_record_dim_count(DD_JAVA_CANONICAL);
+    let rb_dims = loss_record_dim_count(DD_RUBY_CANONICAL);
+
+    assert_eq!(c_dims, 3, "C MUST have 3 loss dimensions (structural + domain + ub)");
+    assert_eq!(j_dims, 2, "Java MUST have 2 loss dimensions (structural + domain)");
+    assert_eq!(rb_dims, 1, "Ruby MUST have 1 loss dimension (structural only)");
+
     assert!(
-        lr.pointer("/structural_divergence").is_some(),
-        "C realization MUST have structural_divergence"
+        c_dims > j_dims,
+        "Projection-distance law: C loss dims ({c_dims}) MUST exceed Java ({j_dims})"
     );
     assert!(
-        lr.pointer("/domain_narrowing").is_some(),
-        "C realization MUST have domain_narrowing (heavy end)"
+        j_dims > rb_dims,
+        "Projection-distance law: Java loss dims ({j_dims}) MUST exceed Ruby ({rb_dims})"
     );
 }
 
 #[test]
-fn projection_distance_law_java_has_structural_no_domain_narrowing() {
-    let j: Json = serde_json::from_str(DD_JAVA_CANONICAL).expect("parse dd->java");
-    let lr = j.pointer("/loss_record").expect("loss_record present");
+fn projection_distance_law_structural_divergence_complexity_strict_ordering() {
+    let c_args  = sd_arg_count(DD_C11_CANONICAL);
+    let j_args  = sd_arg_count(DD_JAVA_CANONICAL);
+    let rb_args = sd_arg_count(DD_RUBY_CANONICAL);
+
+    assert_eq!(c_args,  3, "C structural_divergence MUST have 3 args (2 index + 1 cast)");
+    assert_eq!(j_args,  2, "Java structural_divergence MUST have 2 args (2 itab-method)");
+    assert_eq!(rb_args, 1, "Ruby structural_divergence MUST have 1 arg (1 raise)");
+
     assert!(
-        lr.pointer("/structural_divergence").is_some(),
-        "Java realization MUST have structural_divergence"
+        c_args > j_args,
+        "C sd complexity ({c_args}) MUST exceed Java ({j_args})"
     );
     assert!(
-        lr.pointer("/domain_narrowing").is_none(),
-        "Java realization MUST NOT have domain_narrowing in this fixture (mid)"
+        j_args > rb_args,
+        "Java sd complexity ({j_args}) MUST exceed Ruby ({rb_args})"
     );
 }
 
 #[test]
-fn projection_distance_law_ruby_has_structural_only() {
-    let j: Json = serde_json::from_str(DD_RUBY_CANONICAL).expect("parse dd->ruby");
-    let lr = j.pointer("/loss_record").expect("loss_record present");
+fn projection_distance_law_c_has_ub_introduction_others_do_not() {
+    let c_j: Json  = serde_json::from_str(DD_C11_CANONICAL).expect("parse c11");
+    let j_j: Json  = serde_json::from_str(DD_JAVA_CANONICAL).expect("parse java");
+    let rb_j: Json = serde_json::from_str(DD_RUBY_CANONICAL).expect("parse ruby");
+
     assert!(
-        lr.pointer("/structural_divergence").is_some(),
-        "Ruby realization MUST have structural_divergence"
+        c_j.pointer("/loss_record/ub_introduction").is_some(),
+        "C MUST have ub_introduction (out-of-range tag = UB)"
     );
     assert!(
-        lr.pointer("/domain_narrowing").is_none(),
-        "Ruby realization MUST NOT have domain_narrowing (near-zero end)"
+        j_j.pointer("/loss_record/ub_introduction").is_none(),
+        "Java MUST NOT have ub_introduction"
     );
     assert!(
-        lr.pointer("/ub_introduction").is_none(),
-        "Ruby realization MUST NOT have ub_introduction"
+        rb_j.pointer("/loss_record/ub_introduction").is_none(),
+        "Ruby MUST NOT have ub_introduction"
+    );
+}
+
+#[test]
+fn projection_distance_law_ruby_has_no_domain_narrowing() {
+    let rb_j: Json = serde_json::from_str(DD_RUBY_CANONICAL).expect("parse ruby");
+    assert!(
+        rb_j.pointer("/loss_record/domain_narrowing").is_none(),
+        "Ruby MUST NOT have domain_narrowing (near-zero end: no fixed interface required)"
     );
     assert!(
-        lr.pointer("/value_divergence").is_none(),
-        "Ruby realization MUST NOT have value_divergence"
+        rb_j.pointer("/loss_record/value_divergence").is_none(),
+        "Ruby MUST NOT have value_divergence"
     );
     assert!(
-        lr.pointer("/effect_divergence").is_none(),
-        "Ruby realization MUST NOT have effect_divergence"
+        rb_j.pointer("/loss_record/effect_divergence").is_none(),
+        "Ruby MUST NOT have effect_divergence"
     );
 }

--- a/implementations/rust/provekit-claim-envelope/tests/abstraction_layer_cid_pin.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/abstraction_layer_cid_pin.rs
@@ -359,3 +359,108 @@ fn projection_distance_law_ruby_has_no_domain_narrowing() {
         "Ruby MUST NOT have effect_divergence"
     );
 }
+
+// ================================================================
+// Permanent duplicate-key audit guard (reviewer required action 1)
+// ================================================================
+//
+// serde_json silently deduplicates duplicate object keys (last-key-wins).
+// This means a hand-authored canonical string with duplicate keys can
+// pass a round-trip test while encoding a corrupted structure -- exactly
+// the bug that caused DD_C11's original CID (081b7f07) to be wrong.
+//
+// This test audits all five canonical fixture strings by scanning the
+// raw JSON bytes for duplicate keys within any object at any nesting
+// depth, using a custom recursive walk that processes the token stream
+// before serde deduplication occurs.
+//
+// If this test fails, a hand-authored fixture has duplicate keys and
+// the CID is pinned to a corrupted (serde-deduped) structure.
+
+/// Scan a JSON string recursively for duplicate keys in any object at any
+/// nesting depth. Returns `Err(description)` on the first duplicate found.
+///
+/// Uses `serde_json::Deserializer` with a custom `serde::de::Visitor` that
+/// processes keys BEFORE serde_json's BTreeMap/IndexMap deduplication step.
+/// Both objects and arrays are walked recursively so nested objects are
+/// fully audited.
+fn scan_for_dup_keys(json_str: &str) -> Result<(), String> {
+    struct AnyChecker;
+
+    impl<'de> serde::de::Deserialize<'de> for AnyChecker {
+        fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+            d.deserialize_any(AnyVisitor)?;
+            Ok(AnyChecker)
+        }
+    }
+
+    struct AnyVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for AnyVisitor {
+        type Value = ();
+
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "any JSON value")
+        }
+
+        fn visit_bool<E: serde::de::Error>(self, _: bool) -> Result<(), E> { Ok(()) }
+        fn visit_i64<E: serde::de::Error>(self, _: i64) -> Result<(), E> { Ok(()) }
+        fn visit_u64<E: serde::de::Error>(self, _: u64) -> Result<(), E> { Ok(()) }
+        fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<(), E> { Ok(()) }
+        fn visit_str<E: serde::de::Error>(self, _: &str) -> Result<(), E> { Ok(()) }
+        fn visit_none<E: serde::de::Error>(self) -> Result<(), E> { Ok(()) }
+        fn visit_unit<E: serde::de::Error>(self) -> Result<(), E> { Ok(()) }
+
+        fn visit_some<D: serde::Deserializer<'de>>(self, d: D) -> Result<(), D::Error> {
+            d.deserialize_any(AnyVisitor)
+        }
+
+        fn visit_seq<A: serde::de::SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
+            while seq.next_element::<AnyChecker>()?.is_some() {}
+            Ok(())
+        }
+
+        fn visit_map<A: serde::de::MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+            let mut seen: Vec<String> = Vec::new();
+            while let Some(key) = map.next_key::<String>()? {
+                if seen.contains(&key) {
+                    return Err(serde::de::Error::custom(format!(
+                        "duplicate JSON object key: '{key}'"
+                    )));
+                }
+                seen.push(key);
+                map.next_value::<AnyChecker>()?;
+            }
+            Ok(())
+        }
+    }
+
+    use serde::Deserializer as _;
+    let mut de = serde_json::Deserializer::from_str(json_str);
+    de.deserialize_any(AnyVisitor)
+        .map_err(|e| format!("duplicate key detected: {e}"))
+}
+
+/// Assert that a canonical JSON string contains no duplicate object keys
+/// at any nesting depth. Panics with a descriptive message on failure.
+fn assert_no_duplicate_keys(json_str: &str, label: &str) {
+    if let Err(msg) = scan_for_dup_keys(json_str) {
+        panic!(
+            "{label}: canonical fixture has duplicate JSON keys (CID is pinned to corrupted structure)\n  {msg}"
+        );
+    }
+}
+
+#[test]
+fn all_five_fixtures_have_no_duplicate_keys() {
+    // This test permanently guards against the class of bug that caused
+    // DD_C11's original CID (081b7f07) to be wrong: hand-authored JSON
+    // with duplicate "args" keys inside nested concept:index ctors.
+    // serde_json silently last-key-wins deduplicates, so the round-trip
+    // test passed while the CID was pinned to a corrupted structure.
+    assert_no_duplicate_keys(DYNAMIC_DISPATCH_CANONICAL, "concept:dynamic-dispatch");
+    assert_no_duplicate_keys(DOUBLE_DISPATCH_CANONICAL, "concept:double-dispatch");
+    assert_no_duplicate_keys(DD_C11_CANONICAL, "dd->c11:2d-fn-ptr-table");
+    assert_no_duplicate_keys(DD_JAVA_CANONICAL, "dd->jvm:visitor-pattern");
+    assert_no_duplicate_keys(DD_RUBY_CANONICAL, "dd->ruby:case-type-tuple");
+}

--- a/implementations/rust/provekit-claim-envelope/tests/abstraction_layer_cid_pin.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/abstraction_layer_cid_pin.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CID-pinning tests for the abstraction-layer mementos.
+//
+// Source of truth:
+//   protocol/specs/2026-05-15-concept-hub-abstraction-layer.md §2.1, §2.2, §2.4
+//   protocol/provekit-ir.cddl  (ConceptAbstractionMemento, RealizationDesugaringMemento)
+//
+// What this file pins:
+//
+//   1. Five canonical fixture mementos, each serialized to JCS-canonical JSON,
+//      each BLAKE3-512 CID pinned.
+//
+//   Fixtures:
+//     (A) concept:dynamic-dispatch  -- ConceptAbstractionMemento
+//     (B) concept:double-dispatch   -- ConceptAbstractionMemento
+//     (C) concept:double-dispatch->c11:2d-fn-ptr-table   -- RealizationDesugaringMemento
+//     (D) concept:double-dispatch->jvm:visitor-pattern   -- RealizationDesugaringMemento
+//     (E) concept:double-dispatch->ruby:case-respond_to  -- RealizationDesugaringMemento
+//
+//   2. Round-trip parity: emit -> re-parse -> re-emit -> byte-identical JCS.
+//
+//   3. Projection-distance law held by the three RealizationDesugaringMementos:
+//      C (c11) carries both structural_divergence AND domain_narrowing (heavy).
+//      D (java) carries structural_divergence, less domain_narrowing (mid).
+//      E (ruby) carries only structural_divergence (near-zero).
+//
+// To update pinned CIDs after a deliberate schema change:
+//   1. Remove the assertion and run the test to see the printed CID.
+//   2. Copy the printed CID into the const below.
+//   3. Re-run the test to confirm it is stable.
+
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
+use serde_json::Value as Json;
+
+fn json_to_value(j: &Json) -> Arc<Value> {
+    match j {
+        Json::Null => Value::null(),
+        Json::Bool(b) => Value::boolean(*b),
+        Json::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                Value::integer(u as i64)
+            } else if let Some(f) = n.as_f64() {
+                Value::integer(f as i64)
+            } else {
+                Value::integer(0)
+            }
+        }
+        Json::String(s) => Value::string(s.clone()),
+        Json::Array(items) => {
+            let v: Vec<_> = items.iter().map(json_to_value).collect();
+            Value::array(v)
+        }
+        Json::Object(map) => {
+            let entries: Vec<(String, _)> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), json_to_value(v)))
+                .collect();
+            Arc::new(Value::Object(entries))
+        }
+    }
+}
+
+/// JCS-canonicalize a JSON string and return the BLAKE3-512 CID.
+fn cid_of_json(json_str: &str) -> String {
+    let j: Json = serde_json::from_str(json_str).expect("parse fixture JSON");
+    let v = json_to_value(&j);
+    let jcs = encode_jcs(&v);
+    blake3_512_of(jcs.as_bytes())
+}
+
+/// JCS-canonicalize, then re-parse, then JCS again to prove byte-identity.
+fn assert_jcs_stable(json_str: &str, label: &str) {
+    let j1: Json = serde_json::from_str(json_str).expect("parse");
+    let v1 = json_to_value(&j1);
+    let jcs1 = encode_jcs(&v1);
+
+    // re-parse the JCS bytes and re-emit
+    let j2: Json = serde_json::from_str(&jcs1).expect("re-parse JCS");
+    let v2 = json_to_value(&j2);
+    let jcs2 = encode_jcs(&v2);
+
+    assert_eq!(
+        jcs1, jcs2,
+        "{label}: JCS bytes MUST be byte-identical across emit/parse/emit"
+    );
+}
+
+// ================================================================
+// (A) concept:dynamic-dispatch ConceptAbstractionMemento
+// ================================================================
+
+// NOTE: serde_json serializes BTreeMap keys in sorted order. The
+// canonical JSON below uses the same key order as the Rust struct
+// would emit: serde_json::to_value on the struct gives the same bytes
+// as this manually-written canonical form once parsed and JCS'd.
+// All keys are already in JCS (lexicographic) order within each object.
+
+const DYNAMIC_DISPATCH_CANONICAL: &str = r#"{"contract":{"body":{"operands":[{"args":[{"name":"m","kind":"var"}],"kind":"atomic","name":"defined"},{"args":[{"name":"m","kind":"var"},{"name":"receiver","kind":"var"}],"kind":"atomic","name":"wp_call"}],"kind":"and"},"kind":"choice","sort":{"kind":"primitive","name":"Int"},"varName":"m"},"contract_note":"the call result and effect equal those of the method that resolves from the receiver runtime type for method_name applied to receiver and args; if no such method resolves the behaviour is undefined","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"kind":"concept-abstraction","operator":"concept:dynamic-dispatch","realizations":[],"result_sort":"blake3-512:sort3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333","slots":[{"name":"receiver"},{"name":"method_name"},{"name":"args","variadic":true}],"tier":"abstraction"}"#;
+
+// Pinned BLAKE3-512 CID for concept:dynamic-dispatch fixture.
+const DYNAMIC_DISPATCH_CID: &str =
+    "blake3-512:ca8ff4e631fe41885b37f897b42906e62e2b4079438ce6480885b5eb0f01207314fd38563591e82304aaa9c1b750e94a8baa24f5e9401cd2ed873da0cd0c90da";
+
+#[test]
+fn dynamic_dispatch_cid_stable() {
+    let cid = cid_of_json(DYNAMIC_DISPATCH_CANONICAL);
+    println!("concept:dynamic-dispatch CID = {cid}");
+    assert_eq!(cid, DYNAMIC_DISPATCH_CID, "concept:dynamic-dispatch CID must be pinned");
+}
+
+#[test]
+fn dynamic_dispatch_jcs_round_trip() {
+    assert_jcs_stable(DYNAMIC_DISPATCH_CANONICAL, "concept:dynamic-dispatch");
+}
+
+// ================================================================
+// (B) concept:double-dispatch ConceptAbstractionMemento
+// ================================================================
+
+const DOUBLE_DISPATCH_CANONICAL: &str = r#"{"contract":{"body":{"operands":[{"args":[{"name":"m","kind":"var"}],"kind":"atomic","name":"defined"},{"args":[{"name":"m","kind":"var"},{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"}],"kind":"atomic","name":"wp_call"}],"kind":"and"},"kind":"choice","sort":{"kind":"primitive","name":"Int"},"varName":"m"},"contract_note":"dispatch is resolved from the conjunction of the receiver runtime type and the secondary runtime type for method_name; if no such method resolves the behaviour is undefined","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"kind":"concept-abstraction","operator":"concept:double-dispatch","realizations":[],"result_sort":"blake3-512:sort3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333","slots":[{"name":"receiver"},{"name":"secondary"},{"name":"method_name"},{"name":"args","variadic":true}],"tier":"abstraction"}"#;
+
+const DOUBLE_DISPATCH_CID: &str =
+    "blake3-512:1cc86fe75917b11e41cb847ee5e5815d67e69f5d5c93f89c0fc54c273312060ae26c6170c8c2d9b22170fabbc627b5d614b3c39c486fcd9edc6e44433cff9909";
+
+#[test]
+fn double_dispatch_cid_stable() {
+    let cid = cid_of_json(DOUBLE_DISPATCH_CANONICAL);
+    println!("concept:double-dispatch CID = {cid}");
+    assert_eq!(cid, DOUBLE_DISPATCH_CID, "concept:double-dispatch CID must be pinned");
+}
+
+#[test]
+fn double_dispatch_jcs_round_trip() {
+    assert_jcs_stable(DOUBLE_DISPATCH_CANONICAL, "concept:double-dispatch");
+}
+
+// ================================================================
+// (C) RealizationDesugaringMemento: double-dispatch -> c11
+// ================================================================
+//
+// Heavy structural_divergence + domain_narrowing (C is the unforgiving end).
+
+const DD_C11_CANONICAL: &str = r#"{"direction":"left-to-right","effects":[],"fn_name":"concept:double-dispatch->c11:2d-fn-ptr-table","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"formals":["receiver","secondary","method_name","args"],"kind":"equation","loss_record":{"domain_narrowing":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"}],"kind":"atomic","name":"requires_static_2d_dispatch_table"},"structural_divergence":{"args":[],"kind":"atomic","name":"true"}},"post":{"lhs":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"},{"name":"method_name","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"concept:double-dispatch"},"rhs":{"args":[{"args":[{"args":[{"args":[{"kind":"ctor","name":"concept:member","args":[{"name":"receiver","kind":"var"},{"kind":"const","sort":{"kind":"primitive","name":"String"},"value":"dispatch_tbl"}]}],"kind":"ctor","name":"concept:index","args":[{"kind":"ctor","name":"concept:tag-of","args":[{"name":"receiver","kind":"var"}]}]}],"kind":"ctor","name":"concept:index","args":[{"kind":"ctor","name":"concept:tag-of","args":[{"name":"secondary","kind":"var"}]}]}],"kind":"atomic","name":"concept:call"}],"kind":"atomic","name":"concept:call"}},"pre":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"}],"kind":"atomic","name":"static_dispatch_table"},"role":"abstraction-realization","target_lang":"c11"}"#;
+
+const DD_C11_CID: &str =
+    "blake3-512:081b7f07196d75c4a3796953113d73b3d8b4603ab3ffe1993015bb5cd09a33727122567876855875e62f4196d8c28e997e295bfc96f6b7a37462df4782bbb8a0";
+
+#[test]
+fn dd_c11_cid_stable() {
+    let cid = cid_of_json(DD_C11_CANONICAL);
+    println!("dd->c11 CID = {cid}");
+    assert_eq!(cid, DD_C11_CID, "dd->c11 CID must be pinned");
+}
+
+#[test]
+fn dd_c11_jcs_round_trip() {
+    assert_jcs_stable(DD_C11_CANONICAL, "dd->c11");
+}
+
+// ================================================================
+// (D) RealizationDesugaringMemento: double-dispatch -> java
+// ================================================================
+//
+// Mid structural_divergence, minimal domain_narrowing (Java is the middle).
+
+const DD_JAVA_CANONICAL: &str = r#"{"direction":"left-to-right","effects":[],"fn_name":"concept:double-dispatch->jvm:visitor-pattern","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"formals":["receiver","secondary","method_name","args"],"kind":"equation","loss_record":{"structural_divergence":{"args":[],"kind":"atomic","name":"visitor_pattern_indirection"}},"post":{"lhs":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"},{"name":"method_name","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"concept:double-dispatch"},"rhs":{"args":[{"name":"receiver","kind":"var"},{"name":"method_name","kind":"var"},{"name":"secondary","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"jvm:invokeinterface"}},"role":"abstraction-realization","target_lang":"java"}"#;
+
+const DD_JAVA_CID: &str =
+    "blake3-512:8ea85ecdc492a2c31a9fc2f36626935eb0cf1f7290c1f16c999ba23b2a802e68278c5aa8f019fc56f2ea7e3ab0dcfc3b96c85d9e794d1c77f107c1d8713b0b5c";
+
+#[test]
+fn dd_java_cid_stable() {
+    let cid = cid_of_json(DD_JAVA_CANONICAL);
+    println!("dd->java CID = {cid}");
+    assert_eq!(cid, DD_JAVA_CID, "dd->java CID must be pinned");
+}
+
+#[test]
+fn dd_java_jcs_round_trip() {
+    assert_jcs_stable(DD_JAVA_CANONICAL, "dd->java");
+}
+
+// ================================================================
+// (E) RealizationDesugaringMemento: double-dispatch -> ruby
+// ================================================================
+//
+// Near-zero structural_divergence only (Ruby is the loose end).
+
+const DD_RUBY_CANONICAL: &str = r#"{"direction":"left-to-right","effects":[],"fn_name":"concept:double-dispatch->ruby:case-respond_to","formal_sorts":["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"formals":["receiver","secondary","method_name","args"],"kind":"equation","loss_record":{"structural_divergence":{"args":[],"kind":"atomic","name":"guarded_case_chain"}},"post":{"lhs":{"args":[{"name":"receiver","kind":"var"},{"name":"secondary","kind":"var"},{"name":"method_name","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"concept:double-dispatch"},"rhs":{"args":[{"name":"receiver","kind":"var"},{"name":"method_name","kind":"var"},{"name":"secondary","kind":"var"},{"name":"args","kind":"var"}],"kind":"atomic","name":"ruby:public_send"}},"role":"abstraction-realization","target_lang":"ruby"}"#;
+
+const DD_RUBY_CID: &str =
+    "blake3-512:730a633f0e59e0393261ac911be375821cf86a1c49a61fc3135a1cf01720d2e9ba1e339beca4dac2c67e04a3ffc5695305291b8f101c0b7484178e2a0a66b81c";
+
+#[test]
+fn dd_ruby_cid_stable() {
+    let cid = cid_of_json(DD_RUBY_CANONICAL);
+    println!("dd->ruby CID = {cid}");
+    assert_eq!(cid, DD_RUBY_CID, "dd->ruby CID must be pinned");
+}
+
+#[test]
+fn dd_ruby_jcs_round_trip() {
+    assert_jcs_stable(DD_RUBY_CANONICAL, "dd->ruby");
+}
+
+// ================================================================
+// Projection-distance law
+// ================================================================
+//
+// The three double-dispatch realizations demonstrate the C-far/Java-mid/Ruby-near
+// projection-distance law from spec §3.0:
+//
+//   C:    structural_divergence + domain_narrowing  (heavy)
+//   Java: structural_divergence only                (mid; visitor pattern indirection)
+//   Ruby: structural_divergence only, lighter       (near-zero; native send)
+//
+// This test reads the canonical JSON for each and asserts the expected
+// loss-record shape matches the spec's characterization.
+
+#[test]
+fn projection_distance_law_c_has_structural_and_domain_narrowing() {
+    let j: Json = serde_json::from_str(DD_C11_CANONICAL).expect("parse dd->c11");
+    let lr = j.pointer("/loss_record").expect("loss_record present");
+    assert!(
+        lr.pointer("/structural_divergence").is_some(),
+        "C realization MUST have structural_divergence"
+    );
+    assert!(
+        lr.pointer("/domain_narrowing").is_some(),
+        "C realization MUST have domain_narrowing (heavy end)"
+    );
+}
+
+#[test]
+fn projection_distance_law_java_has_structural_no_domain_narrowing() {
+    let j: Json = serde_json::from_str(DD_JAVA_CANONICAL).expect("parse dd->java");
+    let lr = j.pointer("/loss_record").expect("loss_record present");
+    assert!(
+        lr.pointer("/structural_divergence").is_some(),
+        "Java realization MUST have structural_divergence"
+    );
+    assert!(
+        lr.pointer("/domain_narrowing").is_none(),
+        "Java realization MUST NOT have domain_narrowing in this fixture (mid)"
+    );
+}
+
+#[test]
+fn projection_distance_law_ruby_has_structural_only() {
+    let j: Json = serde_json::from_str(DD_RUBY_CANONICAL).expect("parse dd->ruby");
+    let lr = j.pointer("/loss_record").expect("loss_record present");
+    assert!(
+        lr.pointer("/structural_divergence").is_some(),
+        "Ruby realization MUST have structural_divergence"
+    );
+    assert!(
+        lr.pointer("/domain_narrowing").is_none(),
+        "Ruby realization MUST NOT have domain_narrowing (near-zero end)"
+    );
+    assert!(
+        lr.pointer("/ub_introduction").is_none(),
+        "Ruby realization MUST NOT have ub_introduction"
+    );
+    assert!(
+        lr.pointer("/value_divergence").is_none(),
+        "Ruby realization MUST NOT have value_divergence"
+    );
+    assert!(
+        lr.pointer("/effect_divergence").is_none(),
+        "Ruby realization MUST NOT have effect_divergence"
+    );
+}

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -322,3 +322,137 @@ pub type ConnectiveKind = String;
 
 pub type Term = IrTerm;
 pub type Formula = IrFormula;
+
+// ============================================================
+// NOTE: Manual extension block -- abstraction layer (issue #71)
+// ============================================================
+//
+// The types below are manually added per the convention established in
+// the Sort enum above. They implement the CDDL defined in
+// protocol/provekit-ir.cddl §"Abstraction layer" and are sourced from
+// protocol/specs/2026-05-15-concept-hub-abstraction-layer.md §2.1-§2.4.
+//
+// DO NOT regenerate this file via `cargo run -p provekit-ir-codegen`
+// without re-applying this block. See the Sort enum NOTE above.
+//
+// Key-order rule: struct field names mirror the CDDL key names exactly.
+// serde_json with the default BTreeMap representation emits keys in
+// lexicographic order (JCS canonical order). Fields that are
+// `skip_serializing_if = "Option::is_none"` are OMITTED when None;
+// the JCS bytes must match `serde_json::to_value` output exactly.
+//
+// "effects" is ALWAYS serialized (never skipped) even when empty,
+// because it is a required field in the CDDL schema.
+
+use std::collections::BTreeMap;
+
+/// A map from loss-dimension name to an `ir-formula` characterizing that
+/// dimension's divergence. An absent key means "no loss in that dimension."
+///
+/// Dimension names (§2.4 of the spec):
+///   - "domain_narrowing"    -- inputs the realization cannot accept
+///   - "effect_divergence"   -- inputs where observable effect set differs
+///   - "structural_divergence" -- how far surface form diverges from the abstraction
+///                               (always non-empty for abstraction realizations)
+///   - "ub_introduction"     -- inputs where UB is introduced
+///   - "value_divergence"    -- inputs where result VALUE differs
+///
+/// `structural_divergence` is a successor-mint addition per LSP §4.4 relative
+/// to the #616 schema. Existing #616 loss-records without it read as
+/// structural_divergence = None (formula = ∅). CIDs of previously-minted
+/// mementos are NOT affected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct LossRecord(pub BTreeMap<String, IrFormula>);
+
+/// A single named slot in a `ConceptAbstractionMemento`.
+///
+/// Locked JCS key order: `name`, `variadic` (variadic omitted when absent).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbstractionSlot {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variadic: Option<bool>,
+}
+
+/// A hub node at the abstraction tier of the `concept:*` hub.
+///
+/// Source of truth: protocol/specs/2026-05-15-concept-hub-abstraction-layer.md §2.1
+/// CDDL: protocol/provekit-ir.cddl `ConceptAbstractionMemento`
+///
+/// Locked JCS key order:
+///   kind, operator, tier, slots, formal_sorts, result_sort, contract,
+///   contract_note (omitted when absent), realizations,
+///   superseded_by (omitted when absent), refines (omitted when absent)
+///
+/// NOTE: `realizations` is Vec (zero-or-more) in PR1. PR2 tightens to
+/// one-or-more via a successor mint with `refines = <PR1 schema CID>`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConceptAbstractionMemento {
+    pub kind: String,      // must be "concept-abstraction"
+    pub operator: String,
+    pub tier: String,      // must be "abstraction"
+    pub slots: Vec<AbstractionSlot>,
+    #[serde(rename = "formal_sorts")]
+    pub formal_sorts: Vec<String>,
+    #[serde(rename = "result_sort")]
+    pub result_sort: String,
+    pub contract: IrFormula,
+    #[serde(rename = "contract_note")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract_note: Option<String>,
+    pub realizations: Vec<String>,
+    #[serde(rename = "superseded_by")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refines: Option<String>,
+}
+
+/// The post-condition equation in a `RealizationDesugaringMemento`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RealizationPost {
+    pub lhs: IrFormula,
+    pub rhs: IrFormula,
+}
+
+/// A `DesugaringEquationMemento` (2026-05-11) elected into the
+/// "abstraction-realization" role.
+///
+/// Source of truth: protocol/specs/2026-05-15-concept-hub-abstraction-layer.md §2.2
+/// CDDL: protocol/provekit-ir.cddl `RealizationDesugaringMemento`
+///
+/// Locked JCS key order:
+///   kind, fn_name, formals, formal_sorts, pre (omitted when absent),
+///   post, role, direction, target_lang, loss_record,
+///   discharge_receipt (omitted when absent), effects,
+///   refines (omitted when absent)
+///
+/// NOTE: `discharge_receipt` is optional in PR1. PR2 tightens to required.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RealizationDesugaringMemento {
+    pub kind: String,            // must be "equation"
+    #[serde(rename = "fn_name")]
+    pub fn_name: String,
+    pub formals: Vec<String>,
+    #[serde(rename = "formal_sorts")]
+    pub formal_sorts: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre: Option<IrFormula>,
+    pub post: RealizationPost,
+    pub role: String,            // must be "abstraction-realization"
+    pub direction: String,       // must be "left-to-right"
+    #[serde(rename = "target_lang")]
+    pub target_lang: String,
+    #[serde(rename = "loss_record")]
+    pub loss_record: LossRecord,
+    #[serde(rename = "discharge_receipt")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discharge_receipt: Option<String>,
+    pub effects: Vec<String>,    // always [] for the equation itself; never skip
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refines: Option<String>,
+}
+
+// ============================================================
+// End manual extension block -- abstraction layer (issue #71)
+// ============================================================

--- a/implementations/rust/provekit-ir-types/tests/abstraction_layer_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/abstraction_layer_serde.rs
@@ -1,0 +1,464 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Round-trip serde tests for the abstraction-layer types.
+//
+// Source of truth:
+//   protocol/specs/2026-05-15-concept-hub-abstraction-layer.md §2.1, §2.2, §2.4
+//   protocol/provekit-ir.cddl  (ConceptAbstractionMemento, RealizationDesugaringMemento)
+//
+// These tests pin:
+//   * The Rust abstraction-layer types deserialize from the wire shape the
+//     spec defines.
+//   * Round-trip parity at the serde layer: parse -> serialize -> parse
+//     yields the same value.
+//   * Optional fields (contract_note, superseded_by, refines, pre,
+//     discharge_receipt) are absent from the serialized JSON when None.
+//   * `effects: []` is always present in the serialized JSON even when empty.
+//   * `LossRecord` with `structural_divergence` round-trips correctly.
+//
+// Byte-exact CID pinning lives in
+//   provekit-claim-envelope/tests/abstraction_layer_cid_pin.rs
+// because this crate has no JCS encoder.
+
+use std::collections::BTreeMap;
+
+use provekit_ir_types::{
+    AbstractionSlot, ConceptAbstractionMemento, IrFormula, LossRecord,
+    RealizationDesugaringMemento,
+};
+
+// ================================================================
+// concept:dynamic-dispatch -- ConceptAbstractionMemento fixture
+// ================================================================
+
+const DYNAMIC_DISPATCH_JSON: &str = r#"{
+  "kind": "concept-abstraction",
+  "operator": "concept:dynamic-dispatch",
+  "tier": "abstraction",
+  "slots": [
+    {"name": "receiver"},
+    {"name": "method_name"},
+    {"name": "args", "variadic": true}
+  ],
+  "formal_sorts": [
+    "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+    "blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  ],
+  "result_sort": "blake3-512:sort3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+  "contract": {
+    "kind": "choice",
+    "varName": "m",
+    "sort": {"kind": "primitive", "name": "Int"},
+    "body": {
+      "kind": "and",
+      "operands": [
+        {"kind": "atomic", "name": "defined", "args": [{"kind": "var", "name": "m"}]},
+        {"kind": "atomic", "name": "wp_call", "args": [{"kind": "var", "name": "m"}, {"kind": "var", "name": "receiver"}]}
+      ]
+    }
+  },
+  "contract_note": "the call result and effect equal those of the method that resolves from the receiver runtime type for method_name applied to receiver and args; if no such method resolves the behaviour is undefined",
+  "realizations": []
+}"#;
+
+#[test]
+fn dynamic_dispatch_deserializes_from_spec_shape() {
+    let m: ConceptAbstractionMemento =
+        serde_json::from_str(DYNAMIC_DISPATCH_JSON).expect("parse concept:dynamic-dispatch");
+
+    assert_eq!(m.kind, "concept-abstraction");
+    assert_eq!(m.operator, "concept:dynamic-dispatch");
+    assert_eq!(m.tier, "abstraction");
+    assert_eq!(m.slots.len(), 3);
+    assert_eq!(m.slots[0].name, "receiver");
+    assert_eq!(m.slots[0].variadic, None);
+    assert_eq!(m.slots[1].name, "method_name");
+    assert_eq!(m.slots[2].name, "args");
+    assert_eq!(m.slots[2].variadic, Some(true));
+    assert_eq!(m.formal_sorts.len(), 3);
+    assert!(m.formal_sorts[0].starts_with("blake3-512:"));
+    assert!(m.result_sort.starts_with("blake3-512:"));
+    assert!(m.contract_note.is_some());
+    assert_eq!(m.realizations.len(), 0);
+    assert!(m.superseded_by.is_none());
+    assert!(m.refines.is_none());
+}
+
+#[test]
+fn dynamic_dispatch_round_trips() {
+    let m1: ConceptAbstractionMemento =
+        serde_json::from_str(DYNAMIC_DISPATCH_JSON).expect("parse");
+    let serialized = serde_json::to_string(&m1).expect("serialize");
+    let m2: ConceptAbstractionMemento =
+        serde_json::from_str(&serialized).expect("re-parse");
+    assert_eq!(m1, m2);
+}
+
+#[test]
+fn concept_abstraction_optional_fields_absent_when_none() {
+    // Build a minimal ConceptAbstractionMemento with no optional fields.
+    let m = ConceptAbstractionMemento {
+        kind: "concept-abstraction".into(),
+        operator: "concept:dynamic-dispatch".into(),
+        tier: "abstraction".into(),
+        slots: vec![AbstractionSlot {
+            name: "receiver".into(),
+            variadic: None,
+        }],
+        formal_sorts: vec!["blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".into()],
+        result_sort: "blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111".into(),
+        contract: IrFormula::Atomic {
+            name: "true".into(),
+            args: vec![],
+        },
+        contract_note: None,
+        realizations: vec![],
+        superseded_by: None,
+        refines: None,
+    };
+
+    let json = serde_json::to_string(&m).expect("serialize");
+    assert!(!json.contains("contract_note"), "contract_note must be absent when None");
+    assert!(!json.contains("superseded_by"), "superseded_by must be absent when None");
+    assert!(!json.contains("refines"), "refines must be absent when None");
+    assert!(!json.contains("variadic"), "variadic must be absent when None");
+}
+
+// ================================================================
+// concept:double-dispatch -- ConceptAbstractionMemento fixture
+// ================================================================
+
+const DOUBLE_DISPATCH_JSON: &str = r#"{
+  "kind": "concept-abstraction",
+  "operator": "concept:double-dispatch",
+  "tier": "abstraction",
+  "slots": [
+    {"name": "receiver"},
+    {"name": "secondary"},
+    {"name": "method_name"},
+    {"name": "args", "variadic": true}
+  ],
+  "formal_sorts": [
+    "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+    "blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  ],
+  "result_sort": "blake3-512:sort3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+  "contract": {
+    "kind": "choice",
+    "varName": "m",
+    "sort": {"kind": "primitive", "name": "Int"},
+    "body": {
+      "kind": "and",
+      "operands": [
+        {"kind": "atomic", "name": "defined", "args": [{"kind": "var", "name": "m"}]},
+        {"kind": "atomic", "name": "wp_call", "args": [{"kind": "var", "name": "m"}, {"kind": "var", "name": "receiver"}, {"kind": "var", "name": "secondary"}]}
+      ]
+    }
+  },
+  "contract_note": "dispatch is resolved from the conjunction of the receiver runtime type and the secondary runtime type for method_name; if no such method resolves the behaviour is undefined",
+  "realizations": []
+}"#;
+
+#[test]
+fn double_dispatch_deserializes_from_spec_shape() {
+    let m: ConceptAbstractionMemento =
+        serde_json::from_str(DOUBLE_DISPATCH_JSON).expect("parse concept:double-dispatch");
+
+    assert_eq!(m.kind, "concept-abstraction");
+    assert_eq!(m.operator, "concept:double-dispatch");
+    assert_eq!(m.tier, "abstraction");
+    assert_eq!(m.slots.len(), 4);
+    assert_eq!(m.slots[0].name, "receiver");
+    assert_eq!(m.slots[1].name, "secondary");
+    assert_eq!(m.slots[2].name, "method_name");
+    assert_eq!(m.slots[3].name, "args");
+    assert_eq!(m.slots[3].variadic, Some(true));
+    assert_eq!(m.realizations.len(), 0);
+}
+
+#[test]
+fn double_dispatch_round_trips() {
+    let m1: ConceptAbstractionMemento =
+        serde_json::from_str(DOUBLE_DISPATCH_JSON).expect("parse");
+    let serialized = serde_json::to_string(&m1).expect("serialize");
+    let m2: ConceptAbstractionMemento =
+        serde_json::from_str(&serialized).expect("re-parse");
+    assert_eq!(m1, m2);
+}
+
+// ================================================================
+// RealizationDesugaringMemento -- double-dispatch x {c, java, ruby}
+// ================================================================
+
+const DD_TO_C_JSON: &str = r#"{
+  "kind": "equation",
+  "fn_name": "concept:double-dispatch->c11:2d-fn-ptr-table",
+  "formals": ["receiver", "secondary", "method_name", "args"],
+  "formal_sorts": [
+    "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+    "blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  ],
+  "pre": {
+    "kind": "atomic",
+    "name": "static_dispatch_table",
+    "args": [{"kind": "var", "name": "receiver"}, {"kind": "var", "name": "secondary"}]
+  },
+  "post": {
+    "lhs": {
+      "kind": "atomic",
+      "name": "concept:double-dispatch",
+      "args": [
+        {"kind": "var", "name": "receiver"},
+        {"kind": "var", "name": "secondary"},
+        {"kind": "var", "name": "method_name"},
+        {"kind": "var", "name": "args"}
+      ]
+    },
+    "rhs": {
+      "kind": "atomic",
+      "name": "concept:call",
+      "args": [
+        {"kind": "ctor", "name": "concept:index", "args": [
+          {"kind": "ctor", "name": "concept:index", "args": [
+            {"kind": "ctor", "name": "concept:member", "args": [{"kind": "var", "name": "receiver"}, {"kind": "const", "value": "dispatch_tbl", "sort": {"kind": "primitive", "name": "String"}}]},
+            {"kind": "ctor", "name": "concept:tag-of", "args": [{"kind": "var", "name": "receiver"}]}
+          ]},
+          {"kind": "ctor", "name": "concept:tag-of", "args": [{"kind": "var", "name": "secondary"}]}
+        ]},
+        {"kind": "var", "name": "receiver"},
+        {"kind": "var", "name": "secondary"},
+        {"kind": "var", "name": "args"}
+      ]
+    }
+  },
+  "role": "abstraction-realization",
+  "direction": "left-to-right",
+  "target_lang": "c11",
+  "loss_record": {
+    "structural_divergence": {
+      "kind": "atomic",
+      "name": "true",
+      "args": []
+    },
+    "domain_narrowing": {
+      "kind": "atomic",
+      "name": "requires_static_2d_dispatch_table",
+      "args": [{"kind": "var", "name": "receiver"}, {"kind": "var", "name": "secondary"}]
+    }
+  },
+  "effects": []
+}"#;
+
+const DD_TO_JAVA_JSON: &str = r#"{
+  "kind": "equation",
+  "fn_name": "concept:double-dispatch->jvm:visitor-pattern",
+  "formals": ["receiver", "secondary", "method_name", "args"],
+  "formal_sorts": [
+    "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+    "blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  ],
+  "post": {
+    "lhs": {
+      "kind": "atomic",
+      "name": "concept:double-dispatch",
+      "args": [
+        {"kind": "var", "name": "receiver"},
+        {"kind": "var", "name": "secondary"},
+        {"kind": "var", "name": "method_name"},
+        {"kind": "var", "name": "args"}
+      ]
+    },
+    "rhs": {
+      "kind": "atomic",
+      "name": "jvm:invokeinterface",
+      "args": [
+        {"kind": "var", "name": "receiver"},
+        {"kind": "var", "name": "method_name"},
+        {"kind": "var", "name": "secondary"},
+        {"kind": "var", "name": "args"}
+      ]
+    }
+  },
+  "role": "abstraction-realization",
+  "direction": "left-to-right",
+  "target_lang": "java",
+  "loss_record": {
+    "structural_divergence": {
+      "kind": "atomic",
+      "name": "visitor_pattern_indirection",
+      "args": []
+    }
+  },
+  "effects": []
+}"#;
+
+const DD_TO_RUBY_JSON: &str = r#"{
+  "kind": "equation",
+  "fn_name": "concept:double-dispatch->ruby:case-respond_to",
+  "formals": ["receiver", "secondary", "method_name", "args"],
+  "formal_sorts": [
+    "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blake3-512:sort1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+    "blake3-512:sort2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  ],
+  "post": {
+    "lhs": {
+      "kind": "atomic",
+      "name": "concept:double-dispatch",
+      "args": [
+        {"kind": "var", "name": "receiver"},
+        {"kind": "var", "name": "secondary"},
+        {"kind": "var", "name": "method_name"},
+        {"kind": "var", "name": "args"}
+      ]
+    },
+    "rhs": {
+      "kind": "atomic",
+      "name": "ruby:public_send",
+      "args": [
+        {"kind": "var", "name": "receiver"},
+        {"kind": "var", "name": "method_name"},
+        {"kind": "var", "name": "secondary"},
+        {"kind": "var", "name": "args"}
+      ]
+    }
+  },
+  "role": "abstraction-realization",
+  "direction": "left-to-right",
+  "target_lang": "ruby",
+  "loss_record": {
+    "structural_divergence": {
+      "kind": "atomic",
+      "name": "guarded_case_chain",
+      "args": []
+    }
+  },
+  "effects": []
+}"#;
+
+#[test]
+fn realization_c_deserializes_and_round_trips() {
+    let m: RealizationDesugaringMemento =
+        serde_json::from_str(DD_TO_C_JSON).expect("parse dd->c11");
+
+    assert_eq!(m.kind, "equation");
+    assert_eq!(m.fn_name, "concept:double-dispatch->c11:2d-fn-ptr-table");
+    assert_eq!(m.role, "abstraction-realization");
+    assert_eq!(m.direction, "left-to-right");
+    assert_eq!(m.target_lang, "c11");
+    assert!(m.pre.is_some(), "c11 realization has a pre-condition");
+    assert!(m.discharge_receipt.is_none(), "discharge_receipt absent in PR1");
+    assert_eq!(m.effects, Vec::<String>::new(), "effects must be empty slice");
+
+    // structural_divergence and domain_narrowing both set for C
+    assert!(
+        m.loss_record.0.contains_key("structural_divergence"),
+        "C realization must have structural_divergence"
+    );
+    assert!(
+        m.loss_record.0.contains_key("domain_narrowing"),
+        "C realization must have domain_narrowing"
+    );
+
+    // Round-trip
+    let s = serde_json::to_string(&m).expect("serialize");
+    let m2: RealizationDesugaringMemento = serde_json::from_str(&s).expect("re-parse");
+    assert_eq!(m, m2);
+}
+
+#[test]
+fn realization_java_deserializes_and_round_trips() {
+    let m: RealizationDesugaringMemento =
+        serde_json::from_str(DD_TO_JAVA_JSON).expect("parse dd->java");
+
+    assert_eq!(m.kind, "equation");
+    assert_eq!(m.fn_name, "concept:double-dispatch->jvm:visitor-pattern");
+    assert_eq!(m.target_lang, "java");
+    assert!(m.pre.is_none(), "java realization has no pre-condition");
+
+    // structural_divergence set; domain_narrowing absent (near-zero)
+    assert!(
+        m.loss_record.0.contains_key("structural_divergence"),
+        "Java realization must have structural_divergence"
+    );
+    // Java may or may not have domain_narrowing -- do not assert either way
+
+    let s = serde_json::to_string(&m).expect("serialize");
+    let m2: RealizationDesugaringMemento = serde_json::from_str(&s).expect("re-parse");
+    assert_eq!(m, m2);
+}
+
+#[test]
+fn realization_ruby_deserializes_and_round_trips() {
+    let m: RealizationDesugaringMemento =
+        serde_json::from_str(DD_TO_RUBY_JSON).expect("parse dd->ruby");
+
+    assert_eq!(m.kind, "equation");
+    assert_eq!(m.fn_name, "concept:double-dispatch->ruby:case-respond_to");
+    assert_eq!(m.target_lang, "ruby");
+    assert!(m.pre.is_none(), "ruby realization has no pre-condition");
+
+    assert!(
+        m.loss_record.0.contains_key("structural_divergence"),
+        "Ruby realization must have structural_divergence"
+    );
+
+    let s = serde_json::to_string(&m).expect("serialize");
+    let m2: RealizationDesugaringMemento = serde_json::from_str(&s).expect("re-parse");
+    assert_eq!(m, m2);
+}
+
+#[test]
+fn realization_effects_always_present_in_json() {
+    // effects: [] is a required field; it must appear in the serialized JSON
+    // even when the Vec is empty. This test guards against accidental
+    // `#[serde(skip_serializing_if = "Vec::is_empty")]` on that field.
+    let m: RealizationDesugaringMemento =
+        serde_json::from_str(DD_TO_RUBY_JSON).expect("parse");
+    let json = serde_json::to_string(&m).expect("serialize");
+    assert!(
+        json.contains("\"effects\":"),
+        "effects field MUST always be present in serialized JSON (even when empty)"
+    );
+    assert!(
+        json.contains("\"effects\":[]"),
+        "effects field MUST serialize as empty array []"
+    );
+}
+
+#[test]
+fn loss_record_structural_divergence_round_trips() {
+    // Verify LossRecord with structural_divergence serializes and round-trips.
+    let mut map = BTreeMap::new();
+    map.insert(
+        "structural_divergence".to_string(),
+        IrFormula::Atomic {
+            name: "true".into(),
+            args: vec![],
+        },
+    );
+    let lr = LossRecord(map);
+
+    let json = serde_json::to_string(&lr).expect("serialize");
+    assert!(json.contains("structural_divergence"), "structural_divergence must appear in JSON");
+
+    let lr2: LossRecord = serde_json::from_str(&json).expect("re-parse");
+    assert_eq!(lr, lr2);
+}
+
+#[test]
+fn loss_record_empty_round_trips() {
+    // An empty LossRecord (no dimensions set) is valid: all dimensions = ∅.
+    let lr = LossRecord::default();
+    let json = serde_json::to_string(&lr).expect("serialize");
+    let lr2: LossRecord = serde_json::from_str(&json).expect("re-parse");
+    assert_eq!(lr, lr2);
+}

--- a/implementations/rust/provekit-ir-types/tests/abstraction_layer_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/abstraction_layer_serde.rs
@@ -223,12 +223,18 @@ const DD_TO_C_JSON: &str = r#"{
       "kind": "atomic",
       "name": "concept:call",
       "args": [
-        {"kind": "ctor", "name": "concept:index", "args": [
+        {"kind": "ctor", "name": "concept:cast", "args": [
           {"kind": "ctor", "name": "concept:index", "args": [
-            {"kind": "ctor", "name": "concept:member", "args": [{"kind": "var", "name": "receiver"}, {"kind": "const", "value": "dispatch_tbl", "sort": {"kind": "primitive", "name": "String"}}]},
-            {"kind": "ctor", "name": "concept:tag-of", "args": [{"kind": "var", "name": "receiver"}]}
+            {"kind": "ctor", "name": "concept:index", "args": [
+              {"kind": "ctor", "name": "concept:member", "args": [
+                {"kind": "var", "name": "receiver"},
+                {"kind": "const", "sort": {"kind": "primitive", "name": "String"}, "value": "dispatch_tbl"}
+              ]},
+              {"kind": "ctor", "name": "concept:tag-of", "args": [{"kind": "var", "name": "receiver"}]}
+            ]},
+            {"kind": "ctor", "name": "concept:tag-of", "args": [{"kind": "var", "name": "secondary"}]}
           ]},
-          {"kind": "ctor", "name": "concept:tag-of", "args": [{"kind": "var", "name": "secondary"}]}
+          {"kind": "const", "sort": {"kind": "primitive", "name": "String"}, "value": "fn_ptr_2d"}
         ]},
         {"kind": "var", "name": "receiver"},
         {"kind": "var", "name": "secondary"},
@@ -240,14 +246,23 @@ const DD_TO_C_JSON: &str = r#"{
   "direction": "left-to-right",
   "target_lang": "c11",
   "loss_record": {
-    "structural_divergence": {
-      "kind": "atomic",
-      "name": "true",
-      "args": []
-    },
     "domain_narrowing": {
       "kind": "atomic",
       "name": "requires_static_2d_dispatch_table",
+      "args": [{"kind": "var", "name": "receiver"}, {"kind": "var", "name": "secondary"}]
+    },
+    "structural_divergence": {
+      "kind": "atomic",
+      "name": "open_coded_vtable_replaces_single_op",
+      "args": [
+        {"kind": "ctor", "name": "concept:index", "args": [{"kind": "var", "name": "receiver"}]},
+        {"kind": "ctor", "name": "concept:index", "args": [{"kind": "var", "name": "secondary"}]},
+        {"kind": "ctor", "name": "concept:cast", "args": []}
+      ]
+    },
+    "ub_introduction": {
+      "kind": "atomic",
+      "name": "out_of_range_tag_is_ub",
       "args": [{"kind": "var", "name": "receiver"}, {"kind": "var", "name": "secondary"}]
     }
   },
@@ -277,12 +292,19 @@ const DD_TO_JAVA_JSON: &str = r#"{
     },
     "rhs": {
       "kind": "atomic",
-      "name": "jvm:invokeinterface",
+      "name": "concept:seq",
       "args": [
-        {"kind": "var", "name": "receiver"},
-        {"kind": "var", "name": "method_name"},
-        {"kind": "var", "name": "secondary"},
-        {"kind": "var", "name": "args"}
+        {"kind": "ctor", "name": "concept:itab-method", "args": [
+          {"kind": "var", "name": "receiver"},
+          {"kind": "const", "sort": {"kind": "primitive", "name": "String"}, "value": "accept"},
+          {"kind": "var", "name": "secondary"}
+        ]},
+        {"kind": "ctor", "name": "concept:itab-method", "args": [
+          {"kind": "var", "name": "secondary"},
+          {"kind": "const", "sort": {"kind": "primitive", "name": "String"}, "value": "visit_receiver_type"},
+          {"kind": "var", "name": "receiver"},
+          {"kind": "var", "name": "args"}
+        ]}
       ]
     }
   },
@@ -290,10 +312,18 @@ const DD_TO_JAVA_JSON: &str = r#"{
   "direction": "left-to-right",
   "target_lang": "java",
   "loss_record": {
+    "domain_narrowing": {
+      "kind": "atomic",
+      "name": "visitable_set_fixed_at_declaration",
+      "args": [{"kind": "var", "name": "receiver"}, {"kind": "var", "name": "secondary"}]
+    },
     "structural_divergence": {
       "kind": "atomic",
-      "name": "visitor_pattern_indirection",
-      "args": []
+      "name": "visitor_accept_visit_indirection",
+      "args": [
+        {"kind": "ctor", "name": "concept:itab-method", "args": [{"kind": "var", "name": "receiver"}]},
+        {"kind": "ctor", "name": "concept:itab-method", "args": [{"kind": "var", "name": "secondary"}]}
+      ]
     }
   },
   "effects": []
@@ -301,7 +331,7 @@ const DD_TO_JAVA_JSON: &str = r#"{
 
 const DD_TO_RUBY_JSON: &str = r#"{
   "kind": "equation",
-  "fn_name": "concept:double-dispatch->ruby:case-respond_to",
+  "fn_name": "concept:double-dispatch->ruby:case-type-tuple",
   "formals": ["receiver", "secondary", "method_name", "args"],
   "formal_sorts": [
     "blake3-512:sort0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -322,12 +352,27 @@ const DD_TO_RUBY_JSON: &str = r#"{
     },
     "rhs": {
       "kind": "atomic",
-      "name": "ruby:public_send",
+      "name": "concept:match",
       "args": [
-        {"kind": "var", "name": "receiver"},
-        {"kind": "var", "name": "method_name"},
-        {"kind": "var", "name": "secondary"},
-        {"kind": "var", "name": "args"}
+        {"kind": "ctor", "name": "concept:pair", "args": [
+          {"kind": "ctor", "name": "concept:type-of", "args": [{"kind": "var", "name": "receiver"}]},
+          {"kind": "ctor", "name": "concept:type-of", "args": [{"kind": "var", "name": "secondary"}]}
+        ]},
+        {"kind": "ctor", "name": "concept:match-arm", "args": [
+          {"kind": "ctor", "name": "concept:pair", "args": [
+            {"kind": "ctor", "name": "concept:tag-of", "args": [{"kind": "var", "name": "receiver"}]},
+            {"kind": "ctor", "name": "concept:tag-of", "args": [{"kind": "var", "name": "secondary"}]}
+          ]},
+          {"kind": "ctor", "name": "concept:call", "args": [
+            {"kind": "var", "name": "method_name"},
+            {"kind": "var", "name": "receiver"},
+            {"kind": "var", "name": "secondary"},
+            {"kind": "var", "name": "args"}
+          ]}
+        ]},
+        {"kind": "ctor", "name": "concept:raise", "args": [
+          {"kind": "const", "sort": {"kind": "primitive", "name": "String"}, "value": "TypeError"}
+        ]}
       ]
     }
   },
@@ -337,8 +382,10 @@ const DD_TO_RUBY_JSON: &str = r#"{
   "loss_record": {
     "structural_divergence": {
       "kind": "atomic",
-      "name": "guarded_case_chain",
-      "args": []
+      "name": "case_fallthrough_narrows_open_dispatch",
+      "args": [
+        {"kind": "ctor", "name": "concept:raise", "args": []}
+      ]
     }
   },
   "effects": []
@@ -358,7 +405,7 @@ fn realization_c_deserializes_and_round_trips() {
     assert!(m.discharge_receipt.is_none(), "discharge_receipt absent in PR1");
     assert_eq!(m.effects, Vec::<String>::new(), "effects must be empty slice");
 
-    // structural_divergence and domain_narrowing both set for C
+    // structural_divergence, domain_narrowing AND ub_introduction all set for C (heaviest end)
     assert!(
         m.loss_record.0.contains_key("structural_divergence"),
         "C realization must have structural_divergence"
@@ -366,6 +413,10 @@ fn realization_c_deserializes_and_round_trips() {
     assert!(
         m.loss_record.0.contains_key("domain_narrowing"),
         "C realization must have domain_narrowing"
+    );
+    assert!(
+        m.loss_record.0.contains_key("ub_introduction"),
+        "C realization must have ub_introduction (out-of-range tag -> UB)"
     );
 
     // Round-trip
@@ -384,12 +435,21 @@ fn realization_java_deserializes_and_round_trips() {
     assert_eq!(m.target_lang, "java");
     assert!(m.pre.is_none(), "java realization has no pre-condition");
 
-    // structural_divergence set; domain_narrowing absent (near-zero)
+    // structural_divergence AND domain_narrowing set for Java (mid: visitor adds accept/visit
+    // indirection; visitable-set is fixed at interface declaration time)
     assert!(
         m.loss_record.0.contains_key("structural_divergence"),
         "Java realization must have structural_divergence"
     );
-    // Java may or may not have domain_narrowing -- do not assert either way
+    assert!(
+        m.loss_record.0.contains_key("domain_narrowing"),
+        "Java realization must have domain_narrowing (visitable-set fixed at declaration)"
+    );
+    // Java must NOT have ub_introduction (that's the heavy C end only)
+    assert!(
+        !m.loss_record.0.contains_key("ub_introduction"),
+        "Java realization must NOT have ub_introduction"
+    );
 
     let s = serde_json::to_string(&m).expect("serialize");
     let m2: RealizationDesugaringMemento = serde_json::from_str(&s).expect("re-parse");
@@ -402,13 +462,24 @@ fn realization_ruby_deserializes_and_round_trips() {
         serde_json::from_str(DD_TO_RUBY_JSON).expect("parse dd->ruby");
 
     assert_eq!(m.kind, "equation");
-    assert_eq!(m.fn_name, "concept:double-dispatch->ruby:case-respond_to");
+    assert_eq!(m.fn_name, "concept:double-dispatch->ruby:case-type-tuple");
     assert_eq!(m.target_lang, "ruby");
     assert!(m.pre.is_none(), "ruby realization has no pre-condition");
 
+    // structural_divergence only, near-zero (Ruby writes the implication structure directly
+    // via a case-match over the type tuple -- the realization ≈ the contract)
     assert!(
         m.loss_record.0.contains_key("structural_divergence"),
         "Ruby realization must have structural_divergence"
+    );
+    // Ruby must NOT have domain_narrowing (no fixed interface required) or ub_introduction
+    assert!(
+        !m.loss_record.0.contains_key("domain_narrowing"),
+        "Ruby realization must NOT have domain_narrowing"
+    );
+    assert!(
+        !m.loss_record.0.contains_key("ub_introduction"),
+        "Ruby realization must NOT have ub_introduction"
     );
 
     let s = serde_json::to_string(&m).expect("serialize");

--- a/protocol/provekit-ir.cddl
+++ b/protocol/provekit-ir.cddl
@@ -350,3 +350,127 @@ PinInvariantMemento = {
   ? note: tstr,
 }
 
+; ================================================================
+; Abstraction layer -- concept:* hub tier 2
+; ================================================================
+; Source of truth:
+;   protocol/specs/2026-05-15-concept-hub-abstraction-layer.md §2.1, §2.2, §2.4
+; Implements: issue #71, PR feat/abstraction-layer-1-schemas
+;
+; Two new memento types:
+;   ConceptAbstractionMemento   -- a hub node at the abstraction tier (§2.1)
+;   RealizationDesugaringMemento -- a DesugaringEquationMemento in
+;                                   role "abstraction-realization" (§2.2)
+;
+; One extended loss-record dimension:
+;   structural_divergence        -- new fifth dimension (§2.4); successor mint
+;                                   of the #616 schema per LSP §4.4
+;
+; NOTE: `realizations` is `[* cid]` (zero-or-more) in this PR1 schema.
+; PR2 will tighten it to `[+ cid]` (one-or-more) per spec §2.1 by minting
+; a successor schema with `refines = <PR1 CID>` per LSP §4.4.
+;
+; NOTE: `discharge_receipt` is optional in this PR1 schema. PR2 tightens.
+
+; ----------------------------------------------------------------
+; Shared primitive
+; ----------------------------------------------------------------
+
+; A CID is a blake3-512: prefixed 128-hex-char string.
+; This alias is used throughout.
+; (Also used by PinInvariantMemento above via the same convention.)
+
+; sort-ref is a SortMemento CID (a blake3-512: string)
+sort-ref = tstr
+
+; ----------------------------------------------------------------
+; Loss record (extended with structural_divergence -- §2.4)
+; ----------------------------------------------------------------
+;
+; SUCCESSOR MINT NOTE (structural_divergence):
+;   This dimension is a successor-mint addition per LSP §4.4 relative to
+;   the #616 schema (2026-05-14-transport-gap-and-partial-morphism-protocol.md).
+;   Existing #616 loss-records that omit it read as structural_divergence = ∅.
+;   CIDs of previously-minted mementos are NOT affected.
+;
+; An absent dimension key means "no loss in that dimension" (formula = ∅).
+; The open-map syntax allows forward-compatible dimension additions.
+;
+; Locked key order (alphabetical per JCS):
+;   domain_narrowing, effect_divergence, structural_divergence,
+;   ub_introduction, value_divergence
+
+LossRecord = {
+  ? "domain_narrowing":     ir-formula,   ; inputs target realization cannot accept
+  ? "effect_divergence":    ir-formula,   ; inputs where observable effect set differs
+  ? "structural_divergence": ir-formula,  ; always non-empty for abstraction realizations
+                                          ;   (§2.4): measures how far surface form of the
+                                          ;   realization diverges from the abstraction
+  ? "ub_introduction":      ir-formula,   ; inputs where target introduces UB absent in source
+  ? "value_divergence":     ir-formula,   ; inputs where result VALUE differs
+}
+
+; Convenience alias matching spec §2.4 dimension names
+loss-record = LossRecord
+
+; ----------------------------------------------------------------
+; ConceptAbstractionMemento (§2.1)
+; ----------------------------------------------------------------
+;
+; Locked key order:
+;   kind, operator, tier, slots, formal_sorts, result_sort, contract,
+;   ? contract_note, realizations, ? superseded_by, ? refines
+
+ConceptAbstractionMemento = {
+  kind:              "concept-abstraction",
+  operator:          tstr,               ; e.g. "concept:dynamic-dispatch"
+  tier:              "abstraction",      ; pins the layer
+  slots:             [+ AbstractionSlot],
+  formal_sorts:      [+ sort-ref],       ; one per slot, same order
+  result_sort:       sort-ref,
+  contract:          ir-formula,         ; the wp_rule of the abstraction; see §2.3
+  ? contract_note:   tstr,              ; human-readable; non-load-bearing; OMIT when absent
+  realizations:      [* cid],            ; CIDs of RealizationDesugaringMemento (>= 0 in PR1;
+                                         ;   PR2 tightens to >= 1 per spec §2.1)
+  ? superseded_by:   cid,               ; successor abstraction node CID
+  ? refines:         cid,               ; LSP §4.4 successor-mint chain
+}
+
+; Locked key order: name, ? variadic
+AbstractionSlot = {
+  name:          tstr,                   ; e.g. "receiver", "method_name", "args"
+  ? variadic:    bool,                   ; default false; marks variadic (e.g. "args")
+}
+
+; ----------------------------------------------------------------
+; RealizationDesugaringMemento (§2.2)
+; ----------------------------------------------------------------
+;
+; A DesugaringEquationMemento (2026-05-11) elected into the
+; "abstraction-realization" role with three additive fields:
+;   role, direction, target_lang, loss_record, discharge_receipt.
+;
+; Locked key order:
+;   kind, fn_name, formals, formal_sorts, ? pre, post,
+;   role, direction, target_lang, loss_record, discharge_receipt, effects, ? refines
+
+RealizationDesugaringMemento = {
+  kind:              "equation",               ; unchanged: it IS a desugaring equation
+  fn_name:           tstr,                     ; e.g. "concept:dynamic-dispatch->c11:vtable-indirection"
+  formals:           [+ tstr],                 ; the abstraction's slot variable names
+  formal_sorts:      [+ sort-ref],
+  ? pre:             ir-formula,               ; side condition: WHEN this realization is admissible
+  post: {                                      ; the equation lhs = rhs
+    lhs: ir-formula,                           ; concept:<abstraction>(<slots>)
+    rhs: ir-formula,                           ; per-language operation-layer expansion
+  },
+  role:              "abstraction-realization",
+  direction:         "left-to-right",          ; lhs is abstraction, rhs is lang term
+  target_lang:       tstr,                     ; LSP language id ("c11", "java", "ruby", ...)
+  loss_record:       loss-record,
+  ? discharge_receipt: cid,                    ; CID of a MorphismDischargeReceipt (optional in PR1;
+                                               ;   PR2 tightens to required per spec §2.2)
+  effects:           [* tstr],                 ; always [] for the equation itself; rhs term carries effects
+  ? refines:         cid,
+}
+


### PR DESCRIPTION
## Summary

PR 1 of the abstraction-layer chain (issue #71). Implements the schema and fixture deliverables from spec `protocol/specs/2026-05-15-concept-hub-abstraction-layer.md` (merged PR #617). No hub catalog entries are added; `mint.sh` stays byte-clean.

### Deliverables

**(1) CDDL** -- `protocol/provekit-ir.cddl` extended with:
- `ConceptAbstractionMemento` + `AbstractionSlot`: the abstraction-tier hub node schema (spec §2.1)
- `RealizationDesugaringMemento`: a `DesugaringEquationMemento` in role `abstraction-realization` with `role`, `direction`, `target_lang`, `loss_record`, `discharge_receipt` additive fields (spec §2.2)
- `LossRecord` extended with `structural_divergence` as the fifth dimension (spec §2.4); successor-mint of #616 schema per LSP §4.4

Schema notes:
- `realizations: [* cid]` (zero-or-more) in PR1; PR2 tightens to `[+ cid]` via a successor schema mint with `refines = <PR1 CID>`
- `discharge_receipt: cid` optional in PR1; PR2 tightens to required
- `effects: []` is always serialized (never skipped) per CDDL spec

**(2) Rust types** -- `provekit-ir-types/src/lib.rs` manual-extension block:
- `LossRecord` as `BTreeMap<String, IrFormula>` (lexicographic key order = JCS canonical order)
- `AbstractionSlot`, `ConceptAbstractionMemento`, `RealizationPost`, `RealizationDesugaringMemento`
- All derive `Eq` for test assertions

**(3) `concept:dynamic-dispatch` fixture** (`ConceptAbstractionMemento`):
- Slots: `receiver`, `method_name`, `args` (variadic)
- Contract: Skolem `choice m. defined(m) ∧ wp_call(m, [receiver, ...args])` predicate (§2.3 wp_rule)
- `realizations: []` (empty for PR1)
- Pinned CID: `blake3-512:ca8ff4e631fe41885b37f897b42906e62e2b4079438ce6480885b5eb0f01207314fd38563591e82304aaa9c1b750e94a8baa24f5e9401cd2ed873da0cd0c90da`

**(4) `concept:double-dispatch` fixture** (`ConceptAbstractionMemento`):
- Slots: `receiver`, `secondary`, `method_name`, `args` (variadic)
- Contract: conjunction-of-guarded-clauses Skolem over (receiver, secondary) runtime-type pair
- `realizations: []`
- Pinned CID: `blake3-512:1cc86fe75917b11e41cb847ee5e5815d67e69f5d5c93f89c0fc54c273312060ae26c6170c8c2d9b22170fabbc627b5d614b3c39c486fcd9edc6e44433cff9909`

**(5) Three `RealizationDesugaringMemento` fixtures** -- double-dispatch x {c11, java, ruby}:

The three fixtures demonstrate the projection-distance law from spec §3.0:

| Target | `structural_divergence` | `domain_narrowing` | Pinned CID |
|--------|------------------------|-------------------|------------|
| `c11` (2D fn-ptr table) | heavy (true) | requires_static_2d_dispatch_table | `blake3-512:081b7f07...` |
| `java` (visitor pattern / invokeinterface) | mid (visitor_pattern_indirection) | absent | `blake3-512:8ea85ecd...` |
| `ruby` (case/respond_to chain) | near-zero (guarded_case_chain) | absent | `blake3-512:730a633f...` |

C is the unforgiving end: both `structural_divergence` AND `domain_narrowing` non-empty. Java is the middle: `structural_divergence` only (JVM dispatch is near-native). Ruby is the loose end: `structural_divergence` only, lighter (native `public_send`).

**(6) `structural_divergence` coordination**:
- Declared in CDDL and Rust
- Dimension name `effect_divergence` (not `resource_introduction`) matches the spec §2.4 text and the #66-impl-PR1 `LossRecord` implementation
- Successor-mint of #616 loss-record schema per LSP §4.4: absent dimension = formula ∅; existing mementos unaffected

### Tests

- `provekit-ir-types/tests/abstraction_layer_serde.rs`: 11 serde round-trip tests
- `provekit-claim-envelope/tests/abstraction_layer_cid_pin.rs`: 13 JCS CID-pinning + projection-distance law tests

All 24 new tests pass. Full workspace passes (no regressions).

### mint.sh clean

No new entries in `menagerie/concept-shapes/specs/` or `catalog/`. `cids.tsv` SHA256 unchanged: `2618b39e508112f4d351653eceb58feea121b3e78ecc5a450c824d67ec3e0e23`.

### Coordinates with

- **#66-impl-PR1** (`TransportGapMemento` / `PartialMorphismMemento` / `LossyMorphismMemento`): both PRs declare the same five loss-record dimensions (`value_divergence`, `ub_introduction`, `domain_narrowing`, `effect_divergence`, `structural_divergence`). This PR adds `structural_divergence`; #66-impl-PR1 holds the other four from #616. Neither PR modifies the other's types.
- **#617** (merged spec): this PR implements PR1 of §8.1 of that spec.

### What PR2 adds

- Tighten `realizations: [+ cid]` via a successor schema mint with `refines = <PR1 ConceptAbstractionMemento CID>`
- Tighten `discharge_receipt: cid` (required)
- Populate `realizations` with real `RealizationDesugaringMemento` CIDs from the catalog
- Mint real `MorphismDischargeReceipt` mementos for the three double-dispatch realizations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Abstraction layer added to IR and schema: concept abstractions, realization-desugaring equations, abstraction slots, and loss-records for richer contract/structural modeling.

* **Tests**
  * Extensive serialization and stability tests: canonical JSON/JCS round-trips, pinned-CID verification for fixtures, duplicate-key audit to ensure stable canonicalization, and loss-record shape/assertions across realizations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/634)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->