### PR TITLE
impl(802): Rust types: CatalogSnapshotMemento + canonical_set_cid()

### DIFF
--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -2306,6 +2306,211 @@ fn serde_json_to_canonical_value(
 // ============================================================
 
 // ============================================================
+// Manual extension: CatalogSnapshotMemento substrate primitive (#802)
+// Source of truth:
+//   protocol/specs/2026-05-13-catalog-snapshot-memento.md §1, §3
+//
+// This block intentionally models only the durable artifact and the
+// canonical set-CID helper. Snapshot replay and catalog pull-protocols
+// live outside this crate.
+//
+// Per JCS canonicalization, serde field order MUST equal alphabetical
+// order. The struct fields below are ordered exactly as the spec lists
+// the canonical map keys.
+// ============================================================
+
+/// The catalog namespace named by a `CatalogSnapshotMemento`.
+///
+/// Wire format: a bare JSON string. The three reserved labels are carried
+/// as named variants; extension catalogs round-trip through `Namespaced`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub enum CatalogKind {
+    ConceptShapes,
+    Policy,
+    Realization,
+    /// Namespaced extension catalog kind, e.g. `acme:custom-shapes`.
+    /// MUST be of the form `<namespace>:<kind>` with both segments
+    /// non-empty. Bare unknowns fail closed at deserialization.
+    Namespaced(String),
+}
+
+impl TryFrom<String> for CatalogKind {
+    type Error = CatalogKindError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.as_str() {
+            "concept-shapes" => Ok(CatalogKind::ConceptShapes),
+            "policy" => Ok(CatalogKind::Policy),
+            "realization" => Ok(CatalogKind::Realization),
+            _ => match s.split_once(':') {
+                // Spec: extension labels are `<namespace>:<kind>` with
+                // EXACTLY one colon, both segments non-empty.
+                Some((ns, kind)) if !ns.is_empty() && !kind.is_empty() && !kind.contains(':') => {
+                    Ok(CatalogKind::Namespaced(s))
+                }
+                _ => Err(CatalogKindError {
+                    raw: s,
+                }),
+            },
+        }
+    }
+}
+
+impl From<CatalogKind> for String {
+    fn from(k: CatalogKind) -> String {
+        match k {
+            CatalogKind::ConceptShapes => "concept-shapes".to_string(),
+            CatalogKind::Policy => "policy".to_string(),
+            CatalogKind::Realization => "realization".to_string(),
+            CatalogKind::Namespaced(s) => s,
+        }
+    }
+}
+
+/// Error returned when a `CatalogKind` string is neither a canonical
+/// value nor a well-formed namespaced extension. The spec requires
+/// extensions to use `<namespace>:<kind>` form; bare unknowns fail closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogKindError {
+    pub raw: String,
+}
+
+impl std::fmt::Display for CatalogKindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unrecognized catalog kind {:?}: not a canonical value (concept-shapes / policy / realization) and not a well-formed `<namespace>:<kind>` extension",
+            self.raw
+        )
+    }
+}
+
+impl std::error::Error for CatalogKindError {}
+
+/// The first snapshot for a catalog kind.
+///
+/// Locked JCS key order:
+///   admitted_member_set_cid, catalog_kind, catalog_root_cid, genesis,
+///   policy_set_cid, promotion_decision_set_cid, provenance_cid,
+///   signature, signer_cid, snapshot_time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogSnapshotGenesis {
+    #[serde(rename = "admitted_member_set_cid")]
+    pub admitted_member_set_cid: Cid,
+    #[serde(rename = "catalog_kind")]
+    pub catalog_kind: CatalogKind,
+    #[serde(rename = "catalog_root_cid")]
+    pub catalog_root_cid: Cid,
+    pub genesis: String,
+    #[serde(rename = "policy_set_cid")]
+    pub policy_set_cid: Cid,
+    #[serde(rename = "promotion_decision_set_cid")]
+    pub promotion_decision_set_cid: Cid,
+    #[serde(rename = "provenance_cid")]
+    pub provenance_cid: Cid,
+    pub signature: String,
+    #[serde(rename = "signer_cid")]
+    pub signer_cid: Cid,
+    #[serde(rename = "snapshot_time")]
+    pub snapshot_time: String,
+}
+
+/// A non-genesis snapshot for a catalog kind.
+///
+/// Locked JCS key order:
+///   admitted_member_set_cid, catalog_kind, catalog_root_cid,
+///   parent_snapshot_cid, policy_set_cid, promotion_decision_set_cid,
+///   provenance_cid, signature, signer_cid, snapshot_time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogSnapshotSuccessor {
+    #[serde(rename = "admitted_member_set_cid")]
+    pub admitted_member_set_cid: Cid,
+    #[serde(rename = "catalog_kind")]
+    pub catalog_kind: CatalogKind,
+    #[serde(rename = "catalog_root_cid")]
+    pub catalog_root_cid: Cid,
+    #[serde(rename = "parent_snapshot_cid")]
+    pub parent_snapshot_cid: Cid,
+    #[serde(rename = "policy_set_cid")]
+    pub policy_set_cid: Cid,
+    #[serde(rename = "promotion_decision_set_cid")]
+    pub promotion_decision_set_cid: Cid,
+    #[serde(rename = "provenance_cid")]
+    pub provenance_cid: Cid,
+    pub signature: String,
+    #[serde(rename = "signer_cid")]
+    pub signer_cid: Cid,
+    #[serde(rename = "snapshot_time")]
+    pub snapshot_time: String,
+}
+
+/// The catalog snapshot memento union.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CatalogSnapshotMemento {
+    Genesis(CatalogSnapshotGenesis),
+    Successor(CatalogSnapshotSuccessor),
+}
+
+/// Compute the canonical CID for a set field in a catalog snapshot.
+///
+/// The input slice is sorted in-place by the UTF-8 bytes of each CID
+/// string, encoded as a JCS JSON array of strings, then hashed with the
+/// repository's BLAKE3-512 self-identifying CID helper.
+///
+/// Per the spec these are SET CIDs: duplicate strings violate the set
+/// abstraction and MUST be rejected before hashing. The function takes
+/// `&[Cid]` (immutable) and returns `Err(DuplicateInSetError)` when any
+/// CID appears more than once. The caller may not assume the input slice
+/// is mutated.
+pub fn canonical_set_cid(cids: &[Cid]) -> Result<Cid, DuplicateInSetError> {
+    let mut sorted: Vec<&Cid> = cids.iter().collect();
+    sorted.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+
+    // Reject duplicates: a set cannot contain the same element twice. After
+    // sorting, duplicates appear as adjacent pairs.
+    for window in sorted.windows(2) {
+        if window[0] == window[1] {
+            return Err(DuplicateInSetError {
+                cid: window[0].clone(),
+            });
+        }
+    }
+
+    let values = sorted
+        .iter()
+        .map(|cid| provekit_canonicalizer::Value::string((*cid).clone()))
+        .collect();
+    let jcs = provekit_canonicalizer::encode_jcs(&provekit_canonicalizer::Value::array(values));
+    Ok(provekit_canonicalizer::blake3_512_of(jcs.as_bytes()))
+}
+
+/// Error returned when `canonical_set_cid` finds a duplicate CID in its
+/// input. Per spec these arrays are SET CIDs; multisets are not admissible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateInSetError {
+    /// The CID that appeared at least twice in the input slice.
+    pub cid: Cid,
+}
+
+impl std::fmt::Display for DuplicateInSetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "duplicate CID in canonical set: {} (per spec these are set CIDs; multisets are not admissible)",
+            self.cid
+        )
+    }
+}
+
+impl std::error::Error for DuplicateInSetError {}
+
+// ============================================================
+// End manual extension block -- CatalogSnapshotMemento (#802)
+// ============================================================
+
+// ============================================================
 // MANUAL EXTENSION BLOCK -- DomainClaim normalization (PR-A)
 // Source of truth:
 //   protocol/specs/2026-05-13-domain-claim-normalization.md §1

