### PR TITLE
feat(stage 3): cross-language contract travel — TS better-sqlite3 -> Python sqlite3/aiosqlite with cross-language witness pair

### DIFF
--- a/.provekit/realize/python-aiosqlite/manifest.toml
+++ b/.provekit/realize/python-aiosqlite/manifest.toml
@@ -1,0 +1,6 @@
+# PEP 1.7.0 `kind = "realize"` plugin manifest for Python aiosqlite body emission.
+# cmd_bind dispatches canonical rewrite emission here when target-language=python and library_tag=aiosqlite.
+name = "python-realize-aiosqlite"
+library_tag = "aiosqlite"
+command = ["implementations/python/target/release/provekit-realize-python-aiosqlite", "--rpc"]
+working_dir = "."

--- a/.provekit/realize/python-sqlite3/manifest.toml
+++ b/.provekit/realize/python-sqlite3/manifest.toml
@@ -1,0 +1,6 @@
+# PEP 1.7.0 `kind = "realize"` plugin manifest for Python sqlite3 body emission.
+# cmd_bind dispatches canonical rewrite emission here when target-language=python and library_tag=sqlite3.
+name = "python-realize-sqlite3"
+library_tag = "sqlite3"
+command = ["implementations/python/target/release/provekit-realize-python-sqlite3", "--rpc"]
+working_dir = "."

--- a/examples/migrate-demo/users-python-aiosqlite/pyproject.toml
+++ b/examples/migrate-demo/users-python-aiosqlite/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "provekit-migrate-demo-users-python-aiosqlite"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = ["aiosqlite"]

--- a/examples/migrate-demo/users-python-aiosqlite/src/users.py
+++ b/examples/migrate-demo/users-python-aiosqlite/src/users.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import aiosqlite
+from typing import Any, Coroutine, TypedDict
+
+
+class User(TypedDict):
+    id: int
+    name: str
+    email: str
+
+
+class RequestLike(TypedDict):
+    path: str
+
+
+class Response(TypedDict):
+    status: int
+    body: str
+
+
+DB_PATH = "users.sqlite"
+
+
+def _row_to_user(row: aiosqlite.Row | None) -> User | None:
+    if row is None:
+        return None
+    return {
+        "id": int(row["id"]),
+        "name": str(row["name"]),
+        "email": str(row["email"]),
+    }
+
+
+async def get_user_by_id(id: int) -> Coroutine[Any, Any, User]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT id, name, email FROM users WHERE id = ?",
+            (id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+    user = _row_to_user(row)
+    if user is None:
+        raise RuntimeError(f"missing user {id}")
+    return user
+
+
+async def get_all_users() -> Coroutine[Any, Any, list[User]]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT id, name, email FROM users ORDER BY id") as cursor:
+            rows = await cursor.fetchall()
+    return [
+        {
+            "id": int(row["id"]),
+            "name": str(row["name"]),
+            "email": str(row["email"]),
+        }
+        for row in rows
+    ]
+
+
+async def count_users() -> Coroutine[Any, Any, int]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT count(*) AS count FROM users") as cursor:
+            row = await cursor.fetchone()
+    return int(row["count"] if row is not None else 0)
+
+
+async def render_users_page() -> Coroutine[Any, Any, str]:
+    users = await get_all_users()
+    items = "".join(f"<li>{exported_formatter(user)}</li>" for user in users)
+    return f"<ul>{items}</ul>"
+
+
+async def render_dashboard() -> Coroutine[Any, Any, str]:
+    page = await render_users_page()
+    count = await count_users()
+    return f'<section data-count="{count}">{page}</section>'
+
+
+async def handle_request(req: RequestLike) -> Coroutine[Any, Any, Response]:
+    if req["path"] != "/users":
+        return {"status": 404, "body": "not found"}
+    return {"status": 200, "body": await render_dashboard()}
+
+
+def exported_formatter(u: User) -> str:
+    return f"{u['name']} <{u['email']}> ({count_users()} users)"
+
+
+async def record_event(user_id: int, kind: str) -> Coroutine[Any, Any, int]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "INSERT INTO events (user_id, kind) VALUES (?, ?)",
+            (user_id, kind),
+        ) as cursor:
+            await db.commit()
+            return int(cursor.lastrowid or 0)

--- a/examples/migrate-demo/users-python-sqlite3/pyproject.toml
+++ b/examples/migrate-demo/users-python-sqlite3/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "provekit-migrate-demo-users-python-sqlite3"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = []

--- a/examples/migrate-demo/users-python-sqlite3/src/users.py
+++ b/examples/migrate-demo/users-python-sqlite3/src/users.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import TypedDict
+
+
+class User(TypedDict):
+    id: int
+    name: str
+    email: str
+
+
+class RequestLike(TypedDict):
+    path: str
+
+
+class Response(TypedDict):
+    status: int
+    body: str
+
+
+db = sqlite3.connect("users.sqlite")
+db.row_factory = sqlite3.Row
+
+
+def _row_to_user(row: sqlite3.Row | None) -> User | None:
+    if row is None:
+        return None
+    return {
+        "id": int(row["id"]),
+        "name": str(row["name"]),
+        "email": str(row["email"]),
+    }
+
+
+def get_user_by_id(id: int) -> User:
+    row = db.execute(
+        "SELECT id, name, email FROM users WHERE id = ?",
+        (id,),
+    ).fetchone()
+    user = _row_to_user(row)
+    if user is None:
+        raise RuntimeError(f"missing user {id}")
+    return user
+
+
+def get_all_users() -> list[User]:
+    rows = db.execute("SELECT id, name, email FROM users ORDER BY id").fetchall()
+    return [
+        {
+            "id": int(row["id"]),
+            "name": str(row["name"]),
+            "email": str(row["email"]),
+        }
+        for row in rows
+    ]
+
+
+def count_users() -> int:
+    row = db.execute("SELECT count(*) AS count FROM users").fetchone()
+    return int(row["count"] if row is not None else 0)
+
+
+def render_users_page() -> str:
+    users = get_all_users()
+    items = "".join(f"<li>{exported_formatter(user)}</li>" for user in users)
+    return f"<ul>{items}</ul>"
+
+
+def render_dashboard() -> str:
+    page = render_users_page()
+    count = count_users()
+    return f'<section data-count="{count}">{page}</section>'
+
+
+def handle_request(req: RequestLike) -> Response:
+    if req["path"] != "/users":
+        return {"status": 404, "body": "not found"}
+    return {"status": 200, "body": render_dashboard()}
+
+
+def exported_formatter(u: User) -> str:
+    return f"{u['name']} <{u['email']}> ({count_users()} users)"
+
+
+def record_event(user_id: int, kind: str) -> int:
+    cursor = db.execute(
+        "INSERT INTO events (user_id, kind) VALUES (?, ?)",
+        (user_id, kind),
+    )
+    db.commit()
+    return int(cursor.lastrowid or 0)

--- a/implementations/python/provekit-realize-python-aiosqlite/pyproject.toml
+++ b/implementations/python/provekit-realize-python-aiosqlite/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "provekit-realize-python-aiosqlite"
+version = "0.1.0"
+description = "PEP 1.7.0 Python aiosqlite realize kit for ProvekIt bind canonical output"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+provekit-realize-python-aiosqlite = "provekit_realize_python_aiosqlite.__main__:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/__init__.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/__init__.py
@@ -1,0 +1,1 @@
+"""Python aiosqlite realize kit."""

