### PR TITLE
feat(trinity-java-roundtrip): empirical gap audit -- 0/11 exact, all REFUSE at round-trip layer

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
@@ -1,0 +1,222 @@
+package com.provekit.lift.java_source;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.provekit.ir.Jcs;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Trinity round-trip lift test.
+ *
+ * Empirically documents the per-class lifter verdict for the canonical Java
+ * output produced by:
+ *   provekit bind --root <trinity-fixture> --lang rust
+ *     --target-language java --rewrite canonical --mode monitor
+ *
+ * The bind output is snapshotted at:
+ *   src/test/resources/trinity-roundtrip/lib.java
+ *
+ * Transport-gap spec:
+ *   protocol/specs/2026-05-12-trinity-java-roundtrip-transport-gaps.md
+ *
+ * Per-class lifter verdicts at v0:
+ *
+ *   WrapIdentityTransported         - LIFTED   (classified as concept:pair by bind v0; stub body)
+ *   DoNothingTransported            - REFUSED  (void return: unsupported-return-sort)
+ *   ToggleTransported               - LIFTED   (classified as concept:pair by bind v0; stub body)
+ *   AssertPositiveTransported       - LIFTED   (stub body)
+ *   MaybeFirstTransported           - LIFTED   (&i64 param erased to <any> by JDK error recovery; stub body)
+ *   OptionBindDoubleTransported     - LIFTED   (&i64 param erased to <any> by JDK error recovery; stub body)
+ *   SafeDivideTransported           - LIFTED   (stub body)
+ *   SafeDivideThenDoubleTransported - LIFTED   (stub body)
+ *   SwapPairTransported             - LIFTED   (stub body)
+ *   ListSumTransported              - LIFTED   (&i64 param erased to <any> by JDK error recovery; stub body)
+ *   ClassifyTransported             - LIFTED   (stub body)
+ *   RetryUntilSuccessTransported    - LIFTED   (stub body)
+ *
+ * Round-trip concept verdicts (trichotomy per transport-gap spec §0.1):
+ *
+ *   EXACT:                0 / 11 trinity concepts
+ *   REFUSE (round-trip):  11 -- stub bodies lift successfully but encode a
+ *                               different program (UnsupportedOperationException),
+ *                               not the original Rust logic. The domain of
+ *                               agreement with the source IR is empty. Per Supra
+ *                               omnia rectum this is REFUSE, not lossy.
+ *   REFUSE (lifter):      1  -- do_nothing void return refused by lifter v1 slice
+ *
+ * The distinction: the lifter succeeds on 11 methods (lift-side verdict: lifted).
+ * But the lifted IR does not reproduce the Rust-side contract-content CID for any
+ * concept (round-trip verdict: refuse). Lifting a stub is not the same as closing
+ * the round-trip.
+ */
+class TrinityRoundtripLiftTest {
+
+    private static final String RESOURCE_PATH = "/trinity-roundtrip/lib.java";
+
+    private static JavaSourceLifter.LiftResult result;
+
+    @BeforeAll
+    static void loadAndLift() throws IOException {
+        InputStream stream = TrinityRoundtripLiftTest.class.getResourceAsStream(RESOURCE_PATH);
+        if (stream == null) {
+            throw new IllegalStateException(
+                "Test resource not found: " + RESOURCE_PATH
+                + "\nExpected at: src/test/resources/trinity-roundtrip/lib.java"
+                + "\nRe-generate with: cargo run -p provekit-cli -- bind "
+                + "--root <trinity-fixture> --lang rust --target-language java "
+                + "--rewrite canonical --mode monitor --output /tmp/java-out-trinity"
+                + "\nThen copy /tmp/java-out-trinity/translated/java/lib.java to the resource path.");
+        }
+        String source = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        result = new JavaSourceLifter().liftSource("lib.java", source);
+    }
+
+    // ── lifter-side verdicts ─────────────────────────────────────────────────
+
+    @Test
+    void voidReturnIsRefused() {
+        // DoNothingTransported.do_nothing() has a void return.
+        // The lifter v1 slice refuses void-returning methods: unsupported-return-sort.
+        // This is a lifter-side REFUSE (independent of the round-trip verdict).
+        List<JavaSourceLifter.Refusal> refusals = result.refusals();
+        assertFalse(refusals.isEmpty(), "expected at least one refusal for void do_nothing()");
+        boolean foundVoidRefusal = refusals.stream()
+            .anyMatch(r -> "unsupported-return-sort".equals(r.kind())
+                && r.function() != null && r.function().contains("do_nothing"));
+        assertTrue(foundVoidRefusal,
+            "expected unsupported-return-sort refusal for do_nothing; got: " + refusals);
+    }
+
+    @Test
+    void nonVoidMethodsLiftToDeclarations() {
+        // All 11 non-void methods lift to function-contract declarations.
+        // The stub bodies (throw new UnsupportedOperationException) parse
+        // successfully; the lifter lowers them to java:throw(java:new(...)) terms.
+        Set<String> declNames = declarationFnNames();
+
+        // Scalar-param methods:
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("wrap_identity")),
+            "WrapIdentityTransported.wrap_identity should lift; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("toggle")),
+            "ToggleTransported.toggle should lift; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("assert_positive")),
+            "AssertPositiveTransported.assert_positive should lift; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("safe_divide") && !n.contains("then")),
+            "SafeDivideTransported.safe_divide should lift; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("safe_divide_then_double")),
+            "SafeDivideThenDoubleTransported.safe_divide_then_double should lift; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("swap_pair")),
+            "SwapPairTransported.swap_pair should lift; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("classify")),
+            "ClassifyTransported.classify should lift; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("retry_until_success")),
+            "RetryUntilSuccessTransported.retry_until_success should lift; got: " + declNames);
+        // &i64-param methods (lifted with <any> erasure via JDK error recovery):
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("maybe_first")),
+            "MaybeFirstTransported.maybe_first should lift with <any> erasure; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("option_bind_double")),
+            "OptionBindDoubleTransported.option_bind_double should lift with <any> erasure; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("list_sum")),
+            "ListSumTransported.list_sum should lift with <any> erasure; got: " + declNames);
+    }
+
+    @Test
+    void invalidJavaParamMethodsLiftWithErasedAnyType() {
+        // MaybeFirstTransported, OptionBindDoubleTransported, ListSumTransported have
+        // "&i64" parameter types (not valid Java). The JDK compiler's error-recovery
+        // path erases the unresolvable type to <any>. The lifter still produces
+        // declarations, with "<any>" in the erased parameter type position.
+        //
+        // Transport gap: bind-invalid-java-param-type + lift-any-erasure.
+        // The formal sort is Ref (erased) instead of the intended array sort.
+        Set<String> declNames = declarationFnNames();
+        // Confirm <any> erasure appears in the function name:
+        assertTrue(declNames.stream().anyMatch(n -> n.matches(".*maybe_first.*<any>.*")),
+            "maybe_first declaration should use <any> for erased &i64 param; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.matches(".*option_bind_double.*<any>.*")),
+            "option_bind_double declaration should use <any> for erased &i64 param; got: " + declNames);
+        assertTrue(declNames.stream().anyMatch(n -> n.matches(".*list_sum.*<any>.*")),
+            "list_sum declaration should use <any> for erased &i64 param; got: " + declNames);
+    }
+
+    @Test
+    void liftedStubBodiesContainThrowAndPanicsTerms() {
+        // All lifted methods have stub bodies: throw new UnsupportedOperationException(...)
+        // The lifter lowers this to java:throw(java:new("UnsupportedOperationException", ...))
+        // with a "panics" effect.
+        //
+        // Round-trip implication: the lifted IR captures the stub, not the original logic.
+        // This is the evidence for the round-trip REFUSE verdict on all 11 concepts.
+        String encoded = Jcs.encode(result.toJson());
+        assertTrue(encoded.contains("java:throw"),
+            "lifted declarations should contain java:throw terms from stub bodies");
+        assertTrue(encoded.contains("panics"),
+            "lifted declarations should contain panics effects from throw statements");
+        assertTrue(encoded.contains("UnsupportedOperationException"),
+            "lifted declarations should contain UnsupportedOperationException from stub bodies");
+    }
+
+    // ── round-trip verdicts ──────────────────────────────────────────────────
+
+    @Test
+    void exactRoundTripConceptCountIsZero() {
+        // transport-gap: bind-stub-body-emitted
+        //
+        // The canonical Java output has no original function bodies -- all are
+        // UnsupportedOperationException stubs. Re-lifting produces java:throw terms,
+        // not the original Rust IR. No concept achieves byte-identical IR recovery.
+        //
+        // Round-trip verdict per trichotomy (transport-gap spec §0.1):
+        //   - EXACT requires precondition=true, loss=empty. Not met: the lifted IR
+        //     does not reproduce the source contract-content CID.
+        //   - LOUDLY-BOUNDED-LOSSY requires a non-empty domain of agreement.
+        //     Stub bodies agree with the source on the empty set (the stub never
+        //     returns normally). This is total loss -- not the loudly-bounded case.
+        //   - REFUSE: the correct verdict. The round-trip cannot recover the original
+        //     logic even with characterization. Per Supra omnia rectum: refuse rather
+        //     than claim a partial correctness that does not hold.
+        //
+        // EXACT: 0 / 11 trinity concepts (load-bearing assertion for the PR).
+
+        Set<String> declNames = declarationFnNames();
+        // 11 method declarations + 1 source-unit = at least 12 total.
+        // (1 void method refused by lifter, so 11 method decls from 12 emitted classes.)
+        assertTrue(declNames.size() >= 12,
+            "expected 12 declarations (11 methods + source-unit); got " + declNames.size() + ": " + declNames);
+
+        // The lifted IR encodes stub bodies, not original logic.
+        String encoded = Jcs.encode(result.toJson());
+        assertTrue(encoded.contains("java:throw"),
+            "lifted IR should encode stub bodies as java:throw terms (not original Rust logic)");
+
+        // If any declaration's post-condition matched the Rust-side CID, that would
+        // be an exact hit. No such match exists in v0. The test's presence in the
+        // repo is the standing assertion: run it after each bind improvement to
+        // detect when exact count moves above zero.
+    }
+
+    @Test
+    void sourceUnitDeclarationAlwaysPresent() {
+        // liftSource always prepends a <source-unit:lib.java> contract.
+        Set<String> declNames = declarationFnNames();
+        assertTrue(declNames.stream().anyMatch(n -> n.contains("source-unit")),
+            "source-unit contract should always be present; got: " + declNames);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private Set<String> declarationFnNames() {
+        return result.declarations().stream()
+            .filter(d -> d instanceof Jcs.Obj obj && "function-contract".equals(obj.stringFieldOrNull("kind")))
+            .map(d -> ((Jcs.Obj) d).stringField("fnName"))
+            .collect(Collectors.toSet());
+    }
+}

