### PR TITLE
feat(bootstrap D1): libprovekit Rust-lifter surface audit

### DIFF
--- a/bootstrap/libprovekit-gap-report.md
+++ b/bootstrap/libprovekit-gap-report.md
@@ -1,0 +1,165 @@
+# libprovekit Rust Surface Audit
+
+## Summary
+
+Audit scope was `implementations/rust/libprovekit/src` plus the direct sibling crates named in `libprovekit/Cargo.toml`: `provekit-canonicalizer`, `provekit-proof-envelope`, and `provekit-ir-types`. The CLI `provekit lift` in this branch dispatches configured plugins and does not expose a `--language rust` flag, so classification used the current direct Rust lifter surface in `provekit-walk` (`rust_function_term_json`, `type_decl`, and bind-lift behavior).
+
+Total items audited: 1109
+
+- handles-fully: 217
+- handles-partially-with-loss-record: 309
+- refuses-with-typed-reason: 583
+
+## Per-crate breakdown
+
+### libprovekit
+
+| handles-fully | handles-partially-with-loss-record | refuses-with-typed-reason |
+| ---: | ---: | ---: |
+| 150 | 127 | 414 |
+
+### provekit-canonicalizer
+
+| handles-fully | handles-partially-with-loss-record | refuses-with-typed-reason |
+| ---: | ---: | ---: |
+| 7 | 3 | 28 |
+
+### provekit-ir-types
+
+| handles-fully | handles-partially-with-loss-record | refuses-with-typed-reason |
+| ---: | ---: | ---: |
+| 51 | 175 | 108 |
+
+### provekit-proof-envelope
+
+| handles-fully | handles-partially-with-loss-record | refuses-with-typed-reason |
+| ---: | ---: | ---: |
+| 9 | 4 | 33 |
+
+## Gap classes (grouped by refusal reason)
+
+### unsupported-return-type (267 items)
+
+- `libprovekit::canonical::json_to_cvalue`
+- `libprovekit::ci::ci_job_result_name`
+- `libprovekit::ci::cid_set`
+- `libprovekit::ci::impl CIBlastRadius::cid`
+- `libprovekit::ci::impl CIImpactBodyClaim::cid`
+
+### let-binding (175 items)
+
+- `libprovekit::canonical::is_blake3_512_cid`
+- `libprovekit::canonical::json_cid`
+- `libprovekit::canonical::json_jcs`
+- `libprovekit::ci::check_ci_body`
+- `libprovekit::ci::impl CIBlastRadiusInput::build`
+
+### term-emitter-unsupported (64 items)
+
+- `libprovekit::ci::admit_identical_reuse`
+- `libprovekit::ci::impl CIBlastRadius::validate`
+- `libprovekit::ci::impl CIImpactBodyClaim::validate`
+- `libprovekit::ci::impl CIJobResultBodyClaim::validate`
+- `libprovekit::ci::impl CIReuseBodyClaim::validate`
+
+### ffi-call (44 items)
+
+- `libprovekit::ci::insert_many`
+- `libprovekit::ci::insert_required`
+- `libprovekit::ci::require_cid_field`
+- `libprovekit::ci::require_nonempty`
+- `libprovekit::ci::require_one_of`
+
+### complex-generic (25 items)
+
+- `libprovekit::canonical::serializable_cid`
+- `libprovekit::canonical::serializable_jcs`
+- `libprovekit::core::primitives::address`
+- `libprovekit::core::traits::impl HashMapCatalog::insert`
+- `libprovekit::core::types::impl ArityShape::named`
+
+### statement-macro (5 items)
+
+- `libprovekit::compose::impl AliasingMemento::to_jcs_value`
+- `libprovekit::core::types::impl Cid::from_hash_output`
+- `provekit-canonicalizer::hash::tests::distinct_inputs_distinct_hashes`
+- `provekit-canonicalizer::jcs::tests::empty_object_and_array`
+- `provekit-proof-envelope::sign::tests::verify_rejects_malformed`
+
+### nested-item (3 items)
+
+- `provekit-ir-types::lib::migration_json_to_canonical`
+- `provekit-ir-types::lib::proof_run_json_to_canonical`
+- `provekit-ir-types::lib::serde_json_to_canonical_value`
+
+## Partial-handle classes (grouped by loss-record dimension)
+
+### procedural-macro (254 items)
+
+- `libprovekit::ci::CIJobResult`
+- `libprovekit::ci::CINondeterminismMode`
+- `libprovekit::ci::CIReuseReason`
+- `libprovekit::ci::CIBlastRadius`
+- `libprovekit::ci::CIBlastRadiusInput`
+
+### trait-path-truncated (33 items)
+
+- `libprovekit::compose::impl std::fmt::Display for OpacityError`
+- `libprovekit::core::types::impl fmt::Display for Cid`
+- `libprovekit::desugar::impl fmt::Display for Refusal`
+- `libprovekit::desugar::impl std::error::Error for Refusal`
+- `provekit-ir-types::lib::impl std::error::Error for CanonicalizationExtensionError`
+
+### impl-associated-type-not-lowered (12 items)
+
+- `libprovekit::compose::impl TryFrom<&FunctionContractMemento> for provekit_ir_types :: DomainClaim::Error`
+- `libprovekit::core::types::impl TryFrom<&str> for Cid::Error`
+- `libprovekit::core::types::impl TryFrom<DomainClaim> for Refutation::Error`
+- `libprovekit::core::types::impl TryFrom<DomainClaim> for Truth::Error`
+- `libprovekit::core::types::impl TryFrom<String> for Cid::Error`
+
+### abi-attribute-not-carried (5 items)
+
+- `libprovekit::ffi::pk_compose_chain_contracts`
+- `libprovekit::ffi::pk_composition_result_body_jcs`
+- `libprovekit::ffi::pk_composition_result_cid`
+- `libprovekit::ffi::pk_composition_result_error`
+- `libprovekit::ffi::pk_composition_result_free`
+
+### impl-generics-not-carried (2 items)
+
+- `libprovekit::core::types::impl Deserialize<'de> for Cid`
+- `provekit-ir-types::lib::impl Deserialize<'de> for PolicyMemento`
+
+### complex-generic (1 items)
+
+- `libprovekit::core::traits::Domain::discharge`
+
+### impl-associated-const-not-lowered (1 items)
+
+- `provekit-ir-types::lib::impl DomainClaim::KIND`
+
+### type-sort-opaque (1 items)
+
+- `libprovekit::core::traits::DischargeMode`
+
+## Recommended D2 sub-issues
+
+- fix `unsupported-return-type` (267 items): extend return sort support beyond Unit, Bool, and integer terms.
+- fix `procedural-macro` (254 items): accept named loss for bootstrap unless the attribute changes semantic identity, then add attribute mementos.
+- fix `let-binding` (175 items): extend the term emitter to lower let bindings into the existing `let` operation instead of refusing Stmt::Local.
+- fix `term-emitter-unsupported` (64 items): extend the Rust lifter for this syntax class or file an explicit non-goal if it is not needed for bootstrap.
+- fix `ffi-call` (44 items): extend the lifter with call/method call terms and route unresolved effects into typed call mementos.
+- fix `trait-path-truncated` (33 items): record this as accepted named loss unless D2 needs the missing detail for soundness.
+- fix `complex-generic` (25 items): extend type and impl mementos to carry generics and where predicates before treating them as full lifts.
+- fix `impl-associated-type-not-lowered` (12 items): record this as accepted named loss unless D2 needs the missing detail for soundness.
+- fix `abi-attribute-not-carried` (5 items): record this as accepted named loss unless D2 needs the missing detail for soundness.
+- fix `statement-macro` (5 items): treat macro definitions and macro call bodies as explicit loss unless expanded HIR becomes available.
+- fix `nested-item` (3 items): extend the Rust lifter for this syntax class or file an explicit non-goal if it is not needed for bootstrap.
+
+## Out-of-scope and known-noisy
+
+- `#[cfg(test)]` and unit-test helper items under audited `src/` files are included because they are Rust items in the source surface, but they should not drive bootstrap production leaf priority unless the same gap appears in production code.
+- Direct dependency crates are included only because `libprovekit` composes them through its manifest. Other workspace consumers of `libprovekit`, such as `provekit-mint-amp`, are outside this D1 surface pass.
+- Build scripts, benches, external `tests/`, and third-party dependency sources are excluded.
+- `derive`, `serde`, `repr`, `no_mangle`, and `cfg_attr` entries are treated as current lifter loss because the type/function mementos do not expand or encode those attributes.

