### PR TITLE
feat(#849): Bridge D - 4-language HTTP trinity payload

### DIFF
--- a/implementations/rust/provekit-cli/tests/fixtures/trinity_roundtrip/src/lib.rs
+++ b/implementations/rust/provekit-cli/tests/fixtures/trinity_roundtrip/src/lib.rs
@@ -5,6 +5,7 @@
 // Uses the 11 trinity catalog concepts:
 //   option, pair, result, tagged-union, identity, list,
 //   unit, assert, bool-cell, option-bind, result-bind
+// Plus one API-tier HTTP request concept for the Bridge D receipt.
 //
 // Also includes a retry-loop shape so that seed_catalog() produces
 // at least one classified binding on leg 1, giving the test a
@@ -127,6 +128,13 @@ pub fn retry_until_success(max_attempts: i64) -> bool {
         }
     }
     false
+}
+
+// -- http-request ------------------------------------------------------------
+// concept: http-request
+pub async fn fetch_url_status(url: String) -> i64 {
+    let response = reqwest::get(&url).await.unwrap();
+    response.status().as_u16() as i64
 }
 
 // ── unit tests ────────────────────────────────────────────────────────────────

--- a/implementations/rust/provekit-cli/tests/trinity_roundtrip_test.rs
+++ b/implementations/rust/provekit-cli/tests/trinity_roundtrip_test.rs
@@ -9,17 +9,18 @@
 // The gate is the PR #861 hermetic fixture plus the v0 lossy expectations
 // enforced by this test.
 //
-// Future Branch 1 target: k(k'(k''(I)))=t, three composed transport keys over
-// the 11 trinity concepts with empty loss at each boundary. Java and Python
-// lift fixture wiring is still missing and is out of scope for #859.
+// Future Branch 1 target: four composed transport keys over the trinity
+// concepts with empty loss at each boundary. Java and Python lift fixture
+// wiring is still missing and is out of scope for #859.
 //
-// Three chained legs:
-//   Leg 1  Rust fixture  → Java   (--lang rust  --target-language java)
-//   Leg 2  Leg 1 java/   → Python (--lang auto  --target-language python)
-//   Leg 3  Leg 2 python/ → Rust   (--lang auto  --target-language rust)
+// Four chained legs:
+//   Leg 1  Rust fixture  -> Java   (--lang rust  --target-language java)
+//   Leg 2  Leg 1 java/   -> Python (--lang auto  --target-language python)
+//   Leg 3  Leg 2 python/ -> C      (--lang auto  --target-language c)
+//   Leg 4  Leg 3 c/      -> Rust   (--lang auto  --target-language rust)
 //
 // Each leg writes gaps.json.  compose_losses unions the REAL gap records from
-// all three legs.  No synthetic entries are injected — real loss comes from
+// all four legs.  No synthetic entries are injected; real loss comes from
 // bind's own gap emission (F2: source-language-not-supported records).
 //
 // Trichotomy (Supra omnia, rectum):
@@ -27,13 +28,14 @@
 //   else                      -> v0: assert REAL + EXPECTED gap kinds in composed loss
 //                                (Branch 2 per-line characterization gated; see F3 fix)
 //
-// v0 expected outcome: legs 2 and 3 receive non-Rust sources; bind detects
-// java/python via auto-detect, emits source-language-not-supported gap records
-// in gaps.json.  compose_losses returns real entries from those legs.
+// v0 expected outcome: later legs receive non-Rust sources; bind detects
+// java/python/c via auto-detect when those boundaries are reached, and emits
+// real lift-boundary gap records in gaps.json. compose_losses returns real
+// entries from those legs.
 // Test passes via the "loudly-bounded-lossy is a first-class legitimate outcome"
 // branch, asserting the real gap kinds are present (NOT a permissive predicate).
 //
-// Branch 2 per-line divergence characterization is gated until real Java/Python→Rust
+// Branch 2 per-line divergence characterization is gated until real Java/Python->Rust
 // lifters land + a divergence-pattern registry is built.  See PR-F of #716 follow-up.
 
 use std::collections::BTreeMap;
@@ -56,6 +58,23 @@ fn rust_workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("provekit-cli manifest dir has rust workspace parent")
+        .to_path_buf()
+}
+
+fn repo_root() -> PathBuf {
+    let rust_workspace = rust_workspace_root();
+    rust_workspace
+        .parent()
+        .expect("rust workspace has implementations parent")
+        .parent()
+        .expect("implementations dir has repo parent")
+        .to_path_buf()
+}
+
+fn cargo_profile_dir() -> PathBuf {
+    provekit_bin()
+        .parent()
+        .expect("provekit binary path has parent directory")
         .to_path_buf()
 }
 
@@ -147,6 +166,139 @@ fn ensure_rust_realize_rpc_built() -> PathBuf {
     rpc_bin
 }
 
