### PR TITLE
feat(lift-native): native contract surfaces — Spring/pydantic/Zod v0 (PR-G of #716)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1899,6 +1899,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-lift-native-surfaces"
+version = "0.1.0"
+dependencies = [
+ "provekit-canonicalizer",
+ "provekit-ir-types",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "provekit-lift-openapi"
 version = "0.1.0"
 dependencies = [

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "provekit-lift-evm-bytecode",
     "provekit-lift-openapi",
     "provekit-lift-asm-aarch64",
+    "provekit-lift-native-surfaces",
     "provekit-linker",
     "provekit-lsp",
     "provekit-lsp-rust",

--- a/implementations/rust/provekit-lift-native-surfaces/Cargo.toml
+++ b/implementations/rust/provekit-lift-native-surfaces/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "provekit-lift-native-surfaces"
+version = "0.1.0"
+edition = "2021"
+description = "v0 lifters for per-language native contract annotation surfaces (Spring/Java, pydantic/Python, Zod/TypeScript)"
+license = "Apache-2.0"
+
+[dependencies]
+provekit-ir-types = { path = "../provekit-ir-types" }
+provekit-canonicalizer = { path = "../provekit-canonicalizer" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+regex = "1"
+
+[dev-dependencies]
+# no extra dev deps needed

--- a/implementations/rust/provekit-lift-native-surfaces/src/lib.rs
+++ b/implementations/rust/provekit-lift-native-surfaces/src/lib.rs
@@ -218,14 +218,14 @@ pub(crate) fn make_locator(source_cid: &str, start_line: u32, end_line: u32) -> 
 
 /// Build the mandatory extension fields for a native-surface memento.
 pub(crate) fn native_ext(
-    surface_kind: &str,
+    surface_name: &str,
     target_function_or_field: &str,
     original_text: &str,
 ) -> BTreeMap<String, serde_json::Value> {
     let mut m = BTreeMap::new();
     m.insert(
-        "surface_kind".to_string(),
-        serde_json::Value::String(surface_kind.to_string()),
+        "surface_name".to_string(),
+        serde_json::Value::String(surface_name.to_string()),
     );
     m.insert(
         "target_function_or_field".to_string(),

--- a/implementations/rust/provekit-lift-native-surfaces/src/lib.rs
+++ b/implementations/rust/provekit-lift-native-surfaces/src/lib.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-lift-native-surfaces
+//
+// v0 lifters for per-language native contract annotation surfaces.
+// Each lifter walks the source text of a file via a regex pre-pass and emits
+// `EvidenceMemento` records with `source_kind = "native-surface"`.
+//
+// Covered surfaces (v0):
+//   - Spring (Java)    — @PreCondition, @PostCondition, @NotNull, @Min, @Max, @Size
+//   - pydantic (Python) — Field(ge=, le=, gt=, lt=), deal.pre, deal.post
+//   - Zod (TypeScript) — z.number().min/max, z.string().min/max, z.object chain
+//
+// v0 philosophy: honest under-coverage beats polluting the lattice.
+//   Static annotations (e.g. @NotNull, @Min(0)) → confidence_basis_points = 10000.
+//   Opaque/partial predicates (regex string patterns, deal lambdas) → ~5000.
+//   If we cannot extract a structured IrFormula predicate, we emit an
+//   IrFormula::Atomic with name "opaque" and args = [IrTerm::Const(text)].
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use provekit_ir_types::{
+    EvidenceMemento, IrFormula, IrTerm, Sort, SourceKind, SourceLocator, SourceLocatorPoint,
+    SourceLocatorSpan,
+};
+
+pub mod pydantic;
+pub mod spring;
+pub mod zod;
+
+pub use pydantic::lift_pydantic_file;
+pub use spring::lift_spring_file;
+pub use zod::lift_zod_file;
+
+// ---------------------------------------------------------------------------
+// Sentinel lifter CID — used until PR-F wires the real lifter CID.
+// ---------------------------------------------------------------------------
+pub const AUTO_PROMOTE_LIFTER_CID: &str = concat!(
+    "blake3-512:",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+);
+
+// ---------------------------------------------------------------------------
+// IrFormula constructors used by surface modules.
+// ---------------------------------------------------------------------------
+
+/// Build an atomic predicate: `name(args...)`.
+pub(crate) fn atomic(name: impl Into<String>, args: Vec<IrTerm>) -> IrFormula {
+    IrFormula::Atomic {
+        name: name.into(),
+        args,
+    }
+}
+
+/// An integer constant term.
+pub(crate) fn int_const(value: i64) -> IrTerm {
+    IrTerm::Const {
+        value: serde_json::Value::Number(value.into()),
+        sort: Sort::Primitive {
+            name: "Int".to_string(),
+        },
+    }
+}
+
+/// A string constant term.
+pub(crate) fn str_const(value: impl Into<String>) -> IrTerm {
+    IrTerm::Const {
+        value: serde_json::Value::String(value.into()),
+        sort: Sort::Primitive {
+            name: "String".to_string(),
+        },
+    }
+}
+
+/// A variable term.
+pub(crate) fn var(name: impl Into<String>) -> IrTerm {
+    IrTerm::Var { name: name.into() }
+}
+
+// ---------------------------------------------------------------------------
+// CID helpers (re-implemented locally — not pub in lift-rust-tests).
+// ---------------------------------------------------------------------------
+
+pub(crate) fn serde_json_to_cvalue(v: &serde_json::Value) -> Arc<CValue> {
+    match v {
+        serde_json::Value::Null => CValue::null(),
+        serde_json::Value::Bool(b) => CValue::boolean(*b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CValue::integer(i)
+            } else {
+                CValue::string(n.to_string())
+            }
+        }
+        serde_json::Value::String(s) => CValue::string(s.clone()),
+        serde_json::Value::Array(items) => {
+            let cv: Vec<Arc<CValue>> = items.iter().map(serde_json_to_cvalue).collect();
+            CValue::array(cv)
+        }
+        serde_json::Value::Object(map) => {
+            let entries: Vec<(String, Arc<CValue>)> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json_to_cvalue(v)))
+                .collect();
+            Arc::new(CValue::Object(entries))
+        }
+    }
+}
+
+/// Compute the JCS-canonical CID for an `EvidenceMemento`.
+///
+/// Locked JCS key order (alphabetical, `cid` elided):
+///   confidence_basis_points, extension_fields, kind, lifter_cid,
+///   predicate, schemaVersion, source_kind, source_locator
+pub(crate) fn evidence_memento_cid(
+    confidence_basis_points: u16,
+    extension_fields: &BTreeMap<String, serde_json::Value>,
+    lifter_cid: &str,
+    predicate: &IrFormula,
+    source_kind: &SourceKind,
+    source_locator: &SourceLocator,
+) -> String {
+    let pred_json = serde_json::to_value(predicate).expect("IrFormula must be serializable");
+    let pred_cv = serde_json_to_cvalue(&pred_json);
+
+    let ext_entries: Vec<(String, Arc<CValue>)> = extension_fields
+        .iter()
+        .map(|(k, v)| (k.clone(), serde_json_to_cvalue(v)))
+        .collect();
+    let ext_cv = Arc::new(CValue::Object(ext_entries));
+
+    let kind_str: String = source_kind.clone().into();
+
+    let make_point = |p: &SourceLocatorPoint| {
+        CValue::object([
+            ("col", CValue::integer(p.col as i64)),
+            ("line", CValue::integer(p.line as i64)),
+        ])
+    };
+    let span_cv = CValue::object([
+        ("end", make_point(&source_locator.span.end)),
+        ("start", make_point(&source_locator.span.start)),
+    ]);
+    let locator_cv = CValue::object([
+        (
+            "source_cid",
+            CValue::string(source_locator.source_cid.clone()),
+        ),
+        ("span", span_cv),
+    ]);
+
+    let header = CValue::object([
+        (
+            "confidence_basis_points",
+            CValue::integer(confidence_basis_points as i64),
+        ),
+        ("extension_fields", ext_cv),
+        ("kind", CValue::string("evidence")),
+        ("lifter_cid", CValue::string(lifter_cid.to_string())),
+        ("predicate", pred_cv),
+        ("schemaVersion", CValue::string("1")),
+        ("source_kind", CValue::string(kind_str)),
+        ("source_locator", locator_cv),
+    ]);
+
+    let canonical_bytes = encode_jcs(&header);
+    blake3_512_of(canonical_bytes.as_bytes())
+}
+
+/// Build an `EvidenceMemento` given all fields.
+pub(crate) fn build_memento(
+    confidence_basis_points: u16,
+    extension_fields: BTreeMap<String, serde_json::Value>,
+    predicate: IrFormula,
+    source_kind: SourceKind,
+    source_locator: SourceLocator,
+) -> EvidenceMemento {
+    let cid = evidence_memento_cid(
+        confidence_basis_points,
+        &extension_fields,
+        AUTO_PROMOTE_LIFTER_CID,
+        &predicate,
+        &source_kind,
+        &source_locator,
+    );
+    EvidenceMemento {
+        cid,
+        confidence_basis_points,
+        extension_fields,
+        kind: "evidence".to_string(),
+        lifter_cid: AUTO_PROMOTE_LIFTER_CID.to_string(),
+        predicate,
+        schema_version: "1".to_string(),
+        source_kind,
+        source_locator,
+    }
+}
+
+/// Build a `SourceLocator` from a source CID and a (1-based) line range.
+pub(crate) fn make_locator(source_cid: &str, start_line: u32, end_line: u32) -> SourceLocator {
+    SourceLocator {
+        source_cid: source_cid.to_string(),
+        span: SourceLocatorSpan {
+            start: SourceLocatorPoint {
+                line: start_line,
+                col: 0,
+            },
+            end: SourceLocatorPoint {
+                line: end_line,
+                col: 0,
+            },
+        },
+    }
+}
+
+/// Build the mandatory extension fields for a native-surface memento.
+pub(crate) fn native_ext(
+    surface_kind: &str,
+    target_function_or_field: &str,
+    original_text: &str,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut m = BTreeMap::new();
+    m.insert(
+        "surface_kind".to_string(),
+        serde_json::Value::String(surface_kind.to_string()),
+    );
+    m.insert(
+        "target_function_or_field".to_string(),
+        serde_json::Value::String(target_function_or_field.to_string()),
+    );
+    m.insert(
+        "original_text".to_string(),
+        serde_json::Value::String(original_text.to_string()),
+    );
+    m
+}

--- a/implementations/rust/provekit-lift-native-surfaces/src/pydantic.rs
+++ b/implementations/rust/provekit-lift-native-surfaces/src/pydantic.rs
@@ -285,7 +285,7 @@ mod tests {
             let json = serde_json::to_string(m).expect("must serialize");
             let back: EvidenceMemento = serde_json::from_str(&json).expect("must deserialize");
             assert_eq!(back.cid, m.cid);
-            assert!(back.extension_fields.contains_key("surface_kind"));
+            assert!(back.extension_fields.contains_key("surface_name"));
             assert!(back.extension_fields.contains_key("target_function_or_field"));
             assert!(back.extension_fields.contains_key("original_text"));
         }

--- a/implementations/rust/provekit-lift-native-surfaces/src/pydantic.rs
+++ b/implementations/rust/provekit-lift-native-surfaces/src/pydantic.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// pydantic (Python) native contract surface lifter — v0
+//
+// Recognised annotation idioms:
+//
+//   pydantic Field keyword args:
+//     Field(ge=N)     — emits `≥(self, N)`,  conf 10000
+//     Field(gt=N)     — emits `>(self, N)`,   conf 10000
+//     Field(le=N)     — emits `≤(self, N)`,   conf 10000
+//     Field(lt=N)     — emits `<(self, N)`,   conf 10000
+//     Field(min_length=N) — emits `≥(len(self), N)`, conf 10000
+//     Field(max_length=N) — emits `≤(len(self), N)`, conf 10000
+//     Field(pattern="...")— opaque regex constraint, conf 5000
+//
+//   deal library decorators:
+//     @deal.pre(lambda ...: expr)  — opaque pre, conf 5000
+//     @deal.post(lambda ...: expr) — opaque post, conf 5000
+//     @deal.ensure(lambda ...: expr) — opaque ensure, conf 5000
+//
+// Target name heuristic: for Field(...) we look for `name: Type = Field(...)` or
+// `name = Field(...)` on the same line; for @deal we look at the def line below.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use provekit_ir_types::{EvidenceMemento, IrTerm, SourceKind};
+
+use crate::{atomic, build_memento, int_const, make_locator, native_ext, str_const, var};
+
+// ---------------------------------------------------------------------------
+// Compiled regexes
+// ---------------------------------------------------------------------------
+
+fn re_field() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    // Matches `Field(...)` call anywhere on the line; captures the arg list.
+    R.get_or_init(|| Regex::new(r"Field\s*\(([^)]*)\)").unwrap())
+}
+
+fn re_deal_pre() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@deal\.pre\s*\((.+)\)").unwrap())
+}
+
+fn re_deal_post() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@deal\.post\s*\((.+)\)").unwrap())
+}
+
+fn re_deal_ensure() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@deal\.ensure\s*\((.+)\)").unwrap())
+}
+
+/// Extract the field name from a pydantic Field assignment line.
+/// Matches patterns like `name: Type = Field(...)` and `name = Field(...)`.
+fn extract_py_field_name(line: &str) -> String {
+    let re = Regex::new(r"^\s*([A-Za-z_]\w*)\s*(?::\s*[^=]+)?\s*=\s*Field").unwrap();
+    re.captures(line)
+        .map(|c| c[1].to_string())
+        .unwrap_or_else(|| "_unknown".to_string())
+}
+
+/// Extract a `def` name from a Python function definition line.
+fn extract_py_def_name(line: &str) -> String {
+    let re = Regex::new(r"def\s+([A-Za-z_]\w*)").unwrap();
+    re.captures(line)
+        .map(|c| c[1].to_string())
+        .unwrap_or_else(|| "_unknown".to_string())
+}
+
+/// Parse Field(...) keyword args: `ge`, `gt`, `le`, `lt`, `min_length`,
+/// `max_length`, `pattern`.
+struct FieldArgs {
+    ge: Option<i64>,
+    gt: Option<i64>,
+    le: Option<i64>,
+    lt: Option<i64>,
+    min_length: Option<i64>,
+    max_length: Option<i64>,
+    pattern: Option<String>,
+}
+
+fn parse_field_args(body: &str) -> FieldArgs {
+    let int_arg = |name: &str| -> Option<i64> {
+        let pattern = format!(r"(?:^|,)\s*{}\s*=\s*(-?\d+)", name);
+        Regex::new(&pattern)
+            .unwrap()
+            .captures(body)
+            .and_then(|c| c[1].parse().ok())
+    };
+    let str_arg = |name: &str| -> Option<String> {
+        let pattern = format!(r#"(?:^|,)\s*{}\s*=\s*"([^"]*)""#, name);
+        Regex::new(&pattern)
+            .unwrap()
+            .captures(body)
+            .map(|c| c[1].to_string())
+    };
+    FieldArgs {
+        ge: int_arg("ge"),
+        gt: int_arg("gt"),
+        le: int_arg("le"),
+        lt: int_arg("lt"),
+        min_length: int_arg("min_length"),
+        max_length: int_arg("max_length"),
+        pattern: str_arg("pattern"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Walk `source` (Python file text) and emit `EvidenceMemento` records for
+/// every recognised pydantic/deal annotation idiom.
+pub fn lift_pydantic_file(source: &str, source_cid: &str) -> Vec<EvidenceMemento> {
+    let mut out = Vec::new();
+    let lines: Vec<&str> = source.lines().collect();
+
+    for (line_idx, line) in lines.iter().enumerate() {
+        let line_no = (line_idx + 1) as u32;
+        let next_line = lines.get(line_idx + 1).copied().unwrap_or("");
+        let locator = make_locator(source_cid, line_no, line_no);
+
+        // pydantic Field(...)
+        if let Some(cap) = re_field().captures(line) {
+            let body = &cap[1];
+            let field_name = extract_py_field_name(line);
+            let args = parse_field_args(body);
+
+            let emit_int = |pred_name: &str, n: i64, subject: Vec<IrTerm>| {
+                let ext = native_ext("pydantic", &field_name, line.trim());
+                let predicate = atomic(pred_name, {
+                    let mut v = subject;
+                    v.push(int_const(n));
+                    v
+                });
+                build_memento(10000, ext, predicate, SourceKind::NativeSurface, locator.clone())
+            };
+
+            if let Some(n) = args.ge {
+                out.push(emit_int("≥", n, vec![var("self")]));
+            }
+            if let Some(n) = args.gt {
+                out.push(emit_int(">", n, vec![var("self")]));
+            }
+            if let Some(n) = args.le {
+                out.push(emit_int("≤", n, vec![var("self")]));
+            }
+            if let Some(n) = args.lt {
+                out.push(emit_int("<", n, vec![var("self")]));
+            }
+            if let Some(n) = args.min_length {
+                out.push(emit_int(
+                    "≥",
+                    n,
+                    vec![IrTerm::Ctor {
+                        name: "len".to_string(),
+                        args: vec![var("self")],
+                    }],
+                ));
+            }
+            if let Some(n) = args.max_length {
+                out.push(emit_int(
+                    "≤",
+                    n,
+                    vec![IrTerm::Ctor {
+                        name: "len".to_string(),
+                        args: vec![var("self")],
+                    }],
+                ));
+            }
+            if let Some(pat) = args.pattern {
+                let ext = native_ext("pydantic", &field_name, line.trim());
+                let predicate = atomic("opaque", vec![str_const(pat)]);
+                out.push(build_memento(
+                    5000,
+                    ext,
+                    predicate,
+                    SourceKind::NativeSurface,
+                    locator.clone(),
+                ));
+            }
+        }
+
+        // @deal.pre(...)
+        if let Some(cap) = re_deal_pre().captures(line) {
+            let lambda_text = cap[1].trim().to_string();
+            let target = extract_py_def_name(next_line);
+            let ext = native_ext("pydantic-deal", &target, line.trim());
+            let predicate = atomic("opaque", vec![str_const(&lambda_text)]);
+            out.push(build_memento(
+                5000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+
+        // @deal.post(...)
+        if let Some(cap) = re_deal_post().captures(line) {
+            let lambda_text = cap[1].trim().to_string();
+            let target = extract_py_def_name(next_line);
+            let ext = native_ext("pydantic-deal", &target, line.trim());
+            let predicate = atomic("opaque", vec![str_const(&lambda_text)]);
+            out.push(build_memento(
+                5000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+
+        // @deal.ensure(...)
+        if let Some(cap) = re_deal_ensure().captures(line) {
+            let lambda_text = cap[1].trim().to_string();
+            let target = extract_py_def_name(next_line);
+            let ext = native_ext("pydantic-deal", &target, line.trim());
+            let predicate = atomic("opaque", vec![str_const(&lambda_text)]);
+            out.push(build_memento(
+                5000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use provekit_ir_types::IrFormula;
+
+    const FAKE_CID: &str = "blake3-512:aabbcc";
+
+    #[test]
+    fn test_pydantic_field_ge_recognition() {
+        let src = "    age: int = Field(ge=0, le=120)\n";
+        let mementos = lift_pydantic_file(src, FAKE_CID);
+        assert!(!mementos.is_empty(), "expected mementos for Field(ge=, le=)");
+        assert_eq!(mementos[0].source_kind, SourceKind::NativeSurface);
+        assert_eq!(mementos[0].kind, "evidence");
+    }
+
+    #[test]
+    fn test_pydantic_field_predicate_shape() {
+        let src = "    age: int = Field(ge=0, le=120)\n";
+        let mementos = lift_pydantic_file(src, FAKE_CID);
+        // Should emit ≥(self, 0) and ≤(self, 120)
+        assert_eq!(mementos.len(), 2);
+        let names: Vec<String> = mementos
+            .iter()
+            .filter_map(|m| match &m.predicate {
+                IrFormula::Atomic { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(names.contains(&"≥".to_string()));
+        assert!(names.contains(&"≤".to_string()));
+    }
+
+    #[test]
+    fn test_pydantic_field_json_round_trip() {
+        let src = "    score: float = Field(ge=0.0, le=1.0)\n    age: int = Field(ge=0)\n";
+        let mementos = lift_pydantic_file(src, FAKE_CID);
+        // age line: ge=0 -> one memento
+        let m = mementos.iter().find(|m| {
+            m.extension_fields
+                .get("target_function_or_field")
+                .and_then(|v| v.as_str())
+                == Some("age")
+        });
+        if let Some(m) = m {
+            let json = serde_json::to_string(m).expect("must serialize");
+            let back: EvidenceMemento = serde_json::from_str(&json).expect("must deserialize");
+            assert_eq!(back.cid, m.cid);
+            assert!(back.extension_fields.contains_key("surface_kind"));
+            assert!(back.extension_fields.contains_key("target_function_or_field"));
+            assert!(back.extension_fields.contains_key("original_text"));
+        }
+    }
+
+    #[test]
+    fn test_pydantic_deal_pre_opaque() {
+        let src = "@deal.pre(lambda x: x > 0)\ndef square(x):\n    return x * x\n";
+        let mementos = lift_pydantic_file(src, FAKE_CID);
+        assert!(!mementos.is_empty());
+        let m = &mementos[0];
+        assert_eq!(m.confidence_basis_points, 5000);
+        match &m.predicate {
+            IrFormula::Atomic { name, .. } => assert_eq!(name, "opaque"),
+            other => panic!("expected opaque, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_pydantic_min_max_length() {
+        let src = "    username: str = Field(min_length=3, max_length=50)\n";
+        let mementos = lift_pydantic_file(src, FAKE_CID);
+        assert_eq!(mementos.len(), 2);
+        // Both should wrap in len(self)
+        for m in &mementos {
+            match &m.predicate {
+                IrFormula::Atomic { args, .. } => {
+                    match &args[0] {
+                        provekit_ir_types::IrTerm::Ctor { name, .. } => {
+                            assert_eq!(name, "len");
+                        }
+                        other => panic!("expected Ctor(len, ...), got {:?}", other),
+                    }
+                }
+                other => panic!("expected Atomic, got {:?}", other),
+            }
+        }
+    }
+}

--- a/implementations/rust/provekit-lift-native-surfaces/src/spring.rs
+++ b/implementations/rust/provekit-lift-native-surfaces/src/spring.rs
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Spring (Java) native contract surface lifter — v0
+//
+// Recognised annotation idioms:
+//
+//   @PreCondition("expr")  — pre-condition string; opaque atomic, conf ~5000
+//   @PostCondition("expr") — post-condition string; opaque atomic, conf ~5000
+//   @NotNull               — null-exclusion, conf 10000; emits `≠(self, null)`
+//   @Min(value)            — numeric lower bound, conf 10000; emits `≥(self, N)`
+//   @Max(value)            — numeric upper bound, conf 10000; emits `≤(self, N)`
+//   @Size(min=N)           — collection/string lower-bound, conf 10000
+//   @Size(max=N)           — collection/string upper-bound, conf 10000
+//   @Size(min=N, max=M)    — both bounds, emits two mementos
+//   @Positive              — emits `>(self, 0)`, conf 10000
+//   @PositiveOrZero        — emits `≥(self, 0)`, conf 10000
+//   @Negative              — emits `<(self, 0)`, conf 10000
+//   @NegativeOrZero        — emits `≤(self, 0)`, conf 10000
+//
+// Target heuristic: the annotated field/parameter name is extracted from the
+// next `\w+(\s+\w+)*\s+(\w+)` shape on the same or following line.  If we
+// cannot find one we use the placeholder `"_unknown"`.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use provekit_ir_types::{EvidenceMemento, SourceKind};
+
+use crate::{atomic, build_memento, int_const, make_locator, native_ext, str_const, var};
+
+// ---------------------------------------------------------------------------
+// Compiled regexes (thread-safe via OnceLock)
+// ---------------------------------------------------------------------------
+
+fn re_precondition() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r#"@PreCondition\s*\(\s*"([^"]*)"\s*\)"#).unwrap())
+}
+
+fn re_postcondition() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r#"@PostCondition\s*\(\s*"([^"]*)"\s*\)"#).unwrap())
+}
+
+fn re_notnull() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@NotNull\b").unwrap())
+}
+
+fn re_min() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@Min\s*\(\s*(?:value\s*=\s*)?(-?\d+)\s*\)").unwrap())
+}
+
+fn re_max() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@Max\s*\(\s*(?:value\s*=\s*)?(-?\d+)\s*\)").unwrap())
+}
+
+fn re_size() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    // matches @Size(min=N), @Size(max=N), @Size(min=N, max=M) in any attribute order
+    R.get_or_init(|| Regex::new(r"@Size\s*\(([^)]*)\)").unwrap())
+}
+
+fn re_positive() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@Positive\b").unwrap())
+}
+
+fn re_positive_or_zero() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@PositiveOrZero\b").unwrap())
+}
+
+fn re_negative() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@Negative\b").unwrap())
+}
+
+fn re_negative_or_zero() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"@NegativeOrZero\b").unwrap())
+}
+
+/// Extract `min=N` from a @Size attribute body.
+fn parse_size_attr(body: &str) -> (Option<i64>, Option<i64>) {
+    let re_min_attr =
+        Regex::new(r"min\s*=\s*(-?\d+)").unwrap();
+    let re_max_attr =
+        Regex::new(r"max\s*=\s*(-?\d+)").unwrap();
+    let min = re_min_attr
+        .captures(body)
+        .and_then(|c| c[1].parse::<i64>().ok());
+    let max = re_max_attr
+        .captures(body)
+        .and_then(|c| c[1].parse::<i64>().ok());
+    (min, max)
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Walk `source` (Java file text) and emit `EvidenceMemento` records for
+/// every recognised Spring annotation idiom.  `source_cid` is the
+/// content-address of the source file (caller-supplied, e.g. a fake CID for
+/// tests).
+pub fn lift_spring_file(source: &str, source_cid: &str) -> Vec<EvidenceMemento> {
+    let mut out = Vec::new();
+    let lines: Vec<&str> = source.lines().collect();
+
+    for (line_idx, line) in lines.iter().enumerate() {
+        let line_no = (line_idx + 1) as u32; // 1-based
+        let next_line = lines.get(line_idx + 1).copied().unwrap_or("");
+        let target = extract_java_target(line, next_line);
+        let locator = make_locator(source_cid, line_no, line_no);
+
+        // @PreCondition("expr")
+        if let Some(cap) = re_precondition().captures(line) {
+            let expr = &cap[1];
+            let ext = native_ext("spring", &target, line.trim());
+            let predicate = atomic("opaque", vec![str_const(expr)]);
+            out.push(build_memento(
+                5000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+
+        // @PostCondition("expr")
+        if let Some(cap) = re_postcondition().captures(line) {
+            let expr = &cap[1];
+            let ext = native_ext("spring", &target, line.trim());
+            let predicate = atomic("opaque", vec![str_const(expr)]);
+            out.push(build_memento(
+                5000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+
+        // @NotNull
+        if re_notnull().is_match(line) {
+            let ext = native_ext("spring", &target, line.trim());
+            // ≠(self, null)
+            let predicate = atomic(
+                "≠",
+                vec![var("self"), str_const("null")],
+            );
+            out.push(build_memento(
+                10000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+
+        // @Min(N)
+        if let Some(cap) = re_min().captures(line) {
+            if let Ok(n) = cap[1].parse::<i64>() {
+                let ext = native_ext("spring", &target, line.trim());
+                let predicate = atomic("≥", vec![var("self"), int_const(n)]);
+                out.push(build_memento(
+                    10000,
+                    ext,
+                    predicate,
+                    SourceKind::NativeSurface,
+                    locator.clone(),
+                ));
+            }
+        }
+
+        // @Max(N)
+        if let Some(cap) = re_max().captures(line) {
+            if let Ok(n) = cap[1].parse::<i64>() {
+                let ext = native_ext("spring", &target, line.trim());
+                let predicate = atomic("≤", vec![var("self"), int_const(n)]);
+                out.push(build_memento(
+                    10000,
+                    ext,
+                    predicate,
+                    SourceKind::NativeSurface,
+                    locator.clone(),
+                ));
+            }
+        }
+
+        // @Size(min=N, max=M)
+        if let Some(cap) = re_size().captures(line) {
+            let body = &cap[1];
+            let (min_val, max_val) = parse_size_attr(body);
+            if let Some(n) = min_val {
+                let ext = native_ext("spring", &target, line.trim());
+                let predicate = atomic("≥", vec![var("self"), int_const(n)]);
+                out.push(build_memento(
+                    10000,
+                    ext,
+                    predicate,
+                    SourceKind::NativeSurface,
+                    locator.clone(),
+                ));
+            }
+            if let Some(m) = max_val {
+                let ext = native_ext("spring", &target, line.trim());
+                let predicate = atomic("≤", vec![var("self"), int_const(m)]);
+                out.push(build_memento(
+                    10000,
+                    ext,
+                    predicate,
+                    SourceKind::NativeSurface,
+                    locator.clone(),
+                ));
+            }
+        }
+
+        // @Positive
+        if re_positive_or_zero().is_match(line) {
+            let ext = native_ext("spring", &target, line.trim());
+            let predicate = atomic("≥", vec![var("self"), int_const(0)]);
+            out.push(build_memento(
+                10000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        } else if re_positive().is_match(line) {
+            let ext = native_ext("spring", &target, line.trim());
+            let predicate = atomic(">", vec![var("self"), int_const(0)]);
+            out.push(build_memento(
+                10000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+
+        // @Negative
+        if re_negative_or_zero().is_match(line) {
+            let ext = native_ext("spring", &target, line.trim());
+            let predicate = atomic("≤", vec![var("self"), int_const(0)]);
+            out.push(build_memento(
+                10000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        } else if re_negative().is_match(line) {
+            let ext = native_ext("spring", &target, line.trim());
+            let predicate = atomic("<", vec![var("self"), int_const(0)]);
+            out.push(build_memento(
+                10000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Target name heuristic
+// ---------------------------------------------------------------------------
+
+/// Try to extract the field/parameter name from `annotation_line` and the
+/// following `next_line`.  Returns `"_unknown"` if nothing obvious is found.
+fn extract_java_target(annotation_line: &str, next_line: &str) -> String {
+    // Look in the annotation line itself (inline annotation on a field decl).
+    // Also look at next line (annotation on its own line above the declaration).
+    for candidate in &[annotation_line, next_line] {
+        if let Some(name) = java_decl_last_word(candidate) {
+            return name;
+        }
+    }
+    "_unknown".to_string()
+}
+
+/// Extract the last identifier from a Java-style field or parameter declaration.
+/// Patterns like `private int age` → "age", `String name,` → "name".
+fn java_decl_last_word(line: &str) -> Option<String> {
+    let re = Regex::new(r"\b([A-Za-z_]\w*)\s*[;,=)\{]?\s*$").unwrap();
+    // Strip annotations first so "@NotNull int age" → "int age" → "age"
+    let stripped = Regex::new(r"@\w+(\([^)]*\))?")
+        .unwrap()
+        .replace_all(line, "");
+    re.captures(stripped.trim())
+        .map(|c| c[1].to_string())
+        .filter(|s| !is_java_keyword(s))
+}
+
+fn is_java_keyword(s: &str) -> bool {
+    matches!(
+        s,
+        "public"
+            | "private"
+            | "protected"
+            | "static"
+            | "final"
+            | "int"
+            | "long"
+            | "double"
+            | "float"
+            | "boolean"
+            | "String"
+            | "void"
+            | "class"
+            | "interface"
+            | "enum"
+            | "return"
+            | "null"
+            | "new"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use provekit_ir_types::IrFormula;
+
+    const FAKE_CID: &str = "blake3-512:aabbcc";
+
+    #[test]
+    fn test_spring_notnull_recognition() {
+        let src = "    @NotNull\n    private String email;\n";
+        let mementos = lift_spring_file(src, FAKE_CID);
+        assert!(
+            !mementos.is_empty(),
+            "expected at least one memento for @NotNull"
+        );
+        let m = &mementos[0];
+        assert_eq!(m.source_kind, SourceKind::NativeSurface);
+        assert_eq!(m.kind, "evidence");
+        assert_eq!(m.schema_version, "1");
+        assert_eq!(m.confidence_basis_points, 10000);
+    }
+
+    #[test]
+    fn test_spring_notnull_predicate_shape() {
+        let src = "    @NotNull\n    private String email;\n";
+        let mementos = lift_spring_file(src, FAKE_CID);
+        let m = &mementos[0];
+        match &m.predicate {
+            IrFormula::Atomic { name, args } => {
+                assert_eq!(name, "≠");
+                assert_eq!(args.len(), 2);
+            }
+            other => panic!("expected Atomic, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_spring_notnull_json_round_trip() {
+        let src = "    @NotNull\n    private String email;\n";
+        let mementos = lift_spring_file(src, FAKE_CID);
+        let m = &mementos[0];
+        let json = serde_json::to_string(m).expect("must serialize");
+        let back: EvidenceMemento = serde_json::from_str(&json).expect("must deserialize");
+        assert_eq!(back.cid, m.cid);
+        assert_eq!(back.confidence_basis_points, 10000);
+        // extension_fields must contain the three mandatory keys
+        assert!(back.extension_fields.contains_key("surface_kind"));
+        assert!(back.extension_fields.contains_key("target_function_or_field"));
+        assert!(back.extension_fields.contains_key("original_text"));
+    }
+
+    #[test]
+    fn test_spring_min_max() {
+        let src = "    @Min(0)\n    @Max(120)\n    private int age;\n";
+        let mementos = lift_spring_file(src, FAKE_CID);
+        // Should get ≥ for @Min and ≤ for @Max
+        let names: Vec<String> = mementos
+            .iter()
+            .filter_map(|m| match &m.predicate {
+                IrFormula::Atomic { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(names.contains(&"≥".to_string()), "expected ≥ from @Min");
+        assert!(names.contains(&"≤".to_string()), "expected ≤ from @Max");
+    }
+
+    #[test]
+    fn test_spring_size_both_bounds() {
+        let src = "    @Size(min = 1, max = 255)\n    private String username;\n";
+        let mementos = lift_spring_file(src, FAKE_CID);
+        // Two mementos: ≥ for min, ≤ for max
+        assert_eq!(mementos.len(), 2);
+    }
+
+    #[test]
+    fn test_spring_precondition_opaque() {
+        let src = r#"    @PreCondition("x > 0 && y < 100")
+    public int compute(int x, int y) { return x + y; }
+"#;
+        let mementos = lift_spring_file(src, FAKE_CID);
+        assert!(!mementos.is_empty());
+        let m = &mementos[0];
+        assert_eq!(m.confidence_basis_points, 5000);
+        match &m.predicate {
+            IrFormula::Atomic { name, .. } => assert_eq!(name, "opaque"),
+            other => panic!("expected opaque atomic, got {:?}", other),
+        }
+    }
+}

--- a/implementations/rust/provekit-lift-native-surfaces/src/spring.rs
+++ b/implementations/rust/provekit-lift-native-surfaces/src/spring.rs
@@ -112,8 +112,7 @@ pub fn lift_spring_file(source: &str, source_cid: &str) -> Vec<EvidenceMemento> 
 
     for (line_idx, line) in lines.iter().enumerate() {
         let line_no = (line_idx + 1) as u32; // 1-based
-        let next_line = lines.get(line_idx + 1).copied().unwrap_or("");
-        let target = extract_java_target(line, next_line);
+        let target = extract_java_target(&lines, line_idx);
         let locator = make_locator(source_cid, line_no, line_no);
 
         // @PreCondition("expr")
@@ -273,15 +272,37 @@ pub fn lift_spring_file(source: &str, source_cid: &str) -> Vec<EvidenceMemento> 
 // Target name heuristic
 // ---------------------------------------------------------------------------
 
-/// Try to extract the field/parameter name from `annotation_line` and the
-/// following `next_line`.  Returns `"_unknown"` if nothing obvious is found.
-fn extract_java_target(annotation_line: &str, next_line: &str) -> String {
-    // Look in the annotation line itself (inline annotation on a field decl).
-    // Also look at next line (annotation on its own line above the declaration).
-    for candidate in &[annotation_line, next_line] {
+/// Try to extract the field/parameter name from the annotation at `from_index`
+/// and the lines that follow it.  Scans forward past consecutive annotation
+/// lines (lines whose trimmed text starts with `@`), blank lines, and
+/// single-line `//` comments until a non-annotation, non-blank, non-comment
+/// line is found, then extracts the identifier from that declaration.
+/// Returns `"_unknown"` if nothing obvious is found or EOF is reached.
+fn extract_java_target(lines: &[&str], from_index: usize) -> String {
+    let annotation_line = lines[from_index];
+    // 1. Inline annotation on a field declaration (e.g. `@NotNull int age`).
+    if let Some(name) = java_decl_last_word(annotation_line) {
+        return name;
+    }
+    // 2. Annotation on its own line — walk forward past more annotations,
+    //    blank lines, and `//` comments until a declaration line is found.
+    let mut idx = from_index + 1;
+    while idx < lines.len() {
+        let candidate = lines[idx].trim();
+        if candidate.is_empty() || candidate.starts_with("//") {
+            idx += 1;
+            continue;
+        }
+        if candidate.starts_with('@') {
+            // Another stacked annotation — keep walking.
+            idx += 1;
+            continue;
+        }
+        // Non-annotation, non-blank, non-comment line: this is the declaration.
         if let Some(name) = java_decl_last_word(candidate) {
             return name;
         }
+        break;
     }
     "_unknown".to_string()
 }
@@ -373,7 +394,7 @@ mod tests {
         assert_eq!(back.cid, m.cid);
         assert_eq!(back.confidence_basis_points, 10000);
         // extension_fields must contain the three mandatory keys
-        assert!(back.extension_fields.contains_key("surface_kind"));
+        assert!(back.extension_fields.contains_key("surface_name"));
         assert!(back.extension_fields.contains_key("target_function_or_field"));
         assert!(back.extension_fields.contains_key("original_text"));
     }
@@ -414,6 +435,46 @@ mod tests {
         match &m.predicate {
             IrFormula::Atomic { name, .. } => assert_eq!(name, "opaque"),
             other => panic!("expected opaque atomic, got {:?}", other),
+        }
+    }
+
+    /// Regression: stacked annotations on one field must all resolve to the
+    /// same target, not `_unknown`.  Previously @Min(1) saw next_line=@Max(100)
+    /// and fell through to `_unknown`.
+    #[test]
+    fn test_spring_stacked_annotations_two_same_field() {
+        let src = "    @Min(1)\n    @Max(100)\n    private int score;\n";
+        let mementos = lift_spring_file(src, FAKE_CID);
+        assert_eq!(mementos.len(), 2, "expected one memento per annotation");
+        for m in &mementos {
+            let target = m
+                .extension_fields
+                .get("target_function_or_field")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            assert_eq!(
+                target, "score",
+                "stacked annotation target must be 'score', got '{target}'"
+            );
+        }
+    }
+
+    /// Regression: three stacked annotations — no off-by-one in the forward walk.
+    #[test]
+    fn test_spring_stacked_annotations_three_same_field() {
+        let src = "    @NotNull\n    @Min(1)\n    @Max(100)\n    private int score;\n";
+        let mementos = lift_spring_file(src, FAKE_CID);
+        assert_eq!(mementos.len(), 3, "expected one memento per annotation");
+        for m in &mementos {
+            let target = m
+                .extension_fields
+                .get("target_function_or_field")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            assert_eq!(
+                target, "score",
+                "all three stacked annotations must resolve to 'score', got '{target}'"
+            );
         }
     }
 }

--- a/implementations/rust/provekit-lift-native-surfaces/src/zod.rs
+++ b/implementations/rust/provekit-lift-native-surfaces/src/zod.rs
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Zod (TypeScript) native contract surface lifter — v0
+//
+// Recognised Zod chained-method idioms:
+//
+//   z.number().min(N)       — emits `≥(self, N)`,  conf 10000
+//   z.number().max(N)       — emits `≤(self, N)`,  conf 10000
+//   z.number().int()        — emits `is_integer(self)`, conf 10000
+//   z.number().positive()   — emits `>(self, 0)`,  conf 10000
+//   z.number().nonnegative()— emits `≥(self, 0)`,  conf 10000
+//   z.number().negative()   — emits `<(self, 0)`,  conf 10000
+//   z.number().nonpositive()— emits `≤(self, 0)`,  conf 10000
+//   z.string().min(N)       — emits `≥(len(self), N)`, conf 10000
+//   z.string().max(N)       — emits `≤(len(self), N)`, conf 10000
+//   z.string().length(N)    — emits `=(len(self), N)`, conf 10000
+//   z.string().regex(...)   — opaque regex, conf 5000
+//   z.string().email()      — emits `is_email(self)`, conf 10000
+//   z.string().url()        — emits `is_url(self)`, conf 10000
+//   z.array(...).min(N)     — emits `≥(len(self), N)`, conf 10000
+//   z.array(...).max(N)     — emits `≤(len(self), N)`, conf 10000
+//   z.array(...).length(N)  — emits `=(len(self), N)`, conf 10000
+//
+// Binding heuristic: look for `const name = ...` or `name:` before the z.xxx chain
+// on the same line.
+//
+// Each recognised idiom on a line produces one (or more) mementos for that line.
+// A single chain like `z.number().min(0).max(100)` on one line produces two mementos.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use provekit_ir_types::{EvidenceMemento, IrTerm, SourceKind};
+
+use crate::{atomic, build_memento, int_const, make_locator, native_ext, str_const, var};
+
+// ---------------------------------------------------------------------------
+// Regexes
+// ---------------------------------------------------------------------------
+
+fn re_number_min() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\.min\s*\(\s*(-?\d+)\s*\)").unwrap())
+}
+
+fn re_number_max() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\.max\s*\(\s*(-?\d+)\s*\)").unwrap())
+}
+
+fn re_length() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\.length\s*\(\s*(-?\d+)\s*\)").unwrap())
+}
+
+fn re_zod_chain_type() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    // Captures the Zod primitive type: number, string, array, bigint, etc.
+    R.get_or_init(|| Regex::new(r"\bz\.(number|string|array|bigint|boolean)\b").unwrap())
+}
+
+fn re_zod_unary_method() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    // zero-arg Zod refinement methods
+    R.get_or_init(|| {
+        Regex::new(r"\.(positive|nonnegative|negative|nonpositive|int|email|url)\(\s*\)").unwrap()
+    })
+}
+
+fn re_regex_method() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    // .regex(/.../) or .regex(new RegExp("..."))
+    R.get_or_init(|| Regex::new(r"\.regex\s*\((.+?)\)").unwrap())
+}
+
+/// Detect if the line contains a Zod chain and return the primitive kind.
+fn zod_chain_kind(line: &str) -> Option<&'static str> {
+    let cap = re_zod_chain_type().captures(line)?;
+    match &cap[1] {
+        "number" | "bigint" => Some("number"),
+        "string" => Some("string"),
+        "array" => Some("array"),
+        _ => None,
+    }
+}
+
+/// Extract the binding/schema name from the line.
+/// Matches `const name = ...` or `name:` patterns.
+fn extract_zod_target(line: &str) -> String {
+    // `const name = z.xxx` or `let name = z.xxx` or `var name = z.xxx`
+    let re_const = Regex::new(r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=").unwrap();
+    if let Some(cap) = re_const.captures(line) {
+        return cap[1].to_string();
+    }
+    // `name: z.xxx` (object property)
+    let re_prop = Regex::new(r"^\s*([A-Za-z_$][\w$]*)\s*:").unwrap();
+    if let Some(cap) = re_prop.captures(line) {
+        return cap[1].to_string();
+    }
+    "_unknown".to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Walk `source` (TypeScript file text) and emit `EvidenceMemento` records
+/// for every recognised Zod schema constraint.
+pub fn lift_zod_file(source: &str, source_cid: &str) -> Vec<EvidenceMemento> {
+    let mut out = Vec::new();
+    let lines: Vec<&str> = source.lines().collect();
+
+    for (line_idx, line) in lines.iter().enumerate() {
+        let line_no = (line_idx + 1) as u32;
+        let locator = make_locator(source_cid, line_no, line_no);
+        let target = extract_zod_target(line);
+
+        let Some(kind) = zod_chain_kind(line) else {
+            continue;
+        };
+
+        let len_subject = || IrTerm::Ctor {
+            name: "len".to_string(),
+            args: vec![var("self")],
+        };
+
+        // .min(N) — lower bound
+        for cap in re_number_min().captures_iter(line) {
+            if let Ok(n) = cap[1].parse::<i64>() {
+                let subject = if kind == "number" {
+                    vec![var("self")]
+                } else {
+                    vec![len_subject()]
+                };
+                let ext = native_ext("zod", &target, line.trim());
+                let predicate = atomic("≥", {
+                    let mut v = subject;
+                    v.push(int_const(n));
+                    v
+                });
+                out.push(build_memento(
+                    10000,
+                    ext,
+                    predicate,
+                    SourceKind::NativeSurface,
+                    locator.clone(),
+                ));
+            }
+        }
+
+        // .max(N) — upper bound
+        for cap in re_number_max().captures_iter(line) {
+            if let Ok(n) = cap[1].parse::<i64>() {
+                let subject = if kind == "number" {
+                    vec![var("self")]
+                } else {
+                    vec![len_subject()]
+                };
+                let ext = native_ext("zod", &target, line.trim());
+                let predicate = atomic("≤", {
+                    let mut v = subject;
+                    v.push(int_const(n));
+                    v
+                });
+                out.push(build_memento(
+                    10000,
+                    ext,
+                    predicate,
+                    SourceKind::NativeSurface,
+                    locator.clone(),
+                ));
+            }
+        }
+
+        // .length(N) — exact length (string/array)
+        for cap in re_length().captures_iter(line) {
+            if let Ok(n) = cap[1].parse::<i64>() {
+                let ext = native_ext("zod", &target, line.trim());
+                let predicate = atomic("=", vec![len_subject(), int_const(n)]);
+                out.push(build_memento(
+                    10000,
+                    ext,
+                    predicate,
+                    SourceKind::NativeSurface,
+                    locator.clone(),
+                ));
+            }
+        }
+
+        // zero-arg methods: .positive(), .nonnegative(), etc.
+        for cap in re_zod_unary_method().captures_iter(line) {
+            let method = &cap[1];
+            let (pred_name, args): (&str, Vec<IrTerm>) = match method {
+                "positive" => (">", vec![var("self"), int_const(0)]),
+                "nonnegative" => ("≥", vec![var("self"), int_const(0)]),
+                "negative" => ("<", vec![var("self"), int_const(0)]),
+                "nonpositive" => ("≤", vec![var("self"), int_const(0)]),
+                "int" => ("is_integer", vec![var("self")]),
+                "email" => ("is_email", vec![var("self")]),
+                "url" => ("is_url", vec![var("self")]),
+                _ => continue,
+            };
+            let ext = native_ext("zod", &target, line.trim());
+            let predicate = atomic(pred_name, args);
+            out.push(build_memento(
+                10000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+
+        // .regex(...)
+        if let Some(cap) = re_regex_method().captures(line) {
+            let regex_text = cap[1].trim().to_string();
+            let ext = native_ext("zod", &target, line.trim());
+            let predicate = atomic("opaque", vec![str_const(&regex_text)]);
+            out.push(build_memento(
+                5000,
+                ext,
+                predicate,
+                SourceKind::NativeSurface,
+                locator.clone(),
+            ));
+        }
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use provekit_ir_types::IrFormula;
+
+    const FAKE_CID: &str = "blake3-512:aabbcc";
+
+    #[test]
+    fn test_zod_number_min_max_recognition() {
+        let src = "const score = z.number().min(0).max(100);\n";
+        let mementos = lift_zod_file(src, FAKE_CID);
+        assert_eq!(mementos.len(), 2, "expected 2 mementos: ≥ and ≤");
+        for m in &mementos {
+            assert_eq!(m.source_kind, SourceKind::NativeSurface);
+            assert_eq!(m.kind, "evidence");
+            assert_eq!(m.confidence_basis_points, 10000);
+        }
+    }
+
+    #[test]
+    fn test_zod_number_predicate_shape() {
+        let src = "const age = z.number().min(0).max(120);\n";
+        let mementos = lift_zod_file(src, FAKE_CID);
+        let names: Vec<String> = mementos
+            .iter()
+            .filter_map(|m| match &m.predicate {
+                IrFormula::Atomic { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(names.contains(&"≥".to_string()), "expected ≥ from .min()");
+        assert!(names.contains(&"≤".to_string()), "expected ≤ from .max()");
+        // target should be "age"
+        for m in &mementos {
+            assert_eq!(
+                m.extension_fields["target_function_or_field"]
+                    .as_str()
+                    .unwrap(),
+                "age"
+            );
+        }
+    }
+
+    #[test]
+    fn test_zod_number_json_round_trip() {
+        let src = "const score = z.number().min(0).max(100);\n";
+        let mementos = lift_zod_file(src, FAKE_CID);
+        for m in &mementos {
+            let json = serde_json::to_string(m).expect("must serialize");
+            let back: EvidenceMemento = serde_json::from_str(&json).expect("must deserialize");
+            assert_eq!(back.cid, m.cid);
+            assert!(back.extension_fields.contains_key("surface_kind"));
+            assert!(back.extension_fields.contains_key("target_function_or_field"));
+            assert!(back.extension_fields.contains_key("original_text"));
+        }
+    }
+
+    #[test]
+    fn test_zod_string_length_constraints() {
+        let src = "  username: z.string().min(3).max(20),\n";
+        let mementos = lift_zod_file(src, FAKE_CID);
+        assert_eq!(mementos.len(), 2);
+        // Both should use len(self) as subject
+        for m in &mementos {
+            match &m.predicate {
+                IrFormula::Atomic { args, .. } => match &args[0] {
+                    provekit_ir_types::IrTerm::Ctor { name, .. } => {
+                        assert_eq!(name, "len");
+                    }
+                    other => panic!("expected Ctor(len, ...), got {:?}", other),
+                },
+                other => panic!("expected Atomic, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn test_zod_string_exact_length() {
+        let src = "const zip = z.string().length(5);\n";
+        let mementos = lift_zod_file(src, FAKE_CID);
+        assert_eq!(mementos.len(), 1);
+        match &mementos[0].predicate {
+            IrFormula::Atomic { name, .. } => assert_eq!(name, "="),
+            other => panic!("expected Atomic(=), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_zod_unary_positive() {
+        let src = "const qty = z.number().positive();\n";
+        let mementos = lift_zod_file(src, FAKE_CID);
+        assert_eq!(mementos.len(), 1);
+        match &mementos[0].predicate {
+            IrFormula::Atomic { name, args } => {
+                assert_eq!(name, ">");
+                assert_eq!(args.len(), 2);
+            }
+            other => panic!("expected Atomic(>), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_zod_regex_opaque() {
+        let src = r#"const phone = z.string().regex(/^\d{10}$/);"#;
+        let mementos = lift_zod_file(src, FAKE_CID);
+        assert!(!mementos.is_empty());
+        let m = &mementos[0];
+        assert_eq!(m.confidence_basis_points, 5000);
+        match &m.predicate {
+            IrFormula::Atomic { name, .. } => assert_eq!(name, "opaque"),
+            other => panic!("expected opaque, got {:?}", other),
+        }
+    }
+}

--- a/implementations/rust/provekit-lift-native-surfaces/src/zod.rs
+++ b/implementations/rust/provekit-lift-native-surfaces/src/zod.rs
@@ -284,7 +284,7 @@ mod tests {
             let json = serde_json::to_string(m).expect("must serialize");
             let back: EvidenceMemento = serde_json::from_str(&json).expect("must deserialize");
             assert_eq!(back.cid, m.cid);
-            assert!(back.extension_fields.contains_key("surface_kind"));
+            assert!(back.extension_fields.contains_key("surface_name"));
             assert!(back.extension_fields.contains_key("target_function_or_field"));
             assert!(back.extension_fields.contains_key("original_text"));
         }


### PR DESCRIPTION
## Summary

Closes part of #716 (PR-G: per-language native contract surface lifters).

- New crate `provekit-lift-native-surfaces` under `implementations/rust/`
- Three v0 regex pre-pass lifters, each exporting `lift_<surface>_file(source: &str, source_cid: &str) -> Vec<EvidenceMemento>`:
  - **Spring (Java)**: `@NotNull`, `@Min(N)`, `@Max(N)`, `@Size(min=N, max=M)`, `@Positive`, `@PositiveOrZero`, `@Negative`, `@NegativeOrZero`, `@PreCondition("expr")`, `@PostCondition("expr")`
  - **pydantic (Python)**: `Field(ge=, gt=, le=, lt=, min_length=, max_length=, pattern=)`, `@deal.pre`, `@deal.post`, `@deal.ensure`
  - **Zod (TypeScript)**: `z.number().min/max/positive/nonnegative/negative/nonpositive/int`, `z.string().min/max/length/regex/email/url`, `z.array().min/max/length`

All mementos carry `source_kind = "native-surface"`. Static annotations (structurally unambiguous bounds) emit `confidence_basis_points = 10000`; opaque/regex predicates emit `5000`. Extension fields `surface_kind`, `target_function_or_field`, and `original_text` are present on every memento.

OpenAPI is excluded (existing `provekit-lift-openapi` crate covers it).

## Test plan

- [x] 18 unit tests across 3 surfaces: recognition, predicate shape, JSON round-trip
- [x] `cargo test -p provekit-lift-native-surfaces` — 18/18 pass
- [x] `cargo check --workspace` — clean (warnings only, no errors)
- [ ] Reviewer: verify `confidence_basis_points` values align with loss-budget expectations
- [ ] Reviewer: confirm opaque-atomic shape (`IrFormula::Atomic { name: "opaque", args: [IrTerm::Const(text)] }`) is acceptable for v0 vs. a dedicated `IrFormula` variant

## Architecture notes

- CID helper re-implemented locally (private in `provekit-lift-rust-tests`); uses `provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue}`
- `AUTO_PROMOTE_LIFTER_CID` sentinel (`blake3-512:` + 128 hex zeros) used until PR-F wires the real lifter CID
- v1 follow-ups: AST-based lifters for each language, JML, Sorbet

🤖 Generated with [Claude Code](https://claude.com/claude-code)