--- a/implementations/rust/provekit-ir-types/tests/catalog_snapshot_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/catalog_snapshot_serde.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Round-trip serde tests for CatalogSnapshotMemento and its canonical
+// set-CID helper.
+//
+// Source of truth:
+//   protocol/specs/2026-05-13-catalog-snapshot-memento.md §1, §3
+
+use provekit_ir_types::{
+    canonical_set_cid, CatalogKind, CatalogSnapshotGenesis, CatalogSnapshotMemento,
+    CatalogSnapshotSuccessor, Cid, DuplicateInSetError,
+};
+
+const ROOT_CID: &str = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PARENT_CID: &str = "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PROVENANCE_CID: &str = "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const SIGNER_CID: &str = "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+const SIGNATURE: &str = "ed25519:test-signature";
+const SNAPSHOT_TIME: &str = "2026-05-13T12:00:00Z";
+
+fn cid(hex: char) -> Cid {
+    format!("blake3-512:{}", hex.to_string().repeat(128))
+}
+
+#[test]
+fn canonical_set_cid_is_order_invariant() {
+    let first = vec![cid('c'), cid('a'), cid('b')];
+    let second = vec![cid('b'), cid('c'), cid('a')];
+
+    let first_cid = canonical_set_cid(&first).expect("dedup-free input");
+    let second_cid = canonical_set_cid(&second).expect("dedup-free input");
+
+    assert_eq!(first_cid, second_cid);
+    assert!(first_cid.starts_with("blake3-512:"));
+    assert_eq!(first_cid.len(), "blake3-512:".len() + 128);
+}
+
+#[test]
+fn canonical_set_cid_does_not_mutate_input() {
+    // The new API takes &[Cid]; the caller MUST be able to retain the
+    // original (unsorted) ordering.
+    let input = vec![cid('c'), cid('a'), cid('b')];
+    let _ = canonical_set_cid(&input).expect("dedup-free input");
+    assert_eq!(input, vec![cid('c'), cid('a'), cid('b')]);
+}
+
+#[test]
+fn canonical_set_cid_rejects_duplicates() {
+    // A set CID cannot collapse a multiset silently. The spec says these
+    // are SET CIDs; duplicates must be rejected before hashing so that
+    // `[a, b]` and `[a, a, b]` do NOT produce different "set" CIDs.
+    let input = vec![cid('a'), cid('b'), cid('a')];
+    let err = canonical_set_cid(&input).expect_err("duplicate must fail closed");
+    assert_eq!(err, DuplicateInSetError { cid: cid('a') });
+}
+
+#[test]
+fn canonical_set_cid_rejects_adjacent_duplicates() {
+    let input = vec![cid('z'), cid('z')];
+    let err = canonical_set_cid(&input).expect_err("duplicate must fail closed");
+    assert_eq!(err, DuplicateInSetError { cid: cid('z') });
+}
+
+#[test]
+fn genesis_round_trips_and_set_cids_recompute() {
+    let admitted = vec![cid('2'), cid('1')];
+    let policies = vec![cid('4'), cid('3')];
+    let decisions = vec![cid('6'), cid('5')];
+
+    let snapshot = CatalogSnapshotMemento::Genesis(CatalogSnapshotGenesis {
+        admitted_member_set_cid: canonical_set_cid(&admitted).expect("dedup"),
+        catalog_kind: CatalogKind::ConceptShapes,
+        catalog_root_cid: ROOT_CID.to_string(),
+        genesis: "genesis".to_string(),
+        policy_set_cid: canonical_set_cid(&policies).expect("dedup"),
+        promotion_decision_set_cid: canonical_set_cid(&decisions).expect("dedup"),
+        provenance_cid: PROVENANCE_CID.to_string(),
+        signature: SIGNATURE.to_string(),
+        signer_cid: SIGNER_CID.to_string(),
+        snapshot_time: SNAPSHOT_TIME.to_string(),
+    });
+
+    let serialized = serde_json::to_string(&snapshot).expect("serialize genesis");
+    assert!(serialized.contains(r#""genesis":"genesis""#));
+    assert!(!serialized.contains("parent_snapshot_cid"));
+
+    let parsed: CatalogSnapshotMemento = serde_json::from_str(&serialized).expect("parse genesis");
+    assert_eq!(parsed, snapshot);
+
+    let CatalogSnapshotMemento::Genesis(parsed) = parsed else {
+        panic!("expected genesis variant");
+    };
+    assert_eq!(
+        parsed.admitted_member_set_cid,
+        canonical_set_cid(&admitted).expect("dedup")
+    );
+    assert_eq!(
+        parsed.policy_set_cid,
+        canonical_set_cid(&policies).expect("dedup")
+    );
+    assert_eq!(
+        parsed.promotion_decision_set_cid,
+        canonical_set_cid(&decisions).expect("dedup")
+    );
+}
+
+#[test]
+fn successor_round_trips_and_set_cids_recompute() {
+    let admitted = vec![cid('9'), cid('7'), cid('8')];
+    let policies = vec![cid('b'), cid('a')];
+    let decisions = vec![cid('e'), cid('d'), cid('c')];
+
+    let snapshot = CatalogSnapshotMemento::Successor(CatalogSnapshotSuccessor {
+        admitted_member_set_cid: canonical_set_cid(&admitted).expect("dedup"),
+        catalog_kind: CatalogKind::Namespaced("acme:custom-catalog".to_string()),
+        catalog_root_cid: ROOT_CID.to_string(),
+        parent_snapshot_cid: PARENT_CID.to_string(),
+        policy_set_cid: canonical_set_cid(&policies).expect("dedup"),
+        promotion_decision_set_cid: canonical_set_cid(&decisions).expect("dedup"),
+        provenance_cid: PROVENANCE_CID.to_string(),
+        signature: SIGNATURE.to_string(),
+        signer_cid: SIGNER_CID.to_string(),
+        snapshot_time: SNAPSHOT_TIME.to_string(),
+    });
+
+    let serialized = serde_json::to_string(&snapshot).expect("serialize successor");
+    assert!(serialized.contains(r#""parent_snapshot_cid":"#));
+    assert!(!serialized.contains(r#""genesis":"#));
+    assert!(serialized.contains(r#""catalog_kind":"acme:custom-catalog""#));
+
+    let parsed: CatalogSnapshotMemento =
+        serde_json::from_str(&serialized).expect("parse successor");
+    assert_eq!(parsed, snapshot);
+
+    let CatalogSnapshotMemento::Successor(parsed) = parsed else {
+        panic!("expected successor variant");
+    };
+    assert_eq!(
+        parsed.admitted_member_set_cid,
+        canonical_set_cid(&admitted).expect("dedup")
+    );
+    assert_eq!(
+        parsed.policy_set_cid,
+        canonical_set_cid(&policies).expect("dedup")
+    );
+    assert_eq!(
+        parsed.promotion_decision_set_cid,
+        canonical_set_cid(&decisions).expect("dedup")
+    );
+}
+
+#[test]
+fn catalog_kind_rejects_bare_unknown_at_deserialization() {
+    // Per spec, extension catalog kinds MUST be `<namespace>:<kind>`.
+    // A bare unknown like "custom-kind" (no namespace separator) must
+    // fail closed at deserialization, not silently become Other("custom-kind").
+    let bare = serde_json::json!("custom-kind").to_string();
+    let result: Result<CatalogKind, _> = serde_json::from_str(&bare);
+    assert!(
+        result.is_err(),
+        "bare unknown catalog kind should fail closed, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn catalog_kind_accepts_well_formed_namespaced_extension() {
+    let valid = serde_json::json!("acme:custom-catalog").to_string();
+    let parsed: CatalogKind = serde_json::from_str(&valid).expect("parse");
+    assert_eq!(parsed, CatalogKind::Namespaced("acme:custom-catalog".to_string()));
+}
+
+#[test]
+fn catalog_kind_rejects_multi_colon() {
+    let result: Result<CatalogKind, _> = serde_json::from_str("\"a:b:c\"");
+    assert!(result.is_err(), "multi-colon should fail closed, got {:?}", result);
+}


### PR DESCRIPTION
Closes part of #802 implementation.

Substrate-only Rust type per the merged spec. Adds memento struct(s) to `provekit-ir-types` + JCS canonicalization + BLAKE3-512 CID derivation + structural validation methods where applicable + serde round-trip + CID-recompute tests.

**Strict substrate/kit split** (per architect direction):
- This PR: Rust substrate. Types, serialization, CIDs, structural validation. No language syntax knowledge.
- Per-language kit work (native annotation extraction, sugar emission, target-syntax wrappers) is a separate wave per language under `implementations/<lang>/`. Kits consume these types through the plugin protocol.

Rule of thumb: if the change requires knowing JML / __attribute__ / Python decorators / Java exceptions / C setjmp, it does NOT belong in this PR. If it only knows CIDs, memento schemas, effect occurrence sets, policies, loss records, or protocol envelopes, it does.

Codex draft (medium-effort + file-first); `cargo test -p provekit-ir-types` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog snapshot support with genesis and successor variants.
  * Added catalog namespace handling with explicit kind validation.
  * Added canonical set CID computation for catalog integrity verification.

* **Tests**
  * Added comprehensive tests for catalog snapshot serialization, validation, and namespace handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/831)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->