### PR TITLE
[codex] Implement Java contract comment sugar roundtrip

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.VariableElement;
@@ -205,7 +206,9 @@ public final class JavaBindLifter {
             int bodyEndLine = bodyEndOffset >= 0 && bodyEndOffset <= Integer.MAX_VALUE
                 ? lineOf(source, (int) bodyEndOffset)
                 : fnLine;
-            List<Jcs.Json> observationWitnesses = observationTagWitnesses(source, bodyStartLine, bodyEndLine);
+            List<Jcs.Json> surfaceWitnesses = new ArrayList<>();
+            surfaceWitnesses.addAll(observationTagWitnesses(source, bodyStartLine, bodyEndLine));
+            surfaceWitnesses.addAll(contractTagWitnesses(source, fnLine, bodyStartLine, bodyEndLine));
 
             Jcs.Obj entry = Jcs.object(
                 "attr_post", Jcs.nullValue(),
@@ -220,7 +223,7 @@ public final class JavaBindLifter {
                 "return_type", Jcs.string(returnType),
                 "term_shape", termShape,
                 "term_shape_cid", Jcs.string(termShapeCid),
-                "witnesses", Jcs.array(observationWitnesses)
+                "witnesses", Jcs.array(surfaceWitnesses)
             );
             entries.add(entry);
             return super.visitMethod(method, unused);
@@ -378,6 +381,131 @@ public final class JavaBindLifter {
         ));
     }
 
