### PR TITLE
impl(799): Rust types: PipelineMemento + RunMemento + validate()

### DIFF
--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -3417,6 +3417,187 @@ impl std::fmt::Display for InvalidReceiptError {
     }
 }
 
+// ============================================================
+// NOTE: Manual extension block -- PipelineMemento and RunMemento (#799)
+// ============================================================
+//
+// Generic replayable run graph substrate per
+// protocol/specs/2026-05-13-pipeline-runmemento.md §1.
+//
+// This block defines durable artifact shapes only. It intentionally does not
+// execute pipelines, schedule runs, resolve CIDs, or replay stage receipts.
+//
+// Key-order rule: struct field names mirror the CDDL key names exactly in
+// locked JCS alphabetical order.
+//
+// TODO(#792): Express ProofRunMemento as the verifier PipelineMemento profile.
+
+/// The `pipeline_kind` scalar for a `PipelineMemento`.
+///
+/// Known pipeline kinds are reserved by the generic spec. Namespaced extension
+/// kinds are represented as `Namespaced("<namespace>:<kind>")` so this
+/// substrate type can carry profile-defined pipelines without hard-coding
+/// registry support here. Bare unknowns fail closed at deserialization
+/// per spec §3 + admissibility-spine namespaced-extensions rule.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub enum PipelineKind {
+    Bind,
+    Compose,
+    Link,
+    Promotion,
+    Realization,
+    Transport,
+    Verifier,
+    Namespaced(String),
+}
+
+impl TryFrom<String> for PipelineKind {
+    type Error = PipelineKindError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.as_str() {
+            "bind" => Ok(PipelineKind::Bind),
+            "compose" => Ok(PipelineKind::Compose),
+            "link" => Ok(PipelineKind::Link),
+            "promotion" => Ok(PipelineKind::Promotion),
+            "realization" => Ok(PipelineKind::Realization),
+            "transport" => Ok(PipelineKind::Transport),
+            "verifier" => Ok(PipelineKind::Verifier),
+            _ => match s.split_once(':') {
+                // Spec: extension labels are `<namespace>:<kind>` with
+                // EXACTLY one colon. `a:b:c` is not a valid namespaced
+                // extension; both segments must be non-empty AND the
+                // kind segment must not itself contain a colon.
+                Some((ns, kind)) if !ns.is_empty() && !kind.is_empty() && !kind.contains(':') => {
+                    Ok(PipelineKind::Namespaced(s))
+                }
+                _ => Err(PipelineKindError { raw: s }),
+            },
+        }
+    }
+}
+
+impl From<PipelineKind> for String {
+    fn from(kind: PipelineKind) -> String {
+        match kind {
+            PipelineKind::Bind => "bind".to_string(),
+            PipelineKind::Compose => "compose".to_string(),
+            PipelineKind::Link => "link".to_string(),
+            PipelineKind::Promotion => "promotion".to_string(),
+            PipelineKind::Realization => "realization".to_string(),
+            PipelineKind::Transport => "transport".to_string(),
+            PipelineKind::Verifier => "verifier".to_string(),
+            PipelineKind::Namespaced(s) => s,
+        }
+    }
+}
+
+/// Returned when a `pipeline_kind` string is neither a canonical
+/// pipeline (bind / compose / link / promotion / realization / transport /
+/// verifier) nor a well-formed `<namespace>:<kind>` extension. Per spec
+/// §3 + admissibility-spine namespaced-extensions rule, bare unknowns
+/// MUST fail closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PipelineKindError {
+    pub raw: String,
+}
+
+impl std::fmt::Display for PipelineKindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unrecognized pipeline_kind {:?}: not a canonical pipeline and not a well-formed `<namespace>:<kind>` extension",
+            self.raw
+        )
+    }
+}
+
+impl std::error::Error for PipelineKindError {}
+
+/// The terminal `verdict` scalar for a `RunMemento`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RunVerdict {
+    #[serde(rename = "failed")]
+    Failed,
+    #[serde(rename = "refused")]
+    Refused,
+    #[serde(rename = "succeeded")]
+    Succeeded,
+}
+
+/// A pipeline vocabulary memento.
+///
+/// Locked JCS key order:
+///   accepted_input_kinds, emitted_output_kinds, failure_kinds,
+///   pipeline_kind, pipeline_version, provenance_cid, stage_vocabulary
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineMemento {
+    #[serde(rename = "accepted_input_kinds")]
+    pub accepted_input_kinds: Vec<String>,
+    #[serde(rename = "emitted_output_kinds")]
+    pub emitted_output_kinds: Vec<String>,
+    #[serde(rename = "failure_kinds")]
+    pub failure_kinds: Vec<String>,
+    #[serde(rename = "pipeline_kind")]
+    pub pipeline_kind: PipelineKind,
+    #[serde(rename = "pipeline_version")]
+    pub pipeline_version: String,
+    #[serde(rename = "provenance_cid")]
+    pub provenance_cid: String,
+    #[serde(rename = "stage_vocabulary")]
+    pub stage_vocabulary: Vec<String>,
+}
+
+/// A generic replayable run memento.
+///
+/// Locked JCS key order:
+///   input_cids, output_cids, pipeline_cid, plugin_registry_cid,
+///   predecessor_run_cids, provenance_cid, stage_receipt_cids, verdict
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunMemento {
+    #[serde(rename = "input_cids")]
+    pub input_cids: Vec<String>,
+    #[serde(rename = "output_cids")]
+    pub output_cids: Vec<String>,
+    #[serde(rename = "pipeline_cid")]
+    pub pipeline_cid: String,
+    #[serde(rename = "plugin_registry_cid")]
+    pub plugin_registry_cid: String,
+    #[serde(rename = "predecessor_run_cids")]
+    pub predecessor_run_cids: Vec<String>,
+    #[serde(rename = "provenance_cid")]
+    pub provenance_cid: String,
+    #[serde(rename = "stage_receipt_cids")]
+    pub stage_receipt_cids: Vec<String>,
+    pub verdict: RunVerdict,
+}
+
+/// Generic validation failures for `RunMemento` and `PipelineMemento`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    /// The run does not provide one stage receipt CID per pipeline stage.
+    StageReceiptLengthMismatch { expected: usize, actual: usize },
+    /// A pipeline / run array declared `[+ ...]` in the spec is empty.
+    /// `field` names which array.
+    EmptyRequiredArray { field: &'static str },
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::StageReceiptLengthMismatch { expected, actual } => write!(
+                f,
+                "stage_receipt_cids length mismatch: expected {expected}, got {actual}"
+            ),
+            Self::EmptyRequiredArray { field } => write!(
+                f,
+                "{field} is empty (spec §1 CDDL requires [+ ...] non-empty)"
+            ),
+        }
+    }
+}
+
 impl std::error::Error for InvalidReceiptError {}
 
 impl ObligationReceiptMemento {
@@ -3468,7 +3649,6 @@ impl ObligationReceiptMemento {
                 return Err(InvalidReceiptError::UnknownReceiptKind(other.to_string()));
             }
         }
