### PR TITLE
feat(#849): Bridge E - (language, library_tag) named-axis dispatcher

### DIFF
--- a/.provekit/realize/c/manifest.toml
+++ b/.provekit/realize/c/manifest.toml
@@ -1,0 +1,6 @@
+# PEP 1.7.0 `kind = "realize"` plugin manifest for canonical C body emission.
+# cmd_bind dispatches canonical rewrite emission here when target-language=c.
+name = "c-realize"
+library_tag = "libcurl"
+command = ["implementations/c/provekit-realize-c-core/target/release/provekit-realize-c", "--rpc"]
+working_dir = "."

--- a/.provekit/realize/java/manifest.toml
+++ b/.provekit/realize/java/manifest.toml
@@ -1,0 +1,6 @@
+# PEP 1.7.0 `kind = "realize"` plugin manifest for canonical Java body emission.
+# cmd_bind dispatches canonical rewrite emission here when target-language=java.
+name = "java-realize"
+library_tag = "java-net-http"
+command = ["java", "-jar", "implementations/java/provekit-realize-java-core/target/provekit-realize-java.jar", "--rpc"]
+working_dir = "."

--- a/.provekit/realize/python-requests/manifest.toml
+++ b/.provekit/realize/python-requests/manifest.toml
@@ -1,0 +1,6 @@
+# PEP 1.7.0 `kind = "realize"` plugin manifest for Python requests body emission.
+# cmd_bind dispatches canonical rewrite emission here when target-language=python and library_tag=requests.
+name = "python-realize-requests"
+library_tag = "requests"
+command = ["implementations/python/target/release/provekit-realize-python-requests", "--rpc"]
+working_dir = "."

--- a/.provekit/realize/python/manifest.toml
+++ b/.provekit/realize/python/manifest.toml
@@ -1,0 +1,6 @@
+# PEP 1.7.0 `kind = "realize"` plugin manifest for canonical Python body emission.
+# cmd_bind dispatches canonical rewrite emission here when target-language=python.
+name = "python-realize"
+library_tag = "urllib"
+command = ["implementations/python/target/release/provekit-realize-python", "--rpc"]
+working_dir = "."

--- a/.provekit/realize/rust/manifest.toml
+++ b/.provekit/realize/rust/manifest.toml
@@ -1,5 +1,6 @@
 # PEP 1.7.0 `kind = "realize"` plugin manifest for canonical Rust body emission.
 # cmd_bind dispatches canonical rewrite emission here when target-language=rust.
 name = "rust-realize"
+library_tag = "reqwest"
 command = ["implementations/rust/target/debug/provekit-realize-rust", "--rpc"]
 working_dir = "."

--- a/implementations/python/provekit-realize-python-requests/pyproject.toml
+++ b/implementations/python/provekit-realize-python-requests/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "provekit-realize-python-requests"
+version = "0.1.0"
+description = "PEP 1.7.0 Python requests realize kit for ProvekIt bind canonical output"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+provekit-realize-python-requests = "provekit_realize_python_requests.__main__:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/__init__.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/__init__.py
@@ -1,0 +1,1 @@
+"""Python requests realize kit for ProvekIt."""

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/__main__.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/__main__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import argparse
+
+from .rpc import run_rpc
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rpc", action="store_true", help="run PEP 1.7.0 JSON-RPC over stdio")
+    args = parser.parse_args(argv)
+    if args.rpc:
+        run_rpc()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/realizer.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/realizer.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+BODY_TEMPLATE_REL = Path(
+    "menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-requests.json"
+)
+PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
+
+
+@dataclass(frozen=True)
+class BodyTemplateEntry:
+    concept_name: str
+    template_kind: str
+    template: str
+    min_params: int | None
+    max_params: int | None
+    requires_param_types: tuple[str, ...] | None
+    requires_return_type: str | None
+
+
+def emit_stub(
+    function: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+    concept_name: str,
+) -> dict[str, Any]:
+    body = body_template_for(concept_name, params, param_types, return_type)
+    is_stub = body is None
+    if body is None:
+        body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
+    return {
+        "source": _function_source(function, params, body),
+        "is_stub": is_stub,
+        "extension": "py",
+    }
+
+
+def body_template_for(
+    concept_name: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> str | None:
+    mapped_param_types = [map_source_type(ty) for ty in param_types]
+    mapped_return_type = map_source_type(return_type)
+    candidate_names = (concept_name, concept_name.removeprefix("concept:"))
+    for entry in entries():
+        if entry.concept_name not in candidate_names:
+            continue
+        if entry.min_params is not None and len(params) < entry.min_params:
+            continue
+        if entry.max_params is not None and len(params) > entry.max_params:
+            continue
+        if entry.requires_param_types is not None:
+            if tuple(mapped_param_types) != entry.requires_param_types:
+                continue
+        if entry.requires_return_type is not None:
+            if mapped_return_type != entry.requires_return_type:
+                continue
+        if entry.template_kind != "verbatim":
+            continue
+        rendered = render_template(entry.template, params, mapped_param_types, mapped_return_type)
+        if rendered is None:
+            continue
+        return rendered
+    return None
+
+
+def map_source_type(src: str) -> str:
+    match src:
+        case "()":
+            return "None"
+        case "i64" | "u64" | "i32" | "u32" | "i16" | "u16" | "i8" | "u8" | "int":
+            return "int"
+        case "f64" | "f32" | "float":
+            return "float"
+        case "bool":
+            return "bool"
+        case "String" | "&str" | "&String" | "str":
+            return "str"
+        case _:
+            return src
+
+
+def render_template(
+    template: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> str | None:
+    rendered = template
+    for index, name in enumerate(params):
+        rendered = rendered.replace(f"${{param{index}}}", name)
+    for index, type_name in enumerate(param_types):
+        rendered = rendered.replace(f"${{param_type_{index}}}", type_name)
+    rendered = rendered.replace("${param_count}", str(len(params)))
+    rendered = rendered.replace("${return_type}", return_type)
+    if PLACEHOLDER_RE.search(rendered):
+        return None
+    return rendered
+
+
+@lru_cache(maxsize=1)
+def entries() -> tuple[BodyTemplateEntry, ...]:
+    path = _find_repo_file(BODY_TEMPLATE_REL)
+    if path is None:
+        return ()
+    raw = path.read_text(encoding="utf-8")
+    root = json.loads(raw)
+    content = root.get("header", {}).get("content", {})
+    out: list[BodyTemplateEntry] = []
+    for item in content.get("entries", []):
+        if not isinstance(item, dict):
+            continue
+        template = item.get("emission_template", {})
+        if not isinstance(template, dict):
+            continue
+        guard = item.get("signature_guard", {})
+        if not isinstance(guard, dict):
+            guard = {}
+        concept_name = item.get("concept_name")
+        template_kind = template.get("kind")
+        template_text = template.get("template")
+        if not isinstance(concept_name, str):
+            continue
+        if not isinstance(template_kind, str) or not isinstance(template_text, str):
+            continue
+        requires_param_types = guard.get("requires_param_types")
+        out.append(
+            BodyTemplateEntry(
+                concept_name=concept_name,
+                template_kind=template_kind,
+                template=template_text,
+                min_params=_int_or_none(guard.get("min_params")),
+                max_params=_int_or_none(guard.get("max_params")),
+                requires_param_types=tuple(requires_param_types)
+                if isinstance(requires_param_types, list)
+                else None,
+                requires_return_type=guard.get("requires_return_type")
+                if isinstance(guard.get("requires_return_type"), str)
+                else None,
+            )
+        )
+    return tuple(out)
+
+
+def _function_source(function: str, params: list[str], body: str) -> str:
+    param_list = ", ".join(params)
+    body_lines = body.splitlines() or ["pass"]
+    indented = "\n".join(f"    {line}" if line else "" for line in body_lines)
+    return f"def {function}({param_list}):\n{indented}\n"
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _find_repo_file(relative: Path) -> Path | None:
+    seen: set[Path] = set()
+    for base in _candidate_bases():
+        candidate = base / relative
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _candidate_bases() -> list[Path]:
+    bases: list[Path] = []
+    env_root = os.environ.get("PROVEKIT_REPO_ROOT")
+    if env_root:
+        bases.append(Path(env_root))
+    cwd = Path.cwd().resolve()
+    bases.extend([cwd, *cwd.parents])
+    here = Path(__file__).resolve()
+    bases.extend(here.parents)
+    return bases

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from typing import Any
+
+from .realizer import emit_stub
+
+
+def run_rpc() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        method = ""
+        try:
+            request = json.loads(line)
+            method = str(request.get("method", ""))
+            response = dispatch(request)
+        except json.JSONDecodeError as exc:
+            response = _error(None, -32700, f"PARSE_ERROR: {exc}")
+        except Exception as exc:
+            response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
+        _send(response)
+        if method == "provekit.plugin.shutdown":
+            break
+
+
+def dispatch(request: dict[str, Any]) -> dict[str, Any]:
+    msg_id = request.get("id")
+    method = str(request.get("method", ""))
+    params = request.get("params") or {}
+
+    if method == "provekit.plugin.invoke":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": emit_stub(
+                function=str(params.get("function", "")),
+                params=_string_list(params.get("params")),
+                param_types=_string_list(params.get("param_types")),
+                return_type=str(params.get("return_type", "")),
+                concept_name=str(params.get("concept_name", "")),
+            ),
+        }
+    if method == "provekit.plugin.shutdown":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": None}
+    return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _send(obj: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(obj, separators=(",", ":"), ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": code, "message": message},
+    }

--- a/implementations/python/provekit-realize-python-requests/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-requests/tests/test_realizer.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-requests/src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from provekit_realize_python_requests.realizer import emit_stub
+
+
+def test_http_request_uses_requests_get() -> None:
+    result = emit_stub(
+        function="fetch_status",
+        params=["url"],
+        param_types=["str"],
+        return_type="int",
+        concept_name="concept:http-request",
+    )
+
+    assert result == {
+        "source": "def fetch_status(url):\n    import requests\n    response = requests.get(url)\n    return response.status_code\n",
+        "is_stub": False,
+        "extension": "py",
+    }

--- a/implementations/python/provekit-realize-python-requests/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-requests/tests/test_rpc.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-requests/src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from provekit_realize_python_requests.rpc import dispatch
+
+
+def test_rpc_invoke_renders_requests_body() -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "provekit.plugin.invoke",
+            "params": {
+                "function": "fetch_status",
+                "params": ["url"],
+                "param_types": ["str"],
+                "return_type": "int",
+                "concept_name": "concept:http-request",
+            },
+        }
+    )
+
+    assert response["id"] == 1
+    assert response["result"]["is_stub"] is False
+    assert "requests.get" in response["result"]["source"]
+
+
+def test_rpc_error_for_unknown_method_is_json_serializable() -> None:
+    response = dispatch({"jsonrpc": "2.0", "id": 2, "method": "missing"})
+
+    assert response["error"]["code"] == -32601
+    json.dumps(response)

