### PR TITLE
spec(pep/1.7.0): body-template memento — code-generator sibling of sugar dict

### DIFF
--- a/protocol/specs/2026-05-13-body-template-memento.md
+++ b/protocol/specs/2026-05-13-body-template-memento.md
@@ -1,0 +1,144 @@
+# Body Template Memento (`pep/1.7.0`, kind = `"body-template"`)
+
+**Status:** v1.0.0 normative draft.
+**Date:** 2026-05-13
+**Author:** T Savo
+**Related:**
+- `2026-05-12-plugin-protocol.md` (the protocol this spec consumes)
+- `2026-05-12-sugar-dict-memento.md` (sibling: contract-clause sugar; this spec is method-body sugar)
+- `2026-05-12-loss-function-memento.md` (loss function consulted at selection time)
+- `implementations/rust/provekit-cli/src/cmd_transport.rs` (the consumer; closes `bind-stub-body-emitted` for templated concepts)
+
+## §1. Purpose
+
+`provekit bind --rewrite=canonical --target-language=<L>` emits a function in language `L` for every binding. When no real lifted term graph is available, today's substrate falls through to a language-idiomatic stub (`throw new UnsupportedOperationException(...)` for Java, `raise NotImplementedError(...)` for Python, etc.). The stub is honest under Supra omnia rectum but is the dominant entry in the trinity round-trip's loss-record set (`bind-stub-body-emitted`).
+
+A `body-template` plugin is a content-addressed dictionary mapping `(target_language, concept_name)` to a function-body template renderable from the function's signature alone. Multiple body-template plugins MAY load simultaneously; per-binding selection is loss-minimizing across loaded body-templates.
+
+### §1.1 What a body-template is NOT
+
+- Not a desugaring rule (those go core→source one clause at a time, per `2026-05-11-desugaring-and-the-core-compression.md`).
+- Not a `sugar` plugin (those render contract CLAUSES per `2026-05-12-sugar-dict-memento.md` §1.1: "Not a code generator"). This spec IS a code generator for method bodies, the inverse complement.
+- Not a discharge backend.
+- Not a contract lifter; templates render bodies, not contracts.
+
+### §1.2 Trichotomy mapping
+
+| Outcome | Condition for a single binding |
+|---|---|
+| `exact` | Selected entry's `loss_record_contribution` is empty (no dimension has a non-`false` formula). |
+| `loudly-bounded-lossy` | Selected entry has a non-empty `loss_record_contribution`; loss-record is carried forward. |
+| `refuse` | Under `--strict-body-template`, no entry in any LOADED body-template plugin matched. Emit refuse-memento, NOT stub fallback. |
+
+## §2. The `content` payload
+
+```cddl
+; Imports:
+;   loss-record   ; from 2026-05-14-transport-gap-and-partial-morphism-protocol.md §1.3
+;   cid           ; "blake3-512:" tstr
+
+; Locked JCS key order: entries, target_language, template_name
+body-template-content = {
+  entries:         [+ body-template-entry],
+  target_language: tstr,
+  template_name:   tstr
+}
+
+; Locked JCS key order: concept_name, emission_template, loss_record_contribution, signature_guard
+body-template-entry = {
+  concept_name:              tstr,
+  emission_template:         body-emission-template,
+  loss_record_contribution:  loss-record-contribution,
+  ? signature_guard:         signature-guard
+}
+
+; Locked JCS key order: kind, template
+body-emission-template = {
+  kind:      "verbatim",
+  template:  tstr
+}
+
+; Locked JCS key order: form, value
+loss-record-contribution = {
+  form:  "literal",
+  value: any
+}
+
+; Locked JCS key order: max_params, min_params, requires_param_types, requires_return_type
+signature-guard = {
+  ? max_params:            uint,
+  ? min_params:            uint,
+  ? requires_param_types:  [+ tstr],
+  ? requires_return_type:  tstr
+}
+```
+
+### §2.1 Field semantics
+
+| Field | Required | Meaning |
+|---|---|---|
+| `entries` | yes | One or more entries. MUST be sorted ascending by the JCS-canonical bytes of `concept_name` at JCS time. |
+| `target_language` | yes | Target language identifier (`"java"`, `"python"`, `"rust"`, `"csharp"`, etc.). |
+| `template_name` | yes | Free-form label (e.g., `"java-canonical-bodies"`). Part of the plugin CID. |
+| `concept_name` | yes | The canonical concept name this entry covers (e.g., `"concept:identity"`, `"concept:bool-cell"`). Exact-string match against the binding's resolved concept name; no pattern matching. |
+| `emission_template.template` | yes | Surface-syntax template. `${param0}`, `${param1}`, ... bind to parameter names in order. `${return_type}` binds to the target-language return type after `map_source_type` resolution. Unbound placeholders MUST cause the entry to refuse-match (treated as non-applicable). |
+| `loss_record_contribution` | yes | Loss-record incurred when selected. v1.0.0 form MUST be `"literal"`. |
+| `signature_guard` | no | If present, an entry MAY refuse-match when the binding's signature violates the guard (e.g., a 2-arg entry MUST NOT match a 1-arg binding). Used to bound entry applicability beyond bare concept-name match. |
+
+### §2.2 Selection
+
+For each binding with resolved `concept_name = C`:
+
+1. Look up entries where `entry.concept_name == C` across all LOADED body-template plugins.
+2. For each candidate, check `signature_guard` (if present) against the binding's signature; drop on mismatch.
+3. Of the remaining candidates, select the one whose `loss_record_contribution` minimizes against the loaded loss function (`2026-05-12-loss-function-memento.md`).
+4. Render `emission_template.template` with the binding's parameter and type bindings.
+5. If no candidate remains, fall through to the language stub (`cmd_transport.rs::stub_body_for`) under default mode, or refuse under `--strict-body-template`.
+
+### §2.3 Template substitution
+
+The renderer substitutes:
+- `${param0}`, `${param1}`, ... `${paramN-1}` → parameter names in declaration order.
+- `${param_count}` → number of parameters as a decimal string.
+- `${return_type}` → mapped target-language return type.
+- `${param_type_0}`, ... `${param_type_N-1}` → mapped target-language parameter types.
+
+Any other `${...}` placeholder is unbound and causes refuse-match per §2.1.
+
+## §3. CLI surface
+
+Per `2026-05-12-plugin-protocol.md` §3 and §7:
+
+```
+--plugin body-template:<source>      # canonical
+--body-template <source>             # per-kind alias
+```
+
+Repeated loads compose. Order is preserved into the registry's `load_order` for tie-breaking.
+
+Body-template-specific flags:
+
+| Flag | Effect |
+|---|---|
+| `--strict-body-template` | When no entry matches a binding, refuse instead of falling through to the language stub. |
+| `--no-default-body-templates` | Suppress built-in body-template plugin registration (§7 of plugin-protocol). |
+
+## §4. Default loading
+
+The substrate registers ONE default body-template per target language at `cmd_transport` startup, loaded from:
+
+```
+menagerie/<lang>-language-signature/specs/body-templates/<lang>-canonical-bodies.json
+```
+
+These defaults MUST be content-addressed (a `cid` in the `header` block) and signed per the plugin-protocol authentication rules. The set may be suppressed with `--no-default-body-templates`.
+
+## §5. Compatibility
+
+A binding for which no body-template matches falls through to the existing `stub_body_for` emission (Supra omnia rectum: the substrate must still produce a compilable artifact). The fall-through emits a `bind-stub-body-emitted` gap entry naming the affected concept(s); when ALL concepts in a bind run have matching body-templates, the gap entry is omitted entirely.
+
+## §6. Open follow-ups
+
+- v1.1.0: `kind: "computed"` emission templates that evaluate an `ir-formula` to a string.
+- v1.1.0: cross-language template inheritance (`extends: "<other-plugin-cid>"`).
+- v1.1.0: per-mode templates (witness/emitter/monitor distinct bodies for the same concept).


