### PR TITLE
feat(771): wrap Python lift kit as provekit-lift/1 plugin

### DIFF
--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
@@ -2,11 +2,13 @@
 #
 # provekit.lsp: Language Server Protocol plugin for Python.
 #
-# Implements the ProvekIt LSP plugin protocol: NDJSON over stdio.
+# Implements the ProvekIt lift plugin protocol (provekit-lift/1): NDJSON over stdio.
 # Messages:
 #   { "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }
-#   { "jsonrpc": "2.0", "id": 2, "method": "parse", "params": { "path": "...", "source": "..." } }
+#   { "jsonrpc": "2.0", "id": 2, "method": "lift", "params": { "workspace_root": "...", "source_paths": [...] } }
 #   { "jsonrpc": "2.0", "id": 3, "method": "shutdown" }
+#
+# Legacy parse method is retained for backward compatibility.
 #
 # The plugin walks Python source, lifts contracts, and returns IR JSON.
 
@@ -69,7 +71,12 @@ def handle_initialize(msg_id: Any) -> None:
             "result": {
                 "name": "provekit-lsp-python",
                 "version": "0.1.0",
-                "capabilities": ["parse"],
+                "protocol_version": "provekit-lift/1",
+                "capabilities": {
+                    "authoring_surfaces": ["python-source"],
+                    "ir_version": "v1.1.0",
+                    "emits_signed_mementos": False,
+                },
             },
         }
     )

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
@@ -17,7 +17,7 @@ def initialize_result() -> dict[str, Any]:
     return {
         "name": "provekit-lift-python-source",
         "version": VERSION,
-        "protocol_version": "pep/1.7.0",
+        "protocol_version": "provekit-lift/1",
         "dialect": SURFACE,
         "capabilities": {
             "authoring_surfaces": [SURFACE],

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -166,7 +166,7 @@ def test_rpc_initialize_declares_python_source_draft() -> None:
     result = initialize_result()
 
     assert result["version"] == "0.1.0-draft"
-    assert result["protocol_version"] == "pep/1.7.0"
+    assert result["protocol_version"] == "provekit-lift/1"
     assert result["dialect"] == "python-source"
     assert result["capabilities"]["authoring_surfaces"] == ["python-source"]
     assert result["capabilities"]["emits_signed_mementos"] is False


### PR DESCRIPTION
## Summary

- `rpc.py`: `protocol_version` corrected from `"pep/1.7.0"` to `"provekit-lift/1"`; `lift` handler already returns `ir-document` shape (callEdges:[], diagnostics, opacityReport, refusals)
- `lsp.py`: `handle_initialize` updated to return full `provekit-lift/1` shape with `protocol_version`, `capabilities.authoring_surfaces`, `ir_version`, `emits_signed_mementos`; existing `handle_lift` already returns `ir-document`
- `test_lifter.py`: `test_rpc_initialize_declares_python_source_draft` asserts `protocol_version == "provekit-lift/1"`
- Legacy `parse` method retained for backward compatibility
- concept-tag re-lift recognition deferred to follow-up #756

## Wire shape

```
initialize → {name, version:"0.1.0-draft", protocol_version:"provekit-lift/1", dialect:"python-source", capabilities:{authoring_surfaces:["python-source"], ir_version:"v1.1.0", emits_signed_mementos:false}}
lift        → {kind:"ir-document", ir:[...], callEdges:[], diagnostics:[], opacityReport:[], refusals:[]}
shutdown    → {result:null}
```

## Test plan

- [x] `python3 -m pytest tests/test_lifter.py` — 8/8 pass
- [ ] concept-tag re-lift recognition deferred to follow-up #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)