### PR TITLE
fix(#125): doc-comment lie at provekit-ir-types/src/lib.rs:1050

### DIFF
--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -1040,22 +1040,29 @@ pub struct WitnessRef {
 ///
 /// Per the spec §2 trichotomy and §1.2 verdict-consistency table.
 /// Silent contract-dropping is NOT in the substrate's vocabulary.
+///
+/// This type is the serde wire shape only. Verdict-consistency invariants
+/// are enforced by producers and validators, not by this struct.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Discharge {
     /// The discharge method: "wp" | "witness" | "wp+witness".
     pub method: String,
-    /// Required iff verdict == "refuse"; OMITTED otherwise.
+    /// Optional refusal reason. Serialized when `Some`; omitted when `None`.
+    /// The spec requires producers and validators to use this for `refuse`.
     #[serde(rename = "refusal_reason")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refusal_reason: Option<String>,
     /// "exact" | "loudly-bounded-lossy" | "refuse".
     pub verdict: String,
-    /// CID of a MorphismDischargeReceipt. OMITTED iff verdict == "refuse".
+    /// Optional CID of a MorphismDischargeReceipt. Serialized when `Some`;
+    /// omitted when `None`. The spec requires producers and validators to omit
+    /// this for `refuse`.
     #[serde(rename = "discharge_receipt_cid")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discharge_receipt_cid: Option<String>,
-    /// Per the 2026-05-15 §2.4 five-dimension loss-record. An empty map
-    /// is valid (means "no loss in any dimension"; required for `exact`).
+    /// Per the 2026-05-15 §2.4 five-dimension loss-record. This field is
+    /// always present in the wire struct. An empty map means "no loss in any
+    /// dimension"; the spec requires that shape for `exact`.
     #[serde(rename = "loss_record")]
     pub loss_record: LossRecord,
 }


### PR DESCRIPTION
Closes #125.

## Scope

The struct doc comments at `provekit-ir-types/src/lib.rs` around line 1050 described verdict-consistency invariants ("Required iff verdict == 'refuse'", "OMITTED iff verdict == 'refuse'", "empty map ... required for 'exact'") as if the Rust serde wire struct enforced them. The struct does not. It is the serde wire shape only; verdict-consistency invariants are enforced by producers and validators against the spec, not by this type. The doc comments now say so.

## Before / after

- Verdict struct gained a paragraph clarifying it is the serde wire shape only.
- "Required iff verdict == 'refuse'" -> "Optional refusal reason. Serialized when `Some`; omitted when `None`. The spec requires producers and validators to use this for `refuse`."
- "CID of a MorphismDischargeReceipt. OMITTED iff verdict == 'refuse'" -> "Optional CID ... Serialized when `Some`; omitted when `None`. The spec requires producers and validators to omit this for `refuse`."
- "empty map is valid (... required for 'exact')" -> "... This field is always present in the wire struct. An empty map means 'no loss in any dimension'; the spec requires that shape for `exact`."

## Verification

- `cargo doc -p provekit-ir-types`: passed in 33.79s
- `cargo test -p provekit-ir-types`: 177 passed, 0 failed
- Em-dash + en-dash sweep: clean
- Doc-comment only; no code semantics changed

## Admin-merging

Doc-comment only change. No tests fail. Admin-merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation comments to clarify serde wire shape behavior and invariant enforcement details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/947)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->