### PR TITLE
fix(lift-ts): replace tautological round-trip test with a real shape assertion

### DIFF
--- a/implementations/typescript/src/lift/typescript-source/index.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.test.ts
@@ -151,21 +151,42 @@ describe("typescript-source lifter", () => {
     ]));
   });
 
-  it("preserves source-unit raw bytes for lift(compile(lift(src))) round-trips", () => {
-    const source = "function add(x: number, y: number): number { return x + y; }\n";
+  it("round-trips a multi-statement body through the AST printer path (compileTypeScriptSourceIr without source-unit bytes)", () => {
+    // The tautology this replaces: compileTypeScriptSourceIr short-circuits through the
+    // stored bytes when a ts:source-unit is present, so it never exercised the AST printer.
+    // This test drives the real compile path by stripping the source-unit memento so
+    // compileFunctionContract + emitStatementsFromTerm must reconstruct TypeScript from the IR.
+    const source = `function compute(x: number, y: number): number {
+  let a = x + y;
+  if (a > 0) {
+    a = a - 1;
+  } else {
+    a = a + 1;
+  }
+  return a;
+}
+`;
     const first = liftTypeScriptSourceText(source, "src/roundtrip.ts");
     expect(first.refusals).toEqual([]);
 
-    const compiled = compileTypeScriptSourceIr(first.declarations);
+    // Strip the source-unit memento: forces compileTypeScriptSourceIr onto the AST printer path.
+    const contractsOnly = first.declarations.filter((d) => !d.fnName.endsWith(":<source-unit>"));
+    expect(contractsOnly).toHaveLength(1);
+
+    const compiled = compileTypeScriptSourceIr(contractsOnly);
     const second = liftTypeScriptSourceText(compiled, "src/roundtrip.ts");
 
-    expect(compiled).toBe(source);
     expect(second.refusals).toEqual([]);
-    expect(canonicalJsonString(second.declarations)).toBe(
-      canonicalJsonString(first.declarations),
+    const secondContractsOnly = second.declarations.filter((d) => !d.fnName.endsWith(":<source-unit>"));
+    expect(secondContractsOnly).toHaveLength(1);
+
+    // The body term (rhs of the postcondition) must be structurally identical.
+    expect(canonicalJsonString(rhs(secondContractsOnly[0]!))).toBe(
+      canonicalJsonString(rhs(contractsOnly[0]!)),
     );
-    expect(second.declarations.map(functionContractCid)).toEqual(
-      first.declarations.map(functionContractCid),
+    // And its content-address must match.
+    expect(canonicalCid(rhs(secondContractsOnly[0]!))).toBe(
+      canonicalCid(rhs(contractsOnly[0]!)),
     );
   });
 


### PR DESCRIPTION
## Summary

Closes the test bug flagged in PR #632 as "PR #595 nit #1: TS round-trip test is tautological (doesn't drive real compile path)."

## The tautology

`compileTypeScriptSourceIr` has a fast-path: when a `ts:source-unit` memento is present it returns the stored raw bytes directly, never calling `compileFunctionContract` or `emitStatementsFromTerm`. The old test (`"preserves source-unit raw bytes for lift(compile(lift(src))) round-trips"`) always hit that fast-path, so `compiled === source` was trivially guaranteed by construction. The AST printer could have been completely broken and the test would still pass.

## The fix

Strip the `ts:source-unit` memento before calling `compileTypeScriptSourceIr`. With no source-unit, the function falls through to `compileFunctionContract` + `emitStatementsFromTerm` (the real compile path). The input uses a multi-statement body with `let`, `if/else`, and `return` so the statement emitter is exercised non-trivially. Assertions check structural identity of the body term (both canonical JSON and CID), not just absence of refusals.

A bug in `emitStatementsFromTerm` (e.g. mangled `if` arms, wrong `ts:decl` handling) would produce a structurally different body term on re-lift and the new test would fail. The old test would have passed regardless.

## Test plan

- [x] `vitest run implementations/typescript/src/lift/typescript-source/index.test.ts` -- 8 passed (7 existing + 1 new)
- [x] `cargo test -p libprovekit -p provekit-cli` -- all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened TypeScript source compilation test coverage with enhanced round-trip validation. Tests now verify multi-statement function body handling through the AST-printer compilation path, ensuring structural integrity and content consistency throughout the recompilation process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/638)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->