### PR TITLE
fix(lift-php): token-fallback path misses nested-assign (paren-strip + assign-expr in lowerFallbackExpr)

### DIFF
--- a/implementations/php/provekit-lift-php-source/src/PhpSourceLifter.php
+++ b/implementations/php/provekit-lift-php-source/src/PhpSourceLifter.php
@@ -829,6 +829,12 @@ final class PhpSourceLifter
     private function lowerFallbackExpr(string $expr, EffectSet $effects): array
     {
         $expr = trim($expr);
+        if (str_starts_with($expr, '(') && str_ends_with($expr, ')')) {
+            $inner = substr($expr, 1, -1);
+            if ($this->fallbackParensBalance($inner)) {
+                return $this->lowerFallbackExpr($inner, $effects);
+            }
+        }
         if (preg_match('/^\$GLOBALS\["([^"]+)"\]$/', $expr, $m)) {
             $effects->addRead('GLOBALS.' . $m[1]);
             return ctor('php:index', var_term('GLOBALS'), string_const($m[1]));
@@ -838,6 +844,9 @@ final class PhpSourceLifter
         }
         if (preg_match('/^-?\\d+$/', $expr)) {
             return int_const((int)$expr);
+        }
+        if (preg_match('/^\\$(\\w+)\\s*=\\s*(.+)$/', $expr, $m)) {
+            return ctor('php:assign', var_term($m[1]), $this->lowerFallbackExpr($m[2], $effects));
         }
         if (preg_match('/^(.+)\\s*\\+\\s*(.+)$/', $expr, $m)) {
             return ctor('php:add', $this->lowerFallbackExpr($m[1], $effects), $this->lowerFallbackExpr($m[2], $effects));
@@ -852,6 +861,27 @@ final class PhpSourceLifter
             return ctor('php:lt', $this->lowerFallbackExpr($m[1], $effects), $this->lowerFallbackExpr($m[2], $effects));
         }
         throw new RefusalException('unhandled-syntax', null, 'token fallback cannot lower expression: ' . $expr);
+    }
+
+    /**
+     * Returns true if $s has balanced parentheses (i.e., the outer parens were
+     * the only wrapping layer and the content is self-contained).
+     */
+    private function fallbackParensBalance(string $s): bool
+    {
+        $depth = 0;
+        $len = strlen($s);
+        for ($i = 0; $i < $len; $i++) {
+            if ($s[$i] === '(') {
+                $depth++;
+            } elseif ($s[$i] === ')') {
+                $depth--;
+                if ($depth < 0) {
+                    return false;
+                }
+            }
+        }
+        return $depth === 0;
     }
 
     private function matchingBrace(string $source, int $open): ?int


### PR DESCRIPTION
## Summary

- PR #606 fixed `php:assign` in expression position for the PhpParser path (`exprNode()` + fallback `exprString()`), but left the token fallback *lift* path broken.
- `lowerFallbackExpr()` had no case for `$var = expr`, and the fallback compiler wraps assign-in-expression with parens (`($b = 1)`), so re-lifting compiled output hit an unhandled expression and threw `unhandled-syntax`.
- Two additions to `lowerFallbackExpr()`: paren-stripping at entry (balanced-paren check, then recurse into inner) + `$var = expr` recognizer emitting `ctor('php:assign', ...)` matching the PhpParser path.

## What broke

`$a = $b = 5;` in the token-fallback path (no PhpParser installed):
1. **Lift pass**: `lowerFallbackBody` matches outer `$a = ...` and calls `lowerFallbackExpr('$b = 1', ...)` -- **no handler, throws**. Fixed by the new `$var = expr` regex.
2. **Re-lift of compiled output**: Fallback compiler emits `($b = 1)` (with parens for precedence). Re-lift hits `lowerFallbackExpr('($b = 1)', ...)` -- **no paren-strip, no handler**. Fixed by the paren-strip + recurse.

## Decision: support, not refuse

The PhpParser path already supports nested assignment. The token-fallback path must match. Refusal would create a lifter/compiler asymmetry (compiler can emit it, lifter won't round-trip it).

## Regression test

`test_compile_nested_assign_expression_roundtrip` (added in #606, line 231 of `PhpSourceLifterTest.php`) covers:
- Lift of `function f() { $a = $b = 1; return $a + $b; }` with no refusals
- Compile back to PHP without throwing
- Re-lift asserts byte-identical IR round-trip

Before this fix: test fails on token-fallback path (`lowerFallbackExpr` throws on `$b = 1`).
After: all 7 tests pass.

## Test plan

- [x] `php provekit-lift-php-source/tests/PhpSourceLifterTest.php` — 7 passed
- [ ] CI conformance gate (includes PhpParser path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced PHP code expression parsing to handle additional construct variations, including improved parenthesis handling and assignment expression support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/637)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->