### PR TITLE
feat(767): mint-plugin-cid binary + java-canonical-bodies.json with real CID

### DIFF
--- a/implementations/rust/provekit-plugin-loader/Cargo.toml
+++ b/implementations/rust/provekit-plugin-loader/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/lib.rs"
 name = "provekit-plugin-loader-stub-rpc"
 path = "src/bin/stub_rpc_server.rs"
 
+[[bin]]
+name = "mint-plugin-cid"
+path = "src/bin/mint_plugin_cid.rs"
+
 [dependencies]
 provekit-canonicalizer = { path = "../provekit-canonicalizer" }
 provekit-proof-envelope = { path = "../provekit-proof-envelope" }

--- a/implementations/rust/provekit-plugin-loader/src/bin/mint_plugin_cid.rs
+++ b/implementations/rust/provekit-plugin-loader/src/bin/mint_plugin_cid.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `mint-plugin-cid` — compute the content CID for a plugin file per
+// 2026-05-12-plugin-protocol.md §6.1.
+//
+// Usage:
+//   mint-plugin-cid <path-to-plugin.json>
+//
+// Reads the file as a `{ envelope, header }` plugin file (any layer with a
+// `header` object), parses `header` into PluginHeader (ignoring the existing
+// `cid` field), and prints the computed CID on stdout.
+//
+// This is the canonical minting recipe for plugin defaults under PEP 1.7.0.
+// Used to (re)mint CIDs for substrate defaults like java-canonical.json and
+// java-canonical-bodies.json so the `cid` field in the plugin file matches
+// the loader's verification.
+
+use std::process::ExitCode;
+
+use provekit_plugin_loader::cid::compute_plugin_cid;
+use provekit_plugin_loader::types::PluginHeader;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("usage: {} <plugin.json>", args[0]);
+        return ExitCode::from(2);
+    }
+
+    let path = &args[1];
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("mint-plugin-cid: read {path}: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let root: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("mint-plugin-cid: parse JSON {path}: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    // The header lives at root["header"]. Parse it as PluginHeader (the
+    // existing `cid` field is ignored by compute_plugin_cid per §6.1).
+    let header_val = match root.get("header") {
+        Some(h) => h.clone(),
+        None => {
+            eprintln!("mint-plugin-cid: {path}: missing top-level `header` object");
+            return ExitCode::from(1);
+        }
+    };
+
+    let header: PluginHeader = match serde_json::from_value(header_val) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("mint-plugin-cid: {path}: header does not match PluginHeader shape: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let cid = compute_plugin_cid(&header);
+    println!("{cid}");
+    ExitCode::SUCCESS
+}

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CI drift-prevention tests for substrate default plugin CIDs.
+//
+// Every default plugin file shipped in `menagerie/<lang>-language-signature/specs/.../`
+// declares a `cid` in its header. That CID MUST equal what `compute_plugin_cid`
+// produces from the header (§6.1 of plugin-protocol). If anyone edits a plugin
+// file's content without re-running `mint-plugin-cid` and updating the declared
+// `cid`, this test fails and tells them exactly what the new CID should be.
+//
+// These tests serve two purposes:
+//  1. Document the canonical default plugin set per `2026-05-13-body-template-memento.md` §4
+//     ("the substrate registers ONE default body-template per target language").
+//  2. Catch silent drift between declared CID and re-computed CID (the kind of
+//     drift that nearly shipped a literal `PLACEHOLDER_TO_BE_MINTED` in PR #765).
+//
+// Pinned values are deliberately duplicated from the JSON files so a change to
+// either side surfaces immediately.
+
+use std::path::PathBuf;
+
+use provekit_plugin_loader::cid::compute_plugin_cid;
+use provekit_plugin_loader::types::PluginHeader;
+
+/// Repo root: this crate is at implementations/rust/provekit-plugin-loader/.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Mint the CID for a plugin file given its absolute path.
+///
+/// Reads `header` out of the file's root object, parses it as `PluginHeader`
+/// (the existing `cid` field is ignored by `compute_plugin_cid` per §6.1), and
+/// returns the recomputed CID.
+fn mint_cid_for(path: &PathBuf) -> String {
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let root: serde_json::Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    let header_val = root
+        .get("header")
+        .unwrap_or_else(|| panic!("{}: missing top-level `header`", path.display()))
+        .clone();
+    let header: PluginHeader = serde_json::from_value(header_val)
+        .unwrap_or_else(|e| panic!("{}: header shape: {e}", path.display()));
+    compute_plugin_cid(&header)
+}
+
+/// Read the declared `cid` from a plugin file's header.
+fn declared_cid_for(path: &PathBuf) -> String {
+    let raw = std::fs::read_to_string(path).unwrap();
+    let root: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    root.get("header")
+        .and_then(|h| h.get("cid"))
+        .and_then(|c| c.as_str())
+        .unwrap_or_else(|| panic!("{}: header.cid missing or not a string", path.display()))
+        .to_string()
+}
+
+/// Assert a plugin file's declared CID equals what the minting recipe produces.
+fn assert_self_consistent(path: PathBuf, pinned: &str) {
+    let declared = declared_cid_for(&path);
+    let minted = mint_cid_for(&path);
+    assert_eq!(
+        declared, minted,
+        "{}: declared cid does not match recomputed cid.\n  \
+         declared = {declared}\n  \
+         minted   = {minted}\n  \
+         Re-run mint-plugin-cid and update the file's header.cid.",
+        path.display()
+    );
+    assert_eq!(
+        declared, pinned,
+        "{}: cid drifted from the pin in this test file.\n  \
+         pinned in test = {pinned}\n  \
+         declared in file = {declared}\n  \
+         If this drift is intentional, update the pinned value in this test.",
+        path.display()
+    );
+}
+
+#[test]
+fn java_canonical_sugar_cid_self_consistent() {
+    let path = repo_root()
+        .join("menagerie/java-language-signature/specs/sugar/java-canonical.json");
+    assert_self_consistent(
+        path,
+        "blake3-512:b7ad1160f00d892d310fb33ac3372a4ebb2f89fec563cab1719e7006ab3d7593aae2162b882aedbec1b97e44957240b3c7e8ab1675456f0539c4ad3f45d22a7b",
+    );
+}
+
+#[test]
+fn java_canonical_bodies_cid_self_consistent() {
+    let path = repo_root()
+        .join("menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json");
+    assert_self_consistent(
+        path,
+        "blake3-512:a059900f182649c9bfbefdbc2a87931d185736cef1567cb71e625a29a7931a9dcc4c9b8cd07fa8ea8931056eae1586bc3610a37ce9be591ef5f4ec2d73de6a51",
+    );
+}

--- a/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
+++ b/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
@@ -1,0 +1,67 @@
+{
+  "envelope": {
+    "declaredAt": "2026-05-13T00:00:00.000Z",
+    "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "header": {
+    "cid": "blake3-512:a059900f182649c9bfbefdbc2a87931d185736cef1567cb71e625a29a7931a9dcc4c9b8cd07fa8ea8931056eae1586bc3610a37ce9be591ef5f4ec2d73de6a51",
+    "content": {
+      "entries": [
+        {
+          "concept_name": "bool-cell",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return !${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "identity",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "unit",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 0,
+            "min_params": 0
+          }
+        }
+      ],
+      "target_language": "java",
+      "template_name": "java-canonical-bodies"
+    },
+    "critical": false,
+    "kind": "body-template",
+    "protocol_versions": ["pep/1.7.0"],
+    "provenance_cid": "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "schemaVersion": "1",
+    "version": "1.0.0"
+  }
+}


### PR DESCRIPTION
## Why

First implementation PR after #766 (body-template-memento spec) merged. Closes the §4 "MUST be content-addressed" requirement honestly, instead of the literal `PLACEHOLDER_TO_BE_MINTED_FROM_JCS_OF_CONTENT` that sank #765.

## What

### 1. `mint-plugin-cid` binary — the missing recipe artifact

`implementations/rust/provekit-plugin-loader/src/bin/mint_plugin_cid.rs` — reuses `compute_plugin_cid` (already in the plugin-loader crate, already specced in `2026-05-12-plugin-protocol.md` §6.1) and exposes it as a CLI.

**Verified against slice 2:** running `mint-plugin-cid` on the EXISTING `menagerie/java-language-signature/specs/sugar/java-canonical.json` reproduces its pinned `blake3-512:b7ad1160...` exactly. This is the recipe slice 2 used; it was always in `compute_plugin_cid` (JCS over the full header sans `cid`, BLAKE3-512), but there was no entrypoint to call it on a file.

### 2. `java-canonical-bodies.json` with REAL minted CID

Three v1.0.0 entries per `2026-05-13-body-template-memento.md` §2:

| concept_name | template | signature_guard |
|---|---|---|
| `identity` | `return ${param0};` | 1 param |
| `bool-cell` | `return !${param0};` | 1 param |
| `unit` | `return;` (void) | 0 params |

Header CID: `blake3-512:a059900f182649c9bfbefdbc2a87931d185736cef1567cb71e625a29a7931a9dcc4c9b8cd07fa8ea8931056eae1586bc3610a37ce9be591ef5f4ec2d73de6a51`.

`provenance_cid` + envelope signature use the all-zeros sentinel (same v0 pattern as slice 2's `java-canonical.json`). Substrate-wide sentinel convention; real provenance signing tracked separately.

### 3. Drift-prevention test

`provekit-plugin-loader/tests/substrate_default_cids.rs` asserts for each substrate default plugin file:
- declared `header.cid` == what `compute_plugin_cid` recomputes (catches edits without re-minting),
- declared `header.cid` == pinned-in-test value (catches recipe-side drift).

Covers java-canonical.json (slice 2) + java-canonical-bodies.json (new). Future default plugins just add another `#[test]`.

**This guard is exactly what was missing on #765**: PR #765's JSON shipped with the literal `PLACEHOLDER_TO_BE_MINTED_FROM_JCS_OF_CONTENT` string where the CID should have been, and nothing failed CI. With this test in place, that can't happen again.

## Tests

- `substrate_default_cids::java_canonical_sugar_cid_self_consistent`: **PASS** (re-mints slice 2's CID)
- `substrate_default_cids::java_canonical_bodies_cid_self_consistent`: **PASS** (re-mints new CID)
- Full `provekit-plugin-loader` regression: **all green** (17 + 9 + 2 + smaller groups, zero failures)

## Gated by

#766 (body-template-memento spec, merged at fe1f06b3). This PR is the spec's first consumer.

## Blocks

- **#768** (cmd_transport Java early-return + `is_stub` flag threading) — needs this PR's CID in the resource path it'll bake into the Java jar.
- **#769** (real body emission for `identity` / `bool-cell` / `unit`) — consumes these body templates directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a command-line tool to compute and verify content identifiers for plugin configuration files
  * Added Java canonical bodies template specification, supporting canonical concepts including bool-cell, identity, and unit

* **Tests**
  * Added automated verification tests to ensure consistency of plugin identifiers across Java canonical implementations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/767)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->