### PR TITLE
feat(771): wrap Ruby lift kit as provekit-lift/1 plugin

### DIFF
--- a/implementations/ruby/bin/provekit-lsp-ruby
+++ b/implementations/ruby/bin/provekit-lsp-ruby
@@ -3,10 +3,12 @@
 #
 # provekit-lsp-ruby: NDJSON LSP plugin for Ruby.
 #
-# Protocol:
+# Protocol (provekit-lift/1 over stdio):
 #   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
-#   {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
+#   {"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":"...","source_paths":[...]}}
 #   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
+#
+# Legacy parse method is retained for backward compatibility.
 #
 # Usage: provekit-lsp-ruby --rpc
 
@@ -44,15 +46,75 @@ ARGV.include?("--rpc") || (warn "Usage: provekit-lsp-ruby --rpc"; exit 1)
 
 STDIN.each_line do |line|
   req = JSON.parse(line) rescue next
-  id = req["id"]
+  id     = req["id"]
   method = req["method"]
+  params = req["params"] || {}
 
   case method
   when "initialize"
-    respond id, { name: "provekit-lsp-ruby", version: "0.1.0", capabilities: ["parse"] }
+    respond id, {
+      name: "provekit-lsp-ruby",
+      version: "0.1.0",
+      protocol_version: "provekit-lift/1",
+      capabilities: {
+        authoring_surfaces: ["ruby-source"],
+        ir_version: "v1.1.0",
+        emits_signed_mementos: false,
+      },
+    }
+
+  when "lift"
+    workspace_root = params["workspace_root"] || "."
+    source_paths   = params["source_paths"] || []
+
+    unless source_paths.is_a?(Array) && !source_paths.empty?
+      err id, -32602, "lift: source_paths must be a non-empty array"
+      next
+    end
+
+    all_decls = []
+    diagnostics = []
+
+    source_paths.each do |sp|
+      full_path = File.expand_path(sp.to_s, workspace_root)
+      next unless File.file?(full_path) && full_path.end_with?(".rb")
+
+      begin
+        source = File.read(full_path, encoding: "utf-8")
+      rescue => e
+        diagnostics << { kind: "read-error", path: full_path, reason: e.message }
+        next
+      end
+
+      # Lift annotations.
+      source.each_line.with_index do |line, i|
+        if line =~ /#\s*provekit:\s*contract/
+          fn = source.lines.drop(i + 1).take(10).find { |l| l =~ /def\s+(\w+)/ }
+          fn_name = fn ? $1 : "unknown"
+          all_decls << ContractDecl.new(name: fn_name, post: Provekit::IR.and())
+        end
+        if line =~ /#\s*provekit:\s*implement\s+([\w-]+)/
+          cid = $1
+          fn = source.lines.drop(i + 1).take(10).find { |l| l =~ /def\s+(\w+)/ }
+          fn_name = fn ? $1 : "unknown"
+          all_decls << ContractDecl.new(name: "#{fn_name}->#{cid}", post: Provekit::IR.and())
+        end
+      end
+    end
+
+    jcs = all_decls.empty? ? "[]" : Provekit::IR.marshal_declarations(all_decls)
+    ir = JSON.parse(jcs)
+
+    respond id, {
+      kind: "ir-document",
+      ir: ir,
+      callEdges: [],
+      diagnostics: diagnostics,
+      opacityReport: [],
+      refusals: [],
+    }
 
   when "parse"
-    params = req["params"] || {}
     path   = params["path"] || "source.rb"
     source = params["source"] || ""
 

--- a/implementations/ruby/test/test_daemon_protocol.rb
+++ b/implementations/ruby/test/test_daemon_protocol.rb
@@ -3,8 +3,9 @@
 # Smoke test: protocol conformance of the provekit-lsp-ruby binary.
 #
 # Asserts:
-#   - The binary responds to initialize/parse/shutdown.
-#   - parse response has result.declarations as a JSON array, not a string.
+#   - initialize responds with protocol_version == "provekit-lift/1".
+#   - lift returns result.kind == "ir-document" with ir array.
+#   - parse (legacy) response has result.declarations as a JSON array, not a string.
 #   - parse response has result.callEdges as a JSON array.
 #   - Each declaration in a non-empty result is an object with kind=="contract".
 #   - Byte-determinism: two runs on the same input produce identical output.
