### PR TITLE
feat(774): wrap C realize kit as PEP 1.7.0 plugin

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -2105,6 +2105,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-realize-c-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "provekit-self-contracts"
 version = "0.1.0"
 dependencies = [

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -53,6 +53,7 @@ members = [
     "examples/build_script_demo",
     "provekit-linkerd",
     "provekit-baseline-std",
+    "provekit-realize-c-core",
     "../../menagerie/bug-zoo",
     "../../menagerie/bridgeworks",
     "../../menagerie/supply-chain-rails",

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -105,3 +105,23 @@ fn java_canonical_bodies_cid_self_consistent() {
         "blake3-512:e9c5dd414a182211d5b85e3f2052d491e85c90db5ed29fb1145c7d1ad7f4e34f71de80c12a210202c6bd7efe26639da0e4e1c446beca786245d4a3dc6708204b",
     );
 }
+
+#[test]
+fn c_canonical_sugar_cid_self_consistent() {
+    let path = repo_root()
+        .join("menagerie/c-language-signature/specs/sugar/c-canonical.json");
+    assert_self_consistent(
+        path,
+        "blake3-512:a67012722271aca3a882bc82fa7b92941453e750a65366534ea37ef8eef593921bb3aa33e6b0051bf64531962346014097ef9a99f14f7c3245de1beea6c076dc",
+    );
+}
+
+#[test]
+fn c_canonical_bodies_cid_self_consistent() {
+    let path = repo_root()
+        .join("menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json");
+    assert_self_consistent(
+        path,
+        "blake3-512:44f18ea2725ec26196399f6511bf3887db52db3c0e1356e7e090ff41f893929e177df9786d6639d8015d08641dda54338f83e1bd24a07828b5bf6b33c0d7d329",
+    );
+}

--- a/implementations/rust/provekit-realize-c-core/Cargo.toml
+++ b/implementations/rust/provekit-realize-c-core/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "provekit-realize-c-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "ProvekIt PEP 1.7.0 realize plugin for C: lowers ProofIR to C source via JSON-RPC sidecar."
+
+[[bin]]
+name = "provekit-realize-c"
+path = "src/main.rs"
+
+[lib]
+name = "provekit_realize_c_core"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/implementations/rust/provekit-realize-c-core/src/lib.rs
+++ b/implementations/rust/provekit-realize-c-core/src/lib.rs
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-realize-c-core
+//
+// PEP 1.7.0 realize plugin for C. Lowers ProofIR concept bindings to
+// idiomatic C source. Parallel to `implementations/rust/provekit-realize-rust-core/`
+// which is the template this mirrors.
+//
+// Federation principle: ALL C surface emission lives here. Zero C syntax
+// knowledge belongs in `provekit-cli` or any other Rust crate.
+//
+// Fallthrough chain per the body-template-memento spec §1.2 and the
+// coordinator amendment:
+//   1. sugar dict match (op_pattern entries for concept-level ops, e.g. concept:free)
+//   2. body-template match (canonical body for the concept)
+//   3. language stub: `/* provekit-bind canonical: <concept> */ abort();`
+//
+// `is_stub` is true only when fallthrough reaches step 3.
+//
+// concept:free realization:
+//   C has explicit heap management so concept:free lowers to `free(${ptr});`.
+//   This is a LOSSLESS realization -- the IR concept maps exactly to the C
+//   stdlib call. loss_record = {}.
+
+use serde_json::Value;
+use std::sync::OnceLock;
+
+// ---------------------------------------------------------------------------
+// CID constants (minted by `mint-plugin-cid`, pinned in substrate_default_cids.rs)
+// ---------------------------------------------------------------------------
+
+/// CID for `menagerie/c-language-signature/specs/sugar/c-canonical.json`
+pub const SUGAR_PLUGIN_CID: &str =
+    "blake3-512:a67012722271aca3a882bc82fa7b92941453e750a65366534ea37ef8eef593921bb3aa33e6b0051bf64531962346014097ef9a99f14f7c3245de1beea6c076dc";
+
+/// CID for `menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json`
+pub const BODY_TEMPLATE_PLUGIN_CID: &str =
+    "blake3-512:44f18ea2725ec26196399f6511bf3887db52db3c0e1356e7e090ff41f893929e177df9786d6639d8015d08641dda54338f83e1bd24a07828b5bf6b33c0d7d329";
+
+// ---------------------------------------------------------------------------
+// Realization result
+// ---------------------------------------------------------------------------
+
+/// Result of lowering one function binding.
+///
+/// `is_stub = true` means the body fell through to the language stub;
+/// `is_stub = false` means a body-template or op-pattern entry rendered
+/// a real body. `cmd_bind` uses this to emit accurate per-concept
+/// `bind-stub-body-emitted` gap entries.
+#[derive(Debug, Clone)]
+pub struct Realization {
+    pub source: String,
+    pub is_stub: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Body-template entry (per body-template-memento.md §2)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct BodyTemplateEntry {
+    concept_name: String,
+    template_kind: String,
+    template: String,
+    min_params: Option<usize>,
+    max_params: Option<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Sugar dict entry (per sugar-dict-memento spec)
+// ---------------------------------------------------------------------------
+
+/// Which pattern shape this sugar entry uses.
+///
+/// `Predicate` entries match contract-clause predicates (requires/ensures) and
+/// emit comment-style annotations before the function.
+///
+/// `Op` entries match concept-level ops (e.g. concept:free) and emit inline
+/// code at the op site (e.g. `free(${ptr});` for C).
+#[derive(Debug, Clone)]
+enum SugarKind {
+    Predicate,
+    Op,
+}
+
+#[derive(Debug, Clone)]
+struct SugarEntry {
+    kind: SugarKind,
+    /// `head` is the `predicate_pattern.head` or `op_pattern.head` value.
+    head: String,
+    template: String,
+    surface_locator: String,
+}
+
+// ---------------------------------------------------------------------------
+// Plugin state (loaded once, shared across requests)
+// ---------------------------------------------------------------------------
+
+static BODY_ENTRIES: OnceLock<Vec<BodyTemplateEntry>> = OnceLock::new();
+static SUGAR_ENTRIES: OnceLock<Vec<SugarEntry>> = OnceLock::new();
+
+fn body_entries() -> &'static Vec<BodyTemplateEntry> {
+    BODY_ENTRIES.get_or_init(load_body_entries)
+}
+
+fn sugar_entries() -> &'static Vec<SugarEntry> {
+    SUGAR_ENTRIES.get_or_init(load_sugar_entries)
+}
+
+/// Load body-template entries from the embedded JSON bytes.
+fn load_body_entries() -> Vec<BodyTemplateEntry> {
+    const BODIES_JSON: &str =
+        include_str!("../../../../menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json");
+    parse_body_entries(BODIES_JSON)
+}
+
+fn load_sugar_entries() -> Vec<SugarEntry> {
+    const SUGAR_JSON: &str =
+        include_str!("../../../../menagerie/c-language-signature/specs/sugar/c-canonical.json");
+    parse_sugar_entries(SUGAR_JSON)
+}
+
+/// Return the raw JCS-canonical content JSON string, extracted from the embedded JSON.
+///
+/// Used in `provekit.plugin.describe` responses.
+pub fn sugar_content_json_from_embedded() -> String {
+    const SUGAR_JSON: &str =
+        include_str!("../../../../menagerie/c-language-signature/specs/sugar/c-canonical.json");
+    let root: serde_json::Value = serde_json::from_str(SUGAR_JSON).expect("sugar json parse");
+    let content = root
+        .get("header")
+        .and_then(|h| h.get("content"))
+        .expect("header.content missing");
+    serde_json::to_string(content).expect("serialize content")
+}
+
+fn parse_body_entries(raw: &str) -> Vec<BodyTemplateEntry> {
+    let root: Value = match serde_json::from_str(raw) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
+    let entries = match root
+        .get("header")
+        .and_then(|h| h.get("content"))
+        .and_then(|c| c.get("entries"))
+        .and_then(|e| e.as_array())
+    {
+        Some(a) => a.clone(),
+        None => return vec![],
+    };
+
+    let mut out = Vec::with_capacity(entries.len());
+    for item in &entries {
+        let concept_name = match item.get("concept_name").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let tmpl_obj = match item.get("emission_template") {
+            Some(v) => v,
+            None => continue,
+        };
+        let kind = match tmpl_obj.get("kind").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let template = match tmpl_obj.get("template").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let guard = item.get("signature_guard");
+        let min_params = guard
+            .and_then(|g| g.get("min_params"))
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize);
+        let max_params = guard
+            .and_then(|g| g.get("max_params"))
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize);
+        out.push(BodyTemplateEntry {
+            concept_name,
+            template_kind: kind,
+            template,
+            min_params,
+            max_params,
+        });
+    }
+    out
+}
+
+fn parse_sugar_entries(raw: &str) -> Vec<SugarEntry> {
+    let root: Value = match serde_json::from_str(raw) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
+    let entries = match root
+        .get("header")
+        .and_then(|h| h.get("content"))
+        .and_then(|c| c.get("entries"))
+        .and_then(|e| e.as_array())
+    {
+        Some(a) => a.clone(),
+        None => return vec![],
+    };
+
+    let mut out = Vec::with_capacity(entries.len());
+    for item in &entries {
+        // Determine which pattern shape this entry uses and extract the head.
+        let (kind, head) = if let Some(head) = item
+            .get("predicate_pattern")
+            .and_then(|p| p.get("head"))
+            .and_then(|v| v.as_str())
+        {
+            (SugarKind::Predicate, head.to_string())
+        } else if let Some(head) = item
+            .get("op_pattern")
+            .and_then(|p| p.get("head"))
+            .and_then(|v| v.as_str())
+        {
+            (SugarKind::Op, head.to_string())
+        } else {
+            // Entry has neither predicate_pattern nor op_pattern; skip.
+            continue;
+        };
+
+        let tmpl_obj = match item.get("emission_template") {
+            Some(v) => v,
+            None => continue,
+        };
+        let template = match tmpl_obj.get("template").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let surface_locator = tmpl_obj
+            .get("surface_locator")
+            .and_then(|v| v.as_str())
+            .unwrap_or("annotation:before-method")
+            .to_string();
+        out.push(SugarEntry {
+            kind,
+            head,
+            template,
+            surface_locator,
+        });
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Type mapping
+// ---------------------------------------------------------------------------
+
+/// Map a source type string to a C type string.
+///
+/// For C-to-C targeting, the source type is used as-is when it is already
+/// a valid C type. We apply a small normalization set for common IR types.
+pub fn map_source_type(src: &str) -> &str {
+    match src {
+        "i64" | "int64" => "int64_t",
+        "i32" | "int32" => "int32_t",
+        "u64" | "uint64" => "uint64_t",
+        "u32" | "uint32" => "uint32_t",
+        "bool" => "int",
+        "()" | "void" => "void",
+        other => other,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Annotation prefix (sugar dict: predicate match)
+// ---------------------------------------------------------------------------
+
+/// Render the annotation prefix for a concept given the available sugar entries.
+/// For C, contract-clause annotations emit block comments above the function.
+///
+/// If no predicate entry matches, emits a default `/* concept: <name> */` comment.
+fn annotation_prefix_for(concept_name: &str, sugar_hint: Option<&str>) -> String {
+    let head = sugar_hint.unwrap_or(concept_name);
+    let entries = sugar_entries();
+    for entry in entries {
+        if !matches!(entry.kind, SugarKind::Predicate) {
+            continue;
+        }
+        if entry.head == head {
+            let _ = &entry.surface_locator;
+            let rendered = entry.template.replace("${concept}", concept_name);
+            return format!("{}\n", rendered);
+        }
+    }
+    format!("/* concept: {concept_name} */\n")
+}
+
+/// Look up an op-pattern body for a concept (e.g. concept:free -> `free(${ptr});`).
+///
+/// `concept_name` is matched against `op_pattern.head`. The `surface_locator`
+/// must be `"op:inline"` for the template to apply as a function body.
+/// Parameter names are substituted before returning.
+///
+/// Returns `None` if no op entry matches this concept.
+fn op_body_for(concept_name: &str, param_names: &[String]) -> Option<String> {
+    let entries = sugar_entries();
+    for entry in entries {
+        if !matches!(entry.kind, SugarKind::Op) {
+            continue;
+        }
+        if entry.head != concept_name {
+            continue;
+        }
+        if entry.surface_locator != "op:inline" {
+            continue;
+        }
+        let mut rendered = entry.template.clone();
+        if let Some(first) = param_names.first() {
+            rendered = rendered.replace("${val}", first);
+            rendered = rendered.replace("${ptr}", first);
+            rendered = rendered.replace("${param0}", first);
+        }
+        for (i, name) in param_names.iter().enumerate() {
+            rendered = rendered.replace(&format!("${{param{i}}}"), name);
+        }
+        if rendered.contains("${") {
+            continue;
+        }
+        return Some(rendered);
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Body-template lookup (step 2 of fallthrough)
+// ---------------------------------------------------------------------------
+
+fn body_template_for(concept_name: &str, param_names: &[String]) -> Option<String> {
+    let entries = body_entries();
+    for entry in entries {
+        if entry.concept_name != concept_name {
+            continue;
+        }
+        if let Some(min) = entry.min_params {
+            if param_names.len() < min {
+                continue;
+            }
+        }
+        if let Some(max) = entry.max_params {
+            if param_names.len() > max {
+                continue;
+            }
+        }
+        if entry.template_kind != "verbatim" {
+            continue;
+        }
+        let mut rendered = entry.template.clone();
+        for (i, name) in param_names.iter().enumerate() {
+            rendered = rendered.replace(&format!("${{param{i}}}"), name);
+        }
+        rendered = rendered.replace("${param_count}", &param_names.len().to_string());
+        if rendered.contains("${") {
+            continue;
+        }
+        return Some(rendered);
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Language stub (step 3 of fallthrough)
+// ---------------------------------------------------------------------------
+
+fn stub_body(concept_name: &str) -> String {
+    format!("/* provekit-bind canonical: {concept_name} */\n    abort();")
+}
+
+// ---------------------------------------------------------------------------
+// Core emit function
+// ---------------------------------------------------------------------------
+
+/// Emit a C function for a single binding.
+///
+/// Output shape:
+/// ```text
+/// /* concept: <concept_name> */
+/// <return_type> <function>(<type> <param>, ...) {
+///     <body>
+/// }
+/// ```
+///
+/// - `params`: parameter names in order
+/// - `param_types`: source-language type strings; mapped to C equivalents
+/// - `return_type`: source-language return type; mapped to C equivalent
+/// - `concept_name`: canonical concept name for this binding
+pub fn emit(
+    function: &str,
+    params: &[String],
+    param_types: &[String],
+    return_type: &str,
+    concept_name: &str,
+) -> Realization {
+    // Build typed param list.
+    let typed_params: Vec<String> = params
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let t = param_types.get(i).map(String::as_str).unwrap_or("int64_t");
+            let mapped = map_source_type(t);
+            format!("{mapped} {name}")
+        })
+        .collect();
+    let typed_param_list = if typed_params.is_empty() {
+        "void".to_string()
+    } else {
+        typed_params.join(", ")
+    };
+    let mapped_return = map_source_type(return_type);
+
+    // Annotation prefix (sugar dict: comment form for C).
+    let annotation = annotation_prefix_for(concept_name, None);
+
+    // Body fallthrough chain:
+    //   Step 1a: op_pattern sugar dict match (e.g. concept:free -> free(${ptr});)
+    //   Step 2:  body-template match
+    //   Step 3:  language stub (abort()) -- sets is_stub = true
+    let (body_str, is_stub) = if let Some(op_body) = op_body_for(concept_name, params) {
+        // Op-pattern match: emit inline body.
+        let indented = op_body
+            .lines()
+            .map(|l| format!("    {l}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        (format!("{indented}\n"), false)
+    } else {
+        match body_template_for(concept_name, params) {
+            Some(body) => {
+                // Indent the body one level.
+                let indented = body
+                    .lines()
+                    .map(|l| format!("    {l}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                (format!("{indented}\n"), false)
+            }
+            None => {
+                // Step 3: language stub.
+                (format!("    {}\n", stub_body(concept_name)), true)
+            }
+        }
+    };
+
+    let source = format!(
+        "{annotation}{mapped_return} {function}({typed_param_list}) {{\n{body_str}}}\n"
+    );
+
+    Realization { source, is_stub }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_body_template_renders() {
+        let r = emit("foo", &["x".to_string()], &["i64".to_string()], "i64", "identity");
+        assert!(!r.is_stub, "identity should match body-template");
+        assert!(r.source.contains("return x;"), "body should contain return x");
+        assert!(r.source.contains("int64_t foo(int64_t x)"), "sig shape");
+    }
+
+    #[test]
+    fn option_body_template_renders() {
+        let r = emit("opt", &["v".to_string()], &["int64_t *".to_string()], "i64", "option");
+        assert!(!r.is_stub);
+        assert!(r.source.contains("NULL") || r.source.contains("return"));
+    }
+
+    #[test]
+    fn unknown_concept_falls_through_to_stub() {
+        let r = emit("foo", &["x".to_string()], &["i64".to_string()], "i64", "concept:unknown-xyz");
+        assert!(r.is_stub);
+        assert!(r.source.contains("abort()"));
+    }
+
+    #[test]
+    fn unit_concept_zero_params() {
+        let r = emit("noop", &[], &[], "()", "unit");
+        assert!(!r.is_stub);
+        // C unit -> void return with no params -> "void noop(void)"
+        assert!(r.source.contains("void noop(void)"));
+        assert!(r.source.contains("return;"));
+    }
+
+    #[test]
+    fn annotation_prefix_emitted() {
+        let r = emit("id", &["x".to_string()], &["i64".to_string()], "i64", "identity");
+        assert!(r.source.contains("/* concept: identity */"), "annotation comment");
+    }
+
+    #[test]
+    fn free_concept_emits_free_not_stub() {
+        // concept:free must dispatch via op_pattern -> free(${ptr});
+        // It must NOT fall through to the language stub.
+        let r = emit(
+            "free_resource",
+            &["p".to_string()],
+            &["void *".to_string()],
+            "()",
+            "free",
+        );
+        assert!(!r.is_stub, "concept:free should not be a stub (op_pattern matches)");
+        assert!(
+            r.source.contains("free(p)"),
+            "concept:free body should contain free(p); got:\n{}",
+            r.source
+        );
+    }
+
+    #[test]
+    fn pair_concept_two_params() {
+        let r = emit(
+            "make_pair",
+            &["a".to_string(), "b".to_string()],
+            &["i64".to_string(), "i64".to_string()],
+            "i64",
+            "pair",
+        );
+        assert!(!r.is_stub);
+        assert!(r.source.contains("a + b"));
+    }
+
+    #[test]
+    fn bool_cell_concept() {
+        let r = emit("toggle", &["b".to_string()], &["bool".to_string()], "bool", "bool-cell");
+        assert!(!r.is_stub);
+        assert!(r.source.contains("!b"));
+    }
+
+    #[test]
+    fn type_mapping_i64_to_int64_t() {
+        assert_eq!(map_source_type("i64"), "int64_t");
+        assert_eq!(map_source_type("bool"), "int");
+        assert_eq!(map_source_type("()"), "void");
+        assert_eq!(map_source_type("void"), "void");
+    }
+}

--- a/implementations/rust/provekit-realize-c-core/src/main.rs
+++ b/implementations/rust/provekit-realize-c-core/src/main.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-realize-c: PEP 1.7.0 JSON-RPC stdio sidecar for C lower/realize.
+//
+// Reads newline-delimited JSON-RPC 2.0 requests from stdin, writes responses
+// to stdout. Parallel to `provekit-realize-rust --rpc` from PR #773.
+//
+// Supported methods:
+//   provekit.plugin.describe  -- returns the c-canonical sugar plugin memento
+//   provekit.plugin.invoke    -- lowers one binding to C source
+//   provekit.plugin.shutdown  -- graceful exit
+//
+// Usage:
+//   provekit-realize-c --rpc
+
+use std::io::{self, BufRead, Write};
+
+use provekit_realize_c_core::{emit, SUGAR_PLUGIN_CID, sugar_content_json_from_embedded};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let rpc = args.iter().any(|a| a == "--rpc");
+    if !rpc {
+        eprintln!("Usage: provekit-realize-c --rpc");
+        std::process::exit(1);
+    }
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+
+    for line_result in stdin.lock().lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        let line = line.trim().to_string();
+        if line.is_empty() {
+            continue;
+        }
+        handle_line(&line, &mut out);
+    }
+}
+
+fn handle_line(line: &str, out: &mut impl Write) {
+    let req: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(e) => {
+            let err = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": {"code": -32700, "message": format!("parse error: {e}")}
+            });
+            writeln!(out, "{}", err).ok();
+            return;
+        }
+    };
+
+    let id = req.get("id").cloned().unwrap_or(serde_json::Value::Null);
+    let method = req.get("method").and_then(|v| v.as_str()).unwrap_or("");
+
+    let response = match method {
+        "provekit.plugin.describe" => {
+            let result = describe_result();
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": serde_json::from_str::<serde_json::Value>(&result).unwrap()
+            })
+        }
+        "provekit.plugin.invoke" => {
+            match handle_invoke(&req) {
+                Ok(result_str) => {
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": serde_json::from_str::<serde_json::Value>(&result_str).unwrap()
+                    })
+                }
+                Err(msg) => {
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "error": {"code": -32000, "message": msg}
+                    })
+                }
+            }
+        }
+        "provekit.plugin.shutdown" => {
+            let resp = serde_json::json!({"jsonrpc": "2.0", "id": id, "result": null});
+            writeln!(out, "{}", resp).ok();
+            std::process::exit(0);
+        }
+        other => {
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {"code": -32601, "message": format!("method not found: {other}")}
+            })
+        }
+    };
+
+    writeln!(out, "{}", response).ok();
+}
+
+/// Handle `provekit.plugin.invoke`.
+///
+/// Params:
+///   function      - snake_case function name
+///   params        - JSON array of parameter name strings
+///   param_types   - JSON array of source-language type strings
+///   return_type   - source-language return type string
+///   concept_name  - canonical concept name for this binding
+///
+/// Returns JSON: {"source": "...", "is_stub": bool}
+fn handle_invoke(req: &serde_json::Value) -> Result<String, String> {
+    let params = req
+        .get("params")
+        .ok_or_else(|| "missing params".to_string())?;
+
+    let function = params
+        .get("function")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing params.function".to_string())?;
+
+    let return_type = params
+        .get("return_type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing params.return_type".to_string())?;
+
+    let concept_name = params
+        .get("concept_name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing params.concept_name".to_string())?;
+
+    let param_names: Vec<String> = params
+        .get("params")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let param_types: Vec<String> = params
+        .get("param_types")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let r = emit(function, &param_names, &param_types, return_type, concept_name);
+
+    let result = format!(
+        "{{\"source\":{},\"is_stub\":{}}}",
+        serde_json::to_string(&r.source).map_err(|e| e.to_string())?,
+        if r.is_stub { "true" } else { "false" }
+    );
+    Ok(result)
+}
+
+/// Build the `provekit.plugin.describe` result.
+///
+/// Returns the c-canonical sugar plugin memento. The CID matches
+/// `menagerie/c-language-signature/specs/sugar/c-canonical.json`.
+fn describe_result() -> String {
+    let content = sugar_content_json_from_embedded();
+    format!(
+        r#"{{"envelope":{{"declaredAt":"2026-05-13T00:00:00.000Z","signature":"ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","signer":"ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}},"header":{{"cid":"{cid}","content":{content},"critical":false,"kind":"sugar","protocol_versions":["pep/1.7.0"],"provenance_cid":"blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","schemaVersion":"1","version":"1.0.0"}},"metadata":{{"note":"Canonical C comment sugar dict for ProvekIt contract clause rendering.","source_url":"menagerie/c-language-signature/specs/sugar/c-canonical.json"}}}}"#,
+        cid = SUGAR_PLUGIN_CID,
+        content = content,
+    )
+}

