### PR TITLE
feat(bootstrap D4): Rust lifter term-emitter-unsupported (64 items resolved)

### DIFF
--- a/bootstrap/libprovekit-gap-report.md
+++ b/bootstrap/libprovekit-gap-report.md
@@ -163,3 +163,26 @@ Total items audited: 1109
 - Direct dependency crates are included only because `libprovekit` composes them through its manifest. Other workspace consumers of `libprovekit`, such as `provekit-mint-amp`, are outside this D1 surface pass.
 - Build scripts, benches, external `tests/`, and third-party dependency sources are excluded.
 - `derive`, `serde`, `repr`, `no_mangle`, and `cfg_attr` entries are treated as current lifter loss because the type/function mementos do not expand or encode those attributes.
+
+### D4 resolution of term-emitter-unsupported
+
+The D1 audit classified 64 rows as `term-emitter-unsupported`. D4 resolves all 64 rows with no bootstrap non-goal residue.
+
+| D1 subclass | Count | Resolution |
+| --- | ---: | --- |
+| `cannot prove expression is Int for term emission: Expr::Field` | 5 | Extend. Field expressions lower through `field(...)` with existing assumed-int loss when the field sort is not known. |
+| `cannot prove expression is Int for term emission: Expr::Path` | 6 | Extend. Path expressions lower as variables with existing assumed-int loss when the path sort is not known. |
+| `cannot prove expression is Int for term emission: Expr::Unary` | 2 | Extend. Unary integer expressions lower through existing `neg`, `bit_not`, or `deref` term emission. |
+| `unsupported boolean expression Expr::Field` | 1 | Extend. Boolean field expressions lower through `field(...)` with existing assumed-bool loss when the field sort is not known. |
+| `unsupported boolean expression Expr::Let` | 3 | Accepted loss. Emits `if_let(...)` and records `Expr::Let` because bootstrap preserves the pattern test but not full binding semantics. |
+| `unsupported boolean expression Expr::Macro` | 3 | Accepted loss. Emits an opaque `call:macro:<name>(...)` term and records `Expr::Macro` because this lifter does not expand expression macros. |
+| `unsupported boolean expression Expr::Match` | 4 | Extend. Boolean match expressions lower through `match_expr(...)` with lowered arms. |
+| `unsupported expression statement Expr::Assign` | 3 | Extend. Assignment statements lower through `assign(...)`. |
+| `unsupported expression statement Expr::ForLoop` | 6 | Extend. For-loop statements lower through `for(pattern, into_iter(...), body)`. |
+| `unsupported expression statement Expr::Match` | 3 | Extend. Statement-position matches lower through `match(...)` with statement arms. |
+| `unsupported expression statement Expr::Try` | 21 | Extend. Statement-position try expressions lower through `try(...)`. |
+| `unsupported unit expression Expr::ForLoop` | 1 | Extend. Unit tail for-loops lower as the loop statement followed by `return(unit)`. |
+| `unsupported unit expression Expr::If` | 2 | Extend. Unit tail if-expressions lower as the if statement followed by `return(unit)`. |
+| `unsupported unit expression Expr::Match` | 4 | Extend. Unit tail matches lower as the match statement followed by `return(unit)`. |
+
+Totals: extend 58, accepted loss 6, bootstrap non-goal 0.

--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -158,6 +158,14 @@ const LOSS_ABI_ATTRIBUTE_NOT_CARRIED: &str = "abi-attribute-not-carried";
 /// retained only as an opaque no-op in the emitted term.
 const LOSS_STATEMENT_MACRO: &str = "statement-macro";
 
