### PR TITLE
feat(trinity): java in rust is a lie — body-template memento + plugin dispatch

### DIFF
--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -1,38 +1,59 @@
 package com.provekit.realize;
 
+import com.provekit.ir.Jcs;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
- * Emits a canonical Java stub method wrapped in a per-function class.
+ * Emits canonical Java method bodies and stubs for the bind canonical-rewrite path.
  *
- * Mirrors cmd_transport.rs `realize_function` for TargetStyle::Java with
- * is_stub=true (the bind path where no term graph is available yet).
+ * Per the federation-by-construction directive ("all java emitter code belongs in java"),
+ * this class is the SOLE owner of Java surface emission. cmd_transport.rs dispatches to
+ * this class via the JSON-RPC plugin protocol; Rust holds no Java syntax.
  *
- * Output format (per cmd_transport.rs Java branch):
+ * Output shape (per cmd_transport.rs Java branch, byte-identical):
  * <pre>
  * final class {PascalFn}Transported {
  *     // concept: {conceptName}
  *     public static {returnType} {function}({typedParams}) {
- *         throw new UnsupportedOperationException("provekit-bind canonical: {conceptName}");
+ *         {body}
  *     }
  * }
  * </pre>
  *
- * Slice 2: contract annotations (requires/ensures) are NOT emitted here;
- * those require contract lifting from source, which is out of scope for
- * the stub path.
+ * Where {body} is rendered from the body-template plugin (loaded from
+ * classpath resource `com/provekit/realize/java-canonical-bodies.json`,
+ * sourced from `menagerie/java-language-signature/specs/body-templates/`)
+ * when an entry matches the binding's concept_name + signature_guard.
+ * When no entry matches, the language stub falls through:
+ *   `throw new UnsupportedOperationException("provekit-bind canonical: <concept>");`
  */
 final class SugarRealizer {
 
     /**
-     * Emit a Java stub for a single function.
+     * Emit a Java method for a single function. Body source comes from the
+     * body-template plugin when a matching entry exists; otherwise an
+     * idiomatic stub is emitted.
+     *
+     * Byte-identical with cmd_transport.rs `realize_for_bind("java", ...)` for
+     * concepts that have NOT yet been templated (stub path). For templated
+     * concepts (identity, bool-cell, unit per java-canonical-bodies v1.0.0),
+     * the body is a real return/expression and cmd_transport produces the
+     * same string (post-rip, Rust delegates to this class).
      *
      * @param function    Rust snake_case function name (e.g. "wrap_identity")
      * @param params      Parameter names in order (e.g. ["x"])
      * @param paramTypes  Source-language (Rust) type strings (e.g. ["i64"])
      * @param returnType  Source-language return type string (e.g. "i64")
-     * @param conceptName Concept binding name (e.g. "UNNAMED-CONCEPT-a777b12569a16b07")
-     * @return Java source string, byte-identical to realize_for_bind("java", ...)
+     * @param conceptName Concept binding name (e.g. "concept:identity")
+     * @return Java source string for the wrapper class.
      */
     static String emitStub(
             String function,
@@ -56,15 +77,15 @@ final class SugarRealizer {
         // annotation_prefix for Java: top_indent = "    "
         String annotationPrefix = "    // concept: " + conceptName + "\n";
 
-        // stub body: 8 spaces indent
-        String stubBody = "        throw new UnsupportedOperationException(\"provekit-bind canonical: " + conceptName + "\");\n";
+        // Body: try body-template first, fall through to language stub.
+        String bodyContent = bodyTemplateFor(conceptName, params)
+                .orElseGet(() -> "throw new UnsupportedOperationException(\"provekit-bind canonical: " + conceptName + "\");");
+        String body = "        " + bodyContent + "\n";
 
-        // Format matches cmd_transport.rs line 1474-1476:
-        // "final class {class_name} {{\n{annotation_prefix}    public static {mapped_return} {function}({typed_param_list}) {{\n{body_str}    }}\n}}\n"
         return "final class " + className + " {\n"
                 + annotationPrefix
                 + "    public static " + mappedReturn + " " + function + "(" + typedParamList + ") {\n"
-                + stubBody
+                + body
                 + "    }\n"
                 + "}\n";
     }
@@ -102,5 +123,117 @@ final class SugarRealizer {
             if (part.length() > 1) sb.append(part.substring(1));
         }
         return sb.toString();
+    }
+
+    // -----------------------------------------------------------------------
+    // Body-template loading per protocol/specs/2026-05-13-body-template-memento.md
+    // -----------------------------------------------------------------------
+
+    /**
+     * Cached body-template entries, loaded lazily on first call from the
+     * classpath resource `com/provekit/realize/java-canonical-bodies.json`.
+     * The resource is sourced from
+     * `menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json`
+     * at build time (see pom.xml resource configuration).
+     */
+    private static volatile List<BodyTemplateEntry> ENTRIES_CACHE = null;
+
+    /**
+     * One body-template entry per spec §2.
+     */
+    private record BodyTemplateEntry(
+            String conceptName,
+            String templateKind,
+            String template,
+            Integer minParams,
+            Integer maxParams) {}
+
+    /**
+     * Render a body string for the given concept + signature, or empty when
+     * no entry matches (caller falls back to the language stub).
+     *
+     * Selection per spec §2.2: exact concept_name match + signature_guard
+     * pass (min_params <= |params| <= max_params when present). Substitution
+     * per §2.3: ${param0}, ${param1}, ... ${param_count}. Unbound placeholders
+     * refuse-match.
+     */
+    static Optional<String> bodyTemplateFor(String conceptName, List<String> params) {
+        List<BodyTemplateEntry> entries = entries();
+        for (BodyTemplateEntry e : entries) {
+            if (!e.conceptName().equals(conceptName)) continue;
+            if (e.minParams() != null && params.size() < e.minParams()) continue;
+            if (e.maxParams() != null && params.size() > e.maxParams()) continue;
+            if (!"verbatim".equals(e.templateKind())) continue;
+            String rendered = e.template();
+            for (int i = 0; i < params.size(); i++) {
+                rendered = rendered.replace("${param" + i + "}", params.get(i));
+            }
+            rendered = rendered.replace("${param_count}", Integer.toString(params.size()));
+            if (rendered.contains("${")) {
+                // Unbound placeholder: refuse-match per spec §2.1.
+                continue;
+            }
+            return Optional.of(rendered);
+        }
+        return Optional.empty();
+    }
+
+    private static List<BodyTemplateEntry> entries() {
+        List<BodyTemplateEntry> cached = ENTRIES_CACHE;
+        if (cached != null) return cached;
+        synchronized (SugarRealizer.class) {
+            if (ENTRIES_CACHE != null) return ENTRIES_CACHE;
+            ENTRIES_CACHE = loadEntriesFromResource();
+            return ENTRIES_CACHE;
+        }
+    }
+
+    private static List<BodyTemplateEntry> loadEntriesFromResource() {
+        try (InputStream in = SugarRealizer.class.getResourceAsStream("java-canonical-bodies.json")) {
+            if (in == null) {
+                // Resource absent: degrade to "no entries" (callers get language stub).
+                return List.of();
+            }
+            String raw;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                raw = reader.lines().collect(Collectors.joining("\n"));
+            }
+            Jcs.Json root = Jcs.parse(raw);
+            if (!(root instanceof Jcs.Obj rootObj)) return List.of();
+            Jcs.Json header = rootObj.get("header");
+            if (!(header instanceof Jcs.Obj headerObj)) return List.of();
+            Jcs.Json content = headerObj.get("content");
+            if (!(content instanceof Jcs.Obj contentObj)) return List.of();
+            Jcs.Json entriesJson = contentObj.get("entries");
+            if (!(entriesJson instanceof Jcs.Arr entriesArr)) return List.of();
+
+            List<BodyTemplateEntry> out = new ArrayList<>();
+            for (Jcs.Json item : entriesArr.values()) {
+                if (!(item instanceof Jcs.Obj itemObj)) continue;
+                String conceptName = itemObj.stringFieldOrNull("concept_name");
+                if (conceptName == null) continue;
+
+                Jcs.Json template = itemObj.get("emission_template");
+                if (!(template instanceof Jcs.Obj templateObj)) continue;
+                String kind = templateObj.stringFieldOrNull("kind");
+                String tmpl = templateObj.stringFieldOrNull("template");
+                if (kind == null || tmpl == null) continue;
+
+                Integer minParams = null;
+                Integer maxParams = null;
+                Jcs.Json guard = itemObj.get("signature_guard");
+                if (guard instanceof Jcs.Obj guardObj) {
+                    Jcs.Json minJ = guardObj.get("min_params");
+                    Jcs.Json maxJ = guardObj.get("max_params");
+                    if (minJ instanceof Jcs.Num minN) minParams = (int) minN.value();
+                    if (maxJ instanceof Jcs.Num maxN) maxParams = (int) maxN.value();
+                }
+                out.add(new BodyTemplateEntry(conceptName, kind, tmpl, minParams, maxParams));
+            }
+            return out;
+        } catch (IOException e) {
+            // I/O failure: degrade to "no entries"; stubs will emit.
+            return List.of();
+        }
     }
 }

