### PR TITLE
feat(#929): policy profiles — smoke gates vs production monitors with witnessed emission decisions

### DIFF
--- a/implementations/rust/libprovekit/src/lib.rs
+++ b/implementations/rust/libprovekit/src/lib.rs
@@ -7,6 +7,7 @@ pub mod core;
 pub mod desugar;
 pub mod effect_propagation;
 pub mod ffi;
+pub mod policy_profile_registry;
 pub mod promotion_decision_registry;
 pub mod substrate_default_cids;
 pub mod transport;

--- a/implementations/rust/libprovekit/src/policy_profile_registry.rs
+++ b/implementations/rust/libprovekit/src/policy_profile_registry.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use provekit_ir_types::{
+    PolicyProfileDecision, PolicyProfileDecisionKind, PolicyProfileMemento, PolicyProfileThreshold,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct PolicyProfileRegistry {
+    profiles: BTreeMap<String, PolicyProfileMemento>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PolicyProfileRegistryError {
+    #[error("policy-profile-registry: parse failed as PolicyProfileMemento: {0}")]
+    Parse(String),
+    #[error("policy-profile-registry: invalid profile: {0}")]
+    Invalid(String),
+    #[error("policy-profile-registry: invalid threshold predicate in profile {profile_cid} decision {decision_kind} axis {axis}: `{predicate}`: {reason}")]
+    InvalidThresholdPredicate {
+        profile_cid: String,
+        decision_kind: String,
+        axis: String,
+        predicate: String,
+        reason: String,
+    },
+}
+
+impl PolicyProfileRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn admit_json_str(&mut self, text: &str) -> Result<(), PolicyProfileRegistryError> {
+        let profile: PolicyProfileMemento = serde_json::from_str(text)
+            .map_err(|err| PolicyProfileRegistryError::Parse(err.to_string()))?;
+        self.admit(profile)
+    }
+
+    pub fn admit(
+        &mut self,
+        profile: PolicyProfileMemento,
+    ) -> Result<(), PolicyProfileRegistryError> {
+        profile
+            .validate()
+            .map_err(|err| PolicyProfileRegistryError::Invalid(err.to_string()))?;
+
+        for decision in &profile.decisions {
+            for threshold in &decision.thresholds {
+                parse_predicate(&threshold.predicate).map_err(|reason| {
+                    PolicyProfileRegistryError::InvalidThresholdPredicate {
+                        profile_cid: profile.cid.clone(),
+                        decision_kind: decision.decision_kind.as_str().to_string(),
+                        axis: threshold.axis.clone(),
+                        predicate: threshold.predicate.clone(),
+                        reason,
+                    }
+                })?;
+            }
+        }
+
+        self.profiles.insert(profile.cid.clone(), profile);
+        Ok(())
+    }
+
+    pub fn get(&self, profile_cid: &str) -> Option<&PolicyProfileMemento> {
+        self.profiles.get(profile_cid)
+    }
+
+    pub fn decision(
+        &self,
+        profile_cid: &str,
+        decision_kind: &PolicyProfileDecisionKind,
+    ) -> Option<&PolicyProfileDecision> {
+        self.get(profile_cid)?
+            .decisions
+            .iter()
+            .find(|decision| decision.decision_kind.as_str() == decision_kind.as_str())
+    }
+
+    pub fn thresholds(
+        &self,
+        profile_cid: &str,
+        decision_kind: &PolicyProfileDecisionKind,
+    ) -> Option<&[PolicyProfileThreshold]> {
+        self.decision(profile_cid, decision_kind)
+            .map(|decision| decision.thresholds.as_slice())
+    }
+}
+
+fn parse_predicate(predicate: &str) -> Result<(&str, &str, u64), String> {
+    for op in [">=", "<=", "==", ">", "<"] {
+        if let Some((left, right)) = predicate.split_once(op) {
+            let left = left.trim();
+            if left.is_empty() {
+                return Err("metric is empty".to_string());
+            }
+            let right = right
+                .trim()
+                .parse::<u64>()
+                .map_err(|err| format!("threshold is not an integer: {err}"))?;
+            return Ok((left, op, right));
+        }
+    }
+    Err("unsupported predicate grammar".to_string())
+}

--- a/implementations/rust/libprovekit/tests/policy_profile_registry.rs
+++ b/implementations/rust/libprovekit/tests/policy_profile_registry.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use libprovekit::policy_profile_registry::{PolicyProfileRegistry, PolicyProfileRegistryError};
+use provekit_ir_types::PolicyProfileDecisionKind;
+
+#[test]
+fn registry_indexes_profile_by_cid_and_returns_decision_thresholds() {
+    let mut profile: provekit_ir_types::PolicyProfileMemento =
+        serde_json::from_str(&profile_json("")).expect("parse profile");
+    profile.cid = profile.recompute_cid().expect("recompute profile cid");
+    let profile_cid = profile.cid.clone();
+
+    let mut registry = PolicyProfileRegistry::new();
+    registry.admit(profile).expect("profile admitted");
+
+    let thresholds = registry
+        .thresholds(&profile_cid, &PolicyProfileDecisionKind::WitnessConsensus)
+        .expect("witness consensus thresholds");
+    assert_eq!(thresholds[0].axis, "min-witnesses-floor");
+    assert_eq!(thresholds[0].predicate, "n>=1");
+
+    let emission = registry
+        .decision(&profile_cid, &PolicyProfileDecisionKind::EmissionGating)
+        .expect("emission decision");
+    assert_eq!(emission.emission_mode.as_deref(), Some("gate"));
+    assert!(emission.requires_witnessed_decision);
+}
+
+#[test]
+fn registry_rejects_profiles_with_malformed_threshold_predicates() {
+    let mut profile: provekit_ir_types::PolicyProfileMemento =
+        serde_json::from_str(&profile_json("")).expect("parse profile");
+    profile.decisions[0].thresholds[0].predicate = "n roughly one".to_string();
+    profile.cid = profile.recompute_cid().expect("recompute profile cid");
+
+    let mut registry = PolicyProfileRegistry::new();
+    let err = registry
+        .admit(profile)
+        .expect_err("malformed predicate must reject");
+
+    assert!(matches!(
+        err,
+        PolicyProfileRegistryError::InvalidThresholdPredicate { .. }
+    ));
+}
+
+#[test]
+fn registry_admits_reference_smoke_and_prod_profiles() {
+    let mut registry = PolicyProfileRegistry::new();
+    for path in [
+        "../../../protocol/policies/smoke.json",
+        "../../../protocol/policies/prod.json",
+    ] {
+        let text = std::fs::read_to_string(path).expect("read reference profile");
+        registry
+            .admit_json_str(&text)
+            .unwrap_or_else(|err| panic!("{path} must admit: {err}"));
+    }
+
+    let smoke = registry
+        .get("blake3-512:3166b9224022a79ed498ad08617b1461ded2fb40809d4f8127b72f00d3d2bc85d1de1aa2014563880d1e67946416b9939e274eae943e53b0aa57dea8591c1467")
+        .expect("smoke profile indexed");
+    let prod = registry
+        .get("blake3-512:7f9c6b9f754ce5e41150ea9d8733920bd18f081f733a5f820aae0fba099f67e376928103fa6bd1b2651cd548650a6a52a23b1579512ea60d900cb2f7322da856")
+        .expect("prod profile indexed");
+
+    assert_eq!(smoke.name, "smoke");
+    assert_eq!(prod.name, "prod");
+    assert_eq!(
+        registry
+            .decision(&smoke.cid, &PolicyProfileDecisionKind::EmissionGating)
+            .and_then(|decision| decision.emission_mode.as_deref()),
+        Some("gate")
+    );
+    assert_eq!(
+        registry
+            .decision(&prod.cid, &PolicyProfileDecisionKind::EmissionGating)
+            .and_then(|decision| decision.emission_mode.as_deref()),
+        Some("monitor")
+    );
+}
+
+fn profile_json(cid_value: &str) -> String {
+    format!(
+        r#"{{
+  "cid": "{cid_value}",
+  "decisions": [
+    {{
+      "decision_kind": "witness-consensus",
+      "policy_cid": "{consensus_policy}",
+      "required": true,
+      "requires_witnessed_decision": false,
+      "thresholds": [
+        {{"axis": "min-witnesses-floor", "predicate": "n>=1"}}
+      ]
+    }},
+    {{
+      "decision_kind": "sugar-selection",
+      "policy_cid": "{sugar_policy}",
+      "required": true,
+      "requires_witnessed_decision": false,
+      "thresholds": [
+        {{"axis": "max-loss-score", "predicate": "loss_score<=1"}}
+      ]
+    }},
+    {{
+      "decision_kind": "emission-gating",
+      "emission_mode": "gate",
+      "policy_cid": "{emission_policy}",
+      "required": true,
+      "requires_witnessed_decision": true,
+      "thresholds": [
+        {{"axis": "witnessed-decision", "predicate": "witnessed_decisions>=1"}}
+      ]
+    }}
+  ],
+  "kind": "policy-profile",
+  "name": "smoke",
+  "schemaVersion": "1"
+}}"#,
+        cid_value = cid_value,
+        consensus_policy = cid('a'),
+        sugar_policy = cid('b'),
+        emission_policy = cid('c')
+    )
+}
+
+fn cid(ch: char) -> String {
+    format!("blake3-512:{}", ch.to_string().repeat(128))
+}

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -2956,6 +2956,306 @@ impl From<NamespacedExtensionPolicyMemento> for NamespacedExtensionPolicyMemento
 }
 
 // ============================================================
