### PR TITLE
wire(#796 step 1): CCP callers consume Result<_, CompositionRefusalMemento>

### DIFF
--- a/implementations/rust/libprovekit/src/ffi.rs
+++ b/implementations/rust/libprovekit/src/ffi.rs
@@ -43,7 +43,9 @@ use std::ptr;
 use std::sync::Arc;
 
 use provekit_canonicalizer::Value;
-use provekit_ir_types::{IrFormula, Sort};
+use provekit_ir_types::{
+    composition_refusal_header_cid, CompositionRefusalMemento, IrFormula, Sort,
+};
 use serde::Deserialize;
 
 use crate::compose::{
@@ -248,7 +250,7 @@ enum FfiError {
     EffectsMismatch(usize),
     LengthMismatch { atoms: usize, effects: usize },
     ChainTooShort(usize),
-    ComposeRefused,
+    ComposeRefused(CompositionRefusalMemento),
 }
 
 impl FfiError {
@@ -267,8 +269,14 @@ impl FfiError {
             FfiError::ChainTooShort(n) => {
                 format!("chain has {n} atoms; compose_chain_contracts requires at least 2")
             }
-            FfiError::ComposeRefused => {
-                "compose_chain_contracts refused (impure inputs or non-result post)".to_string()
+            FfiError::ComposeRefused(refusal) => {
+                let cid = composition_refusal_header_cid(&refusal.header);
+                let refusal_json = serde_json::to_string(refusal)
+                    .unwrap_or_else(|e| format!(r#"{{"serialize_error":"{e}"}}"#));
+                format!(
+                    "compose_chain_contracts refused: cid={cid}; kind={}; detail={}; refusal={refusal_json}",
+                    refusal.header.failure_kind, refusal.header.failure_detail
+                )
             }
         }
     }
@@ -379,7 +387,7 @@ fn inner_compose(atoms_jcs: &str, effects_jcs: &str) -> Result<(String, String),
         })
         .collect();
 
-    let composed = compose_chain_contracts(&steps).map_err(|_| FfiError::ComposeRefused)?;
+    let composed = compose_chain_contracts(&steps).map_err(FfiError::ComposeRefused)?;
     let body_jcs = String::from_utf8(composed.canonical_bytes.clone())
         .map_err(|e| FfiError::Schema(format!("composed body not utf-8: {}", e)))?;
     Ok((composed.cid, body_jcs))

--- a/implementations/rust/libprovekit/tests/ffi_smoke.rs
+++ b/implementations/rust/libprovekit/tests/ffi_smoke.rs
@@ -103,6 +103,23 @@ fn build_inputs() -> (String, String) {
     (atoms.to_string(), effects.to_string())
 }
 
+fn build_impure_inputs() -> (String, String) {
+    let inner_body = pure_identity_body_json("inner", "y");
+    let mut outer_body = pure_identity_body_json("outer", "x");
+    outer_body["effects"] = json!([{"kind": "io"}]);
+
+    let atoms = json!([
+        { "memento": inner_body.clone(), "formalIdx": 0 },
+        { "memento": outer_body.clone(), "formalIdx": 0 },
+    ]);
+    let effects = json!([
+        inner_body.get("effects").cloned().unwrap_or(json!([])),
+        outer_body.get("effects").cloned().unwrap_or(json!([])),
+    ]);
+
+    (atoms.to_string(), effects.to_string())
+}
+
 #[test]
 fn rust_jcs_entrypoint_pins_cid() {
     let (atoms_jcs, effects_jcs) = build_inputs();
@@ -115,6 +132,41 @@ fn rust_jcs_entrypoint_pins_cid() {
         cid, PINNED_CID,
         "FFI-side composed CID must equal the Rust-side pinned CID; same algebra → same CID"
     );
+}
+
+#[test]
+fn rust_jcs_entrypoint_impure_input_returns_stable_refusal_cid() {
+    let (atoms_jcs, effects_jcs) = build_impure_inputs();
+    let first =
+        compose_chain_contracts_jcs(&atoms_jcs, &effects_jcs).expect_err("impure input refuses");
+    let second =
+        compose_chain_contracts_jcs(&atoms_jcs, &effects_jcs).expect_err("impure input refuses");
+
+    assert!(
+        first.contains("composition-refusal"),
+        "error must preserve the refusal artifact: {first}"
+    );
+    let first_cid = refusal_cid_from_error(&first);
+    let second_cid = refusal_cid_from_error(&second);
+    assert!(
+        first_cid.starts_with("blake3-512:"),
+        "refusal CID must be self-identifying, got {first_cid}"
+    );
+    assert_eq!(
+        first_cid, second_cid,
+        "same impure input must produce deterministic refusal CID"
+    );
+}
+
+fn refusal_cid_from_error(message: &str) -> String {
+    let (_, json) = message
+        .split_once("refusal=")
+        .expect("error includes serialized refusal");
+    let value: JsonValue = serde_json::from_str(json).expect("refusal JSON parses");
+    value["header"]["cid"]
+        .as_str()
+        .expect("refusal header cid")
+        .to_string()
 }
 
 #[test]

--- a/implementations/rust/provekit-cli/src/cmd_compose.rs
+++ b/implementations/rust/provekit-cli/src/cmd_compose.rs
@@ -57,7 +57,9 @@ use libprovekit::compose::{
     CCP_VERSION,
 };
 use provekit_canonicalizer::Value;
-use provekit_ir_types::{IrFormula, Sort};
+use provekit_ir_types::{
+    composition_refusal_header_cid, CompositionRefusalMemento, IrFormula, Sort,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 
@@ -175,6 +177,12 @@ fn serve_loop<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> u8 {
                         if let Some(cid) = err.atom_cid {
                             envelope.insert("atom_cid".into(), JsonValue::from(cid));
                         }
+                        if let Some(cid) = err.refusal_cid {
+                            envelope.insert("refusal_cid".into(), JsonValue::from(cid));
+                        }
+                        if let Some(refusal) = err.refusal {
+                            envelope.insert("refusal".into(), refusal);
+                        }
                         json!({
                             "jsonrpc": "2.0",
                             "id": id,
@@ -224,6 +232,8 @@ struct RpcError {
     message: String,
     kind: &'static str,
     atom_cid: Option<String>,
+    refusal_cid: Option<String>,
+    refusal: Option<JsonValue>,
 }
 
 impl RpcError {
@@ -233,15 +243,8 @@ impl RpcError {
             message: message.into(),
             kind: "bad_request",
             atom_cid: None,
-        }
-    }
-
-    fn refused(kind: &'static str, message: impl Into<String>) -> Self {
-        Self {
-            code: ERR_COMPOSE_REFUSED,
-            message: message.into(),
-            kind,
-            atom_cid: None,
+            refusal_cid: None,
+            refusal: None,
         }
     }
 
@@ -251,6 +254,29 @@ impl RpcError {
             message: message.into(),
             kind,
             atom_cid: Some(atom_cid),
+            refusal_cid: None,
+            refusal: None,
+        }
+    }
+
+    fn composition_refused(refusal: CompositionRefusalMemento) -> Self {
+        let cid = composition_refusal_header_cid(&refusal.header);
+        let refusal_value = serde_json::to_value(&refusal).unwrap_or_else(|e| {
+            json!({
+                "serialize_error": e.to_string(),
+                "header": {"cid": cid}
+            })
+        });
+        Self {
+            code: ERR_COMPOSE_REFUSED,
+            message: format!(
+                "composition refused: cid={cid}; kind={}; detail={}",
+                refusal.header.failure_kind, refusal.header.failure_detail
+            ),
+            kind: "composition_refused",
+            atom_cid: None,
+            refusal_cid: Some(cid),
+            refusal: Some(refusal_value),
         }
     }
 }
@@ -301,13 +327,6 @@ fn handle_compose(params: JsonValue) -> Result<JsonValue, RpcError> {
                 ));
             }
         }
-        if !contract.is_pure() {
-            return Err(RpcError::refused_with_atom(
-                "impure_input",
-                format!("atom {i} ({}) has non-empty effect set", contract.fn_name),
-                contract.cid.clone(),
-            ));
-        }
         formal_idxs.push(wire_atom.formal_idx.unwrap_or(0));
         contracts.push(contract);
     }
@@ -321,18 +340,15 @@ fn handle_compose(params: JsonValue) -> Result<JsonValue, RpcError> {
         })
         .collect();
 
