### PR TITLE
feat(domain-claim): TryFrom<&FunctionContractMemento> for DomainClaim (PR-B of #717)

### DIFF
--- a/implementations/rust/libprovekit/src/compose.rs
+++ b/implementations/rust/libprovekit/src/compose.rs
@@ -1082,3 +1082,95 @@ pub fn jcs_bytes_of_value(v: &Value) -> Vec<u8> {
 pub use crate::wp::{
     free_vars_formula, free_vars_term, substitute_in_formula, substitute_in_term,
 };
+
+// ============================================================
+// DomainClaim projection for FunctionContractMemento (PR-B of #717)
+//
+// Bare `FunctionContractMemento`s have no inline discharge. They MUST
+// be wrapped in a `ConceptSiteMemento` (the binding) or a
+// `CompoundContractMemento` (PR #716) before reaching the verifier
+// surface. This impl is intentionally always-Err so the type system
+// encodes the invariant: the call-site is forced to handle the error
+// and either reject the bare contract or promote it through a binding
+// (spec §2.3, §6.1).
+// ============================================================
+
+impl TryFrom<&FunctionContractMemento> for provekit_ir_types::DomainClaim {
+    type Error = provekit_ir_types::DomainClaimConversionError;
+
+    fn try_from(_m: &FunctionContractMemento) -> Result<Self, Self::Error> {
+        Err(provekit_ir_types::DomainClaimConversionError::UnboundContract)
+    }
+}
+
+#[cfg(test)]
+mod domain_claim_fcm_tests {
+    use super::*;
+    use provekit_ir_types::{DomainClaimConversionError, IrFormula};
+
+    /// Build a minimal but valid `FunctionContractMemento` for testing.
+    /// `pre` and `post` use `And { operands: [] }` which is the canonical
+    /// encoding of the trivial `true` formula.
+    fn minimal_fcm() -> FunctionContractMemento {
+        FunctionContractMemento {
+            fn_name: "test_fn".to_string(),
+            formals: vec![],
+            formal_sorts: vec![],
+            formal_regions: vec![],
+            return_sort: provekit_ir_types::Sort::Primitive {
+                name: "bool".to_string(),
+            },
+            return_region: None,
+            pre: IrFormula::And { operands: vec![] },
+            post: IrFormula::And { operands: vec![] },
+            body_cid: None,
+            effects: EffectSet::default(),
+            locus: Locus {
+                file: Some("test.rs".to_string()),
+                line: 1,
+                col: 0,
+            },
+            canonical_bytes: vec![],
+            cid: "blake3-512:000000".to_string(),
+            auto_minted_mementos: vec![],
+            concept_hint: None,
+        }
+    }
+
+    #[test]
+    fn bare_fcm_returns_unbound_contract_error() {
+        let fcm = minimal_fcm();
+        let result = provekit_ir_types::DomainClaim::try_from(&fcm);
+        assert_eq!(result, Err(DomainClaimConversionError::UnboundContract));
+    }
+
+    #[test]
+    fn bare_fcm_error_is_deterministic() {
+        let fcm = minimal_fcm();
+        let r1 = provekit_ir_types::DomainClaim::try_from(&fcm);
+        let r2 = provekit_ir_types::DomainClaim::try_from(&fcm);
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn unbound_contract_display_is_informative() {
+        let msg = DomainClaimConversionError::UnboundContract.to_string();
+        assert!(
+            msg.contains("unbound") || msg.contains("bare") || msg.contains("FunctionContract"),
+            "display message should be informative, got: {msg:?}"
+        );
+        assert!(
+            msg.contains("ConceptSiteMemento") || msg.contains("CompoundContract"),
+            "display message should mention the binding type, got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn unbound_contract_error_variant_matches() {
+        let fcm = minimal_fcm();
+        let err = provekit_ir_types::DomainClaim::try_from(&fcm).unwrap_err();
+        // Pattern-match to confirm the correct variant -- won't compile if
+        // the variant is renamed or removed.
+        assert!(matches!(err, DomainClaimConversionError::UnboundContract));
+    }
+}

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -1475,6 +1475,11 @@ pub enum DomainClaimConversionError {
     /// entries and are not directly verifiable through the `DomainClaim`
     /// surface (spec §2.2).
     StandaloneRealization,
+    /// A bare `FunctionContractMemento` was offered directly to the verifier
+    /// surface. Bare contracts have no inline discharge and MUST be wrapped
+    /// in a `ConceptSiteMemento` binding or `CompoundContractMemento` (PR #716)
+    /// before they can be projected onto `DomainClaim` (spec §2.3).
+    UnboundContract,
 }
 
 impl std::fmt::Display for DomainClaimConversionError {
@@ -1490,6 +1495,13 @@ impl std::fmt::Display for DomainClaimConversionError {
                 "RealizationDesugaringMemento is standalone (not cited by a \
                  ConceptSiteMemento); standalone realizations are catalog \
                  entries and do not project directly onto DomainClaim"
+            ),
+            Self::UnboundContract => write!(
+                f,
+                "FunctionContractMemento is unbound: bare contracts have no \
+                 inline discharge and must be wrapped in a ConceptSiteMemento \
+                 or CompoundContractMemento before projecting onto DomainClaim \
+                 (spec §2.3)"
             ),
         }
     }


### PR DESCRIPTION
## Summary

PR-B of the DomainClaim normalization chain (#717 / PR-A landed at ee3fa75a).

Bare `FunctionContractMemento`s have no inline discharge. They must be wrapped in a `ConceptSiteMemento` (the binding) or a `CompoundContractMemento` (PR #716) before reaching the verifier surface (spec §2.3, §6.1). This impl lives in `libprovekit` rather than `provekit-ir-types` because `FunctionContractMemento` is defined in `libprovekit::compose`; placing it in `provekit-ir-types` would invert the dependency direction.

The `TryFrom` impl is intentionally always-`Err` so the type system encodes the invariant at the call site: callers are forced to handle the error and either reject the bare contract or promote it through a binding.

## Changes

- **`provekit-ir-types/src/lib.rs`**: add `UnboundContract` variant to `DomainClaimConversionError` with a spec-citing Display message
- **`libprovekit/src/compose.rs`**: `impl TryFrom<&FunctionContractMemento> for provekit_ir_types::DomainClaim` -- always returns `Err(UnboundContract)`
- **`libprovekit/src/compose.rs`**: 4 unit tests covering error variant identity, determinism across two calls on the same FCM, Display message quality, and pattern-match soundness

## Test plan

- [ ] `cargo test -p libprovekit domain_claim_fcm` -- 4 tests, all green
- [ ] `cargo check --workspace` -- clean (warnings are pre-existing dead code in unrelated crates)
- [ ] Spec compliance: §2.3 says bare contracts are NOT consumable directly; this impl enforces that at the type level
- [ ] Needs Opus deep review before merge (standing rule)

## Notes

The task description's field mapping (`lifter_cid`, `source_cid`, `concept_cid`) does not match the actual `FunctionContractMemento` struct fields. The normative source is spec §2.3 + §6.1, which are unambiguous: bare FCMs always return `Err(UnboundContract)`. The always-Err shape is the correct and complete implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)