### PR TITLE
fix(#859): hermetic trinity fixture root + plugin discovery (PR 2 of #859)

### DIFF
--- a/implementations/rust/provekit-cli/tests/trinity_roundtrip_test.rs
+++ b/implementations/rust/provekit-cli/tests/trinity_roundtrip_test.rs
@@ -44,6 +44,73 @@ fn trinity_fixture_root() -> PathBuf {
         .join("trinity_roundtrip")
 }
 
+fn rust_workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("provekit-cli manifest dir has rust workspace parent")
+        .to_path_buf()
+}
+
+fn exe_name(name: &str) -> String {
+    format!("{name}{}", std::env::consts::EXE_SUFFIX)
+}
+
+fn ensure_rust_lift_rpc_built() -> PathBuf {
+    let provekit = provekit_bin();
+    let bin_dir = provekit
+        .parent()
+        .expect("provekit binary path has parent directory");
+    let rpc_bin = bin_dir.join(exe_name("provekit-walk-rpc"));
+    let rust_workspace = rust_workspace_root();
+    let target_dir = bin_dir
+        .parent()
+        .expect("cargo target dir has profile parent");
+
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut cmd = Command::new(cargo);
+    cmd.current_dir(&rust_workspace)
+        .env("CARGO_TARGET_DIR", target_dir);
+    cmd.arg("build")
+        .arg("--manifest-path")
+        .arg(rust_workspace.join("Cargo.toml"))
+        .arg("-p")
+        .arg("provekit-walk")
+        .arg("--bin")
+        .arg("provekit-walk-rpc");
+    if bin_dir.file_name().and_then(|n| n.to_str()) == Some("release") {
+        cmd.arg("--release");
+    }
+
+    let output = cmd.output().expect("spawn cargo build for rust lift rpc");
+    assert!(
+        output.status.success(),
+        "cargo build failed for rust lift rpc\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        rpc_bin.exists(),
+        "rust lift rpc missing after cargo build at {}",
+        rpc_bin.display()
+    );
+    rpc_bin
+}
+
+fn install_rust_lift_manifest(fixture_root: &Path, rpc_bin: &Path) {
+    let manifest = fixture_root
+        .join(".provekit")
+        .join("lift")
+        .join("rust-bind")
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().expect("manifest path has parent"))
+        .expect("create fixture rust lift manifest dir");
+    let manifest_text = format!(
+        "name = \"rust-bind-lift\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+        rpc_bin.display()
+    );
+    fs::write(&manifest, manifest_text).expect("write fixture rust lift manifest");
+}
+
 fn copy_dir(src: &Path, dst: &Path) {
     let _ = fs::create_dir_all(dst);
     let Ok(entries) = fs::read_dir(src) else {
@@ -172,9 +239,12 @@ fn normalize_whitespace(s: &str) -> String {
 
 #[test]
 fn trinity_round_trip() {
+    let rust_lift_rpc = ensure_rust_lift_rpc_built();
+
     // Copy fixture to a tempdir so annotate writes cannot corrupt checked-in source.
     let fixture_tmp = tempfile::tempdir().expect("tempdir").into_path();
     copy_dir(&trinity_fixture_root(), &fixture_tmp);
+    install_rust_lift_manifest(&fixture_tmp, &rust_lift_rpc);
 
     // ── Leg 1: Rust → Java ────────────────────────────────────────────────────
     let out1 = tempfile::tempdir().expect("tempdir").into_path();


### PR DESCRIPTION
PR 2 of #859. Closes the regression from commit `91c408d6` / PR #779. Test-only change, no substrate code touched.

## What this fixes

Diagnosis at #860 identified: the trinity harness passes a temp fixture root as `workspace_root` to `kit_dispatch::dispatch_bind_lift`. The temp root contains only `src/lib.rs`, not `.provekit/lift/rust-bind/manifest.toml`. Fallback sibling-binary discovery (looking for `provekit-walk-rpc` next to `provekit`) failed in a clean cargo target dir because cargo only built `debug/provekit` for the integration test.

The harness now:

1. **Builds `provekit-walk-rpc`** into the same target dir as the tested `provekit` binary
2. **Writes a temp-fixture `.provekit/lift/rust-bind/manifest.toml`** pointing at that just-built binary (not at the repo-root `debug/provekit-walk-rpc`, which would re-introduce target-dir state dependence)

## Acceptance gate (the empirical receipt)

**Fresh `CARGO_TARGET_DIR`** (the gate the diagnosis prescribed):

```bash
CARGO_TARGET_DIR=$(mktemp -d /private/tmp/pk-trinity-fresh-XXXXXX) \
  cargo test --manifest-path implementations/rust/Cargo.toml \
  -p provekit-cli --test trinity_roundtrip_test -- --nocapture
```

`test result: ok. 1 passed; 0 failed; finished in 5.74s`

**Warm target dir** (no regression):

```bash
cargo test --manifest-path implementations/rust/Cargo.toml \
  -p provekit-cli --test trinity_roundtrip_test -- --nocapture
```

`test result: ok. 1 passed; 0 failed; finished in 2.94s`

Output is `v0 loudly-bounded-lossy outcome (14 loss entries; Branch 2 per-line characterization gated until real lifters land)`. This is the **existing** v0 lossy semantics; Branch 2 byte-identity is PR 3 territory (Rust realize kit + body templates).

## What this PR does NOT touch

- C realizer parseability (PR 4 of #859)
- Rust realize kit + `rust-canonical-bodies.json` (PR 3 of #859)
- HTTP trinity payload (Bridge D, paused)
- v0 lossy semantics / overclaim wording cleanup (separate docs PR; T Savo item 3 in the locked order)

## Closes which of T Savo's locked items

- ✅ (1) Fix the regression from `91c408d6`
- ✅ (2) Make trinity gate hermetic in CI (the test now passes the same way fresh-target as warm-target; CI can't mask the failure)
- ⏳ (3) Correct historical wording (separate docs PR)
- ⏳ (4) Resume Bridge D (post-baseline-green; further PRs may be needed if byte-identity is the gate)

## Pre-existing formatting drift surfaced (not fixed)

`cargo fmt --check` on the provekit-cli manifest reports unrelated formatting drift in `cmd_bind.rs`, `cmd_transport.rs`, `kit_dispatch.rs`. Pre-existing, not caused by this PR, not in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)