### PR TITLE
feat(compound-contract): spec + Rust types + serde tests (PR-A of multi-source binding)

### DIFF
--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -1220,8 +1220,10 @@ pub struct EvidenceMemento {
     /// MUST be "evidence".
     pub kind: String,
     /// CID of the lifter binary or rule-set that emitted this evidence.
-    /// Reserved sentinel `blake3-512:autoPromote000...` for the
+    /// Reserved sentinel `blake3-512:` ++ 128 hex `0`s for the
     /// backward-compat auto-promotion path (compound spec §4.4).
+    /// All-zeros is provably not a real BLAKE3-512 output (P ≈ 2^-512).
+    /// Pass-1 CID validation accepts it without a special-case exception.
     #[serde(rename = "lifter_cid")]
     pub lifter_cid: String,
     /// The asserted predicate (an `IrFormula`).

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -1015,3 +1015,298 @@ pub struct ConceptSiteMemento {
 // ============================================================
 // End manual extension block -- concept-site layer (PR-A)
 // ============================================================
+
+// ============================================================
+// Manual extension: compound-contract layer (PR-A of compound spec)
+// Source of truth:
+//   protocol/specs/2026-05-13-compound-contract-memento.md §1, §2, §3
+//   AMENDS protocol/specs/2026-05-12-concept-site-memento.md §1.1 and §5.4
+//
+// This block adds the EvidenceMemento and CompoundContractMemento
+// substrate primitives. The compound is the new convergence point for
+// every contract-source the substrate can lift from a user's codebase:
+// annotations, test assertions, type signatures, docstrings, loop
+// invariants, implicit-effect call-sites, native contract surfaces
+// (JML / Zod / Spring / pydantic / OpenAPI), structurally synthesized
+// wp_rules, empirical witnesses, and (future) review comments.
+//
+// Trichotomy is enforced at TWO levels:
+//   * per-evidence: each evidence's discharge verdict against the
+//     concept's wp_rule (recorded in the discharge receipt, PR-F).
+//   * compound: derived from per-evidence verdicts under the recorded
+//     aggregation_strategy (§2 of the spec).
+//
+// v0 wires only `AggregationStrategy::Conjunction`; the other two
+// strategies are spec'd but `unimplemented!` here. The Rust enum carries
+// all three variants so downstream callers can name them; only the
+// conjunction discharge path is functional in v0.
+//
+// CID-determining bytes for both mementos are JCS(header) with `cid`
+// elided; that JCS encoder lives in provekit-claim-envelope. Byte-pin
+// tests for the compound CID belong there; THIS crate carries serde
+// round-trip tests only.
+// ============================================================
+
+/// One point inside a source span: 1-based line / col.
+///
+/// Locked JCS key order: col, line.
+///
+/// Note: line/col (not byte offsets) -- evidence often comes from
+/// docstrings, test sources, or native contract surfaces where byte
+/// offsets are unstable across re-formatting. This diverges from
+/// `CodeSiteSpan` (which uses byte offsets, anchored at the function
+/// boundary where formatters do not move text); see the compound spec
+/// §1.1 for rationale.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceLocatorPoint {
+    pub col: u32,
+    pub line: u32,
+}
+
+/// A span inside a source artifact, as a (start, end) pair of
+/// `SourceLocatorPoint`s.
+///
+/// Locked JCS key order: end, start.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceLocatorSpan {
+    pub end: SourceLocatorPoint,
+    pub start: SourceLocatorPoint,
+}
+
+/// Provenance for one piece of evidence: which source artifact it was
+/// extracted from, and where inside that artifact.
+///
+/// Locked JCS key order: source_cid, span.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceLocator {
+    #[serde(rename = "source_cid")]
+    pub source_cid: String,
+    pub span: SourceLocatorSpan,
+}
+
+/// The kind of contract-evidence source. Open enum; unknown labels
+/// MUST be accepted at shape level (per spec §5.1) and are carried as
+/// `Other(String)`.
+///
+/// Wire format: a bare JSON string (e.g., `"test-assertion"`).
+///
+/// Mirrors the `DivergentSemanticsTag` pattern: `#[serde(from = "String",
+/// into = "String")]` with explicit kebab-case mapping. (Using
+/// `#[serde(untagged)]` with all-unit variants silently ignores
+/// `#[serde(rename)]` and serializes every unit variant as `null`, so we
+/// must go through `String`.)
+///
+/// The ten canonical labels are documented in spec §10. `Other(String)`
+/// is the open-extension placeholder; downstream consumers decide how
+/// to treat unknown kinds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
+pub enum SourceKind {
+    Annotation,
+    TestAssertion,
+    TypeSignature,
+    Docstring,
+    LoopInvariant,
+    ImplicitEffect,
+    NativeSurface,
+    StructuralSynthesis,
+    EmpiricalWitness,
+    ReviewComment,
+    Other(String),
+}
+
+impl From<String> for SourceKind {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "annotation" => SourceKind::Annotation,
+            "test-assertion" => SourceKind::TestAssertion,
+            "type-signature" => SourceKind::TypeSignature,
+            "docstring" => SourceKind::Docstring,
+            "loop-invariant" => SourceKind::LoopInvariant,
+            "implicit-effect" => SourceKind::ImplicitEffect,
+            "native-surface" => SourceKind::NativeSurface,
+            "structural-synthesis" => SourceKind::StructuralSynthesis,
+            "empirical-witness" => SourceKind::EmpiricalWitness,
+            "review-comment" => SourceKind::ReviewComment,
+            _ => SourceKind::Other(s),
+        }
+    }
+}
+
+impl From<SourceKind> for String {
+    fn from(k: SourceKind) -> String {
+        match k {
+            SourceKind::Annotation => "annotation".to_string(),
+            SourceKind::TestAssertion => "test-assertion".to_string(),
+            SourceKind::TypeSignature => "type-signature".to_string(),
+            SourceKind::Docstring => "docstring".to_string(),
+            SourceKind::LoopInvariant => "loop-invariant".to_string(),
+            SourceKind::ImplicitEffect => "implicit-effect".to_string(),
+            SourceKind::NativeSurface => "native-surface".to_string(),
+            SourceKind::StructuralSynthesis => "structural-synthesis".to_string(),
+            SourceKind::EmpiricalWitness => "empirical-witness".to_string(),
+            SourceKind::ReviewComment => "review-comment".to_string(),
+            SourceKind::Other(s) => s,
+        }
+    }
+}
+
+/// How per-evidence verdicts compose into the compound's verdict.
+///
+/// v0 NORMATIVE: only `Conjunction` is wired in the discharger
+/// (PR-F). `BestConfidence` and `LoudlyBoundedDisjunction` are spec'd
+/// (compound spec §2.2 and §2.3) and round-trip serde here, but a
+/// discharger that encounters them MUST `unimplemented!` until PR-F+1.
+///
+/// Wire format: a bare JSON string. Same `from/into String` pattern as
+/// `SourceKind`. `Other(String)` is the open-extension placeholder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
+pub enum AggregationStrategy {
+    Conjunction,
+    BestConfidence,
+    LoudlyBoundedDisjunction,
+    Other(String),
+}
+
+impl From<String> for AggregationStrategy {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "conjunction" => AggregationStrategy::Conjunction,
+            "best-confidence" => AggregationStrategy::BestConfidence,
+            "loudly-bounded-disjunction" => AggregationStrategy::LoudlyBoundedDisjunction,
+            _ => AggregationStrategy::Other(s),
+        }
+    }
+}
+
+impl From<AggregationStrategy> for String {
+    fn from(s: AggregationStrategy) -> String {
+        match s {
+            AggregationStrategy::Conjunction => "conjunction".to_string(),
+            AggregationStrategy::BestConfidence => "best-confidence".to_string(),
+            AggregationStrategy::LoudlyBoundedDisjunction => "loudly-bounded-disjunction".to_string(),
+            AggregationStrategy::Other(s) => s,
+        }
+    }
+}
+
+/// One piece of contract evidence from one source. Content-addressed.
+///
+/// Source of truth: protocol/specs/2026-05-13-compound-contract-memento.md §1.1
+///
+/// This is the `header` layer per the substrate envelope/header/metadata
+/// layering (`2026-05-03-substrate-layers-envelope-header-body.md`); the
+/// envelope (`declaredAt`, `signature`, `signer`) and metadata (`note`)
+/// are carried by the wrapping envelope structures in
+/// `provekit-claim-envelope`.
+///
+/// Locked JCS key order (alphabetical):
+///   cid, confidence_basis_points, extension_fields, kind, lifter_cid,
+///   predicate, schemaVersion, source_kind, source_locator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceMemento {
+    /// DERIVED: BLAKE3-512 over JCS(header) with `cid` elided.
+    pub cid: String,
+    /// Lifter's prior on this evidence (0..10000, basis points).
+    /// 10000 for static-derived (annotations, type signatures); lower
+    /// for grammar-extracted or sampled (docstrings, empirical witnesses).
+    #[serde(rename = "confidence_basis_points")]
+    pub confidence_basis_points: u16,
+    /// Per-kind structured metadata. Keys and values participate in
+    /// the CID (open-extension under deterministic addressing).
+    #[serde(rename = "extension_fields")]
+    pub extension_fields: BTreeMap<String, serde_json::Value>,
+    /// MUST be "evidence".
+    pub kind: String,
+    /// CID of the lifter binary or rule-set that emitted this evidence.
+    /// Reserved sentinel `blake3-512:autoPromote000...` for the
+    /// backward-compat auto-promotion path (compound spec §4.4).
+    #[serde(rename = "lifter_cid")]
+    pub lifter_cid: String,
+    /// The asserted predicate (an `IrFormula`).
+    pub predicate: IrFormula,
+    /// MUST be "1".
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    /// The kind of source this evidence was extracted from.
+    #[serde(rename = "source_kind")]
+    pub source_kind: SourceKind,
+    /// Where this evidence was extracted from.
+    #[serde(rename = "source_locator")]
+    pub source_locator: SourceLocator,
+}
+
+/// A reference to an `EvidenceMemento` with a per-compound weight.
+///
+/// Under `Conjunction` (v0) the weight is informational. Under the
+/// spec'd strategies (`BestConfidence`, `LoudlyBoundedDisjunction`) it
+/// is consulted during verdict derivation. The weight participates in
+/// the compound's CID either way (different weights = different
+/// compound bytes = different CID).
+///
+/// Locked JCS key order: evidence_cid, weight_basis_points.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceRef {
+    #[serde(rename = "evidence_cid")]
+    pub evidence_cid: String,
+    #[serde(rename = "weight_basis_points")]
+    pub weight_basis_points: u16,
+}
+
+/// A content-addressed aggregation of `EvidenceMemento`s for one
+/// function. The convergence point for every contract source the
+/// substrate can lift.
+///
+/// Source of truth: protocol/specs/2026-05-13-compound-contract-memento.md §1.2
+///
+/// CID-determining: `aggregation_strategy`, `composed_post`,
+/// `composed_pre`, `evidences` (sorted by evidence_cid at JCS time),
+/// `function_term_cid`, `kind`, `schemaVersion`. Changing one evidence's
+/// bytes rolls its CID, which rolls this compound's CID, which rolls
+/// every binding citing this compound.
+///
+/// `composed_pre` and `composed_post` are DERIVED-AND-STORED (cached
+/// truth-source duality). Validators MUST recompute under the recorded
+/// strategy and reject on mismatch; that recompute requires a JCS
+/// encoder and lives in provekit-claim-envelope.
+///
+/// Locked JCS key order (alphabetical):
+///   aggregation_strategy, cid, composed_post, composed_pre, evidences,
+///   function_term_cid, kind, schemaVersion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompoundContractMemento {
+    /// How per-evidence verdicts compose into the compound's verdict.
+    /// v0: only `Conjunction` is wired.
+    #[serde(rename = "aggregation_strategy")]
+    pub aggregation_strategy: AggregationStrategy,
+    /// DERIVED: BLAKE3-512 over JCS(header) with `cid` elided.
+    pub cid: String,
+    /// DERIVED-AND-STORED: the aggregated post-condition.
+    /// Validators MUST recompute and reject on mismatch.
+    #[serde(rename = "composed_post")]
+    pub composed_post: IrFormula,
+    /// DERIVED-AND-STORED: the aggregated pre-condition.
+    /// Validators MUST recompute and reject on mismatch.
+    #[serde(rename = "composed_pre")]
+    pub composed_pre: IrFormula,
+    /// References to the constituent `EvidenceMemento`s.
+    /// MUST be sorted by `evidence_cid` ascending in the JCS bytes
+    /// (Rust constructors MAY preserve insertion order; the JCS encoder
+    /// sorts at canonicalization time).
+    /// MAY be empty (degenerate compound; composed_pre/post = `true`/`true`).
+    pub evidences: Vec<EvidenceRef>,
+    /// The `FunctionContractMemento.cid` of the function this compound
+    /// is the contract for.
+    #[serde(rename = "function_term_cid")]
+    pub function_term_cid: String,
+    /// MUST be "compound-contract".
+    pub kind: String,
+    /// MUST be "1".
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+}
+
+// ============================================================
+// End manual extension block -- compound-contract layer (PR-A)
+// ============================================================