+    private static List<Jcs.Json> contractTagWitnesses(String source, int fnLine, int startLine, int endLine) {
+        List<Jcs.Json> witnesses = new ArrayList<>();
+        for (List<TagLine> block : contractTagBlocks(scanContractTags(source, fnLine, startLine, endLine))) {
+            contractTagWitness(block).ifPresent(witnesses::add);
+        }
+        return witnesses;
+    }
+
+    private static Optional<Jcs.Json> contractTagWitness(List<TagLine> block) {
+        String payloadText = tagValue(block, "provekit-contract");
+        if (payloadText == null) return Optional.empty();
+        Jcs.Json payloadJson;
+        try {
+            payloadJson = Jcs.parse(payloadText);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+        if (!(payloadJson instanceof Jcs.Obj payload)) return Optional.empty();
+        if (!"provekit-contract-comment-sugar".equals(payload.stringFieldOrNull("artifact_kind"))) return Optional.empty();
+        if (!"1".equals(payload.stringFieldOrNull("schema_version"))) return Optional.empty();
+
+        String role = bindContractRole(payload.stringFieldOrNull("role"));
+        if (role == null) return Optional.empty();
+
+        String conceptSiteCid = payload.stringFieldOrNull("concept_site_cid");
+        String contractCid = payload.stringFieldOrNull("contract_cid");
+        String localContractCid = payload.stringFieldOrNull("local_contract_cid");
+        String formulaCid = payload.stringFieldOrNull("ir_formula_jcs_cid");
+        String policyCid = payload.stringFieldOrNull("policy_cid");
+        String sugarDictCid = payload.stringFieldOrNull("sugar_dict_cid");
+        String lossRecordCid = payload.stringFieldOrNull("loss_record_cid");
+        if (!validCid(conceptSiteCid) || !validCid(contractCid) || !validCid(formulaCid)
+                || !validCid(policyCid) || !validCid(sugarDictCid) || !validCid(lossRecordCid)
+                || (localContractCid != null && !localContractCid.isBlank() && !validCid(localContractCid))
+                || !validEmittedBy(payload.get("emitted_by"))) {
+            return Optional.empty();
+        }
+
+        Jcs.Json predicate = payload.get("ir_formula_jcs");
+        if (predicate == null || predicate instanceof Jcs.Null || !formulaCid.equals(Jcs.cid(predicate))) {
+            return Optional.empty();
+        }
+        String payloadCid = Jcs.cid(payload);
+        String emittedPayloadCid = tagValue(block, "provekit-contract-payload-cid");
+        if (emittedPayloadCid != null && (!validCid(emittedPayloadCid) || !payloadCid.equals(emittedPayloadCid))) {
+            return Optional.empty();
+        }
+        String predicateText = payload.stringFieldOrNull("fol_text");
+        if (predicateText == null) {
+            return Optional.empty();
+        }
+
+        List<Jcs.Field> extensionFieldList = new ArrayList<>();
+        extensionFieldList.add(new Jcs.Field("concept_site_cid", Jcs.string(conceptSiteCid)));
+        extensionFieldList.add(new Jcs.Field("contract_cid", Jcs.string(contractCid)));
+        extensionFieldList.add(new Jcs.Field("ir_formula_jcs_cid", Jcs.string(formulaCid)));
+        if (localContractCid != null && !localContractCid.isBlank()) {
+            extensionFieldList.add(new Jcs.Field("local_contract_cid", Jcs.string(localContractCid)));
+        }
+        extensionFieldList.add(new Jcs.Field("loss_record_cid", Jcs.string(lossRecordCid)));
+        extensionFieldList.add(new Jcs.Field("payload_cid", Jcs.string(payloadCid)));
+        extensionFieldList.add(new Jcs.Field("policy_cid", Jcs.string(policyCid)));
+        extensionFieldList.add(new Jcs.Field("sugar_dict_cid", Jcs.string(sugarDictCid)));
+        extensionFieldList.add(new Jcs.Field("surface", Jcs.string("contract-comment-sugar")));
+        Jcs.Obj extensionFields = new Jcs.Obj(extensionFieldList);
+        return Optional.of(Jcs.object(
+            "col", Jcs.integer(0),
+            "confidence_basis_points", Jcs.integer(10000),
+            "extension_fields", extensionFields,
+            "line", Jcs.integer(block.get(0).line()),
+            "predicate", predicate,
+            "predicate_text", Jcs.string(predicateText),
+            "role", Jcs.string(role),
+            "source_kind", Jcs.string("native-surface")
+        ));
+    }
+
+    private static List<List<TagLine>> contractTagBlocks(List<TagLine> tags) {
+        List<List<TagLine>> blocks = new ArrayList<>();
+        List<TagLine> current = null;
+        for (TagLine tag : tags) {
+            if ("provekit-contract".equals(tag.key())) {
+                current = new ArrayList<>();
+                current.add(tag);
+                blocks.add(current);
+                continue;
+            }
+            if (current != null && tag.key().startsWith("provekit-contract-")) {
+                current.add(tag);
+            }
+        }
+        return blocks;
+    }
+
+    private static List<TagLine> scanContractTags(String source, int fnLine, int startLine, int endLine) {
+        List<TagLine> tags = new ArrayList<>();
+        tags.addAll(scanPreMethodTags(source, fnLine));
+        tags.addAll(scanObservationTags(source, startLine, endLine));
+        return tags;
+    }
+
+    private static List<TagLine> scanPreMethodTags(String source, int fnLine) {
+        if (fnLine <= 1) return List.of();
+        String[] lines = source.split("\n", -1);
+        int cursor = Math.min(lines.length - 1, fnLine - 2);
+        while (cursor >= 0 && isMethodHeaderCompanionLine(lines[cursor].stripLeading())) {
+            cursor--;
+        }
+        int start = cursor + 1;
+        List<TagLine> tags = new ArrayList<>();
+        for (int idx = start; idx < fnLine - 1 && idx < lines.length; idx++) {
+            parseProvekitTagLine(lines[idx], idx + 1).ifPresent(tags::add);
+        }
+        return tags;
+    }
+
+    private static boolean isMethodHeaderCompanionLine(String line) {
+        return line.isEmpty()
+            || line.startsWith("//")
+            || line.startsWith("@")
+            || line.startsWith("/*")
+            || line.startsWith("*")
+            || line.startsWith("*/");
+    }
+
     private static List<TagLine> scanObservationTags(String source, int startLine, int endLine) {
         if (startLine <= 0 || endLine < startLine) return List.of();
         String[] lines = source.split("\n", -1);
@@ -385,17 +513,20 @@ public final class JavaBindLifter {
         int end = Math.min(lines.length, endLine);
         List<TagLine> tags = new ArrayList<>();
         for (int idx = start; idx < end; idx++) {
-            String stripped = lines[idx].stripLeading();
-            if (!stripped.startsWith("// provekit-")) continue;
-            int colon = stripped.indexOf(':');
-            if (colon < 0) continue;
-            String key = stripped.substring("// ".length(), colon).trim();
-            String value = stripped.substring(colon + 1).trim();
-            if (key.startsWith("provekit-")) {
-                tags.add(new TagLine(idx + 1, key, value));
-            }
+            parseProvekitTagLine(lines[idx], idx + 1).ifPresent(tags::add);
         }
         return tags;
+    }
+
+    private static Optional<TagLine> parseProvekitTagLine(String line, int lineNumber) {
+        String stripped = line.stripLeading();
+        if (!stripped.startsWith("// provekit-")) return Optional.empty();
+        int colon = stripped.indexOf(':');
+        if (colon < 0) return Optional.empty();
+        String key = stripped.substring("// ".length(), colon).trim();
+        String value = stripped.substring(colon + 1).trim();
+        if (!key.startsWith("provekit-")) return Optional.empty();
+        return Optional.of(new TagLine(lineNumber, key, value));
     }
 
     private static String tagValue(List<TagLine> tags, String key) {
@@ -407,6 +538,41 @@ public final class JavaBindLifter {
 
     private static Jcs.Json stringOrNull(String value) {
         return value == null || value.isBlank() ? Jcs.nullValue() : Jcs.string(value);
+    }
+
+    private static String bindContractRole(String payloadRole) {
+        return switch (payloadRole == null ? "" : payloadRole) {
+            case "pre" -> "pre";
+            case "post" -> "post";
+            case "invariant" -> "inv";
+            case "throws" -> "throws";
+            case "observation" -> "observation";
+            default -> null;
+        };
+    }
+
+    private static boolean validEmittedBy(Jcs.Json emittedBy) {
+        if (!(emittedBy instanceof Jcs.Obj emittedByObj)) return false;
+        return validCid(emittedByObj.stringFieldOrNull("kit_cid"))
+            && nonBlank(emittedByObj.stringFieldOrNull("kit_kind"))
+            && nonBlank(emittedByObj.stringFieldOrNull("target_language"));
+    }
+
+    private static boolean nonBlank(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static boolean validCid(String cid) {
+        if (cid == null || !cid.startsWith("blake3-512:") || cid.length() != "blake3-512:".length() + 128) {
+            return false;
+        }
+        for (int i = "blake3-512:".length(); i < cid.length(); i++) {
+            char ch = cid.charAt(i);
+            if (!((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     // ---- Helpers -----------------------------------------------------------

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
@@ -282,7 +282,180 @@ class TrinityRoundtripLiftTest {
             "observation native-surface witness must belong only to the method whose body contains the tag: " + encoded);
     }
 
+    @Test
+    void bindLifterRecoversContractCommentTagsAsNativeSurfaceWitnesses() {
+        String source = contractTaggedSource(PRE_FORMULA_CID, POST_FORMULA_CID, "pre", "1");
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Contracts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertEquals(2, countOccurrences(encoded, "\"source_kind\":\"native-surface\""), encoded);
+        assertTrue(encoded.contains("\"role\":\"pre\""), encoded);
+        assertTrue(encoded.contains("\"role\":\"post\""), encoded);
+        assertTrue(encoded.contains("\"predicate_text\":\"non_null(name)\""), encoded);
+        assertTrue(encoded.contains("\"predicate_text\":\"non_null(out)\""), encoded);
+        assertTrue(encoded.contains("\"contract_cid\":\"" + CONTRACT_CID + "\""), encoded);
+        assertTrue(encoded.contains("\"concept_site_cid\":\"" + CONCEPT_SITE_CID + "\""), encoded);
+        assertTrue(encoded.contains("\"ir_formula_jcs_cid\":\"" + PRE_FORMULA_CID + "\""), encoded);
+        assertTrue(encoded.contains("\"ir_formula_jcs_cid\":\"" + POST_FORMULA_CID + "\""), encoded);
+        assertTrue(encoded.contains("\"policy_cid\":\"" + POLICY_CID + "\""), encoded);
+        assertTrue(encoded.contains("\"sugar_dict_cid\":\"" + SUGAR_DICT_CID + "\""), encoded);
+        assertTrue(encoded.contains("\"loss_record_cid\":\"" + LOSS_RECORD_CID + "\""), encoded);
+        assertTrue(encoded.contains("\"payload_cid\":\"blake3-512:"), encoded);
+        assertTrue(encoded.contains("\"surface\":\"contract-comment-sugar\""), encoded);
+    }
+
+    @Test
+    void bindLifterFailsClosedOnContractCommentFormulaCidMismatch() {
+        String source = contractTaggedSource(LOSS_RECORD_CID, POST_FORMULA_CID, "pre", "1");
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Contracts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertFalse(encoded.contains("\"predicate_text\":\"non_null(name)\""), encoded);
+        assertFalse(encoded.contains("\"role\":\"pre\""), encoded);
+        assertTrue(encoded.contains("\"role\":\"post\""), encoded);
+    }
+
+    @Test
+    void bindLifterFailsClosedOnContractCommentUnknownRoleOrSchema() {
+        String unknownRole = contractTaggedSource(PRE_FORMULA_CID, POST_FORMULA_CID, "guard", "1");
+        String unknownSchema = contractTaggedSource(PRE_FORMULA_CID, POST_FORMULA_CID, "pre", "2");
+
+        String roleEncoded = Jcs.encode(new JavaBindLifter().liftPathsFromSource("Contracts.java", unknownRole).toJson());
+        String schemaEncoded = Jcs.encode(new JavaBindLifter().liftPathsFromSource("Contracts.java", unknownSchema).toJson());
+
+        assertFalse(roleEncoded.contains("\"role\":\"guard\""), roleEncoded);
+        assertFalse(roleEncoded.contains("\"predicate_text\":\"non_null(name)\""), roleEncoded);
+        assertTrue(roleEncoded.contains("\"role\":\"post\""), roleEncoded);
+        assertFalse(schemaEncoded.contains("\"predicate_text\":\"non_null(name)\""), schemaEncoded);
+        assertTrue(schemaEncoded.contains("\"role\":\"post\""), schemaEncoded);
+    }
+
+    @Test
+    void bindLifterFailsClosedOnMalformedContractCommentPayloadOrPayloadCidMismatch() {
+        String malformedPayload = """
+            final class BadContractTransported {
+                // concept: lookup
+                // provekit-contract: {"artifact_kind":
+                public static String lookup(String name) {
+                    return name;
+                }
+            }
+            """;
+        String validPrePayload = contractPayload("pre", "1", nonNullPredicate("name"), PRE_FORMULA_CID, "non_null(name)");
+        String wrongPayloadCid = """
+            final class BadContractTransported {
+                // concept: lookup
+                // provekit-contract: __PRE_PAYLOAD__
+                // provekit-contract-payload-cid: __WRONG_CID__
+                public static String lookup(String name) {
+                    return name;
+                }
+            }
+            """
+            .replace("__PRE_PAYLOAD__", validPrePayload)
+            .replace("__WRONG_CID__", LOSS_RECORD_CID);
+
+        String malformedEncoded = Jcs.encode(new JavaBindLifter().liftPathsFromSource("BadContract.java", malformedPayload).toJson());
+        String cidMismatchEncoded = Jcs.encode(new JavaBindLifter().liftPathsFromSource("BadContract.java", wrongPayloadCid).toJson());
+
+        assertFalse(malformedEncoded.contains("\"source_kind\":\"native-surface\""), malformedEncoded);
+        assertFalse(cidMismatchEncoded.contains("\"predicate_text\":\"non_null(name)\""), cidMismatchEncoded);
+        assertFalse(cidMismatchEncoded.contains("\"payload_cid\":\"" + LOSS_RECORD_CID + "\""), cidMismatchEncoded);
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static final String CONTRACT_CID =
+        "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+    private static final String CONCEPT_SITE_CID =
+        "blake3-512:55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555";
+    private static final String POLICY_CID =
+        "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+    private static final String SUGAR_DICT_CID =
+        "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333";
+    private static final String LOSS_RECORD_CID =
+        "blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444";
+    private static final String KIT_CID =
+        "blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666";
+    private static final String PRE_FORMULA_CID = Jcs.cid(nonNullPredicate("name"));
+    private static final String POST_FORMULA_CID = Jcs.cid(nonNullPredicate("out"));
+
+    private static String contractTaggedSource(
+        String preFormulaCid,
+        String postFormulaCid,
+        String preRole,
+        String preSchemaVersion) {
+        String prePayload = contractPayload(preRole, preSchemaVersion, nonNullPredicate("name"), preFormulaCid, "non_null(name)");
+        String postPayload = contractPayload("post", "1", nonNullPredicate("out"), postFormulaCid, "non_null(out)");
+        return """
+            final class ContractTransported {
+                // concept: lookup
+                // provekit-contract: __PRE_PAYLOAD__
+                // provekit-contract-payload-cid: __PRE_PAYLOAD_CID__
+                // requires: non_null(name)
+                // provekit-contract: __POST_PAYLOAD__
+                // provekit-contract-payload-cid: __POST_PAYLOAD_CID__
+                // ensures: non_null(out)
+                public static String lookup(String name) {
+                    return name;
+                }
+            }
+            """
+            .replace("__PRE_PAYLOAD__", prePayload)
+            .replace("__PRE_PAYLOAD_CID__", payloadCid(prePayload))
+            .replace("__POST_PAYLOAD__", postPayload)
+            .replace("__POST_PAYLOAD_CID__", payloadCid(postPayload));
+    }
+
+    private static String contractPayload(
+        String role,
+        String schemaVersion,
+        Jcs.Json formula,
+        String formulaCid,
+        String folText) {
+        return Jcs.encode(Jcs.object(
+            "artifact_kind", Jcs.string("provekit-contract-comment-sugar"),
+            "concept_site_cid", Jcs.string(CONCEPT_SITE_CID),
+            "contract_cid", Jcs.string(CONTRACT_CID),
+            "emitted_by", Jcs.object(
+                "kit_cid", Jcs.string(KIT_CID),
+                "kit_kind", Jcs.string("realize"),
+                "target_language", Jcs.string("java")
+            ),
+            "fol_text", Jcs.string(folText),
+            "ir_formula_jcs", formula,
+            "ir_formula_jcs_cid", Jcs.string(formulaCid),
+            "local_contract_cid", Jcs.string(CONTRACT_CID),
+            "loss_record_cid", Jcs.string(LOSS_RECORD_CID),
+            "policy_cid", Jcs.string(POLICY_CID),
+            "role", Jcs.string(role),
+            "schema_version", Jcs.string(schemaVersion),
+            "sugar_dict_cid", Jcs.string(SUGAR_DICT_CID)
+        ));
+    }
+
+    private static String payloadCid(String payload) {
+        return Jcs.cid(Jcs.parse(payload));
+    }
+
+    private static Jcs.Json nonNullPredicate(String symbol) {
+        return Jcs.object(
+            "args", Jcs.array(
+                Jcs.object("kind", Jcs.string("var"), "name", Jcs.string(symbol)),
+                Jcs.object(
+                    "kind", Jcs.string("const"),
+                    "sort", Jcs.object("kind", Jcs.string("primitive"), "name", Jcs.string("Ref")),
+                    "value", Jcs.nullValue()
+                )
+            ),
+            "kind", Jcs.string("atomic"),
+            "name", Jcs.string("neq")
+        );
+    }
 
     private Set<String> declarationFnNames() {
         return result.declarations().stream()

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -139,7 +139,7 @@ final class SugarRealizer {
         // annotation_prefix for Java: top_indent = "    "
         String annotationPrefix = "    // concept: " + conceptName + "\n"
                 + contractPrefix(contract)
-                + commentPrefix(sugarEmissions);
+                + commentPrefix(contract, sugarEmissions);
 
         Optional<RenderedBody> bodyTemplate = renderBodyTemplateFor(conceptName, params, mode);
         boolean isStub = bodyTemplate.isEmpty();
@@ -522,14 +522,68 @@ final class SugarRealizer {
         return out.toString();
     }
 
-    private static String commentPrefix(List<SugarEmission> emissions) {
+    private static String commentPrefix(ContractPayload contract, List<SugarEmission> emissions) {
         StringBuilder out = new StringBuilder();
         for (SugarEmission emission : emissions) {
             if (emission.surfaceLocator().startsWith("comment:")) {
+                if (contract != null) {
+                    out.append(contractCommentTagBlock(contract, emission));
+                }
                 out.append("    ").append(emission.rendered()).append("\n");
             }
         }
         return out.toString();
+    }
+
+    private static String contractCommentTagBlock(ContractPayload contract, SugarEmission emission) {
+        Jcs.Obj payload = contractCommentPayload(contract, emission);
+        StringBuilder out = new StringBuilder();
+        out.append("    // provekit-contract: ").append(Jcs.encode(payload)).append("\n");
+        out.append("    // provekit-contract-payload-cid: ").append(Jcs.cid(payload)).append("\n");
+        return out.toString();
+    }
+
+    private static Jcs.Obj contractCommentPayload(ContractPayload contract, SugarEmission emission) {
+        return Jcs.object(
+                "artifact_kind", Jcs.string("provekit-contract-comment-sugar"),
+                "concept_site_cid", Jcs.string(contract.conceptSiteCid()),
+                "contract_cid", Jcs.string(contract.localContractCid()),
+                "emitted_by", Jcs.object(
+                        "kit_cid", Jcs.string(contractCommentEmitterKitCid()),
+                        "kit_kind", Jcs.string("realize"),
+                        "target_language", Jcs.string("java")
+                ),
+                "fol_text", Jcs.string(commentLineValue(emission.predicateText())),
+                "ir_formula_jcs", emission.predicate(),
+                "ir_formula_jcs_cid", Jcs.string(Jcs.cid(emission.predicate())),
+                "local_contract_cid", Jcs.string(contract.localContractCid()),
+                "loss_record_cid", Jcs.string(Jcs.cid(emission.lossRecord())),
+                "policy_cid", Jcs.string(contractCommentPolicyCid()),
+                "role", Jcs.string(emission.role()),
+                "schema_version", Jcs.string("1"),
+                "sugar_dict_cid", Jcs.string(emission.sugarCid())
+        );
+    }
+
+    private static String contractCommentPolicyCid() {
+        return Jcs.cid(Jcs.object(
+                "emit_contract_tags", Jcs.bool(true),
+                "kind", Jcs.string("realization-emission-policy"),
+                "schemaVersion", Jcs.string("1"),
+                "surface", Jcs.string("java-contract-comment")
+        ));
+    }
+
+    private static String contractCommentEmitterKitCid() {
+        return Jcs.cid(Jcs.object(
+                "kit_kind", Jcs.string("realize"),
+                "name", Jcs.string("provekit-realize-java"),
+                "target_language", Jcs.string("java")
+        ));
+    }
+
+    private static String commentLineValue(String raw) {
+        return raw == null ? "" : raw.replace('\n', ' ').replace('\r', ' ').trim();
     }
 
     private static boolean contractHasNonNullPrecondition(ContractPayload contract, String param) {
@@ -916,6 +970,9 @@ record SugarEmission(
         String surfaceLocator,
         String rendered,
         String symbol,
+        String role,
+        Jcs.Json predicate,
+        String predicateText,
         Jcs.Json lossRecord) {}
 
 final class SugarDictionary {
@@ -941,6 +998,9 @@ final class SugarDictionary {
                                 entry.surfaceLocator(),
                                 render(entry.template(), match),
                                 match.symbol(),
+                                witness.role(),
+                                witness.predicate(),
+                                witness.predicateText(),
                                 entry.lossRecord()
                         ));
                     }

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
@@ -158,6 +158,47 @@ public class JavaNullBoundaryRealizerTest {
     }
 
     @Test
+    public void contractCommentSugarEmitsReliftablePreAndPostPayloads() {
+        String contractCid = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+        ContractPayload contract = new ContractPayload(
+            "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+            contractCid,
+            "evidence-lift[native-surface]",
+            "loudly-bounded-lossy",
+            java.util.List.of(
+                new ContractWitness("pre", "non_null(name)", "native-surface"),
+                new ContractWitness("post", "non_null(out)", "native-surface")
+            )
+        );
+
+        SugarRealizer.Realization output = SugarRealizer.emitStub(
+            "lookup",
+            java.util.List.of("name"),
+            java.util.List.of("String"),
+            "String",
+            "concept:lookup",
+            "monitor",
+            java.util.List.of("monitor"),
+            contract,
+            java.util.List.of(validCommentSugar())
+        );
+
+        assertEquals(2, countOccurrences(output.source(), "// provekit-contract: {"), output.source());
+        assertEquals(2, countOccurrences(output.source(), "// provekit-contract-payload-cid: blake3-512:"), output.source());
+        assertTrue(output.source().contains("\"artifact_kind\":\"provekit-contract-comment-sugar\""), output.source());
+        assertTrue(output.source().contains("\"schema_version\":\"1\""), output.source());
+        assertTrue(output.source().contains("\"role\":\"pre\""), output.source());
+        assertTrue(output.source().contains("\"role\":\"post\""), output.source());
+        assertTrue(output.source().contains("\"contract_cid\":\"" + contractCid + "\""), output.source());
+        assertEquals(2, countOccurrences(output.source(), "\"ir_formula_jcs_cid\":\"blake3-512:"), output.source());
+        assertEquals(2, countOccurrences(output.source(), "\"policy_cid\":\"blake3-512:"), output.source());
+        assertEquals(2, countOccurrences(output.source(), "\"sugar_dict_cid\":\"blake3-512:"), output.source());
+        assertEquals(2, countOccurrences(output.source(), "\"loss_record_cid\":\"blake3-512:"), output.source());
+        assertTrue(output.source().contains("\"fol_text\":\"non_null(name)\""), output.source());
+        assertTrue(output.source().contains("\"fol_text\":\"non_null(out)\""), output.source());
+    }
+
+    @Test
     public void modeScopedJunitWitnessSugarDoesNotApplyToMonitor() {
         ContractPayload contract = new ContractPayload(
             "blake3-512:site",
@@ -493,6 +534,13 @@ public class JavaNullBoundaryRealizerTest {
         return "{\"header\":{\"cid\":\"java-function-comment\",\"content\":{\"entries\":[{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"comment:above\",\"template\":\"// ${contract_role}: ${formula_pretty_print}\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{\"structural_divergence\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"machine_uncheckable_prose\"}}},\"predicate_pattern\":{\"args\":[],\"kind\":\"atomic\",\"name\":\"${any_formula}\"}}],\"sugar_name\":\"function-comment\",\"target_language\":\"java\"},\"critical\":false,\"kind\":\"sugar\",\"protocol_versions\":[\"pep/1.7.0\"],\"provenance_cid\":\"blake3-512:0\",\"schemaVersion\":\"1\",\"version\":\"1.0.0\"}}";
     }
 
+    private static String validCommentSugar() {
+        return commentSugar().replace(
+            "\"cid\":\"java-function-comment\"",
+            "\"cid\":\"blake3-512:574800417e6f4f57e561dbe9c437adc691b2cd2369d964cbc329348cb715b161f3b38f6f7ccfd41537d033741488c081ec01b6f7cb3f04ba724b7003fa05a7b6\""
+        );
+    }
+
     private static String sugar(String cid, String name, String locator, String template, String loss) {
         return "{\"header\":{\"cid\":\"" + cid + "\",\"content\":{\"entries\":[{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"" + locator + "\",\"template\":\"" + template + "\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":" + loss + "},\"predicate_pattern\":{\"args\":[{\"kind\":\"var\",\"name\":\"${symbol}\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"},\"value\":null}],\"kind\":\"atomic\",\"name\":\"neq\"}}],\"sugar_name\":\"" + name + "\",\"target_language\":\"java\"},\"critical\":false,\"kind\":\"sugar\",\"protocol_versions\":[\"pep/1.7.0\"],\"provenance_cid\":\"blake3-512:0\",\"schemaVersion\":\"1\",\"version\":\"1.0.0\"}}";
     }
@@ -510,5 +558,15 @@ public class JavaNullBoundaryRealizerTest {
             "kind", com.provekit.ir.Jcs.string("atomic"),
             "name", com.provekit.ir.Jcs.string(op)
         );
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) >= 0) {
+            count += 1;
+            idx += needle.length();
+        }
+        return count;
     }
 }


### PR DESCRIPTION
## Summary

- Emits canonical `provekit-contract` JSON payload comments from Java comment sugar, including payload CID and the CIDs required by the contract-comment sugar spec.
- Relifts valid Java contract-comment payloads into `bind-contract-witness-entry` records using `source_kind: native-surface`.
- Adds fail-closed coverage for formula CID mismatch, unknown role/schema, malformed payload JSON, and payload CID mismatch.

## Notes

- This implementation follows the payload shape from #934.
- The PR does not vendor the spec file; it is the Java implementation leaf for #931.

## Validation

- `mvn -q -f implementations/java/pom.xml -pl provekit-realize-java-core,provekit-lift-java-source -am test`
- `git diff --check`

Refs #931 #934.