--- a/bootstrap/libprovekit-surface-audit.csv
+++ b/bootstrap/libprovekit-surface-audit.csv
@@ -1,0 +1,1110 @@
+crate,file,item_kind,item_name,outcome,gap_summary
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,is_blake3_512_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,json_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,json_jcs,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,json_to_cvalue,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,serializable_cid,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,serializable_jcs,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/ci.rs,enum,CIJobResult,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,enum,CINondeterminismMode,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,enum,CIReuseReason,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,admit_identical_reuse,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,check_ci_body,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,ci_job_result_name,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,cid_set,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIBlastRadius::cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIBlastRadius::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIBlastRadiusInput::build,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIImpactBodyClaim::cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIImpactBodyClaim::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIImpactInput::build,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIJobResultBodyClaim::cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIJobResultBodyClaim::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIJobResultInput::build,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIReuseBodyClaim::cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIReuseBodyClaim::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIReuseInput::build,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl Default for CINondeterminism::default,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,insert_many,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,insert_required,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,message,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_cid_field,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::Call
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_cid_vec,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::ForLoop
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_equal,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Path
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_input_cids_close,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_nonempty,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_nonempty_strings,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::ForLoop
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_one_of,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_producer,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,sorted_unique,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIBlastRadius,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIBlastRadiusInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIImpactBodyClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIImpactInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIJobResultBodyClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIJobResultInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIReuseBodyClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIReuseInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl Default for CINondeterminism,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIBlastRadius,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIBlastRadiusInput,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIBodyCheck,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIImpactBodyClaim,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIImpactInput,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIJobResultBodyClaim,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIJobResultInput,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CINondeterminism,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIProducer,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIReuseBodyClaim,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIReuseInput,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,const,AUTO_PROMOTE_LIFTER_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,const,CCP_VERSION,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,AliasingStatus,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,AtomicKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,CompositionError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,Effect,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,OpacityError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_aliasing_memento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_closure_binding,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_drop_contract,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_loop_invariant,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_try_branch,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::lookup_pin_invariant,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,aliasing_mementos_to_value,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,blocking_effects_for_steps,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,build_memento_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,build_value,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,cid_of_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_chain_contracts,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_chain_contracts_internal,refuses-with-typed-reason,ffi-call: cannot prove expression is Int for term emission: Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_function_contracts,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_function_contracts_checked,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_with_composed,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,composition_error_to_refusal,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compound_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::bare_fcm_error_is_deterministic,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::bare_fcm_returns_unbound_contract_error,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::minimal_fcm,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::unbound_contract_display_is_informative,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::unbound_contract_error_variant_matches,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_args_json,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_classification,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_discharge_key,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_occurrence_kind,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_occurrences_for_steps,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_set_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,evidence_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::auto_promotion_source_kind_is_annotation,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::auto_promotion_uses_all_zeros_sentinel_lifter_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::compound_cid_is_symmetric_with_serde_roundtrip,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::compound_round_trips_via_json,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::evidence_cid_is_symmetric_with_serde_roundtrip,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::extension_fields_contain_auto_promoted_from,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::fcm_with_pre_post,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::identical_fcms_produce_identical_compound_cids,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::into_compound_matches_promote_fn,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::nontrivial_fcm_compound_composed_pre_post_match_fcm,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::nontrivial_fcm_promotes_to_single_evidence_compound,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::nontrivial_post,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::nontrivial_pre,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::trivial_fcm_compound_composed_pre_post_are_trivial,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::trivial_fcm_promotes_to_single_evidence_not_zero,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::trivial_formula,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,find_namespaced_result,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,find_result_equation,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,formula_to_canonical,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl AliasingMemento::to_jcs_value,refuses-with-typed-reason,statement-macro: unsupported statement Stmt::Macro
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl AliasingStatus::as_str,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl AtomicKind::as_str,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl CompositionError::failure_detail,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl CompositionError::failure_kind,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Effect::sort_key,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Effect::to_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::add,refuses-with-typed-reason,term-emitter-unsupported: unsupported unit expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::check_opacity_effects,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::ForLoop
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::empty,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::is_pure,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::to_value,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl From<&FunctionContractMemento> for CompoundContractMemento::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl FunctionContractMemento::check_aliasing_discharged,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::ForLoop
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl FunctionContractMemento::is_pure,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl FunctionContractMemento::result_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl FunctionContractMemento::result_var_name,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Locus::is_unknown,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Locus::to_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Locus::unknown,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_aliasing_memento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_closure_binding,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_drop_contract,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_loop_invariant,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_try_branch,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::lookup_pin_invariant,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl TryFrom<&FunctionContractMemento> for provekit_ir_types :: DomainClaim::try_from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl std::fmt::Display for OpacityError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,jcs_bytes_of_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,promote_fcm_to_compound,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,serde_to_canonical,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,sort_to_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl AliasingMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl AliasingStatus,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl AtomicKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl CompositionError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl Effect,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl EffectSet,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl EffectSet,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl From<&FunctionContractMemento> for CompoundContractMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl FunctionContractMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl Locus,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl OpacityMementoLookup for EmptyOpacityPool,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl TryFrom<&FunctionContractMemento> for provekit_ir_types :: DomainClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl std::fmt::Display for OpacityError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+libprovekit,implementations/rust/libprovekit/src/compose.rs,mod,domain_claim_fcm_tests,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,mod,fcm_auto_promote_tests,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,AliasingMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,ChainStep,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,ComposedFunctionContract,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,EffectSet,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Default) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,EmptyOpacityPool,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,FunctionContractMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,Locus,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Default) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,PinInvariantMementoView,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,impl TryFrom<&FunctionContractMemento> for provekit_ir_types :: DomainClaim::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+libprovekit,implementations/rust/libprovekit/src/compose.rs,trait,OpacityMementoLookup,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,enum,LiftPluginKitError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::dialect,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::parse,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::prove,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::serialize,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::transform,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::claim_from_response_term,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::dispatch,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::legacy_response_from_term,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::parse_session,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKitSession::legacy_response,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKitSession::response,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,legacy_response_from_term,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,lift_request_from_input,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,lift_response_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,primitive_sort,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,read_response,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,response_term,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,impl,impl Kit for LiftPluginKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,impl,impl LiftPluginKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,impl,impl LiftPluginKitSession,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,struct,LiftPluginKit,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,struct,LiftPluginKitSession,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,lift_plugin,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,primitives,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,stubs,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,traits,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,types,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,verbs,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,enum,ComposeError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,address,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,compose,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Field
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,compose_function_contract_claims,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,compose_verdict,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,composed_to_contract,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,dropper,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,resolve,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,sign,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Assign
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,verify_sig,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,artifact_reference_term,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Default for CKit::default,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Default for RustKit::default,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Domain for FunctionContractDomain::discharge,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Domain for FunctionContractDomain::name,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Domain for FunctionContractDomain::project,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::dialect,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::parse,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::prove,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::serialize,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::transform,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::dialect,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::parse,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::prove,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::serialize,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::transform,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Portfolio for NoopPortfolio::solve,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,parse_stub_input,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,prove_stub_claim,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,serialize_stub_term,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,term_formals,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,term_name,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,transform_stub_input,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Default for CKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Default for RustKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Domain for FunctionContractDomain,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Kit for CKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Kit for RustKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Portfolio for NoopPortfolio,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,struct,CKit,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,struct,FunctionContractDomain,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy , Default) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,struct,NoopPortfolio,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy , Default) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,struct,RustKit,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,CoreError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,DischargeMode,handles-partially-with-loss-record,type-sort-opaque: 1 variant field type(s) degrade to opaque or unknown sort
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,DomainError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,KitError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,SolverVerdict,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Canonical::canonical_bytes,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Catalog::get,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Domain::discharge,handles-partially-with-loss-record,complex-generic: DischargeMode < '_ > has lifetime/const/binding generic arguments not preserved by Sort
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Domain::name,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Domain::project,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,InputCatalog::get_input,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::dialect,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::parse,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::prove,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::serialize,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::transform,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Portfolio::solve,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl Catalog for HashMapCatalog::get,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl HashMapCatalog::insert,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl HashMapCatalog::put,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl HashMapInputCatalog::insert,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl HashMapInputCatalog::put,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl InputCatalog for HashMapInputCatalog::get_input,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,impl,impl Catalog for HashMapCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,impl,impl HashMapCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,impl,impl HashMapInputCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,impl,impl InputCatalog for HashMapInputCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,struct,HashMapCatalog,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Default) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,struct,HashMapInputCatalog,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Default) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Canonical,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Catalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Domain,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,InputCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Kit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Portfolio,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,const,PATH_DOCUMENT_KIND,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,ArityShape,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,CidError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Dialect,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Hash , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,DomainKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Hash , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Input,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,PathDocumentError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,PathError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,PathInputMaterial,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,SignatureCatalogError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,SlotEvaluation,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy , PartialEq , Eq , Default , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,SlotSort,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy , PartialEq , Eq , Default , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Term,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Verdict,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,VerdictCoercionError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Witness,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,_let_binding_from_term,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,any_sort,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,arity_shape_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,contract_to_cvalue,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,domain_claim_to_value,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,formula_true,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::named,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::named_slots,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::positional,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::set,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::set_of,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl AritySlot::evaluated,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl AritySlot::unevaluated,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl AritySlot::with_shape,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Assign
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl AritySlot::with_slot_sort,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Assign
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for & str::canonical_bytes,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Cid::canonical_bytes,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for DomainClaim::canonical_bytes,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for FunctionContractMemento::canonical_bytes,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Input::canonical_bytes,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for IrFormula::canonical_bytes,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Path::canonical_bytes,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for String::canonical_bytes,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Term::canonical_bytes,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Witness::canonical_bytes,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Cid::as_str,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Cid::from_hash_output,refuses-with-typed-reason,statement-macro: unsupported statement Stmt::Macro
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Cid::into_string,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Cid::parse,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Default for Boundary::default,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Deserialize<'de> for Cid::deserialize,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl DomainClaim::canonical_bytes,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl DomainClaim::cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl DomainClaim::union,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl DomainClaim::unsigned,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl From<Cid> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl From<IrTerm> for Term::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl From<Term> for IrTerm::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::children_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::operation,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::term_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::term_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::with_operation,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Path::cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Path::ordered_steps,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Path::step,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Path::terminal_steps,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl PathDocument::from_path_and_inputs,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl PathDocument::materialized_inputs,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Field
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl PathInputMaterial::to_input,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl PathInputMaterial::try_from_input,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Refutation::claim,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Refutation::into_claim,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Serialize for Cid::serialize,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Truth::claim,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Truth::into_claim,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl TryFrom<&str> for Cid::try_from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl TryFrom<DomainClaim> for Refutation::try_from,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Field
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl TryFrom<DomainClaim> for Truth::try_from,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Field
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl TryFrom<String> for Cid::try_from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl fmt::Display for Cid::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,input_kind,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,input_to_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,jcs_bytes_for_json,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,jcs_bytes_for_serialize,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,json_to_cvalue,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,memento_from_parts,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,operation_name_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,path_algebra_to_value,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,path_to_value,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,require_arity,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,slot_evaluation_is_default,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Unary
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,slot_sort_is_default,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Unary
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl ArityShape,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl AritySlot,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for & str,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for DomainClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for FunctionContractMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Input,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for IrFormula,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Path,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for String,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Term,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Witness,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Default for Boundary,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Deserialize<'de> for Cid,handles-partially-with-loss-record,impl-generics-not-carried: type_decl impl memento carries target and trait name but not impl generics or where predicates
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl DomainClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl From<Cid> for String,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl From<IrTerm> for Term,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl From<Term> for IrTerm,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl LanguageSignature,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Path,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl PathDocument,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl PathInputMaterial,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Refutation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Serialize for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Truth,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl TryFrom<&str> for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl TryFrom<DomainClaim> for Refutation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl TryFrom<DomainClaim> for Truth,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl TryFrom<String> for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl fmt::Display for Cid,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,AritySlot,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Attestation,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Boundary,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Cid,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Hash , PartialOrd , Ord) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,DomainClaim,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,LanguageSignature,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,OperationSignature,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Path,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,PathAlgebra,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,PathDocument,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,PathInputBinding,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Refutation,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Truth,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,impl TryFrom<&str> for Cid::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,impl TryFrom<DomainClaim> for Refutation::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,impl TryFrom<DomainClaim> for Truth::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,impl TryFrom<String> for Cid::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,cross_compile,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,link,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,link_by_shared_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,link_verdict,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,prove,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,realize,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,shared_contract_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,transform,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,verify,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,const,MAX_REWRITE_STEPS,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,enum,EquationTerm,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,enum,RefusalKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,certify_confluence,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::ForLoop
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,certify_termination,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,collect_non_core_ops,refuses-with-typed-reason,term-emitter-unsupported: unsupported unit expression Expr::Match
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,desugar,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,extract_wp_obligation,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,graph_reaches,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,has_cycle,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugarRule::from_json_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugarRule::lhs_root,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugarRule::try_from_json_value,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugaringSet::new,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugaringSet::non_core_ops,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugaringSet::rules,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::collect_op_names,refuses-with-typed-reason,term-emitter-unsupported: unsupported unit expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::contains_unifiable_subpattern,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Match
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::from_json,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::op_names,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::root_op_name,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::substitute,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl Refusal::kind,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl Refusal::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl RefusalKind::as_str,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl fmt::Display for Refusal::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,is_trivially_true,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,load_desugaring_rules_from_dir,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,match_lhs,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,match_pattern,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Match
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,names_alias,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Path
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,parse_sort,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Let
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,patterns_unify,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Match
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,refusal_from_error,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,required_string,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,rewrite_once_innermost,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,string_field,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,unqualified,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl DesugarRule,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl DesugaringSet,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl EquationTerm,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl Refusal,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl RefusalKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl fmt::Display for Refusal,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl std::error::Error for Refusal,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,AppliedRewrite,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,DesugarOutput,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,DesugarRule,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,DesugaringSet,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,Refusal,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,WpObligation,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,enum,PropagationDecision,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,fn,propagate_effects,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,fn,tests::info,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,fn,tests::propagates_until_async_boundary_and_public_refusal,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,mod,tests,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,CallsiteEdge,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,ChangedCallsite,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,FunctionEffectInfo,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,PendingCallsite,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,PropagationInput,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,PropagationPlan,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,enum,EffectDto,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Deserialize , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,enum,FfiError,handles-partially-with-loss-record,procedural-macro: derive(Debug) is not expanded or represented
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,compose_chain_contracts_jcs,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl AliasingMementoDto::into_memento,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl EffectDto::into_effect,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl FfiError::message,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl From<LocusDto> for Locus::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl pk_composition_result::err,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl pk_composition_result::ok,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,inner_compose,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_compose_chain_contracts,handles-partially-with-loss-record,abi-attribute-not-carried: #[no_mangle] is not represented in type or function memento
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_composition_result_body_jcs,handles-partially-with-loss-record,abi-attribute-not-carried: #[no_mangle] is not represented in type or function memento
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_composition_result_cid,handles-partially-with-loss-record,abi-attribute-not-carried: #[no_mangle] is not represented in type or function memento
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_composition_result_error,handles-partially-with-loss-record,abi-attribute-not-carried: #[no_mangle] is not represented in type or function memento
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_composition_result_free,handles-partially-with-loss-record,abi-attribute-not-carried: #[no_mangle] is not represented in type or function memento
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,read_jcs_input,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl AliasingMementoDto,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl EffectDto,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl FfiError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl From<LocusDto> for Locus,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl pk_composition_result,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,AliasingMementoDto,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,AtomEnvelope,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,LocusDto,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Deserialize , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,MementoBody,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,pk_composition_result,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,enum,ProvekitError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , thiserror :: Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,canonical,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,ci,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,compose,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,core,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,desugar,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,effect_propagation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,ffi,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,promotion_decision_registry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,substrate_default_cids,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,transport,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,witness_registry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,wp,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,enum,PromotionDecisionRegistryError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , thiserror :: Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,consensus_vector,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,eval_predicate,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl ConsensusPolicy::admits,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Field
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl ConsensusPolicy::from_json_str,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionKey::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::admit,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::admit_json_str,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::admit_many,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::get,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::statuses,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,index_entries,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Field
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,metric_value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,outcome_count,refuses-with-typed-reason,ffi-call: cannot prove expression is Int for term emission: Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,parse_predicate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::ForLoop
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,payload_string,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,payload_string_array,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,witnesses_consulted,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Let
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,impl,impl ConsensusPolicy,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,impl,impl PromotionDecisionKey,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,impl,impl PromotionDecisionRegistry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,ConsensusPolicy,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,ConsensusThreshold,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Deserialize) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,PromotionDecisionKey,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , PartialOrd , Ord) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,PromotionDecisionRegistry,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Default) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,PromotionStatus,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,PromotionSummary,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/substrate_default_cids.rs,const,CONTRACT_OBSERVATION_CONCEPT_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/substrate_default_cids.rs,const,LOG_EMIT_CONCEPT_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/transport.rs,enum,TransportError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/transport.rs,fn,impl OperationTransport::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/transport.rs,fn,impl TermTransport::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/transport.rs,fn,impl TermTransport::operation,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/transport.rs,fn,transport_term,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/transport.rs,impl,impl OperationTransport,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/transport.rs,impl,impl TermTransport,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/transport.rs,struct,OperationTransport,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/transport.rs,struct,TermTransport,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Default) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,enum,WitnessRegistryError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , thiserror :: Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::admit,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::admit_json_str,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::admit_many,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::get,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::is_empty,refuses-with-typed-reason,ffi-call: cannot prove expression is Int for term emission: Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::len,refuses-with-typed-reason,ffi-call: cannot prove expression is Int for term emission: Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,impl,impl WitnessRegistry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,struct,WitnessRegistry,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Default) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,const,DEFAULT_RESULT_VAR,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,const,RESERVED_POSTCONDITION,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,const,SLOT_TRANSFORMER_PREFIX,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,enum,Refusal,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , thiserror :: Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,enum,SlotKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,enum,WpError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , thiserror :: Error) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,OpContractResolver::lookup,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,aggregate_conjunction,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,discharge_one_evidence,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,find_result_equation,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,free_vars_formula,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,free_vars_formula_into,refuses-with-typed-reason,term-emitter-unsupported: unsupported unit expression Expr::Match
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,free_vars_term,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,free_vars_term_into,refuses-with-typed-reason,term-emitter-unsupported: unsupported unit expression Expr::Match
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,fresh_name,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,handle_formula_binder,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Path
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl OpContractInfo::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl OpContractInfo::rule,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl OpContractInfo::synthesize_value_rule,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl OpContractInfo::value_expr,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl SlotInfo::stmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl SlotInfo::value,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl SlotKind::from_slot_sort_and_hint,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,is_atomic_true,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Macro
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,is_postcondition_placeholder,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Macro
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,is_slot_transformer_name,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,postcondition_placeholder,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,reduce_each,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,reduce_formula,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,slot_transformer_name,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,substitute_in_formula,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,substitute_in_term,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,value_expr_of_term,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,wp,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,wp_compound,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Match
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,wp_op,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,wp_with_result_var,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+libprovekit,implementations/rust/libprovekit/src/wp.rs,impl,impl OpContractInfo,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,impl,impl SlotInfo,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,impl,impl SlotKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,mod,tests,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,struct,CompoundDischargeReport,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,struct,EvidenceVerdict,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,struct,OpContractInfo,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,struct,SlotInfo,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,trait,OpContractResolver,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,const,PINNED_APPLY_NODE_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,const,PINNED_SUBSTITUTE_NODE_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,add_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,and,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,apply,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,apply_node_round_trips_and_canonicalizes_deterministically,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,arity_mismatch_is_a_bug_not_a_refusal,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,atomic,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,authored_if_rule_dijkstra_shape_with_propositional_branches,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,authored_if_rule_instantiated,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,base_resolver,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,contains_schema_node,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Match
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,div_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,eq_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,evaluates_seq_if_return_skip_body,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,evidence_ref,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,formula_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,if_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,impl MapResolver::with,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,impl OpContractResolver for MapResolver::lookup,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,implies,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,int_sort,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,ir_const,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,ir_var,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,make_compound,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,make_evidence,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,malformed_rule_applying_a_non_slot_transformer,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,malformed_rule_applying_a_transformer_for_a_missing_slot,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,neg_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,no_rule_for_value_op_with_no_post,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,not,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,op_term,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,opaque_call_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,opaque_while_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,prop,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,refuses_opaque_loop_naming_the_loop_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,refuses_unknown_op_as_unresolved_call,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,refuses_unresolved_call_naming_the_callee,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,return_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,sentinel_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,seq_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,serde_to_cvalue,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,skip_contract,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,subst,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,substitute_node_round_trips_and_canonicalizes_deterministically,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,synthesize_value_rule_returns_the_substitute_schema_node,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,synthesizes_add_rule_pre_and_q_substituted,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,synthesizes_add_rule_substitutes_into_a_q_that_mentions_result,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,synthesizes_div_rule_not_zero_guard,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,t_const,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,t_op,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,t_var,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,test_locator,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_all_exact_yields_exact,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_empty_evidences_is_exact,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_is_deterministic,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_multiple_lossy_evidences_union_loss_records,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_one_lossy_evidence_yields_lossy,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_one_refuse_yields_compound_refuse,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_other_strategy_returns_err,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_refuse_dominates_lossy,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_report_carries_compound_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_single_exact_evidence,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_unimplemented_strategy_returns_err,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_of_leaves,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,impl,impl MapResolver,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,impl,impl OpContractResolver for MapResolver,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,struct,MapResolver,handles-partially-with-loss-record,procedural-macro: derive(Default) is not expanded or represented
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/bin/compute_fixture_cid.rs,fn,main,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/bin/compute_fixture_cid.rs,fn,to_cvalue,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.invariant.rs,fn,ctor1,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.invariant.rs,fn,invariants,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,const,BLAKE3_512_PREFIX,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,blake3_512_hex,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,blake3_512_of,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,tests::deterministic_across_calls,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,tests::distinct_inputs_distinct_hashes,refuses-with-typed-reason,statement-macro: unsupported statement Stmt::Macro
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,tests::empty_string_hashes_to_known_blake3,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,mod,tests,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.invariant.rs,fn,ctor1,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.invariant.rs,fn,invariants,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,encode_jcs,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,encode_string,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::MethodCall
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,encode_value,refuses-with-typed-reason,term-emitter-unsupported: unsupported unit expression Expr::Match
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::empty_object_and_array,refuses-with-typed-reason,statement-macro: unsupported statement Stmt::Macro
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::encode_nested_array_object,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::encode_simple_object_sorts_keys,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::escape_quotes_and_backslash,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::mixed_ascii_and_unicode_preserved,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::unicode_atomic_predicates_round_trip_verbatim,refuses-with-typed-reason,term-emitter-unsupported: unsupported unit expression Expr::ForLoop
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::unicode_in_object_key_and_value,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,mod,tests,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/lib.rs,enum,CanonicalizerError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , thiserror :: Error) is not expanded or represented"
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/lib.rs,mod,hash,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/lib.rs,mod,jcs,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/lib.rs,mod,value,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,enum,Value,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,enum,ValueKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy , PartialEq , Eq) is not expanded or represented"
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::array,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::boolean,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::integer,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::kind,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::null,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::object,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::string,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,impl,impl Value,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,const,impl DomainClaim::KIND,handles-partially-with-loss-record,impl-associated-const-not-lowered: impl associated const is ignored by type_decl lifter
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,AggregationStrategy,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,BridgeTarget,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,CanonicalizationProfileKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,CatalogKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,CatalogSnapshotMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,Classification,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,Declaration,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,DivergentSemanticsTag,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,DomainClaimConversionError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,GapKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,InvalidReceiptError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,InvariantViolation,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,IrFormula,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,IrTerm,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,LossSeverityLevel,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ModeClassification,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,MorphismDirection,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,OccurrenceKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,OccurrenceRole,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,OptionStatus,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ParametricRealizationError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PipelineKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PolicyMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PromotionDecisionInvariantError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PromotionGate,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PromotionResult,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ProofRunVerdict,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,RealizationPlanError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ResolutionOptionKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,RunVerdict,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,Sort,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,SourceKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,StageVerdict,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,UnsupportedEquivalencePolicy,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ValidationError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,Value,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,VerdictKind,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,canonical_set_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,canonical_value_from_json,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,classify_mode,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Macro
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_compose_input_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_header_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_signature,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_tests::canonical_impure_refusal,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_tests::canonical_impure_refusal_round_trips_and_recomputes_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_tests::cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_tests::same_canonical_refusal_inputs_mint_same_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl AggregateSummaryMemento::recompute_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl AggregateSummaryMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl CrossLanguageWitnessPair::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl Deserialize<'de> for PolicyMemento::deserialize,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl DomainClaim::unsigned,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl EffectOccurrence::classify,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl EffectOccurrence::classify_atomic_access,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl EffectOccurrence::classify_drop,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<AggregationStrategy> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<CanonicalizationProfileKind> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<CatalogKind> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<DivergentSemanticsTag> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<NamespacedExtensionPolicyMemento> for NamespacedExtensionPolicyMementoWire::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<OccurrenceKind> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<PipelineKind> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<PromotionGate> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<SourceKind> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<String> for AggregationStrategy::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<String> for DivergentSemanticsTag::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<String> for PromotionGate::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<String> for SourceKind::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<UnsupportedEquivalencePolicy> for String::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<serde_json::Error> for MigrationReceiptError::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<serde_json::Error> for PromotionDecisionCanonicalizationError::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<serde_json::Error> for ProofRunCanonicalizationError::from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl HaltMemento::recompute_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl HaltMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl LanguageTransitionMemento::recompute_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl LanguageTransitionMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl LossRecordMemento::recompute_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl LossRecordMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrateReceiptEnvelope::index,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrateReceiptEnvelope::parse_json_str,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrateReceiptEnvelope::recompute_root_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrateReceiptEnvelope::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrationConceptSiteMemento::recompute_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrationConceptSiteMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrationReceiptError::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::forbid_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::invalid_verdict,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::require_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::require_verdict_in,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Match
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObservationWrapperMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Match
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl OccurrenceKind::from_str,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ParametricRealizationMemento::validate,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PipelineMemento::validate,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PromotionDecisionCanonicalizationError::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PromotionDecisionMemento::recompute_header_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PromotionDecisionMemento::to_jcs_string,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PromotionDecisionMemento::validate,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ProofRunCanonicalizationError::new,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ProofRunMemento::recompute_header_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ProofRunMemento::to_jcs_string,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl RealizationPlanMemento::validate_against,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl RefusalMemento::recompute_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl RefusalMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl RunMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl Serialize for NamespacedExtensionPolicyMemento::serialize,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl StageReceipt::recompute_header_cid,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl StageReceipt::to_jcs_string,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<&ConceptSiteMemento> for DomainClaim::try_from,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<NamespacedExtensionPolicyMementoWire> for NamespacedExtensionPolicyMemento::try_from,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::Call
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for CanonicalizationProfileKind::try_from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for CatalogKind::try_from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for OccurrenceKind::try_from,refuses-with-typed-reason,term-emitter-unsupported: unsupported boolean expression Expr::Let
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for PipelineKind::try_from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for UnsupportedEquivalencePolicy::try_from,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl WitnessMemento::recompute_cid,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl WitnessMemento::validate,refuses-with-typed-reason,term-emitter-unsupported: unsupported expression statement Expr::Try
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for CanonicalizationExtensionError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for CatalogKindError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for DomainClaimConversionError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for DuplicateInSetError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for InvalidReceiptError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for MigrationReceiptError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for OccurrenceKind::fmt,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for OccurrenceKindError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for ParametricRealizationError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for PipelineKindError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for PromotionDecisionCanonicalizationError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for PromotionDecisionInvariantError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for ProofRunCanonicalizationError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for RealizationPlanError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for ValidationError::fmt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,is_namespaced_extension,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,is_namespaced_policy_kind,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,is_policy_kind_segment,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,migration_cid_without_keys,refuses-with-typed-reason,complex-generic: generic params or where predicates are not carried in emitted rust term
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,migration_json_to_canonical,refuses-with-typed-reason,nested-item: unsupported statement Stmt::Item
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,parse_migrate_receipt,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,parse_verdict_kind,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,proof_run_json_to_canonical,refuses-with-typed-reason,nested-item: unsupported statement Stmt::Item
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,require_kind,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Path
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,require_matching_cid,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Path
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,require_non_empty,refuses-with-typed-reason,ffi-call: unsupported boolean expression Expr::MethodCall
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,require_schema,refuses-with-typed-reason,term-emitter-unsupported: cannot prove expression is Int for term emission: Expr::Path
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,serde_json_to_canonical_value,refuses-with-typed-reason,nested-item: unsupported statement Stmt::Item
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl AggregateSummaryMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl CrossLanguageWitnessPair,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl Deserialize<'de> for PolicyMemento,handles-partially-with-loss-record,impl-generics-not-carried: type_decl impl memento carries target and trait name but not impl generics or where predicates
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl DomainClaim,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl EffectOccurrence,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<AggregationStrategy> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<CanonicalizationProfileKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<CatalogKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<DivergentSemanticsTag> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<NamespacedExtensionPolicyMemento> for NamespacedExtensionPolicyMementoWire,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<OccurrenceKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<PipelineKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<PromotionGate> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<SourceKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<String> for AggregationStrategy,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<String> for DivergentSemanticsTag,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<String> for PromotionGate,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<String> for SourceKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<UnsupportedEquivalencePolicy> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<serde_json::Error> for MigrationReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<serde_json::Error> for PromotionDecisionCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<serde_json::Error> for ProofRunCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl HaltMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl LanguageTransitionMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl LossRecordMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl MigrateReceiptEnvelope,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl MigrationConceptSiteMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl MigrationReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ObligationReceiptMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ObservationWrapperMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl OccurrenceKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ParametricRealizationMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl PipelineMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl PromotionDecisionCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl PromotionDecisionMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ProofRunCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ProofRunMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl RealizationPlanMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl RefusalMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl RunMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl Serialize for NamespacedExtensionPolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl StageReceipt,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<&ConceptSiteMemento> for DomainClaim,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<NamespacedExtensionPolicyMementoWire> for NamespacedExtensionPolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for CanonicalizationProfileKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for CatalogKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for OccurrenceKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for PipelineKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for UnsupportedEquivalencePolicy,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl WitnessMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for CanonicalizationExtensionError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for CatalogKindError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for DomainClaimConversionError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for DuplicateInSetError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for InvalidReceiptError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for MigrationReceiptError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for OccurrenceKindError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for ParametricRealizationError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for PipelineKindError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for PromotionDecisionCanonicalizationError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for PromotionDecisionInvariantError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for ProofRunCanonicalizationError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for RealizationPlanError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for ValidationError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for CanonicalizationExtensionError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for CatalogKindError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for DomainClaimConversionError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for DuplicateInSetError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for InvalidReceiptError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for MigrationReceiptError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for OccurrenceKind,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for OccurrenceKindError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for ParametricRealizationError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for PipelineKindError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for PromotionDecisionCanonicalizationError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for PromotionDecisionInvariantError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for ProofRunCanonicalizationError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for RealizationPlanError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for ValidationError,handles-partially-with-loss-record,trait-path-truncated: type_decl impl memento stores only last trait path segment
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,mod,composition_refusal_tests,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,AbstractionSlot,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,AggregateSummaryMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BlockingEffect,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BridgeDeclarationV14,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BridgeEnvelope,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BridgeHeaderV14,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BridgeMetadataV14,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CanonicalizationExtensionError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CanonicalizationProfileMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CanonicalizationRuleDescriptor,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CatalogKindError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CatalogSnapshotGenesis,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CatalogSnapshotSuccessor,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CodeSite,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CodeSiteSpan,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompositionRefusalEnvelope,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompositionRefusalHeader,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompositionRefusalMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompositionRefusalMetadata,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompoundContractMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ConceptAbstractionMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ConceptSiteMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ConceptSiteProvenance,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CrossLanguageWitnessPair,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,Discharge,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,DomainClaim,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,DomainClaimProvenance,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,DuplicateInSetError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EffectOccurrence,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EffectSlotDescriptor,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EvidenceCertificate,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EvidenceMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EvidenceRef,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EvidenceTerm,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,FieldDelta,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,GapReason,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize , Default) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,HaltMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,HumanAcceptancePolicyMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,IncompatiblePair,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LanguageTransitionMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LetBinding,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LossRecord,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize , Default) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LossRecordMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LossyHomomorphismObligation,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LossyMorphismMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrateReceiptEnvelope,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrateReceiptIndex,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrateReceiptSignature,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrationConceptSiteMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrationEffectDelta,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrationReceiptError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrationSourceLocation,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MissingRequirement,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,NamespacedExtensionPolicyMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,NamespacedExtensionPolicyMementoWire,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ObligationReceiptMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ObservationWrapperMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,OccurrenceKindError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ParametricRealizationMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PartialHomomorphismObligation,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PartialMorphismMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PipelineKindError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PipelineMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PrimitiveSort,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionCanonicalizationError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionEnvelope,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionHeader,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionMetadata,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize , Default) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofGatePolicyMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunCanonicalizationError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunEnvelope,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunHeader,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunMetadata,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize , Default) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PropertyPolicyMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RealizationDesugaringMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RealizationPlanMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RealizationPost,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RefusalMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RepresentationConstraint,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ResolutionOption,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RunMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RuntimeGuard,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SignaturePolicyMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SlotDescriptor,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SortMorphismEnvelope,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SortMorphismHeader,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SortMorphismMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SortMorphismMetadata,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize , Default) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SourceLocator,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SourceLocatorPoint,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SourceLocatorSpan,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,StageReceipt,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,StageReceiptHeader,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,StageReceiptMetadata,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize , Default) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ThresholdPolicyMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,TransportGapMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,VerdictBody,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,WitnessMemento,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,WitnessRef,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , PartialEq , Eq , Serialize , Deserialize) is not expanded or represented"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<&ConceptSiteMemento> for DomainClaim::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<NamespacedExtensionPolicyMementoWire> for NamespacedExtensionPolicyMemento::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for CanonicalizationProfileKind::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for CatalogKind::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for OccurrenceKind::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for PipelineKind::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for UnsupportedEquivalencePolicy::Error,handles-partially-with-loss-record,impl-associated-type-not-lowered: impl associated type is ignored by type_decl lifter
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.invariant.rs,fn,ctor1,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.invariant.rs,fn,invariants,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,enum,CborMajor,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone , Copy) is not expanded or represented"
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_append_head,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_array_head,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_bstr,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_map_head,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_tstr,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_uint,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,tests::shortest_form_uint,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,tests::tstr_round_trip_head,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,mod,tests,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/lib.rs,enum,ProofEnvelopeError,handles-partially-with-loss-record,"procedural-macro: derive(Debug , thiserror :: Error) is not expanded or represented"
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/lib.rs,mod,cbor,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/lib.rs,mod,proof,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/lib.rs,mod,sign,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.invariant.rs,fn,ctor1,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.invariant.rs,fn,invariants,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,body_pairs_unsigned,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,build_proof_envelope,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,emit_sorted_map,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::MethodCall
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,encode_key,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,make_bytes_pair,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,make_members_pair,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,make_string_pair,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,tests::build_minimal_proof_round_trips,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,mod,tests,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,struct,CborPair,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,struct,ProofEnvelopeInput,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,struct,ProofEnvelopeOutput,handles-partially-with-loss-record,"procedural-macro: derive(Debug , Clone) is not expanded or represented"
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.invariant.rs,fn,ctor1,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.invariant.rs,fn,invariants,refuses-with-typed-reason,ffi-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,const,ED25519_KEY_PREFIX,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,const,ED25519_SIG_PREFIX,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_pubkey_string,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_sign_string,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_sign_with_seed,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_verify_bytes,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_verify_string,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::deterministic_signature_for_fixed_seed,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::pubkey_form_has_prefix,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::string_form_has_prefix_and_base64,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::verify_raw_signature_round_trip,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::verify_rejects_malformed,refuses-with-typed-reason,statement-macro: unsupported statement Stmt::Macro
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::verify_round_trip,refuses-with-typed-reason,let-binding: unsupported statement Stmt::Local
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,mod,tests,handles-fully,