--- a/implementations/java/provekit-lift-java-source/src/test/resources/trinity-roundtrip/lib.java
+++ b/implementations/java/provekit-lift-java-source/src/test/resources/trinity-roundtrip/lib.java
@@ -1,0 +1,127 @@
+// canonical rewrite: src/lib.rs -> java
+
+// substrate-origin: empty
+// @provekit_monitor(concept = "pair")
+final class WrapIdentityTransported {
+    // concept: pair
+    public static long wrap_identity(long x) {
+        throw new UnsupportedOperationException("provekit-bind canonical: pair");
+    }
+}
+
+// substrate-origin: empty
+// @provekit_monitor(concept = "unit")
+final class DoNothingTransported {
+    // concept: unit
+    public static void do_nothing() {
+        throw new UnsupportedOperationException("provekit-bind canonical: unit");
+    }
+}
+
+// substrate-origin: empty
+// @provekit_monitor(concept = "pair")
+final class ToggleTransported {
+    // concept: pair
+    public static boolean toggle(boolean flag) {
+        throw new UnsupportedOperationException("provekit-bind canonical: pair");
+    }
+}
+
+// substrate-origin: algebra-synthesis[wp_rule.guard-then-commit.v0]
+// memento-cid: blake3-512:eacde837aabf5f45507f96049d6a75b59e02aba15f574dc3adf0129186fac93b39c786632883b0bce57f42b2f945e67956c6af0bddcc58ca6a5493646904a2dc
+/* @ensures: (out >= 0) || (out == before_state) */
+// @provekit_monitor(concept = "assert")
+final class AssertPositiveTransported {
+    // concept: assert
+    public static long assert_positive(long x) {
+        throw new UnsupportedOperationException("provekit-bind canonical: assert");
+    }
+}
+
+// substrate-origin: algebra-synthesis[wp_rule.guard-then-commit.v0]
+// memento-cid: blake3-512:aea7d8b1cc3ae1d746709bfa86586c510c5deb47bfda580f74d15a7d5a8c19790a5afbe73d1c97df9ddfe69c9251fefce41fc7623f57b78524a9e2b7cc776a98
+/* @ensures: (out >= 0) || (out == before_state) */
+// @provekit_monitor(concept = "option")
+final class MaybeFirstTransported {
+    // concept: option
+    public static long maybe_first(&i64 items) {
+        throw new UnsupportedOperationException("provekit-bind canonical: option");
+    }
+}
+
+// substrate-origin: algebra-synthesis[wp_rule.guard-then-commit.v0]
+// memento-cid: blake3-512:c61acf52939267a77db043a161f9f751d74f36007c590a474640634725841132328c520467551b9e728805a8e68613f0feb1c006c7f2b4516270d1f8ef4b2e5c
+/* @ensures: (out >= 0) || (out == before_state) */
+// @provekit_monitor(concept = "option-bind")
+final class OptionBindDoubleTransported {
+    // concept: option-bind
+    public static long option_bind_double(&i64 items) {
+        throw new UnsupportedOperationException("provekit-bind canonical: option-bind");
+    }
+}
+
+// substrate-origin: algebra-synthesis[wp_rule.guard-then-commit.v0]
+// memento-cid: blake3-512:c2e867773d27b48acc2cab010ed8817ca27cc56331c161b7bab34955efeb1f5392914f4d31539a967da47ce045800d643a9be12f4799f062712f59cdda907841
+/* @ensures: (out >= 0) || (out == before_state) */
+// @provekit_monitor(concept = "result")
+final class SafeDivideTransported {
+    // concept: result
+    public static long safe_divide(long num, long denom) {
+        throw new UnsupportedOperationException("provekit-bind canonical: result");
+    }
+}
+
+// substrate-origin: algebra-synthesis[wp_rule.guard-then-commit.v0]
+// memento-cid: blake3-512:09c9e626c0679682e8acbdb25ffcacdde4a83f73572b0e943a82513e762ca564829353b216c13928bbd21a250f306cc348804ca0f711de8124f5f8fa25f967b3
+/* @ensures: (out >= 0) || (out == before_state) */
+// @provekit_monitor(concept = "result-bind")
+final class SafeDivideThenDoubleTransported {
+    // concept: result-bind
+    public static long safe_divide_then_double(long num, long denom) {
+        throw new UnsupportedOperationException("provekit-bind canonical: result-bind");
+    }
+}
+
+// substrate-origin: empty
+// @provekit_monitor(concept = "pair")
+final class SwapPairTransported {
+    // concept: pair
+    public static long swap_pair(long a, long b) {
+        throw new UnsupportedOperationException("provekit-bind canonical: pair");
+    }
+}
+
+// substrate-origin: algebra-synthesis[wp_rule.retry-with-bounded-attempts.v0]
+// memento-cid: blake3-512:2b9812643379b78b66ed6255d8dc48a638db1d2d2db459620fdd736f61e42b5ff1e5bcb9b588e0c89242a0a3d846ed75d05d2a7f8259a073e4b4190def5870d8
+/* @requires: max_attempts >= 0 */
+/* @ensures: (out == true) || (out == false) */
+// @provekit_monitor(concept = "list")
+final class ListSumTransported {
+    // concept: list
+    public static long list_sum(&i64 items) {
+        throw new UnsupportedOperationException("provekit-bind canonical: list");
+    }
+}
+
+// substrate-origin: algebra-synthesis[wp_rule.guard-then-commit.v0]
+// memento-cid: blake3-512:e128fc20e3e2eda3736094717f200892f5352d248be9d9b212b087dc279370aef3549bfbd354b3c186e133d694c7dbe4d83023cf51ec5f81c9577f66de0d200d
+/* @ensures: (out >= 0) || (out == before_state) */
+// @provekit_monitor(concept = "tagged-union")
+final class ClassifyTransported {
+    // concept: tagged-union
+    public static long classify(long x) {
+        throw new UnsupportedOperationException("provekit-bind canonical: tagged-union");
+    }
+}
+
+// substrate-origin: annotation-lift
+// memento-cid: blake3-512:2fc2de58d816dcadb9099fa622ee52a340e79a78342d0ee33693610b050d9cecf45bcb259e0f092b19858d23c0e4a54b782fa8f172b4f2e230f290d8e8ada636
+/* @requires: max_attempts > 0 */
+/* @ensures: out == true */
+// @provekit_monitor(concept = "retry-loop")
+final class RetryUntilSuccessTransported {
+    // concept: retry-loop
+    public static boolean retry_until_success(long max_attempts) {
+        throw new UnsupportedOperationException("provekit-bind canonical: retry-loop");
+    }
+}