--- a/implementations/rust/provekit-realize-c-core/tests/integration_test.rs
+++ b/implementations/rust/provekit-realize-c-core/tests/integration_test.rs
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Integration test: lower a small IR fixture and assert the emitted C
+// source compiles via `cc -x c -std=c11 -fsyntax-only`.
+//
+// Also tests that the JSON-RPC sidecar binary speaks the PEP 1.7.0 protocol
+// correctly.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use provekit_realize_c_core::{emit, BODY_TEMPLATE_PLUGIN_CID, SUGAR_PLUGIN_CID};
+
+// ---------------------------------------------------------------------------
+// Compile smoke: emit() produces syntactically valid C11
+// ---------------------------------------------------------------------------
+
+/// Write emitted source (wrapped in necessary includes) to a tempfile and
+/// check it with cc -x c -std=c11 -fsyntax-only.
+///
+/// We prepend standard headers because emitted bodies reference int64_t,
+/// abort(), assert(), NULL, size_t, etc. In production use the caller's
+/// translation unit already includes these; the smoke test just checks syntax.
+fn assert_c_parses(source: &str) {
+    // Find a C compiler.
+    let cc = if Command::new("cc").arg("--version").output().map(|o| o.status.success()).unwrap_or(false) {
+        "cc"
+    } else if Command::new("clang").arg("--version").output().map(|o| o.status.success()).unwrap_or(false) {
+        "clang"
+    } else if Command::new("gcc").arg("--version").output().map(|o| o.status.success()).unwrap_or(false) {
+        "gcc"
+    } else {
+        // No C compiler available -- skip the compile check gracefully.
+        eprintln!("assert_c_parses: no C compiler found, skipping compile check");
+        return;
+    };
+
+    let preamble = "\
+#include <stdint.h>\n\
+#include <stddef.h>\n\
+#include <stdlib.h>\n\
+#include <assert.h>\n\n";
+
+    let full_source = format!("{preamble}{source}");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src_path = dir.path().join("fixture.c");
+    std::fs::write(&src_path, &full_source).expect("write fixture");
+
+    let output = Command::new(cc)
+        .args(["-x", "c", "-std=c11", "-fsyntax-only"])
+        .arg(&src_path)
+        .output()
+        .expect("cc spawn failed");
+
+    assert!(
+        output.status.success(),
+        "C syntax check failed for:\n{full_source}\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn identity_concept_compiles() {
+    let r = emit(
+        "wrap_identity",
+        &["x".to_string()],
+        &["i64".to_string()],
+        "i64",
+        "identity",
+    );
+    assert!(!r.is_stub, "identity should not be a stub");
+    assert_c_parses(&r.source);
+}
+
+#[test]
+fn unit_concept_compiles() {
+    let r = emit("wrap_unit", &[], &[], "()", "unit");
+    assert!(!r.is_stub, "unit should not be a stub");
+    assert!(r.source.contains("void wrap_unit(void)"), "void sig");
+    assert_c_parses(&r.source);
+}
+
+#[test]
+fn bool_cell_concept_compiles() {
+    let r = emit(
+        "wrap_bool_cell",
+        &["b".to_string()],
+        &["bool".to_string()],
+        "bool",
+        "bool-cell",
+    );
+    assert!(!r.is_stub, "bool-cell should not be a stub");
+    // C emits `int` for bool, body is `return !b;`
+    assert_c_parses(&r.source);
+}
+
+#[test]
+fn unknown_concept_stub_compiles() {
+    let r = emit(
+        "wrap_unknown",
+        &["x".to_string()],
+        &["i64".to_string()],
+        "i64",
+        "concept:unknown-xyz",
+    );
+    assert!(r.is_stub, "unknown concept should be a stub");
+    assert_c_parses(&r.source);
+}
+
+#[test]
+fn free_concept_emits_free_not_stub() {
+    // concept:free dispatches via op_pattern -> free(${ptr});
+    // C is lossless: free() is the natural surface.
+    let r = emit(
+        "free_resource",
+        &["p".to_string()],
+        &["void *".to_string()],
+        "()",
+        "free",
+    );
+    assert!(!r.is_stub, "concept:free should not be a stub (op_pattern matches)");
+    assert!(
+        r.source.contains("free(p)"),
+        "concept:free body should contain free(p); got:\n{}",
+        r.source
+    );
+    assert_c_parses(&r.source);
+}
+
+#[test]
+fn pair_concept_compiles() {
+    let r = emit(
+        "make_pair",
+        &["a".to_string(), "b".to_string()],
+        &["i64".to_string(), "i64".to_string()],
+        "i64",
+        "pair",
+    );
+    assert!(!r.is_stub);
+    assert!(r.source.contains("a + b"));
+    assert_c_parses(&r.source);
+}
+
+#[test]
+fn option_concept_compiles() {
+    let r = emit(
+        "wrap_option",
+        &["v".to_string()],
+        &["int64_t *".to_string()],
+        "i64",
+        "option",
+    );
+    assert!(!r.is_stub);
+    assert_c_parses(&r.source);
+}
+
+// ---------------------------------------------------------------------------
+// CID constants match the menagerie files
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cid_constants_match_expected_values() {
+    assert_eq!(
+        SUGAR_PLUGIN_CID,
+        "blake3-512:a67012722271aca3a882bc82fa7b92941453e750a65366534ea37ef8eef593921bb3aa33e6b0051bf64531962346014097ef9a99f14f7c3245de1beea6c076dc"
+    );
+    assert_eq!(
+        BODY_TEMPLATE_PLUGIN_CID,
+        "blake3-512:44f18ea2725ec26196399f6511bf3887db52db3c0e1356e7e090ff41f893929e177df9786d6639d8015d08641dda54338f83e1bd24a07828b5bf6b33c0d7d329"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC sidecar: describe and invoke
+// ---------------------------------------------------------------------------
+
+fn rpc_request(method: &str, params: serde_json::Value) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params
+    }))
+    .unwrap()
+}
+
+fn run_rpc_binary(requests: &[String]) -> Vec<serde_json::Value> {
+    let binary = env!("CARGO_BIN_EXE_provekit-realize-c");
+    let mut child = Command::new(binary)
+        .arg("--rpc")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn provekit-realize-c");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        for req in requests {
+            writeln!(stdin, "{req}").expect("write request");
+        }
+        let shutdown = rpc_request("provekit.plugin.shutdown", serde_json::Value::Null);
+        writeln!(stdin, "{shutdown}").expect("write shutdown");
+    }
+
+    let output = child.wait_with_output().expect("wait");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect()
+}
+
+#[test]
+fn rpc_describe_returns_sugar_cid() {
+    let req = rpc_request(
+        "provekit.plugin.describe",
+        serde_json::json!({"runtime_protocol_versions": ["pep/1.7.0"]}),
+    );
+    let responses = run_rpc_binary(&[req]);
+    assert!(!responses.is_empty(), "expected at least one response");
+    let result = &responses[0];
+    assert!(result.get("error").is_none(), "describe should not error: {result}");
+    let cid = result
+        .get("result")
+        .and_then(|r| r.get("header"))
+        .and_then(|h| h.get("cid"))
+        .and_then(|c| c.as_str())
+        .expect("result.header.cid");
+    assert_eq!(cid, SUGAR_PLUGIN_CID);
+}
+
+#[test]
+fn rpc_invoke_identity_not_stub() {
+    let req = rpc_request(
+        "provekit.plugin.invoke",
+        serde_json::json!({
+            "function": "wrap_identity",
+            "params": ["x"],
+            "param_types": ["i64"],
+            "return_type": "i64",
+            "concept_name": "identity"
+        }),
+    );
+    let responses = run_rpc_binary(&[req]);
+    assert!(!responses.is_empty());
+    let result = &responses[0];
+    assert!(result.get("error").is_none(), "invoke error: {result}");
+    let is_stub = result
+        .get("result")
+        .and_then(|r| r.get("is_stub"))
+        .and_then(|v| v.as_bool())
+        .expect("result.is_stub");
+    assert!(!is_stub, "identity should not be a stub");
+}
+
+#[test]
+fn rpc_invoke_unknown_concept_is_stub() {
+    let req = rpc_request(
+        "provekit.plugin.invoke",
+        serde_json::json!({
+            "function": "wrap_unknown",
+            "params": ["x"],
+            "param_types": ["i64"],
+            "return_type": "i64",
+            "concept_name": "concept:unknown-xyz"
+        }),
+    );
+    let responses = run_rpc_binary(&[req]);
+    assert!(!responses.is_empty());
+    let result = &responses[0];
+    assert!(result.get("error").is_none(), "invoke error: {result}");
+    let is_stub = result
+        .get("result")
+        .and_then(|r| r.get("is_stub"))
+        .and_then(|v| v.as_bool())
+        .expect("result.is_stub");
+    assert!(is_stub, "unknown concept should be a stub");
+}
+
+#[test]
+fn rpc_invoke_free_concept_not_stub() {
+    // concept:free via RPC must return is_stub=false and source containing free(p).
+    let req = rpc_request(
+        "provekit.plugin.invoke",
+        serde_json::json!({
+            "function": "free_resource",
+            "params": ["p"],
+            "param_types": ["void *"],
+            "return_type": "()",
+            "concept_name": "free"
+        }),
+    );
+    let responses = run_rpc_binary(&[req]);
+    assert!(!responses.is_empty());
+    let result = &responses[0];
+    assert!(result.get("error").is_none(), "invoke error: {result}");
+    let is_stub = result
+        .get("result")
+        .and_then(|r| r.get("is_stub"))
+        .and_then(|v| v.as_bool())
+        .expect("result.is_stub");
+    assert!(!is_stub, "concept:free should not be a stub via RPC");
+    let source = result
+        .get("result")
+        .and_then(|r| r.get("source"))
+        .and_then(|v| v.as_str())
+        .expect("result.source");
+    assert!(source.contains("free(p)"), "source should contain free(p); got: {source}");
+}

