### PR TITLE
Compose Java emitter observation wrappers

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
@@ -90,6 +90,13 @@ public final class JavaBindLifter {
         return new Result(entries, diagnostics);
     }
 
+    Result liftPathsFromSource(String sourcePath, String source) {
+        List<Jcs.Json> entries = new ArrayList<>();
+        List<Jcs.Json> diagnostics = new ArrayList<>();
+        liftSource(sourcePath, source, entries, diagnostics);
+        return new Result(entries, diagnostics);
+    }
+
     private void liftFile(Path root, Path javaFile, List<Jcs.Json> entries, List<Jcs.Json> diagnostics) {
         String rel = root.relativize(javaFile).toString().replace('\\', '/');
         String source;
@@ -99,7 +106,10 @@ public final class JavaBindLifter {
             diagnostics.add(diag("error", "read failed for " + javaFile + ": " + e.getMessage()));
             return;
         }
+        liftSource(rel, source, entries, diagnostics);
+    }
 
+    private void liftSource(String rel, String source, List<Jcs.Json> entries, List<Jcs.Json> diagnostics) {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         if (compiler == null) {
             diagnostics.add(diag("error", "JDK compiler API unavailable; cannot parse " + rel));
@@ -185,6 +195,7 @@ public final class JavaBindLifter {
             String termShapeCid = Jcs.cid(termShape);
 
             String conceptAnnotation = extractConceptAnnotation(source, fnLine);
+            List<Jcs.Json> observationWitnesses = observationTagWitnesses(source, fnLine);
 
             Jcs.Obj entry = Jcs.object(
                 "attr_post", Jcs.nullValue(),
@@ -198,7 +209,8 @@ public final class JavaBindLifter {
                 "param_types", Jcs.array(paramTypes),
                 "return_type", Jcs.string(returnType),
                 "term_shape", termShape,
-                "term_shape_cid", Jcs.string(termShapeCid)
+                "term_shape_cid", Jcs.string(termShapeCid),
+                "witnesses", Jcs.array(observationWitnesses)
             );
             entries.add(entry);
             return super.visitMethod(method, unused);
@@ -322,6 +334,71 @@ public final class JavaBindLifter {
         return null;
     }
 
+    private static List<Jcs.Json> observationTagWitnesses(String source, int fnLine) {
+        List<TagLine> tags = scanObservationTags(source, fnLine);
+        if (tags.isEmpty()) return List.of();
+        String concept = tagValue(tags, "provekit-observation");
+        String mode = tagValue(tags, "provekit-observation-mode");
+        String term = tagValue(tags, "provekit-observation-term");
+        if (concept == null || concept.isBlank()) return List.of();
+        if (term == null || term.isBlank()) {
+            term = concept;
+        }
+        Jcs.Obj extensionFields = Jcs.object(
+            "concept_site_cid", stringOrNull(tagValue(tags, "provekit-concept-site-cid")),
+            "contract_cid", stringOrNull(tagValue(tags, "provekit-contract-cid")),
+            "emitted_concept", stringOrNull(tagValue(tags, "provekit-emitted-concept")),
+            "mode", stringOrNull(mode),
+            "object_fcm_cid", stringOrNull(tagValue(tags, "provekit-object-fcm-cid")),
+            "observation_concept", Jcs.string(concept),
+            "observation_term", Jcs.string(term),
+            "policy_cid", stringOrNull(tagValue(tags, "provekit-observation-policy-cid")),
+            "role", Jcs.string("observation"),
+            "surface", Jcs.string("java-comment-tag")
+        );
+        return List.of(Jcs.object(
+            "col", Jcs.integer(0),
+            "confidence_basis_points", Jcs.integer(10000),
+            "extension_fields", extensionFields,
+            "line", Jcs.integer(tags.get(0).line()),
+            "predicate", Jcs.object("args", Jcs.array(), "kind", Jcs.string("atomic"), "name", Jcs.string(term)),
+            "predicate_text", Jcs.string(term),
+            "role", Jcs.string("observation"),
+            "source_kind", Jcs.string("native-surface")
+        ));
+    }
+
+    private static List<TagLine> scanObservationTags(String source, int fnLine) {
+        if (fnLine <= 1) return List.of();
+        String[] lines = source.split("\n", -1);
+        int start = Math.max(0, fnLine - 25);
+        int end = Math.min(lines.length, fnLine + 25);
+        List<TagLine> tags = new ArrayList<>();
+        for (int idx = start; idx < end; idx++) {
+            String stripped = lines[idx].stripLeading();
+            if (!stripped.startsWith("// provekit-")) continue;
+            int colon = stripped.indexOf(':');
+            if (colon < 0) continue;
+            String key = stripped.substring("// ".length(), colon).trim();
+            String value = stripped.substring(colon + 1).trim();
+            if (key.startsWith("provekit-")) {
+                tags.add(new TagLine(idx + 1, key, value));
+            }
+        }
+        return tags;
+    }
+
+    private static String tagValue(List<TagLine> tags, String key) {
+        for (TagLine tag : tags) {
+            if (tag.key().equals(key)) return tag.value();
+        }
+        return null;
+    }
+
+    private static Jcs.Json stringOrNull(String value) {
+        return value == null || value.isBlank() ? Jcs.nullValue() : Jcs.string(value);
+    }
+
     // ---- Helpers -----------------------------------------------------------
 
     private static int lineOf(String source, int offset) {
@@ -357,6 +434,8 @@ public final class JavaBindLifter {
             );
         }
     }
+
+    private record TagLine(int line, String key, String value) {}
 
     private static final class JavaFileSource extends SimpleJavaFileObject {
         private final String source;

--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
@@ -195,7 +195,17 @@ public final class JavaBindLifter {
             String termShapeCid = Jcs.cid(termShape);
 
             String conceptAnnotation = extractConceptAnnotation(source, fnLine);
-            List<Jcs.Json> observationWitnesses = observationTagWitnesses(source, fnLine);
+            long bodyStartOffset = trees.getSourcePositions().getStartPosition(
+                path.getCompilationUnit(), method.getBody());
+            long bodyEndOffset = trees.getSourcePositions().getEndPosition(
+                path.getCompilationUnit(), method.getBody());
+            int bodyStartLine = bodyStartOffset >= 0 && bodyStartOffset <= Integer.MAX_VALUE
+                ? lineOf(source, (int) bodyStartOffset)
+                : fnLine;
+            int bodyEndLine = bodyEndOffset >= 0 && bodyEndOffset <= Integer.MAX_VALUE
+                ? lineOf(source, (int) bodyEndOffset)
+                : fnLine;
+            List<Jcs.Json> observationWitnesses = observationTagWitnesses(source, bodyStartLine, bodyEndLine);
 
             Jcs.Obj entry = Jcs.object(
                 "attr_post", Jcs.nullValue(),
@@ -334,8 +344,8 @@ public final class JavaBindLifter {
         return null;
     }
 
-    private static List<Jcs.Json> observationTagWitnesses(String source, int fnLine) {
-        List<TagLine> tags = scanObservationTags(source, fnLine);
+    private static List<Jcs.Json> observationTagWitnesses(String source, int startLine, int endLine) {
+        List<TagLine> tags = scanObservationTags(source, startLine, endLine);
         if (tags.isEmpty()) return List.of();
         String concept = tagValue(tags, "provekit-observation");
         String mode = tagValue(tags, "provekit-observation-mode");
@@ -368,11 +378,11 @@ public final class JavaBindLifter {
         ));
     }
 
-    private static List<TagLine> scanObservationTags(String source, int fnLine) {
-        if (fnLine <= 1) return List.of();
+    private static List<TagLine> scanObservationTags(String source, int startLine, int endLine) {
+        if (startLine <= 0 || endLine < startLine) return List.of();
         String[] lines = source.split("\n", -1);
-        int start = Math.max(0, fnLine - 25);
-        int end = Math.min(lines.length, fnLine + 25);
+        int start = Math.max(0, startLine - 1);
+        int end = Math.min(lines.length, endLine);
         List<TagLine> tags = new ArrayList<>();
         for (int idx = start; idx < end; idx++) {
             String stripped = lines[idx].stripLeading();

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
@@ -1,6 +1,7 @@
 package com.provekit.lift.java_source;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.provekit.ir.Jcs;
@@ -209,6 +210,41 @@ class TrinityRoundtripLiftTest {
         Set<String> declNames = declarationFnNames();
         assertTrue(declNames.stream().anyMatch(n -> n.contains("source-unit")),
             "source-unit contract should always be present; got: " + declNames);
+    }
+
+    @Test
+    void bindLifterRecoversObservationPolicyTagsAsNativeSurfaceWitness() {
+        String source = """
+            final class IdentityTransported {
+                // concept: identity
+                public static long identity(long x) {
+                    long __provekit_result = x;
+                    // provekit-observation: concept:contract-observation
+                    // provekit-observation-term: concept:contract-observation(blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111,blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222,emitter)
+                    // provekit-observation-mode: emitter
+                    // provekit-concept-site-cid: blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
+                    // provekit-object-fcm-cid: blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222
+                    // provekit-contract-cid: blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333
+                    // provekit-emitted-concept: concept:log-emit
+                    // provekit-observation-policy-cid: blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
+                    java.util.logging.Logger.getLogger("provekit").log(java.util.logging.Level.INFO, "observed");
+                    return __provekit_result;
+                }
+            }
+            """;
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Fixture.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertTrue(encoded.contains("\"source_kind\":\"native-surface\""), encoded);
+        assertTrue(encoded.contains("\"role\":\"observation\""), encoded);
+        assertTrue(encoded.contains("concept:contract-observation"), encoded);
+        assertTrue(encoded.contains("concept:log-emit"), encoded);
+        assertTrue(encoded.contains("\"mode\":\"emitter\""), encoded);
+        assertTrue(encoded.contains("\"policy_cid\":\"blake3-512:444444"), encoded);
+        assertTrue(encoded.contains("\"object_fcm_cid\":\"blake3-512:222222"), encoded);
+        assertTrue(encoded.contains("\"contract_cid\":\"blake3-512:333333"), encoded);
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
@@ -247,6 +247,41 @@ class TrinityRoundtripLiftTest {
         assertTrue(encoded.contains("\"contract_cid\":\"blake3-512:333333"), encoded);
     }
 
+    @Test
+    void bindLifterDoesNotBleedObservationTagsIntoAdjacentMethods() {
+        String source = """
+            final class AdjacentTransported {
+                // concept: first
+                public static long first(long x) {
+                    long __provekit_result = x;
+                    // provekit-observation: concept:contract-observation
+                    // provekit-observation-term: concept:contract-observation(blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111,blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222,emitter)
+                    // provekit-observation-mode: emitter
+                    // provekit-concept-site-cid: blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
+                    // provekit-object-fcm-cid: blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222
+                    // provekit-contract-cid: blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333
+                    // provekit-observation-policy-cid: blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
+                    java.util.logging.Logger.getLogger("provekit").log(java.util.logging.Level.INFO, "observed");
+                    return __provekit_result;
+                }
+
+                // concept: second
+                public static long second(long y) {
+                    return y;
+                }
+            }
+            """;
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Adjacent.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(2, lift.entries().size(), encoded);
+        assertEquals(
+            1,
+            countOccurrences(encoded, "\"source_kind\":\"native-surface\""),
+            "observation native-surface witness must belong only to the method whose body contains the tag: " + encoded);
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
 
     private Set<String> declarationFnNames() {
@@ -254,5 +289,15 @@ class TrinityRoundtripLiftTest {
             .filter(d -> d instanceof Jcs.Obj obj && "function-contract".equals(obj.stringFieldOrNull("kind")))
             .map(d -> ((Jcs.Obj) d).stringField("fnName"))
             .collect(Collectors.toSet());
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) >= 0) {
+            count += 1;
+            idx += needle.length();
+        }
+        return count;
     }
 }

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -96,12 +96,16 @@ public final class RpcServer {
         List<String> paramTypes = JsonUtil.decodeJsonStringArray(paramsObj, "param_types");
         SugarRealizer.Realization r =
                 SugarRealizer.emitStub(function, params, paramTypes, returnType, conceptName, mode, modes, contract, sugarPlugins);
+        String wrapperRecord = r.observationWrapperEmissionRecord() == null
+                ? ""
+                : ",\"observation_wrapper_emission_record\":" + r.observationWrapperEmissionRecord();
         return "{\"source\":" + JsonUtil.quoted(r.source())
                 + ",\"emitted_artifact_cid\":"
                 + JsonUtil.quoted(Blake3.blake3_512(r.source().getBytes(StandardCharsets.UTF_8)))
                 + ",\"is_stub\":" + (r.isStub() ? "true" : "false")
                 + ",\"observed_loss_record\":" + r.observedLossRecord()
                 + ",\"used_sugars\":" + r.usedSugarsJson()
+                + wrapperRecord
                 + "}";
     }
 

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -1,5 +1,6 @@
 package com.provekit.realize;
 
+import com.provekit.ir.Blake3;
 import com.provekit.ir.Jcs;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -55,7 +56,8 @@ final class SugarRealizer {
             String source,
             boolean isStub,
             String observedLossRecord,
-            String usedSugarsJson) {}
+            String usedSugarsJson,
+            String observationWrapperEmissionRecord) {}
 
     /**
      * Emit a Java method for a single function. Body source comes from the
@@ -114,7 +116,8 @@ final class SugarRealizer {
 
         String className = snakeToPascal(function) + "Transported";
         String mappedReturn = mapSourceType(returnType);
-        List<SugarEmission> sugarEmissions = SugarDictionary.emitAll(contract, sugarPluginJson, modeList(mode, modes));
+        List<String> requestedModes = modeList(mode, modes);
+        List<SugarEmission> sugarEmissions = SugarDictionary.emitAll(contract, sugarPluginJson, requestedModes);
         boolean hasBeanValidationNotNull = sugarEmissions.stream()
                 .anyMatch(e -> e.surfaceLocator().startsWith("annotation:") && e.rendered().startsWith("@NotNull"));
         boolean hasJUnitWitness = sugarEmissions.stream()
@@ -142,6 +145,22 @@ final class SugarRealizer {
         boolean isStub = bodyTemplate.isEmpty();
         String bodyContent = bodyTemplate.map(RenderedBody::body)
                 .orElse("throw new UnsupportedOperationException(\"provekit-bind canonical: " + conceptName + "\");");
+        Jcs.Json bodyLossRecord = bodyTemplate.map(RenderedBody::lossRecord).orElse(Jcs.object());
+        String observationWrapperEmissionRecord = null;
+        if (!isStub) {
+            Optional<ObservationComposition> observation = composeEmitterAfterReturn(
+                    requestedModes,
+                    bodyContent,
+                    mappedReturn,
+                    function,
+                    conceptName,
+                    contract);
+            if (observation.isPresent()) {
+                bodyContent = observation.get().body();
+                bodyLossRecord = combineLossRecords(bodyLossRecord, observation.get().lossRecord());
+                observationWrapperEmissionRecord = observation.get().observationWrapperEmissionRecord();
+            }
+        }
         // Multi-line templates: each internal line gets the same 8-space
         // method-body indent. Single-line bodies are unaffected (no \n).
         String indentedBody = bodyContent.replace("\n", "\n        ");
@@ -170,8 +189,9 @@ final class SugarRealizer {
         return new Realization(
                 source,
                 isStub,
-                observedLossRecordJson(sugarEmissions, bodyTemplate.map(RenderedBody::lossRecord).orElse(Jcs.object())),
-                usedSugarsJson(sugarEmissions));
+                observedLossRecordJson(sugarEmissions, bodyLossRecord),
+                usedSugarsJson(sugarEmissions),
+                observationWrapperEmissionRecord);
     }
 
     private static String parameterAnnotations(List<SugarEmission> emissions, String paramName) {
@@ -246,6 +266,161 @@ final class SugarRealizer {
                 "kind", Jcs.string("and"),
                 "operands", Jcs.array(existing, next)
         );
+    }
+
+    private static Optional<ObservationComposition> composeEmitterAfterReturn(
+            List<String> requestedModes,
+            String operationBody,
+            String mappedReturn,
+            String function,
+            String conceptName,
+            ContractPayload contract) {
+        if (!isEmitterOnly(requestedModes)
+                || contract == null
+                || !validCid(contract.conceptSiteCid())
+                || !validCid(contract.objectFcmCid())
+                || !validCid(contract.localContractCid())
+                || conceptMatches("concept:contract-observation", conceptName)) {
+            return Optional.empty();
+        }
+        Optional<RenderedBody> observation = renderBodyTemplateFor(
+                "concept:contract-observation",
+                List.of(contract.conceptSiteCid(), contract.localContractCid(), "emitter"),
+                "emitter");
+        if (observation.isEmpty()) {
+            return Optional.empty();
+        }
+        String policyCid = emitterTagPolicyCid();
+        String observationBody = observationTagBlock(contract, policyCid) + "\n" + observation.get().body();
+        Optional<String> composed = composeAfterReturn(operationBody, observationBody, mappedReturn);
+        if (composed.isEmpty()) {
+            return Optional.empty();
+        }
+        String record = observationWrapperEmissionRecord(function, conceptName, mappedReturn, composed.get(), contract, policyCid);
+        return Optional.of(new ObservationComposition(composed.get(), observation.get().lossRecord(), record));
+    }
+
+    private static boolean isEmitterOnly(List<String> requestedModes) {
+        return requestedModes != null
+                && requestedModes.size() == 1
+                && "emitter".equals(requestedModes.get(0));
+    }
+
+    private static Optional<String> composeAfterReturn(String operationBody, String observationBody, String mappedReturn) {
+        String trimmed = operationBody.stripTrailing();
+        String[] lines = trimmed.split("\\R", -1);
+        if (lines.length == 0) return Optional.empty();
+        String last = lines[lines.length - 1].trim();
+        if ("void".equals(mappedReturn)) {
+            return Optional.of(trimmed + "\n" + observationBody);
+        }
+        if (!last.startsWith("return ") || !last.endsWith(";")) {
+            return Optional.empty();
+        }
+        String expression = last.substring("return ".length(), last.length() - 1).trim();
+        if (expression.isEmpty()) return Optional.empty();
+        List<String> out = new ArrayList<>();
+        for (int i = 0; i < lines.length - 1; i++) {
+            out.add(lines[i]);
+        }
+        out.add(mappedReturn + " __provekit_result = " + expression + ";");
+        out.add(observationBody);
+        out.add("return __provekit_result;");
+        return Optional.of(String.join("\n", out));
+    }
+
+    private static String observationWrapperEmissionRecord(
+            String function,
+            String conceptName,
+            String mappedReturn,
+            String composedBody,
+            ContractPayload contract,
+            String policyCid) {
+        Jcs.Obj effect = logIoEffect(function, contract.localContractCid());
+        Jcs.Obj wrapperFcm = Jcs.object(
+                "autoMintedMementos", Jcs.array(),
+                "bodyCid", Jcs.string(Blake3.blake3_512(composedBody.getBytes(StandardCharsets.UTF_8))),
+                "effects", Jcs.array(effect),
+                "fnName", Jcs.string(function + "$provekit_emitter"),
+                "formalSorts", Jcs.array(),
+                "formals", Jcs.array(),
+                "kind", Jcs.string("function-contract"),
+                "locus", Jcs.object("function", Jcs.string(function), "surface", Jcs.string("java-emitter-wrapper")),
+                "post", Jcs.object("args", Jcs.array(), "kind", Jcs.string("atomic"), "name", Jcs.string("true")),
+                "pre", Jcs.object("args", Jcs.array(), "kind", Jcs.string("atomic"), "name", Jcs.string("true")),
+                "returnSort", Jcs.object("args", Jcs.array(), "kind", Jcs.string("ctor"), "name", Jcs.string(mappedReturn)),
+                "schemaVersion", Jcs.string("1")
+        );
+        String wrapperFcmCid = Jcs.cid(wrapperFcm);
+        Jcs.Obj preservationClaim = Jcs.object(
+                "concept_name", Jcs.string(conceptName),
+                "kind", Jcs.string("observation-preservation-claim"),
+                "local_contract_cid", Jcs.string(contract.localContractCid()),
+                "mode", Jcs.string("emitter"),
+                "object_fcm_cid", Jcs.string(contract.objectFcmCid()),
+                "policy_cid", Jcs.string(policyCid),
+                "wrapper_fcm_cid", Jcs.string(wrapperFcmCid)
+        );
+        String preservationClaimCid = Jcs.cid(preservationClaim);
+        return Jcs.encode(Jcs.object(
+                "object_fcm_cid", Jcs.string(contract.objectFcmCid()),
+                "observer_effects", Jcs.array(effect),
+                "policy_cid", Jcs.string(policyCid),
+                "preservation_claim_cid", Jcs.string(preservationClaimCid),
+                "wrapper_fcm_cid", Jcs.string(wrapperFcmCid)
+        ));
+    }
+
+    private static Jcs.Obj logIoEffect(String function, String contractCid) {
+        return Jcs.object(
+                "args", Jcs.object(
+                        "channel", Jcs.string("java.util.logging"),
+                        "contract_cid", Jcs.string(contractCid),
+                        "operation", Jcs.string("log")
+                ),
+                "discharge_key", Jcs.string("io:java-util-logging:log"),
+                "locator", Jcs.object("function", Jcs.string(function), "mode", Jcs.string("emitter")),
+                "occurrence_kind", Jcs.string("Io"),
+                "role", Jcs.string("body"),
+                "signature_cid", Jcs.string(Blake3.blake3_512("java.util.logging.Logger.log(Level,String)".getBytes(StandardCharsets.UTF_8)))
+        );
+    }
+
+    private static String observationTagBlock(ContractPayload contract, String policyCid) {
+        return String.join("\n",
+                "// provekit-observation: concept:contract-observation",
+                "// provekit-observation-term: concept:contract-observation("
+                        + contract.conceptSiteCid() + "," + contract.localContractCid() + ",emitter)",
+                "// provekit-observation-mode: emitter",
+                "// provekit-concept-site-cid: " + contract.conceptSiteCid(),
+                "// provekit-object-fcm-cid: " + contract.objectFcmCid(),
+                "// provekit-contract-cid: " + contract.localContractCid(),
+                "// provekit-emitted-concept: concept:log-emit",
+                "// provekit-observation-policy-cid: " + policyCid
+        );
+    }
+
+    private static String emitterTagPolicyCid() {
+        return Jcs.cid(Jcs.object(
+                "emit_tags", Jcs.bool(true),
+                "kind", Jcs.string("realization-emission-policy"),
+                "modes", Jcs.array(Jcs.string("emitter")),
+                "schemaVersion", Jcs.string("1"),
+                "surface", Jcs.string("java-comment-tags")
+        ));
+    }
+
+    private static boolean validCid(String cid) {
+        if (cid == null || !cid.startsWith("blake3-512:") || cid.length() != "blake3-512:".length() + 128) {
+            return false;
+        }
+        for (int i = "blake3-512:".length(); i < cid.length(); i++) {
+            char ch = cid.charAt(i);
+            if (!((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static String usedSugarsJson(List<SugarEmission> emissions) {
@@ -480,6 +655,11 @@ final class SugarRealizer {
             List<String> params) {}
 
     private record RenderedBody(String body, Jcs.Json lossRecord) {}
+
+    private record ObservationComposition(
+            String body,
+            Jcs.Json lossRecord,
+            String observationWrapperEmissionRecord) {}
 
     /**
      * Render a body string for the given concept + signature, or empty when
@@ -1016,16 +1196,27 @@ record ContractWitness(String role, Jcs.Json predicate, String predicateText, St
 
 record ContractPayload(
         String conceptSiteCid,
+        String objectFcmCid,
         String localContractCid,
         String origin,
         String dischargeVerdict,
         List<ContractWitness> witnesses) {
     ContractPayload {
         conceptSiteCid = conceptSiteCid == null ? "" : conceptSiteCid;
+        objectFcmCid = objectFcmCid == null ? "" : objectFcmCid;
         localContractCid = localContractCid == null ? "" : localContractCid;
         origin = origin == null ? "" : origin;
         dischargeVerdict = dischargeVerdict == null ? "" : dischargeVerdict;
         witnesses = witnesses == null ? List.of() : List.copyOf(witnesses);
+    }
+
+    ContractPayload(
+            String conceptSiteCid,
+            String localContractCid,
+            String origin,
+            String dischargeVerdict,
+            List<ContractWitness> witnesses) {
+        this(conceptSiteCid, localContractCid, localContractCid, origin, dischargeVerdict, witnesses);
     }
 
     static ContractPayload fromJson(String json) {
@@ -1038,6 +1229,7 @@ record ContractPayload(
                 .toList();
         return new ContractPayload(
                 JsonUtil.decodeJsonStringField(json, "concept_site_cid"),
+                JsonUtil.decodeJsonStringField(json, "object_fcm_cid"),
                 JsonUtil.decodeJsonStringField(json, "local_contract_cid"),
                 JsonUtil.decodeJsonStringField(json, "origin"),
                 JsonUtil.decodeJsonStringField(json, "discharge_verdict"),

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -367,6 +367,7 @@ final class SugarRealizer {
                 "observer_effects", Jcs.array(effect),
                 "policy_cid", Jcs.string(policyCid),
                 "preservation_claim_cid", Jcs.string(preservationClaimCid),
+                "wrapper_fcm", wrapperFcm,
                 "wrapper_fcm_cid", Jcs.string(wrapperFcmCid)
         ));
     }

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
@@ -383,6 +383,93 @@ public class JavaNullBoundaryRealizerTest {
         assertTrue(output.observedLossRecord().contains("java-util-logging-level-taxonomy"));
     }
 
+    @Test
+    public void ordinaryIdentityEmitterComposesRecursiveObservationAfterReturnWithoutChangingResult() {
+        ContractPayload contract = new ContractPayload(
+            "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+            "evidence-lift[type-signature]",
+            "exact",
+            java.util.List.of(new ContractWitness("pre", "x >= 0", "type-signature"))
+        );
+
+        SugarRealizer.Realization output = SugarRealizer.emitStub(
+            "identity",
+            java.util.List.of("x"),
+            java.util.List.of("i64"),
+            "i64",
+            "identity",
+            "emitter",
+            java.util.List.of("emitter"),
+            contract,
+            java.util.List.of()
+        );
+
+        assertFalse(output.isStub());
+        assertTrue(output.source().contains("long __provekit_result = x;"), output.source());
+        assertTrue(output.source().contains("// provekit-observation: concept:contract-observation"), output.source());
+        assertTrue(output.source().contains("// provekit-observation-mode: emitter"), output.source());
+        assertTrue(output.source().contains("// provekit-object-fcm-cid: blake3-512:222222"), output.source());
+        assertTrue(output.source().contains("// provekit-observation-policy-cid: blake3-512:"), output.source());
+        assertTrue(output.source().contains("java.util.logging.Logger.getLogger(\"provekit\")"), output.source());
+        assertTrue(output.source().contains("java.util.logging.Level.INFO"), output.source());
+        assertTrue(output.source().contains("return __provekit_result;"), output.source());
+        assertFalse(output.source().contains("return null;"), output.source());
+        assertFalse(output.source().contains("// provekit-wrapper-fcm-cid:"), output.source());
+        assertTrue(
+            output.source().indexOf("long __provekit_result = x;")
+                < output.source().indexOf("// provekit-observation: concept:contract-observation"),
+            output.source()
+        );
+        assertTrue(
+            output.source().indexOf("// provekit-observation: concept:contract-observation")
+                < output.source().indexOf("java.util.logging.Logger.getLogger(\"provekit\")"),
+            output.source()
+        );
+        assertTrue(
+            output.source().indexOf("java.util.logging.Logger.getLogger(\"provekit\")")
+                < output.source().indexOf("return __provekit_result;"),
+            output.source()
+        );
+        assertTrue(output.observedLossRecord().contains("requires-java-util-logging-runtime"));
+        assertTrue(output.observedLossRecord().contains("java-util-logging-formats-structured-fields"));
+        assertTrue(output.observedLossRecord().contains("java-util-logging-level-taxonomy"));
+        assertNotNull(output.observationWrapperEmissionRecord());
+        assertTrue(output.observationWrapperEmissionRecord().contains("\"occurrence_kind\":\"Io\""));
+        assertTrue(output.observationWrapperEmissionRecord().contains("\"wrapper_fcm_cid\":\"blake3-512:"));
+        assertTrue(output.observationWrapperEmissionRecord().contains("\"preservation_claim_cid\":\"blake3-512:"));
+        assertFalse(output.observationWrapperEmissionRecord().contains("placeholder"));
+    }
+
+    @Test
+    public void ordinaryIdentityMonitorDoesNotComposeEmitterObservationWrapper() {
+        ContractPayload contract = new ContractPayload(
+            "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+            "evidence-lift[type-signature]",
+            "exact",
+            java.util.List.of(new ContractWitness("pre", "x >= 0", "type-signature"))
+        );
+
+        SugarRealizer.Realization output = SugarRealizer.emitStub(
+            "identity",
+            java.util.List.of("x"),
+            java.util.List.of("i64"),
+            "i64",
+            "identity",
+            "monitor",
+            java.util.List.of("monitor"),
+            contract,
+            java.util.List.of()
+        );
+
+        assertFalse(output.isStub());
+        assertTrue(output.source().contains("return x;"), output.source());
+        assertFalse(output.source().contains("__provekit_result"), output.source());
+        assertFalse(output.source().contains("java.util.logging.Logger.getLogger(\"provekit\")"), output.source());
+        assertNull(output.observationWrapperEmissionRecord());
+    }
+
     private static String modeScopedBeanValidationSugar(String mode) {
         return "{\"header\":{\"cid\":\"java-bean-validation\",\"content\":{\"entries\":[{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-parameter\",\"template\":\"@NotNull\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"mode\":\"" + mode + "\",\"predicate_pattern\":{\"args\":[{\"kind\":\"var\",\"name\":\"${symbol}\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"},\"value\":null}],\"kind\":\"atomic\",\"name\":\"neq\"}}],\"sugar_name\":\"bean-validation\",\"target_language\":\"java\"},\"critical\":false,\"kind\":\"sugar\",\"protocol_versions\":[\"pep/1.7.0\"],\"provenance_cid\":\"blake3-512:0\",\"schemaVersion\":\"1\",\"version\":\"1.0.0\"}}";
     }

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -525,6 +525,7 @@ pub struct BindingRecord {
     pub param_types: Vec<String>,
     pub return_type: String,
     pub site_memento_cid: String,
+    pub object_fcm_cid: Option<String>,
     pub local_contract_cid: Option<String>,
     pub contract_witnesses: Vec<crate::kit_dispatch::RealizeContractWitness>,
 }
@@ -973,12 +974,14 @@ fn run_bind_engine(
 
         // Mint ConceptSiteMemento when we have a contract.
         let mut local_contract_cid_for_binding: Option<String> = None;
+        let mut object_fcm_cid_for_binding: Option<String> = None;
         let mut realize_witnesses_for_binding = Vec::new();
         let site_memento_cid = if let Some(local_cid) = &_contract_content_cid {
             let source_bytes = std::fs::read(root.join(&lift.file)).unwrap_or_default();
             let source_cid = blake3_512_of(&source_bytes);
             let (span_start, span_end) = byte_span_for_line(&source_bytes, lift.fn_line);
             let fn_term_cid = local_cid.clone();
+            object_fcm_cid_for_binding = Some(fn_term_cid.clone());
             let binding_witnesses =
                 contract_witnesses_for_binding(lift, &origin, pre.as_deref(), post.as_deref());
             realize_witnesses_for_binding = binding_witnesses
@@ -1158,6 +1161,7 @@ fn run_bind_engine(
             param_types: lift.param_types.clone(),
             return_type: lift.return_type.clone(),
             site_memento_cid,
+            object_fcm_cid: object_fcm_cid_for_binding,
             local_contract_cid: local_contract_cid_for_binding,
             contract_witnesses: realize_witnesses_for_binding,
         });
@@ -1489,6 +1493,7 @@ fn apply_canonical_rewrite(
             let contract_payload = b.local_contract_cid.as_ref().map(|local_contract_cid| {
                 crate::kit_dispatch::RealizeContractPayload {
                     concept_site_cid: b.site_memento_cid.clone(),
+                    object_fcm_cid: b.object_fcm_cid.clone().unwrap_or_default(),
                     local_contract_cid: local_contract_cid.clone(),
                     origin: b.origin.label(),
                     discharge_verdict: discharge_verdict_label(&b.discharge_verdict),

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -24,6 +24,9 @@
 //   .provekit/bindings/policies/<cid>.json — bind-default-policy PolicyMemento
 //   .provekit/bindings/promotion-decisions/<cid>.json — one admission record per evidence
 //   .provekit/bindings/sites/<cid>.json   — one ConceptSiteMemento per match
+//   .provekit/bindings/realization-plans/<cid>.json — one RealizationPlanMemento per emit
+//   .provekit/bindings/observation-wrappers/<cid>.json — one ObservationWrapperMemento per wrapper
+//   .provekit/bindings/wrapper-fcms/<cid>.json — one emitted wrapper FunctionContractMemento
 //   .provekit/bindings/index.json         — summary map
 //   .provekit/bindings/gaps.json          — coverage gaps / deferred capabilities
 //   <src-file> (or stdout)                — annotated/canonical/streamed source
@@ -389,10 +392,11 @@ pub fn run(args: BindArgs) -> u8 {
     // Rewrite output. Canonical-rewrite returns the set of concepts whose body
     // fell through to the language stub so we can emit per-concept gap entries
     // per `body-template-memento.md` §5.
-    let (stub_concepts, realization_plan_mementos, observation_wrapper_mementos): (
+    let (stub_concepts, realization_plan_mementos, observation_wrapper_mementos, wrapper_fcms): (
         Vec<String>,
         Vec<RealizationPlanMemento>,
         Vec<ObservationWrapperMemento>,
+        Vec<serde_json::Value>,
     ) = match &args.rewrite {
         RewriteShape::Annotate => {
             // annotate rewrites in-place in source-language syntax.
@@ -407,7 +411,7 @@ pub fn run(args: BindArgs) -> u8 {
                 return EXIT_USER_ERROR;
             }
             apply_annotate_rewrite(&root, &src_files, &result, &modes, /*to_disk=*/ true);
-            (Vec::new(), Vec::new(), Vec::new())
+            (Vec::new(), Vec::new(), Vec::new(), Vec::new())
         }
         RewriteShape::Canonical => apply_canonical_rewrite(
             &root,
@@ -424,7 +428,7 @@ pub fn run(args: BindArgs) -> u8 {
             // canonical for cross-language.
             if target_lang == source_lang {
                 apply_annotate_rewrite(&root, &src_files, &result, &modes, /*to_disk=*/ false);
-                (Vec::new(), Vec::new(), Vec::new())
+                (Vec::new(), Vec::new(), Vec::new(), Vec::new())
             } else {
                 apply_canonical_rewrite(
                     &root,
@@ -454,12 +458,30 @@ pub fn run(args: BindArgs) -> u8 {
     }
     let _ = std::fs::create_dir_all(output_dir.join("observation-wrappers"));
     for wrapper in &observation_wrapper_mementos {
+        let Ok(wrapper_cid) = crate::cmd_transport::cid_for_serializable(wrapper) else {
+            eprintln!("bind: failed to compute observation wrapper memento CID");
+            continue;
+        };
         let path = output_dir
             .join("observation-wrappers")
-            .join(format!("{}.json", safe_filename(&wrapper.wrapper_fcm_cid)));
+            .join(format!("{}.json", safe_filename(&wrapper_cid)));
         let _ = std::fs::write(
             &path,
             serde_json::to_string_pretty(wrapper).unwrap_or_default(),
+        );
+    }
+    let _ = std::fs::create_dir_all(output_dir.join("wrapper-fcms"));
+    for wrapper_fcm in &wrapper_fcms {
+        let Ok(wrapper_fcm_cid) = crate::cmd_transport::cid_for_json_value(wrapper_fcm) else {
+            eprintln!("bind: failed to compute wrapper FCM CID");
+            continue;
+        };
+        let path = output_dir
+            .join("wrapper-fcms")
+            .join(format!("{}.json", safe_filename(&wrapper_fcm_cid)));
+        let _ = std::fs::write(
+            &path,
+            serde_json::to_string_pretty(wrapper_fcm).unwrap_or_default(),
         );
     }
 
@@ -1455,6 +1477,7 @@ fn apply_canonical_rewrite(
     Vec<String>,
     Vec<RealizationPlanMemento>,
     Vec<ObservationWrapperMemento>,
+    Vec<serde_json::Value>,
 ) {
     // The realize plugin owns mode-aware emission; bind passes the selected
     // mode plus the married contract payload so the kit can choose target
@@ -1478,6 +1501,7 @@ fn apply_canonical_rewrite(
     let mut file_extension: Option<String> = None;
     let mut realization_plan_mementos: Vec<RealizationPlanMemento> = Vec::new();
     let mut observation_wrapper_mementos: Vec<ObservationWrapperMemento> = Vec::new();
+    let mut wrapper_fcms: Vec<serde_json::Value> = Vec::new();
 
     for (rel_file, bindings) in &by_file {
         let mut chunks: Vec<String> = Vec::new();
@@ -1546,10 +1570,13 @@ fn apply_canonical_rewrite(
                         &r,
                         &b.site_memento_cid,
                     ) {
-                        Ok((plan, wrapper)) => {
+                        Ok((plan, wrapper, wrapper_fcm)) => {
                             realization_plan_mementos.push(plan);
                             if let Some(w) = wrapper {
                                 observation_wrapper_mementos.push(w);
+                            }
+                            if let Some(fcm) = wrapper_fcm {
+                                wrapper_fcms.push(fcm);
                             }
                         }
                         Err(e) => {
@@ -1618,6 +1645,7 @@ fn apply_canonical_rewrite(
         stub_concepts.into_iter().collect(),
         realization_plan_mementos,
         observation_wrapper_mementos,
+        wrapper_fcms,
     )
 }
 

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -1034,7 +1034,8 @@ pub struct RealizedSource {
     pub used_sugars: Vec<serde_json::Value>,
     /// Raw `observation_wrapper_emission_record` object from the kit response,
     /// present when the kit emitted a wrapper FCM for an observation mode.
-    /// Fields: wrapper_fcm_cid, observer_effects, preservation_claim_cid.
+    /// Fields: object_fcm_cid, wrapper_fcm_cid, observer_effects,
+    /// preservation_claim_cid.
     pub observation_wrapper_emission_record: Option<serde_json::Value>,
 }
 
@@ -1151,6 +1152,13 @@ pub fn mint_realization_artifacts(
                     "observation_wrapper_emission_record missing preservation_claim_cid".to_string()
                 })?
                 .to_string();
+            let object_fcm_cid = record
+                .get("object_fcm_cid")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    "observation_wrapper_emission_record missing object_fcm_cid".to_string()
+                })?
+                .to_string();
             let emitted = realized
                 .emitted_artifact_cid
                 .clone()
@@ -1172,7 +1180,6 @@ pub fn mint_realization_artifacts(
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let object_fcm_cid = concept_site_cid.to_string();
             let w = ObservationWrapperMemento {
                 emitted_artifact_cid: emitted,
                 mode: mode_str.to_string(),
@@ -1438,6 +1445,7 @@ mod mint_realization_artifacts_tests {
             // Supply a minimal valid observation_wrapper_emission_record.
             // observer_effects must be non-empty (spec CDDL invariant).
             let wrapper_record = serde_json::json!({
+                "object_fcm_cid": "object-fcm-cid-xyz",
                 "wrapper_fcm_cid": "wrapper-fcm-cid-xyz",
                 "preservation_claim_cid": "preservation-claim-cid-xyz",
                 "observer_effects": [
@@ -1461,7 +1469,7 @@ mod mint_realization_artifacts_tests {
             let w = wrapper.unwrap();
             assert_eq!(w.mode, mode);
             assert_eq!(w.wrapper_fcm_cid, "wrapper-fcm-cid-xyz");
-            assert_eq!(w.object_fcm_cid, "concept-site-cid-w");
+            assert_eq!(w.object_fcm_cid, "object-fcm-cid-xyz");
             assert!(
                 plan.observation_wrapper_cid.is_some(),
                 "plan.observation_wrapper_cid must be set when wrapper is minted"
@@ -1473,6 +1481,7 @@ mod mint_realization_artifacts_tests {
     fn malformed_observer_effects_fail_closed() {
         let req = make_request(Some("witness"));
         let wrapper_record = serde_json::json!({
+            "object_fcm_cid": "object-fcm-cid-xyz",
             "wrapper_fcm_cid": "wrapper-fcm-cid-xyz",
             "preservation_claim_cid": "preservation-claim-cid-xyz",
             "observer_effects": [
@@ -1498,6 +1507,7 @@ mod mint_realization_artifacts_tests {
     fn missing_observer_effects_fail_closed() {
         let req = make_request(Some("witness"));
         let wrapper_record = serde_json::json!({
+            "object_fcm_cid": "object-fcm-cid-xyz",
             "wrapper_fcm_cid": "wrapper-fcm-cid-xyz",
             "preservation_claim_cid": "preservation-claim-cid-xyz"
         });
@@ -1506,6 +1516,31 @@ mod mint_realization_artifacts_tests {
         assert!(
             err.contains("missing observer_effects"),
             "missing observer_effects must fail closed, got {err}"
+        );
+    }
+
+    #[test]
+    fn missing_object_fcm_cid_fails_closed() {
+        let req = make_request(Some("witness"));
+        let wrapper_record = serde_json::json!({
+            "wrapper_fcm_cid": "wrapper-fcm-cid-xyz",
+            "preservation_claim_cid": "preservation-claim-cid-xyz",
+            "observer_effects": [
+                {
+                    "args": [],
+                    "discharge_key": "informational-dischargeable",
+                    "locator": null,
+                    "occurrence_kind": "Io",
+                    "role": "body",
+                    "signature_cid": "sig-cid-1"
+                }
+            ]
+        });
+        let realized = make_realized(Some(wrapper_record));
+        let err = mint_realization_artifacts(&req, &realized, "concept-site-cid-w").unwrap_err();
+        assert!(
+            err.contains("missing object_fcm_cid"),
+            "missing object_fcm_cid must fail closed, got {err}"
         );
     }
 }

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -5,13 +5,14 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use clap::Parser;
 use libprovekit::core::{Cid, Term};
 use libprovekit::desugar::{load_desugaring_rules_from_dir, DesugaringSet};
 use libprovekit::transport::{transport_term, OperationTransport, TermTransport};
 use owo_colors::OwoColorize;
-use provekit_canonicalizer::blake3_512_of;
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
 use provekit_ir_symbolic::{ConstValue, Formula, Term as SymTerm};
 use provekit_ir_types::{
     EffectOccurrence, EffectSlotDescriptor, ObservationWrapperMemento,
@@ -1044,11 +1045,45 @@ pub struct RealizedSource {
 /// pipeline identity without tying it to the lift.
 const REALIZE_PROVENANCE_CID_SEED: &[u8] = b"provekit-cli/realize-v0/provenance";
 
+pub fn cid_for_serializable<T: Serialize>(value: &T) -> Result<String, String> {
+    let json =
+        serde_json::to_value(value).map_err(|err| format!("serialize value for cid: {err}"))?;
+    cid_for_json_value(&json)
+}
+
+pub fn cid_for_json_value(value: &serde_json::Value) -> Result<String, String> {
+    let canonical = canonical_value_from_json(value)?;
+    Ok(blake3_512_of(encode_jcs(canonical.as_ref()).as_bytes()))
+}
+
+fn canonical_value_from_json(value: &serde_json::Value) -> Result<Arc<CanonicalValue>, String> {
+    match value {
+        serde_json::Value::Null => Ok(CanonicalValue::null()),
+        serde_json::Value::Bool(value) => Ok(CanonicalValue::boolean(*value)),
+        serde_json::Value::Number(number) => {
+            number.as_i64().map(CanonicalValue::integer).ok_or_else(|| {
+                format!("non-i64 JSON number is not supported in JCS CID input: {number}")
+            })
+        }
+        serde_json::Value::String(value) => Ok(CanonicalValue::string(value.clone())),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .map(canonical_value_from_json)
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::array),
+        serde_json::Value::Object(entries) => entries
+            .iter()
+            .map(|(key, value)| canonical_value_from_json(value).map(|value| (key.clone(), value)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::object),
+    }
+}
+
 /// Pure function: given the RealizeRequest and RealizedSource, mint the
 /// `RealizationPlanMemento` (and, when the kit returned an
 /// `observation_wrapper_emission_record`, the `ObservationWrapperMemento`).
 ///
-/// Returns `(plan_memento, wrapper_memento_option)`.
+/// Returns `(plan_memento, wrapper_memento_option, wrapper_fcm_option)`.
 ///
 /// Blocker #1, #2, #4 implementation.  The ParametricRealizationMemento is
 /// constructed synthetically (one slot per param) because the catalog lookup
@@ -1060,7 +1095,14 @@ pub fn mint_realization_artifacts(
     request: &crate::kit_dispatch::RealizeRequest,
     realized: &RealizedSource,
     concept_site_cid: &str,
-) -> Result<(RealizationPlanMemento, Option<ObservationWrapperMemento>), String> {
+) -> Result<
+    (
+        RealizationPlanMemento,
+        Option<ObservationWrapperMemento>,
+        Option<serde_json::Value>,
+    ),
+    String,
+> {
     let provenance_cid = blake3_512_of(REALIZE_PROVENANCE_CID_SEED);
 
     // ---- Build synthetic ParametricRealizationMemento (Blocker #3 inline) ----
@@ -1136,7 +1178,10 @@ pub fn mint_realization_artifacts(
         mode_str,
         "witness" | "monitor" | "emitter" | "gate" | "dispatcher"
     );
-    let wrapper_memento: Option<ObservationWrapperMemento> = if is_observation_mode {
+    let (wrapper_memento, wrapper_fcm): (
+        Option<ObservationWrapperMemento>,
+        Option<serde_json::Value>,
+    ) = if is_observation_mode {
         if let Some(record) = &realized.observation_wrapper_emission_record {
             let wrapper_fcm_cid = record
                 .get("wrapper_fcm_cid")
@@ -1180,6 +1225,38 @@ pub fn mint_realization_artifacts(
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
+            let wrapper_fcm = record
+                .get("wrapper_fcm")
+                .ok_or_else(|| {
+                    "observation_wrapper_emission_record missing wrapper_fcm".to_string()
+                })?
+                .clone();
+            let computed_wrapper_fcm_cid = cid_for_json_value(&wrapper_fcm).map_err(|err| {
+                format!("observation_wrapper_emission_record wrapper_fcm invalid: {err}")
+            })?;
+            if computed_wrapper_fcm_cid != wrapper_fcm_cid {
+                return Err(format!(
+                    "observation_wrapper_emission_record wrapper_fcm_cid mismatch: \
+                     declared {wrapper_fcm_cid}, computed {computed_wrapper_fcm_cid}"
+                ));
+            }
+            let raw_wrapper_effects = wrapper_fcm
+                .get("effects")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    "observation_wrapper_emission_record wrapper_fcm missing effects".to_string()
+                })?;
+            let wrapper_effects: Vec<EffectOccurrence> = raw_wrapper_effects
+                .iter()
+                .enumerate()
+                .map(|(idx, v)| {
+                    serde_json::from_value(v.clone()).map_err(|err| {
+                        format!(
+                            "observation_wrapper_emission_record wrapper_fcm.effects[{idx}] malformed: {err}"
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
             let w = ObservationWrapperMemento {
                 emitted_artifact_cid: emitted,
                 mode: mode_str.to_string(),
@@ -1190,28 +1267,26 @@ pub fn mint_realization_artifacts(
                 wrapper_fcm_cid,
             };
             // validate before persisting (spec §7, fail-closed).
-            // v1: object FCM effects are unknown at realize-time (we only
-            // receive the observer-side effects from the kit). We pass
-            // observer_effects as wrapper_effects so the "each observer
-            // effect is present in the wrapper" invariant trivially holds.
-            // The "observer effect not present in object" check uses &[]
-            // (no object effects known), which is safe because the kit
-            // is contractually responsible for not crossing that boundary.
-            let wrapper_effects_for_validate = w.observer_effects.clone();
-            w.validate(&[], &wrapper_effects_for_validate, &[])
+            // The kit must return the concrete wrapper FCM object so the CID
+            // is resolvable and observer_effects can be checked against the
+            // wrapper's declared effects. Object effects are still not carried
+            // through this v1 dispatch path, so the object side remains an
+            // empty set until the source FCM catalog is threaded here.
+            w.validate(&[], &wrapper_effects, &[])
                 .map_err(|e| format!("ObservationWrapperMemento invariant violation: {e:?}"))?;
-            Some(w)
+            (Some(w), Some(wrapper_fcm))
         } else {
-            None
+            (None, None)
         }
     } else {
-        None
+        (None, None)
     };
 
     // ---- Blocker #1: RealizationPlanMemento ----
     let observation_wrapper_cid = wrapper_memento
         .as_ref()
-        .map(|w| blake3_512_of(serde_json::to_string(w).unwrap_or_default().as_bytes()));
+        .map(cid_for_serializable)
+        .transpose()?;
     let plan = RealizationPlanMemento {
         candidate_set_cid: selected_realization_cid.clone(),
         concept_site_cid: concept_site_cid.to_string(),
@@ -1229,7 +1304,7 @@ pub fn mint_realization_artifacts(
     plan.validate_against(&realization)
         .map_err(|e| format!("RealizationPlanMemento validation failed: {e}"))?;
 
-    Ok((plan, wrapper_memento))
+    Ok((plan, wrapper_memento, wrapper_fcm))
 }
 
 /// Public-crate bridge for `cmd_bind`'s canonical-mode path.
@@ -1398,13 +1473,54 @@ mod mint_realization_artifacts_tests {
         }
     }
 
+    fn valid_effect() -> serde_json::Value {
+        serde_json::json!({
+            "args": [],
+            "discharge_key": "informational-dischargeable",
+            "locator": null,
+            "occurrence_kind": "Io",
+            "role": "body",
+            "signature_cid": "sig-cid-1"
+        })
+    }
+
+    fn valid_wrapper_fcm(effect: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "autoMintedMementos": [],
+            "bodyCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "effects": [effect],
+            "fnName": "foo$provekit_emitter",
+            "formalSorts": [],
+            "formals": [],
+            "kind": "function-contract",
+            "locus": {"function": "foo", "surface": "java-emitter-wrapper"},
+            "post": {"args": [], "kind": "atomic", "name": "true"},
+            "pre": {"args": [], "kind": "atomic", "name": "true"},
+            "returnSort": {"args": [], "kind": "ctor", "name": "int"},
+            "schemaVersion": "1"
+        })
+    }
+
+    fn valid_wrapper_record() -> serde_json::Value {
+        let effect = valid_effect();
+        let wrapper_fcm = valid_wrapper_fcm(effect.clone());
+        let wrapper_fcm_cid = cid_for_json_value(&wrapper_fcm).expect("wrapper fcm cid");
+        serde_json::json!({
+            "object_fcm_cid": "object-fcm-cid-xyz",
+            "wrapper_fcm": wrapper_fcm,
+            "wrapper_fcm_cid": wrapper_fcm_cid,
+            "preservation_claim_cid": "preservation-claim-cid-xyz",
+            "observer_effects": [effect]
+        })
+    }
+
     /// Blocker #1 + #2: RealizationPlanMemento IS minted on a successful
     /// realize call and validate_against passes.
     #[test]
     fn realization_plan_memento_minted_on_success() {
         let req = make_request(Some("monitor"));
         let realized = make_realized(None);
-        let (plan, wrapper) =
+        let (plan, wrapper, wrapper_fcm) =
             mint_realization_artifacts(&req, &realized, "concept-site-cid-123").unwrap();
         assert_eq!(plan.concept_site_cid, "concept-site-cid-123");
         assert_eq!(
@@ -1416,6 +1532,10 @@ mod mint_realization_artifacts_tests {
             wrapper.is_none(),
             "no wrapper_emission_record => no wrapper"
         );
+        assert!(
+            wrapper_fcm.is_none(),
+            "no wrapper_emission_record => no wrapper FCM"
+        );
     }
 
     /// Blocker #2: validate_against passes (no slot-count mismatch).
@@ -1423,7 +1543,7 @@ mod mint_realization_artifacts_tests {
     fn plan_validate_against_passes() {
         let req = make_request(None);
         let realized = make_realized(None);
-        let (plan, _) =
+        let (plan, _, _) =
             mint_realization_artifacts(&req, &realized, "concept-site-cid-999").unwrap();
         // If validate_against failed, mint_realization_artifacts would have
         // returned Err. Reaching here proves it passed.
@@ -1442,25 +1562,13 @@ mod mint_realization_artifacts_tests {
     fn observation_wrapper_memento_minted_for_observation_modes() {
         for mode in ["witness", "monitor", "emitter", "gate"] {
             let req = make_request(Some(mode));
-            // Supply a minimal valid observation_wrapper_emission_record.
-            // observer_effects must be non-empty (spec CDDL invariant).
-            let wrapper_record = serde_json::json!({
-                "object_fcm_cid": "object-fcm-cid-xyz",
-                "wrapper_fcm_cid": "wrapper-fcm-cid-xyz",
-                "preservation_claim_cid": "preservation-claim-cid-xyz",
-                "observer_effects": [
-                    {
-                        "args": [],
-                        "discharge_key": "informational-dischargeable",
-                        "locator": null,
-                        "occurrence_kind": "Io",
-                        "role": "body",
-                        "signature_cid": "sig-cid-1"
-                    }
-                ]
-            });
+            let wrapper_record = valid_wrapper_record();
+            let expected_wrapper_fcm_cid = wrapper_record["wrapper_fcm_cid"]
+                .as_str()
+                .expect("wrapper_fcm_cid")
+                .to_string();
             let realized = make_realized(Some(wrapper_record));
-            let (plan, wrapper) =
+            let (plan, wrapper, wrapper_fcm) =
                 mint_realization_artifacts(&req, &realized, "concept-site-cid-w").unwrap();
             assert!(
                 wrapper.is_some(),
@@ -1468,8 +1576,12 @@ mod mint_realization_artifacts_tests {
             );
             let w = wrapper.unwrap();
             assert_eq!(w.mode, mode);
-            assert_eq!(w.wrapper_fcm_cid, "wrapper-fcm-cid-xyz");
+            assert_eq!(w.wrapper_fcm_cid, expected_wrapper_fcm_cid);
             assert_eq!(w.object_fcm_cid, "object-fcm-cid-xyz");
+            assert!(
+                wrapper_fcm.is_some(),
+                "{mode} mode + wrapper record => wrapper FCM must be returned"
+            );
             assert!(
                 plan.observation_wrapper_cid.is_some(),
                 "plan.observation_wrapper_cid must be set when wrapper is minted"
@@ -1480,21 +1592,15 @@ mod mint_realization_artifacts_tests {
     #[test]
     fn malformed_observer_effects_fail_closed() {
         let req = make_request(Some("witness"));
-        let wrapper_record = serde_json::json!({
-            "object_fcm_cid": "object-fcm-cid-xyz",
-            "wrapper_fcm_cid": "wrapper-fcm-cid-xyz",
-            "preservation_claim_cid": "preservation-claim-cid-xyz",
-            "observer_effects": [
-                {
-                    "args": [],
-                    "discharge_key": "informational-dischargeable",
-                    "locator": null,
-                    "occurrence_kind": "NotARealKind",
-                    "role": "body",
-                    "signature_cid": "sig-cid-1"
-                }
-            ]
-        });
+        let mut wrapper_record = valid_wrapper_record();
+        wrapper_record["observer_effects"] = serde_json::json!([{
+            "args": [],
+            "discharge_key": "informational-dischargeable",
+            "locator": null,
+            "occurrence_kind": "NotARealKind",
+            "role": "body",
+            "signature_cid": "sig-cid-1"
+        }]);
         let realized = make_realized(Some(wrapper_record));
         let err = mint_realization_artifacts(&req, &realized, "concept-site-cid-w").unwrap_err();
         assert!(
@@ -1506,11 +1612,11 @@ mod mint_realization_artifacts_tests {
     #[test]
     fn missing_observer_effects_fail_closed() {
         let req = make_request(Some("witness"));
-        let wrapper_record = serde_json::json!({
-            "object_fcm_cid": "object-fcm-cid-xyz",
-            "wrapper_fcm_cid": "wrapper-fcm-cid-xyz",
-            "preservation_claim_cid": "preservation-claim-cid-xyz"
-        });
+        let mut wrapper_record = valid_wrapper_record();
+        wrapper_record
+            .as_object_mut()
+            .expect("wrapper record object")
+            .remove("observer_effects");
         let realized = make_realized(Some(wrapper_record));
         let err = mint_realization_artifacts(&req, &realized, "concept-site-cid-w").unwrap_err();
         assert!(
@@ -1520,22 +1626,29 @@ mod mint_realization_artifacts_tests {
     }
 
     #[test]
+    fn missing_wrapper_fcm_fails_closed() {
+        let req = make_request(Some("emitter"));
+        let mut wrapper_record = valid_wrapper_record();
+        wrapper_record
+            .as_object_mut()
+            .expect("wrapper record object")
+            .remove("wrapper_fcm");
+        let realized = make_realized(Some(wrapper_record));
+        let err = mint_realization_artifacts(&req, &realized, "concept-site-cid-w").unwrap_err();
+        assert!(
+            err.contains("missing wrapper_fcm"),
+            "wrapper_fcm_cid must resolve to a concrete wrapper FCM object, got {err}"
+        );
+    }
+
+    #[test]
     fn missing_object_fcm_cid_fails_closed() {
         let req = make_request(Some("witness"));
-        let wrapper_record = serde_json::json!({
-            "wrapper_fcm_cid": "wrapper-fcm-cid-xyz",
-            "preservation_claim_cid": "preservation-claim-cid-xyz",
-            "observer_effects": [
-                {
-                    "args": [],
-                    "discharge_key": "informational-dischargeable",
-                    "locator": null,
-                    "occurrence_kind": "Io",
-                    "role": "body",
-                    "signature_cid": "sig-cid-1"
-                }
-            ]
-        });
+        let mut wrapper_record = valid_wrapper_record();
+        wrapper_record
+            .as_object_mut()
+            .expect("wrapper record object")
+            .remove("object_fcm_cid");
         let realized = make_realized(Some(wrapper_record));
         let err = mint_realization_artifacts(&req, &realized, "concept-site-cid-w").unwrap_err();
         assert!(

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -542,6 +542,7 @@ pub struct RealizeRequest {
 #[derive(Debug, Clone, Serialize)]
 pub struct RealizeContractPayload {
     pub concept_site_cid: String,
+    pub object_fcm_cid: String,
     pub local_contract_cid: String,
     pub origin: String,
     pub discharge_verdict: String,
@@ -1095,6 +1096,7 @@ mod tests {
             modes: vec!["monitor".to_string(), "witness".to_string()],
             contract: Some(RealizeContractPayload {
                 concept_site_cid: "blake3-512:site".to_string(),
+                object_fcm_cid: "blake3-512:object".to_string(),
                 local_contract_cid: "blake3-512:compound".to_string(),
                 origin: "evidence-lift[type-signature]".to_string(),
                 discharge_verdict: "exact".to_string(),

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, OnceLock};
 
 use provekit_ir_types::{PromotionDecisionMemento, PromotionGate, PromotionResult};
 
@@ -30,6 +31,17 @@ fn fixture_root() -> PathBuf {
         .join("tests")
         .join("fixtures")
         .join("cmd_bind")
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("provekit-cli parent")
+        .parent()
+        .expect("implementations parent")
+        .parent()
+        .expect("repo root")
+        .to_path_buf()
 }
 
 /// Copy fixture tree to a tempdir (protects checked-in source from annotate writes).
@@ -266,6 +278,82 @@ for line in sys.stdin:
     root
 }
 
+fn copy_fixture_with_identity_contract_manifest() -> PathBuf {
+    let root = copy_fixture_to_temp();
+    let kit_path = root.join("bind-lift-kit.py");
+    let shape_cid = format!("blake3-512:{}", "3".repeat(128));
+    let script = format!(
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+SHAPE_CID = {shape_cid:?}
+
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request.get("method")
+    request_id = request.get("id")
+    if method == "initialize":
+        result = {{}}
+    elif method == "lift":
+        result = {{
+            "kind": "ir-document",
+            "diagnostics": [],
+            "ir": [{{
+                "kind": "bind-lift-entry",
+                "file": "src/account.rs",
+                "fn_name": "identity",
+                "fn_line": 25,
+                "attr_pre": "x >= 0",
+                "attr_post": "out == x",
+                "concept_annotation": "identity",
+                "param_names": ["x"],
+                "param_types": ["i64"],
+                "return_type": "i64",
+                "term_shape": {{"kind": "body", "stmts": [{{"kind": "opaque"}}]}},
+                "term_shape_cid": SHAPE_CID
+            }}]
+        }}
+    elif method == "shutdown":
+        result = {{}}
+    else:
+        print(json.dumps({{"jsonrpc": "2.0", "id": request_id, "error": {{"message": "unknown method"}}}}), flush=True)
+        continue
+    print(json.dumps({{"jsonrpc": "2.0", "id": request_id, "result": result}}), flush=True)
+    if method == "shutdown":
+        break
+"#
+    );
+    fs::write(&kit_path, script).expect("write bind lift kit");
+    let manifest_dir = root.join(".provekit").join("lift").join("rust");
+    fs::create_dir_all(&manifest_dir).expect("create lift manifest dir");
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"test-bind-lift-identity-contract\"\ncommand = [\"python3\", \"{}\"]\n",
+            kit_path.display()
+        ),
+    )
+    .expect("write lift manifest");
+    let jar = repo_root()
+        .join("implementations")
+        .join("java")
+        .join("provekit-realize-java-core")
+        .join("target")
+        .join("provekit-realize-java.jar");
+    let realize_manifest_dir = root.join(".provekit").join("realize").join("java");
+    fs::create_dir_all(&realize_manifest_dir).expect("create realize manifest dir");
+    fs::write(
+        realize_manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"test-java-realize\"\ncommand = [\"java\", \"-jar\", \"{}\", \"--rpc\"]\nlibrary_tag = \"default\"\n",
+            jar.display()
+        ),
+    )
+    .expect("write realize manifest");
+    root
+}
+
 fn bind_cmd(
     root: &Path,
     out: &Path,
@@ -312,6 +400,32 @@ fn read_json_dir(dir: &Path) -> Vec<serde_json::Value> {
             .unwrap_or_else(|err| panic!("parse {}: {err}", path.display()))
         })
         .collect()
+}
+
+static JAVA_REALIZE_BUILD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn ensure_java_realize_jar_built() {
+    let lock = JAVA_REALIZE_BUILD_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let repo = repo_root();
+    let java_dir = repo.join("implementations").join("java");
+    let output = Command::new("mvn")
+        .args([
+            "package",
+            "-pl",
+            "provekit-realize-java-core",
+            "-am",
+            "-DskipTests",
+        ])
+        .current_dir(&java_dir)
+        .output()
+        .expect("spawn mvn package for java realize rpc");
+    assert!(
+        output.status.success(),
+        "mvn package failed for java realize rpc\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 // ============================================================================
@@ -505,6 +619,124 @@ fn canonical_emitter_java_creates_java_output_with_contract() {
     assert!(
         java_src.contains("@requires:") || java_src.contains("/* @requires"),
         "Java output must carry contract annotation for deposit\n{java_src}"
+    );
+}
+
+#[test]
+fn canonical_emitter_java_composes_result_preserving_observation_wrapper() {
+    ensure_java_realize_jar_built();
+    let root = copy_fixture_with_identity_contract_manifest();
+    let out = tempfile::tempdir().expect("tempdir").into_path();
+    let result = bind_cmd(&root, &out, "canonical", "emitter", Some("java"));
+    assert!(
+        result.status.success(),
+        "canonical+emitter+java should succeed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let java_dir = out.join("translated").join("java");
+    let java_file = first_file_with_ext(&java_dir, "java").expect("no .java output");
+    let java_src = fs::read_to_string(&java_file).expect("read emitted java");
+    assert!(
+        java_src.contains("long __provekit_result = x;"),
+        "{java_src}"
+    );
+    assert!(
+        java_src.contains("// provekit-observation: concept:contract-observation"),
+        "{java_src}"
+    );
+    assert!(
+        java_src.contains("// provekit-observation-mode: emitter"),
+        "{java_src}"
+    );
+    assert!(
+        java_src.contains("// provekit-observation-policy-cid: blake3-512:"),
+        "{java_src}"
+    );
+    assert!(
+        java_src.contains("java.util.logging.Logger.getLogger(\"provekit\")"),
+        "{java_src}"
+    );
+    assert!(
+        java_src.contains("java.util.logging.Level.INFO"),
+        "{java_src}"
+    );
+    assert!(java_src.contains("return __provekit_result;"), "{java_src}");
+    assert!(!java_src.contains("return null;"), "{java_src}");
+    assert!(
+        !java_src.contains("// provekit-wrapper-fcm-cid:"),
+        "{java_src}"
+    );
+    assert!(
+        java_src.find("long __provekit_result = x;").unwrap()
+            < java_src
+                .find("// provekit-observation: concept:contract-observation")
+                .unwrap(),
+        "{java_src}"
+    );
+    assert!(
+        java_src
+            .find("// provekit-observation: concept:contract-observation")
+            .unwrap()
+            < java_src
+                .find("java.util.logging.Logger.getLogger(\"provekit\")")
+                .unwrap(),
+        "{java_src}"
+    );
+    assert!(
+        java_src
+            .find("java.util.logging.Logger.getLogger(\"provekit\")")
+            .unwrap()
+            < java_src.find("return __provekit_result;").unwrap(),
+        "{java_src}"
+    );
+
+    let wrappers = read_json_dir(&out.join("observation-wrappers"));
+    assert_eq!(
+        wrappers.len(),
+        1,
+        "expected one observation wrapper: {wrappers:#?}"
+    );
+    let wrapper = &wrappers[0];
+    assert_eq!(wrapper["mode"], "emitter");
+    assert!(
+        wrapper["object_fcm_cid"]
+            .as_str()
+            .is_some_and(|cid| cid.starts_with("blake3-512:")),
+        "{wrapper:#?}"
+    );
+    assert_eq!(
+        wrapper["wrapper_fcm_cid"].as_str(),
+        wrapper["wrapper_fcm_cid"]
+            .as_str()
+            .filter(|cid| cid.starts_with("blake3-512:"))
+    );
+    assert!(
+        wrapper["preservation_claim_cid"]
+            .as_str()
+            .is_some_and(|cid| cid.starts_with("blake3-512:")),
+        "{wrapper:#?}"
+    );
+    let effects = wrapper["observer_effects"]
+        .as_array()
+        .expect("observer_effects array");
+    assert_eq!(effects.len(), 1, "{wrapper:#?}");
+    assert_eq!(effects[0]["occurrence_kind"], "Io");
+    assert_eq!(effects[0]["role"], "body");
+
+    let plans = read_json_dir(&out.join("realization-plans"));
+    assert!(
+        plans
+            .iter()
+            .any(|plan| plan["observation_wrapper_cid"].is_string()
+                && plan["total_loss_record"]
+                    .to_string()
+                    .contains("java-util-logging-level-taxonomy")
+                && plan["total_loss_record"]
+                    .to_string()
+                    .contains("java-util-logging-formats-structured-fields")),
+        "expected realization plan to cite wrapper and body-template/log loss: {plans:#?}"
     );
 }
 

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -402,6 +402,15 @@ fn read_json_dir(dir: &Path) -> Vec<serde_json::Value> {
         .collect()
 }
 
+fn safe_cid_filename(cid: &str) -> String {
+    cid.chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '_',
+        })
+        .collect()
+}
+
 static JAVA_REALIZE_BUILD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 fn ensure_java_realize_jar_built() {
@@ -725,7 +734,43 @@ fn canonical_emitter_java_composes_result_preserving_observation_wrapper() {
     assert_eq!(effects[0]["occurrence_kind"], "Io");
     assert_eq!(effects[0]["role"], "body");
 
+    let wrapper_fcm_cid = wrapper["wrapper_fcm_cid"]
+        .as_str()
+        .expect("wrapper_fcm_cid");
+    let wrapper_fcm_path = out
+        .join("wrapper-fcms")
+        .join(format!("{}.json", safe_cid_filename(wrapper_fcm_cid)));
+    assert!(
+        wrapper_fcm_path.exists(),
+        "wrapper_fcm_cid must resolve to a persisted wrapper FCM at {}",
+        wrapper_fcm_path.display()
+    );
+    let wrapper_fcm: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&wrapper_fcm_path).expect("read wrapper fcm by cid"),
+    )
+    .expect("parse wrapper fcm by cid");
+    let wrapper_fcm_effects = wrapper_fcm["effects"]
+        .as_array()
+        .expect("wrapper FCM effects array");
+    for observer_effect in effects {
+        assert!(
+            wrapper_fcm_effects.contains(observer_effect),
+            "observer effect {observer_effect} must be present in persisted wrapper FCM effects: {wrapper_fcm}"
+        );
+    }
+
     let plans = read_json_dir(&out.join("realization-plans"));
+    let plan_wrapper_cids: Vec<&str> = plans
+        .iter()
+        .filter_map(|plan| plan["observation_wrapper_cid"].as_str())
+        .collect();
+    assert!(
+        plan_wrapper_cids.iter().all(|cid| out
+            .join("observation-wrappers")
+            .join(format!("{}.json", safe_cid_filename(cid)))
+            .exists()),
+        "every plan observation_wrapper_cid must resolve to a persisted wrapper memento: {plans:#?}"
+    );
     assert!(
         plans
             .iter()

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -133,7 +133,7 @@ fn java_canonical_bodies_cid_self_consistent() {
         .join("menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json");
     assert_self_consistent(
         path,
-        "blake3-512:2e33007141618bad39c319d0d943ae83edabe55d1eb53f4baf0fddd8a4665d636b0454f72fc407b36313a6f54b2c2d158b549c400979e25399ee23465b8a51e0",
+        "blake3-512:265b192f573819b1814000f22efb1172e51ff83e0d127acdc0d31fb8dfce725e0aafe58b4f7b0f45469b969c4a561541e8d50e585fedd8056eefdd3e9cf5b7ff",
     );
 }
 

--- a/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
+++ b/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:2e33007141618bad39c319d0d943ae83edabe55d1eb53f4baf0fddd8a4665d636b0454f72fc407b36313a6f54b2c2d158b549c400979e25399ee23465b8a51e0",
+    "cid": "blake3-512:265b192f573819b1814000f22efb1172e51ff83e0d127acdc0d31fb8dfce725e0aafe58b4f7b0f45469b969c4a561541e8d50e585fedd8056eefdd3e9cf5b7ff",
     "content": {
       "entries": [
         {
@@ -97,6 +97,41 @@
             }
           },
           "mode": "monitor",
+          "signature_guard": {
+            "max_params": 3,
+            "min_params": 3
+          }
+        },
+        {
+          "composition_point": "after-return",
+          "concept_name": "concept:contract-observation",
+          "emission_template": {
+            "citations": [
+              {
+                "concept_name": "concept:log-emit",
+                "mode": "emitter",
+                "params": [
+                  "info",
+                  "\"observed \" + ${param0} + \" contract \" + ${param1}",
+                  "${param1}"
+                ],
+                "placeholder": "log_emit"
+              }
+            ],
+            "kind": "verbatim",
+            "template": "${log_emit}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "runtime_dependency": {
+                "args": [],
+                "head": "atomic",
+                "name": "requires-java-util-logging-runtime"
+              }
+            }
+          },
+          "mode": "emitter",
           "signature_guard": {
             "max_params": 3,
             "min_params": 3


### PR DESCRIPTION
## Summary

- Compose Java `--mode emitter` observation wrappers at ordinary callsites using recursive body-template realization: operation body first, then `concept:contract-observation(..., emitter)`, which recursively realizes `concept:log-emit`.
- Preserve the operation result across after-return composition and return a real `observation_wrapper_emission_record` with object FCM CID, wrapper FCM CID, observer effects, preservation claim CID, and policy CID.
- Emit liftable Java comment tags as a policy-selected audit/training surface, then recover those tags in the Java bind lifter as a `native-surface` observation witness.

## Why

This makes observation composition first-order: the runtime emitter is another realized concept, not a Java-only side path. The source tags are optional policy output, but when emitted they close the round-trip learning/audit loop: a later lift can recover which contract-observation concept, mode, contract, object FCM, emitted concept, and policy produced the surface.

## Validation

- `mvn -q -pl provekit-realize-java-core,provekit-lift-java-source -am -Dtest=JavaNullBoundaryRealizerTest,TrinityRoundtripLiftTest test`
- `cargo test -p provekit-cli canonical_emitter_java_composes_result_preserving_observation_wrapper --test cmd_bind_integration`
- `cargo test -p provekit-plugin-loader java_canonical_bodies_cid_self_consistent`
- `git diff --check`

Refs #880 #884 #755


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observation metadata from source code comments is now extracted and included in analysis results.
  * Generated code now automatically composes contract observations with proper wrapper functions when using emitter mode.
  * Added support for Java canonical emission mode with observation wrapper handling.

* **Tests**
  * Added test coverage for observation policy tag recovery and contract observation composition.
  * New integration tests validate Java canonical emission with observation wrapper generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/926)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->