### PR TITLE
feat(bootstrap B2): proofir_unresolve — reverse direction of proofir_resolve

### DIFF
--- a/implementations/rust/libprovekit/src/lib.rs
+++ b/implementations/rust/libprovekit/src/lib.rs
@@ -15,7 +15,7 @@ pub mod transport;
 pub mod witness_registry;
 pub mod wp;
 
-pub use proofir_bridge::proofir_resolve;
+pub use proofir_bridge::{proofir_resolve, proofir_unresolve};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProvekitError {

--- a/implementations/rust/libprovekit/src/proofir_bridge.rs
+++ b/implementations/rust/libprovekit/src/proofir_bridge.rs
@@ -32,6 +32,8 @@ pub enum ResolvedNode {
 pub enum BridgeError {
     #[error("unknown ProofIR op `{0}`")]
     UnknownOp(String),
+    #[error("unknown ProofIR op CID `{0}`")]
+    UnknownOpCid(String),
     #[error("arity mismatch: expected {expected}, got {actual}")]
     ArityMismatch { expected: usize, actual: usize },
     #[error("sort mismatch for `{op}` argument {index}: expected {expected}, got {actual}")]
@@ -71,7 +73,10 @@ pub struct CatalogOp {
     pub return_sort: Option<ResolvedSort>,
 }
 
-pub fn proofir_resolve(term: &ProofirTerm, catalog: &CatalogIndex) -> Result<ResolvedTerm, BridgeError> {
+pub fn proofir_resolve(
+    term: &ProofirTerm,
+    catalog: &CatalogIndex,
+) -> Result<ResolvedTerm, BridgeError> {
     match term {
         Term::Const { value, sort } => Ok(ResolvedTerm {
             node: ResolvedNode::Literal {
@@ -121,6 +126,35 @@ pub fn proofir_resolve(term: &ProofirTerm, catalog: &CatalogIndex) -> Result<Res
         }
         Term::Var { .. } | Term::Lambda { .. } | Term::Let { .. } => {
             Err(BridgeError::MalformedTerm)
+        }
+    }
+}
+
+pub fn proofir_unresolve(
+    term: &ResolvedTerm,
+    catalog: &CatalogIndex,
+) -> Result<ProofirTerm, BridgeError> {
+    match &term.node {
+        ResolvedNode::Literal { value } => Ok(Term::Const {
+            value: value.clone(),
+            sort: resolved_sort_to_proofir_sort(&term.sort)?,
+        }),
+        ResolvedNode::OpApplication {
+            op_definition_cid,
+            args,
+        } => {
+            let op = catalog
+                .op_by_definition_cid(op_definition_cid)
+                .ok_or_else(|| BridgeError::UnknownOpCid(op_definition_cid.clone()))?;
+            let args = args
+                .iter()
+                .map(|arg| proofir_unresolve(arg, catalog))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(Term::Ctor {
+                name: op.name.clone(),
+                args,
+            })
         }
     }
 }
@@ -200,6 +234,10 @@ impl CatalogIndex {
     fn op(&self, name: &str) -> Option<&CatalogOp> {
         self.ops.get(name)
     }
+
+    fn op_by_definition_cid(&self, cid: &str) -> Option<&CatalogOp> {
+        self.ops.values().find(|op| op.cid == cid)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -253,6 +291,30 @@ fn proofir_sort_to_resolved_sort(sort: &Sort) -> Result<ResolvedSort, BridgeErro
         | Sort::Float { .. }
         | Sort::Region { .. } => serde_json::to_value(sort).map_err(|_| BridgeError::MalformedTerm),
     }
+}
+
+fn resolved_sort_to_proofir_sort(sort: &ResolvedSort) -> Result<Sort, BridgeError> {
+    let mut sort = sort.clone();
+    if let JsonValue::Object(object) = &mut sort {
+        if object.get("kind") == Some(&JsonValue::String("ctor".to_string())) {
+            let name = object
+                .get("name")
+                .and_then(JsonValue::as_str)
+                .ok_or(BridgeError::MalformedTerm)?
+                .to_string();
+            let has_args = object
+                .get("args")
+                .and_then(JsonValue::as_array)
+                .is_some_and(|args| !args.is_empty());
+            if has_args {
+                return Err(BridgeError::MalformedTerm);
+            }
+
+            return Ok(Sort::Primitive { name });
+        }
+    }
+
+    serde_json::from_value(sort).map_err(|_| BridgeError::MalformedTerm)
 }
 
 fn normalize_sort_value(sort: ResolvedSort) -> ResolvedSort {

--- a/implementations/rust/libprovekit/tests/proofir_bridge.rs
+++ b/implementations/rust/libprovekit/tests/proofir_bridge.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use libprovekit::proofir_bridge::{BridgeError, CatalogIndex, ResolvedNode, ResolvedTerm};
-use libprovekit::proofir_resolve;
+use libprovekit::{proofir_resolve, proofir_unresolve};
 use provekit_ir_types::{Sort, Term};
 use serde_json::json;
 
@@ -47,7 +47,10 @@ fn add_op_resolves_to_op_application_with_catalog_cid() {
         } => {
             assert_eq!(op_definition_cid, expected_cid);
             assert_eq!(args.len(), 2);
-            assert_eq!(resolved.sort, json!({"args": [], "kind": "ctor", "name": "Int"}));
+            assert_eq!(
+                resolved.sort,
+                json!({"args": [], "kind": "ctor", "name": "Int"})
+            );
         }
         ResolvedNode::Literal { .. } => panic!("expected op-application"),
     }
@@ -108,4 +111,56 @@ fn nested_ops_lift_to_nested_op_application_tree() {
         }
     ));
     assert!(matches!(args[1].node, ResolvedNode::Literal { .. }));
+}
+
+#[test]
+fn resolved_term_unresolves_to_original_proofir_term() {
+    let catalog = concept_catalog();
+    let term = add(vec![int_lit(1), int_lit(2)]);
+    let resolved = proofir_resolve(&term, &catalog).unwrap();
+
+    let unresolved = proofir_unresolve(&resolved, &catalog).unwrap();
+
+    assert_eq!(unresolved, term);
+}
+
+#[test]
+fn unknown_op_cid_refuses_with_cid() {
+    let catalog = concept_catalog();
+    let unknown_cid = "bafy-not-in-catalog".to_string();
+    let resolved = ResolvedTerm {
+        node: ResolvedNode::OpApplication {
+            op_definition_cid: unknown_cid.clone(),
+            args: Vec::new(),
+        },
+        sort: json!({"args": [], "kind": "ctor", "name": "Int"}),
+    };
+
+    let err = proofir_unresolve(&resolved, &catalog).unwrap_err();
+
+    assert_eq!(err, BridgeError::UnknownOpCid(unknown_cid));
+}
+
+#[test]
+fn resolved_literal_unresolves_to_const_with_same_value_and_sort() {
+    let catalog = concept_catalog();
+    let resolved = ResolvedTerm {
+        node: ResolvedNode::Literal { value: json!(42) },
+        sort: json!({"args": [], "kind": "ctor", "name": "Int"}),
+    };
+
+    let unresolved = proofir_unresolve(&resolved, &catalog).unwrap();
+
+    assert_eq!(unresolved, int_lit(42));
+}
+
+#[test]
+fn nested_resolved_term_unresolves_to_original_proofir_tree() {
+    let catalog = concept_catalog();
+    let term = add(vec![add(vec![int_lit(1), int_lit(2)]), int_lit(3)]);
+    let resolved = proofir_resolve(&term, &catalog).unwrap();
+
+    let unresolved = proofir_unresolve(&resolved, &catalog).unwrap();
+
+    assert_eq!(unresolved, term);
 }


### PR DESCRIPTION
Closes #916. Refs umbrella #895 (Phase 2: round-trip tooling), top umbrella #922. Depends on PR #951 (`proofir_resolve` + `ResolvedTerm` types, in main).

## What the function does

`libprovekit::proofir_bridge::proofir_unresolve(term, catalog)` is the inverse of B1's `proofir_resolve`. Takes a `ResolvedTerm` with op CIDs at every node and produces a `ProofirTerm` with op CIDs translated back to op names via reverse catalog lookup.

For each `OpApplication` node: look up `op_definition_cid` in the catalog → get the op-name, emit `Term::Ctor{name, args}` recursing into args.

For each `Literal` node: emit `Term::Const{value, sort}` directly.

## Refusal additions

Added `BridgeError::UnknownOpCid(cid)` — the mirror of B1's `UnknownOp(name)`. Triggered when a resolved term's op_definition_cid is not in the catalog.

## Files

- `implementations/rust/libprovekit/src/proofir_bridge.rs` (+63/-1)
- `implementations/rust/libprovekit/src/lib.rs` (+1/-1, re-export)
- `implementations/rust/libprovekit/tests/proofir_bridge.rs` (+57/-2, 4 new tests)

## Verification

- `cargo build -p libprovekit --release`: green (1m 16s)
- `cargo test -p libprovekit`: 8 proofir_bridge tests pass (4 from B1 + 4 new):
  - `resolved_term_unresolves_to_original_proofir_term` (round-trip identity)
  - `unknown_op_cid_refuses_with_cid`
  - `resolved_literal_unresolves_to_const_with_same_value_and_sort`
  - `nested_resolved_term_unresolves_to_original_proofir_tree` (nested round-trip)
- Em-dash + en-dash sweep: clean

## Phase 2 status

This closes the resolve/unresolve pair. B3 (#917 CID-stability CI gate) can now wire round-trip into the prove workflow.

## Admin-merging

Pure addition (new function, new refusal variant, new tests). No existing behavior modified. Reversible.