+fn ensure_java_realize_rpc_built() -> PathBuf {
+    let repo = repo_root();
+    let java_dir = repo.join("implementations").join("java");
+    let jar = java_dir
+        .join("provekit-realize-java-core")
+        .join("target")
+        .join("provekit-realize-java.jar");
+
+    let output = Command::new("mvn")
+        .args([
+            "package",
+            "-pl",
+            "provekit-realize-java-core",
+            "-am",
+            "-DskipTests",
+        ])
+        .current_dir(&java_dir)
+        .output()
+        .expect("spawn mvn package for java realize rpc");
+    assert!(
+        output.status.success(),
+        "mvn package failed for java realize rpc\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        jar.exists(),
+        "java realize jar missing after mvn package at {}",
+        jar.display()
+    );
+    jar
+}
+
+fn java_bin() -> String {
+    if let Some(java_home) = std::env::var_os("JAVA_HOME") {
+        let candidate = PathBuf::from(java_home).join("bin").join(exe_name("java"));
+        if candidate.exists() {
+            return candidate.display().to_string();
+        }
+    }
+
+    if let Ok(output) = Command::new("mvn").arg("-version").output() {
+        let combined = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        for line in combined.lines() {
+            if let Some((_, runtime)) = line.split_once("runtime: ") {
+                let candidate = PathBuf::from(runtime.trim())
+                    .join("bin")
+                    .join(exe_name("java"));
+                if candidate.exists() {
+                    return candidate.display().to_string();
+                }
+            }
+        }
+    }
+
+    "java".to_string()
+}
+
+fn ensure_c_realize_rpc_built() -> PathBuf {
+    let repo = repo_root();
+    let kit_dir = repo
+        .join("implementations")
+        .join("c")
+        .join("provekit-realize-c-core");
+    let source_bin = kit_dir
+        .join("target")
+        .join("release")
+        .join(exe_name("provekit-realize-c"));
+    let profile_bin = cargo_profile_dir().join(exe_name("provekit-realize-c"));
+
+    let output = Command::new("make")
+        .current_dir(&kit_dir)
+        .output()
+        .expect("spawn make for c realize rpc");
+    assert!(
+        output.status.success(),
+        "make failed for c realize rpc\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        source_bin.exists(),
+        "c realize rpc missing after make at {}",
+        source_bin.display()
+    );
+    fs::copy(&source_bin, &profile_bin).unwrap_or_else(|e| {
+        panic!(
+            "copy c realize rpc {} to {}: {e}",
+            source_bin.display(),
+            profile_bin.display()
+        )
+    });
+    profile_bin
+}
+
+fn ensure_c_lift_rpc_built() -> PathBuf {
+    let repo = repo_root();
+    let kit_dir = repo
+        .join("implementations")
+        .join("c")
+        .join("provekit-walk-c");
+    let source_bin = kit_dir.join(exe_name("provekit-bind-lift-c"));
+    let profile_bin = cargo_profile_dir().join(exe_name("provekit-bind-lift-c"));
+
+    let output = Command::new("make")
+        .current_dir(&kit_dir)
+        .output()
+        .expect("spawn make for c bind lift rpc");
+    assert!(
+        output.status.success(),
+        "make failed for c bind lift rpc\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        source_bin.exists(),
+        "c bind lift rpc missing after make at {}",
+        source_bin.display()
+    );
+    fs::copy(&source_bin, &profile_bin).unwrap_or_else(|e| {
+        panic!(
+            "copy c bind lift rpc {} to {}: {e}",
+            source_bin.display(),
+            profile_bin.display()
+        )
+    });
+    profile_bin
+}
+
 fn install_rust_lift_manifest(fixture_root: &Path, rpc_bin: &Path) {
     let manifest = fixture_root
         .join(".provekit")
@@ -175,6 +327,79 @@ fn install_rust_realize_manifest(fixture_root: &Path, rpc_bin: &Path) {
         rpc_bin.display()
     );
     fs::write(&manifest, manifest_text).expect("write fixture rust realize manifest");
+}
+
+fn manifest_command(command: &[String]) -> String {
+    command
+        .iter()
+        .map(|arg| format!("\"{}\"", arg.replace('\\', "\\\\").replace('"', "\\\"")))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn install_lift_manifest(fixture_root: &Path, surface: &str, name: &str, command: &[String]) {
+    let manifest = fixture_root
+        .join(".provekit")
+        .join("lift")
+        .join(surface)
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().expect("manifest path has parent"))
+        .expect("create fixture lift manifest dir");
+    let manifest_text = format!(
+        "name = \"{name}\"\ncommand = [{}]\nworking_dir = \".\"\n",
+        manifest_command(command)
+    );
+    fs::write(&manifest, manifest_text).expect("write fixture lift manifest");
+}
+
+fn install_realize_manifest(fixture_root: &Path, lang: &str, name: &str, command: &[String]) {
+    let manifest = fixture_root
+        .join(".provekit")
+        .join("realize")
+        .join(lang)
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().expect("manifest path has parent"))
+        .expect("create fixture realize manifest dir");
+    let manifest_text = format!(
+        "name = \"{name}\"\ncommand = [{}]\nworking_dir = \".\"\n",
+        manifest_command(command)
+    );
+    fs::write(&manifest, manifest_text).expect("write fixture realize manifest");
+}
+
+fn java_realize_command(jar: &Path) -> Vec<String> {
+    vec![
+        java_bin(),
+        "-jar".to_string(),
+        jar.display().to_string(),
+        "--rpc".to_string(),
+    ]
+}
+
+fn python_realize_command() -> Vec<String> {
+    vec![
+        std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string()),
+        "-m".to_string(),
+        "provekit_realize_python_core".to_string(),
+        "--rpc".to_string(),
+    ]
+}
+
+fn rpc_command(rpc_bin: &Path) -> Vec<String> {
+    vec![rpc_bin.display().to_string(), "--rpc".to_string()]
+}
+
+fn pythonpath_with_realize_src() -> std::ffi::OsString {
+    let repo = repo_root();
+    let mut paths = vec![repo
+        .join("implementations")
+        .join("python")
+        .join("provekit-realize-python-core")
+        .join("src")];
+    if let Some(existing) = std::env::var_os("PYTHONPATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    std::env::join_paths(paths).expect("join PYTHONPATH")
 }
 
 fn copy_dir(src: &Path, dst: &Path) {
@@ -214,6 +439,8 @@ fn bind_cmd_with_lang(
         .arg("--mode")
         .arg("monitor")
         .arg("--quiet");
+    cmd.env("PROVEKIT_REPO_ROOT", repo_root());
+    cmd.env("PYTHONPATH", pythonpath_with_realize_src());
     if let Some(tl) = target_lang {
         cmd.arg("--target-language").arg(tl);
     }
@@ -251,15 +478,35 @@ fn read_gaps(out_dir: &Path) -> (String, Vec<GapEntry>) {
     (source_lang, gaps)
 }
 
+fn read_sources_with_extension(root: &Path, extension: &str) -> Vec<String> {
+    let Ok(entries) = fs::read_dir(root) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .and_then(|x| x.to_str())
+                .map(|x| x == extension)
+                .unwrap_or(false)
+        })
+        .map(|e| {
+            fs::read_to_string(e.path())
+                .unwrap_or_else(|err| panic!("read translated source: {err}"))
+        })
+        .collect()
+}
+
 // ── Loss composition ─────────────────────────────────────────────────────────
 
 /// Compose gap entries across all legs.
 ///
-/// Unions real gap records from all three legs.  No synthetic entries are
-/// injected here — loss must come from bind itself (via gaps.json) so the
+/// Unions real gap records from all four legs.  No synthetic entries are
+/// injected here; loss must come from bind itself (via gaps.json) so the
 /// composed record is substrate-residue, not test fabrication.
 ///
-/// Deduplication is by (kind, detail) — each unique gap appears once.
+/// Deduplication is by (kind, detail); each unique gap appears once.
 fn compose_losses(
     leg_results: &[(String, Vec<GapEntry>)], // (source_lang, gaps) per leg
 ) -> Vec<GapEntry> {
@@ -291,14 +538,14 @@ fn normalize_whitespace(s: &str) -> String {
 
 // NOTE: compute_diff and diff_is_characterized_by are removed (F3 fix, Option B).
 //
-// Branch 2 per-line divergence characterization is gated until real Java/Python→Rust
+// Branch 2 per-line divergence characterization is gated until real Java/Python->Rust
 // lifters land and a divergence-pattern registry exists.  In v0 the round-trip
 // test's job is to verify the chain runs and emits HONEST loss-records, not to
 // verify per-line divergence mapping.
 //
 // When real lifters land, reactivate Branch 2 as a separate PR with:
 //   - per-function loss mementos from bind
-//   - a `kind → divergence-pattern` registry
+//   - a `kind -> divergence-pattern` registry
 //   - compute_diff + per-line attribution loop
 
 // ── Main test ─────────────────────────────────────────────────────────────────
@@ -307,19 +554,28 @@ fn normalize_whitespace(s: &str) -> String {
 fn trinity_round_trip() {
     let rust_lift_rpc = ensure_rust_lift_rpc_built();
     let rust_realize_rpc = ensure_rust_realize_rpc_built();
+    let java_realize_jar = ensure_java_realize_rpc_built();
+    let c_realize_rpc = ensure_c_realize_rpc_built();
+    let c_lift_rpc = ensure_c_lift_rpc_built();
 
     // Copy fixture to a tempdir so annotate writes cannot corrupt checked-in source.
     let fixture_tmp = tempfile::tempdir().expect("tempdir").into_path();
     copy_dir(&trinity_fixture_root(), &fixture_tmp);
     install_rust_lift_manifest(&fixture_tmp, &rust_lift_rpc);
     install_rust_realize_manifest(&fixture_tmp, &rust_realize_rpc);
+    install_realize_manifest(
+        &fixture_tmp,
+        "java",
+        "java-realize",
+        &java_realize_command(&java_realize_jar),
+    );
 
-    // ── Leg 1: Rust → Java ────────────────────────────────────────────────────
+    // Leg 1: Rust -> Java
     let out1 = tempfile::tempdir().expect("tempdir").into_path();
     let r1 = bind_cmd_with_lang(&fixture_tmp, &out1, "rust", Some("java"));
     assert!(
         r1.status.success(),
-        "Leg 1 (Rust→Java) must succeed; stderr:\n{}",
+        "Leg 1 (Rust->Java) must succeed; stderr:\n{}",
         String::from_utf8_lossy(&r1.stderr)
     );
 
@@ -334,8 +590,28 @@ fn trinity_round_trip() {
         !java_files.is_empty(),
         "Leg 1 must produce at least one .java file"
     );
+    let java_sources = read_sources_with_extension(&java_dir, "java").join("\n");
+    assert!(
+        java_sources.contains("// concept: http-request"),
+        "Leg 1 must carry the HTTP fixture as concept:http-request in Java output; source:\n{}",
+        java_sources
+    );
+    assert!(
+        java_sources.contains("java.net.http.HttpClient"),
+        "Leg 1 must realize the HTTP fixture through the Java HTTP body template; source:\n{}",
+        java_sources
+    );
+    eprintln!(
+        "trinity_round_trip: HTTP fixture recognized as concept:http-request in leg 1 Java output"
+    );
 
     let (leg1_src_lang, leg1_gaps) = read_gaps(&out1);
+    install_realize_manifest(
+        &java_dir,
+        "python",
+        "python-realize",
+        &python_realize_command(),
+    );
 
     // index.json sanity: total_bindings + verdict breakdown.
     let idx1_raw =
@@ -357,41 +633,39 @@ fn trinity_round_trip() {
         "Leg 1: all bindings must have a verdict (exact+lossy+refuse == total)"
     );
 
-    // ── Leg 2: Leg-1 java/ → Python ──────────────────────────────────────────
+    // Leg 2: Leg-1 java/ -> Python
     // Root is the java translated dir; bind detects no .rs files, exits 0, writes
     // gaps.json with source_lang reflecting the auto-detect (not "rust").
     let out2 = tempfile::tempdir().expect("tempdir").into_path();
     let r2 = bind_cmd_with_lang(&java_dir, &out2, "auto", Some("python"));
     assert!(
         r2.status.success(),
-        "Leg 2 (Java→Python) must succeed; stderr:\n{}",
+        "Leg 2 (Java->Python) must succeed; stderr:\n{}",
         String::from_utf8_lossy(&r2.stderr)
     );
 
     let (leg2_src_lang, leg2_gaps) = read_gaps(&out2);
 
     // Leg 2 may or may not produce a python dir (v0 Rust-only; java source skips).
-    // We do NOT assert python dir exists — the loss composition handles the gap.
+    // We do not assert python dir exists; the loss composition handles the gap.
 
-    // ── Leg 3: Leg-2 python/ → Rust ──────────────────────────────────────────
+    // Leg 3: Leg-2 python/ -> C
     // Leg 3 chains from the python translated dir produced by leg 2.
-    // If that dir doesn't exist, bind on leg 2 was unable to cross the
-    // java→python boundary.  This is a legitimate loudly-bounded-lossy outcome
-    // IF AND ONLY IF leg 2's gaps.json contains a real gap record explaining why.
-    // We do NOT silently fall back to out2 (which would chain over Rust-shaped
-    // artifacts and produce garbage, hiding the real gap).
-    //
-    // If python_dir is absent: we verify leg 2 has the real gap, then skip leg 3.
+    // If that dir does not exist, bind on leg 2 was unable to cross the
+    // java->python boundary. This is a legitimate loudly-bounded-lossy outcome
+    // if and only if leg 2's gaps.json contains a real gap record explaining why.
+    // We do not silently fall back to out2, which would hide the boundary gap.
     let python_dir = out2.join("translated").join("python");
 
     // out3 is Some if leg 3 actually ran, None if the python boundary was absent.
     let out3: Option<PathBuf>;
     let (leg3_src_lang, leg3_gaps) = if python_dir.exists() {
+        install_realize_manifest(&python_dir, "c", "c-realize", &rpc_command(&c_realize_rpc));
         let out3_dir = tempfile::tempdir().expect("tempdir").into_path();
-        let r3 = bind_cmd_with_lang(&python_dir, &out3_dir, "auto", Some("rust"));
+        let r3 = bind_cmd_with_lang(&python_dir, &out3_dir, "auto", Some("c"));
         assert!(
             r3.status.success(),
-            "Leg 3 (Python→Rust) must succeed; stderr:\n{}",
+            "Leg 3 (Python->C) must succeed; stderr:\n{}",
             String::from_utf8_lossy(&r3.stderr)
         );
         let gaps3 = read_gaps(&out3_dir);
@@ -413,7 +687,7 @@ fn trinity_round_trip() {
             has_real_gap,
             "Leg 2 produced no translated/python/ dir but also recorded no \
              source-language-not-supported / kit-plugin-unavailable / \
-             bind-lift-empty gap in gaps.json — this is a substrate bug: bind \
+             bind-lift-empty gap in gaps.json. This is a substrate bug: bind \
              must either produce output OR record why it can't. \
              leg2 source_lang={:?}, leg2 gaps={:?}",
             leg2_gap_lang, leg2_real_gaps
@@ -426,19 +700,78 @@ fn trinity_round_trip() {
             vec![GapEntry {
                 kind: "leg-3-not-reached".into(),
                 detail: format!(
-                    "leg 3 (python→rust) was not executed because leg 2 produced no \
+                    "leg 3 (python->c) was not executed because leg 2 produced no \
                      translated/python/ output; leg 2 source_lang={leg2_gap_lang} with \
-                     source-language-not-supported gap"
+                     lift-boundary gap"
                 ),
             }],
         )
     };
 
-    // ── Compose losses across all three legs ──────────────────────────────────
+    // Leg 4: Leg-3 c/ -> Rust
+    let c_dir = out3
+        .as_ref()
+        .map(|out3_dir| out3_dir.join("translated").join("c"));
+    let out4: Option<PathBuf>;
+    let (leg4_src_lang, leg4_gaps) = if let Some(c_dir) = c_dir.as_ref() {
+        if c_dir.exists() {
+            install_lift_manifest(c_dir, "c", "c-bind-lift", &rpc_command(&c_lift_rpc));
+            install_rust_realize_manifest(c_dir, &rust_realize_rpc);
+            let out4_dir = tempfile::tempdir().expect("tempdir").into_path();
+            let r4 = bind_cmd_with_lang(c_dir, &out4_dir, "auto", Some("rust"));
+            assert!(
+                r4.status.success(),
+                "Leg 4 (C->Rust) must succeed; stderr:\n{}",
+                String::from_utf8_lossy(&r4.stderr)
+            );
+            let gaps4 = read_gaps(&out4_dir);
+            out4 = Some(out4_dir);
+            gaps4
+        } else {
+            let (leg3_gap_lang, leg3_real_gaps) = read_gaps(out3.as_ref().unwrap());
+            let has_real_gap = leg3_real_gaps.iter().any(|g| {
+                g.kind == "source-language-not-supported"
+                    || g.kind == "kit-plugin-unavailable"
+                    || g.kind == "bind-lift-empty"
+            });
+            assert!(
+                has_real_gap,
+                "Leg 3 produced no translated/c/ dir but also recorded no \
+                 source-language-not-supported / kit-plugin-unavailable / \
+                 bind-lift-empty gap in gaps.json. \
+                 leg3 source_lang={:?}, leg3 gaps={:?}",
+                leg3_gap_lang, leg3_real_gaps
+            );
+            out4 = None;
+            (
+                leg3_gap_lang.clone(),
+                vec![GapEntry {
+                    kind: "leg-4-not-reached".into(),
+                    detail: format!(
+                        "leg 4 (c->rust) was not executed because leg 3 produced no \
+                         translated/c/ output; leg 3 source_lang={leg3_gap_lang} with \
+                         lift-boundary gap"
+                    ),
+                }],
+            )
+        }
+    } else {
+        out4 = None;
+        (
+            leg3_src_lang.clone(),
+            vec![GapEntry {
+                kind: "leg-4-not-reached".into(),
+                detail: "leg 4 (c->rust) was not executed because leg 3 was not reached".into(),
+            }],
+        )
+    };
+
+    // Compose losses across all four legs.
     let composed_loss = compose_losses(&[
         (leg1_src_lang.clone(), leg1_gaps),
         (leg2_src_lang.clone(), leg2_gaps),
         (leg3_src_lang.clone(), leg3_gaps),
+        (leg4_src_lang.clone(), leg4_gaps),
     ]);
 
     // ── Trichotomy assertion (Supra omnia, rectum) ────────────────────────────
@@ -454,8 +787,9 @@ fn trinity_round_trip() {
     // #860, #861, #862, #863. Branch 1 byte-identity still needs Java and
     // Python lift fixture wiring.
     //
-    // v0 expected outcome: legs 2 and 3 receive non-Rust sources; bind detects
-    // java/python via auto-detect and emits source-language-not-supported gaps.
+    // v0 expected outcome: later legs receive non-Rust sources; bind detects
+    // java/python/c via auto-detect when those boundaries are reached and emits
+    // lift-boundary gaps.
     // We land in Branch 2 with real loss records.
     //
     // The original fixture source is the Rust fixture used in leg 1.
@@ -483,19 +817,19 @@ fn trinity_round_trip() {
     };
 
     if composed_loss.is_empty() {
-        // Future Branch 1: every concept survived all three hops byte-identical.
+        // Future Branch 1: every concept survived all four hops byte-identical.
         // NOT YET REACHABLE in the current #859 state; Java and Python lift
         // fixture wiring is still missing.
-        // Leg-3 must have run and its rust output must match the original fixture.
-        let out3_dir = out3.as_ref().expect(
-            "Branch 1 (empty loss) requires leg 3 to have run; \
-             out3 is None means python_dir was absent, which implies non-empty loss",
+        // Leg 4 must have run and its rust output must match the original fixture.
+        let out4_dir = out4.as_ref().expect(
+            "Branch 1 (empty loss) requires leg 4 to have run; \
+             out4 is None means the c boundary was absent, which implies non-empty loss",
         );
         let original_source = fs::read_to_string(&fixture_path).expect("read original fixture");
-        let rust_out_dir = out3_dir.join("translated").join("rust");
+        let rust_out_dir = out4_dir.join("translated").join("rust");
         assert!(
             rust_out_dir.exists(),
-            "Branch 1 (empty loss): leg 3 must produce translated/rust/ dir"
+            "Branch 1 (empty loss): leg 4 must produce translated/rust/ dir"
         );
         let rs_files: Vec<_> = fs::read_dir(&rust_out_dir)
             .expect("read rust out dir")
@@ -504,29 +838,29 @@ fn trinity_round_trip() {
             .collect();
         assert!(
             !rs_files.is_empty(),
-            "Branch 1: leg 3 rust out dir must contain .rs files"
+            "Branch 1: leg 4 rust out dir must contain .rs files"
         );
         let rust_back_source =
-            fs::read_to_string(rs_files[0].path()).expect("read leg-3 rust output");
+            fs::read_to_string(rs_files[0].path()).expect("read leg-4 rust output");
 
         let normalized_back = normalize_whitespace(&rust_back_source);
         let normalized_orig = normalize_whitespace(&original_source);
         assert_eq!(
             normalized_back, normalized_orig,
             "Branch 1 (empty composed loss): exact round-trip required; \
-             leg-3 rust output must match original fixture source"
+             leg-4 rust output must match original fixture source"
         );
     } else {
-        // v0 Branch 2 (Option B gating — F3 fix):
+        // v0 Branch 2 (Option B gating, F3 fix):
         //
-        // Per-line divergence characterization is NOT asserted in v0 because leg-3
-        // doesn't produce Rust output (lifter not wired).  The vacuous-diff path
-        // (rust_back_source = String::new() → empty diff → permissive predicate
+        // Per-line divergence characterization is NOT asserted in v0 because leg 4
+        // often does not produce Rust output (lifters not wired). The vacuous-diff path
+        // (rust_back_source = String::new() -> empty diff -> permissive predicate
         // returns true) was pre-flagged as F3 in the round-2 review.
         //
         // Instead: assert the composed loss is HONEST and contains the EXPECTED v0
         // gap kinds.  When real lifters land, Branch 2's per-line characterization
-        // can be reactivated (requires divergence-pattern registry — see PR-F of #716
+        // can be reactivated (requires divergence-pattern registry; see PR-F of #716
         // follow-up or the issue created for this gating note).
 
         // All gaps in the composed loss must have non-empty kind and detail.
@@ -547,11 +881,11 @@ fn trinity_round_trip() {
         use std::collections::HashSet;
         let loss_kinds: HashSet<&str> = composed_loss.iter().map(|g| g.kind.as_str()).collect();
 
-        // v0 EXPECTED state: legs 2 and 3 receive non-Rust sources; bind must
+        // v0 EXPECTED state: later legs receive non-Rust sources; bind must
         // emit a real source-language-not-supported gap record (cmd_bind.rs, the
         // `if src_files.is_empty() && source_lang != "rust"` block).
-        // If that emission breaks, this assertion catches it — that's the protocol.
-        if leg2_src_lang != "rust" || leg3_src_lang != "rust" {
+        // If that emission breaks, this assertion catches it. That is the protocol.
+        if leg2_src_lang != "rust" || leg3_src_lang != "rust" || leg4_src_lang != "rust" {
             // Post-PR-770 the lift-boundary gap kind is `kit-plugin-unavailable`
             // (kit registration is now the substrate seam, per PEP 1.7.0 and
             // `2026-05-13-bind-ir-lift-result.md`). `source-language-not-supported`
@@ -564,6 +898,7 @@ fn trinity_round_trip() {
                 "kit-plugin-unavailable",
                 "bind-lift-empty",
                 "leg-3-not-reached",
+                "leg-4-not-reached",
             ];
             assert!(
                 lift_boundary_kinds.iter().any(|k| loss_kinds.contains(k)),
@@ -572,12 +907,13 @@ fn trinity_round_trip() {
                  This assertion fails if the gap-emission pipeline in cmd_bind breaks.\n\
                  got kinds: {:?}\n\
                  expected one of: {:?}\n\
-                 leg2_src_lang={:?} leg3_src_lang={:?}\n\
+                 leg2_src_lang={:?} leg3_src_lang={:?} leg4_src_lang={:?}\n\
                  full composed_loss={:?}",
                 loss_kinds,
                 lift_boundary_kinds,
                 leg2_src_lang,
                 leg3_src_lang,
+                leg4_src_lang,
                 composed_loss
             );
         }
@@ -591,7 +927,7 @@ fn trinity_round_trip() {
             !composed_loss.is_empty(),
             "Trinity round-trip composed_loss is EMPTY in v0. \
              Either the chain produced a perfect round-trip (impossible in v0) \
-             or the loss-emission pipeline broke. Check leg-2/leg-3 gap recording."
+             or the loss-emission pipeline broke. Check later-leg gap recording."
         );
 
         eprintln!(

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -133,7 +133,7 @@ fn java_canonical_bodies_cid_self_consistent() {
         .join("menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json");
     assert_self_consistent(
         path,
-        "blake3-512:e9c5dd414a182211d5b85e3f2052d491e85c90db5ed29fb1145c7d1ad7f4e34f71de80c12a210202c6bd7efe26639da0e4e1c446beca786245d4a3dc6708204b",
+        "blake3-512:8070d5de8bedf4a21c765b6b7f48518c43a1a8547b5e893b7af045467541d7d085d7b1b64857f64f05927a6fabee55002310db293adec3e59b17b56730bd22b9",
     );
 }
 
@@ -154,7 +154,7 @@ fn python_canonical_bodies_cid_self_consistent() {
     );
     assert_self_consistent(
         path,
-        "blake3-512:fb35f2196ebca55a964e1829a5f0f2842a0d3de53406fcca504e93b0aa1e55c09b7735740c382564817d279146479d8e4a3963377ee42878c6bb979da44a5cc7",
+        "blake3-512:f211f2509d6a7deacc2d23d33f87d1259d2835ba7292231f377d7f234f3d22f56dbd2f348314f313accc62ec50ffcec40df6266ca9eb78ca2160a5b80468725e",
     );
 }
 
@@ -173,7 +173,7 @@ fn c_canonical_bodies_cid_self_consistent() {
         .join("menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json");
     assert_self_consistent(
         path,
-        "blake3-512:8ef55920ab677d4fb44260ed9993295585fd76cc7df67c28673424a2cf49c2f76164e4cc9f1f2739a063ed2f27cb11cd34024c54a6cdfa9af2828e9946d1ff0e",
+        "blake3-512:f0948c8f4f00359bfdafb3c1bc19227ffc70f95807dcc53450f4c84be2d44bc77770aaa54f3058014febbad276a759ebcf8cc2acabf5e6e6bddada8167c684a2",
     );
 }
 
@@ -183,6 +183,6 @@ fn rust_canonical_bodies_cid_self_consistent() {
         .join("menagerie/rust-language-signature/specs/body-templates/rust-canonical-bodies.json");
     assert_self_consistent(
         path,
-        "blake3-512:f4a13083c93185636c3116bd0ba55bae949d4b89b9736184552400d4dd93b4906e8d99be2837e592679b8e6df08352318b78b8563b38251c356fabc1e2761cec",
+        "blake3-512:aa5946b88c2798cd7399ec22db6f170970a8d0f9dac88b1e81fc0a31ab40eddada236730450594894f745096cf033607dbbb35d0cd2a59300fa9ac5e2df340cd",
     );
 }

--- a/menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json
+++ b/menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:8ef55920ab677d4fb44260ed9993295585fd76cc7df67c28673424a2cf49c2f76164e4cc9f1f2739a063ed2f27cb11cd34024c54a6cdfa9af2828e9946d1ff0e",
+    "cid": "blake3-512:f0948c8f4f00359bfdafb3c1bc19227ffc70f95807dcc53450f4c84be2d44bc77770aaa54f3058014febbad276a759ebcf8cc2acabf5e6e6bddada8167c684a2",
     "content": {
       "entries": [
         {
@@ -73,6 +73,69 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
+          }
+        },
+        {
+          "concept_name": "http-request",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "long status = 0;\nCURL *curl = curl_easy_init();\nif (curl == NULL) return 0;\ncurl_easy_setopt(curl, CURLOPT_URL, ${param0});\ncurl_easy_setopt(curl, CURLOPT_NOBODY, 1L);\ncurl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);\nif (curl_easy_perform(curl) == CURLE_OK) {\n    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);\n}\ncurl_easy_cleanup(curl);\nreturn status;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:784dab96537ebae452cba5fdbcf88e07395d5e0634099055008d819f21d0fb51930fc29877afda069cdf0c1ec893fba5de47b025717fd024919c687381baee43"
+                  },
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-request-cites-concept-cids"
+              },
+              "header_dependency": {
+                "args": [],
+                "head": "atomic",
+                "name": "c-libcurl-template-requires-curl-header"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "long"
+          }
+        },
+        {
+          "concept_name": "http-response",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "long status = 0;\ncurl_easy_getinfo(${param0}, CURLINFO_RESPONSE_CODE, &status);\nreturn status;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-response-cites-concept-cid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "long"
           }
         },
         {

--- a/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
+++ b/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:e9c5dd414a182211d5b85e3f2052d491e85c90db5ed29fb1145c7d1ad7f4e34f71de80c12a210202c6bd7efe26639da0e4e1c446beca786245d4a3dc6708204b",
+    "cid": "blake3-512:8070d5de8bedf4a21c765b6b7f48518c43a1a8547b5e893b7af045467541d7d085d7b1b64857f64f05927a6fabee55002310db293adec3e59b17b56730bd22b9",
     "content": {
       "entries": [
         {
@@ -57,6 +57,64 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
+          }
+        },
+        {
+          "concept_name": "http-request",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "try {\n    java.net.http.HttpClient client = java.net.http.HttpClient.newHttpClient();\n    java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder(java.net.URI.create(${param0})).GET().build();\n    java.net.http.HttpResponse<Void> response = client.send(request, java.net.http.HttpResponse.BodyHandlers.discarding());\n    return (long) response.statusCode();\n} catch (java.io.IOException e) {\n    throw new RuntimeException(e);\n} catch (InterruptedException e) {\n    Thread.currentThread().interrupt();\n    throw new RuntimeException(e);\n}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:784dab96537ebae452cba5fdbcf88e07395d5e0634099055008d819f21d0fb51930fc29877afda069cdf0c1ec893fba5de47b025717fd024919c687381baee43"
+                  },
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-request-cites-concept-cids"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "long"
+          }
+        },
+        {
+          "concept_name": "http-response",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (long) ${param0}.statusCode();"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-response-cites-concept-cid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "long"
           }
         },
         {

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:fb35f2196ebca55a964e1829a5f0f2842a0d3de53406fcca504e93b0aa1e55c09b7735740c382564817d279146479d8e4a3963377ee42878c6bb979da44a5cc7",
+    "cid": "blake3-512:f211f2509d6a7deacc2d23d33f87d1259d2835ba7292231f377d7f234f3d22f56dbd2f348314f313accc62ec50ffcec40df6266ca9eb78ca2160a5b80468725e",
     "content": {
       "entries": [
         {
@@ -57,6 +57,64 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
+          }
+        },
+        {
+          "concept_name": "http-request",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "import urllib.request\nwith urllib.request.urlopen(${param0}) as response:\n    return response.status"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:784dab96537ebae452cba5fdbcf88e07395d5e0634099055008d819f21d0fb51930fc29877afda069cdf0c1ec893fba5de47b025717fd024919c687381baee43"
+                  },
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-request-cites-concept-cids"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "http-response",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0}.status"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-response-cites-concept-cid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "int"
           }
         },
         {

--- a/menagerie/rust-language-signature/specs/body-templates/rust-canonical-bodies.json
+++ b/menagerie/rust-language-signature/specs/body-templates/rust-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:f4a13083c93185636c3116bd0ba55bae949d4b89b9736184552400d4dd93b4906e8d99be2837e592679b8e6df08352318b78b8563b38251c356fabc1e2761cec",
+    "cid": "blake3-512:aa5946b88c2798cd7399ec22db6f170970a8d0f9dac88b1e81fc0a31ab40eddada236730450594894f745096cf033607dbbb35d0cd2a59300fa9ac5e2df340cd",
     "content": {
       "entries": [
         {
@@ -57,6 +57,69 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
+          }
+        },
+        {
+          "concept_name": "http-request",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "let response = reqwest::get(${param0}).await.unwrap();\nresponse.status().as_u16() as i64"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:784dab96537ebae452cba5fdbcf88e07395d5e0634099055008d819f21d0fb51930fc29877afda069cdf0c1ec893fba5de47b025717fd024919c687381baee43"
+                  },
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-request-cites-concept-cids"
+              },
+              "sync_vs_async": {
+                "args": [],
+                "head": "atomic",
+                "name": "rust-reqwest-template-requires-async-context"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "i64"
+          }
+        },
+        {
+          "concept_name": "http-response",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "${param0}.status().as_u16() as i64"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-response-cites-concept-cid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "i64"
           }
         },
         {


### PR DESCRIPTION
Extends the trinity round-trip from 3 legs (Rust -> Java -> Python -> Rust) to 4 legs (Rust -> Java -> Python -> C -> Rust) and adds an HTTP-using fixture function that exercises the concept hub at the API tier. Empirical receipt for paper 21 §3 (cross-language at API tier).

### What

* HTTP body templates added to all four canonical-bodies.json files (rust/java/python/c) for \`concept:http-request\` and \`concept:http-response\`, citing Bridge B's hub CIDs exactly.
* Canonical libraries per language: \`reqwest\` (Rust), \`java.net.http.HttpClient\` (Java stdlib), \`urllib.request\` (Python stdlib), \`libcurl\` (C).
* CID pins in \`substrate_default_cids.rs\` updated for the four new body-template files.
* Trinity fixture gains \`fetch_url_status(url) -> u16\`; leg 1 (Rust source -> Java realize) recognizes it as \`concept:http-request\` and emits a \`java.net.http.HttpClient\` call in the realized Java output.
* C leg wired (Java/C build helpers + manifest plumbing + dispatch) but not executed because Java lift is unavailable in this environment.

### Acceptance gate

Fresh \`CARGO_TARGET_DIR\` run passes:

\`\`\`
trinity_round_trip: HTTP fixture recognized as concept:http-request in leg 1 Java output
trinity_round_trip: v0 loudly-bounded-lossy outcome (3 loss entries; Branch 2 per-line characterization gated until real lifters land):
  [kit-plugin-unavailable] no \`kind = \"lift\"\` plugin available for source language \`java\`
  [leg-3-not-reached] leg 3 (python->c) was not executed because leg 2 produced no translated/python/ output
  [leg-4-not-reached] leg 4 (c->rust) was not executed because leg 3 was not reached
test trinity_round_trip ... ok
\`\`\`

### Honest claim shape

The HTTP fixture lifts and is tagged \`concept:http-request\` at the concept hub. The 4-leg cycle is wired for all four languages. Reaching legs 3 and 4 requires a Java lift kit, which is the structural blocker (\`implementations/java/provekit-walk-java\` exists but does not yet expose the bind lift RPC protocol). v0 loudly-bounded-lossy with those losses named.

### Files

* \`implementations/rust/provekit-cli/tests/fixtures/trinity_roundtrip/src/lib.rs\` (+8)
* \`implementations/rust/provekit-cli/tests/trinity_roundtrip_test.rs\` (+452/-)
* \`implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs\` (+8/-)
* \`menagerie/{c,java,python,rust}-language-signature/specs/body-templates/*-canonical-bodies.json\`

Refs #849.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP request and response handling capabilities across multiple programming languages (C, Java, Python, Rust).
  * Expanded integration testing to validate a 4-language translation chain.

* **Tests**
  * Updated expected canonical values for language signature validations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/865)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->