### PR DESCRIPTION
## Spec-only PR (split from closed #765)

Adds `protocol/specs/2026-05-13-body-template-memento.md` — a new PEP 1.7.0 substrate primitive with `kind = "body-template"`, sibling of the existing `sugar` dict.

The sugar-dict spec (`2026-05-12-sugar-dict-memento.md` §1.1) explicitly excludes code generation: "Not a code generator. A sugar dict emits ONE clause at a time given ONE canonical clause; it does not compose against a program structure." Body-template IS a code generator for method bodies, the natural inverse complement.

## Why

`provekit bind --rewrite=canonical --target-language=<L>` today emits language stubs (`throw new UnsupportedOperationException("provekit-bind canonical: <concept>")`) for every binding. The stub is honest under Supra omnia rectum but is the dominant `bind-stub-body-emitted` entry in the trinity round-trip's loss-record set.

Body-template plugins close that gap concept-by-concept: when an entry matches (`concept_name` exact, `signature_guard` pass), a real body emits; when no entry matches, the language stub falls through and the substrate records a per-concept `bind-stub-body-emitted` gap (§5).

## What the spec mandates (review focus)

- **§4 Default loading.** Defaults MUST be content-addressed (`cid` in the `header` block) and signed per the plugin-protocol authentication rules. No placeholder CIDs in real defaults.
- **§5 Compatibility.** Fall-through to the language stub MUST emit a per-concept `bind-stub-body-emitted` gap naming the affected concept(s). When ALL concepts have templates, the gap is omitted entirely. The accurate-vs-inaccurate distinction is the substrate's honesty guarantee.

## Why spec-only

Closed #765 bundled four substrate-defining changes (spec + data + dispatch + fill) into one PR, which created internal contradictions (§4 PLACEHOLDER CID, §5 removed gap) any reviewer correctly catches. This PR is the spec alone so review can be done on the protocol level without code drift.

If §4 or §5 needs softening (e.g., v0 `unsigned` mode for defaults, or "gap is SHOULD not MUST"), this is the right PR to amend the language before implementation lands.

## Follow-up PRs (gated on this landing)

- **#767 (data):** JSON files for `java-canonical-bodies` with real minted CIDs. A real finding from #765: `compute_fixture_cid` over slice 2's `header.content` produces `blake3-512:533d8c48...` but slice 2's pinned CID is `blake3-512:b7ad1160...` — the minting recipe for sugar/body-template plugins is not yet documented. PR #767 will find slice 2's recipe or open an architectural-call issue for it.
- **#768 (dispatch):** `cmd_transport.rs` Java early-return to plugin, RPC response carries `is_stub: bool` so cmd_bind can emit the §5-mandated per-concept gap.
- **#769 (fill):** the actual identity/bool-cell/unit entries consumed by real dispatch.

Trinity verdict moves with #768 (architecture truth, bodies still stubs) and again with #769 (3 real bodies; verdict's stub count drops 12→9).

## Tests

Spec-only; no code; no tests. CI will pass through trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification for the body-template memento format, including template content schemas, selection algorithms, placeholder substitution rules, CLI configuration options, and fallback behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/766)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->