--- a/menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json
+++ b/menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json
@@ -1,0 +1,270 @@
+{
+  "envelope": {
+    "declaredAt": "2026-05-13T00:00:00.000Z",
+    "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "header": {
+    "cid": "blake3-512:44f18ea2725ec26196399f6511bf3887db52db3c0e1356e7e090ff41f893929e177df9786d6639d8015d08641dda54338f83e1bd24a07828b5bf6b33c0d7d329",
+    "content": {
+      "entries": [
+        {
+          "concept_name": "assert",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "assert(${param0} > 0);\nreturn ${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "fixture_specific_message": {
+                "args": [],
+                "head": "atomic",
+                "name": "assert-message-not-preserved-c-assert-no-message"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "bool-cell",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return !${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "identity",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "list",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "int64_t _sum = 0;\nfor (size_t _i = 0; _i < ${param0}_len; _i++) { _sum += ${param0}[_i]; }\nreturn _sum;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "length_param_convention": {
+                "args": [],
+                "head": "atomic",
+                "name": "list-length-passed-as-param0-name-underscore-len-convention"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "option",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0} != NULL) ? *${param0} : -1;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "sentinel_for_none": {
+                "args": [],
+                "head": "atomic",
+                "name": "option-none-encoded-as-negative-one-sentinel"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "option-bind",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "if (${param0} == NULL) return -1;\nif (*${param0} <= 0) return -1;\nreturn *${param0} * 2;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "fixture_specific_doubling": {
+                "args": [],
+                "head": "atomic",
+                "name": "option-bind-body-fixture-specific-doubling-not-canonical"
+              },
+              "sentinel_for_none": {
+                "args": [],
+                "head": "atomic",
+                "name": "option-none-encoded-as-negative-one-sentinel"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "pair",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} + ${param1};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "pair_encoded_as_sum": {
+                "args": [],
+                "head": "atomic",
+                "name": "pair-encoded-as-sum-c-has-no-tuple-type"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
+          "concept_name": "result",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0} >= 0) ? ${param0} : -1;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "sentinel_for_err": {
+                "args": [],
+                "head": "atomic",
+                "name": "result-err-encoded-as-negative-one-sentinel"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "result-bind",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "if (${param0} < 0) return -1;\nif (${param0} <= 0) return -1;\nreturn ${param0} * 2;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "fixture_specific_doubling": {
+                "args": [],
+                "head": "atomic",
+                "name": "result-bind-body-fixture-specific-doubling-not-canonical"
+              },
+              "sentinel_for_err": {
+                "args": [],
+                "head": "atomic",
+                "name": "result-err-encoded-as-negative-one-sentinel"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "retry-loop",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "uint64_t _attempts = 0;\nwhile (1) {\n    _attempts++;\n    if (_attempts >= (uint64_t)${param0}) break;\n}\nreturn (int64_t)_attempts;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "fixture_specific_loop_body": {
+                "args": [],
+                "head": "atomic",
+                "name": "retry-loop-body-fixture-specific-not-canonical"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "tagged-union",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "switch (${param0}) {\n    case 0: return 0;\n    default: return ${param0};\n}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "fixture_specific_match_body": {
+                "args": [],
+                "head": "atomic",
+                "name": "tagged-union-match-body-fixture-specific-not-canonical"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1
+          }
+        },
+        {
+          "concept_name": "unit",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 0,
+            "min_params": 0
+          }
+        }
+      ],
+      "target_language": "c",
+      "template_name": "c-canonical-bodies"
+    },
+    "critical": false,
+    "kind": "body-template",
+    "protocol_versions": ["pep/1.7.0"],
+    "provenance_cid": "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "schemaVersion": "1",
+    "version": "1.0.0"
+  },
+  "metadata": {
+    "note": "Canonical C body templates for the 12 trinity concepts. C has explicit heap management (lossless concept:free via free()), no native Option/Result/tuple, so option/result use -1 sentinel and pair is encoded as sum. Loss records are honest.",
+    "source_url": "menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json"
+  }
+}