### PR DESCRIPTION
Closes #921. Refs umbrella #897 (Phase 4: libprovekit Rust bootstrap), top umbrella #922.

## Scope

Read-only audit of `implementations/rust/libprovekit/src` plus the direct sibling crates named in `libprovekit/Cargo.toml`: `provekit-canonicalizer`, `provekit-proof-envelope`, `provekit-ir-types`. The CLI `provekit lift` in this branch dispatches configured plugins and does not expose a `--language rust` flag, so classification used the current direct Rust lifter surface in `provekit-walk` (`rust_function_term_json`, `type_decl`, bind-lift).

## Findings

Total items audited: 1109.

| Outcome | Count |
|---|---:|
| handles-fully | 217 |
| handles-partially-with-loss-record | 309 |
| refuses-with-typed-reason | 583 |

### Top gap classes

| Class | Count |
|---|---:|
| unsupported-return-type | 267 |
| procedural-macro | 254 |
| let-binding | 175 |
| term-emitter-unsupported | 64 |
| ffi-call | 44 |
| trait-path-truncated | 33 |
| complex-generic | 25 |
| impl-associated-type-not-lowered | 12 |
| abi-attribute-not-carried | 5 |
| statement-macro | 5 |
| nested-item | 3 |

The load-bearing finding: the blocker is not unsafe Rust or async, it is the direct Rust term emitter's narrow return-type and statement coverage. The highest-leverage D2 item is `let-binding` (175 functions, maps cleanly to an existing `let` operation in the Rust signature).

## Deliverables

- `bootstrap/libprovekit-surface-audit.csv` (1110 lines: 1 header + 1109 data rows)
- `bootstrap/libprovekit-gap-report.md` (6 sections: Summary, Per-crate breakdown, Gap classes, Partial-handle classes, Recommended D2 sub-issues, Out-of-scope)

## Acceptance gates

- Em-dash + en-dash sweep: clean
- Two output files only (no source modifications)
- Read-only audit (no libprovekit or lifter source touched)

## Next

After merge: file D2-D7 sub-issues per the "Recommended D2 sub-issues" section. Each carries the gap class, count, example items, and approach hint.