--- a/protocol/specs/2026-05-12-trinity-java-roundtrip-transport-gaps.md
+++ b/protocol/specs/2026-05-12-trinity-java-roundtrip-transport-gaps.md
@@ -1,0 +1,220 @@
+# Trinity Round-Trip Transport Gaps: Java Leg
+
+**Date:** 2026-05-12
+**Status:** empirical finding (v0)
+**Branch:** feat/trinity-java-roundtrip
+**Companion spec:** 2026-05-14-transport-gap-and-partial-morphism-protocol.md
+**Companion test:** implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
+
+## Summary
+
+The trinity round-trip fixture (11 catalog concepts + retry-loop) was run through
+`provekit bind --rewrite=canonical --target-language=java` and the emitted Java was
+re-lifted with `provekit-lift-java-source`. This document records the per-concept
+verdicts and the gap reasons per the transport-gap spec trichotomy
+(Exact / Loudly-Bounded-Lossy / Refuse).
+
+**v0 result: 0 / 11 concepts exact.**
+
+## How the bind was run
+
+```
+cargo run -p provekit-cli --quiet -- bind \
+  --root implementations/rust/provekit-cli/tests/fixtures/trinity_roundtrip \
+  --lang rust \
+  --target-language java \
+  --rewrite canonical \
+  --mode monitor \
+  --output /tmp/java-out-trinity
+```
+
+Output: `bind: 12 bindings (7 exact / 1 lossy / 4 refused)`
+
+The bind-side verdicts (exact/lossy/refused) refer to the Rust-lift-to-concept transport,
+not the Java leg. See `/tmp/java-out-trinity/index.json` and `/tmp/java-out-trinity/gaps.json`
+for the bind-side records.
+
+## Gap 1: `bind-stub-body-emitted` (applies to all 12 bindings)
+
+**Kind:** `missing-target-construct` (v0 capability gap)
+
+**Source:** bind v0 canonical rewrite emits stub bodies for all Java classes:
+```java
+throw new UnsupportedOperationException("provekit-bind canonical: <concept>");
+```
+
+The original Rust function bodies are not translated. No term graph representing
+the source logic appears in the emitted Java.
+
+**Effect on re-lift:** The lifter successfully parses and lifts each class. The
+lifted post-condition for each function is:
+```
+eq(return_value, java:throw(java:new("UnsupportedOperationException", ...)))
+```
+with a `panics` effect. This is correct for the stub, but it does not encode the
+original concept logic. The Rust-side IR cannot be recovered.
+
+**Gap tags from bind:** `bind-stub-body-emitted` (recorded in `/tmp/java-out-trinity/gaps.json`)
+
+**Resolution option:** `deferred` -- v1 body translation would require a Java
+realizer that lowers concept IR to Java expressions. The bind-side ORP realizer
+currently emits stubs for all canonical rewrites. This is the primary gap blocking
+exact round-trip closure.
+
+## Gap 2: `&i64` parameter type not valid Java (option, option-bind, list)
+
+**Concepts affected:** `concept:option` (maybe_first), `concept:option-bind`
+(option_bind_double), `concept:list` (list_sum)
+
+**Kind:** `arity-shape-mismatch` (bind v0 emits Rust slice notation verbatim)
+
+**Source:** bind v0 emits `&i64 items` as the parameter type for slice parameters.
+This is not valid Java syntax. Example from emitted lib.java:
+```java
+public static long maybe_first(&i64 items) {
+```
+
+**Effect on re-lift:** The JDK compiler's error-recovery path processes the
+`&i64` type token as an unresolvable reference and erases it to `<any>`. The
+method IS attributed as an `ExecutableElement` and the lifter produces a
+declaration. However, the formal sort is `Ref` (erased) instead of the intended
+array sort. The lifted function name is `MaybeFirstTransported.maybe_first(<any>)`,
+not a valid Java erased name. Type information is lost.
+
+**Gap tags:** `bind-invalid-java-param-type`, `lift-any-erasure`
+
+**Resolution option:** `deferred` -- bind v0 must emit valid Java array parameters
+(`long[] items`) for slice types. This requires the Java realizer to know the
+Java representation of `&[T]` (Java array or `long[]`).
+
+## Gap 3: Concept misclassification (identity, bool-cell)
+
+**Concepts affected:** `concept:identity` (wrap_identity), `concept:bool-cell` (toggle)
+
+**Kind:** `wp-rule-mismatch` (bind v0 soft-match classification error)
+
+**Source:** bind v0 classifies both `wrap_identity` and `toggle` as `concept:pair`
+(confirmed in emitted lib.java annotations and `/tmp/java-out-trinity/index.json`).
+
+```java
+// @provekit_monitor(concept = "pair")
+final class WrapIdentityTransported {
+    // concept: pair
+    public static long wrap_identity(long x) { ... }
+}
+```
+
+The identity concept has `0 sites` in the bind output (recorded in gaps.json:
+`below-threshold: concept:identity has 0 sites`). Same for bool-cell.
+
+**Effect on re-lift:** The lifted contracts for `wrap_identity` and `toggle` carry
+the `concept:pair` annotation, not `concept:identity` / `concept:bool-cell`. Even
+if bodies were real, the round-trip IR would not match the Rust-lift IR for these
+concepts because the concept CID would differ.
+
+**Gap tags:** `bind-concept-misclassification`, `below-threshold`
+
+**Resolution option:** `deferred` -- requires bind v0 classifier improvement for
+single-parameter identity and boolean-negation patterns.
+
+## Gap 4: `do_nothing` void return (unit concept)
+
+**Concept:** `concept:unit`
+
+**Kind:** `missing-target-construct` (lifter v1 slice excludes void returns)
+
+**Source:** The emitted Java class is:
+```java
+final class DoNothingTransported {
+    public static void do_nothing() {
+        throw new UnsupportedOperationException("provekit-bind canonical: unit");
+    }
+}
+```
+
+**Effect on re-lift:** The lifter explicitly refuses void-returning methods with
+`unsupported-return-sort`. The `do_nothing` method produces a `Refusal` record,
+not a function-contract declaration.
+
+**Gap tags:** `lift-void-return-refused`, `lift-v1-slice-limitation`
+
+**Resolution option:** `deferred` -- the lifter v1 slice is value-returning only.
+Lifting `unit`-concept functions requires either a wrapper return type or an
+extension to the lifter slice to handle `void`.
+
+## Per-concept verdict table
+
+Two verdict columns: "Lifter" (what the lifter does with the emitted Java) and
+"Round-trip" (whether the lifted IR recovers the original Rust concept IR).
+
+| Concept      | Rust fn                  | Emitted class                   | Lifter verdict | Round-trip verdict | Primary gap                              |
+|--------------|--------------------------|----------------------------------|----------------|--------------------|------------------------------------------|
+| identity     | wrap_identity            | WrapIdentityTransported          | LIFTED         | REFUSE             | Gap 1 (stub body) + Gap 3 (misclassified as pair) |
+| unit         | do_nothing               | DoNothingTransported             | REFUSED        | REFUSE             | Gap 4 (void return refused by lifter)    |
+| bool-cell    | toggle                   | ToggleTransported                | LIFTED         | REFUSE             | Gap 1 (stub body) + Gap 3 (misclassified as pair) |
+| assert       | assert_positive          | AssertPositiveTransported        | LIFTED         | REFUSE             | Gap 1 (stub body)                        |
+| option       | maybe_first              | MaybeFirstTransported            | LIFTED (&any)  | REFUSE             | Gap 1 (stub body) + Gap 2 (&i64)         |
+| option-bind  | option_bind_double       | OptionBindDoubleTransported      | LIFTED (&any)  | REFUSE             | Gap 1 (stub body) + Gap 2 (&i64)         |
+| result       | safe_divide              | SafeDivideTransported            | LIFTED         | REFUSE             | Gap 1 (stub body)                        |
+| result-bind  | safe_divide_then_double  | SafeDivideThenDoubleTransported  | LIFTED         | REFUSE             | Gap 1 (stub body)                        |
+| pair         | swap_pair                | SwapPairTransported              | LIFTED         | REFUSE             | Gap 1 (stub body)                        |
+| list         | list_sum                 | ListSumTransported               | LIFTED (&any)  | REFUSE             | Gap 1 (stub body) + Gap 2 (&i64)         |
+| tagged-union | classify                 | ClassifyTransported              | LIFTED         | REFUSE             | Gap 1 (stub body)                        |
+| retry-loop   | retry_until_success      | RetryUntilSuccessTransported     | LIFTED         | REFUSE             | Gap 1 (stub body)                        |
+
+Note: retry-loop is the 12th binding (not one of the 11 trinity concepts). Included for completeness.
+
+**Round-trip EXACT: 0 / 11 trinity concepts.**
+**Round-trip REFUSE: 11 (stub bodies lift but do not recover original Rust IR; see below)**
+**Lifter REFUSE: 1 (do_nothing: void return refused by lifter v1 slice)**
+
+### Why REFUSE and not LOUDLY-BOUNDED-LOSSY for stub bodies
+
+Per transport-gap spec §0.1, LOUDLY-BOUNDED-LOSSY is the legitimate case when the
+transformation is "correct *except* on a precisely-characterized failure set" --
+i.e., there is a non-empty domain of agreement.
+
+Stub bodies (`throw new UnsupportedOperationException(...)`) agree with the source
+Rust logic on the **empty set**: the stub never returns normally, so no input
+witnesses agreement. The domain-of-agreement is empty. This is total loss, not
+bounded loss. Per Supra omnia rectum, REFUSE is the honest verdict.
+
+The distinction: LOUDLY-BOUNDED-LOSSY would mean "we know where it is wrong and we
+ship the bridge anyway." REFUSE means "we cannot characterize a domain where it is
+right." Gap 1 is in the second category until the bind realizer emits real bodies.
+
+### What the lifted IR does capture (non-zero recoverable information)
+
+The round-trip is not entirely without value. Each lifted method's post-condition is:
+```
+post: eq(return_value, java:throw(java:new("UnsupportedOperationException", "provekit-bind canonical: <concept>")))
+effects: [panics]
+```
+
+The recoverable information from the round-trip:
+1. Function signature (parameter names and types, modulo &i64 erasure for slice params)
+2. Class name (e.g. `MaybeFirstTransported`)
+3. Concept annotation (from `@provekit_monitor` comment -- parsed as a comment, not a declaration)
+4. Memento-CID comment (for algebra-synthesis origin classes; the CID is in the comment)
+
+The original Rust function bodies are absent. No concept logic is preserved.
+
+## What closes the gaps
+
+All four gaps are upstream of the lifter. The lifter correctly processes the
+emitted Java. The path to exact round-trip is:
+
+1. **Gap 1 (stub bodies):** Implement a Java body realizer in the bind pipeline
+   that lowers concept IR to Java expressions. This is the primary v1 milestone.
+
+2. **Gap 2 (&i64 params):** Fix bind v0 to emit `long[]` (or `List<Long>`) for
+   slice parameters instead of `&i64`.
+
+3. **Gap 3 (misclassification):** Fix bind v0 classifier for identity and bool-cell
+   single-parameter patterns.
+
+4. **Gap 4 (void lift):** Extend the lifter v1 slice to handle void-returning
+   methods (or emit a return type wrapper for unit-concept functions).
+
+Gaps 2, 3, 4 are individually closeable; Gap 1 is the high-value milestone.
+None of these require changes to the realizer pipeline or the trinity fixture.


