### PR TITLE
feat(771): wrap TypeScript lift kit as provekit-lift/1 plugin

### DIFF
--- a/implementations/typescript/src/lsp/daemon.test.ts
+++ b/implementations/typescript/src/lsp/daemon.test.ts
@@ -4,8 +4,9 @@
  * Mirrors implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py.
  *
  * Asserts:
- *   - initialize responds with name == "provekit-lsp-ts" and capabilities == ["parse"].
- *   - parse returns result.declarations as a JSON array (not a string).
+ *   - initialize responds with protocol_version == "provekit-lift/1" and capabilities object.
+ *   - lift returns result.kind == "ir-document" with ir array.
+ *   - parse (legacy) returns result.declarations as a JSON array (not a string).
  *   - parse returns result.callEdges as a JSON array.
  *   - With a contract-bearing fixture, each declaration has kind == "contract".
  *   - Empty source returns declarations == [] and callEdges == [].
@@ -16,6 +17,8 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -57,6 +60,16 @@ function buildSession(source: string, path: string): string {
   return msgs.map((m) => JSON.stringify(m)).join("\n") + "\n";
 }
 
+/** Build NDJSON for initialize -> lift -> shutdown. */
+function buildLiftSession(workspaceRoot: string, sourcePaths: string[]): string {
+  const msgs = [
+    { jsonrpc: "2.0", id: 10, method: "initialize", params: {} },
+    { jsonrpc: "2.0", id: 11, method: "lift", params: { workspace_root: workspaceRoot, source_paths: sourcePaths } },
+    { jsonrpc: "2.0", id: 12, method: "shutdown" },
+  ];
+  return msgs.map((m) => JSON.stringify(m)).join("\n") + "\n";
+}
+
 // A fixture with a Zod schema to guarantee at least one declaration.
 const ZOD_FIXTURE_SOURCE = `
 import { z } from "zod";
@@ -78,6 +91,7 @@ let emptyResponses: Record<string, unknown>[] = [];
 let unknownMethodResponses: Record<string, unknown>[] = [];
 let unsupportedLanguageResponses: Record<string, unknown>[] = [];
 let zodResponses2: Record<string, unknown>[] = [];   // second run for determinism
+let liftResponses: Record<string, unknown>[] = [];
 
 // Per-suite vitest timeout. Each individual test just reads cached data.
 const SUITE_TIMEOUT_MS = 60_000;
@@ -87,6 +101,13 @@ describe("daemon protocol conformance (provekit-lsp-ts)", () => {
     zodResponses = runLsp(buildSession(ZOD_FIXTURE_SOURCE, ZOD_FIXTURE_PATH));
     emptyResponses = runLsp(buildSession("// no contracts here\n", "empty.ts"));
     zodResponses2 = runLsp(buildSession(ZOD_FIXTURE_SOURCE, ZOD_FIXTURE_PATH));
+
+    // Write the Zod fixture to a temp file for the lift test.
+    const tmpFixtureDir = resolve(tmpdir(), `pk-lsp-ts-test-${Date.now()}`);
+    mkdirSync(tmpFixtureDir, { recursive: true });
+    const tmpFixturePath = resolve(tmpFixtureDir, "fixture.ts");
+    writeFileSync(tmpFixturePath, ZOD_FIXTURE_SOURCE, "utf8");
+    liftResponses = runLsp(buildLiftSession(tmpFixtureDir, ["fixture.ts"]));
 
     const unknownMsgs = [
       { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
@@ -110,13 +131,43 @@ describe("daemon protocol conformance (provekit-lsp-ts)", () => {
     );
   }, SUITE_TIMEOUT_MS);
 
-  it("initialize: name == provekit-lsp-ts and capabilities includes parse", () => {
+  it("initialize: name == provekit-lsp-ts and protocol_version == provekit-lift/1", () => {
     const initResp = zodResponses.find((r) => r.id === 1);
     expect(initResp).toBeDefined();
     const result = initResp!.result as Record<string, unknown>;
     expect(result.name).toBe("provekit-lsp-ts");
-    expect(Array.isArray(result.capabilities)).toBe(true);
-    expect(result.capabilities).toContain("parse");
+    expect(result.protocol_version).toBe("provekit-lift/1");
+    const caps = result.capabilities as Record<string, unknown>;
+    expect(Array.isArray(caps.authoring_surfaces)).toBe(true);
+    expect((caps.authoring_surfaces as string[]).includes("typescript-source")).toBe(true);
+    expect(caps.emits_signed_mementos).toBe(false);
+  });
+
+  it("lift: kind == ir-document with ir array", () => {
+    const initResp = liftResponses.find((r) => r.id === 10);
+    expect(initResp).toBeDefined();
+    const initResult = initResp!.result as Record<string, unknown>;
+    expect(initResult.protocol_version).toBe("provekit-lift/1");
+
+    const liftResp = liftResponses.find((r) => r.id === 11);
+    expect(liftResp).toBeDefined();
+    expect(liftResp!.error).toBeUndefined();
+    const liftResult = liftResp!.result as Record<string, unknown>;
+    expect(liftResult.kind).toBe("ir-document");
+    expect(Array.isArray(liftResult.ir)).toBe(true);
+    expect(Array.isArray(liftResult.callEdges)).toBe(true);
+    expect(Array.isArray(liftResult.diagnostics)).toBe(true);
+    expect(Array.isArray(liftResult.refusals)).toBe(true);
+  });
+
+  it("lift: zod fixture produces at least one ir entry with kind == contract", () => {
+    const liftResp = liftResponses.find((r) => r.id === 11);
+    const liftResult = liftResp!.result as Record<string, unknown>;
+    const ir = liftResult.ir as Record<string, unknown>[];
+    expect(ir.length).toBeGreaterThanOrEqual(1);
+    for (const entry of ir) {
+      expect(entry.kind).toBe("contract");
+    }
   });
 
   it("parse: declarations is a JSON array (not a string)", () => {

--- a/implementations/typescript/src/lsp/daemon.ts
+++ b/implementations/typescript/src/lsp/daemon.ts
@@ -1,23 +1,23 @@
 /**
  * provekit-lsp-ts: NDJSON LSP plugin for TypeScript.
  *
- * Protocol (NDJSON over stdin/stdout):
+ * Protocol (provekit-lift/1 over stdio):
  *
  *   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
- *   {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
+ *   {"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":"...","source_paths":[...]}}
  *   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
  *
- * Implements the ProvekIt parse-protocol wire shape so the linkerd's
- * multi-kit dispatch can use it via `spawn_kit_lifter`.
+ * Legacy parse method is retained for backward compatibility.
  *
- * Wire shape for parse response:
- *   result.declarations: JSON array of IR contract objects:
- *     { kind: "contract", name, outBinding, pre?, post?, inv? }
- *   result.callEdges: JSON array (empty; TS lifter does not emit call edges)
- *   result.warnings: JSON array of warning strings
+ * Wire shape for lift response:
+ *   result.kind: "ir-document"
+ *   result.ir: JSON array of IR contract objects
+ *   result.callEdges: [] (TS lifter cannot compute contract CIDs; follow-up #756)
+ *   result.diagnostics: JSON array
+ *   result.opacityReport: []
+ *   result.refusals: []
  *
- * Mirrors implementations/go/cmd/provekit-lsp-go/main.go and
- * implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py.
+ * Mirrors implementations/go/provekit-lift-go/rpc.go.
  *
  * JCS gotcha: do NOT pass IrFormula objects through JSON.stringify and embed
  * the resulting string. JSON.parse them first so the response contains a
@@ -26,6 +26,8 @@
  */
 
 import { createInterface } from "node:readline";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import ts from "typescript";
 import { liftFile as liftZodFile } from "../lift/adapters/zod.js";
 import { liftFile as liftFastCheckFile } from "../lift/adapters/fast-check.js";
@@ -34,10 +36,12 @@ import { liftFile as liftVitestTestsFile } from "../lift/adapters/vitest-tests.j
 import type { ContractDecl } from "../lift/types.js";
 
 // ---------------------------------------------------------------------------
-// Version
+// Version / protocol constants
 // ---------------------------------------------------------------------------
 
 const VERSION = "0.1.0";
+const PROTOCOL_VERSION = "provekit-lift/1";
+const SURFACE = "typescript-source";
 
 // ---------------------------------------------------------------------------
 // Wire types
@@ -54,6 +58,11 @@ interface ParseParams {
   path: string;
   source: string;
   language?: string;
+}
+
+interface LiftParams {
+  workspace_root?: string;
+  source_paths?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -111,8 +120,82 @@ function handleInitialize(id: unknown): void {
   respond(id, {
     name: "provekit-lsp-ts",
     version: VERSION,
-    capabilities: ["parse"],
+    protocol_version: PROTOCOL_VERSION,
+    capabilities: {
+      authoring_surfaces: [SURFACE],
+      ir_version: "v1.1.0",
+      emits_signed_mementos: false,
+    },
   });
+}
+
+function liftSourceToDecls(
+  source: string,
+  path: string,
+): { decls: ContractDecl[]; warnings: string[] } {
+  const sf = ts.createSourceFile(path, source, ts.ScriptTarget.ES2022, true);
+  const decls: ContractDecl[] = [];
+  const warnings: string[] = [];
+
+  const z = liftZodFile(sf, path);
+  decls.push(...z.decls);
+  for (const w of z.warnings) warnings.push(`zod: ${w.itemName}: ${w.reason}`);
+
+  const f = liftFastCheckFile(sf, path);
+  decls.push(...f.decls);
+  for (const w of f.warnings) warnings.push(`fast-check: ${w.itemName}: ${w.reason}`);
+
+  const cv = liftClassValidatorFile(sf, path);
+  decls.push(...cv.decls);
+  for (const w of cv.warnings) warnings.push(`class-validator: ${w.itemName}: ${w.reason}`);
+
+  const vt = liftVitestTestsFile(sf, path);
+  decls.push(...vt.decls);
+  for (const w of vt.warnings) warnings.push(`vitest-tests: ${w.itemName}: ${w.reason}`);
+
+  return { decls, warnings };
+}
+
+function handleLift(id: unknown, params: Record<string, unknown>): void {
+  const p = params as unknown as LiftParams;
+  const workspaceRoot = p.workspace_root ?? ".";
+  const sourcePaths = p.source_paths ?? [];
+
+  if (!Array.isArray(sourcePaths) || sourcePaths.length === 0) {
+    respondError(id, -32602, "lift: source_paths must be a non-empty array");
+    return;
+  }
+
+  try {
+    const ir: ReturnType<typeof contractDeclToWire>[] = [];
+    const diagnostics: unknown[] = [];
+
+    for (const sp of sourcePaths) {
+      const fullPath = resolve(workspaceRoot, sp);
+      let source: string;
+      try {
+        source = readFileSync(fullPath, "utf8");
+      } catch {
+        // File not readable: skip with a diagnostic entry.
+        diagnostics.push({ kind: "read-error", path: fullPath });
+        continue;
+      }
+
+      const { decls } = liftSourceToDecls(source, fullPath);
+      for (const decl of decls) ir.push(contractDeclToWire(decl));
+    }
+
+    respond(id, {
+      kind: "ir-document",
+      ir,
+      callEdges: [],
+      diagnostics,
+      opacityReport: [],
+      refusals: [],
+    });
+  } catch (err) {
+    respondError(id, -32603, (err as Error).message);
+  }
 }
 
 function handleParse(id: unknown, params: Record<string, unknown>): void {
@@ -127,32 +210,9 @@ function handleParse(id: unknown, params: Record<string, unknown>): void {
   }
 
   try {
-    const sf = ts.createSourceFile(path, source, ts.ScriptTarget.ES2022, true);
-
-    const decls: ContractDecl[] = [];
-    const warnings: string[] = [];
-
-    const z = liftZodFile(sf, path);
-    decls.push(...z.decls);
-    for (const w of z.warnings) warnings.push(`zod: ${w.itemName}: ${w.reason}`);
-
-    const f = liftFastCheckFile(sf, path);
-    decls.push(...f.decls);
-    for (const w of f.warnings) warnings.push(`fast-check: ${w.itemName}: ${w.reason}`);
-
-    const cv = liftClassValidatorFile(sf, path);
-    decls.push(...cv.decls);
-    for (const w of cv.warnings) warnings.push(`class-validator: ${w.itemName}: ${w.reason}`);
-
-    const vt = liftVitestTestsFile(sf, path);
-    decls.push(...vt.decls);
-    for (const w of vt.warnings) warnings.push(`vitest-tests: ${w.itemName}: ${w.reason}`);
+    const { decls, warnings } = liftSourceToDecls(source, path);
 
     // Convert ContractDecl[] to wire-format array.
-    // IrFormula values are plain objects: JSON.parse(JSON.stringify(x)) is
-    // equivalent to a deep clone; we skip it and embed directly since the
-    // values are already plain JSON-serializable objects. The `send()` call
-    // will serialize via JSON.stringify.
     const declarations = decls.map(contractDeclToWire);
 
     // TS lifter does not emit call edges. The linkerd treats absent/empty
@@ -191,6 +251,10 @@ export function handleRequest(line: string): boolean {
   switch (method) {
     case "initialize":
       handleInitialize(id);
+      return true;
+
+    case "lift":
+      handleLift(id, (params ?? {}) as Record<string, unknown>);
       return true;
 
     case "parse":


### PR DESCRIPTION
## Summary

- `daemon.ts`: `handleInitialize` returns `protocol_version:"provekit-lift/1"` with `capabilities:{authoring_surfaces:["typescript-source"], ir_version:"v1.1.0", emits_signed_mementos:false}`; new `handleLift` reads `source_paths`, calls all lift adapters (Zod, fast-check, class-validator, vitest-tests), returns `ir-document` shape; refactored `handleParse` to share `liftSourceToDecls` helper; legacy `parse` method retained
- `daemon.test.ts`: initialize test updated to assert `protocol_version` and capabilities object shape; new lift tests verify `ir-document` shape and that zod fixture produces IR entries
- concept-tag re-lift recognition deferred to follow-up #756

## Wire shape

```
initialize → {name, version:"0.1.0", protocol_version:"provekit-lift/1", capabilities:{authoring_surfaces:["typescript-source"], ir_version:"v1.1.0", emits_signed_mementos:false}}
lift        → {kind:"ir-document", ir:[...contracts...], callEdges:[], diagnostics:[], opacityReport:[], refusals:[]}
shutdown    → {result:null}
```

## Test plan

- [x] `pnpm test` — 789/789 tests pass (44 test files)
- [ ] concept-tag re-lift recognition deferred to follow-up #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)