--- a/implementations/rust/provekit-ir-types/tests/compound_contract_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/compound_contract_serde.rs
@@ -55,7 +55,9 @@ const SRC_CID: &str = "blake3-512:src2222222222222222222222222222222222222222222
 const LIFTER_CID: &str = "blake3-512:lift33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333";
 const COMPOUND_CID: &str = "blake3-512:comp44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444";
 // Reserved sentinel for the auto-promote backward-compat path; spec §4.4.
-const AUTO_PROMOTE_LIFTER_CID: &str = "blake3-512:autoPromote00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+// 128 hex 0s -- provably not a real BLAKE3-512 output (P ≈ 2^-512).
+// All-hex so pass-1 CID format validation accepts it without a special-case exception.
+const AUTO_PROMOTE_LIFTER_CID: &str = "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
 // ================================================================
 // SourceKind round-trips through every canonical label
@@ -533,4 +535,115 @@ fn compound_evidences_always_present_even_when_empty() {
     };
     let s = serde_json::to_string(&c).expect("serialize");
     assert!(s.contains("\"evidences\":[]"), "got: {}", s);
+}
+
+// ================================================================
+// §4.5 byte-offset → line/col conversion (normative algorithm test)
+// ================================================================
+//
+// These tests pin the §4.5 algorithm used when auto-promotion (§4.3)
+// derives a source_locator from a FunctionContractMemento byte-offset
+// locus. The implementation of `byte_offset_to_line_col` lives in
+// the PR-B validator; these tests serve as the normative spec fixture.
+//
+// Algorithm (from §4.5):
+//   line := 1, col := 0
+//   for i in 0..byte_offset: if src[i]==LF => line+=1, col:=0; else col+=1
+//   return (line, col)
+
+fn byte_offset_to_line_col(source_bytes: &[u8], byte_offset: usize) -> (u32, u32) {
+    assert!(
+        byte_offset <= source_bytes.len(),
+        "byte_offset out of range"
+    );
+    let mut line: u32 = 1;
+    let mut col: u32 = 0;
+    for b in &source_bytes[..byte_offset] {
+        if *b == b'\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}
+
+#[test]
+fn byte_offset_line_col_start_of_file() {
+    // offset 0 → line 1, col 0
+    let src = b"fn foo() {}";
+    assert_eq!(byte_offset_to_line_col(src, 0), (1, 0));
+}
+
+#[test]
+fn byte_offset_line_col_mid_first_line() {
+    // "fn foo" → offset 3 = 'f' of 'foo' → line 1, col 3
+    let src = b"fn foo() {}";
+    assert_eq!(byte_offset_to_line_col(src, 3), (1, 3));
+}
+
+#[test]
+fn byte_offset_line_col_start_of_second_line() {
+    // "fn foo()\n" → offset 9 = first byte of line 2 → line 2, col 0
+    let src = b"fn foo()\nfn bar()";
+    assert_eq!(byte_offset_to_line_col(src, 9), (2, 0));
+}
+
+#[test]
+fn byte_offset_line_col_mid_second_line() {
+    // "fn foo()\nfn bar()" → offset 12 = 'b' in 'bar' → line 2, col 3
+    let src = b"fn foo()\nfn bar()";
+    assert_eq!(byte_offset_to_line_col(src, 12), (2, 3));
+}
+
+#[test]
+fn byte_offset_line_col_three_lines() {
+    // "a\nb\nc" → offset 4 = 'c' → line 3, col 0
+    let src = b"a\nb\nc";
+    assert_eq!(byte_offset_to_line_col(src, 4), (3, 0));
+}
+
+#[test]
+fn byte_offset_line_col_crlf_cr_is_ordinary_byte() {
+    // CRLF: CR is ordinary byte (increments col), LF advances line.
+    // "a\r\nb" → bytes: [97, 13, 10, 98]
+    //   offset 0 = 'a' → (1, 0)
+    //   offset 1 = '\r' → (1, 1)  [CR counted as col byte]
+    //   offset 2 = '\n' → (1, 2)  [LF not yet consumed]
+    //   offset 3 = 'b' → (2, 0)
+    let src = b"a\r\nb";
+    assert_eq!(byte_offset_to_line_col(src, 0), (1, 0));
+    assert_eq!(byte_offset_to_line_col(src, 1), (1, 1)); // after 'a', before CR
+    assert_eq!(byte_offset_to_line_col(src, 2), (1, 2)); // after CR, before LF
+    assert_eq!(byte_offset_to_line_col(src, 3), (2, 0)); // after LF, start of line 2
+}
+
+#[test]
+fn byte_offset_line_col_tab_is_one_byte() {
+    // Tab counts as 1 byte, no tab-stop expansion.
+    // "\tfoo" → offset 1 = 'f' → line 1, col 1
+    let src = b"\tfoo";
+    assert_eq!(byte_offset_to_line_col(src, 0), (1, 0));
+    assert_eq!(byte_offset_to_line_col(src, 1), (1, 1));
+    assert_eq!(byte_offset_to_line_col(src, 2), (1, 2));
+}
+
+#[test]
+fn byte_offset_line_col_end_of_file() {
+    // offset == src.len() is the one-past-the-end position.
+    let src = b"ab\ncd";
+    assert_eq!(byte_offset_to_line_col(src, 5), (2, 2));
+}
+
+#[test]
+fn byte_offset_line_col_multibyte_utf8() {
+    // UTF-8 multibyte chars: col counts bytes, not codepoints.
+    // "é" = [0xC3, 0xA9] (2 bytes). Source: "éx"
+    // offset 0 → (1, 0), offset 1 → (1, 1), offset 2 → (1, 2)
+    let src = "éx".as_bytes(); // [0xC3, 0xA9, 0x78]
+    assert_eq!(byte_offset_to_line_col(src, 0), (1, 0));
+    assert_eq!(byte_offset_to_line_col(src, 1), (1, 1));
+    assert_eq!(byte_offset_to_line_col(src, 2), (1, 2)); // char boundary for 'x'
+    assert_eq!(byte_offset_to_line_col(src, 3), (1, 3));
 }

--- a/implementations/rust/provekit-ir-types/tests/compound_contract_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/compound_contract_serde.rs
@@ -1,0 +1,536 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Round-trip serde tests for EvidenceMemento and CompoundContractMemento.
+//
+// Source of truth:
+//   protocol/specs/2026-05-13-compound-contract-memento.md §1, §2, §3
+//
+// These tests pin:
+//   * EvidenceMemento and CompoundContractMemento deserialize from the
+//     wire shape the spec defines.
+//   * Round-trip parity at the serde layer: parse -> serialize -> parse
+//     yields the same value.
+//   * SourceKind round-trips through its kebab-case wire form for every
+//     canonical label, including `Other(String)` for open-extension.
+//   * AggregationStrategy round-trips through its wire form for every
+//     canonical strategy.
+//   * Empty extension_fields, empty evidences (degenerate compound),
+//     single-evidence (auto-promotion case), and multi-evidence
+//     compounds all serde-round-trip.
+//   * Conjunction-aggregation verdict-derivation table is captured
+//     (as a pure-Rust helper, not a serde concern, but pinned here
+//     because §2.1 is normative for v0).
+//
+// Byte-exact CID pinning and the composed_pre/post recompute INVARIANT
+// require the JCS encoder, which lives in `provekit-claim-envelope`.
+// Those tests belong there; this crate carries serde shape only.
+//
+// Tests are deliberately VERBOSE: every fixture is hand-written JSON
+// so the wire shape is unambiguous to a human reviewer.
+
+use std::collections::BTreeMap;
+
+use provekit_ir_types::{
+    AggregationStrategy, CompoundContractMemento, EvidenceMemento, EvidenceRef, IrFormula,
+    SourceKind, SourceLocator, SourceLocatorPoint, SourceLocatorSpan,
+};
+
+/// The "true" atomic predicate in IrFormula. Used as the trivial
+/// predicate for round-trip tests; the substantive predicate content
+/// is irrelevant for serde-shape verification.
+fn ir_true() -> IrFormula {
+    IrFormula::Atomic {
+        name: "true".to_string(),
+        args: vec![],
+    }
+}
+
+// 128 hex chars after the "blake3-512:" prefix; deterministic placeholders.
+// The trailing letter distinguishes each.
+const EVID_CID_A: &str = "blake3-512:evid00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a";
+const EVID_CID_B: &str = "blake3-512:evid00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b";
+const EVID_CID_C: &str = "blake3-512:evid00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c";
+const FN_CID: &str = "blake3-512:fn1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+const SRC_CID: &str = "blake3-512:src22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+const LIFTER_CID: &str = "blake3-512:lift33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333";
+const COMPOUND_CID: &str = "blake3-512:comp44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444";
+// Reserved sentinel for the auto-promote backward-compat path; spec §4.4.
+const AUTO_PROMOTE_LIFTER_CID: &str = "blake3-512:autoPromote00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+// ================================================================
+// SourceKind round-trips through every canonical label
+// ================================================================
+
+#[test]
+fn source_kind_round_trip_canonical_labels() {
+    // (variant, wire-string) pairs for every canonical label.
+    let canonical = [
+        (SourceKind::Annotation, "\"annotation\""),
+        (SourceKind::TestAssertion, "\"test-assertion\""),
+        (SourceKind::TypeSignature, "\"type-signature\""),
+        (SourceKind::Docstring, "\"docstring\""),
+        (SourceKind::LoopInvariant, "\"loop-invariant\""),
+        (SourceKind::ImplicitEffect, "\"implicit-effect\""),
+        (SourceKind::NativeSurface, "\"native-surface\""),
+        (SourceKind::StructuralSynthesis, "\"structural-synthesis\""),
+        (SourceKind::EmpiricalWitness, "\"empirical-witness\""),
+        (SourceKind::ReviewComment, "\"review-comment\""),
+    ];
+    for (variant, wire) in canonical.iter() {
+        let serialized = serde_json::to_string(variant).expect("serialize");
+        assert_eq!(&serialized, wire, "serialize {:?}", variant);
+        let parsed: SourceKind = serde_json::from_str(wire).expect("parse");
+        assert_eq!(&parsed, variant, "parse {:?}", wire);
+    }
+}
+
+#[test]
+fn source_kind_unknown_label_maps_to_other() {
+    let wire = "\"future-source-kind-x99\"";
+    let parsed: SourceKind = serde_json::from_str(wire).expect("parse unknown");
+    assert_eq!(
+        parsed,
+        SourceKind::Other("future-source-kind-x99".to_string())
+    );
+    // Round-trip back.
+    let s = serde_json::to_string(&parsed).expect("serialize Other");
+    assert_eq!(s, wire);
+}
+
+// ================================================================
+// AggregationStrategy round-trips through every canonical label
+// ================================================================
+
+#[test]
+fn aggregation_strategy_round_trip_canonical() {
+    let canonical = [
+        (AggregationStrategy::Conjunction, "\"conjunction\""),
+        (AggregationStrategy::BestConfidence, "\"best-confidence\""),
+        (
+            AggregationStrategy::LoudlyBoundedDisjunction,
+            "\"loudly-bounded-disjunction\"",
+        ),
+    ];
+    for (variant, wire) in canonical.iter() {
+        let serialized = serde_json::to_string(variant).expect("serialize");
+        assert_eq!(&serialized, wire, "serialize {:?}", variant);
+        let parsed: AggregationStrategy = serde_json::from_str(wire).expect("parse");
+        assert_eq!(&parsed, variant, "parse {:?}", wire);
+    }
+}
+
+#[test]
+fn aggregation_strategy_unknown_maps_to_other() {
+    let wire = "\"weighted-bayes\"";
+    let parsed: AggregationStrategy = serde_json::from_str(wire).expect("parse unknown");
+    assert_eq!(
+        parsed,
+        AggregationStrategy::Other("weighted-bayes".to_string())
+    );
+}
+
+// ================================================================
+// EvidenceMemento -- one canonical wire fixture per source_kind
+// ================================================================
+
+fn locator_fixture() -> SourceLocator {
+    SourceLocator {
+        source_cid: SRC_CID.to_string(),
+        span: SourceLocatorSpan {
+            end: SourceLocatorPoint { line: 12, col: 18 },
+            start: SourceLocatorPoint { line: 12, col: 1 },
+        },
+    }
+}
+
+fn make_evidence(
+    cid: &str,
+    source_kind: SourceKind,
+    confidence: u16,
+    extension: BTreeMap<String, serde_json::Value>,
+) -> EvidenceMemento {
+    EvidenceMemento {
+        cid: cid.to_string(),
+        confidence_basis_points: confidence,
+        extension_fields: extension,
+        kind: "evidence".to_string(),
+        lifter_cid: LIFTER_CID.to_string(),
+        predicate: ir_true(),
+        schema_version: "1".to_string(),
+        source_kind,
+        source_locator: locator_fixture(),
+    }
+}
+
+#[test]
+fn evidence_memento_round_trip_annotation() {
+    let e = make_evidence(EVID_CID_A, SourceKind::Annotation, 10000, BTreeMap::new());
+    let s = serde_json::to_string(&e).expect("serialize");
+    let parsed: EvidenceMemento = serde_json::from_str(&s).expect("parse");
+    assert_eq!(parsed, e);
+    assert_eq!(parsed.kind, "evidence");
+    assert_eq!(parsed.schema_version, "1");
+    assert_eq!(parsed.source_kind, SourceKind::Annotation);
+    assert_eq!(parsed.confidence_basis_points, 10000);
+    assert!(parsed.extension_fields.is_empty());
+}
+
+#[test]
+fn evidence_memento_round_trip_test_assertion_with_extension() {
+    let mut ext = BTreeMap::new();
+    ext.insert(
+        "test_target_function_cid".to_string(),
+        serde_json::Value::String(FN_CID.to_string()),
+    );
+    let e = make_evidence(EVID_CID_B, SourceKind::TestAssertion, 10000, ext.clone());
+    let s = serde_json::to_string(&e).expect("serialize");
+    let parsed: EvidenceMemento = serde_json::from_str(&s).expect("parse");
+    assert_eq!(parsed, e);
+    assert_eq!(parsed.source_kind, SourceKind::TestAssertion);
+    assert_eq!(
+        parsed
+            .extension_fields
+            .get("test_target_function_cid")
+            .and_then(|v| v.as_str()),
+        Some(FN_CID)
+    );
+}
+
+#[test]
+fn evidence_memento_round_trip_docstring_with_lower_confidence() {
+    let mut ext = BTreeMap::new();
+    ext.insert(
+        "extracted_phrase".to_string(),
+        serde_json::Value::String("Returns None when the divisor is zero.".to_string()),
+    );
+    let e = make_evidence(EVID_CID_C, SourceKind::Docstring, 6500, ext);
+    let s = serde_json::to_string(&e).expect("serialize");
+    let parsed: EvidenceMemento = serde_json::from_str(&s).expect("parse");
+    assert_eq!(parsed, e);
+    assert_eq!(parsed.confidence_basis_points, 6500);
+    assert_eq!(parsed.source_kind, SourceKind::Docstring);
+}
+
+#[test]
+fn evidence_memento_each_canonical_source_kind_round_trips() {
+    // Build one evidence per canonical label and verify all of them
+    // round-trip through JSON.
+    let kinds = [
+        SourceKind::Annotation,
+        SourceKind::TestAssertion,
+        SourceKind::TypeSignature,
+        SourceKind::Docstring,
+        SourceKind::LoopInvariant,
+        SourceKind::ImplicitEffect,
+        SourceKind::NativeSurface,
+        SourceKind::StructuralSynthesis,
+        SourceKind::EmpiricalWitness,
+        SourceKind::ReviewComment,
+    ];
+    for (i, k) in kinds.into_iter().enumerate() {
+        // Build a deterministic 128-hex CID from the index. The two-hex
+        // prefix encodes `i`; the remaining 126 chars are filler.
+        let tail: String = std::iter::repeat_with(|| 'a').take(126).collect();
+        let cid = format!("blake3-512:{:02x}{}", i, tail);
+        let e = make_evidence(&cid, k.clone(), 9999, BTreeMap::new());
+        let s = serde_json::to_string(&e).expect("serialize");
+        let parsed: EvidenceMemento = serde_json::from_str(&s).expect("parse");
+        assert_eq!(parsed, e, "round-trip for kind {:?}", k);
+    }
+}
+
+#[test]
+fn evidence_memento_with_unknown_source_kind_extension() {
+    let e = EvidenceMemento {
+        cid: EVID_CID_A.to_string(),
+        confidence_basis_points: 5000,
+        extension_fields: BTreeMap::new(),
+        kind: "evidence".to_string(),
+        lifter_cid: LIFTER_CID.to_string(),
+        predicate: ir_true(),
+        schema_version: "1".to_string(),
+        source_kind: SourceKind::Other("future-source-kind-x99".to_string()),
+        source_locator: locator_fixture(),
+    };
+    let s = serde_json::to_string(&e).expect("serialize");
+    assert!(s.contains("\"future-source-kind-x99\""));
+    let parsed: EvidenceMemento = serde_json::from_str(&s).expect("parse");
+    assert_eq!(parsed, e);
+}
+
+// ================================================================
+// CompoundContractMemento -- empty / single / multi
+// ================================================================
+
+#[test]
+fn compound_empty_evidences_degenerate_round_trips() {
+    // Spec §5.2: the degenerate compound has empty evidences and
+    // composed_pre / composed_post = true. This is the substrate's
+    // base case before any lifter has run.
+    let c = CompoundContractMemento {
+        aggregation_strategy: AggregationStrategy::Conjunction,
+        cid: COMPOUND_CID.to_string(),
+        composed_post: ir_true(),
+        composed_pre: ir_true(),
+        evidences: vec![],
+        function_term_cid: FN_CID.to_string(),
+        kind: "compound-contract".to_string(),
+        schema_version: "1".to_string(),
+    };
+    let s = serde_json::to_string(&c).expect("serialize");
+    let parsed: CompoundContractMemento = serde_json::from_str(&s).expect("parse");
+    assert_eq!(parsed, c);
+    assert!(parsed.evidences.is_empty());
+    assert_eq!(parsed.aggregation_strategy, AggregationStrategy::Conjunction);
+}
+
+#[test]
+fn compound_single_evidence_auto_promotion_case() {
+    // Spec §4.3: the backward-compat path mints a single-evidence
+    // compound with an `annotation` evidence whose lifter_cid is the
+    // reserved auto-promote sentinel. This test pins that shape.
+    let promoted_evidence = EvidenceMemento {
+        cid: EVID_CID_A.to_string(),
+        confidence_basis_points: 10000,
+        extension_fields: {
+            let mut m = BTreeMap::new();
+            m.insert(
+                "auto_promoted_from".to_string(),
+                serde_json::Value::String(FN_CID.to_string()),
+            );
+            m
+        },
+        kind: "evidence".to_string(),
+        lifter_cid: AUTO_PROMOTE_LIFTER_CID.to_string(),
+        predicate: ir_true(),
+        schema_version: "1".to_string(),
+        source_kind: SourceKind::Annotation,
+        source_locator: locator_fixture(),
+    };
+    let s = serde_json::to_string(&promoted_evidence).expect("serialize evidence");
+    let parsed_evid: EvidenceMemento = serde_json::from_str(&s).expect("parse evidence");
+    assert_eq!(parsed_evid, promoted_evidence);
+    assert_eq!(parsed_evid.lifter_cid, AUTO_PROMOTE_LIFTER_CID);
+
+    let compound = CompoundContractMemento {
+        aggregation_strategy: AggregationStrategy::Conjunction,
+        cid: COMPOUND_CID.to_string(),
+        composed_post: ir_true(),
+        composed_pre: ir_true(),
+        evidences: vec![EvidenceRef {
+            evidence_cid: EVID_CID_A.to_string(),
+            weight_basis_points: 10000,
+        }],
+        function_term_cid: FN_CID.to_string(),
+        kind: "compound-contract".to_string(),
+        schema_version: "1".to_string(),
+    };
+    let s = serde_json::to_string(&compound).expect("serialize compound");
+    let parsed: CompoundContractMemento = serde_json::from_str(&s).expect("parse compound");
+    assert_eq!(parsed, compound);
+    assert_eq!(parsed.evidences.len(), 1);
+}
+
+#[test]
+fn compound_multi_evidence_round_trips() {
+    // Three evidences with three distinct CIDs and weights.
+    let compound = CompoundContractMemento {
+        aggregation_strategy: AggregationStrategy::Conjunction,
+        cid: COMPOUND_CID.to_string(),
+        composed_post: ir_true(),
+        composed_pre: ir_true(),
+        evidences: vec![
+            EvidenceRef {
+                evidence_cid: EVID_CID_A.to_string(),
+                weight_basis_points: 10000,
+            },
+            EvidenceRef {
+                evidence_cid: EVID_CID_B.to_string(),
+                weight_basis_points: 9500,
+            },
+            EvidenceRef {
+                evidence_cid: EVID_CID_C.to_string(),
+                weight_basis_points: 6500,
+            },
+        ],
+        function_term_cid: FN_CID.to_string(),
+        kind: "compound-contract".to_string(),
+        schema_version: "1".to_string(),
+    };
+    let s = serde_json::to_string(&compound).expect("serialize");
+    let parsed: CompoundContractMemento = serde_json::from_str(&s).expect("parse");
+    assert_eq!(parsed, compound);
+    assert_eq!(parsed.evidences.len(), 3);
+    // Weight basis-points preserved.
+    let weights: Vec<u16> = parsed.evidences.iter().map(|e| e.weight_basis_points).collect();
+    assert_eq!(weights, vec![10000, 9500, 6500]);
+}
+
+// ================================================================
+// Compound CID stability is sensitive to inputs
+// ================================================================
+
+#[test]
+fn compound_with_different_aggregation_strategy_is_different_value() {
+    // Spec §3.1: aggregation_strategy is part of the CID input.
+    // The same set of evidences aggregated under "conjunction" vs
+    // "best-confidence" are two different compounds. We can't run JCS
+    // here, but we CAN verify that Rust treats them as PartialEq-unequal,
+    // which is the precondition for the CID divergence.
+    let evidences = vec![EvidenceRef {
+        evidence_cid: EVID_CID_A.to_string(),
+        weight_basis_points: 10000,
+    }];
+
+    let c_conj = CompoundContractMemento {
+        aggregation_strategy: AggregationStrategy::Conjunction,
+        cid: "blake3-512:aa".to_string() + &"0".repeat(126),
+        composed_post: ir_true(),
+        composed_pre: ir_true(),
+        evidences: evidences.clone(),
+        function_term_cid: FN_CID.to_string(),
+        kind: "compound-contract".to_string(),
+        schema_version: "1".to_string(),
+    };
+    let c_best = CompoundContractMemento {
+        aggregation_strategy: AggregationStrategy::BestConfidence,
+        ..c_conj.clone()
+    };
+    assert_ne!(c_conj, c_best);
+    assert_ne!(c_conj.aggregation_strategy, c_best.aggregation_strategy);
+}
+
+#[test]
+fn compound_with_different_evidence_set_is_different_value() {
+    // Spec §0.2: different evidence-sets = different compound bytes.
+    let c_one = CompoundContractMemento {
+        aggregation_strategy: AggregationStrategy::Conjunction,
+        cid: "blake3-512:bb".to_string() + &"0".repeat(126),
+        composed_post: ir_true(),
+        composed_pre: ir_true(),
+        evidences: vec![EvidenceRef {
+            evidence_cid: EVID_CID_A.to_string(),
+            weight_basis_points: 10000,
+        }],
+        function_term_cid: FN_CID.to_string(),
+        kind: "compound-contract".to_string(),
+        schema_version: "1".to_string(),
+    };
+    let c_two = CompoundContractMemento {
+        evidences: vec![
+            EvidenceRef {
+                evidence_cid: EVID_CID_A.to_string(),
+                weight_basis_points: 10000,
+            },
+            EvidenceRef {
+                evidence_cid: EVID_CID_B.to_string(),
+                weight_basis_points: 9000,
+            },
+        ],
+        ..c_one.clone()
+    };
+    assert_ne!(c_one, c_two);
+    assert_ne!(c_one.evidences.len(), c_two.evidences.len());
+}
+
+// ================================================================
+// Wire-shape pin: hand-written JSON deserializes to the expected value
+// ================================================================
+
+#[test]
+fn evidence_memento_from_spec_shape() {
+    // Hand-written fixture: spec §1.1 wire shape. Keys in alphabetical
+    // JCS order (envelope is in the wrapping; here we serialize only
+    // the header layer, which is what `EvidenceMemento` represents).
+    let fixture = r#"{
+        "cid": "blake3-512:evid00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a",
+        "confidence_basis_points": 10000,
+        "extension_fields": {},
+        "kind": "evidence",
+        "lifter_cid": "blake3-512:lift33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+        "predicate": {"kind": "atomic", "name": "true", "args": []},
+        "schemaVersion": "1",
+        "source_kind": "annotation",
+        "source_locator": {
+            "source_cid": "blake3-512:src22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+            "span": {
+                "end":   {"col": 18, "line": 12},
+                "start": {"col":  1, "line": 12}
+            }
+        }
+    }"#;
+    let parsed: EvidenceMemento = serde_json::from_str(fixture).expect("parse spec fixture");
+    assert_eq!(parsed.cid, EVID_CID_A);
+    assert_eq!(parsed.confidence_basis_points, 10000);
+    assert_eq!(parsed.source_kind, SourceKind::Annotation);
+    assert_eq!(parsed.lifter_cid, LIFTER_CID);
+    assert_eq!(parsed.source_locator.source_cid, SRC_CID);
+    assert_eq!(parsed.source_locator.span.start.line, 12);
+    assert_eq!(parsed.source_locator.span.start.col, 1);
+    assert_eq!(parsed.source_locator.span.end.line, 12);
+    assert_eq!(parsed.source_locator.span.end.col, 18);
+}
+
+#[test]
+fn compound_memento_from_spec_shape() {
+    let fixture = r#"{
+        "aggregation_strategy": "conjunction",
+        "cid": "blake3-512:comp44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444",
+        "composed_post": {"kind": "atomic", "name": "true", "args": []},
+        "composed_pre":  {"kind": "atomic", "name": "true", "args": []},
+        "evidences": [
+            {"evidence_cid": "blake3-512:evid00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a", "weight_basis_points": 10000},
+            {"evidence_cid": "blake3-512:evid00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b", "weight_basis_points":  9500}
+        ],
+        "function_term_cid": "blake3-512:fn1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+        "kind": "compound-contract",
+        "schemaVersion": "1"
+    }"#;
+    let parsed: CompoundContractMemento =
+        serde_json::from_str(fixture).expect("parse spec fixture");
+    assert_eq!(parsed.cid, COMPOUND_CID);
+    assert_eq!(parsed.aggregation_strategy, AggregationStrategy::Conjunction);
+    assert_eq!(parsed.kind, "compound-contract");
+    assert_eq!(parsed.schema_version, "1");
+    assert_eq!(parsed.function_term_cid, FN_CID);
+    assert_eq!(parsed.evidences.len(), 2);
+    assert_eq!(parsed.evidences[0].evidence_cid, EVID_CID_A);
+    assert_eq!(parsed.evidences[0].weight_basis_points, 10000);
+    assert_eq!(parsed.evidences[1].evidence_cid, EVID_CID_B);
+    assert_eq!(parsed.evidences[1].weight_basis_points, 9500);
+}
+
+// ================================================================
+// Optional / absent fields
+// ================================================================
+
+#[test]
+fn evidence_extension_fields_always_present_even_when_empty() {
+    // Spec §1.1.1: extension_fields is REQUIRED (no `?`). An empty
+    // BTreeMap MUST serialize as `{}` and NOT be elided.
+    let e = make_evidence(EVID_CID_A, SourceKind::Annotation, 10000, BTreeMap::new());
+    let s = serde_json::to_string(&e).expect("serialize");
+    assert!(
+        s.contains("\"extension_fields\":{}"),
+        "extension_fields must be present as empty object, got: {}",
+        s
+    );
+}
+
+#[test]
+fn compound_evidences_always_present_even_when_empty() {
+    // Spec §1.2.1: evidences is REQUIRED. Empty array MUST serialize
+    // as `[]` (the degenerate compound is a valid shape).
+    let c = CompoundContractMemento {
+        aggregation_strategy: AggregationStrategy::Conjunction,
+        cid: COMPOUND_CID.to_string(),
+        composed_post: ir_true(),
+        composed_pre: ir_true(),
+        evidences: vec![],
+        function_term_cid: FN_CID.to_string(),
+        kind: "compound-contract".to_string(),
+        schema_version: "1".to_string(),
+    };
+    let s = serde_json::to_string(&c).expect("serialize");
+    assert!(s.contains("\"evidences\":[]"), "got: {}", s);
+}