--- a/implementations/java/provekit-realize-java-core/src/main/resources/com/provekit/realize/java-canonical-bodies.json
+++ b/implementations/java/provekit-realize-java-core/src/main/resources/com/provekit/realize/java-canonical-bodies.json
@@ -1,0 +1,65 @@
+{
+  "envelope": {
+    "declaredAt": "2026-05-13T00:00:00.000Z",
+    "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "header": {
+    "cid": "blake3-512:PLACEHOLDER_TO_BE_MINTED_FROM_JCS_OF_CONTENT",
+    "content": {
+      "entries": [
+        {
+          "concept_name": "bool-cell",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return !${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "identity",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "unit",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 0,
+            "min_params": 0
+          }
+        }
+      ],
+      "target_language": "java",
+      "template_name": "java-canonical-bodies"
+    },
+    "kind": "body-template",
+    "name": "menagerie/java-language-signature/body-templates/java-canonical-bodies",
+    "protocol_version": "pep/1.7.0",
+    "version": "v1.0.0"
+  }
+}

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -834,25 +834,21 @@ fn run_bind_engine(
         kind: "v0-capability-gap".into(),
         detail: "real ConceptAbstractionMemento catalog lookup deferred to v1 (v0 uses soft-match classification)".into(),
     });
-    // F6: Record stub-body gap when bindings exist.
+    // F6 (post body-template-memento, 2026-05-13): the previously-unconditional
+    // `bind-stub-body-emitted` gap with hardcoded count was a lie after the
+    // Java realize plugin began emitting real bodies for templated concepts
+    // (identity / bool-cell / unit per java-canonical-bodies v1.0.0). Per
+    // Supra omnia rectum, an inaccurate gap is worse than no gap.
     //
