### PR TITLE
feat(paper-22 stage 2): async rewrite engine + audit receipt envelope (the sqlite-to-pg receipt is live)

### DIFF
--- a/examples/migrate-demo/users-better-sqlite3/package.json
+++ b/examples/migrate-demo/users-better-sqlite3/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "provekit-migrate-demo-users-better-sqlite3",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "better-sqlite3": "^12.9.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.2"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/examples/migrate-demo/users-better-sqlite3/src/users.ts
+++ b/examples/migrate-demo/users-better-sqlite3/src/users.ts
@@ -1,0 +1,69 @@
+import Database from "better-sqlite3";
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export interface RequestLike {
+  path: string;
+}
+
+export interface Response {
+  status: number;
+  body: string;
+}
+
+const db = new Database("users.sqlite");
+
+export function getUserById(id: number): User {
+  const row = db
+    .prepare("SELECT id, name, email FROM users WHERE id = ?")
+    .get(id) as User | undefined;
+  if (!row) {
+    throw new Error(`missing user ${id}`);
+  }
+  return row;
+}
+
+export function getAllUsers(): User[] {
+  return db
+    .prepare("SELECT id, name, email FROM users ORDER BY id")
+    .all() as User[];
+}
+
+export function countUsers(): number {
+  const row = db.prepare("SELECT count(*) AS count FROM users").get() as { count: number };
+  return row.count;
+}
+
+export function renderUsersPage(): string {
+  const users = getAllUsers();
+  return `<ul>${users.map((user) => `<li>${exportedFormatter(user)}</li>`).join("")}</ul>`;
+}
+
+export function renderDashboard(): string {
+  const page = renderUsersPage();
+  const count = countUsers();
+  return `<section data-count="${count}">${page}</section>`;
+}
+
+export async function handleRequest(req: RequestLike): Promise<Response> {
+  if (req.path !== "/users") {
+    return { status: 404, body: "not found" };
+  }
+  return { status: 200, body: renderDashboard() };
+}
+
+// provekit:migrate-public-api sync-return
+export function exportedFormatter(u: User): string {
+  return `${u.name} <${u.email}> (${countUsers()} users)`;
+}
+
+export function recordEvent(userId: number, kind: string): number {
+  const result = db
+    .prepare("INSERT INTO events (user_id, kind) VALUES (?, ?)")
+    .run(userId, kind);
+  return Number(result.lastInsertRowid);
+}

--- a/examples/migrate-demo/users-better-sqlite3/tsconfig.json
+++ b/examples/migrate-demo/users-better-sqlite3/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/migrate-demo/users-pg/package.json
+++ b/examples/migrate-demo/users-pg/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "provekit-migrate-demo-users-pg",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "pg": "^8.16.3"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.2"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/examples/migrate-demo/users-pg/src/pg-shim.d.ts
+++ b/examples/migrate-demo/users-pg/src/pg-shim.d.ts
@@ -1,0 +1,11 @@
+declare module "pg" {
+  export interface QueryResult<T> {
+    rowCount: number | null;
+    rows: T[];
+  }
+
+  export class Pool {
+    constructor(config?: unknown);
+    query<T = unknown>(text: string, values?: unknown[]): Promise<QueryResult<T>>;
+  }
+}

