### PR TITLE
feat(771): wrap C++ lift kit as provekit-lift/1 plugin

### DIFF
--- a/implementations/cpp/provekit-lsp-cpp/main.cpp
+++ b/implementations/cpp/provekit-lsp-cpp/main.cpp
@@ -2,26 +2,21 @@
 //
 // provekit-lsp-cpp: canonical NDJSON LSP plugin for C++.
 //
-// Protocol (identical to provekit-lsp-go):
+// Protocol (provekit-lift/1 over stdio):
 //
 //   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
-//   {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
+//   {"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":"...","source_paths":[...]}}
 //   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
 //
-// initialize returns:
-//   {"name":"provekit-lsp-cpp","version":"0.1.0","capabilities":["parse"]}
+// Legacy parse method is retained for backward compatibility.
 //
-// parse returns:
-//   {"declarations":[...IR ContractDecl objects...],"callEdges":[],"warnings":[]}
-//
-// Lifted using provekit-lift-cpp's scan_file + lift_annotations logic
-// from provekit/ir.hpp. callEdges is always [] (no call-graph analysis
-// implemented in the C++ LSP; zig precedent in linkerd/methods.rs).
+// Wire shape matches implementations/go/provekit-lift-go/rpc.go.
 //
 // Binary name: provekit-lsp-cpp (no args required; reads NDJSON from stdin)
 
 #include "provekit/ir.hpp"
 
+#include <fstream>
 #include <iostream>
 #include <regex>
 #include <sstream>
@@ -171,6 +166,54 @@ static std::string extract_id(const std::string& line) {
     return "null";
 }
 
