### PR TITLE
wire(#796 step 3): provekit bind mints PromotionDecisionMemento per admitted evidence

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -21,6 +21,8 @@
 // Output layout:
 //   .provekit/bindings/evidence/<cid>.json — one EvidenceMemento per contract source
 //   .provekit/bindings/contracts/<cid>.json — one CompoundContractMemento per local contract
+//   .provekit/bindings/policies/<cid>.json — bind-default-policy PolicyMemento
+//   .provekit/bindings/promotion-decisions/<cid>.json — one admission record per evidence
 //   .provekit/bindings/sites/<cid>.json   — one ConceptSiteMemento per match
 //   .provekit/bindings/index.json         — summary map
 //   .provekit/bindings/gaps.json          — coverage gaps / deferred capabilities
@@ -44,7 +46,9 @@ use provekit_claim_envelope::{mint_contract, Authoring, MintContractArgs};
 use provekit_ir_types::{
     AggregationStrategy, CodeSite, CodeSiteSpan, CompoundContractMemento, ConceptSiteMemento,
     ConceptSiteProvenance, Discharge, EvidenceMemento, EvidenceRef, IrFormula, LossRecord,
-    SourceKind, SourceLocator, SourceLocatorPoint, SourceLocatorSpan,
+    PolicyMemento, PromotionDecisionEnvelope, PromotionDecisionHeader, PromotionDecisionMemento,
+    PromotionDecisionMetadata, PromotionGate, PromotionResult, ProofGatePolicyMemento, SourceKind,
+    SourceLocator, SourceLocatorPoint, SourceLocatorSpan,
 };
 use provekit_proof_envelope::Ed25519Seed;
 
@@ -291,6 +295,16 @@ pub fn run(args: BindArgs) -> u8 {
             serde_json::to_string_pretty(evidence).unwrap_or_default(),
         );
     }
