### PR TITLE
Scope Java contract-observation sugars by mode

### DIFF
--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -89,12 +89,13 @@ public final class RpcServer {
         String returnType = JsonUtil.decodeJsonStringField(paramsObj, "return_type");
         String conceptName = JsonUtil.decodeJsonStringField(paramsObj, "concept_name");
         String mode = JsonUtil.decodeJsonStringField(paramsObj, "mode");
+        List<String> modes = JsonUtil.decodeJsonStringArray(paramsObj, "modes");
         ContractPayload contract = ContractPayload.fromJson(JsonUtil.extractObjectField(paramsObj, "contract"));
         List<String> sugarPlugins = JsonUtil.decodeJsonObjectArray(paramsObj, "sugar_plugins");
         List<String> params = JsonUtil.decodeJsonStringArray(paramsObj, "params");
         List<String> paramTypes = JsonUtil.decodeJsonStringArray(paramsObj, "param_types");
         SugarRealizer.Realization r =
-                SugarRealizer.emitStub(function, params, paramTypes, returnType, conceptName, mode, contract, sugarPlugins);
+                SugarRealizer.emitStub(function, params, paramTypes, returnType, conceptName, mode, modes, contract, sugarPlugins);
         return "{\"source\":" + JsonUtil.quoted(r.source())
                 + ",\"emitted_artifact_cid\":"
                 + JsonUtil.quoted(Blake3.blake3_512(r.source().getBytes(StandardCharsets.UTF_8)))

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -97,10 +97,23 @@ final class SugarRealizer {
             String mode,
             ContractPayload contract,
             List<String> sugarPluginJson) {
+        return emitStub(function, params, paramTypes, returnType, conceptName, mode, modeList(mode), contract, sugarPluginJson);
+    }
+
+    static Realization emitStub(
+            String function,
+            List<String> params,
+            List<String> paramTypes,
+            String returnType,
+            String conceptName,
+            String mode,
+            List<String> modes,
+            ContractPayload contract,
+            List<String> sugarPluginJson) {
 
         String className = snakeToPascal(function) + "Transported";
         String mappedReturn = mapSourceType(returnType);
-        List<SugarEmission> sugarEmissions = SugarDictionary.emitAll(contract, sugarPluginJson);
+        List<SugarEmission> sugarEmissions = SugarDictionary.emitAll(contract, sugarPluginJson, modeList(mode, modes));
         boolean hasBeanValidationNotNull = sugarEmissions.stream()
                 .anyMatch(e -> e.surfaceLocator().startsWith("annotation:"));
         boolean hasJUnitWitness = sugarEmissions.stream()
@@ -154,6 +167,23 @@ final class SugarRealizer {
                 + "}\n"
                 + witnessClass;
         return new Realization(source, isStub, observedLossRecordJson(sugarEmissions), usedSugarsJson(sugarEmissions));
+    }
+
+    private static List<String> modeList(String mode) {
+        return mode == null || mode.isBlank() ? List.of() : List.of(mode);
+    }
+
+    private static List<String> modeList(String mode, List<String> modes) {
+        List<String> out = new ArrayList<>();
+        if (modes != null) {
+            for (String m : modes) {
+                if (m != null && !m.isBlank() && !out.contains(m)) out.add(m);
+            }
+        }
+        if (out.isEmpty() && mode != null && !mode.isBlank()) {
+            out.add(mode);
+        }
+        return out;
     }
 
     private static String observedLossRecordJson(List<SugarEmission> emissions) {
@@ -509,7 +539,7 @@ record SugarEmission(
 final class SugarDictionary {
     private SugarDictionary() {}
 
-    static List<SugarEmission> emitAll(ContractPayload contract, List<String> pluginJson) {
+    static List<SugarEmission> emitAll(ContractPayload contract, List<String> pluginJson, List<String> requestModes) {
         if (contract == null || pluginJson == null || pluginJson.isEmpty()) {
             return List.of();
         }
@@ -520,6 +550,7 @@ final class SugarDictionary {
             for (ContractWitness witness : contract.witnesses()) {
                 Jcs.Json predicate = witness.predicate();
                 for (SugarEntry entry : plugin.entries()) {
+                    if (!modeMatches(entry.mode(), requestModes)) continue;
                     Match match = match(predicate, entry.pattern(), witness);
                     if (match != null) {
                         out.add(new SugarEmission(
@@ -535,6 +566,11 @@ final class SugarDictionary {
             }
         }
         return out;
+    }
+
+    private static boolean modeMatches(String entryMode, List<String> requestModes) {
+        if (entryMode == null || entryMode.isBlank()) return true;
+        return requestModes != null && requestModes.contains(entryMode);
     }
 
     private static Match match(Jcs.Json predicate, Jcs.Json pattern, ContractWitness witness) {
@@ -639,7 +675,7 @@ final class SugarDictionary {
         }
     }
 
-    private record SugarEntry(String surfaceLocator, String template, Jcs.Json pattern, Jcs.Json lossRecord) {
+    private record SugarEntry(String surfaceLocator, String template, String mode, Jcs.Json pattern, Jcs.Json lossRecord) {
         static SugarEntry fromJson(Jcs.Obj entry) {
             Jcs.Json templateJson = entry.get("emission_template");
             if (!(templateJson instanceof Jcs.Obj templateObj)) return null;
@@ -651,6 +687,7 @@ final class SugarDictionary {
             return new SugarEntry(
                     templateObj.stringFieldOrNull("surface_locator"),
                     templateObj.stringFieldOrNull("template"),
+                    entry.stringFieldOrNull("mode"),
                     pattern,
                     value == null ? new Jcs.Obj(List.of()) : value
             );

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
@@ -132,9 +132,10 @@ public class JavaNullBoundaryRealizerTest {
             java.util.List.of("String"),
             "String",
             "concept:lookup",
-            "monitor",
+            "witness",
+            java.util.List.of("witness", "gate"),
             contract,
-            java.util.List.of(beanValidationSugar(), junitSugar(), commentSugar())
+            java.util.List.of(modeScopedBeanValidationSugar("gate"), modeScopedJunitSugar("witness"), commentSugar())
         );
 
         assertTrue(output.source().contains("import jakarta.validation.constraints.NotNull;"));
@@ -154,6 +155,33 @@ public class JavaNullBoundaryRealizerTest {
         assertTrue(output.usedSugarsJson().contains("java-bean-validation"));
         assertTrue(output.usedSugarsJson().contains("java-junit5"));
         assertTrue(output.usedSugarsJson().contains("java-function-comment"));
+    }
+
+    @Test
+    public void modeScopedJunitWitnessSugarDoesNotApplyToMonitor() {
+        ContractPayload contract = new ContractPayload(
+            "blake3-512:site",
+            "blake3-512:compound",
+            "evidence-lift[type-signature]",
+            "exact",
+            java.util.List.of(new ContractWitness("pre", "non_null(name)", "type-signature"))
+        );
+
+        SugarRealizer.Realization output = SugarRealizer.emitStub(
+            "lookup",
+            java.util.List.of("name"),
+            java.util.List.of("String"),
+            "String",
+            "concept:lookup",
+            "monitor",
+            contract,
+            java.util.List.of(modeScopedJunitSugar("witness"))
+        );
+
+        assertFalse(output.source().contains("org.junit.jupiter.api"));
+        assertFalse(output.source().contains("WitnessTest"));
+        assertFalse(output.source().contains("assertNotNull(name);"));
+        assertFalse(output.usedSugarsJson().contains("java-junit5"));
     }
 
     @Test
@@ -182,24 +210,12 @@ public class JavaNullBoundaryRealizerTest {
         assertTrue(body.isEmpty());
     }
 
-    private static String beanValidationSugar() {
-        return sugar(
-            "java-bean-validation",
-            "bean-validation",
-            "annotation:before-parameter",
-            "@NotNull",
-            "{}"
-        );
+    private static String modeScopedBeanValidationSugar(String mode) {
+        return "{\"header\":{\"cid\":\"java-bean-validation\",\"content\":{\"entries\":[{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-parameter\",\"template\":\"@NotNull\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"mode\":\"" + mode + "\",\"predicate_pattern\":{\"args\":[{\"kind\":\"var\",\"name\":\"${symbol}\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"},\"value\":null}],\"kind\":\"atomic\",\"name\":\"neq\"}}],\"sugar_name\":\"bean-validation\",\"target_language\":\"java\"},\"critical\":false,\"kind\":\"sugar\",\"protocol_versions\":[\"pep/1.7.0\"],\"provenance_cid\":\"blake3-512:0\",\"schemaVersion\":\"1\",\"version\":\"1.0.0\"}}";
     }
 
-    private static String junitSugar() {
-        return sugar(
-            "java-junit5",
-            "junit5",
-            "witness:junit5-test",
-            "assertNotNull(${symbol});",
-            "{\"domain_narrowing\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"witness_requires_test_execution\"},\"structural_divergence\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"witness_skeleton_requires_concrete_values\"}}"
-        );
+    private static String modeScopedJunitSugar(String mode) {
+        return "{\"header\":{\"cid\":\"java-junit5\",\"content\":{\"entries\":[{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"witness:junit5-test\",\"template\":\"assertNotNull(${symbol});\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{\"domain_narrowing\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"witness_requires_test_execution\"},\"structural_divergence\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"witness_skeleton_requires_concrete_values\"}}},\"mode\":\"" + mode + "\",\"predicate_pattern\":{\"args\":[{\"kind\":\"var\",\"name\":\"${symbol}\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"},\"value\":null}],\"kind\":\"atomic\",\"name\":\"neq\"}}],\"sugar_name\":\"junit5\",\"target_language\":\"java\"},\"critical\":false,\"kind\":\"sugar\",\"protocol_versions\":[\"pep/1.7.0\"],\"provenance_cid\":\"blake3-512:0\",\"schemaVersion\":\"1\",\"version\":\"1.0.0\"}}";
     }
 
     private static String commentSugar() {

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -104,7 +104,7 @@ fn java_bean_validation_sugar_cid_self_consistent() {
         repo_root().join("menagerie/java-language-signature/specs/sugar/java-bean-validation.json");
     assert_self_consistent(
         path,
-        "blake3-512:dbfbb31b64445c500281daf4577285a2f5ac1073336a1e8f9fcc7d745508d2eeba0e5974e5d258ce88998d19630119c9a06fa665764369e910e7d466fc742ca1",
+        "blake3-512:279b2ff4bc9dedf5144d83a4dc41f08ec46038a92c04139f865892fea88380fecb302bda9c23e541050b39fe4e7a3870fd90f175a57ea76239fa1ef5517b492c",
     );
 }
 
@@ -113,7 +113,7 @@ fn java_junit5_sugar_cid_self_consistent() {
     let path = repo_root().join("menagerie/java-language-signature/specs/sugar/java-junit5.json");
     assert_self_consistent(
         path,
-        "blake3-512:eb878a4dd45a863bacdd6b86c9a0c32fac3d91be2a33a4ce3ffbbc0d372f2e5dbc074305bed7a51248b47ab0305ff63411428655cc3f015497b19ee6538bdf49",
+        "blake3-512:95f3f61d9c904c43c0965e483c70db7d293fea01e2993664b1050260466d101bf1366b9bddf53ab4b287b90866295c3a5bee9d877f07c9b0f8355db70b3a6e16",
     );
 }
 

--- a/menagerie/java-language-signature/specs/sugar/java-bean-validation.json
+++ b/menagerie/java-language-signature/specs/sugar/java-bean-validation.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:dbfbb31b64445c500281daf4577285a2f5ac1073336a1e8f9fcc7d745508d2eeba0e5974e5d258ce88998d19630119c9a06fa665764369e910e7d466fc742ca1",
+    "cid": "blake3-512:279b2ff4bc9dedf5144d83a4dc41f08ec46038a92c04139f865892fea88380fecb302bda9c23e541050b39fe4e7a3870fd90f175a57ea76239fa1ef5517b492c",
     "content": {
       "entries": [
         {
@@ -18,6 +18,7 @@
             "form": "literal",
             "value": {}
           },
+          "mode": "gate",
           "predicate_pattern": {
             "args": [
               {"kind": "var", "name": "${symbol}"},
@@ -39,7 +40,7 @@
     "version": "1.0.0"
   },
   "metadata": {
-    "note": "Java Bean Validation contract sugar for exact non-null boundary clauses.",
+    "note": "Java Bean Validation contract sugar for exact non-null boundary clauses. Applies to contract-observation gate mode.",
     "source_url": "menagerie/java-language-signature/specs/sugar/java-bean-validation.json"
   }
 }

--- a/menagerie/java-language-signature/specs/sugar/java-junit5.json
+++ b/menagerie/java-language-signature/specs/sugar/java-junit5.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:eb878a4dd45a863bacdd6b86c9a0c32fac3d91be2a33a4ce3ffbbc0d372f2e5dbc074305bed7a51248b47ab0305ff63411428655cc3f015497b19ee6538bdf49",
+    "cid": "blake3-512:95f3f61d9c904c43c0965e483c70db7d293fea01e2993664b1050260466d101bf1366b9bddf53ab4b287b90866295c3a5bee9d877f07c9b0f8355db70b3a6e16",
     "content": {
       "entries": [
         {
@@ -29,6 +29,7 @@
               }
             }
           },
+          "mode": "witness",
           "predicate_pattern": {
             "args": [
               {"kind": "var", "name": "${symbol}"},
@@ -50,7 +51,7 @@
     "version": "1.0.0"
   },
   "metadata": {
-    "note": "JUnit 5 witness sugar for non-null clauses. The loss record is honest: this emits a disabled skeleton until concrete example values are supplied.",
+    "note": "JUnit 5 witness sugar for non-null clauses. Applies only to contract-observation witness mode. The loss record is honest: this emits a disabled skeleton until concrete example values are supplied.",
     "source_url": "menagerie/java-language-signature/specs/sugar/java-junit5.json"
   }
 }

--- a/protocol/specs/2026-05-12-sugar-dict-memento.md
+++ b/protocol/specs/2026-05-12-sugar-dict-memento.md
@@ -15,9 +15,9 @@
 
 ## §1. Purpose
 
-Canonical contract clauses produced by the core-form realizer are abstract `IrFormula` trees. To be readable by a target-language tool (a Spring app, a JML-annotated Java method, a JUnit 5 test, or a comment-as-documentation line), they MUST be rendered into surface syntax. The rendering is NOT a single fixed function: it is plural by construction. Different surfaces compete for the same canonical clause; the substrate picks the rendering that incurs the LOWEST loss against the loaded loss function (`2026-05-12-loss-function-memento.md`).
+Canonical contract clauses produced by the core-form realizer are abstract `IrFormula` trees. To be readable by a target-language tool (a Spring app, a JML-annotated Java method, a JUnit 5 test, or a comment-as-documentation line), they MUST be rendered into surface syntax. The rendering is NOT a single fixed function: it is plural by construction. Different surfaces compete for the same canonical clause under best-only policy; under inclusive policy, multiple selected surfaces intentionally compose. Every selected surface carries its own loss record, scored against the loaded loss function (`2026-05-12-loss-function-memento.md`).
 
-A `sugar` plugin is a content-addressed dictionary of rendering entries. Multiple sugar plugins MAY be loaded simultaneously; per-clause selection is loss-minimizing (§4). The mechanism replaces the "cosmetic re-sugaring after the core-form realizer" item parked in `implementations/rust/provekit-cli/src/cmd_transport.rs` line 296 (`deferred` field of `TransportReport`).
+A `sugar` plugin is a content-addressed dictionary of rendering entries. Multiple sugar plugins MAY be loaded simultaneously; per-clause selection is loss-minimizing or inclusive depending on the active emission policy (§4). The mechanism replaces the "cosmetic re-sugaring after the core-form realizer" item parked in `implementations/rust/provekit-cli/src/cmd_transport.rs` line 296 (`deferred` field of `TransportReport`).
 
 ### §1.1 What a sugar dict is NOT
 
@@ -51,11 +51,12 @@ sugar-content = {
 }
 
 ; Locked JCS key order: applicability_guard, emission_template,
-; loss_record_contribution, predicate_pattern
+; loss_record_contribution, mode, predicate_pattern
 sugar-entry = {
   ? applicability_guard:     ir-formula,       ; OPTIONAL; if present, MUST evaluate to true for the entry to apply
   emission_template:         emission-template,
   loss_record_contribution:  loss-record-contribution,
+  ? mode:                    tstr,             ; OPTIONAL; when present, entry applies only when request modes include it
   predicate_pattern:         ir-formula        ; with named holes (free variables) the matcher binds
 }
 
@@ -94,10 +95,21 @@ loss-record-contribution = {
 | `sugar-entry.applicability_guard`        | no       | OPTIONAL `IrFormula` over the bound holes. If present, MUST evaluate to `true` for the entry to apply (e.g., a Spring `@Min` entry MIGHT guard on `is_integer_literal(${k})` to refuse non-literal lower bounds). OMITTED when absent. |
 | `sugar-entry.emission_template`          | yes      | The surface-syntax template, plus a `surface_locator` placing it relative to the host code element. |
 | `sugar-entry.loss_record_contribution`   | yes      | The loss-record this entry incurs when selected. Under v1.0.0 the `form` MUST be `"literal"`; the `value` is a `loss-record` literal as defined in `2026-05-14-transport-gap-and-partial-morphism-protocol.md` §1.3. |
+| `sugar-entry.mode`                       | no       | OPTIONAL runtime observation mode applicability filter. When present, the entry applies only if the current realization request's mode vector includes the same mode string (for example `"witness"` for JUnit witness harness sugar, or `"gate"` for Bean Validation gate sugar). When absent, the entry is mode-agnostic and remains compatible with non-observation clauses. |
 
 ### §2.2 Pattern matching
 
 The matcher unifies `predicate_pattern` against the canonical clause's `IrFormula` per `2026-04-30-ir-formal-grammar.md` first-order syntactic unification, treating any free variable as a hole. Bound holes flow into `applicability_guard` (if present) and into `emission_template.template` via `${name}` substitution. Unification failure means the entry does NOT match.
+
+### §2.3 Observation-mode applicability
+
+`concept:contract-observation(callsite_cid, contract_cid, mode)` routes
+Witness, Monitor, Emitter, and Gate through the same concept hub. Sugar entries
+that are meaningful for only one of those modes MUST declare `mode`. For
+example, a JUnit witness harness entry declares `"mode": "witness"` so it cannot
+render for a request whose mode vector omits `witness`; a Bean Validation entry
+declares `"mode": "gate"` so it renders only when gate sugar is requested.
+Comment-floor entries and other universal fallbacks omit `mode`.
 
 ## §3. CLI surface
 
@@ -117,17 +129,29 @@ Additional sugar-specific flags:
 | `--strict-sugar`              | When no entry in any LOADED sugar dict matches a clause, refuse instead of falling through. §5.   |
 | `--allow-comment-fallback`    | Permits the special `comment` sugar to act as a final fallback even when other sugars matched. §5.|
 
-## §4. Selection algorithm
+## §4. Selection and emission algorithm
 
 For each canonical contract clause C produced by the realizer:
+
+### §4.0 Emission policy
+
+A sugar consumer MUST apply one of these policies for a clause:
+
+| Policy | Meaning |
+|--------|---------|
+| `best-only` | Candidate surfaces compete. The consumer emits exactly one selected candidate: the lowest-loss candidate after §4.2 scoring and §4.4 tie-break. |
+| `inclusive` | Candidate surfaces compose. The consumer emits every applicable candidate that survives §4.1, ordered by §4.2 scoring and §4.4 tie-break. No candidate is discarded merely because another applicable candidate has lower loss. |
+
+`best-only` is the default for ordinary single-surface contract rendering. `inclusive` is REQUIRED when a realization request carries a `concept:contract-observation` mode vector and the selected sugars cover different requested modes. A kit MUST NOT drop a `witness` sugar because a `gate` sugar has lower loss, or vice versa; those are additive observations over the same contract. Mode-agnostic entries (for example comment-floor sugar) also participate under `inclusive` and MUST carry their declared loss record if emitted.
 
 ### §4.1 Step 1: enumerate matching entries
 
 For each sugar plugin S in the registry's `load_order` (CLI flag order plus built-ins at end), for each entry E in `S.content.entries`:
 
 1. Attempt unification of `E.predicate_pattern` against C. If unification fails, skip E.
-2. If `E.applicability_guard` is present, evaluate it under the bound holes. If it evaluates to anything other than `true`, skip E.
-3. Otherwise, record `(S, E, bindings)` as a candidate.
+2. If `E.mode` is present and the current realization request mode vector does not include it, skip E.
+3. If `E.applicability_guard` is present, evaluate it under the bound holes. If it evaluates to anything other than `true`, skip E.
+4. Otherwise, record `(S, E, bindings)` as a candidate.
 
 The matcher MUST be deterministic: two runs with identical inputs MUST produce the same candidate list in the same order.
 
@@ -135,9 +159,13 @@ The matcher MUST be deterministic: two runs with identical inputs MUST produce t
 
 For each candidate `(S, E, bindings)`, the candidate's loss-record is `E.loss_record_contribution.value` (literal form; v1.0.0). Hand the loss-record to the LOADED loss function (`2026-05-12-loss-function-memento.md`); the loss function returns a score.
 
-### §4.3 Step 3: rank and pick
+### §4.3 Step 3: rank and select
 
-Sort candidates by score ascending (lower = better). The TOP candidate (lowest score) wins.
+Sort candidates by score ascending (lower = better).
+
+Under `best-only`, the TOP candidate (lowest score after tie-break) wins and all other candidates are rejected for this clause.
+
+Under `inclusive`, every candidate remains selected. Ranking is still normative because it defines deterministic emission order and audit order, but it does not discard lower-ranked candidates.
 
 ### §4.4 Step 4: tie-break
 
@@ -145,11 +173,13 @@ If two or more candidates tie, break ties as follows:
 
 1. Prefer the candidate whose sugar dict appears LATER in `load_order` (later flags win; matches the §7 rule of the protocol spec for "user-loaded plugins beat built-ins of the same kind").
 2. If still tied, prefer the candidate whose entry index within its sugar dict is LOWER (entries earlier in `entries` win).
-3. If still tied (impossible by §2.1 sort INVARIANT, but recorded for completeness), refuse with `reason_kind = "sugar-tiebreak-ambiguity"`.
+3. If still tied (impossible by §2.1 sort INVARIANT, but recorded for completeness), refuse with `reason_kind = "sugar-tiebreak-ambiguity"` under `best-only`; under `inclusive`, preserve deterministic registry order and include both candidates.
 
 ### §4.5 Step 5: emit
 
-Render the winning candidate's `emission_template` with the bound holes substituted. Attach the candidate's `loss_record_contribution` to the emission's audit trail (carried forward in any compound that aggregates the emission, per `2026-05-13-compound-contract-memento.md` §6.2).
+Render each selected candidate's `emission_template` with the bound holes substituted. Attach each selected candidate's `loss_record_contribution` to the emission's audit trail (carried forward in any compound that aggregates the emission, per `2026-05-13-compound-contract-memento.md` §6.2).
+
+For example, when a `witness,gate` Java realization has matching JUnit witness sugar and Bean Validation gate sugar for the same canonical non-null clause, an inclusive consumer MUST emit both. Those surfaces are not competing alternatives in inclusive mode; they are two observation wrappers with separate loss records.
 
 ## §5. Strict mode
 


### PR DESCRIPTION
## Summary
- add optional `mode` applicability to the sugar-dict spec for contract-observation runtime modes
- make the Java realizer match sugar entries against the full request mode vector
- scope Java Bean Validation sugar to `gate` and JUnit5 sugar to `witness`, with re-minted plugin CIDs

## Verification
- RED first: `mvn -q -pl provekit-realize-java-core -am -Dtest=JavaNullBoundaryRealizerTest#modeScopedJunitWitnessSugarDoesNotApplyToMonitor test` failed before the matcher fix
- `mvn -q -pl provekit-realize-java-core -am -Dtest=JavaNullBoundaryRealizerTest test`
- `cargo test -p provekit-plugin-loader java_`
- `git diff --check`

Refs #735, #737, #880.