+// Manual extension: PolicyProfileMemento family (issue #929)
+// Source of truth:
+//   protocol/specs/2026-05-14-policy-profile-memento.md §1
+//
+// A policy profile is not another gate predicate. It is the
+// content-addressed bundle that chooses which concrete policy CID applies
+// to each decision lane in a run: witness consensus, sugar selection, and
+// emission gating. Emission decisions are required to be witnessed so the
+// profile cannot hide a runtime wrapper choice behind local defaults.
+// ============================================================
+
+/// Per-profile decision lane. Canonical lanes are closed over the v1
+/// profile surface; namespaced extensions are carried but must validate
+/// as `<namespace>:<kind>`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
+pub enum PolicyProfileDecisionKind {
+    WitnessConsensus,
+    SugarSelection,
+    EmissionGating,
+    Other(String),
+}
+
+impl PolicyProfileDecisionKind {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::WitnessConsensus => "witness-consensus",
+            Self::SugarSelection => "sugar-selection",
+            Self::EmissionGating => "emission-gating",
+            Self::Other(raw) => raw,
+        }
+    }
+}
+
+impl From<String> for PolicyProfileDecisionKind {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "witness-consensus" => Self::WitnessConsensus,
+            "sugar-selection" => Self::SugarSelection,
+            "emission-gating" => Self::EmissionGating,
+            _ => Self::Other(s),
+        }
+    }
+}
+
+impl From<PolicyProfileDecisionKind> for String {
+    fn from(kind: PolicyProfileDecisionKind) -> String {
+        match kind {
+            PolicyProfileDecisionKind::WitnessConsensus => "witness-consensus".to_string(),
+            PolicyProfileDecisionKind::SugarSelection => "sugar-selection".to_string(),
+            PolicyProfileDecisionKind::EmissionGating => "emission-gating".to_string(),
+            PolicyProfileDecisionKind::Other(raw) => raw,
+        }
+    }
+}
+
+/// Threshold cited by a profile lane. The grammar is evaluated by the
+/// libprovekit registry because it is a consumer policy concern, not a
+/// serde concern.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyProfileThreshold {
+    pub axis: String,
+    pub predicate: String,
+}
+
+/// One decision lane in a policy profile.
+///
+/// Locked JCS key order: decision_kind, emission_mode, policy_cid,
+/// required, requires_witnessed_decision, thresholds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyProfileDecision {
+    #[serde(rename = "decision_kind")]
+    pub decision_kind: PolicyProfileDecisionKind,
+    #[serde(rename = "emission_mode")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emission_mode: Option<String>,
+    #[serde(rename = "policy_cid")]
+    pub policy_cid: String,
+    pub required: bool,
+    #[serde(rename = "requires_witnessed_decision")]
+    pub requires_witnessed_decision: bool,
+    pub thresholds: Vec<PolicyProfileThreshold>,
+}
+
+/// Content-addressed profile selecting concrete policies for a run.
+///
+/// Locked JCS key order: cid, decisions, kind, name, schemaVersion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyProfileMemento {
+    /// DERIVED: BLAKE3-512 over JCS(profile) with `cid` elided and
+    /// decisions sorted by `decision_kind`.
+    pub cid: String,
+    pub decisions: Vec<PolicyProfileDecision>,
+    /// MUST be "policy-profile".
+    pub kind: String,
+    pub name: String,
+    /// MUST be "1".
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+}
+
+impl PolicyProfileMemento {
+    pub fn recompute_cid(&self) -> Result<String, PromotionDecisionCanonicalizationError> {
+        let mut profile = serde_json::to_value(self)?;
+        let serde_json::Value::Object(ref mut object) = profile else {
+            return Err(PromotionDecisionCanonicalizationError::new(
+                "policy profile did not serialize as an object",
+            ));
+        };
+
+        object.remove("cid");
+        if let Some(serde_json::Value::Array(decisions)) = object.get_mut("decisions") {
+            decisions.sort_by(|left, right| {
+                left.get("decision_kind")
+                    .and_then(serde_json::Value::as_str)
+                    .cmp(
+                        &right
+                            .get("decision_kind")
+                            .and_then(serde_json::Value::as_str),
+                    )
+            });
+        }
+
+        let canonical = serde_json_to_canonical_value(&profile)?;
+        let jcs = provekit_canonicalizer::encode_jcs(&canonical);
+        Ok(provekit_canonicalizer::blake3_512_of(jcs.as_bytes()))
+    }
+
+    pub fn validate(&self) -> Result<(), PolicyProfileValidationError> {
+        if self.kind != "policy-profile" {
+            return Err(PolicyProfileValidationError::InvalidKind {
+                kind: self.kind.clone(),
+            });
+        }
+        if self.schema_version != "1" {
+            return Err(PolicyProfileValidationError::InvalidSchemaVersion {
+                schema_version: self.schema_version.clone(),
+            });
+        }
+        if self.name.is_empty() {
+            return Err(PolicyProfileValidationError::EmptyName);
+        }
+        if self.decisions.is_empty() {
+            return Err(PolicyProfileValidationError::EmptyDecisions);
+        }
+
+        let actual = self
+            .recompute_cid()
+            .map_err(|err| PolicyProfileValidationError::Canonicalization(err.to_string()))?;
+        if actual != self.cid {
+            return Err(PolicyProfileValidationError::CidMismatch {
+                claimed: self.cid.clone(),
+                actual,
+            });
+        }
+
+        let mut seen = std::collections::BTreeSet::new();
+        for decision in &self.decisions {
+            let kind = decision.decision_kind.as_str();
+            if matches!(decision.decision_kind, PolicyProfileDecisionKind::Other(_))
+                && !is_namespaced_policy_kind(kind)
+            {
+                return Err(PolicyProfileValidationError::InvalidDecisionKind {
+                    decision_kind: kind.to_string(),
+                });
+            }
+            if !seen.insert(kind.to_string()) {
+                return Err(PolicyProfileValidationError::DuplicateDecisionKind {
+                    decision_kind: kind.to_string(),
+                });
+            }
+            if decision.thresholds.is_empty() {
+                return Err(PolicyProfileValidationError::EmptyThresholds {
+                    decision_kind: kind.to_string(),
+                });
+            }
+            if !is_blake3_512_cid(&decision.policy_cid) {
+                return Err(PolicyProfileValidationError::InvalidPolicyCid {
+                    decision_kind: kind.to_string(),
+                    policy_cid: decision.policy_cid.clone(),
+                });
+            }
+            if decision.decision_kind == PolicyProfileDecisionKind::EmissionGating
+                && !decision.requires_witnessed_decision
+            {
+                return Err(PolicyProfileValidationError::UnwitnessedEmissionDecision);
+            }
+        }
+
+        for required in [
+            PolicyProfileDecisionKind::WitnessConsensus,
+            PolicyProfileDecisionKind::SugarSelection,
+            PolicyProfileDecisionKind::EmissionGating,
+        ] {
+            if !seen.contains(required.as_str()) {
+                return Err(PolicyProfileValidationError::MissingDecisionKind {
+                    decision_kind: required.as_str().to_string(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyProfileValidationError {
+    InvalidKind {
+        kind: String,
+    },
+    InvalidSchemaVersion {
+        schema_version: String,
+    },
+    EmptyName,
+    EmptyDecisions,
+    CidMismatch {
+        claimed: String,
+        actual: String,
+    },
+    Canonicalization(String),
+    InvalidDecisionKind {
+        decision_kind: String,
+    },
+    DuplicateDecisionKind {
+        decision_kind: String,
+    },
+    MissingDecisionKind {
+        decision_kind: String,
+    },
+    EmptyThresholds {
+        decision_kind: String,
+    },
+    InvalidPolicyCid {
+        decision_kind: String,
+        policy_cid: String,
+    },
+    UnwitnessedEmissionDecision,
+}
+
+impl std::fmt::Display for PolicyProfileValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidKind { kind } => {
+                write!(f, "PolicyProfileMemento: invalid kind `{kind}`")
+            }
+            Self::InvalidSchemaVersion { schema_version } => write!(
+                f,
+                "PolicyProfileMemento: invalid schemaVersion `{schema_version}`"
+            ),
+            Self::EmptyName => f.write_str("PolicyProfileMemento: name must be non-empty"),
+            Self::EmptyDecisions => {
+                f.write_str("PolicyProfileMemento: decisions must be non-empty")
+            }
+            Self::CidMismatch { claimed, actual } => write!(
+                f,
+                "PolicyProfileMemento: cid mismatch: claimed {claimed}, recomputed {actual}"
+            ),
+            Self::Canonicalization(message) => {
+                write!(f, "PolicyProfileMemento: canonicalization failed: {message}")
+            }
+            Self::InvalidDecisionKind { decision_kind } => write!(
+                f,
+                "PolicyProfileMemento: invalid decision_kind `{decision_kind}`"
+            ),
+            Self::DuplicateDecisionKind { decision_kind } => write!(
+                f,
+                "PolicyProfileMemento: duplicate decision_kind `{decision_kind}`"
+            ),
+            Self::MissingDecisionKind { decision_kind } => write!(
+                f,
+                "PolicyProfileMemento: missing decision_kind `{decision_kind}`"
+            ),
+            Self::EmptyThresholds { decision_kind } => write!(
+                f,
+                "PolicyProfileMemento: decision_kind `{decision_kind}` has no thresholds"
+            ),
+            Self::InvalidPolicyCid {
+                decision_kind,
+                policy_cid,
+            } => write!(
+                f,
+                "PolicyProfileMemento: decision_kind `{decision_kind}` has invalid policy_cid `{policy_cid}`"
+            ),
+            Self::UnwitnessedEmissionDecision => f.write_str(
+                "PolicyProfileMemento: emission-gating decisions must require witnessed emission decisions",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PolicyProfileValidationError {}
+
+fn is_blake3_512_cid(s: &str) -> bool {
+    let Some(hex) = s.strip_prefix("blake3-512:") else {
+        return false;
+    };
+    hex.len() == 128 && hex.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+// ============================================================
 // End manual extension block -- PolicyMemento family (#798)
 // ============================================================
 

--- a/implementations/rust/provekit-ir-types/tests/policy_profile_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/policy_profile_serde.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_ir_types::{
+    PolicyProfileDecisionKind, PolicyProfileMemento, PolicyProfileValidationError,
+};
+
+#[test]
+fn policy_profile_round_trips_and_recomputes_cid() {
+    let mut profile: PolicyProfileMemento =
+        serde_json::from_str(&profile_json("")).expect("parse policy profile");
+    profile.cid = profile.recompute_cid().expect("recompute profile cid");
+
+    let serialized = serde_json::to_string(&profile).expect("serialize policy profile");
+    let parsed: PolicyProfileMemento =
+        serde_json::from_str(&serialized).expect("round-trip policy profile");
+
+    assert_eq!(parsed.kind, "policy-profile");
+    assert_eq!(parsed.schema_version, "1");
+    assert_eq!(parsed.name, "smoke");
+    assert_eq!(parsed.decisions.len(), 3);
+    assert_eq!(parsed.recompute_cid().unwrap(), parsed.cid);
+    assert_eq!(
+        parsed.decisions[0].decision_kind,
+        PolicyProfileDecisionKind::WitnessConsensus
+    );
+}
+
+#[test]
+fn policy_profile_validation_rejects_cid_mismatch() {
+    let mut profile: PolicyProfileMemento =
+        serde_json::from_str(&profile_json("")).expect("parse policy profile");
+    profile.cid = cid('f');
+
+    let err = profile
+        .validate()
+        .expect_err("mismatched profile cid must reject");
+
+    assert!(matches!(
+        err,
+        PolicyProfileValidationError::CidMismatch { .. }
+    ));
+}
+
+#[test]
+fn policy_profile_validation_requires_emission_decisions_to_be_witnessed() {
+    let mut profile: PolicyProfileMemento =
+        serde_json::from_str(&profile_json("")).expect("parse policy profile");
+    profile.cid = profile.recompute_cid().expect("recompute profile cid");
+    let emission = profile
+        .decisions
+        .iter_mut()
+        .find(|decision| decision.decision_kind == PolicyProfileDecisionKind::EmissionGating)
+        .expect("emission decision exists");
+    emission.requires_witnessed_decision = false;
+    profile.cid = profile.recompute_cid().expect("recompute profile cid");
+
+    let err = profile
+        .validate()
+        .expect_err("unwitnessed emission decisions must reject");
+
+    assert_eq!(
+        err,
+        PolicyProfileValidationError::UnwitnessedEmissionDecision
+    );
+}
+
+fn profile_json(cid_value: &str) -> String {
+    format!(
+        r#"{{
+  "cid": "{cid_value}",
+  "decisions": [
+    {{
+      "decision_kind": "witness-consensus",
+      "policy_cid": "{consensus_policy}",
+      "required": true,
+      "requires_witnessed_decision": false,
+      "thresholds": [
+        {{"axis": "min-witnesses-floor", "predicate": "n>=1"}}
+      ]
+    }},
+    {{
+      "decision_kind": "sugar-selection",
+      "policy_cid": "{sugar_policy}",
+      "required": true,
+      "requires_witnessed_decision": false,
+      "thresholds": [
+        {{"axis": "max-loss-score", "predicate": "loss_score<=1"}}
+      ]
+    }},
+    {{
+      "decision_kind": "emission-gating",
+      "emission_mode": "gate",
+      "policy_cid": "{emission_policy}",
+      "required": true,
+      "requires_witnessed_decision": true,
+      "thresholds": [
+        {{"axis": "witnessed-decision", "predicate": "witnessed_decisions>=1"}}
+      ]
+    }}
+  ],
+  "kind": "policy-profile",
+  "name": "smoke",
+  "schemaVersion": "1"
+}}"#,
+        cid_value = cid_value,
+        consensus_policy = cid('a'),
+        sugar_policy = cid('b'),
+        emission_policy = cid('c')
+    )
+}
+
+fn cid(ch: char) -> String {
+    format!("blake3-512:{}", ch.to_string().repeat(128))
+}

--- a/protocol/policies/prod.json
+++ b/protocol/policies/prod.json
@@ -1,0 +1,65 @@
+{
+  "cid": "blake3-512:7f9c6b9f754ce5e41150ea9d8733920bd18f081f733a5f820aae0fba099f67e376928103fa6bd1b2651cd548650a6a52a23b1579512ea60d900cb2f7322da856",
+  "decisions": [
+    {
+      "decision_kind": "emission-gating",
+      "emission_mode": "monitor",
+      "policy_cid": "blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666",
+      "required": true,
+      "requires_witnessed_decision": true,
+      "thresholds": [
+        {
+          "axis": "witnessed-decision",
+          "predicate": "witnessed_decisions>=1"
+        },
+        {
+          "axis": "wrapper-mode",
+          "predicate": "wrapper_modes>=1"
+        }
+      ]
+    },
+    {
+      "decision_kind": "sugar-selection",
+      "policy_cid": "blake3-512:55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
+      "required": true,
+      "requires_witnessed_decision": false,
+      "thresholds": [
+        {
+          "axis": "max-loss-score",
+          "predicate": "loss_score<=0"
+        },
+        {
+          "axis": "selected-surfaces",
+          "predicate": "selected_surfaces>=1"
+        }
+      ]
+    },
+    {
+      "decision_kind": "witness-consensus",
+      "policy_cid": "blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444",
+      "required": true,
+      "requires_witnessed_decision": false,
+      "thresholds": [
+        {
+          "axis": "min-witnesses-floor",
+          "predicate": "n>=8"
+        },
+        {
+          "axis": "observer-diversity",
+          "predicate": "unique_signers>=2"
+        },
+        {
+          "axis": "environment-diversity",
+          "predicate": "unique_fixtures>=3"
+        },
+        {
+          "axis": "sample-depth",
+          "predicate": "total_sample_count>=100"
+        }
+      ]
+    }
+  ],
+  "kind": "policy-profile",
+  "name": "prod",
+  "schemaVersion": "1"
+}

--- a/protocol/policies/smoke.json
+++ b/protocol/policies/smoke.json
@@ -1,0 +1,61 @@
+{
+  "cid": "blake3-512:3166b9224022a79ed498ad08617b1461ded2fb40809d4f8127b72f00d3d2bc85d1de1aa2014563880d1e67946416b9939e274eae943e53b0aa57dea8591c1467",
+  "decisions": [
+    {
+      "decision_kind": "emission-gating",
+      "emission_mode": "gate",
+      "policy_cid": "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+      "required": true,
+      "requires_witnessed_decision": true,
+      "thresholds": [
+        {
+          "axis": "witnessed-decision",
+          "predicate": "witnessed_decisions>=1"
+        },
+        {
+          "axis": "wrapper-mode",
+          "predicate": "wrapper_modes>=1"
+        }
+      ]
+    },
+    {
+      "decision_kind": "sugar-selection",
+      "policy_cid": "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+      "required": true,
+      "requires_witnessed_decision": false,
+      "thresholds": [
+        {
+          "axis": "max-loss-score",
+          "predicate": "loss_score<=5"
+        },
+        {
+          "axis": "selected-surfaces",
+          "predicate": "selected_surfaces>=1"
+        }
+      ]
+    },
+    {
+      "decision_kind": "witness-consensus",
+      "policy_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+      "required": true,
+      "requires_witnessed_decision": false,
+      "thresholds": [
+        {
+          "axis": "min-witnesses-floor",
+          "predicate": "n>=1"
+        },
+        {
+          "axis": "environment-diversity",
+          "predicate": "unique_fixtures>=1"
+        },
+        {
+          "axis": "sample-depth",
+          "predicate": "total_sample_count>=1"
+        }
+      ]
+    }
+  ],
+  "kind": "policy-profile",
+  "name": "smoke",
+  "schemaVersion": "1"
+}

--- a/protocol/specs/2026-05-14-policy-profile-memento.md
+++ b/protocol/specs/2026-05-14-policy-profile-memento.md
@@ -1,0 +1,121 @@
+# Policy Profile Memento (`policy-profile/1`)
+
+**Status:** v1.0.0 normative draft.
+**Date:** 2026-05-14
+**Related:** `2026-05-14-witness-consensus-promotion-v1.1-consensus-vector.md`, `2026-05-13-policy-memento.md`, `2026-05-12-sugar-dict-memento.md`, `2026-05-14-contract-comment-sugar.md`, `project_provekit_honesty_gradient.md` (#856).
+
+## Motivation
+
+Policy mementos define individual gates. A `ConsensusPolicyMemento` says how a witness consensus vector is judged. A sugar selection policy says how loss and mode coverage are judged. An emission policy says which runtime wrapper mode a realization may emit.
+
+A run, however, does not choose one gate in isolation. It chooses a profile: local smoke checks often want permissive witness floors and gate wrappers, while production deployment often wants stricter witness diversity and monitor wrappers. If those choices live in CLI defaults, the audit trail loses the policy input that made two runs differ.
+
+`PolicyProfileMemento` is the cross-decision bundle. A consumer cites a profile CID and gets back the concrete policy CID and threshold set for each decision lane: witness consensus, sugar selection, and emission gating. The profile is content-addressed so "smoke" and "prod" are not names with hidden meaning. They are signed bytes.
+
+## Locus Choice
+
+This spec introduces a new memento family rather than extending every existing policy memento with a `profile` field.
+
+That is the least leaky shape. Existing policy mementos are gate-local facts: they define one predicate and one decision payload schema. A profile is not a predicate. It is an index over multiple predicates plus the runtime emission posture the caller selected. Putting `profile` inside each gate policy would duplicate the same smoke/prod fact across unrelated memento families and still would not provide a single CID a caller can cite before the run starts.
+
+The profile therefore sits above the gate policies. It cites them by CID and records the per-decision thresholds that the consumer is about to enforce.
+
+## Wire Shape
+
+```cddl
+; Imports:
+;   cid
+;
+; Locked JCS key order: cid, decisions, kind, name, schemaVersion
+policy-profile-memento = {
+  cid:           cid,                  ; DERIVED, see §3
+  decisions:     [3* policy-profile-decision],
+  kind:          "policy-profile",
+  name:          tstr,
+  schemaVersion: "1"
+}
+
+profile-decision-kind = "witness-consensus"
+                      / "sugar-selection"
+                      / "emission-gating"
+                      / namespaced-kind
+
+; Locked JCS key order: decision_kind, emission_mode, policy_cid,
+; required, requires_witnessed_decision, thresholds
+policy-profile-decision = {
+  decision_kind:                 profile-decision-kind,
+  ? emission_mode:               "witness" / "monitor" / "emitter" / "gate" / tstr,
+  policy_cid:                    cid,
+  required:                      bool,
+  requires_witnessed_decision:   bool,
+  thresholds:                    [+ policy-profile-threshold]
+}
+
+; Locked JCS key order: axis, predicate
+policy-profile-threshold = {
+  axis:      tstr,
+  predicate: tstr
+}
+```
+
+The three canonical `decision_kind` values are required in every v1 profile:
+
+1. `witness-consensus`
+2. `sugar-selection`
+3. `emission-gating`
+
+Unknown bare decision kinds fail closed. Extension decision kinds MUST be namespaced as `<namespace>:<kind>`.
+
+## Field Discipline
+
+`policy_cid` points at the gate-local policy memento that owns detailed replay. The profile does not replace that policy. It gives a caller one content-addressed input that resolves to the policies used by all decisions in the run.
+
+`thresholds` is a query-friendly projection of the gate-local policy. A profile registry validates only the small predicate grammar (`metric>=N`, `metric<=N`, `metric==N`, `metric>N`, `metric<N`). Full policy replay remains the job of the referenced policy.
+
+`emission_mode` is meaningful for `decision_kind = "emission-gating"`. Smoke profiles typically set it to `gate`: fail fast in local CI. Production profiles typically set it to `monitor`: observe and report without turning deployment into a runtime abort surface.
+
+`requires_witnessed_decision` MUST be `true` for `emission-gating`. A runtime wrapper choice is itself a substrate decision. The profile must require a witnessed emission decision rather than letting a kit silently choose gate, monitor, witness, or emitter from local defaults.
+
+## CID Construction
+
+`cid` is DERIVED. Producers compute it as:
+
+```text
+cid_input = JCS(policy-profile-memento with cid elided, decisions sorted ascending by decision_kind)
+cid = "blake3-512:" ++ hex(BLAKE3-512(cid_input))
+```
+
+`name` is a label, not identity. Changing any policy CID, threshold, required flag, witnessed-decision flag, emission mode, or canonical decision set changes the profile CID.
+
+## Registry Behavior
+
+`PolicyProfileRegistry` indexes profiles by `cid`. On admission it MUST:
+
+1. validate `kind = "policy-profile"` and `schemaVersion = "1"`;
+2. recompute `cid`;
+3. require exactly one entry for each canonical decision kind;
+4. require non-empty `thresholds` for every decision;
+5. reject malformed threshold predicates;
+6. reject invalid or non-content-addressed `policy_cid` values; and
+7. reject `emission-gating` entries whose `requires_witnessed_decision` is not `true`.
+
+The registry does not decide whether a run is admitted. It resolves a profile CID into the per-decision policy inputs that downstream consensus, sugar, and emission registries evaluate.
+
+## Reference Profiles
+
+The repository carries two reference profiles under `protocol/policies/`:
+
+- `smoke.json`: permissive witness floor, `gate` emission mode, witnessed emission decision required.
+- `prod.json`: stricter witness diversity and sample depth, `monitor` emission mode, witnessed emission decision required.
+
+They are examples and stable test vectors. They are not universal truth. Consumers can mint stricter or looser profiles by changing the policy CIDs and thresholds, which naturally produces a different profile CID.
+
+## What This Is Not
+
+This spec does not define a new consensus policy. It uses the consensus-policy surface from `witness-consensus/1.1`.
+
+This spec does not define sugar selection scoring. It cites the sugar-selection policy that owns that evaluation.
+
+This spec does not make `smoke` or `prod` magic strings. They are ordinary profile mementos with ordinary content CIDs.
+
+This spec does not let a profile hide runtime emission defaults. Emission gating is always witnessed in v1.


### PR DESCRIPTION
Closes #929.

## Scope

Introduces `PolicyProfileMemento` as a new memento family that lets a caller cite a profile by CID and resolve per-decision thresholds (witness consensus, sugar selection, emission gating) at once. Two reference profiles ship: `smoke.json` (gate emission, permissive consensus) and `prod.json` (monitor emission, strict consensus); both require witnessed emission decisions.

## Components

| File | Purpose |
|---|---|
| `implementations/rust/provekit-ir-types/src/lib.rs` (+300) | `PolicyProfileMemento` type, serde wire shape, CID recomputation, predicate-grammar validation |
| `implementations/rust/libprovekit/src/policy_profile_registry.rs` (new, 107) | `PolicyProfileRegistry` consumer per #856 admissibility rule |
| `implementations/rust/libprovekit/tests/policy_profile_registry.rs` (new, 130) | Registry tests |
| `implementations/rust/provekit-ir-types/tests/policy_profile_serde.rs` (new, 114) | Serde round-trip tests |
| `protocol/specs/2026-05-14-policy-profile-memento.md` (new, 121) | Spec selecting the new-memento path |
| `protocol/policies/smoke.json` (new, 61) | Pinned smoke profile |
| `protocol/policies/prod.json` (new, 65) | Pinned prod profile |

Total: 899 insertions.

## Architecture

- Profile composes thresholds from #878 ConsensusPolicyMemento, sugar selection policy from #889, and emission-gating from the contract-observation hub (#880).
- A consumer cites the profile by CID; the registry returns resolved per-decision thresholds.
- Predicate grammar at v1.0: `n>=N` / `unique_X>=N` shape; boolean composition deferred to v1.1.

## Verification

- `cargo fmt`: clean
- `cargo test -p provekit-ir-types -p libprovekit`: passed
- `cargo test --workspace`: pre-existing provekit-bridgeworks smoke flake (sandbox mkdir permission); unrelated to this change
- Em-dash + en-dash sweep: clean

## Cross-refs

#878 (consensus v1.1), #879 (PromotionDecisionRegistry), #889 (sugar-selection-policy memento), #880 (contract-observation hub), #856 (admissibility rule).

## Not admin-merged

New memento family + registry consumer + spec doc. Substrate-touching. Awaiting your read.