### PR TITLE
impl(801): Rust types: ParametricRealizationMemento + RealizationPlanMemento

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
 name = "provekit-ir-types"
 version = "0.1.0"
 dependencies = [
+ "provekit-canonicalizer",
  "serde",
  "serde_json",
 ]

--- a/implementations/rust/provekit-ir-types/Cargo.toml
+++ b/implementations/rust/provekit-ir-types/Cargo.toml
@@ -9,3 +9,6 @@ description = "ProvekIt IR generated types from CDDL grammar."
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+provekit-canonicalizer = { path = "../provekit-canonicalizer" }

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -428,9 +428,9 @@ pub struct AbstractionSlot {
 /// one-or-more via a successor mint with `refines = <PR1 schema CID>`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConceptAbstractionMemento {
-    pub kind: String,      // must be "concept-abstraction"
+    pub kind: String, // must be "concept-abstraction"
     pub operator: String,
-    pub tier: String,      // must be "abstraction"
+    pub tier: String, // must be "abstraction"
     pub slots: Vec<AbstractionSlot>,
     #[serde(rename = "formal_sorts")]
     pub formal_sorts: Vec<String>,
@@ -470,7 +470,7 @@ pub struct RealizationPost {
 /// NOTE: `discharge_receipt` is optional in PR1. PR2 tightens to required.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RealizationDesugaringMemento {
-    pub kind: String,            // must be "equation"
+    pub kind: String, // must be "equation"
     #[serde(rename = "fn_name")]
     pub fn_name: String,
     pub formals: Vec<String>,
@@ -479,8 +479,8 @@ pub struct RealizationDesugaringMemento {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pre: Option<IrFormula>,
     pub post: RealizationPost,
-    pub role: String,            // must be "abstraction-realization"
-    pub direction: String,       // must be "left-to-right"
+    pub role: String,      // must be "abstraction-realization"
+    pub direction: String, // must be "left-to-right"
     #[serde(rename = "target_lang")]
     pub target_lang: String,
     #[serde(rename = "loss_record")]
@@ -488,7 +488,7 @@ pub struct RealizationDesugaringMemento {
     #[serde(rename = "discharge_receipt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discharge_receipt: Option<String>,
-    pub effects: Vec<String>,    // always [] for the equation itself; never skip
+    pub effects: Vec<String>, // always [] for the equation itself; never skip
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refines: Option<String>,
 }
@@ -737,7 +737,7 @@ pub struct TransportGapMemento {
     pub fn_name: String,
     #[serde(rename = "gap_kind")]
     pub gap_kind: GapKind,
-    pub kind: String,           // must be "TransportGapMemento"
+    pub kind: String, // must be "TransportGapMemento"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<GapReason>,
     #[serde(rename = "reason_note")]
@@ -791,7 +791,7 @@ pub struct PartialMorphismMemento {
     pub gap_memento_cid: Option<String>,
     #[serde(rename = "homomorphism_obligation")]
     pub homomorphism_obligation: PartialHomomorphismObligation,
-    pub kind: String,           // must be "PartialMorphismMemento"
+    pub kind: String, // must be "PartialMorphismMemento"
     #[serde(rename = "literal_map")]
     pub literal_map: serde_json::Value,
     #[serde(rename = "operator_map")]
@@ -844,7 +844,7 @@ pub struct LossyMorphismMemento {
     pub gap_memento_cid: Option<String>,
     #[serde(rename = "homomorphism_obligation")]
     pub homomorphism_obligation: LossyHomomorphismObligation,
-    pub kind: String,           // must be "LossyMorphismMemento"
+    pub kind: String, // must be "LossyMorphismMemento"
     #[serde(rename = "literal_map")]
     pub literal_map: serde_json::Value,
     pub loss: LossRecord,
@@ -1017,6 +1017,246 @@ pub struct ConceptSiteMemento {
 // ============================================================
 
 // ============================================================
+// Manual extension: parametric realization mementos (issue #801)
+// Source of truth:
+//   protocol/specs/2026-05-13-parametric-realization.md §1
+//
+// This block adds durable substrate shapes for two-stage realization:
+// a reusable catalog template and a per-site selection receipt. It does
+// not implement realization lookup, sort-slot solving, effect transforms,
+// loss evaluation, or language-kit emission.
+//
+// Per JCS canonicalization, field order MUST equal the locked alphabetical
+// order in the spec. JSON-valued fields are intentionally opaque.
+// ============================================================
+
+pub type Cid = String;
+
+/// A required sort-morphism slot in a parametric realization.
+///
+/// Locked JCS key order: slot_name, source_type_variable,
+/// target_type_variable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SlotDescriptor {
+    #[serde(rename = "slot_name")]
+    pub slot_name: String,
+    #[serde(rename = "source_type_variable")]
+    pub source_type_variable: String,
+    #[serde(rename = "target_type_variable")]
+    pub target_type_variable: String,
+}
+
+/// A required effect transform slot in a parametric realization.
+///
+/// Locked JCS key order: concept_effect, slot_name, target_effect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EffectSlotDescriptor {
+    #[serde(rename = "concept_effect")]
+    pub concept_effect: String,
+    #[serde(rename = "slot_name")]
+    pub slot_name: String,
+    #[serde(rename = "target_effect")]
+    pub target_effect: String,
+}
+
+/// A reusable catalog template for realizing a concept pattern into a
+/// target-language pattern.
+///
+/// Source of truth: protocol/specs/2026-05-13-parametric-realization.md §1.1
+///
+/// Locked JCS key order:
+///   body_template_cids, concept_pattern, effect_transform_slots,
+///   loss_record_template, provenance_cid, required_sort_morphism_slots,
+///   sugar_cids, target_pattern, type_variables.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParametricRealizationMemento {
+    #[serde(rename = "body_template_cids")]
+    pub body_template_cids: Vec<Cid>,
+    #[serde(rename = "concept_pattern")]
+    pub concept_pattern: serde_json::Value,
+    #[serde(rename = "effect_transform_slots")]
+    pub effect_transform_slots: Vec<EffectSlotDescriptor>,
+    #[serde(rename = "loss_record_template")]
+    pub loss_record_template: serde_json::Value,
+    #[serde(rename = "provenance_cid")]
+    pub provenance_cid: Cid,
+    #[serde(rename = "required_sort_morphism_slots")]
+    pub required_sort_morphism_slots: Vec<SlotDescriptor>,
+    #[serde(rename = "sugar_cids")]
+    pub sugar_cids: Vec<Cid>,
+    #[serde(rename = "target_pattern")]
+    pub target_pattern: serde_json::Value,
+    #[serde(rename = "type_variables")]
+    pub type_variables: Vec<String>,
+}
+
+/// A per-site selection receipt that instantiates a
+/// `ParametricRealizationMemento`.
+///
+/// Source of truth: protocol/specs/2026-05-13-parametric-realization.md §1.2
+///
+/// Locked JCS key order:
+///   candidate_set_cid, concept_site_cid, effect_occurrence_transform,
+///   loss_function_cid, observation_wrapper_cid, provenance_cid,
+///   selected_candidate_cid, selected_realization_cid, sort_morphism_cids,
+///   total_loss_record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RealizationPlanMemento {
+    #[serde(rename = "candidate_set_cid")]
+    pub candidate_set_cid: Cid,
+    #[serde(rename = "concept_site_cid")]
+    pub concept_site_cid: Cid,
+    #[serde(rename = "effect_occurrence_transform")]
+    pub effect_occurrence_transform: serde_json::Value,
+    #[serde(rename = "loss_function_cid")]
+    pub loss_function_cid: Cid,
+    #[serde(rename = "observation_wrapper_cid")]
+    pub observation_wrapper_cid: Option<Cid>,
+    #[serde(rename = "provenance_cid")]
+    pub provenance_cid: Cid,
+    #[serde(rename = "selected_candidate_cid")]
+    pub selected_candidate_cid: Cid,
+    #[serde(rename = "selected_realization_cid")]
+    pub selected_realization_cid: Cid,
+    #[serde(rename = "sort_morphism_cids")]
+    pub sort_morphism_cids: Vec<Cid>,
+    #[serde(rename = "total_loss_record")]
+    pub total_loss_record: serde_json::Value,
+}
+
+/// Returned when a `ParametricRealizationMemento` violates one of its
+/// load-time invariants per `2026-05-13-parametric-realization.md`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParametricRealizationError {
+    /// Spec §1.1 CDDL: `type_variables: [+ tstr]` (non-empty).
+    EmptyTypeVariables,
+    /// Spec §1.1 CDDL: `required_sort_morphism_slots: [+ slot-descriptor]`
+    /// (non-empty).
+    EmptyRequiredSortMorphismSlots,
+    /// A slot descriptor references a type variable not in
+    /// `type_variables`. This would be unresolvable at instantiation
+    /// time.
+    SlotReferencesUnknownTypeVariable {
+        slot_name: String,
+        variable: String,
+        side: &'static str,
+    },
+}
+
+impl std::fmt::Display for ParametricRealizationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyTypeVariables => f.write_str(
+                "ParametricRealizationMemento: type_variables is empty (spec §1.1 CDDL requires [+ tstr])",
+            ),
+            Self::EmptyRequiredSortMorphismSlots => f.write_str(
+                "ParametricRealizationMemento: required_sort_morphism_slots is empty (spec §1.1 CDDL requires [+ slot-descriptor])",
+            ),
+            Self::SlotReferencesUnknownTypeVariable {
+                slot_name,
+                variable,
+                side,
+            } => write!(
+                f,
+                "ParametricRealizationMemento: slot {slot_name:?} {side}_type_variable {variable:?} is not in type_variables",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParametricRealizationError {}
+
+impl ParametricRealizationMemento {
+    /// Check load-time invariants per spec §1.1.
+    ///
+    /// Enforced:
+    /// 1. `type_variables` non-empty (CDDL `[+ tstr]`)
+    /// 2. `required_sort_morphism_slots` non-empty (CDDL `[+ slot-descriptor]`)
+    /// 3. every slot's `source_type_variable` and `target_type_variable`
+    ///    is a member of `type_variables`
+    pub fn validate(&self) -> Result<(), ParametricRealizationError> {
+        if self.type_variables.is_empty() {
+            return Err(ParametricRealizationError::EmptyTypeVariables);
+        }
+        if self.required_sort_morphism_slots.is_empty() {
+            return Err(ParametricRealizationError::EmptyRequiredSortMorphismSlots);
+        }
+        let known: std::collections::HashSet<&str> =
+            self.type_variables.iter().map(String::as_str).collect();
+        for slot in &self.required_sort_morphism_slots {
+            if !known.contains(slot.source_type_variable.as_str()) {
+                return Err(ParametricRealizationError::SlotReferencesUnknownTypeVariable {
+                    slot_name: slot.slot_name.clone(),
+                    variable: slot.source_type_variable.clone(),
+                    side: "source",
+                });
+            }
+            if !known.contains(slot.target_type_variable.as_str()) {
+                return Err(ParametricRealizationError::SlotReferencesUnknownTypeVariable {
+                    slot_name: slot.slot_name.clone(),
+                    variable: slot.target_type_variable.clone(),
+                    side: "target",
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Returned when a `RealizationPlanMemento` does not match its cited
+/// `ParametricRealizationMemento`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RealizationPlanError {
+    /// The plan's `sort_morphism_cids` length must equal the
+    /// realization's `required_sort_morphism_slots` length: one CID
+    /// per slot.
+    SortMorphismCountMismatch { expected: usize, actual: usize },
+    /// The realization itself was malformed; this plan cannot be
+    /// validated against it.
+    RealizationInvalid(ParametricRealizationError),
+}
+
+impl std::fmt::Display for RealizationPlanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SortMorphismCountMismatch { expected, actual } => write!(
+                f,
+                "RealizationPlanMemento: sort_morphism_cids.len() = {actual}, expected {expected} (one per realization required_sort_morphism_slots entry)",
+            ),
+            Self::RealizationInvalid(inner) => write!(f, "RealizationPlanMemento: cited realization is invalid: {inner}"),
+        }
+    }
+}
+
+impl std::error::Error for RealizationPlanError {}
+
+impl RealizationPlanMemento {
+    /// Check the plan-vs-realization slot-count invariant per spec §1.2.
+    ///
+    /// The plan's `sort_morphism_cids` is the ordered list of CIDs
+    /// filling the realization's `required_sort_morphism_slots`; the
+    /// lengths MUST match.
+    pub fn validate_against(
+        &self,
+        realization: &ParametricRealizationMemento,
+    ) -> Result<(), RealizationPlanError> {
+        realization
+            .validate()
+            .map_err(RealizationPlanError::RealizationInvalid)?;
+        let expected = realization.required_sort_morphism_slots.len();
+        let actual = self.sort_morphism_cids.len();
+        if expected != actual {
+            return Err(RealizationPlanError::SortMorphismCountMismatch { expected, actual });
+        }
+        Ok(())
+    }
+}
+
+// ============================================================
+// End manual extension block -- parametric realization mementos
+// ============================================================
+
+// ============================================================
 // Manual extension: compound-contract layer (PR-A of compound spec)
 // Source of truth:
 //   protocol/specs/2026-05-13-compound-contract-memento.md §1, §2, §3
@@ -1185,7 +1425,9 @@ impl From<AggregationStrategy> for String {
         match s {
             AggregationStrategy::Conjunction => "conjunction".to_string(),
             AggregationStrategy::BestConfidence => "best-confidence".to_string(),
-            AggregationStrategy::LoudlyBoundedDisjunction => "loudly-bounded-disjunction".to_string(),
+            AggregationStrategy::LoudlyBoundedDisjunction => {
+                "loudly-bounded-disjunction".to_string()
+            }
             AggregationStrategy::Other(s) => s,
         }
     }

--- a/implementations/rust/provekit-ir-types/tests/abstraction_layer_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/abstraction_layer_serde.rs
@@ -23,8 +23,7 @@
 use std::collections::BTreeMap;
 
 use provekit_ir_types::{
-    AbstractionSlot, ConceptAbstractionMemento, IrFormula, LossRecord,
-    RealizationDesugaringMemento,
+    AbstractionSlot, ConceptAbstractionMemento, IrFormula, LossRecord, RealizationDesugaringMemento,
 };
 
 // ================================================================
@@ -87,11 +86,9 @@ fn dynamic_dispatch_deserializes_from_spec_shape() {
 
 #[test]
 fn dynamic_dispatch_round_trips() {
-    let m1: ConceptAbstractionMemento =
-        serde_json::from_str(DYNAMIC_DISPATCH_JSON).expect("parse");
+    let m1: ConceptAbstractionMemento = serde_json::from_str(DYNAMIC_DISPATCH_JSON).expect("parse");
     let serialized = serde_json::to_string(&m1).expect("serialize");
-    let m2: ConceptAbstractionMemento =
-        serde_json::from_str(&serialized).expect("re-parse");
+    let m2: ConceptAbstractionMemento = serde_json::from_str(&serialized).expect("re-parse");
     assert_eq!(m1, m2);
 }
 
@@ -119,10 +116,22 @@ fn concept_abstraction_optional_fields_absent_when_none() {
     };
 
     let json = serde_json::to_string(&m).expect("serialize");
-    assert!(!json.contains("contract_note"), "contract_note must be absent when None");
-    assert!(!json.contains("superseded_by"), "superseded_by must be absent when None");
-    assert!(!json.contains("refines"), "refines must be absent when None");
-    assert!(!json.contains("variadic"), "variadic must be absent when None");
+    assert!(
+        !json.contains("contract_note"),
+        "contract_note must be absent when None"
+    );
+    assert!(
+        !json.contains("superseded_by"),
+        "superseded_by must be absent when None"
+    );
+    assert!(
+        !json.contains("refines"),
+        "refines must be absent when None"
+    );
+    assert!(
+        !json.contains("variadic"),
+        "variadic must be absent when None"
+    );
 }
 
 // ================================================================
@@ -181,11 +190,9 @@ fn double_dispatch_deserializes_from_spec_shape() {
 
 #[test]
 fn double_dispatch_round_trips() {
-    let m1: ConceptAbstractionMemento =
-        serde_json::from_str(DOUBLE_DISPATCH_JSON).expect("parse");
+    let m1: ConceptAbstractionMemento = serde_json::from_str(DOUBLE_DISPATCH_JSON).expect("parse");
     let serialized = serde_json::to_string(&m1).expect("serialize");
-    let m2: ConceptAbstractionMemento =
-        serde_json::from_str(&serialized).expect("re-parse");
+    let m2: ConceptAbstractionMemento = serde_json::from_str(&serialized).expect("re-parse");
     assert_eq!(m1, m2);
 }
 
@@ -402,8 +409,15 @@ fn realization_c_deserializes_and_round_trips() {
     assert_eq!(m.direction, "left-to-right");
     assert_eq!(m.target_lang, "c11");
     assert!(m.pre.is_some(), "c11 realization has a pre-condition");
-    assert!(m.discharge_receipt.is_none(), "discharge_receipt absent in PR1");
-    assert_eq!(m.effects, Vec::<String>::new(), "effects must be empty slice");
+    assert!(
+        m.discharge_receipt.is_none(),
+        "discharge_receipt absent in PR1"
+    );
+    assert_eq!(
+        m.effects,
+        Vec::<String>::new(),
+        "effects must be empty slice"
+    );
 
     // structural_divergence, domain_narrowing AND ub_introduction all set for C (heaviest end)
     assert!(
@@ -492,8 +506,7 @@ fn realization_effects_always_present_in_json() {
     // effects: [] is a required field; it must appear in the serialized JSON
     // even when the Vec is empty. This test guards against accidental
     // `#[serde(skip_serializing_if = "Vec::is_empty")]` on that field.
-    let m: RealizationDesugaringMemento =
-        serde_json::from_str(DD_TO_RUBY_JSON).expect("parse");
+    let m: RealizationDesugaringMemento = serde_json::from_str(DD_TO_RUBY_JSON).expect("parse");
     let json = serde_json::to_string(&m).expect("serialize");
     assert!(
         json.contains("\"effects\":"),
@@ -519,7 +532,10 @@ fn loss_record_structural_divergence_round_trips() {
     let lr = LossRecord(map);
 
     let json = serde_json::to_string(&lr).expect("serialize");
-    assert!(json.contains("structural_divergence"), "structural_divergence must appear in JSON");
+    assert!(
+        json.contains("structural_divergence"),
+        "structural_divergence must appear in JSON"
+    );
 
     let lr2: LossRecord = serde_json::from_str(&json).expect("re-parse");
     assert_eq!(lr, lr2);

--- a/implementations/rust/provekit-ir-types/tests/compound_contract_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/compound_contract_serde.rs
@@ -283,7 +283,10 @@ fn compound_empty_evidences_degenerate_round_trips() {
     let parsed: CompoundContractMemento = serde_json::from_str(&s).expect("parse");
     assert_eq!(parsed, c);
     assert!(parsed.evidences.is_empty());
-    assert_eq!(parsed.aggregation_strategy, AggregationStrategy::Conjunction);
+    assert_eq!(
+        parsed.aggregation_strategy,
+        AggregationStrategy::Conjunction
+    );
 }
 
 #[test]
@@ -364,7 +367,11 @@ fn compound_multi_evidence_round_trips() {
     assert_eq!(parsed, compound);
     assert_eq!(parsed.evidences.len(), 3);
     // Weight basis-points preserved.
-    let weights: Vec<u16> = parsed.evidences.iter().map(|e| e.weight_basis_points).collect();
+    let weights: Vec<u16> = parsed
+        .evidences
+        .iter()
+        .map(|e| e.weight_basis_points)
+        .collect();
     assert_eq!(weights, vec![10000, 9500, 6500]);
 }
 
@@ -491,7 +498,10 @@ fn compound_memento_from_spec_shape() {
     let parsed: CompoundContractMemento =
         serde_json::from_str(fixture).expect("parse spec fixture");
     assert_eq!(parsed.cid, COMPOUND_CID);
-    assert_eq!(parsed.aggregation_strategy, AggregationStrategy::Conjunction);
+    assert_eq!(
+        parsed.aggregation_strategy,
+        AggregationStrategy::Conjunction
+    );
     assert_eq!(parsed.kind, "compound-contract");
     assert_eq!(parsed.schema_version, "1");
     assert_eq!(parsed.function_term_cid, FN_CID);

--- a/implementations/rust/provekit-ir-types/tests/concept_site_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/concept_site_serde.rs
@@ -90,7 +90,10 @@ fn exact_deserializes_from_spec_shape() {
     assert_eq!(m.discharge.method, "wp+witness");
     assert_eq!(m.discharge.verdict, "exact");
     assert!(m.discharge.refusal_reason.is_none());
-    assert_eq!(m.discharge.discharge_receipt_cid.as_deref(), Some(RECEIPT_CID));
+    assert_eq!(
+        m.discharge.discharge_receipt_cid.as_deref(),
+        Some(RECEIPT_CID)
+    );
     assert!(m.discharge.loss_record.0.is_empty());
 
     assert_eq!(m.provenance.lifter_cid, LIFTER_CID);
@@ -334,7 +337,8 @@ fn loss_record_multidim_round_trips() {
     };
     loss.0.insert("domain_narrowing".into(), f_true.clone());
     loss.0.insert("effect_divergence".into(), f_false.clone());
-    loss.0.insert("structural_divergence".into(), f_true.clone());
+    loss.0
+        .insert("structural_divergence".into(), f_true.clone());
     loss.0.insert("ub_introduction".into(), f_false.clone());
     loss.0.insert("value_divergence".into(), f_true.clone());
 

--- a/implementations/rust/provekit-ir-types/tests/domain_claim_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/domain_claim_serde.rs
@@ -77,7 +77,10 @@ fn exact_wire_deserializes() {
     assert_eq!(c.input_cid, INPUT_CID);
     assert_eq!(c.truth_cid, TRUTH_CID);
     assert_eq!(c.verdict.kind, VerdictKind::Exact);
-    assert_eq!(c.verdict.discharge_receipt_cid.as_deref(), Some(RECEIPT_CID));
+    assert_eq!(
+        c.verdict.discharge_receipt_cid.as_deref(),
+        Some(RECEIPT_CID)
+    );
     assert!(c.verdict.refusal_reason.is_none());
     assert!(c.verdict.loss_record.0.is_empty());
     assert_eq!(c.provenance.signer, SIGNER);
@@ -126,7 +129,10 @@ const LOUDLY_LOSSY_FIXTURE: &str = r#"{
 fn loudly_lossy_wire_deserializes() {
     let c: DomainClaim = serde_json::from_str(LOUDLY_LOSSY_FIXTURE).expect("parse lossy");
     assert_eq!(c.verdict.kind, VerdictKind::LoudlyBoundedLossy);
-    assert_eq!(c.verdict.discharge_receipt_cid.as_deref(), Some(RECEIPT_CID));
+    assert_eq!(
+        c.verdict.discharge_receipt_cid.as_deref(),
+        Some(RECEIPT_CID)
+    );
     assert!(c.verdict.refusal_reason.is_none());
     assert_eq!(c.verdict.loss_record.0.len(), 1);
     assert!(c.verdict.loss_record.0.contains_key("domain_narrowing"));

--- a/implementations/rust/provekit-ir-types/tests/parametric_realization_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/parametric_realization_serde.rs
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Round-trip and CID recompute tests for the parametric realization substrate.
+//
+// Source of truth:
+//   protocol/specs/2026-05-13-parametric-realization.md §1
+
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
+use provekit_ir_types::{
+    EffectSlotDescriptor, ParametricRealizationMemento, RealizationPlanMemento, SlotDescriptor,
+};
+use serde_json::{json, Value as Json};
+
+const BODY_TEMPLATE_CID: &str = "blake3-512:111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+const SUGAR_CID: &str = "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+const PARAM_PROVENANCE_CID: &str = "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333";
+const SORT_MORPHISM_CID: &str = "blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444";
+const CANDIDATE_SET_CID: &str = "blake3-512:55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555";
+const CONCEPT_SITE_CID: &str = "blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666";
+const LOSS_FUNCTION_CID: &str = "blake3-512:77777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777";
+const PLAN_PROVENANCE_CID: &str = "blake3-512:88888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888";
+const SELECTED_CANDIDATE_CID: &str = "blake3-512:99999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999";
+const SELECTED_REALIZATION_CID: &str = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+const PARAMETRIC_REALIZATION_CID: &str = "blake3-512:0ade364c6dd99155b5ac2c8c37beb8206dbab8b55059858725b568d250e45d80344b7621f00cda5b0dcd72849b1d04805149dc4f70045b3d97e4b8cc7858a83e";
+const REALIZATION_PLAN_CID: &str = "blake3-512:4f5e0ecf43a406ec3c655d8fab0efda0042928dc0c58e444423eda5b73383d5f01ae2468d7e0eb7b8ee35e832e4837567a16a3a382e44314f20f8d8b607458f0";
+
+fn json_to_value(j: &Json) -> Arc<Value> {
+    match j {
+        Json::Null => Value::null(),
+        Json::Bool(b) => Value::boolean(*b),
+        Json::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                Value::integer(u as i64)
+            } else {
+                panic!("fixture uses a non-integer JSON number")
+            }
+        }
+        Json::String(s) => Value::string(s.clone()),
+        Json::Array(items) => Value::array(items.iter().map(json_to_value).collect()),
+        Json::Object(map) => Arc::new(Value::Object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), json_to_value(v)))
+                .collect(),
+        )),
+    }
+}
+
+fn cid_for<T: serde::Serialize>(memento: &T) -> String {
+    let json = serde_json::to_value(memento).expect("serialize to JSON");
+    let canonical = encode_jcs(&json_to_value(&json));
+    blake3_512_of(canonical.as_bytes())
+}
+
+fn parametric_example() -> ParametricRealizationMemento {
+    ParametricRealizationMemento {
+        body_template_cids: vec![BODY_TEMPLATE_CID.to_string()],
+        concept_pattern: json!({"args": ["T"], "head": "concept:option"}),
+        effect_transform_slots: vec![EffectSlotDescriptor {
+            concept_effect: "concept:alloc".to_string(),
+            slot_name: "effect-slot-0".to_string(),
+            target_effect: "java:allocation".to_string(),
+        }],
+        loss_record_template: json!({"structural_divergence": "template-only"}),
+        provenance_cid: PARAM_PROVENANCE_CID.to_string(),
+        required_sort_morphism_slots: vec![SlotDescriptor {
+            slot_name: "T_to_U".to_string(),
+            source_type_variable: "T".to_string(),
+            target_type_variable: "U".to_string(),
+        }],
+        sugar_cids: vec![SUGAR_CID.to_string()],
+        target_pattern: json!({"args": ["U"], "head": "java:Optional"}),
+        type_variables: vec!["T".to_string(), "U".to_string()],
+    }
+}
+
+fn plan_example() -> RealizationPlanMemento {
+    RealizationPlanMemento {
+        candidate_set_cid: CANDIDATE_SET_CID.to_string(),
+        concept_site_cid: CONCEPT_SITE_CID.to_string(),
+        effect_occurrence_transform: json!({"occurrence:0": "java:allocation"}),
+        loss_function_cid: LOSS_FUNCTION_CID.to_string(),
+        observation_wrapper_cid: None,
+        provenance_cid: PLAN_PROVENANCE_CID.to_string(),
+        selected_candidate_cid: SELECTED_CANDIDATE_CID.to_string(),
+        selected_realization_cid: SELECTED_REALIZATION_CID.to_string(),
+        sort_morphism_cids: vec![SORT_MORPHISM_CID.to_string()],
+        total_loss_record: json!({"structural_divergence": 1}),
+    }
+}
+
+#[test]
+fn parametric_realization_round_trips_and_recomputes_cid() {
+    let m1 = parametric_example();
+    let serialized = serde_json::to_string(&m1).expect("serialize");
+
+    assert_eq!(
+        serialized,
+        r#"{"body_template_cids":["blake3-512:111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"],"concept_pattern":{"args":["T"],"head":"concept:option"},"effect_transform_slots":[{"concept_effect":"concept:alloc","slot_name":"effect-slot-0","target_effect":"java:allocation"}],"loss_record_template":{"structural_divergence":"template-only"},"provenance_cid":"blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333","required_sort_morphism_slots":[{"slot_name":"T_to_U","source_type_variable":"T","target_type_variable":"U"}],"sugar_cids":["blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"],"target_pattern":{"args":["U"],"head":"java:Optional"},"type_variables":["T","U"]}"#
+    );
+
+    let m2: ParametricRealizationMemento = serde_json::from_str(&serialized).expect("re-parse");
+    assert_eq!(m1, m2);
+    assert_eq!(cid_for(&m1), PARAMETRIC_REALIZATION_CID);
+}
+
+#[test]
+fn realization_plan_round_trips_and_recomputes_cid() {
+    let m1 = plan_example();
+    let serialized = serde_json::to_string(&m1).expect("serialize");
+
+    assert_eq!(
+        serialized,
+        r#"{"candidate_set_cid":"blake3-512:55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555","concept_site_cid":"blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666","effect_occurrence_transform":{"occurrence:0":"java:allocation"},"loss_function_cid":"blake3-512:77777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777","observation_wrapper_cid":null,"provenance_cid":"blake3-512:88888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888","selected_candidate_cid":"blake3-512:99999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999","selected_realization_cid":"blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","sort_morphism_cids":["blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444"],"total_loss_record":{"structural_divergence":1}}"#
+    );
+
+    let m2: RealizationPlanMemento = serde_json::from_str(&serialized).expect("re-parse");
+    assert_eq!(m1, m2);
+    assert_eq!(cid_for(&m1), REALIZATION_PLAN_CID);
+}
+
+#[test]
+fn parametric_realization_rejects_empty_type_variables() {
+    use provekit_ir_types::{ParametricRealizationError, ParametricRealizationMemento, SlotDescriptor};
+    let m = ParametricRealizationMemento {
+        body_template_cids: vec![],
+        concept_pattern: serde_json::json!({}),
+        effect_transform_slots: vec![],
+        loss_record_template: serde_json::json!({}),
+        provenance_cid: "blake3-512:0".repeat(1),
+        required_sort_morphism_slots: vec![SlotDescriptor {
+            slot_name: "s".to_string(),
+            source_type_variable: "T".to_string(),
+            target_type_variable: "U".to_string(),
+        }],
+        sugar_cids: vec![],
+        target_pattern: serde_json::json!({}),
+        type_variables: vec![],
+    };
+    assert_eq!(m.validate(), Err(ParametricRealizationError::EmptyTypeVariables));
+}
+
+#[test]
+fn parametric_realization_rejects_empty_required_slots() {
+    use provekit_ir_types::{ParametricRealizationError, ParametricRealizationMemento};
+    let m = ParametricRealizationMemento {
+        body_template_cids: vec![],
+        concept_pattern: serde_json::json!({}),
+        effect_transform_slots: vec![],
+        loss_record_template: serde_json::json!({}),
+        provenance_cid: "blake3-512:0".repeat(1),
+        required_sort_morphism_slots: vec![],
+        sugar_cids: vec![],
+        target_pattern: serde_json::json!({}),
+        type_variables: vec!["T".to_string()],
+    };
+    assert_eq!(
+        m.validate(),
+        Err(ParametricRealizationError::EmptyRequiredSortMorphismSlots)
+    );
+}
+
+#[test]
+fn parametric_realization_rejects_slot_referencing_unknown_type_variable() {
+    use provekit_ir_types::{ParametricRealizationError, ParametricRealizationMemento, SlotDescriptor};
+    let m = ParametricRealizationMemento {
+        body_template_cids: vec![],
+        concept_pattern: serde_json::json!({}),
+        effect_transform_slots: vec![],
+        loss_record_template: serde_json::json!({}),
+        provenance_cid: "blake3-512:0".repeat(1),
+        required_sort_morphism_slots: vec![SlotDescriptor {
+            slot_name: "s".to_string(),
+            source_type_variable: "T".to_string(),
+            target_type_variable: "UnknownU".to_string(),
+        }],
+        sugar_cids: vec![],
+        target_pattern: serde_json::json!({}),
+        type_variables: vec!["T".to_string(), "U".to_string()],
+    };
+    assert_eq!(
+        m.validate(),
+        Err(ParametricRealizationError::SlotReferencesUnknownTypeVariable {
+            slot_name: "s".to_string(),
+            variable: "UnknownU".to_string(),
+            side: "target",
+        })
+    );
+}
+
+#[test]
+fn realization_plan_validates_against_matching_realization() {
+    use provekit_ir_types::{
+        ParametricRealizationMemento, RealizationPlanMemento, SlotDescriptor,
+    };
+    let realization = ParametricRealizationMemento {
+        body_template_cids: vec![],
+        concept_pattern: serde_json::json!({}),
+        effect_transform_slots: vec![],
+        loss_record_template: serde_json::json!({}),
+        provenance_cid: "blake3-512:0".repeat(1),
+        required_sort_morphism_slots: vec![
+            SlotDescriptor {
+                slot_name: "s1".to_string(),
+                source_type_variable: "T".to_string(),
+                target_type_variable: "U".to_string(),
+            },
+            SlotDescriptor {
+                slot_name: "s2".to_string(),
+                source_type_variable: "T".to_string(),
+                target_type_variable: "U".to_string(),
+            },
+        ],
+        sugar_cids: vec![],
+        target_pattern: serde_json::json!({}),
+        type_variables: vec!["T".to_string(), "U".to_string()],
+    };
+    let plan = RealizationPlanMemento {
+        candidate_set_cid: "blake3-512:c".repeat(1),
+        concept_site_cid: "blake3-512:s".repeat(1),
+        effect_occurrence_transform: serde_json::json!({}),
+        loss_function_cid: "blake3-512:l".repeat(1),
+        observation_wrapper_cid: None,
+        provenance_cid: "blake3-512:p".repeat(1),
+        selected_candidate_cid: "blake3-512:x".repeat(1),
+        selected_realization_cid: "blake3-512:r".repeat(1),
+        sort_morphism_cids: vec!["blake3-512:m1".to_string(), "blake3-512:m2".to_string()],
+        total_loss_record: serde_json::json!({}),
+    };
+    plan.validate_against(&realization).expect("matching counts");
+}
+
+#[test]
+fn realization_plan_rejects_sort_morphism_count_mismatch() {
+    use provekit_ir_types::{
+        ParametricRealizationMemento, RealizationPlanError, RealizationPlanMemento, SlotDescriptor,
+    };
+    let realization = ParametricRealizationMemento {
+        body_template_cids: vec![],
+        concept_pattern: serde_json::json!({}),
+        effect_transform_slots: vec![],
+        loss_record_template: serde_json::json!({}),
+        provenance_cid: "blake3-512:0".repeat(1),
+        required_sort_morphism_slots: vec![SlotDescriptor {
+            slot_name: "s".to_string(),
+            source_type_variable: "T".to_string(),
+            target_type_variable: "U".to_string(),
+        }],
+        sugar_cids: vec![],
+        target_pattern: serde_json::json!({}),
+        type_variables: vec!["T".to_string(), "U".to_string()],
+    };
+    let plan = RealizationPlanMemento {
+        candidate_set_cid: "blake3-512:c".repeat(1),
+        concept_site_cid: "blake3-512:s".repeat(1),
+        effect_occurrence_transform: serde_json::json!({}),
+        loss_function_cid: "blake3-512:l".repeat(1),
+        observation_wrapper_cid: None,
+        provenance_cid: "blake3-512:p".repeat(1),
+        selected_candidate_cid: "blake3-512:x".repeat(1),
+        selected_realization_cid: "blake3-512:r".repeat(1),
+        sort_morphism_cids: vec![
+            "blake3-512:m1".to_string(),
+            "blake3-512:m2".to_string(),
+            "blake3-512:m3".to_string(),
+        ],
+        total_loss_record: serde_json::json!({}),
+    };
+    let err = plan.validate_against(&realization).expect_err("count mismatch");
+    assert_eq!(
+        err,
+        RealizationPlanError::SortMorphismCountMismatch {
+            expected: 1,
+            actual: 3,
+        }
+    );
+}

--- a/implementations/rust/provekit-ir-types/tests/transport_gap_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/transport_gap_serde.rs
@@ -75,20 +75,24 @@ fn python_add_gap_deserializes_from_spec_shape() {
     assert!(m.reason.is_some());
     assert!(m.reason_note.is_some());
     assert_eq!(m.resolution_options.len(), 2);
-    assert_eq!(m.resolution_options[0].option_kind, ResolutionOptionKind::PartialMorphism);
+    assert_eq!(
+        m.resolution_options[0].option_kind,
+        ResolutionOptionKind::PartialMorphism
+    );
     assert_eq!(m.resolution_options[0].status, OptionStatus::Recommended);
-    assert_eq!(m.resolution_options[1].option_kind, ResolutionOptionKind::AcceptPermanent);
+    assert_eq!(
+        m.resolution_options[1].option_kind,
+        ResolutionOptionKind::AcceptPermanent
+    );
     assert_eq!(m.resolution_options[1].status, OptionStatus::Deferred);
     assert!(m.signature.is_none());
 }
 
 #[test]
 fn python_add_gap_round_trips() {
-    let m: TransportGapMemento =
-        serde_json::from_str(PYTHON_ADD_GAP_JSON).expect("parse");
+    let m: TransportGapMemento = serde_json::from_str(PYTHON_ADD_GAP_JSON).expect("parse");
     let serialized = serde_json::to_string(&m).expect("serialize");
-    let m2: TransportGapMemento =
-        serde_json::from_str(&serialized).expect("re-parse");
+    let m2: TransportGapMemento = serde_json::from_str(&serialized).expect("re-parse");
     assert_eq!(m, m2);
 }
 
@@ -123,7 +127,10 @@ fn no_such_concept_op_gap_deserializes() {
         serde_json::from_str(NO_CONCEPT_OP_GAP_JSON).expect("parse no-such-concept-op gap");
 
     assert_eq!(m.gap_kind, GapKind::NoSuchConceptOp);
-    assert!(m.target_op_cid.is_none(), "target_op_cid must be absent for no-such-concept-op");
+    assert!(
+        m.target_op_cid.is_none(),
+        "target_op_cid must be absent for no-such-concept-op"
+    );
     assert_eq!(m.source_lang, "go");
     assert!(m.reason.is_some());
     let reason = m.reason.as_ref().unwrap();
@@ -132,18 +139,15 @@ fn no_such_concept_op_gap_deserializes() {
 
 #[test]
 fn no_such_concept_op_gap_round_trips() {
-    let m: TransportGapMemento =
-        serde_json::from_str(NO_CONCEPT_OP_GAP_JSON).expect("parse");
+    let m: TransportGapMemento = serde_json::from_str(NO_CONCEPT_OP_GAP_JSON).expect("parse");
     let serialized = serde_json::to_string(&m).expect("serialize");
-    let m2: TransportGapMemento =
-        serde_json::from_str(&serialized).expect("re-parse");
+    let m2: TransportGapMemento = serde_json::from_str(&serialized).expect("re-parse");
     assert_eq!(m, m2);
 }
 
 #[test]
 fn no_such_concept_op_omits_target_op_cid_when_none() {
-    let m: TransportGapMemento =
-        serde_json::from_str(NO_CONCEPT_OP_GAP_JSON).expect("parse");
+    let m: TransportGapMemento = serde_json::from_str(NO_CONCEPT_OP_GAP_JSON).expect("parse");
     let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
     assert!(
         v.get("target_op_cid").is_none(),
@@ -229,7 +233,10 @@ fn python_add_partial_morphism_deserializes() {
     assert_eq!(m.fn_name, "partial-morphism:python:add:to:concept:add");
     assert_eq!(m.kind, "PartialMorphismMemento");
     assert_eq!(m.schema_version, "1");
-    assert_eq!(m.homomorphism_obligation.kind, "wp-refinement-under-precondition");
+    assert_eq!(
+        m.homomorphism_obligation.kind,
+        "wp-refinement-under-precondition"
+    );
     assert!(m.gap_memento_cid.is_some());
     assert!(m.signature.is_none());
     // Confirm validity_precondition parsed
@@ -241,20 +248,16 @@ fn python_add_partial_morphism_deserializes() {
 
 #[test]
 fn partial_morphism_round_trips() {
-    let m: PartialMorphismMemento =
-        serde_json::from_str(PYTHON_ADD_PARTIAL_JSON).expect("parse");
+    let m: PartialMorphismMemento = serde_json::from_str(PYTHON_ADD_PARTIAL_JSON).expect("parse");
     let serialized = serde_json::to_string(&m).expect("serialize");
-    let m2: PartialMorphismMemento =
-        serde_json::from_str(&serialized).expect("re-parse");
+    let m2: PartialMorphismMemento = serde_json::from_str(&serialized).expect("re-parse");
     assert_eq!(m, m2);
 }
 
 #[test]
 fn partial_morphism_omits_signature_when_none() {
-    let m: PartialMorphismMemento =
-        serde_json::from_str(PYTHON_ADD_PARTIAL_JSON).expect("parse");
-    let v: serde_json::Value =
-        serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
+    let m: PartialMorphismMemento = serde_json::from_str(PYTHON_ADD_PARTIAL_JSON).expect("parse");
+    let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
     assert!(
         v.get("signature").is_none(),
         "signature must be absent in serialized JSON when None"
@@ -303,7 +306,10 @@ fn python_add_lossy_morphism_deserializes() {
     assert_eq!(m.kind, "LossyMorphismMemento");
     assert_eq!(m.schema_version, "1");
     assert_eq!(m.coarsening_kind, "quotient-target-sort");
-    assert_eq!(m.homomorphism_obligation.kind, "wp-refinement-into-coarsening");
+    assert_eq!(
+        m.homomorphism_obligation.kind,
+        "wp-refinement-into-coarsening"
+    );
     assert!(m.gap_memento_cid.is_none());
     assert!(m.signature.is_none());
     // Confirm loss dimensions
@@ -323,20 +329,16 @@ fn python_add_lossy_morphism_deserializes() {
 
 #[test]
 fn lossy_morphism_round_trips() {
-    let m: LossyMorphismMemento =
-        serde_json::from_str(PYTHON_ADD_LOSSY_JSON).expect("parse");
+    let m: LossyMorphismMemento = serde_json::from_str(PYTHON_ADD_LOSSY_JSON).expect("parse");
     let serialized = serde_json::to_string(&m).expect("serialize");
-    let m2: LossyMorphismMemento =
-        serde_json::from_str(&serialized).expect("re-parse");
+    let m2: LossyMorphismMemento = serde_json::from_str(&serialized).expect("re-parse");
     assert_eq!(m, m2);
 }
 
 #[test]
 fn lossy_morphism_omits_gap_memento_cid_when_none() {
-    let m: LossyMorphismMemento =
-        serde_json::from_str(PYTHON_ADD_LOSSY_JSON).expect("parse");
-    let v: serde_json::Value =
-        serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
+    let m: LossyMorphismMemento = serde_json::from_str(PYTHON_ADD_LOSSY_JSON).expect("parse");
+    let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
     assert!(
         v.get("gap_memento_cid").is_none(),
         "gap_memento_cid must be absent in serialized JSON when None"
@@ -377,12 +379,27 @@ fn gap_reason_source_supported_false_round_trips() {
 fn divergent_tag_named_variant_serializes_to_spec_string() {
     // Each named variant must serialize to its spec-defined kebab string, NOT "null".
     let cases: &[(DivergentSemanticsTag, &str)] = &[
-        (DivergentSemanticsTag::TruncatedVsFlooredModulo, "\"truncated-vs-floored-modulo\""),
-        (DivergentSemanticsTag::BoundedVsUnboundedInteger, "\"bounded-vs-unbounded-integer\""),
-        (DivergentSemanticsTag::IntegerVsTrueDivision, "\"integer-vs-true-division\""),
-        (DivergentSemanticsTag::OverflowBehavior, "\"overflow-behavior\""),
+        (
+            DivergentSemanticsTag::TruncatedVsFlooredModulo,
+            "\"truncated-vs-floored-modulo\"",
+        ),
+        (
+            DivergentSemanticsTag::BoundedVsUnboundedInteger,
+            "\"bounded-vs-unbounded-integer\"",
+        ),
+        (
+            DivergentSemanticsTag::IntegerVsTrueDivision,
+            "\"integer-vs-true-division\"",
+        ),
+        (
+            DivergentSemanticsTag::OverflowBehavior,
+            "\"overflow-behavior\"",
+        ),
         (DivergentSemanticsTag::RoundingMode, "\"rounding-mode\""),
-        (DivergentSemanticsTag::ShortCircuitVsEager, "\"short-circuit-vs-eager\""),
+        (
+            DivergentSemanticsTag::ShortCircuitVsEager,
+            "\"short-circuit-vs-eager\"",
+        ),
     ];
     for (tag, expected) in cases {
         let json = serde_json::to_string(tag).unwrap();
@@ -407,10 +424,12 @@ fn divergent_tag_spec_string_deserializes_to_named_variant() {
 
     let tag2: DivergentSemanticsTag =
         serde_json::from_str("\"bounded-vs-unbounded-integer\"").unwrap();
-    assert!(matches!(tag2, DivergentSemanticsTag::BoundedVsUnboundedInteger));
+    assert!(matches!(
+        tag2,
+        DivergentSemanticsTag::BoundedVsUnboundedInteger
+    ));
 
-    let tag3: DivergentSemanticsTag =
-        serde_json::from_str("\"integer-vs-true-division\"").unwrap();
+    let tag3: DivergentSemanticsTag = serde_json::from_str("\"integer-vs-true-division\"").unwrap();
     assert!(matches!(tag3, DivergentSemanticsTag::IntegerVsTrueDivision));
 
     let tag4: DivergentSemanticsTag = serde_json::from_str("\"overflow-behavior\"").unwrap();


### PR DESCRIPTION
Closes part of #801 implementation.

Substrate-only Rust type per the merged spec. Adds memento struct(s) to `provekit-ir-types` + JCS canonicalization + BLAKE3-512 CID derivation + structural validation methods where applicable + serde round-trip + CID-recompute tests.

**Strict substrate/kit split** (per architect direction):
- This PR: Rust substrate. Types, serialization, CIDs, structural validation. No language syntax knowledge.
- Per-language kit work (native annotation extraction, sugar emission, target-syntax wrappers) is a separate wave per language under `implementations/<lang>/`. Kits consume these types through the plugin protocol.

Rule of thumb: if the change requires knowing JML / __attribute__ / Python decorators / Java exceptions / C setjmp, it does NOT belong in this PR. If it only knows CIDs, memento schemas, effect occurrence sets, policies, loss records, or protocol envelopes, it does.

Codex draft (medium-effort + file-first); `cargo test -p provekit-ir-types` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)