### PR TITLE
docs(readme): add federation-by-construction section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,52 @@ carried across languages, repositories, package ecosystems, commits, and time.
 The contracts were often already in your code; ProvekIt turns them into
 accountable edges the rest of the graph must satisfy.
 
+## Federation by Construction
+
+A substrate that promises portable correctness has to answer how it scales
+without drowning. Every prior framework that tried to cover many languages,
+many checkers, many proof obligations, and many target runtimes ran into the
+same wall: each new dimension multiplied the surface that had to be built,
+audited, and trusted. M sources times N targets times K checkers times L
+sugars is unbounded. ProvekIt is structured so that wall is never met.
+
+Each semantic axis collapses through the same hub topology. Languages do not
+translate to each other; they translate to and from canonical operation CIDs.
+Lifters do not bind to specific provers; they emit ProofIR and the discharge
+portfolio chooses. Loss functions do not bind to specific transports; they
+rank candidate transformations by content-addressed loss records. The cost of
+extending the substrate is linear in the number of plugged-in components, not
+quadratic in the number of pairs they could connect.
+
+| Axis | What plugs in |
+| --- | --- |
+| Source languages | Lifters that emit terms over canonical operation CIDs |
+| Target runtimes | Realizers that consume terms and emit per-target source |
+| Sugar dictionaries | JSON files or JSON-RPC plugins per host idiom (Spring, JML, JUnit, ...) |
+| Loss functions | JSON files or JSON-RPC plugins that rank candidate transformations |
+| Discharge backends | Solver portfolios that close obligations into signed receipts |
+| Effect signatures | Catalogs that name the side effects an op is permitted to admit |
+| Concept catalogs | Federated stores of canonical operation and abstraction CIDs |
+
+Every plug is content-addressed. Every plug is byte-deterministic. The
+`provekit` binary is the protocol implementation; the protocol is the set of
+plugins currently loaded; the loaded set is itself a content-addressed object
+any audit can replay. Two installations that load the same plugin set produce
+the same receipts. Two installations that load different plugin sets disagree
+by exactly the loss records their plugins emit, and the disagreement is itself
+addressable.
+
+The substrate grows by being used. A new sugar dictionary published as a JSON
+file becomes a citable artifact the moment something runs against it. A new
+lifter for an unsupported language extends coverage the moment it discharges
+its first obligation cleanly. A new loss function published with a fidelity
+receipt becomes a lens any caller can adopt. The hub is the public good and
+the spokes are the contributions; use is publication.
+
+That externalization is tracked end to end in [#732](https://github.com/TSavo/provekit/issues/732),
+which enumerates the surfaces being moved out of the binary and into
+content-addressed federable mementos.
+
 ## I want to...
 
 | | |


### PR DESCRIPTION
## What

Adds a `## Federation by Construction` section to the top-level README, between `## Canonical Truth` (ends line 109) and `## I want to...` (was line 111).

## Why

The README currently explains *why* `k(I)=t` claims matter (proofchain, three correctness layers, ProofIR as canonical truth) but does not explain *how* the architecture scales without the combinatorial drowning that buried every prior verification framework. Sir flagged the gap directly 2026-05-12: the M+N collapse plus catalog-grows-by-running thesis is not anywhere in the README.

## What the new section covers

Four load-bearing claims, in order:

1. **The M+N collapse on every axis.** Not just M sources × N targets. M loss functions × N rankings, M sugar dicts × N languages, M lifters × N runtimes, M concept catalogs × N teams. All linear in the number of plugged-in components, not quadratic in the pairs.
2. **Every semantic decision externalized** as content-addressed federable plugins (sugar dicts, loss functions, lifters, realizers, discharge backends, effect signatures, concept catalogs). The `provekit` binary is the protocol implementation; the protocol is the plugin set.
3. **Byte-determinism is the federation guarantee.** Two installs with the same plugin set produce the same receipts; two with different sets disagree by exactly the loss records their plugins emit, addressably.
4. **The catalog grows by running.** Use is publication.

## Citation

[#732](https://github.com/TSavo/provekit/issues/732) (plugin protocol umbrella) is cited once at the end as concrete in-flight evidence that the architecture is being built out, not aspirational.

## Constraints honored

- 417 words in the section body (target was 300-500, sweet spot 380-420).
- No em-dashes or en-dashes anywhere.
- No "you / your / imagine / consider / we believe" addressing.
- One small table for the axis-collapse pattern, matching the style of the existing `I want to...` table.
- Present-tense factual voice, matching `Canonical Truth`.
- No Schneier / Cypherpunk lineage references in body (those belong in the papers, not the public README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)