### PR TITLE
fix(walk): exhaustive match for IrFormula::Substitute and IrFormula::Apply

### DIFF
--- a/implementations/rust/provekit-walk/tests/end_to_end_demo.rs
+++ b/implementations/rust/provekit-walk/tests/end_to_end_demo.rs
@@ -160,6 +160,8 @@ fn is_ground(formula: &IrFormula) -> bool {
         IrFormula::Forall { body, .. }
         | IrFormula::Exists { body, .. }
         | IrFormula::Choice { body, .. } => is_ground(body),
+        IrFormula::Substitute { target, term, .. } => is_ground(target) && is_ground_term(term),
+        IrFormula::Apply { args, .. } => args.iter().all(is_ground),
     }
 }
 


### PR DESCRIPTION
Rebase-fallout fix unblocking #725, #727, #728.

The `is_ground()` helper in `provekit-walk/tests/end_to_end_demo.rs` did not cover `IrFormula::Substitute` and `IrFormula::Apply` — two variants added to main via the wp-as-formula spec (protocol/specs/2026-05-13-wp-as-formula.md §2.3). Arms added consistent with neighboring second-order variant handling:

- `Substitute { target, term, .. }` — recurses into the formula child and the term child (only variant that touches both, natural combination of the two helper calls)
- `Apply { args, .. }` — iterates formula children, mirrors `And/Or/Not/Implies` pattern

Verified locally:
- `cargo check --tests -p provekit-walk` — clean
- `cargo check --tests --workspace` — clean (no errors; 2 pre-existing warnings in provekit-ir-types, not introduced here)
- `cargo test -p provekit-walk --test end_to_end_demo` — 2/2 passed

`ground_truth()` match in the same file already has a `_ => false` fallback and is unaffected.

Once merged, #725 / #727 / #728 each need `gh pr update-branch` to inherit.