### PR TITLE
[codex] Add witness consensus promotion

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_witness.rs
+++ b/implementations/rust/provekit-cli/src/cmd_witness.rs
@@ -16,25 +16,48 @@
 //   5. If unsat: mint witness memento, save to .provekit/witnesses/
 //   6. The witness can be shipped with the package
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use chrono::{SecondsFormat, Utc};
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use provekit_ir_types::{
+    MigrateReceiptEnvelope, PromotionDecisionEnvelope, PromotionDecisionHeader,
+    PromotionDecisionMemento, PromotionDecisionMetadata, PromotionGate, PromotionResult,
+    WitnessMemento,
+};
+use serde_json::json;
 use serde_json::Value as Json;
+use walkdir::WalkDir;
 
 use crate::{EXIT_OK, EXIT_SOLVER_FAIL, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
 
 pub fn run(args: crate::WitnessArgs) -> u8 {
+    if args.command_or_contract == "consensus" {
+        return run_consensus(args);
+    }
+
     let project_root = args
         .project
+        .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap());
+    let contract_cid = args.command_or_contract.clone();
+    let property = match args.property.as_ref() {
+        Some(path) => path.clone(),
+        None => {
+            eprintln!("error: witness requires <CONTRACT_CID> <PROPERTY>");
+            return EXIT_USER_ERROR;
+        }
+    };
 
     // 1. Load pool
     let pool = provekit_verifier::load_all_proofs::run(&project_root);
 
     // 2. Find contract
-    let contract = match pool.mementos.get(&args.contract_cid) {
+    let contract = match pool.mementos.get(&contract_cid) {
         Some(c) => c,
         None => {
-            eprintln!("error: contract {} not found in pool", args.contract_cid);
+            eprintln!("error: contract {contract_cid} not found in pool");
             return EXIT_USER_ERROR;
         }
     };
@@ -49,7 +72,7 @@ pub fn run(args: crate::WitnessArgs) -> u8 {
     };
 
     // 4. Load property formula
-    let property_formula = match load_formula(&args.property) {
+    let property_formula = match load_formula(&property) {
         Ok(f) => f,
         Err(e) => {
             eprintln!("error: failed to load property: {e}");
@@ -78,7 +101,7 @@ pub fn run(args: crate::WitnessArgs) -> u8 {
     // 7. Run solver
     println!(
         "witness: proving {} implies property...",
-        short(&args.contract_cid)
+        short(&contract_cid)
     );
     let result = run_solver(&args.z3, &smt);
 
@@ -88,7 +111,7 @@ pub fn run(args: crate::WitnessArgs) -> u8 {
             // TODO: mint witness memento
             // For now, print what would be minted
             println!("witness: memento would be:");
-            println!("  antecedent: {}", args.contract_cid);
+            println!("  antecedent: {contract_cid}");
             println!("  consequent: <property CID>");
             println!("  prover: z3");
             EXIT_OK
@@ -107,6 +130,128 @@ pub fn run(args: crate::WitnessArgs) -> u8 {
             EXIT_SOLVER_FAIL
         }
     }
+}
+
+fn run_consensus(args: crate::WitnessArgs) -> u8 {
+    let project_root = args
+        .project
+        .unwrap_or_else(|| std::env::current_dir().unwrap());
+    let concept = match args.concept.as_deref() {
+        Some(concept) if !concept.trim().is_empty() => concept.to_string(),
+        _ => {
+            eprintln!("error: witness consensus requires --concept");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let fixture = match args.require_fixture.as_deref() {
+        Some(fixture) if !fixture.trim().is_empty() => fixture.to_string(),
+        _ => {
+            eprintln!("error: witness consensus requires --require-fixture");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let emit = match args.emit.as_ref() {
+        Some(path) => path.clone(),
+        None => {
+            eprintln!("error: witness consensus requires --emit <PATH>");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let catalog_roots = if args.catalogs.is_empty() {
+        let project_catalog = project_root.join(".provekit");
+        if project_catalog.exists() {
+            vec![project_catalog]
+        } else {
+            vec![project_root]
+        }
+    } else {
+        args.catalogs.clone()
+    };
+
+    let witnesses = match collect_witnesses(&catalog_roots) {
+        Ok(witnesses) => witnesses,
+        Err(err) => {
+            eprintln!("error: witness consensus catalog scan failed: {err}");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let selected: Vec<WitnessMemento> = witnesses
+        .into_iter()
+        .filter(|witness| {
+            witness.witness_for == concept
+                && witness.fixture_state_cid == fixture
+                && witness.outcome == "pass"
+        })
+        .collect();
+    if selected.len() < args.min_witnesses {
+        eprintln!(
+            "witness consensus: rejected: {} matching passing witnesses, require {}",
+            selected.len(),
+            args.min_witnesses
+        );
+        return EXIT_VERIFY_FAIL;
+    }
+
+    let row_schema = match consensus_row_schema(&selected) {
+        Ok(row_schema) => row_schema,
+        Err(err) => {
+            eprintln!("witness consensus: rejected: {err}");
+            return EXIT_VERIFY_FAIL;
+        }
+    };
+
+    let decision = match promotion_decision_for_consensus(
+        &concept,
+        &fixture,
+        args.min_witnesses,
+        &selected,
+        row_schema,
+    ) {
+        Ok(decision) => decision,
+        Err(err) => {
+            eprintln!("error: mint promotion decision: {err}");
+            return EXIT_USER_ERROR;
+        }
+    };
+    if let Some(parent) = emit.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            eprintln!("error: create {}: {err}", parent.display());
+            return EXIT_USER_ERROR;
+        }
+    }
+    let bytes = match serde_json::to_string_pretty(&decision) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!("error: serialize promotion decision: {err}");
+            return EXIT_USER_ERROR;
+        }
+    };
+    if let Err(err) = std::fs::write(&emit, format!("{bytes}\n")) {
+        eprintln!("error: write {}: {err}", emit.display());
+        return EXIT_USER_ERROR;
+    }
+
+    if args.out.json {
+        let summary = json!({
+            "agreement": "byte-equal",
+            "promotion_cid": decision.header.cid,
+            "promotion_receipt": emit.display().to_string(),
+            "result": "admitted",
+            "witnesses_consulted": selected.len()
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&summary).unwrap_or_else(|_| summary.to_string())
+        );
+    } else if !args.out.quiet {
+        println!("witness consensus: admitted");
+        println!("  concept: {concept}");
+        println!("  fixture: {fixture}");
+        println!("  witnesses: {}", selected.len());
+        println!("  agreement: byte-equal");
+        println!("  receipt: {}", emit.display());
+    }
+    EXIT_OK
 }
 
 fn extract_post(contract: &Json) -> Option<Json> {
@@ -135,6 +280,200 @@ fn build_witness_obligation(post: &Json, property: &Json) -> Result<Json, String
         );
         m
     }))
+}
+
+fn collect_witnesses(catalog_roots: &[PathBuf]) -> Result<Vec<WitnessMemento>, String> {
+    let mut witnesses = Vec::new();
+    for root in catalog_roots {
+        if root.is_file() {
+            collect_witnesses_from_file(root, &mut witnesses)?;
+            continue;
+        }
+        if !root.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(root)
+            .into_iter()
+            .filter_entry(|entry| should_descend(entry.path()))
+        {
+            let entry = entry.map_err(|e| e.to_string())?;
+            if entry.file_type().is_file() {
+                collect_witnesses_from_file(entry.path(), &mut witnesses)?;
+            }
+        }
+    }
+    witnesses.sort_by(|left, right| left.cid.cmp(&right.cid));
+    witnesses.dedup_by(|left, right| left.cid == right.cid);
+    Ok(witnesses)
+}
+
+fn should_descend(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return true;
+    };
+    !matches!(
+        name,
+        ".git" | ".worktrees" | "target" | "node_modules" | "vendor" | ".venv"
+    )
+}
+
+fn collect_witnesses_from_file(
+    path: &Path,
+    witnesses: &mut Vec<WitnessMemento>,
+) -> Result<(), String> {
+    let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+        return Ok(());
+    };
+    if !matches!(ext, "json" | "proof") {
+        return Ok(());
+    }
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(_) => return Ok(()),
+    };
+    if let Ok(witness) = serde_json::from_str::<WitnessMemento>(&text) {
+        if witness.validate().is_ok() {
+            witnesses.push(witness);
+        }
+        return Ok(());
+    }
+    if let Ok(receipt) = MigrateReceiptEnvelope::parse_json_str(&text) {
+        witnesses.extend(receipt.witnesses);
+    }
+    Ok(())
+}
+
+fn consensus_row_schema(witnesses: &[WitnessMemento]) -> Result<Json, String> {
+    let mut schemas = witnesses.iter().map(|witness| {
+        witness
+            .measurements
+            .get("row_schema")
+            .cloned()
+            .ok_or_else(|| format!("witness {} missing measurements.row_schema", witness.cid))
+    });
+    let first = schemas
+        .next()
+        .ok_or_else(|| "no witnesses selected".to_string())??;
+    let first_bytes = canonical_json_bytes(&first);
+    for schema in schemas {
+        let schema = schema?;
+        let bytes = canonical_json_bytes(&schema);
+        if bytes != first_bytes {
+            return Err("measurements.row_schema disagreement".to_string());
+        }
+    }
+    Ok(first)
+}
+
+fn promotion_decision_for_consensus(
+    concept: &str,
+    fixture: &str,
+    min_witnesses: usize,
+    witnesses: &[WitnessMemento],
+    row_schema: Json,
+) -> Result<PromotionDecisionMemento, String> {
+    let mut evidence_cids: Vec<String> = witnesses.iter().map(|w| w.cid.clone()).collect();
+    evidence_cids.sort();
+    let subjects: Vec<String> = witnesses.iter().map(|w| w.subject.clone()).collect();
+    let total_observations: u64 = witnesses.iter().map(|w| w.sample_count).sum();
+    let policy_cid = cid_for_json(&json!({
+        "kind": "consensus-policy",
+        "min_witnesses": min_witnesses,
+        "name": "provekit-witness-consensus-row-schema-v1"
+    }));
+    let decider_cid = cid_for_json(&json!({
+        "kind": "decider",
+        "name": "provekit-witness-consensus"
+    }));
+    let candidate_cid = cid_for_json(&json!({
+        "concept": concept,
+        "kind": "concept-candidate"
+    }));
+    let promoted_cid = cid_for_json(&json!({
+        "concept": concept,
+        "fixture_state_cid": fixture,
+        "kind": "promoted-concept-tier",
+        "tier": "empirically-witnessed"
+    }));
+    let reason = format!(
+        "{} witnesses on 1 fixture, all measurements.row_schema byte-equal",
+        witnesses.len()
+    );
+    let mut decision = PromotionDecisionMemento {
+        envelope: PromotionDecisionEnvelope {
+            declared_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+            signature: String::new(),
+            signer: decider_cid.clone(),
+        },
+        header: PromotionDecisionHeader {
+            candidate_cid,
+            cid: String::new(),
+            decider_cid,
+            decision_payload: json!({
+                "agreement": "byte-equal",
+                "fixtures_consulted": [fixture],
+                "min_witnesses": min_witnesses,
+                "promotion": "documentary -> empirically-witnessed",
+                "promoted_op": concept,
+                "reason": reason,
+                "row_schema": row_schema,
+                "subjects_consulted": subjects,
+                "total_observations": total_observations,
+                "witnesses_consulted": evidence_cids
+            }),
+            evidence_cids,
+            gate: PromotionGate::Threshold,
+            kind: "promotion-decision".to_string(),
+            policy_cid,
+            promoted_cid,
+            result: PromotionResult::Admitted,
+            schema_version: "1".to_string(),
+        },
+        metadata: PromotionDecisionMetadata {
+            counterexample_cids: None,
+            note: Some("witness consensus promoted empirical contract tier".to_string()),
+            source_url: None,
+        },
+    };
+    decision.header.cid = decision.recompute_header_cid().map_err(|e| e.to_string())?;
+    decision.validate().map_err(|e| e.to_string())?;
+    Ok(decision)
+}
+
+fn canonical_json_bytes(value: &Json) -> Vec<u8> {
+    let canonical = json_to_value(value);
+    encode_jcs(&canonical).into_bytes()
+}
+
+fn cid_for_json(value: &Json) -> String {
+    blake3_512_of(&canonical_json_bytes(value))
+}
+
+fn json_to_value(j: &Json) -> Arc<CValue> {
+    match j {
+        Json::String(s) => CValue::string(s.clone()),
+        Json::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CValue::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                if let Ok(i) = i64::try_from(u) {
+                    CValue::integer(i)
+                } else {
+                    CValue::string(n.to_string())
+                }
+            } else {
+                CValue::string(n.to_string())
+            }
+        }
+        Json::Bool(b) => CValue::boolean(*b),
+        Json::Null => CValue::null(),
+        Json::Array(items) => CValue::array(items.iter().map(json_to_value).collect()),
+        Json::Object(map) => CValue::object(
+            map.iter()
+                .map(|(key, value)| (key.as_str(), json_to_value(value)))
+                .collect::<Vec<_>>(),
+        ),
+    }
 }
 
 enum SolverOutput {

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -303,11 +303,26 @@ pub struct VerifyProtocolArgs {
 
 #[derive(Parser, Debug, Clone)]
 pub struct WitnessArgs {
-    /// CID of the contract to witness from (the base theorem).
-    pub contract_cid: String,
-    /// Path to an IR-JSON formula file representing the property to prove.
-    /// Use `-` for stdin.
-    pub property: PathBuf,
+    /// Legacy witness contract CID, or the mode name `consensus`.
+    pub command_or_contract: String,
+    /// Legacy path to an IR-JSON formula file representing the property to prove.
+    /// Use `-` for stdin. Not used by `witness consensus`.
+    pub property: Option<PathBuf>,
+    /// Concept identifier required by `witness consensus`.
+    #[arg(long)]
+    pub concept: Option<String>,
+    /// Fixture-state CID required for consensus.
+    #[arg(long = "require-fixture")]
+    pub require_fixture: Option<String>,
+    /// Minimum passing witnesses required before admission.
+    #[arg(long = "min-witnesses", default_value_t = 1)]
+    pub min_witnesses: usize,
+    /// File or directory to scan for WitnessMementos or migration receipts.
+    #[arg(long = "catalog")]
+    pub catalogs: Vec<PathBuf>,
+    /// Path where the PromotionDecisionMemento should be written.
+    #[arg(long)]
+    pub emit: Option<PathBuf>,
     /// Project root to load the contract from. Defaults to current directory.
     #[arg(long)]
     pub project: Option<PathBuf>,

--- a/implementations/rust/provekit-cli/tests/witness_consensus_test.rs
+++ b/implementations/rust/provekit-cli/tests/witness_consensus_test.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use provekit_ir_types::{PromotionDecisionMemento, PromotionGate, PromotionResult, WitnessMemento};
+use serde_json::{json, Value};
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+#[test]
+fn witness_consensus_emits_promotion_decision_for_byte_equal_row_shape() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let catalog = tmp.path().join("catalog");
+    fs::create_dir_all(&catalog).expect("create catalog dir");
+    let out = tmp.path().join("promotion-receipt.proof");
+    let concept = "concept:sql-query";
+    let fixture = format!("blake3-512:{}", "a".repeat(128));
+    let row_schema = json!({
+        "columns": [
+            {"name": "id", "declared_type": "INTEGER", "observed_typeof": "integer"},
+            {"name": "name", "declared_type": "TEXT", "observed_typeof": "text"}
+        ]
+    });
+
+    for i in 0..4 {
+        let witness = witness(
+            concept,
+            &format!("ts:getUserById:{i}"),
+            &fixture,
+            &row_schema,
+            i,
+        );
+        fs::write(
+            catalog.join(format!("witness-{i}.json")),
+            serde_json::to_string_pretty(&witness).expect("serialize witness"),
+        )
+        .expect("write witness");
+    }
+
+    let output = Command::new(provekit_bin())
+        .arg("witness")
+        .arg("consensus")
+        .arg("--concept")
+        .arg(concept)
+        .arg("--require-fixture")
+        .arg(&fixture)
+        .arg("--min-witnesses")
+        .arg("4")
+        .arg("--catalog")
+        .arg(&catalog)
+        .arg("--emit")
+        .arg(&out)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit witness consensus");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "witness consensus failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let summary: Value = serde_json::from_slice(&output.stdout).expect("parse summary json");
+    assert_eq!(summary["result"], "admitted");
+    assert_eq!(summary["witnesses_consulted"], 4);
+    assert_eq!(summary["agreement"], "byte-equal");
+    assert_eq!(summary["promotion_receipt"], out.display().to_string());
+
+    let raw = fs::read_to_string(&out).expect("promotion receipt written");
+    let decision: PromotionDecisionMemento =
+        serde_json::from_str(&raw).expect("parse promotion decision");
+    decision.validate().expect("promotion decision validates");
+    assert_eq!(
+        decision.header.cid,
+        decision
+            .recompute_header_cid()
+            .expect("recompute promotion decision cid")
+    );
+    assert_eq!(decision.header.kind, "promotion-decision");
+    assert_eq!(decision.header.gate, PromotionGate::Threshold);
+    assert_eq!(decision.header.result, PromotionResult::Admitted);
+    assert_eq!(decision.header.evidence_cids.len(), 4);
+    assert_eq!(decision.header.decision_payload["promoted_op"], concept);
+    assert_eq!(
+        decision.header.decision_payload["promotion"],
+        "documentary -> empirically-witnessed"
+    );
+    assert_eq!(decision.header.decision_payload["agreement"], "byte-equal");
+    assert_eq!(decision.header.decision_payload["total_observations"], 4);
+    assert_eq!(
+        decision.header.decision_payload["fixtures_consulted"],
+        json!([fixture])
+    );
+    assert_eq!(decision.header.decision_payload["row_schema"], row_schema);
+}
+
+#[test]
+fn witness_consensus_rejects_row_shape_disagreement() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let catalog = tmp.path().join("catalog");
+    fs::create_dir_all(&catalog).expect("create catalog dir");
+    let out = tmp.path().join("promotion-receipt.proof");
+    let concept = "concept:sql-query";
+    let fixture = format!("blake3-512:{}", "b".repeat(128));
+    let row_schema = json!({
+        "columns": [
+            {"name": "id", "declared_type": "INTEGER", "observed_typeof": "integer"}
+        ]
+    });
+    let divergent_row_schema = json!({
+        "columns": [
+            {"name": "id", "declared_type": "INTEGER", "observed_typeof": "integer"},
+            {"name": "email", "declared_type": "TEXT", "observed_typeof": "text"}
+        ]
+    });
+
+    for i in 0..3 {
+        let witness = witness(
+            concept,
+            &format!("ts:getUserById:{i}"),
+            &fixture,
+            &row_schema,
+            i,
+        );
+        fs::write(
+            catalog.join(format!("witness-{i}.json")),
+            serde_json::to_string_pretty(&witness).expect("serialize witness"),
+        )
+        .expect("write witness");
+    }
+    let divergent = witness(
+        concept,
+        "python:get_user_by_id:0",
+        &fixture,
+        &divergent_row_schema,
+        99,
+    );
+    fs::write(
+        catalog.join("witness-divergent.json"),
+        serde_json::to_string_pretty(&divergent).expect("serialize divergent witness"),
+    )
+    .expect("write divergent witness");
+
+    let output = Command::new(provekit_bin())
+        .arg("witness")
+        .arg("consensus")
+        .arg("--concept")
+        .arg(concept)
+        .arg("--require-fixture")
+        .arg(&fixture)
+        .arg("--min-witnesses")
+        .arg("4")
+        .arg("--catalog")
+        .arg(&catalog)
+        .arg("--emit")
+        .arg(&out)
+        .output()
+        .expect("spawn provekit witness consensus");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "row-shape disagreement must reject promotion"
+    );
+    assert!(
+        stderr.contains("measurements.row_schema disagreement"),
+        "stderr should identify the discovered loss axis:\n{stderr}"
+    );
+    assert!(
+        !out.exists(),
+        "rejected consensus must not emit a promotion decision"
+    );
+}
+
+fn witness(
+    concept: &str,
+    subject: &str,
+    fixture: &str,
+    row_schema: &Value,
+    idx: usize,
+) -> WitnessMemento {
+    let mut witness = WitnessMemento {
+        cid: String::new(),
+        fixture_state_cid: fixture.to_string(),
+        kind: "witness".to_string(),
+        measurements: json!({
+            "query": {
+                "sql": format!("SELECT id, name FROM users WHERE id = {idx}"),
+                "sample_args": [idx]
+            },
+            "row_schema": row_schema,
+            "sample_row": {
+                "id": idx,
+                "name": format!("user-{idx}")
+            }
+        }),
+        observed_at: "2026-05-14T00:00:00.000Z".to_string(),
+        outcome: "pass".to_string(),
+        sample_count: 1,
+        schema_version: "1".to_string(),
+        signature: None,
+        signed_by: None,
+        subject: subject.to_string(),
+        witness_for: concept.to_string(),
+    };
+    witness.cid = witness.recompute_cid().expect("witness cid");
+    witness
+}

