### PR TITLE
Add policy-based promotion decision registry

### DIFF
--- a/implementations/rust/libprovekit/src/lib.rs
+++ b/implementations/rust/libprovekit/src/lib.rs
@@ -7,6 +7,7 @@ pub mod core;
 pub mod desugar;
 pub mod effect_propagation;
 pub mod ffi;
+pub mod promotion_decision_registry;
 pub mod transport;
 pub mod witness_registry;
 pub mod wp;

--- a/implementations/rust/libprovekit/src/promotion_decision_registry.rs
+++ b/implementations/rust/libprovekit/src/promotion_decision_registry.rs
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use provekit_ir_types::{MigrateReceiptEnvelope, PromotionDecisionMemento, PromotionResult};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PromotionDecisionKey {
+    pub promoted_op: String,
+    pub fixture_cid: String,
+}
+
+impl PromotionDecisionKey {
+    pub fn new(promoted_op: impl Into<String>, fixture_cid: impl Into<String>) -> Self {
+        Self {
+            promoted_op: promoted_op.into(),
+            fixture_cid: fixture_cid.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PromotionStatus {
+    pub key: PromotionDecisionKey,
+    pub decision_cids: Vec<String>,
+    pub decision_policy_cids: Vec<String>,
+    pub consensus_vector: Value,
+    pub witnesses_consulted: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PromotionDecisionRegistry {
+    decisions: BTreeMap<String, PromotionDecisionMemento>,
+    by_key: BTreeMap<PromotionDecisionKey, BTreeSet<String>>,
+    summaries: BTreeMap<String, PromotionSummary>,
+}
+
+#[derive(Debug, Clone)]
+struct PromotionSummary {
+    decision_policy_cid: String,
+    consensus_vector: Value,
+    witnesses_consulted: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConsensusPolicy {
+    #[serde(default)]
+    pub cid: Option<String>,
+    #[serde(default)]
+    pub thresholds: Vec<ConsensusThreshold>,
+    #[serde(default)]
+    pub allow_failures: bool,
+    #[serde(default)]
+    pub require_loss_dim_coverage: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConsensusThreshold {
+    pub axis: String,
+    pub predicate: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PromotionDecisionRegistryError {
+    #[error("promotion-decision-registry: parse failed as PromotionDecisionMemento ({decision}) and MigrateReceiptEnvelope ({receipt})")]
+    Parse { decision: String, receipt: String },
+    #[error("promotion-decision-registry: invalid decision: {0}")]
+    Invalid(String),
+    #[error(
+        "promotion-decision-registry: header.cid mismatch: claimed {claimed}, recomputed {actual}"
+    )]
+    HeaderCidMismatch { claimed: String, actual: String },
+    #[error("promotion-decision-registry: parse consensus policy: {0}")]
+    PolicyParse(String),
+    #[error("promotion-decision-registry: invalid consensus policy: {0}")]
+    InvalidPolicy(String),
+}
+
+impl ConsensusPolicy {
+    pub fn from_json_str(text: &str) -> Result<Self, PromotionDecisionRegistryError> {
+        let policy: Self = serde_json::from_str(text)
+            .map_err(|err| PromotionDecisionRegistryError::PolicyParse(err.to_string()))?;
+        if policy.thresholds.is_empty() {
+            return Err(PromotionDecisionRegistryError::InvalidPolicy(
+                "thresholds must be non-empty".to_string(),
+            ));
+        }
+        for threshold in &policy.thresholds {
+            parse_predicate(&threshold.predicate).map_err(|err| {
+                PromotionDecisionRegistryError::InvalidPolicy(format!(
+                    "threshold axis `{}` predicate `{}`: {err}",
+                    threshold.axis, threshold.predicate
+                ))
+            })?;
+        }
+        if let Some(mode) = policy.require_loss_dim_coverage.as_deref() {
+            if mode != "all-named" {
+                return Err(PromotionDecisionRegistryError::InvalidPolicy(format!(
+                    "unsupported require_loss_dim_coverage `{mode}`"
+                )));
+            }
+        }
+        Ok(policy)
+    }
+
+    pub fn admits(&self, status: &PromotionStatus) -> Result<(), String> {
+        if !self.allow_failures && outcome_count(&status.consensus_vector, "fail") > 0 {
+            return Err("policy rejected: failure_mode_distribution contains fail".to_string());
+        }
+        if self.require_loss_dim_coverage.as_deref() == Some("all-named") {
+            let unwitnessed = status
+                .consensus_vector
+                .pointer("/loss_dim_coverage/unwitnessed")
+                .and_then(Value::as_array)
+                .map(Vec::len)
+                .unwrap_or(0);
+            if unwitnessed > 0 {
+                return Err("policy rejected: loss_dim_coverage is not all-named".to_string());
+            }
+        }
+        for threshold in &self.thresholds {
+            eval_predicate(&threshold.predicate, status).map_err(|err| {
+                format!(
+                    "policy rejected on axis `{}` predicate `{}`: {err}",
+                    threshold.axis, threshold.predicate
+                )
+            })?;
+        }
+        Ok(())
+    }
+}
+
+impl PromotionDecisionRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn admit_json_str(&mut self, text: &str) -> Result<usize, PromotionDecisionRegistryError> {
+        match serde_json::from_str::<PromotionDecisionMemento>(text) {
+            Ok(decision) => self.admit(decision),
+            Err(decision_err) => match MigrateReceiptEnvelope::parse_json_str(text) {
+                Ok(receipt) => self.admit_many(receipt.promotion_decisions),
+                Err(receipt_err) => Err(PromotionDecisionRegistryError::Parse {
+                    decision: decision_err.to_string(),
+                    receipt: receipt_err.to_string(),
+                }),
+            },
+        }
+    }
+
+    pub fn admit_many<I>(&mut self, decisions: I) -> Result<usize, PromotionDecisionRegistryError>
+    where
+        I: IntoIterator<Item = PromotionDecisionMemento>,
+    {
+        let mut indexed = 0usize;
+        for decision in decisions {
+            indexed += self.admit(decision)?;
+        }
+        Ok(indexed)
+    }
+
+    pub fn admit(
+        &mut self,
+        decision: PromotionDecisionMemento,
+    ) -> Result<usize, PromotionDecisionRegistryError> {
+        decision
+            .validate()
+            .map_err(|err| PromotionDecisionRegistryError::Invalid(err.to_string()))?;
+        let actual = decision
+            .recompute_header_cid()
+            .map_err(|err| PromotionDecisionRegistryError::Invalid(err.to_string()))?;
+        if actual != decision.header.cid {
+            return Err(PromotionDecisionRegistryError::HeaderCidMismatch {
+                claimed: decision.header.cid.clone(),
+                actual,
+            });
+        }
+
+        let decision_cid = decision.header.cid.clone();
+        if self.decisions.contains_key(&decision_cid) {
+            return Ok(0);
+        }
+
+        let entries = index_entries(&decision);
+        self.decisions.insert(decision_cid.clone(), decision);
+        for (key, summary) in entries {
+            self.by_key
+                .entry(key)
+                .or_default()
+                .insert(decision_cid.clone());
+            self.summaries.insert(decision_cid.clone(), summary);
+        }
+        Ok(self
+            .by_key
+            .values()
+            .filter(|cids| cids.contains(&decision_cid))
+            .count())
+    }
+
+    pub fn get(&self, key: &PromotionDecisionKey) -> Option<PromotionStatus> {
+        self.statuses(key).into_iter().max_by(|left, right| {
+            left.witnesses_consulted
+                .cmp(&right.witnesses_consulted)
+                .then(left.decision_cids.cmp(&right.decision_cids))
+        })
+    }
+
+    pub fn statuses(&self, key: &PromotionDecisionKey) -> Vec<PromotionStatus> {
+        let Some(cids) = self.by_key.get(key) else {
+            return Vec::new();
+        };
+        cids.iter()
+            .filter_map(|cid| {
+                let summary = self.summaries.get(cid)?;
+                Some(PromotionStatus {
+                    key: key.clone(),
+                    decision_cids: vec![cid.clone()],
+                    decision_policy_cids: vec![summary.decision_policy_cid.clone()],
+                    consensus_vector: summary.consensus_vector.clone(),
+                    witnesses_consulted: summary.witnesses_consulted,
+                })
+            })
+            .collect()
+    }
+}
+
+fn index_entries(
+    decision: &PromotionDecisionMemento,
+) -> Vec<(PromotionDecisionKey, PromotionSummary)> {
+    if decision.header.result != PromotionResult::Admitted {
+        return Vec::new();
+    }
+    let Some(promoted_op) = payload_string(&decision.header.decision_payload, "promoted_op") else {
+        return Vec::new();
+    };
+    let fixtures = payload_string_array(&decision.header.decision_payload, "fixtures_consulted");
+    if fixtures.is_empty() {
+        return Vec::new();
+    }
+    let summary = PromotionSummary {
+        decision_policy_cid: decision.header.policy_cid.clone(),
+        consensus_vector: consensus_vector(&decision.header.decision_payload, decision),
+        witnesses_consulted: witnesses_consulted(decision),
+    };
+    fixtures
+        .into_iter()
+        .map(|fixture| {
+            (
+                PromotionDecisionKey::new(promoted_op.clone(), fixture),
+                summary.clone(),
+            )
+        })
+        .collect()
+}
+
+fn consensus_vector(payload: &Value, decision: &PromotionDecisionMemento) -> Value {
+    payload
+        .get("consensus_vector")
+        .cloned()
+        .unwrap_or_else(|| {
+            json!({
+                "failure_mode_distribution": [
+                    {"outcome": "pass", "count": witnesses_consulted(decision)},
+                    {"outcome": "fail", "count": 0},
+                    {"outcome": "inconclusive", "count": 0}
+                ],
+                "input_distribution_summary": {"shape": "unspanned"},
+                "loss_dim_coverage": {
+                    "named_in_concept_spec": [],
+                    "unwitnessed": [],
+                    "witnessed": []
+                },
+                "temporal_spread": {
+                    "first_observed_at": null,
+                    "last_observed_at": null,
+                    "span_seconds": 0
+                },
+                "total_sample_count": payload.get("total_observations").and_then(Value::as_u64).unwrap_or(0),
+                "unique_fixtures": payload.get("fixtures_consulted").and_then(Value::as_array).map(Vec::len).unwrap_or(0),
+                "unique_signer_keys": ["unsigned"],
+                "unique_signers": 1
+            })
+        })
+}
+
+fn eval_predicate(predicate: &str, status: &PromotionStatus) -> Result<(), String> {
+    let (left, op, right) = parse_predicate(predicate)?;
+    let actual = metric_value(left, status).ok_or_else(|| format!("unknown metric `{left}`"))?;
+    let ok = match op {
+        ">=" => actual >= right,
+        "<=" => actual <= right,
+        "==" => actual == right,
+        ">" => actual > right,
+        "<" => actual < right,
+        _ => return Err(format!("unsupported operator `{op}`")),
+    };
+    if ok {
+        Ok(())
+    } else {
+        Err(format!("{left} was {actual}, required {op}{right}"))
+    }
+}
+
+fn parse_predicate(predicate: &str) -> Result<(&str, &str, u64), String> {
+    for op in [">=", "<=", "==", ">", "<"] {
+        if let Some((left, right)) = predicate.split_once(op) {
+            let right = right
+                .trim()
+                .parse::<u64>()
+                .map_err(|err| format!("threshold is not an integer: {err}"))?;
+            return Ok((left.trim(), op, right));
+        }
+    }
+    Err("unsupported predicate grammar".to_string())
+}
+
+fn metric_value(metric: &str, status: &PromotionStatus) -> Option<u64> {
+    match metric {
+        "n" | "witnesses_consulted" => Some(status.witnesses_consulted),
+        other => status.consensus_vector.get(other).and_then(Value::as_u64),
+    }
+}
+
+fn outcome_count(vector: &Value, outcome: &str) -> u64 {
+    vector
+        .get("failure_mode_distribution")
+        .and_then(Value::as_array)
+        .and_then(|items| {
+            items.iter().find_map(|item| {
+                (item.get("outcome").and_then(Value::as_str) == Some(outcome))
+                    .then(|| item.get("count").and_then(Value::as_u64).unwrap_or(0))
+            })
+        })
+        .unwrap_or(0)
+}
+
+fn payload_string(payload: &Value, field: &str) -> Option<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn payload_string_array(payload: &Value, field: &str) -> Vec<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn witnesses_consulted(decision: &PromotionDecisionMemento) -> u64 {
+    if let Some(items) = decision
+        .header
+        .decision_payload
+        .get("witnesses_consulted")
+        .and_then(Value::as_array)
+    {
+        return items.len() as u64;
+    }
+    if let Some(count) = decision
+        .header
+        .decision_payload
+        .get("witnesses_consulted")
+        .and_then(Value::as_u64)
+    {
+        return count;
+    }
+    decision.header.evidence_cids.len() as u64
+}

--- a/implementations/rust/libprovekit/tests/promotion_decision_registry.rs
+++ b/implementations/rust/libprovekit/tests/promotion_decision_registry.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use libprovekit::promotion_decision_registry::{
+    ConsensusPolicy, PromotionDecisionKey, PromotionDecisionRegistry,
+};
+use provekit_ir_types::{
+    PromotionDecisionEnvelope, PromotionDecisionHeader, PromotionDecisionMemento,
+    PromotionDecisionMetadata, PromotionGate, PromotionResult,
+};
+use serde_json::json;
+
+const FIXTURE_STATE_CID: &str = "blake3-512:295e0fd280088fc1e5e00d7bade11a2bf850c932180622e28f2fc92e64f97cd5bd757a73acf07f888b7c523e8efb65d8f0d01d50bc02740e5d771e750485d8f4";
+
+#[test]
+fn registry_indexes_admitted_consensus_vector_by_typed_key() {
+    let decision = consensus_decision(
+        "concept:sql-query",
+        FIXTURE_STATE_CID,
+        "documentary -> empirically-witnessed",
+        8,
+        PromotionResult::Admitted,
+    );
+
+    let mut registry = PromotionDecisionRegistry::new();
+    registry.admit(decision.clone()).expect("decision admitted");
+
+    let key = PromotionDecisionKey::new("concept:sql-query", FIXTURE_STATE_CID);
+    let status = registry
+        .get(&key)
+        .expect("admitted consensus vector should be indexed");
+
+    assert_eq!(status.key, key);
+    assert_eq!(status.decision_cids, vec![decision.header.cid.clone()]);
+    assert_eq!(
+        status.decision_policy_cids,
+        vec![decision.header.policy_cid.clone()]
+    );
+    assert_eq!(status.witnesses_consulted, 8);
+    assert_eq!(status.consensus_vector["unique_signers"], 1);
+    assert_eq!(status.consensus_vector["unique_fixtures"], 1);
+    assert_eq!(status.consensus_vector["total_sample_count"], 8);
+}
+
+#[test]
+fn consensus_policy_decides_whether_a_vector_is_sufficient() {
+    let decision = consensus_decision(
+        "concept:sql-query",
+        FIXTURE_STATE_CID,
+        "documentary -> empirically-witnessed",
+        8,
+        PromotionResult::Admitted,
+    );
+    let mut registry = PromotionDecisionRegistry::new();
+    registry.admit(decision).expect("decision admitted");
+    let status = registry
+        .get(&PromotionDecisionKey::new(
+            "concept:sql-query",
+            FIXTURE_STATE_CID,
+        ))
+        .expect("status indexed");
+
+    let permissive = ConsensusPolicy::from_json_str(
+        r#"{
+          "kind": "consensus-policy",
+          "schemaVersion": "1",
+          "thresholds": [
+            {"axis": "min-witnesses-floor", "predicate": "n>=8"},
+            {"axis": "environment-diversity", "predicate": "unique_fixtures>=1"},
+            {"axis": "sample-depth", "predicate": "total_sample_count>=8"}
+          ],
+          "allow_failures": false
+        }"#,
+    )
+    .expect("policy parses");
+    assert!(permissive.admits(&status).is_ok());
+
+    let stricter = ConsensusPolicy::from_json_str(
+        r#"{
+          "kind": "consensus-policy",
+          "schemaVersion": "1",
+          "thresholds": [
+            {"axis": "observer-diversity", "predicate": "unique_signers>=2"}
+          ],
+          "allow_failures": false
+        }"#,
+    )
+    .expect("policy parses");
+    let err = stricter
+        .admits(&status)
+        .expect_err("one unsigned signer must not satisfy signer-diversity policy");
+    assert!(
+        err.contains("observer-diversity") && err.contains("unique_signers was 1"),
+        "unexpected policy rejection: {err}"
+    );
+}
+
+#[test]
+fn consensus_policy_does_not_synthesize_strength_across_decisions() {
+    let enough_witnesses_low_diversity = consensus_decision_with_vector(
+        "concept:sql-query",
+        FIXTURE_STATE_CID,
+        "documentary -> empirically-witnessed",
+        8,
+        PromotionResult::Admitted,
+        json!({
+            "failure_mode_distribution": [
+                {"outcome": "pass", "count": 8},
+                {"outcome": "fail", "count": 0},
+                {"outcome": "inconclusive", "count": 0}
+            ],
+            "input_distribution_summary": {"shape": "unspanned"},
+            "loss_dim_coverage": {
+                "named_in_concept_spec": [],
+                "unwitnessed": [],
+                "witnessed": []
+            },
+            "temporal_spread": {
+                "first_observed_at": "2026-05-14T00:00:00.000Z",
+                "last_observed_at": "2026-05-14T00:00:00.000Z",
+                "span_seconds": 0
+            },
+            "total_sample_count": 8,
+            "unique_fixtures": 1,
+            "unique_signer_keys": ["unsigned"],
+            "unique_signers": 1
+        }),
+    );
+    let high_diversity_too_few_witnesses = consensus_decision_with_vector(
+        "concept:sql-query",
+        FIXTURE_STATE_CID,
+        "documentary -> empirically-witnessed",
+        1,
+        PromotionResult::Admitted,
+        json!({
+            "failure_mode_distribution": [
+                {"outcome": "pass", "count": 1},
+                {"outcome": "fail", "count": 0},
+                {"outcome": "inconclusive", "count": 0}
+            ],
+            "input_distribution_summary": {"shape": "unspanned"},
+            "loss_dim_coverage": {
+                "named_in_concept_spec": [],
+                "unwitnessed": [],
+                "witnessed": []
+            },
+            "temporal_spread": {
+                "first_observed_at": "2026-05-14T00:00:00.000Z",
+                "last_observed_at": "2026-05-14T00:00:00.000Z",
+                "span_seconds": 0
+            },
+            "total_sample_count": 1,
+            "unique_fixtures": 3,
+            "unique_signer_keys": ["a", "b", "c"],
+            "unique_signers": 3
+        }),
+    );
+    let mut registry = PromotionDecisionRegistry::new();
+    registry
+        .admit(enough_witnesses_low_diversity)
+        .expect("first decision admitted");
+    registry
+        .admit(high_diversity_too_few_witnesses)
+        .expect("second decision admitted");
+
+    let key = PromotionDecisionKey::new("concept:sql-query", FIXTURE_STATE_CID);
+    let policy = ConsensusPolicy::from_json_str(
+        r#"{
+          "kind": "consensus-policy",
+          "schemaVersion": "1",
+          "thresholds": [
+            {"axis": "min-witnesses-floor", "predicate": "n>=8"},
+            {"axis": "environment-diversity", "predicate": "unique_fixtures>=3"}
+          ],
+          "allow_failures": false
+        }"#,
+    )
+    .expect("policy parses");
+
+    assert!(
+        registry
+            .statuses(&key)
+            .iter()
+            .all(|status| policy.admits(status).is_err()),
+        "policy must evaluate each observed vector independently"
+    );
+}
+
+#[test]
+fn registry_does_not_index_rejected_decisions() {
+    let decision = consensus_decision(
+        "concept:sql-query",
+        FIXTURE_STATE_CID,
+        "documentary -> empirically-witnessed",
+        8,
+        PromotionResult::Rejected,
+    );
+
+    let mut registry = PromotionDecisionRegistry::new();
+    registry
+        .admit(decision)
+        .expect("valid rejected decision admitted");
+
+    assert!(registry
+        .get(&PromotionDecisionKey::new(
+            "concept:sql-query",
+            FIXTURE_STATE_CID
+        ))
+        .is_none());
+}
+
+#[test]
+fn registry_rejects_header_cid_mismatch() {
+    let mut decision = consensus_decision(
+        "concept:sql-query",
+        FIXTURE_STATE_CID,
+        "documentary -> empirically-witnessed",
+        8,
+        PromotionResult::Admitted,
+    );
+    decision.header.cid = cid('a');
+
+    let mut registry = PromotionDecisionRegistry::new();
+    let err = registry
+        .admit(decision)
+        .expect_err("mismatched header cid must reject");
+
+    assert!(
+        err.to_string().contains("header.cid mismatch"),
+        "unexpected error: {err}"
+    );
+}
+
+fn consensus_decision(
+    promoted_op: &str,
+    fixture: &str,
+    promotion: &str,
+    min_witnesses: u64,
+    result: PromotionResult,
+) -> PromotionDecisionMemento {
+    consensus_decision_with_vector(
+        promoted_op,
+        fixture,
+        promotion,
+        min_witnesses,
+        result,
+        json!({
+            "failure_mode_distribution": [
+                {"outcome": "pass", "count": min_witnesses},
+                {"outcome": "fail", "count": 0},
+                {"outcome": "inconclusive", "count": 0}
+            ],
+            "input_distribution_summary": {"shape": "unspanned"},
+            "loss_dim_coverage": {
+                "named_in_concept_spec": ["row-order"],
+                "unwitnessed": ["row-order"],
+                "witnessed": []
+            },
+            "temporal_spread": {
+                "first_observed_at": "2026-05-14T00:00:00.000Z",
+                "last_observed_at": "2026-05-14T00:00:00.000Z",
+                "span_seconds": 0
+            },
+            "total_sample_count": min_witnesses,
+            "unique_fixtures": 1,
+            "unique_signer_keys": ["unsigned"],
+            "unique_signers": 1
+        }),
+    )
+}
+
+fn consensus_decision_with_vector(
+    promoted_op: &str,
+    fixture: &str,
+    promotion: &str,
+    min_witnesses: u64,
+    result: PromotionResult,
+    consensus_vector: serde_json::Value,
+) -> PromotionDecisionMemento {
+    let evidence_cids = (0..min_witnesses)
+        .map(|idx| cid(char::from(b'1' + (idx as u8 % 8))))
+        .collect::<Vec<_>>();
+    let mut decision = PromotionDecisionMemento {
+        envelope: PromotionDecisionEnvelope {
+            declared_at: "2026-05-14T00:00:00.000Z".to_string(),
+            signature: String::new(),
+            signer: cid('d'),
+        },
+        header: PromotionDecisionHeader {
+            candidate_cid: cid('c'),
+            cid: String::new(),
+            decider_cid: cid('d'),
+            decision_payload: json!({
+                "agreement": "byte-equal",
+                "fixtures_consulted": [fixture],
+                "min_witnesses": min_witnesses,
+                "promotion": promotion,
+                "promoted_op": promoted_op,
+                "reason": "test consensus",
+                "total_observations": min_witnesses,
+                "witnesses_consulted": evidence_cids,
+                "consensus_vector": consensus_vector,
+            }),
+            evidence_cids,
+            gate: PromotionGate::Threshold,
+            kind: "promotion-decision".to_string(),
+            policy_cid: cid('e'),
+            promoted_cid: cid('f'),
+            result,
+            schema_version: "1".to_string(),
+        },
+        metadata: PromotionDecisionMetadata::default(),
+    };
+    decision.header.cid = decision
+        .recompute_header_cid()
+        .expect("fixture decision cid recomputes");
+    decision
+}
+
+fn cid(ch: char) -> String {
+    format!("blake3-512:{}", ch.to_string().repeat(128))
+}

--- a/implementations/rust/provekit-cli/src/cmd_prove.rs
+++ b/implementations/rust/provekit-cli/src/cmd_prove.rs
@@ -481,6 +481,10 @@ fn run_kit(kit: &str, quiet: bool, json_out: bool) -> u8 {
 // ---------------------------------------------------------------------------
 
 pub fn run(args: ProveArgs) -> u8 {
+    if args.require_empirically_witnessed.is_some() {
+        return run_empirically_witnessed_gate(&args);
+    }
+
     if args.artifact.is_some() || args.proof.is_some() || args.policy.is_some() {
         return run_admission_gate(&args);
     }
@@ -568,6 +572,99 @@ pub fn run(args: ProveArgs) -> u8 {
     }
 
     report_fmt::report_exit_code(&report)
+}
+
+fn run_empirically_witnessed_gate(args: &ProveArgs) -> u8 {
+    let concept = match args.require_empirically_witnessed.as_deref() {
+        Some(concept) if !concept.trim().is_empty() => concept,
+        _ => {
+            eprintln!(
+                "{}: --require-empirically-witnessed requires a concept",
+                "error".red().bold()
+            );
+            return crate::EXIT_USER_ERROR;
+        }
+    };
+    let fixture = match args.require_fixture.as_deref() {
+        Some(fixture) if !fixture.trim().is_empty() => fixture,
+        _ => {
+            eprintln!(
+                "{}: --require-fixture is required with --require-empirically-witnessed",
+                "error".red().bold()
+            );
+            return crate::EXIT_USER_ERROR;
+        }
+    };
+    let project_root: PathBuf = args.project.clone().unwrap_or_else(|| PathBuf::from("."));
+    if !project_root.exists() {
+        eprintln!(
+            "{}: project root does not exist: {}",
+            "error".red().bold(),
+            project_root.display()
+        );
+        return crate::EXIT_USER_ERROR;
+    }
+    let policy_path = match args.consensus_policy.as_ref() {
+        Some(path) => path,
+        None => {
+            eprintln!(
+                "{}: --consensus-policy is required with --require-empirically-witnessed",
+                "error".red().bold()
+            );
+            return crate::EXIT_USER_ERROR;
+        }
+    };
+    let policy = match crate::promotion_query::load_consensus_policy(policy_path) {
+        Ok(policy) => policy,
+        Err(err) => {
+            eprintln!("{}: {err}", "error".red().bold());
+            return crate::EXIT_USER_ERROR;
+        }
+    };
+
+    match crate::promotion_query::query_consensus_vector_for_policy(
+        &project_root,
+        &args.with.iter().map(PathBuf::from).collect::<Vec<_>>(),
+        concept,
+        fixture,
+        &policy,
+    ) {
+        Ok(Some(hit)) => {
+            let report = crate::promotion_query::status_json(concept, fixture, &hit, Some(&policy));
+            let ok = report["ok"].as_bool().unwrap_or(false);
+            if args.out.json {
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            } else if !args.out.quiet {
+                println!(
+                    "verify empirically-witnessed: {}",
+                    if ok { "accepted" } else { "rejected" }
+                );
+                println!("  concept: {concept}");
+                println!("  fixture: {fixture}");
+                println!("  promoted_op: {}", hit.status.key.promoted_op);
+                println!("  decisions: {}", hit.status.decision_cids.len());
+            }
+            if ok {
+                crate::EXIT_OK
+            } else {
+                crate::EXIT_VERIFY_FAIL
+            }
+        }
+        Ok(None) => {
+            let report = crate::promotion_query::missing_json(concept, fixture);
+            if args.out.json {
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            } else if !args.out.quiet {
+                println!("verify empirically-witnessed: rejected");
+                println!("  reason: required promotion was not found");
+            }
+            crate::EXIT_VERIFY_FAIL
+        }
+        Err(err) => {
+            eprintln!("{}: {err}", "error".red().bold());
+            crate::EXIT_USER_ERROR
+        }
+    }
 }
 
 fn run_admission_gate(args: &ProveArgs) -> u8 {

--- a/implementations/rust/provekit-cli/src/cmd_witness.rs
+++ b/implementations/rust/provekit-cli/src/cmd_witness.rs
@@ -17,14 +17,13 @@
 //   6. The witness can be shipped with the package
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use chrono::{SecondsFormat, Utc};
-use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use libprovekit::promotion_decision_registry::{PromotionDecisionKey, PromotionStatus};
 use provekit_ir_types::{
-    MigrateReceiptEnvelope, PromotionDecisionEnvelope, PromotionDecisionHeader,
-    PromotionDecisionMemento, PromotionDecisionMetadata, PromotionGate, PromotionResult,
-    WitnessMemento,
+    CrossLanguageWitnessPair, MigrateReceiptEnvelope, PromotionDecisionEnvelope,
+    PromotionDecisionHeader, PromotionDecisionMemento, PromotionDecisionMetadata, PromotionGate,
+    PromotionResult, WitnessMemento,
 };
 use serde_json::json;
 use serde_json::Value as Json;
@@ -35,6 +34,9 @@ use crate::{EXIT_OK, EXIT_SOLVER_FAIL, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
 pub fn run(args: crate::WitnessArgs) -> u8 {
     if args.command_or_contract == "consensus" {
         return run_consensus(args);
+    }
+    if args.command_or_contract == "status" {
+        return run_status(args);
     }
 
     let project_root = args
@@ -157,55 +159,85 @@ fn run_consensus(args: crate::WitnessArgs) -> u8 {
             return EXIT_USER_ERROR;
         }
     };
-    let catalog_roots = if args.catalogs.is_empty() {
-        let project_catalog = project_root.join(".provekit");
-        if project_catalog.exists() {
-            vec![project_catalog]
-        } else {
-            vec![project_root]
-        }
-    } else {
-        args.catalogs.clone()
-    };
+    let catalog_roots = crate::promotion_query::catalog_roots(&project_root, &args.catalogs);
+    let concept_terms = crate::promotion_query::concept_query_terms(&project_root, &concept);
 
-    let witnesses = match collect_witnesses(&catalog_roots) {
-        Ok(witnesses) => witnesses,
+    let catalog = match collect_witness_catalog(&catalog_roots) {
+        Ok(catalog) => catalog,
         Err(err) => {
             eprintln!("error: witness consensus catalog scan failed: {err}");
             return EXIT_USER_ERROR;
         }
     };
-    let selected: Vec<WitnessMemento> = witnesses
+    let selected: Vec<WitnessMemento> = catalog
+        .witnesses
         .into_iter()
         .filter(|witness| {
-            witness.witness_for == concept
+            concept_terms
+                .iter()
+                .any(|candidate| candidate == &witness.witness_for)
                 && witness.fixture_state_cid == fixture
                 && witness.outcome == "pass"
         })
         .collect();
-    if selected.len() < args.min_witnesses {
-        eprintln!(
-            "witness consensus: rejected: {} matching passing witnesses, require {}",
-            selected.len(),
-            args.min_witnesses
-        );
-        return EXIT_VERIFY_FAIL;
-    }
 
-    let row_schema = match consensus_row_schema(&selected) {
-        Ok(row_schema) => row_schema,
+    let consensus = match consensus_evidence(&selected, &catalog.cross_language_pairs) {
+        Ok(consensus) => consensus,
         Err(err) => {
             eprintln!("witness consensus: rejected: {err}");
             return EXIT_VERIFY_FAIL;
         }
     };
 
+    if consensus.witnesses.len() < args.min_witnesses {
+        eprintln!(
+            "witness consensus: rejected: {} matching passing witnesses, require {}",
+            consensus.witnesses.len(),
+            args.min_witnesses
+        );
+        return EXIT_VERIFY_FAIL;
+    }
+
+    let policy_path = match args.consensus_policy.as_ref() {
+        Some(path) => path,
+        None => {
+            eprintln!("error: witness consensus requires --consensus-policy");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let policy = match crate::promotion_query::load_consensus_policy(policy_path) {
+        Ok(policy) => policy,
+        Err(err) => {
+            eprintln!("error: {err}");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let policy_cid = policy
+        .cid
+        .clone()
+        .expect("load_consensus_policy fills missing policy cid");
+    let loss_dimensions = crate::promotion_query::concept_loss_dimensions(&project_root, &concept);
+    let consensus_vector = consensus_vector(&consensus.witnesses, &loss_dimensions);
+    let status_for_policy = PromotionStatus {
+        key: PromotionDecisionKey::new(concept.clone(), fixture.clone()),
+        decision_cids: Vec::new(),
+        decision_policy_cids: vec![policy_cid.clone()],
+        consensus_vector: consensus_vector.clone(),
+        witnesses_consulted: consensus.witnesses.len() as u64,
+    };
+    if let Err(err) = policy.admits(&status_for_policy) {
+        eprintln!("witness consensus: rejected by policy: {err}");
+        return EXIT_VERIFY_FAIL;
+    }
+
     let decision = match promotion_decision_for_consensus(
         &concept,
         &fixture,
         args.min_witnesses,
-        &selected,
-        row_schema,
+        &consensus.witnesses,
+        consensus.row_schema,
+        consensus_vector,
+        policy_cid,
     ) {
         Ok(decision) => decision,
         Err(err) => {
@@ -237,7 +269,7 @@ fn run_consensus(args: crate::WitnessArgs) -> u8 {
             "promotion_cid": decision.header.cid,
             "promotion_receipt": emit.display().to_string(),
             "result": "admitted",
-            "witnesses_consulted": selected.len()
+            "witnesses_consulted": consensus.witnesses.len()
         });
         println!(
             "{}",
@@ -247,11 +279,72 @@ fn run_consensus(args: crate::WitnessArgs) -> u8 {
         println!("witness consensus: admitted");
         println!("  concept: {concept}");
         println!("  fixture: {fixture}");
-        println!("  witnesses: {}", selected.len());
+        println!("  witnesses: {}", consensus.witnesses.len());
         println!("  agreement: byte-equal");
         println!("  receipt: {}", emit.display());
     }
     EXIT_OK
+}
+
+fn run_status(args: crate::WitnessArgs) -> u8 {
+    let project_root = args
+        .project
+        .unwrap_or_else(|| std::env::current_dir().unwrap());
+    let concept = match args.concept.as_deref() {
+        Some(concept) if !concept.trim().is_empty() => concept.to_string(),
+        _ => {
+            eprintln!("error: witness status requires --concept");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let fixture = match args.require_fixture.as_deref() {
+        Some(fixture) if !fixture.trim().is_empty() => fixture.to_string(),
+        _ => {
+            eprintln!("error: witness status requires --require-fixture");
+            return EXIT_USER_ERROR;
+        }
+    };
+
+    match crate::promotion_query::query_consensus_vector(
+        &project_root,
+        &args.catalogs,
+        &concept,
+        &fixture,
+    ) {
+        Ok(Some(hit)) => {
+            if args.out.json {
+                let report = crate::promotion_query::status_json(&concept, &fixture, &hit, None);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report).unwrap_or_else(|_| report.to_string())
+                );
+            } else if !args.out.quiet {
+                println!("witness status: consensus-vector present");
+                println!("  concept: {concept}");
+                println!("  fixture: {fixture}");
+                println!("  promoted_op: {}", hit.status.key.promoted_op);
+                println!("  decisions: {}", hit.status.decision_cids.len());
+                println!("  witnesses_consulted: {}", hit.status.witnesses_consulted);
+            }
+            EXIT_OK
+        }
+        Ok(None) => {
+            if args.out.json {
+                let report = crate::promotion_query::missing_json(&concept, &fixture);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report).unwrap_or_else(|_| report.to_string())
+                );
+            } else {
+                eprintln!("witness status: missing consensus vector");
+            }
+            EXIT_VERIFY_FAIL
+        }
+        Err(err) => {
+            eprintln!("error: witness status catalog scan failed: {err}");
+            EXIT_USER_ERROR
+        }
+    }
 }
 
 fn extract_post(contract: &Json) -> Option<Json> {
@@ -282,11 +375,23 @@ fn build_witness_obligation(post: &Json, property: &Json) -> Result<Json, String
     }))
 }
 
-fn collect_witnesses(catalog_roots: &[PathBuf]) -> Result<Vec<WitnessMemento>, String> {
-    let mut witnesses = Vec::new();
+#[derive(Debug, Default)]
+struct WitnessCatalog {
+    witnesses: Vec<WitnessMemento>,
+    cross_language_pairs: Vec<CrossLanguageWitnessPair>,
+}
+
+#[derive(Debug)]
+struct ConsensusEvidence {
+    witnesses: Vec<WitnessMemento>,
+    row_schema: Json,
+}
+
+fn collect_witness_catalog(catalog_roots: &[PathBuf]) -> Result<WitnessCatalog, String> {
+    let mut catalog = WitnessCatalog::default();
     for root in catalog_roots {
         if root.is_file() {
-            collect_witnesses_from_file(root, &mut witnesses)?;
+            collect_witnesses_from_file(root, &mut catalog)?;
             continue;
         }
         if !root.exists() {
@@ -298,13 +403,24 @@ fn collect_witnesses(catalog_roots: &[PathBuf]) -> Result<Vec<WitnessMemento>, S
         {
             let entry = entry.map_err(|e| e.to_string())?;
             if entry.file_type().is_file() {
-                collect_witnesses_from_file(entry.path(), &mut witnesses)?;
+                collect_witnesses_from_file(entry.path(), &mut catalog)?;
             }
         }
     }
-    witnesses.sort_by(|left, right| left.cid.cmp(&right.cid));
-    witnesses.dedup_by(|left, right| left.cid == right.cid);
-    Ok(witnesses)
+    catalog
+        .witnesses
+        .sort_by(|left, right| left.cid.cmp(&right.cid));
+    catalog
+        .witnesses
+        .dedup_by(|left, right| left.cid == right.cid);
+    catalog.cross_language_pairs.sort_by(|left, right| {
+        left.concept_site_cid
+            .cmp(&right.concept_site_cid)
+            .then(left.source_witness_cid.cmp(&right.source_witness_cid))
+            .then(left.target_witness_cid.cmp(&right.target_witness_cid))
+    });
+    catalog.cross_language_pairs.dedup();
+    Ok(catalog)
 }
 
 fn should_descend(path: &Path) -> bool {
@@ -317,10 +433,7 @@ fn should_descend(path: &Path) -> bool {
     )
 }
 
-fn collect_witnesses_from_file(
-    path: &Path,
-    witnesses: &mut Vec<WitnessMemento>,
-) -> Result<(), String> {
+fn collect_witnesses_from_file(path: &Path, catalog: &mut WitnessCatalog) -> Result<(), String> {
     let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
         return Ok(());
     };
@@ -333,14 +446,86 @@ fn collect_witnesses_from_file(
     };
     if let Ok(witness) = serde_json::from_str::<WitnessMemento>(&text) {
         if witness.validate().is_ok() {
-            witnesses.push(witness);
+            catalog.witnesses.push(witness);
         }
         return Ok(());
     }
     if let Ok(receipt) = MigrateReceiptEnvelope::parse_json_str(&text) {
-        witnesses.extend(receipt.witnesses);
+        catalog.witnesses.extend(receipt.witnesses);
+        catalog
+            .cross_language_pairs
+            .extend(receipt.cross_language_witness_pairs);
     }
     Ok(())
+}
+
+fn consensus_evidence(
+    witnesses: &[WitnessMemento],
+    pairs: &[CrossLanguageWitnessPair],
+) -> Result<ConsensusEvidence, String> {
+    match consensus_row_schema(witnesses) {
+        Ok(row_schema) => {
+            return Ok(ConsensusEvidence {
+                witnesses: witnesses.to_vec(),
+                row_schema,
+            });
+        }
+        Err(err) if pairs.is_empty() => return Err(err),
+        Err(_) => {}
+    }
+    consensus_pairwise_row_schema(witnesses, pairs)
+}
+
+fn consensus_pairwise_row_schema(
+    witnesses: &[WitnessMemento],
+    pairs: &[CrossLanguageWitnessPair],
+) -> Result<ConsensusEvidence, String> {
+    let by_cid = witnesses
+        .iter()
+        .map(|witness| (witness.cid.as_str(), witness))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let mut evidence_cids = std::collections::BTreeSet::new();
+    let mut pair_count = 0usize;
+    for pair in pairs {
+        if pair.equivalence_outcome != "pass" {
+            continue;
+        }
+        let Some(source) = by_cid.get(pair.source_witness_cid.as_str()) else {
+            continue;
+        };
+        let Some(target) = by_cid.get(pair.target_witness_cid.as_str()) else {
+            continue;
+        };
+        let source_schema = source
+            .measurements
+            .get("row_schema")
+            .ok_or_else(|| format!("witness {} missing measurements.row_schema", source.cid))?;
+        let target_schema = target
+            .measurements
+            .get("row_schema")
+            .ok_or_else(|| format!("witness {} missing measurements.row_schema", target.cid))?;
+        if canonical_json_bytes(source_schema) != canonical_json_bytes(target_schema) {
+            return Err("cross_language_witness_pairs row_schema disagreement".to_string());
+        }
+        evidence_cids.insert(source.cid.clone());
+        evidence_cids.insert(target.cid.clone());
+        pair_count += 1;
+    }
+    if evidence_cids.is_empty() {
+        return Err("measurements.row_schema disagreement".to_string());
+    }
+    let consensus_witnesses = witnesses
+        .iter()
+        .filter(|witness| evidence_cids.contains(&witness.cid))
+        .cloned()
+        .collect::<Vec<_>>();
+    Ok(ConsensusEvidence {
+        witnesses: consensus_witnesses,
+        row_schema: json!({
+            "agreement_axis": "cross_language_witness_pairs.measurements.row_schema",
+            "pair_count": pair_count
+        }),
+    })
 }
 
 fn consensus_row_schema(witnesses: &[WitnessMemento]) -> Result<Json, String> {
@@ -371,32 +556,29 @@ fn promotion_decision_for_consensus(
     min_witnesses: usize,
     witnesses: &[WitnessMemento],
     row_schema: Json,
+    consensus_vector: Json,
+    policy_cid: String,
 ) -> Result<PromotionDecisionMemento, String> {
     let mut evidence_cids: Vec<String> = witnesses.iter().map(|w| w.cid.clone()).collect();
     evidence_cids.sort();
     let subjects: Vec<String> = witnesses.iter().map(|w| w.subject.clone()).collect();
     let total_observations: u64 = witnesses.iter().map(|w| w.sample_count).sum();
-    let policy_cid = cid_for_json(&json!({
-        "kind": "consensus-policy",
-        "min_witnesses": min_witnesses,
-        "name": "provekit-witness-consensus-row-schema-v1"
-    }));
-    let decider_cid = cid_for_json(&json!({
+    let decider_cid = crate::promotion_query::content_cid_for_json(&json!({
         "kind": "decider",
         "name": "provekit-witness-consensus"
     }));
-    let candidate_cid = cid_for_json(&json!({
+    let candidate_cid = crate::promotion_query::content_cid_for_json(&json!({
         "concept": concept,
         "kind": "concept-candidate"
     }));
-    let promoted_cid = cid_for_json(&json!({
+    let promoted_cid = crate::promotion_query::content_cid_for_json(&json!({
         "concept": concept,
         "fixture_state_cid": fixture,
         "kind": "promoted-concept-tier",
         "tier": "empirically-witnessed"
     }));
     let reason = format!(
-        "{} witnesses on 1 fixture, all measurements.row_schema byte-equal",
+        "{} witnesses selected; consensus vector records the observed axes",
         witnesses.len()
     );
     let mut decision = PromotionDecisionMemento {
@@ -419,7 +601,8 @@ fn promotion_decision_for_consensus(
                 "row_schema": row_schema,
                 "subjects_consulted": subjects,
                 "total_observations": total_observations,
-                "witnesses_consulted": evidence_cids
+                "witnesses_consulted": evidence_cids,
+                "consensus_vector": consensus_vector
             }),
             evidence_cids,
             gate: PromotionGate::Threshold,
@@ -440,40 +623,98 @@ fn promotion_decision_for_consensus(
     Ok(decision)
 }
 
-fn canonical_json_bytes(value: &Json) -> Vec<u8> {
-    let canonical = json_to_value(value);
-    encode_jcs(&canonical).into_bytes()
-}
-
-fn cid_for_json(value: &Json) -> String {
-    blake3_512_of(&canonical_json_bytes(value))
-}
-
-fn json_to_value(j: &Json) -> Arc<CValue> {
-    match j {
-        Json::String(s) => CValue::string(s.clone()),
-        Json::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                CValue::integer(i)
-            } else if let Some(u) = n.as_u64() {
-                if let Ok(i) = i64::try_from(u) {
-                    CValue::integer(i)
-                } else {
-                    CValue::string(n.to_string())
-                }
-            } else {
-                CValue::string(n.to_string())
-            }
-        }
-        Json::Bool(b) => CValue::boolean(*b),
-        Json::Null => CValue::null(),
-        Json::Array(items) => CValue::array(items.iter().map(json_to_value).collect()),
-        Json::Object(map) => CValue::object(
-            map.iter()
-                .map(|(key, value)| (key.as_str(), json_to_value(value)))
-                .collect::<Vec<_>>(),
-        ),
+fn consensus_vector(witnesses: &[WitnessMemento], loss_dimensions: &[String]) -> Json {
+    let mut signer_keys = witnesses
+        .iter()
+        .map(|witness| {
+            witness
+                .signed_by
+                .clone()
+                .unwrap_or_else(|| "unsigned".to_string())
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    if signer_keys.is_empty() {
+        signer_keys.insert("unsigned".to_string());
     }
+    let fixtures = witnesses
+        .iter()
+        .map(|witness| witness.fixture_state_cid.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    let total_sample_count: u64 = witnesses.iter().map(|witness| witness.sample_count).sum();
+    let mut observed_times = witnesses
+        .iter()
+        .filter_map(|witness| {
+            chrono::DateTime::parse_from_rfc3339(&witness.observed_at)
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc))
+        })
+        .collect::<Vec<_>>();
+    observed_times.sort();
+    let first_observed_at = observed_times
+        .first()
+        .map(|dt| dt.to_rfc3339_opts(SecondsFormat::Millis, true));
+    let last_observed_at = observed_times
+        .last()
+        .map(|dt| dt.to_rfc3339_opts(SecondsFormat::Millis, true));
+    let span_seconds = match (observed_times.first(), observed_times.last()) {
+        (Some(first), Some(last)) => (*last - *first).num_seconds().max(0),
+        _ => 0,
+    };
+    let mut outcomes = std::collections::BTreeMap::<String, u64>::new();
+    for witness in witnesses {
+        *outcomes.entry(witness.outcome.clone()).or_default() += 1;
+    }
+    let witnessed_loss_dims = witnesses
+        .iter()
+        .flat_map(|witness| {
+            witness
+                .measurements
+                .pointer("/observer/loss_dims_exercised")
+                .and_then(Json::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Json::as_str)
+                .map(str::to_string)
+        })
+        .filter(|dim| loss_dimensions.iter().any(|known| known == dim))
+        .collect::<std::collections::BTreeSet<_>>();
+    let named_loss_dims = loss_dimensions
+        .iter()
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    let unwitnessed_loss_dims = named_loss_dims
+        .difference(&witnessed_loss_dims)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    json!({
+        "unique_signers": signer_keys.len(),
+        "unique_signer_keys": signer_keys.into_iter().collect::<Vec<_>>(),
+        "unique_fixtures": fixtures.len(),
+        "total_sample_count": total_sample_count,
+        "loss_dim_coverage": {
+            "named_in_concept_spec": named_loss_dims.into_iter().collect::<Vec<_>>(),
+            "witnessed": witnessed_loss_dims.into_iter().collect::<Vec<_>>(),
+            "unwitnessed": unwitnessed_loss_dims
+        },
+        "input_distribution_summary": {
+            "shape": "unspanned"
+        },
+        "temporal_spread": {
+            "first_observed_at": first_observed_at,
+            "last_observed_at": last_observed_at,
+            "span_seconds": span_seconds
+        },
+        "failure_mode_distribution": [
+            {"outcome": "pass", "count": outcomes.get("pass").copied().unwrap_or(0)},
+            {"outcome": "fail", "count": outcomes.get("fail").copied().unwrap_or(0)},
+            {"outcome": "inconclusive", "count": outcomes.get("inconclusive").copied().unwrap_or(0)}
+        ]
+    })
+}
+
+fn canonical_json_bytes(value: &Json) -> Vec<u8> {
+    crate::promotion_query::canonical_json_bytes(value)
 }
 
 enum SolverOutput {

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -47,6 +47,7 @@ mod cmd_witness;
 mod kit_dispatch;
 mod lift_plugin;
 mod project_config;
+mod promotion_query;
 mod prompts;
 mod protocol;
 mod report_fmt;
@@ -185,6 +186,15 @@ pub struct ProveArgs {
     /// Consumer policy proof/receipt used for policy admission checks.
     #[arg(long, requires = "proof")]
     pub policy: Option<PathBuf>,
+    /// Require that a concept has reached the empirically-witnessed promotion tier.
+    #[arg(long = "require-empirically-witnessed")]
+    pub require_empirically_witnessed: Option<String>,
+    /// Fixture-state CID for tier queries such as --require-empirically-witnessed.
+    #[arg(long = "require-fixture")]
+    pub require_fixture: Option<String>,
+    /// Consensus policy JSON used to evaluate a required empirical witness vector.
+    #[arg(long = "consensus-policy", requires = "require_empirically_witnessed")]
+    pub consensus_policy: Option<PathBuf>,
     /// Kit conformance gate: verify the named kit's lifter implements the
     /// canonical lift-plugin-protocol contracts (C1-C8). When set, the six-stage
     /// verifier is bypassed; instead the kit's lifter is spawned via JSON-RPC and
@@ -314,9 +324,13 @@ pub struct WitnessArgs {
     /// Fixture-state CID required for consensus.
     #[arg(long = "require-fixture")]
     pub require_fixture: Option<String>,
-    /// Minimum passing witnesses required before admission.
+    /// Minimum passing witnesses required before evaluating consensus.
+    /// This is a cardinality floor, not the admission policy.
     #[arg(long = "min-witnesses", default_value_t = 1)]
     pub min_witnesses: usize,
+    /// Consensus policy JSON used to decide whether the observed vector admits promotion.
+    #[arg(long = "consensus-policy")]
+    pub consensus_policy: Option<PathBuf>,
     /// File or directory to scan for WitnessMementos or migration receipts.
     #[arg(long = "catalog")]
     pub catalogs: Vec<PathBuf>,

--- a/implementations/rust/provekit-cli/src/promotion_query.rs
+++ b/implementations/rust/provekit-cli/src/promotion_query.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use libprovekit::promotion_decision_registry::{
+    ConsensusPolicy, PromotionDecisionKey, PromotionDecisionRegistry, PromotionStatus,
+};
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use serde_json::{json, Value};
+use walkdir::WalkDir;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ConsensusQueryHit {
+    pub status: PromotionStatus,
+}
+
+pub(crate) fn query_consensus_vector(
+    project_root: &Path,
+    catalogs: &[PathBuf],
+    concept: &str,
+    fixture: &str,
+) -> Result<Option<ConsensusQueryHit>, String> {
+    let roots = catalog_roots(project_root, catalogs);
+    let registry = load_promotion_registry(&roots)?;
+    let terms = concept_query_terms(project_root, concept);
+    for term in terms {
+        let key = PromotionDecisionKey::new(term, fixture);
+        if let Some(status) = registry.get(&key) {
+            return Ok(Some(ConsensusQueryHit { status }));
+        }
+    }
+    Ok(None)
+}
+
+pub(crate) fn query_consensus_vector_for_policy(
+    project_root: &Path,
+    catalogs: &[PathBuf],
+    concept: &str,
+    fixture: &str,
+    policy: &ConsensusPolicy,
+) -> Result<Option<ConsensusQueryHit>, String> {
+    let roots = catalog_roots(project_root, catalogs);
+    let registry = load_promotion_registry(&roots)?;
+    let terms = concept_query_terms(project_root, concept);
+    let mut rejected = None;
+    for term in terms {
+        let key = PromotionDecisionKey::new(term, fixture);
+        for status in registry.statuses(&key) {
+            if policy.admits(&status).is_ok() {
+                return Ok(Some(ConsensusQueryHit { status }));
+            }
+            rejected.get_or_insert(ConsensusQueryHit { status });
+        }
+    }
+    Ok(rejected)
+}
+
+pub(crate) fn concept_query_terms(project_root: &Path, concept: &str) -> Vec<String> {
+    let mut terms = BTreeSet::new();
+    terms.insert(concept.to_string());
+    if let Some(resolved) = resolve_concept_counterpart(project_root, concept) {
+        terms.insert(resolved);
+    }
+    terms.into_iter().collect()
+}
+
+pub(crate) fn concept_loss_dimensions(project_root: &Path, concept: &str) -> Vec<String> {
+    let Some((repo_root, entry)) = resolve_concept_index_entry(project_root, concept) else {
+        return Vec::new();
+    };
+    let Some(path) = entry.get("path").and_then(Value::as_str) else {
+        return Vec::new();
+    };
+    let spec_path = repo_root
+        .join("menagerie")
+        .join("concept-shapes")
+        .join("catalog")
+        .join(path);
+    let Ok(raw) = std::fs::read_to_string(spec_path) else {
+        return Vec::new();
+    };
+    let Ok(spec) = serde_json::from_str::<Value>(&raw) else {
+        return Vec::new();
+    };
+    spec.get("loss_dimensions")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub(crate) fn catalog_roots(project_root: &Path, catalogs: &[PathBuf]) -> Vec<PathBuf> {
+    if !catalogs.is_empty() {
+        return catalogs.to_vec();
+    }
+    let project_catalog = project_root.join(".provekit");
+    if project_catalog.exists() {
+        vec![project_catalog]
+    } else {
+        vec![project_root.to_path_buf()]
+    }
+}
+
+pub(crate) fn load_promotion_registry(
+    catalog_roots: &[PathBuf],
+) -> Result<PromotionDecisionRegistry, String> {
+    let mut registry = PromotionDecisionRegistry::new();
+    for root in catalog_roots {
+        if root.is_file() {
+            admit_promotion_file(root, &mut registry)?;
+            continue;
+        }
+        if !root.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(root)
+            .into_iter()
+            .filter_entry(|entry| should_descend(entry.path()))
+        {
+            let entry = entry.map_err(|err| err.to_string())?;
+            if entry.file_type().is_file() {
+                admit_promotion_file(entry.path(), &mut registry)?;
+            }
+        }
+    }
+    Ok(registry)
+}
+
+pub(crate) fn load_consensus_policy(path: &Path) -> Result<ConsensusPolicy, String> {
+    let raw =
+        std::fs::read_to_string(path).map_err(|err| format!("read {}: {err}", path.display()))?;
+    let value: Value = serde_json::from_str(&raw)
+        .map_err(|err| format!("parse consensus policy {}: {err}", path.display()))?;
+    let mut policy = ConsensusPolicy::from_json_str(&raw).map_err(|err| format!("{err}"))?;
+    if policy.cid.as_deref().map(str::is_empty).unwrap_or(true) {
+        policy.cid = Some(content_cid_for_json(&value));
+    }
+    Ok(policy)
+}
+
+pub(crate) fn content_cid_for_json(value: &Value) -> String {
+    blake3_512_of(&canonical_json_bytes(value))
+}
+
+pub(crate) fn canonical_json_bytes(value: &Value) -> Vec<u8> {
+    encode_jcs(&json_to_value(value)).into_bytes()
+}
+
+pub(crate) fn status_json(
+    requested_concept: &str,
+    fixture: &str,
+    hit: &ConsensusQueryHit,
+    policy: Option<&ConsensusPolicy>,
+) -> Value {
+    let policy_verdict = policy.map(|policy| policy.admits(&hit.status));
+    let ok = policy_verdict.as_ref().map(|r| r.is_ok()).unwrap_or(true);
+    let reason = policy_verdict
+        .as_ref()
+        .and_then(|result| result.as_ref().err())
+        .cloned();
+    json!({
+        "ok": ok,
+        "verdict": if ok { "accepted" } else { "rejected" },
+        "reason": reason,
+        "requirement": {
+            "concept": requested_concept,
+            "fixture_state_cid": fixture,
+            "policy_cid": policy.and_then(|policy| policy.cid.clone())
+        },
+        "promotion": {
+            "consensus_vector": hit.status.consensus_vector.clone(),
+            "decision_cids": hit.status.decision_cids.clone(),
+            "decision_policy_cids": hit.status.decision_policy_cids.clone(),
+            "promoted_op": hit.status.key.promoted_op.clone(),
+            "witnesses_consulted": hit.status.witnesses_consulted
+        }
+    })
+}
+
+pub(crate) fn missing_json(requested_concept: &str, fixture: &str) -> Value {
+    json!({
+        "ok": false,
+        "verdict": "rejected",
+        "reason": "required empirically-witnessed promotion was not found",
+        "requirement": {
+            "concept": requested_concept,
+            "fixture_state_cid": fixture,
+            "policy_cid": null
+        }
+    })
+}
+
+fn admit_promotion_file(
+    path: &Path,
+    registry: &mut PromotionDecisionRegistry,
+) -> Result<(), String> {
+    let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+        return Ok(());
+    };
+    if !matches!(ext, "json" | "proof") {
+        return Ok(());
+    }
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(_) => return Ok(()),
+    };
+    let _ = registry.admit_json_str(&text);
+    Ok(())
+}
+
+fn should_descend(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return true;
+    };
+    !matches!(
+        name,
+        ".git" | ".worktrees" | "target" | "node_modules" | "vendor" | ".venv"
+    )
+}
+
+fn resolve_concept_counterpart(project_root: &Path, concept: &str) -> Option<String> {
+    let (_, entry) = resolve_concept_index_entry(project_root, concept)?;
+    let entry_cid = entry.get("cid").and_then(Value::as_str)?;
+    let name = entry.get("name").and_then(Value::as_str)?;
+    if concept == name {
+        Some(entry_cid.to_string())
+    } else if concept == entry_cid {
+        Some(name.to_string())
+    } else {
+        None
+    }
+}
+
+fn resolve_concept_index_entry(project_root: &Path, concept: &str) -> Option<(PathBuf, Value)> {
+    let repo_root = repo_root_for_concepts(project_root)?;
+    let index_path = repo_root
+        .join("menagerie")
+        .join("concept-shapes")
+        .join("catalog")
+        .join("index.json");
+    let raw = std::fs::read_to_string(index_path).ok()?;
+    let index: Value = serde_json::from_str(&raw).ok()?;
+    let entries = index
+        .get("entries")
+        .and_then(Value::as_object)
+        .or_else(|| index.as_object())?;
+    for (cid, entry) in entries {
+        let entry_cid = entry.get("cid").and_then(Value::as_str).unwrap_or(cid);
+        let name = entry.get("name").and_then(Value::as_str);
+        if name == Some(concept) || concept == entry_cid {
+            return Some((repo_root, entry.clone()));
+        }
+    }
+    None
+}
+
+fn repo_root_for_concepts(project_root: &Path) -> Option<PathBuf> {
+    for base in [project_root.to_path_buf(), std::env::current_dir().ok()?] {
+        for candidate in base.ancestors() {
+            if candidate
+                .join("menagerie")
+                .join("concept-shapes")
+                .join("catalog")
+                .join("index.json")
+                .exists()
+            {
+                return Some(candidate.to_path_buf());
+            }
+        }
+    }
+    None
+}
+
+fn json_to_value(j: &Value) -> Arc<CValue> {
+    match j {
+        Value::String(s) => CValue::string(s.clone()),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CValue::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                if let Ok(i) = i64::try_from(u) {
+                    CValue::integer(i)
+                } else {
+                    CValue::string(n.to_string())
+                }
+            } else {
+                CValue::string(n.to_string())
+            }
+        }
+        Value::Bool(b) => CValue::boolean(*b),
+        Value::Null => CValue::null(),
+        Value::Array(items) => CValue::array(items.iter().map(json_to_value).collect()),
+        Value::Object(map) => CValue::object(
+            map.iter()
+                .map(|(key, value)| (key.as_str(), json_to_value(value)))
+                .collect::<Vec<_>>(),
+        ),
+    }
+}

--- a/implementations/rust/provekit-cli/tests/promotion_decision_query_test.rs
+++ b/implementations/rust/provekit-cli/tests/promotion_decision_query_test.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use provekit_ir_types::MigrateReceiptEnvelope;
+use serde_json::Value;
+
+const FIXTURE_STATE_CID: &str = "blake3-512:295e0fd280088fc1e5e00d7bade11a2bf850c932180622e28f2fc92e64f97cd5bd757a73acf07f888b7c523e8efb65d8f0d01d50bc02740e5d771e750485d8f4";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("provekit-cli has rust workspace parent")
+        .parent()
+        .expect("rust workspace has implementations parent")
+        .parent()
+        .expect("implementations dir has repo parent")
+        .to_path_buf()
+}
+
+#[test]
+fn verifier_requires_empirically_witnessed_cross_language_consensus() {
+    let repo = repo_root();
+    let temp = tempfile::tempdir().expect("temp output");
+
+    let sqlite_receipt = temp.path().join("sqlite3").join("migrate-receipt.proof");
+    assert_success(
+        "python-sqlite3",
+        &run_migrate(
+            &repo,
+            "python-sqlite3",
+            sqlite_receipt.parent().unwrap(),
+            &sqlite_receipt,
+        ),
+    );
+
+    let aiosqlite_receipt = temp.path().join("aiosqlite").join("migrate-receipt.proof");
+    assert_success(
+        "python-aiosqlite",
+        &run_migrate(
+            &repo,
+            "python-aiosqlite",
+            aiosqlite_receipt.parent().unwrap(),
+            &aiosqlite_receipt,
+        ),
+    );
+
+    assert!(
+        sql_query_witness_count(&[&sqlite_receipt, &aiosqlite_receipt]) >= 8,
+        "the #877 cross-language receipts must carry enough sql-query witnesses for the policy vector"
+    );
+
+    let catalog = temp.path().join(".provekit").join("promotions");
+    fs::create_dir_all(&catalog).expect("create promotion catalog");
+    let promotion = catalog.join("sql-query-consensus.proof");
+    let policy = temp.path().join("consensus-policy.json");
+    write_consensus_policy(&policy);
+    assert_success(
+        "witness consensus",
+        &Command::new(cargo())
+            .current_dir(repo.join("implementations").join("rust"))
+            .arg("run")
+            .arg("-p")
+            .arg("provekit-cli")
+            .arg("--")
+            .arg("witness")
+            .arg("consensus")
+            .arg("--concept")
+            .arg("concept:sql-query")
+            .arg("--require-fixture")
+            .arg(FIXTURE_STATE_CID)
+            .arg("--min-witnesses")
+            .arg("8")
+            .arg("--consensus-policy")
+            .arg(&policy)
+            .arg("--catalog")
+            .arg(&sqlite_receipt)
+            .arg("--catalog")
+            .arg(&aiosqlite_receipt)
+            .arg("--emit")
+            .arg(&promotion)
+            .output()
+            .expect("spawn witness consensus"),
+    );
+
+    let status = Command::new(cargo())
+        .current_dir(repo.join("implementations").join("rust"))
+        .arg("run")
+        .arg("-p")
+        .arg("provekit-cli")
+        .arg("--")
+        .arg("witness")
+        .arg("status")
+        .arg("--project")
+        .arg(temp.path())
+        .arg("--concept")
+        .arg("concept:sql-query")
+        .arg("--require-fixture")
+        .arg(FIXTURE_STATE_CID)
+        .arg("--json")
+        .output()
+        .expect("spawn witness status");
+    assert_success("witness status", &status);
+
+    let verify = Command::new(cargo())
+        .current_dir(repo.join("implementations").join("rust"))
+        .arg("run")
+        .arg("-p")
+        .arg("provekit-cli")
+        .arg("--")
+        .arg("verify")
+        .arg(temp.path())
+        .arg("--require-empirically-witnessed")
+        .arg("concept:sql-query")
+        .arg("--require-fixture")
+        .arg(FIXTURE_STATE_CID)
+        .arg("--consensus-policy")
+        .arg(&policy)
+        .arg("--json")
+        .output()
+        .expect("spawn verify tier query");
+    assert_success("verify --require-empirically-witnessed", &verify);
+
+    let stdout = String::from_utf8(verify.stdout).expect("verify stdout utf8");
+    let report: Value = serde_json::from_str(&stdout).expect("verify JSON report");
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["verdict"], "accepted");
+    assert_eq!(report["requirement"]["concept"], "concept:sql-query");
+    assert_eq!(
+        report["requirement"]["fixture_state_cid"],
+        FIXTURE_STATE_CID
+    );
+    assert!(report["requirement"]["policy_cid"]
+        .as_str()
+        .unwrap_or_default()
+        .starts_with("blake3-512:"));
+    assert_eq!(
+        report["promotion"]["consensus_vector"]["unique_fixtures"],
+        1
+    );
+    assert!(
+        report["promotion"]["witnesses_consulted"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 8,
+        "promotion must cite at least the policy's witness floor"
+    );
+    assert!(
+        report["promotion"]["consensus_vector"]["total_sample_count"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 8,
+        "policy consumes the vector's sample-depth axis"
+    );
+}
+
+fn write_consensus_policy(path: &Path) {
+    fs::write(
+        path,
+        r#"{
+  "kind": "consensus-policy",
+  "schemaVersion": "1",
+  "name": "test-cross-language-sql-query",
+  "thresholds": [
+    {"axis": "min-witnesses-floor", "predicate": "n>=8"},
+    {"axis": "environment-diversity", "predicate": "unique_fixtures>=1"},
+    {"axis": "sample-depth", "predicate": "total_sample_count>=8"}
+  ],
+  "allow_failures": false
+}
+"#,
+    )
+    .expect("write consensus policy");
+}
+
+fn run_migrate(
+    repo: &Path,
+    library_to: &str,
+    out_dir: &Path,
+    receipt: &Path,
+) -> std::process::Output {
+    let source_dir = repo
+        .join("examples")
+        .join("migrate-demo")
+        .join("users-better-sqlite3");
+    let fixture = source_dir.join("fixture.sqlite");
+    Command::new(cargo())
+        .current_dir(repo.join("implementations").join("rust"))
+        .arg("run")
+        .arg("-p")
+        .arg("provekit-cli")
+        .arg("--")
+        .arg("bind")
+        .arg("--library-from")
+        .arg("typescript-better-sqlite3")
+        .arg("--library-to")
+        .arg(library_to)
+        .arg("--source-dir")
+        .arg(source_dir)
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg("--receipt")
+        .arg(receipt)
+        .arg("--witness-fixture")
+        .arg(fixture)
+        .arg("--write")
+        .output()
+        .expect("spawn cargo run migrate bind")
+}
+
+fn sql_query_witness_count(paths: &[&Path]) -> usize {
+    let mut cids = std::collections::BTreeSet::new();
+    for path in paths {
+        let raw = fs::read_to_string(path).expect("receipt written");
+        let receipt: MigrateReceiptEnvelope = serde_json::from_str(&raw).expect("parse receipt");
+        receipt.validate().expect("receipt validates");
+        cids.extend(
+            receipt
+                .witnesses
+                .iter()
+                .filter(|witness| witness.fixture_state_cid == FIXTURE_STATE_CID)
+                .filter(|witness| witness.witness_for == sql_query_concept_cid())
+                .map(|witness| witness.cid.clone()),
+        );
+    }
+    cids.len()
+}
+
+fn sql_query_concept_cid() -> &'static str {
+    "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1"
+}
+
+fn assert_success(label: &str, output: &std::process::Output) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "{label} failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+fn cargo() -> std::ffi::OsString {
+    std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into())
+}

--- a/implementations/rust/provekit-cli/tests/witness_consensus_test.rs
+++ b/implementations/rust/provekit-cli/tests/witness_consensus_test.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use provekit_ir_types::{PromotionDecisionMemento, PromotionGate, PromotionResult, WitnessMemento};
@@ -17,6 +17,8 @@ fn witness_consensus_emits_promotion_decision_for_byte_equal_row_shape() {
     let catalog = tmp.path().join("catalog");
     fs::create_dir_all(&catalog).expect("create catalog dir");
     let out = tmp.path().join("promotion-receipt.proof");
+    let policy = tmp.path().join("consensus-policy.json");
+    write_consensus_policy(&policy, 4);
     let concept = "concept:sql-query";
     let fixture = format!("blake3-512:{}", "a".repeat(128));
     let row_schema = json!({
@@ -50,6 +52,8 @@ fn witness_consensus_emits_promotion_decision_for_byte_equal_row_shape() {
         .arg(&fixture)
         .arg("--min-witnesses")
         .arg("4")
+        .arg("--consensus-policy")
+        .arg(&policy)
         .arg("--catalog")
         .arg(&catalog)
         .arg("--emit")
@@ -84,6 +88,7 @@ fn witness_consensus_emits_promotion_decision_for_byte_equal_row_shape() {
     assert_eq!(decision.header.gate, PromotionGate::Threshold);
     assert_eq!(decision.header.result, PromotionResult::Admitted);
     assert_eq!(decision.header.evidence_cids.len(), 4);
+    assert!(decision.header.policy_cid.starts_with("blake3-512:"));
     assert_eq!(decision.header.decision_payload["promoted_op"], concept);
     assert_eq!(
         decision.header.decision_payload["promotion"],
@@ -96,6 +101,14 @@ fn witness_consensus_emits_promotion_decision_for_byte_equal_row_shape() {
         json!([fixture])
     );
     assert_eq!(decision.header.decision_payload["row_schema"], row_schema);
+    assert_eq!(
+        decision.header.decision_payload["consensus_vector"]["unique_fixtures"],
+        1
+    );
+    assert_eq!(
+        decision.header.decision_payload["consensus_vector"]["total_sample_count"],
+        4
+    );
 }
 
 #[test]
@@ -208,4 +221,25 @@ fn witness(
     };
     witness.cid = witness.recompute_cid().expect("witness cid");
     witness
+}
+
+fn write_consensus_policy(path: &Path, min_witnesses: usize) {
+    fs::write(
+        path,
+        format!(
+            r#"{{
+  "kind": "consensus-policy",
+  "schemaVersion": "1",
+  "name": "test-row-schema-consensus",
+  "thresholds": [
+    {{"axis": "min-witnesses-floor", "predicate": "n>={min_witnesses}"}},
+    {{"axis": "environment-diversity", "predicate": "unique_fixtures>=1"}},
+    {{"axis": "sample-depth", "predicate": "total_sample_count>={min_witnesses}"}}
+  ],
+  "allow_failures": false
+}}
+"#
+        ),
+    )
+    .expect("write consensus policy");
 }


### PR DESCRIPTION
## Summary
- add libprovekit PromotionDecisionRegistry for admitted promotion decisions and per-vector ConsensusPolicy evaluation
- make witness consensus emit v1.1 consensus_vector payloads and require an explicit --consensus-policy for admission
- add witness status plus verify --require-empirically-witnessed --consensus-policy read paths
- cover Stage 3 SQL cross-language witnesses through consensus, registry, and verifier policy gating

## Tests
- cargo test -p libprovekit --test promotion_decision_registry -- --nocapture
- cargo test -p provekit-cli --test witness_consensus_test -- --nocapture
- cargo test -p provekit-cli --test promotion_decision_query_test -- --nocapture
- git diff --check