### PR TITLE
feat(cmd-bind): close v0-orp-delegation-gap — canonical-mode now delegates to ORP

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -763,6 +763,25 @@ fn run_bind_engine(
         kind: "v0-capability-gap".into(),
         detail: "real ConceptAbstractionMemento catalog lookup deferred to v1 (v0 uses soft-match classification)".into(),
     });
+    // F6: Record stub-body gap when bindings exist.
+    //
+    // In v0 the canonical-rewrite path has no full term graph; it delegates to
+    // `realize_for_bind` which always emits idiomatic stub bodies (panic/raise/todo).
+    // This gap record is the honest substrate disclosure: real lifted source bodies
+    // are NOT present in these outputs.  A future PR that wires the term graph to the
+    // canonical path should remove this gap kind and replace it with a "term-body-realized"
+    // kind.
+    if !bindings.is_empty() {
+        gaps.push(GapRecord {
+            kind: "bind-stub-body-emitted".into(),
+            detail: format!(
+                "canonical-rewrite emitted stub bodies for {n} binding(s): no real lifted term \
+                 graph available in v0; bodies are idiomatic language stubs \
+                 (panic/raise/todo/throw). Real bodies deferred to v1.",
+                n = bindings.len()
+            ),
+        });
+    }
     Ok(EngineResult {
         bindings,
         concepts,
@@ -1018,8 +1037,19 @@ fn apply_canonical_rewrite(
             by_fn.insert(b.site_fn.clone(), b);
         }
 
+        // F2: use target-language comment prefix (not always `//`).
+        let cmt = comment_prefix_for(target_lang);
+
+        // F1: emit file-level header exactly once per output file.
+        // Go needs `package main`, PHP needs `<?php`, others need nothing.
+        let file_header = crate::cmd_transport::realize_file_header(target_lang);
+
         let mut chunks: Vec<String> = Vec::new();
-        chunks.push(format!("// canonical rewrite: {rel_file} -> {target_lang}\n"));
+        // File-level header (may be empty) comes first.
+        if !file_header.is_empty() {
+            chunks.push(file_header);
+        }
+        chunks.push(format!("{cmt} canonical rewrite: {rel_file} -> {target_lang}\n"));
 
         for item in &file.items {
             if let syn::Item::Fn(item_fn) = item {
@@ -1067,10 +1097,16 @@ fn apply_canonical_rewrite(
                 } else {
                     // Coverage gap: no binding for this function.
                     chunks.push(format!(
-                        "// bind:canonical:gap: fn {fn_name} has no concept binding for {target_lang}\n"
+                        "{cmt} bind:canonical:gap: fn {fn_name} has no concept binding for {target_lang}\n"
                     ));
                 }
             }
+        }
+
+        // F1: emit file-level footer exactly once per output file (currently empty for all langs).
+        let file_footer = crate::cmd_transport::realize_file_footer(target_lang);
+        if !file_footer.is_empty() {
+            chunks.push(file_footer);
         }
 
         let output_src = chunks.join("\n");
@@ -1097,8 +1133,20 @@ fn apply_canonical_rewrite(
     for path in src_files {
         let rel = path.strip_prefix(root).unwrap_or(path).display().to_string();
         if !by_file.contains_key(&rel) && !to_disk {
-            println!("// bind:canonical:no-bindings:{rel}");
+            let cmt = comment_prefix_for(target_lang);
+            println!("{cmt} bind:canonical:no-bindings:{rel}");
         }
+    }
+}
+
+/// Return the line-comment prefix for the target language.
+///
+/// Python and Ruby use `#` for comments; `//` is the floor-division operator
+/// and would produce a syntax error. All other supported languages use `//`.
+fn comment_prefix_for(target_lang: &str) -> &'static str {
+    match target_lang {
+        "python" | "ruby" => "#",
+        _ => "//",
     }
 }
 
@@ -1148,9 +1196,11 @@ fn build_target_annotations(
     }
 
     // Contract attributes in target-language syntax.
+    // F3: Zig does NOT use Rust `#[cfg_attr(...)]` syntax; give it `// @provekit:` comments.
     if let Some(pre) = &binding.pretty_pre {
         match target_lang {
-            "rust" | "zig" => lines.push(format!("#[cfg_attr(any(), requires({pre}))]")),
+            "rust" => lines.push(format!("#[cfg_attr(any(), requires({pre}))]")),
+            "zig" => lines.push(format!("// @requires: {pre}")),
             "java" | "csharp" => lines.push(format!("/* @requires: {pre} */")),
             "python" | "ruby" => lines.push(format!("# @requires: {pre}")),
             _ => lines.push(format!("// @requires: {pre}")),
@@ -1158,7 +1208,8 @@ fn build_target_annotations(
     }
     if let Some(post) = &binding.pretty_post {
         match target_lang {
-            "rust" | "zig" => lines.push(format!("#[cfg_attr(any(), ensures({post}))]")),
+            "rust" => lines.push(format!("#[cfg_attr(any(), ensures({post}))]")),
+            "zig" => lines.push(format!("// @ensures: {post}")),
             "java" | "csharp" => lines.push(format!("/* @ensures: {post} */")),
             "python" | "ruby" => lines.push(format!("# @ensures: {post}")),
             _ => lines.push(format!("// @ensures: {post}")),
@@ -1172,6 +1223,7 @@ fn build_target_annotations(
                 "rust" => lines.push(format!(
                     "#[cfg_attr(any(), provekit_monitor(concept = \"{concept_name}\"))]"
                 )),
+                "zig" => lines.push(format!("// @provekit_monitor(concept = \"{concept_name}\")")),
                 "java" => lines.push(format!("// @provekit_monitor(concept = \"{concept_name}\")")),
                 "python" => lines.push(format!("# @provekit_monitor(concept = \"{concept_name}\")")),
                 _ => lines.push(format!("// @provekit_monitor(concept = \"{concept_name}\")")),
@@ -1182,6 +1234,7 @@ fn build_target_annotations(
                 "rust" => lines.push(format!(
                     "#[cfg_attr(any(), provekit_emitter(concept = \"{concept_name}\"))]"
                 )),
+                "zig" => lines.push(format!("// @provekit_emitter(concept = \"{concept_name}\")")),
                 _ => lines.push(format!("// @provekit_emitter(concept = \"{concept_name}\")")),
             }
         }
@@ -1190,6 +1243,7 @@ fn build_target_annotations(
                 "rust" => lines.push(format!(
                     "#[cfg_attr(any(), provekit_witness(concept = \"{concept_name}\"))]"
                 )),
+                "zig" => lines.push(format!("// @provekit_witness(concept = \"{concept_name}\")")),
                 _ => lines.push(format!("// @provekit_witness(concept = \"{concept_name}\")")),
             }
         }
@@ -1228,9 +1282,11 @@ fn build_bind_meta_comment(
     // These come from the bind engine's own lift pass, which is authoritative for the
     // source language. ORP may also emit contract lines in its prefix; these ensure
     // they are always present.
+    // F3: Zig does NOT use Rust `#[cfg_attr(...)]` syntax.
     if let Some(pre) = &binding.pretty_pre {
         match target_lang {
-            "rust" | "zig" => lines.push(format!("#[cfg_attr(any(), requires({pre}))]")),
+            "rust" => lines.push(format!("#[cfg_attr(any(), requires({pre}))]")),
+            "zig" => lines.push(format!("// @requires: {pre}")),
             "java" | "csharp" => lines.push(format!("/* @requires: {pre} */")),
             "python" | "ruby" => lines.push(format!("# @requires: {pre}")),
             _ => lines.push(format!("// @requires: {pre}")),
@@ -1238,7 +1294,8 @@ fn build_bind_meta_comment(
     }
     if let Some(post) = &binding.pretty_post {
         match target_lang {
-            "rust" | "zig" => lines.push(format!("#[cfg_attr(any(), ensures({post}))]")),
+            "rust" => lines.push(format!("#[cfg_attr(any(), ensures({post}))]")),
+            "zig" => lines.push(format!("// @ensures: {post}")),
             "java" | "csharp" => lines.push(format!("/* @ensures: {post} */")),
             "python" | "ruby" => lines.push(format!("# @ensures: {post}")),
             _ => lines.push(format!("// @ensures: {post}")),

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -12,8 +12,8 @@
 //   - Three runtime modes:  witness / emitter / monitor.
 //   - Target-language axis: rust / python / java / go / csharp / typescript /
 //     zig / ruby / php (default = source language).
-//   - canonical rewrite emits per-language contract stubs (v0); full ORP delegation
-//     via realize_function deferred to v1 (realize_function is fn not pub today).
+//   - canonical rewrite delegates to cmd_transport::realize_for_bind (ORP); falls
+//     back to emit_target_stub only when the ORP realizer refuses (unknown language).
 //   - invisible writes to stdout instead of disk.
 //   - All 9 (rewrite x mode) combinations handled; canonical-mode branches
 //     converge to ORP.
@@ -763,13 +763,6 @@ fn run_bind_engine(
         kind: "v0-capability-gap".into(),
         detail: "real ConceptAbstractionMemento catalog lookup deferred to v1 (v0 uses soft-match classification)".into(),
     });
-    gaps.push(GapRecord {
-        kind: "v0-orp-delegation-gap".into(),
-        detail: "emit_target_stub emits per-language contract stubs directly; full ORP delegation via \
-                 realize_function deferred to v1 (realize_function is fn not pub; visibility change \
-                 needed for cross-module delegation)".into(),
-    });
-
     Ok(EngineResult {
         bindings,
         concepts,
@@ -1049,16 +1042,28 @@ fn apply_canonical_rewrite(
 
                 if let Some(b) = by_fn.get(&fn_name) {
                     let concept_name = name_for_annotation(&result.concepts[b.concept_idx].name);
-                    // Emit target-language stub (v0; full ORP delegation in v1 when realize_function is pub).
-                    let realized = emit_target_stub(
+                    // Delegate to ORP realize_for_bind; fall back to emit_target_stub if
+                    // the ORP realizer refuses (e.g. unsupported language).
+                    let realized_chunk = match crate::cmd_transport::realize_for_bind(
                         target_lang,
                         &fn_name,
                         &params,
-                        b,
+                        &orig,
                         &concept_name,
-                        mode,
-                    );
-                    chunks.push(realized);
+                    ) {
+                        Ok(r) => {
+                            // Prepend bind-specific metadata (substrate-origin, memento-cid,
+                            // contract annotations, runtime-mode) before the ORP-generated snippet.
+                            let meta = build_bind_meta_comment(target_lang, &concept_name, b, mode);
+                            format!("{meta}\n{}", r.source)
+                        }
+                        Err(_) => {
+                            // ORP refused (unsupported language or parse error); fall back
+                            // to the annotation-level stub so output is never empty.
+                            emit_target_stub(target_lang, &fn_name, &params, b, &concept_name, mode)
+                        }
+                    };
+                    chunks.push(realized_chunk);
                 } else {
                     // Coverage gap: no binding for this function.
                     chunks.push(format!(
@@ -1097,19 +1102,10 @@ fn apply_canonical_rewrite(
     }
 }
 
-/// Delegate a single function's canonical rewrite to the ORP realize infrastructure.
-///
-/// Builds the annotation set from the binding's contract and concept name,
-/// then emits a target-language snippet. This is not a full ORP invocation
-/// (which requires a loaded Term graph and catalog entry); it is the CLI-level
-/// bridge that prepares the annotation block in the target style and emits a
-/// typed stub for the function.
-///
-/// For a full ORP invocation (with real Term traversal), see
-/// `cmd_transport::realize_function` which requires a parsed Term body.
-/// That path is used by `provekit transport`; bind delegates at the
-/// annotation level here and records the gap when real body realization
-/// is needed.
+/// Fallback stub emitter used when ORP `realize_for_bind` refuses (e.g. an
+/// unsupported target language). Emits bind-level annotations without real
+/// body realization. Canonical mode always tries `realize_for_bind` first;
+/// this path is only taken on refusal.
 fn emit_target_stub(
     target_lang: &str,
     fn_name: &str,
@@ -1199,6 +1195,83 @@ fn build_target_annotations(
         }
     }
 
+    lines.join("\n")
+}
+
+/// Build bind-specific metadata comment block to prepend before an ORP-realized
+/// snippet. Carries substrate-origin, memento-cid, contract annotations from
+/// the binding record, and the runtime-mode attribute. The ORP realizer may also
+/// emit concept+contract lines in its own prefix; the bind-layer ones here ensure
+/// provenance is always present even when ORP cannot re-lift contracts from source.
+fn build_bind_meta_comment(
+    target_lang: &str,
+    concept_name: &str,
+    binding: &BindingRecord,
+    mode: &RuntimeMode,
+) -> String {
+    let comment_prefix = match target_lang {
+        "python" | "ruby" => "#",
+        _ => "//",
+    };
+    let mut lines: Vec<String> = Vec::new();
+    lines.push(format!(
+        "{comment_prefix} substrate-origin: {}",
+        binding.origin.label()
+    ));
+    if !binding.site_memento_cid.is_empty() {
+        lines.push(format!(
+            "{comment_prefix} memento-cid: {}",
+            binding.site_memento_cid
+        ));
+    }
+    // Contract annotations from the binding record (pre/post as pretty-printed strings).
+    // These come from the bind engine's own lift pass, which is authoritative for the
+    // source language. ORP may also emit contract lines in its prefix; these ensure
+    // they are always present.
+    if let Some(pre) = &binding.pretty_pre {
+        match target_lang {
+            "rust" | "zig" => lines.push(format!("#[cfg_attr(any(), requires({pre}))]")),
+            "java" | "csharp" => lines.push(format!("/* @requires: {pre} */")),
+            "python" | "ruby" => lines.push(format!("# @requires: {pre}")),
+            _ => lines.push(format!("// @requires: {pre}")),
+        }
+    }
+    if let Some(post) = &binding.pretty_post {
+        match target_lang {
+            "rust" | "zig" => lines.push(format!("#[cfg_attr(any(), ensures({post}))]")),
+            "java" | "csharp" => lines.push(format!("/* @ensures: {post} */")),
+            "python" | "ruby" => lines.push(format!("# @ensures: {post}")),
+            _ => lines.push(format!("// @ensures: {post}")),
+        }
+    }
+    match mode {
+        RuntimeMode::Monitor => {
+            match target_lang {
+                "rust" => lines.push(format!(
+                    "#[cfg_attr(any(), provekit_monitor(concept = \"{concept_name}\"))]"
+                )),
+                "java" => lines.push(format!("// @provekit_monitor(concept = \"{concept_name}\")")),
+                "python" => lines.push(format!("# @provekit_monitor(concept = \"{concept_name}\")")),
+                _ => lines.push(format!("{comment_prefix} @provekit_monitor(concept = \"{concept_name}\")")),
+            }
+        }
+        RuntimeMode::Emitter => {
+            match target_lang {
+                "rust" => lines.push(format!(
+                    "#[cfg_attr(any(), provekit_emitter(concept = \"{concept_name}\"))]"
+                )),
+                _ => lines.push(format!("{comment_prefix} @provekit_emitter(concept = \"{concept_name}\")")),
+            }
+        }
+        RuntimeMode::Witness => {
+            match target_lang {
+                "rust" => lines.push(format!(
+                    "#[cfg_attr(any(), provekit_witness(concept = \"{concept_name}\"))]"
+                )),
+                _ => lines.push(format!("{comment_prefix} @provekit_witness(concept = \"{concept_name}\")")),
+            }
+        }
+    }
     lines.join("\n")
 }
 

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -60,7 +60,7 @@ struct StageReport {
 }
 
 #[derive(Debug, thiserror::Error)]
-enum TransportCliError {
+pub(crate) enum TransportCliError {
     #[error("Refusal: {0}")]
     Refusal(String),
     #[error("{0}")]
@@ -1176,9 +1176,30 @@ fn emit_annotation_prefix(
 }
 
 #[derive(Debug)]
-struct RealizedSource {
-    extension: &'static str,
-    source: String,
+pub(crate) struct RealizedSource {
+    pub(crate) extension: &'static str,
+    pub(crate) source: String,
+}
+
+/// Public-crate bridge for `cmd_bind`'s canonical-mode path.
+///
+/// Lifts contract annotations from `source_text` (Rust source of the origin
+/// file) for the named function, then calls `realize_function` with a
+/// `Term::Unit` body. The body is `Unit` because `cmd_bind` operates at the
+/// annotation/concept level; full Term-graph realization is `cmd_transport`'s
+/// domain and is not available from the bind context.
+///
+/// Returns a `RealizedSource` on success. The `source` field carries the
+/// full target-language snippet including the ORP annotation prefix.
+pub(crate) fn realize_for_bind(
+    language: &str,
+    function: &str,
+    params: &[String],
+    source_text: &str,
+    concept_name: &str,
+) -> Result<RealizedSource, TransportCliError> {
+    let annotations = lift_rust_contracts(source_text, function);
+    realize_function(language, function, params, &Term::Unit, &annotations, concept_name)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -227,6 +227,13 @@ fn run_inner(args: TransportArgs) -> Result<TransportReport, TransportCliError> 
         ContractAnnotations::default()
     };
 
+    // Extract source-language type information for signature threading.
+    let (param_types, return_type) = if source_language == "rust" {
+        parse_rust_fn_types(&source_text, &args.function)
+    } else {
+        (Vec::new(), "i64".to_string())
+    };
+
     // Derive a stable concept binding for the `// concept: ...` comment.
     // The name is deterministic from the target term's JSON serialization so
     // every distinct function shape gets a unique, stable, per-function name.
@@ -236,6 +243,8 @@ fn run_inner(args: TransportArgs) -> Result<TransportReport, TransportCliError> 
         &target_language,
         &args.function,
         &params,
+        &param_types,
+        &return_type,
         &target_term,
         &annotations,
         &concept_name,
@@ -874,6 +883,60 @@ fn parse_int_params(source: &str, function: &str) -> Option<Vec<String>> {
     }
 }
 
+/// Parse param types and return type for a named function from Rust source.
+/// Returns (param_types, return_type) where param_types are per-parameter type
+/// strings (as written in the source) and return_type is the return type
+/// string.  Falls back to ("i64", "i64") defaults if syn parsing fails or the
+/// function cannot be found.
+fn parse_rust_fn_types(source: &str, function: &str) -> (Vec<String>, String) {
+    let Ok(file) = syn::parse_file(source) else {
+        return (Vec::new(), "i64".to_string());
+    };
+    for item in &file.items {
+        if let syn::Item::Fn(item_fn) = item {
+            if item_fn.sig.ident == function {
+                let param_types: Vec<String> = item_fn
+                    .sig
+                    .inputs
+                    .iter()
+                    .filter_map(|arg| match arg {
+                        syn::FnArg::Typed(pt) => {
+                            Some(type_to_str(pt.ty.as_ref()))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                let return_type = match &item_fn.sig.output {
+                    syn::ReturnType::Default => "()".to_string(),
+                    syn::ReturnType::Type(_, ty) => type_to_str(ty.as_ref()),
+                };
+                return (param_types, return_type);
+            }
+        }
+    }
+    (Vec::new(), "i64".to_string())
+}
+
+/// Convert a syn Type to a compact string representation.
+fn type_to_str(ty: &syn::Type) -> String {
+    match ty {
+        syn::Type::Path(tp) => {
+            let seg = tp.path.segments.last();
+            seg.map(|s| s.ident.to_string()).unwrap_or_else(|| "i64".to_string())
+        }
+        syn::Type::Reference(r) => {
+            let inner = type_to_str(r.elem.as_ref());
+            if r.mutability.is_some() {
+                format!("&mut {inner}")
+            } else {
+                format!("&{inner}")
+            }
+        }
+        syn::Type::Tuple(tt) if tt.elems.is_empty() => "()".to_string(),
+        _ => "i64".to_string(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Contract annotation loading and formatting
 // ---------------------------------------------------------------------------
@@ -1184,10 +1247,12 @@ pub(crate) struct RealizedSource {
 /// Public-crate bridge for `cmd_bind`'s canonical-mode path.
 ///
 /// Lifts contract annotations from `source_text` (Rust source of the origin
-/// file) for the named function, then calls `realize_function` with a
-/// `Term::Unit` body. The body is `Unit` because `cmd_bind` operates at the
-/// annotation/concept level; full Term-graph realization is `cmd_transport`'s
-/// domain and is not available from the bind context.
+/// file) for the named function, then calls `realize_function` with a stub
+/// body appropriate for each target language.  Source types (param types and
+/// return type as target-language strings) are threaded through so that the
+/// emitted signature matches the origin — e.g. an `i64` source param emits
+/// `i64` in Rust/Zig, `long` in Java/C#, `int64` in Go, `number` in
+/// TypeScript, and untyped in Python/Ruby.
 ///
 /// Returns a `RealizedSource` on success. The `source` field carries the
 /// full target-language snippet including the ORP annotation prefix.
@@ -1199,7 +1264,19 @@ pub(crate) fn realize_for_bind(
     concept_name: &str,
 ) -> Result<RealizedSource, TransportCliError> {
     let annotations = lift_rust_contracts(source_text, function);
-    realize_function(language, function, params, &Term::Unit, &annotations, concept_name)
+    let (param_types, return_type) = parse_rust_fn_types(source_text, function);
+    // Pass Term::Unit as body: the bind path has no term graph yet.
+    // realize_function detects Unit and emits a compilable idiomatic stub.
+    realize_function(
+        language,
+        function,
+        params,
+        &param_types,
+        &return_type,
+        &Term::Unit,
+        &annotations,
+        concept_name,
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1234,6 +1311,8 @@ fn realize_function(
     language: &str,
     function: &str,
     params: &[String],
+    param_types: &[String],
+    return_type: &str,
     body: &Term,
     annotations: &ContractAnnotations,
     concept_name: &str,
@@ -1254,83 +1333,135 @@ fn realize_function(
 
     let annotation_prefix = emit_annotation_prefix(concept_name, annotations, style, top_indent);
 
+    // When body is Term::Unit it signals "no term graph available" (the bind path).
+    // Emit a language-idiomatic compilable stub rather than `();` which is not
+    // a valid expression in a typed return position.
+    let is_stub = matches!(body, Term::Unit);
+
+    // Translate source-language type name to target-language type name.
+    let map_type = |src: &str| map_source_type(src, style);
+
+    // Build typed param list for languages that need explicit types.
+    let typed_params: Vec<String> = params
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let t = param_types.get(i).map(String::as_str).unwrap_or("i64");
+            let mapped = map_type(t);
+            typed_param(name, &mapped, style)
+        })
+        .collect();
+    let typed_param_list = typed_params.join(", ");
+
+    let mapped_return = map_type(return_type);
+
+    // Per-function class name for languages that require top-level class wrappers
+    // (Java, C#).  Using function name prevents duplicate-class errors when
+    // multiple functions are emitted into one output file.
+    let class_name = snake_to_pascal_local(function) + "Transported";
+
     let source = match style {
-        TargetStyle::Rust => format!(
-            "{annotation_prefix}pub fn {function}({}) -> i32 {{\n{}}}\n",
-            params
-                .iter()
-                .map(|param| format!("{param}: i32"))
-                .collect::<Vec<_>>()
-                .join(", "),
-            emit_stmt(body, style, 1)?
-        ),
-        TargetStyle::Python => format!(
-            "{annotation_prefix}def {function}({}):\n{}",
-            params.join(", "),
-            emit_block(body, style, 1)?
-        ),
-        TargetStyle::Go => {
-            // Go: package header first, then annotations above the function.
-            format!(
-                "package main\n\n{annotation_prefix}func {function}({}) int {{\n{}}}\n",
-                params
-                    .iter()
-                    .map(|param| format!("{param} int"))
-                    .collect::<Vec<_>>()
-                    .join(", "),
+        TargetStyle::Rust => {
+            let body_str = if is_stub {
+                format!("    {}\n", stub_body_for(style, concept_name))
+            } else {
                 emit_stmt(body, style, 1)?
+            };
+            format!(
+                "{annotation_prefix}pub fn {function}({typed_param_list}) -> {mapped_return} {{\n{body_str}}}\n"
             )
         }
-        TargetStyle::CSharp => format!(
-            "public static class Transported {{\n{annotation_prefix}    public static int {function}({}) {{\n{}    }}\n}}\n",
-            params
-                .iter()
-                .map(|param| format!("int {param}"))
-                .collect::<Vec<_>>()
-                .join(", "),
-            emit_stmt(body, style, 2)?
-        ),
-        TargetStyle::TypeScript => format!(
-            "{annotation_prefix}export function {function}({}): number {{\n{}}}\n",
-            params
-                .iter()
-                .map(|param| format!("{param}: number"))
-                .collect::<Vec<_>>()
-                .join(", "),
-            emit_stmt(body, style, 1)?
-        ),
-        TargetStyle::Zig => format!(
-            "{annotation_prefix}pub fn {function}({}) i32 {{\n{}}}\n",
-            params
-                .iter()
-                .map(|param| format!("{param}: i32"))
-                .collect::<Vec<_>>()
-                .join(", "),
-            emit_stmt(body, style, 1)?
-        ),
-        TargetStyle::Ruby => format!(
-            "{annotation_prefix}def {function}({})\n{}end\n",
-            params.join(", "),
-            emit_block(body, style, 1)?
-        ),
-        TargetStyle::Php => format!(
-            "<?php\n{annotation_prefix}function {function}({}) {{\n{}}}\n",
-            params
-                .iter()
-                .map(|param| format!("${param}"))
-                .collect::<Vec<_>>()
-                .join(", "),
-            emit_stmt(body, style, 1)?
-        ),
-        TargetStyle::Java => format!(
-            "final class Transported {{\n{annotation_prefix}    public static int {function}({}) {{\n{}    }}\n}}\n",
-            params
-                .iter()
-                .map(|param| format!("int {param}"))
-                .collect::<Vec<_>>()
-                .join(", "),
-            emit_stmt(body, style, 2)?
-        ),
+        TargetStyle::Python => {
+            let body_str = if is_stub {
+                format!("    {}\n", stub_body_for(style, concept_name))
+            } else {
+                emit_block(body, style, 1)?
+            };
+            format!("{annotation_prefix}def {function}({}):\n{body_str}", params.join(", "))
+        }
+        TargetStyle::Go => {
+            let body_str = if is_stub {
+                format!("    {}\n", stub_body_for(style, concept_name))
+            } else {
+                emit_stmt(body, style, 1)?
+            };
+            // Go: package header first, then annotations above the function.
+            // When return type is empty (void/unit), omit it from signature.
+            let go_ret = if mapped_return.is_empty() {
+                String::new()
+            } else {
+                format!(" {mapped_return}")
+            };
+            format!(
+                "package main\n\n{annotation_prefix}func {function}({typed_param_list}){go_ret} {{\n{body_str}}}\n"
+            )
+        }
+        TargetStyle::CSharp => {
+            let body_str = if is_stub {
+                format!("        {}\n", stub_body_for(style, concept_name))
+            } else {
+                emit_stmt(body, style, 2)?
+            };
+            format!(
+                "public static class {class_name} {{\n{annotation_prefix}    public static {mapped_return} {function}({typed_param_list}) {{\n{body_str}    }}\n}}\n"
+            )
+        }
+        TargetStyle::TypeScript => {
+            let body_str = if is_stub {
+                format!("    {}\n", stub_body_for(style, concept_name))
+            } else {
+                emit_stmt(body, style, 1)?
+            };
+            format!(
+                "{annotation_prefix}export function {function}({typed_param_list}): {mapped_return} {{\n{body_str}}}\n"
+            )
+        }
+        TargetStyle::Zig => {
+            let body_str = if is_stub {
+                format!("    {}\n", stub_body_for(style, concept_name))
+            } else {
+                emit_stmt(body, style, 1)?
+            };
+            format!(
+                "{annotation_prefix}pub fn {function}({typed_param_list}) {mapped_return} {{\n{body_str}}}\n"
+            )
+        }
+        TargetStyle::Ruby => {
+            let body_str = if is_stub {
+                format!("    {}\n", stub_body_for(style, concept_name))
+            } else {
+                emit_block(body, style, 1)?
+            };
+            format!(
+                "{annotation_prefix}def {function}({})\n{body_str}end\n",
+                params.join(", ")
+            )
+        }
+        TargetStyle::Php => {
+            let body_str = if is_stub {
+                format!("    {}\n", stub_body_for(style, concept_name))
+            } else {
+                emit_stmt(body, style, 1)?
+            };
+            format!(
+                "<?php\n{annotation_prefix}function {function}({}) {{\n{body_str}}}\n",
+                params
+                    .iter()
+                    .map(|param| format!("${param}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }
+        TargetStyle::Java => {
+            let body_str = if is_stub {
+                format!("        {}\n", stub_body_for(style, concept_name))
+            } else {
+                emit_stmt(body, style, 2)?
+            };
+            format!(
+                "final class {class_name} {{\n{annotation_prefix}    public static {mapped_return} {function}({typed_param_list}) {{\n{body_str}    }}\n}}\n"
+            )
+        }
     };
     let extension = match style {
         TargetStyle::Rust => "rs",
@@ -1344,6 +1475,112 @@ fn realize_function(
         TargetStyle::Java => "java",
     };
     Ok(RealizedSource { extension, source })
+}
+
+/// Emit a language-idiomatic compilable stub body string.
+/// Used when `cmd_bind` delegates to ORP but no term graph is available yet.
+fn stub_body_for(style: TargetStyle, concept_name: &str) -> String {
+    match style {
+        TargetStyle::Rust => format!("todo!(\"provekit-bind canonical: {concept_name}\")"),
+        TargetStyle::Python => format!("raise NotImplementedError(\"provekit-bind canonical: {concept_name}\")"),
+        TargetStyle::Go => format!("panic(\"provekit-bind canonical: {concept_name}\")"),
+        TargetStyle::Java => format!("throw new UnsupportedOperationException(\"provekit-bind canonical: {concept_name}\");"),
+        TargetStyle::CSharp => format!("throw new System.NotImplementedException(\"provekit-bind canonical: {concept_name}\");"),
+        TargetStyle::TypeScript => format!("throw new Error(\"provekit-bind canonical: {concept_name}\");"),
+        TargetStyle::Zig => format!("@panic(\"provekit-bind canonical: {concept_name}\");"),
+        TargetStyle::Ruby => format!("raise NotImplementedError, \"provekit-bind canonical: {concept_name}\""),
+        TargetStyle::Php => format!("throw new \\RuntimeException(\"provekit-bind canonical: {concept_name}\");"),
+    }
+}
+
+/// Map a Rust/source-language type name to the idiomatic name for the target style.
+fn map_source_type(src: &str, style: TargetStyle) -> String {
+    match style {
+        TargetStyle::Rust | TargetStyle::Zig => src.to_string(),
+        TargetStyle::Python | TargetStyle::Ruby => String::new(), // untyped
+        TargetStyle::Go => match src {
+            "()" => "".to_string(),
+            "i64" | "u64" => "int64".to_string(),
+            "i32" | "u32" => "int32".to_string(),
+            "i16" | "u16" => "int16".to_string(),
+            "i8" | "u8" => "int8".to_string(),
+            "f64" => "float64".to_string(),
+            "f32" => "float32".to_string(),
+            "bool" => "bool".to_string(),
+            "String" | "&str" | "&String" => "string".to_string(),
+            other => other.to_string(),
+        },
+        TargetStyle::Java => match src {
+            "()" => "void".to_string(),
+            "i64" | "u64" => "long".to_string(),
+            "i32" | "u32" => "int".to_string(),
+            "i16" | "u16" => "short".to_string(),
+            "i8" | "u8" => "byte".to_string(),
+            "f64" => "double".to_string(),
+            "f32" => "float".to_string(),
+            "bool" => "boolean".to_string(),
+            "String" | "&str" | "&String" => "String".to_string(),
+            other => other.to_string(),
+        },
+        TargetStyle::CSharp => match src {
+            "()" => "void".to_string(),
+            "i64" | "u64" => "long".to_string(),
+            "i32" | "u32" => "int".to_string(),
+            "i16" | "u16" => "short".to_string(),
+            "i8" | "u8" => "byte".to_string(),
+            "f64" => "double".to_string(),
+            "f32" => "float".to_string(),
+            "bool" => "bool".to_string(),
+            "String" | "&str" | "&String" => "string".to_string(),
+            other => other.to_string(),
+        },
+        TargetStyle::TypeScript => match src {
+            "()" => "void".to_string(),
+            "i64" | "u64" | "i32" | "u32" | "i16" | "u16" | "i8" | "u8"
+            | "f64" | "f32" => "number".to_string(),
+            "bool" => "boolean".to_string(),
+            "String" | "&str" | "&String" => "string".to_string(),
+            other => other.to_string(),
+        },
+        TargetStyle::Php => match src {
+            "()" => "void".to_string(),
+            "i64" | "u64" | "i32" | "u32" | "i16" | "u16" | "i8" | "u8" => "int".to_string(),
+            "f64" | "f32" => "float".to_string(),
+            "bool" => "bool".to_string(),
+            "String" | "&str" | "&String" => "string".to_string(),
+            other => other.to_string(),
+        },
+    }
+}
+
+/// Format a typed parameter for the target language.
+fn typed_param(name: &str, mapped_type: &str, style: TargetStyle) -> String {
+    match style {
+        // untyped — Python and Ruby don't annotate params in signatures
+        TargetStyle::Python | TargetStyle::Ruby => name.to_string(),
+        // type-after-name
+        TargetStyle::Rust | TargetStyle::Zig => format!("{name}: {mapped_type}"),
+        TargetStyle::TypeScript => format!("{name}: {mapped_type}"),
+        TargetStyle::Go => format!("{name} {mapped_type}"),
+        // type-before-name
+        TargetStyle::Java | TargetStyle::CSharp => format!("{mapped_type} {name}"),
+        TargetStyle::Php => format!("${name}"),
+    }
+}
+
+/// Convert snake_case to PascalCase for class name construction.
+/// Duplicated here from cmd_bind to avoid cross-module coupling.
+fn snake_to_pascal_local(s: &str) -> String {
+    s.split('_')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+            }
+        })
+        .collect()
 }
 
 fn emit_block(term: &Term, style: TargetStyle, indent: usize) -> Result<String, TransportCliError> {
@@ -1941,10 +2178,10 @@ pub fn bar(x: i32) -> i32 { x + 1 }
 
     #[test]
     fn test_realize_function_emits_concept_comment_rust() {
-        // Use Term::Unit as a minimal valid body (emit_stmt handles it).
+        // Term::Unit signals "no body available yet" -- should emit a compilable todo!() stub.
         let body = Term::Unit;
         let anns = ContractAnnotations::default();
-        let result = realize_function("rust", "foo", &[], &body, &anns, "seq");
+        let result = realize_function("rust", "foo", &[], &[], "()", &body, &anns, "seq");
         assert!(result.is_ok());
         let src = result.unwrap().source;
         assert!(
@@ -1955,6 +2192,15 @@ pub fn bar(x: i32) -> i32 { x + 1 }
             src.contains("pub fn foo()"),
             "function def missing in: {src}"
         );
+        assert!(
+            src.contains("todo!("),
+            "compilable stub body missing in: {src}"
+        );
+        // Must NOT emit `();` as a statement (uncompilable when return type != ())
+        assert!(
+            !src.contains("();\n"),
+            "unit expression as statement found (uncompilable): {src}"
+        );
     }
 
     #[test]
@@ -1964,12 +2210,14 @@ pub fn bar(x: i32) -> i32 { x + 1 }
             pre: Some(gt(var("x"), num(0))),
             post: None,
         };
-        let result = realize_function("rust", "foo", &["x".to_string()], &body, &anns, "my-concept");
+        let result = realize_function("rust", "foo", &["x".to_string()], &["i64".to_string()], "i64", &body, &anns, "my-concept");
         assert!(result.is_ok());
         let src = result.unwrap().source;
         assert!(src.contains("// concept: my-concept"), "concept comment missing in: {src}");
         assert!(src.contains("#[requires(x > 0)]"), "#[requires] missing in: {src}");
-        assert!(src.contains("pub fn foo(x: i32)"), "function def missing in: {src}");
+        // Type is threaded from source: i64 -> i64 in Rust
+        assert!(src.contains("pub fn foo(x: i64)"), "function def with i64 missing in: {src}");
+        assert!(src.contains("-> i64"), "return type i64 missing in: {src}");
     }
 
     #[test]
@@ -1979,25 +2227,36 @@ pub fn bar(x: i32) -> i32 { x + 1 }
             pre: Some(gt(var("n"), num(0))),
             post: None,
         };
-        let result = realize_function("python", "compute", &["n".to_string()], &body, &anns, "seq");
+        let result = realize_function("python", "compute", &["n".to_string()], &["i64".to_string()], "i64", &body, &anns, "seq");
         assert!(result.is_ok());
         let src = result.unwrap().source;
         // Python: concept comment uses `#`, not `//` (which is floor-division).
         assert!(src.contains("# concept: seq"), "concept comment missing in: {src}");
         assert!(src.contains("# requires: n > 0"), "python requires comment missing in: {src}");
         assert!(src.contains("def compute(n):"), "def missing in: {src}");
+        assert!(
+            src.contains("raise NotImplementedError"),
+            "compilable stub body missing in: {src}"
+        );
     }
 
     #[test]
     fn test_realize_function_emits_concept_comment_java() {
         let body = Term::Unit;
         let anns = ContractAnnotations::default();
-        let result = realize_function("java", "compute", &["n".to_string()], &body, &anns, "seq");
+        let result = realize_function("java", "compute", &["n".to_string()], &["i64".to_string()], "i64", &body, &anns, "seq");
         assert!(result.is_ok());
         let src = result.unwrap().source;
         // Java: concept comment is indented inside the class wrapper
         assert!(src.contains("// concept: seq"), "concept comment missing in: {src}");
-        assert!(src.contains("public static int compute(int n)"), "method sig missing in: {src}");
+        // Type is threaded: i64 -> long in Java
+        assert!(src.contains("public static long compute(long n)"), "method sig with long missing in: {src}");
+        // Per-function class name avoids duplicate-class errors
+        assert!(src.contains("final class ComputeTransported"), "per-function class name missing in: {src}");
+        assert!(
+            src.contains("throw new UnsupportedOperationException"),
+            "compilable stub body missing in: {src}"
+        );
     }
 
     // ------------------------------------------------------------------

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -1194,9 +1194,14 @@ fn emit_annotation_prefix(
         // are already in scope from the function signature.
         let body = peel_quantifiers(pre);
         let expr = formula_to_syntax(body, style);
+        // F3: Zig does NOT support Rust `#[requires(...)]` attribute syntax.
+        // Give Zig a `// @requires:` comment annotation instead.
         match style {
-            TargetStyle::Rust | TargetStyle::Zig => {
+            TargetStyle::Rust => {
                 out.push_str(&format!("{indent}#[requires({expr})]\n"));
+            }
+            TargetStyle::Zig => {
+                out.push_str(&format!("{indent}// @requires: {expr}\n"));
             }
             TargetStyle::Python | TargetStyle::Ruby => {
                 out.push_str(&format!("{indent}# requires: {expr}\n"));
@@ -1217,8 +1222,11 @@ fn emit_annotation_prefix(
         let body = peel_quantifiers(post);
         let expr = formula_to_syntax(body, style);
         match style {
-            TargetStyle::Rust | TargetStyle::Zig => {
+            TargetStyle::Rust => {
                 out.push_str(&format!("{indent}#[ensures({expr})]\n"));
+            }
+            TargetStyle::Zig => {
+                out.push_str(&format!("{indent}// @ensures: {expr}\n"));
             }
             TargetStyle::Python | TargetStyle::Ruby => {
                 out.push_str(&format!("{indent}# ensures: {expr}\n"));
@@ -1385,7 +1393,9 @@ fn realize_function(
             } else {
                 emit_stmt(body, style, 1)?
             };
-            // Go: package header first, then annotations above the function.
+            // Go: annotations above the function, NO package declaration here.
+            // File-level header (`package main`) is emitted once per file by the
+            // caller via `realize_file_header`.
             // When return type is empty (void/unit), omit it from signature.
             let go_ret = if mapped_return.is_empty() {
                 String::new()
@@ -1393,7 +1403,7 @@ fn realize_function(
                 format!(" {mapped_return}")
             };
             format!(
-                "package main\n\n{annotation_prefix}func {function}({typed_param_list}){go_ret} {{\n{body_str}}}\n"
+                "{annotation_prefix}func {function}({typed_param_list}){go_ret} {{\n{body_str}}}\n"
             )
         }
         TargetStyle::CSharp => {
@@ -1443,8 +1453,11 @@ fn realize_function(
             } else {
                 emit_stmt(body, style, 1)?
             };
+            // PHP: NO `<?php` open tag here; emitted once per file by the caller
+            // via `realize_file_header`. Multiple `<?php` tags in one file is a
+            // parse error.
             format!(
-                "<?php\n{annotation_prefix}function {function}({}) {{\n{body_str}}}\n",
+                "{annotation_prefix}function {function}({}) {{\n{body_str}}}\n",
                 params
                     .iter()
                     .map(|param| format!("${param}"))
@@ -1475,6 +1488,29 @@ fn realize_function(
         TargetStyle::Java => "java",
     };
     Ok(RealizedSource { extension, source })
+}
+
+/// Emit the file-level header for a given target language.
+///
+/// Languages like Go (`package main`) and PHP (`<?php`) require exactly one
+/// file-level declaration per output file; emitting it once here and omitting
+/// it from per-function snippets prevents duplicate-declaration parse errors.
+///
+/// Most languages (Rust, Python, TypeScript, Java, C#, Zig, Ruby) need no
+/// file-level preamble, so this returns an empty string for them.
+pub(crate) fn realize_file_header(language: &str) -> String {
+    match language {
+        "go" => "package main\n\n".to_string(),
+        "php" => "<?php\n".to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Emit the file-level footer for a given target language.
+///
+/// Currently no supported language needs a file footer; reserved for future use.
+pub(crate) fn realize_file_footer(_language: &str) -> String {
+    String::new()
 }
 
 /// Emit a language-idiomatic compilable stub body string.

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -541,8 +541,8 @@ fn gaps_doc_records_v0_capability_gaps() {
         "gaps.json must record at least one v0-capability-gap"
     );
     assert!(
-        kinds.contains(&"v0-orp-delegation-gap"),
-        "gaps.json must record v0-orp-delegation-gap (realize_function is fn not pub)"
+        !kinds.contains(&"v0-orp-delegation-gap"),
+        "gaps.json must NOT record v0-orp-delegation-gap after delegation is closed"
     );
 }
 

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -567,3 +567,404 @@ fn canonical_go_target_creates_go_output() {
     let go_src = fs::read_to_string(go_files[0].path()).unwrap();
     assert!(go_src.contains("concept:"), "Go output must carry concept annotation");
 }
+
+// ============================================================================
+// F5: Per-language syntax-checker regression tests (Test 18-26)
+//
+// Each test:
+//   1. Invokes bind --rewrite canonical --target-language <lang>
+//   2. Reads the emitted output file
+//   3. Pipes it through the language's own syntax checker (or asserts structural
+//      validity when a checker is not universally available).
+//   4. Fails if the checker reports a syntax error.
+//
+// This is the load-bearing protocol. CI must not regress any of these without
+// the checker explicitly reporting success.
+// ============================================================================
+
+/// Run `rustc --crate-type=lib --emit=metadata` on a file; return Ok(()) or Err(stderr).
+fn rustc_check(path: &std::path::Path) -> Result<(), String> {
+    let out_dir = tempfile::tempdir().expect("tempdir");
+    let out = std::process::Command::new("rustc")
+        .args(["--crate-type=lib", "--emit=metadata", "--edition=2021"])
+        .arg("--out-dir")
+        .arg(out_dir.path())
+        .arg(path)
+        .output()
+        .expect("spawn rustc");
+    if out.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+        // Warnings are fine; only fail on errors.
+        if stderr.lines().any(|l| l.starts_with("error")) {
+            Err(stderr)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Run `python3 -m py_compile` on a file.
+fn python_check(path: &std::path::Path) -> Result<(), String> {
+    let out = std::process::Command::new("python3")
+        .args(["-m", "py_compile"])
+        .arg(path)
+        .output()
+        .expect("spawn python3");
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).to_string())
+    }
+}
+
+/// Run `gofmt -e` on a file (parse check).
+fn go_check(path: &std::path::Path) -> Result<(), String> {
+    let out = std::process::Command::new("gofmt")
+        .arg("-e")
+        .arg(path)
+        .output()
+        .expect("spawn gofmt");
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).to_string())
+    }
+}
+
+/// Run `ruby -c` on a file.
+fn ruby_check(path: &std::path::Path) -> Result<(), String> {
+    let out = std::process::Command::new("ruby")
+        .arg("-c")
+        .arg(path)
+        .output()
+        .expect("spawn ruby");
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).to_string())
+    }
+}
+
+/// Run `php -l` on a file.
+fn php_check(path: &std::path::Path) -> Result<(), String> {
+    let out = std::process::Command::new("php")
+        .arg("-l")
+        .arg(path)
+        .output()
+        .expect("spawn php");
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stdout).to_string()
+            + &String::from_utf8_lossy(&out.stderr))
+    }
+}
+
+/// Run `javac` on a file.
+fn javac_check(path: &std::path::Path) -> Result<(), String> {
+    let out_dir = tempfile::tempdir().expect("tempdir");
+    let out = std::process::Command::new("javac")
+        .arg("-d")
+        .arg(out_dir.path())
+        .arg(path)
+        .output()
+        .expect("spawn javac");
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).to_string())
+    }
+}
+
+/// Run `zig fmt --check` on a file.
+fn zig_check(path: &std::path::Path) -> Result<(), String> {
+    let out = std::process::Command::new("zig")
+        .args(["fmt", "--check"])
+        .arg(path)
+        .output()
+        .expect("spawn zig");
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).to_string()
+            + &String::from_utf8_lossy(&out.stdout))
+    }
+}
+
+/// Find the first file with the given extension under a directory.
+fn first_file_with_ext(dir: &std::path::Path, ext: &str) -> Option<std::path::PathBuf> {
+    fs::read_dir(dir).ok()?.flatten()
+        .find(|e| e.path().extension().map(|x| x == ext).unwrap_or(false))
+        .map(|e| e.path())
+}
+
+// ============================================================================
+// Test 18: Rust canonical output passes rustc
+// ============================================================================
+
+#[test]
+fn f5_rust_canonical_parses() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("rust"));
+    assert!(result.status.success(), "bind rust must exit 0");
+    let dir = out.join("translated").join("rust");
+    let f = first_file_with_ext(&dir, "rs").expect("no .rs output");
+    rustc_check(&f).unwrap_or_else(|e| panic!("Rust syntax error in emitted .rs file:\n{e}"));
+}
+
+// ============================================================================
+// Test 19: Python canonical output passes python3 -m py_compile
+// ============================================================================
+
+#[test]
+fn f5_python_canonical_parses() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("python"));
+    assert!(result.status.success(), "bind python must exit 0");
+    let dir = out.join("translated").join("python");
+    let f = first_file_with_ext(&dir, "py").expect("no .py output");
+    python_check(&f).unwrap_or_else(|e| panic!("Python syntax error in emitted .py file:\n{e}"));
+}
+
+// ============================================================================
+// Test 20: Go canonical output passes gofmt -e (exactly one `package main`)
+// ============================================================================
+
+#[test]
+fn f5_go_canonical_parses() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("go"));
+    assert!(result.status.success(), "bind go must exit 0");
+    let dir = out.join("translated").join("go");
+    let f = first_file_with_ext(&dir, "go").expect("no .go output");
+    let src = fs::read_to_string(&f).unwrap();
+    let pkg_count = src.lines().filter(|l| l.trim_start() == "package main").count();
+    assert_eq!(
+        pkg_count, 1,
+        "Go output must contain exactly one `package main` declaration, found {pkg_count}"
+    );
+    go_check(&f).unwrap_or_else(|e| panic!("Go syntax error in emitted .go file:\n{e}"));
+}
+
+// ============================================================================
+// Test 21: Java canonical output passes javac
+// ============================================================================
+
+#[test]
+fn f5_java_canonical_parses() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("java"));
+    assert!(result.status.success(), "bind java must exit 0");
+    let dir = out.join("translated").join("java");
+    let f = first_file_with_ext(&dir, "java").expect("no .java output");
+    javac_check(&f).unwrap_or_else(|e| panic!("Java syntax error in emitted .java file:\n{e}"));
+}
+
+// ============================================================================
+// Test 22: Zig canonical output passes zig fmt --check (no #[cfg_attr])
+// ============================================================================
+
+#[test]
+fn f5_zig_canonical_parses() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("zig"));
+    assert!(result.status.success(), "bind zig must exit 0");
+    let dir = out.join("translated").join("zig");
+    let f = first_file_with_ext(&dir, "zig").expect("no .zig output");
+    let src = fs::read_to_string(&f).unwrap();
+    assert!(
+        !src.contains("#[cfg_attr"),
+        "Zig output must NOT contain Rust #[cfg_attr(...)] syntax\n{src}"
+    );
+    zig_check(&f).unwrap_or_else(|e| panic!("Zig syntax error in emitted .zig file:\n{e}"));
+}
+
+// ============================================================================
+// Test 23: Ruby canonical output passes ruby -c (uses `#` not `//` for comments)
+// ============================================================================
+
+#[test]
+fn f5_ruby_canonical_parses() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("ruby"));
+    assert!(result.status.success(), "bind ruby must exit 0");
+    let dir = out.join("translated").join("ruby");
+    let f = first_file_with_ext(&dir, "rb").expect("no .rb output");
+    let src = fs::read_to_string(&f).unwrap();
+    // The canonical rewrite header must use `#` not `//` for Ruby.
+    assert!(
+        src.contains("# canonical rewrite:"),
+        "Ruby output must use `#` comment prefix, not `//`\n{src}"
+    );
+    ruby_check(&f).unwrap_or_else(|e| panic!("Ruby syntax error in emitted .rb file:\n{e}"));
+}
+
+// ============================================================================
+// Test 24: PHP canonical output passes php -l (exactly one `<?php`)
+// ============================================================================
+
+#[test]
+fn f5_php_canonical_parses() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("php"));
+    assert!(result.status.success(), "bind php must exit 0");
+    let dir = out.join("translated").join("php");
+    let f = first_file_with_ext(&dir, "php").expect("no .php output");
+    let src = fs::read_to_string(&f).unwrap();
+    let php_tag_count = src.matches("<?php").count();
+    assert_eq!(
+        php_tag_count, 1,
+        "PHP output must contain exactly one `<?php` open tag, found {php_tag_count}"
+    );
+    php_check(&f).unwrap_or_else(|e| panic!("PHP syntax error in emitted .php file:\n{e}"));
+}
+
+// ============================================================================
+// Test 25: TypeScript canonical output is structurally valid
+//          (checks for export function, no duplicate declarations)
+// ============================================================================
+
+#[test]
+fn f5_typescript_canonical_parses() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("typescript"));
+    assert!(result.status.success(), "bind typescript must exit 0");
+    let dir = out.join("translated").join("typescript");
+    let f = first_file_with_ext(&dir, "ts").expect("no .ts output");
+    let src = fs::read_to_string(&f).unwrap();
+    // Structural invariants: must contain export functions (not just a stub comment).
+    assert!(
+        src.contains("export function"),
+        "TypeScript output must contain `export function`\n{src}"
+    );
+    // Must not contain duplicate `export function deposit` (would be a concat bug).
+    let export_count = src.matches("export function deposit").count();
+    assert_eq!(
+        export_count, 1,
+        "TypeScript output must have exactly one `export function deposit`, found {export_count}\n{src}"
+    );
+    // tsc syntax check (if tsc is available; structural check is always enforced above).
+    let tsc_path = std::process::Command::new("which")
+        .arg("tsc")
+        .output()
+        .ok()
+        .filter(|o| o.status.success());
+    if tsc_path.is_some() {
+        let ts_dir = tempfile::tempdir().expect("tempdir");
+        let ts_copy = ts_dir.path().join("account.ts");
+        fs::copy(&f, &ts_copy).unwrap();
+        fs::write(
+            ts_dir.path().join("tsconfig.json"),
+            r#"{"compilerOptions":{"noEmit":true,"strict":true,"target":"ES2020","module":"commonjs"},"include":["*.ts"]}"#,
+        ).unwrap();
+        let tsc_out = std::process::Command::new("tsc")
+            .arg("--noEmit")
+            .current_dir(ts_dir.path())
+            .output()
+            .expect("spawn tsc");
+        assert!(
+            tsc_out.status.success(),
+            "TypeScript syntax error:\n{}",
+            String::from_utf8_lossy(&tsc_out.stdout)
+        );
+    }
+}
+
+// ============================================================================
+// Test 26: C# canonical output is structurally valid
+//          (checks for public static class, no duplicate declarations)
+// ============================================================================
+
+#[test]
+fn f5_csharp_canonical_parses() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("csharp"));
+    assert!(result.status.success(), "bind csharp must exit 0");
+    let dir = out.join("translated").join("csharp");
+    let f = first_file_with_ext(&dir, "cs").expect("no .cs output");
+    let src = fs::read_to_string(&f).unwrap();
+    // Structural invariants: must contain public static class wrappers.
+    assert!(
+        src.contains("public static class"),
+        "C# output must contain `public static class`\n{src}"
+    );
+    // Class names must be unique (per-function class naming prevents duplicate-class errors).
+    let deposit_class_count = src.matches("class DepositTransported").count();
+    assert_eq!(
+        deposit_class_count, 1,
+        "C# must have exactly one DepositTransported class, found {deposit_class_count}\n{src}"
+    );
+    // dotnet syntax check (if dotnet is available and operational).
+    // Note: `dotnet build` occasionally fails in tmp-dir contexts due to MSBuild
+    // environment issues (NuGet cache, SDK discovery from arbitrary paths). The
+    // structural assertions above are always enforced; the dotnet check is
+    // best-effort and skipped if dotnet is absent OR if the SDK reports an
+    // environment error unrelated to C# syntax.
+    let dotnet_available = std::process::Command::new("dotnet")
+        .arg("--version")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .is_some();
+    if dotnet_available {
+        let cs_dir = tempfile::tempdir().expect("tempdir");
+        let cs_copy = cs_dir.path().join("account.cs");
+        fs::copy(&f, &cs_copy).unwrap();
+        fs::write(
+            cs_dir.path().join("test.csproj"),
+            r#"<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Library</OutputType><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>"#,
+        ).unwrap();
+        let dotnet_out = std::process::Command::new("dotnet")
+            .args(["build", "--nologo", "-q"])
+            .current_dir(cs_dir.path())
+            .output()
+            .expect("spawn dotnet");
+        // Only assert on actual C# parse errors (lines starting with "error CS").
+        // MSBuild environment errors (MSBUILD errors, path creation warnings) are
+        // non-deterministic in tmp contexts and must not be treated as C# syntax failures.
+        let combined = String::from_utf8_lossy(&dotnet_out.stdout).to_string()
+            + &String::from_utf8_lossy(&dotnet_out.stderr);
+        let has_cs_error = combined.lines().any(|l| {
+            let t = l.trim();
+            t.contains("error CS") || t.contains(": error CS")
+        });
+        assert!(
+            !has_cs_error,
+            "C# syntax error in emitted .cs file:\n{combined}"
+        );
+    }
+}
+
+// ============================================================================
+// F6: Test 27 -- gaps.json records bind-stub-body-emitted for stub functions
+// ============================================================================
+
+#[test]
+fn f6_gaps_record_stub_body_emitted() {
+    let root = fixture_root();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    // Use invisible mode so the bind engine runs without writing files.
+    let result = bind_cmd(&root, &out, "invisible", "monitor", None);
+    assert!(result.status.success(), "bind invisible must succeed");
+    let gaps: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out.join("gaps.json")).unwrap()).unwrap();
+    let gap_arr = gaps["gaps"].as_array().expect("gaps must be array");
+    let kinds: Vec<&str> = gap_arr.iter().filter_map(|g| g["kind"].as_str()).collect();
+    // v0 canonical bind always emits stub bodies (no term graph yet).
+    // The gap record is the honest disclosure: substrate knows stubs were emitted.
+    assert!(
+        kinds.contains(&"bind-stub-body-emitted"),
+        "gaps.json must record bind-stub-body-emitted when canonical stubs are emitted; kinds found: {kinds:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Makes `TransportCliError` and `RealizedSource` `pub(crate)` in `cmd_transport.rs`
- Adds `pub(crate) fn realize_for_bind(language, function, params, source_text, concept_name)` to `cmd_transport`: lifts contracts via `lift_rust_contracts` then delegates to `realize_function` with a `Term::Unit` body
- `apply_canonical_rewrite` in `cmd_bind` now calls `realize_for_bind` first; falls back to `emit_target_stub` only on ORP refusal (unknown language)
- New `build_bind_meta_comment` prepends bind-layer provenance (substrate-origin, memento-cid, contract annotations from `BindingRecord.pretty_pre/post`, runtime-mode attr) before the ORP-generated snippet
- Removes the `v0-orp-delegation-gap` push from `run_bind_engine`
- Test 16 (`gaps_doc_records_v0_capability_gaps`) flipped: now asserts the gap is absent

## What changed architecturally

PR #718 recorded an honest gap: `realize_function` in `cmd_transport` was `fn` (private), so `cmd_bind`'s canonical-mode dispatched to `emit_target_stub` instead of the real ORP realizer. This PR closes that gap.

The wrapper approach (`realize_for_bind`) is used rather than directly exposing `realize_function` because `realize_function` takes `ContractAnnotations` (holding `Rc<Formula>` trees from provekit-lift-contracts) while `cmd_bind` holds `pretty_pre`/`pretty_post` as plain strings. The wrapper calls `lift_rust_contracts` on the source file to build `ContractAnnotations`, then calls `realize_function` with `Term::Unit` body. Bind-layer provenance (substrate-origin, memento-cid, contracts, mode) is prepended to the ORP output as a separate comment block.

## Test plan

- [ ] `cargo test -p provekit-cli --test cmd_bind_integration` — all 17 tests pass
- [ ] `cargo check --workspace` — clean (no new errors, pre-existing warnings only)
- [ ] `test_daemon_polyglot_smoke` pre-existing failure (requires `provekit-linkerd` binary not present in dev env) — not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)