+// Extract a JSON string array field from a JSON line.
+// Returns a vector of unescaped strings.
+static std::vector<std::string> extract_string_array(const std::string& line, const std::string& key) {
+    std::string search = "\"" + key + "\"";
+    size_t pos = line.find(search);
+    if (pos == std::string::npos) return {};
+    size_t colon = line.find(':', pos + search.size());
+    if (colon == std::string::npos) return {};
+    size_t bracket = line.find('[', colon + 1);
+    if (bracket == std::string::npos) return {};
+
+    std::vector<std::string> result;
+    size_t i = bracket + 1;
+    while (i < line.size()) {
+        while (i < line.size() && (line[i] == ' ' || line[i] == '\t' || line[i] == ',')) ++i;
+        if (i >= line.size() || line[i] == ']') break;
+        if (line[i] != '"') break;
+        ++i;
+        std::string elem;
+        while (i < line.size() && line[i] != '"') {
+            if (line[i] == '\\' && i + 1 < line.size()) {
+                ++i;
+                switch (line[i]) {
+                    case '"':  elem += '"';  break;
+                    case '\\': elem += '\\'; break;
+                    case 'n':  elem += '\n'; break;
+                    case 'r':  elem += '\r'; break;
+                    case 't':  elem += '\t'; break;
+                    default:   elem += line[i]; break;
+                }
+            } else {
+                elem += line[i];
+            }
+            ++i;
+        }
+        if (i < line.size() && line[i] == '"') ++i;
+        result.push_back(std::move(elem));
+    }
+    return result;
+}
+
+// Read entire file to string. Returns empty string on failure.
+static std::string read_file(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return "";
+    return std::string(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
+}
+
 // ---------------------------------------------------------------------------
 // Response writers
 // ---------------------------------------------------------------------------
@@ -213,9 +256,55 @@ int main() {
 
         if (method == "initialize") {
             send_result(id,
-                "{\"name\":\"provekit-lsp-cpp\","
-                "\"version\":\"0.1.0\","
-                "\"capabilities\":[\"parse\"]}");
+                "{\"capabilities\":{"
+                "\"authoring_surfaces\":[\"cpp-source\"],"
+                "\"emits_signed_mementos\":false,"
+                "\"ir_version\":\"v1.1.0\"},"
+                "\"name\":\"provekit-lsp-cpp\","
+                "\"protocol_version\":\"provekit-lift/1\","
+                "\"version\":\"0.1.0\"}");
+
+        } else if (method == "lift") {
+            // Extract workspace_root and source_paths from params.
+            std::string workspace_root = extract_string(line, "workspace_root");
+            if (workspace_root.empty()) workspace_root = ".";
+
+            std::vector<std::string> source_paths = extract_string_array(line, "source_paths");
+            if (source_paths.empty()) {
+                send_error(id, -32602, "lift: source_paths must be a non-empty array");
+                continue;
+            }
+
+            // Lift each file; aggregate declarations.
+            reset_collector();
+            begin_collecting();
+
+            for (const auto& sp : source_paths) {
+                std::string full_path = sp;
+                if (!sp.empty() && sp[0] != '/') {
+                    full_path = workspace_root + "/" + sp;
+                }
+                std::string source = read_file(full_path);
+                if (source.empty()) continue;
+
+                auto anns = scan_source(source);
+                for (const auto& ann : anns) {
+                    if (ann.kind == Annotation::Contract) {
+                        auto post = atomic_("true", {});
+                        contract(ann.function_name, nullptr, post);
+                    }
+                }
+            }
+
+            auto decls = finish();
+            std::string ir_json = marshal_declarations(decls);
+            send_result(id,
+                "{\"callEdges\":[],"
+                "\"diagnostics\":[],"
+                "\"ir\":" + ir_json + ","
+                "\"kind\":\"ir-document\","
+                "\"opacityReport\":[],"
+                "\"refusals\":[]}");
 
         } else if (method == "parse") {
             // Extract path and source from params.

--- a/implementations/cpp/provekit-lsp-cpp/test_lsp.sh
+++ b/implementations/cpp/provekit-lsp-cpp/test_lsp.sh
@@ -1,14 +1,8 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 # Integration test for provekit-lsp-cpp.
 #
-# Lifecycle: initialize -> parse (fixture with //provekit:contract) -> shutdown.
-# Asserts:
-#   1. initialize response has name="provekit-lsp-cpp", version="0.1.0",
-#      capabilities=["parse"]
-#   2. parse response contains declarations array, callEdges array, warnings array
-#   3. declarations is non-empty (at least one contract lifted from fixture)
-#   4. callEdges is empty array []
-#   5. shutdown response result is null
+# Tests provekit-lift/1 protocol: initialize, lift, parse (legacy), shutdown.
 #
 # Usage: sh test_lsp.sh [path-to-binary]
 
@@ -30,7 +24,7 @@ assert_contains() {
     label="$1"
     text="$2"
     pattern="$3"
-    if echo "$text" | grep -qF "$pattern"; then
+    if printf '%s' "$text" | grep -qF "$pattern"; then
         echo "  PASS: $label"
         PASS=$((PASS + 1))
     else
@@ -45,7 +39,7 @@ assert_not_contains() {
     label="$1"
     text="$2"
     pattern="$3"
-    if echo "$text" | grep -qF "$pattern"; then
+    if printf '%s' "$text" | grep -qF "$pattern"; then
         echo "  FAIL: $label (should NOT contain: $pattern)"
         echo "    got: $text"
         FAIL=$((FAIL + 1))
@@ -55,39 +49,56 @@ assert_not_contains() {
     fi
 }
 
-# Fixture: a tiny C++ source with one //provekit:contract annotation.
-FIXTURE='//provekit:contract\nint compute_sum(int a, int b) { return a + b; }'
-
-# Build the NDJSON conversation.
-INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
-PARSE='{"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"fixture.cpp","source":"//provekit:contract\nint compute_sum(int a, int b) { return a + b; }"}}'
-SHUTDOWN='{"jsonrpc":"2.0","id":3,"method":"shutdown","params":{}}'
-
-INPUT="$(printf '%s\n%s\n%s\n' "$INIT" "$PARSE" "$SHUTDOWN")"
-
-OUTPUT="$(printf '%s' "$INPUT" | "$BIN")"
-
-INIT_RESP="$(printf '%s' "$OUTPUT" | head -1)"
-PARSE_RESP="$(printf '%s' "$OUTPUT" | sed -n '2p')"
-SHUTDOWN_RESP="$(printf '%s' "$OUTPUT" | sed -n '3p')"
+# Create a temp directory with a fixture C++ file.
+TMPDIR_PATH="$(mktemp -d)"
+cat > "$TMPDIR_PATH/fixture.cpp" << 'EOF'
+//provekit:contract
+int compute_sum(int a, int b) { return a + b; }
+EOF
 
 echo "=== initialize ==="
-assert_contains "name field"          "$INIT_RESP"     '"name":"provekit-lsp-cpp"'
-assert_contains "version field"       "$INIT_RESP"     '"version":"0.1.0"'
-assert_contains "capabilities parse"  "$INIT_RESP"     '"capabilities":["parse"]'
-assert_not_contains "no error"        "$INIT_RESP"     '"error"'
+INIT_INPUT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+INIT_RESP=$(printf '%s\n{"jsonrpc":"2.0","id":2,"method":"shutdown"}\n' "$INIT_INPUT" | "$BIN" | head -1)
+assert_contains "name field"              "$INIT_RESP" '"name":"provekit-lsp-cpp"'
+assert_contains "version field"           "$INIT_RESP" '"version":"0.1.0"'
+assert_contains "protocol_version"        "$INIT_RESP" '"protocol_version":"provekit-lift/1"'
+assert_contains "authoring_surfaces"      "$INIT_RESP" '"authoring_surfaces":["cpp-source"]'
+assert_not_contains "no error"            "$INIT_RESP" '"error"'
 
-echo "=== parse ==="
-assert_contains "declarations field"  "$PARSE_RESP"    '"declarations":'
-assert_contains "callEdges field"     "$PARSE_RESP"    '"callEdges":[]'
-assert_contains "warnings field"      "$PARSE_RESP"    '"warnings":[]'
-assert_contains "at least one decl"   "$PARSE_RESP"    '"kind":"contract"'
-assert_contains "contract name"       "$PARSE_RESP"    '"name":"compute_sum"'
-assert_not_contains "no error"        "$PARSE_RESP"    '"error"'
+echo "=== lift ==="
+LIFT_INPUT=$(printf '%s\n%s\n%s\n' \
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+    "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"lift\",\"params\":{\"workspace_root\":\"$TMPDIR_PATH\",\"source_paths\":[\"fixture.cpp\"]}}" \
+    '{"jsonrpc":"2.0","id":3,"method":"shutdown"}')
+LIFT_OUTPUT=$(printf '%s\n' "$LIFT_INPUT" | "$BIN")
+LIFT_RESP=$(printf '%s\n' "$LIFT_OUTPUT" | sed -n '2p')
+assert_contains "kind ir-document"        "$LIFT_RESP" '"kind":"ir-document"'
+assert_contains "ir key"                  "$LIFT_RESP" '"ir":'
+assert_contains "contract compute_sum"    "$LIFT_RESP" '"name":"compute_sum"'
+assert_contains "callEdges empty"         "$LIFT_RESP" '"callEdges":[]'
+assert_contains "diagnostics key"         "$LIFT_RESP" '"diagnostics":[]'
+assert_not_contains "no error"            "$LIFT_RESP" '"error"'
+
+echo "=== parse (legacy) ==="
+PARSE_INPUT=$(printf '%s\n%s\n%s\n' \
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+    '{"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"fixture.cpp","source":"//provekit:contract\nint compute_sum(int a, int b) { return a + b; }"}}' \
+    '{"jsonrpc":"2.0","id":3,"method":"shutdown"}')
+PARSE_OUTPUT=$(printf '%s\n' "$PARSE_INPUT" | "$BIN")
+PARSE_RESP=$(printf '%s\n' "$PARSE_OUTPUT" | sed -n '2p')
+assert_contains "declarations field"      "$PARSE_RESP" '"declarations":'
+assert_contains "callEdges empty"         "$PARSE_RESP" '"callEdges":[]'
+assert_contains "at least one decl"       "$PARSE_RESP" '"kind":"contract"'
+assert_contains "contract name"           "$PARSE_RESP" '"name":"compute_sum"'
+assert_not_contains "no error"            "$PARSE_RESP" '"error"'
 
 echo "=== shutdown ==="
-assert_contains "result null"         "$SHUTDOWN_RESP" '"result":null'
-assert_not_contains "no error"        "$SHUTDOWN_RESP" '"error"'
+SHUTDOWN_RESP=$(printf '%s\n' "$LIFT_OUTPUT" | sed -n '3p')
+assert_contains "result null"             "$SHUTDOWN_RESP" '"result":null'
+assert_not_contains "no error"            "$SHUTDOWN_RESP" '"error"'
+
+# Cleanup
+rm -rf "$TMPDIR_PATH"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

- `main.cpp`: `initialize` returns `protocol_version:"provekit-lift/1"` with `capabilities:{authoring_surfaces:["cpp-source"], ir_version:"v1.1.0", emits_signed_mementos:false}`; new `lift` method reads `source_paths`, scans `.cpp` files for `//provekit:contract` annotations using existing `scan_source`, returns `ir-document` shape; adds `extract_string_array` and `read_file` helpers; legacy `parse` method retained
- `test_lsp.sh`: updated to cover initialize (protocol_version, authoring_surfaces), lift (ir-document shape, contracts present), parse (legacy shape), shutdown — 18 assertions total
- concept-tag re-lift recognition deferred to follow-up #756

## Wire shape

```
initialize → {name, version:"0.1.0", protocol_version:"provekit-lift/1", capabilities:{authoring_surfaces:["cpp-source"], ir_version:"v1.1.0", emits_signed_mementos:false}}
lift        → {kind:"ir-document", ir:[...], callEdges:[], diagnostics:[], opacityReport:[], refusals:[]}
shutdown    → {result:null}
```

## Test plan

- [x] `tools/build-cpp-lsp.sh` — clean build
- [x] `sh implementations/cpp/provekit-lsp-cpp/test_lsp.sh` — 18/18 pass
- [ ] concept-tag re-lift recognition deferred to follow-up #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)