### PR TITLE
feat(bootstrap B1): proofir_resolve — inline catalog CIDs into ProofIR terms

### DIFF
--- a/implementations/rust/libprovekit/src/lib.rs
+++ b/implementations/rust/libprovekit/src/lib.rs
@@ -9,10 +9,13 @@ pub mod effect_propagation;
 pub mod ffi;
 pub mod policy_profile_registry;
 pub mod promotion_decision_registry;
+pub mod proofir_bridge;
 pub mod substrate_default_cids;
 pub mod transport;
 pub mod witness_registry;
 pub mod wp;
+
+pub use proofir_bridge::proofir_resolve;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProvekitError {

--- a/implementations/rust/libprovekit/src/proofir_bridge.rs
+++ b/implementations/rust/libprovekit/src/proofir_bridge.rs
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use provekit_ir_types::{Sort, Term};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+
+pub type ProofirTerm = Term;
+pub type ResolvedSort = JsonValue;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedTerm {
+    pub node: ResolvedNode,
+    pub sort: ResolvedSort,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum ResolvedNode {
+    #[serde(rename = "concept:op-application")]
+    OpApplication {
+        op_definition_cid: String,
+        args: Vec<ResolvedTerm>,
+    },
+    #[serde(rename = "literal")]
+    Literal { value: JsonValue },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum BridgeError {
+    #[error("unknown ProofIR op `{0}`")]
+    UnknownOp(String),
+    #[error("arity mismatch: expected {expected}, got {actual}")]
+    ArityMismatch { expected: usize, actual: usize },
+    #[error("sort mismatch for `{op}` argument {index}: expected {expected}, got {actual}")]
+    SortMismatch {
+        op: String,
+        index: usize,
+        expected: ResolvedSort,
+        actual: ResolvedSort,
+    },
+    #[error("malformed ProofIR term")]
+    MalformedTerm,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CatalogLoadError {
+    #[error("failed to read catalog file `{path}`: {kind:?}")]
+    Io {
+        path: PathBuf,
+        kind: std::io::ErrorKind,
+    },
+    #[error("failed to parse catalog file `{path}`: {message}")]
+    Json { path: PathBuf, message: String },
+    #[error("bad cids.tsv row {line}: expected 4 tab-separated fields")]
+    BadCidsRow { line: usize },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CatalogIndex {
+    ops: BTreeMap<String, CatalogOp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogOp {
+    pub name: String,
+    pub cid: String,
+    pub formal_sorts: Option<Vec<ResolvedSort>>,
+    pub return_sort: Option<ResolvedSort>,
+}
+
+pub fn proofir_resolve(term: &ProofirTerm, catalog: &CatalogIndex) -> Result<ResolvedTerm, BridgeError> {
+    match term {
+        Term::Const { value, sort } => Ok(ResolvedTerm {
+            node: ResolvedNode::Literal {
+                value: value.clone(),
+            },
+            sort: proofir_sort_to_resolved_sort(sort)?,
+        }),
+        Term::Ctor { name, args } => {
+            let op = catalog
+                .op(name)
+                .ok_or_else(|| BridgeError::UnknownOp(name.clone()))?;
+
+            if let Some(formal_sorts) = &op.formal_sorts {
+                if formal_sorts.len() != args.len() {
+                    return Err(BridgeError::ArityMismatch {
+                        expected: formal_sorts.len(),
+                        actual: args.len(),
+                    });
+                }
+            }
+
+            let mut lifted_args = Vec::with_capacity(args.len());
+            for (index, arg) in args.iter().enumerate() {
+                let lifted = proofir_resolve(arg, catalog)?;
+                if let Some(expected) = op.formal_sorts.as_ref().and_then(|sorts| sorts.get(index))
+                {
+                    if &lifted.sort != expected {
+                        return Err(BridgeError::SortMismatch {
+                            op: name.clone(),
+                            index,
+                            expected: expected.clone(),
+                            actual: lifted.sort,
+                        });
+                    }
+                }
+                lifted_args.push(lifted);
+            }
+
+            let sort = op.return_sort.clone().ok_or(BridgeError::MalformedTerm)?;
+            Ok(ResolvedTerm {
+                node: ResolvedNode::OpApplication {
+                    op_definition_cid: op.cid.clone(),
+                    args: lifted_args,
+                },
+                sort,
+            })
+        }
+        Term::Var { .. } | Term::Lambda { .. } | Term::Let { .. } => {
+            Err(BridgeError::MalformedTerm)
+        }
+    }
+}
+
+impl CatalogIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert_op(
+        &mut self,
+        name: impl Into<String>,
+        cid: impl Into<String>,
+        formal_sorts: Option<Vec<ResolvedSort>>,
+        return_sort: Option<ResolvedSort>,
+    ) {
+        let name = name.into();
+        self.ops.insert(
+            name.clone(),
+            CatalogOp {
+                name,
+                cid: cid.into(),
+                formal_sorts,
+                return_sort,
+            },
+        );
+    }
+
+    pub fn op_definition_cid(&self, name: &str) -> Option<&str> {
+        self.op(name).map(|op| op.cid.as_str())
+    }
+
+    pub fn from_catalog_root(root: impl AsRef<Path>) -> Result<Self, CatalogLoadError> {
+        let root = resolve_existing_path(root.as_ref());
+        let index_path = root.join("index.json");
+        let raw_index: RawCatalogIndex = read_json(&index_path)?;
+        let mut catalog = CatalogIndex::new();
+
+        for entry in raw_index.entries.values() {
+            if entry.kind != "algorithm" {
+                continue;
+            }
+            let envelope_path = root.join(&entry.path);
+            let op = read_catalog_op(&envelope_path, &entry.name, &entry.cid)?;
+            catalog.ops.insert(entry.name.clone(), op);
+        }
+
+        Ok(catalog)
+    }
+
+    pub fn from_cids_tsv(path: impl AsRef<Path>) -> Result<Self, CatalogLoadError> {
+        let path = resolve_existing_path(path.as_ref());
+        let text = read_to_string(&path)?;
+        let mut catalog = CatalogIndex::new();
+
+        for (line_index, line) in text.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let fields = line.split('\t').collect::<Vec<_>>();
+            if fields.len() != 4 {
+                return Err(CatalogLoadError::BadCidsRow {
+                    line: line_index + 1,
+                });
+            }
+
+            let name = fields[1];
+            let cid = fields[2];
+            let payload_path = resolve_catalog_payload_path(&path, fields[3]);
+            let op = read_catalog_op(&payload_path, name, cid)?;
+            catalog.ops.insert(name.to_string(), op);
+        }
+
+        Ok(catalog)
+    }
+
+    fn op(&self, name: &str) -> Option<&CatalogOp> {
+        self.ops.get(name)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCatalogIndex {
+    entries: BTreeMap<String, RawCatalogEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCatalogEntry {
+    cid: String,
+    kind: String,
+    name: String,
+    path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawEnvelope {
+    memento: RawMemento,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMemento {
+    #[serde(default)]
+    formal_sorts: Option<Vec<ResolvedSort>>,
+    #[serde(default)]
+    return_sort: Option<ResolvedSort>,
+}
+
+fn read_catalog_op(path: &Path, name: &str, cid: &str) -> Result<CatalogOp, CatalogLoadError> {
+    let envelope: RawEnvelope = read_json(path)?;
+    Ok(CatalogOp {
+        name: name.to_string(),
+        cid: cid.to_string(),
+        formal_sorts: envelope
+            .memento
+            .formal_sorts
+            .map(|sorts| sorts.into_iter().map(normalize_sort_value).collect()),
+        return_sort: envelope.memento.return_sort.map(normalize_sort_value),
+    })
+}
+
+fn proofir_sort_to_resolved_sort(sort: &Sort) -> Result<ResolvedSort, BridgeError> {
+    match sort {
+        Sort::Primitive { name } => Ok(json!({
+            "args": [],
+            "kind": "ctor",
+            "name": name,
+        })),
+        Sort::Function { .. }
+        | Sort::Dependent { .. }
+        | Sort::Float { .. }
+        | Sort::Region { .. } => serde_json::to_value(sort).map_err(|_| BridgeError::MalformedTerm),
+    }
+}
+
+fn normalize_sort_value(sort: ResolvedSort) -> ResolvedSort {
+    let JsonValue::Object(mut object) = sort else {
+        return sort;
+    };
+
+    if object.get("kind") == Some(&JsonValue::String("primitive".to_string())) {
+        object.insert("kind".to_string(), JsonValue::String("ctor".to_string()));
+        object
+            .entry("args".to_string())
+            .or_insert_with(|| JsonValue::Array(Vec::new()));
+    }
+
+    JsonValue::Object(object)
+}
+
+fn read_json<T>(path: &Path) -> Result<T, CatalogLoadError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let text = read_to_string(path)?;
+    serde_json::from_str(&text).map_err(|source| CatalogLoadError::Json {
+        path: path.to_path_buf(),
+        message: source.to_string(),
+    })
+}
+
+fn read_to_string(path: &Path) -> Result<String, CatalogLoadError> {
+    std::fs::read_to_string(path).map_err(|source| CatalogLoadError::Io {
+        path: path.to_path_buf(),
+        kind: source.kind(),
+    })
+}
+
+fn resolve_existing_path(path: &Path) -> PathBuf {
+    if path.exists() || path.is_absolute() {
+        return path.to_path_buf();
+    }
+
+    if let Ok(cwd) = std::env::current_dir() {
+        for ancestor in cwd.ancestors() {
+            let candidate = ancestor.join(path);
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+
+    path.to_path_buf()
+}
+
+fn resolve_catalog_payload_path(cids_path: &Path, payload_path: &str) -> PathBuf {
+    let raw = PathBuf::from(payload_path);
+    if raw.exists() || raw.is_absolute() {
+        return raw;
+    }
+
+    if let Ok(cwd) = std::env::current_dir() {
+        for ancestor in cwd.ancestors() {
+            let candidate = ancestor.join(&raw);
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+
+    for ancestor in cids_path.ancestors() {
+        let candidate = ancestor.join(&raw);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    cids_path
+        .parent()
+        .map(|parent| parent.join(&raw))
+        .unwrap_or(raw)
+}

--- a/implementations/rust/libprovekit/tests/proofir_bridge.rs
+++ b/implementations/rust/libprovekit/tests/proofir_bridge.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+use libprovekit::proofir_bridge::{BridgeError, CatalogIndex, ResolvedNode, ResolvedTerm};
+use libprovekit::proofir_resolve;
+use provekit_ir_types::{Sort, Term};
+use serde_json::json;
+
+fn int_sort() -> Sort {
+    Sort::Primitive { name: "Int".into() }
+}
+
+fn int_lit(value: i64) -> Term {
+    Term::Const {
+        value: json!(value),
+        sort: int_sort(),
+    }
+}
+
+fn add(args: Vec<Term>) -> Term {
+    Term::Ctor {
+        name: "concept:add".into(),
+        args,
+    }
+}
+
+fn concept_catalog() -> CatalogIndex {
+    CatalogIndex::from_catalog_root(Path::new("menagerie/concept-shapes/catalog"))
+        .expect("concept-shapes catalog loads")
+}
+
+#[test]
+fn add_op_resolves_to_op_application_with_catalog_cid() {
+    let catalog = concept_catalog();
+    let expected_cid = catalog
+        .op_definition_cid("concept:add")
+        .expect("concept:add is cataloged")
+        .to_string();
+
+    let resolved = proofir_resolve(&add(vec![int_lit(1), int_lit(2)]), &catalog).unwrap();
+
+    match resolved.node {
+        ResolvedNode::OpApplication {
+            op_definition_cid,
+            args,
+        } => {
+            assert_eq!(op_definition_cid, expected_cid);
+            assert_eq!(args.len(), 2);
+            assert_eq!(resolved.sort, json!({"args": [], "kind": "ctor", "name": "Int"}));
+        }
+        ResolvedNode::Literal { .. } => panic!("expected op-application"),
+    }
+}
+
+#[test]
+fn unknown_op_refuses_with_op_name() {
+    let catalog = concept_catalog();
+    let err = proofir_resolve(
+        &Term::Ctor {
+            name: "concept:not-in-catalog".into(),
+            args: vec![int_lit(1)],
+        },
+        &catalog,
+    )
+    .unwrap_err();
+
+    assert_eq!(err, BridgeError::UnknownOp("concept:not-in-catalog".into()));
+}
+
+#[test]
+fn arity_mismatch_refuses_with_expected_and_actual_counts() {
+    let catalog = concept_catalog();
+    let err = proofir_resolve(&add(vec![int_lit(1)]), &catalog).unwrap_err();
+
+    assert_eq!(
+        err,
+        BridgeError::ArityMismatch {
+            expected: 2,
+            actual: 1,
+        }
+    );
+}
+
+#[test]
+fn nested_ops_lift_to_nested_op_application_tree() {
+    let catalog = concept_catalog();
+    let resolved = proofir_resolve(
+        &add(vec![add(vec![int_lit(1), int_lit(2)]), int_lit(3)]),
+        &catalog,
+    )
+    .unwrap();
+
+    let ResolvedTerm {
+        node: ResolvedNode::OpApplication { args, .. },
+        ..
+    } = resolved
+    else {
+        panic!("expected outer op-application");
+    };
+
+    assert_eq!(args.len(), 2);
+    assert!(matches!(
+        args[0].node,
+        ResolvedNode::OpApplication {
+            op_definition_cid: _,
+            args: _
+        }
+    ));
+    assert!(matches!(args[1].node, ResolvedNode::Literal { .. }));
+}


### PR DESCRIPTION
Closes #915. Refs umbrella #895 (Phase 2: round-trip tooling), top umbrella #922. Depends on #945 (op-definition + op-application meta-layer, in main).

## What the function does

`libprovekit::proofir_bridge::proofir_resolve(term, catalog)` takes a ProofIR term carrying op names that reference the catalog and returns a ProofIR term where every op reference has been resolved to its op-definition CID. Same algebra. References resolved.

The operation is name resolution: each op-name string is looked up in the catalog and substituted with the CID of the corresponding op-definition. After resolve, the term is fully content-addressed at every node and needs no catalog to interpret. This is ProofIR's terminal form (paper 25's substrate-as-language recognition).

## Refusal taxonomy

| Refusal | When |
|---|---|
| `UnknownOp(name)` | op-name not in catalog |
| `ArityMismatch{expected, actual}` | args.length doesn't match formals.length |
| `SortMismatch{expected, actual}` | arg sort doesn't match formal_sorts[i] |
| `MalformedTerm` | term JSON does not parse as ProofIR |

Constants pass through as literal terminal terms. Term::Ctor invocations recurse into nested op-applications.

## Files

- `implementations/rust/libprovekit/src/proofir_bridge.rs` (resolution + types)
- `implementations/rust/libprovekit/tests/proofir_bridge.rs` (4 tests)
- `libprovekit/src/lib.rs`: re-export `proofir_resolve` at crate root

## Types

- `ResolvedTerm { node, sort }`
- `ResolvedNode` (`Literal` | `OpApplication`)
- `ResolvedSort` (alias for `JsonValue`)

## Verification

- `cargo build -p libprovekit --release`: green
- `cargo test -p libprovekit`: passed
- 4 bridge tests pass: `add_op_resolves_to_op_application_with_catalog_cid`, `unknown_op_refuses_with_op_name`, `arity_mismatch_refuses_with_expected_and_actual_counts`, `nested_ops_lift_to_nested_op_application_tree`
- Em-dash + en-dash sweep: clean

## Admin-merging

Pure addition (new module + tests). No existing behavior modified. Reversible.