--- a/implementations/python/target/release/provekit-realize-python-requests
+++ b/implementations/python/target/release/provekit-realize-python-requests
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PYTHONPATH="$DIR/provekit-realize-python-requests/src:$PYTHONPATH" exec python3 -m provekit_realize_python_requests "$@"

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -1454,7 +1454,7 @@ fn apply_canonical_rewrite(
                     .collect(),
                 sugar_plugins: sugar_plugins.to_vec(),
             };
-            match crate::kit_dispatch::dispatch_realize(root, target_lang, &request) {
+            match crate::kit_dispatch::dispatch_realize(root, target_lang, None, &request) {
                 Ok(realized) => {
                     let r = crate::cmd_transport::RealizedSource {
                         extension: Box::leak(realized.extension.into_boxed_str()),

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -1346,7 +1346,7 @@ fn realize_function(
         sugar_cids,
         sugar_plugins,
     };
-    let realized = crate::kit_dispatch::dispatch_realize(&workspace_root, language, &request)
+    let realized = crate::kit_dispatch::dispatch_realize(&workspace_root, language, None, &request)
         .map_err(|e| {
             TransportCliError::Refusal(format!("realize-time:kit-plugin-unavailable {e}"))
         })?;

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -16,10 +16,11 @@
 //      and decodes `ir-document.ir[]` into `BindLiftEntry` records per
 //      `2026-05-13-bind-ir-lift-result.md`.
 //
-//   2. `dispatch_realize(target_lang, request)`
+//   2. `dispatch_realize(target_lang, library_tag, request)`
 //      Resolves a `kind = "realize"` (sugar/body-template) plugin for
-//      `target_lang` via convention (`.provekit/realize/<lang>/manifest.toml`
-//      or a built-in path; the Java built-in path is
+//      `(target_lang, library_tag.unwrap_or("default"))` via convention
+//      (`.provekit/realize/<surface>/manifest.toml` or a built-in path; the
+//      Java built-in path is
 //      `implementations/java/provekit-realize-java-core/target/...`).
 //      Invokes the PEP 1.7.0 `provekit.plugin.invoke` method and returns
 //      `{ source, is_stub }`.
@@ -299,6 +300,7 @@ struct ParsedManifest {
     name: String,
     command: Vec<String>,
     working_dir: Option<PathBuf>,
+    library_tag: Option<String>,
 }
 
 fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
@@ -307,6 +309,7 @@ fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
     let mut name = String::new();
     let mut command: Vec<String> = Vec::new();
     let mut working_dir: Option<PathBuf> = None;
+    let mut library_tag: Option<String> = None;
     for line in text.lines() {
         let line = match line.find('#') {
             Some(pos) => &line[..pos],
@@ -322,6 +325,16 @@ fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
         match key {
             "name" => name = val.trim_matches('"').to_string(),
             "working_dir" => working_dir = Some(PathBuf::from(val.trim_matches('"'))),
+            "library_tag" => {
+                let tag = val.trim_matches('"').to_string();
+                validate_library_tag(&tag).map_err(|detail| {
+                    format!(
+                        "manifest {} has invalid `library_tag` `{tag}`: {detail}",
+                        path.display()
+                    )
+                })?;
+                library_tag = Some(tag);
+            }
             "command" => {
                 let inner = val.trim_matches(|c| c == '[' || c == ']');
                 command = inner
@@ -340,7 +353,22 @@ fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
         name,
         command,
         working_dir,
+        library_tag,
     })
+}
+
+fn validate_library_tag(tag: &str) -> Result<(), &'static str> {
+    let mut chars = tag.chars();
+    let Some(first) = chars.next() else {
+        return Err("expected [a-z][a-z0-9-]*");
+    };
+    if !first.is_ascii_lowercase() {
+        return Err("expected [a-z][a-z0-9-]*");
+    }
+    if !chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+        return Err("expected [a-z][a-z0-9-]*");
+    }
+    Ok(())
 }
 
 fn rpc_lift(
@@ -540,16 +568,19 @@ pub struct RealizedSource {
     pub observation_wrapper_emission_record: Option<Value>,
 }
 
-/// Dispatch a realize call for `target_lang`. Returns `Err(KitUnavailable)`
-/// when no realize plugin exists. Callers turn this into a
+const DEFAULT_LIBRARY_TAG: &str = "default";
+
+/// Dispatch a realize call for `(target_lang, library_tag)`. Returns
+/// `Err(KitUnavailable)` when no realize plugin exists. Callers turn this into a
 /// `kit-plugin-unavailable` gap record so the run is loudly-bounded-lossy
 /// at the realize boundary rather than silently empty.
 pub fn dispatch_realize(
     workspace_root: &Path,
     target_lang: &str,
+    library_tag: Option<&str>,
     request: &RealizeRequest,
 ) -> Result<RealizedSource, KitUnavailable> {
-    let resolved = resolve_realize_command(workspace_root, target_lang)?;
+    let resolved = resolve_realize_command(workspace_root, target_lang, library_tag)?;
     invoke_realize(target_lang, &resolved, request).map_err(|e| KitUnavailable {
         kit_kind: "realize",
         language: target_lang.to_string(),
@@ -560,70 +591,194 @@ pub fn dispatch_realize(
 fn resolve_realize_command(
     workspace_root: &Path,
     target_lang: &str,
+    library_tag: Option<&str>,
 ) -> Result<ResolvedCommand, KitUnavailable> {
-    // 1: manifest at .provekit/realize/<lang>/manifest.toml.
-    let manifest = workspace_root
-        .join(".provekit")
-        .join("realize")
-        .join(target_lang)
-        .join("manifest.toml");
-    if manifest.exists() {
-        if let Ok(parsed) = parse_manifest(&manifest) {
-            let working_dir = parsed
-                .working_dir
-                .map(|wd| {
-                    if wd.is_absolute() {
-                        wd
-                    } else {
-                        workspace_root.join(wd)
-                    }
-                })
-                .or_else(|| Some(workspace_root.to_path_buf()));
-            return Ok(ResolvedCommand {
-                argv: parsed.command,
-                working_dir,
+    if let Some(tag) = library_tag {
+        if let Err(detail) = validate_library_tag(tag) {
+            return Err(KitUnavailable {
+                kit_kind: "realize",
+                language: target_lang.to_string(),
+                detail: format!("invalid requested library_tag `{tag}`: {detail}"),
             });
         }
     }
 
-    // 2: env-var override.
+    let candidates = registered_realize_candidates(workspace_root, target_lang)?;
+    let requested = library_tag.unwrap_or(DEFAULT_LIBRARY_TAG);
+    if let Some(candidate) = candidates
+        .iter()
+        .find(|candidate| candidate.tag == requested)
+    {
+        return Ok(candidate.command.clone());
+    }
+
+    if library_tag.is_none() {
+        if candidates.len() == 1 {
+            return Ok(candidates[0].command.clone());
+        }
+        if !candidates.is_empty() {
+            let tags = candidates
+                .iter()
+                .map(|candidate| format!("{} from {}", candidate.tag, candidate.source))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(KitUnavailable {
+                kit_kind: "realize",
+                language: target_lang.to_string(),
+                detail: format!(
+                    "multiple realize plugins registered for language `{target_lang}` but none \
+                     has library_tag `default`; pass an explicit library_tag. registered: {tags}"
+                ),
+            });
+        }
+    }
+
     let env_var = format!("PROVEKIT_REALIZE_{}_BIN", target_lang.to_uppercase());
-    if let Ok(bin) = std::env::var(&env_var) {
-        return Ok(ResolvedCommand {
-            argv: vec![bin, "--rpc".to_string()],
-            working_dir: Some(workspace_root.to_path_buf()),
-        });
-    }
-
-    // 3: substrate-convention built-in binaries. Same shape as lift:
-    // the dispatcher consults the FILESYSTEM, not a hard-coded list.
-    for candidate in builtin_realize_candidates(workspace_root, target_lang) {
-        if candidate.path.exists() {
-            return Ok(ResolvedCommand {
-                argv: candidate.argv,
-                working_dir: Some(workspace_root.to_path_buf()),
-            });
-        }
-    }
-
-    // 4: PATH probe.
-    let bin = format!("provekit-realize-{target_lang}");
-    if which_on_path(&bin).is_some() {
-        return Ok(ResolvedCommand {
-            argv: vec![bin, "--rpc".to_string()],
-            working_dir: Some(workspace_root.to_path_buf()),
-        });
-    }
-
+    let registered = if candidates.is_empty() {
+        "none".to_string()
+    } else {
+        candidates
+            .iter()
+            .map(|candidate| format!("{} from {}", candidate.tag, candidate.source))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
     Err(KitUnavailable {
         kit_kind: "realize",
         language: target_lang.to_string(),
         detail: format!(
-            "no manifest at .provekit/realize/{target_lang}/, no env {env_var}, \
-             no built-in binary under implementations/{target_lang}/, \
-             no `provekit-realize-{target_lang}` on PATH"
+            "no realize plugin for language `{target_lang}` and library_tag `{requested}`. \
+             looked in .provekit/realize/*/manifest.toml, env {env_var}, built-in binaries \
+             under implementations/{target_lang}/, and `provekit-realize-{target_lang}` on \
+             PATH. registered: {registered}"
         ),
     })
+}
+
+#[derive(Debug, Clone)]
+struct RealizeCandidate {
+    tag: String,
+    command: ResolvedCommand,
+    source: String,
+}
+
+fn registered_realize_candidates(
+    workspace_root: &Path,
+    target_lang: &str,
+) -> Result<Vec<RealizeCandidate>, KitUnavailable> {
+    let mut candidates =
+        project_realize_candidates(workspace_root, target_lang).map_err(|e| KitUnavailable {
+            kit_kind: "realize",
+            language: target_lang.to_string(),
+            detail: e,
+        })?;
+
+    // Env-var, built-in, and PATH fallbacks have no manifest tag, so they occupy
+    // the back-compatible default slot.
+    let env_var = format!("PROVEKIT_REALIZE_{}_BIN", target_lang.to_uppercase());
+    if let Ok(bin) = std::env::var(&env_var) {
+        candidates.push(RealizeCandidate {
+            tag: DEFAULT_LIBRARY_TAG.to_string(),
+            command: ResolvedCommand {
+                argv: vec![bin, "--rpc".to_string()],
+                working_dir: Some(workspace_root.to_path_buf()),
+            },
+            source: env_var,
+        });
+    }
+
+    // Substrate-convention built-in binaries. Same shape as lift:
+    // the dispatcher consults the FILESYSTEM, not a hard-coded list.
+    for candidate in builtin_realize_candidates(workspace_root, target_lang) {
+        if candidate.path.exists() {
+            candidates.push(RealizeCandidate {
+                tag: DEFAULT_LIBRARY_TAG.to_string(),
+                command: ResolvedCommand {
+                    argv: candidate.argv,
+                    working_dir: Some(workspace_root.to_path_buf()),
+                },
+                source: candidate.path.display().to_string(),
+            });
+        }
+    }
+
+    // PATH probe.
+    let bin = format!("provekit-realize-{target_lang}");
+    if which_on_path(&bin).is_some() {
+        candidates.push(RealizeCandidate {
+            tag: DEFAULT_LIBRARY_TAG.to_string(),
+            command: ResolvedCommand {
+                argv: vec![bin.clone(), "--rpc".to_string()],
+                working_dir: Some(workspace_root.to_path_buf()),
+            },
+            source: format!("PATH:{bin}"),
+        });
+    }
+
+    Ok(candidates)
+}
+
+fn project_realize_candidates(
+    workspace_root: &Path,
+    target_lang: &str,
+) -> Result<Vec<RealizeCandidate>, String> {
+    let realize_dir = workspace_root.join(".provekit").join("realize");
+    let Ok(entries) = std::fs::read_dir(&realize_dir) else {
+        return Ok(Vec::new());
+    };
+    let mut surfaces = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_dir() {
+                return None;
+            }
+            let surface = path.file_name()?.to_str()?.to_string();
+            Some((surface, path))
+        })
+        .collect::<Vec<_>>();
+    surfaces.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut out = Vec::new();
+    for (surface, path) in surfaces {
+        if !realize_surface_matches_target(&surface, target_lang) {
+            continue;
+        }
+        let manifest = path.join("manifest.toml");
+        if !manifest.exists() {
+            continue;
+        }
+        let parsed = parse_manifest(&manifest)?;
+        let working_dir = parsed
+            .working_dir
+            .map(|wd| {
+                if wd.is_absolute() {
+                    wd
+                } else {
+                    workspace_root.join(wd)
+                }
+            })
+            .or_else(|| Some(workspace_root.to_path_buf()));
+        out.push(RealizeCandidate {
+            tag: parsed
+                .library_tag
+                .unwrap_or_else(|| DEFAULT_LIBRARY_TAG.to_string()),
+            command: ResolvedCommand {
+                argv: parsed.command,
+                working_dir,
+            },
+            source: manifest.display().to_string(),
+        });
+    }
+    Ok(out)
+}
+
+fn realize_surface_matches_target(surface: &str, target_lang: &str) -> bool {
+    surface == target_lang
+        || surface
+            .strip_prefix(target_lang)
+            .and_then(|suffix| suffix.strip_prefix('-'))
+            .is_some()
 }
 
 struct RealizeBuiltin {
@@ -807,9 +962,8 @@ fn invoke_realize(
             }
         }
     }
-    let observation_wrapper_emission_record = result
-        .get("observation_wrapper_emission_record")
-        .cloned();
+    let observation_wrapper_emission_record =
+        result.get("observation_wrapper_emission_record").cloned();
     Ok(RealizedSource {
         extension,
         source,
@@ -947,5 +1101,16 @@ mod tests {
         );
         assert_eq!(params["sugar_plugins"][0]["header"]["kind"], "sugar");
         assert_eq!(params["sugar_cids"][0], "blake3-512:sugar");
+    }
+
+    #[test]
+    fn library_tag_validation_accepts_stable_identifier_shape() {
+        assert!(validate_library_tag("urllib").is_ok());
+        assert!(validate_library_tag("apache-httpclient").is_ok());
+        assert!(validate_library_tag("httpx2").is_ok());
+        assert!(validate_library_tag("").is_err());
+        assert!(validate_library_tag("Requests").is_err());
+        assert!(validate_library_tag("urllib.request").is_err());
+        assert!(validate_library_tag("1requests").is_err());
     }
 }

--- a/implementations/rust/provekit-cli/tests/library_tag_dispatch_test.rs
+++ b/implementations/rust/provekit-cli/tests/library_tag_dispatch_test.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use provekit_cli::kit_dispatch::{dispatch_realize, RealizeRequest};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("provekit-cli has rust workspace parent")
+        .parent()
+        .expect("rust workspace has implementations parent")
+        .parent()
+        .expect("implementations dir has repo parent")
+        .to_path_buf()
+}
+
+fn python_bin() -> String {
+    std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string())
+}
+
+fn pythonpath_with_realize_srcs() -> std::ffi::OsString {
+    let repo = repo_root();
+    let paths = [
+        repo.join("implementations")
+            .join("python")
+            .join("provekit-realize-python-core")
+            .join("src"),
+        repo.join("implementations")
+            .join("python")
+            .join("provekit-realize-python-requests")
+            .join("src"),
+    ];
+    let mut all = paths.to_vec();
+    if let Some(existing) = std::env::var_os("PYTHONPATH") {
+        all.extend(std::env::split_paths(&existing));
+    }
+    std::env::join_paths(all).expect("join PYTHONPATH")
+}
+
+fn install_manifest(root: &Path, surface: &str, module: &str, library_tag: &str) {
+    let manifest = root
+        .join(".provekit")
+        .join("realize")
+        .join(surface)
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().expect("manifest path has parent"))
+        .expect("create manifest dir");
+    let manifest_text = format!(
+        "name = \"python-realize-{library_tag}\"\n\
+         library_tag = \"{library_tag}\"\n\
+         command = [\"{}\", \"-m\", \"{module}\", \"--rpc\"]\n\
+         working_dir = \".\"\n",
+        python_bin().replace('\\', "\\\\").replace('"', "\\\""),
+    );
+    fs::write(manifest, manifest_text).expect("write manifest");
+}
+
+fn http_request_realize_request() -> RealizeRequest {
+    RealizeRequest {
+        function: "fetch_status".to_string(),
+        params: vec!["url".to_string()],
+        param_types: vec!["str".to_string()],
+        return_type: "int".to_string(),
+        concept_name: "concept:http-request".to_string(),
+        mode: None,
+        contract: None,
+        sugar_cids: Vec::new(),
+        sugar_plugins: Vec::new(),
+    }
+}
+
+#[test]
+fn dispatch_realize_routes_python_library_tags_to_distinct_kits() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    install_manifest(
+        workspace.path(),
+        "python",
+        "provekit_realize_python_core",
+        "urllib",
+    );
+    install_manifest(
+        workspace.path(),
+        "python-requests",
+        "provekit_realize_python_requests",
+        "requests",
+    );
+
+    std::env::set_var("PROVEKIT_REPO_ROOT", repo_root());
+    std::env::set_var("PYTHONPATH", pythonpath_with_realize_srcs());
+
+    let request = http_request_realize_request();
+    let urllib = dispatch_realize(workspace.path(), "python", Some("urllib"), &request)
+        .expect("dispatch urllib realize kit");
+    let requests = dispatch_realize(workspace.path(), "python", Some("requests"), &request)
+        .expect("dispatch requests realize kit");
+
+    assert_ne!(urllib.source, requests.source);
+    assert!(
+        urllib.source.contains("urllib.request.urlopen"),
+        "urllib output should use urllib.request.urlopen, got:\n{}",
+        urllib.source
+    );
+    assert!(
+        requests.source.contains("requests.get"),
+        "requests output should use requests.get, got:\n{}",
+        requests.source
+    );
+}

--- a/implementations/rust/provekit-cli/tests/trinity_roundtrip_test.rs
+++ b/implementations/rust/provekit-cli/tests/trinity_roundtrip_test.rs
@@ -323,7 +323,7 @@ fn install_rust_realize_manifest(fixture_root: &Path, rpc_bin: &Path) {
     fs::create_dir_all(manifest.parent().expect("manifest path has parent"))
         .expect("create fixture rust realize manifest dir");
     let manifest_text = format!(
-        "name = \"rust-realize\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+        "name = \"rust-realize\"\nlibrary_tag = \"reqwest\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
         rpc_bin.display()
     );
     fs::write(&manifest, manifest_text).expect("write fixture rust realize manifest");
@@ -335,6 +335,16 @@ fn manifest_command(command: &[String]) -> String {
         .map(|arg| format!("\"{}\"", arg.replace('\\', "\\\\").replace('"', "\\\"")))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn canonical_library_tag(lang: &str) -> &str {
+    match lang {
+        "c" => "libcurl",
+        "java" => "java-net-http",
+        "python" => "urllib",
+        "rust" => "reqwest",
+        _ => "default",
+    }
 }
 
 fn install_lift_manifest(fixture_root: &Path, surface: &str, name: &str, command: &[String]) {
@@ -361,7 +371,8 @@ fn install_realize_manifest(fixture_root: &Path, lang: &str, name: &str, command
     fs::create_dir_all(manifest.parent().expect("manifest path has parent"))
         .expect("create fixture realize manifest dir");
     let manifest_text = format!(
-        "name = \"{name}\"\ncommand = [{}]\nworking_dir = \".\"\n",
+        "name = \"{name}\"\nlibrary_tag = \"{}\"\ncommand = [{}]\nworking_dir = \".\"\n",
+        canonical_library_tag(lang),
         manifest_command(command)
     );
     fs::write(&manifest, manifest_text).expect("write fixture realize manifest");

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -159,6 +159,17 @@ fn python_canonical_bodies_cid_self_consistent() {
 }
 
 #[test]
+fn python_requests_canonical_bodies_cid_self_consistent() {
+    let path = repo_root().join(
+        "menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-requests.json",
+    );
+    assert_self_consistent(
+        path,
+        "blake3-512:6612c844a35e288836a838e2a7615be2791eee36e159b3df333db0f63266cbe56db8754e33a8b33cce4fb89927f6e9236c2c5b0cc093eb6d80b1f1f124a2c52b",
+    );
+}
+
+#[test]
 fn c_canonical_sugar_cid_self_consistent() {
     let path = repo_root().join("menagerie/c-language-signature/specs/sugar/c-canonical.json");
     assert_self_consistent(

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-requests.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-requests.json
@@ -1,0 +1,138 @@
+{
+  "envelope": {
+    "declaredAt": "2026-05-14T00:00:00.000Z",
+    "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "header": {
+    "cid": "blake3-512:6612c844a35e288836a838e2a7615be2791eee36e159b3df333db0f63266cbe56db8754e33a8b33cce4fb89927f6e9236c2c5b0cc093eb6d80b1f1f124a2c52b",
+    "content": {
+      "entries": [
+        {
+          "concept_name": "concept:http-request",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "import requests\nresponse = requests.get(${param0})\nreturn response.status_code"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:784dab96537ebae452cba5fdbcf88e07395d5e0634099055008d819f21d0fb51930fc29877afda069cdf0c1ec893fba5de47b025717fd024919c687381baee43"
+                  },
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-request-cites-concept-cids"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "concept:http-request",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "import requests\nresponse = requests.post(${param0}, json=${param1})\nreturn response.status_code"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:784dab96537ebae452cba5fdbcf88e07395d5e0634099055008d819f21d0fb51930fc29877afda069cdf0c1ec893fba5de47b025717fd024919c687381baee43"
+                  },
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-request-cites-concept-cids"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "concept:http-response",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0}.status_code"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-response-cites-concept-cid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "concept:http-response",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0}.json()"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:38a31226e5e2f593fa12b1e7a2b18d9f7755301ce537115b34ac486aedcc479ca599327dbea7de0e0cee0d035b831ad4933436c2b7c8c84d4f4694dc42d161f5"
+                  }
+                ],
+                "head": "atomic",
+                "name": "bridge-b-http-response-cites-concept-cid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "dict"
+          }
+        }
+      ],
+      "target_language": "python",
+      "template_name": "python-canonical-bodies-requests"
+    },
+    "critical": false,
+    "kind": "body-template",
+    "protocol_versions": ["pep/1.7.0"],
+    "provenance_cid": "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "schemaVersion": "1",
+    "version": "1.0.0"
+  }
+}


### PR DESCRIPTION
Extends realize target identifier from \`language\` to \`(language, library_tag)\` so multiple realize kits can register for one language, keyed by which library they target. The named-axis rung of the substrate honesty gradient: dispatcher key, no semantic claim on body-template content. LibraryRealizationProfile / CID-bound upgrade (#858) remains on hold.

### What

* \`library_tag: Option<String>\` on the realize manifest TOML; absent = \`\"default\"\`; validated against \`[a-z][a-z0-9-]*\`.
* Persistent \`.provekit/realize/{java,python,c}\` manifests created (previously only Rust had one). Explicit tags: \`rust=reqwest\`, \`java=java-net-http\`, \`python=urllib\`, \`c=libcurl\`.
* Dispatcher key widened from \`language\` to \`(language, library_tag)\`. Legacy callers pass \`None\` and resolve to \`default\` or the only-registered kit per language.
* Proof-of-life second target: \`implementations/python/provekit-realize-python-requests/\` + \`.provekit/realize/python-requests/manifest.toml\` (\`library_tag = \"requests\"\`) + \`menagerie/.../python-canonical-bodies-requests.json\`.
* Body-template CID pinned in \`substrate_default_cids.rs\`: \`blake3-512:6612c844...c52b\`.

### Acceptance gates (both green, fresh CARGO_TARGET_DIR)

(a) Legacy trinity unchanged. Dispatcher auto-picks \`default\` for legacy callers; loss output identical to pre-Bridge-E shape (3 entries: \`kit-plugin-unavailable\` for java lift, \`leg-3-not-reached\`, \`leg-4-not-reached\`).

(b) New \`library_tag_dispatch_test\` asserts \`(python, urllib)\` and \`(python, requests)\` route to distinct realize kits producing different body output:
* urllib emits \`urllib.request.urlopen\`
* requests emits \`requests.get\`

The catalog widens correctly under M+N: adding a new library is one realize kit + one body-template file, no architectural change.

### Files

* \`implementations/rust/provekit-cli/src/kit_dispatch.rs\` (+267/-)
* \`implementations/rust/provekit-cli/tests/library_tag_dispatch_test.rs\` (new)
* \`implementations/rust/provekit-cli/tests/trinity_roundtrip_test.rs\` (+15/-)
* \`implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs\` (+11/-)
* \`.provekit/realize/{rust,java,python,c,python-requests}/manifest.toml\` (rust +1, others new)
* \`implementations/python/provekit-realize-python-requests/\` (new kit)
* \`menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-requests.json\` (new)

Refs #849. Unblocks Bridge F (permutation driver + cross-library truth-table receipt; corpus locked at \`better-sqlite3\` -> \`pg\` per memory).