-
         Ok(())
     }
 
@@ -3507,6 +3687,78 @@ impl ObligationReceiptMemento {
             receipt_kind: self.receipt_kind.clone(),
             verdict: self.verdict.clone(),
         }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+impl PipelineMemento {
+    /// Check load-time invariants per spec §1.1.
+    ///
+    /// All four arrays are declared `[+ ...]` in the CDDL:
+    /// `accepted_input_kinds`, `emitted_output_kinds`, `failure_kinds`,
+    /// `stage_vocabulary`. An empty pipeline cannot accept any input,
+    /// emit any output, fail in any declared way, or run any stage; it
+    /// is not a valid pipeline declaration.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.accepted_input_kinds.is_empty() {
+            return Err(ValidationError::EmptyRequiredArray {
+                field: "accepted_input_kinds",
+            });
+        }
+        if self.emitted_output_kinds.is_empty() {
+            return Err(ValidationError::EmptyRequiredArray {
+                field: "emitted_output_kinds",
+            });
+        }
+        if self.failure_kinds.is_empty() {
+            return Err(ValidationError::EmptyRequiredArray {
+                field: "failure_kinds",
+            });
+        }
+        if self.stage_vocabulary.is_empty() {
+            return Err(ValidationError::EmptyRequiredArray {
+                field: "stage_vocabulary",
+            });
+        }
+        Ok(())
+    }
+}
+
+impl RunMemento {
+    /// Validate generic run shape against the resolved pipeline vocabulary.
+    ///
+    /// This substrate method only checks invariants available from the two
+    /// mementos themselves. CID resolution, plugin registry checks, stage
+    /// receipt body checks, and replay are higher-layer responsibilities.
+    ///
+    /// Enforces:
+    /// 1. The pipeline itself validates (non-empty required arrays).
+    /// 2. `input_cids` is non-empty (spec §1.2 CDDL `[+ cid]`).
+    /// 3. `stage_receipt_cids` is non-empty (spec §1.2 CDDL `[+ cid]`).
+    /// 4. `stage_receipt_cids.len() == pipeline.stage_vocabulary.len()`.
+    pub fn validate(&self, pipeline: &PipelineMemento) -> Result<(), ValidationError> {
+        pipeline.validate()?;
+
+        if self.input_cids.is_empty() {
+            return Err(ValidationError::EmptyRequiredArray {
+                field: "input_cids",
+            });
+        }
+        if self.stage_receipt_cids.is_empty() {
+            return Err(ValidationError::EmptyRequiredArray {
+                field: "stage_receipt_cids",
+            });
+        }
+
+        let expected = pipeline.stage_vocabulary.len();
+        let actual = self.stage_receipt_cids.len();
+
+        if actual != expected {
+            return Err(ValidationError::StageReceiptLengthMismatch { expected, actual });
+        }
+
+        Ok(())
     }
 }
 
