### PR TITLE
impl(795): Rust types: CompositionRefusalMemento + CCP API conversion

### DIFF
--- a/implementations/rust/libprovekit/src/compose.rs
+++ b/implementations/rust/libprovekit/src/compose.rs
@@ -36,7 +36,10 @@ use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
 use provekit_ir_types::{
-    AggregationStrategy, CompoundContractMemento, EvidenceMemento, EvidenceRef, IrFormula, IrTerm,
+    composition_refusal_compose_input_cid, composition_refusal_header_cid,
+    composition_refusal_signature, AggregationStrategy, BlockingEffect, CompositionRefusalEnvelope,
+    CompositionRefusalHeader, CompositionRefusalMemento, CompositionRefusalMetadata,
+    CompoundContractMemento, EffectOccurrence, EvidenceMemento, EvidenceRef, IrFormula, IrTerm, OccurrenceKind, OccurrenceRole,
     Sort, SourceKind, SourceLocator, SourceLocatorPoint, SourceLocatorSpan,
 };
 
@@ -951,26 +954,366 @@ pub struct ChainStep<'a> {
     pub formal_idx: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompositionError {
+    ChainTooShort {
+        len: usize,
+    },
+    ImpureInput {
+        atom_index: usize,
+        atom_cid: String,
+    },
+    FormalIndexOutOfRange {
+        atom_index: usize,
+        formal_idx: usize,
+        formals_len: usize,
+        atom_cid: String,
+    },
+    MissingResultEquation {
+        atom_index: usize,
+        atom_cid: String,
+    },
+}
+
+impl CompositionError {
+    fn failure_kind(&self) -> &'static str {
+        match self {
+            Self::ImpureInput { .. } => "impure-input",
+            Self::ChainTooShort { .. } | Self::FormalIndexOutOfRange { .. } => "ordering-conflict",
+            Self::MissingResultEquation { .. } => "unsatisfiable-precondition",
+        }
+    }
+
+    fn failure_detail(&self) -> String {
+        match self {
+            Self::ChainTooShort { len } => {
+                format!("chain has {len} atoms; at least 2 atoms are required")
+            }
+            Self::ImpureInput {
+                atom_index,
+                atom_cid,
+            } => format!("impure atom {atom_cid} at chain index {atom_index}"),
+            Self::FormalIndexOutOfRange {
+                atom_index,
+                formal_idx,
+                formals_len,
+                atom_cid,
+            } => format!(
+                "atom {atom_cid} at chain index {atom_index} uses formal_idx {formal_idx}, but has {formals_len} formals"
+            ),
+            Self::MissingResultEquation {
+                atom_index,
+                atom_cid,
+            } => format!(
+                "atom {atom_cid} at chain index {atom_index} has no deterministic result equation"
+            ),
+        }
+    }
+}
+
 /// Compose a chain of pure function contracts left-to-right. Each
 /// step's contract receives the previous step's result at its
-/// `formal_idx`-th formal. Returns None if any contract is impure or
-/// the chain is shorter than 2 steps.
+/// `formal_idx`-th formal. Returns a canonical refusal memento if any
+/// contract is impure or the chain cannot be composed.
 ///
 /// Per CCP §2 + §9: this is the canonical primitive named in the spec.
 /// The chain's overall CID is derivable from its component CIDs in
 /// order; re-composing the same chain produces the same CID
 /// byte-for-byte. Cross-language consumers (C lifter via FFI, future
 /// JSON-RPC subprocess) call into this function.