--- a/menagerie/c-language-signature/specs/sugar/c-canonical.json
+++ b/menagerie/c-language-signature/specs/sugar/c-canonical.json
@@ -1,0 +1,169 @@
+{
+  "envelope": {
+    "declaredAt": "2026-05-13T00:00:00.000Z",
+    "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "header": {
+    "cid": "blake3-512:a67012722271aca3a882bc82fa7b92941453e750a65366534ea37ef8eef593921bb3aa33e6b0051bf64531962346014097ef9a99f14f7c3245de1beea6c076dc",
+    "content": {
+      "entries": [
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "/* # requires: ${lhs} == ${rhs} */"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "eq"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "/* # ensures: ${lhs} == ${rhs} */"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "ensures_eq"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "/* # ensures: ${lhs} > ${rhs} */"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "ensures_gt"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "op:inline",
+            "template": "free(${ptr});"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "op_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${ptr}"}
+            ],
+            "head": "free"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "/* # requires: ${lhs} >= ${rhs} */"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "ge"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "/* # requires: ${lhs} > ${rhs} */"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "gt"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "/* # requires: ${lhs} <= ${rhs} */"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "le"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-method",
+            "template": "/* # requires: ${lhs} < ${rhs} */"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "predicate_pattern": {
+            "args": [
+              {"args": [], "head": "var", "name": "${lhs}"},
+              {"args": [], "head": "var", "name": "${rhs}"}
+            ],
+            "head": "lt"
+          }
+        }
+      ],
+      "sugar_name": "canonical",
+      "target_language": "c"
+    },
+    "critical": false,
+    "kind": "sugar",
+    "protocol_versions": ["pep/1.7.0"],
+    "provenance_cid": "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "schemaVersion": "1",
+    "version": "1.0.0"
+  },
+  "metadata": {
+    "note": "Canonical C sugar dict for ProvekIt. Two pattern shapes: predicate_pattern entries emit contract-clause block-comment annotations (requires/ensures); op_pattern entries emit op-level lowering (e.g., concept:free -> free(${ptr})). C has explicit heap semantics so concept:free is lossless.",
+    "source_url": "menagerie/c-language-signature/specs/sugar/c-canonical.json"
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Wraps the C realize kit as a PEP 1.7.0 JSON-RPC stdio sidecar (`provekit-realize-c --rpc`), following PR #773 (Rust) as the template.
- Ships two menagerie files with minted CIDs and 12 trinity concepts covered.
- Extends `substrate_default_cids.rs` with two new CID pin tests for C.

## concept:free realization

| Language | Emission | loss_record | Reason |
|---|---|---|---|
| c | `free(${ptr});` | `{}` | Natural C surface, lossless |

C has explicit heap management -- `free()` is the direct stdlib surface for deallocation. The op_pattern entry in the sugar dict dispatches this losslessly; no sentinel encoding, no GC tagged-comment needed.

## Menagerie CIDs (minted via `mint-plugin-cid`)

- Sugar dict (`kind: "sugar"`): `blake3-512:a67012722271aca3a882bc82fa7b92941453e750a65366534ea37ef8eef593921bb3aa33e6b0051bf64531962346014097ef9a99f14f7c3245de1beea6c076dc`
- Body-template memento (`kind: "body-template"`): `blake3-512:44f18ea2725ec26196399f6511bf3887db52db3c0e1356e7e090ff41f893929e177df9786d6639d8015d08641dda54338f83e1bd24a07828b5bf6b33c0d7d329`

Both CIDs are pinned in `substrate_default_cids.rs` and verified self-consistent.

## C-specific body-template notes (honest loss records)

- `identity`, `bool-cell`, `unit`, `assert`: lossless (C has direct equivalents)
- `option`, `result`: sentinel -1 encoding (C has no native Option/Result)
- `pair`: encoded as sum (C has no tuple type); loss_record documents this
- `list`: length passed as `${param0}_len` convention; documented in loss_record
- `retry-loop`, `tagged-union`, `option-bind`, `result-bind`: fixture-specific bodies; documented

## Integration test results

```
running 9 tests (unit)
test tests::type_mapping_i64_to_int64_t ... ok
test tests::free_concept_emits_free_not_stub ... ok
test tests::bool_cell_concept ... ok
test tests::unknown_concept_falls_through_to_stub ... ok
test tests::option_body_template_renders ... ok
test tests::pair_concept_two_params ... ok
test tests::identity_body_template_renders ... ok
test tests::annotation_prefix_emitted ... ok
test tests::unit_concept_zero_params ... ok

running 12 tests (integration)
test cid_constants_match_expected_values ... ok
test unit_concept_compiles ... ok
test identity_concept_compiles ... ok
test unknown_concept_stub_compiles ... ok
test option_concept_compiles ... ok
test pair_concept_compiles ... ok
test free_concept_emits_free_not_stub ... ok
test bool_cell_concept_compiles ... ok
test rpc_invoke_free_concept_not_stub ... ok
test rpc_invoke_unknown_concept_is_stub ... ok
test rpc_invoke_identity_not_stub ... ok
test rpc_describe_returns_sugar_cid ... ok

running 4 tests (substrate_default_cids)
test c_canonical_sugar_cid_self_consistent ... ok
test java_canonical_sugar_cid_self_consistent ... ok
test c_canonical_bodies_cid_self_consistent ... ok
test java_canonical_bodies_cid_self_consistent ... ok
```

## Files

- `menagerie/c-language-signature/specs/sugar/c-canonical.json` -- sugar dict with `op_pattern` for concept:free and `predicate_pattern` entries for contract-clause annotations
- `menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json` -- body-template memento with all 12 trinity concepts
- `implementations/rust/provekit-realize-c-core/` -- Rust crate: lib.rs (emit + fallthrough chain), main.rs (JSON-RPC sidecar), tests/integration_test.rs
- `implementations/rust/Cargo.toml` -- `provekit-realize-c-core` added to workspace members
- `implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs` -- two new C CID pin tests

Template: PR #773 (Rust realize plugin).
EOF
)