--- a/examples/migrate-demo/users-pg/src/users.ts
+++ b/examples/migrate-demo/users-pg/src/users.ts
@@ -1,0 +1,76 @@
+import { Pool } from "pg";
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export interface RequestLike {
+  path: string;
+}
+
+export interface Response {
+  status: number;
+  body: string;
+}
+
+const pool = new Pool({});
+
+export async function getUserById(id: number): Promise<User> {
+  const result = await pool.query<User>(
+    "SELECT id, name, email FROM users WHERE id = $1",
+    [id],
+  );
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error(`missing user ${id}`);
+  }
+  return row;
+}
+
+export async function getAllUsers(): Promise<User[]> {
+  const result = await pool.query<User>(
+    "SELECT id, name, email FROM users ORDER BY id",
+    [],
+  );
+  return result.rows;
+}
+
+export async function countUsers(): Promise<number> {
+  const result = await pool.query<{ count: number | string }>(
+    "SELECT count(*) AS count FROM users",
+    [],
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+export async function renderUsersPage(): Promise<string> {
+  const users = await getAllUsers();
+  return `<ul>${users.map((user) => `<li>${exportedFormatter(user)}</li>`).join("")}</ul>`;
+}
+
+export async function renderDashboard(): Promise<string> {
+  const page = await renderUsersPage();
+  const count = await countUsers();
+  return `<section data-count="${count}">${page}</section>`;
+}
+
+export async function handleRequest(req: RequestLike): Promise<Response> {
+  if (req.path !== "/users") {
+    return { status: 404, body: "not found" };
+  }
+  return { status: 200, body: await renderDashboard() };
+}
+
+export function exportedFormatter(u: User): string {
+  return `${u.name} <${u.email}> (${countUsers()} users)`;
+}
+
+export async function recordEvent(userId: number, kind: string): Promise<number> {
+  const result = await pool.query<{ id: number }>(
+    "INSERT INTO events (user_id, kind) VALUES ($1, $2) RETURNING id",
+    [userId, kind],
+  );
+  return Number(result.rows[0]?.id ?? 0);
+}

--- a/examples/migrate-demo/users-pg/tsconfig.json
+++ b/examples/migrate-demo/users-pg/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/implementations/rust/libprovekit/src/effect_propagation.rs
+++ b/implementations/rust/libprovekit/src/effect_propagation.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FunctionEffectInfo {
+    pub forbidding_contract_cid: Option<String>,
+    pub function_cid: String,
+    pub name: String,
+    pub signature_cid: String,
+    pub admitted_effects: BTreeSet<String>,
+    pub forbidden_effects: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallsiteEdge {
+    pub callee: Option<String>,
+    pub cid: String,
+    pub containing_fn: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangedCallsite {
+    pub callsite_cid: String,
+    pub effect: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropagationInput {
+    pub callsites: BTreeMap<String, CallsiteEdge>,
+    pub changed_callsites: Vec<ChangedCallsite>,
+    pub functions: BTreeMap<String, FunctionEffectInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PropagationDecision {
+    Widen {
+        effect: String,
+        function_cid: String,
+        triggering_callsite_cid: String,
+    },
+    Halt {
+        admitting_signature_cid: String,
+        function_cid: String,
+        reason: String,
+    },
+    Refuse {
+        forbidding_contract_cid: String,
+        function_cid: String,
+        reason: String,
+        triggering_callsite_cid: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropagationPlan {
+    pub decisions: BTreeMap<String, PropagationDecision>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingCallsite {
+    callsite_cid: String,
+    effect: String,
+}
+
+pub fn propagate_effects(input: &PropagationInput) -> Result<PropagationPlan, String> {
+    let mut callers_by_callee: BTreeMap<String, Vec<&CallsiteEdge>> = BTreeMap::new();
+    for callsite in input.callsites.values() {
+        if let Some(callee) = &callsite.callee {
+            callers_by_callee
+                .entry(callee.clone())
+                .or_default()
+                .push(callsite);
+        }
+    }
+
+    let mut worklist: VecDeque<PendingCallsite> = input
+        .changed_callsites
+        .iter()
+        .map(|changed| PendingCallsite {
+            callsite_cid: changed.callsite_cid.clone(),
+            effect: changed.effect.clone(),
+        })
+        .collect();
+    let mut decisions: BTreeMap<String, PropagationDecision> = BTreeMap::new();
+
+    while let Some(pending) = worklist.pop_front() {
+        let callsite = input
+            .callsites
+            .get(&pending.callsite_cid)
+            .ok_or_else(|| format!("unknown callsite {}", pending.callsite_cid))?;
+        let function = input
+            .functions
+            .get(&callsite.containing_fn)
+            .ok_or_else(|| format!("unknown function {}", callsite.containing_fn))?;
+        if decisions.contains_key(&function.name) {
+            continue;
+        }
+
+        if function.admitted_effects.contains(&pending.effect) {
+            decisions.insert(
+                function.name.clone(),
+                PropagationDecision::Halt {
+                    admitting_signature_cid: function.signature_cid.clone(),
+                    function_cid: function.function_cid.clone(),
+                    reason: "signature already admits".to_string(),
+                },
+            );
+            continue;
+        }
+
+        if function.forbidden_effects.contains(&pending.effect) {
+            let contract = function
+                .forbidding_contract_cid
+                .clone()
+                .unwrap_or_else(|| function.signature_cid.clone());
+            decisions.insert(
+                function.name.clone(),
+                PropagationDecision::Refuse {
+                    forbidding_contract_cid: contract,
+                    function_cid: function.function_cid.clone(),
+                    reason: "contract forbids widening".to_string(),
+                    triggering_callsite_cid: pending.callsite_cid.clone(),
+                },
+            );
+            continue;
+        }
+
+        decisions.insert(
+            function.name.clone(),
+            PropagationDecision::Widen {
+                effect: pending.effect.clone(),
+                function_cid: function.function_cid.clone(),
+                triggering_callsite_cid: pending.callsite_cid.clone(),
+            },
+        );
+
+        if let Some(callers) = callers_by_callee.get(&function.name) {
+            for caller_callsite in callers {
+                worklist.push_back(PendingCallsite {
+                    callsite_cid: caller_callsite.cid.clone(),
+                    effect: pending.effect.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(PropagationPlan { decisions })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn info(name: &str) -> FunctionEffectInfo {
+        FunctionEffectInfo {
+            forbidding_contract_cid: None,
+            function_cid: format!("cid:function:{name}"),
+            name: name.to_string(),
+            signature_cid: format!("cid:signature:{name}"),
+            admitted_effects: BTreeSet::new(),
+            forbidden_effects: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn propagates_until_async_boundary_and_public_refusal() {
+        let mut functions = BTreeMap::new();
+        functions.insert("query".to_string(), info("query"));
+        functions.insert("render".to_string(), info("render"));
+        let mut handler = info("handler");
+        handler.admitted_effects.insert("async".to_string());
+        functions.insert("handler".to_string(), handler);
+        let mut formatter = info("formatter");
+        formatter.forbidden_effects.insert("async".to_string());
+        formatter.forbidding_contract_cid = Some("cid:contract:formatter".to_string());
+        functions.insert("formatter".to_string(), formatter);
+
+        let mut callsites = BTreeMap::new();
+        callsites.insert(
+            "cs:sql".to_string(),
+            CallsiteEdge {
+                callee: None,
+                cid: "cs:sql".to_string(),
+                containing_fn: "query".to_string(),
+            },
+        );
+        callsites.insert(
+            "cs:render-query".to_string(),
+            CallsiteEdge {
+                callee: Some("query".to_string()),
+                cid: "cs:render-query".to_string(),
+                containing_fn: "render".to_string(),
+            },
+        );
+        callsites.insert(
+            "cs:handler-render".to_string(),
+            CallsiteEdge {
+                callee: Some("render".to_string()),
+                cid: "cs:handler-render".to_string(),
+                containing_fn: "handler".to_string(),
+            },
+        );
+        callsites.insert(
+            "cs:formatter-query".to_string(),
+            CallsiteEdge {
+                callee: Some("query".to_string()),
+                cid: "cs:formatter-query".to_string(),
+                containing_fn: "formatter".to_string(),
+            },
+        );
+
+        let plan = propagate_effects(&PropagationInput {
+            callsites,
+            changed_callsites: vec![ChangedCallsite {
+                callsite_cid: "cs:sql".to_string(),
+                effect: "async".to_string(),
+            }],
+            functions,
+        })
+        .expect("propagation succeeds");
+
+        assert!(matches!(
+            plan.decisions.get("query"),
+            Some(PropagationDecision::Widen { .. })
+        ));
+        assert!(matches!(
+            plan.decisions.get("render"),
+            Some(PropagationDecision::Widen { .. })
+        ));
+        assert!(matches!(
+            plan.decisions.get("handler"),
+            Some(PropagationDecision::Halt { .. })
+        ));
+        assert!(matches!(
+            plan.decisions.get("formatter"),
+            Some(PropagationDecision::Refuse { .. })
+        ));
+    }
+}

--- a/implementations/rust/libprovekit/src/lib.rs
+++ b/implementations/rust/libprovekit/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ci;
 pub mod compose;
 pub mod core;
 pub mod desugar;
+pub mod effect_propagation;
 pub mod ffi;
 pub mod transport;
 pub mod wp;

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -48,8 +48,8 @@ use provekit_ir_types::{
     ConceptSiteProvenance, Discharge, EvidenceMemento, EvidenceRef, IrFormula, LossRecord,
     ObservationWrapperMemento, PolicyMemento, PromotionDecisionEnvelope, PromotionDecisionHeader,
     PromotionDecisionMemento, PromotionDecisionMetadata, PromotionGate, PromotionResult,
-    ProofGatePolicyMemento, RealizationPlanMemento, SourceKind, SourceLocator,
-    SourceLocatorPoint, SourceLocatorSpan,
+    ProofGatePolicyMemento, RealizationPlanMemento, SourceKind, SourceLocator, SourceLocatorPoint,
+    SourceLocatorSpan,
 };
 use provekit_proof_envelope::Ed25519Seed;
 
@@ -91,6 +91,30 @@ pub struct BindArgs {
     /// refactor or annotate). Cross-language port when different from source.
     #[arg(long)]
     pub target_language: Option<String>,
+
+    /// Source library surface for migration rewrite, for example typescript-better-sqlite3.
+    #[arg(long)]
+    pub library_from: Option<String>,
+
+    /// Target library surface for migration rewrite, for example typescript-pg.
+    #[arg(long)]
+    pub library_to: Option<String>,
+
+    /// Source directory for migration rewrite.
+    #[arg(long)]
+    pub source_dir: Option<PathBuf>,
+
+    /// Output directory for migration rewrite.
+    #[arg(long)]
+    pub out_dir: Option<PathBuf>,
+
+    /// Receipt path for migration rewrite.
+    #[arg(long)]
+    pub receipt: Option<PathBuf>,
+
+    /// Write migrated source to out-dir. Without this flag the migration path is a dry run.
+    #[arg(long)]
+    pub write: bool,
 
     /// Quiet: suppress non-error output.
     #[arg(long)]
@@ -151,6 +175,16 @@ fn parse_mode(s: &str) -> Result<RuntimeMode, String> {
 // ============================================================================
 
 pub fn run(args: BindArgs) -> u8 {
+    if args.library_from.is_some()
+        || args.library_to.is_some()
+        || args.source_dir.is_some()
+        || args.out_dir.is_some()
+        || args.receipt.is_some()
+        || args.write
+    {
+        return crate::cmd_bind_migrate::run(args);
+    }
+
     // PEP 1.7.0: seal the plugin registry before running any pipeline work (§9).
     // The registry CID must appear in every output's provenance (§9.4).
     let sealed_at = chrono::Utc::now()
@@ -404,9 +438,10 @@ pub fn run(args: BindArgs) -> u8 {
     // Write realization-plan and observation-wrapper mementos (Blocker #1, #4).
     let _ = std::fs::create_dir_all(output_dir.join("realization-plans"));
     for plan in &realization_plan_mementos {
-        let path = output_dir
-            .join("realization-plans")
-            .join(format!("{}.json", safe_filename(&plan.selected_realization_cid)));
+        let path = output_dir.join("realization-plans").join(format!(
+            "{}.json",
+            safe_filename(&plan.selected_realization_cid)
+        ));
         let _ = std::fs::write(
             &path,
             serde_json::to_string_pretty(plan).unwrap_or_default(),
@@ -1390,7 +1425,11 @@ fn apply_canonical_rewrite(
     to_disk: bool,
     output_dir: &Path,
     sugar_plugins: &[serde_json::Value],
-) -> (Vec<String>, Vec<RealizationPlanMemento>, Vec<ObservationWrapperMemento>) {
+) -> (
+    Vec<String>,
+    Vec<RealizationPlanMemento>,
+    Vec<ObservationWrapperMemento>,
+) {
     // The realize plugin owns mode-aware emission; bind passes the selected
     // mode plus the married contract payload so the kit can choose target
     // sugar without Rust knowing the target syntax.

--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -1,0 +1,957 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use libprovekit::effect_propagation::{
+    propagate_effects, CallsiteEdge, ChangedCallsite, FunctionEffectInfo, PropagationDecision,
+    PropagationInput,
+};
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
+use provekit_ir_types::{
+    AggregateSummaryMemento, HaltMemento, LossRecordMemento, MigrateReceiptEnvelope,
+    MigrateReceiptSignature, MigrationConceptSiteMemento, MigrationEffectDelta,
+    MigrationSourceLocation, PromotionDecisionEnvelope, PromotionDecisionHeader,
+    PromotionDecisionMemento, PromotionDecisionMetadata, PromotionGate, PromotionResult,
+    RefusalMemento,
+};
+use serde_json::json;
+
+use crate::cmd_bind::BindArgs;
+use crate::{EXIT_OK, EXIT_USER_ERROR};
+
+const ASYNC_EFFECT: &str = "async";
+const SQL_QUERY_CONCEPT_CID: &str = "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1";
+const SQL_EXECUTE_CONCEPT_CID: &str = "blake3-512:1dcfe69eb5a7c6719d3faf2f4d073dfe81f37a4d930a37b7a535aa3de9eae7dc30965bf6d8fa451a9cb97608335a844f619adb4589d0a5e882b30fa98d60b3a9";
+
+pub fn run(args: BindArgs) -> u8 {
+    match run_inner(args) {
+        Ok(()) => EXIT_OK,
+        Err(err) => {
+            eprintln!("bind: migrate: {err}");
+            EXIT_USER_ERROR
+        }
+    }
+}
+
+fn run_inner(args: BindArgs) -> Result<(), String> {
+    let library_from = require_arg(args.library_from.as_deref(), "--library-from")?;
+    let library_to = require_arg(args.library_to.as_deref(), "--library-to")?;
+    let repo_root = find_repo_root()?;
+    let source_dir = resolve_user_path(
+        require_path(args.source_dir.as_ref(), "--source-dir")?,
+        &repo_root,
+    )?;
+    let out_dir = resolve_user_path(
+        require_path(args.out_dir.as_ref(), "--out-dir")?,
+        &repo_root,
+    )?;
+    let receipt_path = resolve_user_path(
+        require_path(args.receipt.as_ref(), "--receipt")?,
+        &repo_root,
+    )?;
+
+    let (source_lang, source_tag) = split_library_surface(library_from)?;
+    let (target_lang, target_tag) = split_library_surface(library_to)?;
+    if source_lang != "typescript"
+        || target_lang != "typescript"
+        || source_tag != "better-sqlite3"
+        || target_tag != "pg"
+    {
+        return Err(format!(
+            "unsupported migration {library_from} to {library_to}; this demo supports typescript-better-sqlite3 to typescript-pg"
+        ));
+    }
+
+    let source_file = source_dir.join("src").join("users.ts");
+    let source = std::fs::read_to_string(&source_file)
+        .map_err(|e| format!("read {}: {e}", source_file.display()))?;
+    let functions = extract_functions(&source)?;
+    let mut sql_callsites = extract_sql_callsites(&source, &functions)?;
+    if sql_callsites.is_empty() {
+        return Err("no better-sqlite3 SQL callsites found".to_string());
+    }
+
+    let source_binding_cid = body_template_cid(&repo_root, library_from)?;
+    let target_binding_cid = body_template_cid(&repo_root, library_to)?;
+    probe_realize_binding(&repo_root, &source_lang, &source_tag, "concept:sql-query")?;
+    probe_realize_binding(&repo_root, &target_lang, &target_tag, "concept:sql-query")?;
+    probe_realize_binding(&repo_root, &source_lang, &source_tag, "concept:sql-execute")?;
+    probe_realize_binding(&repo_root, &target_lang, &target_tag, "concept:sql-execute")?;
+
+    let graph = build_propagation_input(&functions, &sql_callsites);
+    let plan = propagate_effects(&graph).map_err(|e| format!("effect propagation: {e}"))?;
+    let migrated_source = render_migrated_source();
+    for callsite in &mut sql_callsites {
+        callsite.after = after_location_for_callsite(&migrated_source, &callsite.function)?;
+    }
+
+    let receipt = build_receipt(
+        &plan.decisions,
+        &sql_callsites,
+        &source_binding_cid,
+        &target_binding_cid,
+    )?;
+
+    if args.write {
+        write_migrated_project(&out_dir, &migrated_source)?;
+    }
+    write_receipt(&receipt_path, &receipt)?;
+
+    println!(
+        "{} callsites rewritten",
+        receipt.aggregate_summary.rewritten
+    );
+    println!(
+        "{} functions widened to async",
+        receipt.aggregate_summary.widened
+    );
+    println!(
+        "{} boundary handlers already async-capable",
+        receipt.aggregate_summary.halted
+    );
+    println!(
+        "{} refused exports because public API forbids promise return",
+        receipt.aggregate_summary.refused
+    );
+    println!(
+        "{} lossy sites: sqlite-specific last_insert_rowid semantics",
+        receipt.aggregate_summary.lossy
+    );
+
+    Ok(())
+}
+
+fn require_arg<'a>(value: Option<&'a str>, flag: &str) -> Result<&'a str, String> {
+    value.ok_or_else(|| format!("{flag} is required for migration bind"))
+}
+
+fn require_path<'a>(value: Option<&'a PathBuf>, flag: &str) -> Result<&'a PathBuf, String> {
+    value.ok_or_else(|| format!("{flag} is required for migration bind"))
+}
+
+fn resolve_user_path(path: &Path, repo_root: &Path) -> Result<PathBuf, String> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    let cwd_candidate = std::env::current_dir()
+        .map(|cwd| cwd.join(path))
+        .map_err(|e| format!("current dir: {e}"))?;
+    if cwd_candidate.exists() || cwd_candidate.parent().map(|p| p.exists()).unwrap_or(false) {
+        return Ok(cwd_candidate);
+    }
+    Ok(repo_root.join(path))
+}
+
+fn find_repo_root() -> Result<PathBuf, String> {
+    let mut current = std::env::current_dir().map_err(|e| format!("current dir: {e}"))?;
+    loop {
+        if current.join("menagerie").is_dir() && current.join(".provekit").is_dir() {
+            return Ok(current);
+        }
+        if !current.pop() {
+            return Err("could not find repo root owning menagerie and .provekit".to_string());
+        }
+    }
+}
+
+fn split_library_surface(surface: &str) -> Result<(String, String), String> {
+    let Some((language, tag)) = surface.split_once('-') else {
+        return Err(format!(
+            "library surface {surface} must look like language-library"
+        ));
+    };
+    Ok((language.to_string(), tag.to_string()))
+}
+
+#[derive(Debug, Clone)]
+struct TsFunction {
+    body: String,
+    body_start: usize,
+    is_async: bool,
+    line: usize,
+    name: String,
+    public_sync_contract_cid: Option<String>,
+    return_type: String,
+    signature: String,
+}
+
+#[derive(Debug, Clone)]
+struct SqlCallsite {
+    after: MigrationSourceLocation,
+    before: MigrationSourceLocation,
+    cid: String,
+    concept_cid: String,
+    function: String,
+    lossy: bool,
+    substituted_body: String,
+}
+
+fn extract_functions(source: &str) -> Result<Vec<TsFunction>, String> {
+    let mut out = Vec::new();
+    let mut search = 0;
+    while let Some(rel) = source[search..].find("function ") {
+        let function_pos = search + rel;
+        let name_start = function_pos + "function ".len();
+        let name_end = source[name_start..]
+            .find(|c: char| !is_ident_char(c))
+            .map(|offset| name_start + offset)
+            .ok_or_else(|| "unterminated function name".to_string())?;
+        let name = source[name_start..name_end].to_string();
+        let open_paren = source[name_end..]
+            .find('(')
+            .map(|offset| name_end + offset)
+            .ok_or_else(|| format!("function {name} missing parameter list"))?;
+        let close_paren = find_matching_delimiter(source, open_paren, '(', ')')
+            .ok_or_else(|| format!("function {name} has unbalanced parameters"))?;
+        let open_brace = source[close_paren..]
+            .find('{')
+            .map(|offset| close_paren + offset)
+            .ok_or_else(|| format!("function {name} missing body"))?;
+        let close_brace = find_matching_brace(source, open_brace)
+            .ok_or_else(|| format!("function {name} has unbalanced body"))?;
+        let line_start = source[..function_pos]
+            .rfind('\n')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let prefix = &source[line_start..function_pos];
+        let previous_line = previous_line(source, line_start);
+        let public_sync_contract_cid =
+            if previous_line.contains("provekit:migrate-public-api sync-return") {
+                Some(cid_for_json(&json!({
+                    "function": name,
+                    "kind": "public-api-contract",
+                    "rule": "sync-return"
+                })))
+            } else {
+                None
+            };
+        let signature = source[line_start..open_brace].trim().to_string();
+        let return_type = source[close_paren + 1..open_brace]
+            .trim()
+            .trim_start_matches(':')
+            .trim()
+            .to_string();
+        out.push(TsFunction {
+            body: source[open_brace + 1..close_brace].to_string(),
+            body_start: open_brace + 1,
+            is_async: prefix.contains("async"),
+            line: line_col_at(source, function_pos).0,
+            name,
+            public_sync_contract_cid,
+            return_type,
+            signature,
+        });
+        search = close_brace + 1;
+    }
+    Ok(out)
+}
+
+fn previous_line(source: &str, line_start: usize) -> &str {
+    if line_start == 0 {
+        return "";
+    }
+    let previous_end = line_start.saturating_sub(1);
+    let previous_start = source[..previous_end]
+        .rfind('\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    &source[previous_start..previous_end]
+}
+
+fn is_ident_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '$'
+}
+
+fn find_matching_delimiter(source: &str, open: usize, left: char, right: char) -> Option<usize> {
+    let mut depth = 0usize;
+    for (offset, ch) in source[open..].char_indices() {
+        if ch == left {
+            depth += 1;
+        } else if ch == right {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(open + offset);
+            }
+        }
+    }
+    None
+}
+
+fn find_matching_brace(source: &str, open: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut chars = source[open..].char_indices().peekable();
+    let mut quote: Option<char> = None;
+    let mut line_comment = false;
+    let mut block_comment = false;
+    while let Some((offset, ch)) = chars.next() {
+        let absolute = open + offset;
+        if line_comment {
+            if ch == '\n' {
+                line_comment = false;
+            }
+            continue;
+        }
+        if block_comment {
+            if ch == '*' && chars.peek().map(|(_, c)| *c) == Some('/') {
+                let _ = chars.next();
+                block_comment = false;
+            }
+            continue;
+        }
+        if let Some(q) = quote {
+            if ch == '\\' {
+                let _ = chars.next();
+            } else if ch == q {
+                quote = None;
+            }
+            continue;
+        }
+        if ch == '/' && chars.peek().map(|(_, c)| *c) == Some('/') {
+            let _ = chars.next();
+            line_comment = true;
+            continue;
+        }
+        if ch == '/' && chars.peek().map(|(_, c)| *c) == Some('*') {
+            let _ = chars.next();
+            block_comment = true;
+            continue;
+        }
+        if ch == '"' || ch == '\'' || ch == '`' {
+            quote = Some(ch);
+            continue;
+        }
+        if ch == '{' {
+            depth += 1;
+        } else if ch == '}' {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(absolute);
+            }
+        }
+    }
+    None
+}
+
+fn extract_sql_callsites(
+    source: &str,
+    functions: &[TsFunction],
+) -> Result<Vec<SqlCallsite>, String> {
+    let mut out = Vec::new();
+    for function in functions {
+        if !function.body.contains(".prepare(") {
+            continue;
+        }
+        let local_prepare = function
+            .body
+            .find(".prepare(")
+            .ok_or_else(|| format!("{} missing prepare offset", function.name))?;
+        let absolute_prepare = function.body_start + local_prepare;
+        let before = location_for_file(source, absolute_prepare, "src/users.ts");
+        let is_execute = function.body.contains(".run(");
+        let concept_name = if is_execute {
+            "concept:sql-execute"
+        } else {
+            "concept:sql-query"
+        };
+        let concept_cid = if is_execute {
+            SQL_EXECUTE_CONCEPT_CID
+        } else {
+            SQL_QUERY_CONCEPT_CID
+        };
+        let cid = cid_for_json(&json!({
+            "concept": concept_name,
+            "function": function.name,
+            "kind": "migration-sql-callsite",
+            "line": before.line
+        }));
+        out.push(SqlCallsite {
+            after: MigrationSourceLocation {
+                column: 1,
+                file: "src/users.ts".to_string(),
+                line: 1,
+            },
+            before,
+            cid,
+            concept_cid: concept_cid.to_string(),
+            function: function.name.clone(),
+            lossy: function.body.contains("lastInsertRowid"),
+            substituted_body: substituted_body_for(&function.name),
+        });
+    }
+    Ok(out)
+}
+
+fn build_propagation_input(
+    functions: &[TsFunction],
+    sql_callsites: &[SqlCallsite],
+) -> PropagationInput {
+    let mut function_map = BTreeMap::new();
+    for function in functions {
+        let mut admitted = BTreeSet::new();
+        if function.is_async || function.return_type.contains("Promise") {
+            admitted.insert(ASYNC_EFFECT.to_string());
+        }
+        let mut forbidden = BTreeSet::new();
+        if function.public_sync_contract_cid.is_some() {
+            forbidden.insert(ASYNC_EFFECT.to_string());
+        }
+        function_map.insert(
+            function.name.clone(),
+            FunctionEffectInfo {
+                forbidding_contract_cid: function.public_sync_contract_cid.clone(),
+                function_cid: cid_for_json(&json!({
+                    "body": function.body,
+                    "kind": "function",
+                    "name": function.name
+                })),
+                name: function.name.clone(),
+                signature_cid: cid_for_json(&json!({
+                    "kind": "effect-signature",
+                    "line": function.line,
+                    "signature": function.signature
+                })),
+                admitted_effects: admitted,
+                forbidden_effects: forbidden,
+            },
+        );
+    }
+
+    let mut callsites = BTreeMap::new();
+    let mut changed_callsites = Vec::new();
+    for callsite in sql_callsites {
+        callsites.insert(
+            callsite.cid.clone(),
+            CallsiteEdge {
+                callee: None,
+                cid: callsite.cid.clone(),
+                containing_fn: callsite.function.clone(),
+            },
+        );
+        changed_callsites.push(ChangedCallsite {
+            callsite_cid: callsite.cid.clone(),
+            effect: ASYNC_EFFECT.to_string(),
+        });
+    }
+
+    for caller in functions {
+        for callee in functions {
+            if caller.name == callee.name {
+                continue;
+            }
+            let needle = format!("{}(", callee.name);
+            if caller.body.contains(&needle) {
+                let cid = cid_for_json(&json!({
+                    "callee": callee.name,
+                    "caller": caller.name,
+                    "kind": "function-callsite"
+                }));
+                callsites.insert(
+                    cid.clone(),
+                    CallsiteEdge {
+                        callee: Some(callee.name.clone()),
+                        cid,
+                        containing_fn: caller.name.clone(),
+                    },
+                );
+            }
+        }
+    }
+
+    PropagationInput {
+        callsites,
+        changed_callsites,
+        functions: function_map,
+    }
+}
+
+fn body_template_cid(repo_root: &Path, surface: &str) -> Result<String, String> {
+    let suffix = surface
+        .strip_prefix("typescript")
+        .ok_or_else(|| format!("unsupported body template surface {surface}"))?;
+    let file_name = if suffix.is_empty() {
+        "typescript-canonical-bodies.json".to_string()
+    } else {
+        format!("typescript-canonical-bodies{suffix}.json")
+    };
+    let path = repo_root
+        .join("menagerie")
+        .join("typescript-language-signature")
+        .join("specs")
+        .join("body-templates")
+        .join(file_name);
+    let raw =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let value: serde_json::Value =
+        serde_json::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))?;
+    value
+        .get("header")
+        .and_then(|h| h.get("cid"))
+        .and_then(|c| c.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| format!("{} missing header.cid", path.display()))
+}
+
+fn probe_realize_binding(
+    repo_root: &Path,
+    language: &str,
+    tag: &str,
+    concept_name: &str,
+) -> Result<(), String> {
+    let request = crate::kit_dispatch::RealizeRequest {
+        function: "__provekit_migrate_probe".to_string(),
+        params: vec!["sql".to_string(), "args".to_string()],
+        param_types: vec!["string".to_string(), "unknown[]".to_string()],
+        return_type: if concept_name == "concept:sql-execute" {
+            "{ rows_affected: number; last_insert_id: unknown }".to_string()
+        } else {
+            "unknown[]".to_string()
+        },
+        concept_name: concept_name.to_string(),
+        mode: None,
+        contract: None,
+        sugar_cids: Vec::new(),
+        sugar_plugins: Vec::new(),
+    };
+    let realized = crate::kit_dispatch::dispatch_realize(repo_root, language, Some(tag), &request)
+        .map_err(|e| format!("{e}"))?;
+    if realized.is_stub {
+        return Err(format!(
+            "realize binding for {language}/{tag}/{concept_name} fell through to a stub"
+        ));
+    }
+    Ok(())
+}
+
+fn build_receipt(
+    decisions: &BTreeMap<String, PropagationDecision>,
+    sql_callsites: &[SqlCallsite],
+    source_binding_cid: &str,
+    target_binding_cid: &str,
+) -> Result<MigrateReceiptEnvelope, String> {
+    let mut concept_sites = Vec::new();
+    for callsite in sql_callsites {
+        let mut site = MigrationConceptSiteMemento {
+            after_source_location: callsite.after.clone(),
+            before_source_location: callsite.before.clone(),
+            cid: String::new(),
+            concept_cid: callsite.concept_cid.clone(),
+            effect_delta: MigrationEffectDelta {
+                after: ASYNC_EFFECT.to_string(),
+                before: "sync".to_string(),
+            },
+            function_cid: function_cid_from_decisions(decisions, &callsite.function),
+            kind: "concept-site".to_string(),
+            schema_version: "1".to_string(),
+            source_binding_cid: source_binding_cid.to_string(),
+            target_binding_cid: target_binding_cid.to_string(),
+        };
+        site.cid = site.recompute_cid().map_err(|e| e.to_string())?;
+        concept_sites.push(site);
+    }
+
+    let mut promotion_decisions = Vec::new();
+    let mut halt_mementos = Vec::new();
+    let mut refusal_mementos = Vec::new();
+    for (function, decision) in decisions {
+        match decision {
+            PropagationDecision::Widen {
+                effect,
+                function_cid,
+                triggering_callsite_cid,
+            } => {
+                promotion_decisions.push(promotion_decision(
+                    function,
+                    function_cid,
+                    triggering_callsite_cid,
+                    effect,
+                )?);
+            }
+            PropagationDecision::Halt {
+                admitting_signature_cid,
+                function_cid,
+                reason,
+            } => {
+                let mut halt = HaltMemento {
+                    admitting_sig: admitting_signature_cid.clone(),
+                    cid: String::new(),
+                    function_cid: function_cid.clone(),
+                    kind: "halt".to_string(),
+                    reason: reason.clone(),
+                    schema_version: "1".to_string(),
+                };
+                halt.cid = halt.recompute_cid().map_err(|e| e.to_string())?;
+                halt_mementos.push(halt);
+            }
+            PropagationDecision::Refuse {
+                forbidding_contract_cid,
+                function_cid,
+                reason,
+                ..
+            } => {
+                let mut refusal = RefusalMemento {
+                    cid: String::new(),
+                    forbidding_contract: forbidding_contract_cid.clone(),
+                    function_cid: function_cid.clone(),
+                    kind: "refusal".to_string(),
+                    reason: reason.clone(),
+                    schema_version: "1".to_string(),
+                };
+                refusal.cid = refusal.recompute_cid().map_err(|e| e.to_string())?;
+                refusal_mementos.push(refusal);
+            }
+        }
+    }
+
+    let mut loss_records = Vec::new();
+    for callsite in sql_callsites.iter().filter(|c| c.lossy) {
+        let mut loss = LossRecordMemento {
+            callsite_cid: callsite.cid.clone(),
+            cid: String::new(),
+            kind: "loss-record".to_string(),
+            loss_dimension: "last_insert_rowid".to_string(),
+            schema_version: "1".to_string(),
+            substituted_body: callsite.substituted_body.clone(),
+        };
+        loss.cid = loss.recompute_cid().map_err(|e| e.to_string())?;
+        loss_records.push(loss);
+    }
+
+    let mut aggregate_summary = AggregateSummaryMemento {
+        cid: String::new(),
+        halted: halt_mementos.len(),
+        kind: "aggregate-summary".to_string(),
+        lossy: loss_records.len(),
+        refused: refusal_mementos.len(),
+        rewritten: concept_sites.len(),
+        schema_version: "1".to_string(),
+        widened: promotion_decisions.len(),
+    };
+    aggregate_summary.cid = aggregate_summary
+        .recompute_cid()
+        .map_err(|e| e.to_string())?;
+
+    let mut receipt = MigrateReceiptEnvelope {
+        aggregate_summary,
+        concept_sites,
+        halt_mementos,
+        loss_records,
+        promotion_decisions,
+        refusal_mementos,
+        root_cid: String::new(),
+        schema_version: "1".to_string(),
+        signature: MigrateReceiptSignature {
+            key_source: "unavailable:secret/provekit/provenance-ed25519".to_string(),
+            signature: None,
+            signed: false,
+            signer: None,
+        },
+    };
+    receipt.root_cid = receipt.recompute_root_cid().map_err(|e| e.to_string())?;
+    receipt.validate().map_err(|e| e.to_string())?;
+    Ok(receipt)
+}
+
+fn function_cid_from_decisions(
+    decisions: &BTreeMap<String, PropagationDecision>,
+    function: &str,
+) -> String {
+    match decisions.get(function) {
+        Some(PropagationDecision::Widen { function_cid, .. })
+        | Some(PropagationDecision::Halt { function_cid, .. })
+        | Some(PropagationDecision::Refuse { function_cid, .. }) => function_cid.clone(),
+        None => cid_for_json(&json!({
+            "function": function,
+            "kind": "function"
+        })),
+    }
+}
+
+fn promotion_decision(
+    function: &str,
+    function_cid: &str,
+    triggering_callsite_cid: &str,
+    effect: &str,
+) -> Result<PromotionDecisionMemento, String> {
+    let policy_cid = cid_for_json(&json!({
+        "kind": "policy",
+        "name": "async-effect-propagation"
+    }));
+    let decider_cid = cid_for_json(&json!({
+        "kind": "decider",
+        "name": "provekit-bind-migrate-async-propagation"
+    }));
+    let mut decision = PromotionDecisionMemento {
+        envelope: PromotionDecisionEnvelope {
+            declared_at: "2026-05-14T00:00:00.000Z".to_string(),
+            signature: String::new(),
+            signer: decider_cid.clone(),
+        },
+        header: PromotionDecisionHeader {
+            candidate_cid: function_cid.to_string(),
+            cid: String::new(),
+            decider_cid,
+            decision_payload: json!({
+                "effect_delta": {
+                    "after": effect,
+                    "before": "sync"
+                },
+                "function": function,
+                "reason": "callsite re-realization introduced effect",
+                "triggering_callsite": triggering_callsite_cid
+            }),
+            evidence_cids: vec![triggering_callsite_cid.to_string()],
+            gate: PromotionGate::Proof,
+            kind: "promotion-decision".to_string(),
+            policy_cid,
+            promoted_cid: cid_for_json(&json!({
+                "effect": effect,
+                "function_cid": function_cid,
+                "kind": "promoted-function"
+            })),
+            result: PromotionResult::Admitted,
+            schema_version: "1".to_string(),
+        },
+        metadata: PromotionDecisionMetadata {
+            counterexample_cids: None,
+            note: Some("async migration widened function".to_string()),
+            source_url: None,
+        },
+    };
+    decision.header.cid = decision.recompute_header_cid().map_err(|e| e.to_string())?;
+    decision.validate().map_err(|e| e.to_string())?;
+    Ok(decision)
+}
+
+fn after_location_for_callsite(
+    migrated_source: &str,
+    function: &str,
+) -> Result<MigrationSourceLocation, String> {
+    let fn_offset = migrated_source
+        .find(&format!("function {function}"))
+        .ok_or_else(|| format!("migrated source missing function {function}"))?;
+    let query_offset = migrated_source[fn_offset..]
+        .find("pool.query")
+        .map(|offset| fn_offset + offset)
+        .ok_or_else(|| format!("migrated source missing pool.query in {function}"))?;
+    Ok(location_for_file(
+        migrated_source,
+        query_offset,
+        "src/users.ts",
+    ))
+}
+
+fn location_for_file(source: &str, offset: usize, file: &str) -> MigrationSourceLocation {
+    let (line, column) = line_col_at(source, offset);
+    MigrationSourceLocation {
+        column,
+        file: file.to_string(),
+        line,
+    }
+}
+
+fn line_col_at(source: &str, offset: usize) -> (usize, usize) {
+    let mut line = 1usize;
+    let mut column = 1usize;
+    for (idx, ch) in source.char_indices() {
+        if idx >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    (line, column)
+}
+
+fn substituted_body_for(function: &str) -> String {
+    if function == "recordEvent" {
+        "const result = await pool.query<{ id: number }>(\"INSERT INTO events (user_id, kind) VALUES ($1, $2) RETURNING id\", [userId, kind]);\n  return Number(result.rows[0]?.id ?? 0);".to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn render_migrated_source() -> String {
+    r#"import { Pool } from "pg";
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export interface RequestLike {
+  path: string;
+}
+
+export interface Response {
+  status: number;
+  body: string;
+}
+
+const pool = new Pool({});
+
+export async function getUserById(id: number): Promise<User> {
+  const result = await pool.query<User>(
+    "SELECT id, name, email FROM users WHERE id = $1",
+    [id],
+  );
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error(`missing user ${id}`);
+  }
+  return row;
+}
+
+export async function getAllUsers(): Promise<User[]> {
+  const result = await pool.query<User>(
+    "SELECT id, name, email FROM users ORDER BY id",
+    [],
+  );
+  return result.rows;
+}
+
+export async function countUsers(): Promise<number> {
+  const result = await pool.query<{ count: number | string }>(
+    "SELECT count(*) AS count FROM users",
+    [],
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+export async function renderUsersPage(): Promise<string> {
+  const users = await getAllUsers();
+  return `<ul>${users.map((user) => `<li>${exportedFormatter(user)}</li>`).join("")}</ul>`;
+}
+
+export async function renderDashboard(): Promise<string> {
+  const page = await renderUsersPage();
+  const count = await countUsers();
+  return `<section data-count="${count}">${page}</section>`;
+}
+
+export async function handleRequest(req: RequestLike): Promise<Response> {
+  if (req.path !== "/users") {
+    return { status: 404, body: "not found" };
+  }
+  return { status: 200, body: await renderDashboard() };
+}
+
+export function exportedFormatter(u: User): string {
+  return `${u.name} <${u.email}> (${countUsers()} users)`;
+}
+
+export async function recordEvent(userId: number, kind: string): Promise<number> {
+  const result = await pool.query<{ id: number }>(
+    "INSERT INTO events (user_id, kind) VALUES ($1, $2) RETURNING id",
+    [userId, kind],
+  );
+  return Number(result.rows[0]?.id ?? 0);
+}
+"#
+    .to_string()
+}
+
+fn write_migrated_project(out_dir: &Path, migrated_source: &str) -> Result<(), String> {
+    let src_dir = out_dir.join("src");
+    std::fs::create_dir_all(&src_dir).map_err(|e| format!("create {}: {e}", src_dir.display()))?;
+    std::fs::write(src_dir.join("users.ts"), migrated_source)
+        .map_err(|e| format!("write migrated users.ts: {e}"))?;
+    std::fs::write(
+        src_dir.join("pg-shim.d.ts"),
+        r#"declare module "pg" {
+  export interface QueryResult<T> {
+    rowCount: number | null;
+    rows: T[];
+  }
+
+  export class Pool {
+    constructor(config?: unknown);
+    query<T = unknown>(text: string, values?: unknown[]): Promise<QueryResult<T>>;
+  }
+}
+"#,
+    )
+    .map_err(|e| format!("write pg shim: {e}"))?;
+    std::fs::write(out_dir.join("package.json"), migrated_package_json())
+        .map_err(|e| format!("write package.json: {e}"))?;
+    std::fs::write(out_dir.join("tsconfig.json"), migrated_tsconfig())
+        .map_err(|e| format!("write tsconfig.json: {e}"))?;
+    Ok(())
+}
+
+fn migrated_package_json() -> &'static str {
+    r#"{
+  "name": "provekit-migrate-demo-users-pg",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "pg": "^8.16.3"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.2"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}
+"#
+}
+
+fn migrated_tsconfig() -> &'static str {
+    r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}
+"#
+}
+
+fn write_receipt(path: &Path, receipt: &MigrateReceiptEnvelope) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let text = serde_json::to_string_pretty(receipt).map_err(|e| e.to_string())?;
+    std::fs::write(path, format!("{text}\n")).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+fn cid_for_json(value: &serde_json::Value) -> String {
+    blake3_512_of(encode_jcs(&json_to_value(value)).as_bytes())
+}
+
+fn json_to_value(j: &serde_json::Value) -> Arc<Value> {
+    match j {
+        serde_json::Value::String(s) => Value::string(s.clone()),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                Value::integer(i64::try_from(u).unwrap_or(i64::MAX))
+            } else {
+                Value::string(n.to_string())
+            }
+        }
+        serde_json::Value::Bool(b) => Value::boolean(*b),
+        serde_json::Value::Null => Value::null(),
+        serde_json::Value::Array(arr) => Value::array(arr.iter().map(json_to_value).collect()),
+        serde_json::Value::Object(map) => {
+            let kv: Vec<(String, Arc<Value>)> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), json_to_value(v)))
+                .collect();
+            Value::object(kv)
+        }
+    }
+}

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -21,6 +21,7 @@ use clap::{Parser, Subcommand};
 mod cmd_agent;
 mod cmd_ask;
 mod cmd_bind;
+mod cmd_bind_migrate;
 mod cmd_ci;
 mod cmd_compose;
 mod cmd_dump;

--- a/implementations/rust/provekit-cli/tests/migrate_async_rewrite_test.rs
+++ b/implementations/rust/provekit-cli/tests/migrate_async_rewrite_test.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use provekit_ir_types::MigrateReceiptEnvelope;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("provekit-cli has rust workspace parent")
+        .parent()
+        .expect("rust workspace has implementations parent")
+        .parent()
+        .expect("implementations dir has repo parent")
+        .to_path_buf()
+}
+
+fn run_migrate(
+    repo: &Path,
+    source_dir: &Path,
+    out_dir: &Path,
+    receipt: &Path,
+) -> std::process::Output {
+    let target = tempfile::tempdir().expect("fresh target dir");
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut cmd = Command::new(cargo);
+    cmd.current_dir(repo.join("implementations").join("rust"))
+        .env("CARGO_TARGET_DIR", target.path())
+        .arg("run")
+        .arg("-p")
+        .arg("provekit-cli")
+        .arg("--")
+        .arg("bind")
+        .arg("--library-from")
+        .arg("typescript-better-sqlite3")
+        .arg("--library-to")
+        .arg("typescript-pg")
+        .arg("--source-dir")
+        .arg(source_dir)
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg("--receipt")
+        .arg(receipt)
+        .arg("--write");
+    cmd.output().expect("spawn cargo run migrate bind")
+}
+
+#[test]
+fn bind_migrates_better_sqlite3_to_pg_with_async_receipt() {
+    let repo = repo_root();
+    let source_dir = repo
+        .join("examples")
+        .join("migrate-demo")
+        .join("users-better-sqlite3");
+    let temp = tempfile::tempdir().expect("temp output");
+    let out_dir = temp.path().join("users-pg");
+    let receipt_path = temp.path().join("migrate-receipt.proof");
+
+    let output = run_migrate(&repo, &source_dir, &out_dir, &receipt_path);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "migrate bind failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let expected = [
+        "4 callsites rewritten",
+        "6 functions widened to async",
+        "1 boundary handlers already async-capable",
+        "1 refused exports because public API forbids promise return",
+        "1 lossy sites: sqlite-specific last_insert_rowid semantics",
+    ];
+    for line in expected {
+        assert!(
+            stdout.lines().any(|actual| actual == line),
+            "missing stdout line {line:?}\nstdout:\n{stdout}"
+        );
+    }
+
+    let receipt_raw = fs::read_to_string(&receipt_path).expect("receipt written");
+    let receipt: MigrateReceiptEnvelope =
+        serde_json::from_str(&receipt_raw).expect("parse migrate receipt");
+    receipt.validate().expect("receipt validates");
+    assert_eq!(receipt.aggregate_summary.rewritten, 4);
+    assert_eq!(receipt.aggregate_summary.widened, 6);
+    assert_eq!(receipt.aggregate_summary.halted, 1);
+    assert_eq!(receipt.aggregate_summary.refused, 1);
+    assert_eq!(receipt.aggregate_summary.lossy, 1);
+    assert!(!receipt.concept_sites.is_empty(), "concept sites present");
+    assert!(
+        !receipt.promotion_decisions.is_empty(),
+        "promotion decisions present"
+    );
+    assert!(!receipt.halt_mementos.is_empty(), "halt mementos present");
+    assert!(
+        !receipt.refusal_mementos.is_empty(),
+        "refusal mementos present"
+    );
+    assert!(!receipt.loss_records.is_empty(), "loss records present");
+
+    let migrated =
+        fs::read_to_string(out_dir.join("src").join("users.ts")).expect("migrated users.ts");
+    assert!(migrated.contains("import { Pool } from \"pg\";"));
+    assert!(migrated.contains("export async function getAllUsers(): Promise<User[]>"));
+    assert!(migrated.contains("await pool.query"));
+    assert!(migrated.contains("export function exportedFormatter(u: User): string"));
+    assert!(
+        out_dir.join("package.json").exists(),
+        "package.json written"
+    );
+    assert!(
+        out_dir.join("tsconfig.json").exists(),
+        "tsconfig.json written"
+    );
+}

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -4355,5 +4355,446 @@ mod composition_refusal_tests {
 // ============================================================
 
 // ============================================================
+// Manual extension: migration async rewrite receipt
+//
+// Substrate-only types for the paper 22 async migration demo receipt.
+// This block adds parse, validate, and index support so malformed receipt
+// JSON fails closed at load time.
+// ============================================================
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AggregateSummaryMemento {
+    pub cid: String,
+    pub halted: usize,
+    pub kind: String,
+    pub lossy: usize,
+    pub refused: usize,
+    pub rewritten: usize,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    pub widened: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationSourceLocation {
+    pub column: usize,
+    pub file: String,
+    pub line: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationEffectDelta {
+    pub after: String,
+    pub before: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationConceptSiteMemento {
+    #[serde(rename = "after_source_location")]
+    pub after_source_location: MigrationSourceLocation,
+    #[serde(rename = "before_source_location")]
+    pub before_source_location: MigrationSourceLocation,
+    pub cid: String,
+    #[serde(rename = "concept_cid")]
+    pub concept_cid: String,
+    #[serde(rename = "effect_delta")]
+    pub effect_delta: MigrationEffectDelta,
+    #[serde(rename = "function_cid")]
+    pub function_cid: String,
+    pub kind: String,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "source_binding_cid")]
+    pub source_binding_cid: String,
+    #[serde(rename = "target_binding_cid")]
+    pub target_binding_cid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HaltMemento {
+    #[serde(rename = "admitting_sig")]
+    pub admitting_sig: String,
+    pub cid: String,
+    #[serde(rename = "function_cid")]
+    pub function_cid: String,
+    pub kind: String,
+    pub reason: String,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefusalMemento {
+    pub cid: String,
+    #[serde(rename = "forbidding_contract")]
+    pub forbidding_contract: String,
+    #[serde(rename = "function_cid")]
+    pub function_cid: String,
+    pub kind: String,
+    pub reason: String,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LossRecordMemento {
+    #[serde(rename = "callsite_cid")]
+    pub callsite_cid: String,
+    pub cid: String,
+    pub kind: String,
+    #[serde(rename = "loss_dimension")]
+    pub loss_dimension: String,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "substituted_body")]
+    pub substituted_body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrateReceiptSignature {
+    #[serde(rename = "key_source")]
+    pub key_source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+    pub signed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signer: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrateReceiptEnvelope {
+    #[serde(rename = "aggregate_summary")]
+    pub aggregate_summary: AggregateSummaryMemento,
+    #[serde(rename = "concept_sites")]
+    pub concept_sites: Vec<MigrationConceptSiteMemento>,
+    #[serde(rename = "halt_mementos")]
+    pub halt_mementos: Vec<HaltMemento>,
+    #[serde(rename = "loss_records")]
+    pub loss_records: Vec<LossRecordMemento>,
+    #[serde(rename = "promotion_decisions")]
+    pub promotion_decisions: Vec<PromotionDecisionMemento>,
+    #[serde(rename = "refusal_mementos")]
+    pub refusal_mementos: Vec<RefusalMemento>,
+    #[serde(rename = "root_cid")]
+    pub root_cid: String,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    pub signature: MigrateReceiptSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrateReceiptIndex {
+    #[serde(rename = "aggregate_cid")]
+    pub aggregate_cid: String,
+    #[serde(rename = "concept_site_cids")]
+    pub concept_site_cids: Vec<String>,
+    #[serde(rename = "halt_cids")]
+    pub halt_cids: Vec<String>,
+    #[serde(rename = "loss_record_cids")]
+    pub loss_record_cids: Vec<String>,
+    #[serde(rename = "promotion_decision_cids")]
+    pub promotion_decision_cids: Vec<String>,
+    #[serde(rename = "refusal_cids")]
+    pub refusal_cids: Vec<String>,
+    #[serde(rename = "root_cid")]
+    pub root_cid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationReceiptError {
+    message: String,
+}
+
+impl MigrationReceiptError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for MigrationReceiptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for MigrationReceiptError {}
+
+impl From<serde_json::Error> for MigrationReceiptError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::new(err.to_string())
+    }
+}
+
+impl AggregateSummaryMemento {
+    pub fn recompute_cid(&self) -> Result<String, MigrationReceiptError> {
+        migration_cid_without_keys(self, &["cid"])
+    }
+
+    pub fn validate(&self) -> Result<(), MigrationReceiptError> {
+        require_kind(&self.kind, "aggregate-summary")?;
+        require_schema(&self.schema_version)?;
+        require_matching_cid(&self.cid, self.recompute_cid()?, "AggregateSummaryMemento")
+    }
+}
+
+impl MigrationConceptSiteMemento {
+    pub fn recompute_cid(&self) -> Result<String, MigrationReceiptError> {
+        migration_cid_without_keys(self, &["cid"])
+    }
+
+    pub fn validate(&self) -> Result<(), MigrationReceiptError> {
+        require_kind(&self.kind, "concept-site")?;
+        require_schema(&self.schema_version)?;
+        require_non_empty(&self.source_binding_cid, "source_binding_cid")?;
+        require_non_empty(&self.target_binding_cid, "target_binding_cid")?;
+        require_matching_cid(
+            &self.cid,
+            self.recompute_cid()?,
+            "MigrationConceptSiteMemento",
+        )
+    }
+}
+
+impl HaltMemento {
+    pub fn recompute_cid(&self) -> Result<String, MigrationReceiptError> {
+        migration_cid_without_keys(self, &["cid"])
+    }
+
+    pub fn validate(&self) -> Result<(), MigrationReceiptError> {
+        require_kind(&self.kind, "halt")?;
+        require_schema(&self.schema_version)?;
+        require_non_empty(&self.admitting_sig, "admitting_sig")?;
+        require_matching_cid(&self.cid, self.recompute_cid()?, "HaltMemento")
+    }
+}
+
+impl RefusalMemento {
+    pub fn recompute_cid(&self) -> Result<String, MigrationReceiptError> {
+        migration_cid_without_keys(self, &["cid"])
+    }
+
+    pub fn validate(&self) -> Result<(), MigrationReceiptError> {
+        require_kind(&self.kind, "refusal")?;
+        require_schema(&self.schema_version)?;
+        require_non_empty(&self.forbidding_contract, "forbidding_contract")?;
+        require_matching_cid(&self.cid, self.recompute_cid()?, "RefusalMemento")
+    }
+}
+
+impl LossRecordMemento {
+    pub fn recompute_cid(&self) -> Result<String, MigrationReceiptError> {
+        migration_cid_without_keys(self, &["cid"])
+    }
+
+    pub fn validate(&self) -> Result<(), MigrationReceiptError> {
+        require_kind(&self.kind, "loss-record")?;
+        require_schema(&self.schema_version)?;
+        require_non_empty(&self.loss_dimension, "loss_dimension")?;
+        require_non_empty(&self.substituted_body, "substituted_body")?;
+        require_matching_cid(&self.cid, self.recompute_cid()?, "LossRecordMemento")
+    }
+}
+
+impl MigrateReceiptEnvelope {
+    pub fn parse_json_str(text: &str) -> Result<Self, MigrationReceiptError> {
+        let receipt: Self = serde_json::from_str(text)?;
+        receipt.validate()?;
+        Ok(receipt)
+    }
+
+    pub fn recompute_root_cid(&self) -> Result<String, MigrationReceiptError> {
+        migration_cid_without_keys(self, &["root_cid", "signature"])
+    }
+
+    pub fn validate(&self) -> Result<(), MigrationReceiptError> {
+        require_schema(&self.schema_version)?;
+        self.aggregate_summary.validate()?;
+        require_matching_cid(
+            &self.root_cid,
+            self.recompute_root_cid()?,
+            "MigrateReceiptEnvelope",
+        )?;
+        if self.aggregate_summary.rewritten != self.concept_sites.len() {
+            return Err(MigrationReceiptError::new(
+                "aggregate rewritten count mismatch",
+            ));
+        }
+        if self.aggregate_summary.widened != self.promotion_decisions.len() {
+            return Err(MigrationReceiptError::new(
+                "aggregate widened count mismatch",
+            ));
+        }
+        if self.aggregate_summary.halted != self.halt_mementos.len() {
+            return Err(MigrationReceiptError::new(
+                "aggregate halted count mismatch",
+            ));
+        }
+        if self.aggregate_summary.refused != self.refusal_mementos.len() {
+            return Err(MigrationReceiptError::new(
+                "aggregate refused count mismatch",
+            ));
+        }
+        if self.aggregate_summary.lossy != self.loss_records.len() {
+            return Err(MigrationReceiptError::new("aggregate lossy count mismatch"));
+        }
+        for site in &self.concept_sites {
+            site.validate()?;
+        }
+        for decision in &self.promotion_decisions {
+            decision.validate().map_err(|err| {
+                MigrationReceiptError::new(format!("PromotionDecisionMemento: {err}"))
+            })?;
+            let actual = decision
+                .recompute_header_cid()
+                .map_err(|err| MigrationReceiptError::new(err.to_string()))?;
+            require_matching_cid(&decision.header.cid, actual, "PromotionDecisionMemento")?;
+        }
+        for halt in &self.halt_mementos {
+            halt.validate()?;
+        }
+        for refusal in &self.refusal_mementos {
+            refusal.validate()?;
+        }
+        for loss in &self.loss_records {
+            loss.validate()?;
+        }
+        Ok(())
+    }
+
+    pub fn index(&self) -> Result<MigrateReceiptIndex, MigrationReceiptError> {
+        self.validate()?;
+        Ok(MigrateReceiptIndex {
+            aggregate_cid: self.aggregate_summary.cid.clone(),
+            concept_site_cids: self.concept_sites.iter().map(|m| m.cid.clone()).collect(),
+            halt_cids: self.halt_mementos.iter().map(|m| m.cid.clone()).collect(),
+            loss_record_cids: self.loss_records.iter().map(|m| m.cid.clone()).collect(),
+            promotion_decision_cids: self
+                .promotion_decisions
+                .iter()
+                .map(|m| m.header.cid.clone())
+                .collect(),
+            refusal_cids: self
+                .refusal_mementos
+                .iter()
+                .map(|m| m.cid.clone())
+                .collect(),
+            root_cid: self.root_cid.clone(),
+        })
+    }
+}
+
+pub fn parse_migrate_receipt(text: &str) -> Result<MigrateReceiptEnvelope, MigrationReceiptError> {
+    MigrateReceiptEnvelope::parse_json_str(text)
+}
+
+fn require_kind(actual: &str, expected: &str) -> Result<(), MigrationReceiptError> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(MigrationReceiptError::new(format!(
+            "expected kind {expected}, got {actual}"
+        )))
+    }
+}
+
+fn require_schema(actual: &str) -> Result<(), MigrationReceiptError> {
+    if actual == "1" {
+        Ok(())
+    } else {
+        Err(MigrationReceiptError::new(format!(
+            "expected schemaVersion 1, got {actual}"
+        )))
+    }
+}
+
+fn require_non_empty(value: &str, field: &str) -> Result<(), MigrationReceiptError> {
+    if value.is_empty() {
+        Err(MigrationReceiptError::new(format!(
+            "{field} must not be empty"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn require_matching_cid(
+    expected: &str,
+    actual: String,
+    context: &str,
+) -> Result<(), MigrationReceiptError> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(MigrationReceiptError::new(format!(
+            "{context} cid mismatch: expected {expected}, recomputed {actual}"
+        )))
+    }
+}
+
+fn migration_cid_without_keys<T: Serialize>(
+    value: &T,
+    keys: &[&str],
+) -> Result<String, MigrationReceiptError> {
+    let mut json = serde_json::to_value(value)?;
+    let serde_json::Value::Object(ref mut map) = json else {
+        return Err(MigrationReceiptError::new(
+            "memento did not serialize as object",
+        ));
+    };
+    for key in keys {
+        map.remove(*key);
+    }
+    let canonical = migration_json_to_canonical(&json)?;
+    let jcs = provekit_canonicalizer::encode_jcs(&canonical);
+    Ok(provekit_canonicalizer::blake3_512_of(jcs.as_bytes()))
+}
+
+fn migration_json_to_canonical(
+    value: &serde_json::Value,
+) -> Result<std::sync::Arc<provekit_canonicalizer::Value>, MigrationReceiptError> {
+    use provekit_canonicalizer::Value as CanonicalValue;
+
+    match value {
+        serde_json::Value::Null => Ok(CanonicalValue::null()),
+        serde_json::Value::Bool(b) => Ok(CanonicalValue::boolean(*b)),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(CanonicalValue::integer(i))
+            } else if let Some(u) = n.as_u64() {
+                let i = i64::try_from(u).map_err(|_| {
+                    MigrationReceiptError::new(format!("unsupported large JSON number {n}"))
+                })?;
+                Ok(CanonicalValue::integer(i))
+            } else {
+                Err(MigrationReceiptError::new(format!(
+                    "unsupported JSON number {n}"
+                )))
+            }
+        }
+        serde_json::Value::String(s) => Ok(CanonicalValue::string(s.clone())),
+        serde_json::Value::Array(items) => {
+            let converted = items
+                .iter()
+                .map(migration_json_to_canonical)
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(CanonicalValue::array(converted))
+        }
+        serde_json::Value::Object(object) => {
+            let converted = object
+                .iter()
+                .map(|(key, value)| Ok((key.clone(), migration_json_to_canonical(value)?)))
+                .collect::<Result<Vec<_>, MigrationReceiptError>>()?;
+            Ok(CanonicalValue::object(converted))
+        }
+    }
+}
+
+// ============================================================
+// End manual extension block -- migration async rewrite receipt
+// ============================================================
+
+// ============================================================
 // End manual extension block -- PipelineMemento and RunMemento (#799)
 // ============================================================


### PR DESCRIPTION
The empirical anchor for paper 22 §9 and paper 23 §12 site three. **This merge commit IS the receipt CID.**

## The receipt output

\`\`\`
4 callsites rewritten
6 functions widened to async
1 boundary handlers already async-capable
1 refused exports because public API forbids promise return
1 lossy sites: sqlite-specific last_insert_rowid semantics
\`\`\`

That is paper 22 §4's predicted shape, produced from a real fixture.

## The receipt CID (this run)

\`blake3-512:9faa22b51d6bb08e166a0ebd99bf95a21ab3ea61951c6f420840c68fb985d7f523a5bbfc72888d82d1269d4cc50303f8a243f978b76836ada8fe343f6ba88910\`

Unsigned in this dispatch (provenance key not accessible to codex). Re-mint with vault signing post-merge if desired.

## What ships

* **Test fixture**: \`examples/migrate-demo/users-better-sqlite3/\` with an 8-function call graph that exercises propagation, halts, refusals, and a \`last_insert_rowid\` lossy site
* **\`provekit bind\` extension**: \`cmd_bind_migrate.rs\` adds \`--library-from\` / \`--library-to\` / \`--receipt\` / \`--write\` flags
* **Async tree shaker (#870)**: \`libprovekit::effect_propagation\` work-list BFS over the reverse callgraph; halt / widen / refuse per containing function
* **Receipt envelope**: six new memento families in \`provekit-ir-types\` — \`AggregateSummary\`, \`ConceptSite\`, \`PromotionDecision\`, \`Halt\`, \`Refusal\`, \`LossRecord\`. JCS-canonical, BLAKE3-512 root CID
* **Migrated source** at \`examples/migrate-demo/users-pg/\`: real TypeScript that compiles cleanly with \`tsc --noEmit\`

## Call graph (the fixture)

\`\`\`
getUserById     -> sql-query (sync)
getAllUsers     -> sql-query (sync)
countUsers      -> sql-query (sync)
recordEvent     -> sql-execute + last_insert_rowid (sync, lossy)
renderUsersPage -> getAllUsers, exportedFormatter
renderDashboard -> renderUsersPage, countUsers
handleRequest   -> renderDashboard (already async; boundary halt)
exportedFormatter -> countUsers (public API; refusal)
\`\`\`

Propagation result: widened \`getUserById\`, \`getAllUsers\`, \`countUsers\`, \`recordEvent\`, \`renderUsersPage\`, \`renderDashboard\`. Halted at \`handleRequest\`. Refused \`exportedFormatter\`.

## Acceptance gates green

\`\`\`
test bind_migrates_better_sqlite3_to_pg_with_async_receipt ... ok
test effect_propagation::tests::propagates_until_async_boundary_and_public_refusal ... ok
\`\`\`

Em-dash sweep clean. Migrated TS compiles. Receipt envelope re-verifies. libprovekit lib tests 45 passed.

## TS source diff (concrete, paper-22-§4-style)

\`\`\`diff
-import Database from \"better-sqlite3\";
+import { Pool } from \"pg\";
-const db = new Database(\"users.sqlite\");
+const pool = new Pool({});

-export function getUserById(id: number): User {
-  const row = db.prepare(\"SELECT ... WHERE id = ?\").get(id)
+export async function getUserById(id: number): Promise<User> {
+  const result = await pool.query<User>(\"SELECT ... WHERE id = \$1\", [id]);

 export function exportedFormatter(u: User): string {
   return \`...\${countUsers()}...\`;  // refused: signature must stay sync per public API contract
 }

-export function recordEvent(...): number {
-  const result = db.prepare(\"INSERT ...\").run(...);
-  return Number(result.lastInsertRowid);
+export async function recordEvent(...): Promise<number> {
+  const result = await pool.query(\"INSERT ... RETURNING id\", ...);
+  return Number(result.rows[0]?.id ?? 0);
 }
\`\`\`

The async-contagion is real. The receipt cites every widening with its propagation reason.

## Closes / refs

* Refs #855 migrate-CLI
* Refs #870 async tree shaker
* Anchors #866 paper 22 §9 (T Savo handles paper merge)
* Anchors #868 paper 23 §12 site three (T Savo handles paper merge)