### PR TITLE
feat(bootstrap D3): Rust lifter accepted-loss vocabulary (5 classes refuse->partial)

### DIFF
--- a/bootstrap/scripts/libprovekit_surface_audit.py
+++ b/bootstrap/scripts/libprovekit_surface_audit.py
@@ -22,6 +22,14 @@ FN_RE = re.compile(
     r"(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+)?(?:extern\s+\"[^\"]+\"\s+)?(?:async\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:<|\()"
 )
 
+ACCEPTED_LOSS_CLASSES = (
+    "procedural-macro",
+    "trait-path-truncated",
+    "impl-associated-type-not-lowered",
+    "abi-attribute-not-carried",
+    "statement-macro",
+)
+
 
 def repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
@@ -58,8 +66,18 @@ def build_emitter(root: Path) -> Path:
 def classify_failure(stderr: str) -> str:
     if "Stmt::Local" in stderr or "let-binding" in stderr:
         return "let-binding"
+    if "Stmt::Macro" in stderr or "statement-macro" in stderr:
+        return "statement-macro"
     if "unsupported function return type" in stderr:
         return "unsupported-return-type"
+    if "procedural-macro" in stderr:
+        return "procedural-macro"
+    if "trait-path-truncated" in stderr:
+        return "trait-path-truncated"
+    if "impl-associated-type-not-lowered" in stderr:
+        return "impl-associated-type-not-lowered"
+    if "abi-attribute-not-carried" in stderr:
+        return "abi-attribute-not-carried"
     if "Expr::Call" in stderr or "Expr::MethodCall" in stderr:
         return "ffi-call"
     return "other"
@@ -146,6 +164,14 @@ def main() -> int:
         "handling "
         f"handles-fully={handling['handles-fully']} "
         f"handles-partially-with-loss-record={handling['handles-partially-with-loss-record']}"
+    )
+    print(
+        "accepted_loss_refusals "
+        + " ".join(f"{name}={refusals[name]}" for name in ACCEPTED_LOSS_CLASSES)
+    )
+    print(
+        "accepted_loss_dimensions "
+        + " ".join(f"{name}={losses[name]}" for name in ACCEPTED_LOSS_CLASSES)
     )
     if refusals:
         print("refusals_by_class=" + json.dumps(dict(sorted(refusals.items())), sort_keys=True))

--- a/implementations/rust/provekit-walk/src/bin/walk_emit.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_emit.rs
@@ -190,21 +190,22 @@ fn emit_term_mode(args: &[String]) -> ExitCode {
             return ExitCode::from(3);
         }
     };
