### PR TITLE
impl(803): Rust types: CanonicalizationProfileMemento

### DIFF
--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -2698,6 +2698,62 @@ impl TryFrom<String> for CatalogKind {
     }
 }
 
+// ============================================================
+// Manual extension: canonicalization-profile memento (#803)
+// Source of truth:
+//   protocol/specs/2026-05-13-canonicalization-profile-memento.md §1
+//
+// This block adds the substrate-only declaration shape for
+// CanonicalizationProfileMemento. It intentionally does not execute,
+// parse, or validate any canonicalization rule language. Rule descriptors
+// declare documented behavior by id/version and optional payload CIDs;
+// higher layers decide whether and how to run those rules.
+//
+// Per JCS canonicalization (2026-04-30-canonicalization-grammar.md),
+// serde field order MUST equal the locked alphabetical order from the
+// spec §1 inside each object. Optional rule fields are omitted from the
+// serialized JSON when None. Required rule lists are emitted as arrays,
+// including empty arrays.
+// ============================================================
+
+/// Scope of a canonicalization profile.
+///
+/// Wire format: a bare JSON string. Bare unknowns fail closed at
+/// deserialization; namespaced extensions (`<namespace>:<kind>`) are
+/// carried as `Namespaced(String)` per the spec §3 namespaced-extensions
+/// rule.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub enum CanonicalizationProfileKind {
+    IrFormula,
+    ConceptShape,
+    FunctionContract,
+    Namespaced(String),
+}
+
+impl TryFrom<String> for CanonicalizationProfileKind {
+    type Error = CanonicalizationExtensionError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.as_str() {
+            "ir-formula" => Ok(CanonicalizationProfileKind::IrFormula),
+            "concept-shape" => Ok(CanonicalizationProfileKind::ConceptShape),
+            "function-contract" => Ok(CanonicalizationProfileKind::FunctionContract),
+            _ => match s.split_once(':') {
+                // Spec §3: extension labels are `<namespace>:<kind>` with
+                // EXACTLY one colon, both segments non-empty.
+                Some((ns, kind)) if !ns.is_empty() && !kind.is_empty() && !kind.contains(':') => {
+                    Ok(CanonicalizationProfileKind::Namespaced(s))
+                }
+                _ => Err(CanonicalizationExtensionError {
+                    field: "profile_kind",
+                    raw: s,
+                }),
+            },
+        }
+    }
+}
+
 impl From<CatalogKind> for String {
     fn from(k: CatalogKind) -> String {
         match k {
@@ -2705,6 +2761,17 @@ impl From<CatalogKind> for String {
             CatalogKind::Policy => "policy".to_string(),
             CatalogKind::Realization => "realization".to_string(),
             CatalogKind::Namespaced(s) => s,
+        }
+    }
+}
+
+impl From<CanonicalizationProfileKind> for String {
+    fn from(k: CanonicalizationProfileKind) -> String {
+        match k {
+            CanonicalizationProfileKind::IrFormula => "ir-formula".to_string(),
+            CanonicalizationProfileKind::ConceptShape => "concept-shape".to_string(),
+            CanonicalizationProfileKind::FunctionContract => "function-contract".to_string(),
+            CanonicalizationProfileKind::Namespaced(s) => s,
         }
     }
 }
@@ -2723,6 +2790,73 @@ impl std::fmt::Display for CatalogKindError {
             f,
             "unrecognized catalog kind {:?}: not a canonical value (concept-shapes / policy / realization) and not a well-formed `<namespace>:<kind>` extension",
             self.raw
+        )
+    }
+}
+
+/// Behavior when a canonicalizer sees an equivalence class it does not
+/// understand.
+///
+/// Wire format: a bare JSON string. Bare unknowns fail closed at
+/// deserialization; namespaced extensions are carried as
+/// `Namespaced(String)`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub enum UnsupportedEquivalencePolicy {
+    Preserve,
+    Refuse,
+    Namespaced(String),
+}
+
+impl TryFrom<String> for UnsupportedEquivalencePolicy {
+    type Error = CanonicalizationExtensionError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.as_str() {
+            "preserve" => Ok(UnsupportedEquivalencePolicy::Preserve),
+            "refuse" => Ok(UnsupportedEquivalencePolicy::Refuse),
+            _ => match s.split_once(':') {
+                // Spec §3: extension labels are `<namespace>:<kind>` with
+                // EXACTLY one colon, both segments non-empty.
+                Some((ns, kind)) if !ns.is_empty() && !kind.is_empty() && !kind.contains(':') => {
+                    Ok(UnsupportedEquivalencePolicy::Namespaced(s))
+                }
+                _ => Err(CanonicalizationExtensionError {
+                    field: "unsupported_equivalence_policy",
+                    raw: s,
+                }),
+            },
+        }
+    }
+}
+
+impl From<UnsupportedEquivalencePolicy> for String {
+    fn from(p: UnsupportedEquivalencePolicy) -> String {
+        match p {
+            UnsupportedEquivalencePolicy::Preserve => "preserve".to_string(),
+            UnsupportedEquivalencePolicy::Refuse => "refuse".to_string(),
+            UnsupportedEquivalencePolicy::Namespaced(s) => s,
+        }
+    }
+}
+
+/// Returned when a `CanonicalizationProfileKind` or
+/// `UnsupportedEquivalencePolicy` string is neither a reserved value nor a
+/// well-formed `<namespace>:<kind>` extension. Per spec §3 +
+/// admissibility-spine namespaced-extensions rule, bare unknowns fail
+/// closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalizationExtensionError {
+    pub field: &'static str,
+    pub raw: String,
+}
+
+impl std::fmt::Display for CanonicalizationExtensionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unrecognized {} value {:?}: not a reserved label and not a well-formed `<namespace>:<kind>` extension",
+            self.field, self.raw
         )
     }
 }