--- a/protocol/specs/2026-05-14-witness-consensus-promotion.md
+++ b/protocol/specs/2026-05-14-witness-consensus-promotion.md
@@ -1,0 +1,67 @@
+# Witness Consensus Promotion (`witness-consensus/1`)
+
+**Status:** v1.0.0 operational draft for empirical promotion from `WitnessMemento` sets.
+**Date:** 2026-05-14
+**Related:** `2026-05-13-compound-contract-memento.md`, `2026-05-13-bind-ir-lift-result.md`
+
+## Purpose
+
+`WitnessMemento` records one empirical observation. Witness consensus is the local promotion rule that turns enough agreeing observations into a substrate upgrade event.
+
+The output is not a new receipt family. It is a `PromotionDecisionMemento` with `gate = "threshold"` and `result = "admitted"` when the configured policy admits the witness set.
+
+## CLI Shape
+
+```sh
+provekit witness consensus \
+  --concept concept:sql-query \
+  --require-fixture blake3-512:<fixture> \
+  --min-witnesses 4 \
+  --catalog <file-or-dir> \
+  --emit promotion-receipt.proof
+```
+
+`--catalog` MAY be repeated. Each path is walked recursively. Consumers admit standalone `WitnessMemento` JSON files and migration receipts containing `witnesses[]`.
+
+## Selection
+
+A witness participates when all predicates hold:
+
+- `witness_for == --concept`
+- `fixture_state_cid == --require-fixture`
+- `outcome == "pass"`
+
+If fewer than `--min-witnesses` witnesses remain, the command rejects and emits no promotion decision.
+
+## Agreement
+
+For `concept:sql-query`, the first operational agreement axis is:
+
+```json
+measurements.row_schema
+```
+
+The command JCS-canonicalizes each selected `measurements.row_schema` value and requires byte equality across the selected set.
+
+If the selected witnesses disagree, the command rejects and emits no promotion decision. The disagreement names the loss axis (`measurements.row_schema`) so later slices can mint an explicit `LossRecordMemento` instead of treating disagreement as a generic failure.
+
+## Promotion Payload
+
+On admission, the `PromotionDecisionMemento.header.decision_payload` carries at least:
+
+```json
+{
+  "agreement": "byte-equal",
+  "fixtures_consulted": ["blake3-512:<fixture>"],
+  "min_witnesses": 4,
+  "promotion": "documentary -> empirically-witnessed",
+  "promoted_op": "concept:sql-query",
+  "reason": "<human summary>",
+  "row_schema": {},
+  "subjects_consulted": [],
+  "total_observations": 4,
+  "witnesses_consulted": []
+}
+```
+
+`header.evidence_cids` MUST contain the consulted witness CIDs. `header.policy_cid` identifies the consensus policy. `header.decider_cid` identifies the consensus command implementation or equivalent policy runner.


### PR DESCRIPTION
## Summary
- Add `provekit witness consensus` as the Stage 4 consensus command for concept + fixture witness aggregation.
- Mint `PromotionDecisionMemento` receipts when passing witnesses agree on `measurements.row_schema` by JCS byte equality.
- Add a protocol spec note and focused tests for admission and disagreement rejection.

## Validation
- `cargo test -p provekit-cli --test witness_consensus_test -- --nocapture`
- `cargo test -p provekit-cli --test witness_row_shape_test`
- `cargo test -p provekit-cli`
- `bazel test //...`