### PR DESCRIPTION
## Summary

- Runs `provekit bind --rewrite=canonical --target-language=java` against the trinity round-trip fixture (11 concepts + retry-loop), re-lifts the emitted Java with `provekit-lift-java-source`, and records honest per-concept verdicts per the transport-gap spec trichotomy.
- v0 result: **0 / 11 concepts exact.** All 11 round-trip verdicts are REFUSE (not loudly-bounded-lossy), because bind v0 emits stub bodies whose domain-of-agreement with the original Rust IR is empty.
- Four gaps documented in `protocol/specs/2026-05-12-trinity-java-roundtrip-transport-gaps.md`.

## New files

- `TrinityRoundtripLiftTest.java` -- 6 empirical JUnit tests against the snapshotted bind output. All pass standalone (no `/tmp` dependency). Test evidence: the lifter lifts 11/12 classes; `do_nothing` is lifter-refused (void return); `maybe_first`/`option_bind_double`/`list_sum` lift with `<any>` erasure due to `&i64` params.
- `src/test/resources/trinity-roundtrip/lib.java` -- snapshotted bind output so the tests are sealed regressions.
- `protocol/specs/2026-05-12-trinity-java-roundtrip-transport-gaps.md` -- per-concept verdict table + four gap records with resolution options.

## Per-concept verdict table (round-trip)