@@ -2849,6 +2983,68 @@ impl std::error::Error for DuplicateInSetError {}
 
 // ============================================================
 // End manual extension block -- CatalogSnapshotMemento (#802)
+// ============================================================
+
+impl std::error::Error for CanonicalizationExtensionError {}
+
+/// A documented canonicalization behavior declaration.
+///
+/// Locked JCS key order:
+///   description, language_signature_cid (omitted when absent),
+///   reference_cid (omitted when absent), rule_id,
+///   rule_payload (omitted when absent), rule_version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CanonicalizationRuleDescriptor {
+    pub description: String,
+    #[serde(rename = "language_signature_cid")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language_signature_cid: Option<String>,
+    #[serde(rename = "reference_cid")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_cid: Option<String>,
+    #[serde(rename = "rule_id")]
+    pub rule_id: String,
+    #[serde(rename = "rule_payload")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_payload: Option<serde_json::Value>,
+    #[serde(rename = "rule_version")]
+    pub rule_version: String,
+}
+
+/// Declaration of the conservative canonicalization profile applied before
+/// a substrate object is content-addressed.
+///
+/// Source of truth: protocol/specs/2026-05-13-canonicalization-profile-memento.md §1
+///
+/// Locked JCS key order:
+///   alpha_equivalence_rules, binder_normalization_rules,
+///   formal_name_normalization_rules, formula_canonicalization_rules,
+///   profile_kind, profile_version, provenance_cid, sort_alias_rules,
+///   unsupported_equivalence_policy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CanonicalizationProfileMemento {
+    #[serde(rename = "alpha_equivalence_rules")]
+    pub alpha_equivalence_rules: Vec<CanonicalizationRuleDescriptor>,
+    #[serde(rename = "binder_normalization_rules")]
+    pub binder_normalization_rules: Vec<CanonicalizationRuleDescriptor>,
+    #[serde(rename = "formal_name_normalization_rules")]
+    pub formal_name_normalization_rules: Vec<CanonicalizationRuleDescriptor>,
+    #[serde(rename = "formula_canonicalization_rules")]
+    pub formula_canonicalization_rules: Vec<CanonicalizationRuleDescriptor>,
+    #[serde(rename = "profile_kind")]
+    pub profile_kind: CanonicalizationProfileKind,
+    #[serde(rename = "profile_version")]
+    pub profile_version: String,
+    #[serde(rename = "provenance_cid")]
+    pub provenance_cid: String,
+    #[serde(rename = "sort_alias_rules")]
+    pub sort_alias_rules: Vec<CanonicalizationRuleDescriptor>,
+    #[serde(rename = "unsupported_equivalence_policy")]
+    pub unsupported_equivalence_policy: UnsupportedEquivalencePolicy,
+}
+
+// ============================================================
+// End manual extension block -- canonicalization-profile memento (#803)
 // ============================================================
 
 // ============================================================

