### PR TITLE
Implement Python contract sugar relift

### DIFF
--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lift/pydantic.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lift/pydantic.py
@@ -16,10 +16,23 @@
 from __future__ import annotations
 
 import inspect
+import json
 import sys
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Type, Union, get_type_hints
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Type,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
+from ..canonicalizer import encode_jcs
 from ..ir import (
     ContractDecl,
     Formula,
@@ -41,6 +54,7 @@ from ..ir import (
     ctor,
     and_,
     or_,
+    formula_to_value,
 )
 
 
@@ -179,3 +193,182 @@ def _fold_and(parts: List[Formula]) -> Formula:
     if len(parts) == 1:
         return parts[0]
     return and_(parts)
+
+
+# ---------------------------------------------------------------------------
+# Sugar bridge helpers: pydantic source/witness shape
+# ---------------------------------------------------------------------------
+
+
+def emit_pydantic_model_source(model_name: str, fields: List[Dict[str, Any]]) -> str:
+    """Emit a small pydantic model surface from structured field specs."""
+    lines = [f"class {model_name}(BaseModel):"]
+    if not fields:
+        lines.append("    pass")
+        return "\n".join(lines) + "\n"
+    for field in fields:
+        name = str(field["name"])
+        type_name = str(field.get("type", "Any"))
+        args = field.get("field_args") if isinstance(field.get("field_args"), dict) else {}
+        if args:
+            rendered_args = ", ".join(
+                f"{key}={_py_literal(value)}" for key, value in sorted(args.items())
+            )
+            lines.append(f"    {name}: {type_name} = Field(..., {rendered_args})")
+        else:
+            lines.append(f"    {name}: {type_name}")
+    return "\n".join(lines) + "\n"
+
+
+def lift_pydantic_model_witnesses(
+    model_cls: Type,
+    *,
+    concept_site_cid: str | None = None,
+    contract_cid: str | None = None,
+    original_predicate_text: str | None = None,
+) -> List[Dict[str, Any]]:
+    """Lift pydantic fields into bind witness records with honest loss."""
+    fields = _get_fields(model_cls)
+    if fields is None:
+        return []
+    try:
+        annotations = get_type_hints(model_cls, include_extras=True)
+    except Exception:
+        annotations = getattr(model_cls, "__annotations__", {})
+
+    witnesses: List[Dict[str, Any]] = []
+    for field_name, field_info in fields.items():
+        annotation = annotations.get(field_name, getattr(field_info, "annotation", None))
+        formulas: List[Formula] = []
+        if _field_required(field_info) and not _is_optional_annotation(annotation):
+            formulas.append(ne(make_var(field_name), ctor("None", [])))
+        type_name = _annotation_name(annotation)
+        if type_name and type_name != "Any":
+            formulas.append(atomic("is_type", [make_var(field_name), str_const(type_name)]))
+        formulas.extend(_lift_field_constraints(field_name, field_info))
+
+        for formula in formulas:
+            predicate = _formula_to_json(formula)
+            predicate_text = _formula_text(predicate)
+            extension_fields: Dict[str, Any] = {
+                "field": field_name,
+                "loss_record": _pydantic_loss_record(
+                    original_predicate_text,
+                    predicate_text,
+                ),
+                "surface": "pydantic-field",
+            }
+            if concept_site_cid is not None:
+                extension_fields["concept_site_cid"] = concept_site_cid
+            if contract_cid is not None:
+                extension_fields["contract_cid"] = contract_cid
+            witnesses.append(
+                {
+                    "col": None,
+                    "confidence_basis_points": 10000,
+                    "extension_fields": extension_fields,
+                    "line": None,
+                    "predicate": predicate,
+                    "predicate_text": predicate_text,
+                    "role": "pre",
+                    "source_kind": "native-surface",
+                }
+            )
+    return witnesses
+
+
+def _py_literal(value: Any) -> str:
+    if isinstance(value, str):
+        return repr(value)
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if value is None:
+        return "None"
+    return str(value)
+
+
+def _field_required(field_info: Any) -> bool:
+    is_required = getattr(field_info, "is_required", None)
+    if callable(is_required):
+        try:
+            return bool(is_required())
+        except Exception:
+            return False
+    required = getattr(field_info, "required", None)
+    if required is not None:
+        return bool(required)
+    return getattr(field_info, "default", None) is ...
+
+
+def _is_optional_annotation(annotation: Any) -> bool:
+    args = get_args(annotation)
+    return any(arg is type(None) for arg in args)
+
+
+def _annotation_name(annotation: Any) -> str:
+    if annotation is None:
+        return "Any"
+    origin = get_origin(annotation)
+    if origin is not None and str(origin).endswith("Annotated"):
+        args = get_args(annotation)
+        if args:
+            return _annotation_name(args[0])
+    if annotation in (str, int, bool, float):
+        return annotation.__name__
+    name = getattr(annotation, "__name__", None)
+    if isinstance(name, str):
+        return name
+    text = str(annotation)
+    return text.replace("<class '", "").replace("'>", "")
+
+
+def _formula_to_json(formula: Formula) -> Dict[str, Any]:
+    return json.loads(encode_jcs(formula_to_value(formula)))
+
+
+def _pydantic_loss_record(
+    original_predicate_text: str | None,
+    surface_predicate_text: str,
+) -> Dict[str, Any]:
+    if original_predicate_text is None or original_predicate_text == surface_predicate_text:
+        return {}
+    return {
+        "pydantic_expressivity_gap": {
+            "original_predicate_text": original_predicate_text,
+            "surface_predicate_text": surface_predicate_text,
+        }
+    }
+
+
+def _formula_text(formula: Dict[str, Any]) -> str:
+    if formula.get("kind") == "atomic":
+        name = formula.get("name")
+        args = formula.get("args")
+        if name == "is_type" and isinstance(args, list) and len(args) == 2:
+            return f"type({_term_text(args[0])}) == {_term_text(args[1])}"
+        if isinstance(name, str) and isinstance(args, list):
+            if len(args) == 2:
+                return f"{_term_text(args[0])} {_operator_text(name)} {_term_text(args[1])}"
+            return f"{name}({', '.join(_term_text(arg) for arg in args)})"
+    if formula.get("kind") in {"and", "or"} and isinstance(formula.get("operands"), list):
+        sep = f" {formula['kind']} "
+        return sep.join(_formula_text(part) for part in formula["operands"])
+    return "<formula>"
+
+
+def _operator_text(name: str) -> str:
+    return {"=": "==", "≠": "!=", "≥": ">=", "≤": "<="}.get(name, name)
+
+
+def _term_text(term: Dict[str, Any]) -> str:
+    if term.get("kind") == "var":
+        return str(term.get("name"))
+    if term.get("kind") == "const":
+        value = term.get("value")
+        return "None" if value is None else str(value)
+    if term.get("kind") == "ctor":
+        name = str(term.get("name"))
+        args = term.get("args")
+        if isinstance(args, list):
+            return f"{name}({', '.join(_term_text(arg) for arg in args)})"
+    return "<?>"

--- a/implementations/python/provekit-lift-py-tests/tests/test_lift_pydantic.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_lift_pydantic.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 import pytest
 
-from provekit_lift_py_tests.lift.pydantic import lift_pydantic_model
-
-
-# Only run these if pydantic is installed.
-pydantic = pytest.importorskip("pydantic")
+from provekit_lift_py_tests.lift.pydantic import (
+    emit_pydantic_model_source,
+    lift_pydantic_model,
+    lift_pydantic_model_witnesses,
+)
 
 
 class TestPydanticLift:
     def test_pydantic_v2_field_constraints(self):
+        pytest.importorskip("pydantic")
         from pydantic import BaseModel, Field
 
         class User(BaseModel):
@@ -27,6 +28,7 @@ class TestPydanticLift:
         assert "User.email" in names
 
     def test_pydantic_v2_numeric_range(self):
+        pytest.importorskip("pydantic")
         from pydantic import BaseModel, Field
 
         class Score(BaseModel):
@@ -39,6 +41,7 @@ class TestPydanticLift:
         assert decl.pre is not None
 
     def test_pydantic_v2_annotated_types(self):
+        pytest.importorskip("pydantic")
         from pydantic import BaseModel
         from typing import Annotated
         from annotated_types import Gt, Lt
@@ -49,3 +52,50 @@ class TestPydanticLift:
         decls = lift_pydantic_model(Item)
         assert len(decls) == 1
         assert decls[0].name == "Item.quantity"
+
+    def test_pydantic_bridge_emits_source_and_lifts_lossy_witness_without_importing_pydantic(self):
+        class FieldInfo:
+            metadata = []
+            min_length = 1
+            max_length = None
+            ge = None
+            gt = None
+            le = None
+            lt = None
+            pattern = None
+
+            def is_required(self):
+                return True
+
+        class User:
+            __annotations__ = {"name": str}
+            model_fields = {"name": FieldInfo()}
+
+        source = emit_pydantic_model_source(
+            "User",
+            [
+                {
+                    "name": "name",
+                    "type": "str",
+                    "field_args": {"min_length": 1},
+                }
+            ],
+        )
+
+        witnesses = lift_pydantic_model_witnesses(
+            User,
+            concept_site_cid="blake3-512:" + "1" * 128,
+            contract_cid="blake3-512:" + "2" * 128,
+            original_predicate_text="name is not None and type(name) == str and len(name) >= 1 and normalized(name)",
+        )
+
+        assert "class User(BaseModel):" in source
+        assert "name: str = Field(..., min_length=1)" in source
+        assert witnesses
+        assert all(w["source_kind"] == "native-surface" for w in witnesses)
+        assert {w["extension_fields"]["surface"] for w in witnesses} == {"pydantic-field"}
+        assert any(w["extension_fields"]["loss_record"] for w in witnesses)
+        predicate_text = " ".join(w["predicate_text"] for w in witnesses)
+        assert "name != None" in predicate_text
+        assert "type(name) == str" in predicate_text
+        assert "strlen(name) >= 1" in predicate_text

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -1,14 +1,29 @@
 from __future__ import annotations
 
 import ast
+import json
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
+from provekit_lift_py_tests.canonicalizer import encode_jcs
+from provekit_lift_py_tests.decorators import _parse_expr_string
+from provekit_lift_py_tests.ir import formula_to_value
+
 from .canonical import cid_of_json
 
 Json = Any
+CID_RE = re.compile(r"^blake3-512:[0-9a-f]{128}$")
+CONTRACT_COMMENT_KIND = "provekit-contract-comment-sugar"
+CONTRACT_COMMENT_ROLE_MAP = {
+    "pre": "pre",
+    "post": "post",
+    "invariant": "inv",
+    "throws": "throws",
+    "observation": "observation",
+}
 
 
 @dataclass
@@ -42,7 +57,9 @@ def lift_source(source: str, source_path: str) -> BindLiftResult:
     lines = source.splitlines()
     rel_path = source_path.replace(os.sep, "/")
     for info in collector.definitions:
-        result.ir.append(_entry_for_function(info.node, rel_path, lines))
+        result.ir.append(
+            _entry_for_function(info.node, rel_path, lines, result.diagnostics)
+        )
     return result
 
 
@@ -115,6 +132,7 @@ def _entry_for_function(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
     rel_path: str,
     lines: list[str],
+    diagnostics: list[Json],
 ) -> Json:
     concept, attr_pre, attr_post = _extract_leading_annotations(lines, node.lineno)
     term_shape = _function_shape(node)
@@ -124,6 +142,9 @@ def _entry_for_function(
         return_type = "Any"
     elif return_type == "None":
         return_type = "()"
+    witnesses = []
+    witnesses.extend(_contract_comment_witnesses(lines, node, rel_path, diagnostics))
+    witnesses.extend(_decorator_contract_witnesses(node, param_names, rel_path, diagnostics))
 
     return {
         "attr_post": attr_post,
@@ -138,6 +159,7 @@ def _entry_for_function(
         "return_type": return_type,
         "term_shape": term_shape,
         "term_shape_cid": cid_of_json(term_shape),
+        "witnesses": witnesses,
     }
 
 
@@ -169,7 +191,10 @@ def _annotation_text(annotation: ast.expr | None) -> str | None:
 
 def _function_shape(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Json:
     statements = [stmt for stmt in node.body if not _is_docstring_stmt(stmt)]
-    return {"kind": "body", "stmts": [_shape_stmt(stmt, top_level=True) for stmt in statements]}
+    return {
+        "kind": "body",
+        "stmts": [_shape_stmt(stmt, top_level=True) for stmt in statements],
+    }
 
 
 def _shape_block(statements: list[ast.stmt]) -> Json:
@@ -298,6 +323,315 @@ def _extract_leading_annotations(
             continue
         break
     return concept, attr_pre, attr_post
+
+
+def _contract_comment_witnesses(
+    lines: list[str],
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    rel_path: str,
+    diagnostics: list[Json],
+) -> list[Json]:
+    witnesses: list[Json] = []
+    witnesses.extend(
+        _contract_comment_witnesses_from_surface_lines(
+            _leading_contract_comment_surface(lines, node.lineno),
+            rel_path,
+            diagnostics,
+        )
+    )
+    docstring = ast.get_docstring(node, clean=True)
+    if docstring:
+        doc_lines = [
+            (getattr(node.body[0], "lineno", node.lineno), line.strip())
+            for line in docstring.splitlines()
+        ]
+        witnesses.extend(
+            _contract_comment_witnesses_from_surface_lines(
+                doc_lines,
+                rel_path,
+                diagnostics,
+            )
+        )
+    return witnesses
+
+
+def _leading_contract_comment_surface(
+    lines: list[str],
+    fn_line: int,
+) -> list[tuple[int, str]]:
+    start = fn_line - 2
+    while start >= 0:
+        stripped = lines[start].strip()
+        if stripped == "" or stripped.startswith("#") or stripped.startswith("@"):
+            start -= 1
+            continue
+        break
+    surface: list[tuple[int, str]] = []
+    for idx in range(start + 1, fn_line - 1):
+        stripped = lines[idx].strip()
+        if stripped.startswith("#"):
+            surface.append((idx + 1, stripped[1:].strip()))
+    return surface
+
+
+def _contract_comment_witnesses_from_surface_lines(
+    surface_lines: list[tuple[int, str]],
+    rel_path: str,
+    diagnostics: list[Json],
+) -> list[Json]:
+    witnesses: list[Json] = []
+    idx = 0
+    while idx < len(surface_lines):
+        line_no, content = surface_lines[idx]
+        if not content.startswith("provekit-contract:"):
+            idx += 1
+            continue
+        raw_payload = content[len("provekit-contract:") :].strip()
+        payload_cid: str | None = None
+        if idx + 1 < len(surface_lines):
+            _, next_content = surface_lines[idx + 1]
+            if next_content.startswith("provekit-contract-payload-cid:"):
+                payload_cid = next_content[
+                    len("provekit-contract-payload-cid:") :
+                ].strip()
+                idx += 1
+        witness = _contract_comment_witness(
+            raw_payload,
+            payload_cid,
+            rel_path,
+            line_no,
+            diagnostics,
+        )
+        if witness is not None:
+            witnesses.append(witness)
+        idx += 1
+    return witnesses
+
+
+def _contract_comment_witness(
+    raw_payload: str,
+    emitted_payload_cid: str | None,
+    rel_path: str,
+    line_no: int,
+    diagnostics: list[Json],
+) -> Json | None:
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        _contract_comment_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            f"malformed JSON: {exc.msg}",
+        )
+        return None
+    if not isinstance(payload, dict):
+        _contract_comment_diag(diagnostics, rel_path, line_no, "payload is not an object")
+        return None
+
+    def require_str(key: str) -> str | None:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+        _contract_comment_diag(diagnostics, rel_path, line_no, f"missing {key}")
+        return None
+
+    if payload.get("artifact_kind") != CONTRACT_COMMENT_KIND:
+        _contract_comment_diag(diagnostics, rel_path, line_no, "wrong artifact_kind")
+        return None
+    if payload.get("schema_version") != "1":
+        _contract_comment_diag(diagnostics, rel_path, line_no, "unknown schema_version")
+        return None
+
+    fol_text = require_str("fol_text")
+    if fol_text is None:
+        return None
+
+    emitted_by = payload.get("emitted_by")
+    if not _valid_emitted_by(emitted_by):
+        _contract_comment_diag(diagnostics, rel_path, line_no, "malformed emitted_by")
+        return None
+
+    role = require_str("role")
+    if role not in CONTRACT_COMMENT_ROLE_MAP:
+        _contract_comment_diag(diagnostics, rel_path, line_no, "unknown role")
+        return None
+
+    cid_fields = [
+        "concept_site_cid",
+        "contract_cid",
+        "ir_formula_jcs_cid",
+        "loss_record_cid",
+        "policy_cid",
+        "sugar_dict_cid",
+    ]
+    for key in cid_fields:
+        value = require_str(key)
+        if value is None or not CID_RE.fullmatch(value):
+            _contract_comment_diag(diagnostics, rel_path, line_no, f"malformed {key}")
+            return None
+    local_contract_cid = payload.get("local_contract_cid")
+    if local_contract_cid is not None and (
+        not isinstance(local_contract_cid, str) or not CID_RE.fullmatch(local_contract_cid)
+    ):
+        _contract_comment_diag(diagnostics, rel_path, line_no, "malformed local_contract_cid")
+        return None
+
+    predicate = payload.get("ir_formula_jcs")
+    if not isinstance(predicate, dict):
+        _contract_comment_diag(diagnostics, rel_path, line_no, "missing ir_formula_jcs")
+        return None
+    if not _valid_formula_shape(predicate):
+        _contract_comment_diag(diagnostics, rel_path, line_no, "invalid formula shape")
+        return None
+    if cid_of_json(predicate) != payload["ir_formula_jcs_cid"]:
+        _contract_comment_diag(diagnostics, rel_path, line_no, "formula CID mismatch")
+        return None
+
+    payload_cid = cid_of_json(payload)
+    if emitted_payload_cid is not None and not CID_RE.fullmatch(emitted_payload_cid):
+        _contract_comment_diag(diagnostics, rel_path, line_no, "malformed payload CID")
+        return None
+    if emitted_payload_cid is not None and emitted_payload_cid != payload_cid:
+        _contract_comment_diag(diagnostics, rel_path, line_no, "payload CID mismatch")
+        return None
+
+    extension_fields = {
+        "concept_site_cid": payload["concept_site_cid"],
+        "contract_cid": payload["contract_cid"],
+        "ir_formula_jcs_cid": payload["ir_formula_jcs_cid"],
+        "loss_record_cid": payload["loss_record_cid"],
+        "payload_cid": payload_cid,
+        "policy_cid": payload["policy_cid"],
+        "sugar_dict_cid": payload["sugar_dict_cid"],
+        "surface": "contract-comment-sugar",
+    }
+    if isinstance(local_contract_cid, str):
+        extension_fields["local_contract_cid"] = local_contract_cid
+    return {
+        "col": 0,
+        "confidence_basis_points": 10000,
+        "extension_fields": extension_fields,
+        "line": line_no,
+        "predicate": predicate,
+        "predicate_text": fol_text,
+        "role": CONTRACT_COMMENT_ROLE_MAP[role],
+        "source_kind": "native-surface",
+    }
+
+
+def _valid_emitted_by(value: Json) -> bool:
+    if not isinstance(value, dict):
+        return False
+    kit_cid = value.get("kit_cid")
+    kit_kind = value.get("kit_kind")
+    target_language = value.get("target_language")
+    return (
+        isinstance(kit_cid, str)
+        and CID_RE.fullmatch(kit_cid) is not None
+        and isinstance(kit_kind, str)
+        and bool(kit_kind)
+        and isinstance(target_language, str)
+        and bool(target_language)
+    )
+
+
+def _valid_formula_shape(formula: Json) -> bool:
+    if not isinstance(formula, dict):
+        return False
+    kind = formula.get("kind")
+    if kind == "atomic":
+        return isinstance(formula.get("name"), str) and isinstance(
+            formula.get("args"),
+            list,
+        )
+    if kind in {"and", "or", "not", "implies"}:
+        operands = formula.get("operands")
+        return isinstance(operands, list) and all(
+            _valid_formula_shape(operand) for operand in operands
+        )
+    if kind in {"forall", "exists"}:
+        return (
+            isinstance(formula.get("name"), str)
+            and isinstance(formula.get("sort"), dict)
+            and _valid_formula_shape(formula.get("body"))
+        )
+    return False
+
+
+def _contract_comment_diag(
+    diagnostics: list[Json],
+    rel_path: str,
+    line_no: int,
+    message: str,
+) -> None:
+    diagnostics.append(
+        {
+            "kind": "contract-comment-invalid",
+            "message": message,
+            "path": rel_path,
+            "line": line_no,
+        }
+    )
+
+
+def _decorator_contract_witnesses(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    param_names: list[str],
+    rel_path: str,
+    diagnostics: list[Json],
+) -> list[Json]:
+    witnesses: list[Json] = []
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        if _decorator_name(decorator.func) not in {"contract", "provekit_contract"}:
+            continue
+        for keyword in decorator.keywords:
+            role = {"pre": "pre", "post": "post", "inv": "inv"}.get(keyword.arg or "")
+            if role is None or not isinstance(keyword.value, ast.Constant):
+                continue
+            if not isinstance(keyword.value.value, str):
+                continue
+            text = keyword.value.value
+            try:
+                names = [*param_names, "out"] if role == "post" else param_names
+                formula = _parse_expr_string(text, names)
+                predicate = json.loads(encode_jcs(formula_to_value(formula)))
+            except Exception as exc:
+                diagnostics.append(
+                    {
+                        "kind": "decorator-contract-invalid",
+                        "message": str(exc),
+                        "path": rel_path,
+                        "line": getattr(decorator, "lineno", node.lineno),
+                    }
+                )
+                continue
+            witnesses.append(
+                {
+                    "col": getattr(decorator, "col_offset", 0),
+                    "confidence_basis_points": 10000,
+                    "extension_fields": {
+                        "decorator": _decorator_name(decorator.func),
+                        "surface": "python-decorator-contract",
+                    },
+                    "line": getattr(decorator, "lineno", node.lineno),
+                    "predicate": predicate,
+                    "predicate_text": text,
+                    "role": role,
+                    "source_kind": "native-surface",
+                }
+            )
+    return witnesses
+
+
+def _decorator_name(node: ast.expr) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return ""
 
 
 def _iter_python_files(path: Path) -> Iterable[Path]:

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -7,14 +7,77 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[4]
 PKG_SRC = ROOT / "implementations/python/provekit-lift-python-source/src"
 PY_TESTS_SRC = ROOT / "implementations/python/provekit-lift-py-tests/src"
+REALIZER_SRC = ROOT / "implementations/python/provekit-realize-python-core/src"
 if str(PY_TESTS_SRC) not in sys.path:
     sys.path.insert(0, str(PY_TESTS_SRC))
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
+if str(REALIZER_SRC) not in sys.path:
+    sys.path.insert(0, str(REALIZER_SRC))
 
 from provekit_lift_python_source.bind_lifter import lift_source
 from provekit_lift_python_source.bind_rpc import dispatch, initialize_result
 from provekit_lift_python_source.canonical import cid_of_json
+from provekit_realize_python_core.realizer import emit_stub
+
+
+def _cid(ch: str) -> str:
+    return "blake3-512:" + ch * 128
+
+
+def _formula_gte_x_zero() -> dict:
+    return {
+        "args": [
+            {"kind": "var", "name": "x"},
+            {
+                "kind": "const",
+                "sort": {"kind": "primitive", "name": "Int"},
+                "value": 0,
+            },
+        ],
+        "kind": "atomic",
+        "name": "≥",
+    }
+
+
+def _formula_out_eq_x() -> dict:
+    return {
+        "args": [{"kind": "var", "name": "out"}, {"kind": "var", "name": "x"}],
+        "kind": "atomic",
+        "name": "=",
+    }
+
+
+def _contract_comment_payload(role: str, formula: dict, fol_text: str) -> tuple[dict, str]:
+    payload = {
+        "artifact_kind": "provekit-contract-comment-sugar",
+        "concept_site_cid": _cid("1"),
+        "contract_cid": _cid("2"),
+        "emitted_by": {
+            "kit_cid": _cid("3"),
+            "kit_kind": "realize",
+            "target_language": "python",
+        },
+        "fol_text": fol_text,
+        "ir_formula_jcs": formula,
+        "ir_formula_jcs_cid": cid_of_json(formula),
+        "local_contract_cid": _cid("2"),
+        "loss_record_cid": _cid("4"),
+        "policy_cid": _cid("5"),
+        "role": role,
+        "schema_version": "1",
+        "sugar_dict_cid": _cid("6"),
+    }
+    return payload, cid_of_json(payload)
+
+
+def _comment_lines(payload: dict, payload_cid: str) -> str:
+    return (
+        "# provekit-contract: "
+        + json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        + "\n"
+        + f"# provekit-contract-payload-cid: {payload_cid}\n"
+    )
 
 
 def test_bind_lift_source_emits_language_neutral_entries() -> None:
@@ -135,3 +198,131 @@ def test_bind_rpc_lift_returns_ir_document(tmp_path: Path) -> None:
     assert response["result"]["kind"] == "ir-document"
     assert response["result"]["diagnostics"] == []
     assert response["result"]["ir"][0]["concept_annotation"] == "identity"
+
+
+def test_bind_lift_recovers_contract_comment_witness() -> None:
+    payload, payload_cid = _contract_comment_payload("pre", _formula_gte_x_zero(), "x >= 0")
+    source = (
+        _comment_lines(payload, payload_cid)
+        + "# concept: identity\n"
+        + "def wrap_identity(x: int) -> int:\n"
+        + "    return x\n"
+    )
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.diagnostics == []
+    witnesses = result.ir[0]["witnesses"]
+    assert len(witnesses) == 1
+    witness = witnesses[0]
+    assert witness["role"] == "pre"
+    assert witness["source_kind"] == "native-surface"
+    assert witness["confidence_basis_points"] == 10000
+    assert witness["predicate"] == _formula_gte_x_zero()
+    assert witness["predicate_text"] == "x >= 0"
+    assert witness["extension_fields"] == {
+        "concept_site_cid": _cid("1"),
+        "contract_cid": _cid("2"),
+        "ir_formula_jcs_cid": cid_of_json(_formula_gte_x_zero()),
+        "local_contract_cid": _cid("2"),
+        "loss_record_cid": _cid("4"),
+        "payload_cid": payload_cid,
+        "policy_cid": _cid("5"),
+        "sugar_dict_cid": _cid("6"),
+        "surface": "contract-comment-sugar",
+    }
+
+
+def test_bind_lift_recovers_docstring_contract_comment_witness() -> None:
+    payload, payload_cid = _contract_comment_payload("post", _formula_out_eq_x(), "out == x")
+    source = (
+        "def wrap_identity(x: int) -> int:\n"
+        "    \"\"\"\n"
+        "    human prose stays non-authoritative\n"
+        "    provekit-contract: "
+        + json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        + "\n"
+        f"    provekit-contract-payload-cid: {payload_cid}\n"
+        "    \"\"\"\n"
+        "    return x\n"
+    )
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.diagnostics == []
+    witness = result.ir[0]["witnesses"][0]
+    assert witness["role"] == "post"
+    assert witness["predicate"] == _formula_out_eq_x()
+    assert witness["extension_fields"]["payload_cid"] == payload_cid
+
+
+def test_bind_lift_contract_comment_fails_closed_for_bad_payloads() -> None:
+    payload, payload_cid = _contract_comment_payload("pre", _formula_gte_x_zero(), "x >= 0")
+    cases = [
+        _comment_lines({**payload, "role": "sideways"}, cid_of_json({**payload, "role": "sideways"})),
+        _comment_lines({**payload, "schema_version": "2"}, cid_of_json({**payload, "schema_version": "2"})),
+        _comment_lines({**payload, "ir_formula_jcs_cid": _cid("7")}, cid_of_json({**payload, "ir_formula_jcs_cid": _cid("7")})),
+        _comment_lines(payload, _cid("8")),
+        "# provekit-contract: {not json}\n",
+    ]
+
+    for prefix in cases:
+        result = lift_source(prefix + "def f(x: int) -> int:\n    return x\n", "pkg/foo.py")
+
+        assert result.ir[0].get("witnesses", []) == []
+        assert any(diag["kind"] == "contract-comment-invalid" for diag in result.diagnostics)
+
+
+def test_bind_lift_recovers_decorator_contract_witnesses() -> None:
+    source = (
+        "from provekit_lift_py_tests.decorators import contract\n"
+        "@contract(pre=\"x >= 0\", post=\"out >= 0\")\n"
+        "def nonnegative_identity(x: int) -> int:\n"
+        "    return x\n"
+    )
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.diagnostics == []
+    witnesses = result.ir[0]["witnesses"]
+    assert [witness["role"] for witness in witnesses] == ["pre", "post"]
+    assert [witness["predicate_text"] for witness in witnesses] == ["x >= 0", "out >= 0"]
+    assert all(witness["source_kind"] == "native-surface" for witness in witnesses)
+    assert all(
+        witness["extension_fields"]["surface"] == "python-decorator-contract"
+        for witness in witnesses
+    )
+
+
+def test_python_realize_then_lift_keeps_contract_and_concept_site_cids() -> None:
+    realized = emit_stub(
+        function="wrap_identity",
+        params=["x"],
+        param_types=["int"],
+        return_type="int",
+        concept_name="identity",
+        contract={
+            "concept_site_cid": _cid("1"),
+            "local_contract_cid": _cid("2"),
+            "object_fcm_cid": _cid("3"),
+            "origin": "evidence-lift[native-surface]",
+            "discharge_verdict": "exact",
+            "witnesses": [
+                {
+                    "role": "pre",
+                    "predicate": _formula_gte_x_zero(),
+                    "predicate_text": "x >= 0",
+                    "source_kind": "native-surface",
+                }
+            ],
+        },
+    )
+
+    result = lift_source(realized["source"], "generated.py")
+
+    assert result.diagnostics == []
+    witness = result.ir[0]["witnesses"][0]
+    assert witness["extension_fields"]["concept_site_cid"] == _cid("1")
+    assert witness["extension_fields"]["contract_cid"] == _cid("2")
+    assert witness["extension_fields"]["local_contract_cid"] == _cid("2")
+    assert witness["predicate"] == _formula_gte_x_zero()

--- a/implementations/python/provekit-realize-python-core/pyproject.toml
+++ b/implementations/python/provekit-realize-python-core/pyproject.toml
@@ -7,7 +7,9 @@ name = "provekit-realize-python-core"
 version = "0.1.0"
 description = "PEP 1.7.0 Python realize kit for ProvekIt bind canonical output"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "blake3>=0.3.0",
+]
 
 [project.scripts]
 provekit-realize-python = "provekit_realize_python_core.__main__:main"

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
@@ -8,10 +8,21 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+import blake3
+
 BODY_TEMPLATE_REL = Path(
     "menagerie/python-language-signature/specs/body-templates/python-canonical-bodies.json"
 )
 PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
+DEFAULT_KIT_CID = "blake3-512:" + blake3.blake3(
+    b"provekit-realize-python-core@0.1.0"
+).digest(length=64).hex()
+DEFAULT_POLICY_CID = "blake3-512:" + blake3.blake3(
+    b"provekit-realize-python-core/default-contract-comment-policy"
+).digest(length=64).hex()
+DEFAULT_SUGAR_DICT_CID = "blake3-512:" + blake3.blake3(
+    b"provekit-realize-python-core/contract-comment-sugar-v1"
+).digest(length=64).hex()
 
 
 @dataclass(frozen=True)
@@ -31,16 +42,176 @@ def emit_stub(
     param_types: list[str],
     return_type: str,
     concept_name: str,
+    contract: dict[str, Any] | None = None,
+    sugar_cids: list[str] | None = None,
+    sugar_plugins: list[Any] | None = None,
 ) -> dict[str, Any]:
     body = body_template_for(concept_name, params, param_types, return_type)
     is_stub = body is None
     if body is None:
         body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
-    return {
-        "source": _function_source(function, params, body),
+    contract_lines = contract_comment_lines(contract, sugar_cids or [], sugar_plugins or [])
+    result = {
+        "source": _function_source(function, params, body, leading_lines=contract_lines),
         "is_stub": is_stub,
         "extension": "py",
     }
+    if contract_lines:
+        result["observed_loss_record"] = {}
+        result["used_sugars"] = [sugar_cids[0]] if sugar_cids else []
+    return result
+
+
+def contract_comment_lines(
+    contract: dict[str, Any] | None,
+    sugar_cids: list[str],
+    sugar_plugins: list[Any],
+) -> list[str]:
+    if not isinstance(contract, dict):
+        return []
+    witnesses = contract.get("witnesses")
+    if not isinstance(witnesses, list):
+        return []
+
+    lines: list[str] = []
+    for witness in witnesses:
+        if not isinstance(witness, dict):
+            continue
+        payload = _contract_comment_payload(contract, witness, sugar_cids, sugar_plugins)
+        if payload is None:
+            continue
+        payload_cid = _cid_of_json(payload)
+        payload_json = json.dumps(
+            payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        lines.append(f"# provekit-contract: {payload_json}")
+        lines.append(f"# provekit-contract-payload-cid: {payload_cid}")
+    return lines
+
+
+def _contract_comment_payload(
+    contract: dict[str, Any],
+    witness: dict[str, Any],
+    sugar_cids: list[str],
+    sugar_plugins: list[Any],
+) -> dict[str, Any] | None:
+    role = _payload_role(str(witness.get("role", "")))
+    predicate = witness.get("predicate")
+    if role is None or not isinstance(predicate, dict):
+        return None
+
+    concept_site_cid = contract.get("concept_site_cid")
+    local_contract_cid = contract.get("local_contract_cid")
+    if not isinstance(concept_site_cid, str) or not isinstance(local_contract_cid, str):
+        return None
+
+    extension_fields = witness.get("extension_fields")
+    contract_cid = None
+    if isinstance(extension_fields, dict):
+        value = extension_fields.get("contract_cid")
+        if isinstance(value, str):
+            contract_cid = value
+    if contract_cid is None:
+        contract_cid = local_contract_cid
+
+    fol_text = witness.get("predicate_text")
+    if not isinstance(fol_text, str) or not fol_text:
+        fol_text = _formula_debug_text(predicate)
+
+    loss_record: dict[str, Any] = {}
+    payload: dict[str, Any] = {
+        "artifact_kind": "provekit-contract-comment-sugar",
+        "concept_site_cid": concept_site_cid,
+        "contract_cid": contract_cid,
+        "emitted_by": {
+            "kit_cid": DEFAULT_KIT_CID,
+            "kit_kind": "realize",
+            "target_language": "python",
+        },
+        "fol_text": fol_text,
+        "ir_formula_jcs": predicate,
+        "ir_formula_jcs_cid": _cid_of_json(predicate),
+        "local_contract_cid": local_contract_cid,
+        "loss_record_cid": _cid_of_json(loss_record),
+        "policy_cid": _policy_cid(contract),
+        "role": role,
+        "schema_version": "1",
+        "sugar_dict_cid": _sugar_dict_cid(sugar_cids, sugar_plugins),
+    }
+    return payload
+
+
+def _payload_role(role: str) -> str | None:
+    match role:
+        case "pre" | "post" | "throws" | "observation":
+            return role
+        case "inv" | "invariant":
+            return "invariant"
+        case _:
+            return None
+
+
+def _policy_cid(contract: dict[str, Any]) -> str:
+    value = contract.get("policy_cid")
+    if isinstance(value, str) and value.startswith("blake3-512:"):
+        return value
+    return DEFAULT_POLICY_CID
+
+
+def _sugar_dict_cid(sugar_cids: list[str], sugar_plugins: list[Any]) -> str:
+    if sugar_cids:
+        return sugar_cids[0]
+    for plugin in sugar_plugins:
+        if not isinstance(plugin, dict):
+            continue
+        header = plugin.get("header")
+        cid = header.get("cid") if isinstance(header, dict) else None
+        if isinstance(cid, str):
+            return cid
+    return DEFAULT_SUGAR_DICT_CID
+
+
+def _cid_of_json(value: Any) -> str:
+    return (
+        "blake3-512:"
+        + blake3.blake3(_canonical_json_bytes(value)).digest(length=64).hex()
+    )
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _formula_debug_text(formula: dict[str, Any]) -> str:
+    if formula.get("kind") == "atomic":
+        name = formula.get("name")
+        args = formula.get("args")
+        if isinstance(name, str) and isinstance(args, list):
+            rendered = ", ".join(_term_debug_text(arg) for arg in args)
+            return f"{name}({rendered})"
+    return "<formula>"
+
+
+def _term_debug_text(term: Any) -> str:
+    if isinstance(term, dict):
+        if term.get("kind") == "var" and isinstance(term.get("name"), str):
+            return term["name"]
+        if term.get("kind") == "const":
+            return repr(term.get("value"))
+        if term.get("kind") == "ctor" and isinstance(term.get("name"), str):
+            args = term.get("args")
+            if isinstance(args, list):
+                rendered = ", ".join(_term_debug_text(arg) for arg in args)
+                return f"{term['name']}({rendered})"
+    return "<?>"
 
 
 def body_template_for(
@@ -152,11 +323,20 @@ def entries() -> tuple[BodyTemplateEntry, ...]:
     return tuple(out)
 
 
-def _function_source(function: str, params: list[str], body: str) -> str:
+def _function_source(
+    function: str,
+    params: list[str],
+    body: str,
+    *,
+    leading_lines: list[str] | None = None,
+) -> str:
     param_list = ", ".join(params)
     body_lines = body.splitlines() or ["pass"]
     indented = "\n".join(f"    {line}" if line else "" for line in body_lines)
-    return f"def {function}({param_list}):\n{indented}\n"
+    prefix = ""
+    if leading_lines:
+        prefix = "\n".join(leading_lines) + "\n"
+    return f"{prefix}def {function}({param_list}):\n{indented}\n"
 
 
 def _int_or_none(value: Any) -> int | None:

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
@@ -44,6 +44,11 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
                 param_types=_string_list(params.get("param_types")),
                 return_type=str(params.get("return_type", "")),
                 concept_name=str(params.get("concept_name", "")),
+                contract=params.get("contract") if isinstance(params.get("contract"), dict) else None,
+                sugar_cids=_string_list(params.get("sugar_cids")),
+                sugar_plugins=params.get("sugar_plugins")
+                if isinstance(params.get("sugar_plugins"), list)
+                else [],
             ),
         }
     if method == "provekit.plugin.shutdown":

--- a/implementations/python/provekit-realize-python-core/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -9,6 +10,66 @@ if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
 from provekit_realize_python_core.realizer import emit_stub
+
+
+def _cid(ch: str) -> str:
+    return "blake3-512:" + ch * 128
+
+
+def _formula_gte_x_zero() -> dict:
+    return {
+        "args": [
+            {"kind": "var", "name": "x"},
+            {
+                "kind": "const",
+                "sort": {"kind": "primitive", "name": "Int"},
+                "value": 0,
+            },
+        ],
+        "kind": "atomic",
+        "name": "≥",
+    }
+
+
+def _formula_out_eq_x() -> dict:
+    return {
+        "args": [{"kind": "var", "name": "out"}, {"kind": "var", "name": "x"}],
+        "kind": "atomic",
+        "name": "=",
+    }
+
+
+def _contract_payload() -> dict:
+    return {
+        "concept_site_cid": _cid("1"),
+        "local_contract_cid": _cid("2"),
+        "object_fcm_cid": _cid("3"),
+        "origin": "evidence-lift[native-surface]",
+        "discharge_verdict": "exact",
+        "witnesses": [
+            {
+                "role": "pre",
+                "predicate": _formula_gte_x_zero(),
+                "predicate_text": "x >= 0",
+                "source_kind": "native-surface",
+            },
+            {
+                "role": "post",
+                "predicate": _formula_out_eq_x(),
+                "predicate_text": "out == x",
+                "source_kind": "native-surface",
+            },
+        ],
+    }
+
+
+def _contract_comment_payloads(source: str) -> list[dict]:
+    payloads: list[dict] = []
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# provekit-contract: "):
+            payloads.append(json.loads(stripped.removeprefix("# provekit-contract: ")))
+    return payloads
 
 
 def test_identity_renders_python_function_from_body_template() -> None:
@@ -99,3 +160,34 @@ def test_unknown_concept_falls_back_to_python_stub() -> None:
         "is_stub": True,
         "extension": "py",
     }
+
+
+def test_contract_witnesses_emit_liftable_contract_comment_payloads() -> None:
+    result = emit_stub(
+        function="wrap_identity",
+        params=["x"],
+        param_types=["int"],
+        return_type="int",
+        concept_name="identity",
+        contract=_contract_payload(),
+    )
+
+    source = result["source"]
+    assert source.index("# provekit-contract:") < source.index("def wrap_identity")
+    assert source.count("# provekit-contract-payload-cid: blake3-512:") == 2
+
+    payloads = _contract_comment_payloads(source)
+    assert [payload["role"] for payload in payloads] == ["pre", "post"]
+    for payload in payloads:
+        assert payload["artifact_kind"] == "provekit-contract-comment-sugar"
+        assert payload["schema_version"] == "1"
+        assert payload["concept_site_cid"] == _cid("1")
+        assert payload["contract_cid"] == _cid("2")
+        assert payload["local_contract_cid"] == _cid("2")
+        assert payload["emitted_by"]["kit_kind"] == "realize"
+        assert payload["emitted_by"]["target_language"] == "python"
+        assert payload["ir_formula_jcs_cid"].startswith("blake3-512:")
+        assert payload["loss_record_cid"].startswith("blake3-512:")
+        assert payload["policy_cid"].startswith("blake3-512:")
+        assert payload["sugar_dict_cid"].startswith("blake3-512:")
+        assert isinstance(payload["ir_formula_jcs"], dict)


### PR DESCRIPTION
## Summary
- emit liftable Python contract-comment payloads from the Python realize kit when bind passes contract witnesses
- relift Python line-comment/docstring contract payloads into structured bind witnesses with fail-closed CID/formula validation
- relift `@contract(pre=..., post=...)` decorator surfaces as native-surface witnesses
- add pydantic source/witness bridge helpers with explicit loss records for stricter original contracts

Closes #928.

## Tests
- `pytest -q implementations/python/provekit-realize-python-core/tests`
- `pytest -q implementations/python/provekit-lift-python-source/tests`
- `pytest -q implementations/python/provekit-lift-py-tests/tests/test_decorators.py implementations/python/provekit-lift-py-tests/tests/test_lift_pydantic.py`
- `make test-python`
- `git diff --check`