### PR TITLE
feat(760-slice2): Java realize plugin + java-canonical.json + byte-identical trinity test

### DIFF
--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/JsonUtil.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/JsonUtil.java
@@ -1,5 +1,8 @@
 package com.provekit.realize;
 
+import java.util.ArrayList;
+import java.util.List;
+
 final class JsonUtil {
     private JsonUtil() {}
 
@@ -98,5 +101,99 @@ final class JsonUtil {
 
     static String extractMethod(String json) {
         return decodeJsonStringField(json, "method");
+    }
+
+    /**
+     * Extract the JSON-RPC "params" value as a raw substring.
+     * Handles the case where "params" is a JSON object {...}.
+     * Returns the object content (including braces), or "{}" if not found.
+     */
+    static String extractParamsObject(String json) {
+        String key = "\"params\"";
+        int ki = json.indexOf(key);
+        if (ki < 0) return "{}";
+        int pos = ki + key.length();
+        while (pos < json.length()
+            && (json.charAt(pos) == ':' || json.charAt(pos) == ' ' || json.charAt(pos) == '\t')) {
+            pos++;
+        }
+        if (pos >= json.length() || json.charAt(pos) != '{') return "{}";
+        // Find the matching closing brace.
+        int depth = 0;
+        int start = pos;
+        while (pos < json.length()) {
+            char c = json.charAt(pos);
+            if (c == '{') depth++;
+            else if (c == '}') {
+                depth--;
+                if (depth == 0) { pos++; break; }
+            } else if (c == '"') {
+                // skip string content
+                pos++;
+                while (pos < json.length()) {
+                    char sc = json.charAt(pos);
+                    if (sc == '\\') { pos += 2; continue; }
+                    if (sc == '"') break;
+                    pos++;
+                }
+            }
+            pos++;
+        }
+        return json.substring(start, pos);
+    }
+
+    /**
+     * Decode a JSON array of strings from the given field name.
+     * Handles flat one-level arrays of quoted strings only.
+     * Returns an empty list if the field is missing or not an array.
+     */
+    static List<String> decodeJsonStringArray(String json, String field) {
+        String key = "\"" + field + "\"";
+        int ki = json.indexOf(key);
+        if (ki < 0) return List.of();
+        int pos = ki + key.length();
+        while (pos < json.length()
+            && (json.charAt(pos) == ':' || json.charAt(pos) == ' ' || json.charAt(pos) == '\t')) {
+            pos++;
+        }
+        if (pos >= json.length() || json.charAt(pos) != '[') return List.of();
+        pos++; // skip '['
+
+        List<String> result = new ArrayList<>();
+        while (pos < json.length() && json.charAt(pos) != ']') {
+            char c = json.charAt(pos);
+            if (c == '"') {
+                // parse quoted string
+                pos++;
+                StringBuilder sb = new StringBuilder();
+                while (pos < json.length()) {
+                    char ch = json.charAt(pos);
+                    if (ch == '"') { pos++; break; }
+                    if (ch == '\\') {
+                        pos++;
+                        if (pos < json.length()) {
+                            char esc = json.charAt(pos);
+                            switch (esc) {
+                                case '"' -> sb.append('"');
+                                case '\\' -> sb.append('\\');
+                                case 'n' -> sb.append('\n');
+                                case 'r' -> sb.append('\r');
+                                case 't' -> sb.append('\t');
+                                default -> sb.append(esc);
+                            }
+                        }
+                    } else {
+                        sb.append(ch);
+                    }
+                    pos++;
+                }
+                result.add(sb.toString());
+            } else if (c == ',' || c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+                pos++;
+            } else {
+                pos++;
+            }
+        }
+        return result;
     }
 }

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -4,8 +4,16 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class RpcServer {
+    // PEP 1.7.0 sugar plugin CID for java-canonical.
+    // Computed by compute_plugin_cid() over the java-canonical.json content.
+    // Update this value if java-canonical.json content changes.
+    static final String PLUGIN_CID =
+        "blake3-512:b7ad1160f00d892d310fb33ac3372a4ebb2f89fec563cab1719e7006ab3d7593aae2162b882aedbec1b97e44957240b3c7e8ab1675456f0539c4ad3f45d22a7b";
+
     private final BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
     private final PrintWriter out = new PrintWriter(System.out, true);
     private final JavaNullBoundaryRealizer realizer = new JavaNullBoundaryRealizer();
@@ -27,6 +35,17 @@ public final class RpcServer {
         String method = JsonUtil.extractMethod(line);
         try {
             switch (method) {
+                // PEP 1.7.0 methods
+                case "provekit.plugin.describe" -> sendResponse(id, describeResult());
+                case "provekit.plugin.invoke" -> {
+                    String source = handleInvoke(line);
+                    sendResponse(id, "{\"source\":" + JsonUtil.quoted(source) + "}");
+                }
+                case "provekit.plugin.shutdown" -> {
+                    sendResponse(id, "null");
+                    System.exit(0);
+                }
+                // ORP v1 methods (backward compatibility)
                 case "initialize" -> sendResponse(id, initResult());
                 case "realize" -> {
                     RealizerPlan plan = RealizerPlan.fromJsonLine(line);
@@ -40,8 +59,83 @@ public final class RpcServer {
                 default -> sendError(id, -32601, "unknown method: " + method);
             }
         } catch (Exception e) {
-            sendError(id, -32000, e.getMessage());
+            sendError(id, -32000, e.getMessage() != null ? e.getMessage() : e.getClass().getName());
         }
+    }
+
+    /**
+     * Handle provekit.plugin.invoke.
+     *
+     * Params (from the JSON-RPC request "params" object):
+     *   function      - snake_case function name
+     *   params        - JSON array of parameter name strings
+     *   param_types   - JSON array of source-language type strings
+     *   return_type   - source-language return type string
+     *   concept_name  - concept binding name for annotation + stub body
+     *
+     * Returns: Java stub source string.
+     */
+    private String handleInvoke(String line) {
+        // Extract the inner params object to avoid ambiguity with the RPC "params" key.
+        String paramsObj = JsonUtil.extractParamsObject(line);
+        String function = JsonUtil.decodeJsonStringField(paramsObj, "function");
+        String returnType = JsonUtil.decodeJsonStringField(paramsObj, "return_type");
+        String conceptName = JsonUtil.decodeJsonStringField(paramsObj, "concept_name");
+        List<String> params = JsonUtil.decodeJsonStringArray(paramsObj, "params");
+        List<String> paramTypes = JsonUtil.decodeJsonStringArray(paramsObj, "param_types");
+        return SugarRealizer.emitStub(function, params, paramTypes, returnType, conceptName);
+    }
+
+    /**
+     * PEP 1.7.0 provekit.plugin.describe result.
+     *
+     * Returns the java-canonical sugar plugin memento (without envelope/metadata;
+     * those are loader-level fields). The result IS the plugin memento body per §4.2.1.
+     */
+    private String describeResult() {
+        // The content payload mirrors java-canonical.json header.content.
+        // The CID is pre-computed and matches the fixture file.
+        return "{"
+            + "\"envelope\":{"
+            + "\"declaredAt\":\"2026-05-12T00:00:00.000Z\","
+            + "\"signature\":\"ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\","
+            + "\"signer\":\"ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\""
+            + "},"
+            + "\"header\":{"
+            + "\"cid\":" + JsonUtil.quoted(PLUGIN_CID) + ","
+            + "\"content\":" + contentJson() + ","
+            + "\"critical\":false,"
+            + "\"kind\":\"sugar\","
+            + "\"protocol_versions\":[\"pep/1.7.0\"],"
+            + "\"provenance_cid\":\"blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\","
+            + "\"schemaVersion\":\"1\","
+            + "\"version\":\"1.0.0\""
+            + "},"
+            + "\"metadata\":{"
+            + "\"note\":\"Canonical Java annotation sugar dict for ProvekIt contract clause rendering.\","
+            + "\"source_url\":\"menagerie/java-language-signature/specs/sugar/java-canonical.json\""
+            + "}"
+            + "}";
+    }
+
+    /**
+     * Returns the JSON-serialized content payload for the java-canonical sugar dict.
+     * Must be byte-identical to java-canonical.json header.content.
+     */
+    private String contentJson() {
+        return "{"
+            + "\"entries\":["
+            + "{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-method\",\"template\":\"// @requires(${lhs} > ${rhs})\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"predicate_pattern\":{\"args\":[{\"args\":[],\"head\":\"var\",\"name\":\"${lhs}\"},{\"args\":[],\"head\":\"var\",\"name\":\"${rhs}\"}],\"head\":\"gt\"}},"
+            + "{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-method\",\"template\":\"// @requires(${lhs} >= ${rhs})\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"predicate_pattern\":{\"args\":[{\"args\":[],\"head\":\"var\",\"name\":\"${lhs}\"},{\"args\":[],\"head\":\"var\",\"name\":\"${rhs}\"}],\"head\":\"ge\"}},"
+            + "{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-method\",\"template\":\"// @requires(${lhs} < ${rhs})\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"predicate_pattern\":{\"args\":[{\"args\":[],\"head\":\"var\",\"name\":\"${lhs}\"},{\"args\":[],\"head\":\"var\",\"name\":\"${rhs}\"}],\"head\":\"lt\"}},"
+            + "{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-method\",\"template\":\"// @requires(${lhs} <= ${rhs})\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"predicate_pattern\":{\"args\":[{\"args\":[],\"head\":\"var\",\"name\":\"${lhs}\"},{\"args\":[],\"head\":\"var\",\"name\":\"${rhs}\"}],\"head\":\"le\"}},"
+            + "{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-method\",\"template\":\"// @requires(${lhs} == ${rhs})\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"predicate_pattern\":{\"args\":[{\"args\":[],\"head\":\"var\",\"name\":\"${lhs}\"},{\"args\":[],\"head\":\"var\",\"name\":\"${rhs}\"}],\"head\":\"eq\"}},"
+            + "{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-method\",\"template\":\"// @ensures(${lhs} > ${rhs})\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"predicate_pattern\":{\"args\":[{\"args\":[],\"head\":\"var\",\"name\":\"${lhs}\"},{\"args\":[],\"head\":\"var\",\"name\":\"${rhs}\"}],\"head\":\"ensures_gt\"}},"
+            + "{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-method\",\"template\":\"// @ensures(${lhs} == ${rhs})\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"predicate_pattern\":{\"args\":[{\"args\":[],\"head\":\"var\",\"name\":\"${lhs}\"},{\"args\":[],\"head\":\"var\",\"name\":\"${rhs}\"}],\"head\":\"ensures_eq\"}}"
+            + "],"
+            + "\"sugar_name\":\"canonical\","
+            + "\"target_language\":\"java\""
+            + "}";
     }
 
     private String initResult() {

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -1,0 +1,106 @@
+package com.provekit.realize;
+
+import java.util.List;
+
+/**
+ * Emits a canonical Java stub method wrapped in a per-function class.
+ *
+ * Mirrors cmd_transport.rs `realize_function` for TargetStyle::Java with
+ * is_stub=true (the bind path where no term graph is available yet).
+ *
+ * Output format (per cmd_transport.rs Java branch):
+ * <pre>
+ * final class {PascalFn}Transported {
+ *     // concept: {conceptName}
+ *     public static {returnType} {function}({typedParams}) {
+ *         throw new UnsupportedOperationException("provekit-bind canonical: {conceptName}");
+ *     }
+ * }
+ * </pre>
+ *
+ * Slice 2: contract annotations (requires/ensures) are NOT emitted here;
+ * those require contract lifting from source, which is out of scope for
+ * the stub path.
+ */
+final class SugarRealizer {
+
+    /**
+     * Emit a Java stub for a single function.
+     *
+     * @param function    Rust snake_case function name (e.g. "wrap_identity")
+     * @param params      Parameter names in order (e.g. ["x"])
+     * @param paramTypes  Source-language (Rust) type strings (e.g. ["i64"])
+     * @param returnType  Source-language return type string (e.g. "i64")
+     * @param conceptName Concept binding name (e.g. "UNNAMED-CONCEPT-a777b12569a16b07")
+     * @return Java source string, byte-identical to realize_for_bind("java", ...)
+     */
+    static String emitStub(
+            String function,
+            List<String> params,
+            List<String> paramTypes,
+            String returnType,
+            String conceptName) {
+
+        String className = snakeToPascal(function) + "Transported";
+        String mappedReturn = mapSourceType(returnType);
+
+        StringBuilder typedParamList = new StringBuilder();
+        for (int i = 0; i < params.size(); i++) {
+            String name = params.get(i);
+            String srcType = i < paramTypes.size() ? paramTypes.get(i) : "i64";
+            String mapped = mapSourceType(srcType);
+            if (i > 0) typedParamList.append(", ");
+            typedParamList.append(mapped).append(" ").append(name);
+        }
+
+        // annotation_prefix for Java: top_indent = "    "
+        String annotationPrefix = "    // concept: " + conceptName + "\n";
+
+        // stub body: 8 spaces indent
+        String stubBody = "        throw new UnsupportedOperationException(\"provekit-bind canonical: " + conceptName + "\");\n";
+
+        // Format matches cmd_transport.rs line 1474-1476:
+        // "final class {class_name} {{\n{annotation_prefix}    public static {mapped_return} {function}({typed_param_list}) {{\n{body_str}    }}\n}}\n"
+        return "final class " + className + " {\n"
+                + annotationPrefix
+                + "    public static " + mappedReturn + " " + function + "(" + typedParamList + ") {\n"
+                + stubBody
+                + "    }\n"
+                + "}\n";
+    }
+
+    /**
+     * Map a Rust source type to the Java equivalent.
+     *
+     * Mirrors cmd_transport.rs map_source_type for TargetStyle::Java.
+     */
+    static String mapSourceType(String src) {
+        return switch (src) {
+            case "()" -> "void";
+            case "i64", "u64" -> "long";
+            case "i32", "u32" -> "int";
+            case "i16", "u16" -> "short";
+            case "i8", "u8" -> "byte";
+            case "f64" -> "double";
+            case "f32" -> "float";
+            case "bool" -> "boolean";
+            case "String", "&str", "&String" -> "String";
+            default -> src;
+        };
+    }
+
+    /**
+     * Convert snake_case to PascalCase.
+     *
+     * Mirrors cmd_transport.rs snake_to_pascal_local.
+     */
+    static String snakeToPascal(String s) {
+        StringBuilder sb = new StringBuilder();
+        for (String part : s.split("_", -1)) {
+            if (part.isEmpty()) continue;
+            sb.append(Character.toUpperCase(part.charAt(0)));
+            if (part.length() > 1) sb.append(part.substring(1));
+        }
+        return sb.toString();
+    }
+}

--- a/implementations/rust/provekit-cli/Cargo.toml
+++ b/implementations/rust/provekit-cli/Cargo.toml
@@ -10,6 +10,10 @@ description = "ProvekIt user-facing CLI: prove / verify / hash / dump / search /
 name = "provekit"
 path = "src/main.rs"
 
+[lib]
+name = "provekit_cli"
+path = "src/lib.rs"
+
 [dependencies]
 # Workspace-internal libs.
 provekit-canonicalizer = { path = "../provekit-canonicalizer" }

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -60,7 +60,7 @@ struct StageReport {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum TransportCliError {
+pub enum TransportCliError {
     #[error("Refusal: {0}")]
     Refusal(String),
     #[error("{0}")]
@@ -888,7 +888,7 @@ fn parse_int_params(source: &str, function: &str) -> Option<Vec<String>> {
 /// strings (as written in the source) and return_type is the return type
 /// string.  Falls back to ("i64", "i64") defaults if syn parsing fails or the
 /// function cannot be found.
-fn parse_rust_fn_types(source: &str, function: &str) -> (Vec<String>, String) {
+pub fn parse_rust_fn_types(source: &str, function: &str) -> (Vec<String>, String) {
     let Ok(file) = syn::parse_file(source) else {
         return (Vec::new(), "i64".to_string());
     };
@@ -1247,9 +1247,9 @@ fn emit_annotation_prefix(
 }
 
 #[derive(Debug)]
-pub(crate) struct RealizedSource {
-    pub(crate) extension: &'static str,
-    pub(crate) source: String,
+pub struct RealizedSource {
+    pub extension: &'static str,
+    pub source: String,
 }
 
 /// Public-crate bridge for `cmd_bind`'s canonical-mode path.
@@ -1264,7 +1264,7 @@ pub(crate) struct RealizedSource {
 ///
 /// Returns a `RealizedSource` on success. The `source` field carries the
 /// full target-language snippet including the ORP annotation prefix.
-pub(crate) fn realize_for_bind(
+pub fn realize_for_bind(
     language: &str,
     function: &str,
     params: &[String],

--- a/implementations/rust/provekit-cli/src/lib.rs
+++ b/implementations/rust/provekit-cli/src/lib.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-cli library root.
+//
+// Exposes selected internal modules for integration-test access.
+// The binary (src/main.rs) is the full CLI; this lib target provides
+// the pub surface for test crates that need to call internal functions
+// (e.g. realize_for_bind in the slice2 byte-identical integration test).
+//
+// Only the modules needed by integration tests are declared here.
+// Adding a module here does NOT automatically add it to the CLI binary;
+// main.rs has its own module list.
+
+use clap::Parser;
+
+/// Exit codes used across subcommands.
+pub const EXIT_OK: u8 = 0;
+pub const EXIT_VERIFY_FAIL: u8 = 1;
+pub const EXIT_USER_ERROR: u8 = 2;
+pub const EXIT_SOLVER_FAIL: u8 = 3;
+
+/// Common output flags. Each subcommand embeds these so users can pass
+/// `--json` / `--quiet` after the subcommand name.
+#[derive(Parser, Debug, Clone, Default)]
+pub struct OutputFlags {
+    /// Emit structured JSON instead of human-readable text.
+    #[arg(long, global = true)]
+    pub json: bool,
+    /// Suppress non-error output.
+    #[arg(long, global = true)]
+    pub quiet: bool,
+}
+
+pub mod cmd_transport;

--- a/implementations/rust/provekit-cli/tests/slice2_java_realize_plugin_byte_identical.rs
+++ b/implementations/rust/provekit-cli/tests/slice2_java_realize_plugin_byte_identical.rs
@@ -24,6 +24,7 @@
 use std::io::{BufRead, BufReader, Write as IoWrite};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::{Mutex, OnceLock};
 
 use provekit_cli::cmd_transport::realize_for_bind;
 
@@ -43,15 +44,52 @@ fn java_jar() -> PathBuf {
         .join("../../java/provekit-realize-java-core/target/provekit-realize-java.jar")
 }
 
-/// Send one provekit.plugin.invoke RPC to the Java plugin and return the source string.
-fn java_invoke(function: &str, params: &[&str], param_types: &[&str], return_type: &str, concept_name: &str) -> String {
+/// Serializes the one-time Maven build across parallel test threads.
+/// The `OnceLock` holds a `Mutex<()>` so that the first thread to arrive
+/// grabs the lock, runs `mvn package`, and releases it. Every subsequent
+/// thread acquires and immediately releases (jar already present).
+static JAR_BUILD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Build the Java realize jar via Maven if it is not already present.
+/// Thread-safe: concurrent callers block until the single build finishes.
+/// Panics only if the jar is still missing after the build attempt.
+fn ensure_jar_built() {
+    let mtx = JAR_BUILD_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = mtx.lock().unwrap_or_else(|p| p.into_inner());
+
     let jar = java_jar();
+    if jar.exists() {
+        return;
+    }
+
+    let java_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../java");
+
+    let status = Command::new("mvn")
+        .args(["package", "-pl", "provekit-realize-java-core", "-am", "-DskipTests"])
+        .current_dir(&java_dir)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn mvn: {e}"));
+
+    if !status.success() {
+        panic!(
+            "mvn package failed (exit {status}); cannot build {jar}",
+            jar = jar.display()
+        );
+    }
+
     if !jar.exists() {
         panic!(
-            "java jar not found at {}; build with: mvn package -pl provekit-realize-java-core -am",
+            "java jar still not found at {} after mvn package",
             jar.display()
         );
     }
+}
+
+/// Send one provekit.plugin.invoke RPC to the Java plugin and return the source string.
+fn java_invoke(function: &str, params: &[&str], param_types: &[&str], return_type: &str, concept_name: &str) -> String {
+    ensure_jar_built();
+    let jar = java_jar();
 
     let params_json: String = params
         .iter()
@@ -222,13 +260,8 @@ fn trinity_retry_until_success_byte_identical() {
 #[test]
 fn pep_describe_returns_valid_sugar_plugin() {
     use provekit_plugin_loader::load_plugin_from_rpc;
+    ensure_jar_built();
     let jar = java_jar();
-    if !jar.exists() {
-        panic!(
-            "java jar not found at {}; build with: mvn package -pl provekit-realize-java-core -am",
-            jar.display()
-        );
-    }
     let endpoint = format!("stdio:java -jar {} --rpc", jar.display());
     let plugin = load_plugin_from_rpc(&endpoint)
         .unwrap_or_else(|e| panic!("load_plugin_from_rpc failed: {e}"));

--- a/implementations/rust/provekit-cli/tests/slice2_java_realize_plugin_byte_identical.rs
+++ b/implementations/rust/provekit-cli/tests/slice2_java_realize_plugin_byte_identical.rs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Slice 2 of #760 — Trinity byte-identical assertion:
+//   Java RPC plugin (provekit.plugin.invoke) MUST produce byte-identical
+//   Java source to Rust's realize_for_bind("java", ...) for all 11 trinity
+//   fixture functions.
+//
+// The bind path uses Term::Unit (no term graph yet), so every function
+// becomes a compilable stub: a final class wrapping a static method that
+// throws UnsupportedOperationException.
+//
+// Test structure per function:
+//   1. Call realize_for_bind("java", ...) → rust_src
+//   2. Send provekit.plugin.invoke to the Java RPC server → java_src
+//   3. Assert rust_src == java_src (byte-identical)
+//
+// §6.2 (PEP 1.7.0): CID is delivery-independent; the content hash of the
+// stub source MUST be identical whether produced by the Rust path or the
+// Java plugin path.
+//
+// Constraint: does NOT modify trinity_roundtrip_test.rs or its fixtures.
+// Does NOT remove cmd_transport.rs Java match arms.
+
+use std::io::{BufRead, BufReader, Write as IoWrite};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use provekit_cli::cmd_transport::realize_for_bind;
+
+/// Trinity fixture source file.
+fn trinity_src() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/trinity_roundtrip/src/lib.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read trinity fixture: {e}"))
+}
+
+/// Path to the Java realize jar (built by Maven).
+fn java_jar() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // Relative to provekit-cli crate: ../../java/provekit-realize-java-core/target/...
+    manifest
+        .join("../../java/provekit-realize-java-core/target/provekit-realize-java.jar")
+}
+
+/// Send one provekit.plugin.invoke RPC to the Java plugin and return the source string.
+fn java_invoke(function: &str, params: &[&str], param_types: &[&str], return_type: &str, concept_name: &str) -> String {
+    let jar = java_jar();
+    if !jar.exists() {
+        panic!(
+            "java jar not found at {}; build with: mvn package -pl provekit-realize-java-core -am",
+            jar.display()
+        );
+    }
+
+    let params_json: String = params
+        .iter()
+        .map(|s| format!("{:?}", s))
+        .collect::<Vec<_>>()
+        .join(",");
+    let param_types_json: String = param_types
+        .iter()
+        .map(|s| format!("{:?}", s))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let request = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"provekit.plugin.invoke","params":{{"function":{fn_q},"params":[{params_json}],"param_types":[{param_types_json}],"return_type":{ret_q},"concept_name":{concept_q}}}}}"#,
+        fn_q = format!("{:?}", function),
+        params_json = params_json,
+        param_types_json = param_types_json,
+        ret_q = format!("{:?}", return_type),
+        concept_q = format!("{:?}", concept_name),
+    );
+
+    let mut child = Command::new("java")
+        .args(["-jar", jar.to_str().unwrap(), "--rpc"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn java jar");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        stdin.write_all(request.as_bytes()).expect("write request");
+        stdin.write_all(b"\n").expect("write newline");
+    }
+
+    let stdout = child.stdout.take().expect("stdout");
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read response");
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    // Parse: {"jsonrpc":"2.0","id":1,"result":{"source":"..."}}
+    let v: serde_json::Value = serde_json::from_str(line.trim())
+        .unwrap_or_else(|e| panic!("java response not valid JSON: {e}\nraw: {line}"));
+    if let Some(err) = v.get("error") {
+        panic!("java plugin invoke returned error: {err}");
+    }
+    v["result"]["source"]
+        .as_str()
+        .unwrap_or_else(|| panic!("missing result.source in java response\nraw: {line}"))
+        .to_string()
+}
+
+/// Run one byte-identical assertion: Rust realize_for_bind vs Java plugin.
+fn assert_byte_identical(
+    function: &str,
+    params: &[&str],
+    source_text: &str,
+    concept_name: &str,
+) {
+    let param_strings: Vec<String> = params.iter().map(|s| s.to_string()).collect();
+
+    let rust_result = realize_for_bind("java", function, &param_strings, source_text, concept_name)
+        .unwrap_or_else(|e| panic!("realize_for_bind failed for {function}: {e}"));
+    let rust_src = &rust_result.source;
+
+    // Extract param_types from what realize_for_bind used internally.
+    // parse_rust_fn_types is pub so we can call it directly.
+    let (param_types, return_type) = provekit_cli::cmd_transport::parse_rust_fn_types(source_text, function);
+    let param_type_strs: Vec<&str> = param_types.iter().map(String::as_str).collect();
+
+    let java_src = java_invoke(function, params, &param_type_strs, &return_type, concept_name);
+
+    assert_eq!(
+        rust_src,
+        &java_src,
+        "byte-identical failure for {function}\n\
+         Rust output:\n{rust_src}\n\
+         Java output:\n{java_src}"
+    );
+}
+
+// Use a single concept name for all stub functions (bind path with Term::Unit).
+const CONCEPT: &str = "UNNAMED-CONCEPT-a777b12569a16b07";
+
+#[test]
+fn trinity_wrap_identity_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("wrap_identity", &["x"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_do_nothing_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("do_nothing", &[], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_toggle_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("toggle", &["flag"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_assert_positive_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("assert_positive", &["x"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_maybe_first_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("maybe_first", &["items"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_option_bind_double_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("option_bind_double", &["items"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_safe_divide_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("safe_divide", &["num", "denom"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_safe_divide_then_double_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("safe_divide_then_double", &["num", "denom"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_swap_pair_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("swap_pair", &["a", "b"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_list_sum_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("list_sum", &["items"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_classify_byte_identical() {
+    let src = trinity_src();
+    assert_byte_identical("classify", &["x"], &src, CONCEPT);
+}
+
+#[test]
+fn trinity_retry_until_success_byte_identical() {
+    let src = trinity_src();
+    // retry_until_success has #[requires] and #[ensures] annotations.
+    // realize_for_bind lifts these from the source text; the Java plugin
+    // does not receive annotation contracts in the invoke params (slice 2
+    // scope: stub path only). This test verifies that the stub body and
+    // signature are byte-identical; annotation divergence is documented
+    // as an in-scope gap for slice 3.
+    assert_byte_identical("retry_until_success", &["max_attempts"], &src, CONCEPT);
+}
+
+/// §4: Load the Java plugin via PEP 1.7.0 provekit.plugin.describe.
+/// The CID in the response must match the pinned java-canonical.json CID.
+#[test]
+fn pep_describe_returns_valid_sugar_plugin() {
+    use provekit_plugin_loader::load_plugin_from_rpc;
+    let jar = java_jar();
+    if !jar.exists() {
+        panic!(
+            "java jar not found at {}; build with: mvn package -pl provekit-realize-java-core -am",
+            jar.display()
+        );
+    }
+    let endpoint = format!("stdio:java -jar {} --rpc", jar.display());
+    let plugin = load_plugin_from_rpc(&endpoint)
+        .unwrap_or_else(|e| panic!("load_plugin_from_rpc failed: {e}"));
+
+    assert_eq!(plugin.kind(), "sugar", "plugin kind must be 'sugar'");
+    assert_eq!(
+        plugin.cid(),
+        "blake3-512:b7ad1160f00d892d310fb33ac3372a4ebb2f89fec563cab1719e7006ab3d7593aae2162b882aedbec1b97e44957240b3c7e8ab1675456f0539c4ad3f45d22a7b",
+        "java-canonical plugin CID must match pinned value"
+    );
+    assert!(!plugin.is_critical(), "java-canonical sugar is not critical");
+    assert!(
+        plugin.header.protocol_versions.contains(&"pep/1.7.0".to_string()),
+        "java-canonical must declare pep/1.7.0"
+    );
+}

--- a/implementations/rust/provekit-plugin-loader/src/cid.rs
+++ b/implementations/rust/provekit-plugin-loader/src/cid.rs
@@ -213,4 +213,5 @@ mod tests {
         assert_eq!(c1, c2);
         assert!(c1.starts_with("blake3-512:"));
     }
+
 }

--- a/implementations/rust/provekit-plugin-loader/tests/integration.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/integration.rs
@@ -153,6 +153,27 @@ fn registry_memento_includes_loaded_cid() {
 }
 
 // ---------------------------------------------------------------------------
+// java-canonical.json: file-load CID pin
+// ---------------------------------------------------------------------------
+
+#[test]
+fn java_canonical_sugar_file_load_pinned_cid() {
+    // §6.1 byte-stability: the java-canonical.json file must load cleanly and
+    // produce the pinned CID. If the content changes, the CID changes and this
+    // test catches the drift.
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../menagerie/java-language-signature/specs/sugar/java-canonical.json");
+    let plugin = load_plugin_from_file(&path).expect("should load java-canonical.json");
+    assert_eq!(
+        plugin.cid(),
+        "blake3-512:b7ad1160f00d892d310fb33ac3372a4ebb2f89fec563cab1719e7006ab3d7593aae2162b882aedbec1b97e44957240b3c7e8ab1675456f0539c4ad3f45d22a7b",
+        "java-canonical.json CID must match pinned value"
+    );
+    assert_eq!(plugin.kind(), "sugar");
+    assert!(!plugin.is_critical());
+}
+
+// ---------------------------------------------------------------------------
 // §4: JSON-RPC stdio interface
 // ---------------------------------------------------------------------------
 

--- a/menagerie/java-language-signature/specs/sugar/java-canonical.json
+++ b/menagerie/java-language-signature/specs/sugar/java-canonical.json
@@ -1,0 +1,152 @@
+{
+  "envelope": {
+    "declaredAt": "2026-05-12T00:00:00.000Z",
+    "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "header": {
+    "cid": "blake3-512:b7ad1160f00d892d310fb33ac3372a4ebb2f89fec563cab1719e7006ab3d7593aae2162b882aedbec1b97e44957240b3c7e8ab1675456f0539c4ad3f45d22a7b",
+    "content": {
+      "entries": [
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "// @requires(${lhs} > ${rhs})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "gt"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "// @requires(${lhs} >= ${rhs})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "ge"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "// @requires(${lhs} < ${rhs})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "lt"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "// @requires(${lhs} <= ${rhs})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "le"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "// @requires(${lhs} == ${rhs})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "eq"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "// @ensures(${lhs} > ${rhs})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "ensures_gt"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "// @ensures(${lhs} == ${rhs})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "ensures_eq"
+          }
+        }
+      ],
+      "sugar_name": "canonical",
+      "target_language": "java"
+    },
+    "critical": false,
+    "kind": "sugar",
+    "protocol_versions": ["pep/1.7.0"],
+    "provenance_cid": "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "schemaVersion": "1",
+    "version": "1.0.0"
+  },
+  "metadata": {
+    "note": "Canonical Java annotation sugar dict for ProvekIt contract clause rendering. Migrated from cmd_transport.rs Java match arms.",
+    "source_url": "menagerie/java-language-signature/specs/sugar/java-canonical.json"
+  }
+}


### PR DESCRIPTION
## Summary

- **java-canonical.json**: New sugar dict (`kind=sugar`, `pep/1.7.0`) at `menagerie/java-language-signature/specs/sugar/java-canonical.json` with 7 entries covering Java annotation rendering patterns. Pinned CID locked in integration test.
- **Java plugin (PEP 1.7.0)**: `RpcServer.java` gains `provekit.plugin.describe` and `provekit.plugin.invoke` handlers. `SugarRealizer.java` implements stub emission byte-identical to the Rust `realize_for_bind("java",...)` path. ORP v1 handlers preserved.
- **Rust integration test**: `slice2_java_realize_plugin_byte_identical.rs` — 13 tests asserting byte-identical Java stub output between Rust and Java paths for all 11 trinity functions plus 1 PEP describe CID pin. All 13 pass.

## Constraints honored

- `cmd_transport.rs` Java match arms NOT removed
- `trinity_roundtrip_test.rs` NOT touched
- No three-axis convergence claimed
- `provekit-plugin-loader` integration test gains `java_canonical_sugar_file_load_pinned_cid` (9th test)

## Supporting changes

- `realize_for_bind`, `parse_rust_fn_types`, `RealizedSource`, `TransportCliError` made `pub` (was `pub(crate)`) for integration-test access
- `provekit-cli` gains a `[lib]` target (`src/lib.rs`) re-exporting `cmd_transport`

## Test plan

- [x] `cargo test -p provekit-cli --test slice2_java_realize_plugin_byte_identical` — 13/13 pass
- [x] `cargo test -p provekit-plugin-loader` — 9/9 pass (was 8)
- [x] `cargo test -p provekit-cli --test cmd_bind_integration` — 27/27 pass
- [x] `cargo test -p provekit-cli` — all suites green except pre-existing `polyglot_smoke::test_daemon_polyglot_smoke` (linkerd socket, unrelated)

Closes slice 2 of #760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PEP 1.7.0 plugin RPC protocol support for Java with describe and invoke capabilities
  * Introduced Java stub code generation for function signatures
  * Added canonical Java language specification for annotation-sugar plugin

* **Tests**
  * Added comprehensive integration tests verifying Java-Rust plugin interoperability
  * Added plugin loader verification tests

* **Refactor**
  * Restructured CLI as a library with shared exit codes and output configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/761)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->