--- a/implementations/rust/provekit-ir-types/tests/canonicalization_profile_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/canonicalization_profile_serde.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Round-trip serde and CID tests for CanonicalizationProfileMemento.
+//
+// Source of truth:
+//   protocol/specs/2026-05-13-canonicalization-profile-memento.md §1, §7
+//
+// These tests pin the substrate declaration shape only. They do not
+// execute canonicalization rules or define a rule sublanguage.
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use provekit_ir_types::{
+    CanonicalizationProfileKind, CanonicalizationProfileMemento, CanonicalizationRuleDescriptor,
+    UnsupportedEquivalencePolicy,
+};
+use std::sync::Arc;
+
+const PROVENANCE_CID: &str = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+const LANGUAGE_SIGNATURE_CID: &str = "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+const REFERENCE_CID: &str = "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333";
+const EXPECTED_PROFILE_CID: &str = "blake3-512:e4ee17f130cf96b0a396c4660fae5721dd2e6bdd178346819e403e367936eeda92b95b0886f73be9dfceb63ce38efb3673f167049722f92843e106b2c58bbcca";
+
+fn cvalue_from_json(value: &serde_json::Value) -> Arc<CValue> {
+    match value {
+        serde_json::Value::Null => CValue::null(),
+        serde_json::Value::Bool(b) => CValue::boolean(*b),
+        serde_json::Value::Number(n) => CValue::integer(n.as_i64().expect("test numbers fit i64")),
+        serde_json::Value::String(s) => CValue::string(s.clone()),
+        serde_json::Value::Array(values) => {
+            CValue::array(values.iter().map(cvalue_from_json).collect())
+        }
+        serde_json::Value::Object(map) => CValue::object(
+            map.iter()
+                .map(|(key, value)| (key.clone(), cvalue_from_json(value)))
+                .collect::<Vec<_>>(),
+        ),
+    }
+}
+
+fn cid_of_profile(profile: &CanonicalizationProfileMemento) -> String {
+    let json = serde_json::to_value(profile).expect("profile serializes to JSON");
+    let canonical = cvalue_from_json(&json);
+    blake3_512_of(encode_jcs(&canonical).as_bytes())
+}
+
+fn rule(rule_id: &str, description: &str) -> CanonicalizationRuleDescriptor {
+    CanonicalizationRuleDescriptor {
+        description: description.to_string(),
+        language_signature_cid: None,
+        reference_cid: Some(REFERENCE_CID.to_string()),
+        rule_id: rule_id.to_string(),
+        rule_payload: None,
+        rule_version: "1.0.0".to_string(),
+    }
+}
+
+fn full_profile(policy: UnsupportedEquivalencePolicy) -> CanonicalizationProfileMemento {
+    CanonicalizationProfileMemento {
+        alpha_equivalence_rules: vec![rule(
+            "alpha.bound-variable-renaming",
+            "Bound-variable renaming preserves identity when binding structure is unchanged.",
+        )],
+        binder_normalization_rules: vec![rule(
+            "binder.de-bruijn-index",
+            "Bound variables may be represented by De Bruijn index under explicit binders.",
+        )],
+        formal_name_normalization_rules: vec![CanonicalizationRuleDescriptor {
+            description: "Slot aliases normalize to the declared formal parameter slot."
+                .to_string(),
+            language_signature_cid: Some(LANGUAGE_SIGNATURE_CID.to_string()),
+            reference_cid: Some(REFERENCE_CID.to_string()),
+            rule_id: "formal.slot-alias".to_string(),
+            rule_payload: Some(serde_json::json!({
+                "canonical": "$arg0",
+                "slot": 0,
+                "variants": ["$arg0", "$arg_0", "$0"]
+            })),
+            rule_version: "1.0.0".to_string(),
+        }],
+        formula_canonicalization_rules: vec![rule(
+            "formula.redundant-parentheses",
+            "Redundant parentheses may be removed when parse structure is unchanged.",
+        )],
+        profile_kind: CanonicalizationProfileKind::IrFormula,
+        profile_version: "2026-05-13.1".to_string(),
+        provenance_cid: PROVENANCE_CID.to_string(),
+        sort_alias_rules: vec![CanonicalizationRuleDescriptor {
+            description: "Sort aliases collapse only under the pinned language signature."
+                .to_string(),
+            language_signature_cid: Some(LANGUAGE_SIGNATURE_CID.to_string()),
+            reference_cid: Some(REFERENCE_CID.to_string()),
+            rule_id: "sort.pinned-alias".to_string(),
+            rule_payload: Some(serde_json::json!({
+                "aliases": [["int", "i32"]]
+            })),
+            rule_version: "1.0.0".to_string(),
+        }],
+        unsupported_equivalence_policy: policy,
+    }
+}
+
+#[test]
+fn profile_with_all_rule_categories_round_trips_and_recomputes_cid() {
+    let profile = full_profile(UnsupportedEquivalencePolicy::Preserve);
+
+    let serialized = serde_json::to_string(&profile).expect("serialize");
+    assert!(serialized.contains("\"alpha_equivalence_rules\""));
+    assert!(serialized.contains("\"binder_normalization_rules\""));
+    assert!(serialized.contains("\"formal_name_normalization_rules\""));
+    assert!(serialized.contains("\"formula_canonicalization_rules\""));
+    assert!(serialized.contains("\"sort_alias_rules\""));
+    assert!(!serialized.contains("\"cid\""));
+
+    let parsed: CanonicalizationProfileMemento =
+        serde_json::from_str(&serialized).expect("parse serialized profile");
+    assert_eq!(parsed, profile);
+    assert_eq!(parsed.alpha_equivalence_rules.len(), 1);
+    assert_eq!(parsed.binder_normalization_rules.len(), 1);
+    assert_eq!(parsed.formal_name_normalization_rules.len(), 1);
+    assert_eq!(parsed.formula_canonicalization_rules.len(), 1);
+    assert_eq!(parsed.sort_alias_rules.len(), 1);
+
+    assert_eq!(cid_of_profile(&profile), EXPECTED_PROFILE_CID);
+    assert_eq!(cid_of_profile(&parsed), EXPECTED_PROFILE_CID);
+}
+
+#[test]
+fn unsupported_equivalence_policy_round_trips() {
+    let cases = [
+        (UnsupportedEquivalencePolicy::Preserve, "\"preserve\""),
+        (UnsupportedEquivalencePolicy::Refuse, "\"refuse\""),
+        (
+            UnsupportedEquivalencePolicy::Namespaced("vendor:diagnose-only".to_string()),
+            "\"vendor:diagnose-only\"",
+        ),
+    ];
+
+    for (policy, wire) in cases {
+        let serialized = serde_json::to_string(&policy).expect("serialize policy");
+        assert_eq!(serialized, wire);
+        let parsed: UnsupportedEquivalencePolicy =
+            serde_json::from_str(wire).expect("parse policy");
+        assert_eq!(parsed, policy);
+    }
+
+    let refuse_profile = full_profile(UnsupportedEquivalencePolicy::Refuse);
+    let serialized = serde_json::to_string(&refuse_profile).expect("serialize profile");
+    assert!(serialized.contains("\"unsupported_equivalence_policy\":\"refuse\""));
+    let parsed: CanonicalizationProfileMemento =
+        serde_json::from_str(&serialized).expect("parse refuse profile");
+    assert_eq!(
+        parsed.unsupported_equivalence_policy,
+        UnsupportedEquivalencePolicy::Refuse
+    );
+}
+
+#[test]
+fn profile_kind_rejects_bare_unknown() {
+    // Per spec §3 + admissibility-spine namespaced-extensions rule, a bare
+    // unknown profile_kind (no `:` separator) MUST fail closed at
+    // deserialization, not silently become Other(s).
+    let result: Result<CanonicalizationProfileKind, _> =
+        serde_json::from_str("\"weird-kind\"");
+    assert!(
+        result.is_err(),
+        "bare unknown profile_kind should fail closed, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn profile_kind_accepts_well_formed_namespaced_extension() {
+    let parsed: CanonicalizationProfileKind =
+        serde_json::from_str("\"acme:loop-shape\"").expect("parse namespaced");
+    assert_eq!(
+        parsed,
+        CanonicalizationProfileKind::Namespaced("acme:loop-shape".to_string())
+    );
+}
+
+#[test]
+fn unsupported_equivalence_policy_rejects_bare_unknown() {
+    let result: Result<UnsupportedEquivalencePolicy, _> =
+        serde_json::from_str("\"ignore\"");
+    assert!(
+        result.is_err(),
+        "bare unknown policy should fail closed, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn profile_kind_rejects_multi_colon() {
+    let result: Result<CanonicalizationProfileKind, _> =
+        serde_json::from_str("\"a:b:c\"");
+    assert!(result.is_err(), "multi-colon should fail closed, got {:?}", result);
+}
+
+#[test]
+fn unsupported_equivalence_policy_rejects_multi_colon() {
+    let result: Result<UnsupportedEquivalencePolicy, _> =
+        serde_json::from_str("\"a:b:c\"");
+    assert!(result.is_err(), "multi-colon should fail closed, got {:?}", result);
+}


### PR DESCRIPTION
Closes part of #803 implementation.

Substrate-only Rust type per the merged spec. Adds memento struct(s) to `provekit-ir-types` + JCS canonicalization + BLAKE3-512 CID derivation + structural validation methods where applicable + serde round-trip + CID-recompute tests.

**Strict substrate/kit split** (per architect direction):
- This PR: Rust substrate. Types, serialization, CIDs, structural validation. No language syntax knowledge.
- Per-language kit work (native annotation extraction, sugar emission, target-syntax wrappers) is a separate wave per language under `implementations/<lang>/`. Kits consume these types through the plugin protocol.

Rule of thumb: if the change requires knowing JML / __attribute__ / Python decorators / Java exceptions / C setjmp, it does NOT belong in this PR. If it only knows CIDs, memento schemas, effect occurrence sets, policies, loss records, or protocol envelopes, it does.

Codex draft (medium-effort + file-first); `cargo test -p provekit-ir-types` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)