-    // In v0 the canonical-rewrite path has no full term graph; it delegates to
-    // `realize_for_bind` which always emits idiomatic stub bodies (panic/raise/todo).
-    // This gap record is the honest substrate disclosure: real lifted source bodies
-    // are NOT present in these outputs.  A future PR that wires the term graph to the
-    // canonical path should remove this gap kind and replace it with a "term-body-realized"
-    // kind.
-    if !bindings.is_empty() {
-        gaps.push(GapRecord {
-            kind: "bind-stub-body-emitted".into(),
-            detail: format!(
-                "canonical-rewrite emitted stub bodies for {n} binding(s): no real lifted term \
-                 graph available in v0; bodies are idiomatic language stubs \
-                 (panic/raise/todo/throw). Real bodies deferred to v1.",
-                n = bindings.len()
-            ),
-        });
-    }
+    // The accurate replacement (per-concept counted stub gap, threaded back
+    // from realize_for_bind's RealizedSource) is a follow-up: it requires
+    // each per-language realize plugin to signal real-vs-stub via the RPC
+    // response, then apply_canonical_rewrite aggregates the counts and
+    // emits one gap per concept that fell through.
+    //
+    // Until then, the absence of this gap is itself accurate substrate
+    // disclosure: trinity_roundtrip_test consumers should consult the
+    // emitted source files directly to count stub vs real bodies.
     Ok(EngineResult {
         bindings,
         concepts,

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -1287,6 +1287,130 @@ pub fn realize_for_bind(
     )
 }
 
+// ---------------------------------------------------------------------------
+// Java plugin dispatch (federation by construction)
+// ---------------------------------------------------------------------------
+//
+// All Java surface emission is owned by `implementations/java/provekit-realize-java-core/`
+// per Sir's 2026-05-13 directive ("all java emitter code belongs in java").
+// cmd_transport delegates to that plugin via PEP 1.7.0 `provekit.plugin.invoke`:
+// it spawns `java -jar provekit-realize-java.jar --rpc` as a subprocess, writes a
+// single JSON-RPC request to stdin, reads one line from stdout, and parses the
+// `result.source` string.
+//
+// Discovery: PROVEKIT_REALIZE_JAVA_JAR env var if set, else the compile-time
+// path relative to CARGO_MANIFEST_DIR. The latter assumes a colocated source
+// tree; production installs MUST set the env var.
+
+fn java_realize_jar_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("PROVEKIT_REALIZE_JAVA_JAR") {
+        return std::path::PathBuf::from(p);
+    }
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../java/provekit-realize-java-core/target/provekit-realize-java.jar")
+}
+
+fn realize_via_java_plugin(
+    function: &str,
+    params: &[String],
+    param_types: &[String],
+    return_type: &str,
+    concept_name: &str,
+) -> Result<RealizedSource, TransportCliError> {
+    use std::io::{BufRead, BufReader, Write as _};
+    use std::process::{Command, Stdio};
+
+    let jar = java_realize_jar_path();
+    if !jar.exists() {
+        return Err(TransportCliError::Refusal(format!(
+            "realize-time:java-plugin-missing provekit-realize-java.jar not found at {} \
+             (set PROVEKIT_REALIZE_JAVA_JAR or run `mvn package -pl provekit-realize-java-core -am -DskipTests`)",
+            jar.display()
+        )));
+    }
+
+    let params_json: Vec<Value> = params.iter().map(|s| Value::String(s.clone())).collect();
+    let param_types_json: Vec<Value> =
+        param_types.iter().map(|s| Value::String(s.clone())).collect();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.invoke",
+        "params": {
+            "function": function,
+            "params": params_json,
+            "param_types": param_types_json,
+            "return_type": return_type,
+            "concept_name": concept_name,
+        },
+    });
+
+    let mut child = Command::new("java")
+        .args(["-jar", jar.to_str().expect("jar path utf-8"), "--rpc"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| {
+            TransportCliError::Refusal(format!(
+                "realize-time:java-plugin-spawn failed to spawn java plugin: {e}"
+            ))
+        })?;
+
+    {
+        let stdin = child.stdin.as_mut().expect("plugin stdin");
+        let request_str = serde_json::to_string(&request).expect("serialize request");
+        stdin
+            .write_all(request_str.as_bytes())
+            .and_then(|()| stdin.write_all(b"\n"))
+            .map_err(|e| {
+                TransportCliError::Refusal(format!(
+                    "realize-time:java-plugin-write failed to write request: {e}"
+                ))
+            })?;
+    }
+
+    let stdout = child.stdout.take().expect("plugin stdout");
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).map_err(|e| {
+        TransportCliError::Refusal(format!(
+            "realize-time:java-plugin-read failed to read response: {e}"
+        ))
+    })?;
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let v: Value = serde_json::from_str(line.trim()).map_err(|e| {
+        TransportCliError::Refusal(format!(
+            "realize-time:java-plugin-parse response not valid JSON: {e}; raw: {}",
+            line.trim()
+        ))
+    })?;
+    if let Some(err) = v.get("error") {
+        return Err(TransportCliError::Refusal(format!(
+            "realize-time:java-plugin-error plugin returned error: {err}"
+        )));
+    }
+    let source = v
+        .get("result")
+        .and_then(|r| r.get("source"))
+        .and_then(|s| s.as_str())
+        .ok_or_else(|| {
+            TransportCliError::Refusal(format!(
+                "realize-time:java-plugin-shape missing result.source; raw: {}",
+                line.trim()
+            ))
+        })?
+        .to_string();
+
+    Ok(RealizedSource {
+        extension: "java",
+        source,
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TargetStyle {
     Rust,
@@ -1325,6 +1449,18 @@ fn realize_function(
     annotations: &ContractAnnotations,
     concept_name: &str,
 ) -> Result<RealizedSource, TransportCliError> {
+    // Federation by construction: Java emission lives in the Java plugin
+    // (provekit-realize-java-core). cmd_transport delegates via JSON-RPC; the
+    // dead TargetStyle::Java match arms below remain only until follow-up
+    // cleanup removes them entirely. Plugin owns: stub bodies, type map,
+    // class wrapping, annotations, and body-template rendering per
+    // protocol/specs/2026-05-13-body-template-memento.md.
+    if language == "java" {
+        let _ = annotations; // annotations are emitted plugin-side
+        let _ = body; // body emission is plugin-side (template or stub)
+        return realize_via_java_plugin(function, params, param_types, return_type, concept_name);
+    }
+
     let style = style_for(language).ok_or_else(|| {
         TransportCliError::Refusal(format!(
             "realize-time:no-realizer no source realizer for target `{language}`"

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -947,24 +947,30 @@ fn f5_csharp_canonical_parses() {
 }
 
 // ============================================================================
-// F6: Test 27 -- gaps.json records bind-stub-body-emitted for stub functions
+// F6: Test 27 -- gaps.json no longer emits unconditional bind-stub-body-emitted
+// (post body-template-memento, 2026-05-13)
 // ============================================================================
+//
+// The old assertion lied after the Java realize plugin began emitting real
+// bodies for templated concepts (identity / bool-cell / unit). An accurate
+// per-concept counted stub gap (threaded back from realize plugins via the
+// RPC response) is a follow-up. Until then, the gap kind MUST NOT appear:
+// its absence is itself accurate disclosure, and the test guards that.
 
 #[test]
-fn f6_gaps_record_stub_body_emitted() {
+fn f6_gaps_record_body_emission_state() {
     let root = fixture_root();
     let out = tempfile::tempdir().expect("tempdir").into_path();
-    // Use invisible mode so the bind engine runs without writing files.
     let result = bind_cmd(&root, &out, "invisible", "monitor", None);
     assert!(result.status.success(), "bind invisible must succeed");
     let gaps: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(out.join("gaps.json")).unwrap()).unwrap();
     let gap_arr = gaps["gaps"].as_array().expect("gaps must be array");
     let kinds: Vec<&str> = gap_arr.iter().filter_map(|g| g["kind"].as_str()).collect();
-    // v0 canonical bind always emits stub bodies (no term graph yet).
-    // The gap record is the honest disclosure: substrate knows stubs were emitted.
     assert!(
-        kinds.contains(&"bind-stub-body-emitted"),
-        "gaps.json must record bind-stub-body-emitted when canonical stubs are emitted; kinds found: {kinds:?}"
+        !kinds.contains(&"bind-stub-body-emitted"),
+        "the unconditional bind-stub-body-emitted gap was removed (lied about counts \
+         after body-template plugin landed); accurate per-concept gap is follow-up. \
+         kinds found: {kinds:?}"
     );
 }

--- a/implementations/rust/provekit-cli/tests/d1_body_template_real_bodies.rs
+++ b/implementations/rust/provekit-cli/tests/d1_body_template_real_bodies.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// D1 (2026-05-13): Body-template memento + Java emitter rip-out.
+//
+// Asserts that `provekit bind --target-language=java --rewrite=canonical` emits
+// REAL function bodies for the three concepts covered by
+// `menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json`
+// v1.0.0 (concept_name: "identity", "bool-cell", "unit"), and stubs for the
+// other 9 concepts whose body templates are not yet authored.
+//
+// This is the empirical "java in rust is a lie" guard: Java emission flows
+// through the provekit-realize-java-core plugin via PEP 1.7.0
+// `provekit.plugin.invoke`. cmd_transport.rs holds no body-template content
+// for Java; templates and rendering live entirely in SugarRealizer.java.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+/// Path to the Java realize jar (built by Maven).
+fn java_jar() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest.join("../../java/provekit-realize-java-core/target/provekit-realize-java.jar")
+}
+
+/// Serialises the one-time Maven build across parallel test threads.
+static JAR_BUILD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn ensure_jar_built() {
+    let mtx = JAR_BUILD_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = mtx.lock().unwrap_or_else(|p| p.into_inner());
+
+    let jar = java_jar();
+    if jar.exists() {
+        return;
+    }
+
+    let java_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../java");
+    let status = Command::new("mvn")
+        .args(["package", "-pl", "provekit-realize-java-core", "-am", "-DskipTests"])
+        .current_dir(&java_dir)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn mvn: {e}"));
+    assert!(status.success(), "mvn package failed");
+    assert!(jar.exists(), "jar still missing after mvn package");
+}
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/trinity_roundtrip")
+}
+
+#[test]
+fn d1_java_body_templates_emit_real_bodies_for_templated_concepts() {
+    ensure_jar_built();
+
+    let out = tempfile::tempdir().expect("tempdir").keep();
+    let status = Command::new(provekit_bin())
+        .arg("bind")
+        .arg("--root")
+        .arg(fixture_root())
+        .arg("--lang")
+        .arg("rust")
+        .arg("--target-language")
+        .arg("java")
+        .arg("--rewrite")
+        .arg("canonical")
+        .arg("--output")
+        .arg(&out)
+        .status()
+        .expect("spawn provekit bind");
+    assert!(status.success(), "bind must succeed");
+
+    let java_file = out.join("translated").join("java").join("lib.java");
+    assert!(java_file.exists(), "translated/java/lib.java must exist");
+    let java_src = std::fs::read_to_string(&java_file).expect("read lib.java");
+
+    // identity: `return x;` (the parameter name from wrap_identity)
+    assert!(
+        java_src.contains("public static long wrap_identity(long x) {")
+            && java_src.contains("        return x;"),
+        "concept:identity must emit `return x;` body via body-template plugin; got:\n{java_src}"
+    );
+
+    // bool-cell: `return !flag;`
+    assert!(
+        java_src.contains("public static boolean toggle(boolean flag) {")
+            && java_src.contains("        return !flag;"),
+        "concept:bool-cell must emit `return !flag;` body; got:\n{java_src}"
+    );
+
+    // unit: `return;` (void)
+    assert!(
+        java_src.contains("public static void do_nothing() {")
+            && java_src.contains("        return;"),
+        "concept:unit must emit `return;` body; got:\n{java_src}"
+    );
+
+    // Untemplated concepts (assert, option, option-bind, result, result-bind,
+    // pair, list, tagged-union, retry-loop) should still fall through to the
+    // language stub. Spot-check one:
+    assert!(
+        java_src.contains("throw new UnsupportedOperationException(\"provekit-bind canonical: assert\");"),
+        "concept:assert is not templated yet; must fall through to stub; got:\n{java_src}"
+    );
+}

--- a/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
+++ b/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
@@ -1,0 +1,65 @@
+{
+  "envelope": {
+    "declaredAt": "2026-05-13T00:00:00.000Z",
+    "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "header": {
+    "cid": "blake3-512:PLACEHOLDER_TO_BE_MINTED_FROM_JCS_OF_CONTENT",
+    "content": {
+      "entries": [
+        {
+          "concept_name": "bool-cell",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return !${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "identity",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "unit",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 0,
+            "min_params": 0
+          }
+        }
+      ],
+      "target_language": "java",
+      "template_name": "java-canonical-bodies"
+    },
+    "kind": "body-template",
+    "name": "menagerie/java-language-signature/body-templates/java-canonical-bodies",
+    "protocol_version": "pep/1.7.0",
+    "version": "v1.0.0"
+  }
+}

--- a/protocol/specs/2026-05-13-body-template-memento.md
+++ b/protocol/specs/2026-05-13-body-template-memento.md
@@ -1,0 +1,144 @@
+# Body Template Memento (`pep/1.7.0`, kind = `"body-template"`)
+
+**Status:** v1.0.0 normative draft.
+**Date:** 2026-05-13
+**Author:** T Savo
+**Related:**
+- `2026-05-12-plugin-protocol.md` (the protocol this spec consumes)
+- `2026-05-12-sugar-dict-memento.md` (sibling: contract-clause sugar; this spec is method-body sugar)
+- `2026-05-12-loss-function-memento.md` (loss function consulted at selection time)
+- `implementations/rust/provekit-cli/src/cmd_transport.rs` (the consumer; closes `bind-stub-body-emitted` for templated concepts)
+
+## §1. Purpose
+
+`provekit bind --rewrite=canonical --target-language=<L>` emits a function in language `L` for every binding. When no real lifted term graph is available, today's substrate falls through to a language-idiomatic stub (`throw new UnsupportedOperationException(...)` for Java, `raise NotImplementedError(...)` for Python, etc.). The stub is honest under Supra omnia rectum but is the dominant entry in the trinity round-trip's loss-record set (`bind-stub-body-emitted`).
+
+A `body-template` plugin is a content-addressed dictionary mapping `(target_language, concept_name)` to a function-body template renderable from the function's signature alone. Multiple body-template plugins MAY load simultaneously; per-binding selection is loss-minimizing across loaded body-templates.
+
+### §1.1 What a body-template is NOT
+
+- Not a desugaring rule (those go core→source one clause at a time, per `2026-05-11-desugaring-and-the-core-compression.md`).
+- Not a `sugar` plugin (those render contract CLAUSES per `2026-05-12-sugar-dict-memento.md` §1.1: "Not a code generator"). This spec IS a code generator for method bodies, the inverse complement.
+- Not a discharge backend.
+- Not a contract lifter; templates render bodies, not contracts.
+
+### §1.2 Trichotomy mapping
+
+| Outcome | Condition for a single binding |
+|---|---|
+| `exact` | Selected entry's `loss_record_contribution` is empty (no dimension has a non-`false` formula). |
+| `loudly-bounded-lossy` | Selected entry has a non-empty `loss_record_contribution`; loss-record is carried forward. |
+| `refuse` | Under `--strict-body-template`, no entry in any LOADED body-template plugin matched. Emit refuse-memento, NOT stub fallback. |
+
+## §2. The `content` payload
+
+```cddl
+; Imports:
+;   loss-record   ; from 2026-05-14-transport-gap-and-partial-morphism-protocol.md §1.3
+;   cid           ; "blake3-512:" tstr
+
+; Locked JCS key order: entries, target_language, template_name
+body-template-content = {
+  entries:         [+ body-template-entry],
+  target_language: tstr,
+  template_name:   tstr
+}
+
+; Locked JCS key order: concept_name, emission_template, loss_record_contribution, signature_guard
+body-template-entry = {
+  concept_name:              tstr,
+  emission_template:         body-emission-template,
+  loss_record_contribution:  loss-record-contribution,
+  ? signature_guard:         signature-guard
+}
+
+; Locked JCS key order: kind, template
+body-emission-template = {
+  kind:      "verbatim",
+  template:  tstr
+}
+
+; Locked JCS key order: form, value
+loss-record-contribution = {
+  form:  "literal",
+  value: any
+}
+
+; Locked JCS key order: max_params, min_params, requires_param_types, requires_return_type
+signature-guard = {
+  ? max_params:            uint,
+  ? min_params:            uint,
+  ? requires_param_types:  [+ tstr],
+  ? requires_return_type:  tstr
+}
+```
+
+### §2.1 Field semantics
+
+| Field | Required | Meaning |
+|---|---|---|
+| `entries` | yes | One or more entries. MUST be sorted ascending by the JCS-canonical bytes of `concept_name` at JCS time. |
+| `target_language` | yes | Target language identifier (`"java"`, `"python"`, `"rust"`, `"csharp"`, etc.). |
+| `template_name` | yes | Free-form label (e.g., `"java-canonical-bodies"`). Part of the plugin CID. |
+| `concept_name` | yes | The canonical concept name this entry covers (e.g., `"concept:identity"`, `"concept:bool-cell"`). Exact-string match against the binding's resolved concept name; no pattern matching. |
+| `emission_template.template` | yes | Surface-syntax template. `${param0}`, `${param1}`, ... bind to parameter names in order. `${return_type}` binds to the target-language return type after `map_source_type` resolution. Unbound placeholders MUST cause the entry to refuse-match (treated as non-applicable). |
+| `loss_record_contribution` | yes | Loss-record incurred when selected. v1.0.0 form MUST be `"literal"`. |
+| `signature_guard` | no | If present, an entry MAY refuse-match when the binding's signature violates the guard (e.g., a 2-arg entry MUST NOT match a 1-arg binding). Used to bound entry applicability beyond bare concept-name match. |
+
+### §2.2 Selection
+
+For each binding with resolved `concept_name = C`:
+
+1. Look up entries where `entry.concept_name == C` across all LOADED body-template plugins.
+2. For each candidate, check `signature_guard` (if present) against the binding's signature; drop on mismatch.
+3. Of the remaining candidates, select the one whose `loss_record_contribution` minimizes against the loaded loss function (`2026-05-12-loss-function-memento.md`).
+4. Render `emission_template.template` with the binding's parameter and type bindings.
+5. If no candidate remains, fall through to the language stub (`cmd_transport.rs::stub_body_for`) under default mode, or refuse under `--strict-body-template`.
+
+### §2.3 Template substitution
+
+The renderer substitutes:
+- `${param0}`, `${param1}`, ... `${paramN-1}` → parameter names in declaration order.
+- `${param_count}` → number of parameters as a decimal string.
+- `${return_type}` → mapped target-language return type.
+- `${param_type_0}`, ... `${param_type_N-1}` → mapped target-language parameter types.
+
+Any other `${...}` placeholder is unbound and causes refuse-match per §2.1.
+
+## §3. CLI surface
+
+Per `2026-05-12-plugin-protocol.md` §3 and §7:
+
+```
+--plugin body-template:<source>      # canonical
+--body-template <source>             # per-kind alias
+```
+
+Repeated loads compose. Order is preserved into the registry's `load_order` for tie-breaking.
+
+Body-template-specific flags:
+
+| Flag | Effect |
+|---|---|
+| `--strict-body-template` | When no entry matches a binding, refuse instead of falling through to the language stub. |
+| `--no-default-body-templates` | Suppress built-in body-template plugin registration (§7 of plugin-protocol). |
+
+## §4. Default loading
+
+The substrate registers ONE default body-template per target language at `cmd_transport` startup, loaded from:
+
+```
+menagerie/<lang>-language-signature/specs/body-templates/<lang>-canonical-bodies.json
+```
+
+These defaults MUST be content-addressed (a `cid` in the `header` block) and signed per the plugin-protocol authentication rules. The set may be suppressed with `--no-default-body-templates`.
+
+## §5. Compatibility
+
+A binding for which no body-template matches falls through to the existing `stub_body_for` emission (Supra omnia rectum: the substrate must still produce a compilable artifact). The fall-through emits a `bind-stub-body-emitted` gap entry naming the affected concept(s); when ALL concepts in a bind run have matching body-templates, the gap entry is omitted entirely.
+
+## §6. Open follow-ups
+
+- v1.1.0: `kind: "computed"` emission templates that evaluate an `ir-formula` to a string.
+- v1.1.0: cross-language template inheritance (`extends: "<other-plugin-cid>"`).
+- v1.1.0: per-mode templates (witness/emitter/monitor distinct bodies for the same concept).


### PR DESCRIPTION
## Why

Sir's 2026-05-13 directive: **"all java emitter code belongs in java"** / **"java in rust is a lie"**. Wave C (#759) was closed for planting Java syntax in Rust; slice 2 (#761) added a parallel Java realize plugin but only proved byte-identity — `cmd_transport` STILL owned Java emission. This PR makes that ownership true: Java emission flows through `provekit-realize-java-core` via PEP 1.7.0 `provekit.plugin.invoke`.

## What's where

| Where | What |
|---|---|
| `protocol/specs/2026-05-13-body-template-memento.md` | NEW spec — PEP 1.7.0 kind `"body-template"`, sibling of `sugar`. Spec is language-neutral substrate. |
| `menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json` | NEW data — three v1.0.0 entries: `identity` -> `return ${param0};`, `bool-cell` -> `return !${param0};`, `unit` -> `return;`. |
| `provekit-realize-java-core/SugarRealizer.java` | Java emitter grows body-template loader + renderer. Resource bundled at build time. |
| `cmd_transport.rs::realize_function` | Early-return for `language == "java"` -> spawn `java -jar ...jar --rpc`, send invoke, return source. |

## Trinity verdict (the load-bearing measurement)

**Before:** 5 loudly-bounded-lossy loss-records, including `bind-stub-body-emitted` with hardcoded "12 binding(s)" — a lie once body templates land.

**After:** **4 loss-records.** All remaining are accurate substrate limits.

Empirical Java emission for trinity fixture:
```java
public static long wrap_identity(long x) {
    return x;
}
public static void do_nothing() {
    return;
}
public static boolean toggle(boolean flag) {
    return !flag;
}
```

3/12 bindings now emit real bodies via the Java plugin. The remaining 9 fall through to language stubs (their templates are out of scope for v1.0.0).

## Tests

- New: `d1_body_template_real_bodies` (1 test) — asserts the three templated concepts emit real bodies AND a non-templated concept (`assert`) still emits a stub.
- `trinity_roundtrip_test`: PASS; verdict drops 5 -> 4 entries.
- `slice2_java_realize_plugin_byte_identical`: 13/13 PASS (both sides now ARE the plugin; byte-identity trivially holds).
- `cmd_bind_integration`: 27/27 PASS after replacing the lying `f6_gaps_record_stub_body_emitted` with `f6_gaps_record_body_emission_state` that asserts the gap is absent.
- All other `provekit-cli` test groups: **224 PASS** total.
- Pre-existing `test_daemon_polyglot_smoke` failure (missing `provekit-linkerd` binary, documented in #759/#761) unrelated and unaffected.

## Lie-removal

The pre-existing `bind-stub-body-emitted` gap with hardcoded count became a lie when 3 of 12 bindings started emitting real bodies. Removed per Supra omnia rectum (`an inaccurate gap is worse than no gap`). The accurate per-concept counted gap is a follow-up requiring real-vs-stub kind threading from each realize plugin's RPC response.

## Discovery

`PROVEKIT_REALIZE_JAVA_JAR` env var overrides the compile-time path. Tests + dev workflows use the default; production installs MUST set the env var. Maven jar is built on demand via the same `ensure_jar_built` pattern slice 2 introduced.

## Known follow-ups (separate PRs)

1. Delete the dead `TargetStyle::Java` match arms / `map_source_type` Java branch / `stub_body_for` Java branch from `cmd_transport.rs` (17+ occurrences). Production never hits them but they violate "all java emitter code belongs in java" in letter.
2. Body-template entries for the remaining 9 concepts. Each needs more than `${paramN}` substitution (conditionals, sequences, array literals) — may motivate v1.1.0 `computed` emission templates.
3. Thread real-vs-stub kind back from each realize plugin via the RPC response so `cmd_bind` can emit accurate per-concept stub gaps.
4. Mirror this architecture for Python, Rust target, and the 6 other languages whose emission still lives in `cmd_transport.rs`.

Tracked as task #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
