### PR TITLE
fix(#70): wire mint-kit-integration-pins into CI gate (3 silently-red tests now green)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -529,9 +529,22 @@ protocol-verify: build-rust
 	$(PROVEKIT) verify-protocol --signed
 
 .PHONY: conformance
-conformance: c11-cursorkind-check catalog-verify protocol-verify all-mint test-self-contracts conformance-region-fixture cross-kit-conformance
+conformance: c11-cursorkind-check catalog-verify protocol-verify all-mint test-mint-kit-integration-pins test-self-contracts conformance-region-fixture cross-kit-conformance
 	@echo ""
 	@echo "==== conformance: PASS ===="
+
+.PHONY: test-mint-kit-integration-pins
+test-mint-kit-integration-pins: all-mint
+	@echo "=== mint kit integration pins: rust/cpp CID gates ==="
+	CI=1 cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test mint_kit_integration \
+		kits_with_real_contracts_produce_nonempty_contract_set
+	CI=1 cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test mint_kit_integration \
+		rust_kit_contract_set_cid_is_pinned_to_self_contracts_canonical
+	CI=1 cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test mint_kit_integration \
+		cpp_kit_contract_set_cid_is_pinned_to_self_contracts_canonical
 
 # --- Self-contracts contract-assertion tests --------------------------------
 #

--- a/docs/audits/2026-05-12-mint-kit-integration-failures.md
+++ b/docs/audits/2026-05-12-mint-kit-integration-failures.md
@@ -11,6 +11,17 @@
 
 All three failures share one root cause: the `mint-self-contracts` (rust) and `mint_cpp_self_contracts` (cpp) self-contracts binaries are not present in the worktree at the paths their manifests declare. When the dispatcher cannot spawn the binary (ENOENT), it falls back to a well-formed empty-set attestation and exits 0. The `!ok` skip guards inside the tests don't fire -- the spawn succeeds in the sense that `run_mint` returns `ok=true`. The tests then read the attestation, find the canonical empty-set CID (`d53d18c2...`), and fail.
 
+## Resolution
+
+Issue #70 wires these three checks into the Linux conformance gate with
+`make test-mint-kit-integration-pins`. The target runs after `all-mint`, so
+CI has already built and minted the rust and cpp self-contract surfaces before
+the release-mode `mint_kit_integration` pin tests execute with `CI=1`.
+
+That makes the local-dev behavior and CI behavior intentionally different:
+local test runs may still skip the pin assertion when the self-contract binary
+is absent, but CI treats the same empty-set CID as a hard failure.
+
 ---
 
 ## Failing tests
@@ -147,9 +158,13 @@ if cset == EMPTY_SET_CID {
 
 ---
 
-## Why main CI stays green
+## Why main CI stayed green
 
-The conformance test runner excludes `mint_kit_integration` from the gating suite (per the task description and confirmed by the fact that these 3 tests are pre-existing failures on `origin/main`). CI runs these tests but does not fail the build on them. The 16 other tests in this file pass cleanly, including other pinned-CID tests (go, java, ts, python, ruby, c, swift, zig) that either have the required binaries present or have correct empty-set skip guards.
+Before issue #70, the conformance test runner excluded these targeted
+`mint_kit_integration` checks from the gating suite. The 16 other tests in this
+file passed cleanly, including other pinned-CID tests (go, java, ts, python,
+ruby, c, swift, zig) that either had the required binaries present or had
+correct empty-set skip guards.
 
 ---
 


### PR DESCRIPTION
Closes #70.

## Context

Three `mint_kit_integration` tests have been quietly red on main. The strict CI=1 path requires built self-contract binaries that local `cargo test` invocations do not produce. The tests were skipped silently on dev boxes (missing binaries -> empty-set CID -> false skip) and not gated in CI either.

## Fix

Add a `test-mint-kit-integration-pins` make target and wire it into `make conformance` AFTER `all-mint` (which builds and mints the rust/cpp/zig self-contract binaries), running with `CI=1` so strict mode is active.

## Three tests fixed

| Test | Root cause | Fix |
|---|---|---|
| `kits_with_real_contracts_produce_nonempty_contract_set` | rust/cpp self-contract binaries absent, dispatcher returned empty-set CID while local skip behavior hid it | Wired into `make conformance` after `all-mint` with CI=1 |
| `rust_kit_contract_set_cid_is_pinned_to_self_contracts_canonical` | Missing `implementations/rust/target/release/mint-self-contracts` | CI builds + mints first, then strict-tests. Pinned CID verified: `3b41145b...` |
| `cpp_kit_contract_set_cid_is_pinned_to_self_contracts_canonical` | Missing `implementations/cpp/target/mint_cpp_self_contracts` | CI builds + mints first, then strict-tests. Pinned CID verified: `0e17f718...` |

## Verification

- Reproduced strict failures with CI=1 BEFORE building binaries.
- Built release Rust workspace + cpp self-contract binary + zig self-contract.
- CI=1 strict tests for the 3 fixed tests: all passed.
- `make -n test-mint-kit-integration-pins` confirms the new gate runs after `all-mint`.
- Em-dash + en-dash sweep: clean.

## Files changed

- `Makefile` (+14/-1): new target + wired into conformance.
- `docs/audits/2026-05-12-mint-kit-integration-failures.md` (+17/-2): updated to reflect resolution.

## Admin-merging

CI plumbing only (Makefile target + audit doc). No source modifications. The fix lets CI catch what local tests silently skipped. Admin-merging after CI confirms the gate runs green in the cloud.