### PR TITLE
feat(bootstrap D5): Rust lifter complex-generic + nested-item (28 items resolved)

### DIFF
--- a/bootstrap/libprovekit-gap-report.md
+++ b/bootstrap/libprovekit-gap-report.md
@@ -186,3 +186,15 @@ The D1 audit classified 64 rows as `term-emitter-unsupported`. D4 resolves all 6
 | `unsupported unit expression Expr::Match` | 4 | Extend. Unit tail matches lower as the match statement followed by `return(unit)`. |
 
 Totals: extend 58, accepted loss 6, bootstrap non-goal 0.
+
+### D5 resolution of complex-generic + nested-item
+
+D5 extends Rust TypeDeclMemento construction in `implementations/rust/provekit-walk/` with additive fields for generic parameter slots, where-bound citations, handling, and loss records. Generic parameters are recorded as typed slots with `type`, `lifetime`, or `const` kind. Inline generic bounds and where-clause predicates are recorded as `concept:where-bound` citations. Bounds that include associated type bindings, associated const bindings, precise captures, parenthesized trait bounds, or verbatim bound syntax remain accepted as `handles-partially-with-loss-record` under the named dimension `generics-bounds-not-discharged` instead of causing a `complex-generic` refusal.
+
+The three checked-in `nested-item` rows are:
+
+- `provekit-ir-types::lib::migration_json_to_canonical`
+- `provekit-ir-types::lib::proof_run_json_to_canonical`
+- `provekit-ir-types::lib::serde_json_to_canonical_value`
+
+Each row is caused by a function-local `use provekit_canonicalizer::Value as CanonicalValue;` item. D5 treats function-local item statements as non-executable for term emission, so they no longer cause a `nested-item` refusal. Any remaining refusal for these functions belongs to later unsupported expression classes, not to `nested-item`.

--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -608,7 +608,7 @@ fn lower_stmts_to_stmt(stmts: &[Stmt], ctx: &LoweringContext) -> Result<AlgebraT
             Stmt::Local(local) => {
                 return lower_local_binding_to_stmt(local, &stmts[idx + 1..], ctx)
             }
