### PR TITLE
fix(789): ship discoverable provekit-realize-python wrapper

### DIFF
--- a/implementations/python/target/release/provekit-realize-python
+++ b/implementations/python/target/release/provekit-realize-python
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PYTHONPATH="$DIR/provekit-realize-python-core/src:$PYTHONPATH" exec python3 -m provekit_realize_python_core "$@"


### PR DESCRIPTION
Tiny shim that makes PR #788's python realize kit actually discoverable by the dispatcher.

The dispatcher's built-in discovery looks for `implementations/python/target/release/provekit-realize-python` (substrate convention, mirrors Rust's target/release/ path). PR #788 shipped the package source but no executable shim, so the kit returned kit-plugin-unavailable from any workspace_root that didn't ship a manifest.

The shim is 4 lines: sets PYTHONPATH to the package src and execs `python3 -m provekit_realize_python_core`. No build step required.

## Empirical

With #779 + #784/#785/#786/#788 + this PR + the C bind-lift kit + Java realize jar built:

`provekit bind --root <java-dir> --lang java --target-language python` produces real Python via the dispatcher:

```python
def wrap_identity(x):
    return x

def toggle(flag):
    return not flag
```

Leg 2 of the C→Java→Python→C trinity is empirically demonstrable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)