### PR TITLE
feat(bootstrap D2): Rust lifter — let-binding + return-type + ffi-call extensions

### DIFF
--- a/bootstrap/scripts/libprovekit_surface_audit.py
+++ b/bootstrap/scripts/libprovekit_surface_audit.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Audit libprovekit Rust functions through provekit-walk term emission.
+
+The original D1 audit artifacts are not present in this worktree. This driver
+walks the libprovekit Rust surface, invokes the real provekit-walk term emitter
+for each discovered function name, and tallies the refusal classes used by the
+D2 issue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+FN_RE = re.compile(
+    r"(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+)?(?:extern\s+\"[^\"]+\"\s+)?(?:async\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:<|\()"
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def rust_workspace(root: Path) -> Path:
+    return root / "implementations" / "rust"
+
+
+def default_surface(root: Path) -> list[Path]:
+    base = root / "implementations" / "rust" / "libprovekit"
+    paths = list((base / "src").rglob("*.rs")) + list((base / "tests").rglob("*.rs"))
+    return sorted(paths)
+
+
+def discover_functions(paths: list[Path]) -> list[tuple[Path, str]]:
+    out: list[tuple[Path, str]] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for match in FN_RE.finditer(text):
+            out.append((path, match.group(1)))
+    return out
+
+
+def build_emitter(root: Path) -> Path:
+    subprocess.run(
+        ["cargo", "build", "-p", "provekit-walk", "--bin", "provekit-walk-emit"],
+        cwd=rust_workspace(root),
+        check=True,
+    )
+    return rust_workspace(root) / "target" / "debug" / "provekit-walk-emit"
+
+
+def classify_failure(stderr: str) -> str:
+    if "Stmt::Local" in stderr or "let-binding" in stderr:
+        return "let-binding"
+    if "unsupported function return type" in stderr:
+        return "unsupported-return-type"
+    if "Expr::Call" in stderr or "Expr::MethodCall" in stderr:
+        return "ffi-call"
+    return "other"
+
+
+def run_one(emitter: Path, path: Path, function: str) -> dict:
+    proc = subprocess.run(
+        [str(emitter), "term", str(path), function],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    row = {
+        "path": str(path),
+        "function": function,
+        "status": "ok" if proc.returncode == 0 else "refused",
+        "refusal_class": None,
+        "handling": None,
+        "losses": [],
+        "stderr": proc.stderr.strip(),
+    }
+    if proc.returncode != 0:
+        row["refusal_class"] = classify_failure(proc.stderr)
+        return row
+    try:
+        emitted = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        row["status"] = "refused"
+        row["refusal_class"] = "invalid-json"
+        row["stderr"] = str(exc)
+        return row
+    row["handling"] = emitted.get("handling")
+    row["losses"] = [
+        loss.get("loss")
+        for loss in emitted.get("loss_record", [])
+        if isinstance(loss, dict) and loss.get("loss")
+    ]
+    return row
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--skip-build", action="store_true")
+    args = parser.parse_args()
+
+    root = repo_root()
+    emitter = rust_workspace(root) / "target" / "debug" / "provekit-walk-emit"
+    if not args.skip_build:
+        emitter = build_emitter(root)
+    if not emitter.exists():
+        parser.error(f"emitter not found: {emitter}")
+
+    functions = discover_functions(default_surface(root))
+    rows = [run_one(emitter, path, function) for path, function in functions]
+    refusals = Counter(row["refusal_class"] for row in rows if row["status"] == "refused")
+    handling = Counter(row["handling"] for row in rows if row["status"] == "ok")
+    losses = Counter(loss for row in rows for loss in row["losses"])
+    target_total = sum(refusals[name] for name in ("let-binding", "unsupported-return-type", "ffi-call"))
+
+    report = {
+        "surface_items": len(rows),
+        "status": Counter(row["status"] for row in rows),
+        "handling": handling,
+        "refusals": refusals,
+        "losses": losses,
+        "target_refusal_total": target_total,
+        "rows": rows,
+    }
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    print(f"surface_items={len(rows)}")
+    print(f"ok={report['status']['ok']} refused={report['status']['refused']}")
+    print(
+        "target_refusals "
+        f"let-binding={refusals['let-binding']} "
+        f"unsupported-return-type={refusals['unsupported-return-type']} "
+        f"ffi-call={refusals['ffi-call']} "
+        f"combined={target_total}"
+    )
+    print(
+        "handling "
+        f"handles-fully={handling['handles-fully']} "
+        f"handles-partially-with-loss-record={handling['handles-partially-with-loss-record']}"
+    )
+    if refusals:
+        print("refusals_by_class=" + json.dumps(dict(sorted(refusals.items())), sort_keys=True))
+    if losses:
+        print("losses=" + json.dumps(dict(sorted(losses.items())), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/implementations/rust/provekit-walk/src/bin/walk_emit.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_emit.rs
@@ -231,10 +231,38 @@ fn emit_term_mode(args: &[String]) -> ExitCode {
 }
 
 fn find_fn(file: &syn::File, name: &str) -> Option<syn::ItemFn> {
-    file.items.iter().find_map(|item| match item {
-        syn::Item::Fn(f) if f.sig.ident == name => Some(f.clone()),
-        _ => None,
-    })
+    find_fn_in_items(&file.items, name)
+}
+
+fn find_fn_in_items(items: &[syn::Item], name: &str) -> Option<syn::ItemFn> {
+    for item in items {
+        match item {
+            syn::Item::Fn(f) if f.sig.ident == name => return Some(f.clone()),
+            syn::Item::Impl(impl_block) => {
+                for impl_item in &impl_block.items {
+                    if let syn::ImplItem::Fn(method) = impl_item {
+                        if method.sig.ident == name {
+                            return Some(syn::ItemFn {
+                                attrs: method.attrs.clone(),
+                                vis: method.vis.clone(),
+                                sig: method.sig.clone(),
+                                block: Box::new(method.block.clone()),
+                            });
+                        }
+                    }
+                }
+            }
+            syn::Item::Mod(module) => {
+                if let Some((_, nested_items)) = &module.content {
+                    if let Some(found) = find_fn_in_items(nested_items, name) {
+                        return Some(found);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 fn all_param_names(item_fn: &syn::ItemFn) -> Vec<String> {

--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -16,10 +16,12 @@
 // JCS+BLAKE3-addressed bundle that downstream substrate tools (lift,
 // linker, mint) can consume.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
 
 use provekit_canonicalizer::Value;
+use quote::ToTokens;
 use serde_json::{json, Value as JsonValue};
+use syn::parse::Parser;
 use syn::{BinOp, Expr, ExprIf, Lit, ReturnType, Stmt, Type, UnOp};
 
 use crate::canonical::{cid_of_value, jcs_bytes_of_value, serde_to_canonical};
@@ -68,10 +70,18 @@ pub fn rust_function_term_json_value(
     let ctx = LoweringContext::from_item_fn(item_fn);
     let term = lower_function_body_to_term(item_fn, &ctx)?;
     let term_surface = term.surface();
+    let loss_record = ctx.loss_record_json();
+    let handling = if loss_record.is_empty() {
+        "handles-fully"
+    } else {
+        "handles-partially-with-loss-record"
+    };
     Ok(json!({
         "kind": "rust-algebra-term",
         "signature_cid": RUST_LANGUAGE_SIGNATURE_CID,
         "source": source.into(),
+        "handling": handling,
+        "loss_record": loss_record,
         "term_surface": term_surface,
         "term": term.to_json()?,
     }))
@@ -84,6 +94,12 @@ enum AlgebraTerm {
         args: Vec<AlgebraTerm>,
     },
     Var(String),
+    Symbol(String),
+    List(Vec<AlgebraTerm>),
+    Struct {
+        name: String,
+        fields: Vec<(String, AlgebraTerm)>,
+    },
     ConstInt(i64),
     ConstBool(bool),
     Unit,
@@ -119,6 +135,30 @@ impl AlgebraTerm {
                 }))
             }
             AlgebraTerm::Var(name) => Ok(json!({"kind": "var", "name": name})),
+            AlgebraTerm::Symbol(name) => Ok(json!({"kind": "symbol", "name": name})),
+            AlgebraTerm::List(items) => {
+                let items = items
+                    .iter()
+                    .map(AlgebraTerm::to_json)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(json!({"kind": "list", "items": items}))
+            }
+            AlgebraTerm::Struct { name, fields } => {
+                let fields = fields
+                    .iter()
+                    .map(|(field, value)| {
+                        Ok(json!({
+                            "name": field,
+                            "value": value.to_json()?,
+                        }))
+                    })
+                    .collect::<Result<Vec<_>, String>>()?;
+                Ok(json!({
+                    "kind": "struct",
+                    "name": name,
+                    "fields": fields,
+                }))
+            }
             AlgebraTerm::ConstInt(value) => Ok(json!({
                 "kind": "const",
                 "value": value,
@@ -149,6 +189,23 @@ impl AlgebraTerm {
                 format!("{name}({args})")
             }
             AlgebraTerm::Var(name) => name.clone(),
+            AlgebraTerm::Symbol(name) => name.clone(),
+            AlgebraTerm::List(items) => {
+                let items = items
+                    .iter()
+                    .map(AlgebraTerm::surface)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("[{items}]")
+            }
+            AlgebraTerm::Struct { name, fields } => {
+                let fields = fields
+                    .iter()
+                    .map(|(field, value)| format!("{field}: {}", value.surface()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{name}{{{fields}}}")
+            }
             AlgebraTerm::ConstInt(value) => value.to_string(),
             AlgebraTerm::ConstBool(value) => value.to_string(),
             AlgebraTerm::Unit => "unit".to_string(),
@@ -173,10 +230,36 @@ impl ExprSort {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ReturnShape {
+    Full(ExprSort),
+    Partial {
+        loss: &'static str,
+        rust_type: String,
+    },
+    Unsupported,
+}
+
+impl ReturnShape {
+    fn sort(&self) -> Option<ExprSort> {
+        match self {
+            ReturnShape::Full(sort) => Some(*sort),
+            ReturnShape::Partial { .. } | ReturnShape::Unsupported => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LossRecord {
+    loss: &'static str,
+    detail: String,
+}
+
+#[derive(Debug, Clone)]
 struct LoweringContext {
-    return_sort: Option<ExprSort>,
+    return_shape: ReturnShape,
     vars: HashMap<String, ExprSort>,
+    losses: Rc<RefCell<Vec<LossRecord>>>,
 }
 
 impl LoweringContext {
@@ -193,10 +276,55 @@ impl LoweringContext {
                 vars.insert(ident.ident.to_string(), sort);
             }
         }
-        Self {
-            return_sort: sort_from_return_type(&item_fn.sig.output),
-            vars,
+        let losses = Rc::new(RefCell::new(Vec::new()));
+        let return_shape = return_shape_from_return_type(&item_fn.sig.output);
+        if let ReturnShape::Partial { loss, rust_type } = &return_shape {
+            losses.borrow_mut().push(LossRecord {
+                loss,
+                detail: rust_type.clone(),
+            });
         }
+        Self {
+            return_shape,
+            vars,
+            losses,
+        }
+    }
+
+    fn with_var(&self, name: impl Into<String>, sort: Option<ExprSort>) -> Self {
+        let mut vars = self.vars.clone();
+        if let Some(sort) = sort {
+            vars.insert(name.into(), sort);
+        }
+        Self {
+            return_shape: self.return_shape.clone(),
+            vars,
+            losses: Rc::clone(&self.losses),
+        }
+    }
+
+    fn add_loss(&self, loss: &'static str, detail: impl Into<String>) {
+        let detail = detail.into();
+        let mut losses = self.losses.borrow_mut();
+        if !losses
+            .iter()
+            .any(|record| record.loss == loss && record.detail == detail)
+        {
+            losses.push(LossRecord { loss, detail });
+        }
+    }
+
+    fn loss_record_json(&self) -> Vec<JsonValue> {
+        self.losses
+            .borrow()
+            .iter()
+            .map(|record| {
+                json!({
+                    "loss": record.loss,
+                    "detail": record.detail,
+                })
+            })
+            .collect()
     }
 }
 
@@ -208,18 +336,52 @@ fn lower_function_body_to_term(
 }
 
 fn lower_stmts_to_stmt(stmts: &[Stmt], ctx: &LoweringContext) -> Result<AlgebraTerm, String> {
+    if let Some((first, rest)) = stmts.split_first() {
+        if let Stmt::Local(local) = first {
+            return lower_local_binding_to_stmt(local, rest, ctx);
+        }
+    }
+
     let mut lowered = Vec::new();
     for (idx, stmt) in stmts.iter().enumerate() {
         let is_tail = idx + 1 == stmts.len();
         match stmt {
             Stmt::Expr(expr, None) if is_tail => lowered.push(lower_tail_expr_to_stmt(expr, ctx)?),
             Stmt::Expr(expr, _) => lowered.push(lower_expr_to_stmt(expr, ctx)?),
-            Stmt::Local(_) => return Err("unsupported statement Stmt::Local".to_string()),
+            Stmt::Local(local) => {
+                return lower_local_binding_to_stmt(local, &stmts[idx + 1..], ctx)
+            }
             Stmt::Item(_) => return Err("unsupported statement Stmt::Item".to_string()),
             Stmt::Macro(_) => return Err("unsupported statement Stmt::Macro".to_string()),
         }
     }
     Ok(seq_all(lowered))
+}
+
+fn lower_local_binding_to_stmt(
+    local: &syn::Local,
+    rest: &[Stmt],
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    let Some(name) = simple_binding_name(&local.pat) else {
+        return Err("unsupported let-binding pattern".to_string());
+    };
+    let Some(init) = &local.init else {
+        return Err("unsupported let-binding without initializer".to_string());
+    };
+    let value = lower_expr_to_value_term(&init.expr, ctx)?;
+    let declared_sort = local_pat_type(&local.pat).and_then(sort_from_type);
+    let inferred_sort = declared_sort.or_else(|| expr_sort(&init.expr, ctx));
+    let nested_ctx = ctx.with_var(name.clone(), inferred_sort);
+    let body = lower_stmts_to_stmt(rest, &nested_ctx)?;
+    Ok(AlgebraTerm::op(
+        "let",
+        vec![
+            AlgebraTerm::op("pattern_bind", vec![AlgebraTerm::Symbol(name)]),
+            value,
+            body,
+        ],
+    ))
 }
 
 fn seq_all(terms: Vec<AlgebraTerm>) -> AlgebraTerm {
@@ -273,7 +435,7 @@ fn lower_expr_to_stmt(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm,
         Expr::Return(ret) => {
             let value = match &ret.expr {
                 Some(value) => lower_return_expr_to_value_term(value, ctx)?,
-                None if ctx.return_sort == Some(ExprSort::Unit) => AlgebraTerm::Unit,
+                None if ctx.return_shape.sort() == Some(ExprSort::Unit) => AlgebraTerm::Unit,
                 None => {
                     return Err("bare return in non-unit function".to_string());
                 }
@@ -301,11 +463,26 @@ fn lower_return_expr_to_value_term(
     expr: &Expr,
     ctx: &LoweringContext,
 ) -> Result<AlgebraTerm, String> {
-    match ctx.return_sort {
-        Some(ExprSort::Bool) => lower_expr_to_bool_term(expr, ctx),
-        Some(ExprSort::Int) => lower_expr_to_int_term(expr, ctx),
-        Some(ExprSort::Unit) => lower_expr_to_unit_term(expr),
-        None => Err("unsupported function return type for term emission".to_string()),
+    match &ctx.return_shape {
+        ReturnShape::Full(ExprSort::Bool) => {
+            if matches!(expr, Expr::Call(_) | Expr::MethodCall(_)) {
+                lower_expr_to_value_term(expr, ctx)
+            } else {
+                lower_expr_to_bool_term(expr, ctx)
+            }
+        }
+        ReturnShape::Full(ExprSort::Int) => {
+            if matches!(expr, Expr::Call(_) | Expr::MethodCall(_)) {
+                lower_expr_to_value_term(expr, ctx)
+            } else {
+                lower_expr_to_int_term(expr, ctx)
+            }
+        }
+        ReturnShape::Full(ExprSort::Unit) => lower_expr_to_unit_term(expr),
+        ReturnShape::Partial { .. } => lower_expr_to_value_term(expr, ctx),
+        ReturnShape::Unsupported => {
+            Err("unsupported function return type for term emission".to_string())
+        }
     }
 }
 
@@ -355,8 +532,15 @@ fn lower_expr_to_bool_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebra
                     "expected Bool path in boolean term, found {} for `{name}`",
                     sort.name()
                 )),
-                None => Err(format!("unknown path `{name}` in boolean term")),
+                None => {
+                    ctx.add_loss("type-inference-assumed-bool", name.clone());
+                    Ok(AlgebraTerm::Var(name))
+                }
             }
+        }
+        Expr::Call(_) | Expr::MethodCall(_) => {
+            ctx.add_loss("type-inference-assumed-bool", expr_kind(expr));
+            lower_expr_to_value_term(expr, ctx)
         }
         _ => Err(format!(
             "unsupported boolean expression {}",
@@ -373,6 +557,22 @@ fn lower_expr_to_int_term(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraT
             sort.name(),
             expr_kind(expr)
         )),
+        None if matches!(
+            expr,
+            Expr::Binary(_)
+                | Expr::Block(_)
+                | Expr::Call(_)
+                | Expr::Field(_)
+                | Expr::Index(_)
+                | Expr::MethodCall(_)
+                | Expr::Paren(_)
+                | Expr::Path(_)
+                | Expr::Unary(_)
+        ) =>
+        {
+            ctx.add_loss("type-inference-assumed-int", expr_kind(expr));
+            lower_expr_to_value_term(expr, ctx)
+        }
         None => Err(format!(
             "cannot prove expression is Int for term emission: {}",
             expr_kind(expr)
@@ -402,6 +602,7 @@ fn lower_expr_to_value_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebr
             .map(AlgebraTerm::Var)
             .ok_or_else(|| "empty path expression".to_string()),
         Expr::Paren(paren) => lower_expr_to_value_term(&paren.expr, ctx),
+        Expr::Group(group) => lower_expr_to_value_term(&group.expr, ctx),
         Expr::Block(block) => {
             let Some(tail) = block_single_tail_expr(&block.block) else {
                 return Err("block expression has no single tail expression".to_string());
@@ -449,6 +650,60 @@ fn lower_expr_to_value_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebr
                 ],
             ))
         }
+        Expr::Call(call) => lower_call_expr_to_value_term(call, ctx),
+        Expr::MethodCall(method) => lower_method_call_expr_to_value_term(method, ctx),
+        Expr::Array(array) => {
+            let items = array
+                .elems
+                .iter()
+                .map(|expr| lower_expr_to_value_term(expr, ctx))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(AlgebraTerm::op("array", vec![AlgebraTerm::List(items)]))
+        }
+        Expr::Repeat(repeat) => Ok(AlgebraTerm::op(
+            "array_repeat",
+            vec![
+                lower_expr_to_value_term(&repeat.expr, ctx)?,
+                lower_expr_to_int_term(&repeat.len, ctx)?,
+            ],
+        )),
+        Expr::Tuple(tuple) => {
+            if tuple.elems.is_empty() {
+                return Ok(AlgebraTerm::Unit);
+            }
+            let items = tuple
+                .elems
+                .iter()
+                .map(|expr| lower_expr_to_value_term(expr, ctx))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(AlgebraTerm::op("tuple", vec![AlgebraTerm::List(items)]))
+        }
+        Expr::Struct(strukt) => lower_struct_expr_to_value_term(strukt, ctx),
+        Expr::Field(field) => Ok(AlgebraTerm::op(
+            "field",
+            vec![
+                lower_expr_to_value_term(&field.base, ctx)?,
+                AlgebraTerm::Symbol(field.member.to_token_stream().to_string()),
+            ],
+        )),
+        Expr::Index(index) => Ok(AlgebraTerm::op(
+            "index",
+            vec![
+                lower_expr_to_value_term(&index.expr, ctx)?,
+                lower_expr_to_int_term(&index.index, ctx)?,
+            ],
+        )),
+        Expr::Try(try_expr) => {
+            let op = match &ctx.return_shape {
+                ReturnShape::Partial { loss, .. } if *loss == "return-type-option" => "try_option",
+                _ => "try",
+            };
+            Ok(AlgebraTerm::op(
+                op,
+                vec![lower_expr_to_value_term(&try_expr.expr, ctx)?],
+            ))
+        }
+        Expr::Macro(mac) if mac.mac.path.is_ident("vec") => lower_vec_macro_to_value_term(mac, ctx),
         Expr::Reference(reference) => {
             let op = if reference.mutability.is_some() {
                 "borrow_mut"
@@ -463,6 +718,90 @@ fn lower_expr_to_value_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebr
         Expr::Cast(_) => Err("unsupported value expression Expr::Cast".to_string()),
         _ => Err(format!("unsupported value expression {}", expr_kind(expr))),
     }
+}
+
+fn lower_call_expr_to_value_term(
+    call: &syn::ExprCall,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    let callee = match &*call.func {
+        Expr::Path(path) => path_name(path).unwrap_or_else(|| "unknown".to_string()),
+        other => {
+            ctx.add_loss(
+                "ffi-call-unresolved-callee",
+                format!("non-path callee {}", expr_kind(other)),
+            );
+            "unknown".to_string()
+        }
+    };
+    ctx.add_loss("ffi-call-unresolved-effect", callee.clone());
+    let args = call
+        .args
+        .iter()
+        .map(|arg| lower_expr_to_value_term(arg, ctx))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(AlgebraTerm::op(
+        format!("call:{callee}"),
+        vec![AlgebraTerm::Symbol(callee), AlgebraTerm::List(args)],
+    ))
+}
+
+fn lower_method_call_expr_to_value_term(
+    method: &syn::ExprMethodCall,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    let method_name = method.method.to_string();
+    ctx.add_loss("ffi-call-unresolved-effect", method_name.clone());
+    let receiver = lower_expr_to_value_term(&method.receiver, ctx)?;
+    let args = method
+        .args
+        .iter()
+        .map(|arg| lower_expr_to_value_term(arg, ctx))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(AlgebraTerm::op(
+        format!("method:{method_name}"),
+        vec![receiver, AlgebraTerm::List(args)],
+    ))
+}
+
+fn lower_struct_expr_to_value_term(
+    strukt: &syn::ExprStruct,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    let name = strukt
+        .path
+        .segments
+        .last()
+        .map(|segment| segment.ident.to_string())
+        .unwrap_or_else(|| "anonymous".to_string());
+    let fields = strukt
+        .fields
+        .iter()
+        .map(|field| {
+            let name = field.member.to_token_stream().to_string();
+            let value = lower_expr_to_value_term(&field.expr, ctx)?;
+            Ok((name, value))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(AlgebraTerm::Struct { name, fields })
+}
+
+fn lower_vec_macro_to_value_term(
+    mac: &syn::ExprMacro,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    ctx.add_loss("vec-macro-desugared-to-array", "vec!");
+    let parser = syn::punctuated::Punctuated::<Expr, syn::Token![,]>::parse_terminated;
+    let items = match parser.parse2(mac.mac.tokens.clone()) {
+        Ok(items) => items
+            .iter()
+            .map(|expr| lower_expr_to_value_term(expr, ctx))
+            .collect::<Result<Vec<_>, _>>()?,
+        Err(err) => {
+            return Err(format!("unsupported vec! macro body: {err}"));
+        }
+    };
+    Ok(AlgebraTerm::op("array", vec![AlgebraTerm::List(items)]))
 }
 
 fn expr_sort(expr: &Expr, ctx: &LoweringContext) -> Option<ExprSort> {
@@ -554,10 +893,21 @@ fn bitwise_binary_op(op: &BinOp) -> Option<&'static str> {
     }
 }
 
-fn sort_from_return_type(output: &ReturnType) -> Option<ExprSort> {
+fn return_shape_from_return_type(output: &ReturnType) -> ReturnShape {
     match output {
-        ReturnType::Default => Some(ExprSort::Unit),
-        ReturnType::Type(_, ty) => sort_from_type(ty),
+        ReturnType::Default => ReturnShape::Full(ExprSort::Unit),
+        ReturnType::Type(_, ty) => {
+            if let Some(sort) = sort_from_type(ty) {
+                ReturnShape::Full(sort)
+            } else if let Some(loss) = partial_return_loss(ty) {
+                ReturnShape::Partial {
+                    loss,
+                    rust_type: type_surface(ty),
+                }
+            } else {
+                ReturnShape::Unsupported
+            }
+        }
     }
 }
 
@@ -579,6 +929,65 @@ fn sort_from_type_name(name: &str) -> Option<ExprSort> {
         "bool" => Some(ExprSort::Bool),
         "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128"
         | "usize" => Some(ExprSort::Int),
+        _ => None,
+    }
+}
+
+fn partial_return_loss(ty: &Type) -> Option<&'static str> {
+    match ty {
+        Type::Path(path) if path.qself.is_none() => {
+            let segment = path.path.segments.last()?;
+            let ident = segment.ident.to_string();
+            match ident.as_str() {
+                "Result" => Some("return-type-result"),
+                "Option" => Some("return-type-option"),
+                "Vec" if path_type_arg_is_u8(segment) => Some("return-type-byte-vec"),
+                "Vec" => Some("return-type-vec"),
+                _ => Some("return-type-user-defined"),
+            }
+        }
+        Type::Array(array) if type_is_u8(&array.elem) => Some("return-type-byte-array"),
+        Type::Reference(reference) => partial_return_loss(&reference.elem),
+        Type::Paren(paren) => partial_return_loss(&paren.elem),
+        Type::Group(group) => partial_return_loss(&group.elem),
+        _ => None,
+    }
+}
+
+fn path_type_arg_is_u8(segment: &syn::PathSegment) -> bool {
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return false;
+    };
+    args.args.iter().any(|arg| match arg {
+        syn::GenericArgument::Type(ty) => type_is_u8(ty),
+        _ => false,
+    })
+}
+
+fn type_is_u8(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Path(path)
+            if path.qself.is_none()
+                && path.path.segments.last().map(|segment| segment.ident == "u8").unwrap_or(false)
+    )
+}
+
+fn type_surface(ty: &Type) -> String {
+    ty.to_token_stream().to_string()
+}
+
+fn simple_binding_name(pat: &syn::Pat) -> Option<String> {
+    match pat {
+        syn::Pat::Ident(ident) => Some(ident.ident.to_string()),
+        syn::Pat::Type(pat_type) => simple_binding_name(&pat_type.pat),
+        _ => None,
+    }
+}
+
+fn local_pat_type(pat: &syn::Pat) -> Option<&Type> {
+    match pat {
+        syn::Pat::Type(pat_type) => Some(&pat_type.ty),
         _ => None,
     }
 }
@@ -764,15 +1173,16 @@ mod tests {
     }
 
     #[test]
-    fn rust_term_json_rejects_local_bindings() {
+    fn rust_term_json_lowers_local_bindings() {
         let src = r#"
             fn with_let(x: i32) -> i32 { let y = x + 1; y }
         "#;
         let item_fn = parse_named(src, "with_let");
-        let err = rust_function_term_json(&item_fn, "with_let.rs").unwrap_err();
-        assert!(
-            err.contains("unsupported statement Stmt::Local"),
-            "unexpected error: {err}"
+        let bytes = rust_function_term_json(&item_fn, "with_let.rs").unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("valid JSON");
+        assert_eq!(
+            parsed["term_surface"].as_str(),
+            Some("let(pattern_bind(y), add(x, 1), return(y))")
         );
     }
 

--- a/implementations/rust/provekit-walk/tests/term_emit_d2.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d2.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_walk::emit::rust_function_term_json;
+
+fn parse_named(src: &str, name: &str) -> syn::ItemFn {
+    let file: syn::File = syn::parse_str(src).unwrap();
+    file.items
+        .into_iter()
+        .find_map(|item| match item {
+            syn::Item::Fn(f) if f.sig.ident == name => Some(f),
+            _ => None,
+        })
+        .unwrap()
+}
+
+fn term_json(src: &str, name: &str) -> serde_json::Value {
+    let item_fn = parse_named(src, name);
+    let bytes = rust_function_term_json(&item_fn, "d2.rs").unwrap();
+    serde_json::from_slice(&bytes).expect("term JSON")
+}
+
+#[test]
+fn lowers_let_binding_to_rust_let_op() {
+    let parsed = term_json(
+        r#"
+            fn with_let(x: i32) -> i32 {
+                let y = x + 1;
+                y
+            }
+        "#,
+        "with_let",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("let(pattern_bind(y), add(x, 1), return(y))")
+    );
+    assert_eq!(parsed["term"]["name"].as_str(), Some("let"));
+}
+
+#[test]
+fn lowers_struct_return_type_with_partial_loss_record() {
+    let parsed = term_json(
+        r#"
+            struct Point { x: i32, y: i32 }
+            fn make_point(x: i32) -> Point {
+                Point { x, y: x + 1 }
+            }
+        "#,
+        "make_point",
+    );
+    assert_eq!(
+        parsed["handling"].as_str(),
+        Some("handles-partially-with-loss-record")
+    );
+    assert_eq!(
+        parsed["loss_record"][0]["loss"].as_str(),
+        Some("return-type-user-defined")
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("return(Point{x: x, y: add(x, 1)})")
+    );
+}
+
+#[test]
+fn lowers_result_return_type_with_partial_loss_record() {
+    let parsed = term_json(
+        r#"
+            fn ok_value(x: i32) -> Result<i32, i32> {
+                Ok(x)
+            }
+        "#,
+        "ok_value",
+    );
+    assert_eq!(
+        parsed["handling"].as_str(),
+        Some("handles-partially-with-loss-record")
+    );
+    assert!(parsed["term_surface"].as_str().unwrap().contains("call:Ok"));
+    assert!(parsed["loss_record"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|loss| loss["loss"] == "return-type-result"));
+}
+
+#[test]
+fn lowers_option_return_type_with_partial_loss_record() {
+    let parsed = term_json(
+        r#"
+            fn maybe_value(x: i32) -> Option<i32> {
+                Some(x)
+            }
+        "#,
+        "maybe_value",
+    );
+    assert_eq!(
+        parsed["handling"].as_str(),
+        Some("handles-partially-with-loss-record")
+    );
+    assert!(parsed["term_surface"]
+        .as_str()
+        .unwrap()
+        .contains("call:Some"));
+    assert!(parsed["loss_record"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|loss| loss["loss"] == "return-type-option"));
+}
+
+#[test]
+fn lowers_byte_vec_return_type_with_partial_loss_record() {
+    let parsed = term_json(
+        r#"
+            fn bytes() -> Vec<u8> {
+                vec![1u8, 2u8, 3u8]
+            }
+        "#,
+        "bytes",
+    );
+    assert_eq!(
+        parsed["handling"].as_str(),
+        Some("handles-partially-with-loss-record")
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("return(array([1, 2, 3]))")
+    );
+    assert!(parsed["loss_record"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|loss| loss["loss"] == "return-type-byte-vec"));
+}
+
+#[test]
+fn lowers_simple_call_expression_with_unresolved_call_loss() {
+    let parsed = term_json(
+        r#"
+            fn helper(x: i32) -> i32 { x + 1 }
+            fn caller(x: i32) -> i32 { helper(x) }
+        "#,
+        "caller",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("return(call:helper(helper, [x]))")
+    );
+    assert!(parsed["loss_record"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|loss| loss["loss"] == "ffi-call-unresolved-effect"));
+}
+
+#[test]
+fn lowers_simple_method_call_expression_with_unresolved_call_loss() {
+    let parsed = term_json(
+        r#"
+            struct Counter(i32);
+            impl Counter {
+                fn bump(&self, by: i32) -> i32 { self.0 + by }
+            }
+            fn caller(c: Counter) -> i32 { c.bump(1) }
+        "#,
+        "caller",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("return(method:bump(c, [1]))")
+    );
+    assert!(parsed["loss_record"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|loss| loss["loss"] == "ffi-call-unresolved-effect"));
+}


### PR DESCRIPTION
Closes #938. Refs umbrella #897 (Phase 4 libprovekit Rust bootstrap), top umbrella #922, audit anchor PR #937.

## Audit-delta headline

| Gap class | Before (D1) | After (D2) | Drop |
|---|---:|---:|---:|
| let-binding | 175 | 17 | 90.3% |
| unsupported-return-type | 267 | 7 | 97.4% |
| ffi-call | 44 | 24 | 45.5% |
| **combined** | **486** | **48** | **90.1%** |

Beats the 80% target stated in the issue's acceptance gate.

## Lifter changes

- **let-binding**: lowers simple `Stmt::Local` through the existing Rust `let` and `pattern_bind` operations.
- **unsupported-return-type**: accepts struct, `Result<T, E>`, `Option<T>`, `Vec<u8>`, `[u8; N]`, and named return envelopes as partial lifts with explicit loss records instead of refusing.
- **ffi-call**: lowers free calls and method calls into signature-backed call terms; unresolved call effects recorded as named losses rather than refusal.

## New tests

`implementations/rust/provekit-walk/tests/term_emit_d2.rs` — 7 regression tests:
- let-binding
- struct return type
- Result return type
- Option return type
- byte-vec return type
- simple call
- simple method call

## Audit script

`bootstrap/scripts/libprovekit_surface_audit.py` (158 lines). D1's audit driver was not committed on main, so this PR adds a re-runnable Python script. D6 (#942 audit re-run) can call this directly.

## Verification

- `cargo build -p provekit-walk --release`: green (1m 07s)
- `cargo test -p provekit-walk`: 236 lib tests + 7 D2 regression = 243 passed
- `cargo test -p provekit-cli`: pre-existing zig integration flake (`lift_zig_shows_production_composes_but_unit_tests_conflict` fails with PermissionDenied on zig-out path — unrelated to D2; matches task #72 territory). All non-zig tests pass.
- Audit script confirms the audit-delta numbers above.
- Em-dash + en-dash sweep: clean

## Out of scope (sibling sub-issues)

- #939: procedural-macro acceptance vocabulary
- #940: term-emitter-unsupported other than the three named classes
- #941: complex-generic + nested-item

## Not admin-merged

Substrate-touching (the Rust lifter is core). Awaiting your read.