@@ -60,7 +61,66 @@ class TestDaemonProtocol < Minitest::Test
     assert init_resp, "Expected id 1 not found. Available ids: #{responses.map { |r| r['id'] }}"
     result = init_resp["result"]
     assert_equal "provekit-lsp-ruby", result["name"]
-    assert_includes result["capabilities"], "parse"
+    assert_equal "provekit-lift/1", result["protocol_version"],
+                 "expected protocol_version == 'provekit-lift/1'"
+    caps = result["capabilities"]
+    assert_instance_of Hash, caps, "capabilities should be a Hash"
+    assert_includes caps["authoring_surfaces"], "ruby-source"
+    assert_equal false, caps["emits_signed_mementos"]
+  end
+
+  def test_lift_ir_document_shape
+    # Write a fixture file then exercise the lift method.
+    require "tmpdir"
+    Dir.mktmpdir do |dir|
+      fixture_path = File.join(dir, "fixture.rb")
+      File.write(fixture_path, FIXTURE_SOURCE)
+
+      msgs = [
+        { jsonrpc: "2.0", id: 10, method: "initialize", params: {} },
+        { jsonrpc: "2.0", id: 11, method: "lift",
+          params: { workspace_root: dir, source_paths: ["fixture.rb"] } },
+        { jsonrpc: "2.0", id: 12, method: "shutdown" },
+      ]
+      ndjson = msgs.map { |m| JSON.generate(m) }.join("\n") + "\n"
+      responses = run_lsp(ndjson)
+
+      lift_resp = responses.find { |r| r["id"] == 11 }
+      assert lift_resp, "Expected lift id 11 not found. Available ids: #{responses.map { |r| r['id'] }}"
+      refute lift_resp["error"], "lift returned error: #{lift_resp.inspect}"
+      result = lift_resp["result"]
+      assert_equal "ir-document", result["kind"]
+      assert_instance_of Array, result["ir"]
+      assert_instance_of Array, result["callEdges"]
+      assert_equal [], result["callEdges"]
+      assert_instance_of Array, result["diagnostics"]
+      assert_instance_of Array, result["refusals"]
+    end
+  end
+
+  def test_lift_ir_contains_contract_entries
+    require "tmpdir"
+    Dir.mktmpdir do |dir|
+      fixture_path = File.join(dir, "fixture.rb")
+      File.write(fixture_path, FIXTURE_SOURCE)
+
+      msgs = [
+        { jsonrpc: "2.0", id: 10, method: "initialize", params: {} },
+        { jsonrpc: "2.0", id: 11, method: "lift",
+          params: { workspace_root: dir, source_paths: ["fixture.rb"] } },
+        { jsonrpc: "2.0", id: 12, method: "shutdown" },
+      ]
+      ndjson = msgs.map { |m| JSON.generate(m) }.join("\n") + "\n"
+      responses = run_lsp(ndjson)
+
+      lift_resp = responses.find { |r| r["id"] == 11 }
+      result = lift_resp["result"]
+      ir = result["ir"]
+      assert ir.length >= 1, "Expected at least one IR entry from contract-bearing fixture"
+      ir.each do |entry|
+        assert_equal "contract", entry["kind"], "IR entry kind should be 'contract'"
+      end
+    end
   end
 
   def test_parse_declarations_is_array


### PR DESCRIPTION
## Summary

- `bin/provekit-lsp-ruby`: `initialize` returns `protocol_version:"provekit-lift/1"` with `capabilities:{authoring_surfaces:["ruby-source"], ir_version:"v1.1.0", emits_signed_mementos:false}`; new `lift` method reads `source_paths`, scans `.rb` files for `# provekit:contract` annotations, returns `ir-document` shape; `params` extracted at loop-top so both `lift` and `parse` share it; legacy `parse` method retained
- `test/test_daemon_protocol.rb`: initialize test updated to assert `protocol_version` and capabilities object; two new tests for lift: `ir-document` shape and IR entries have `kind:"contract"`
- concept-tag re-lift recognition deferred to follow-up #756

## Wire shape

```
initialize → {name, version:"0.1.0", protocol_version:"provekit-lift/1", capabilities:{authoring_surfaces:["ruby-source"], ir_version:"v1.1.0", emits_signed_mementos:false}}
lift        → {kind:"ir-document", ir:[...], callEdges:[], diagnostics:[], opacityReport:[], refusals:[]}
shutdown    → {result:null}
```

## Test plan

- [x] `ruby test/test_daemon_protocol.rb` — 10/10 pass
- [ ] concept-tag re-lift recognition deferred to follow-up #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)