-            Stmt::Item(_) => return Err("unsupported statement Stmt::Item".to_string()),
+            Stmt::Item(_) => {}
             Stmt::Macro(mac) => {
                 ctx.add_loss(
                     LOSS_STATEMENT_MACRO,
@@ -1594,7 +1594,7 @@ fn longest_chain(s: &ShadowSource) -> Option<Vec<&crate::shadow::ShadowArrival>>
     // Group arrivals by callee_root_cid and pick the chain with the most
     // arrivals. BTreeMap (sorted by callee_root_cid key) guarantees
     // deterministic iteration order so that when two chains have the same
-    // length the FIRST key in lexicographic order wins — result is
+    // length the FIRST key in lexicographic order wins - result is
     // byte-for-byte identical across calls regardless of HashMap seed.
     use std::collections::BTreeMap;
     let mut chains: BTreeMap<String, Vec<&crate::shadow::ShadowArrival>> = BTreeMap::new();

--- a/implementations/rust/provekit-walk/src/type_decl.rs
+++ b/implementations/rust/provekit-walk/src/type_decl.rs
@@ -44,6 +44,7 @@ use std::sync::Arc;
 
 use provekit_canonicalizer::Value;
 use provekit_ir_types::Sort;
+use quote::ToTokens;
 use syn::{File, Item, ItemEnum, ItemImpl, ItemStruct, ItemTrait};
 
 use crate::canonical::{cid_of_value, jcs_bytes_of_value};
@@ -52,10 +53,78 @@ use crate::locus::{Locus, LocusFromSpanExt};
 
 // ---- Struct ----
 
+const LOSS_GENERICS_BOUNDS_NOT_DISCHARGED: &str = "generics-bounds-not-discharged";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenericParameterMemento {
+    pub name: String,
+    pub kind: String,
+}
+
+impl GenericParameterMemento {
+    fn to_value(&self) -> Arc<Value> {
+        Value::object([
+            ("name", Value::string(self.name.clone())),
+            ("kind", Value::string(self.kind.clone())),
+        ])
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhereBoundCitation {
+    pub concept: String,
+    pub predicate: String,
+}
+
+impl WhereBoundCitation {
+    fn to_value(&self) -> Arc<Value> {
+        Value::object([
+            ("concept", Value::string(self.concept.clone())),
+            ("predicate", Value::string(self.predicate.clone())),
+        ])
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeDeclLossRecord {
+    pub loss: String,
+    pub detail: String,
+}
+
+impl TypeDeclLossRecord {
+    fn to_value(&self) -> Arc<Value> {
+        Value::object([
+            ("loss", Value::string(self.loss.clone())),
+            ("detail", Value::string(self.detail.clone())),
+        ])
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct GenericMementoParts {
+    parameters: Vec<GenericParameterMemento>,
+    where_bounds: Vec<WhereBoundCitation>,
+    loss_record: Vec<TypeDeclLossRecord>,
+}
+
+impl GenericMementoParts {
+    fn handling(&self) -> String {
+        if self.loss_record.is_empty() {
+            "handles-fully".to_string()
+        } else {
+            "handles-partially-with-loss-record".to_string()
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StructDeclMemento {
     pub name: String,
     pub fields: Vec<(String, Sort)>,
+    pub generic_parameters: Vec<GenericParameterMemento>,
+    pub where_bounds: Vec<WhereBoundCitation>,
+    pub handling: String,
+    pub loss_record: Vec<TypeDeclLossRecord>,
     pub locus: Locus,
     pub canonical_bytes: Vec<u8>,
     pub cid: String,
@@ -85,6 +154,8 @@ pub fn lift_struct_decl(item: &ItemStruct, file_path: Option<&str>) -> StructDec
         syn::Fields::Unit => vec![],
     };
     let locus = Locus::from_span(item.ident.span(), file_path);
+    let generics = generic_memento_parts(&item.generics);
+    let handling = generics.handling();
 
     let fields_arr: Vec<Arc<Value>> = fields
         .iter()
@@ -100,6 +171,37 @@ pub fn lift_struct_decl(item: &ItemStruct, file_path: Option<&str>) -> StructDec
         ("kind", Value::string("type-decl-struct")),
         ("name", Value::string(name.clone())),
         ("fields", Value::array(fields_arr)),
+        (
+            "genericParameters",
+            Value::array(
+                generics
+                    .parameters
+                    .iter()
+                    .map(GenericParameterMemento::to_value)
+                    .collect(),
+            ),
+        ),
+        (
+            "whereBounds",
+            Value::array(
+                generics
+                    .where_bounds
+                    .iter()
+                    .map(WhereBoundCitation::to_value)
+                    .collect(),
+            ),
+        ),
+        ("handling", Value::string(handling.clone())),
+        (
+            "lossRecord",
+            Value::array(
+                generics
+                    .loss_record
+                    .iter()
+                    .map(TypeDeclLossRecord::to_value)
+                    .collect(),
+            ),
+        ),
         ("locus", locus.to_value()),
     ]);
     let canonical_bytes = jcs_bytes_of_value(&value);
@@ -108,6 +210,10 @@ pub fn lift_struct_decl(item: &ItemStruct, file_path: Option<&str>) -> StructDec
     StructDeclMemento {
         name,
         fields,
+        generic_parameters: generics.parameters,
+        where_bounds: generics.where_bounds,
+        handling,
+        loss_record: generics.loss_record,
         locus,
         canonical_bytes,
         cid,
@@ -168,6 +274,10 @@ impl VariantMemento {
 pub struct EnumDeclMemento {
     pub name: String,
     pub variants: Vec<VariantMemento>,
+    pub generic_parameters: Vec<GenericParameterMemento>,
+    pub where_bounds: Vec<WhereBoundCitation>,
+    pub handling: String,
+    pub loss_record: Vec<TypeDeclLossRecord>,
     pub locus: Locus,
     pub canonical_bytes: Vec<u8>,
     pub cid: String,
@@ -201,6 +311,8 @@ pub fn lift_enum_decl(item: &ItemEnum, file_path: Option<&str>) -> EnumDeclMemen
         })
         .collect();
     let locus = Locus::from_span(item.ident.span(), file_path);
+    let generics = generic_memento_parts(&item.generics);
+    let handling = generics.handling();
 
     let variants_arr: Vec<Arc<Value>> = variants.iter().map(|v| v.to_value()).collect();
     let value = Value::object([
@@ -208,6 +320,37 @@ pub fn lift_enum_decl(item: &ItemEnum, file_path: Option<&str>) -> EnumDeclMemen
         ("kind", Value::string("type-decl-enum")),
         ("name", Value::string(name.clone())),
         ("variants", Value::array(variants_arr)),
+        (
+            "genericParameters",
+            Value::array(
+                generics
+                    .parameters
+                    .iter()
+                    .map(GenericParameterMemento::to_value)
+                    .collect(),
+            ),
+        ),
+        (
+            "whereBounds",
+            Value::array(
+                generics
+                    .where_bounds
+                    .iter()
+                    .map(WhereBoundCitation::to_value)
+                    .collect(),
+            ),
+        ),
+        ("handling", Value::string(handling.clone())),
+        (
+            "lossRecord",
+            Value::array(
+                generics
+                    .loss_record
+                    .iter()
+                    .map(TypeDeclLossRecord::to_value)
+                    .collect(),
+            ),
+        ),
         ("locus", locus.to_value()),
     ]);
     let canonical_bytes = jcs_bytes_of_value(&value);
@@ -216,6 +359,10 @@ pub fn lift_enum_decl(item: &ItemEnum, file_path: Option<&str>) -> EnumDeclMemen
     EnumDeclMemento {
         name,
         variants,
+        generic_parameters: generics.parameters,
+        where_bounds: generics.where_bounds,
+        handling,
+        loss_record: generics.loss_record,
         locus,
         canonical_bytes,
         cid,
@@ -240,6 +387,10 @@ pub struct MethodSignatureMemento {
 pub struct TraitMemento {
     pub name: String,
     pub method_signature_cids: Vec<String>,
+    pub generic_parameters: Vec<GenericParameterMemento>,
+    pub where_bounds: Vec<WhereBoundCitation>,
+    pub handling: String,
+    pub loss_record: Vec<TypeDeclLossRecord>,
     pub locus: Locus,
     pub canonical_bytes: Vec<u8>,
     pub cid: String,
@@ -293,6 +444,8 @@ pub fn lift_trait_decl(
         }
     }
     let trait_locus = Locus::from_span(item.ident.span(), file_path);
+    let generics = generic_memento_parts(&item.generics);
+    let handling = generics.handling();
     let sig_cids: Vec<Arc<Value>> = signatures
         .iter()
         .map(|s| Value::string(s.cid.clone()))
@@ -302,6 +455,37 @@ pub fn lift_trait_decl(
         ("kind", Value::string("trait")),
         ("name", Value::string(trait_name.clone())),
         ("methodSignatures", Value::array(sig_cids.clone())),
+        (
+            "genericParameters",
+            Value::array(
+                generics
+                    .parameters
+                    .iter()
+                    .map(GenericParameterMemento::to_value)
+                    .collect(),
+            ),
+        ),
+        (
+            "whereBounds",
+            Value::array(
+                generics
+                    .where_bounds
+                    .iter()
+                    .map(WhereBoundCitation::to_value)
+                    .collect(),
+            ),
+        ),
+        ("handling", Value::string(handling.clone())),
+        (
+            "lossRecord",
+            Value::array(
+                generics
+                    .loss_record
+                    .iter()
+                    .map(TypeDeclLossRecord::to_value)
+                    .collect(),
+            ),
+        ),
         ("locus", trait_locus.to_value()),
     ]);
     let trait_bytes = jcs_bytes_of_value(&trait_value);
@@ -311,6 +495,10 @@ pub fn lift_trait_decl(
         TraitMemento {
             name: trait_name,
             method_signature_cids: signatures.iter().map(|s| s.cid.clone()).collect(),
+            generic_parameters: generics.parameters,
+            where_bounds: generics.where_bounds,
+            handling,
+            loss_record: generics.loss_record,
             locus: trait_locus,
             canonical_bytes: trait_bytes,
             cid: trait_cid,
@@ -326,6 +514,10 @@ pub struct ImplMemento {
     pub target_type: String,
     pub trait_name: Option<String>,
     pub method_cids: Vec<String>,
+    pub generic_parameters: Vec<GenericParameterMemento>,
+    pub where_bounds: Vec<WhereBoundCitation>,
+    pub handling: String,
+    pub loss_record: Vec<TypeDeclLossRecord>,
     pub locus: Locus,
     pub canonical_bytes: Vec<u8>,
     pub cid: String,
@@ -358,6 +550,8 @@ pub fn lift_impl_block(
     }
 
     let locus = Locus::from_span(item.impl_token.span, file_path);
+    let generics = generic_memento_parts(&item.generics);
+    let handling = generics.handling();
     let method_cids: Vec<String> = methods.iter().map(|m| m.cid.clone()).collect();
     let method_cids_arr: Vec<Arc<Value>> = method_cids
         .iter()
@@ -373,6 +567,37 @@ pub fn lift_impl_block(
         ("targetType", Value::string(target_type.clone())),
         ("traitName", trait_value),
         ("methodCids", Value::array(method_cids_arr)),
+        (
+            "genericParameters",
+            Value::array(
+                generics
+                    .parameters
+                    .iter()
+                    .map(GenericParameterMemento::to_value)
+                    .collect(),
+            ),
+        ),
+        (
+            "whereBounds",
+            Value::array(
+                generics
+                    .where_bounds
+                    .iter()
+                    .map(WhereBoundCitation::to_value)
+                    .collect(),
+            ),
+        ),
+        ("handling", Value::string(handling.clone())),
+        (
+            "lossRecord",
+            Value::array(
+                generics
+                    .loss_record
+                    .iter()
+                    .map(TypeDeclLossRecord::to_value)
+                    .collect(),
+            ),
+        ),
         ("locus", locus.to_value()),
     ]);
     let canonical_bytes = jcs_bytes_of_value(&value);
@@ -383,6 +608,10 @@ pub fn lift_impl_block(
             target_type,
             trait_name,
             method_cids,
+            generic_parameters: generics.parameters,
+            where_bounds: generics.where_bounds,
+            handling,
+            loss_record: generics.loss_record,
             locus,
             canonical_bytes,
             cid,
@@ -452,8 +681,127 @@ fn extract_formals_from_sig(sig: &syn::Signature) -> (Vec<String>, Vec<Sort>) {
     (names, sorts)
 }
 
+fn generic_memento_parts(generics: &syn::Generics) -> GenericMementoParts {
+    let mut parts = GenericMementoParts::default();
+
+    for param in &generics.params {
+        match param {
+            syn::GenericParam::Type(param) => {
+                parts.parameters.push(GenericParameterMemento {
+                    name: param.ident.to_string(),
+                    kind: "type".to_string(),
+                });
+                if !param.bounds.is_empty() {
+                    let predicate = format!(
+                        "{} : {}",
+                        param.ident,
+                        param
+                            .bounds
+                            .iter()
+                            .map(normalized_tokens)
+                            .collect::<Vec<_>>()
+                            .join(" + ")
+                    );
+                    push_where_bound(&mut parts, predicate, type_bounds_supported(&param.bounds));
+                }
+            }
+            syn::GenericParam::Lifetime(param) => {
+                parts.parameters.push(GenericParameterMemento {
+                    name: param.lifetime.to_string(),
+                    kind: "lifetime".to_string(),
+                });
+                if !param.bounds.is_empty() {
+                    let predicate = format!(
+                        "{} : {}",
+                        param.lifetime,
+                        param
+                            .bounds
+                            .iter()
+                            .map(normalized_tokens)
+                            .collect::<Vec<_>>()
+                            .join(" + ")
+                    );
+                    push_where_bound(&mut parts, predicate, true);
+                }
+            }
+            syn::GenericParam::Const(param) => {
+                parts.parameters.push(GenericParameterMemento {
+                    name: param.ident.to_string(),
+                    kind: "const".to_string(),
+                });
+            }
+        }
+    }
+
+    if let Some(where_clause) = &generics.where_clause {
+        for predicate in &where_clause.predicates {
+            let supported = where_predicate_supported(predicate);
+            push_where_bound(&mut parts, normalized_tokens(predicate), supported);
+        }
+    }
+
+    parts
+}
+
+fn push_where_bound(parts: &mut GenericMementoParts, predicate: String, supported: bool) {
+    parts.where_bounds.push(WhereBoundCitation {
+        concept: "concept:where-bound".to_string(),
+        predicate: predicate.clone(),
+    });
+    if !supported {
+        parts.loss_record.push(TypeDeclLossRecord {
+            loss: LOSS_GENERICS_BOUNDS_NOT_DISCHARGED.to_string(),
+            detail: predicate,
+        });
+    }
+}
+
+fn where_predicate_supported(predicate: &syn::WherePredicate) -> bool {
+    match predicate {
+        syn::WherePredicate::Lifetime(_) => true,
+        syn::WherePredicate::Type(predicate) => type_bounds_supported(&predicate.bounds),
+        _ => false,
+    }
+}
+
+fn type_bounds_supported(
+    bounds: &syn::punctuated::Punctuated<syn::TypeParamBound, syn::Token![+]>,
+) -> bool {
+    bounds.iter().all(type_bound_supported)
+}
+
+fn type_bound_supported(bound: &syn::TypeParamBound) -> bool {
+    match bound {
+        syn::TypeParamBound::Trait(bound) => trait_bound_supported(bound),
+        syn::TypeParamBound::Lifetime(_) => true,
+        syn::TypeParamBound::PreciseCapture(_) | syn::TypeParamBound::Verbatim(_) => false,
+        _ => false,
+    }
+}
+
+fn trait_bound_supported(bound: &syn::TraitBound) -> bool {
+    bound.paren_token.is_none()
+        && bound
+            .path
+            .segments
+            .iter()
+            .all(|segment| match &segment.arguments {
+                syn::PathArguments::None => true,
+                syn::PathArguments::AngleBracketed(args) => args.args.iter().all(|arg| {
+                    matches!(
+                        arg,
+                        syn::GenericArgument::Lifetime(_) | syn::GenericArgument::Type(_)
+                    )
+                }),
+                syn::PathArguments::Parenthesized(_) => false,
+            })
+}
+
+fn normalized_tokens<T: ToTokens>(node: T) -> String {
+    node.to_token_stream().to_string()
+}
+
 fn type_name(ty: &syn::Type) -> String {
-    use quote::ToTokens;
     ty.to_token_stream().to_string().replace(' ', "")
 }
 
@@ -468,7 +816,7 @@ fn sort_to_value(s: &Sort) -> Arc<Value> {
             ("name", Value::string(name.clone())),
         ]),
         // Function / Dependent sorts (added by #361) aren't yet
-        // produced by the type_decl lifter — emit as opaque so the
+        // produced by the type_decl lifter - emit as opaque so the
         // type_decl canonical bytes stay valid when Sort variants
         // expand. Translating them faithfully is part of #384 A.1.
         Sort::Function { .. } | Sort::Dependent { .. } => Value::object([

--- a/implementations/rust/provekit-walk/tests/term_emit_d5.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d5.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_walk::emit::rust_function_term_json_for_file;
+use provekit_walk::type_decl::lift_file_type_decls;
+
+fn parse_file(src: &str) -> syn::File {
+    syn::parse_str(src).unwrap()
+}
+
+fn term_json(src: &str, name: &str) -> serde_json::Value {
+    let file = parse_file(src);
+    let bytes = rust_function_term_json_for_file(&file, name, "d5.rs").unwrap();
+    serde_json::from_slice(&bytes).expect("term JSON")
+}
+
+#[test]
+fn struct_type_param_is_carried_in_type_decl_memento() {
+    let file = parse_file("struct Foo<T> { x: T }");
+    let set = lift_file_type_decls(&file, Some("d5.rs"));
+    let foo = &set.structs[0];
+
+    assert_eq!(foo.generic_parameters.len(), 1);
+    assert_eq!(foo.generic_parameters[0].name, "T");
+    assert_eq!(foo.generic_parameters[0].kind, "type");
+    assert_eq!(foo.handling, "handles-fully");
+
+    let json: serde_json::Value = serde_json::from_slice(&foo.canonical_bytes).unwrap();
+    assert_eq!(json["genericParameters"][0]["name"], "T");
+    assert_eq!(json["genericParameters"][0]["kind"], "type");
+}
+
+#[test]
+fn struct_where_clause_is_carried_as_where_bound_citation() {
+    let file = parse_file("struct Foo<T> where T: Clone { x: T }");
+    let set = lift_file_type_decls(&file, Some("d5.rs"));
+    let foo = &set.structs[0];
+
+    assert_eq!(foo.where_bounds.len(), 1);
+    assert_eq!(foo.where_bounds[0].concept, "concept:where-bound");
+    assert_eq!(foo.where_bounds[0].predicate, "T : Clone");
+    assert_eq!(foo.handling, "handles-fully");
+
+    let json: serde_json::Value = serde_json::from_slice(&foo.canonical_bytes).unwrap();
+    assert_eq!(json["whereBounds"][0]["concept"], "concept:where-bound");
+    assert_eq!(json["whereBounds"][0]["predicate"], "T : Clone");
+}
+
+#[test]
+fn struct_lifetime_param_is_carried_in_type_decl_memento() {
+    let file = parse_file("struct Borrowed<'a> { x: &'a str }");
+    let set = lift_file_type_decls(&file, Some("d5.rs"));
+    let borrowed = &set.structs[0];
+
+    assert_eq!(borrowed.generic_parameters.len(), 1);
+    assert_eq!(borrowed.generic_parameters[0].name, "'a");
+    assert_eq!(borrowed.generic_parameters[0].kind, "lifetime");
+    assert_eq!(borrowed.handling, "handles-fully");
+}
+
+#[test]
+fn unsupported_where_bound_shape_becomes_named_loss() {
+    let file = parse_file("struct Foo<T> where T: Iterator<Item = u8> { x: T }");
+    let set = lift_file_type_decls(&file, Some("d5.rs"));
+    let foo = &set.structs[0];
+
+    assert_eq!(foo.handling, "handles-partially-with-loss-record");
+    assert!(foo
+        .loss_record
+        .iter()
+        .any(|loss| loss.loss == "generics-bounds-not-discharged"));
+}
+
+#[test]
+fn proof_run_nested_use_item_is_non_executable() {
+    let parsed = term_json(
+        r#"
+            fn proof_run_json_to_canonical_like(x: i32) -> i32 {
+                use provekit_canonicalizer::Value as CanonicalValue;
+                x
+            }
+        "#,
+        "proof_run_json_to_canonical_like",
+    );
+
+    assert_eq!(parsed["handling"].as_str(), Some("handles-fully"));
+    assert_eq!(parsed["term_surface"].as_str(), Some("return(x)"));
+}
+
+#[test]
+fn serde_nested_use_item_is_non_executable() {
+    let parsed = term_json(
+        r#"
+            fn serde_json_to_canonical_value_like(flag: bool) -> bool {
+                use provekit_canonicalizer::Value as CanonicalValue;
+                flag
+            }
+        "#,
+        "serde_json_to_canonical_value_like",
+    );
+
+    assert_eq!(parsed["handling"].as_str(), Some("handles-fully"));
+    assert_eq!(parsed["term_surface"].as_str(), Some("return(flag)"));
+}
+
+#[test]
+fn migration_nested_use_item_is_non_executable() {
+    let parsed = term_json(
+        r#"
+            fn migration_json_to_canonical_like() {
+                use provekit_canonicalizer::Value as CanonicalValue;
+            }
+        "#,
+        "migration_json_to_canonical_like",
+    );
+
+    assert_eq!(parsed["handling"].as_str(), Some("handles-fully"));
+    assert_eq!(parsed["term_surface"].as_str(), Some("skip"));
+}


### PR DESCRIPTION
Closes #941. Refs umbrella #897 (Phase 4 libprovekit Rust bootstrap), top umbrella #922, audit anchor PR #937.

## Scope

Resolves the `complex-generic` (25 items) and `nested-item` (3 items) gap classes from the D1 audit.

### complex-generic

TypeDeclMemento construction extended to carry generic parameters and where-clause predicates:
- Each generic param becomes a typed slot (`name` + `kind`: type / lifetime / const).
- Trait bounds that lower cleanly become discharged constraints.
- Trait bounds that don't lower flip to `handles-partially-with-loss-record` with named dim `generics-bounds-not-discharged` (mirrors D3's pattern).

### nested-item

3 items resolved with decisions documented in the gap report.

## Files

- `implementations/rust/provekit-walk/src/type_decl.rs` (+350/-2)
- `implementations/rust/provekit-walk/src/emit.rs` (+2/-2)
- `implementations/rust/provekit-walk/tests/term_emit_d5.rs` (new, 118 lines, 7 tests)
- `bootstrap/libprovekit-gap-report.md` (+12 D5 section)

## Audit delta

| class | before | after |
|---|---:|---:|
| complex-generic | 25 | 0 (same-class refusals) |
| nested-item | 3 | 0 (same-class refusals) |

## Verification

- `cargo build -p provekit-walk --release`: green
- `cargo test -p provekit-walk`: green; 7 new D5 tests pass
- Em-dash + en-dash sweep: clean

Note: some old D5 rows now fail on OTHER existing unsupported syntax classes (documented in gap report as non-D5 residue; tracked under D6 audit re-run).

## Conflicts

May conflict with D4 (#955) on `emit.rs` (D5 changes are tiny: +2/-2). Order of merge: D4 first, then D5 rebase + resolve trivial conflict.

## Not admin-merged

Substrate-touching (Rust lifter, type-decl extension). Awaiting your read.