### PR TITLE
fix(bind): route site_indices by bucket_key, drop 2 trinity loss-records (7→5)

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -556,12 +556,23 @@ fn run_bind_engine(
         }
     }
 
-    // shape -> concept idx lookup
+    // shape -> concept idx lookup.
+    //
+    // NOTE on bucket-key vs shape-cid collisions: when two distinct concepts
+    // (different bucket_keys, e.g. different `// concept: X` annotations) share
+    // the same term-shape CID, this map can only hold ONE concept per shape.
+    // Before this fix, the second loop below used shape_to_concept blindly, so a
+    // later-registered concept could steal site_indices that belonged to an
+    // annotated function (concept:identity / concept:bool-cell were observed at
+    // 0 sites in the trinity fixture, triggering "below-threshold" gaps). The
+    // second loop now resolves concept_idx by the same bucket_key the first
+    // loop used (annotation > catalog > shape), and only falls back to this map
+    // when no key match exists.
     let mut shape_to_concept: BTreeMap<String, usize> = BTreeMap::new();
     for (ci, c) in concepts.iter().enumerate() {
-        shape_to_concept.insert(c.shape_cid.clone(), ci);
+        shape_to_concept.entry(c.shape_cid.clone()).or_insert(ci);
         for alias in &c.shape_cid_aliases {
-            shape_to_concept.insert(alias.clone(), ci);
+            shape_to_concept.entry(alias.clone()).or_insert(ci);
         }
     }
 
@@ -583,8 +594,21 @@ fn run_bind_engine(
 
     for lift in &raw_lifts {
         let shape_cid = lift.term_shape.shape_cid();
-        let concept_idx = *shape_to_concept
-            .get(&shape_cid)
+        // Re-derive bucket_key with the same priority the first loop used so we
+        // route THIS lift to the concept its annotation/catalog match created,
+        // not whichever concept happens to currently own its shape_cid in
+        // shape_to_concept.
+        let matched_catalog = catalog.match_shape(&shape_cid, &lift.term_shape);
+        let bucket_key = if let Some(human) = lift.concept_annotation.as_ref() {
+            format!("human:{human}")
+        } else if let Some(c) = matched_catalog {
+            format!("catalog:{}", c.id)
+        } else {
+            format!("shape:{shape_cid}")
+        };
+        let concept_idx = *key_to_concept_idx
+            .get(&bucket_key)
+            .or_else(|| shape_to_concept.get(&shape_cid))
             .expect("shape was clustered");
 
         // Contract origin priority: attribute > test > algebra-synthesis > empty.


### PR DESCRIPTION
## Summary

Bucket-key collision in `cmd_bind.rs`'s site-attribution loop was zeroing `concept:identity` and `concept:bool-cell`. Fixing it drops two `below-threshold` loss-records from the trinity round-trip verdict (7→5).

## Root cause

`shape_to_concept: BTreeMap<shape_cid, concept_idx>` was built with plain `insert()`, so when two concepts shared a shape, the LATER one's mapping overwrote the earlier. The second-pass loop then routed every lift with that shape to the wrong concept, leaving the original empty.

## Fix

1. `shape_to_concept` is now built with `entry().or_insert()` — first concept to claim a shape wins, deterministic with the cluster loop's insertion order.
2. Second loop re-derives the same `bucket_key` priority (`annotation > catalog > shape`) the first loop used and looks up `key_to_concept_idx` directly, falling back to `shape_to_concept` only when no key match exists.

## Empirical verification

**Before** (Rust→Java leg on the trinity fixture):
```
bind: top concepts:
  concept:pair: 3 site(s)
  [concept:identity, concept:bool-cell absent — 0 sites in gaps.json]

trinity_round_trip: 7 loss entries including
  [below-threshold] concept:identity has 0 site(s)
  [below-threshold] concept:bool-cell has 0 site(s)
```

**After**:
```
bind: top concepts:
  concept:identity: 1 site(s)
  concept:unit: 1 site(s)
  concept:bool-cell: 1 site(s)
  [...10 named concepts, sum = 12 bindings]

trinity_round_trip: 5 loss entries — below-threshold gone.
```

## Tests

- `trinity_roundtrip_test`: PASS, verdict drops 7→5 entries.
- `cmd_bind_integration`: 27/27 PASS.
- All other `provekit-cli` test groups: 29 + 114 + 15 + 13 + 27 + 1 + 2 + 19 + 4 = 224 PASS.
- Pre-existing `test_daemon_polyglot_smoke` failure (missing `provekit-linkerd` binary, documented in #759/#761 PR bodies) unrelated and unaffected.

## Why this matters

The two below-threshold gaps were the only loss-records caused by an actual classifier bug — not by substrate limits. The other five (`bind-stub-body-emitted`, `v0-capability-gap`×2, `source-language-not-supported`, `leg-3-not-reached`) are genuine deferred-to-v1 limits and remain honestly recorded. Branch 2 LBL stays first-class; Branch 1 (byte-identical exact trinity) is closer to achievable now that 2/7 loss-dims are eliminated.

Tracked as task #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the bind engine's collision handling for scenarios where multiple distinct concepts share shape characteristics. The binding process now correctly preserves individual concept identity during clustering and assignment, preventing incorrect concept attribution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/764)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->