--- a/protocol/specs/2026-05-12-concept-site-memento.md
+++ b/protocol/specs/2026-05-12-concept-site-memento.md
@@ -147,7 +147,7 @@ concept-site-memento = {
 | header   | `concept_cid`            | yes      | The `ConceptAbstractionMemento.cid` this site binds to. Substrate matches exactly. |
 | header   | `discharge`              | yes      | Verdict, loss, receipt, method. See §1.2. |
 | header   | `kind`                   | yes      | MUST be `"concept-site"`. |
-| header   | `local_contract_cid`     | yes      | The `FunctionContractMemento.cid` of the user-lifted contract for this function. |
+| header   | `local_contract_cid`     | yes      | The `FunctionContractMemento.cid` of the user-lifted contract for this function. *(Amended by `2026-05-13-compound-contract-memento.md` §0.4: after the compound layer lands, this field points at a `CompoundContractMemento.cid` instead; bare `FunctionContractMemento`s are auto-promoted per that spec's §4.4.)* |
 | header   | `provenance`             | yes      | The three CIDs of the producers (lifter, clusterer, discharger). |
 | header   | `realization_mode_hint`  | no       | Deployment policy hint. OMITTED when discharger does not opinion. |
 | header   | `schemaVersion`          | yes      | MUST be `"1"`. |
@@ -320,7 +320,7 @@ Per the §1.2 table:
 ### §5.4 Pass 4: REFERENT constraints (pool-level)
 
 - The pool MUST contain a `ConceptAbstractionMemento` with `cid = header.concept_cid`.
-- The pool MUST contain a `FunctionContractMemento` with `cid = header.local_contract_cid`.
+- The pool MUST contain EITHER a `CompoundContractMemento` with `cid = header.local_contract_cid`, OR a `FunctionContractMemento` with that CID that the validator auto-promotes per `2026-05-13-compound-contract-memento.md` §4.4. *(Amended by `2026-05-13-compound-contract-memento.md` §0.4.)*
 - The pool MUST contain a `FunctionContractMemento` with `cid = header.code_site.function_term_cid`.
 - For each `witness-ref` in `witnesses`, the pool MUST contain a `WitnessMemento` with that CID.
 - For non-`refuse` verdicts, the pool MUST contain a `MorphismDischargeReceipt` with `cid = header.discharge.discharge_receipt_cid`.

--- a/protocol/specs/2026-05-13-compound-contract-memento.md
+++ b/protocol/specs/2026-05-13-compound-contract-memento.md
@@ -1,0 +1,561 @@
+# CompoundContractMemento + EvidenceMemento -- Normative Spec (PR-A: schema + Rust types)
+
+**Status:** v1.6.x normative-draft (PR-A of a multi-PR landing; see §8)
+**Date:** 2026-05-13
+**Related:**
+- `2026-05-12-concept-site-memento.md` (this spec AMENDS its §1.1 and §5.4; see §0.4 below)
+- `2026-05-15-concept-hub-abstraction-layer.md` (§2.1 ConceptAbstractionMemento, §2.4 loss-record dimensions, §2.5 discharge)
+- `2026-05-03-substrate-layers-envelope-header-body.md` (envelope/header/metadata layering)
+- `2026-05-03-contract-cid-vs-attestation-cid.md` (CID semantics for inter-memento references)
+- `2026-04-30-canonicalization-grammar.md` (JCS canonicalization, normative)
+- `2026-04-30-ir-formal-grammar.md` (IrFormula shape)
+- `2026-05-13-wp-as-formula.md` (wp_rule synthesis at clustering-mint time)
+- `docs/papers/09-lossy-boundary-compression.md` (obligation-preserving loss; trichotomy precedent)
+
+## §0. Purpose
+
+A real function in a user codebase carries contract evidence from many sources:
+
+1. `#[requires]` / `#[ensures]` annotations (already lifted by `provekit-lift-contracts`).
+2. Test assertions targeting the function (e.g., `assert_eq!(f(3), 9)` inside `#[test]`).
+3. Type signatures, where the return type itself carries a partial post (e.g., `-> Option<T>` says "may be absent").
+4. Docstring contracts (e.g., `/// Returns None if key missing`).
+5. Bounded-loop assert invariants already lifted as `LoopInvariantMemento`.
+6. `assert!()` / `panic!()` / `unwrap()` / `?` call-sites as implicit pre/post.
+7. Native contract surfaces (JML on Java, Zod on TS, Spring annotations, pydantic, OpenAPI).
+8. `wp_rule` synthesized structurally from the term algebra at clustering-mint time (for discovered unnamed clusters; per `2026-05-13-wp-as-formula.md`).
+9. Empirical witnesses from past runs (`WitnessMemento` instances).
+10. Human review comments in PR history mentioning invariants (priority: future).
+
+Each is a typed piece of evidence about what the function does. The substrate already mints `FunctionContractMemento` from source (1). `ConceptSiteMemento.local_contract_cid` (per `2026-05-12-concept-site-memento.md` §1.1) points at exactly one `FunctionContractMemento`. That binding is the convergence point user-code -> catalog. But pinning that field to a single source-shape collapses the many evidence channels prematurely.
+
+This spec defines two new mementos that fix the convergence point:
+
+- `EvidenceMemento`: one piece of contract evidence from one source, content-addressed.
+- `CompoundContractMemento`: a content-addressed aggregation of evidences for one function, carrying composed pre/post and a `aggregation_strategy` that derives a single compound verdict from per-evidence verdicts.
+
+The convergence point becomes the compound. `ConceptSiteMemento.local_contract_cid` now points at a `CompoundContractMemento`, not a bare `FunctionContractMemento`. The substrate's binding stays load-bearing across all ten derivation sources.
+
+### §0.1 The trichotomy is by construction at TWO levels
+
+Per Supra omnia, rectum (the 2026-05-11 refinement: "never claim more than you can prove"), the trichotomy `{exact, loudly-bounded-lossy, refuse}` is enforced both per-evidence and at the compound level. Silent contract-dropping is impossible at either level.
+
+- **Per-evidence verdict.** Each evidence has its own verdict when discharged against the concept's `wp_rule`. Verdicts are recorded in the discharge receipt (PR-F), not inside the evidence itself; the evidence is the raw contract bytes, not the discharge.
+- **Compound verdict.** The compound's verdict is DERIVED from the per-evidence verdicts under the recorded `aggregation_strategy`. See §2.
+
+### §0.2 Why the evidence-set bytes are part of the compound CID
+
+Two compounds aggregating the same function's evidence but drawing from different sources (one with annotations only, one with annotations + tests + docstring) live at different CIDs. Different evidence-sets = different compound bytes = different CID. This is the same principle as ConceptSite §0.2 (different loss-record bytes = different binding CID): different addresses, different things. Adding a new evidence rolls the compound's CID, which rolls the binding's CID, which rolls every downstream consumer that cited that binding. The substrate's address space is its propagation engine.
+
+### §0.3 Evidence is data; verdict is discharge
+
+An `EvidenceMemento` carries a predicate plus its provenance (source kind, source locator, lifter CID). It does NOT carry a discharge verdict. The verdict comes when the compound is discharged against a concept by the wp evaluator + witness sampler (PR-F). The evidence-memento is content-addressed by its data, including `confidence_basis_points` (the lifter's prior on how reliably this source asserts what it claims, e.g., 10000 for static `#[ensures]` annotation, lower for docstring-extracted predicates with grammar ambiguity).
+
+### §0.4 Amendment to 2026-05-12-concept-site-memento.md
+
+The following fields of `2026-05-12-concept-site-memento.md` are AMENDED by this spec:
+
+- **§1.1 field semantics, `local_contract_cid` row.** Was: "The `FunctionContractMemento.cid` of the user-lifted contract for this function." NOW READS: "The `CompoundContractMemento.cid` of the user-lifted compound contract for this function. A pool entry that is a bare `FunctionContractMemento` at this CID is auto-promoted to a single-evidence compound during validation (see §4.4 below); this preserves backward compatibility for bindings minted before the compound layer landed."
+- **§5.4 pool-referent constraint, `local_contract_cid` row.** Was: "The pool MUST contain a `FunctionContractMemento` with `cid = header.local_contract_cid`." NOW READS: "The pool MUST contain EITHER a `CompoundContractMemento` with that CID, OR a `FunctionContractMemento` with that CID that the validator auto-promotes per §4.4."
+
+`2026-05-12-concept-site-memento.md` SHOULD carry a one-line footnote on its §1.1 and §5.4 tables citing this amendment for an audit-trail. The footnote MUST NOT alter the original normative text; the amendment lives here.
+
+The `code_site.function_term_cid` field of `ConceptSiteMemento` continues to point at a `FunctionContractMemento` (it is the term-CID of the surrounding function, not a contract source); only `local_contract_cid` changes.
+
+## §1. Wire shape (CDDL, v1.6.x layered)
+
+### §1.1 `EvidenceMemento`
+
+```cddl
+; Shared scalar types:
+;   hash, cid, signature, pubkey, iso8601, ir-formula, json-value
+
+; Locked JCS key order: end, start
+; Both points are {line, col} pairs (1-based, line/col instead of byte
+; offsets, because evidence often comes from formatters / docstrings /
+; tests where byte offsets are unstable across re-formatting).
+source-locator-span = {
+  end:   { line: uint, col: uint },
+  start: { line: uint, col: uint }
+}
+
+; Locked JCS key order: source_cid, span
+source-locator = {
+  source_cid: cid,                    ; CID of the canonicalized source artifact
+  span:       source-locator-span
+}
+
+; Open enum of source-kind labels. Validators MUST accept any unknown
+; label as a deferred-extension placeholder; downstream consumers DECIDE
+; how to treat unknown kinds. The ten canonical labels are listed in §10.
+source-kind = tstr                   ; one of the canonical labels OR an extension label
+
+; The evidence-memento itself.
+;
+; Locked JCS key order (header, alphabetical):
+;   cid, confidence_basis_points, extension_fields, kind, lifter_cid,
+;   predicate, schemaVersion, source_kind, source_locator
+evidence-memento = {
+  envelope: {
+    declaredAt: iso8601,
+    signature:  signature,            ; over JCS(header ++ metadata)
+    signer:     pubkey
+  },
+  header: {
+    cid:                       cid,   ; DERIVED -- see §3
+    confidence_basis_points:   uint,  ; 0..10000 inclusive; lifter prior
+    extension_fields:          { * tstr => json-value },
+    kind:                      "evidence",
+    lifter_cid:                cid,   ; which lifter emitted this evidence
+    predicate:                 ir-formula,
+    schemaVersion:             "1",
+    source_kind:               source-kind,
+    source_locator:            source-locator
+  },
+  metadata: {
+    ? note: tstr
+  }
+}
+```
+
+#### §1.1.1 Field semantics
+
+| Layer    | Field                       | Required | Meaning |
+|----------|-----------------------------|----------|---------|
+| envelope | `declaredAt`                | yes      | ISO-8601 UTC minting timestamp. |
+| envelope | `signature`                 | yes (swarm) | Ed25519 over `JCS(header ++ metadata)`. |
+| envelope | `signer`                    | yes      | `ed25519:<base64>` minter public key. |
+| header   | `cid`                       | yes      | Content CID; DERIVED per §3.1. |
+| header   | `confidence_basis_points`   | yes      | Lifter's prior on how reliably this source asserts what it claims. 10000 for static-derived (annotations, type signatures); lower for sampled or grammar-extracted predicates (docstrings, empirical witnesses). MUST be in `[0, 10000]`. |
+| header   | `extension_fields`          | yes      | Per-kind structured metadata; e.g., `test_target_function_cid` for `test-assertion`-kind evidence pinning the function the assertion targets. MAY be empty `{}`. Keys and values participate in the CID (§3). |
+| header   | `kind`                      | yes      | MUST be `"evidence"`. |
+| header   | `lifter_cid`                | yes      | CID of the lifter binary or rule-set that emitted this evidence. |
+| header   | `predicate`                 | yes      | The asserted predicate (an `IrFormula`). For pre-condition evidence this is the pre; for post-condition evidence this is the post (in pre/post-conjunction form per §6). For an `Option<T>` return-type evidence, this is a predicate of the form `result.is_some() \/ result.is_none()`. |
+| header   | `schemaVersion`             | yes      | MUST be `"1"`. |
+| header   | `source_kind`               | yes      | One of the canonical labels (§10) or an extension label (unknown labels MUST NOT be rejected by shape validation; downstream consumers decide). |
+| header   | `source_locator`            | yes      | Where this evidence was extracted from. |
+| metadata | `note`                      | no       | Human-readable annotation. OMITTED when absent. |
+
+### §1.2 `CompoundContractMemento`
+
+```cddl
+; A reference to an EvidenceMemento with a per-compound weight (in basis
+; points). Under v0 conjunction the weight is informational; under
+; best-confidence and loudly-bounded-disjunction (spec'd, not v0) it is
+; consulted during verdict derivation.
+;
+; Locked JCS key order: evidence_cid, weight_basis_points
+evidence-ref = {
+  evidence_cid:         cid,
+  weight_basis_points:  uint            ; 0..10000 inclusive
+}
+
+; Open enum; v0 ships ONLY "conjunction". Other strategies have their
+; verdict-derivation rule specified in §2, but the Rust impl ships them
+; as `unimplemented!`.
+aggregation-strategy = tstr               ; "conjunction" | "best-confidence" | "loudly-bounded-disjunction" | extension label
+
+; The compound-contract memento itself.
+;
+; Locked JCS key order (header, alphabetical):
+;   aggregation_strategy, cid, composed_post, composed_pre, evidences,
+;   function_term_cid, kind, schemaVersion
+compound-contract-memento = {
+  envelope: {
+    declaredAt: iso8601,
+    signature:  signature,
+    signer:     pubkey
+  },
+  header: {
+    aggregation_strategy: aggregation-strategy,
+    cid:                  cid,            ; DERIVED -- see §3
+    composed_post:        ir-formula,     ; DERIVED -- see §2 and §6
+    composed_pre:         ir-formula,     ; DERIVED -- see §2 and §6
+    evidences:            [* evidence-ref],
+    function_term_cid:    cid,            ; the FunctionContractMemento.cid of the function this is a contract for
+    kind:                 "compound-contract",
+    schemaVersion:        "1"
+  },
+  metadata: {
+    ? note: tstr
+  }
+}
+```
+
+#### §1.2.1 Field semantics
+
+| Layer    | Field                   | Required | Meaning |
+|----------|-------------------------|----------|---------|
+| header   | `aggregation_strategy`  | yes      | How per-evidence verdicts compose. v0 normative value: `"conjunction"`. Others spec'd in §2 but unimplemented. |
+| header   | `cid`                   | yes      | DERIVED per §3.1. |
+| header   | `composed_post`         | yes      | DERIVED. The aggregated post-condition. Under `"conjunction"`, the JCS-normalized conjunction of every evidence's post-predicate (after pre/post separation per §6). Validators MUST recompute and reject on mismatch; see §5.3 INVARIANT (composed-pre/post). |
+| header   | `composed_pre`          | yes      | DERIVED. The aggregated pre-condition. Same recompute INVARIANT. |
+| header   | `evidences`             | yes      | List of `evidence-ref`s. MAY be empty (degenerate compound; the function has no contract evidence yet; composed_pre/post = `true`/`true` respectively). MUST be sorted by `evidence_cid` ascending at JCS time (§3.2). |
+| header   | `function_term_cid`     | yes      | The `FunctionContractMemento.cid` of the function this compound is the contract for. |
+| header   | `kind`                  | yes      | MUST be `"compound-contract"`. |
+| header   | `schemaVersion`         | yes      | MUST be `"1"`. |
+
+### §1.3 Confidence semantics under conjunction
+
+Under `aggregation_strategy = "conjunction"`, the compound's overall confidence is `min(e.confidence_basis_points for e in evidences)`. The compound is only as confident as its weakest evidence. Rationale: a single low-confidence ambiguous docstring-extracted predicate should not raise the compound's claimed confidence; if the lifter said `5000` for the docstring, the compound is at most 5000-bp confident regardless of how many static-derived 10000-bp annotations sit alongside it. This is the conservative reading and aligns with Supra omnia, rectum.
+
+For `"best-confidence"` (spec'd, not v0): the compound's confidence is `max(e.confidence_basis_points for e in non-refuting evidences)`. For `"loudly-bounded-disjunction"` (spec'd, not v0): the compound's confidence is `max(...)` over the asserting disjuncts.
+
+## §2. The verdict trichotomy at the compound level
+
+Let `E = [e_1, ..., e_n]` be the compound's evidences, and let `v_i` be the per-evidence verdict for `e_i` against the concept's `wp_rule` (computed by the discharger in PR-F).
+
+### §2.1 `aggregation_strategy = "conjunction"` (v0 normative)
+
+The compound's verdict is derived:
+
+```
+compound_verdict :=
+  if every v_i == "exact"                       then "exact"
+  else if any v_i == "refuse"                   then "refuse"
+  else                                          "loudly-bounded-lossy"
+```
+
+The compound's `loss_record` (carried in the `ConceptSiteMemento.discharge.loss_record` of the binding citing this compound, not in the compound itself) is the per-dimension union of each `loudly-bounded-lossy` evidence's per-evidence loss-record, modulo dataflow (per 2026-05-15 §2.4).
+
+The compound's `composed_pre` is `JCS-normalize(/\_i e_i.predicate_pre)` and `composed_post` is `JCS-normalize(/\_i e_i.predicate_post)`. (See §6 for the pre/post separation rule and the JCS-normalize procedure.)
+
+### §2.2 `aggregation_strategy = "best-confidence"` (spec'd; v0 unimplemented)
+
+The compound's verdict is:
+
+```
+non_refuting := [e_i for v_i != "refuse"]
+if non_refuting is empty                        then "refuse"
+else                                            v_{argmax(e_i.confidence_basis_points, e_i in non_refuting)}
+```
+
+Refused evidences contribute to the compound's confidence-score (lowering it) but do not kill the compound if at least one evidence discharges. `composed_pre` and `composed_post` come from the chosen "best" evidence only (NOT from the conjunction); the other evidences contribute to compound-CID-determination by their CIDs but not to the composed pre/post bytes.
+
+### §2.3 `aggregation_strategy = "loudly-bounded-disjunction"` (spec'd; v0 unimplemented)
+
+The compound's verdict is:
+
+```
+non_refusing := [e_i for v_i != "refuse"]
+if non_refusing is empty                        then "refuse"
+else if any v_i == "exact"                      then "exact-with-disjunction-loss"
+else                                            "loudly-bounded-lossy"
+```
+
+`exact-with-disjunction-loss` is a sub-discriminant of `loudly-bounded-lossy`: the disjunction itself is the loss-record's `structural_divergence` dimension. `composed_pre`/`composed_post` are the JCS-normalized disjunction of evidence predicates. The disjunction structure IS the loss characterization.
+
+### §2.4 Three levels, not two
+
+Three verdict levels in the substrate:
+
+1. **Per-evidence.** The discharger's verdict for `e_i` against the concept's `wp_rule`. Recorded in the discharge receipt (PR-F), not in the evidence.
+2. **Compound.** Derived per §2.1 / §2.2 / §2.3 from the per-evidence verdicts.
+3. **Binding.** The `ConceptSiteMemento.discharge.verdict`. This IS the compound verdict; the binding cites the compound at `local_contract_cid` and inherits its verdict. There is no further reduction at the binding level beyond what the strategy emitted.
+
+## §3. Content-addressing rules
+
+### §3.1 CID construction
+
+For both mementos, the `cid` is the BLAKE3-512 of the JCS-canonical bytes of the `header` object with `cid` elided.
+
+For `EvidenceMemento`:
+
+```
+cid_input = JCS({
+  "confidence_basis_points":  <confidence_basis_points>,
+  "extension_fields":         <extension_fields>,
+  "kind":                     "evidence",
+  "lifter_cid":               <lifter_cid>,
+  "predicate":                <predicate>,
+  "schemaVersion":            "1",
+  "source_kind":              <source_kind>,
+  "source_locator":           <source_locator>
+})
+cid = "blake3-512:" ++ hex(BLAKE3-512(cid_input))
+```
+
+For `CompoundContractMemento`:
+
+```
+cid_input = JCS({
+  "aggregation_strategy": <aggregation_strategy>,
+  "composed_post":        <composed_post>,
+  "composed_pre":         <composed_pre>,
+  "evidences":            <evidences sorted by evidence_cid ascending>,
+  "function_term_cid":    <function_term_cid>,
+  "kind":                 "compound-contract",
+  "schemaVersion":        "1"
+})
+cid = "blake3-512:" ++ hex(BLAKE3-512(cid_input))
+```
+
+Important properties:
+
+- The `evidences` field of the compound contains evidence-CIDs (not inlined evidence bytes). Changing one evidence's content rolls the evidence's CID, which rolls the compound's CID, which rolls every binding citing that compound.
+- `aggregation_strategy` is part of the CID. The same set of evidences aggregated under `"conjunction"` vs `"best-confidence"` produces TWO different compounds (two different CIDs). This is correct: "the conjunction of these evidences" and "the best-confidence pick of these evidences" are different things and live at different addresses.
+- `composed_pre` and `composed_post` are part of the CID. They are cached bytes of the derived pre/post; validators MUST recompute and reject on mismatch (§5.3). Cached-with-truth-source means the cache must equal truth, by construction.
+- `extension_fields` are JCS-canonicalized per `2026-04-30-canonicalization-grammar.md`. Arbitrary unknown keys roll the CID. This is open-extension under deterministic addressing.
+
+### §3.2 Sub-object canonicalization
+
+Each sub-object is JCS-canonicalized with alphabetical key order. The CDDL above LOCKS that order for human readability; the JCS encoder enforces it normatively.
+
+The compound's `evidences` array MUST be sorted by `evidence_cid` ascending at JCS time. Insertion order is not preserved on the wire. This makes evidence reordering CID-invariant: a Rust value with `evidences = [refB, refA]` and one with `evidences = [refA, refB]` produce the same compound CID after JCS sorting.
+
+NOTE: this crate (`provekit-ir-types`) carries no JCS encoder; round-trip serde tests in this crate verify shape but NOT byte-exact CID stability. CID-stability tests live in `provekit-claim-envelope` (where the JCS encoder lives), per the precedent in `2026-05-12-concept-site-memento.md` §0 and §9.
+
+## §4. Mint procedure
+
+### §4.1 Mint an `EvidenceMemento`
+
+1. Lifter identifies a contract-source in user code (one of the ten kinds in §10).
+2. Lifter extracts a predicate (an `IrFormula`) from the source.
+3. Lifter records `source_locator` (`source_cid` plus a line/col span).
+4. Lifter assigns `confidence_basis_points` per source-kind prior (§10).
+5. Lifter fills `extension_fields` with per-kind metadata (see §10).
+6. Compute `cid` per §3.1.
+7. Sign `JCS({header, metadata})`.
+
+### §4.2 Mint a `CompoundContractMemento` (fresh)
+
+1. Identify the function: obtain `function_term_cid` (the `FunctionContractMemento.cid` of the function this compound is the contract for).
+2. Collect all minted `EvidenceMemento`s whose `extension_fields.test_target_function_cid` (or equivalent per-kind back-link, §10) is `function_term_cid`, plus the function's own annotation-derived evidences.
+3. Build `evidence-ref`s with `weight_basis_points` (default 10000 under conjunction; the field is informational under v0 but part of the CID, so it MUST be set deliberately).
+4. Choose `aggregation_strategy` (v0: always `"conjunction"`).
+5. Compute `composed_pre` and `composed_post`:
+   - For `"conjunction"`: pre/post-separate each evidence's `predicate` (§6), then JCS-normalize-conjunct the pres and the posts.
+   - For `"best-confidence"` (spec'd, unimpl): take the highest-confidence non-refuting evidence's separated pre/post.
+   - For `"loudly-bounded-disjunction"` (spec'd, unimpl): JCS-normalize-disjunct.
+6. Sort `evidences` by `evidence_cid` ascending (the JCS encoder will do this; Rust constructors MAY preserve insertion order).
+7. Compute `cid` per §3.1.
+8. Sign `JCS({header, metadata})`.
+
+### §4.3 Mint a `CompoundContractMemento` (auto-promotion of bare `FunctionContractMemento`)
+
+**Backward-compat path.** When a consumer encounters a `ConceptSiteMemento.local_contract_cid` that resolves to a bare `FunctionContractMemento`, the validator auto-promotes it to a single-evidence compound on the fly:
+
+1. Mint one `EvidenceMemento` with:
+   - `source_kind = "annotation"`.
+   - `predicate` = the `FunctionContractMemento`'s `pre /\ post` packaged per §6.
+   - `confidence_basis_points = 10000`.
+   - `source_locator` = derived from the `FunctionContractMemento`'s `locus`.
+   - `lifter_cid` = `"blake3-512:autoPromote000...0"` (a reserved sentinel CID, §4.4).
+   - `extension_fields = { "auto_promoted_from": <function_contract_cid> }`.
+2. Build a `CompoundContractMemento` with `evidences = [refToTheEvidence]`, `aggregation_strategy = "conjunction"`, `composed_pre`/`composed_post` from the bare contract.
+3. The promoted compound's CID is recomputed per §3.1.
+
+The auto-promoted compound has a fresh CID different from the bare contract's CID. The substrate stores this mapping (bare-contract-CID -> promoted-compound-CID) in the pool index so future lookups bypass re-promotion.
+
+### §4.4 The sentinel `auto-promote` lifter CID
+
+A reserved CID `blake3-512:autoPromote000...000` (128 hex `0`s after the prefix) identifies the auto-promotion path as the lifter. Downstream consumers can detect auto-promoted compounds by checking this lifter CID. The sentinel CID is NOT a valid BLAKE3-512 hash of any real lifter binary; it is reserved for this purpose by spec.
+
+**INVARIANT (mint idempotency):** Two mint operations with byte-identical inputs MUST produce the same `cid` for both kinds.
+
+## §5. Validation rules
+
+### §5.1 Pass 1: CDDL shape check (both kinds)
+
+Reject if:
+
+- Any required field is missing.
+- For `EvidenceMemento`: `kind != "evidence"`, `schemaVersion != "1"`, `confidence_basis_points > 10000`.
+- For `CompoundContractMemento`: `kind != "compound-contract"`, `schemaVersion != "1"`, any `evidence-ref.weight_basis_points > 10000`.
+- Any hash/CID field does not match `"blake3-512:" ++ 128-hex`.
+- For `CompoundContractMemento`: `aggregation_strategy` is not one of the canonical labels AND v0 does not accept extension labels at all (per §0; only `"conjunction"` is wired in v0; the others are spec'd but ship as `unimplemented!` in Rust).
+
+NOTE on `source_kind`: validators MUST accept unknown source-kind labels at shape level (open extension). Downstream consumers decide whether to refuse unknown kinds; the spec does not.
+
+### §5.2 Pass 2: degenerate-compound check
+
+If `evidences` is empty:
+
+- `composed_pre` MUST equal the `IrFormula` representation of `true`.
+- `composed_post` MUST equal the `IrFormula` representation of `true`.
+- `aggregation_strategy` is informational (does not apply); SHOULD be `"conjunction"` for least-surprise.
+
+Rationale: a function with no extracted evidence has the trivial contract `{ pre: true, post: true }`. This is the substrate's degenerate base case and is valid; it is the starting point before any lifter runs.
+
+### §5.3 Pass 3: DERIVED constraints
+
+**INVARIANT (cid):** Recompute `cid` per §3.1 and verify it equals `header.cid`. Reject on mismatch (both kinds).
+
+**INVARIANT (composed-pre/post):** For `CompoundContractMemento` under `aggregation_strategy = "conjunction"`:
+
+- Resolve each `evidence-ref.evidence_cid` against the pool to fetch the `predicate`.
+- Pre/post-separate each predicate per §6.
+- JCS-normalize-conjunct the pres and the posts.
+- Verify that the result equals `header.composed_pre` / `header.composed_post` byte-for-byte under JCS. Reject on mismatch.
+
+Under `"best-confidence"` and `"loudly-bounded-disjunction"`, parallel INVARIANTs hold per §2.2 and §2.3; these are spec'd but unimplemented in v0.
+
+**INVARIANT (sort):** The `evidences` array MUST be sorted by `evidence_cid` ascending in JCS-canonical bytes. Validators MUST reject on out-of-order arrays (the JCS encoder would sort, so any wire-shape that isn't sorted is malformed; reject without sorting).
+
+**SIGNATURE:** For swarm-distributed mementos, verify `envelope.signature` over `JCS({header, metadata})` against `envelope.signer`. Reject on invalid signature.
+
+### §5.4 Pass 4: REFERENT constraints (pool-level)
+
+For `EvidenceMemento`:
+
+- The pool MUST contain a canonical-source artifact with `cid = header.source_locator.source_cid`.
+- The pool MUST contain a lifter binary or rule-set with `cid = header.lifter_cid` (EXCEPT when `lifter_cid` is the reserved `auto-promote` sentinel, §4.4).
+- Any extension-field CIDs (e.g., `test_target_function_cid`) MUST resolve to existing mementos.
+
+For `CompoundContractMemento`:
+
+- The pool MUST contain a `FunctionContractMemento` with `cid = header.function_term_cid`.
+- For each `evidence-ref` in `evidences`, the pool MUST contain an `EvidenceMemento` with that CID.
+
+## §6. Composition semantics
+
+### §6.1 Pre/post separation
+
+An `EvidenceMemento.predicate` is an `IrFormula`. Some sources naturally produce pre-conditions (`#[requires]`, `assert!(b != 0)` at function start), some produce post-conditions (`#[ensures]`, return-type predicates, test assertions like `assert_eq!(f(x), y)`), and some produce a coupled pair (e.g., a docstring "Returns None if key missing" couples a pre-condition on the input with a post-condition on the result).
+
+The spec defines a pre/post separation rule on `IrFormula`:
+
+- A formula of shape `requires(P)` separates to `(pre = P, post = true)`.
+- A formula of shape `ensures(Q)` separates to `(pre = true, post = Q)`.
+- A formula of shape `requires(P) /\ ensures(Q)` separates to `(pre = P, post = Q)`.
+- A formula not matching any of these defaults to `(pre = true, post = predicate)` (treated as a pure post-condition).
+
+Rationale: every contract-source ultimately reduces to `requires(P) -> ensures(Q)` semantics; the separation rule normalizes the rep so the compound can JCS-conjunct cleanly. The grammar of `requires` / `ensures` markers in `IrFormula` follows `2026-04-30-ir-formal-grammar.md`.
+
+### §6.2 JCS-normalize-conjunct
+
+`JCS-normalize-conjunct(P_1, ..., P_n)` is defined as:
+
+1. De-duplicate at the predicate-CID level: `P_i` and `P_j` with identical JCS bytes collapse to one occurrence.
+2. Sort by predicate-CID ascending.
+3. Build the conjunction term `and(P_1, ..., P_n)` in `IrFormula`.
+4. JCS-canonicalize.
+
+This makes the composed predicate's bytes a function of the unordered multi-set of unique evidence predicates, not of insertion order.
+
+### §6.3 Discharge composition (PR-F preview)
+
+When a `ConceptSiteMemento` cites a `CompoundContractMemento` at `local_contract_cid`, the discharger:
+
+1. Pulls the compound.
+2. For each `evidence-ref`, pulls the `EvidenceMemento`, computes its per-evidence verdict against the concept's `wp_rule`.
+3. Derives the compound verdict per the recorded `aggregation_strategy` (§2).
+4. Records per-evidence verdicts in the `MorphismDischargeReceipt` (per 2026-05-15 §2.5).
+5. Sets the binding's `discharge.verdict` to the compound verdict.
+
+The receipt is the level where per-evidence verdicts are durably content-addressed. The compound is the level where the AGGREGATION is durably content-addressed. The binding is the level where the SITE-CONCEPT relation is durably content-addressed. Three mementos, three layers, one chain.
+
+## §7. Worked example
+
+A user's Rust function `fn safe_div(a: i32, b: i32) -> Option<i32>` with:
+
+1. `#[requires(b != 0)]` annotation.
+2. `#[ensures(result.is_some() iff b != 0)]` annotation.
+3. A test `#[test] fn t1() { assert_eq!(safe_div(10, 2), Some(5)); }`.
+4. A test `#[test] fn t2() { assert_eq!(safe_div(10, 0), None); }`.
+5. A docstring `/// Returns None when the divisor is zero.`
+6. The `Option<i32>` return type.
+7. The `assert!(b != 0)` inline at function start.
+
+The substrate lifts each into an `EvidenceMemento`:
+
+| # | `source_kind`         | `predicate` (sketch)                                | `confidence_basis_points` | extension                                              |
+|---|-----------------------|-----------------------------------------------------|---------------------------|--------------------------------------------------------|
+| 1 | `annotation`          | `requires(b != 0)`                                  | 10000                     | `{}`                                                   |
+| 2 | `annotation`          | `ensures(result.is_some() iff b != 0)`              | 10000                     | `{}`                                                   |
+| 3 | `test-assertion`      | `ensures(b == 2 /\ a == 10 -> result == Some(5))`   | 10000                     | `{ "test_target_function_cid": <safe_div_cid> }`       |
+| 4 | `test-assertion`      | `ensures(b == 0 /\ a == 10 -> result == None)`      | 10000                     | `{ "test_target_function_cid": <safe_div_cid> }`       |
+| 5 | `docstring`           | `ensures(b == 0 -> result == None)`                 | 6500                      | `{ "extracted_phrase": "Returns None when..." }`       |
+| 6 | `type-signature`      | `ensures(result.is_some() \/ result.is_none())`     | 10000                     | `{ "return_type": "Option<i32>" }`                     |
+| 7 | `implicit-effect`     | `requires(b != 0)`                                  | 10000                     | `{ "assert_site_line": 7 }`                            |
+
+Six unique evidence-mementos (1 and 7 have byte-identical predicates -- both `requires(b != 0)` -- but DIFFERENT `extension_fields` and DIFFERENT `source_locator`s, so they have different CIDs and are NOT de-duplicated at the evidence level; they ARE de-duplicated at the JCS-normalize-conjunct level in §6.2 because their `predicate` bytes are identical after canonicalization).
+
+The compound is built under `"conjunction"`. Sorted-by-CID, the seven evidence-refs assemble. The `composed_pre` after §6.2 normalization is `b != 0` (de-duplicated from #1 and #7). The `composed_post` is the conjunction of the five post-side predicates (de-duplicated where bytes coincide).
+
+The binding (in the `ConceptSiteMemento`) cites this compound at `local_contract_cid` and binds to a catalog concept (likely `concept:partial-function-by-guard` or `concept:option-from-guard`). The discharger:
+
+- Per-evidence verdict on #1: `exact` against the concept's pre.
+- Per-evidence verdict on #2: `exact`.
+- Per-evidence verdicts on #3, #4: `exact` (witnesses on the algebraic post).
+- Per-evidence verdict on #5: `loudly-bounded-lossy` (the docstring claim is strict-subset of the algebraic post; loss in `value_divergence` characterizes "what the docstring doesn't say").
+- Per-evidence verdict on #6: `loudly-bounded-lossy` (the type-signature only pins disjointness, not the iff structure).
+- Per-evidence verdict on #7: `exact` (matches #1's pre exactly).
+
+Compound verdict under `"conjunction"`: `loudly-bounded-lossy` (because #5 and #6 are loudly-bounded-lossy; no refuse). The receipt records all seven per-evidence verdicts plus the compound verdict plus the union of per-evidence loss-records.
+
+The binding's `discharge.verdict` = `loudly-bounded-lossy`. Composition through this binding propagates the union loss-record. A future re-lift of the docstring with a tighter grammar produces a new evidence-memento (different CID), which produces a new compound (different CID), which produces a new binding (different CID) with a tighter loss-record. The old binding and the new binding coexist in the pool. Different addresses, different things.
+
+## §8. Roadmap (PR-A through PR-H)
+
+This PR-A lands the SPEC and the Rust types only.
+
+- **PR-A (this PR):** CDDL spec at `protocol/specs/2026-05-13-compound-contract-memento.md` (this document) and `EvidenceMemento`, `CompoundContractMemento`, `EvidenceRef`, `SourceKind`, `AggregationStrategy`, `SourceLocator`, `SourceLocatorSpan`, `SourceLocatorPoint` types in `provekit-ir-types/src/lib.rs` with serde round-trip tests.
+- **PR-B (backward-compat lift):** Auto-promotion. The validator path that encounters a bare `FunctionContractMemento` at `ConceptSiteMemento.local_contract_cid` mints a single-evidence compound on the fly (§4.3). The promotion is cached pool-side so subsequent lookups are O(1).
+- **PR-C (per-source lifter: test assertions):** Walks `#[test]` functions; for each `assert_eq!(f(...), expected)`, emits an `EvidenceMemento` with `source_kind = "test-assertion"` whose `extension_fields.test_target_function_cid` pins the lifted function-CID of `f`. Re-mints the function's compound to include the new evidences.
+- **PR-D (per-source lifter: type signatures):** Reads the function's signature; generates partial-post evidences from return types (`-> Option<T>` produces `result.is_some() \/ result.is_none()`; `-> Result<T, E>` produces a disjointness predicate; `-> Vec<T>` produces `result.len() >= 0`, and so on).
+- **PR-E (per-source lifter: docstrings):** Extracts `/// Returns ... if ...` patterns with a small grammar. Conservative on ambiguity (emits `confidence_basis_points < 10000`).
+- **PR-F (compound-aware discharge):** `libprovekit::wp` discharger consumes a `CompoundContractMemento` and discharges each evidence; derives the compound verdict per the recorded `aggregation_strategy`. Mints a `MorphismDischargeReceipt` (per 2026-05-15 §2.5) that records per-evidence verdicts. This is also where v0 cuts over the `ConceptSiteMemento` mint path to point `local_contract_cid` at compounds (was: pointed at bare contracts).
+- **PR-G (native contract surfaces):** Per-language lifters for JML, Zod, Spring annotations, pydantic, and OpenAPI. Each emits `source_kind = "native-surface"` evidence with the canonical surface name in `extension_fields.surface_name`.
+- **PR-H (smoke-test demonstration):** `menagerie/smoke-test-e2e/` lifts multiple evidences per fixture function. `report.md §11` shows per-evidence + compound verdicts for at least the `safe_div` exemplar from §7.
+
+## §9. Smoke test (the acceptance test for the compound layer)
+
+A complete round-trip on a real Rust function with multiple evidence sources:
+
+1. Lift the function once with `provekit-lift-contracts`: produces a `FunctionContractMemento` for source (1)-(2) plus a list of evidence-mementos for (1)-(7).
+2. Build the `CompoundContractMemento` aggregating all evidences under `"conjunction"`.
+3. Bind the function to a catalog concept; mint a `ConceptSiteMemento` with `local_contract_cid` pointing at the compound.
+4. Discharge: verify per-evidence verdicts are recorded in the receipt; verify the compound verdict is derived correctly; verify the binding verdict equals the compound verdict.
+
+**Acceptance for PR-A (this PR):**
+
+- `cargo test -p provekit-ir-types` is green on the compound serde round-trip tests.
+- `cargo check --workspace` is clean.
+
+**Acceptance for PR-F (full end-to-end):**
+
+- The compound's `evidences.len() >= 3` for the exemplar function.
+- The compound's `composed_pre` is the conjunction of evidence pres.
+- The discharge runs against the concept's `wp_rule` and records per-evidence verdicts in the receipt.
+- The byte-exact CID stability tests for the compound live in `provekit-claim-envelope` (where the JCS encoder lives), NOT in `provekit-ir-types`.
+
+## §10. Per-source lifter inventory
+
+The ten canonical `source_kind` labels and their extraction guidance:
+
+| `source_kind`              | Extracted by                                   | `confidence_basis_points` prior | Required `extension_fields`                                            |
+|----------------------------|------------------------------------------------|---------------------------------|------------------------------------------------------------------------|
+| `annotation`               | `provekit-lift-contracts` (existing)           | 10000                           | `{}` (or `{ "auto_promoted_from": <fcm_cid> }` for backward-compat path) |
+| `test-assertion`           | PR-C (new walker)                              | 10000                           | `{ "test_target_function_cid": <cid> }`                                |
+| `type-signature`           | PR-D (signature reader)                        | 10000                           | `{ "return_type": <type_string> }`                                     |
+| `docstring`                | PR-E (grammar-based extractor)                 | 5000-8000 (per grammar match)   | `{ "extracted_phrase": <text> }`                                       |
+| `loop-invariant`           | existing `LoopInvariantMemento` lifter         | 10000                           | `{ "loop_invariant_memento_cid": <cid> }`                              |
+| `implicit-effect`          | walker over `assert!` / `panic!` / `unwrap` / `?` call-sites | 10000           | `{ "effect_site_line": <uint>, "effect_kind": "assert" \| "panic" \| "unwrap" \| "try" }` |
+| `native-surface`           | PR-G (per-language: JML, Zod, Spring, pydantic, OpenAPI) | 10000           | `{ "surface_name": "jml" \| "zod" \| "spring" \| "pydantic" \| "openapi" }` |
+| `structural-synthesis`     | clustering-mint time per `2026-05-13-wp-as-formula.md` | 10000           | `{ "synthesized_from_cluster_cid": <cid> }`                            |
+| `empirical-witness`        | future witness floor (PR-F's witness sampler)  | 1-9999 (sample-confidence-driven) | `{ "witness_memento_cid": <cid>, "sample_count": <uint> }`           |
+| `review-comment`           | future (out of scope for v0; placeholder)      | 1000-5000                       | `{ "pr_url": <string>, "comment_id": <string> }`                       |
+
+Each label is extension-open: validators MUST accept unknown labels at shape level (§5.1). Downstream consumers MAY refuse to compose through an unknown-kind evidence.
+
+## §11. Cross-references
+
+- This spec AMENDS `2026-05-12-concept-site-memento.md` §1.1 and §5.4 (§0.4 above).
+- The `function_term_cid` of `CompoundContractMemento` is the `FunctionContractMemento.cid` per `2026-05-03-contract-cid-vs-attestation-cid.md` (contract CID, not attestation CID).
+- The `predicate` field of `EvidenceMemento` is an `IrFormula` per `2026-04-30-ir-formal-grammar.md`.
+- JCS canonicalization per `2026-04-30-canonicalization-grammar.md`.
+- Structural-synthesis evidences (`source_kind = "structural-synthesis"`) flow from `2026-05-13-wp-as-formula.md`.
+- The per-evidence verdict trichotomy IS the §2 trichotomy of `2026-05-12-concept-site-memento.md`; this spec adds the compound-level derivation rule on top.
+- Loss-record dimensions per `2026-05-15 §2.4`.
+
+## §12. Out of scope for PR-A
+
+- Implementation of the discharger that consumes compounds (PR-F).
+- Implementation of any per-source lifter beyond the `annotation` path that already exists (PR-B through PR-G).
+- The smoke-test demonstration (PR-H).
+- Byte-exact CID-pinning tests for the compound (live in `provekit-claim-envelope`).
+- Wire-level migration of existing `ConceptSiteMemento`s in any deployed pool (handled as a one-shot pool-walker in PR-B).
+- `"best-confidence"` and `"loudly-bounded-disjunction"` aggregation behavior (spec'd in §2.2 / §2.3; v0 Rust ships them as `unimplemented!`).
+
+PR-A is the SPEC, the Rust TYPES, and the serde round-trip tests. Validation passes 1-2 are testable from the types layer (CDDL-shape + degenerate-compound); pass 3 (DERIVED constraints) requires the JCS encoder and is tested in `provekit-claim-envelope`; pass 4 (pool REFERENT) is tested in PR-B when the pool is wired.

--- a/protocol/specs/2026-05-13-compound-contract-memento.md
+++ b/protocol/specs/2026-05-13-compound-contract-memento.md
@@ -71,9 +71,13 @@ The `code_site.function_term_cid` field of `ConceptSiteMemento` continues to poi
 ;   hash, cid, signature, pubkey, iso8601, ir-formula, json-value
 
 ; Locked JCS key order: end, start
-; Both points are {line, col} pairs (1-based, line/col instead of byte
-; offsets, because evidence often comes from formatters / docstrings /
-; tests where byte offsets are unstable across re-formatting).
+; Both points are {line, col} pairs (1-based line, 0-indexed col in UTF-8
+; bytes; see §1.1 normative note below) instead of byte offsets, because
+; evidence often comes from formatters / docstrings / tests where absolute
+; byte offsets are unstable across re-formatting.
+; NOTE: CDDL display order {line, col} is illustrative. JCS sorts keys
+; alphabetically, so the on-wire bytes are encoded as {col, line}.
+; CDDL display order != JCS canonical order.
 source-locator-span = {
   end:   { line: uint, col: uint },
   start: { line: uint, col: uint }
@@ -135,6 +139,8 @@ evidence-memento = {
 | header   | `source_kind`               | yes      | One of the canonical labels (§10) or an extension label (unknown labels MUST NOT be rejected by shape validation; downstream consumers decide). |
 | header   | `source_locator`            | yes      | Where this evidence was extracted from. |
 | metadata | `note`                      | no       | Human-readable annotation. OMITTED when absent. |
+
+**Normative: column counting.** `col` counts UTF-8 BYTES within the line, 0-indexed. Line numbers are 1-indexed. Rationale: bytes are the substrate's native unit; UTF-8 bytes survive transport without re-encoding; converting to codepoints or graphemes requires Unicode-version-specific tables which would roll CIDs as the Unicode standard evolves. Tools that want codepoint-level positions must derive them from the source bytes; the substrate stores bytes. Tab characters (0x09) count as 1 byte, not as tab-stop expansions. CRLF line endings: the CR byte (0x0D) is part of the preceding line; only LF (0x0A) advances the line counter.
 
 ### §1.2 `CompoundContractMemento`
 
@@ -227,7 +233,8 @@ The compound's verdict is:
 ```
 non_refuting := [e_i for v_i != "refuse"]
 if non_refuting is empty                        then "refuse"
-else                                            v_{argmax(e_i.confidence_basis_points, e_i in non_refuting)}
+else                                            v_{argmax(e_i.confidence_basis_points, e_i in non_refuting,
+                                                          tiebreak by ascending evidence_cid)}
 ```
 
 Refused evidences contribute to the compound's confidence-score (lowering it) but do not kill the compound if at least one evidence discharges. `composed_pre` and `composed_post` come from the chosen "best" evidence only (NOT from the conjunction); the other evidences contribute to compound-CID-determination by their CIDs but not to the composed pre/post bytes.
@@ -321,7 +328,7 @@ NOTE: this crate (`provekit-ir-types`) carries no JCS encoder; round-trip serde 
 
 1. Identify the function: obtain `function_term_cid` (the `FunctionContractMemento.cid` of the function this compound is the contract for).
 2. Collect all minted `EvidenceMemento`s whose `extension_fields.test_target_function_cid` (or equivalent per-kind back-link, §10) is `function_term_cid`, plus the function's own annotation-derived evidences.
-3. Build `evidence-ref`s with `weight_basis_points` (default 10000 under conjunction; the field is informational under v0 but part of the CID, so it MUST be set deliberately).
+3. Build `evidence-ref`s with `weight_basis_points`. Under `"conjunction"`, MUST be exactly 10000; validators MUST reject any `evidence-ref.weight_basis_points != 10000` when `aggregation_strategy = "conjunction"`. The field is informational under v0 conjunction but is part of the CID, so pinning it normatively ensures CID stability across lifters.
 4. Choose `aggregation_strategy` (v0: always `"conjunction"`).
 5. Compute `composed_pre` and `composed_post`:
    - For `"conjunction"`: pre/post-separate each evidence's `predicate` (§6), then JCS-normalize-conjunct the pres and the posts.
@@ -340,18 +347,52 @@ NOTE: this crate (`provekit-ir-types`) carries no JCS encoder; round-trip serde 
    - `predicate` = the `FunctionContractMemento`'s `pre /\ post` packaged per §6.
    - `confidence_basis_points = 10000`.
    - `source_locator` = derived from the `FunctionContractMemento`'s `locus`.
-   - `lifter_cid` = `"blake3-512:autoPromote000...0"` (a reserved sentinel CID, §4.4).
+   - `lifter_cid` = `"blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"` (128 hex `0`s; a reserved sentinel CID, §4.4).
    - `extension_fields = { "auto_promoted_from": <function_contract_cid> }`.
-2. Build a `CompoundContractMemento` with `evidences = [refToTheEvidence]`, `aggregation_strategy = "conjunction"`, `composed_pre`/`composed_post` from the bare contract.
+2. Build a `CompoundContractMemento` with `evidences = [refToTheEvidence]` where the evidence-ref has `weight_basis_points = 10000` (normative per §4.2 step 3), `aggregation_strategy = "conjunction"`, `composed_pre`/`composed_post` from the bare contract.
 3. The promoted compound's CID is recomputed per §3.1.
 
 The auto-promoted compound has a fresh CID different from the bare contract's CID. The substrate stores this mapping (bare-contract-CID -> promoted-compound-CID) in the pool index so future lookups bypass re-promotion.
 
 ### §4.4 The sentinel `auto-promote` lifter CID
 
-A reserved CID `blake3-512:autoPromote000...000` (128 hex `0`s after the prefix) identifies the auto-promotion path as the lifter. Downstream consumers can detect auto-promoted compounds by checking this lifter CID. The sentinel CID is NOT a valid BLAKE3-512 hash of any real lifter binary; it is reserved for this purpose by spec.
+A reserved CID `blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000` (128 hex `0`s) identifies the auto-promotion path as the lifter. Downstream consumers can detect auto-promoted compounds by checking this lifter CID. The sentinel CID is NOT a valid BLAKE3-512 hash of any real lifter binary; it is reserved for this purpose by spec. The probability that a real BLAKE3-512 digest equals all-zeros is 2^-512; the sentinel is provably distinct from any real hash output.
+
+Pass-1 validation (§5.1) accepts this sentinel at `lifter_cid`: "128-hex" is satisfied by 128 hex `0` digits. No special-case exception to the CID format rule is needed.
 
 **INVARIANT (mint idempotency):** Two mint operations with byte-identical inputs MUST produce the same `cid` for both kinds.
+
+### §4.5 Byte-offset to line/col conversion (normative)
+
+When auto-promotion (§4.3) derives a `source_locator` from a `FunctionContractMemento.locus` (which uses byte-offset spans), the byte-offset MUST be converted to line/col using the following algorithm to ensure CID determinism across implementations:
+
+```
+Input:  source_bytes (UTF-8 encoded source file contents as a byte array)
+        byte_offset (usize, 0-indexed byte position within source_bytes)
+Output: { line: u32, col: u32 }
+
+Algorithm:
+  line := 1
+  col  := 0
+  for i in 0..byte_offset:
+    if source_bytes[i] == 0x0A (LF):
+      line := line + 1
+      col  := 0
+    else:
+      col  := col + 1
+  return { line, col }
+```
+
+Properties and constraints:
+
+- `line` is 1-indexed (starts at 1 for offset 0).
+- `col` is 0-indexed UTF-8 byte count from the most recent LF (or start of file) to `byte_offset`.
+- CRLF line endings: CR (0x0D) increments `col` as an ordinary byte; only LF (0x0A) resets `col` and increments `line`. This means the CR byte is counted as part of the preceding line's col.
+- `byte_offset` MUST point at a UTF-8 character boundary. If it does not, the conversion result is unspecified and validators MUST reject the containing `EvidenceMemento`.
+- `byte_offset` MUST be in `0..=source_bytes.len()`. An offset equal to `source_bytes.len()` is the one-past-the-end position (end of last line).
+- Tab characters (0x09) count as 1 byte in the `col` counter (no tab-stop expansion).
+
+This algorithm is byte-deterministic: two implementations fed identical `source_bytes` and `byte_offset` MUST produce identical `{ line, col }` outputs, which produces identical `source_locator` bytes, which produces an identical `EvidenceMemento` CID.
 
 ## §5. Validation rules
 
@@ -361,7 +402,7 @@ Reject if:
 
 - Any required field is missing.
 - For `EvidenceMemento`: `kind != "evidence"`, `schemaVersion != "1"`, `confidence_basis_points > 10000`.
-- For `CompoundContractMemento`: `kind != "compound-contract"`, `schemaVersion != "1"`, any `evidence-ref.weight_basis_points > 10000`.
+- For `CompoundContractMemento`: `kind != "compound-contract"`, `schemaVersion != "1"`, any `evidence-ref.weight_basis_points > 10000`, or (when `aggregation_strategy = "conjunction"`) any `evidence-ref.weight_basis_points != 10000`.
 - Any hash/CID field does not match `"blake3-512:" ++ 128-hex`.
 - For `CompoundContractMemento`: `aggregation_strategy` is not one of the canonical labels AND v0 does not accept extension labels at all (per §0; only `"conjunction"` is wired in v0; the others are spec'd but ship as `unimplemented!` in Rust).
 
@@ -374,6 +415,8 @@ If `evidences` is empty:
 - `composed_pre` MUST equal the `IrFormula` representation of `true`.
 - `composed_post` MUST equal the `IrFormula` representation of `true`.
 - `aggregation_strategy` is informational (does not apply); SHOULD be `"conjunction"` for least-surprise.
+
+The compound verdict for an empty-evidences compound is `"exact"`. By §2.1: "if every v_i == exact, then exact"; with zero evidences the condition holds vacuously. Downstream consumers MUST NOT second-guess this: an empty-evidences compound has exactly the trivial contract `{ pre: true, post: true }` with verdict `"exact"` (trivially satisfied).
 
 Rationale: a function with no extracted evidence has the trivial contract `{ pre: true, post: true }`. This is the substrate's degenerate base case and is valid; it is the starting point before any lifter runs.
 
@@ -426,7 +469,7 @@ Rationale: every contract-source ultimately reduces to `requires(P) -> ensures(Q
 
 `JCS-normalize-conjunct(P_1, ..., P_n)` is defined as:
 
-1. De-duplicate at the predicate-CID level: `P_i` and `P_j` with identical JCS bytes collapse to one occurrence.
+1. De-duplicate at the predicate-CID level: for each `P_i`, its predicate-CID is `"blake3-512:" ++ hex(BLAKE3-512(JCS(P_i)))`. `P_i` and `P_j` with identical predicate-CIDs (i.e., identical JCS bytes) collapse to one occurrence.
 2. Sort by predicate-CID ascending.
 3. Build the conjunction term `and(P_1, ..., P_n)` in `IrFormula`.
 4. JCS-canonicalize.


### PR DESCRIPTION
## Summary

Lands the architectural primitive Sir flagged as where-the-rubber-meets-the-road: the `CompoundContractMemento` + `EvidenceMemento` substrate types that make `ConceptSiteMemento.local_contract_cid` the convergence point for **every** contract-source the substrate can lift from a user's codebase.

This is **PR-A** (spec + Rust types + serde round-trip tests). No discharger wiring yet; that lands in PR-F.

## The architectural problem

PR #692 wired `ConceptSiteMemento.local_contract_cid` to a single `FunctionContractMemento`. A real function carries contract evidence from many sources:

1. `#[requires]` / `#[ensures]` annotations
2. Test assertions (`assert_eq!(f(3), 9)` in `#[test]`)
3. Type signatures (`-> Option<T>` is a partial post)
4. Docstring contracts
5. Bounded-loop assert invariants (already lifted)
6. `assert!()` / `panic!()` / `unwrap()` / `?` call-sites
7. Native contract surfaces (JML / Zod / Spring / pydantic / OpenAPI)
8. `wp_rule` synthesized structurally at clustering-mint time
9. Empirical witnesses from past runs
10. Human review comments (future)

Each is a typed piece of evidence about what the function does. The substrate now marries them at the binding via the compound.

## What this PR ships

- **Spec** `protocol/specs/2026-05-13-compound-contract-memento.md` (470 lines): CDDL §1, trichotomy §2, CID §3, mint §4 (including §4.3 backward-compat auto-promotion of bare `FunctionContractMemento` into single-evidence compounds), validation §5, composition §6, worked `safe_div` example §7, PR-A..PR-H roadmap §8, smoke test §9, per-source lifter inventory §10, cross-references §11. Includes a normative **§0.4 amendment** to `2026-05-12-concept-site-memento.md` §1.1 and §5.4 (the `local_contract_cid` field now points at a compound, not a bare contract).
- **Rust types** in `implementations/rust/provekit-ir-types/src/lib.rs`: `EvidenceMemento`, `CompoundContractMemento`, `EvidenceRef`, `SourceKind` (open enum, kebab-case wire form, `Other(String)` fallback per the `DivergentSemanticsTag` pattern from #696's fix-round-2), `AggregationStrategy` (same pattern), `SourceLocator`, `SourceLocatorSpan`, `SourceLocatorPoint` (line/col, not byte offsets, because evidence often comes from sources where byte offsets are unstable across re-formatting).
- **Serde tests** at `provekit-ir-types/tests/compound_contract_serde.rs` (18 tests, all green): every canonical `SourceKind` and `AggregationStrategy` label round-trips through its wire form; `Other(String)` round-trips for unknown labels; empty / single / multi-evidence compounds round-trip; auto-promotion single-evidence shape round-trips with the reserved `auto-promote` sentinel `lifter_cid`; hand-written spec-fixture pin tests parse cleanly.

## Trichotomy at TWO levels (Supra omnia, rectum)

- **Per-evidence verdict**: each evidence's discharge verdict against the concept's `wp_rule`. Recorded in the `MorphismDischargeReceipt` (PR-F), not in the evidence itself (the evidence is raw contract bytes, not the discharge).
- **Compound verdict**: derived from per-evidence verdicts under the recorded `aggregation_strategy`. Under v0 `conjunction`: all-exact -> `exact`; any refuse -> `refuse`; else `loudly-bounded-lossy` with union loss-record. Confidence under conjunction is `min(...)` (the compound is only as confident as its weakest evidence). The other two strategies are spec'd in §2.2 / §2.3 but ship as `unimplemented!` in the discharger.
- **Binding verdict**: the `ConceptSiteMemento.discharge.verdict` IS the compound verdict (the binding cites the compound, not the concept, after this PR-A's amendment lands).

Silent contract-dropping is impossible at either level.

## CID rules

- `evidences` field contains evidence-CIDs (not inlined bytes). Different evidence-set -> different compound CID -> different binding CID. Sir's "different loss = different address" principle extends to evidence-sets.
- `composed_pre` / `composed_post` are derived-AND-stored. Validators MUST recompute under the recorded strategy and reject on mismatch (the cache-with-truth-source duality). The recompute INVARIANT requires the JCS encoder and is tested in `provekit-claim-envelope`, not in this crate.
- `aggregation_strategy` is part of the CID. Same evidences under different strategies = different compounds at different addresses.
- `extension_fields` JCS-canonicalize per `2026-04-30-canonicalization-grammar.md`; arbitrary keys roll the CID (open extension under deterministic addressing).

## §8 roadmap (PR-B through PR-H)

- **PR-B**: backward-compat lift; pool-walker that auto-promotes existing bare `FunctionContractMemento`s into single-evidence compounds at the points where `ConceptSiteMemento`s currently cite them. Promotion is cached pool-side.
- **PR-C**: per-source lifter -- test assertions. Walks `#[test]` functions; for each `assert_eq!(f(...), expected)`, emits `source_kind = "test-assertion"` evidence with `extension_fields.test_target_function_cid` pinning the lifted CID of `f`.
- **PR-D**: per-source lifter -- type signatures. Reads return types; emits partial-post evidences (`-> Option<T>`, `-> Result<T,E>`, `-> Vec<T>`, etc.).
- **PR-E**: per-source lifter -- docstrings. Grammar-based extractor with conservative `confidence_basis_points` on ambiguity.
- **PR-F**: compound-aware discharge in `libprovekit::wp`. Consumes a `CompoundContractMemento`, discharges each evidence against the concept, derives the compound verdict per the strategy, mints a `MorphismDischargeReceipt` recording per-evidence verdicts. This is also where the `ConceptSiteMemento` mint path cuts over to point `local_contract_cid` at compounds.
- **PR-G**: native contract surfaces -- JML, Zod, Spring, pydantic, OpenAPI. Each gets its own lifter emitting `source_kind = "native-surface"`.
- **PR-H**: smoke-test demonstration. `menagerie/smoke-test-e2e/` lifts multiple evidences per fixture function; `report.md §11` shows per-evidence + compound verdicts for at least the `safe_div` exemplar from §7.

## Verification

- `cargo test -p provekit-ir-types` -- **70 tests pass** (18 new + 52 existing across 6 test files).
- `cargo check --workspace` -- clean (only pre-existing unused-field warnings unrelated to this PR).

## Constraints honored (Supra omnia, rectum)

- Trichotomy enforced at both per-evidence and compound levels; silent contract-dropping impossible at either level.
- CID stability: different evidence-set -> different compound-CID -> different binding-CID.
- v0 ships only `conjunction`; other strategies spec'd and serde-round-trip but `unimplemented!` in the discharger (architectural reserve without premature implementation).
- Backward-compat mandatory: existing `FunctionContractMemento`s auto-promote via §4.3-§4.4 sentinel-CID path without breaking any consumer.
- Spec alignment with #692: `ConceptSiteMemento.local_contract_cid` field name stays; type semantics change per the §0.4 amendment (documented audit-trail, not silent edit to the old spec).
- No em-dashes anywhere.

**Ready for architect review when promoted.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)