@@ -3790,4 +4042,8 @@ mod composition_refusal_tests {
 
 // ============================================================
 // End manual extension block -- CompositionRefusalMemento
+// ============================================================
+
+// ============================================================
+// End manual extension block -- PipelineMemento and RunMemento (#799)
 // ============================================================

--- a/implementations/rust/provekit-ir-types/tests/pipeline_run_memento_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/pipeline_run_memento_serde.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Round-trip serde and JCS CID tests for PipelineMemento and RunMemento.
+//
+// Source of truth:
+//   protocol/specs/2026-05-13-pipeline-runmemento.md §1, §8
+
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use provekit_ir_types::{PipelineKind, PipelineMemento, RunMemento, RunVerdict, ValidationError};
+use serde_json::{json, Value as Json};
+
+fn json_to_cvalue(j: &Json) -> Arc<CValue> {
+    match j {
+        Json::Null => CValue::null(),
+        Json::Bool(b) => CValue::boolean(*b),
+        Json::Number(n) => CValue::integer(n.as_i64().expect("fixture integer")),
+        Json::String(s) => CValue::string(s.clone()),
+        Json::Array(items) => CValue::array(items.iter().map(json_to_cvalue).collect()),
+        Json::Object(obj) => {
+            CValue::object(obj.iter().map(|(k, v)| (k.clone(), json_to_cvalue(v))))
+        }
+    }
+}
+
+fn cid_of_json(j: &Json) -> String {
+    let value = json_to_cvalue(j);
+    let jcs = encode_jcs(&value);
+    blake3_512_of(jcs.as_bytes())
+}
+
+fn cid_of_serde<T: serde::Serialize>(value: &T) -> String {
+    let json = serde_json::to_value(value).expect("serialize to JSON value");
+    cid_of_json(&json)
+}
+
+fn sample_pipeline() -> PipelineMemento {
+    PipelineMemento {
+        accepted_input_kinds: vec!["proof-envelope".into(), "link-bundle".into()],
+        emitted_output_kinds: vec!["domain-claim".into()],
+        failure_kinds: vec!["invalid-proof".into(), "plugin-refusal".into()],
+        pipeline_kind: PipelineKind::Verifier,
+        pipeline_version: "1.0.0".into(),
+        provenance_cid: "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111".into(),
+        stage_vocabulary: vec!["load".into(), "check".into(), "seal".into()],
+    }
+}
+
+fn sample_run(pipeline_cid: String) -> RunMemento {
+    RunMemento {
+        input_cids: vec![
+            "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222".into(),
+        ],
+        output_cids: vec![
+            "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333".into(),
+        ],
+        pipeline_cid,
+        plugin_registry_cid: "blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444".into(),
+        predecessor_run_cids: vec![],
+        provenance_cid: "blake3-512:55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555".into(),
+        stage_receipt_cids: vec![
+            "blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666".into(),
+            "blake3-512:77777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777".into(),
+            "blake3-512:88888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888".into(),
+        ],
+        verdict: RunVerdict::Succeeded,
+    }
+}
+
+#[test]
+fn pipeline_memento_round_trips_and_recomputes_cid() {
+    let pipeline = sample_pipeline();
+    let serialized = serde_json::to_string(&pipeline).expect("serialize PipelineMemento");
+    let reparsed: PipelineMemento =
+        serde_json::from_str(&serialized).expect("reparse PipelineMemento");
+    assert_eq!(pipeline, reparsed);
+
+    let json = serde_json::to_value(&pipeline).expect("PipelineMemento JSON");
+    assert_eq!(
+        json,
+        json!({
+            "accepted_input_kinds": ["proof-envelope", "link-bundle"],
+            "emitted_output_kinds": ["domain-claim"],
+            "failure_kinds": ["invalid-proof", "plugin-refusal"],
+            "pipeline_kind": "verifier",
+            "pipeline_version": "1.0.0",
+            "provenance_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "stage_vocabulary": ["load", "check", "seal"]
+        })
+    );
+
+    let recomputed = cid_of_serde(&pipeline);
+    assert!(recomputed.starts_with("blake3-512:"));
+    assert_eq!(recomputed.len(), 139);
+    assert_eq!(recomputed, cid_of_json(&json));
+}
+
+#[test]
+fn run_memento_round_trips_and_recomputes_cid() {
+    let pipeline = sample_pipeline();
+    let pipeline_cid = cid_of_serde(&pipeline);
+    let run = sample_run(pipeline_cid.clone());
+
+    let serialized = serde_json::to_string(&run).expect("serialize RunMemento");
+    let reparsed: RunMemento = serde_json::from_str(&serialized).expect("reparse RunMemento");
+    assert_eq!(run, reparsed);
+
+    let json = serde_json::to_value(&run).expect("RunMemento JSON");
+    assert_eq!(
+        json,
+        json!({
+            "input_cids": ["blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],
+            "output_cids": ["blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333"],
+            "pipeline_cid": pipeline_cid,
+            "plugin_registry_cid": "blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444",
+            "predecessor_run_cids": [],
+            "provenance_cid": "blake3-512:55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
+            "stage_receipt_cids": [
+                "blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666",
+                "blake3-512:77777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777",
+                "blake3-512:88888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888"
+            ],
+            "verdict": "succeeded"
+        })
+    );
+
+    let recomputed = cid_of_serde(&run);
+    assert!(recomputed.starts_with("blake3-512:"));
+    assert_eq!(recomputed.len(), 139);
+    assert_eq!(recomputed, cid_of_json(&json));
+}
+
+#[test]
+fn run_validate_rejects_stage_receipt_length_mismatch() {
+    let pipeline = sample_pipeline();
+    let mut run = sample_run(cid_of_serde(&pipeline));
+    run.stage_receipt_cids.pop();
+
+    let err = run
+        .validate(&pipeline)
+        .expect_err("mismatched stage lengths fail");
+    assert_eq!(
+        err,
+        ValidationError::StageReceiptLengthMismatch {
+            expected: 3,
+            actual: 2,
+        }
+    );
+}
+
+#[test]
+fn run_validate_accepts_matching_stage_receipt_length() {
+    let pipeline = sample_pipeline();
+    let run = sample_run(cid_of_serde(&pipeline));
+
+    run.validate(&pipeline)
+        .expect("matching stage lengths validate");
+}
+
+#[test]
+fn pipeline_kind_rejects_bare_unknown() {
+    // Per spec §3 + admissibility-spine namespaced-extensions rule, a bare
+    // unknown pipeline_kind MUST fail closed at deserialization.
+    use provekit_ir_types::PipelineKind;
+    let result: Result<PipelineKind, _> = serde_json::from_str("\"benchmark\"");
+    assert!(
+        result.is_err(),
+        "bare unknown pipeline_kind should fail closed, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn pipeline_kind_accepts_well_formed_namespaced_extension() {
+    use provekit_ir_types::PipelineKind;
+    let parsed: PipelineKind =
+        serde_json::from_str("\"acme:benchmark\"").expect("parse namespaced");
+    assert_eq!(parsed, PipelineKind::Namespaced("acme:benchmark".to_string()));
+}
+
+#[test]
+fn pipeline_kind_rejects_multi_colon() {
+    // Spec: extension labels are `<namespace>:<kind>` with EXACTLY one
+    // colon. `a:b:c` is not a valid namespaced extension.
+    use provekit_ir_types::PipelineKind;
+    let result: Result<PipelineKind, _> = serde_json::from_str("\"a:b:c\"");
+    assert!(
+        result.is_err(),
+        "multi-colon should fail closed, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn pipeline_validate_rejects_empty_required_arrays() {
+    use provekit_ir_types::ValidationError;
+    let mut pipeline = sample_pipeline();
+    pipeline.stage_vocabulary.clear();
+    assert_eq!(
+        pipeline.validate(),
+        Err(ValidationError::EmptyRequiredArray {
+            field: "stage_vocabulary"
+        })
+    );
+
+    let mut pipeline = sample_pipeline();
+    pipeline.accepted_input_kinds.clear();
+    assert_eq!(
+        pipeline.validate(),
+        Err(ValidationError::EmptyRequiredArray {
+            field: "accepted_input_kinds"
+        })
+    );
+
+    let mut pipeline = sample_pipeline();
+    pipeline.emitted_output_kinds.clear();
+    assert_eq!(
+        pipeline.validate(),
+        Err(ValidationError::EmptyRequiredArray {
+            field: "emitted_output_kinds"
+        })
+    );
+
+    let mut pipeline = sample_pipeline();
+    pipeline.failure_kinds.clear();
+    assert_eq!(
+        pipeline.validate(),
+        Err(ValidationError::EmptyRequiredArray {
+            field: "failure_kinds"
+        })
+    );
+}
+
+#[test]
+fn run_validate_rejects_empty_input_cids() {
+    use provekit_ir_types::ValidationError;
+    let pipeline = sample_pipeline();
+    let mut run = sample_run(cid_of_serde(&pipeline));
+    run.input_cids.clear();
+    assert_eq!(
+        run.validate(&pipeline),
+        Err(ValidationError::EmptyRequiredArray {
+            field: "input_cids"
+        })
+    );
+}
+
+#[test]
+fn run_validate_rejects_empty_stage_receipt_cids() {
+    use provekit_ir_types::ValidationError;
+    let pipeline = sample_pipeline();
+    let mut run = sample_run(cid_of_serde(&pipeline));
+    run.stage_receipt_cids.clear();
+    assert_eq!(
+        run.validate(&pipeline),
+        Err(ValidationError::EmptyRequiredArray {
+            field: "stage_receipt_cids"
+        })
+    );
+}


### PR DESCRIPTION
Closes part of #799 implementation.

Substrate-only Rust type per the merged spec. Adds memento struct(s) to `provekit-ir-types` + JCS canonicalization + BLAKE3-512 CID derivation + structural validation methods where applicable + serde round-trip + CID-recompute tests.

**Strict substrate/kit split** (per architect direction):
- This PR: Rust substrate. Types, serialization, CIDs, structural validation. No language syntax knowledge.
- Per-language kit work (native annotation extraction, sugar emission, target-syntax wrappers) is a separate wave per language under `implementations/<lang>/`. Kits consume these types through the plugin protocol.

Rule of thumb: if the change requires knowing JML / __attribute__ / Python decorators / Java exceptions / C setjmp, it does NOT belong in this PR. If it only knows CIDs, memento schemas, effect occurrence sets, policies, loss records, or protocol envelopes, it does.

Codex draft (medium-effort + file-first); `cargo test -p provekit-ir-types` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)