+/// Accepted-loss dimension for boolean `let` expressions whose pattern test is
+/// kept but whose binding semantics are not fully represented during bootstrap.
+const LOSS_D4_EXPR_LET: &str = "Expr::Let";
+
+/// Accepted-loss dimension for expression-position macros that are retained as
+/// opaque macro-call terms because this lifter does not expand macro bodies.
+const LOSS_D4_EXPR_MACRO: &str = "Expr::Macro";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum AlgebraTerm {
     Op {
@@ -648,6 +656,14 @@ fn seq_all(terms: Vec<AlgebraTerm>) -> AlgebraTerm {
 }
 
 fn lower_tail_expr_to_stmt(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm, String> {
+    if ctx.return_shape.sort() == Some(ExprSort::Unit)
+        && matches!(expr, Expr::ForLoop(_) | Expr::If(_) | Expr::Match(_))
+    {
+        return Ok(seq_all(vec![
+            lower_expr_to_stmt(expr, ctx)?,
+            AlgebraTerm::op("return", vec![AlgebraTerm::Unit]),
+        ]));
+    }
     if let Expr::If(if_expr) = expr {
         if let Some(term) = lower_tail_if_expr_to_stmt(if_expr, ctx)? {
             return Ok(term);
@@ -706,11 +722,70 @@ fn lower_expr_to_stmt(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm,
             };
             Ok(AlgebraTerm::op("if", vec![cond, then_branch, else_branch]))
         }
+        Expr::Assign(assign) => lower_assign_expr_to_stmt(assign, ctx),
         Expr::Block(block) => lower_stmts_to_stmt(&block.block.stmts, ctx),
+        Expr::ForLoop(for_loop) => lower_for_loop_to_stmt(for_loop, ctx),
+        Expr::Match(match_expr) => lower_match_to_stmt(match_expr, ctx),
+        Expr::Try(try_expr) => Ok(AlgebraTerm::op(
+            "try",
+            vec![lower_expr_to_value_term(&try_expr.expr, ctx)?],
+        )),
+        Expr::Tuple(tuple) if tuple.elems.is_empty() => Ok(AlgebraTerm::skip()),
         _ => Err(format!(
             "unsupported expression statement {}",
             expr_kind(expr)
         )),
+    }
+}
+
+fn lower_assign_expr_to_stmt(
+    assign: &syn::ExprAssign,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    Ok(AlgebraTerm::op(
+        "assign",
+        vec![
+            lower_expr_to_value_term(&assign.left, ctx)?,
+            lower_expr_to_value_term(&assign.right, ctx)?,
+        ],
+    ))
+}
+
+fn lower_for_loop_to_stmt(
+    for_loop: &syn::ExprForLoop,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    Ok(AlgebraTerm::op(
+        "for",
+        vec![
+            lower_pat_to_pattern_term(&for_loop.pat),
+            AlgebraTerm::op(
+                "into_iter",
+                vec![lower_expr_to_value_term(&for_loop.expr, ctx)?],
+            ),
+            lower_stmts_to_stmt(&for_loop.body.stmts, ctx)?,
+        ],
+    ))
+}
+
+fn lower_match_to_stmt(
+    match_expr: &syn::ExprMatch,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    Ok(AlgebraTerm::op(
+        "match",
+        vec![
+            lower_expr_to_value_term(&match_expr.expr, ctx)?,
+            lower_match_arms_to_terms(&match_expr.arms, ctx, lower_match_arm_body_to_stmt)?,
+        ],
+    ))
+}
+
+fn lower_match_arm_body_to_stmt(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm, String> {
+    match expr {
+        Expr::Tuple(tuple) if tuple.elems.is_empty() => Ok(AlgebraTerm::skip()),
+        Expr::Block(block) if block.block.stmts.is_empty() => Ok(AlgebraTerm::skip()),
+        _ => lower_expr_to_stmt(expr, ctx),
     }
 }
 
@@ -733,7 +808,7 @@ fn lower_return_expr_to_value_term(
                 lower_expr_to_int_term(expr, ctx)
             }
         }
-        ReturnShape::Full(ExprSort::Unit) => lower_expr_to_unit_term(expr),
+        ReturnShape::Full(ExprSort::Unit) => lower_expr_to_unit_term(expr, ctx),
         ReturnShape::Partial { .. } => lower_expr_to_value_term(expr, ctx),
         ReturnShape::Unsupported => {
             Err("unsupported function return type for term emission".to_string())
@@ -768,6 +843,13 @@ fn lower_expr_to_bool_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebra
             "not",
             vec![lower_expr_to_bool_term(&unary.expr, ctx)?],
         )),
+        Expr::Field(_) => {
+            ctx.add_loss("type-inference-assumed-bool", expr_kind(expr));
+            lower_expr_to_value_term(expr, ctx)
+        }
+        Expr::Let(let_expr) => lower_let_expr_to_bool_term(let_expr, ctx),
+        Expr::Macro(mac) => lower_macro_to_value_term(mac, ctx),
+        Expr::Match(match_expr) => lower_match_to_bool_term(match_expr, ctx),
         Expr::Paren(paren) => lower_expr_to_bool_term(&paren.expr, ctx),
         Expr::Block(block) => {
             let Some(tail) = block_single_tail_expr(&block.block) else {
@@ -836,10 +918,25 @@ fn lower_expr_to_int_term(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraT
     }
 }
 
-fn lower_expr_to_unit_term(expr: &Expr) -> Result<AlgebraTerm, String> {
+fn lower_let_expr_to_bool_term(
+    let_expr: &syn::ExprLet,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    ctx.add_loss(LOSS_D4_EXPR_LET, let_expr.to_token_stream().to_string());
+    Ok(AlgebraTerm::op(
+        "if_let",
+        vec![
+            lower_pat_to_pattern_term(&let_expr.pat),
+            lower_expr_to_value_term(&let_expr.expr, ctx)?,
+        ],
+    ))
+}
+
+fn lower_expr_to_unit_term(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm, String> {
     match expr {
         Expr::Tuple(tuple) if tuple.elems.is_empty() => Ok(AlgebraTerm::Unit),
         Expr::Block(block) if block.block.stmts.is_empty() => Ok(AlgebraTerm::Unit),
+        Expr::ForLoop(_) | Expr::If(_) | Expr::Match(_) => lower_expr_to_stmt(expr, ctx),
         _ => Err(format!("unsupported unit expression {}", expr_kind(expr))),
     }
 }
@@ -960,6 +1057,8 @@ fn lower_expr_to_value_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebr
             ))
         }
         Expr::Macro(mac) if mac.mac.path.is_ident("vec") => lower_vec_macro_to_value_term(mac, ctx),
+        Expr::Macro(mac) => lower_macro_to_value_term(mac, ctx),
+        Expr::Match(match_expr) => lower_match_to_value_term(match_expr, ctx),
         Expr::Reference(reference) => {
             let op = if reference.mutability.is_some() {
                 "borrow_mut"
@@ -973,6 +1072,100 @@ fn lower_expr_to_value_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebr
         }
         Expr::Cast(_) => Err("unsupported value expression Expr::Cast".to_string()),
         _ => Err(format!("unsupported value expression {}", expr_kind(expr))),
+    }
+}
+
+fn lower_match_to_value_term(
+    match_expr: &syn::ExprMatch,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    Ok(AlgebraTerm::op(
+        "match_expr",
+        vec![
+            lower_expr_to_value_term(&match_expr.expr, ctx)?,
+            lower_match_arms_to_terms(&match_expr.arms, ctx, lower_expr_to_value_term)?,
+        ],
+    ))
+}
+
+fn lower_match_to_bool_term(
+    match_expr: &syn::ExprMatch,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    Ok(AlgebraTerm::op(
+        "match_expr",
+        vec![
+            lower_expr_to_value_term(&match_expr.expr, ctx)?,
+            lower_match_arms_to_terms(&match_expr.arms, ctx, lower_expr_to_bool_term)?,
+        ],
+    ))
+}
+
+fn lower_match_arms_to_terms(
+    arms: &[syn::Arm],
+    ctx: &LoweringContext,
+    mut lower_body: impl FnMut(&Expr, &LoweringContext) -> Result<AlgebraTerm, String>,
+) -> Result<AlgebraTerm, String> {
+    let arms = arms
+        .iter()
+        .map(|arm| {
+            let pattern = lower_pat_to_pattern_term(&arm.pat);
+            let body = lower_body(&arm.body, ctx)?;
+            if let Some((_, guard)) = &arm.guard {
+                return Ok(AlgebraTerm::op(
+                    "guarded_arm",
+                    vec![pattern, lower_expr_to_bool_term(guard, ctx)?, body],
+                ));
+            }
+            Ok(AlgebraTerm::op("arm", vec![pattern, body]))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(AlgebraTerm::op("arms", vec![AlgebraTerm::List(arms)]))
+}
+
+fn lower_pat_to_pattern_term(pat: &syn::Pat) -> AlgebraTerm {
+    match pat {
+        syn::Pat::Ident(ident) => AlgebraTerm::op(
+            "pattern_bind",
+            vec![AlgebraTerm::Symbol(ident.ident.to_string())],
+        ),
+        syn::Pat::Lit(lit) => AlgebraTerm::op(
+            "pattern_bind",
+            vec![AlgebraTerm::Symbol(lit.to_token_stream().to_string())],
+        ),
+        syn::Pat::Path(path) => AlgebraTerm::op(
+            "pattern_bind",
+            vec![AlgebraTerm::Symbol(path.to_token_stream().to_string())],
+        ),
+        syn::Pat::Reference(reference) => lower_pat_to_pattern_term(&reference.pat),
+        syn::Pat::TupleStruct(tuple) => {
+            let name = tuple
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string());
+            let args = tuple
+                .elems
+                .iter()
+                .map(lower_pat_to_pattern_term)
+                .collect::<Vec<_>>();
+            match name.as_deref() {
+                Some("Ok") => AlgebraTerm::op("pattern_ok", args),
+                Some("Err") => AlgebraTerm::op("pattern_err", args),
+                Some("Some") => AlgebraTerm::op("pattern_some", args),
+                Some("None") => AlgebraTerm::op("pattern_none", args),
+                _ => AlgebraTerm::op(
+                    "pattern_bind",
+                    vec![AlgebraTerm::Symbol(tuple.to_token_stream().to_string())],
+                ),
+            }
+        }
+        syn::Pat::Type(pat_type) => lower_pat_to_pattern_term(&pat_type.pat),
+        syn::Pat::Wild(_) => AlgebraTerm::op("pattern_wild", vec![]),
+        _ => AlgebraTerm::op(
+            "pattern_bind",
+            vec![AlgebraTerm::Symbol(pat.to_token_stream().to_string())],
+        ),
     }
 }
 
@@ -1040,6 +1233,24 @@ fn lower_struct_expr_to_value_term(
         })
         .collect::<Result<Vec<_>, String>>()?;
     Ok(AlgebraTerm::Struct { name, fields })
+}
+
+fn lower_macro_to_value_term(
+    mac: &syn::ExprMacro,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    let name = mac
+        .mac
+        .path
+        .segments
+        .last()
+        .map(|segment| segment.ident.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    ctx.add_loss(LOSS_D4_EXPR_MACRO, format!("{name}!"));
+    Ok(AlgebraTerm::op(
+        format!("call:macro:{name}"),
+        vec![AlgebraTerm::Symbol(name), AlgebraTerm::List(Vec::new())],
+    ))
 }
 
 fn lower_vec_macro_to_value_term(

--- a/implementations/rust/provekit-walk/tests/term_emit_d4.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d4.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_walk::emit::rust_function_term_json_for_file;
+
+fn term_json(src: &str, name: &str) -> serde_json::Value {
+    let file: syn::File = syn::parse_str(src).unwrap();
+    let bytes = rust_function_term_json_for_file(&file, name, "d4.rs").unwrap();
+    serde_json::from_slice(&bytes).expect("term JSON")
+}
+
+fn assert_loss(parsed: &serde_json::Value, dimension: &str) {
+    assert_eq!(
+        parsed["handling"].as_str(),
+        Some("handles-partially-with-loss-record")
+    );
+    assert!(parsed["loss_record"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|loss| loss["loss"] == dimension));
+}
+
+#[test]
+fn d4_lowers_int_field_expression() {
+    let parsed = term_json(
+        r#"
+            struct Point { x: i32 }
+            fn get_x(p: Point) -> i32 {
+                p.x + 1
+            }
+        "#,
+        "get_x",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("return(add(field(p, x), 1))")
+    );
+    assert_loss(&parsed, "type-inference-assumed-int");
+}
+
+#[test]
+fn d4_lowers_int_path_expression() {
+    let parsed = term_json(
+        r#"
+            const ONE: i32 = 1;
+            fn add_one(x: i32) -> i32 {
+                x + ONE
+            }
+        "#,
+        "add_one",
+    );
+    assert_eq!(parsed["term_surface"].as_str(), Some("return(add(x, ONE))"));
+    assert_loss(&parsed, "type-inference-assumed-int");
+}
+
+#[test]
+fn d4_lowers_int_unary_expression() {
+    let parsed = term_json(
+        r#"
+            fn negated(x: i32) -> i32 {
+                -x
+            }
+        "#,
+        "negated",
+    );
+    assert_eq!(parsed["term_surface"].as_str(), Some("return(neg(x))"));
+}
+
+#[test]
+fn d4_lowers_boolean_field_expression() {
+    let parsed = term_json(
+        r#"
+            struct Flags { ok: bool }
+            fn is_ok(flags: Flags) -> bool {
+                flags.ok
+            }
+        "#,
+        "is_ok",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("return(field(flags, ok))")
+    );
+    assert_loss(&parsed, "type-inference-assumed-bool");
+}
+
+#[test]
+fn d4_accepts_boolean_let_expression_as_named_loss() {
+    let parsed = term_json(
+        r#"
+            fn has_value(value: Option<i32>) -> bool {
+                if let Some(x) = value {
+                    true
+                } else {
+                    false
+                }
+            }
+        "#,
+        "has_value",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(if(if_let(pattern_some(pattern_bind(x)), value), return(true), skip), return(false))")
+    );
+    assert_loss(&parsed, "Expr::Let");
+}
+
+#[test]
+fn d4_accepts_boolean_macro_expression_as_named_loss() {
+    let parsed = term_json(
+        r#"
+            fn is_one(x: i32) -> bool {
+                matches!(x, 1)
+            }
+        "#,
+        "is_one",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("return(call:macro:matches(matches, []))")
+    );
+    assert_loss(&parsed, "Expr::Macro");
+}
+
+#[test]
+fn d4_lowers_boolean_match_expression() {
+    let parsed = term_json(
+        r#"
+            fn is_zero(x: i32) -> bool {
+                match x {
+                    0 => true,
+                    _ => false,
+                }
+            }
+        "#,
+        "is_zero",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some(
+            "return(match_expr(x, arms([arm(pattern_bind(0), true), arm(pattern_wild(), false)])))"
+        )
+    );
+}
+
+#[test]
+fn d4_lowers_assignment_statement() {
+    let parsed = term_json(
+        r#"
+            fn assign_value(mut x: i32) {
+                x = 1;
+            }
+        "#,
+        "assign_value",
+    );
+    assert_eq!(parsed["term_surface"].as_str(), Some("assign(x, 1)"));
+}
+
+#[test]
+fn d4_lowers_for_loop_statement() {
+    let parsed = term_json(
+        r#"
+            fn visit(xs: Vec<i32>) {
+                for x in xs {};
+            }
+        "#,
+        "visit",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("for(pattern_bind(x), into_iter(xs), skip)")
+    );
+}
+
+#[test]
+fn d4_lowers_match_statement() {
+    let parsed = term_json(
+        r#"
+            fn visit_match(x: i32) {
+                match x {
+                    0 => (),
+                    _ => (),
+                };
+            }
+        "#,
+        "visit_match",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("match(x, arms([arm(pattern_bind(0), skip), arm(pattern_wild(), skip)]))")
+    );
+}
+
+#[test]
+fn d4_lowers_try_statement() {
+    let parsed = term_json(
+        r#"
+            fn maybe() -> Result<(), i32> { Ok(()) }
+            fn use_try() -> Result<(), i32> {
+                maybe()?;
+                Ok(())
+            }
+        "#,
+        "use_try",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(try(call:maybe(maybe, [])), return(call:Ok(Ok, [unit])))")
+    );
+}
+
+#[test]
+fn d4_lowers_unit_for_loop_tail_expression() {
+    let parsed = term_json(
+        r#"
+            fn visit_tail(xs: Vec<i32>) {
+                for x in xs {}
+            }
+        "#,
+        "visit_tail",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(for(pattern_bind(x), into_iter(xs), skip), return(unit))")
+    );
+}
+
+#[test]
+fn d4_lowers_unit_if_tail_expression() {
+    let parsed = term_json(
+        r#"
+            fn unit_if(x: bool) {
+                if x {}
+            }
+        "#,
+        "unit_if",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(if(x, skip, skip), return(unit))")
+    );
+}
+
+#[test]
+fn d4_lowers_unit_match_tail_expression() {
+    let parsed = term_json(
+        r#"
+            fn unit_match(x: i32) {
+                match x {
+                    0 => (),
+                    _ => (),
+                }
+            }
+        "#,
+        "unit_match",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(match(x, arms([arm(pattern_bind(0), skip), arm(pattern_wild(), skip)])), return(unit))")
+    );
+}


### PR DESCRIPTION
Closes #940. Refs umbrella #897 (Phase 4 libprovekit Rust bootstrap), top umbrella #922, audit anchor PR #937, D2 PR #946, D3 PR #953.

## Scope

Triages and resolves the 64 `term-emitter-unsupported` items from the D1 audit.

| Resolution | Count |
|---|---:|
| Extend (term-emission added) | 58 |
| Accepted loss (refuse → partial with named dim) | 6 |
| Bootstrap non-goal | 0 |

Accepted-loss subclasses (6 items):
- `unsupported boolean expression Expr::Let` (3 items)
- `unsupported boolean expression Expr::Macro` (3 items)

## Files

- `implementations/rust/provekit-walk/src/emit.rs` (+213/-2)
- `implementations/rust/provekit-walk/tests/term_emit_d4.rs` (new, 261 lines, 14 tests)
- `bootstrap/libprovekit-gap-report.md` (+23 D4 section)

## Verification

- `cargo build -p provekit-walk --release`: green
- `cargo test -p provekit-walk`: green; 14 new D4 tests pass
- `python3 bootstrap/scripts/libprovekit_surface_audit.py`: `term-emitter-unsupported` 64 → 0
- Em-dash + en-dash sweep: clean

## Not admin-merged

Substrate-touching (Rust lifter, large extension). Awaiting your read.

D5 (#941) is in flight and will rebase on top of this.