-pub fn compose_chain_contracts(steps: &[ChainStep<'_>]) -> Option<ComposedFunctionContract> {
+pub fn compose_chain_contracts(
+    steps: &[ChainStep<'_>],
+) -> Result<ComposedFunctionContract, CompositionRefusalMemento> {
+    compose_chain_contracts_internal(steps)
+        .map_err(|error| composition_error_to_refusal(steps, error))
+}
+
+fn compose_chain_contracts_internal(
+    steps: &[ChainStep<'_>],
+) -> Result<ComposedFunctionContract, CompositionError> {
     if steps.len() < 2 {
-        return None;
+        return Err(CompositionError::ChainTooShort { len: steps.len() });
+    }
+    for (atom_index, step) in steps.iter().enumerate() {
+        if !step.contract.is_pure() {
+            return Err(CompositionError::ImpureInput {
+                atom_index,
+                atom_cid: step.contract.cid.clone(),
+            });
+        }
+    }
+    if steps[1].formal_idx >= steps[1].contract.formals.len() {
+        return Err(CompositionError::FormalIndexOutOfRange {
+            atom_index: 1,
+            formal_idx: steps[1].formal_idx,
+            formals_len: steps[1].contract.formals.len(),
+            atom_cid: steps[1].contract.cid.clone(),
+        });
+    }
+    if steps[0].contract.result_value().is_none() {
+        return Err(CompositionError::MissingResultEquation {
+            atom_index: 0,
+            atom_cid: steps[0].contract.cid.clone(),
+        });
     }
     let mut acc =
-        compose_function_contracts(steps[1].contract, steps[0].contract, steps[1].formal_idx)?;
-    for step in &steps[2..] {
-        acc = compose_with_composed(step.contract, &acc, step.formal_idx)?;
+        compose_function_contracts(steps[1].contract, steps[0].contract, steps[1].formal_idx)
+            .ok_or_else(|| CompositionError::MissingResultEquation {
+                atom_index: 0,
+                atom_cid: steps[0].contract.cid.clone(),
+            })?;
+    for (atom_index, step) in steps.iter().enumerate().skip(2) {
+        if step.formal_idx >= step.contract.formals.len() {
+            return Err(CompositionError::FormalIndexOutOfRange {
+                atom_index,
+                formal_idx: step.formal_idx,
+                formals_len: step.contract.formals.len(),
+                atom_cid: step.contract.cid.clone(),
+            });
+        }
+        acc = compose_with_composed(step.contract, &acc, step.formal_idx).ok_or_else(|| {
+            CompositionError::MissingResultEquation {
+                atom_index: atom_index - 1,
+                atom_cid: steps[atom_index - 1].contract.cid.clone(),
+            }
+        })?;
     }
-    Some(acc)
+    Ok(acc)
+}
+
+fn composition_error_to_refusal(
+    steps: &[ChainStep<'_>],
+    error: CompositionError,
+) -> CompositionRefusalMemento {
+    let atoms_cids: Vec<String> = steps.iter().map(|s| s.contract.cid.clone()).collect();
+    let effect_set_cids: Vec<String> = steps
+        .iter()
+        .map(|s| effect_set_cid(&s.contract.effects))
+        .collect();
+    let compose_input_cid =
+        composition_refusal_compose_input_cid(&atoms_cids, &effect_set_cids, CCP_VERSION);
+    let effect_occurrences = effect_occurrences_for_steps(steps);
+    let blocking_effects = blocking_effects_for_steps(steps);
+
+    let mut header = CompositionRefusalHeader {
+        atoms_cids,
+        blocking_effects: if blocking_effects.is_empty() {
+            None
+        } else {
+            Some(blocking_effects)
+        },
+        ccp_version: CCP_VERSION.to_string(),
+        cid: String::new(),
+        compose_input_cid,
+        effect_occurrences: if effect_occurrences.is_empty() {
+            None
+        } else {
+            Some(effect_occurrences)
+        },
+        effect_set_cids,
+        failure_detail: error.failure_detail(),
+        failure_kind: error.failure_kind().to_string(),
+        incompatible_pair: None,
+        kind: "composition-refusal".to_string(),
+        missing_memento_requirements: None,
+        schema_version: "1".to_string(),
+    };
+    header.cid = composition_refusal_header_cid(&header);
+    let metadata = CompositionRefusalMetadata::default();
+    let signature = composition_refusal_signature(&header, &metadata);
+    CompositionRefusalMemento {
+        envelope: CompositionRefusalEnvelope {
+            declared_at: "1970-01-01T00:00:00Z".to_string(),
+            signature,
+            signer: "substrate:libprovekit".to_string(),
+        },
+        header,
+        metadata,
+    }
+}
+
+fn effect_set_cid(effect_set: &EffectSet) -> String {
+    cid_of_value(&effect_set.to_value())
+}
+
+fn effect_occurrences_for_steps(steps: &[ChainStep<'_>]) -> Vec<EffectOccurrence> {
+    steps
+        .iter()
+        .flat_map(|step| {
+            step.contract
+                .effects
+                .effects
+                .iter()
+                .enumerate()
+                .map(move |(idx, effect)| {
+                    let occurrence_kind = OccurrenceKind::from_str(effect_occurrence_kind(effect)).expect("canonical effect kind");
+                    let discharge_key = effect_discharge_key(effect);
+                    EffectOccurrence {
+                        args: effect_args_json(effect),
+                        discharge_key,
+                        locator: serde_json::json!({
+                            "atom_cid": step.contract.cid,
+                            "effect_index": idx,
+                        }),
+                        occurrence_kind,
+                        // Per EffectOccurrence #793 spec §2: declared-effects-of-the-contract
+                        // carry role "body". The composer doesn't see a narrower position
+                        // unless the producing lifter records it.
+                        role: OccurrenceRole::Body,
+                        signature_cid: cid_of_value(&effect.to_value()),
+                    }
+                })
+        })
+        .collect()
+}
+
+fn blocking_effects_for_steps(steps: &[ChainStep<'_>]) -> Vec<BlockingEffect> {
+    steps
+        .iter()
+        .flat_map(|step| {
+            step.contract
+                .effects
+                .effects
+                .iter()
+                .map(move |effect| BlockingEffect {
+                    atom_cid: step.contract.cid.clone(),
+                    classification: effect_classification(effect).to_string(),
+                    discharge_key: effect_discharge_key(effect),
+                    occurrence_kind: effect_occurrence_kind(effect).to_string(),
+                })
+        })
+        .collect()
+}
+
+/// Canonical occurrence-kind labels per `EffectOccurrence` spec §3 (#793).
+/// MUST be PascalCase; CCP refusal mementos that compose with the
+/// EffectOccurrence type need byte-identical kind names.
+fn effect_occurrence_kind(effect: &Effect) -> &'static str {
+    match effect {
+        Effect::Reads { .. } => "Reads",
+        Effect::Writes { .. } => "Writes",
+        Effect::Io => "Io",
+        Effect::Unsafe => "Unsafe",
+        Effect::Panics => "Panics",
+        Effect::UnresolvedCall { .. } => "UnresolvedCall",
+        Effect::OpaqueLoop { .. } => "OpaqueLoop",
+        Effect::EarlyReturn { .. } => "EarlyReturn",
+        Effect::ClosureCapture { .. } => "ClosureCapture",
+        Effect::PinnedReference { .. } => "PinnedReference",
+        Effect::RawPointerProvenance { .. } => "RawPointerProvenance",
+        Effect::AtomicAccess { .. } => "AtomicAccess",
+        Effect::PossibleAliasing { .. } => "PossibleAliasing",
+        Effect::Drop { .. } => "Drop",
+    }
+}
+
+/// Per-occurrence classification per `2026-05-06-effect-discharge-classification.md`
+/// and `EffectOccurrence` spec §4 (#793). The blocking-effect record carries this
+/// so refusal consumers can see WHY a given effect blocked composition, not just
+/// that some effect did.
+///
+/// - `block` (UnconditionallyBlocked): Reads/Writes/Io/Panics/Unsafe at v1
+/// - `memento-required`: OpaqueLoop / UnresolvedCall / EarlyReturn / ClosureCapture
+///   / PinnedReference / RawPointerProvenance / PossibleAliasing / non-trivial Drop
+///   / AtomicAccess with `ordering: None`
+/// - `informational-dischargeable`: AtomicAccess with concrete `ordering`
+fn effect_classification(effect: &Effect) -> &'static str {
+    match effect {
+        Effect::Reads { .. }
+        | Effect::Writes { .. }
+        | Effect::Io
+        | Effect::Unsafe
+        | Effect::Panics => "block",
+        Effect::OpaqueLoop { .. }
+        | Effect::UnresolvedCall { .. }
+        | Effect::EarlyReturn { .. }
+        | Effect::ClosureCapture { .. }
+        | Effect::PinnedReference { .. }
+        | Effect::RawPointerProvenance { .. }
+        | Effect::PossibleAliasing { .. }
+        | Effect::Drop { .. } => "memento-required",
+        Effect::AtomicAccess { ordering, .. } => {
+            if ordering.is_some() {
+                "informational-dischargeable"
+            } else {
+                "memento-required"
+            }
+        }
+    }
+}
+
+/// Canonical discharge-key shape per `EffectOccurrence` spec §3 (#793).
+/// Format: `<occurrence-kind-lowercase-segment>:<payload-segments>`. The
+/// segments here match the §3 examples (e.g. `read:x`, `opaque-loop:<cid>`,
+/// `raw-pointer-provenance:<target>:<mut>`) so a refusal memento composes
+/// byte-identically with an EffectOccurrence minted by a lifter.
+fn effect_discharge_key(effect: &Effect) -> String {
+    match effect {
+        Effect::Reads { target } => format!("read:{target}"),
+        Effect::Writes { target } => format!("write:{target}"),
+        Effect::Io => "io".to_string(),
+        Effect::Unsafe => "unsafe".to_string(),
+        Effect::Panics => "panic".to_string(),
+        Effect::UnresolvedCall { name } => format!("unresolved-call:{name}"),
+        Effect::OpaqueLoop { loop_cid } => format!("opaque-loop:{loop_cid}"),
+        Effect::EarlyReturn { try_cid } => format!("early-return:{try_cid}"),
+        Effect::ClosureCapture {
+            body_fn_cid,
+            n_captures,
+        } => format!("closure-capture:{body_fn_cid}:{n_captures}"),
+        Effect::PinnedReference { target } => format!("pinned-reference:{target}"),
+        Effect::RawPointerProvenance { target, mutable } => {
+            format!(
+                "raw-pointer-provenance:{target}:{}",
+                if *mutable { "mut" } else { "const" }
+            )
+        }
+        Effect::AtomicAccess {
+            target,
+            kind,
+            ordering,
+        } => format!(
+            "atomic:{target}:{}:{}",
+            kind.as_str(),
+            ordering.as_deref().unwrap_or("null")
+        ),
+        Effect::PossibleAliasing { formals } => format!("possible-aliasing:{}", formals.join(",")),
+        Effect::Drop { name } => format!("drop:{name}"),
+    }
+}
+
+fn effect_args_json(effect: &Effect) -> serde_json::Value {
+    match effect {
+        Effect::Reads { target }
+        | Effect::Writes { target }
+        | Effect::PinnedReference { target } => serde_json::json!({ "target": target }),
+        Effect::Io | Effect::Unsafe | Effect::Panics => serde_json::json!({}),
+        Effect::UnresolvedCall { name } | Effect::Drop { name } => {
+            serde_json::json!({ "name": name })
+        }
+        Effect::OpaqueLoop { loop_cid } => serde_json::json!({ "loop_cid": loop_cid }),
+        Effect::EarlyReturn { try_cid } => serde_json::json!({ "try_cid": try_cid }),
+        Effect::ClosureCapture {
+            body_fn_cid,
+            n_captures,
+        } => serde_json::json!({
+            "body_fn_cid": body_fn_cid,
+            "n_captures": n_captures,
+        }),
+        Effect::RawPointerProvenance { target, mutable } => {
+            serde_json::json!({ "target": target, "mutable": mutable })
+        }
+        Effect::AtomicAccess {
+            target,
+            kind,
+            ordering,
+        } => serde_json::json!({
+            "target": target,
+            "kind": kind.as_str(),
+            "ordering": ordering,
+        }),
+        Effect::PossibleAliasing { formals } => serde_json::json!({ "formals": formals }),
+    }
 }
 
 fn find_namespaced_result(formula: &IrFormula) -> Option<IrTerm> {
@@ -1083,9 +1426,7 @@ pub fn jcs_bytes_of_value(v: &Value) -> Vec<u8> {
 // `libprovekit::compose::substitute_in_formula` keep working.
 // ============================================================
 
-pub use crate::wp::{
-    free_vars_formula, free_vars_term, substitute_in_formula, substitute_in_term,
-};
+pub use crate::wp::{free_vars_formula, free_vars_term, substitute_in_formula, substitute_in_term};
 
 // ============================================================
 // DomainClaim projection for FunctionContractMemento (PR-B of #717)
@@ -1213,24 +1554,15 @@ fn evidence_cid(
             "confidence_basis_points".to_string(),
             Value::integer(i64::from(confidence_basis_points)),
         ),
-        (
-            "extension_fields".to_string(),
-            Value::object(ext_entries),
-        ),
+        ("extension_fields".to_string(), Value::object(ext_entries)),
         ("kind".to_string(), Value::string("evidence".to_string())),
         (
             "lifter_cid".to_string(),
             Value::string(lifter_cid.to_string()),
         ),
         ("predicate".to_string(), formula_to_canonical(predicate)),
-        (
-            "schemaVersion".to_string(),
-            Value::string("1".to_string()),
-        ),
-        (
-            "source_kind".to_string(),
-            Value::string(source_kind_str),
-        ),
+        ("schemaVersion".to_string(), Value::string("1".to_string())),
+        ("source_kind".to_string(), Value::string(source_kind_str)),
         ("source_locator".to_string(), sloc_value),
     ]);
 
@@ -1299,10 +1631,7 @@ fn compound_cid(
             "kind".to_string(),
             Value::string("compound-contract".to_string()),
         ),
-        (
-            "schemaVersion".to_string(),
-            Value::string("1".to_string()),
-        ),
+        ("schemaVersion".to_string(), Value::string("1".to_string())),
     ]);
 
     cid_of_value(&header)
@@ -1486,10 +1815,14 @@ mod fcm_auto_promote_tests {
         IrFormula::Atomic {
             name: ">=".to_string(),
             args: vec![
-                IrTerm::Var { name: "x".to_string() },
+                IrTerm::Var {
+                    name: "x".to_string(),
+                },
                 IrTerm::Const {
                     value: serde_json::Value::Number(serde_json::Number::from(0)),
-                    sort: Sort::Primitive { name: "Int".to_string() },
+                    sort: Sort::Primitive {
+                        name: "Int".to_string(),
+                    },
                 },
             ],
         }
@@ -1500,8 +1833,12 @@ mod fcm_auto_promote_tests {
         IrFormula::Atomic {
             name: ">=".to_string(),
             args: vec![
-                IrTerm::Var { name: "result".to_string() },
-                IrTerm::Var { name: "x".to_string() },
+                IrTerm::Var {
+                    name: "result".to_string(),
+                },
+                IrTerm::Var {
+                    name: "x".to_string(),
+                },
             ],
         }
     }
@@ -1521,7 +1858,10 @@ mod fcm_auto_promote_tests {
         );
         let (_ev, compound) = promote_fcm_to_compound(&fcm);
         assert_eq!(compound.evidences.len(), 1);
-        assert_eq!(compound.aggregation_strategy, AggregationStrategy::Conjunction);
+        assert_eq!(
+            compound.aggregation_strategy,
+            AggregationStrategy::Conjunction
+        );
         assert_eq!(compound.kind, "compound-contract");
         assert_eq!(compound.schema_version, "1");
         assert_eq!(compound.function_term_cid, "blake3-512:aaaa");
@@ -1622,7 +1962,9 @@ mod fcm_auto_promote_tests {
 
         // The compound's evidence ref CID is a valid blake3-512 CID.
         assert!(
-            compound.evidences[0].evidence_cid.starts_with("blake3-512:"),
+            compound.evidences[0]
+                .evidence_cid
+                .starts_with("blake3-512:"),
             "evidence CID should be a valid blake3-512 CID"
         );
 
@@ -1679,7 +2021,10 @@ mod fcm_auto_promote_tests {
             .extension_fields
             .get("auto_promoted_from")
             .expect("auto_promoted_from must be present");
-        assert_eq!(from, &serde_json::Value::String("blake3-512:abcd".to_string()));
+        assert_eq!(
+            from,
+            &serde_json::Value::String("blake3-512:abcd".to_string())
+        );
     }
 
     // ----------------------------------------------------------------
@@ -1698,8 +2043,7 @@ mod fcm_auto_promote_tests {
         let (_ev, compound) = promote_fcm_to_compound(&fcm);
 
         let json1 = serde_json::to_string(&compound).expect("serialize");
-        let deser: CompoundContractMemento =
-            serde_json::from_str(&json1).expect("deserialize");
+        let deser: CompoundContractMemento = serde_json::from_str(&json1).expect("deserialize");
         let json2 = serde_json::to_string(&deser).expect("re-serialize");
 
         assert_eq!(json1, json2, "round-trip must produce identical bytes");
@@ -1771,7 +2115,8 @@ mod fcm_auto_promote_tests {
         let (_ev, compound) = promote_fcm_to_compound(&fcm);
 
         // Recompute CID via serde path: serialize → remove cid → canonical → CID.
-        let mut as_value = serde_json::to_value(&compound).expect("CompoundContractMemento serializes");
+        let mut as_value =
+            serde_json::to_value(&compound).expect("CompoundContractMemento serializes");
         as_value
             .as_object_mut()
             .expect("CompoundContractMemento serializes as object")

--- a/implementations/rust/libprovekit/src/ffi.rs
+++ b/implementations/rust/libprovekit/src/ffi.rs
@@ -379,7 +379,7 @@ fn inner_compose(atoms_jcs: &str, effects_jcs: &str) -> Result<(String, String),
         })
         .collect();
 
-    let composed = compose_chain_contracts(&steps).ok_or(FfiError::ComposeRefused)?;
+    let composed = compose_chain_contracts(&steps).map_err(|_| FfiError::ComposeRefused)?;
     let body_jcs = String::from_utf8(composed.canonical_bytes.clone())
         .map_err(|e| FfiError::Schema(format!("composed body not utf-8: {}", e)))?;
     Ok((composed.cid, body_jcs))

--- a/implementations/rust/libprovekit/src/wp.rs
+++ b/implementations/rust/libprovekit/src/wp.rs
@@ -352,7 +352,9 @@ pub enum WpError {
     /// meta-var for a slot the op does not have (or that was classified
     /// value-typed), or `apply`s something that is not a slot
     /// transformer at all.
-    #[error("op `{op}`: wp_rule applies `{fn_name}`, which is not a Stmt-slot transformer of this op")]
+    #[error(
+        "op `{op}`: wp_rule applies `{fn_name}`, which is not a Stmt-slot transformer of this op"
+    )]
     MalformedRule {
         /// The op name.
         op: String,
@@ -608,12 +610,24 @@ fn reduce_formula<R: OpContractResolver + ?Sized>(
         IrFormula::Forall { name, sort, body } => Ok(IrFormula::Forall {
             name,
             sort,
-            body: Box::new(reduce_formula(*body, q, stmt_transformers, op_name, resolver)?),
+            body: Box::new(reduce_formula(
+                *body,
+                q,
+                stmt_transformers,
+                op_name,
+                resolver,
+            )?),
         }),
         IrFormula::Exists { name, sort, body } => Ok(IrFormula::Exists {
             name,
             sort,
-            body: Box::new(reduce_formula(*body, q, stmt_transformers, op_name, resolver)?),
+            body: Box::new(reduce_formula(
+                *body,
+                q,
+                stmt_transformers,
+                op_name,
+                resolver,
+            )?),
         }),
         IrFormula::Choice {
             var_name,
@@ -622,7 +636,13 @@ fn reduce_formula<R: OpContractResolver + ?Sized>(
         } => Ok(IrFormula::Choice {
             var_name,
             sort,
-            body: Box::new(reduce_formula(*body, q, stmt_transformers, op_name, resolver)?),
+            body: Box::new(reduce_formula(
+                *body,
+                q,
+                stmt_transformers,
+                op_name,
+                resolver,
+            )?),
         }),
         // `substitute { target, var, term }` — reduce the target first
         // (so the postcondition placeholder becomes `q` and any nested
@@ -643,7 +663,8 @@ fn reduce_formula<R: OpContractResolver + ?Sized>(
                 });
             }
             let slot_name = &r#fn[SLOT_TRANSFORMER_PREFIX.len()..];
-            let Some((_, slot_term)) = stmt_transformers.iter().find(|(n, _)| n == slot_name) else {
+            let Some((_, slot_term)) = stmt_transformers.iter().find(|(n, _)| n == slot_name)
+            else {
                 return Err(WpError::MalformedRule {
                     op: op_name.to_string(),
                     fn_name: r#fn,
@@ -1193,8 +1214,7 @@ pub fn wp_compound(
     }
 
     // Conjunction aggregation (spec §2.1).
-    let (compound_verdict, composed_loss_record) =
-        aggregate_conjunction(&per_evidence_verdicts);
+    let (compound_verdict, composed_loss_record) = aggregate_conjunction(&per_evidence_verdicts);
 
     Ok(CompoundDischargeReport {
         compound_cid: compound.cid.clone(),
@@ -1250,9 +1270,7 @@ fn discharge_one_evidence(
 /// - otherwise → `LoudlyBoundedLossy`, union of per-evidence loss records
 ///
 /// Returns `(compound_verdict, composed_loss_record)`.
-pub(crate) fn aggregate_conjunction(
-    verdicts: &[EvidenceVerdict],
-) -> (VerdictKind, LossRecord) {
+pub(crate) fn aggregate_conjunction(verdicts: &[EvidenceVerdict]) -> (VerdictKind, LossRecord) {
     // Empty compound: vacuously exact (spec §5.2).
     if verdicts.is_empty() {
         return (VerdictKind::Exact, LossRecord(BTreeMap::new()));

--- a/implementations/rust/libprovekit/src/wp/tests.rs
+++ b/implementations/rust/libprovekit/src/wp/tests.rs
@@ -51,7 +51,9 @@ fn int_sort() -> Sort {
     }
 }
 fn t_var(n: &str) -> Term {
-    Term::Var { name: n.to_string() }
+    Term::Var {
+        name: n.to_string(),
+    }
 }
 fn t_const(n: i64) -> Term {
     Term::Const {
@@ -72,7 +74,9 @@ fn sentinel_cid() -> Cid {
     Cid::parse(format!("blake3-512:{}", "0".repeat(128))).expect("sentinel cid is valid")
 }
 fn ir_var(n: &str) -> IrTerm {
-    IrTerm::Var { name: n.to_string() }
+    IrTerm::Var {
+        name: n.to_string(),
+    }
 }
 fn ir_const(n: i64) -> IrTerm {
     IrTerm::Const {
@@ -132,7 +136,10 @@ fn add_contract() -> OpContractInfo {
     ));
     c.post = Some(atomic(
         "=",
-        vec![ir_var("result"), op_term("add", vec![ir_var("lhs"), ir_var("rhs")])],
+        vec![
+            ir_var("result"),
+            op_term("add", vec![ir_var("lhs"), ir_var("rhs")]),
+        ],
     ));
     c
 }
@@ -144,7 +151,10 @@ fn div_contract() -> OpContractInfo {
     c.pre = Some(atomic("not_zero", vec![ir_var("rhs")]));
     c.post = Some(atomic(
         "=",
-        vec![ir_var("result"), op_term("div", vec![ir_var("lhs"), ir_var("rhs")])],
+        vec![
+            ir_var("result"),
+            op_term("div", vec![ir_var("lhs"), ir_var("rhs")]),
+        ],
     ));
     c
 }
@@ -152,7 +162,10 @@ fn div_contract() -> OpContractInfo {
 /// `uop_neg` — value-op, `post = (result == neg(x))`.
 fn neg_contract() -> OpContractInfo {
     let mut c = OpContractInfo::new(vec![SlotInfo::value("x")]);
-    c.post = Some(atomic("=", vec![ir_var("result"), op_term("neg", vec![ir_var("x")])]));
+    c.post = Some(atomic(
+        "=",
+        vec![ir_var("result"), op_term("neg", vec![ir_var("x")])],
+    ));
     c
 }
 
@@ -161,7 +174,10 @@ fn eq_contract() -> OpContractInfo {
     let mut c = OpContractInfo::new(vec![SlotInfo::value("lhs"), SlotInfo::value("rhs")]);
     c.post = Some(atomic(
         "=",
-        vec![ir_var("result"), op_term("eq", vec![ir_var("lhs"), ir_var("rhs")])],
+        vec![
+            ir_var("result"),
+            op_term("eq", vec![ir_var("lhs"), ir_var("rhs")]),
+        ],
     ));
     c
 }
@@ -186,7 +202,10 @@ fn if_contract() -> OpContractInfo {
         SlotInfo::stmt("else_branch"),
     ]);
     c.wp_rule = Some(and(vec![
-        implies(prop("cond"), apply("wp_then_branch", postcondition_placeholder())),
+        implies(
+            prop("cond"),
+            apply("wp_then_branch", postcondition_placeholder()),
+        ),
         implies(
             not(prop("cond")),
             apply("wp_else_branch", postcondition_placeholder()),
@@ -211,7 +230,11 @@ fn seq_contract() -> OpContractInfo {
 /// a control-flow op with no `Stmt` slots and a `substitute` node.)
 fn return_contract() -> OpContractInfo {
     let mut c = OpContractInfo::new(vec![SlotInfo::value("value")]);
-    c.wp_rule = Some(subst(postcondition_placeholder(), "result", ir_var("value")));
+    c.wp_rule = Some(subst(
+        postcondition_placeholder(),
+        "result",
+        ir_var("value"),
+    ));
     c
 }
 
@@ -305,9 +328,14 @@ fn synthesize_value_rule_returns_the_substitute_schema_node() {
     // Before instantiation a synthesized value-op rule is literally
     // `pre ∧ substitute(Q, result, value_expr)` — the schema node is the
     // payload that gets reduced once Q is known.
-    let rule = add_contract().synthesize_value_rule().expect("synthesizable");
+    let rule = add_contract()
+        .synthesize_value_rule()
+        .expect("synthesizable");
     let expected = and(vec![
-        atomic("no_signed_overflow", vec![op_term("add", vec![ir_var("lhs"), ir_var("rhs")])]),
+        atomic(
+            "no_signed_overflow",
+            vec![op_term("add", vec![ir_var("lhs"), ir_var("rhs")])],
+        ),
         subst(
             postcondition_placeholder(),
             "result",
@@ -354,7 +382,10 @@ fn authored_if_rule_instantiated() {
         implies(not(prop("cond")), else_wp),
     ]);
     assert_eq!(got, expected);
-    assert!(!contains_schema_node(&got), "no Substitute/Apply nodes remain after instantiation");
+    assert!(
+        !contains_schema_node(&got),
+        "no Substitute/Apply nodes remain after instantiation"
+    );
 }
 
 #[test]
@@ -409,10 +440,16 @@ fn evaluates_seq_if_return_skip_body() {
     let got = wp(&term, &q, &base_resolver()).expect("evaluated");
     let expected = and(vec![
         implies(prop("cond"), atomic("=", vec![ir_var("x"), ir_var("out")])),
-        implies(not(prop("cond")), atomic("=", vec![ir_var("y"), ir_var("out")])),
+        implies(
+            not(prop("cond")),
+            atomic("=", vec![ir_var("y"), ir_var("out")]),
+        ),
     ]);
     assert_eq!(got, expected);
-    assert!(!contains_schema_node(&got), "no Substitute/Apply nodes remain");
+    assert!(
+        !contains_schema_node(&got),
+        "no Substitute/Apply nodes remain"
+    );
 }
 
 #[test]
@@ -420,12 +457,22 @@ fn wp_of_leaves() {
     let r = base_resolver();
     // wp(var v, Q) = Q[result := v]
     assert_eq!(
-        wp(&t_var("v"), &atomic("=", vec![ir_var("result"), ir_const(3)]), &r).unwrap(),
+        wp(
+            &t_var("v"),
+            &atomic("=", vec![ir_var("result"), ir_const(3)]),
+            &r
+        )
+        .unwrap(),
         atomic("=", vec![ir_var("v"), ir_const(3)])
     );
     // wp(const 5, Q) = Q[result := 5]
     assert_eq!(
-        wp(&t_const(5), &atomic("<", vec![ir_var("result"), ir_const(9)]), &r).unwrap(),
+        wp(
+            &t_const(5),
+            &atomic("<", vec![ir_var("result"), ir_const(9)]),
+            &r
+        )
+        .unwrap(),
         atomic("<", vec![ir_const(5), ir_const(9)])
     );
     // wp(unit, Q) = Q
@@ -444,7 +491,13 @@ fn refuses_opaque_loop_naming_the_loop_cid() {
     let term = t_op(
         "seq",
         vec![
-            t_op("while", vec![t_op("bop_eq", vec![t_var("i"), t_var("n")]), t_op("skip", vec![])]),
+            t_op(
+                "while",
+                vec![
+                    t_op("bop_eq", vec![t_var("i"), t_var("n")]),
+                    t_op("skip", vec![]),
+                ],
+            ),
             t_op("skip", vec![]),
         ],
     );
@@ -458,7 +511,10 @@ fn refuses_opaque_loop_naming_the_loop_cid() {
 #[test]
 fn refuses_unresolved_call_naming_the_callee() {
     let resolver = base_resolver().with("indirect_call", opaque_call_contract("fn_ptr"));
-    let term = t_op("seq", vec![t_op("indirect_call", vec![]), t_op("skip", vec![])]);
+    let term = t_op(
+        "seq",
+        vec![t_op("indirect_call", vec![]), t_op("skip", vec![])],
+    );
     let err = wp(&term, &prop("Q"), &resolver).unwrap_err();
     match err {
         WpError::Refused(Refusal::OpaqueCall { callee }) => assert_eq!(callee, "fn_ptr"),
@@ -471,7 +527,9 @@ fn refuses_unknown_op_as_unresolved_call() {
     let term = t_op("totally_unknown_op", vec![]);
     let err = wp(&term, &prop("Q"), &base_resolver()).unwrap_err();
     match err {
-        WpError::Refused(Refusal::OpaqueCall { callee }) => assert_eq!(callee, "totally_unknown_op"),
+        WpError::Refused(Refusal::OpaqueCall { callee }) => {
+            assert_eq!(callee, "totally_unknown_op")
+        }
         other => panic!("expected OpaqueCall refusal, got {other:?}"),
     }
 }
@@ -496,7 +554,9 @@ fn malformed_rule_applying_a_transformer_for_a_missing_slot() {
     let resolver = base_resolver().with("weird", c);
     let term = t_op("weird", vec![t_op("skip", vec![])]);
     let err = wp(&term, &prop("Q"), &resolver).unwrap_err();
-    assert!(matches!(err, WpError::MalformedRule { op, fn_name } if op == "weird" && fn_name == "wp_body"));
+    assert!(
+        matches!(err, WpError::MalformedRule { op, fn_name } if op == "weird" && fn_name == "wp_body")
+    );
 }
 
 #[test]
@@ -601,12 +661,12 @@ const PINNED_APPLY_NODE_CID: &str =
 // Compound-aware discharge tests (PR-F of #716).
 // ============================================================
 
-use std::collections::BTreeMap;
+use crate::wp::{aggregate_conjunction, wp_compound, EvidenceVerdict};
 use provekit_ir_types::{
     AggregationStrategy, CompoundContractMemento, EvidenceMemento, EvidenceRef, LossRecord,
     SourceKind, SourceLocator, SourceLocatorPoint, SourceLocatorSpan, VerdictKind,
 };
-use crate::wp::{aggregate_conjunction, EvidenceVerdict, wp_compound};
+use std::collections::BTreeMap;
 
 /// Build a minimal `SourceLocator` for test fixtures.
 fn test_locator() -> SourceLocator {
@@ -671,7 +731,10 @@ fn wp_compound_empty_evidences_is_exact() {
     assert_eq!(report.compound_cid, "cid-empty");
     assert_eq!(report.per_evidence_verdicts, vec![]);
     assert_eq!(report.compound_verdict, VerdictKind::Exact);
-    assert!(report.composed_loss_record.0.is_empty(), "vacuous exact has no loss");
+    assert!(
+        report.composed_loss_record.0.is_empty(),
+        "vacuous exact has no loss"
+    );
 }
 
 // ---- Test 2: single exact evidence ----
@@ -688,8 +751,8 @@ fn wp_compound_single_exact_evidence() {
     );
     let target = t_op("skip", vec![]);
 
-    let report = wp_compound(&compound, &target, &[evidence], &base_resolver())
-        .expect("single exact");
+    let report =
+        wp_compound(&compound, &target, &[evidence], &base_resolver()).expect("single exact");
 
     assert_eq!(report.compound_verdict, VerdictKind::Exact);
     assert_eq!(report.per_evidence_verdicts.len(), 1);
@@ -711,11 +774,13 @@ fn wp_compound_all_exact_yields_exact() {
     );
     let target = t_op("skip", vec![]);
 
-    let report = wp_compound(&compound, &target, &[e1, e2], &base_resolver())
-        .expect("all exact");
+    let report = wp_compound(&compound, &target, &[e1, e2], &base_resolver()).expect("all exact");
 
     assert_eq!(report.compound_verdict, VerdictKind::Exact);
-    assert!(report.per_evidence_verdicts.iter().all(|v| v.verdict == VerdictKind::Exact));
+    assert!(report
+        .per_evidence_verdicts
+        .iter()
+        .all(|v| v.verdict == VerdictKind::Exact));
 }
 
 // ---- Test 4: one lossy evidence → compound loudly-bounded-lossy ----
@@ -741,16 +806,21 @@ fn wp_compound_one_lossy_evidence_yields_lossy() {
     );
     let target = t_op("uop_neg", vec![t_var("x")]);
 
-    let report =
-        wp_compound(&compound, &target, &[exact_ev, lossy_ev], &base_resolver())
-            .expect("lossy compound");
+    let report = wp_compound(&compound, &target, &[exact_ev, lossy_ev], &base_resolver())
+        .expect("lossy compound");
 
     assert_eq!(report.compound_verdict, VerdictKind::LoudlyBoundedLossy);
     // composed loss record must contain the divergence key
-    assert!(report.composed_loss_record.0.contains_key("structural_divergence"));
+    assert!(report
+        .composed_loss_record
+        .0
+        .contains_key("structural_divergence"));
     // per-evidence: first is exact, second is lossy
     assert_eq!(report.per_evidence_verdicts[0].verdict, VerdictKind::Exact);
-    assert_eq!(report.per_evidence_verdicts[1].verdict, VerdictKind::LoudlyBoundedLossy);
+    assert_eq!(
+        report.per_evidence_verdicts[1].verdict,
+        VerdictKind::LoudlyBoundedLossy
+    );
 }
 
 // ---- Test 5: one refuse evidence → compound refuse ----
@@ -791,7 +861,10 @@ fn wp_compound_one_refuse_yields_compound_refuse() {
         .expect("refuse compound result");
 
     assert_eq!(report.compound_verdict, VerdictKind::Refuse);
-    assert!(report.composed_loss_record.0.is_empty(), "refuse has no loss");
+    assert!(
+        report.composed_loss_record.0.is_empty(),
+        "refuse has no loss"
+    );
     assert_eq!(report.per_evidence_verdicts[0].verdict, VerdictKind::Refuse);
 }
 
@@ -901,10 +974,14 @@ fn wp_compound_is_deterministic() {
     );
     let target = t_op("skip", vec![]);
 
-    let r1 = wp_compound(&compound, &target, &[e1.clone(), e2.clone()], &base_resolver())
-        .expect("first run");
-    let r2 = wp_compound(&compound, &target, &[e1, e2], &base_resolver())
-        .expect("second run");
+    let r1 = wp_compound(
+        &compound,
+        &target,
+        &[e1.clone(), e2.clone()],
+        &base_resolver(),
+    )
+    .expect("first run");
+    let r2 = wp_compound(&compound, &target, &[e1, e2], &base_resolver()).expect("second run");
 
     assert_eq!(r1, r2, "wp_compound must be deterministic");
 }
@@ -922,8 +999,7 @@ fn wp_compound_report_carries_compound_cid() {
     );
     let target = t_op("skip", vec![]);
 
-    let report = wp_compound(&compound, &target, &[e1], &base_resolver())
-        .expect("report");
+    let report = wp_compound(&compound, &target, &[e1], &base_resolver()).expect("report");
 
     assert_eq!(report.compound_cid, "the-compound-cid");
     assert_eq!(report.per_evidence_verdicts[0].evidence_cid, "cid-e1");
@@ -946,7 +1022,7 @@ fn wp_compound_multiple_lossy_evidences_union_loss_records() {
     //   ev1: predicate = (result == 0)  → wp = (neg(x) == 0)  — diverges → F1 in loss
     //   ev2: predicate = (result == 1)  → wp = (neg(x) == 1)  — diverges → F2 in loss
     let result_is_zero = atomic("=", vec![ir_var("result"), ir_const(0)]);
-    let result_is_one  = atomic("=", vec![ir_var("result"), ir_const(1)]);
+    let result_is_one = atomic("=", vec![ir_var("result"), ir_const(1)]);
 
     let ev1 = make_evidence("cid-lossy-1", result_is_zero.clone());
     let ev2 = make_evidence("cid-lossy-2", result_is_one.clone());
@@ -958,8 +1034,8 @@ fn wp_compound_multiple_lossy_evidences_union_loss_records() {
     );
     let target = t_op("uop_neg", vec![t_var("x")]);
 
-    let report = wp_compound(&compound, &target, &[ev1, ev2], &base_resolver())
-        .expect("two-lossy compound");
+    let report =
+        wp_compound(&compound, &target, &[ev1, ev2], &base_resolver()).expect("two-lossy compound");
 
     assert_eq!(report.compound_verdict, VerdictKind::LoudlyBoundedLossy);
 
@@ -978,9 +1054,9 @@ fn wp_compound_multiple_lossy_evidences_union_loss_records() {
                 "union must be And of two formulas, not LWW singleton"
             );
         }
-        other => panic!(
-            "expected IrFormula::And (union of two divergence formulas), got {other:?}"
-        ),
+        other => {
+            panic!("expected IrFormula::And (union of two divergence formulas), got {other:?}")
+        }
     }
 }
 

--- a/implementations/rust/libprovekit/tests/compose_smoke.rs
+++ b/implementations/rust/libprovekit/tests/compose_smoke.rs
@@ -18,11 +18,11 @@
 use std::sync::Arc;
 
 use libprovekit::compose::{
-    build_value, cid_of_value, compose_chain_contracts, jcs_bytes_of_value, ChainStep, EffectSet,
-    FunctionContractMemento, Locus,
+    build_value, cid_of_value, compose_chain_contracts, jcs_bytes_of_value, ChainStep, Effect,
+    EffectSet, FunctionContractMemento, Locus,
 };
 use provekit_canonicalizer::Value;
-use provekit_ir_types::{IrFormula, IrTerm, Sort};
+use provekit_ir_types::{composition_refusal_header_cid, IrFormula, IrTerm, Sort};
 
 /// Build a trivial pure FunctionContractMemento whose post is
 /// `result = <formal>`. The result-equation is the algebraic input that
@@ -88,6 +88,26 @@ fn pure_identity_contract(fn_name: &str, formal: &str) -> FunctionContractMement
     }
 }
 
+fn impure_identity_contract(fn_name: &str, formal: &str) -> FunctionContractMemento {
+    let mut contract = pure_identity_contract(fn_name, formal);
+    contract.effects.add(Effect::Io);
+    let value: Arc<Value> = build_value(
+        &contract.fn_name,
+        &contract.formals,
+        &contract.formal_sorts,
+        &contract.return_sort,
+        &contract.pre,
+        &contract.post,
+        contract.body_cid.as_deref(),
+        &contract.effects,
+        &contract.locus,
+        &contract.auto_minted_mementos,
+    );
+    contract.canonical_bytes = jcs_bytes_of_value(&value);
+    contract.cid = cid_of_value(&value);
+    contract
+}
+
 #[test]
 fn compose_chain_two_pure_atoms_pins_cid() {
     let inner = pure_identity_contract("inner", "y");
@@ -124,4 +144,42 @@ fn compose_chain_two_pure_atoms_pins_cid() {
         composed.cid, PINNED_CID,
         "composed CID drifted; algebra must not change without a CCP version bump"
     );
+}
+
+#[test]
+fn compose_chain_impure_input_returns_stable_refusal_memento() {
+    let inner = pure_identity_contract("inner", "y");
+    let outer = impure_identity_contract("outer", "x");
+
+    let chain = vec![
+        ChainStep {
+            contract: &inner,
+            formal_idx: 0,
+        },
+        ChainStep {
+            contract: &outer,
+            formal_idx: 0,
+        },
+    ];
+
+    let refusal = compose_chain_contracts(&chain).expect_err("impure input refuses");
+    assert_eq!(refusal.header.failure_kind, "impure-input");
+    assert_eq!(refusal.header.kind, "composition-refusal");
+    assert_eq!(refusal.header.schema_version, "1");
+    assert_eq!(
+        refusal
+            .header
+            .blocking_effects
+            .as_ref()
+            .expect("impure refusal has blocking effects")[0]
+            .atom_cid,
+        outer.cid
+    );
+    assert_eq!(
+        composition_refusal_header_cid(&refusal.header),
+        refusal.header.cid
+    );
+
+    let refusal2 = compose_chain_contracts(&chain).expect_err("impure input refuses again");
+    assert_eq!(refusal.header.cid, refusal2.header.cid);
 }

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -2983,3 +2983,274 @@ fn is_namespaced_extension(value: &str) -> bool {
 // ============================================================
 // End manual extension block -- ObligationReceiptMemento substrate (#800)
 // ============================================================
+// ============================================================
+
+// ============================================================
+// MANUAL EXTENSION BLOCK -- CompositionRefusalMemento
+// Source of truth:
+//   protocol/specs/2026-05-13-composition-refusal-memento.md §1, §4
+//
+// This block adds the canonical CCP refusal artifact. CID identity is
+// JCS(header with `cid` elided); envelope and metadata never participate
+// in the refusal CID.
+// ============================================================
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionRefusalEnvelope {
+    #[serde(rename = "declaredAt")]
+    pub declared_at: String,
+    pub signature: String,
+    pub signer: String,
+}
+
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockingEffect {
+    #[serde(rename = "atom_cid")]
+    pub atom_cid: String,
+    pub classification: String,
+    #[serde(rename = "discharge_key")]
+    pub discharge_key: String,
+    #[serde(rename = "occurrence_kind")]
+    pub occurrence_kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IncompatiblePair {
+    #[serde(rename = "atom_a_cid")]
+    pub atom_a_cid: String,
+    #[serde(rename = "atom_b_cid")]
+    pub atom_b_cid: String,
+    #[serde(rename = "effect_a")]
+    pub effect_a: String,
+    #[serde(rename = "effect_b")]
+    pub effect_b: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MissingRequirement {
+    #[serde(rename = "expected_cid")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_cid: Option<String>,
+    #[serde(rename = "memento_kind")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memento_kind: Option<String>,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+}
+
+/// Header layer for a CCP refusal.
+///
+/// Locked JCS key order (alphabetical):
+///   atoms_cids, blocking_effects, ccp_version, cid, compose_input_cid,
+///   effect_occurrences, effect_set_cids, failure_detail, failure_kind,
+///   incompatible_pair, kind, missing_memento_requirements, schemaVersion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionRefusalHeader {
+    #[serde(rename = "atoms_cids")]
+    pub atoms_cids: Vec<String>,
+    #[serde(rename = "blocking_effects")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocking_effects: Option<Vec<BlockingEffect>>,
+    #[serde(rename = "ccp_version")]
+    pub ccp_version: String,
+    /// DERIVED: BLAKE3-512 over JCS(header) with `cid` elided.
+    pub cid: String,
+    #[serde(rename = "compose_input_cid")]
+    pub compose_input_cid: String,
+    #[serde(rename = "effect_occurrences")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effect_occurrences: Option<Vec<EffectOccurrence>>,
+    #[serde(rename = "effect_set_cids")]
+    pub effect_set_cids: Vec<String>,
+    #[serde(rename = "failure_detail")]
+    pub failure_detail: String,
+    #[serde(rename = "failure_kind")]
+    pub failure_kind: String,
+    #[serde(rename = "incompatible_pair")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub incompatible_pair: Option<IncompatiblePair>,
+    pub kind: String,
+    #[serde(rename = "missing_memento_requirements")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub missing_memento_requirements: Option<Vec<MissingRequirement>>,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionRefusalMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(rename = "provenance_cid")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance_cid: Option<String>,
+    #[serde(rename = "refused_at")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refused_at: Option<String>,
+    #[serde(rename = "source_url")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionRefusalMemento {
+    pub envelope: CompositionRefusalEnvelope,
+    pub header: CompositionRefusalHeader,
+    pub metadata: CompositionRefusalMetadata,
+}
+
+fn canonical_value_from_json(value: serde_json::Value) -> provekit_canonicalizer::Value {
+    match value {
+        serde_json::Value::Null => provekit_canonicalizer::Value::Null,
+        serde_json::Value::Bool(b) => provekit_canonicalizer::Value::Bool(b),
+        serde_json::Value::Number(n) => provekit_canonicalizer::Value::Integer(
+            n.as_i64()
+                .expect("CompositionRefusalMemento canonical numbers must fit i64"),
+        ),
+        serde_json::Value::String(s) => provekit_canonicalizer::Value::String(s),
+        serde_json::Value::Array(items) => provekit_canonicalizer::Value::Array(
+            items
+                .into_iter()
+                .map(canonical_value_from_json)
+                .map(std::sync::Arc::new)
+                .collect(),
+        ),
+        serde_json::Value::Object(map) => provekit_canonicalizer::Value::Object(
+            map.into_iter()
+                .map(|(k, v)| (k, std::sync::Arc::new(canonical_value_from_json(v))))
+                .collect(),
+        ),
+    }
+}
+
+pub fn composition_refusal_header_cid(header: &CompositionRefusalHeader) -> String {
+    let mut value =
+        serde_json::to_value(header).expect("CompositionRefusalHeader serializes to JSON");
+    value
+        .as_object_mut()
+        .expect("CompositionRefusalHeader serializes as object")
+        .remove("cid");
+    let canonical = canonical_value_from_json(value);
+    let bytes = provekit_canonicalizer::encode_jcs(&canonical);
+    provekit_canonicalizer::blake3_512_of(bytes.as_bytes())
+}
+
+pub fn composition_refusal_compose_input_cid(
+    atoms_cids: &[String],
+    effect_set_cids: &[String],
+    ccp_version: &str,
+) -> String {
+    let value = serde_json::json!({
+        "atoms_cids": atoms_cids,
+        "ccp_version": ccp_version,
+        "effect_set_cids": effect_set_cids,
+    });
+    let canonical = canonical_value_from_json(value);
+    let bytes = provekit_canonicalizer::encode_jcs(&canonical);
+    provekit_canonicalizer::blake3_512_of(bytes.as_bytes())
+}
+
+pub fn composition_refusal_signature(
+    header: &CompositionRefusalHeader,
+    metadata: &CompositionRefusalMetadata,
+) -> String {
+    let value = serde_json::json!({
+        "header": header,
+        "metadata": metadata,
+    });
+    let canonical = canonical_value_from_json(value);
+    let bytes = provekit_canonicalizer::encode_jcs(&canonical);
+    format!(
+        "unsigned-substrate:{}",
+        provekit_canonicalizer::blake3_512_of(bytes.as_bytes())
+    )
+}
+
+#[cfg(test)]
+mod composition_refusal_tests {
+    use super::*;
+
+    fn cid(ch: char) -> String {
+        format!("blake3-512:{}", ch.to_string().repeat(128))
+    }
+
+    fn canonical_impure_refusal() -> CompositionRefusalMemento {
+        let atoms_cids = vec![cid('a'), cid('b')];
+        let effect_set_cids = vec![cid('c'), cid('d')];
+        let occurrence = EffectOccurrence {
+            args: serde_json::json!({"target":"stdout"}),
+            discharge_key: "io:stdout".to_string(),
+            locator: serde_json::json!({"atom_cid": atoms_cids[1]}),
+            occurrence_kind: OccurrenceKind::Io,
+            role: OccurrenceRole::Body,
+            signature_cid: cid('e'),
+        };
+        let blocking = BlockingEffect {
+            atom_cid: atoms_cids[1].clone(),
+            classification: "block".to_string(),
+            discharge_key: occurrence.discharge_key.clone(),
+            occurrence_kind: occurrence.occurrence_kind.to_string(),
+        };
+        let compose_input_cid =
+            composition_refusal_compose_input_cid(&atoms_cids, &effect_set_cids, "1.0.0");
+        let mut header = CompositionRefusalHeader {
+            atoms_cids,
+            blocking_effects: Some(vec![blocking]),
+            ccp_version: "1.0.0".to_string(),
+            cid: String::new(),
+            compose_input_cid,
+            effect_occurrences: Some(vec![occurrence]),
+            effect_set_cids,
+            failure_detail: format!("impure atom {}", cid('b')),
+            failure_kind: "impure-input".to_string(),
+            incompatible_pair: None,
+            kind: "composition-refusal".to_string(),
+            missing_memento_requirements: None,
+            schema_version: "1".to_string(),
+        };
+        header.cid = composition_refusal_header_cid(&header);
+        let metadata = CompositionRefusalMetadata::default();
+        let signature = composition_refusal_signature(&header, &metadata);
+        CompositionRefusalMemento {
+            envelope: CompositionRefusalEnvelope {
+                declared_at: "1970-01-01T00:00:00Z".to_string(),
+                signature,
+                signer: "substrate:test".to_string(),
+            },
+            header,
+            metadata,
+        }
+    }
+
+    #[test]
+    fn canonical_impure_refusal_round_trips_and_recomputes_cid() {
+        let refusal = canonical_impure_refusal();
+        let json = serde_json::to_string(&refusal).expect("serialize refusal");
+        let decoded: CompositionRefusalMemento =
+            serde_json::from_str(&json).expect("deserialize refusal");
+
+        assert_eq!(decoded, refusal);
+        assert_eq!(
+            composition_refusal_header_cid(&decoded.header),
+            decoded.header.cid
+        );
+        assert_eq!(decoded.header.failure_kind, "impure-input");
+    }
+
+    #[test]
+    fn same_canonical_refusal_inputs_mint_same_cid() {
+        let first = canonical_impure_refusal();
+        let mut second = canonical_impure_refusal();
+        second.envelope.declared_at = "2026-05-13T00:00:00Z".to_string();
+        second.envelope.signer = "substrate:other".to_string();
+        second.metadata.note = Some("operator note outside refusal identity".to_string());
+
+        assert_eq!(first.header.cid, second.header.cid);
+    }
+}
+
+// ============================================================
+// End manual extension block -- CompositionRefusalMemento
+// ============================================================


### PR DESCRIPTION
Closes part of #795 implementation.

Substrate-only Rust type per the merged spec. Adds memento struct(s) to `provekit-ir-types` + JCS canonicalization + BLAKE3-512 CID derivation + structural validation methods where applicable + serde round-trip + CID-recompute tests.

**Strict substrate/kit split** (per architect direction):
- This PR: Rust substrate. Types, serialization, CIDs, structural validation. No language syntax knowledge.
- Per-language kit work (native annotation extraction, sugar emission, target-syntax wrappers) is a separate wave per language under `implementations/<lang>/`. Kits consume these types through the plugin protocol.

Rule of thumb: if the change requires knowing JML / __attribute__ / Python decorators / Java exceptions / C setjmp, it does NOT belong in this PR. If it only knows CIDs, memento schemas, effect occurrence sets, policies, loss records, or protocol envelopes, it does.

Codex draft (medium-effort + file-first); `cargo test -p provekit-ir-types` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)