### PR TITLE
[codex] Make bind witnesses authoritative

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -613,23 +613,26 @@ struct ContractWitness {
 /// reaches the eight-verb engine; there is no language-specific path.
 fn raw_lift_from_kit_entry(entry: &crate::kit_dispatch::BindLiftEntry) -> RawLift {
     let mut witnesses = Vec::new();
-    if let Some(pre) = entry.attr_pre.as_deref() {
-        witnesses.push(annotation_contract_witness(
-            "pre",
-            pre,
-            entry.fn_line as usize,
-            &entry.file,
-            &entry.fn_name,
-        ));
-    }
-    if let Some(post) = entry.attr_post.as_deref() {
-        witnesses.push(annotation_contract_witness(
-            "post",
-            post,
-            entry.fn_line as usize,
-            &entry.file,
-            &entry.fn_name,
-        ));
+    let use_legacy_attr_shim = entry.witnesses.is_empty();
+    if use_legacy_attr_shim {
+        if let Some(pre) = entry.attr_pre.as_deref() {
+            witnesses.push(annotation_contract_witness(
+                "pre",
+                pre,
+                entry.fn_line as usize,
+                &entry.file,
+                &entry.fn_name,
+            ));
+        }
+        if let Some(post) = entry.attr_post.as_deref() {
+            witnesses.push(annotation_contract_witness(
+                "post",
+                post,
+                entry.fn_line as usize,
+                &entry.file,
+                &entry.fn_name,
+            ));
+        }
     }
     witnesses.extend(
         entry
@@ -642,8 +645,16 @@ fn raw_lift_from_kit_entry(entry: &crate::kit_dispatch::BindLiftEntry) -> RawLif
         file: entry.file.clone(),
         fn_name: entry.fn_name.clone(),
         fn_line: entry.fn_line as usize,
-        attr_pre: entry.attr_pre.clone(),
-        attr_post: entry.attr_post.clone(),
+        attr_pre: if use_legacy_attr_shim {
+            entry.attr_pre.clone()
+        } else {
+            None
+        },
+        attr_post: if use_legacy_attr_shim {
+            entry.attr_post.clone()
+        } else {
+            None
+        },
         witnesses,
         concept_annotation: entry.concept_annotation.clone(),
         term_shape: TermShape::from_kit(entry.term_shape.clone(), entry.term_shape_cid.clone()),
@@ -895,22 +906,22 @@ fn run_bind_engine(
             .or_else(|| shape_to_concept.get(&shape_cid))
             .expect("shape was clustered");
 
-        // Contract origin priority: attribute > test > algebra-synthesis > empty.
+        // Contract origin priority: normalized witnesses > legacy attr shim > test >
+        // algebra-synthesis > empty. Non-empty witnesses[] are the primary contract
+        // channel; attr_pre/attr_post only feed the compatibility shim above.
         let explicit_pre = contract_text_from_witnesses(&lift.witnesses, "pre");
         let explicit_post = contract_text_from_witnesses(&lift.witnesses, "post");
-        let (origin, pre, post) = if lift.attr_pre.is_some() || lift.attr_post.is_some() {
+        let (origin, pre, post) = if explicit_pre.is_some() || explicit_post.is_some() {
+            (
+                contract_origin_for_witnesses(&lift.witnesses),
+                explicit_pre,
+                explicit_post,
+            )
+        } else if lift.attr_pre.is_some() || lift.attr_post.is_some() {
             (
                 ContractOrigin::AttributeLift,
                 lift.attr_pre.clone(),
                 lift.attr_post.clone(),
-            )
-        } else if explicit_pre.is_some() || explicit_post.is_some() {
-            (
-                ContractOrigin::EvidenceLift {
-                    source_kind: dominant_source_kind_label(&lift.witnesses),
-                },
-                explicit_pre,
-                explicit_post,
             )
         } else if let Some(test_post) = test_post_map.get(&lift.fn_name) {
             (ContractOrigin::TestLift, None, Some(test_post.clone()))
@@ -2143,6 +2154,20 @@ fn dominant_source_kind_label(witnesses: &[ContractWitness]) -> String {
             .next()
             .unwrap_or_else(|| "unspecified".to_string()),
         _ => "mixed".to_string(),
+    }
+}
+
+fn contract_origin_for_witnesses(witnesses: &[ContractWitness]) -> ContractOrigin {
+    if !witnesses.is_empty()
+        && witnesses
+            .iter()
+            .all(|w| matches!(w.source_kind, SourceKind::Annotation))
+    {
+        ContractOrigin::AttributeLift
+    } else {
+        ContractOrigin::EvidenceLift {
+            source_kind: dominant_source_kind_label(witnesses),
+        }
     }
 }
 

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -197,6 +197,75 @@ for line in sys.stdin:
     root
 }
 
+fn copy_fixture_with_attrs_and_authoritative_witness_manifest() -> PathBuf {
+    let root = copy_fixture_to_temp();
+    let kit_path = root.join("bind-lift-kit.py");
+    let shape_cid = format!("blake3-512:{}", "2".repeat(128));
+    let script = format!(
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+SHAPE_CID = {shape_cid:?}
+
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request.get("method")
+    request_id = request.get("id")
+    if method == "initialize":
+        result = {{}}
+    elif method == "lift":
+        result = {{
+            "kind": "ir-document",
+            "diagnostics": [],
+            "ir": [{{
+                "kind": "bind-lift-entry",
+                "file": "src/account.rs",
+                "fn_name": "deposit",
+                "fn_line": 14,
+                "attr_pre": "amount > 0",
+                "attr_post": "out >= 0",
+                "concept_annotation": "deposit-then-balance",
+                "param_names": ["balance", "amount"],
+                "param_types": ["i64", "i64"],
+                "return_type": "i64",
+                "term_shape": {{"kind": "body", "stmts": [{{"kind": "opaque"}}]}},
+                "term_shape_cid": SHAPE_CID,
+                "witnesses": [
+                    {{
+                        "role": "post",
+                        "predicate_text": "out == balance + amount",
+                        "source_kind": "test-assertion",
+                        "line": 7,
+                        "col": 8
+                    }}
+                ]
+            }}]
+        }}
+    elif method == "shutdown":
+        result = {{}}
+    else:
+        print(json.dumps({{"jsonrpc": "2.0", "id": request_id, "error": {{"message": "unknown method"}}}}), flush=True)
+        continue
+    print(json.dumps({{"jsonrpc": "2.0", "id": request_id, "result": result}}), flush=True)
+    if method == "shutdown":
+        break
+"#
+    );
+    fs::write(&kit_path, script).expect("write bind lift kit");
+    let manifest_dir = root.join(".provekit").join("lift").join("rust");
+    fs::create_dir_all(&manifest_dir).expect("create lift manifest dir");
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"test-bind-lift-authoritative-witness\"\ncommand = [\"python3\", \"{}\"]\n",
+            kit_path.display()
+        ),
+    )
+    .expect("write lift manifest");
+    root
+}
+
 fn bind_cmd(
     root: &Path,
     out: &Path,
@@ -300,6 +369,32 @@ fn annotate_monitor_injects_concept_and_monitor_attr() {
     assert!(
         rewritten.contains("provekit_monitor"),
         "monitor mode must inject provekit_monitor attribute"
+    );
+}
+
+#[test]
+fn witnesses_are_authoritative_over_legacy_attr_fields() {
+    let tmp = copy_fixture_with_attrs_and_authoritative_witness_manifest();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&tmp, &out, "annotate", "monitor", None);
+    assert!(
+        result.status.success(),
+        "annotate+monitor should succeed\nstderr: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let rewritten = fs::read_to_string(tmp.join("src").join("account.rs")).unwrap();
+    assert!(
+        rewritten.contains("ensures(out == balance + amount)"),
+        "non-empty witnesses[] must drive emitted postconditions:\n{rewritten}"
+    );
+    assert!(
+        !rewritten.contains("ensures(out >= 0)"),
+        "legacy attr_post must not override non-empty witnesses[]:\n{rewritten}"
+    );
+    assert!(
+        !rewritten.contains("requires(amount > 0)"),
+        "legacy attr_pre must not be promoted when witnesses[] is non-empty:\n{rewritten}"
     );
 }
 

--- a/protocol/specs/2026-05-13-bind-ir-lift-result.md
+++ b/protocol/specs/2026-05-13-bind-ir-lift-result.md
@@ -25,8 +25,8 @@ This spec defines the JSON shape every entry of `ir-document.ir[]` MUST take whe
 ; Locked JCS key order: alphabetical within the object.
 
 bind-lift-entry = {
-  attr_post:          tstr / null,    ; user-declared postcondition formula text, JSON-encoded
-  attr_pre:           tstr / null,    ; user-declared precondition formula text, JSON-encoded
+  attr_post:          tstr / null,    ; LEGACY compatibility postcondition text; see §1.1
+  attr_pre:           tstr / null,    ; LEGACY compatibility precondition text; see §1.1
   concept_annotation: tstr / null,    ; the `// concept: NAME` annotation, NAME only (no prefix)
   file:               tstr,           ; project-root-relative path of the source file
   fn_line:            uint,           ; 1-based line number of the `fn` keyword
@@ -68,8 +68,8 @@ source-kind = "annotation"
 
 | Field                | Required | Meaning |
 |----------------------|----------|---------|
-| `attr_pre`           | yes      | The user-supplied precondition formula text extracted from the language's contract annotation surface (e.g., Rust `#[requires(...)]`, Java `@requires`, Python `# @requires:`). `null` when no annotation is present. |
-| `attr_post`          | yes      | The user-supplied postcondition formula text. `null` when absent. |
+| `attr_pre`           | yes      | LEGACY compatibility precondition text extracted from older annotation-only lift kits. New producers SHOULD emit `null` and place all contract evidence in `witnesses[]`. Consumers MUST use this field only when `witnesses[]` is empty. |
+| `attr_post`          | yes      | LEGACY compatibility postcondition text extracted from older annotation-only lift kits. New producers SHOULD emit `null` and place all contract evidence in `witnesses[]`. Consumers MUST use this field only when `witnesses[]` is empty. |
 | `concept_annotation` | yes      | The NAME from a `// concept: NAME` (or language-equivalent) comment immediately preceding the function. The kit MUST strip the `concept:` prefix; producers emit `identity`, not `concept:identity`. `null` when absent. |
 | `file`               | yes      | Path relative to the project root (the `workspace_root` lift-params field). Forward slashes only; the kit MUST normalize. |
 | `fn_line`            | yes      | The 1-based line number of the function declaration (the line containing the `fn`/`def`/method keyword). |
@@ -80,13 +80,15 @@ source-kind = "annotation"
 | `return_type`        | yes      | The source-language return type, or `"()"` for unit/void. |
 | `term_shape`         | yes      | A language-neutral structural fingerprint of the function body, defined per §2. |
 | `term_shape_cid`     | yes      | `"blake3-512:" + hex(BLAKE3-512(JCS-canonical bytes of `term_shape`))`. Used as the bucket key for clustering. |
-| `witnesses`          | yes      | Contract witnesses already married to this function/concept site. Each witness is promoted directly to an `EvidenceMemento` by cmd_bind. Legacy `attr_pre` / `attr_post` producers MAY leave this empty; cmd_bind auto-promotes those fields as `source_kind = "annotation"` witnesses for backward compatibility. |
+| `witnesses`          | yes      | Authoritative contract witnesses already married to this function/concept site. Each witness is promoted directly to an `EvidenceMemento` by cmd_bind. Legacy `attr_pre` / `attr_post` producers MAY leave this empty; cmd_bind auto-promotes those fields as `source_kind = "annotation"` witnesses for backward compatibility. |
 
 ### §1.2 Contract witness semantics
 
 `bind-contract-witness-entry.source_kind` MUST use the existing `EvidenceMemento.source_kind` vocabulary from `2026-05-13-compound-contract-memento.md` §10. Lift kits MUST NOT invent a parallel bind-only source-kind enum. Unknown future labels are carried as open extensions and map to `SourceKind::Other`.
 
 `predicate` is preferred when the lifter has an `IrFormula`. `predicate_text` is the compatibility surface for existing annotation strings and native extractor ecosystems that have not yet lowered their predicate into IR. When both are present, `predicate` is authoritative for evidence minting and `predicate_text` is retained only for source re-emission surfaces.
+
+When `witnesses[]` is non-empty, it is the complete contract evidence set for the bind entry. `attr_pre` and `attr_post` MUST NOT add predicates, override predicates, or alter the composed contract in a conforming consumer. They are ignored except for diagnostics. A producer that still has only legacy annotation strings MAY set `witnesses[] = []`; the consumer compatibility shim then lifts `attr_pre` / `attr_post` as annotation witnesses.
 
 ### §1.3 What is OUT OF scope for this entry
 


### PR DESCRIPTION
## Summary
- Treat non-empty bind `witnesses[]` as the authoritative contract evidence channel.
- Use `attr_pre` / `attr_post` only as a legacy compatibility shim when a kit emits no witnesses.
- Document the precedence in the bind-IR lift-result spec and add an integration regression for mixed legacy attrs plus witness evidence.

## Root Cause
`cmd_bind` normalized legacy attrs into witnesses, but then selected raw `attr_pre` / `attr_post` before the normalized witness text. A kit that emitted both channels could lose richer witness predicates during annotation and contract composition.

## Validation
- `cargo test -p provekit-cli --test cmd_bind_integration witnesses_are_authoritative_over_legacy_attr_fields -- --nocapture`
- `cargo test -p provekit-cli --test cmd_bind_integration`
- `cargo test -p provekit-cli`
- `bazel test //...`