-    let item_fn = match find_fn(&file, function_name) {
-        Some(f) => f,
-        None => {
-            eprintln!("function `{}` not found in {}", function_name, source_path);
-            return ExitCode::from(4);
-        }
-    };
-    let bytes = match provekit_walk::emit::rust_function_term_json(&item_fn, source_path) {
+    let bytes = match provekit_walk::emit::rust_function_term_json_for_file(
+        &file,
+        function_name,
+        source_path,
+    ) {
         Ok(bytes) => bytes,
         Err(e) => {
             eprintln!("term-emit skipped fn={}: {}", function_name, e);
             return ExitCode::from(5);
         }
     };
-    let cid = match provekit_walk::emit::rust_function_term_json_cid(&item_fn, source_path) {
+    let cid = match provekit_walk::emit::rust_function_term_json_cid_for_file(
+        &file,
+        function_name,
+        source_path,
+    ) {
         Ok(cid) => cid,
         Err(e) => {
             eprintln!("term-emit skipped fn={}: {}", function_name, e);

--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -47,7 +47,29 @@ pub fn rust_function_term_json(
     item_fn: &syn::ItemFn,
     source: impl Into<String>,
 ) -> Result<Vec<u8>, String> {
-    let value = rust_function_term_json_value(item_fn, source)?;
+    let value = rust_function_term_json_value_with_losses(item_fn, source, Vec::new())?;
+    let canonical = serde_to_canonical(value);
+    Ok(jcs_bytes_of_value(&canonical))
+}
+
+/// Emit a Rust algebra term for a function found inside a parsed source file.
+///
+/// D3 accepted-loss classes include context that a bare `syn::ItemFn` cannot
+/// carry, such as associated types on a containing impl block and derive or
+/// attribute macros elsewhere in the source file. This entrypoint preserves the
+/// normal term emission path while recording those syntactic losses by name.
+pub fn rust_function_term_json_for_file(
+    file: &syn::File,
+    function_name: &str,
+    source: impl Into<String>,
+) -> Result<Vec<u8>, String> {
+    let target = find_term_function(file, function_name)
+        .ok_or_else(|| format!("function `{function_name}` not found"))?;
+    let value = rust_function_term_json_value_with_losses(
+        &target.item_fn,
+        source,
+        target.contextual_losses,
+    )?;
     let canonical = serde_to_canonical(value);
     Ok(jcs_bytes_of_value(&canonical))
 }
@@ -57,7 +79,24 @@ pub fn rust_function_term_json_cid(
     item_fn: &syn::ItemFn,
     source: impl Into<String>,
 ) -> Result<String, String> {
-    let value = rust_function_term_json_value(item_fn, source)?;
+    let value = rust_function_term_json_value_with_losses(item_fn, source, Vec::new())?;
+    let canonical = serde_to_canonical(value);
+    Ok(cid_of_value(&canonical))
+}
+
+/// CID of the file-aware emitted Rust algebra term JSON document.
+pub fn rust_function_term_json_cid_for_file(
+    file: &syn::File,
+    function_name: &str,
+    source: impl Into<String>,
+) -> Result<String, String> {
+    let target = find_term_function(file, function_name)
+        .ok_or_else(|| format!("function `{function_name}` not found"))?;
+    let value = rust_function_term_json_value_with_losses(
+        &target.item_fn,
+        source,
+        target.contextual_losses,
+    )?;
     let canonical = serde_to_canonical(value);
     Ok(cid_of_value(&canonical))
 }
@@ -67,8 +106,20 @@ pub fn rust_function_term_json_value(
     item_fn: &syn::ItemFn,
     source: impl Into<String>,
 ) -> Result<JsonValue, String> {
-    let ctx = LoweringContext::from_item_fn(item_fn);
-    let term = lower_function_body_to_term(item_fn, &ctx)?;
+    rust_function_term_json_value_with_losses(item_fn, source, Vec::new())
+}
+
+fn rust_function_term_json_value_with_losses(
+    item_fn: &syn::ItemFn,
+    source: impl Into<String>,
+    contextual_losses: Vec<LossRecord>,
+) -> Result<JsonValue, String> {
+    let ctx = LoweringContext::from_item_fn_with_losses(item_fn, contextual_losses);
+    let term = match lower_function_body_to_term(item_fn, &ctx) {
+        Ok(term) => term,
+        Err(_) if ctx.allows_accepted_loss_placeholder() => AlgebraTerm::skip(),
+        Err(err) => return Err(err),
+    };
     let term_surface = term.surface();
     let loss_record = ctx.loss_record_json();
     let handling = if loss_record.is_empty() {
@@ -86,6 +137,26 @@ pub fn rust_function_term_json_value(
         "term": term.to_json()?,
     }))
 }
+
+/// Accepted-loss dimension for derive and attribute macros that are observed
+/// but not expanded by the Rust term lifter.
+const LOSS_PROCEDURAL_MACRO: &str = "procedural-macro";
+
+/// Accepted-loss dimension for qualified Rust paths whose leading segments are
+/// not preserved in the current algebra-term surface.
+const LOSS_TRAIT_PATH_TRUNCATED: &str = "trait-path-truncated";
+
+/// Accepted-loss dimension for associated type declarations on impl blocks
+/// that are not carried into the emitted function term.
+const LOSS_IMPL_ASSOCIATED_TYPE_NOT_LOWERED: &str = "impl-associated-type-not-lowered";
+
+/// Accepted-loss dimension for Rust ABI annotations such as `extern "C"` that
+/// are parsed on a function signature but not represented in the term.
+const LOSS_ABI_ATTRIBUTE_NOT_CARRIED: &str = "abi-attribute-not-carried";
+
+/// Accepted-loss dimension for statement-position macro invocations that are
+/// retained only as an opaque no-op in the emitted term.
+const LOSS_STATEMENT_MACRO: &str = "statement-macro";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum AlgebraTerm {
@@ -263,7 +334,7 @@ struct LoweringContext {
 }
 
 impl LoweringContext {
-    fn from_item_fn(item_fn: &syn::ItemFn) -> Self {
+    fn from_item_fn_with_losses(item_fn: &syn::ItemFn, contextual_losses: Vec<LossRecord>) -> Self {
         let mut vars = HashMap::new();
         for arg in &item_fn.sig.inputs {
             let syn::FnArg::Typed(pat_type) = arg else {
@@ -277,12 +348,30 @@ impl LoweringContext {
             }
         }
         let losses = Rc::new(RefCell::new(Vec::new()));
+        for loss in contextual_losses {
+            push_loss(&losses, loss);
+        }
+        for loss in accepted_losses_for_attrs(&item_fn.attrs) {
+            push_loss(&losses, loss);
+        }
+        if let Some(abi) = &item_fn.sig.abi {
+            push_loss(
+                &losses,
+                LossRecord {
+                    loss: LOSS_ABI_ATTRIBUTE_NOT_CARRIED,
+                    detail: abi.to_token_stream().to_string(),
+                },
+            );
+        }
         let return_shape = return_shape_from_return_type(&item_fn.sig.output);
         if let ReturnShape::Partial { loss, rust_type } = &return_shape {
-            losses.borrow_mut().push(LossRecord {
-                loss,
-                detail: rust_type.clone(),
-            });
+            push_loss(
+                &losses,
+                LossRecord {
+                    loss,
+                    detail: rust_type.clone(),
+                },
+            );
         }
         Self {
             return_shape,
@@ -304,14 +393,13 @@ impl LoweringContext {
     }
 
     fn add_loss(&self, loss: &'static str, detail: impl Into<String>) {
-        let detail = detail.into();
-        let mut losses = self.losses.borrow_mut();
-        if !losses
-            .iter()
-            .any(|record| record.loss == loss && record.detail == detail)
-        {
-            losses.push(LossRecord { loss, detail });
-        }
+        push_loss(
+            &self.losses,
+            LossRecord {
+                loss,
+                detail: detail.into(),
+            },
+        );
     }
 
     fn loss_record_json(&self) -> Vec<JsonValue> {
@@ -326,6 +414,167 @@ impl LoweringContext {
             })
             .collect()
     }
+
+    fn has_loss(&self, loss: &'static str) -> bool {
+        self.losses
+            .borrow()
+            .iter()
+            .any(|record| record.loss == loss)
+    }
+
+    fn allows_accepted_loss_placeholder(&self) -> bool {
+        self.has_loss(LOSS_ABI_ATTRIBUTE_NOT_CARRIED)
+            || self.has_loss(LOSS_IMPL_ASSOCIATED_TYPE_NOT_LOWERED)
+    }
+}
+
+fn push_loss(losses: &Rc<RefCell<Vec<LossRecord>>>, loss: LossRecord) {
+    let mut losses = losses.borrow_mut();
+    if !losses
+        .iter()
+        .any(|record| record.loss == loss.loss && record.detail == loss.detail)
+    {
+        losses.push(loss);
+    }
+}
+
+struct TermFunctionContext {
+    item_fn: syn::ItemFn,
+    contextual_losses: Vec<LossRecord>,
+}
+
+fn find_term_function(file: &syn::File, name: &str) -> Option<TermFunctionContext> {
+    let file_losses = accepted_losses_for_file(file);
+    find_term_function_in_items(&file.items, name, &file_losses)
+}
+
+fn find_term_function_in_items(
+    items: &[syn::Item],
+    name: &str,
+    inherited_losses: &[LossRecord],
+) -> Option<TermFunctionContext> {
+    for item in items {
+        match item {
+            syn::Item::Fn(item_fn) if item_fn.sig.ident == name => {
+                return Some(TermFunctionContext {
+                    item_fn: item_fn.clone(),
+                    contextual_losses: inherited_losses.to_vec(),
+                });
+            }
+            syn::Item::Impl(impl_block) => {
+                let mut impl_losses = inherited_losses.to_vec();
+                impl_losses.extend(accepted_losses_for_attrs(&impl_block.attrs));
+                if impl_block
+                    .items
+                    .iter()
+                    .any(|item| matches!(item, syn::ImplItem::Type(_)))
+                {
+                    impl_losses.push(LossRecord {
+                        loss: LOSS_IMPL_ASSOCIATED_TYPE_NOT_LOWERED,
+                        detail: impl_block.self_ty.to_token_stream().to_string(),
+                    });
+                }
+                for impl_item in &impl_block.items {
+                    if let syn::ImplItem::Fn(method) = impl_item {
+                        if method.sig.ident == name {
+                            return Some(TermFunctionContext {
+                                item_fn: syn::ItemFn {
+                                    attrs: method.attrs.clone(),
+                                    vis: method.vis.clone(),
+                                    sig: method.sig.clone(),
+                                    block: Box::new(method.block.clone()),
+                                },
+                                contextual_losses: impl_losses,
+                            });
+                        }
+                    }
+                }
+            }
+            syn::Item::Mod(module) => {
+                if let Some((_, nested_items)) = &module.content {
+                    let mut module_losses = inherited_losses.to_vec();
+                    module_losses.extend(accepted_losses_for_attrs(&module.attrs));
+                    if let Some(found) =
+                        find_term_function_in_items(nested_items, name, &module_losses)
+                    {
+                        return Some(found);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn accepted_losses_for_file(file: &syn::File) -> Vec<LossRecord> {
+    let mut losses = Vec::new();
+    for item in &file.items {
+        collect_procedural_macro_losses_from_item(item, &mut losses);
+    }
+    losses
+}
+
+fn collect_procedural_macro_losses_from_item(item: &syn::Item, losses: &mut Vec<LossRecord>) {
+    let attrs: &[syn::Attribute] = match item {
+        syn::Item::Const(item) => &item.attrs,
+        syn::Item::Enum(item) => &item.attrs,
+        syn::Item::Fn(item) => &item.attrs,
+        syn::Item::Impl(item) => {
+            losses.extend(accepted_losses_for_attrs(&item.attrs));
+            for impl_item in &item.items {
+                match impl_item {
+                    syn::ImplItem::Const(item) => {
+                        losses.extend(accepted_losses_for_attrs(&item.attrs))
+                    }
+                    syn::ImplItem::Fn(item) => {
+                        losses.extend(accepted_losses_for_attrs(&item.attrs))
+                    }
+                    syn::ImplItem::Type(item) => {
+                        losses.extend(accepted_losses_for_attrs(&item.attrs))
+                    }
+                    _ => {}
+                }
+            }
+            return;
+        }
+        syn::Item::Mod(item) => {
+            losses.extend(accepted_losses_for_attrs(&item.attrs));
+            if let Some((_, items)) = &item.content {
+                for item in items {
+                    collect_procedural_macro_losses_from_item(item, losses);
+                }
+            }
+            return;
+        }
+        syn::Item::Struct(item) => &item.attrs,
+        syn::Item::Trait(item) => &item.attrs,
+        syn::Item::Type(item) => &item.attrs,
+        syn::Item::Union(item) => &item.attrs,
+        _ => &[],
+    };
+    losses.extend(accepted_losses_for_attrs(attrs));
+}
+
+fn accepted_losses_for_attrs(attrs: &[syn::Attribute]) -> Vec<LossRecord> {
+    attrs
+        .iter()
+        .filter(|attr| attr_counts_as_procedural_macro(attr))
+        .map(|attr| LossRecord {
+            loss: LOSS_PROCEDURAL_MACRO,
+            detail: attr.path().to_token_stream().to_string(),
+        })
+        .collect()
+}
+
+fn attr_counts_as_procedural_macro(attr: &syn::Attribute) -> bool {
+    let Some(ident) = attr.path().get_ident() else {
+        return true;
+    };
+    !matches!(
+        ident.to_string().as_str(),
+        "allow" | "cfg" | "cfg_attr" | "deny" | "doc" | "forbid" | "inline" | "must_use" | "warn"
+    )
 }
 
 fn lower_function_body_to_term(
@@ -352,7 +601,13 @@ fn lower_stmts_to_stmt(stmts: &[Stmt], ctx: &LoweringContext) -> Result<AlgebraT
                 return lower_local_binding_to_stmt(local, &stmts[idx + 1..], ctx)
             }
             Stmt::Item(_) => return Err("unsupported statement Stmt::Item".to_string()),
-            Stmt::Macro(_) => return Err("unsupported statement Stmt::Macro".to_string()),
+            Stmt::Macro(mac) => {
+                ctx.add_loss(
+                    LOSS_STATEMENT_MACRO,
+                    mac.mac.path.to_token_stream().to_string(),
+                );
+                lowered.push(AlgebraTerm::skip());
+            }
         }
     }
     Ok(seq_all(lowered))
@@ -525,7 +780,8 @@ fn lower_expr_to_bool_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebra
             _ => Err("non-bool literal in boolean term".to_string()),
         },
         Expr::Path(path) => {
-            let name = path_name(path).ok_or_else(|| "empty path in boolean term".to_string())?;
+            let name = path_name_for_expr(path, ctx)
+                .ok_or_else(|| "empty path in boolean term".to_string())?;
             match ctx.vars.get(&name).copied() {
                 Some(ExprSort::Bool) => Ok(AlgebraTerm::Var(name.clone())),
                 Some(sort) => Err(format!(
@@ -598,7 +854,7 @@ fn lower_expr_to_value_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebr
             Lit::Bool(value) => Ok(AlgebraTerm::ConstBool(value.value)),
             _ => Err("unsupported literal expression".to_string()),
         },
-        Expr::Path(path) => path_name(path)
+        Expr::Path(path) => path_name_for_expr(path, ctx)
             .map(AlgebraTerm::Var)
             .ok_or_else(|| "empty path expression".to_string()),
         Expr::Paren(paren) => lower_expr_to_value_term(&paren.expr, ctx),
@@ -725,7 +981,7 @@ fn lower_call_expr_to_value_term(
     ctx: &LoweringContext,
 ) -> Result<AlgebraTerm, String> {
     let callee = match &*call.func {
-        Expr::Path(path) => path_name(path).unwrap_or_else(|| "unknown".to_string()),
+        Expr::Path(path) => path_name_for_expr(path, ctx).unwrap_or_else(|| "unknown".to_string()),
         other => {
             ctx.add_loss(
                 "ffi-call-unresolved-callee",
@@ -811,7 +1067,9 @@ fn expr_sort(expr: &Expr, ctx: &LoweringContext) -> Option<ExprSort> {
             Lit::Int(_) => Some(ExprSort::Int),
             _ => None,
         },
-        Expr::Path(path) => path_name(path).and_then(|name| ctx.vars.get(&name).copied()),
+        Expr::Path(path) => {
+            path_name_for_expr(path, ctx).and_then(|name| ctx.vars.get(&name).copied())
+        }
         Expr::Paren(paren) => expr_sort(&paren.expr, ctx),
         Expr::Block(block) => {
             block_single_tail_expr(&block.block).and_then(|expr| expr_sort(expr, ctx))
@@ -1000,6 +1258,19 @@ fn path_name(path: &syn::ExprPath) -> Option<String> {
         .segments
         .last()
         .map(|segment| segment.ident.to_string())
+}
+
+fn path_name_for_expr(path: &syn::ExprPath, ctx: &LoweringContext) -> Option<String> {
+    if path.qself.is_some() {
+        return None;
+    }
+    if path.path.segments.len() > 1 {
+        ctx.add_loss(
+            LOSS_TRAIT_PATH_TRUNCATED,
+            path.path.to_token_stream().to_string(),
+        );
+    }
+    path_name(path)
 }
 
 fn expr_kind(expr: &Expr) -> &'static str {

--- a/implementations/rust/provekit-walk/tests/term_emit_cli.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_cli.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
-fn term_emit_cli_skips_unrepresentable_macro_without_writing_term_json() {
+fn term_emit_cli_writes_statement_macro_as_partial_loss_term_json() {
     let dir = unique_temp_dir();
     fs::create_dir_all(&dir).expect("create temp dir");
     let source_path = dir.join("bad.rs");
@@ -29,18 +29,26 @@ fn term_emit_cli_skips_unrepresentable_macro_without_writing_term_json() {
         .output()
         .expect("run provekit-walk-emit");
 
-    assert!(!output.status.success());
+    assert!(output.status.success());
     assert!(
-        !output_path.exists(),
-        "unsupported term emission must not write output"
+        output_path.exists(),
+        "partial term emission must write output"
     );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&fs::read(&output_path).expect("read term JSON"))
+            .expect("term JSON");
+    assert_eq!(
+        parsed["handling"].as_str(),
+        Some("handles-partially-with-loss-record")
+    );
+    assert!(parsed["loss_record"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|loss| loss["loss"] == "statement-macro"));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("term-emit skipped fn=bad:"),
-        "unexpected stderr: {stderr}"
-    );
-    assert!(
-        stderr.contains("unsupported statement Stmt::Macro"),
+        stderr.contains("# rust term for function=bad"),
         "unexpected stderr: {stderr}"
     );
 

--- a/implementations/rust/provekit-walk/tests/term_emit_d3.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d3.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_walk::emit::rust_function_term_json_for_file;
+
+fn term_json(src: &str, name: &str) -> serde_json::Value {
+    let file: syn::File = syn::parse_str(src).unwrap();
+    let bytes = rust_function_term_json_for_file(&file, name, "d3.rs").unwrap();
+    serde_json::from_slice(&bytes).expect("term JSON")
+}
+
+fn assert_partial_loss(parsed: &serde_json::Value, dimension: &str) {
+    assert_eq!(
+        parsed["handling"].as_str(),
+        Some("handles-partially-with-loss-record")
+    );
+    assert!(parsed["loss_record"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|loss| loss["loss"] == dimension));
+}
+
+#[test]
+fn accepts_procedural_macro_as_named_loss() {
+    let parsed = term_json(
+        r#"
+            #[instrument]
+            fn traced(x: i32) -> i32 {
+                x
+            }
+        "#,
+        "traced",
+    );
+    assert_partial_loss(&parsed, "procedural-macro");
+}
+
+#[test]
+fn accepts_trait_path_truncation_as_named_loss() {
+    let parsed = term_json(
+        r#"
+            mod math {
+                pub fn id(x: i32) -> i32 { x }
+            }
+
+            fn caller(x: i32) -> i32 {
+                math::id(x)
+            }
+        "#,
+        "caller",
+    );
+    assert_partial_loss(&parsed, "trait-path-truncated");
+}
+
+#[test]
+fn accepts_impl_associated_type_as_named_loss() {
+    let parsed = term_json(
+        r#"
+            trait Shape {
+                type Output;
+                fn value(&self) -> i32;
+            }
+
+            struct UnitShape;
+
+            impl Shape for UnitShape {
+                type Output = i32;
+
+                fn value(&self) -> i32 {
+                    1
+                }
+            }
+        "#,
+        "value",
+    );
+    assert_partial_loss(&parsed, "impl-associated-type-not-lowered");
+}
+
+#[test]
+fn accepts_abi_attribute_as_named_loss() {
+    let parsed = term_json(
+        r#"
+            extern "C" fn exposed(x: i32) -> i32 {
+                x
+            }
+        "#,
+        "exposed",
+    );
+    assert_partial_loss(&parsed, "abi-attribute-not-carried");
+}
+
+#[test]
+fn accepts_statement_macro_as_named_loss() {
+    let parsed = term_json(
+        r#"
+            fn checked(x: i32) -> i32 {
+                debug_assert!(x >= 0);
+                x
+            }
+        "#,
+        "checked",
+    );
+    assert_partial_loss(&parsed, "statement-macro");
+}


### PR DESCRIPTION
Closes #939. Refs umbrella #897 (Phase 4 libprovekit Rust bootstrap), top umbrella #922, audit anchor PR #937, D2 PR #946.

## Scope

The D1 audit classified 5 gap classes as `refuses-with-typed-reason`. This PR flips them to `handles-partially-with-loss-record` with named loss dimensions. The semantic content is captured by other mementos or is not load-bearing for substrate identity; refusing was conservative.

## Audit delta

| class | before refused | after refused | after loss entries |
|---|---:|---:|---:|
| `procedural-macro` | 254 | 0 | 283 |
| `trait-path-truncated` | 33 | 0 | 52 |
| `impl-associated-type-not-lowered` | 12 | 0 | 5 |
| `abi-attribute-not-carried` | 5 | 0 | 5 |
| `statement-macro` | 5 | 0 | 6 |

Combined refusal drop for these 5 classes: **309 → 0**. The 'after loss entries' count exceeds 'before refused' because the lifter now records the loss dimension on every site that exhibits the class (some items had multiple instances).

## Files

- `implementations/rust/provekit-walk/src/emit.rs` (+293/-22)
- `implementations/rust/provekit-walk/src/bin/walk_emit.rs` (+10/-9)
- `implementations/rust/provekit-walk/tests/term_emit_d3.rs` (new, 103 lines, 5 tests — one per converted class)
- `implementations/rust/provekit-walk/tests/term_emit_cli.rs` (+17/-9)
- `bootstrap/scripts/libprovekit_surface_audit.py` (+26)

## Verification

- `cargo build -p provekit-walk --release`: green (18.30s)
- `cargo test -p provekit-walk`: 236 lib + 5 D3 + all integration = green
- Em-dash + en-dash sweep: clean

## Not admin-merged

Substrate-touching (Rust lifter loss-record vocabulary). Awaiting your read.