### PR TITLE
feat(#930): learn concept names from human-edited emitted tags

### DIFF
--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -728,29 +728,69 @@ fn extract_concept_annotation(src: &str, fn_name: &str) -> Option<String> {
     for (i, line) in lines.iter().enumerate() {
         if line.contains(&needle) {
             let mut j = i;
+            let mut comment_annotation: Option<String> = None;
             while j > 0 {
                 let prev = lines[j - 1].trim_start();
+                if let Some(tag) = extract_emitted_concept_tag(prev) {
+                    return Some(tag);
+                }
                 if let Some(rest) = prev.strip_prefix("// concept:") {
-                    let trimmed = rest.trim().to_string();
-                    if trimmed.starts_with("UNNAMED-CONCEPT-") {
-                        return None;
+                    if comment_annotation.is_none() {
+                        comment_annotation = normalize_concept_annotation(rest);
                     }
-                    return Some(trimmed);
                 }
                 if prev.starts_with("#[")
                     || prev.starts_with("// substrate-origin:")
                     || prev.starts_with("// memento-cid:")
                     || prev.starts_with("// witness-inherited-from:")
+                    || prev.starts_with("// concept:")
                 {
                     j -= 1;
                     continue;
                 }
                 break;
             }
-            return None;
+            return comment_annotation;
         }
     }
     None
+}
+
+fn extract_emitted_concept_tag(line: &str) -> Option<String> {
+    for marker in ["provekit_monitor", "provekit_emitter", "provekit_witness"] {
+        let Some(marker_pos) = line.find(marker) else {
+            continue;
+        };
+        let rest = &line[marker_pos + marker.len()..];
+        let Some(concept_pos) = rest.find("concept") else {
+            continue;
+        };
+        let after_key = rest[concept_pos + "concept".len()..].trim_start();
+        let Some(after_eq) = after_key.strip_prefix('=') else {
+            continue;
+        };
+        let after_eq = after_eq.trim_start();
+        let Some(quoted) = after_eq.strip_prefix('"') else {
+            continue;
+        };
+        let Some(end) = quoted.find('"') else {
+            continue;
+        };
+        if let Some(name) = normalize_concept_annotation(&quoted[..end]) {
+            return Some(name);
+        }
+    }
+    None
+}
+
+fn normalize_concept_annotation(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let name = trimmed.strip_prefix("concept:").unwrap_or(trimmed).trim();
+    if name.is_empty() || name.starts_with("UNNAMED-CONCEPT-") {
+        None
+    } else {
+        Some(name.to_string())
+    }
 }
 
 fn term_shape_for_fn(item_fn: &syn::ItemFn) -> std::sync::Arc<CValue> {
@@ -960,6 +1000,40 @@ pub fn wrap_positive(amount: usize) -> Option<usize> {
         );
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn concept_annotation_reads_human_edited_emitted_monitor_tag() {
+        let src = r#"
+// concept: deposit-then-balance
+// substrate-origin: annotation-lift
+// memento-cid: blake3-512:abc
+#[cfg_attr(any(), requires(amount > 0))]
+#[cfg_attr(any(), provekit_monitor(concept = "ledger-deposit"))]
+pub fn deposit(balance: i64, amount: i64) -> i64 {
+    balance + amount
+}
+"#;
+
+        assert_eq!(
+            extract_concept_annotation(src, "deposit").as_deref(),
+            Some("ledger-deposit")
+        );
+    }
+
+    #[test]
+    fn concept_annotation_strips_prefix_from_emitted_observation_tag() {
+        let src = r#"
+#[cfg_attr(any(), provekit_emitter(concept = "concept:ledger-deposit"))]
+pub fn deposit(balance: i64, amount: i64) -> i64 {
+    balance + amount
+}
+"#;
+
+        assert_eq!(
+            extract_concept_annotation(src, "deposit").as_deref(),
+            Some("ledger-deposit")
+        );
     }
 
     fn temp_workspace(name: &str) -> PathBuf {

--- a/protocol/specs/2026-05-13-bind-ir-lift-result.md
+++ b/protocol/specs/2026-05-13-bind-ir-lift-result.md
@@ -70,7 +70,7 @@ source-kind = "annotation"
 |----------------------|----------|---------|
 | `attr_pre`           | yes      | LEGACY compatibility precondition text extracted from older annotation-only lift kits. New producers SHOULD emit `null` and place all contract evidence in `witnesses[]`. Consumers MUST use this field only when `witnesses[]` is empty. |
 | `attr_post`          | yes      | LEGACY compatibility postcondition text extracted from older annotation-only lift kits. New producers SHOULD emit `null` and place all contract evidence in `witnesses[]`. Consumers MUST use this field only when `witnesses[]` is empty. |
-| `concept_annotation` | yes      | The NAME from a `// concept: NAME` (or language-equivalent) comment immediately preceding the function. The kit MUST strip the `concept:` prefix; producers emit `identity`, not `concept:identity`. `null` when absent. |
+| `concept_annotation` | yes      | The NAME from a `// concept: NAME` (or language-equivalent) comment immediately preceding the function, or from an emitted observation tag such as `provekit_monitor(concept = "NAME")` when that tag is the edited source surface. The kit MUST strip the `concept:` prefix; producers emit `identity`, not `concept:identity`. `null` when absent. |
 | `file`               | yes      | Path relative to the project root (the `workspace_root` lift-params field). Forward slashes only; the kit MUST normalize. |
 | `fn_line`            | yes      | The 1-based line number of the function declaration (the line containing the `fn`/`def`/method keyword). |
 | `fn_name`            | yes      | The function identifier exactly as it appears in source (no module qualification). |


### PR DESCRIPTION
Closes #930.

## Scope

The Rust bind lift extractor (`implementations/rust/provekit-walk/src/bin/walk_rpc.rs`) now learns concept names from emitted observation tags:

- `provekit_monitor`
- `provekit_emitter`
- `provekit_witness`

Normalization: edited values with an accidental `concept:` prefix get stripped. Empty values and `UNNAMED-CONCEPT-*` placeholder names are still ignored.

## Spec update

`protocol/specs/2026-05-13-bind-ir-lift-result.md` now explicitly admits emitted observation tags as a `concept_annotation` source surface.

## Verification

- `cargo test -p provekit-walk`: 236 lib tests + bin/integration/doc tests green
- `cargo test -p provekit-cli --test cmd_bind_integration annotate_monitor_injects_concept_and_monitor_attr`: passed
- `git diff --check origin/main`: clean
- Em-dash + en-dash sweep: clean

## Tests added

- Edited emitted monitor tags
- Prefixed emitted tags (`concept:foo` -> `foo`)

## Deferred

Parity work for non-Rust lift kits is left as follow-up if needed.

## Not admin-merged

Touches `provekit-walk` binary and a protocol spec; both are substrate-adjacent. Awaiting your read.