### PR TITLE
feat(771): wrap PHP lift kit as provekit-lift/1 plugin

### DIFF
--- a/implementations/php/provekit-lift/src/lspd.php
+++ b/implementations/php/provekit-lift/src/lspd.php
@@ -1,8 +1,8 @@
 <?php
 /** ProvekIt PHP LSP daemon: parses PHP source, extracts contracts + call edges.
  *  Mirrors the Go LSP (`provekit-lsp-go`).
- *  Methods: initialize, parse, shutdown.
- *  Response shape: declarations + callEdges.
+ *  Protocol: provekit-lift/1 over stdio.
+ *  Methods: initialize, lift, parse (legacy), shutdown.
  */
 
 declare(strict_types=1);
@@ -44,10 +44,18 @@ class AnnotationScanner
 
             // @provekit-contract
             if (preg_match('#^//\s*@provekit-contract#', $trimmed)) {
-                if ($funcName) {
+                // Look ahead up to 10 lines for the function definition.
+                $target = $funcName;
+                for ($j = $i + 1; $j < min($i + 10, count($lines)); $j++) {
+                    if (preg_match('/\bfunction\s+(\w+)\b/', $lines[$j], $fm)) {
+                        $target = $fm[1];
+                        break;
+                    }
+                }
+                if ($target) {
                     $declarations[] = [
                         'kind' => 'contract',
-                        'name' => $funcName,
+                        'name' => $target,
                         'outBinding' => 'out',
                         'post' => ['kind' => 'atomic', 'name' => 'true', 'args' => []],
                     ];
@@ -167,8 +175,63 @@ while (($line = fgets($stdin)) !== false) {
         match ($method) {
             'initialize' => send(json_encode([
                 'jsonrpc' => '2.0', 'id' => $id,
-                'result' => ['name' => 'provekit-lsp-php', 'version' => '1.0.0', 'capabilities' => []],
+                'result' => [
+                    'name'             => 'provekit-lsp-php',
+                    'version'          => '1.0.0',
+                    'protocol_version' => 'provekit-lift/1',
+                    'capabilities'     => [
+                        'authoring_surfaces'    => ['php-source'],
+                        'ir_version'            => 'v1.1.0',
+                        'emits_signed_mementos' => false,
+                    ],
+                ],
             ])),
+
+            'lift' => (function () use ($id, $params) {
+                $workspaceRoot = $params['workspace_root'] ?? '.';
+                $sourcePaths   = $params['source_paths'] ?? [];
+
+                if (!is_array($sourcePaths) || empty($sourcePaths)) {
+                    send(json_encode([
+                        'jsonrpc' => '2.0', 'id' => $id,
+                        'error' => ['code' => -32602, 'message' => 'lift: source_paths must be a non-empty array'],
+                    ]));
+                    return;
+                }
+
+                $ir          = [];
+                $diagnostics = [];
+
+                foreach ($sourcePaths as $sp) {
+                    $fullPath = $sp && $sp[0] === '/'
+                        ? $sp
+                        : rtrim($workspaceRoot, '/') . '/' . $sp;
+                    if (!is_file($fullPath) || !str_ends_with($fullPath, '.php')) {
+                        continue;
+                    }
+                    $source = @file_get_contents($fullPath);
+                    if ($source === false) {
+                        $diagnostics[] = ['kind' => 'read-error', 'path' => $fullPath];
+                        continue;
+                    }
+                    $scanned = AnnotationScanner::scan($source, $fullPath);
+                    foreach ($scanned['declarations'] as $decl) {
+                        $ir[] = $decl;
+                    }
+                }
+
+                send(json_encode([
+                    'jsonrpc' => '2.0', 'id' => $id,
+                    'result' => [
+                        'kind'          => 'ir-document',
+                        'ir'            => $ir,
+                        'callEdges'     => [],
+                        'diagnostics'   => $diagnostics,
+                        'opacityReport' => [],
+                        'refusals'      => [],
+                    ],
+                ]));
+            })(),
 
             'parse' => (function () use ($id, $params) {
                 $path = $params['path'] ?? '';

--- a/implementations/php/provekit-lift/tests/integration_lsp.sh
+++ b/implementations/php/provekit-lift/tests/integration_lsp.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Integration test for provekit-lsp-php (lspd.php).
+#
+# Tests provekit-lift/1 protocol: initialize, lift, parse (legacy), shutdown.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LSPD="$SCRIPT_DIR/../src/lspd.php"
+
+if [ ! -f "$LSPD" ]; then
+    echo "FAIL: lspd.php not found: $LSPD" >&2
+    exit 1
+fi
+
+PHP_BIN="${PHP_BIN:-php}"
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    local response="$2"
+    local must_contain="$3"
+
+    if printf '%s' "$response" | grep -qF "$must_contain"; then
+        printf "  PASS: %s\n" "$label"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s\n" "$label" >&2
+        printf "        expected to contain: %s\n" "$must_contain" >&2
+        printf "        got: %s\n" "$response" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Create a temp fixture PHP file with a @provekit-contract annotation.
+# ---------------------------------------------------------------------------
+TMPDIR_PATH="$(mktemp -d)"
+FIXTURE="$TMPDIR_PATH/fixture.php"
+cat > "$FIXTURE" << 'EOF'
+<?php
+// @provekit-contract
+function add_numbers(int $a, int $b): int {
+    return $a + $b;
+}
+EOF
+
+printf "Running provekit-lsp-php integration tests...\n"
+
+# ---------------------------------------------------------------------------
+# Round 1: initialize + lift + shutdown
+# ---------------------------------------------------------------------------
+printf "\n-- initialize / lift / shutdown --\n"
+
+LIFT_REQUESTS=$(printf '%s\n%s\n%s\n' \
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+    "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"lift\",\"params\":{\"workspace_root\":\"$TMPDIR_PATH\",\"source_paths\":[\"fixture.php\"]}}" \
+    '{"jsonrpc":"2.0","id":3,"method":"shutdown"}')
+
+LIFT_RESPONSES=$(printf '%s\n' "$LIFT_REQUESTS" | "$PHP_BIN" "$LSPD")
+
+LIFT1=$(printf '%s\n' "$LIFT_RESPONSES" | sed -n '1p')
+LIFT2=$(printf '%s\n' "$LIFT_RESPONSES" | sed -n '2p')
+LIFT3=$(printf '%s\n' "$LIFT_RESPONSES" | sed -n '3p')
+
+check "T1 initialize: name"              "$LIFT1" '"name":"provekit-lsp-php"'
+check "T2 initialize: protocol_version"  "$LIFT1" '"protocol_version":"provekit-lift'
+check "T3 initialize: authoring_surfaces" "$LIFT1" '"authoring_surfaces":["php-source"]'
+check "T4 initialize: emits_signed_mementos false" "$LIFT1" '"emits_signed_mementos":false'
+check "T5 lift: kind ir-document"        "$LIFT2" '"kind":"ir-document"'
+check "T6 lift: ir key present"          "$LIFT2" '"ir":'
+check "T7 lift: contract add_numbers"    "$LIFT2" '"name":"add_numbers"'
+check "T8 lift: callEdges empty"         "$LIFT2" '"callEdges":[]'
+check "T9 lift: diagnostics key present" "$LIFT2" '"diagnostics":'
+check "T10 lift: refusals key present"   "$LIFT2" '"refusals":'
+check "T11 shutdown: result null"        "$LIFT3" '"result":null'
+
+# ---------------------------------------------------------------------------
+# Round 2: legacy parse method
+# ---------------------------------------------------------------------------
+printf "\n-- legacy parse --\n"
+
+SOURCE=$(cat "$FIXTURE" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' | tr -d '\n' | sed 's/\\n$//')
+
+PARSE_REQUESTS=$(printf '%s\n%s\n%s\n' \
+    '{"jsonrpc":"2.0","id":10,"method":"initialize","params":{}}' \
+    "{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"parse\",\"params\":{\"path\":\"fixture.php\",\"source\":\"$SOURCE\"}}" \
+    '{"jsonrpc":"2.0","id":12,"method":"shutdown"}')
+
+PARSE_RESPONSES=$(printf '%s\n' "$PARSE_REQUESTS" | "$PHP_BIN" "$LSPD")
+
+PARSE2=$(printf '%s\n' "$PARSE_RESPONSES" | sed -n '2p')
+
+check "T12 parse: declarations key"    "$PARSE2" '"declarations":'
+check "T13 parse: contract add_numbers" "$PARSE2" '"name":"add_numbers"'
+
+# Cleanup
+rm -rf "$TMPDIR_PATH"
+
+printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- `lspd.php`: `initialize` returns `protocol_version:"provekit-lift/1"` with `capabilities:{authoring_surfaces:["php-source"], ir_version:"v1.1.0", emits_signed_mementos:false}`; new `lift` case reads `source_paths`, scans `.php` files for `@provekit-contract` annotations, returns `ir-document` shape; fix `AnnotationScanner::scan` look-ahead so annotations preceding function definitions are recognized; legacy `parse` method retained
- `tests/integration_lsp.sh`: new 13-assertion shell integration test covering initialize/lift/parse/shutdown protocol conformance
- concept-tag re-lift recognition deferred to follow-up #756

## Wire shape

```
initialize → {name, version:"1.0.0", protocol_version:"provekit-lift/1", capabilities:{authoring_surfaces:["php-source"], ir_version:"v1.1.0", emits_signed_mementos:false}}
lift        → {kind:"ir-document", ir:[...], callEdges:[], diagnostics:[], opacityReport:[], refusals:[]}
shutdown    → {result:null}
```

## Test plan

- [x] `sh tests/integration_lsp.sh` — 13/13 pass
- [ ] concept-tag re-lift recognition deferred to follow-up #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)