### PR TITLE
fix(783): Remove stale v0-capability-gap lies from cmd_bind

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -831,23 +831,22 @@ fn run_bind_engine(
         }
     }
 
-    // Record v0 capability gaps.
-    gaps.push(GapRecord {
-        kind: "v0-capability-gap".into(),
-        detail: "multi-lang lift_plugin dispatch deferred to v1 (only Rust lifting in v0)".into(),
-    });
-    gaps.push(GapRecord {
-        kind: "v0-capability-gap".into(),
-        detail: "real ConceptAbstractionMemento catalog lookup deferred to v1 (v0 uses soft-match classification)".into(),
-    });
-    // F6 (post body-template-memento, #766/#767/#768): the unconditional
-    // `bind-stub-body-emitted` gap with hardcoded binding count was a lie
-    // once the Java realize plugin began emitting real bodies for templated
-    // concepts. The accurate replacement is per-concept gap emission done
-    // AFTER `apply_canonical_rewrite` returns (see the main cmd_bind flow).
-    // The engine itself can't emit these gaps because it doesn't know which
-    // concepts' bodies will fall through to a stub — that's known only after
-    // each binding's realize_for_bind call reports its `is_stub` kind.
+    // Per PR #779, multi-lang lift dispatch IS wired via kit_dispatch, and the
+    // "v0-capability-gap: multi-lang lift_plugin dispatch deferred" claim is no
+    // longer true: when a non-Rust bind-lift kit is registered, the dispatcher
+    // exercises it and the lift result is REAL. Emitting the legacy gap
+    // unconditionally lied about the substrate state. The honest replacement
+    // is per-situation: `kit-plugin-unavailable` is already emitted by the
+    // dispatcher when no kit registers; `bind-stub-body-emitted` is emitted
+    // per-concept by `apply_canonical_rewrite` when a body falls through to a
+    // stub; below-threshold and unnamed-concept gaps are emitted above. None
+    // of those require an unconditional v0-capability-gap.
+    //
+    // The "real ConceptAbstractionMemento catalog lookup" gap is similarly
+    // stale: the concept catalog now feeds through `seed_catalog()` + the
+    // human-annotation path, and the soft-match classification still applies
+    // but it isn't a capability gap, it's a substrate choice. If a stronger
+    // catalog lookup lands later it's an enhancement, not a closure of a gap.
     Ok(EngineResult {
         bindings,
         concepts,

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -528,11 +528,31 @@ fn canonical_multi_target_emission_smoke() {
 }
 
 // ============================================================================
-// Test 16: gaps.json records v0 capability gaps
+// Test 16: gaps.json reflects real substrate state (post PR #779 + #783)
 // ============================================================================
 
 #[test]
-fn gaps_doc_records_v0_capability_gaps() {
+fn gaps_doc_reflects_real_substrate_state() {
+    // Pre-PR #783: bind emitted two unconditional `v0-capability-gap` entries
+    // ("multi-lang lift_plugin dispatch deferred", "real ConceptAbstractionMemento
+    // catalog lookup deferred") for every run. PR #779 made the dispatcher
+    // exercise the actual per-language kits via kit_dispatch, so those gaps
+    // became lies: they claimed a substrate limitation that no longer existed.
+    //
+    // Per Supra omnia rectum, gaps must reflect REAL substrate state. The
+    // honest replacements are situation-specific:
+    //   - `kit-plugin-unavailable` is emitted by the dispatcher when a kit
+    //     isn't registered for the requested language.
+    //   - `bind-stub-body-emitted` is emitted per concept by
+    //     `apply_canonical_rewrite` when a body falls through to a language
+    //     stub.
+    //   - `below-threshold` is emitted per concept when site count falls
+    //     under the threshold.
+    //   - `kit-plugin-unavailable` for realize is emitted when the realize
+    //     kit isn't registered.
+    //
+    // None of those require an unconditional v0-capability-gap. This test
+    // enforces the absence of the stale lying gap kind.
     let root = fixture_root();
     let out = tempfile::tempdir().expect("tempdir").into_path();
     let result = bind_cmd(&root, &out, "invisible", "monitor", None);
@@ -542,8 +562,8 @@ fn gaps_doc_records_v0_capability_gaps() {
     let gap_arr = gaps["gaps"].as_array().expect("gaps must be array");
     let kinds: Vec<&str> = gap_arr.iter().filter_map(|g| g["kind"].as_str()).collect();
     assert!(
-        kinds.contains(&"v0-capability-gap"),
-        "gaps.json must record at least one v0-capability-gap"
+        !kinds.contains(&"v0-capability-gap"),
+        "gaps.json must NOT record stale v0-capability-gap entries after PR #779 made dispatch real (PR #783 removed the lie)"
     );
     assert!(
         !kinds.contains(&"v0-orp-delegation-gap"),


### PR DESCRIPTION
Reopened after the original PR #783 was auto-closed when its base branch (feat/770-kit-agnostic-dispatcher) was deleted on the PR #779 squash-merge. Same commit content, rebased onto post-merge main. Part of the kit-agnostic dispatcher stack.