### PR TITLE
Add numeric Bean Validation gate sugar

### DIFF
--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -115,7 +115,7 @@ final class SugarRealizer {
         String mappedReturn = mapSourceType(returnType);
         List<SugarEmission> sugarEmissions = SugarDictionary.emitAll(contract, sugarPluginJson, modeList(mode, modes));
         boolean hasBeanValidationNotNull = sugarEmissions.stream()
-                .anyMatch(e -> e.surfaceLocator().startsWith("annotation:"));
+                .anyMatch(e -> e.surfaceLocator().startsWith("annotation:") && e.rendered().startsWith("@NotNull"));
         boolean hasJUnitWitness = sugarEmissions.stream()
                 .anyMatch(e -> e.surfaceLocator().startsWith("witness:junit5"));
 
@@ -125,8 +125,9 @@ final class SugarRealizer {
             String srcType = i < paramTypes.size() ? paramTypes.get(i) : "i64";
             String mapped = mapSourceType(srcType);
             if (i > 0) typedParamList.append(", ");
-            if (hasBeanValidationNotNull && contractHasNonNullPrecondition(contract, name)) {
-                typedParamList.append("@NotNull ");
+            String parameterAnnotations = parameterAnnotations(sugarEmissions, name);
+            if (!parameterAnnotations.isBlank()) {
+                typedParamList.append(parameterAnnotations).append(" ");
             }
             typedParamList.append(mapped).append(" ").append(name);
         }
@@ -146,7 +147,7 @@ final class SugarRealizer {
         String indentedBody = bodyContent.replace("\n", "\n        ");
         String body = "        " + indentedBody + "\n";
         String methodAnnotation = hasBeanValidationNotNull && contractHasNonNullPostcondition(contract) ? "    @NotNull\n" : "";
-        String imports = importsFor(hasBeanValidationNotNull, hasJUnitWitness);
+        String imports = importsFor(sugarEmissions, !methodAnnotation.isEmpty(), hasJUnitWitness);
         String witnessClass = hasJUnitWitness
                 ? "\nfinal class " + className + "WitnessTest {\n"
                         + "    @Disabled(\"provekit witness skeleton requires concrete values\")\n"
@@ -167,6 +168,17 @@ final class SugarRealizer {
                 + "}\n"
                 + witnessClass;
         return new Realization(source, isStub, observedLossRecordJson(sugarEmissions), usedSugarsJson(sugarEmissions));
+    }
+
+    private static String parameterAnnotations(List<SugarEmission> emissions, String paramName) {
+        StringBuilder out = new StringBuilder();
+        for (SugarEmission emission : emissions) {
+            if (!emission.surfaceLocator().startsWith("annotation:")) continue;
+            if (!paramName.equals(emission.symbol())) continue;
+            if (!out.isEmpty()) out.append(" ");
+            out.append(emission.rendered());
+        }
+        return out.toString();
     }
 
     private static List<String> modeList(String mode) {
@@ -225,10 +237,22 @@ final class SugarRealizer {
         return Jcs.encode(Jcs.array(used));
     }
 
-    private static String importsFor(boolean hasBeanValidationNotNull, boolean hasJUnitWitness) {
+    private static String importsFor(
+            List<SugarEmission> emissions,
+            boolean hasMethodNotNull,
+            boolean hasJUnitWitness) {
         StringBuilder imports = new StringBuilder();
-        if (hasBeanValidationNotNull) {
+        if (hasMethodNotNull || hasRenderedAnnotation(emissions, "@NotNull")) {
             imports.append("import jakarta.validation.constraints.NotNull;\n");
+        }
+        if (hasRenderedAnnotation(emissions, "@Min")) {
+            imports.append("import jakarta.validation.constraints.Min;\n");
+        }
+        if (hasRenderedAnnotation(emissions, "@Max")) {
+            imports.append("import jakarta.validation.constraints.Max;\n");
+        }
+        if (hasRenderedAnnotation(emissions, "@Size")) {
+            imports.append("import jakarta.validation.constraints.Size;\n");
         }
         if (hasJUnitWitness) {
             imports.append("import org.junit.jupiter.api.Disabled;\n");
@@ -239,6 +263,11 @@ final class SugarRealizer {
             imports.append("\n");
         }
         return imports.toString();
+    }
+
+    private static boolean hasRenderedAnnotation(List<SugarEmission> emissions, String annotationName) {
+        return emissions.stream().anyMatch(e ->
+                e.surfaceLocator().startsWith("annotation:") && e.rendered().startsWith(annotationName));
     }
 
     private static String junitWitnessBody(List<SugarEmission> emissions) {
@@ -551,7 +580,7 @@ final class SugarDictionary {
                 Jcs.Json predicate = witness.predicate();
                 for (SugarEntry entry : plugin.entries()) {
                     if (!modeMatches(entry.mode(), requestModes)) continue;
-                    Match match = match(predicate, entry.pattern(), witness);
+                    Match match = match(predicate, entry.pattern(), entry.template(), witness);
                     if (match != null) {
                         out.add(new SugarEmission(
                                 plugin.cid(),
@@ -573,11 +602,11 @@ final class SugarDictionary {
         return requestModes != null && requestModes.contains(entryMode);
     }
 
-    private static Match match(Jcs.Json predicate, Jcs.Json pattern, ContractWitness witness) {
+    private static Match match(Jcs.Json predicate, Jcs.Json pattern, String template, ContractWitness witness) {
         if (!(pattern instanceof Jcs.Obj patternObj)) return null;
         String patternName = patternObj.stringFieldOrNull("name");
         if (patternName != null && patternName.startsWith("${")) {
-            return new Match(witnessSymbol(witness), witness.predicateText(), witness.role());
+            return new Match(witnessSymbol(witness), witness.predicateText(), witness.role(), Map.of());
         }
         if (!(predicate instanceof Jcs.Obj predicateObj)) return null;
         if (!"atomic".equals(predicateObj.stringFieldOrNull("kind"))) return null;
@@ -589,28 +618,73 @@ final class SugarDictionary {
                 || patternArgs.values().size() != predicateArgs.values().size()) {
             return null;
         }
-        String symbol = "";
+        Map<String, String> bindings = new TreeMap<>();
         for (int i = 0; i < patternArgs.values().size(); i++) {
             Jcs.Json p = patternArgs.get(i);
             Jcs.Json actual = predicateArgs.get(i);
-            if (isHoleVar(p, "symbol") && actual instanceof Jcs.Obj actualObj) {
-                symbol = actualObj.stringFieldOrNull("name");
-                continue;
-            }
-            if (isConstNullPattern(p) && isConstNullPattern(actual)) {
+            if (bindTerm(p, actual, template, bindings)) {
                 continue;
             }
             if (!Jcs.encode(p).equals(Jcs.encode(actual))) {
                 return null;
             }
         }
-        return new Match(symbol, witness.predicateText(), witness.role());
+        return new Match(bindings.getOrDefault("symbol", ""), witness.predicateText(), witness.role(), bindings);
     }
 
-    private static boolean isHoleVar(Jcs.Json json, String name) {
-        return json instanceof Jcs.Obj obj
-                && "var".equals(obj.stringFieldOrNull("kind"))
-                && ("${" + name + "}").equals(obj.stringFieldOrNull("name"));
+    private static boolean bindTerm(Jcs.Json pattern, Jcs.Json actual, String template, Map<String, String> bindings) {
+        if (pattern instanceof Jcs.Obj patternObj
+                && "var".equals(patternObj.stringFieldOrNull("kind"))
+                && actual instanceof Jcs.Obj actualObj
+                && "var".equals(actualObj.stringFieldOrNull("kind"))) {
+            String hole = holeName(patternObj.stringFieldOrNull("name"));
+            String actualName = actualObj.stringFieldOrNull("name");
+            if (hole != null && actualName != null) {
+                bindings.put(hole, actualName);
+                return true;
+            }
+        }
+        if (pattern instanceof Jcs.Obj patternObj
+                && "const".equals(patternObj.stringFieldOrNull("kind"))
+                && patternObj.get("value") instanceof Jcs.Str holeValue
+                && actual instanceof Jcs.Obj actualObj
+                && "const".equals(actualObj.stringFieldOrNull("kind"))
+                && actualObj.get("value") instanceof Jcs.Num number) {
+            String hole = holeName(holeValue.value());
+            if (hole != null) {
+                long value = number.value();
+                String plusOne = null;
+                String minusOne = null;
+                try {
+                    if (referencesTemplateBinding(template, hole + "_plus_one")) {
+                        plusOne = Long.toString(Math.addExact(value, 1L));
+                    }
+                    if (referencesTemplateBinding(template, hole + "_minus_one")) {
+                        minusOne = Long.toString(Math.subtractExact(value, 1L));
+                    }
+                } catch (ArithmeticException overflow) {
+                    return false;
+                }
+                bindings.put(hole, Long.toString(value));
+                if (plusOne != null) {
+                    bindings.put(hole + "_plus_one", plusOne);
+                }
+                if (minusOne != null) {
+                    bindings.put(hole + "_minus_one", minusOne);
+                }
+                return true;
+            }
+        }
+        return isConstNullPattern(pattern) && isConstNullPattern(actual);
+    }
+
+    private static boolean referencesTemplateBinding(String template, String binding) {
+        return template != null && template.contains("${" + binding + "}");
+    }
+
+    private static String holeName(String raw) {
+        if (raw == null || !raw.startsWith("${") || !raw.endsWith("}")) return null;
+        return raw.substring(2, raw.length() - 1);
     }
 
     private static boolean isConstNullPattern(Jcs.Json json) {
@@ -631,10 +705,14 @@ final class SugarDictionary {
     }
 
     private static String render(String template, Match match) {
-        return template
+        String rendered = template
                 .replace("${symbol}", match.symbol())
                 .replace("${formula_pretty_print}", match.formulaPrettyPrint())
                 .replace("${contract_role}", roleKeyword(match.role()));
+        for (Map.Entry<String, String> binding : match.bindings().entrySet()) {
+            rendered = rendered.replace("${" + binding.getKey() + "}", binding.getValue());
+        }
+        return rendered;
     }
 
     private static String roleKeyword(String role) {
@@ -645,7 +723,7 @@ final class SugarDictionary {
         };
     }
 
-    private record Match(String symbol, String formulaPrettyPrint, String role) {}
+    private record Match(String symbol, String formulaPrettyPrint, String role, Map<String, String> bindings) {}
 
     private record SugarPlugin(String cid, String sugarName, String targetLanguage, List<SugarEntry> entries) {
         static SugarPlugin fromJson(String raw) {

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
@@ -185,6 +185,104 @@ public class JavaNullBoundaryRealizerTest {
     }
 
     @Test
+    public void bindContractNumericWitnessesEmitMinMaxGateSugar() {
+        ContractPayload contract = new ContractPayload(
+            "blake3-512:site",
+            "blake3-512:compound",
+            "evidence-lift[test-assertion]",
+            "exact",
+            java.util.List.of(
+                new ContractWitness("pre", numericPredicate("gt", "age", 0), "age > 0", "test-assertion"),
+                new ContractWitness("pre", numericPredicate("le", "age", 130), "age <= 130", "test-assertion")
+            )
+        );
+
+        SugarRealizer.Realization output = SugarRealizer.emitStub(
+            "admit",
+            java.util.List.of("age"),
+            java.util.List.of("i32"),
+            "()",
+            "concept:admit",
+            "gate",
+            java.util.List.of("gate"),
+            contract,
+            java.util.List.of(modeScopedBeanValidationNumericSugar("gate"))
+        );
+
+        assertTrue(output.source().contains("import jakarta.validation.constraints.Min;"));
+        assertTrue(output.source().contains("import jakarta.validation.constraints.Max;"));
+        assertTrue(output.source().contains("public static void admit(@Min(1) @Max(130) int age)"));
+        assertTrue(output.usedSugarsJson().contains("java-bean-validation"));
+        assertEquals("{}", output.observedLossRecord());
+    }
+
+    @Test
+    public void strictNumericBoundOverflowDoesNotEmitWrappedGateSugar() {
+        ContractPayload contract = new ContractPayload(
+            "blake3-512:site",
+            "blake3-512:compound",
+            "evidence-lift[test-assertion]",
+            "exact",
+            java.util.List.of(
+                new ContractWitness("pre", numericPredicate("gt", "age", Long.MAX_VALUE), "age > Long.MAX_VALUE", "test-assertion"),
+                new ContractWitness("pre", numericPredicate("lt", "score", Long.MIN_VALUE), "score < Long.MIN_VALUE", "test-assertion")
+            )
+        );
+
+        SugarRealizer.Realization output = SugarRealizer.emitStub(
+            "admit",
+            java.util.List.of("age", "score"),
+            java.util.List.of("i64", "i64"),
+            "()",
+            "concept:admit",
+            "gate",
+            java.util.List.of("gate"),
+            contract,
+            java.util.List.of(modeScopedBeanValidationNumericSugar("gate"))
+        );
+
+        assertFalse(output.source().contains("@Min("));
+        assertFalse(output.source().contains("@Max("));
+        assertFalse(output.source().contains("import jakarta.validation.constraints.Min;"));
+        assertFalse(output.source().contains("import jakarta.validation.constraints.Max;"));
+        assertFalse(output.usedSugarsJson().contains("java-bean-validation"));
+        assertEquals("{}", output.observedLossRecord());
+    }
+
+    @Test
+    public void inclusiveNumericBoundsAtLongExtremaStillEmitExactGateSugar() {
+        ContractPayload contract = new ContractPayload(
+            "blake3-512:site",
+            "blake3-512:compound",
+            "evidence-lift[test-assertion]",
+            "exact",
+            java.util.List.of(
+                new ContractWitness("pre", numericPredicate("ge", "age", Long.MAX_VALUE), "age >= Long.MAX_VALUE", "test-assertion"),
+                new ContractWitness("pre", numericPredicate("le", "score", Long.MIN_VALUE), "score <= Long.MIN_VALUE", "test-assertion")
+            )
+        );
+
+        SugarRealizer.Realization output = SugarRealizer.emitStub(
+            "admit",
+            java.util.List.of("age", "score"),
+            java.util.List.of("i64", "i64"),
+            "()",
+            "concept:admit",
+            "gate",
+            java.util.List.of("gate"),
+            contract,
+            java.util.List.of(modeScopedBeanValidationNumericSugar("gate"))
+        );
+
+        assertTrue(output.source().contains("import jakarta.validation.constraints.Min;"));
+        assertTrue(output.source().contains("import jakarta.validation.constraints.Max;"));
+        assertTrue(output.source().contains("@Min(9223372036854775807) long age"));
+        assertTrue(output.source().contains("@Max(-9223372036854775808) long score"));
+        assertTrue(output.usedSugarsJson().contains("java-bean-validation"));
+        assertEquals("{}", output.observedLossRecord());
+    }
+
+    @Test
     public void contractObservationWitnessBodyTemplateEmitsWitnessCall() {
         java.util.Optional<String> body = SugarRealizer.bodyTemplateFor(
             "concept:contract-observation",
@@ -214,6 +312,17 @@ public class JavaNullBoundaryRealizerTest {
         return "{\"header\":{\"cid\":\"java-bean-validation\",\"content\":{\"entries\":[{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-parameter\",\"template\":\"@NotNull\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"mode\":\"" + mode + "\",\"predicate_pattern\":{\"args\":[{\"kind\":\"var\",\"name\":\"${symbol}\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"},\"value\":null}],\"kind\":\"atomic\",\"name\":\"neq\"}}],\"sugar_name\":\"bean-validation\",\"target_language\":\"java\"},\"critical\":false,\"kind\":\"sugar\",\"protocol_versions\":[\"pep/1.7.0\"],\"provenance_cid\":\"blake3-512:0\",\"schemaVersion\":\"1\",\"version\":\"1.0.0\"}}";
     }
 
+    private static String modeScopedBeanValidationNumericSugar(String mode) {
+        return """
+            {"header":{"cid":"java-bean-validation","content":{"entries":[
+              {"emission_template":{"kind":"verbatim","surface_locator":"annotation:before-parameter","template":"@Min(${k})"},"loss_record_contribution":{"form":"literal","value":{}},"mode":"__MODE__","predicate_pattern":{"args":[{"kind":"var","name":"${symbol}"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":"${k}"}],"kind":"atomic","name":"ge"}},
+              {"emission_template":{"kind":"verbatim","surface_locator":"annotation:before-parameter","template":"@Min(${k_plus_one})"},"loss_record_contribution":{"form":"literal","value":{}},"mode":"__MODE__","predicate_pattern":{"args":[{"kind":"var","name":"${symbol}"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":"${k}"}],"kind":"atomic","name":"gt"}},
+              {"emission_template":{"kind":"verbatim","surface_locator":"annotation:before-parameter","template":"@Max(${k})"},"loss_record_contribution":{"form":"literal","value":{}},"mode":"__MODE__","predicate_pattern":{"args":[{"kind":"var","name":"${symbol}"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":"${k}"}],"kind":"atomic","name":"le"}},
+              {"emission_template":{"kind":"verbatim","surface_locator":"annotation:before-parameter","template":"@Max(${k_minus_one})"},"loss_record_contribution":{"form":"literal","value":{}},"mode":"__MODE__","predicate_pattern":{"args":[{"kind":"var","name":"${symbol}"},{"kind":"const","sort":{"kind":"primitive","name":"Int"},"value":"${k}"}],"kind":"atomic","name":"lt"}}
+            ],"sugar_name":"bean-validation","target_language":"java"},"critical":false,"kind":"sugar","protocol_versions":["pep/1.7.0"],"provenance_cid":"blake3-512:0","schemaVersion":"1","version":"1.0.0"}}
+            """.replace("__MODE__", mode);
+    }
+
     private static String modeScopedJunitSugar(String mode) {
         return "{\"header\":{\"cid\":\"java-junit5\",\"content\":{\"entries\":[{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"witness:junit5-test\",\"template\":\"assertNotNull(${symbol});\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{\"domain_narrowing\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"witness_requires_test_execution\"},\"structural_divergence\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"witness_skeleton_requires_concrete_values\"}}},\"mode\":\"" + mode + "\",\"predicate_pattern\":{\"args\":[{\"kind\":\"var\",\"name\":\"${symbol}\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"},\"value\":null}],\"kind\":\"atomic\",\"name\":\"neq\"}}],\"sugar_name\":\"junit5\",\"target_language\":\"java\"},\"critical\":false,\"kind\":\"sugar\",\"protocol_versions\":[\"pep/1.7.0\"],\"provenance_cid\":\"blake3-512:0\",\"schemaVersion\":\"1\",\"version\":\"1.0.0\"}}";
     }
@@ -224,5 +333,20 @@ public class JavaNullBoundaryRealizerTest {
 
     private static String sugar(String cid, String name, String locator, String template, String loss) {
         return "{\"header\":{\"cid\":\"" + cid + "\",\"content\":{\"entries\":[{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"" + locator + "\",\"template\":\"" + template + "\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":" + loss + "},\"predicate_pattern\":{\"args\":[{\"kind\":\"var\",\"name\":\"${symbol}\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"},\"value\":null}],\"kind\":\"atomic\",\"name\":\"neq\"}}],\"sugar_name\":\"" + name + "\",\"target_language\":\"java\"},\"critical\":false,\"kind\":\"sugar\",\"protocol_versions\":[\"pep/1.7.0\"],\"provenance_cid\":\"blake3-512:0\",\"schemaVersion\":\"1\",\"version\":\"1.0.0\"}}";
+    }
+
+    private static com.provekit.ir.Jcs.Json numericPredicate(String op, String symbol, long value) {
+        return com.provekit.ir.Jcs.object(
+            "args", com.provekit.ir.Jcs.array(
+                com.provekit.ir.Jcs.object("kind", com.provekit.ir.Jcs.string("var"), "name", com.provekit.ir.Jcs.string(symbol)),
+                com.provekit.ir.Jcs.object(
+                    "kind", com.provekit.ir.Jcs.string("const"),
+                    "sort", com.provekit.ir.Jcs.object("kind", com.provekit.ir.Jcs.string("primitive"), "name", com.provekit.ir.Jcs.string("Int")),
+                    "value", new com.provekit.ir.Jcs.Num(value)
+                )
+            ),
+            "kind", com.provekit.ir.Jcs.string("atomic"),
+            "name", com.provekit.ir.Jcs.string(op)
+        );
     }
 }

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -104,7 +104,7 @@ fn java_bean_validation_sugar_cid_self_consistent() {
         repo_root().join("menagerie/java-language-signature/specs/sugar/java-bean-validation.json");
     assert_self_consistent(
         path,
-        "blake3-512:279b2ff4bc9dedf5144d83a4dc41f08ec46038a92c04139f865892fea88380fecb302bda9c23e541050b39fe4e7a3870fd90f175a57ea76239fa1ef5517b492c",
+        "blake3-512:d0405739130eeb2c5814c81584bb61f9bf079989e7c4d5e1ecd3c5066660ba53fc0e29ba0ecbdf2fb615da4359c647c04e44654ea7a924d50bb9a06a439fc5ba",
     );
 }
 

--- a/menagerie/java-language-signature/specs/sugar/java-bean-validation.json
+++ b/menagerie/java-language-signature/specs/sugar/java-bean-validation.json
@@ -5,9 +5,89 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:279b2ff4bc9dedf5144d83a4dc41f08ec46038a92c04139f865892fea88380fecb302bda9c23e541050b39fe4e7a3870fd90f175a57ea76239fa1ef5517b492c",
+    "cid": "blake3-512:d0405739130eeb2c5814c81584bb61f9bf079989e7c4d5e1ecd3c5066660ba53fc0e29ba0ecbdf2fb615da4359c647c04e44654ea7a924d50bb9a06a439fc5ba",
     "content": {
       "entries": [
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-parameter",
+            "template": "@Min(${k})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "mode": "gate",
+          "predicate_pattern": {
+            "args": [
+              {"kind": "var", "name": "${symbol}"},
+              {"kind": "const", "sort": {"kind": "primitive", "name": "Int"}, "value": "${k}"}
+            ],
+            "kind": "atomic",
+            "name": "ge"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-parameter",
+            "template": "@Min(${k_plus_one})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "mode": "gate",
+          "predicate_pattern": {
+            "args": [
+              {"kind": "var", "name": "${symbol}"},
+              {"kind": "const", "sort": {"kind": "primitive", "name": "Int"}, "value": "${k}"}
+            ],
+            "kind": "atomic",
+            "name": "gt"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-parameter",
+            "template": "@Max(${k})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "mode": "gate",
+          "predicate_pattern": {
+            "args": [
+              {"kind": "var", "name": "${symbol}"},
+              {"kind": "const", "sort": {"kind": "primitive", "name": "Int"}, "value": "${k}"}
+            ],
+            "kind": "atomic",
+            "name": "le"
+          }
+        },
+        {
+          "emission_template": {
+            "kind": "verbatim",
+            "surface_locator": "annotation:before-parameter",
+            "template": "@Max(${k_minus_one})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "mode": "gate",
+          "predicate_pattern": {
+            "args": [
+              {"kind": "var", "name": "${symbol}"},
+              {"kind": "const", "sort": {"kind": "primitive", "name": "Int"}, "value": "${k}"}
+            ],
+            "kind": "atomic",
+            "name": "lt"
+          }
+        },
         {
           "emission_template": {
             "kind": "verbatim",
@@ -40,7 +120,7 @@
     "version": "1.0.0"
   },
   "metadata": {
-    "note": "Java Bean Validation contract sugar for exact non-null boundary clauses. Applies to contract-observation gate mode.",
+    "note": "Java Bean Validation contract sugar for exact non-null and integer bound clauses. Applies to contract-observation gate mode.",
     "source_url": "menagerie/java-language-signature/specs/sugar/java-bean-validation.json"
   }
 }


### PR DESCRIPTION
## Summary
- extend Java Bean Validation gate sugar with integer bound clauses: `gt/ge/lt/le` -> `@Min/@Max`
- teach the Java sugar matcher to bind numeric template holes (`${k}`, `${k_plus_one}`, `${k_minus_one}`) from IR constants
- render all parameter annotation sugars from selected emissions, including imports for `@Min`, `@Max`, and `@Size`
- re-mint the Bean Validation sugar CID and update the pinned CID test

## Verification
- RED first: `mvn -q -pl provekit-realize-java-core -am -Dtest=JavaNullBoundaryRealizerTest#bindContractNumericWitnessesEmitMinMaxGateSugar test` failed before implementation
- `mvn -q -pl provekit-realize-java-core -am -Dtest=JavaNullBoundaryRealizerTest test`
- `cargo test -p provekit-plugin-loader java_bean_validation_sugar_cid_self_consistent`
- `git diff --check`

Refs #735, #739, #880.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added numeric validation constraints (@Min, @Max) for method parameters derived from contract predicates.

* **Improvements**
  * Enhanced parameter-level annotation generation to dynamically emit constraint-based Java annotations.
  * Improved template placeholder substitution to support flexible constraint bindings.

* **Tests**
  * Added comprehensive test coverage for numeric boundary validation and gate sugar emissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/891)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->