+    let _ = std::fs::create_dir_all(output_dir.join("policies"));
+    for (policy_cid, policy) in &result.policies {
+        let path = output_dir
+            .join("policies")
+            .join(format!("{}.json", safe_filename(policy_cid)));
+        let _ = std::fs::write(
+            &path,
+            serde_json::to_string_pretty(policy).unwrap_or_default(),
+        );
+    }
     let _ = std::fs::create_dir_all(output_dir.join("contracts"));
     for contract in &result.compound_contracts {
         let path = output_dir
@@ -299,6 +313,16 @@ pub fn run(args: BindArgs) -> u8 {
         let _ = std::fs::write(
             &path,
             serde_json::to_string_pretty(contract).unwrap_or_default(),
+        );
+    }
+    let _ = std::fs::create_dir_all(output_dir.join("promotion-decisions"));
+    for decision in &result.promotion_decisions {
+        let path = output_dir
+            .join("promotion-decisions")
+            .join(format!("{}.json", safe_filename(&decision.header.cid)));
+        let _ = std::fs::write(
+            &path,
+            serde_json::to_string_pretty(decision).unwrap_or_default(),
         );
     }
     let _ = std::fs::create_dir_all(output_dir.join("sites"));
@@ -406,7 +430,9 @@ pub struct EngineResult {
     pub bindings: Vec<BindingRecord>,
     pub concepts: Vec<ConceptRecord>,
     pub evidence_mementos: Vec<EvidenceMemento>,
+    pub policies: BTreeMap<String, PolicyMemento>,
     pub compound_contracts: Vec<CompoundContractMemento>,
+    pub promotion_decisions: Vec<PromotionDecisionMemento>,
     pub site_mementos: Vec<ConceptSiteMemento>,
     pub gaps: Vec<GapRecord>,
 }
@@ -761,12 +787,17 @@ fn run_bind_engine(
     // ---- Verb 4: SCOPE + Verb 6: IDENTIFY + Verb 7: REALIZE ----------------
     let mut bindings: Vec<BindingRecord> = Vec::new();
     let mut evidence_mementos: Vec<EvidenceMemento> = Vec::new();
+    let mut policies: BTreeMap<String, PolicyMemento> = BTreeMap::new();
     let mut compound_contracts: Vec<CompoundContractMemento> = Vec::new();
+    let mut promotion_decisions: Vec<PromotionDecisionMemento> = Vec::new();
     let mut site_mementos: Vec<ConceptSiteMemento> = Vec::new();
 
     let lifter_cid = blake3_512_of(b"provekit-cli/bind-v0/lifter");
     let clusterer_cid = blake3_512_of(b"provekit-cli/bind-v0/clusterer");
     let discharger_cid = blake3_512_of(b"provekit-cli/bind-v0/discharger");
+    let bind_default_policy = bind_default_policy_memento(&lifter_cid);
+    let bind_default_policy_cid = policy_memento_cid(&bind_default_policy);
+    policies.insert(bind_default_policy_cid.clone(), bind_default_policy);
 
     for lift in &raw_lifts {
         let shape_cid = lift.term_shape.shape_cid();
@@ -869,6 +900,24 @@ fn run_bind_engine(
                 .as_ref()
                 .map(|c| c.cid.clone())
                 .unwrap_or_else(|| local_cid.clone());
+            if let Some(compound) = compound.as_ref() {
+                for evidence in &site_evidences {
+                    let decision = promotion_decision_memento(
+                        &local_cid,
+                        &compound.cid,
+                        evidence,
+                        &bind_default_policy_cid,
+                        &lifter_cid,
+                    )
+                    .map_err(|err| {
+                        format!(
+                            "promotion decision failed for evidence {} into {}: {err}",
+                            evidence.cid, compound.cid
+                        )
+                    })?;
+                    promotion_decisions.push(decision);
+                }
+            }
             evidence_mementos.extend(site_evidences);
             if let Some(compound) = compound {
                 compound_contracts.push(compound);
@@ -1052,7 +1101,9 @@ fn run_bind_engine(
         bindings,
         concepts,
         evidence_mementos,
+        policies,
         compound_contracts,
+        promotion_decisions,
         site_mementos,
         gaps,
     })
@@ -2105,6 +2156,108 @@ fn evidence_memento_cid(
         ("source_locator", source_locator_to_value(source_locator)),
     ]);
     blake3_512_of(encode_jcs(&header).as_bytes())
+}
+
+fn bind_default_policy_memento(lifter_cid: &str) -> PolicyMemento {
+    PolicyMemento::ProofGate(ProofGatePolicyMemento {
+        admission_rule: serde_json::json!({
+            "result": "admitted",
+            "requires": ["non-empty evidence_cids"]
+        }),
+        checker_cid: lifter_cid.to_string(),
+        decision_payload_schema: serde_json::json!({
+            "type": "object",
+            "required": ["evidence_count", "gate_evaluated", "result"]
+        }),
+        input_requirements: serde_json::json!({
+            "evidence_cids": "non-empty",
+            "candidate_cid": "required",
+            "promoted_cid": "required"
+        }),
+        policy_kind: "proof_gate".to_string(),
+        policy_version: "bind-default-policy".to_string(),
+        proof_artifact_schema: serde_json::json!({
+            "kind": "bind-admission"
+        }),
+        proof_system: "provekit-bind".to_string(),
+        provenance_cid: lifter_cid.to_string(),
+        refusal_rule: serde_json::json!({
+            "result": "rejected"
+        }),
+        theorem_ref: "bind-default-policy".to_string(),
+        trusted_base_cid: lifter_cid.to_string(),
+    })
+}
+
+fn policy_memento_cid(policy: &PolicyMemento) -> String {
+    let json = serde_json::to_value(policy).expect("PolicyMemento must serialize");
+    let value = json_to_value(&json);
+    blake3_512_of(encode_jcs(&value).as_bytes())
+}
+
+fn promotion_decision_memento(
+    candidate_cid: &str,
+    promoted_cid: &str,
+    evidence: &EvidenceMemento,
+    policy_cid: &str,
+    decider_cid: &str,
+) -> Result<PromotionDecisionMemento, String> {
+    let gate = promotion_gate_for_evidence(evidence);
+    let gate_label = promotion_gate_label(&gate);
+    let mut decision = PromotionDecisionMemento {
+        envelope: PromotionDecisionEnvelope {
+            declared_at: "2026-05-13T00:00:00.000Z".to_string(),
+            signature: String::new(),
+            signer: decider_cid.to_string(),
+        },
+        header: PromotionDecisionHeader {
+            candidate_cid: candidate_cid.to_string(),
+            cid: String::new(),
+            decider_cid: decider_cid.to_string(),
+            decision_payload: serde_json::json!({
+                "evidence_count": 1,
+                "gate_evaluated": gate_label,
+                "result": "admitted"
+            }),
+            evidence_cids: vec![evidence.cid.clone()],
+            gate,
+            kind: "promotion-decision".to_string(),
+            policy_cid: policy_cid.to_string(),
+            promoted_cid: promoted_cid.to_string(),
+            result: PromotionResult::Admitted,
+            schema_version: "1".to_string(),
+        },
+        metadata: PromotionDecisionMetadata {
+            counterexample_cids: None,
+            note: Some(format!(
+                "bind admitted {} evidence into compound contract",
+                source_kind_label(&evidence.source_kind)
+            )),
+            source_url: None,
+        },
+    };
+    decision.header.cid = decision
+        .recompute_header_cid()
+        .map_err(|err| err.to_string())?;
+    decision.validate().map_err(|err| err.to_string())?;
+    Ok(decision)
+}
+
+fn promotion_gate_for_evidence(evidence: &EvidenceMemento) -> PromotionGate {
+    match &evidence.source_kind {
+        SourceKind::NativeSurface => PromotionGate::Human,
+        _ => PromotionGate::Proof,
+    }
+}
+
+fn promotion_gate_label(gate: &PromotionGate) -> &'static str {
+    match gate {
+        PromotionGate::Human => "human",
+        PromotionGate::Proof => "proof",
+        PromotionGate::Property => "property",
+        PromotionGate::Threshold => "threshold",
+        PromotionGate::Other(_) => "other",
+    }
 }
 
 fn compound_contract_memento(

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -19,6 +19,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use provekit_ir_types::{PromotionDecisionMemento, PromotionGate, PromotionResult};
+
 fn provekit_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
 }
@@ -114,6 +116,87 @@ for line in sys.stdin:
     root
 }
 
