### PR TITLE
feat(781): Python bind-lift kit — walks Python to concepts

### DIFF
--- a/.provekit/lift/python-bind/manifest.toml
+++ b/.provekit/lift/python-bind/manifest.toml
@@ -1,0 +1,11 @@
+# PEP 1.7.0 `kind = "lift"` plugin manifest for the Python bind-IR surface.
+# Walks .py files with the Python ast module and returns `ir-document` with
+# `bind-lift-entry` records per `2026-05-13-bind-ir-lift-result.md`. cmd_bind
+# dispatches Verb 1 (Lift) here when --lang=python or auto-detected as python.
+#
+# The kit emits concepts via term_shape + concept_annotation, not python:*
+# surface ops. ProofIR is concept-language; this kit bridges Python syntax to
+# concept-shaped records the dispatcher's downstream verbs consume.
+name = "python-bind-lift"
+command = ["provekit-bind-lift-python", "--rpc"]
+working_dir = "."

--- a/implementations/python/provekit-lift-python-source/pyproject.toml
+++ b/implementations/python/provekit-lift-python-source/pyproject.toml
@@ -18,6 +18,7 @@ test = ["pytest>=7"]
 
 [project.scripts]
 provekit-lift-python-source = "provekit_lift_python_source.rpc:main"
+provekit-bind-lift-python = "provekit_lift_python_source.bind_rpc:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import ast
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from .canonical import cid_of_json
+
+Json = Any
+
+
+@dataclass
+class BindLiftResult:
+    ir: list[Json] = field(default_factory=list)
+    diagnostics: list[Json] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _FunctionInfo:
+    node: ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def lift_source(source: str, source_path: str) -> BindLiftResult:
+    result = BindLiftResult()
+    try:
+        tree = ast.parse(source, filename=source_path)
+    except SyntaxError as exc:
+        result.diagnostics.append(
+            {
+                "kind": "parse-error",
+                "message": exc.msg,
+                "path": source_path,
+                "line": exc.lineno,
+            }
+        )
+        return result
+
+    collector = _DefinitionCollector()
+    collector.visit(tree)
+    lines = source.splitlines()
+    rel_path = source_path.replace(os.sep, "/")
+    for info in collector.definitions:
+        result.ir.append(_entry_for_function(info.node, rel_path, lines))
+    return result
+
+
+def lift_paths(workspace_root: str, source_paths: Iterable[str]) -> BindLiftResult:
+    result = BindLiftResult()
+    root = Path(workspace_root or ".").resolve()
+    paths = list(source_paths) or ["."]
+    for requested in paths:
+        path = Path(requested)
+        full = path if path.is_absolute() else root / path
+        try:
+            resolved = full.resolve()
+        except OSError as exc:
+            result.diagnostics.append(
+                {
+                    "kind": "io-error",
+                    "message": f"cannot resolve path '{requested}': {exc}",
+                }
+            )
+            continue
+        if not _is_relative_to(resolved, root):
+            result.diagnostics.append(
+                {
+                    "kind": "path-traversal",
+                    "message": f"path '{requested}' escapes workspace root '{root}'",
+                }
+            )
+            continue
+        files = list(_iter_python_files(resolved))
+        if not files:
+            result.diagnostics.append(
+                {
+                    "kind": "warning",
+                    "message": f"path not found or not .py: {resolved}",
+                }
+            )
+            continue
+        for file_path in files:
+            try:
+                source = file_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                result.diagnostics.append(
+                    {
+                        "kind": "io-error",
+                        "message": f"cannot read '{file_path}': {exc}",
+                    }
+                )
+                continue
+            display_path = os.path.relpath(file_path, root).replace(os.sep, "/")
+            file_result = lift_source(source, display_path)
+            result.ir.extend(file_result.ir)
+            result.diagnostics.extend(file_result.diagnostics)
+    return result
+
+
+class _DefinitionCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.definitions: list[_FunctionInfo] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.definitions.append(_FunctionInfo(node=node))
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.definitions.append(_FunctionInfo(node=node))
+        self.generic_visit(node)
+
+
+def _entry_for_function(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    rel_path: str,
+    lines: list[str],
+) -> Json:
+    concept, attr_pre, attr_post = _extract_leading_annotations(lines, node.lineno)
+    term_shape = _function_shape(node)
+    param_names, param_types = _signature_params(node.args)
+    return_type = _annotation_text(node.returns)
+    if return_type is None:
+        return_type = "Any"
+    elif return_type == "None":
+        return_type = "()"
+
+    return {
+        "attr_post": attr_post,
+        "attr_pre": attr_pre,
+        "concept_annotation": concept,
+        "file": rel_path,
+        "fn_line": node.lineno,
+        "fn_name": node.name,
+        "kind": "bind-lift-entry",
+        "param_names": param_names,
+        "param_types": param_types,
+        "return_type": return_type,
+        "term_shape": term_shape,
+        "term_shape_cid": cid_of_json(term_shape),
+    }
+
+
+def _signature_params(args: ast.arguments) -> tuple[list[str], list[str]]:
+    names: list[str] = []
+    types: list[str] = []
+    ordered_args: list[ast.arg] = []
+    ordered_args.extend(args.posonlyargs)
+    ordered_args.extend(args.args)
+    if args.vararg is not None:
+        ordered_args.append(args.vararg)
+    ordered_args.extend(args.kwonlyargs)
+    if args.kwarg is not None:
+        ordered_args.append(args.kwarg)
+    for arg in ordered_args:
+        names.append(arg.arg)
+        types.append(_annotation_text(arg.annotation) or "Any")
+    return names, types
+
+
+def _annotation_text(annotation: ast.expr | None) -> str | None:
+    if annotation is None:
+        return None
+    try:
+        return ast.unparse(annotation)
+    except Exception:
+        return "Any"
+
+
+def _function_shape(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Json:
+    statements = [stmt for stmt in node.body if not _is_docstring_stmt(stmt)]
+    return {"kind": "body", "stmts": [_shape_stmt(stmt, top_level=True) for stmt in statements]}
+
+
+def _shape_block(statements: list[ast.stmt]) -> Json:
+    return {
+        "kind": "block",
+        "stmts": [
+            _shape_stmt(stmt, top_level=False)
+            for stmt in statements
+            if not _is_docstring_stmt(stmt)
+        ],
+    }
+
+
+def _shape_stmt(node: ast.stmt, *, top_level: bool) -> Json:
+    if isinstance(node, ast.If):
+        shaped: dict[str, Json] = {
+            "cond": _shape_expr(node.test),
+            "kind": "if",
+            "then": _shape_block(node.body),
+        }
+        if node.orelse:
+            shaped = {
+                "cond": shaped["cond"],
+                "else": _shape_block(node.orelse),
+                "kind": shaped["kind"],
+                "then": shaped["then"],
+            }
+        return shaped
+    if isinstance(node, ast.While):
+        return {
+            "body": _shape_block(node.body),
+            "cond": _shape_expr(node.test),
+            "kind": "while",
+        }
+    if isinstance(node, (ast.For, ast.AsyncFor)):
+        return {"body": _shape_block(node.body), "kind": "for"}
+    if isinstance(node, (ast.Return, ast.Break, ast.Continue)):
+        return {"kind": "exit"}
+    if isinstance(node, ast.Assign):
+        if top_level and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            return {"kind": "let"}
+        return {"kind": "assign"}
+    if isinstance(node, ast.AnnAssign):
+        if top_level and isinstance(node.target, ast.Name):
+            return {"kind": "let"}
+        return {"kind": "assign"}
+    if isinstance(node, ast.AugAssign):
+        return {"kind": "assign"}
+    if isinstance(node, ast.Expr):
+        return _shape_expr(node.value)
+    return {"kind": "opaque"}
+
+
+def _shape_expr(node: ast.expr) -> Json:
+    if isinstance(node, ast.BinOp):
+        return {"kind": "bin", "op": _bin_op(node.op)}
+    if isinstance(node, ast.Compare):
+        op = _rel_op(node.ops[0]) if node.ops else "opaque-op"
+        return {"kind": "rel", "op": op}
+    if isinstance(node, ast.Call):
+        return {"kind": "call"}
+    return {"kind": "opaque"}
+
+
+def _bin_op(op: ast.operator) -> str:
+    if isinstance(op, ast.Add):
+        return "+"
+    if isinstance(op, ast.Sub):
+        return "-"
+    if isinstance(op, ast.Mult):
+        return "*"
+    if isinstance(op, ast.Div):
+        return "/"
+    if isinstance(op, ast.Mod):
+        return "%"
+    return "opaque-op"
+
+
+def _rel_op(op: ast.cmpop) -> str:
+    if isinstance(op, ast.Eq):
+        return "=="
+    if isinstance(op, ast.NotEq):
+        return "!="
+    if isinstance(op, ast.Lt):
+        return "<"
+    if isinstance(op, ast.LtE):
+        return "<="
+    if isinstance(op, ast.Gt):
+        return ">"
+    if isinstance(op, ast.GtE):
+        return ">="
+    return "opaque-op"
+
+
+def _extract_leading_annotations(
+    lines: list[str],
+    fn_line: int,
+) -> tuple[str | None, str | None, str | None]:
+    concept: str | None = None
+    attr_pre: str | None = None
+    attr_post: str | None = None
+    idx = fn_line - 2
+    while idx >= 0:
+        line = lines[idx].strip()
+        if line.startswith("# concept:"):
+            if concept is None:
+                candidate = line[len("# concept:") :].strip()
+                if candidate.startswith("UNNAMED-CONCEPT-"):
+                    concept = None
+                    break
+                concept = candidate
+            idx -= 1
+            continue
+        if line.startswith("# @requires:"):
+            if attr_pre is None:
+                attr_pre = line[len("# @requires:") :].strip()
+            idx -= 1
+            continue
+        if line.startswith("# @ensures:"):
+            if attr_post is None:
+                attr_post = line[len("# @ensures:") :].strip()
+            idx -= 1
+            continue
+        if line == "" or line.startswith("#") or line.startswith("@"):
+            idx -= 1
+            continue
+        break
+    return concept, attr_pre, attr_post
+
+
+def _iter_python_files(path: Path) -> Iterable[Path]:
+    if path.is_dir():
+        yield from sorted(p for p in path.rglob("*.py") if p.is_file())
+    elif path.is_file() and path.suffix == ".py":
+        yield path
+
+
+def _is_relative_to(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_docstring_stmt(node: ast.stmt) -> bool:
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_rpc.py
@@ -6,22 +6,19 @@ import sys
 import traceback
 from typing import Any
 
-from .compiler import compile_ir_document
-from .lifter import lift_paths
+from .bind_lifter import lift_paths
 
-SURFACE = "python-source"
-VERSION = "0.1.0-draft"
+VERSION = "0.1.0"
 
 
 def initialize_result() -> dict[str, Any]:
     return {
-        "name": "provekit-lift-python-source",
+        "name": "provekit-lift-python-bind",
         "version": VERSION,
         "protocol_version": "pep/1.7.0",
-        "dialect": SURFACE,
         "capabilities": {
-            "authoring_surfaces": [SURFACE],
-            "ir_version": "v1.1.0",
+            "authoring_surfaces": ["python", "python-bind"],
+            "ir_version": "bind-ir/1.0.0",
             "emits_signed_mementos": False,
         },
     }
@@ -51,25 +48,20 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         return {"jsonrpc": "2.0", "id": msg_id, "result": initialize_result()}
     if method == "lift":
         return _lift(msg_id, params)
-    if method == "compile":
-        return _compile(msg_id, params)
     if method == "shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
 
 
 def _lift(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
-    surface = params.get("surface", SURFACE)
-    if surface != SURFACE:
-        return _error(msg_id, 1003, f"SURFACE_NOT_SUPPORTED: {surface}")
-
     source_paths = params.get("source_paths")
-    if not isinstance(source_paths, list) or not source_paths:
-        return _error(msg_id, -32602, "source_paths must be a non-empty array")
-
-    paths = [str(path) for path in source_paths if str(path)]
+    paths: list[str]
+    if isinstance(source_paths, list):
+        paths = [str(path) for path in source_paths if str(path)]
+    else:
+        paths = ["."]
     if not paths:
-        return _error(msg_id, -32602, "source_paths must contain strings")
+        paths = ["."]
 
     result = lift_paths(str(params.get("workspace_root", ".")), paths)
     return {
@@ -78,24 +70,7 @@ def _lift(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
         "result": {
             "kind": "ir-document",
             "ir": result.ir,
-            "callEdges": [],
             "diagnostics": result.diagnostics,
-            "opacityReport": result.opacity_report,
-            "refusals": result.refusals,
-        },
-    }
-
-
-def _compile(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
-    ir = params.get("ir")
-    if not isinstance(ir, list):
-        return _error(msg_id, -32602, "ir must be an array")
-    return {
-        "jsonrpc": "2.0",
-        "id": msg_id,
-        "result": {
-            "kind": "compiled-formula",
-            "body": compile_ir_document(ir),
         },
     }
 
@@ -115,14 +90,14 @@ def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--rpc", action="store_true", help="run JSON-RPC over stdio")
-    parser.add_argument("--bind-rpc", action="store_true", help="run bind JSON-RPC over stdio")
+    parser.add_argument("--rpc", action="store_true", help="run bind JSON-RPC over stdio")
+    parser.add_argument("--bind-rpc", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
-    if args.bind_rpc:
-        from .bind_rpc import run_rpc as run_bind_rpc
-
-        run_bind_rpc()
-    elif args.rpc:
+    if args.rpc or args.bind_rpc:
         run_rpc()
     else:
         parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-lift-python-source/src"
+PY_TESTS_SRC = ROOT / "implementations/python/provekit-lift-py-tests/src"
+if str(PY_TESTS_SRC) not in sys.path:
+    sys.path.insert(0, str(PY_TESTS_SRC))
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from provekit_lift_python_source.bind_lifter import lift_source
+from provekit_lift_python_source.bind_rpc import dispatch, initialize_result
+from provekit_lift_python_source.canonical import cid_of_json
+
+
+def test_bind_lift_source_emits_language_neutral_entries() -> None:
+    source = (
+        "# concept: identity\n"
+        "# @requires: x >= 0\n"
+        "# @ensures: result >= 0\n"
+        "def wrap_identity(x: int) -> int:\n"
+        "    return x\n"
+        "\n"
+        "class Cell:\n"
+        "    # unrelated comment\n"
+        "    # concept: bool-cell\n"
+        "    @staticmethod\n"
+        "    def toggle(flag: bool) -> bool:\n"
+        "        return not flag\n"
+        "\n"
+        "# concept: option\n"
+        "def maybe_first(items: list) -> int:\n"
+        "    first = 0\n"
+        "    if len(items) == 0:\n"
+        "        return -1\n"
+        "    else:\n"
+        "        return items[0]\n"
+    )
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.diagnostics == []
+    assert [entry["fn_name"] for entry in result.ir] == [
+        "wrap_identity",
+        "toggle",
+        "maybe_first",
+    ]
+    assert [entry["concept_annotation"] for entry in result.ir] == [
+        "identity",
+        "bool-cell",
+        "option",
+    ]
+    assert result.ir[0]["attr_pre"] == "x >= 0"
+    assert result.ir[0]["attr_post"] == "result >= 0"
+    assert result.ir[0]["param_names"] == ["x"]
+    assert result.ir[0]["param_types"] == ["int"]
+    assert result.ir[0]["return_type"] == "int"
+    assert result.ir[0]["term_shape"] == {
+        "kind": "body",
+        "stmts": [{"kind": "exit"}],
+    }
+    assert result.ir[2]["term_shape"] == {
+        "kind": "body",
+        "stmts": [
+            {"kind": "let"},
+            {
+                "cond": {"kind": "rel", "op": "=="},
+                "else": {"kind": "block", "stmts": [{"kind": "exit"}]},
+                "kind": "if",
+                "then": {"kind": "block", "stmts": [{"kind": "exit"}]},
+            },
+        ],
+    }
+    for entry in result.ir:
+        assert entry["kind"] == "bind-lift-entry"
+        assert entry["file"] == "pkg/foo.py"
+        assert entry["term_shape_cid"] == cid_of_json(entry["term_shape"])
+    assert "python:" not in json.dumps(result.ir, sort_keys=True)
+
+
+def test_bind_lift_filters_unnamed_concepts_and_void_return() -> None:
+    source = (
+        "# concept: UNNAMED-CONCEPT-deadbeef\n"
+        "def generated(x):\n"
+        "    x += 1\n"
+        "    return None\n"
+        "\n"
+        "def no_annotation(y) -> None:\n"
+        "    return None\n"
+    )
+
+    result = lift_source(source, "foo.py")
+
+    assert [entry["concept_annotation"] for entry in result.ir] == [None, None]
+    assert result.ir[0]["param_names"] == ["x"]
+    assert result.ir[0]["param_types"] == ["Any"]
+    assert result.ir[0]["return_type"] == "Any"
+    assert result.ir[0]["term_shape"]["stmts"][0] == {"kind": "assign"}
+    assert result.ir[1]["return_type"] == "()"
+
+
+def test_bind_rpc_initialize_declares_bind_ir_surface() -> None:
+    result = initialize_result()
+
+    assert result["name"] == "provekit-lift-python-bind"
+    assert result["protocol_version"] == "pep/1.7.0"
+    assert result["capabilities"] == {
+        "authoring_surfaces": ["python", "python-bind"],
+        "emits_signed_mementos": False,
+        "ir_version": "bind-ir/1.0.0",
+    }
+
+
+def test_bind_rpc_lift_returns_ir_document(tmp_path: Path) -> None:
+    source = tmp_path / "foo.py"
+    source.write_text("# concept: identity\ndef f(x: int) -> int:\n    return x\n", encoding="utf-8")
+
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "lift",
+            "params": {
+                "workspace_root": str(tmp_path),
+                "source_paths": ["foo.py"],
+            },
+        }
+    )
+
+    assert response["id"] == 7
+    assert response["result"]["kind"] == "ir-document"
+    assert response["result"]["diagnostics"] == []
+    assert response["result"]["ir"][0]["concept_annotation"] == "identity"


### PR DESCRIPTION
Reopened after the original PR #781 was auto-closed when its base branch (feat/770-kit-agnostic-dispatcher) was deleted on the PR #779 squash-merge. Same commit content, rebased onto post-merge main. Part of the kit-agnostic dispatcher stack.