### PR TITLE
feat(768): cmd_transport Java early-return to plugin RPC + is_stub flag threading

### DIFF
--- a/implementations/java/provekit-realize-java-core/pom.xml
+++ b/implementations/java/provekit-realize-java-core/pom.xml
@@ -47,6 +47,37 @@
 
     <build>
         <plugins>
+            <!--
+              Copy the canonical body-template plugin file from menagerie/
+              into the jar's classpath resources. The menagerie file is the
+              source of truth (per body-template-memento.md §4); this is a
+              build-time copy so the jar is self-contained at runtime.
+              Drift between the two is caught by the substrate_default_cids
+              regression test (provekit-plugin-loader/tests/).
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-body-template-defaults</id>
+                        <phase>process-resources</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/com/provekit/realize</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/../../../menagerie/java-language-signature/specs/body-templates</directory>
+                                    <includes>
+                                        <include>java-canonical-bodies.json</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -38,8 +38,9 @@ public final class RpcServer {
                 // PEP 1.7.0 methods
                 case "provekit.plugin.describe" -> sendResponse(id, describeResult());
                 case "provekit.plugin.invoke" -> {
-                    String source = handleInvoke(line);
-                    sendResponse(id, "{\"source\":" + JsonUtil.quoted(source) + "}");
+                    // handleInvoke returns a full JSON object: {"source":..., "is_stub":...}
+                    String resultObj = handleInvoke(line);
+                    sendResponse(id, resultObj);
                 }
                 case "provekit.plugin.shutdown" -> {
                     sendResponse(id, "null");
@@ -73,7 +74,11 @@ public final class RpcServer {
      *   return_type   - source-language return type string
      *   concept_name  - concept binding name for annotation + stub body
      *
-     * Returns: Java stub source string.
+     * Returns: JSON object with `source` (Java string) and `is_stub` (boolean).
+     * `is_stub=true` means the body fell through to the language stub
+     * (no body-template matched); `is_stub=false` means a body-template
+     * entry rendered a real body. cmd_bind uses this to emit accurate
+     * per-concept `bind-stub-body-emitted` gap entries per body-template-memento.md §5.
      */
     private String handleInvoke(String line) {
         // Extract the inner params object to avoid ambiguity with the RPC "params" key.
@@ -83,7 +88,10 @@ public final class RpcServer {
         String conceptName = JsonUtil.decodeJsonStringField(paramsObj, "concept_name");
         List<String> params = JsonUtil.decodeJsonStringArray(paramsObj, "params");
         List<String> paramTypes = JsonUtil.decodeJsonStringArray(paramsObj, "param_types");
-        return SugarRealizer.emitStub(function, params, paramTypes, returnType, conceptName);
+        SugarRealizer.Realization r =
+                SugarRealizer.emitStub(function, params, paramTypes, returnType, conceptName);
+        return "{\"source\":" + JsonUtil.quoted(r.source())
+                + ",\"is_stub\":" + (r.isStub() ? "true" : "false") + "}";
     }
 
     /**

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -1,40 +1,66 @@
 package com.provekit.realize;
 
+import com.provekit.ir.Jcs;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
- * Emits a canonical Java stub method wrapped in a per-function class.
+ * Emits canonical Java method bodies and stubs for the bind canonical-rewrite path.
  *
- * Mirrors cmd_transport.rs `realize_function` for TargetStyle::Java with
- * is_stub=true (the bind path where no term graph is available yet).
+ * Per the federation-by-construction directive ("all java emitter code belongs in java"),
+ * this class is the SOLE owner of Java surface emission. cmd_transport.rs dispatches to
+ * this class via the JSON-RPC plugin protocol; Rust holds no Java syntax.
  *
- * Output format (per cmd_transport.rs Java branch):
+ * Output shape (per cmd_transport.rs Java branch, byte-identical):
  * <pre>
  * final class {PascalFn}Transported {
  *     // concept: {conceptName}
  *     public static {returnType} {function}({typedParams}) {
- *         throw new UnsupportedOperationException("provekit-bind canonical: {conceptName}");
+ *         {body}
  *     }
  * }
  * </pre>
  *
- * Slice 2: contract annotations (requires/ensures) are NOT emitted here;
- * those require contract lifting from source, which is out of scope for
- * the stub path.
+ * Where {body} is rendered from the body-template plugin (loaded from
+ * classpath resource `com/provekit/realize/java-canonical-bodies.json`,
+ * sourced from `menagerie/java-language-signature/specs/body-templates/`)
+ * when an entry matches the binding's concept_name + signature_guard.
+ * When no entry matches, the language stub falls through:
+ *   `throw new UnsupportedOperationException("provekit-bind canonical: <concept>");`
  */
 final class SugarRealizer {
 
     /**
-     * Emit a Java stub for a single function.
+     * Realization result: the emitted Java source plus a flag indicating
+     * whether the body came from a body-template (real body, `is_stub=false`)
+     * or fell through to the language stub (`is_stub=true`).
+     *
+     * Carried through to the JSON-RPC response so the caller (cmd_bind) can
+     * emit accurate per-concept `bind-stub-body-emitted` gap entries per
+     * `2026-05-13-body-template-memento.md` §5.
+     */
+    record Realization(String source, boolean isStub) {}
+
+    /**
+     * Emit a Java method for a single function. Body source comes from the
+     * body-template plugin when a matching entry exists; otherwise an
+     * idiomatic stub is emitted.
      *
      * @param function    Rust snake_case function name (e.g. "wrap_identity")
      * @param params      Parameter names in order (e.g. ["x"])
      * @param paramTypes  Source-language (Rust) type strings (e.g. ["i64"])
      * @param returnType  Source-language return type string (e.g. "i64")
-     * @param conceptName Concept binding name (e.g. "UNNAMED-CONCEPT-a777b12569a16b07")
-     * @return Java source string, byte-identical to realize_for_bind("java", ...)
+     * @param conceptName Concept binding name (e.g. "identity")
+     * @return Realization carrying source + is_stub flag.
      */
-    static String emitStub(
+    static Realization emitStub(
             String function,
             List<String> params,
             List<String> paramTypes,
@@ -56,17 +82,20 @@ final class SugarRealizer {
         // annotation_prefix for Java: top_indent = "    "
         String annotationPrefix = "    // concept: " + conceptName + "\n";
 
-        // stub body: 8 spaces indent
-        String stubBody = "        throw new UnsupportedOperationException(\"provekit-bind canonical: " + conceptName + "\");\n";
+        // Body: try body-template first, fall through to language stub.
+        Optional<String> bodyTemplate = bodyTemplateFor(conceptName, params);
+        boolean isStub = bodyTemplate.isEmpty();
+        String bodyContent = bodyTemplate
+                .orElse("throw new UnsupportedOperationException(\"provekit-bind canonical: " + conceptName + "\");");
+        String body = "        " + bodyContent + "\n";
 
-        // Format matches cmd_transport.rs line 1474-1476:
-        // "final class {class_name} {{\n{annotation_prefix}    public static {mapped_return} {function}({typed_param_list}) {{\n{body_str}    }}\n}}\n"
-        return "final class " + className + " {\n"
+        String source = "final class " + className + " {\n"
                 + annotationPrefix
                 + "    public static " + mappedReturn + " " + function + "(" + typedParamList + ") {\n"
-                + stubBody
+                + body
                 + "    }\n"
                 + "}\n";
+        return new Realization(source, isStub);
     }
 
     /**
@@ -102,5 +131,117 @@ final class SugarRealizer {
             if (part.length() > 1) sb.append(part.substring(1));
         }
         return sb.toString();
+    }
+
+    // -----------------------------------------------------------------------
+    // Body-template loading per protocol/specs/2026-05-13-body-template-memento.md
+    // -----------------------------------------------------------------------
+
+    /**
+     * Cached body-template entries, loaded lazily on first call from the
+     * classpath resource `com/provekit/realize/java-canonical-bodies.json`.
+     * The resource is sourced from
+     * `menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json`
+     * at build time (see pom.xml resource configuration).
+     */
+    private static volatile List<BodyTemplateEntry> ENTRIES_CACHE = null;
+
+    /**
+     * One body-template entry per spec §2.
+     */
+    private record BodyTemplateEntry(
+            String conceptName,
+            String templateKind,
+            String template,
+            Integer minParams,
+            Integer maxParams) {}
+
+    /**
+     * Render a body string for the given concept + signature, or empty when
+     * no entry matches (caller falls back to the language stub).
+     *
+     * Selection per spec §2.2: exact concept_name match + signature_guard
+     * pass (min_params <= |params| <= max_params when present). Substitution
+     * per §2.3: ${param0}, ${param1}, ... ${param_count}. Unbound placeholders
+     * refuse-match.
+     */
+    static Optional<String> bodyTemplateFor(String conceptName, List<String> params) {
+        List<BodyTemplateEntry> entries = entries();
+        for (BodyTemplateEntry e : entries) {
+            if (!e.conceptName().equals(conceptName)) continue;
+            if (e.minParams() != null && params.size() < e.minParams()) continue;
+            if (e.maxParams() != null && params.size() > e.maxParams()) continue;
+            if (!"verbatim".equals(e.templateKind())) continue;
+            String rendered = e.template();
+            for (int i = 0; i < params.size(); i++) {
+                rendered = rendered.replace("${param" + i + "}", params.get(i));
+            }
+            rendered = rendered.replace("${param_count}", Integer.toString(params.size()));
+            if (rendered.contains("${")) {
+                // Unbound placeholder: refuse-match per spec §2.1.
+                continue;
+            }
+            return Optional.of(rendered);
+        }
+        return Optional.empty();
+    }
+
+    private static List<BodyTemplateEntry> entries() {
+        List<BodyTemplateEntry> cached = ENTRIES_CACHE;
+        if (cached != null) return cached;
+        synchronized (SugarRealizer.class) {
+            if (ENTRIES_CACHE != null) return ENTRIES_CACHE;
+            ENTRIES_CACHE = loadEntriesFromResource();
+            return ENTRIES_CACHE;
+        }
+    }
+
+    private static List<BodyTemplateEntry> loadEntriesFromResource() {
+        try (InputStream in = SugarRealizer.class.getResourceAsStream("java-canonical-bodies.json")) {
+            if (in == null) {
+                // Resource absent: degrade to "no entries" (callers get language stub).
+                return List.of();
+            }
+            String raw;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                raw = reader.lines().collect(Collectors.joining("\n"));
+            }
+            Jcs.Json root = Jcs.parse(raw);
+            if (!(root instanceof Jcs.Obj rootObj)) return List.of();
+            Jcs.Json header = rootObj.get("header");
+            if (!(header instanceof Jcs.Obj headerObj)) return List.of();
+            Jcs.Json content = headerObj.get("content");
+            if (!(content instanceof Jcs.Obj contentObj)) return List.of();
+            Jcs.Json entriesJson = contentObj.get("entries");
+            if (!(entriesJson instanceof Jcs.Arr entriesArr)) return List.of();
+
+            List<BodyTemplateEntry> out = new ArrayList<>();
+            for (Jcs.Json item : entriesArr.values()) {
+                if (!(item instanceof Jcs.Obj itemObj)) continue;
+                String conceptName = itemObj.stringFieldOrNull("concept_name");
+                if (conceptName == null) continue;
+
+                Jcs.Json template = itemObj.get("emission_template");
+                if (!(template instanceof Jcs.Obj templateObj)) continue;
+                String kind = templateObj.stringFieldOrNull("kind");
+                String tmpl = templateObj.stringFieldOrNull("template");
+                if (kind == null || tmpl == null) continue;
+
+                Integer minParams = null;
+                Integer maxParams = null;
+                Jcs.Json guard = itemObj.get("signature_guard");
+                if (guard instanceof Jcs.Obj guardObj) {
+                    Jcs.Json minJ = guardObj.get("min_params");
+                    Jcs.Json maxJ = guardObj.get("max_params");
+                    if (minJ instanceof Jcs.Num minN) minParams = (int) minN.value();
+                    if (maxJ instanceof Jcs.Num maxN) maxParams = (int) maxN.value();
+                }
+                out.add(new BodyTemplateEntry(conceptName, kind, tmpl, minParams, maxParams));
+            }
+            return out;
+        } catch (IOException e) {
+            // I/O failure: degrade to "no entries"; stubs will emit.
+            return List.of();
+        }
     }
 }

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -29,7 +29,7 @@
 //   loudly-bounded-lossy   — annotation/test-lift (structural shim)
 //   refuse                 — no contract recovered or wp-error
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -284,14 +284,11 @@ pub fn run(args: BindArgs) -> u8 {
         output_dir.join("index.json"),
         serde_json::to_string_pretty(&index).unwrap_or_default(),
     );
-    let gaps = build_gaps_doc(&source_lang, &result.gaps);
-    let _ = std::fs::write(
-        output_dir.join("gaps.json"),
-        serde_json::to_string_pretty(&gaps).unwrap_or_default(),
-    );
 
-    // Rewrite output.
-    match &args.rewrite {
+    // Rewrite output. Canonical-rewrite returns the set of concepts whose body
+    // fell through to the language stub so we can emit per-concept gap entries
+    // per `body-template-memento.md` §5.
+    let stub_concepts: Vec<String> = match &args.rewrite {
         RewriteShape::Annotate => {
             // annotate rewrites in-place in source-language syntax.
             // Cross-language annotation is not supported in v0; use --rewrite=canonical.
@@ -307,18 +304,17 @@ pub fn run(args: BindArgs) -> u8 {
             apply_annotate_rewrite(
                 &root, &src_files, &result, &args.mode, /*to_disk=*/ true,
             );
+            Vec::new()
         }
-        RewriteShape::Canonical => {
-            apply_canonical_rewrite(
-                &root,
-                &src_files,
-                &result,
-                &args.mode,
-                &target_lang,
-                /*to_disk=*/ true,
-                &output_dir,
-            );
-        }
+        RewriteShape::Canonical => apply_canonical_rewrite(
+            &root,
+            &src_files,
+            &result,
+            &args.mode,
+            &target_lang,
+            /*to_disk=*/ true,
+            &output_dir,
+        ),
         RewriteShape::Invisible => {
             // Invisible: stream to stdout. Apply annotate-shape for same-language,
             // canonical for cross-language.
@@ -326,6 +322,7 @@ pub fn run(args: BindArgs) -> u8 {
                 apply_annotate_rewrite(
                     &root, &src_files, &result, &args.mode, /*to_disk=*/ false,
                 );
+                Vec::new()
             } else {
                 apply_canonical_rewrite(
                     &root,
@@ -335,10 +332,30 @@ pub fn run(args: BindArgs) -> u8 {
                     &target_lang,
                     /*to_disk=*/ false,
                     &output_dir,
-                );
+                )
             }
         }
+    };
+
+    // Augment gaps with per-concept `bind-stub-body-emitted` entries for
+    // every concept whose body fell through during canonical rewrite, per
+    // `body-template-memento.md` §5. Then write gaps.json with the augmented
+    // set. When every concept matched a body-template, no entries are added.
+    let mut augmented_gaps = result.gaps.clone();
+    for concept in &stub_concepts {
+        augmented_gaps.push(GapRecord {
+            kind: "bind-stub-body-emitted".into(),
+            detail: format!(
+                "canonical-rewrite fell through to language stub for concept '{concept}'; \
+                 no body-template matched. Author a body-template entry to close this gap."
+            ),
+        });
     }
+    let gaps_doc = build_gaps_doc(&source_lang, &augmented_gaps);
+    let _ = std::fs::write(
+        output_dir.join("gaps.json"),
+        serde_json::to_string_pretty(&gaps_doc).unwrap_or_default(),
+    );
 
     // Print summary.
     if !args.quiet {
@@ -834,25 +851,14 @@ fn run_bind_engine(
         kind: "v0-capability-gap".into(),
         detail: "real ConceptAbstractionMemento catalog lookup deferred to v1 (v0 uses soft-match classification)".into(),
     });
-    // F6: Record stub-body gap when bindings exist.
-    //
-    // In v0 the canonical-rewrite path has no full term graph; it delegates to
-    // `realize_for_bind` which always emits idiomatic stub bodies (panic/raise/todo).
-    // This gap record is the honest substrate disclosure: real lifted source bodies
-    // are NOT present in these outputs.  A future PR that wires the term graph to the
-    // canonical path should remove this gap kind and replace it with a "term-body-realized"
-    // kind.
-    if !bindings.is_empty() {
-        gaps.push(GapRecord {
-            kind: "bind-stub-body-emitted".into(),
-            detail: format!(
-                "canonical-rewrite emitted stub bodies for {n} binding(s): no real lifted term \
-                 graph available in v0; bodies are idiomatic language stubs \
-                 (panic/raise/todo/throw). Real bodies deferred to v1.",
-                n = bindings.len()
-            ),
-        });
-    }
+    // F6 (post body-template-memento, #766/#767/#768): the unconditional
+    // `bind-stub-body-emitted` gap with hardcoded binding count was a lie
+    // once the Java realize plugin began emitting real bodies for templated
+    // concepts. The accurate replacement is per-concept gap emission done
+    // AFTER `apply_canonical_rewrite` returns (see the main cmd_bind flow).
+    // The engine itself can't emit these gaps because it doesn't know which
+    // concepts' bodies will fall through to a stub — that's known only after
+    // each binding's realize_for_bind call reports its `is_stub` kind.
     Ok(EngineResult {
         bindings,
         concepts,
@@ -1077,6 +1083,13 @@ fn inject_annotations(
 ///
 /// When `to_disk` is true, writes to `.provekit/bindings/translated/<lang>/`.
 /// When false (invisible), streams to stdout.
+/// Apply the canonical rewrite (delegating Java emission to the realize plugin
+/// when target_lang == "java"; other languages still use the inline path).
+///
+/// Returns the set of concept names (sorted, deduplicated) whose realized
+/// body fell through to the language stub — i.e. no body-template matched.
+/// Caller emits one `bind-stub-body-emitted` gap per name per §5 of
+/// `2026-05-13-body-template-memento.md`.
 fn apply_canonical_rewrite(
     root: &Path,
     src_files: &[PathBuf],
@@ -1085,7 +1098,7 @@ fn apply_canonical_rewrite(
     target_lang: &str,
     to_disk: bool,
     output_dir: &Path,
-) {
+) -> Vec<String> {
     // Group bindings by file.
     let mut by_file: BTreeMap<String, Vec<&BindingRecord>> = BTreeMap::new();
     for b in &result.bindings {
@@ -1096,6 +1109,10 @@ fn apply_canonical_rewrite(
     if to_disk {
         let _ = std::fs::create_dir_all(&translated_dir);
     }
+
+    // Track concepts whose realized body was a stub. Deduplicated + sorted at
+    // the end so the gap-emission caller produces one gap per affected concept.
+    let mut stub_concepts: BTreeSet<String> = BTreeSet::new();
 
     for (rel_file, bindings) in &by_file {
         let in_path = root.join(rel_file);
@@ -1163,6 +1180,13 @@ fn apply_canonical_rewrite(
                         &concept_name,
                     ) {
                         Ok(r) => {
+                            // Per body-template-memento.md §5: when the realizer's body fell
+                            // through to the language stub (no body-template matched), record
+                            // the concept so the caller emits a per-concept
+                            // `bind-stub-body-emitted` gap entry.
+                            if r.is_stub {
+                                stub_concepts.insert(concept_name.to_string());
+                            }
                             // Prepend bind-specific metadata (substrate-origin, memento-cid,
                             // contract annotations, runtime-mode) before the ORP-generated snippet.
                             let meta = build_bind_meta_comment(target_lang, &concept_name, b, mode);
@@ -1170,7 +1194,9 @@ fn apply_canonical_rewrite(
                         }
                         Err(_) => {
                             // ORP refused (unsupported language or parse error); fall back
-                            // to the annotation-level stub so output is never empty.
+                            // to the annotation-level stub so output is never empty. This is
+                            // also a stub path — record the concept.
+                            stub_concepts.insert(concept_name.to_string());
                             emit_target_stub(target_lang, &fn_name, &params, b, &concept_name, mode)
                         }
                     };
@@ -1222,6 +1248,9 @@ fn apply_canonical_rewrite(
             println!("{cmt} bind:canonical:no-bindings:{rel}");
         }
     }
+
+    // BTreeSet → sorted Vec for deterministic gap-record output order.
+    stub_concepts.into_iter().collect()
 }
 
 /// Return the line-comment prefix for the target language.

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -1250,6 +1250,17 @@ fn emit_annotation_prefix(
 pub struct RealizedSource {
     pub extension: &'static str,
     pub source: String,
+    /// True when the body fell through to the language stub (no body-template
+    /// matched). False when a body-template plugin rendered a real body.
+    ///
+    /// Used by `cmd_bind::apply_canonical_rewrite` to emit accurate
+    /// per-concept `bind-stub-body-emitted` gap entries per
+    /// `2026-05-13-body-template-memento.md` §5.
+    ///
+    /// For target languages whose realizer does not yet support body
+    /// templates (everything except Java in v1.0.0), this is unconditionally
+    /// true — the body is always a stub.
+    pub is_stub: bool,
 }
 
 /// Public-crate bridge for `cmd_bind`'s canonical-mode path.
@@ -1315,6 +1326,152 @@ fn style_for(language: &str) -> Option<TargetStyle> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Java plugin dispatch (federation by construction)
+// ---------------------------------------------------------------------------
+//
+// All Java surface emission is owned by `implementations/java/provekit-realize-java-core/`
+// per body-template-memento.md §4 ("the substrate registers ONE default
+// body-template per target language"). cmd_transport delegates to that
+// plugin via PEP 1.7.0 `provekit.plugin.invoke`: it spawns
+// `java -jar provekit-realize-java.jar --rpc` as a subprocess, writes a
+// single JSON-RPC request to stdin, reads one line from stdout, and parses
+// `{source, is_stub}` from the response.
+//
+// `is_stub` flows back through `RealizedSource` so cmd_bind can emit
+// accurate per-concept `bind-stub-body-emitted` gap entries per §5.
+//
+// Discovery: PROVEKIT_REALIZE_JAVA_JAR env var if set, else the compile-time
+// path relative to CARGO_MANIFEST_DIR. The latter assumes a colocated source
+// tree; production installs MUST set the env var.
+
+fn java_realize_jar_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("PROVEKIT_REALIZE_JAVA_JAR") {
+        return std::path::PathBuf::from(p);
+    }
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../java/provekit-realize-java-core/target/provekit-realize-java.jar")
+}
+
+fn realize_via_java_plugin(
+    function: &str,
+    params: &[String],
+    param_types: &[String],
+    return_type: &str,
+    concept_name: &str,
+) -> Result<RealizedSource, TransportCliError> {
+    use std::io::{BufRead, BufReader, Write as _};
+    use std::process::{Command, Stdio};
+
+    let jar = java_realize_jar_path();
+    if !jar.exists() {
+        return Err(TransportCliError::Refusal(format!(
+            "realize-time:java-plugin-missing provekit-realize-java.jar not found at {} \
+             (set PROVEKIT_REALIZE_JAVA_JAR or run `mvn package -pl provekit-realize-java-core -am -DskipTests`)",
+            jar.display()
+        )));
+    }
+
+    let params_json: Vec<Value> = params.iter().map(|s| Value::String(s.clone())).collect();
+    let param_types_json: Vec<Value> =
+        param_types.iter().map(|s| Value::String(s.clone())).collect();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.invoke",
+        "params": {
+            "function": function,
+            "params": params_json,
+            "param_types": param_types_json,
+            "return_type": return_type,
+            "concept_name": concept_name,
+        },
+    });
+
+    let mut child = Command::new("java")
+        .args(["-jar", jar.to_str().expect("jar path utf-8"), "--rpc"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| {
+            TransportCliError::Refusal(format!(
+                "realize-time:java-plugin-spawn failed to spawn java plugin: {e}"
+            ))
+        })?;
+
+    {
+        let stdin = child.stdin.as_mut().expect("plugin stdin");
+        let request_str = serde_json::to_string(&request).expect("serialize request");
+        stdin
+            .write_all(request_str.as_bytes())
+            .and_then(|()| stdin.write_all(b"\n"))
+            .map_err(|e| {
+                TransportCliError::Refusal(format!(
+                    "realize-time:java-plugin-write failed to write request: {e}"
+                ))
+            })?;
+    }
+
+    let stdout = child.stdout.take().expect("plugin stdout");
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).map_err(|e| {
+        TransportCliError::Refusal(format!(
+            "realize-time:java-plugin-read failed to read response: {e}"
+        ))
+    })?;
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let v: Value = serde_json::from_str(line.trim()).map_err(|e| {
+        TransportCliError::Refusal(format!(
+            "realize-time:java-plugin-parse response not valid JSON: {e}; raw: {}",
+            line.trim()
+        ))
+    })?;
+    if let Some(err) = v.get("error") {
+        return Err(TransportCliError::Refusal(format!(
+            "realize-time:java-plugin-error plugin returned error: {err}"
+        )));
+    }
+    let result = v.get("result").ok_or_else(|| {
+        TransportCliError::Refusal(format!(
+            "realize-time:java-plugin-shape missing result object; raw: {}",
+            line.trim()
+        ))
+    })?;
+    let source = result
+        .get("source")
+        .and_then(|s| s.as_str())
+        .ok_or_else(|| {
+            TransportCliError::Refusal(format!(
+                "realize-time:java-plugin-shape missing result.source; raw: {}",
+                line.trim()
+            ))
+        })?
+        .to_string();
+    // is_stub MUST be present per the body-template-memento §5 contract; if
+    // missing we refuse rather than guess. Real bodies cannot be silently
+    // misclassified as stubs (or vice versa) under Supra omnia rectum.
+    let is_stub = result
+        .get("is_stub")
+        .and_then(|s| s.as_bool())
+        .ok_or_else(|| {
+            TransportCliError::Refusal(format!(
+                "realize-time:java-plugin-shape missing or non-boolean result.is_stub; raw: {}",
+                line.trim()
+            ))
+        })?;
+
+    Ok(RealizedSource {
+        extension: "java",
+        source,
+        is_stub,
+    })
+}
+
 fn realize_function(
     language: &str,
     function: &str,
@@ -1325,6 +1482,17 @@ fn realize_function(
     annotations: &ContractAnnotations,
     concept_name: &str,
 ) -> Result<RealizedSource, TransportCliError> {
+    // Federation by construction: Java emission lives in the Java plugin
+    // (provekit-realize-java-core). cmd_transport delegates via JSON-RPC.
+    // The TargetStyle::Java match arms below remain only as dead code paths
+    // for the non-bind realize callers (cross-language transport CLI); a
+    // future PR removes them entirely once those callers also delegate.
+    if language == "java" {
+        let _ = annotations; // emitted plugin-side
+        let _ = body; // body emission is plugin-side (template or stub)
+        return realize_via_java_plugin(function, params, param_types, return_type, concept_name);
+    }
+
     let style = style_for(language).ok_or_else(|| {
         TransportCliError::Refusal(format!(
             "realize-time:no-realizer no source realizer for target `{language}`"
@@ -1487,7 +1655,15 @@ fn realize_function(
         TargetStyle::Php => "php",
         TargetStyle::Java => "java",
     };
-    Ok(RealizedSource { extension, source })
+    // v1.0.0: only the Java target consumes body-template plugins (via the
+    // early-return to provekit-realize-java-core, below). Every other
+    // language's body is the language stub from `stub_body_for`, so
+    // is_stub is unconditionally true here.
+    Ok(RealizedSource {
+        extension,
+        source,
+        is_stub: true,
+    })
 }
 
 /// Emit the file-level header for a given target language.

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -947,24 +947,43 @@ fn f5_csharp_canonical_parses() {
 }
 
 // ============================================================================
-// F6: Test 27 -- gaps.json records bind-stub-body-emitted for stub functions
+// F6 (post #766/#767/#768): gaps.json records bind-stub-body-emitted PER
+// CONCEPT for every concept whose body fell through to the language stub.
+// Annotate-rewrite path does NOT emit stub bodies (in-place source rewrite),
+// so this test exercises a cross-language canonical rewrite where the
+// realizer reports is_stub for each binding.
 // ============================================================================
 
 #[test]
-fn f6_gaps_record_stub_body_emitted() {
+fn f6_gaps_record_stub_body_emitted_per_concept() {
     let root = fixture_root();
     let out = tempfile::tempdir().expect("tempdir").into_path();
-    // Use invisible mode so the bind engine runs without writing files.
-    let result = bind_cmd(&root, &out, "invisible", "monitor", None);
-    assert!(result.status.success(), "bind invisible must succeed");
+    // Canonical Rust→Go forces the realize path for every binding, and none
+    // of the Go templates exist in v1.0.0, so every concept must produce a
+    // per-concept `bind-stub-body-emitted` gap entry.
+    let result = bind_cmd(&root, &out, "canonical", "monitor", Some("go"));
+    assert!(result.status.success(), "bind canonical → go must succeed");
     let gaps: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(out.join("gaps.json")).unwrap()).unwrap();
     let gap_arr = gaps["gaps"].as_array().expect("gaps must be array");
-    let kinds: Vec<&str> = gap_arr.iter().filter_map(|g| g["kind"].as_str()).collect();
-    // v0 canonical bind always emits stub bodies (no term graph yet).
-    // The gap record is the honest disclosure: substrate knows stubs were emitted.
+    let stub_entries: Vec<&serde_json::Value> = gap_arr
+        .iter()
+        .filter(|g| g["kind"].as_str() == Some("bind-stub-body-emitted"))
+        .collect();
     assert!(
-        kinds.contains(&"bind-stub-body-emitted"),
-        "gaps.json must record bind-stub-body-emitted when canonical stubs are emitted; kinds found: {kinds:?}"
+        !stub_entries.is_empty(),
+        "gaps.json must record at least one per-concept bind-stub-body-emitted entry; \
+         no Go body templates exist in v1.0.0 so every concept should emit one. \
+         Got: {:?}",
+        gap_arr
     );
+    // Each entry must name a specific concept in its detail (not the old
+    // single-record-with-count-of-bindings shape).
+    for entry in &stub_entries {
+        let detail = entry["detail"].as_str().unwrap_or("");
+        assert!(
+            detail.contains("concept '"),
+            "bind-stub-body-emitted entry must name a specific concept; got: {detail}"
+        );
+    }
 }


### PR DESCRIPTION
## Why

Third PR in the body-template stack. Java emission now flows through `provekit-realize-java-core` via JSON-RPC; the `is_stub` kind flows back through `cmd_bind` so `gaps.json` emits per-concept `bind-stub-body-emitted` entries per `body-template-memento.md` §5.

## Architecture: "java in rust is a lie" closure

`cmd_transport.rs::realize_function` now early-returns when `language == "java"` to a JSON-RPC subprocess client that spawns `java -jar provekit-realize-java.jar --rpc`, sends one `provekit.plugin.invoke` request, and parses `{source, is_stub}` from the response.

The Java plugin embeds `java-canonical-bodies.json` (from #767) as a classpath resource via maven-resources-plugin copy from `menagerie/`. Source of truth stays in menagerie; drift caught by #767's `substrate_default_cids` test.

## §5 compliance: per-concept gap emission

`apply_canonical_rewrite` now returns `Vec<String>` of concept names whose realized body fell through to a stub. The main flow augments `gaps` with one `bind-stub-body-emitted` entry per name BEFORE writing `gaps.json`.

**Removed:** the unconditional hardcoded-count `bind-stub-body-emitted` gap in `run_bind_engine`. That was the lie #765 surfaced — the engine cannot know which concepts will fall through to stubs; only the realizer does.

## Trinity verdict (the load-bearing measurement)

```
trinity_round_trip: 13 loss entries (was 5):
  [bind-stub-body-emitted] concept 'assert'
  [bind-stub-body-emitted] concept 'list'
  [bind-stub-body-emitted] concept 'option'
  [bind-stub-body-emitted] concept 'option-bind'
  [bind-stub-body-emitted] concept 'pair'
  [bind-stub-body-emitted] concept 'result'
  [bind-stub-body-emitted] concept 'result-bind'
  [bind-stub-body-emitted] concept 'retry-loop'
  [bind-stub-body-emitted] concept 'tagged-union'
  [leg-3-not-reached] ...
  [source-language-not-supported] (java)
  [v0-capability-gap] multi-lang lift_plugin dispatch deferred
  [v0-capability-gap] real ConceptAbstractionMemento catalog deferred
```

Count went UP (5 → 13) because we're being **precise** now. Each entry names a specific concept or capability and points at a specific way to close it. `identity`, `bool-cell`, and `unit` are **correctly absent** because their real bodies emit via the Java plugin (verified empirically: `return x;`, `return !flag;`, `return;`).

The 9 named stub concepts ARE the exact #769 backlog. The 4 substrate-deferred items remain honestly noted.

## Tests

- `trinity_roundtrip_test`: PASS
- `cmd_bind_integration::f6_gaps_record_stub_body_emitted_per_concept` (renamed): PASS — asserts each entry's `detail` names a specific concept
- `cmd_bind_integration`: 27/27 PASS
- All other `provekit-cli` test groups: **224 PASS** total
- Pre-existing `test_daemon_polyglot_smoke` failure (missing `provekit-linkerd` binary) unrelated and unaffected

## Gated by

#766 (spec, merged), #767 (data + minting recipe, merged)

## Blocks

#769 — real body emission for the remaining 9 concepts. The 9 `bind-stub-body-emitted` entries this PR emits ARE the literal deliverable list.

## Known follow-ups (separate PRs)

1. `TargetStyle::Java` match arms + `stub_body_for(Java)` + `map_source_type` Java branch remain in `cmd_transport.rs` as dead code for non-bind realize callers (cross-language transport CLI). Boy-scout PR removes them once those callers also delegate. **The production bind path NEVER hits them** — the early-return guards.
2. Slice 2 byte-identical tests are now plugin-vs-plugin tautologies. Still pass. Converting to snapshot or deleting is follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