+fn copy_fixture_with_three_evidence_manifest() -> PathBuf {
+    let root = copy_fixture_to_temp();
+    let kit_path = root.join("bind-lift-kit.py");
+    let shape_cid = format!("blake3-512:{}", "1".repeat(128));
+    let script = format!(
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+SHAPE_CID = {shape_cid:?}
+
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request.get("method")
+    request_id = request.get("id")
+    if method == "initialize":
+        result = {{}}
+    elif method == "lift":
+        result = {{
+            "kind": "ir-document",
+            "diagnostics": [],
+            "ir": [{{
+                "kind": "bind-lift-entry",
+                "file": "src/account.rs",
+                "fn_name": "deposit",
+                "fn_line": 14,
+                "concept_annotation": "deposit-then-balance",
+                "param_names": ["balance", "amount"],
+                "param_types": ["i64", "i64"],
+                "return_type": "i64",
+                "term_shape": {{"kind": "body", "stmts": [{{"kind": "opaque"}}]}},
+                "term_shape_cid": SHAPE_CID,
+                "witnesses": [
+                    {{
+                        "role": "pre",
+                        "predicate_text": "amount > 0",
+                        "source_kind": "type-signature",
+                        "line": 14,
+                        "col": 20
+                    }},
+                    {{
+                        "role": "post",
+                        "predicate_text": "out >= balance",
+                        "source_kind": "docstring",
+                        "line": 13,
+                        "col": 0
+                    }},
+                    {{
+                        "role": "post",
+                        "predicate_text": "out == balance + amount",
+                        "source_kind": "test-assertion",
+                        "line": 7,
+                        "col": 8
+                    }}
+                ]
+            }}]
+        }}
+    elif method == "shutdown":
+        result = {{}}
+    else:
+        print(json.dumps({{"jsonrpc": "2.0", "id": request_id, "error": {{"message": "unknown method"}}}}), flush=True)
+        continue
+    print(json.dumps({{"jsonrpc": "2.0", "id": request_id, "result": result}}), flush=True)
+    if method == "shutdown":
+        break
+"#
+    );
+    fs::write(&kit_path, script).expect("write bind lift kit");
+    let manifest_dir = root.join(".provekit").join("lift").join("rust");
+    fs::create_dir_all(&manifest_dir).expect("create lift manifest dir");
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"test-bind-lift-three-evidence\"\ncommand = [\"python3\", \"{}\"]\n",
+            kit_path.display()
+        ),
+    )
+    .expect("write lift manifest");
+    root
+}
+
 fn bind_cmd(
     root: &Path,
     out: &Path,
@@ -189,7 +272,7 @@ fn help_lists_bind_command() {
 
 #[test]
 fn annotate_monitor_injects_concept_and_monitor_attr() {
-    let tmp = copy_fixture_to_temp();
+    let tmp = copy_fixture_with_bind_lift_manifest();
     let out = tempfile::tempdir().expect("tempdir").into_path();
     let result = bind_cmd(&tmp, &out, "annotate", "monitor", None);
     assert!(
@@ -222,7 +305,7 @@ fn annotate_monitor_injects_concept_and_monitor_attr() {
 
 #[test]
 fn annotate_emitter_injects_emitter_attribute() {
-    let tmp = copy_fixture_to_temp();
+    let tmp = copy_fixture_with_bind_lift_manifest();
     let out = tempfile::tempdir().expect("tempdir").into_path();
     let result = bind_cmd(&tmp, &out, "annotate", "emitter", None);
     assert!(result.status.success(), "annotate+emitter should succeed");
@@ -235,7 +318,7 @@ fn annotate_emitter_injects_emitter_attribute() {
 
 #[test]
 fn annotate_witness_injects_witness_attribute() {
-    let tmp = copy_fixture_to_temp();
+    let tmp = copy_fixture_with_bind_lift_manifest();
     let out = tempfile::tempdir().expect("tempdir").into_path();
     let result = bind_cmd(&tmp, &out, "annotate", "witness", None);
     assert!(result.status.success(), "annotate+witness should succeed");
@@ -252,7 +335,7 @@ fn annotate_witness_injects_witness_attribute() {
 
 #[test]
 fn canonical_monitor_rust_target_creates_translated_dir() {
-    let root = fixture_root();
+    let root = copy_fixture_with_bind_lift_manifest();
     let out = tempfile::tempdir().expect("tempdir").into_path();
     let result = bind_cmd(&root, &out, "canonical", "monitor", Some("rust"));
     assert!(
@@ -368,7 +451,7 @@ fn invisible_witness_does_not_modify_source() {
 
 #[test]
 fn bind_writes_site_mementos_index_and_gaps() {
-    let root = fixture_root();
+    let root = copy_fixture_with_bind_lift_manifest();
     let out = tempfile::tempdir().expect("tempdir").into_path();
     let result = bind_cmd(&root, &out, "invisible", "monitor", None);
     assert!(result.status.success(), "invisible+monitor should succeed");
@@ -469,6 +552,69 @@ fn bind_writes_evidence_and_compound_contracts() {
         }),
         "ConceptSiteMemento.local_contract_cid must point at a compound contract CID"
     );
+}
+
+#[test]
+fn bind_mints_promotion_decisions_for_admitted_evidence() {
+    let root = copy_fixture_with_three_evidence_manifest();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "invisible", "monitor", None);
+    assert!(
+        result.status.success(),
+        "invisible+monitor should succeed\nstderr: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let evidence_docs = read_json_dir(&out.join("evidence"));
+    assert_eq!(
+        evidence_docs.len(),
+        3,
+        "fixture should admit exactly three EvidenceMementos"
+    );
+
+    let promotion_dir = out.join("promotion-decisions");
+    assert!(
+        promotion_dir.exists(),
+        "promotion-decisions/ must be written"
+    );
+    let promotion_docs = read_json_dir(&promotion_dir);
+    assert_eq!(
+        promotion_docs.len(),
+        evidence_docs.len(),
+        "bind must mint one PromotionDecisionMemento per admitted evidence field"
+    );
+
+    for doc in promotion_docs {
+        let decision: PromotionDecisionMemento =
+            serde_json::from_value(doc).expect("parse PromotionDecisionMemento");
+        decision
+            .validate()
+            .expect("promotion decisions must carry non-empty evidence_cids");
+        assert_eq!(
+            decision.header.cid,
+            decision
+                .recompute_header_cid()
+                .expect("recompute header cid"),
+            "header.cid must match recomputed CID"
+        );
+        let serialized = serde_json::to_string(&decision).expect("serialize promotion decision");
+        let round_trip: PromotionDecisionMemento =
+            serde_json::from_str(&serialized).expect("deserialize promotion decision");
+        assert_eq!(decision, round_trip, "promotion decision must round-trip");
+        assert_eq!(decision.header.kind, "promotion-decision");
+        assert_eq!(decision.header.schema_version, "1");
+        assert_eq!(decision.header.result, PromotionResult::Admitted);
+        assert_eq!(decision.header.gate, PromotionGate::Proof);
+        assert_eq!(
+            decision.header.decision_payload["result"].as_str(),
+            Some("admitted")
+        );
+        assert_eq!(
+            decision.header.evidence_cids.len(),
+            1,
+            "each per-field admission should cite the admitted evidence CID"
+        );
+    }
 }
 
 // ============================================================================
@@ -1200,7 +1346,7 @@ fn f5_csharp_canonical_parses() {
 
 #[test]
 fn f6_gaps_record_stub_body_emitted_per_concept() {
-    let root = fixture_root();
+    let root = copy_fixture_with_bind_lift_manifest();
     let out = tempfile::tempdir().expect("tempdir").into_path();
     // Canonical Rust→Go forces the realize path for every binding, and none
     // of the Go templates exist in v1.0.0, so every concept must produce a


### PR DESCRIPTION
Step #3 of the substrate-types wiring sequence (admissibility-spine #796 next-phase plan).

provekit bind now persists a baked `bind-default-policy` PolicyMemento (ProofGatePolicyMemento variant) and mints one validated, content-addressed PromotionDecisionMemento per evidence admitted into a CompoundContractMemento. Every admission becomes a durable, citable record per the master-frame admissibility-spine framing: every irreversible substrate claim needs a memento that says what was observed, what policy admitted it, what semantic object resulted.

## Per admission

| Field | Value |
|---|---|
| `candidate_cid` | pre-admission contract shape |
| `promoted_cid` | resulting compound/FCM CID |
| `evidence_cids` | non-empty per #824 .validate() |
| `gate` | `PromotionGate::Proof` |
| `policy_cid` | baked-in `bind-default-policy` ProofGatePolicyMemento CID |
| `decision_payload` | structured `{evidence_count, gate_evaluated, result}` |
| `decider_cid` | lifter/extractor identity |
| `result` | `PromotionResult::Admitted` |

`header.cid` via `PromotionDecisionMemento::recompute_header_cid()`. `.validate()` called before persistence (rejects empty evidence_cids per spec §1 CDDL `[+ cid]`).

## Files modified

- `provekit-cli/src/cmd_bind.rs`
- `provekit-cli/src/cmd_compose.rs`
- `provekit-walk/src/chain.rs`
- `provekit-cli/tests/cmd_bind_integration.rs`

## Tests

`cmd_bind_integration`: 14 passed.
`provekit-walk`: 288 passed.

Integration test: `bind_mints_promotion_decisions_for_admitted_evidence` — 3 admitted evidences → 3 PromotionDecisionMementos, each validates, recomputes, round-trips, uses Proof gate + Admitted result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)