-    let composed = compose_chain_contracts(&steps).ok_or_else(|| {
-        RpcError::refused(
-            "composition_refused",
-            "compose_chain_contracts returned None (impure input, formal index out of range, or missing result equation)",
-        )
-    })?;
+    let composed = compose_chain_contracts(&steps).map_err(RpcError::composition_refused)?;
 
     let body_jcs = String::from_utf8(composed.canonical_bytes.clone()).map_err(|e| RpcError {
         code: ERR_INTERNAL,
         message: format!("composed bytes are not utf-8 JCS: {e}"),
         kind: "internal_error",
         atom_cid: None,
+        refusal_cid: None,
+        refusal: None,
     })?;
 
     Ok(json!({

--- a/implementations/rust/provekit-cli/tests/compose_rpc_smoke.rs
+++ b/implementations/rust/provekit-cli/tests/compose_rpc_smoke.rs
@@ -71,6 +71,14 @@ fn pure_identity_atom(fn_name: &str, formal: &str) -> JsonValue {
     })
 }
 
+fn impure_identity_atom(fn_name: &str, formal: &str) -> JsonValue {
+    let mut atom = pure_identity_atom(fn_name, formal);
+    atom["effects"] = json!({
+        "effects": [{"kind": "io"}]
+    });
+    atom
+}
+
 #[test]
 fn compose_rpc_returns_pinned_cid() {
     let bin = provekit_bin();
@@ -182,6 +190,86 @@ fn compose_rpc_returns_pinned_cid() {
         status.success(),
         "provekit compose --rpc exited non-zero: {status:?}"
     );
+}
+
+#[test]
+fn compose_rpc_impure_input_returns_refusal_memento_with_stable_cid() {
+    let bin = provekit_bin();
+    assert!(
+        bin.exists(),
+        "provekit binary missing at {}; run `cargo build -p provekit-cli` first",
+        bin.display()
+    );
+
+    let first = rpc_compose(json!([
+        pure_identity_atom("inner", "y"),
+        impure_identity_atom("outer", "x")
+    ]));
+    let second = rpc_compose(json!([
+        pure_identity_atom("inner", "y"),
+        impure_identity_atom("outer", "x")
+    ]));
+
+    for response in [&first, &second] {
+        let err = response.get("error").expect("impure compose returns error");
+        assert_eq!(err["kind"], json!("composition_refused"));
+        let refusal_cid = err["refusal_cid"]
+            .as_str()
+            .expect("error includes refusal_cid");
+        assert!(
+            refusal_cid.starts_with("blake3-512:"),
+            "refusal CID must be self-identifying, got {refusal_cid}"
+        );
+        assert_eq!(
+            err["refusal"]["header"]["cid"],
+            json!(refusal_cid),
+            "error must carry the durable refusal artifact"
+        );
+        assert_eq!(
+            err["refusal"]["header"]["failure_kind"],
+            json!("impure-input")
+        );
+    }
+
+    assert_eq!(
+        first["error"]["refusal_cid"], second["error"]["refusal_cid"],
+        "same impure input must produce deterministic refusal CID"
+    );
+}
+
+fn rpc_compose(atoms: JsonValue) -> JsonValue {
+    let bin = provekit_bin();
+    let mut child = Command::new(&bin)
+        .args(["compose", "--rpc"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn provekit compose --rpc");
+
+    let mut stdin = child.stdin.take().expect("stdin pipe");
+    let stdout = child.stdout.take().expect("stdout pipe");
+    let mut reader = BufReader::new(stdout);
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "compose",
+            "params": {"atoms": atoms}
+        })
+    )
+    .unwrap();
+    let response = read_response(&mut reader);
+    drop(stdin);
+    let status = child.wait().expect("wait child");
+    assert!(
+        status.success(),
+        "provekit compose --rpc exited non-zero: {status:?}"
+    );
+    response
 }
 
 fn read_response<R: BufRead>(reader: &mut R) -> JsonValue {

--- a/implementations/rust/provekit-walk/src/chain.rs
+++ b/implementations/rust/provekit-walk/src/chain.rs
@@ -18,7 +18,8 @@ use std::collections::HashMap;
 use syn::Expr;
 
 use crate::contract::{
-    compose_chain_contracts, ChainStep, ComposedFunctionContract, FunctionContractMemento,
+    compose_chain_contracts, ChainStep, ComposedFunctionContract, CompositionRefusalMemento,
+    FunctionContractMemento,
 };
 
 /// One method-call in a detected chain. The receiver is the implicit
@@ -54,7 +55,8 @@ pub fn detect_method_chain(expr: &Expr) -> Option<Vec<MethodCallStep>> {
 }
 
 /// Compose an iterator chain by looking up each step's contract in
-/// the registry. Returns None if any contract is missing or impure.
+/// the registry. Returns Ok(None) if any contract is missing, and
+/// propagates the canonical refusal memento if composition is refused.
 ///
 /// All chain steps use formal_idx = 0 because methods are normalized
 /// as `method:foo(receiver, args)` per the lifter (paper 07
@@ -63,13 +65,15 @@ pub fn detect_method_chain(expr: &Expr) -> Option<Vec<MethodCallStep>> {
 pub fn compose_method_chain(
     chain: &[MethodCallStep],
     registry: &HashMap<String, FunctionContractMemento>,
-) -> Option<ComposedFunctionContract> {
+) -> Result<Option<ComposedFunctionContract>, CompositionRefusalMemento> {
     if chain.len() < 2 {
-        return None;
+        return Ok(None);
     }
     let mut contracts: Vec<&FunctionContractMemento> = Vec::with_capacity(chain.len());
     for step in chain {
-        let contract = registry.get(&step.method_name)?;
+        let Some(contract) = registry.get(&step.method_name) else {
+            return Ok(None);
+        };
         contracts.push(contract);
     }
     let steps: Vec<ChainStep<'_>> = contracts
@@ -79,7 +83,7 @@ pub fn compose_method_chain(
             formal_idx: 0,
         })
         .collect();
-    compose_chain_contracts(&steps)
+    compose_chain_contracts(&steps).map(Some)
 }
 
 #[cfg(test)]
@@ -156,13 +160,15 @@ mod tests {
         registry.insert("sum".to_string(), double);
 
         let chain = detect_method_chain(&parse_expr("v.iter().map(f).sum()")).unwrap();
-        let composed = compose_method_chain(&chain, &registry).expect("compose succeeds");
+        let composed = compose_method_chain(&chain, &registry)
+            .expect("compose does not refuse")
+            .expect("compose succeeds");
         assert!(composed.cid.starts_with("blake3-512:"));
         // The chain has 3 steps → 3 component CIDs.
         assert_eq!(composed.component_cids.len(), 3);
 
         // Re-composition is deterministic.
-        let composed2 = compose_method_chain(&chain, &registry).unwrap();
+        let composed2 = compose_method_chain(&chain, &registry).unwrap().unwrap();
         assert_eq!(composed.cid, composed2.cid);
         assert_eq!(composed.canonical_bytes, composed2.canonical_bytes);
     }
@@ -171,6 +177,6 @@ mod tests {
     fn compose_method_chain_returns_none_on_missing_contract() {
         let registry: HashMap<String, FunctionContractMemento> = HashMap::new();
         let chain = detect_method_chain(&parse_expr("v.iter().sum()")).unwrap();
-        assert!(compose_method_chain(&chain, &registry).is_none());
+        assert!(compose_method_chain(&chain, &registry).unwrap().is_none());
     }
 }

--- a/implementations/rust/provekit-walk/src/contract.rs
+++ b/implementations/rust/provekit-walk/src/contract.rs
@@ -28,6 +28,7 @@ pub use libprovekit::compose::{
     EffectSet, EmptyOpacityPool, FunctionContractMemento, Locus, OpacityError,
     OpacityMementoLookup, PinInvariantMementoView,
 };
+pub use provekit_ir_types::CompositionRefusalMemento;
 
 // ---- AST builders ----
 

--- a/implementations/rust/provekit-walk/tests/compose_method_chain_refusal.rs
+++ b/implementations/rust/provekit-walk/tests/compose_method_chain_refusal.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use provekit_walk::build_function_contract;
+use provekit_walk::chain::{compose_method_chain, MethodCallStep};
+
+fn contract(src: &str) -> provekit_walk::contract::FunctionContractMemento {
+    build_function_contract(&syn::parse_str::<syn::ItemFn>(src).unwrap(), None)
+}
+
+#[test]
+fn compose_method_chain_impure_input_returns_stable_refusal_cid() {
+    let mut registry = HashMap::new();
+    registry.insert("iter".to_string(), contract("fn iter(v: u32) -> u32 { v }"));
+    registry.insert(
+        "sum".to_string(),
+        contract(r#"fn sum(x: u32) -> u32 { println!("{}", x); x }"#),
+    );
+    let chain = vec![
+        MethodCallStep {
+            method_name: "iter".to_string(),
+            _arg_count: 0,
+        },
+        MethodCallStep {
+            method_name: "sum".to_string(),
+            _arg_count: 0,
+        },
+    ];
+
+    let refusal = compose_method_chain(&chain, &registry).expect_err("impure input refuses");
+    let refusal2 = compose_method_chain(&chain, &registry).expect_err("impure input refuses");
+
+    assert!(
+        !refusal.header.cid.is_empty(),
+        "refusal CID must be populated"
+    );
+    assert_eq!(refusal.header.failure_kind, "impure-input");
+    assert_eq!(
+        refusal.header.cid, refusal2.header.cid,
+        "same impure input must produce deterministic refusal CID"
+    );
+}


### PR DESCRIPTION
First wiring step in the substrate-types phase (admissibility-spine #796 next-phase plan).

PR #827 landed the new `compose_chain_contracts -> Result<ComposedFunctionContract, CompositionRefusalMemento>` signature. This PR adapts every Rust caller of that API to consume the new error type and preserve refusal CIDs as durable artifacts.

## Call sites updated

| File | Line | Change |
|---|---|---|
| `libprovekit/src/ffi.rs` | 390 | `FfiError::ComposeRefused` carries memento, formats CID + serialized refusal |
| `provekit-cli/src/cmd_compose.rs` | 343 | compose RPC maps refusal → `refusal_cid` + full refusal JSON payload |
| `provekit-walk/src/chain.rs` | 85 | method-chain wrapper now returns `Result<Option<_>, CompositionRefusalMemento>` |

## Integration tests (3 new, all passing)

- `ffi_smoke::rust_jcs_entrypoint_impure_input_returns_stable_refusal_cid`
- `compose_rpc_smoke::compose_rpc_impure_input_returns_refusal_memento_with_stable_cid`
- `compose_method_chain_refusal::compose_method_chain_impure_input_returns_stable_refusal_cid`

Each asserts the refusal CID is non-empty AND deterministic across two runs (per spec §0.1).

## Pre-existing failures (NOT introduced here)

Verified by re-running on clean main:
- `provekit-bridgeworks::smoke::checked_add_exhibit_passes` — fails on clean main
- `provekit-cli::cli_surface::lift_zig_shows_production_composes_but_unit_tests_conflict` — Zig environment flake (`.zig-cache` PermissionDenied), unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)