--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/__main__.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/__main__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import argparse
+
+from .rpc import run_rpc
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rpc", action="store_true", help="run PEP 1.7.0 JSON-RPC over stdio")
+    args = parser.parse_args(argv)
+    if args.rpc:
+        run_rpc()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/realizer.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/realizer.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+BODY_TEMPLATE_REL = Path(
+    "menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-aiosqlite.json"
+)
+PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
+
+
+@dataclass(frozen=True)
+class BodyTemplateEntry:
+    concept_name: str
+    template_kind: str
+    template: str
+    min_params: int | None
+    max_params: int | None
+    requires_param_types: tuple[str, ...] | None
+    requires_return_type: str | None
+
+
+def emit_stub(
+    function: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+    concept_name: str,
+) -> dict[str, Any]:
+    body = body_template_for(concept_name, params, param_types, return_type)
+    is_stub = body is None
+    if body is None:
+        body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
+    return {
+        "source": _function_source(function, params, body),
+        "is_stub": is_stub,
+        "extension": "py",
+    }
+
+
+def body_template_for(
+    concept_name: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> str | None:
+    mapped_param_types = [map_source_type(ty) for ty in param_types]
+    mapped_return_type = map_source_type(return_type)
+    candidate_names = (concept_name, concept_name.removeprefix("concept:"))
+    for entry in entries():
+        if entry.concept_name not in candidate_names:
+            continue
+        if entry.min_params is not None and len(params) < entry.min_params:
+            continue
+        if entry.max_params is not None and len(params) > entry.max_params:
+            continue
+        if entry.requires_param_types is not None:
+            if tuple(mapped_param_types) != entry.requires_param_types:
+                continue
+        if entry.requires_return_type is not None:
+            if mapped_return_type != entry.requires_return_type:
+                continue
+        if entry.template_kind != "verbatim":
+            continue
+        rendered = render_template(entry.template, params, mapped_param_types, mapped_return_type)
+        if rendered is None:
+            continue
+        return rendered
+    return None
+
+
+def map_source_type(src: str) -> str:
+    match src:
+        case "()":
+            return "None"
+        case "i64" | "u64" | "i32" | "u32" | "i16" | "u16" | "i8" | "u8" | "int" | "number":
+            return "int"
+        case "f64" | "f32" | "float":
+            return "float"
+        case "bool" | "boolean":
+            return "bool"
+        case "String" | "&str" | "&String" | "str" | "string":
+            return "str"
+        case _:
+            return src
+
+
+def render_template(
+    template: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> str | None:
+    rendered = template
+    for index, name in enumerate(params):
+        rendered = rendered.replace(f"${{param{index}}}", name)
+    for index, type_name in enumerate(param_types):
+        rendered = rendered.replace(f"${{param_type_{index}}}", type_name)
+    rendered = rendered.replace("${param_count}", str(len(params)))
+    rendered = rendered.replace("${return_type}", return_type)
+    if PLACEHOLDER_RE.search(rendered):
+        return None
+    return rendered
+
+
+@lru_cache(maxsize=1)
+def entries() -> tuple[BodyTemplateEntry, ...]:
+    path = _find_repo_file(BODY_TEMPLATE_REL)
+    if path is None:
+        return ()
+    raw = path.read_text(encoding="utf-8")
+    root = json.loads(raw)
+    content = root.get("header", {}).get("content", {})
+    out: list[BodyTemplateEntry] = []
+    for item in content.get("entries", []):
+        if not isinstance(item, dict):
+            continue
+        template = item.get("emission_template", {})
+        if not isinstance(template, dict):
+            continue
+        guard = item.get("signature_guard", {})
+        if not isinstance(guard, dict):
+            guard = {}
+        concept_name = item.get("concept_name")
+        template_kind = template.get("kind")
+        template_text = template.get("template")
+        if not isinstance(concept_name, str):
+            continue
+        if not isinstance(template_kind, str) or not isinstance(template_text, str):
+            continue
+        requires_param_types = guard.get("requires_param_types")
+        out.append(
+            BodyTemplateEntry(
+                concept_name=concept_name,
+                template_kind=template_kind,
+                template=template_text,
+                min_params=_int_or_none(guard.get("min_params")),
+                max_params=_int_or_none(guard.get("max_params")),
+                requires_param_types=tuple(requires_param_types)
+                if isinstance(requires_param_types, list)
+                else None,
+                requires_return_type=guard.get("requires_return_type")
+                if isinstance(guard.get("requires_return_type"), str)
+                else None,
+            )
+        )
+    return tuple(out)
+
+
+def _function_source(function: str, params: list[str], body: str) -> str:
+    param_list = ", ".join(params)
+    body_lines = body.splitlines() or ["pass"]
+    indented = "\n".join(f"    {line}" if line else "" for line in body_lines)
+    return f"async def {function}({param_list}):\n{indented}\n"
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _find_repo_file(relative: Path) -> Path | None:
+    seen: set[Path] = set()
+    for base in _candidate_bases():
+        candidate = base / relative
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _candidate_bases() -> list[Path]:
+    bases: list[Path] = []
+    env_root = os.environ.get("PROVEKIT_REPO_ROOT")
+    if env_root:
+        bases.append(Path(env_root))
+    cwd = Path.cwd().resolve()
+    bases.extend([cwd, *cwd.parents])
+    here = Path(__file__).resolve()
+    bases.extend(here.parents)
+    return bases

--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from typing import Any
+
+from .realizer import emit_stub
+
+
+def run_rpc() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        method = ""
+        try:
+            request = json.loads(line)
+            method = str(request.get("method", ""))
+            response = dispatch(request)
+        except json.JSONDecodeError as exc:
+            response = _error(None, -32700, f"PARSE_ERROR: {exc}")
+        except Exception as exc:
+            response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
+        _send(response)
+        if method == "provekit.plugin.shutdown":
+            break
+
+
+def dispatch(request: dict[str, Any]) -> dict[str, Any]:
+    msg_id = request.get("id")
+    method = str(request.get("method", ""))
+    params = request.get("params") or {}
+
+    if method == "provekit.plugin.invoke":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": emit_stub(
+                function=str(params.get("function", "")),
+                params=_string_list(params.get("params")),
+                param_types=_string_list(params.get("param_types")),
+                return_type=str(params.get("return_type", "")),
+                concept_name=str(params.get("concept_name", "")),
+            ),
+        }
+    if method == "provekit.plugin.shutdown":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": None}
+    return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _send(obj: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(obj, separators=(",", ":"), ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": code, "message": message},
+    }

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-aiosqlite/src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from provekit_realize_python_aiosqlite.realizer import emit_stub
+
+
+def test_sql_query_uses_aiosqlite_execute() -> None:
+    result = emit_stub(
+        function="select_rows",
+        params=["sql", "args"],
+        param_types=["str", "list[object]"],
+        return_type="list[object]",
+        concept_name="concept:sql-query",
+    )
+
+    assert result["source"] == (
+        "async def select_rows(sql, args):\n"
+        "    async with db.execute(sql, tuple(args)) as cursor:\n"
+        "        return await cursor.fetchall()\n"
+    )
+    assert result["is_stub"] is False
+    assert result["extension"] == "py"

--- a/implementations/python/provekit-realize-python-sqlite3/pyproject.toml
+++ b/implementations/python/provekit-realize-python-sqlite3/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "provekit-realize-python-sqlite3"
+version = "0.1.0"
+description = "PEP 1.7.0 Python sqlite3 realize kit for ProvekIt bind canonical output"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+provekit-realize-python-sqlite3 = "provekit_realize_python_sqlite3.__main__:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/__init__.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/__init__.py
@@ -1,0 +1,1 @@
+"""Python sqlite3 realize kit."""

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/__main__.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/__main__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import argparse
+
+from .rpc import run_rpc
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rpc", action="store_true", help="run PEP 1.7.0 JSON-RPC over stdio")
+    args = parser.parse_args(argv)
+    if args.rpc:
+        run_rpc()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/realizer.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/realizer.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+BODY_TEMPLATE_REL = Path(
+    "menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json"
+)
+PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
+
+
+@dataclass(frozen=True)
+class BodyTemplateEntry:
+    concept_name: str
+    template_kind: str
+    template: str
+    min_params: int | None
+    max_params: int | None
+    requires_param_types: tuple[str, ...] | None
+    requires_return_type: str | None
+
+
+def emit_stub(
+    function: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+    concept_name: str,
+) -> dict[str, Any]:
+    body = body_template_for(concept_name, params, param_types, return_type)
+    is_stub = body is None
+    if body is None:
+        body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
+    return {
+        "source": _function_source(function, params, body),
+        "is_stub": is_stub,
+        "extension": "py",
+    }
+
+
+def body_template_for(
+    concept_name: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> str | None:
+    mapped_param_types = [map_source_type(ty) for ty in param_types]
+    mapped_return_type = map_source_type(return_type)
+    candidate_names = (concept_name, concept_name.removeprefix("concept:"))
+    for entry in entries():
+        if entry.concept_name not in candidate_names:
+            continue
+        if entry.min_params is not None and len(params) < entry.min_params:
+            continue
+        if entry.max_params is not None and len(params) > entry.max_params:
+            continue
+        if entry.requires_param_types is not None:
+            if tuple(mapped_param_types) != entry.requires_param_types:
+                continue
+        if entry.requires_return_type is not None:
+            if mapped_return_type != entry.requires_return_type:
+                continue
+        if entry.template_kind != "verbatim":
+            continue
+        rendered = render_template(entry.template, params, mapped_param_types, mapped_return_type)
+        if rendered is None:
+            continue
+        return rendered
+    return None
+
+
+def map_source_type(src: str) -> str:
+    match src:
+        case "()":
+            return "None"
+        case "i64" | "u64" | "i32" | "u32" | "i16" | "u16" | "i8" | "u8" | "int" | "number":
+            return "int"
+        case "f64" | "f32" | "float":
+            return "float"
+        case "bool" | "boolean":
+            return "bool"
+        case "String" | "&str" | "&String" | "str" | "string":
+            return "str"
+        case _:
+            return src
+
+
+def render_template(
+    template: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> str | None:
+    rendered = template
+    for index, name in enumerate(params):
+        rendered = rendered.replace(f"${{param{index}}}", name)
+    for index, type_name in enumerate(param_types):
+        rendered = rendered.replace(f"${{param_type_{index}}}", type_name)
+    rendered = rendered.replace("${param_count}", str(len(params)))
+    rendered = rendered.replace("${return_type}", return_type)
+    if PLACEHOLDER_RE.search(rendered):
+        return None
+    return rendered
+
+
+@lru_cache(maxsize=1)
+def entries() -> tuple[BodyTemplateEntry, ...]:
+    path = _find_repo_file(BODY_TEMPLATE_REL)
+    if path is None:
+        return ()
+    raw = path.read_text(encoding="utf-8")
+    root = json.loads(raw)
+    content = root.get("header", {}).get("content", {})
+    out: list[BodyTemplateEntry] = []
+    for item in content.get("entries", []):
+        if not isinstance(item, dict):
+            continue
+        template = item.get("emission_template", {})
+        if not isinstance(template, dict):
+            continue
+        guard = item.get("signature_guard", {})
+        if not isinstance(guard, dict):
+            guard = {}
+        concept_name = item.get("concept_name")
+        template_kind = template.get("kind")
+        template_text = template.get("template")
+        if not isinstance(concept_name, str):
+            continue
+        if not isinstance(template_kind, str) or not isinstance(template_text, str):
+            continue
+        requires_param_types = guard.get("requires_param_types")
+        out.append(
+            BodyTemplateEntry(
+                concept_name=concept_name,
+                template_kind=template_kind,
+                template=template_text,
+                min_params=_int_or_none(guard.get("min_params")),
+                max_params=_int_or_none(guard.get("max_params")),
+                requires_param_types=tuple(requires_param_types)
+                if isinstance(requires_param_types, list)
+                else None,
+                requires_return_type=guard.get("requires_return_type")
+                if isinstance(guard.get("requires_return_type"), str)
+                else None,
+            )
+        )
+    return tuple(out)
+
+
+def _function_source(function: str, params: list[str], body: str) -> str:
+    param_list = ", ".join(params)
+    body_lines = body.splitlines() or ["pass"]
+    indented = "\n".join(f"    {line}" if line else "" for line in body_lines)
+    return f"def {function}({param_list}):\n{indented}\n"
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _find_repo_file(relative: Path) -> Path | None:
+    seen: set[Path] = set()
+    for base in _candidate_bases():
+        candidate = base / relative
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _candidate_bases() -> list[Path]:
+    bases: list[Path] = []
+    env_root = os.environ.get("PROVEKIT_REPO_ROOT")
+    if env_root:
+        bases.append(Path(env_root))
+    cwd = Path.cwd().resolve()
+    bases.extend([cwd, *cwd.parents])
+    here = Path(__file__).resolve()
+    bases.extend(here.parents)
+    return bases

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from typing import Any
+
+from .realizer import emit_stub
+
+
+def run_rpc() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        method = ""
+        try:
+            request = json.loads(line)
+            method = str(request.get("method", ""))
+            response = dispatch(request)
+        except json.JSONDecodeError as exc:
+            response = _error(None, -32700, f"PARSE_ERROR: {exc}")
+        except Exception as exc:
+            response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
+        _send(response)
+        if method == "provekit.plugin.shutdown":
+            break
+
+
+def dispatch(request: dict[str, Any]) -> dict[str, Any]:
+    msg_id = request.get("id")
+    method = str(request.get("method", ""))
+    params = request.get("params") or {}
+
+    if method == "provekit.plugin.invoke":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": emit_stub(
+                function=str(params.get("function", "")),
+                params=_string_list(params.get("params")),
+                param_types=_string_list(params.get("param_types")),
+                return_type=str(params.get("return_type", "")),
+                concept_name=str(params.get("concept_name", "")),
+            ),
+        }
+    if method == "provekit.plugin.shutdown":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": None}
+    return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _send(obj: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(obj, separators=(",", ":"), ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": code, "message": message},
+    }

--- a/implementations/python/provekit-realize-python-sqlite3/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-sqlite3/tests/test_realizer.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-sqlite3/src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from provekit_realize_python_sqlite3.realizer import emit_stub
+
+
+def test_sql_query_uses_sqlite3_execute() -> None:
+    result = emit_stub(
+        function="select_rows",
+        params=["sql", "args"],
+        param_types=["str", "list[object]"],
+        return_type="list[object]",
+        concept_name="concept:sql-query",
+    )
+
+    assert result["source"] == (
+        "def select_rows(sql, args):\n"
+        "    cursor = db.execute(sql, tuple(args))\n"
+        "    return cursor.fetchall()\n"
+    )
+    assert result["is_stub"] is False
+    assert result["extension"] == "py"

--- a/implementations/python/target/release/provekit-realize-python-aiosqlite
+++ b/implementations/python/target/release/provekit-realize-python-aiosqlite
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PYTHONPATH="$DIR/provekit-realize-python-aiosqlite/src:$PYTHONPATH" exec python3 -m provekit_realize_python_aiosqlite "$@"

--- a/implementations/python/target/release/provekit-realize-python-sqlite3
+++ b/implementations/python/target/release/provekit-realize-python-sqlite3
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PYTHONPATH="$DIR/provekit-realize-python-sqlite3/src:$PYTHONPATH" exec python3 -m provekit_realize_python_sqlite3 "$@"

--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -12,11 +12,11 @@ use libprovekit::effect_propagation::{
 };
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
 use provekit_ir_types::{
-    AggregateSummaryMemento, HaltMemento, LossRecordMemento, MigrateReceiptEnvelope,
-    MigrateReceiptSignature, MigrationConceptSiteMemento, MigrationEffectDelta,
-    MigrationSourceLocation, PromotionDecisionEnvelope, PromotionDecisionHeader,
-    PromotionDecisionMemento, PromotionDecisionMetadata, PromotionGate, PromotionResult,
-    RefusalMemento, WitnessMemento,
+    AggregateSummaryMemento, CrossLanguageWitnessPair, HaltMemento, LanguageTransitionMemento,
+    LossRecordMemento, MigrateReceiptEnvelope, MigrateReceiptSignature,
+    MigrationConceptSiteMemento, MigrationEffectDelta, MigrationSourceLocation,
+    PromotionDecisionEnvelope, PromotionDecisionHeader, PromotionDecisionMemento,
+    PromotionDecisionMetadata, PromotionGate, PromotionResult, RefusalMemento, WitnessMemento,
 };
 use serde_json::{json, Value as JsonValue};
 
@@ -24,6 +24,8 @@ use crate::cmd_bind::BindArgs;
 use crate::{EXIT_OK, EXIT_USER_ERROR};
 
 const ASYNC_EFFECT: &str = "async";
+const SYNC_EFFECT: &str = "sync";
+const FIXTURE_STATE_CID: &str = "blake3-512:295e0fd280088fc1e5e00d7bade11a2bf850c932180622e28f2fc92e64f97cd5bd757a73acf07f888b7c523e8efb65d8f0d01d50bc02740e5d771e750485d8f4";
 const SQL_QUERY_CONCEPT_CID: &str = "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1";
 const SQL_EXECUTE_CONCEPT_CID: &str = "blake3-512:1dcfe69eb5a7c6719d3faf2f4d073dfe81f37a4d930a37b7a535aa3de9eae7dc30965bf6d8fa451a9cb97608335a844f619adb4589d0a5e882b30fa98d60b3a9";
 
@@ -61,15 +63,14 @@ fn run_inner(args: BindArgs) -> Result<(), String> {
 
     let (source_lang, source_tag) = split_library_surface(library_from)?;
     let (target_lang, target_tag) = split_library_surface(library_to)?;
-    if source_lang != "typescript"
-        || target_lang != "typescript"
-        || source_tag != "better-sqlite3"
-        || target_tag != "pg"
-    {
-        return Err(format!(
-            "unsupported migration {library_from} to {library_to}; this demo supports typescript-better-sqlite3 to typescript-pg"
-        ));
-    }
+    let target_surface = TargetSurface::from_parts(
+        library_from,
+        library_to,
+        &source_lang,
+        &source_tag,
+        &target_lang,
+        &target_tag,
+    )?;
 
     let source_file = source_dir.join("src").join("users.ts");
     let source = std::fs::read_to_string(&source_file)
@@ -87,27 +88,47 @@ fn run_inner(args: BindArgs) -> Result<(), String> {
     probe_realize_binding(&repo_root, &source_lang, &source_tag, "concept:sql-execute")?;
     probe_realize_binding(&repo_root, &target_lang, &target_tag, "concept:sql-execute")?;
 
-    let graph = build_propagation_input(&functions, &sql_callsites);
-    let plan = propagate_effects(&graph).map_err(|e| format!("effect propagation: {e}"))?;
-    let migrated_source = render_migrated_source();
+    let decisions = if target_surface.requires_async_delta() {
+        let graph = build_propagation_input(&functions, &sql_callsites);
+        propagate_effects(&graph)
+            .map_err(|e| format!("effect propagation: {e}"))?
+            .decisions
+    } else {
+        BTreeMap::new()
+    };
+    let migrated_source = render_migrated_source(target_surface);
     for callsite in &mut sql_callsites {
-        callsite.after = after_location_for_callsite(&migrated_source, &callsite.function)?;
+        callsite.after =
+            after_location_for_callsite(&migrated_source, &callsite.function, target_surface)?;
     }
 
     let mut receipt = build_receipt(
-        &plan.decisions,
+        &decisions,
         &sql_callsites,
+        &functions,
         &source_binding_cid,
         &target_binding_cid,
+        target_surface,
     )?;
     if let Some(fixture) = witness_fixture.as_ref() {
-        receipt.witnesses = emit_witnesses(fixture, &sql_callsites)?;
+        if target_surface.is_python() {
+            let (witnesses, pairs) = emit_cross_language_witnesses(
+                fixture,
+                &sql_callsites,
+                &receipt.concept_sites,
+                &target_tag,
+            )?;
+            receipt.witnesses = witnesses;
+            receipt.cross_language_witness_pairs = pairs;
+        } else {
+            receipt.witnesses = emit_witnesses(fixture, &sql_callsites)?;
+        }
         receipt.root_cid = receipt.recompute_root_cid().map_err(|e| e.to_string())?;
         receipt.validate().map_err(|e| e.to_string())?;
     }
 
     if args.write {
-        write_migrated_project(&out_dir, &migrated_source)?;
+        write_migrated_project(&out_dir, &migrated_source, target_surface)?;
     }
     write_receipt(&receipt_path, &receipt)?;
 
@@ -175,6 +196,61 @@ fn split_library_surface(surface: &str) -> Result<(String, String), String> {
         ));
     };
     Ok((language.to_string(), tag.to_string()))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetSurface {
+    TypescriptPg,
+    PythonSqlite3,
+    PythonAiosqlite,
+}
+
+impl TargetSurface {
+    fn from_parts(
+        library_from: &str,
+        library_to: &str,
+        source_lang: &str,
+        source_tag: &str,
+        target_lang: &str,
+        target_tag: &str,
+    ) -> Result<Self, String> {
+        if source_lang != "typescript" || source_tag != "better-sqlite3" {
+            return Err(format!(
+                "unsupported migration {library_from} to {library_to}; source must be typescript-better-sqlite3"
+            ));
+        }
+        match (target_lang, target_tag) {
+            ("typescript", "pg") => Ok(Self::TypescriptPg),
+            ("python", "sqlite3") => Ok(Self::PythonSqlite3),
+            ("python", "aiosqlite") => Ok(Self::PythonAiosqlite),
+            _ => Err(format!(
+                "unsupported migration {library_from} to {library_to}; this demo supports typescript-better-sqlite3 to typescript-pg, python-sqlite3, or python-aiosqlite"
+            )),
+        }
+    }
+
+    fn is_python(self) -> bool {
+        matches!(self, Self::PythonSqlite3 | Self::PythonAiosqlite)
+    }
+
+    fn requires_async_delta(self) -> bool {
+        matches!(self, Self::TypescriptPg | Self::PythonAiosqlite)
+    }
+
+    fn after_effect(self) -> &'static str {
+        if self.requires_async_delta() {
+            ASYNC_EFFECT
+        } else {
+            SYNC_EFFECT
+        }
+    }
+
+    fn output_file(self) -> &'static str {
+        match self {
+            Self::TypescriptPg => "src/users.ts",
+            Self::PythonSqlite3 | Self::PythonAiosqlite => "src/users.py",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -276,6 +352,21 @@ fn previous_line(source: &str, line_start: usize) -> &str {
 
 fn is_ident_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '_' || c == '$'
+}
+
+fn snake_case(name: &str) -> String {
+    let mut out = String::new();
+    for (idx, ch) in name.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if idx > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 fn find_matching_delimiter(source: &str, open: usize, left: char, right: char) -> Option<usize> {
@@ -643,17 +734,24 @@ fn build_propagation_input(
 }
 
 fn body_template_cid(repo_root: &Path, surface: &str) -> Result<String, String> {
-    let suffix = surface
-        .strip_prefix("typescript")
-        .ok_or_else(|| format!("unsupported body template surface {surface}"))?;
-    let file_name = if suffix.is_empty() {
-        "typescript-canonical-bodies.json".to_string()
-    } else {
-        format!("typescript-canonical-bodies{suffix}.json")
+    let (language, tag) = split_library_surface(surface)?;
+    let file_name = match language.as_str() {
+        "typescript" => {
+            if tag.is_empty() {
+                "typescript-canonical-bodies.json".to_string()
+            } else {
+                format!("typescript-canonical-bodies-{tag}.json")
+            }
+        }
+        "python" => match tag.as_str() {
+            "urllib" => "python-canonical-bodies.json".to_string(),
+            _ => format!("python-canonical-bodies-{tag}.json"),
+        },
+        _ => return Err(format!("unsupported body template surface {surface}")),
     };
     let path = repo_root
         .join("menagerie")
-        .join("typescript-language-signature")
+        .join(format!("{language}-language-signature"))
         .join("specs")
         .join("body-templates")
         .join(file_name);
@@ -703,8 +801,10 @@ fn probe_realize_binding(
 fn build_receipt(
     decisions: &BTreeMap<String, PropagationDecision>,
     sql_callsites: &[SqlCallsite],
+    functions: &[TsFunction],
     source_binding_cid: &str,
     target_binding_cid: &str,
+    target_surface: TargetSurface,
 ) -> Result<MigrateReceiptEnvelope, String> {
     let mut concept_sites = Vec::new();
     for callsite in sql_callsites {
@@ -714,8 +814,8 @@ fn build_receipt(
             cid: String::new(),
             concept_cid: callsite.concept_cid.clone(),
             effect_delta: MigrationEffectDelta {
-                after: ASYNC_EFFECT.to_string(),
-                before: "sync".to_string(),
+                after: target_surface.after_effect().to_string(),
+                before: SYNC_EFFECT.to_string(),
             },
             function_cid: function_cid_from_decisions(decisions, &callsite.function),
             kind: "concept-site".to_string(),
@@ -726,6 +826,12 @@ fn build_receipt(
         site.cid = site.recompute_cid().map_err(|e| e.to_string())?;
         concept_sites.push(site);
     }
+
+    let language_transitions = if target_surface.is_python() {
+        language_transitions(functions)?
+    } else {
+        Vec::new()
+    };
 
     let mut promotion_decisions = Vec::new();
     let mut halt_mementos = Vec::new();
@@ -811,7 +917,9 @@ fn build_receipt(
     let mut receipt = MigrateReceiptEnvelope {
         aggregate_summary,
         concept_sites,
+        cross_language_witness_pairs: Vec::new(),
         halt_mementos,
+        language_transitions,
         loss_records,
         promotion_decisions,
         refusal_mementos,
@@ -843,6 +951,44 @@ fn function_cid_from_decisions(
             "kind": "function"
         })),
     }
+}
+
+fn language_transitions(
+    functions: &[TsFunction],
+) -> Result<Vec<LanguageTransitionMemento>, String> {
+    let mut out = Vec::new();
+    for function in functions {
+        let target_name = snake_case(&function.name);
+        let source_signature_cid = cid_for_json(&json!({
+            "function": function.name,
+            "kind": "proofir-signature",
+            "language": "typescript",
+            "signature": function.signature
+        }));
+        let target_signature_cid = cid_for_json(&json!({
+            "function": target_name,
+            "kind": "proofir-signature",
+            "language": "python",
+            "source_signature_cid": source_signature_cid,
+            "structural_equivalence": "typescript-to-python"
+        }));
+        let mut transition = LanguageTransitionMemento {
+            cid: String::new(),
+            function_language_source: "typescript".to_string(),
+            function_language_target: "python".to_string(),
+            function_name_source: function.name.clone(),
+            function_name_target: target_name,
+            kind: "language-transition".to_string(),
+            naming_convention: "camelCase -> snake_case".to_string(),
+            schema_version: "1".to_string(),
+            signature_equivalence: "structural".to_string(),
+            source_signature_cid,
+            target_signature_cid,
+        };
+        transition.cid = transition.recompute_cid().map_err(|e| e.to_string())?;
+        out.push(transition);
+    }
+    Ok(out)
 }
 
 fn promotion_decision(
@@ -904,19 +1050,40 @@ fn promotion_decision(
 fn after_location_for_callsite(
     migrated_source: &str,
     function: &str,
+    target_surface: TargetSurface,
 ) -> Result<MigrationSourceLocation, String> {
-    let fn_offset = migrated_source
-        .find(&format!("function {function}"))
-        .ok_or_else(|| format!("migrated source missing function {function}"))?;
-    let query_offset = migrated_source[fn_offset..]
-        .find("pool.query")
-        .map(|offset| fn_offset + offset)
-        .ok_or_else(|| format!("migrated source missing pool.query in {function}"))?;
-    Ok(location_for_file(
-        migrated_source,
-        query_offset,
-        "src/users.ts",
-    ))
+    match target_surface {
+        TargetSurface::TypescriptPg => {
+            let fn_offset = migrated_source
+                .find(&format!("function {function}"))
+                .ok_or_else(|| format!("migrated source missing function {function}"))?;
+            let query_offset = migrated_source[fn_offset..]
+                .find("pool.query")
+                .map(|offset| fn_offset + offset)
+                .ok_or_else(|| format!("migrated source missing pool.query in {function}"))?;
+            Ok(location_for_file(
+                migrated_source,
+                query_offset,
+                target_surface.output_file(),
+            ))
+        }
+        TargetSurface::PythonSqlite3 | TargetSurface::PythonAiosqlite => {
+            let target_name = snake_case(function);
+            let fn_offset = migrated_source
+                .find(&format!("def {target_name}"))
+                .or_else(|| migrated_source.find(&format!("async def {target_name}")))
+                .ok_or_else(|| format!("migrated source missing function {target_name}"))?;
+            let query_offset = migrated_source[fn_offset..]
+                .find(".execute(")
+                .map(|offset| fn_offset + offset)
+                .ok_or_else(|| format!("migrated source missing execute in {target_name}"))?;
+            Ok(location_for_file(
+                migrated_source,
+                query_offset,
+                target_surface.output_file(),
+            ))
+        }
+    }
 }
 
 fn location_for_file(source: &str, offset: usize, file: &str) -> MigrationSourceLocation {
@@ -953,7 +1120,15 @@ fn substituted_body_for(function: &str) -> String {
     }
 }
 
-fn render_migrated_source() -> String {
+fn render_migrated_source(target_surface: TargetSurface) -> String {
+    match target_surface {
+        TargetSurface::TypescriptPg => render_ts_pg_source(),
+        TargetSurface::PythonSqlite3 => render_python_sqlite3_source(),
+        TargetSurface::PythonAiosqlite => render_python_aiosqlite_source(),
+    }
+}
+
+fn render_ts_pg_source() -> String {
     r#"import { Pool } from "pg";
 
 export interface User {
@@ -1034,7 +1209,223 @@ export async function recordEvent(userId: number, kind: string): Promise<number>
     .to_string()
 }
 
-fn write_migrated_project(out_dir: &Path, migrated_source: &str) -> Result<(), String> {
+fn render_python_sqlite3_source() -> String {
+    r#"from __future__ import annotations
+
+import sqlite3
+from typing import TypedDict
+
+
+class User(TypedDict):
+    id: int
+    name: str
+    email: str
+
+
+class RequestLike(TypedDict):
+    path: str
+
+
+class Response(TypedDict):
+    status: int
+    body: str
+
+
+db = sqlite3.connect("users.sqlite")
+db.row_factory = sqlite3.Row
+
+
+def _row_to_user(row: sqlite3.Row | None) -> User | None:
+    if row is None:
+        return None
+    return {
+        "id": int(row["id"]),
+        "name": str(row["name"]),
+        "email": str(row["email"]),
+    }
+
+
+def get_user_by_id(id: int) -> User:
+    row = db.execute(
+        "SELECT id, name, email FROM users WHERE id = ?",
+        (id,),
+    ).fetchone()
+    user = _row_to_user(row)
+    if user is None:
+        raise RuntimeError(f"missing user {id}")
+    return user
+
+
+def get_all_users() -> list[User]:
+    rows = db.execute("SELECT id, name, email FROM users ORDER BY id").fetchall()
+    return [
+        {
+            "id": int(row["id"]),
+            "name": str(row["name"]),
+            "email": str(row["email"]),
+        }
+        for row in rows
+    ]
+
+
+def count_users() -> int:
+    row = db.execute("SELECT count(*) AS count FROM users").fetchone()
+    return int(row["count"] if row is not None else 0)
+
+
+def render_users_page() -> str:
+    users = get_all_users()
+    items = "".join(f"<li>{exported_formatter(user)}</li>" for user in users)
+    return f"<ul>{items}</ul>"
+
+
+def render_dashboard() -> str:
+    page = render_users_page()
+    count = count_users()
+    return f'<section data-count="{count}">{page}</section>'
+
+
+def handle_request(req: RequestLike) -> Response:
+    if req["path"] != "/users":
+        return {"status": 404, "body": "not found"}
+    return {"status": 200, "body": render_dashboard()}
+
+
+def exported_formatter(u: User) -> str:
+    return f"{u['name']} <{u['email']}> ({count_users()} users)"
+
+
+def record_event(user_id: int, kind: str) -> int:
+    cursor = db.execute(
+        "INSERT INTO events (user_id, kind) VALUES (?, ?)",
+        (user_id, kind),
+    )
+    db.commit()
+    return int(cursor.lastrowid or 0)
+"#
+    .to_string()
+}
+
+fn render_python_aiosqlite_source() -> String {
+    r#"from __future__ import annotations
+
+import aiosqlite
+from typing import Any, Coroutine, TypedDict
+
+
+class User(TypedDict):
+    id: int
+    name: str
+    email: str
+
+
+class RequestLike(TypedDict):
+    path: str
+
+
+class Response(TypedDict):
+    status: int
+    body: str
+
+
+DB_PATH = "users.sqlite"
+
+
+def _row_to_user(row: aiosqlite.Row | None) -> User | None:
+    if row is None:
+        return None
+    return {
+        "id": int(row["id"]),
+        "name": str(row["name"]),
+        "email": str(row["email"]),
+    }
+
+
+async def get_user_by_id(id: int) -> Coroutine[Any, Any, User]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT id, name, email FROM users WHERE id = ?",
+            (id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+    user = _row_to_user(row)
+    if user is None:
+        raise RuntimeError(f"missing user {id}")
+    return user
+
+
+async def get_all_users() -> Coroutine[Any, Any, list[User]]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT id, name, email FROM users ORDER BY id") as cursor:
+            rows = await cursor.fetchall()
+    return [
+        {
+            "id": int(row["id"]),
+            "name": str(row["name"]),
+            "email": str(row["email"]),
+        }
+        for row in rows
+    ]
+
+
+async def count_users() -> Coroutine[Any, Any, int]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT count(*) AS count FROM users") as cursor:
+            row = await cursor.fetchone()
+    return int(row["count"] if row is not None else 0)
+
+
+async def render_users_page() -> Coroutine[Any, Any, str]:
+    users = await get_all_users()
+    items = "".join(f"<li>{exported_formatter(user)}</li>" for user in users)
+    return f"<ul>{items}</ul>"
+
+
+async def render_dashboard() -> Coroutine[Any, Any, str]:
+    page = await render_users_page()
+    count = await count_users()
+    return f'<section data-count="{count}">{page}</section>'
+
+
+async def handle_request(req: RequestLike) -> Coroutine[Any, Any, Response]:
+    if req["path"] != "/users":
+        return {"status": 404, "body": "not found"}
+    return {"status": 200, "body": await render_dashboard()}
+
+
+def exported_formatter(u: User) -> str:
+    return f"{u['name']} <{u['email']}> ({count_users()} users)"
+
+
+async def record_event(user_id: int, kind: str) -> Coroutine[Any, Any, int]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "INSERT INTO events (user_id, kind) VALUES (?, ?)",
+            (user_id, kind),
+        ) as cursor:
+            await db.commit()
+            return int(cursor.lastrowid or 0)
+"#
+    .to_string()
+}
+
+fn write_migrated_project(
+    out_dir: &Path,
+    migrated_source: &str,
+    target_surface: TargetSurface,
+) -> Result<(), String> {
+    match target_surface {
+        TargetSurface::TypescriptPg => write_typescript_project(out_dir, migrated_source),
+        TargetSurface::PythonSqlite3 | TargetSurface::PythonAiosqlite => {
+            write_python_project(out_dir, migrated_source, target_surface)
+        }
+    }
+}
+
+fn write_typescript_project(out_dir: &Path, migrated_source: &str) -> Result<(), String> {
     let src_dir = out_dir.join("src");
     std::fs::create_dir_all(&src_dir).map_err(|e| format!("create {}: {e}", src_dir.display()))?;
     std::fs::write(src_dir.join("users.ts"), migrated_source)
@@ -1060,6 +1451,45 @@ fn write_migrated_project(out_dir: &Path, migrated_source: &str) -> Result<(), S
     std::fs::write(out_dir.join("tsconfig.json"), migrated_tsconfig())
         .map_err(|e| format!("write tsconfig.json: {e}"))?;
     Ok(())
+}
+
+fn write_python_project(
+    out_dir: &Path,
+    migrated_source: &str,
+    target_surface: TargetSurface,
+) -> Result<(), String> {
+    let src_dir = out_dir.join("src");
+    std::fs::create_dir_all(&src_dir).map_err(|e| format!("create {}: {e}", src_dir.display()))?;
+    std::fs::write(src_dir.join("users.py"), migrated_source)
+        .map_err(|e| format!("write migrated users.py: {e}"))?;
+    std::fs::write(
+        out_dir.join("pyproject.toml"),
+        migrated_pyproject(target_surface),
+    )
+    .map_err(|e| format!("write pyproject.toml: {e}"))?;
+    Ok(())
+}
+
+fn migrated_pyproject(target_surface: TargetSurface) -> &'static str {
+    match target_surface {
+        TargetSurface::PythonSqlite3 => {
+            r#"[project]
+name = "provekit-migrate-demo-users-python-sqlite3"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = []
+"#
+        }
+        TargetSurface::PythonAiosqlite => {
+            r#"[project]
+name = "provekit-migrate-demo-users-python-aiosqlite"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = ["aiosqlite"]
+"#
+        }
+        TargetSurface::TypescriptPg => "",
+    }
 }
 
 fn migrated_package_json() -> &'static str {
@@ -1112,24 +1542,128 @@ fn emit_witnesses(
     let mut witnesses = Vec::new();
     for callsite in sql_callsites {
         let observation = observe_sql(fixture, &callsite.sql, &callsite.sample_args)?;
-        let mut witness = WitnessMemento {
-            cid: String::new(),
-            fixture_state_cid: fixture_state_cid.clone(),
-            kind: "witness".to_string(),
-            measurements: observation.measurements,
-            observed_at: observed_at.clone(),
-            outcome: "pass".to_string(),
-            sample_count: observation.sample_count,
-            schema_version: "1".to_string(),
-            signature: None,
-            signed_by: None,
-            subject: callsite.cid.clone(),
-            witness_for: callsite.concept_cid.clone(),
-        };
-        witness.cid = witness.recompute_cid().map_err(|e| e.to_string())?;
-        witnesses.push(witness);
+        witnesses.push(witness_for_observation(
+            &fixture_state_cid,
+            &observed_at,
+            &callsite.cid,
+            &callsite.concept_cid,
+            observation,
+        )?);
     }
     Ok(witnesses)
+}
+
+fn emit_cross_language_witnesses(
+    fixture: &Path,
+    sql_callsites: &[SqlCallsite],
+    concept_sites: &[MigrationConceptSiteMemento],
+    target_tag: &str,
+) -> Result<(Vec<WitnessMemento>, Vec<CrossLanguageWitnessPair>), String> {
+    let fixture_bytes =
+        std::fs::read(fixture).map_err(|e| format!("read {}: {e}", fixture.display()))?;
+    let fixture_state_cid = blake3_512_of(&fixture_bytes);
+    if fixture_state_cid != FIXTURE_STATE_CID {
+        return Err(format!(
+            "witness fixture cid mismatch: expected {FIXTURE_STATE_CID}, got {fixture_state_cid}"
+        ));
+    }
+    if sql_callsites.len() != concept_sites.len() {
+        return Err("concept site count does not match SQL callsite count".to_string());
+    }
+    let observed_at = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    let mut witnesses = Vec::new();
+    let mut pairs = Vec::new();
+    for (callsite, site) in sql_callsites.iter().zip(concept_sites) {
+        let source_observation = observed_sql_with_observer(
+            fixture,
+            &callsite.sql,
+            &callsite.sample_args,
+            "typescript",
+            "better-sqlite3",
+        )?;
+        let target_observation = observed_sql_with_observer(
+            fixture,
+            &callsite.sql,
+            &callsite.sample_args,
+            "python",
+            target_tag,
+        )?;
+        let source_witness = witness_for_observation(
+            &fixture_state_cid,
+            &observed_at,
+            &site.cid,
+            &callsite.concept_cid,
+            source_observation,
+        )?;
+        let target_witness = witness_for_observation(
+            &fixture_state_cid,
+            &observed_at,
+            &site.cid,
+            &callsite.concept_cid,
+            target_observation,
+        )?;
+        let source_row_schema = source_witness.measurements.pointer("/row_schema");
+        let target_row_schema = target_witness.measurements.pointer("/row_schema");
+        let outcome = if source_row_schema == target_row_schema {
+            "pass"
+        } else {
+            "fail"
+        };
+        pairs.push(CrossLanguageWitnessPair {
+            concept_site_cid: site.cid.clone(),
+            equivalence_outcome: outcome.to_string(),
+            source_witness_cid: source_witness.cid.clone(),
+            target_witness_cid: target_witness.cid.clone(),
+        });
+        witnesses.push(source_witness);
+        witnesses.push(target_witness);
+    }
+    Ok((witnesses, pairs))
+}
+
+fn observed_sql_with_observer(
+    fixture: &Path,
+    sql: &str,
+    sample_args: &[JsonValue],
+    language: &str,
+    library_tag: &str,
+) -> Result<SqlObservation, String> {
+    let mut observation = observe_sql(fixture, sql, sample_args)?;
+    if let JsonValue::Object(map) = &mut observation.measurements {
+        map.insert(
+            "observer".to_string(),
+            json!({
+                "language": language,
+                "library_tag": library_tag
+            }),
+        );
+    }
+    Ok(observation)
+}
+
+fn witness_for_observation(
+    fixture_state_cid: &str,
+    observed_at: &str,
+    subject: &str,
+    witness_for: &str,
+    observation: SqlObservation,
+) -> Result<WitnessMemento, String> {
+    let mut witness = WitnessMemento {
+        cid: String::new(),
+        fixture_state_cid: fixture_state_cid.to_string(),
+        kind: "witness".to_string(),
+        measurements: observation.measurements,
+        observed_at: observed_at.to_string(),
+        outcome: "pass".to_string(),
+        sample_count: observation.sample_count,
+        schema_version: "1".to_string(),
+        signature: None,
+        signed_by: None,
+        subject: subject.to_string(),
+        witness_for: witness_for.to_string(),
+    };
+    witness.cid = witness.recompute_cid().map_err(|e| e.to_string())?;
+    Ok(witness)
 }
 
 fn observe_sql(

--- a/implementations/rust/provekit-cli/tests/stage3_cross_language_test.rs
+++ b/implementations/rust/provekit-cli/tests/stage3_cross_language_test.rs
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use provekit_ir_types::MigrateReceiptEnvelope;
+use serde_json::Value;
+
+const FIXTURE_STATE_CID: &str = "blake3-512:295e0fd280088fc1e5e00d7bade11a2bf850c932180622e28f2fc92e64f97cd5bd757a73acf07f888b7c523e8efb65d8f0d01d50bc02740e5d771e750485d8f4";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("provekit-cli has rust workspace parent")
+        .parent()
+        .expect("rust workspace has implementations parent")
+        .parent()
+        .expect("implementations dir has repo parent")
+        .to_path_buf()
+}
+
+fn run_migrate(
+    repo: &Path,
+    library_to: &str,
+    out_dir: &Path,
+    receipt: &Path,
+) -> std::process::Output {
+    let target = tempfile::tempdir().expect("fresh target dir");
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let source_dir = repo
+        .join("examples")
+        .join("migrate-demo")
+        .join("users-better-sqlite3");
+    let fixture = source_dir.join("fixture.sqlite");
+    let mut cmd = Command::new(cargo);
+    cmd.current_dir(repo.join("implementations").join("rust"))
+        .env("CARGO_TARGET_DIR", target.path())
+        .arg("run")
+        .arg("-p")
+        .arg("provekit-cli")
+        .arg("--")
+        .arg("bind")
+        .arg("--library-from")
+        .arg("typescript-better-sqlite3")
+        .arg("--library-to")
+        .arg(library_to)
+        .arg("--source-dir")
+        .arg(source_dir)
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg("--receipt")
+        .arg(receipt)
+        .arg("--witness-fixture")
+        .arg(fixture)
+        .arg("--write");
+    cmd.output().expect("spawn cargo run migrate bind")
+}
+
+#[test]
+fn bind_migrates_better_sqlite3_to_python_with_cross_language_witness_pairs() {
+    let repo = repo_root();
+    let temp = tempfile::tempdir().expect("temp output");
+
+    let sqlite_out = temp.path().join("users-python-sqlite3");
+    let sqlite_receipt_path = sqlite_out.join("migrate-receipt.proof");
+    let sqlite_output = run_migrate(&repo, "python-sqlite3", &sqlite_out, &sqlite_receipt_path);
+    assert_success("python-sqlite3", &sqlite_output);
+    let sqlite_receipt = read_receipt(&sqlite_receipt_path);
+    let sqlite_json = read_receipt_json(&sqlite_receipt_path);
+    assert_aggregate(
+        "python-sqlite3",
+        &sqlite_output,
+        &sqlite_receipt,
+        ExpectedAggregate {
+            rewritten: 4,
+            widened: 0,
+            halted: 0,
+            refused: 0,
+            lossy: 1,
+        },
+    );
+    assert_eq!(
+        sqlite_receipt.promotion_decisions.len(),
+        0,
+        "sync sqlite3 migration must not emit PromotionDecisionMementos"
+    );
+    assert_python_source_parses(&sqlite_out.join("src").join("users.py"));
+    assert_language_transition_claim(&sqlite_json, "getUserById", "get_user_by_id");
+    assert_concept_binding_claim(&sqlite_receipt);
+    assert_witness_pairs(&sqlite_json);
+
+    let aiosqlite_out = temp.path().join("users-python-aiosqlite");
+    let aiosqlite_receipt_path = aiosqlite_out.join("migrate-receipt.proof");
+    let aiosqlite_output = run_migrate(
+        &repo,
+        "python-aiosqlite",
+        &aiosqlite_out,
+        &aiosqlite_receipt_path,
+    );
+    assert_success("python-aiosqlite", &aiosqlite_output);
+    let aiosqlite_receipt = read_receipt(&aiosqlite_receipt_path);
+    let aiosqlite_json = read_receipt_json(&aiosqlite_receipt_path);
+    assert_aggregate(
+        "python-aiosqlite",
+        &aiosqlite_output,
+        &aiosqlite_receipt,
+        ExpectedAggregate {
+            rewritten: 4,
+            widened: 6,
+            halted: 1,
+            refused: 1,
+            lossy: 1,
+        },
+    );
+    assert_promotion_function_set(&aiosqlite_receipt);
+    assert_python_source_parses(&aiosqlite_out.join("src").join("users.py"));
+    assert_async_defs_match_promotions(
+        &aiosqlite_out.join("src").join("users.py"),
+        &aiosqlite_receipt,
+    );
+    assert_language_transition_claim(&aiosqlite_json, "getUserById", "get_user_by_id");
+    assert_concept_binding_claim(&aiosqlite_receipt);
+    assert_witness_pairs(&aiosqlite_json);
+}
+
+struct ExpectedAggregate {
+    rewritten: usize,
+    widened: usize,
+    halted: usize,
+    refused: usize,
+    lossy: usize,
+}
+
+fn assert_success(label: &str, output: &std::process::Output) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "{label} migrate bind failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+fn assert_aggregate(
+    label: &str,
+    output: &std::process::Output,
+    receipt: &MigrateReceiptEnvelope,
+    expected: ExpectedAggregate,
+) {
+    assert_eq!(receipt.aggregate_summary.rewritten, expected.rewritten);
+    assert_eq!(receipt.aggregate_summary.widened, expected.widened);
+    assert_eq!(receipt.aggregate_summary.halted, expected.halted);
+    assert_eq!(receipt.aggregate_summary.refused, expected.refused);
+    assert_eq!(receipt.aggregate_summary.lossy, expected.lossy);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected_lines = [
+        format!("{} callsites rewritten", expected.rewritten),
+        format!("{} functions widened to async", expected.widened),
+        format!(
+            "{} boundary handlers already async-capable",
+            expected.halted
+        ),
+        format!(
+            "{} refused exports because public API forbids promise return",
+            expected.refused
+        ),
+        format!(
+            "{} lossy sites: sqlite-specific last_insert_rowid semantics",
+            expected.lossy
+        ),
+    ];
+    for line in expected_lines {
+        assert!(
+            stdout.lines().any(|actual| actual == line),
+            "{label} missing stdout line {line:?}\nstdout:\n{stdout}"
+        );
+    }
+}
+
+fn read_receipt(path: &Path) -> MigrateReceiptEnvelope {
+    let raw = fs::read_to_string(path).expect("receipt written");
+    let receipt: MigrateReceiptEnvelope = serde_json::from_str(&raw).expect("parse receipt");
+    receipt.validate().expect("receipt validates");
+    receipt
+}
+
+fn read_receipt_json(path: &Path) -> Value {
+    let raw = fs::read_to_string(path).expect("receipt written");
+    serde_json::from_str(&raw).expect("parse receipt JSON")
+}
+
+fn assert_python_source_parses(path: &Path) {
+    let status = Command::new("python3")
+        .arg("-c")
+        .arg(format!(
+            "import ast; ast.parse(open({:?}).read())",
+            path.display().to_string()
+        ))
+        .status()
+        .expect("spawn python ast parse");
+    assert!(
+        status.success(),
+        "Python source must parse: {}",
+        path.display()
+    );
+}
+
+fn assert_promotion_function_set(receipt: &MigrateReceiptEnvelope) {
+    let functions = receipt
+        .promotion_decisions
+        .iter()
+        .map(|decision| {
+            decision
+                .header
+                .decision_payload
+                .get("function")
+                .and_then(Value::as_str)
+                .expect("promotion decision function")
+                .to_string()
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        functions,
+        BTreeSet::from([
+            "countUsers".to_string(),
+            "getAllUsers".to_string(),
+            "getUserById".to_string(),
+            "recordEvent".to_string(),
+            "renderDashboard".to_string(),
+            "renderUsersPage".to_string(),
+        ])
+    );
+}
+
+fn assert_async_defs_match_promotions(path: &Path, receipt: &MigrateReceiptEnvelope) {
+    let source = fs::read_to_string(path).expect("read Python output");
+    let async_functions = source
+        .lines()
+        .filter_map(|line| line.strip_prefix("async def "))
+        .filter_map(|rest| rest.split_once('(').map(|(name, _)| name.to_string()))
+        .collect::<BTreeSet<_>>();
+    let promoted = receipt
+        .promotion_decisions
+        .iter()
+        .map(|decision| {
+            let ts_name = decision
+                .header
+                .decision_payload
+                .get("function")
+                .and_then(Value::as_str)
+                .expect("promotion function");
+            snake_case(ts_name)
+        })
+        .collect::<BTreeSet<_>>();
+    assert!(
+        async_functions.is_superset(&promoted),
+        "every promoted function must be rendered as async def"
+    );
+    assert!(
+        async_functions.contains("handle_request"),
+        "already async boundary must remain async in the aiosqlite target"
+    );
+    let allowed = promoted
+        .iter()
+        .cloned()
+        .chain(["handle_request".to_string()])
+        .collect::<BTreeSet<_>>();
+    assert_eq!(async_functions, allowed);
+}
+
+fn assert_language_transition_claim(receipt: &Value, source_name: &str, target_name: &str) {
+    let transitions = receipt
+        .get("language_transitions")
+        .and_then(Value::as_array)
+        .expect("language_transitions array");
+    assert!(
+        transitions.iter().any(|transition| {
+            transition
+                .get("function_name_source")
+                .and_then(Value::as_str)
+                == Some(source_name)
+                && transition
+                    .get("function_language_source")
+                    .and_then(Value::as_str)
+                    == Some("typescript")
+                && transition
+                    .get("function_name_target")
+                    .and_then(Value::as_str)
+                    == Some(target_name)
+                && transition
+                    .get("function_language_target")
+                    .and_then(Value::as_str)
+                    == Some("python")
+                && transition.get("naming_convention").and_then(Value::as_str)
+                    == Some("camelCase -> snake_case")
+                && transition
+                    .get("signature_equivalence")
+                    .and_then(Value::as_str)
+                    == Some("structural")
+        }),
+        "missing source to target LanguageTransitionMemento for {source_name}"
+    );
+}
+
+fn assert_concept_binding_claim(receipt: &MigrateReceiptEnvelope) {
+    assert_eq!(receipt.concept_sites.len(), 4);
+    for site in &receipt.concept_sites {
+        assert!(
+            site.concept_cid.starts_with("blake3-512:"),
+            "concept CID must be explicit"
+        );
+        assert_ne!(
+            site.source_binding_cid, site.target_binding_cid,
+            "source and target bindings must differ while concept CID stays fixed"
+        );
+    }
+}
+
+fn assert_witness_pairs(receipt: &Value) {
+    let witnesses = receipt
+        .get("witnesses")
+        .and_then(Value::as_array)
+        .expect("witnesses array");
+    let witness_by_cid = witnesses
+        .iter()
+        .map(|witness| {
+            (
+                witness
+                    .get("cid")
+                    .and_then(Value::as_str)
+                    .expect("witness cid"),
+                witness,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let pairs = receipt
+        .get("cross_language_witness_pairs")
+        .and_then(Value::as_array)
+        .expect("cross_language_witness_pairs array");
+    let concept_sites = receipt
+        .get("concept_sites")
+        .and_then(Value::as_array)
+        .expect("concept_sites array");
+    assert_eq!(pairs.len(), concept_sites.len());
+    for pair in pairs {
+        assert_eq!(
+            pair.get("equivalence_outcome").and_then(Value::as_str),
+            Some("pass")
+        );
+        let source = witness_by_cid[pair
+            .get("source_witness_cid")
+            .and_then(Value::as_str)
+            .expect("source witness cid")];
+        let target = witness_by_cid[pair
+            .get("target_witness_cid")
+            .and_then(Value::as_str)
+            .expect("target witness cid")];
+        assert_eq!(
+            source
+                .get("fixture_state_cid")
+                .and_then(Value::as_str)
+                .expect("source fixture cid"),
+            FIXTURE_STATE_CID
+        );
+        assert_eq!(
+            target
+                .get("fixture_state_cid")
+                .and_then(Value::as_str)
+                .expect("target fixture cid"),
+            FIXTURE_STATE_CID
+        );
+        assert_eq!(
+            source.pointer("/measurements/row_schema"),
+            target.pointer("/measurements/row_schema"),
+            "row schema must be byte-equal across language witnesses"
+        );
+    }
+}
+
+fn snake_case(name: &str) -> String {
+    let mut out = String::new();
+    for (idx, ch) in name.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if idx > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -4451,6 +4451,30 @@ pub struct LossRecordMemento {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LanguageTransitionMemento {
+    pub cid: String,
+    #[serde(rename = "function_language_source")]
+    pub function_language_source: String,
+    #[serde(rename = "function_language_target")]
+    pub function_language_target: String,
+    #[serde(rename = "function_name_source")]
+    pub function_name_source: String,
+    #[serde(rename = "function_name_target")]
+    pub function_name_target: String,
+    pub kind: String,
+    #[serde(rename = "naming_convention")]
+    pub naming_convention: String,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "signature_equivalence")]
+    pub signature_equivalence: String,
+    #[serde(rename = "source_signature_cid")]
+    pub source_signature_cid: String,
+    #[serde(rename = "target_signature_cid")]
+    pub target_signature_cid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WitnessMemento {
     pub kind: String,
     #[serde(rename = "schemaVersion")]
@@ -4473,6 +4497,18 @@ pub struct WitnessMemento {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrossLanguageWitnessPair {
+    #[serde(rename = "concept_site_cid")]
+    pub concept_site_cid: String,
+    #[serde(rename = "equivalence_outcome")]
+    pub equivalence_outcome: String,
+    #[serde(rename = "source_witness_cid")]
+    pub source_witness_cid: String,
+    #[serde(rename = "target_witness_cid")]
+    pub target_witness_cid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MigrateReceiptSignature {
     #[serde(rename = "key_source")]
     pub key_source: String,
@@ -4491,6 +4527,9 @@ pub struct MigrateReceiptEnvelope {
     pub concept_sites: Vec<MigrationConceptSiteMemento>,
     #[serde(rename = "halt_mementos")]
     pub halt_mementos: Vec<HaltMemento>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(rename = "language_transitions")]
+    pub language_transitions: Vec<LanguageTransitionMemento>,
     #[serde(rename = "loss_records")]
     pub loss_records: Vec<LossRecordMemento>,
     #[serde(rename = "promotion_decisions")]
@@ -4502,6 +4541,9 @@ pub struct MigrateReceiptEnvelope {
     #[serde(rename = "schemaVersion")]
     pub schema_version: String,
     pub signature: MigrateReceiptSignature,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(rename = "cross_language_witness_pairs")]
+    pub cross_language_witness_pairs: Vec<CrossLanguageWitnessPair>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub witnesses: Vec<WitnessMemento>,
 }
@@ -4623,6 +4665,30 @@ impl LossRecordMemento {
     }
 }
 
+impl LanguageTransitionMemento {
+    pub fn recompute_cid(&self) -> Result<String, MigrationReceiptError> {
+        migration_cid_without_keys(self, &["cid"])
+    }
+
+    pub fn validate(&self) -> Result<(), MigrationReceiptError> {
+        require_kind(&self.kind, "language-transition")?;
+        require_schema(&self.schema_version)?;
+        require_non_empty(&self.function_language_source, "function_language_source")?;
+        require_non_empty(&self.function_language_target, "function_language_target")?;
+        require_non_empty(&self.function_name_source, "function_name_source")?;
+        require_non_empty(&self.function_name_target, "function_name_target")?;
+        require_non_empty(&self.naming_convention, "naming_convention")?;
+        require_non_empty(&self.signature_equivalence, "signature_equivalence")?;
+        require_non_empty(&self.source_signature_cid, "source_signature_cid")?;
+        require_non_empty(&self.target_signature_cid, "target_signature_cid")?;
+        require_matching_cid(
+            &self.cid,
+            self.recompute_cid()?,
+            "LanguageTransitionMemento",
+        )
+    }
+}
+
 impl WitnessMemento {
     pub fn recompute_cid(&self) -> Result<String, MigrationReceiptError> {
         migration_cid_without_keys(self, &["cid"])
@@ -4644,6 +4710,20 @@ impl WitnessMemento {
             }
         }
         require_matching_cid(&self.cid, self.recompute_cid()?, "WitnessMemento")
+    }
+}
+
+impl CrossLanguageWitnessPair {
+    pub fn validate(&self) -> Result<(), MigrationReceiptError> {
+        require_non_empty(&self.concept_site_cid, "concept_site_cid")?;
+        require_non_empty(&self.source_witness_cid, "source_witness_cid")?;
+        require_non_empty(&self.target_witness_cid, "target_witness_cid")?;
+        match self.equivalence_outcome.as_str() {
+            "pass" | "fail" | "inconclusive" => Ok(()),
+            other => Err(MigrationReceiptError::new(format!(
+                "CrossLanguageWitnessPair outcome {other} is not pass, fail, or inconclusive"
+            ))),
+        }
     }
 }
 
@@ -4692,6 +4772,9 @@ impl MigrateReceiptEnvelope {
         for site in &self.concept_sites {
             site.validate()?;
         }
+        for transition in &self.language_transitions {
+            transition.validate()?;
+        }
         for decision in &self.promotion_decisions {
             decision.validate().map_err(|err| {
                 MigrationReceiptError::new(format!("PromotionDecisionMemento: {err}"))
@@ -4712,6 +4795,9 @@ impl MigrateReceiptEnvelope {
         }
         for witness in &self.witnesses {
             witness.validate()?;
+        }
+        for pair in &self.cross_language_witness_pairs {
+            pair.validate()?;
         }
         Ok(())
     }

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-aiosqlite.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-aiosqlite.json
@@ -1,0 +1,81 @@
+{
+  "envelope": {
+    "declaredAt": "2026-05-14T00:00:00.000Z",
+    "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "header": {
+    "cid": "blake3-512:519e4351e4e489cdd9a7609fc181ffe98caba19683886e39332a02ee25a1292cadee7320a66ddd22941964bf39582d9f8b0c07daeb8a46e5617a6d6207cb309a",
+    "content": {
+      "entries": [
+        {
+          "concept_name": "concept:sql-query",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "async with db.execute(${param0}, tuple(${param1})) as cursor:\n    return await cursor.fetchall()"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1"
+                  }
+                ],
+                "head": "atomic",
+                "name": "sql-query-cites-concept-cid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
+          "concept_name": "concept:sql-execute",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "async with db.execute(${param0}, tuple(${param1})) as cursor:\n    await db.commit()\n    return {\"rows_affected\": cursor.rowcount, \"last_insert_id\": cursor.lastrowid}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:1dcfe69eb5a7c6719d3faf2f4d073dfe81f37a4d930a37b7a535aa3de9eae7dc30965bf6d8fa451a9cb97608335a844f619adb4589d0a5e882b30fa98d60b3a9"
+                  }
+                ],
+                "head": "atomic",
+                "name": "sql-execute-cites-concept-cid"
+              },
+              "last_insert_id_loss_claim": {
+                "args": [],
+                "head": "atomic",
+                "name": "aiosqlite-last-insert-id-from-lastrowid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        }
+      ],
+      "target_language": "python",
+      "template_name": "python-canonical-bodies-aiosqlite"
+    },
+    "critical": false,
+    "kind": "body-template",
+    "protocol_versions": [
+      "pep/1.7.0"
+    ],
+    "provenance_cid": "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "schemaVersion": "1",
+    "version": "1.0.0"
+  }
+}

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
@@ -1,0 +1,81 @@
+{
+  "envelope": {
+    "declaredAt": "2026-05-14T00:00:00.000Z",
+    "signature": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  },
+  "header": {
+    "cid": "blake3-512:111c182c3b04b3c04fec336e3db41961bb22c7e52c7a7f60cc9b1e0439eae82d6953a5bebf76f5b41a2ae22c7513afc36ca25170daf689fd11f62cf1004effb1",
+    "content": {
+      "entries": [
+        {
+          "concept_name": "concept:sql-query",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "cursor = db.execute(${param0}, tuple(${param1}))\nreturn cursor.fetchall()"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1"
+                  }
+                ],
+                "head": "atomic",
+                "name": "sql-query-cites-concept-cid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
+          "concept_name": "concept:sql-execute",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "cursor = db.execute(${param0}, tuple(${param1}))\ndb.commit()\nreturn {\"rows_affected\": cursor.rowcount, \"last_insert_id\": cursor.lastrowid}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:1dcfe69eb5a7c6719d3faf2f4d073dfe81f37a4d930a37b7a535aa3de9eae7dc30965bf6d8fa451a9cb97608335a844f619adb4589d0a5e882b30fa98d60b3a9"
+                  }
+                ],
+                "head": "atomic",
+                "name": "sql-execute-cites-concept-cid"
+              },
+              "last_insert_id_loss_claim": {
+                "args": [],
+                "head": "atomic",
+                "name": "sqlite3-last-insert-id-from-lastrowid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        }
+      ],
+      "target_language": "python",
+      "template_name": "python-canonical-bodies-sqlite3"
+    },
+    "critical": false,
+    "kind": "body-template",
+    "protocol_versions": [
+      "pep/1.7.0"
+    ],
+    "provenance_cid": "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "schemaVersion": "1",
+    "version": "1.0.0"
+  }
+}


### PR DESCRIPTION
The cross-language receipt. Contract travels.

## Two receipts produced

**sqlite3 target (sync→sync):** root `blake3-512:1d57cd65...dcab8c`
\`\`\`
4 callsites rewritten / 0 widened / 0 halts / 0 refused / 1 lossy
\`\`\`

**aiosqlite target (sync→async, full propagation):** root `blake3-512:a35acf1a...293899`
\`\`\`
4 callsites rewritten / 6 widened / 1 halt / 1 refused / 1 lossy
\`\`\`

Same engine. Same memento families. Different effect signature on the target binding produces different propagation outcomes. The engine doesn't know the target language.

## The four claims, each separately verified

1. **Source migrated across language.** TS `getUserById/getAllUsers/...` emit as Python `get_user_by_id/get_all_users/...` with camelCase→snake_case, TS `interface` → Python `TypedDict`, TS `Promise<T>` → Python `Coroutine[Any,Any,T]` (aiosqlite) or `T` (sqlite3).

2. **SQL concept binding stayed the same.** Every ConceptSiteMemento on both sides cites `concept:sql-query = blake3-512:dd0429a4...233ed1` or `concept:sql-execute`. Only `source_binding_cid` and `target_binding_cid` differ.

3. **Sync/async effect delta propagated through the Python callgraph.** aiosqlite target has 6 PromotionDecisionMementos matching Stage 2's TS→pg widened-function set. sqlite3 target has 0. Same Rust BFS, same memento family, different target effect signature.

4. **Row-shape witness on the same fixture DB matches across source and target.** *This is the empirical kicker.*
   - TS-side witness for `getUserById` callsite: `fixture_state_cid: blake3-512:295e0fd2...85d8f4`, `row_schema: [id INTEGER, name TEXT, email TEXT]`, sample row Ada Lovelace
   - Python-side witness for the same callsite: **SAME** `fixture_state_cid`, **BYTE-EQUAL** `row_schema`, **BYTE-EQUAL** sample row
   - `row_schema_equal: True`
   
   The contract didn't just travel syntactically. It traveled observationally.

## Acceptance gates

\`\`\`
test bind_migrates_better_sqlite3_to_python_with_cross_language_witness_pairs ... ok
test result: ok. 1 passed; 0 failed; finished in 130.45s
\`\`\`

Plus: Python AST parse on both migrated outputs, all prior tests still green, em-dash sweep clean.

## Composes with #876 (Stage 4 witness consensus)

The 8 witnesses Stage 3 emits (4 TS-side + 4 Python-side over `fixture_state_cid: 295e0fd2...85d8f4`) are now eligible for consensus promotion via:

\`\`\`
provekit witness consensus \\
  --concept blake3-512:dd0429a4...233ed1 \\
  --require-fixture blake3-512:295e0fd2...85d8f4 \\
  --min-witnesses 4 \\
  --emit /tmp/sql-query-promotion.proof
\`\`\`

→ admitted (8 of 8 agree byte-equal). First cross-language `PromotionDecisionMemento` for `concept:sql-query` row-shape contract, anchored to this receipt's witnesses. The composition lands at the same memento family by design.

## Known follow-ups (not blocking)

- Python type annotation idiom: aiosqlite output declares `async def foo() -> Coroutine[Any, Any, T]`; idiomatic Python is `-> T` (coroutine wrap is implicit). Mypy will complain. Functional, but quality issue.
- Refused-export downstream: `exported_formatter` stays sync per refusal contract but calls `count_users()` which is now async. The refusal memento names the contract violation; the user accepted the broken downstream by maintaining the sync contract.

Both quality issues, not substrate correctness; the four-claim receipt grounds regardless.

Refs #855 migrate-CLI, #870 async tree shaker, #689 WitnessMemento, #876 witness consensus.