| Concept | Round-trip verdict | Primary gap |
|---|---|---|
| identity | REFUSE | Gap 1 (stub body) + Gap 3 (misclassified as pair) |
| unit | REFUSE | Gap 4 (void return refused by lifter) |
| bool-cell | REFUSE | Gap 1 (stub body) + Gap 3 (misclassified as pair) |
| assert | REFUSE | Gap 1 (stub body) |
| option | REFUSE | Gap 1 (stub body) + Gap 2 (&i64 erasure) |
| option-bind | REFUSE | Gap 1 (stub body) + Gap 2 (&i64 erasure) |
| result | REFUSE | Gap 1 (stub body) |
| result-bind | REFUSE | Gap 1 (stub body) |
| pair | REFUSE | Gap 1 (stub body) |
| list | REFUSE | Gap 1 (stub body) + Gap 2 (&i64 erasure) |
| tagged-union | REFUSE | Gap 1 (stub body) |

**EXACT: 0 / 11**

## Why REFUSE and not LOUDLY-BOUNDED-LOSSY

Per transport-gap spec §0.1, LOUDLY-BOUNDED-LOSSY requires a non-empty domain of agreement. Stub bodies (`throw new UnsupportedOperationException(...)`) agree with the source Rust logic on the empty set -- no input witnesses agreement. Per Supra omnia rectum, REFUSE is the honest verdict for total loss.

## Constraints respected

- `cmd_bind.rs`, `cmd_transport.rs`, realizer pipeline: not modified
- Trinity fixture (`fixtures/trinity_roundtrip/src/lib.rs`): not modified
- `trinity_roundtrip_test.rs`: not modified (passes: `cargo test -p provekit-cli --test trinity_roundtrip_test` = 1 passed)

## Test plan

- [ ] `mvn test -pl provekit-lift-java-source` -- 14 tests pass (5 existing + 2 existing + 6 new + 1 existing RPC = 14)
- [ ] `cargo test -p provekit-cli --test trinity_roundtrip_test` -- 1 test passes
- [ ] Read `protocol/specs/2026-05-12-trinity-java-roundtrip-transport-gaps.md` per-concept table