### PR TITLE
feat(bootstrap D6): post-D5 audit re-run + delta receipt

### DIFF
--- a/bootstrap/audit-delta-v1-to-v2.md
+++ b/bootstrap/audit-delta-v1-to-v2.md
@@ -1,0 +1,114 @@
+# Audit Delta v1 to v2
+
+## Summary
+
+| Outcome | v1 | v2 | Delta |
+| --- | ---: | ---: | ---: |
+| handles-fully | 217 | 497 | 280 |
+| handles-partially-with-loss-record | 309 | 261 | -48 |
+| refuses-with-typed-reason | 583 | 351 | -232 |
+
+- Total items audited v2: 1109
+- Success metric: handles-fully v2 497 vs required 434; refuses v2 351 vs fallback ceiling 200.
+- Success metric result: pass
+- Target check handles-fully plus partial: 758/1109 (68.3%) vs 90.0%.
+
+## Per-gap-class delta
+
+| Class | v1 | v2 | Delta | Resolution PR |
+| --- | ---: | ---: | ---: | --- |
+| `Expr::Let` | 0 | 7 | 7 | #955 |
+| `Expr::Macro` | 0 | 25 | 25 | #955 |
+| `abi-attribute-not-carried` | 5 | 5 | 0 | #953 |
+| `block-without-tail` | 0 | 17 | 17 | post-D5 residual |
+| `complex-generic` | 26 | 0 | -26 | #956 |
+| `ffi-call` | 44 | 0 | -44 | #946 |
+| `ffi-call-unresolved-effect` | 0 | 204 | 204 | #946 |
+| `function-not-found` | 0 | 11 | 11 | post-D5 residual |
+| `impl-associated-const-not-lowered` | 1 | 0 | -1 | post-D5 residual |
+| `impl-associated-type-not-lowered` | 12 | 12 | 0 | #953 |
+| `impl-generics-not-carried` | 2 | 0 | -2 | post-D5 residual |
+| `let-binding` | 175 | 0 | -175 | #946 |
+| `nested-item` | 3 | 0 | -3 | #956 |
+| `procedural-macro` | 254 | 249 | -5 | #953 |
+| `residual-term-emitter` | 0 | 1 | 1 | post-D5 residual |
+| `return-type-byte-vec` | 0 | 13 | 13 | #946 |
+| `return-type-option` | 0 | 16 | 16 | #946 |
+| `return-type-result` | 0 | 65 | 65 | #946 |
+| `return-type-user-defined` | 0 | 131 | 131 | #946 |
+| `return-type-vec` | 0 | 1 | 1 | #946 |
+| `statement-macro` | 5 | 10 | 5 | #953 |
+| `term-emitter-unsupported` | 64 | 0 | -64 | #955 |
+| `trait-path-truncated` | 33 | 106 | 73 | #953 |
+| `type-inference-assumed-bool` | 0 | 11 | 11 | #955 |
+| `type-inference-assumed-int` | 0 | 10 | 10 | #955 |
+| `type-sort-opaque` | 1 | 0 | -1 | post-D5 residual |
+| `unsupported-boolean-if` | 0 | 1 | 1 | post-D5 residual |
+| `unsupported-let-pattern` | 0 | 27 | 27 | post-D5 residual |
+| `unsupported-literal` | 0 | 160 | 160 | post-D5 residual |
+| `unsupported-return-type` | 267 | 4 | -263 | #946 |
+| `unsupported-stmt-binary` | 0 | 1 | 1 | post-D5 residual |
+| `unsupported-stmt-call` | 0 | 25 | 25 | post-D5 residual |
+| `unsupported-stmt-method-call` | 0 | 34 | 34 | post-D5 residual |
+| `unsupported-stmt-while` | 0 | 1 | 1 | post-D5 residual |
+| `unsupported-value-cast` | 0 | 2 | 2 | post-D5 residual |
+| `unsupported-value-closure` | 0 | 46 | 46 | post-D5 residual |
+| `unsupported-value-for-loop` | 0 | 1 | 1 | post-D5 residual |
+| `unsupported-value-if` | 0 | 13 | 13 | post-D5 residual |
+| `unsupported-value-loop` | 0 | 1 | 1 | post-D5 residual |
+| `unsupported-value-range` | 0 | 1 | 1 | post-D5 residual |
+| `unsupported-value-return` | 0 | 4 | 4 | post-D5 residual |
+| `unsupported-value-unsafe` | 0 | 1 | 1 | post-D5 residual |
+| `vec-macro-desugared-to-array` | 0 | 17 | 17 | #946 |
+
+## Newly-emerged gap classes
+
+- `block-without-tail`: 17
+- `function-not-found`: 11
+- `residual-term-emitter`: 1
+- `unsupported-boolean-if`: 1
+- `unsupported-let-pattern`: 27
+- `unsupported-literal`: 160
+- `unsupported-stmt-binary`: 1
+- `unsupported-stmt-call`: 25
+- `unsupported-stmt-method-call`: 34
+- `unsupported-stmt-while`: 1
+- `unsupported-value-cast`: 2
+- `unsupported-value-closure`: 46
+- `unsupported-value-for-loop`: 1
+- `unsupported-value-if`: 13
+- `unsupported-value-loop`: 1
+- `unsupported-value-range`: 1
+- `unsupported-value-return`: 4
+- `unsupported-value-unsafe`: 1
+
+## Refused floor
+
+Residual refused classes remain:
+
+- `unsupported-literal`: 160
+- `unsupported-value-closure`: 46
+- `unsupported-stmt-method-call`: 34
+- `unsupported-let-pattern`: 27
+- `unsupported-stmt-call`: 25
+- `block-without-tail`: 17
+- `unsupported-value-if`: 13
+- `function-not-found`: 11
+- `unsupported-value-return`: 4
+- `unsupported-return-type`: 4
+- `unsupported-value-cast`: 2
+- `unsupported-value-for-loop`: 1
+- `unsupported-value-range`: 1
+- `unsupported-stmt-while`: 1
+- `unsupported-boolean-if`: 1
+- `unsupported-value-unsafe`: 1
+- `unsupported-stmt-binary`: 1
+- `unsupported-value-loop`: 1
+- `residual-term-emitter`: 1
+
+## Resolution PR map
+
+- #946: D2 return sort, let binding, and call/method-call lifting.
+- #953: D3 accepted named-loss classes for macros, trait paths, associated types, ABI attributes, and statement macros.
+- #955: D4 term-emitter expression and statement coverage.
+- #956: D5 generic and nested-item handling.

--- a/bootstrap/libprovekit-gap-report.v2.md
+++ b/bootstrap/libprovekit-gap-report.v2.md
@@ -1,0 +1,309 @@
+# libprovekit Rust Surface Audit v2
+
+## Summary
+
+Audit scope was the fixed D1 surface inventory: `implementations/rust/libprovekit/src` plus direct sibling crates `provekit-canonicalizer`, `provekit-proof-envelope`, and `provekit-ir-types`. Function rows were re-run through the post-D5 `provekit-walk-emit term` path. Non-function rows reflect the post-D5 type-declaration surface, where the current mementos carry the item without a typed refusal.
+
+Total items audited: 1109
+
+- handles-fully: 497
+- handles-partially-with-loss-record: 261
+- refuses-with-typed-reason: 351
+
+## Per-crate breakdown
+
+### libprovekit
+
+| handles-fully | handles-partially-with-loss-record | refuses-with-typed-reason |
+| ---: | ---: | ---: |
+| 248 | 199 | 244 |
+
+### provekit-canonicalizer
+
+| handles-fully | handles-partially-with-loss-record | refuses-with-typed-reason |
+| ---: | ---: | ---: |
+| 10 | 11 | 17 |
+
+### provekit-ir-types
+
+| handles-fully | handles-partially-with-loss-record | refuses-with-typed-reason |
+| ---: | ---: | ---: |
+| 226 | 45 | 63 |
+
+### provekit-proof-envelope
+
+| handles-fully | handles-partially-with-loss-record | refuses-with-typed-reason |
+| ---: | ---: | ---: |
+| 13 | 6 | 27 |
+
+## Gap classes (grouped by refusal reason)
+
+### unsupported-literal (160 items)
+
+- `libprovekit::ci::check_ci_body`
+- `libprovekit::ci::ci_job_result_name`
+- `libprovekit::ci::impl CIBlastRadius::validate`
+- `libprovekit::ci::impl CIImpactBodyClaim::validate`
+- `libprovekit::ci::impl CIJobResultBodyClaim::validate`
+
+### unsupported-value-closure (46 items)
+
+- `libprovekit::canonical::serializable_jcs`
+- `libprovekit::compose::blocking_effects_for_steps`
+- `libprovekit::compose::build_value`
+- `libprovekit::compose::compose_chain_contracts`
+- `libprovekit::compose::compose_function_contracts_checked`
+
+### unsupported-stmt-method-call (34 items)
+
+- `libprovekit::ci::insert_many`
+- `libprovekit::ci::insert_required`
+- `libprovekit::ci::require_cid_field`
+- `libprovekit::ci::require_cid_vec`
+- `libprovekit::ci::require_input_cids_close`
+
+### unsupported-let-pattern (27 items)
+
+- `libprovekit::canonical::is_blake3_512_cid`
+- `libprovekit::lift_plugin::impl LiftPluginKit::parse_session`
+- `libprovekit::primitives::dropper`
+- `libprovekit::primitives::verify_sig`
+- `libprovekit::types::impl Cid::parse`
+
+### unsupported-stmt-call (25 items)
+
+- `libprovekit::ci::impl CIBlastRadiusInput::build`
+- `libprovekit::ci::impl CIImpactInput::build`
+- `libprovekit::ci::impl CIJobResultInput::build`
+- `libprovekit::ci::impl CIReuseInput::build`
+- `libprovekit::desugar::impl DesugaringSet::non_core_ops`
+
+### block-without-tail (17 items)
+
+- `libprovekit::canonical::json_to_cvalue`
+- `libprovekit::compose::find_namespaced_result`
+- `libprovekit::compose::find_result_equation`
+- `libprovekit::stubs::impl Domain for FunctionContractDomain::discharge`
+- `libprovekit::stubs::term_formals`
+
+### unsupported-value-if (13 items)
+
+- `libprovekit::compose::compose_chain_contracts_internal`
+- `libprovekit::compose::impl EffectSet::check_opacity_effects`
+- `libprovekit::compose::impl FunctionContractMemento::check_aliasing_discharged`
+- `libprovekit::types::impl Path::ordered_steps`
+- `libprovekit::types::json_to_cvalue`
+
+### function-not-found (11 items)
+
+- `libprovekit::traits::Canonical::canonical_bytes`
+- `libprovekit::traits::Domain::discharge`
+- `libprovekit::traits::Domain::name`
+- `libprovekit::traits::Domain::project`
+- `libprovekit::traits::Kit::dialect`
+
+### unsupported-value-return (4 items)
+
+- `libprovekit::lift_plugin::impl LiftPluginKit::claim_from_response_term`
+- `libprovekit::ffi::impl AliasingMementoDto::into_memento`
+- `provekit-proof-envelope::sign::ed25519_verify_bytes`
+- `provekit-proof-envelope::sign::ed25519_verify_string`
+
+### unsupported-return-type (4 items)
+
+- `libprovekit::desugar::impl DesugaringSet::rules`
+- `libprovekit::witness_registry::impl WitnessRegistry::get`
+- `libprovekit::wp::aggregate_conjunction`
+- `libprovekit::wp::handle_formula_binder`
+
+### unsupported-value-cast (2 items)
+
+- `libprovekit::compose::promote_fcm_to_compound`
+- `provekit-proof-envelope::cbor::cbor_append_head`
+
+### unsupported-value-for-loop (1 items)
+
+- `libprovekit::desugar::certify_confluence`
+
+### unsupported-value-range (1 items)
+
+- `libprovekit::desugar::desugar`
+
+### unsupported-stmt-while (1 items)
+
+- `libprovekit::desugar::graph_reaches`
+
+### unsupported-boolean-if (1 items)
+
+- `libprovekit::desugar::has_cycle`
+
+### unsupported-value-unsafe (1 items)
+
+- `libprovekit::ffi::read_jcs_input`
+
+### unsupported-stmt-binary (1 items)
+
+- `libprovekit::promotion_decision_registry::impl PromotionDecisionRegistry::admit_many`
+
+### unsupported-value-loop (1 items)
+
+- `libprovekit::wp::fresh_name`
+
+### residual-term-emitter (1 items)
+
+- `provekit-ir-types::src::require_schema`
+
+## Partial-handle classes (grouped by loss-record dimension)
+
+### procedural-macro (249 items)
+
+- `libprovekit::ci::admit_identical_reuse`
+- `libprovekit::ci::cid_set`
+- `libprovekit::ci::impl CIBlastRadius::cid`
+- `libprovekit::ci::impl CIImpactBodyClaim::cid`
+- `libprovekit::ci::impl CIJobResultBodyClaim::cid`
+
+### ffi-call-unresolved-effect (204 items)
+
+- `libprovekit::canonical::json_cid`
+- `libprovekit::canonical::json_jcs`
+- `libprovekit::canonical::serializable_cid`
+- `libprovekit::ci::admit_identical_reuse`
+- `libprovekit::ci::cid_set`
+
+### return-type-user-defined (131 items)
+
+- `libprovekit::ci::cid_set`
+- `libprovekit::ci::impl Default for CINondeterminism::default`
+- `libprovekit::ci::message`
+- `libprovekit::compose::build_memento_value`
+- `libprovekit::compose::cid_of_value`
+
+### trait-path-truncated (106 items)
+
+- `libprovekit::ci::admit_identical_reuse`
+- `libprovekit::ci::cid_set`
+- `libprovekit::ci::impl Default for CINondeterminism::default`
+- `libprovekit::ci::message`
+- `libprovekit::compose::domain_claim_fcm_tests::bare_fcm_error_is_deterministic`
+
+### return-type-result (65 items)
+
+- `libprovekit::canonical::json_cid`
+- `libprovekit::canonical::json_jcs`
+- `libprovekit::canonical::serializable_cid`
+- `libprovekit::ci::admit_identical_reuse`
+- `libprovekit::ci::impl CIBlastRadius::cid`
+
+### Expr::Macro (25 items)
+
+- `libprovekit::ci::admit_identical_reuse`
+- `libprovekit::ci::require_equal`
+- `libprovekit::ci::require_nonempty`
+- `libprovekit::ci::require_one_of`
+- `libprovekit::compose::effect_args_json`
+
+### vec-macro-desugared-to-array (17 items)
+
+- `libprovekit::compose::fcm_auto_promote_tests::trivial_formula`
+- `libprovekit::compose::impl EffectSet::empty`
+- `libprovekit::primitives::composed_to_contract`
+- `libprovekit::types::memento_from_parts`
+- `libprovekit::desugar::refusal_from_error`
+
+### return-type-option (16 items)
+
+- `libprovekit::compose::OpacityMementoLookup::lookup_pin_invariant`
+- `libprovekit::compose::impl OpacityMementoLookup for EmptyOpacityPool::lookup_pin_invariant`
+- `libprovekit::primitives::resolve`
+- `libprovekit::traits::Catalog::get`
+- `libprovekit::traits::InputCatalog::get_input`
+
+### return-type-byte-vec (13 items)
+
+- `libprovekit::compose::jcs_bytes_of_value`
+- `libprovekit::types::impl Canonical for & str::canonical_bytes`
+- `libprovekit::types::impl Canonical for Cid::canonical_bytes`
+- `libprovekit::types::impl Canonical for DomainClaim::canonical_bytes`
+- `libprovekit::types::impl Canonical for FunctionContractMemento::canonical_bytes`
+
+### impl-associated-type-not-lowered (12 items)
+
+- `libprovekit::compose::impl TryFrom<&FunctionContractMemento> for provekit_ir_types :: DomainClaim::try_from`
+- `libprovekit::types::impl TryFrom<&str> for Cid::try_from`
+- `libprovekit::types::impl TryFrom<DomainClaim> for Refutation::try_from`
+- `libprovekit::types::impl TryFrom<DomainClaim> for Truth::try_from`
+- `libprovekit::types::impl TryFrom<String> for Cid::try_from`
+
+### type-inference-assumed-bool (11 items)
+
+- `libprovekit::ci::require_nonempty`
+- `libprovekit::ci::require_one_of`
+- `libprovekit::compose::impl Locus::is_unknown`
+- `libprovekit::desugar::match_lhs`
+- `libprovekit::ffi::pk_composition_result_body_jcs`
+
+### type-inference-assumed-int (10 items)
+
+- `libprovekit::ci::admit_identical_reuse`
+- `libprovekit::ci::require_equal`
+- `libprovekit::compose::impl Locus::is_unknown`
+- `libprovekit::types::slot_evaluation_is_default`
+- `libprovekit::types::slot_sort_is_default`
+
+### statement-macro (10 items)
+
+- `libprovekit::compose::domain_claim_fcm_tests::bare_fcm_error_is_deterministic`
+- `libprovekit::compose::domain_claim_fcm_tests::bare_fcm_returns_unbound_contract_error`
+- `libprovekit::compose::domain_claim_fcm_tests::unbound_contract_display_is_informative`
+- `libprovekit::compose::domain_claim_fcm_tests::unbound_contract_error_variant_matches`
+- `libprovekit::types::impl Cid::from_hash_output`
+
+### Expr::Let (7 items)
+
+- `provekit-ir-types::src::impl TryFrom<&ConceptSiteMemento> for DomainClaim::try_from`
+- `provekit-ir-types::src::impl TryFrom<NamespacedExtensionPolicyMementoWire> for NamespacedExtensionPolicyMemento::try_from`
+- `provekit-ir-types::src::impl TryFrom<String> for CanonicalizationProfileKind::try_from`
+- `provekit-ir-types::src::impl TryFrom<String> for CatalogKind::try_from`
+- `provekit-ir-types::src::impl TryFrom<String> for OccurrenceKind::try_from`
+
+### abi-attribute-not-carried (5 items)
+
+- `libprovekit::ffi::pk_compose_chain_contracts`
+- `libprovekit::ffi::pk_composition_result_body_jcs`
+- `libprovekit::ffi::pk_composition_result_cid`
+- `libprovekit::ffi::pk_composition_result_error`
+- `libprovekit::ffi::pk_composition_result_free`
+
+### return-type-vec (1 items)
+
+- `libprovekit::ci::sorted_unique`
+
+## Recommended residual sub-issues
+
+- triage `unsupported-literal` (160 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-value-closure` (46 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-stmt-method-call` (34 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-let-pattern` (27 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-stmt-call` (25 items): residual post-D5 term-emitter surface class.
+- triage `block-without-tail` (17 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-value-if` (13 items): residual post-D5 term-emitter surface class.
+- triage `function-not-found` (11 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-value-return` (4 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-return-type` (4 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-value-cast` (2 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-value-for-loop` (1 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-value-range` (1 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-stmt-while` (1 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-boolean-if` (1 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-value-unsafe` (1 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-stmt-binary` (1 items): residual post-D5 term-emitter surface class.
+- triage `unsupported-value-loop` (1 items): residual post-D5 term-emitter surface class.
+- triage `residual-term-emitter` (1 items): residual post-D5 term-emitter surface class.
+
+## Out-of-scope and known-noisy
+
+- `#[cfg(test)]` and unit-test helper items under audited `src/` files remain included because they are Rust items in the fixed surface inventory.
+- Direct dependency crates are included only because `libprovekit` composes them through its manifest. Other workspace consumers remain outside this surface pass.
+- Build scripts, benches, external `tests/`, and third-party dependency sources remain excluded.
+- `provekit-walk-emit term` accepts a simple function name, so same-file duplicate method names are constrained by that existing CLI dispatch surface.

--- a/bootstrap/libprovekit-surface-audit.v2.csv
+++ b/bootstrap/libprovekit-surface-audit.v2.csv
@@ -1,0 +1,1110 @@
+crate,file,item_kind,item_name,outcome,gap_summary
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,is_blake3_512_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,json_cid,handles-partially-with-loss-record,return-type-result: Result < String >; ffi-call-unresolved-effect: json_jcs
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,json_jcs,handles-partially-with-loss-record,return-type-result: Result < String >; ffi-call-unresolved-effect: json_to_cvalue
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,json_to_cvalue,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,serializable_cid,handles-partially-with-loss-record,return-type-result: Result < String >; ffi-call-unresolved-effect: serializable_jcs
+libprovekit,implementations/rust/libprovekit/src/canonical.rs,fn,serializable_jcs,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/ci.rs,enum,CIJobResult,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,enum,CINondeterminismMode,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,enum,CIReuseReason,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,admit_identical_reuse,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: Result < CIReuseBodyClaim >; ffi-call-unresolved-effect: validate; type-inference-assumed-int: Expr::Field; Expr::Macro: format!; trait-path-truncated: CIJobResult :: Pass
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,check_ci_body,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,ci_job_result_name,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,cid_set,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: BTreeSet < String >; trait-path-truncated: BTreeSet :: new; ffi-call-unresolved-effect: new
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIBlastRadius::cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: Result < String >; ffi-call-unresolved-effect: serializable_cid
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIBlastRadius::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIBlastRadiusInput::build,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIImpactBodyClaim::cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: Result < String >; ffi-call-unresolved-effect: serializable_cid
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIImpactBodyClaim::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIImpactInput::build,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIJobResultBodyClaim::cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: Result < String >; ffi-call-unresolved-effect: serializable_cid
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIJobResultBodyClaim::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIJobResultInput::build,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIReuseBodyClaim::cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: Result < String >; ffi-call-unresolved-effect: serializable_cid
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIReuseBodyClaim::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl CIReuseInput::build,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,impl Default for CINondeterminism::default,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; trait-path-truncated: CINondeterminismMode :: Forbidden
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,insert_many,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,insert_required,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,message,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: ProvekitError; trait-path-truncated: ProvekitError :: Message; ffi-call-unresolved-effect: Message
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_cid_field,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_cid_vec,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_equal,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: Result < () >; type-inference-assumed-int: Expr::Path; ffi-call-unresolved-effect: Ok; Expr::Macro: format!
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_input_cids_close,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_nonempty,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: Result < () >; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: is_empty; Expr::Macro: format!
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_nonempty_strings,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: Result < () >; ffi-call-unresolved-effect: require_nonempty
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_one_of,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: Result < () >; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: contains; Expr::Macro: format!
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,require_producer,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/ci.rs,fn,sorted_unique,handles-partially-with-loss-record,procedural-macro: derive; return-type-vec: Vec < String >; ffi-call-unresolved-effect: collect
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIBlastRadius,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIBlastRadiusInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIImpactBodyClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIImpactInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIJobResultBodyClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIJobResultInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIReuseBodyClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl CIReuseInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,impl,impl Default for CINondeterminism,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIBlastRadius,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIBlastRadiusInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIBodyCheck,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIImpactBodyClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIImpactInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIJobResultBodyClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIJobResultInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CINondeterminism,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIProducer,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIReuseBodyClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ci.rs,struct,CIReuseInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,const,AUTO_PROMOTE_LIFTER_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,const,CCP_VERSION,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,AliasingStatus,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,AtomicKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,CompositionError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,Effect,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,enum,OpacityError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_aliasing_memento,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_closure_binding,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_drop_contract,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_loop_invariant,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::has_try_branch,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,OpacityMementoLookup::lookup_pin_invariant,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < PinInvariantMementoView >
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,aliasing_mementos_to_value,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,blocking_effects_for_steps,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,build_memento_value,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Arc < Value >; ffi-call-unresolved-effect: build_value
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,build_value,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,cid_of_value,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: String; ffi-call-unresolved-effect: blake3_512_of
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_chain_contracts,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_chain_contracts_internal,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_function_contracts,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_function_contracts_checked,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compose_with_composed,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,composition_error_to_refusal,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,compound_cid,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::bare_fcm_error_is_deterministic,handles-partially-with-loss-record,procedural-macro: derive; ffi-call-unresolved-effect: minimal_fcm; trait-path-truncated: provekit_ir_types :: DomainClaim :: try_from; statement-macro: assert_eq
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::bare_fcm_returns_unbound_contract_error,handles-partially-with-loss-record,procedural-macro: derive; ffi-call-unresolved-effect: minimal_fcm; trait-path-truncated: provekit_ir_types :: DomainClaim :: try_from; statement-macro: assert_eq
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::minimal_fcm,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::unbound_contract_display_is_informative,handles-partially-with-loss-record,procedural-macro: derive; ffi-call-unresolved-effect: to_string; trait-path-truncated: DomainClaimConversionError :: UnboundContract; statement-macro: assert
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,domain_claim_fcm_tests::unbound_contract_error_variant_matches,handles-partially-with-loss-record,procedural-macro: derive; ffi-call-unresolved-effect: minimal_fcm; trait-path-truncated: provekit_ir_types :: DomainClaim :: try_from; statement-macro: assert
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_args_json,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: serde_json :: Value; Expr::Macro: json!
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_classification,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_discharge_key,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_occurrence_kind,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_occurrences_for_steps,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,effect_set_cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: String; ffi-call-unresolved-effect: cid_of_value
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,evidence_cid,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::auto_promotion_source_kind_is_annotation,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::auto_promotion_uses_all_zeros_sentinel_lifter_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::compound_cid_is_symmetric_with_serde_roundtrip,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::compound_round_trips_via_json,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::evidence_cid_is_symmetric_with_serde_roundtrip,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::extension_fields_contain_auto_promoted_from,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::fcm_with_pre_post,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::identical_fcms_produce_identical_compound_cids,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::into_compound_matches_promote_fn,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::nontrivial_fcm_compound_composed_pre_post_match_fcm,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::nontrivial_fcm_promotes_to_single_evidence_compound,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::nontrivial_post,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::nontrivial_pre,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::trivial_fcm_compound_composed_pre_post_are_trivial,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::trivial_fcm_promotes_to_single_evidence_not_zero,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,fcm_auto_promote_tests::trivial_formula,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrFormula; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,find_namespaced_result,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,find_result_equation,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,formula_to_canonical,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl AliasingMemento::to_jcs_value,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl AliasingStatus::as_str,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl AtomicKind::as_str,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl CompositionError::failure_detail,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: String; Expr::Macro: format!
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl CompositionError::failure_kind,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Effect::sort_key,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Effect::to_value,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::add,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::check_opacity_effects,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::empty,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::is_pure,handles-partially-with-loss-record,procedural-macro: derive; ffi-call-unresolved-effect: is_empty
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl EffectSet::to_value,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl From<&FunctionContractMemento> for CompoundContractMemento::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: CompoundContractMemento; ffi-call-unresolved-effect: promote_fcm_to_compound
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl FunctionContractMemento::check_aliasing_discharged,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl FunctionContractMemento::is_pure,handles-partially-with-loss-record,procedural-macro: derive; ffi-call-unresolved-effect: is_empty
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl FunctionContractMemento::result_value,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl FunctionContractMemento::result_var_name,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: String; ffi-call-unresolved-effect: collect; Expr::Macro: format!
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Locus::is_unknown,handles-partially-with-loss-record,procedural-macro: derive; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: is_none; type-inference-assumed-int: Expr::Field
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Locus::to_value,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl Locus::unknown,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; trait-path-truncated: Self :: default; ffi-call-unresolved-effect: default
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_aliasing_memento,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_closure_binding,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_drop_contract,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_loop_invariant,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::has_try_branch,handles-partially-with-loss-record,procedural-macro: derive
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl OpacityMementoLookup for EmptyOpacityPool::lookup_pin_invariant,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < PinInvariantMementoView >
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl TryFrom<&FunctionContractMemento> for provekit_ir_types :: DomainClaim::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: provekit_ir_types :: DomainClaim; return-type-result: Result < Self , Self :: Error >; ffi-call-unresolved-effect: Err; trait-path-truncated: provekit_ir_types :: DomainClaimConversionError :: UnboundContract"
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,impl std::fmt::Display for OpacityError::fmt,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: std :: fmt :: Result; Expr::Macro: write!
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,jcs_bytes_of_value,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: into_bytes
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,promote_fcm_to_compound,refuses-with-typed-reason,unsupported-value-cast: unsupported value expression Expr::Cast
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,serde_to_canonical,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,fn,sort_to_value,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl AliasingMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl AliasingStatus,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl AtomicKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl CompositionError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl Effect,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl EffectSet,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl EffectSet,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl From<&FunctionContractMemento> for CompoundContractMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl FunctionContractMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl Locus,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl OpacityMementoLookup for EmptyOpacityPool,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl TryFrom<&FunctionContractMemento> for provekit_ir_types :: DomainClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,impl,impl std::fmt::Display for OpacityError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,mod,domain_claim_fcm_tests,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,mod,fcm_auto_promote_tests,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,AliasingMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,ChainStep,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,ComposedFunctionContract,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,EffectSet,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,EmptyOpacityPool,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,FunctionContractMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,Locus,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,PinInvariantMementoView,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,struct,impl TryFrom<&FunctionContractMemento> for provekit_ir_types :: DomainClaim::Error,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/compose.rs,trait,OpacityMementoLookup,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,enum,LiftPluginKitError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::dialect,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Dialect; trait-path-truncated: Dialect :: Other; ffi-call-unresolved-effect: Other; Expr::Macro: format!
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::parse,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::prove,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < DomainClaim , KitError >; ffi-call-unresolved-effect: Ok"
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::serialize,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl Kit for LiftPluginKit::transform,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::claim_from_response_term,refuses-with-typed-reason,unsupported-value-return: unsupported value expression Expr::Return
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::dispatch,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::legacy_response_from_term,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < & Value , LiftPluginKitError >; ffi-call-unresolved-effect: legacy_response_from_term"
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKit::parse_session,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKitSession::legacy_response,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < & Value , LiftPluginKitError >; ffi-call-unresolved-effect: Ok"
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,impl LiftPluginKitSession::response,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: & Value
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,legacy_response_from_term,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < & Value , LiftPluginKitError >; ffi-call-unresolved-effect: legacy_response_from_term"
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,lift_request_from_input,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,lift_response_contract,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,primitive_sort,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Sort; ffi-call-unresolved-effect: to_string
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,read_response,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,fn,response_term,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,impl,impl Kit for LiftPluginKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,impl,impl LiftPluginKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,impl,impl LiftPluginKitSession,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,struct,LiftPluginKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/lift_plugin.rs,struct,LiftPluginKitSession,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,lift_plugin,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,primitives,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,stubs,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,traits,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,types,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/mod.rs,mod,verbs,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,enum,ComposeError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,address,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Cid; trait-path-truncated: Cid :: from_hash_output; ffi-call-unresolved-effect: from_hash_output
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,compose,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,compose_function_contract_claims,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,compose_verdict,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Verdict; trait-path-truncated: Verdict :: Refuted
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,composed_to_contract,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Contract; Expr::Macro: format!; ffi-call-unresolved-effect: clone; trait-path-truncated: crate :: compose :: EffectSet :: empty; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,dropper,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,resolve,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < Vec < u8 > >; ffi-call-unresolved-effect: get
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,sign,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: DomainClaim; ffi-call-unresolved-effect: cid
+libprovekit,implementations/rust/libprovekit/src/core/primitives.rs,fn,verify_sig,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,artifact_reference_term,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Term; Expr::Macro: json!; ffi-call-unresolved-effect: any_sort
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Default for CKit::default,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; trait-path-truncated: Dialect :: C
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Default for RustKit::default,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; trait-path-truncated: Dialect :: C
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Domain for FunctionContractDomain::discharge,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Domain for FunctionContractDomain::name,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: DomainKind; trait-path-truncated: DomainKind :: FunctionContract
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Domain for FunctionContractDomain::project,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::dialect,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Dialect; ffi-call-unresolved-effect: clone
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::parse,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < Term , KitError >; ffi-call-unresolved-effect: parse_stub_input"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::prove,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < DomainClaim , KitError >; ffi-call-unresolved-effect: prove_stub_claim"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::serialize,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < Input , KitError >; ffi-call-unresolved-effect: serialize_stub_term"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for CKit::transform,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < DomainClaim , KitError >; ffi-call-unresolved-effect: transform_stub_input"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::dialect,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Dialect; ffi-call-unresolved-effect: clone
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::parse,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < Term , KitError >; ffi-call-unresolved-effect: parse_stub_input"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::prove,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < DomainClaim , KitError >; ffi-call-unresolved-effect: prove_stub_claim"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::serialize,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < Input , KitError >; ffi-call-unresolved-effect: serialize_stub_term"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Kit for RustKit::transform,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < DomainClaim , KitError >; ffi-call-unresolved-effect: transform_stub_input"
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,impl Portfolio for NoopPortfolio::solve,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: SolverVerdict; Expr::Macro: json!
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,parse_stub_input,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,prove_stub_claim,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,serialize_stub_term,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,term_formals,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,term_name,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,fn,transform_stub_input,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Default for CKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Default for RustKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Domain for FunctionContractDomain,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Kit for CKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Kit for RustKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,impl,impl Portfolio for NoopPortfolio,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,struct,CKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,struct,FunctionContractDomain,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,struct,NoopPortfolio,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/stubs.rs,struct,RustKit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,CoreError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,DischargeMode,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,DomainError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,KitError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,enum,SolverVerdict,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Canonical::canonical_bytes,refuses-with-typed-reason,function-not-found: function `canonical_bytes` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Catalog::get,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < Vec < u8 > >; ffi-call-unresolved-effect: cloned
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Domain::discharge,refuses-with-typed-reason,function-not-found: function `discharge` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Domain::name,refuses-with-typed-reason,function-not-found: function `name` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Domain::project,refuses-with-typed-reason,function-not-found: function `project` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,InputCatalog::get_input,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < Input >; ffi-call-unresolved-effect: cloned
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::dialect,refuses-with-typed-reason,function-not-found: function `dialect` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::parse,refuses-with-typed-reason,function-not-found: function `parse` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::prove,refuses-with-typed-reason,function-not-found: function `prove` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::serialize,refuses-with-typed-reason,function-not-found: function `serialize` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Kit::transform,refuses-with-typed-reason,function-not-found: function `transform` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,Portfolio::solve,refuses-with-typed-reason,function-not-found: function `solve` not found
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl Catalog for HashMapCatalog::get,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < Vec < u8 > >; ffi-call-unresolved-effect: cloned
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl HashMapCatalog::insert,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl HashMapCatalog::put,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl HashMapInputCatalog::insert,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl HashMapInputCatalog::put,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,fn,impl InputCatalog for HashMapInputCatalog::get_input,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < Input >; ffi-call-unresolved-effect: cloned
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,impl,impl Catalog for HashMapCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,impl,impl HashMapCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,impl,impl HashMapInputCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,impl,impl InputCatalog for HashMapInputCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,struct,HashMapCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,struct,HashMapInputCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Canonical,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Catalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Domain,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,InputCatalog,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Kit,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/traits.rs,trait,Portfolio,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,const,PATH_DOCUMENT_KIND,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,ArityShape,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,CidError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Dialect,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,DomainKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Input,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,PathDocumentError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,PathError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,PathInputMaterial,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,SignatureCatalogError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,SlotEvaluation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,SlotSort,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Term,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Verdict,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,VerdictCoercionError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,enum,Witness,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,_let_binding_from_term,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: LetBinding; trait-path-truncated: IrTerm :: from; ffi-call-unresolved-effect: from
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,any_sort,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,arity_shape_value,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,contract_to_cvalue,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Arc < CValue >; ffi-call-unresolved-effect: unknown; trait-path-truncated: serde_json :: from_slice :: < JsonValue >
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,domain_claim_to_value,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,formula_true,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::named,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: collect; trait-path-truncated: AritySlot :: evaluated
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::named_slots,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: collect
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::positional,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::set,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; trait-path-truncated: SlotSort :: Term
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl ArityShape::set_of,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl AritySlot::evaluated,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into; trait-path-truncated: SlotEvaluation :: Evaluated
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl AritySlot::unevaluated,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into; trait-path-truncated: SlotEvaluation :: Unevaluated
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl AritySlot::with_shape,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: Some; trait-path-truncated: Box :: new
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl AritySlot::with_slot_sort,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for & str::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Cid::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for DomainClaim::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for FunctionContractMemento::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Input::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for IrFormula::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Path::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for String::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Term::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Canonical for Witness::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Cid::as_str,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: & str
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Cid::from_hash_output,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; statement-macro: debug_assert; ffi-call-unresolved-effect: Self
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Cid::into_string,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: String
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Cid::parse,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Default for Boundary::default,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Deserialize<'de> for Cid::deserialize,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < Self , D :: Error >; trait-path-truncated: String :: deserialize; ffi-call-unresolved-effect: deserialize"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl DomainClaim::canonical_bytes,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: unknown
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl DomainClaim::cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: & Cid
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl DomainClaim::union,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < Self , super :: primitives :: ComposeError >; trait-path-truncated: super :: primitives :: compose; ffi-call-unresolved-effect: compose"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl DomainClaim::unsigned,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: clone
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl From<Cid> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl From<IrTerm> for Term::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl From<Term> for IrTerm::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::children_value,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: & Cid
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; trait-path-truncated: BTreeMap :: new; ffi-call-unresolved-effect: new
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::operation,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < & OperationSignature >; ffi-call-unresolved-effect: get
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::term_cid,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < Cid , SignatureCatalogError >; ffi-call-unresolved-effect: term_value; trait-path-truncated: Cid :: from_hash_output"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::term_value,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl LanguageSignature::with_operation,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Path::cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: & Cid
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Path::ordered_steps,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Path::step,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Path::terminal_steps,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl PathDocument::from_path_and_inputs,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl PathDocument::materialized_inputs,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl PathInputMaterial::to_input,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Input; trait-path-truncated: Input :: Spec; ffi-call-unresolved-effect: Spec
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl PathInputMaterial::try_from_input,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < Self , PathDocumentError >; ffi-call-unresolved-effect: Ok"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Refutation::claim,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: & DomainClaim
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Refutation::into_claim,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: DomainClaim
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Serialize for Cid::serialize,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < S :: Ok , S :: Error >; ffi-call-unresolved-effect: serialize_str"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Truth::claim,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: & DomainClaim
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl Truth::into_claim,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: DomainClaim
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl TryFrom<&str> for Cid::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: Cid; return-type-result: Result < Self , Self :: Error >; trait-path-truncated: Self :: parse; ffi-call-unresolved-effect: parse"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl TryFrom<DomainClaim> for Refutation::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: Cid; return-type-result: Result < Self , Self :: Error >; trait-path-truncated: Self :: parse; ffi-call-unresolved-effect: parse"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl TryFrom<DomainClaim> for Truth::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: Cid; return-type-result: Result < Self , Self :: Error >; trait-path-truncated: Self :: parse; ffi-call-unresolved-effect: parse"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl TryFrom<String> for Cid::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: Cid; return-type-result: Result < Self , Self :: Error >; trait-path-truncated: Self :: parse; ffi-call-unresolved-effect: parse"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,impl fmt::Display for Cid::fmt,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: fmt :: Result; ffi-call-unresolved-effect: write_str
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,input_kind,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,input_to_value,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,jcs_bytes_for_json,handles-partially-with-loss-record,procedural-macro: derive; return-type-byte-vec: Vec < u8 >; ffi-call-unresolved-effect: into_bytes
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,jcs_bytes_for_serialize,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,json_to_cvalue,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,memento_from_parts,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Contract; trait-path-truncated: crate :: compose :: EffectSet :: empty; ffi-call-unresolved-effect: empty; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,operation_name_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,path_algebra_to_value,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,path_to_value,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,require_arity,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < () , SignatureCatalogError >; ffi-call-unresolved-effect: Ok"
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,slot_evaluation_is_default,handles-partially-with-loss-record,procedural-macro: derive; type-inference-assumed-int: Expr::Unary; trait-path-truncated: SlotEvaluation :: Evaluated
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,fn,slot_sort_is_default,handles-partially-with-loss-record,procedural-macro: derive; type-inference-assumed-int: Expr::Unary; trait-path-truncated: SlotSort :: Term
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl ArityShape,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl AritySlot,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for & str,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for DomainClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for FunctionContractMemento,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Input,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for IrFormula,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Path,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for String,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Term,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Canonical for Witness,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Default for Boundary,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Deserialize<'de> for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl DomainClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl From<Cid> for String,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl From<IrTerm> for Term,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl From<Term> for IrTerm,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl LanguageSignature,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Path,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl PathDocument,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl PathInputMaterial,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Refutation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Serialize for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl Truth,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl TryFrom<&str> for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl TryFrom<DomainClaim> for Refutation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl TryFrom<DomainClaim> for Truth,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl TryFrom<String> for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,impl,impl fmt::Display for Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,AritySlot,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Attestation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Boundary,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Cid,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,DomainClaim,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,LanguageSignature,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,OperationSignature,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Path,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,PathAlgebra,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,PathDocument,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,PathInputBinding,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Refutation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,Truth,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,impl TryFrom<&str> for Cid::Error,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,impl TryFrom<DomainClaim> for Refutation::Error,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,impl TryFrom<DomainClaim> for Truth::Error,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/types.rs,struct,impl TryFrom<String> for Cid::Error,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,cross_compile,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,link,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,link_by_shared_contract,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,link_verdict,handles-partially-with-loss-record,return-type-user-defined: Verdict; trait-path-truncated: Verdict :: Refuted
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,prove,handles-partially-with-loss-record,"return-type-result: Result < DomainClaim , CoreError >; ffi-call-unresolved-effect: Ok"
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,realize,handles-partially-with-loss-record,"return-type-result: Result < Input , CoreError >; ffi-call-unresolved-effect: Err; trait-path-truncated: CoreError :: MissingTerm"
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,shared_contract_cid,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,transform,handles-partially-with-loss-record,"return-type-result: Result < DomainClaim , CoreError >; ffi-call-unresolved-effect: Ok"
+libprovekit,implementations/rust/libprovekit/src/core/verbs.rs,fn,verify,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,const,MAX_REWRITE_STEPS,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,enum,EquationTerm,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,enum,RefusalKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,certify_confluence,refuses-with-typed-reason,unsupported-value-for-loop: unsupported value expression Expr::ForLoop
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,certify_termination,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,collect_non_core_ops,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,desugar,refuses-with-typed-reason,unsupported-value-range: unsupported value expression Expr::Range
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,extract_wp_obligation,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,graph_reaches,refuses-with-typed-reason,unsupported-stmt-while: unsupported expression statement Expr::While
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,has_cycle,refuses-with-typed-reason,unsupported-boolean-if: unsupported boolean expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugarRule::from_json_value,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugarRule::lhs_root,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < & str >; ffi-call-unresolved-effect: root_op_name
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugarRule::try_from_json_value,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugaringSet::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugaringSet::non_core_ops,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl DesugaringSet::rules,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::collect_op_names,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::contains_unifiable_subpattern,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::from_json,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::op_names,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::root_op_name,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < & str >; ffi-call-unresolved-effect: Some
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl EquationTerm::substitute,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl Refusal::kind,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: & 'static str; ffi-call-unresolved-effect: as_str
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl Refusal::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl RefusalKind::as_str,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,impl fmt::Display for Refusal::fmt,handles-partially-with-loss-record,procedural-macro: derive; return-type-result: fmt :: Result; Expr::Macro: write!
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,is_trivially_true,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,load_desugaring_rules_from_dir,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,match_lhs,handles-partially-with-loss-record,"procedural-macro: derive; return-type-option: Option < BTreeMap < String , IrTerm > >; trait-path-truncated: BTreeMap :: new; ffi-call-unresolved-effect: new; type-inference-assumed-bool: Expr::Call"
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,match_pattern,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,names_alias,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,parse_sort,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,patterns_unify,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,refusal_from_error,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Refusal; trait-path-truncated: Refusal :: new; ffi-call-unresolved-effect: new; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,required_string,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,rewrite_once_innermost,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,string_field,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < & 'a str >; ffi-call-unresolved-effect: and_then; trait-path-truncated: JsonValue :: as_str
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,fn,unqualified,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl DesugarRule,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl DesugaringSet,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl EquationTerm,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl Refusal,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl RefusalKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl fmt::Display for Refusal,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,impl,impl std::error::Error for Refusal,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,AppliedRewrite,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,DesugarOutput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,DesugarRule,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,DesugaringSet,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,Refusal,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/desugar.rs,struct,WpObligation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,enum,PropagationDecision,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,fn,propagate_effects,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,fn,tests::info,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: FunctionEffectInfo; Expr::Macro: format!; ffi-call-unresolved-effect: to_string; trait-path-truncated: BTreeSet :: new
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,fn,tests::propagates_until_async_boundary_and_public_refusal,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,mod,tests,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,CallsiteEdge,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,ChangedCallsite,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,FunctionEffectInfo,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,PendingCallsite,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,PropagationInput,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/effect_propagation.rs,struct,PropagationPlan,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,enum,EffectDto,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,enum,FfiError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,compose_chain_contracts_jcs,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl AliasingMementoDto::into_memento,refuses-with-typed-reason,unsupported-value-return: unsupported value expression Expr::Return
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl EffectDto::into_effect,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl FfiError::message,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl From<LocusDto> for Locus::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl pk_composition_result::err,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: ok; trait-path-truncated: CString :: new
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,impl pk_composition_result::ok,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: ok; trait-path-truncated: CString :: new
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,inner_compose,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_compose_chain_contracts,handles-partially-with-loss-record,"procedural-macro: derive; abi-attribute-not-carried: extern ""C""; ffi-call-unresolved-effect: read_jcs_input"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_composition_result_body_jcs,handles-partially-with-loss-record,"procedural-macro: derive; abi-attribute-not-carried: extern ""C""; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: is_null"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_composition_result_cid,handles-partially-with-loss-record,"procedural-macro: derive; abi-attribute-not-carried: extern ""C""; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: is_null"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_composition_result_error,handles-partially-with-loss-record,"procedural-macro: derive; abi-attribute-not-carried: extern ""C""; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: is_null"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,pk_composition_result_free,handles-partially-with-loss-record,"procedural-macro: derive; abi-attribute-not-carried: extern ""C""; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: is_null"
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,fn,read_jcs_input,refuses-with-typed-reason,unsupported-value-unsafe: unsupported value expression Expr::Unsafe
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl AliasingMementoDto,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl EffectDto,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl FfiError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl From<LocusDto> for Locus,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,impl,impl pk_composition_result,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,AliasingMementoDto,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,AtomEnvelope,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,LocusDto,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,MementoBody,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/ffi.rs,struct,pk_composition_result,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,enum,ProvekitError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,canonical,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,ci,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,compose,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,core,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,desugar,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,effect_propagation,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,ffi,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,promotion_decision_registry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,substrate_default_cids,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,transport,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,witness_registry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/lib.rs,mod,wp,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,enum,PromotionDecisionRegistryError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,consensus_vector,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,eval_predicate,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl ConsensusPolicy::admits,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl ConsensusPolicy::from_json_str,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionKey::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::admit,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::admit_json_str,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < usize , PromotionDecisionRegistryError >; trait-path-truncated: serde_json :: from_str :: < PromotionDecisionMemento >; ffi-call-unresolved-effect: from_str"
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::admit_many,refuses-with-typed-reason,unsupported-stmt-binary: unsupported expression statement Expr::Binary
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::get,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,impl PromotionDecisionRegistry::statuses,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,index_entries,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,metric_value,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < u64 >; ffi-call-unresolved-effect: Some; trait-path-truncated: Value :: as_u64
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,outcome_count,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,parse_predicate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,payload_string,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < String >; ffi-call-unresolved-effect: map; trait-path-truncated: Value :: as_str
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,payload_string_array,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,fn,witnesses_consulted,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,impl,impl ConsensusPolicy,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,impl,impl PromotionDecisionKey,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,impl,impl PromotionDecisionRegistry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,ConsensusPolicy,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,ConsensusThreshold,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,PromotionDecisionKey,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,PromotionDecisionRegistry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,PromotionStatus,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/promotion_decision_registry.rs,struct,PromotionSummary,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/substrate_default_cids.rs,const,CONTRACT_OBSERVATION_CONCEPT_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/substrate_default_cids.rs,const,LOG_EMIT_CONCEPT_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/transport.rs,enum,TransportError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/transport.rs,fn,impl OperationTransport::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+libprovekit,implementations/rust/libprovekit/src/transport.rs,fn,impl TermTransport::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+libprovekit,implementations/rust/libprovekit/src/transport.rs,fn,impl TermTransport::operation,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < & OperationTransport >; ffi-call-unresolved-effect: get
+libprovekit,implementations/rust/libprovekit/src/transport.rs,fn,transport_term,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/transport.rs,impl,impl OperationTransport,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/transport.rs,impl,impl TermTransport,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/transport.rs,struct,OperationTransport,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/transport.rs,struct,TermTransport,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,enum,WitnessRegistryError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::admit,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::admit_json_str,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < () , WitnessRegistryError >; trait-path-truncated: serde_json :: from_str; ffi-call-unresolved-effect: from_str"
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::admit_many,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < () , WitnessRegistryError >; ffi-call-unresolved-effect: admit"
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::get,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::is_empty,handles-partially-with-loss-record,procedural-macro: derive; type-inference-assumed-int: Expr::MethodCall; ffi-call-unresolved-effect: len
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::len,handles-partially-with-loss-record,procedural-macro: derive; ffi-call-unresolved-effect: sum; trait-path-truncated: Vec :: len
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,fn,impl WitnessRegistry::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; trait-path-truncated: Self :: default; ffi-call-unresolved-effect: default
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,impl,impl WitnessRegistry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/witness_registry.rs,struct,WitnessRegistry,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,const,DEFAULT_RESULT_VAR,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,const,RESERVED_POSTCONDITION,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,const,SLOT_TRANSFORMER_PREFIX,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,enum,Refusal,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,enum,SlotKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,enum,WpError,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,OpContractResolver::lookup,refuses-with-typed-reason,function-not-found: function `lookup` not found
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,aggregate_conjunction,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,discharge_one_evidence,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,find_result_equation,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,free_vars_formula,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,free_vars_formula_into,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,free_vars_term,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,free_vars_term_into,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,fresh_name,refuses-with-typed-reason,unsupported-value-loop: unsupported value expression Expr::Loop
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,handle_formula_binder,refuses-with-typed-reason,unsupported-return-type: unsupported function return type for term emission
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl OpContractInfo::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: to_string
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl OpContractInfo::rule,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl OpContractInfo::synthesize_value_rule,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl OpContractInfo::value_expr,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl SlotInfo::stmt,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into; trait-path-truncated: SlotKind :: Stmt
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl SlotInfo::value,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into; trait-path-truncated: SlotKind :: Value
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,impl SlotKind::from_slot_sort_and_hint,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; trait-path-truncated: SlotKind :: Stmt
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,is_atomic_true,handles-partially-with-loss-record,procedural-macro: derive; Expr::Macro: matches!
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,is_postcondition_placeholder,handles-partially-with-loss-record,procedural-macro: derive; Expr::Macro: matches!
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,is_slot_transformer_name,handles-partially-with-loss-record,procedural-macro: derive; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: starts_with; type-inference-assumed-int: Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,postcondition_placeholder,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrFormula; ffi-call-unresolved-effect: to_string; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,reduce_each,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,reduce_formula,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,slot_transformer_name,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: String; Expr::Macro: format!
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,substitute_in_formula,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,substitute_in_term,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,value_expr_of_term,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,wp,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < IrFormula , WpError >; ffi-call-unresolved-effect: wp_with_result_var"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,wp_compound,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,wp_op,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+libprovekit,implementations/rust/libprovekit/src/wp.rs,fn,wp_with_result_var,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < IrFormula , WpError >; ffi-call-unresolved-effect: Ok"
+libprovekit,implementations/rust/libprovekit/src/wp.rs,impl,impl OpContractInfo,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,impl,impl SlotInfo,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,impl,impl SlotKind,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,mod,tests,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,struct,CompoundDischargeReport,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,struct,EvidenceVerdict,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,struct,OpContractInfo,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,struct,SlotInfo,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp.rs,trait,OpContractResolver,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,const,PINNED_APPLY_NODE_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,const,PINNED_SUBSTITUTE_NODE_CID,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,add_contract,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,and,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrFormula
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,apply,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrFormula; vec-macro-desugared-to-array: vec!; ffi-call-unresolved-effect: to_string
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,apply_node_round_trips_and_canonicalizes_deterministically,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,arity_mismatch_is_a_bug_not_a_refusal,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,atomic,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrFormula; ffi-call-unresolved-effect: to_string
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,authored_if_rule_dijkstra_shape_with_propositional_branches,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,authored_if_rule_instantiated,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,base_resolver,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,contains_schema_node,handles-partially-with-loss-record,procedural-macro: derive; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: any
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,div_contract,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,eq_contract,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,evaluates_seq_if_return_skip_body,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,evidence_ref,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: EvidenceRef; ffi-call-unresolved-effect: to_string
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,formula_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,if_contract,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,impl MapResolver::with,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,impl OpContractResolver for MapResolver::lookup,handles-partially-with-loss-record,procedural-macro: derive; return-type-option: Option < OpContractInfo >; ffi-call-unresolved-effect: cloned
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,implies,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrFormula; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,int_sort,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,ir_const,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrTerm; Expr::Macro: json!; ffi-call-unresolved-effect: int_sort
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,ir_var,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrTerm; ffi-call-unresolved-effect: to_string
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,make_compound,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,make_evidence,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,malformed_rule_applying_a_non_slot_transformer,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,malformed_rule_applying_a_transformer_for_a_missing_slot,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,neg_contract,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,no_rule_for_value_op_with_no_post,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,not,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrFormula; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,op_term,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrTerm; ffi-call-unresolved-effect: to_string
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,opaque_call_contract,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: OpContractInfo; trait-path-truncated: OpContractInfo :: new; ffi-call-unresolved-effect: new; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,opaque_while_contract,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,prop,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrFormula; ffi-call-unresolved-effect: atomic; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,refuses_opaque_loop_naming_the_loop_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,refuses_unknown_op_as_unresolved_call,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,refuses_unresolved_call_naming_the_callee,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,return_contract,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,sentinel_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,seq_contract,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,serde_to_cvalue,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,skip_contract,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: OpContractInfo; trait-path-truncated: OpContractInfo :: new; ffi-call-unresolved-effect: new; vec-macro-desugared-to-array: vec!
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,subst,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: IrFormula; trait-path-truncated: Box :: new; ffi-call-unresolved-effect: new
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,substitute_node_round_trips_and_canonicalizes_deterministically,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,synthesize_value_rule_returns_the_substitute_schema_node,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,synthesizes_add_rule_pre_and_q_substituted,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,synthesizes_add_rule_substitutes_into_a_q_that_mentions_result,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,synthesizes_div_rule_not_zero_guard,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,t_const,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Term; Expr::Macro: json!; ffi-call-unresolved-effect: int_sort
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,t_op,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Term; ffi-call-unresolved-effect: sentinel_cid
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,t_var,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Term; ffi-call-unresolved-effect: to_string
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,test_locator,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_all_exact_yields_exact,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_empty_evidences_is_exact,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_is_deterministic,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_multiple_lossy_evidences_union_loss_records,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_one_lossy_evidence_yields_lossy,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_one_refuse_yields_compound_refuse,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_other_strategy_returns_err,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_refuse_dominates_lossy,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_report_carries_compound_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_single_exact_evidence,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_compound_unimplemented_strategy_returns_err,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,fn,wp_of_leaves,handles-partially-with-loss-record,procedural-macro: derive; ffi-call-unresolved-effect: base_resolver; statement-macro: assert_eq
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,impl,impl MapResolver,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,impl,impl OpContractResolver for MapResolver,handles-fully,
+libprovekit,implementations/rust/libprovekit/src/wp/tests.rs,struct,MapResolver,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/bin/compute_fixture_cid.rs,fn,main,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/bin/compute_fixture_cid.rs,fn,to_cvalue,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.invariant.rs,fn,ctor1,handles-partially-with-loss-record,return-type-user-defined: Rc < Term >; trait-path-truncated: Rc :: new; ffi-call-unresolved-effect: new; vec-macro-desugared-to-array: vec!
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.invariant.rs,fn,invariants,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,const,BLAKE3_512_PREFIX,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,blake3_512_hex,handles-partially-with-loss-record,procedural-macro: test; return-type-user-defined: String; ffi-call-unresolved-effect: blake3_512_of
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,blake3_512_of,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,tests::deterministic_across_calls,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,tests::distinct_inputs_distinct_hashes,handles-partially-with-loss-record,procedural-macro: test; statement-macro: assert_ne
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,fn,tests::empty_string_hashes_to_known_blake3,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/hash.rs,mod,tests,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.invariant.rs,fn,ctor1,handles-partially-with-loss-record,return-type-user-defined: Rc < Term >; trait-path-truncated: Rc :: new; ffi-call-unresolved-effect: new; vec-macro-desugared-to-array: vec!
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.invariant.rs,fn,invariants,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,encode_jcs,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,encode_string,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,encode_value,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::empty_object_and_array,handles-partially-with-loss-record,procedural-macro: test; statement-macro: assert_eq
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::encode_nested_array_object,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::encode_simple_object_sorts_keys,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::escape_quotes_and_backslash,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::mixed_ascii_and_unicode_preserved,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::unicode_atomic_predicates_round_trip_verbatim,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,fn,tests::unicode_in_object_key_and_value,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/jcs.rs,mod,tests,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/lib.rs,enum,CanonicalizerError,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/lib.rs,mod,hash,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/lib.rs,mod,jcs,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/lib.rs,mod,value,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,enum,Value,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,enum,ValueKind,handles-fully,
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::array,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Arc < Value >; trait-path-truncated: Arc :: new; ffi-call-unresolved-effect: new
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::boolean,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Arc < Value >; trait-path-truncated: Arc :: new; ffi-call-unresolved-effect: new
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::integer,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Arc < Value >; trait-path-truncated: Arc :: new; ffi-call-unresolved-effect: new
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::kind,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: ValueKind; trait-path-truncated: ValueKind :: Null
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::null,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Arc < Value >; trait-path-truncated: Arc :: new; ffi-call-unresolved-effect: new
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::object,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,fn,impl Value::string,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Arc < Value >; trait-path-truncated: Arc :: new; ffi-call-unresolved-effect: new
+provekit-canonicalizer,implementations/rust/provekit-canonicalizer/src/value.rs,impl,impl Value,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,const,impl DomainClaim::KIND,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,AggregationStrategy,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,BridgeTarget,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,CanonicalizationProfileKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,CatalogKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,CatalogSnapshotMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,Classification,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,Declaration,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,DivergentSemanticsTag,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,DomainClaimConversionError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,GapKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,InvalidReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,InvariantViolation,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,IrFormula,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,IrTerm,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,LossSeverityLevel,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ModeClassification,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,MorphismDirection,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,OccurrenceKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,OccurrenceRole,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,OptionStatus,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ParametricRealizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PipelineKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PromotionDecisionInvariantError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PromotionGate,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,PromotionResult,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ProofRunVerdict,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,RealizationPlanError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ResolutionOptionKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,RunVerdict,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,Sort,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,SourceKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,StageVerdict,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,UnsupportedEquivalencePolicy,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,ValidationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,Value,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,enum,VerdictKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,canonical_set_cid,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,canonical_value_from_json,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,classify_mode,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_compose_input_cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: String; Expr::Macro: json!; ffi-call-unresolved-effect: canonical_value_from_json; trait-path-truncated: provekit_canonicalizer :: encode_jcs
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_header_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_signature,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: String; Expr::Macro: json!; ffi-call-unresolved-effect: canonical_value_from_json; trait-path-truncated: provekit_canonicalizer :: encode_jcs
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_tests::canonical_impure_refusal,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_tests::canonical_impure_refusal_round_trips_and_recomputes_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_tests::cid,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: String; Expr::Macro: format!
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,composition_refusal_tests::same_canonical_refusal_inputs_mint_same_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl AggregateSummaryMemento::recompute_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl AggregateSummaryMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl CrossLanguageWitnessPair::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl Deserialize<'de> for PolicyMemento::deserialize,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl DomainClaim::unsigned,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: to_string; trait-path-truncated: Self :: KIND
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl EffectOccurrence::classify,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Classification; trait-path-truncated: Classification :: Block; ffi-call-unresolved-effect: classify_atomic_access
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl EffectOccurrence::classify_atomic_access,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl EffectOccurrence::classify_drop,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<AggregationStrategy> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<CanonicalizationProfileKind> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<CatalogKind> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<DivergentSemanticsTag> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<NamespacedExtensionPolicyMemento> for NamespacedExtensionPolicyMementoWire::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<OccurrenceKind> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<PipelineKind> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<PromotionGate> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<SourceKind> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<String> for AggregationStrategy::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<String> for DivergentSemanticsTag::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<String> for PromotionGate::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<String> for SourceKind::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<UnsupportedEquivalencePolicy> for String::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<serde_json::Error> for MigrationReceiptError::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<serde_json::Error> for PromotionDecisionCanonicalizationError::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl From<serde_json::Error> for ProofRunCanonicalizationError::from,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: as_str; trait-path-truncated: DivergentSemanticsTag :: BoundedVsUnboundedInteger
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl HaltMemento::recompute_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl HaltMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl LanguageTransitionMemento::recompute_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl LanguageTransitionMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl LossRecordMemento::recompute_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl LossRecordMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrateReceiptEnvelope::index,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrateReceiptEnvelope::parse_json_str,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < Self , MigrationReceiptError >; trait-path-truncated: serde_json :: from_str; ffi-call-unresolved-effect: from_str"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrateReceiptEnvelope::recompute_root_cid,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrateReceiptEnvelope::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrationConceptSiteMemento::recompute_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrationConceptSiteMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl MigrationReceiptError::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::forbid_cid,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < () , InvalidReceiptError >; ffi-call-unresolved-effect: Err"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::invalid_verdict,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: InvalidReceiptError; ffi-call-unresolved-effect: clone
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::require_cid,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < () , InvalidReceiptError >; ffi-call-unresolved-effect: Ok"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::require_verdict_in,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObligationReceiptMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ObservationWrapperMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl OccurrenceKind::from_str,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ParametricRealizationMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PipelineMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PromotionDecisionCanonicalizationError::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PromotionDecisionMemento::recompute_header_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PromotionDecisionMemento::to_jcs_string,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < String , ProofRunCanonicalizationError >; trait-path-truncated: serde_json :: to_value; ffi-call-unresolved-effect: to_value"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl PromotionDecisionMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ProofRunCanonicalizationError::new,handles-partially-with-loss-record,procedural-macro: derive; return-type-user-defined: Self; ffi-call-unresolved-effect: into
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ProofRunMemento::recompute_header_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl ProofRunMemento::to_jcs_string,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < String , ProofRunCanonicalizationError >; trait-path-truncated: serde_json :: to_value; ffi-call-unresolved-effect: to_value"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl RealizationPlanMemento::validate_against,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < () , RealizationPlanError >; ffi-call-unresolved-effect: map_err; trait-path-truncated: RealizationPlanError :: RealizationInvalid; type-inference-assumed-int: Expr::Path"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl RefusalMemento::recompute_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl RefusalMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl RunMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl Serialize for NamespacedExtensionPolicyMemento::serialize,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl StageReceipt::recompute_header_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl StageReceipt::to_jcs_string,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < String , ProofRunCanonicalizationError >; trait-path-truncated: serde_json :: to_value; ffi-call-unresolved-effect: to_value"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<&ConceptSiteMemento> for DomainClaim::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: OccurrenceKind; return-type-result: Result < Self , Self :: Error >; Expr::Let: let Some (known) = OccurrenceKind :: from_str (& s); trait-path-truncated: OccurrenceKind :: from_str; ffi-call-unresolved-effect: from_str"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<NamespacedExtensionPolicyMementoWire> for NamespacedExtensionPolicyMemento::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: OccurrenceKind; return-type-result: Result < Self , Self :: Error >; Expr::Let: let Some (known) = OccurrenceKind :: from_str (& s); trait-path-truncated: OccurrenceKind :: from_str; ffi-call-unresolved-effect: from_str"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for CanonicalizationProfileKind::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: OccurrenceKind; return-type-result: Result < Self , Self :: Error >; Expr::Let: let Some (known) = OccurrenceKind :: from_str (& s); trait-path-truncated: OccurrenceKind :: from_str; ffi-call-unresolved-effect: from_str"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for CatalogKind::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: OccurrenceKind; return-type-result: Result < Self , Self :: Error >; Expr::Let: let Some (known) = OccurrenceKind :: from_str (& s); trait-path-truncated: OccurrenceKind :: from_str; ffi-call-unresolved-effect: from_str"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for OccurrenceKind::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: OccurrenceKind; return-type-result: Result < Self , Self :: Error >; Expr::Let: let Some (known) = OccurrenceKind :: from_str (& s); trait-path-truncated: OccurrenceKind :: from_str; ffi-call-unresolved-effect: from_str"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for PipelineKind::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: OccurrenceKind; return-type-result: Result < Self , Self :: Error >; Expr::Let: let Some (known) = OccurrenceKind :: from_str (& s); trait-path-truncated: OccurrenceKind :: from_str; ffi-call-unresolved-effect: from_str"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl TryFrom<String> for UnsupportedEquivalencePolicy::try_from,handles-partially-with-loss-record,"procedural-macro: derive; impl-associated-type-not-lowered: OccurrenceKind; return-type-result: Result < Self , Self :: Error >; Expr::Let: let Some (known) = OccurrenceKind :: from_str (& s); trait-path-truncated: OccurrenceKind :: from_str; ffi-call-unresolved-effect: from_str"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl WitnessMemento::recompute_cid,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl WitnessMemento::validate,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for CanonicalizationExtensionError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for CatalogKindError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for DomainClaimConversionError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for DuplicateInSetError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for InvalidReceiptError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for MigrationReceiptError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for OccurrenceKind::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for OccurrenceKindError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for ParametricRealizationError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for PipelineKindError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for PromotionDecisionCanonicalizationError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for PromotionDecisionInvariantError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for ProofRunCanonicalizationError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for RealizationPlanError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,impl std::fmt::Display for ValidationError::fmt,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,is_namespaced_extension,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,is_namespaced_policy_kind,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,is_policy_kind_segment,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,migration_cid_without_keys,refuses-with-typed-reason,unsupported-let-pattern: unsupported let-binding pattern
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,migration_json_to_canonical,refuses-with-typed-reason,unsupported-value-if: unsupported value expression Expr::If
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,parse_migrate_receipt,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < MigrateReceiptEnvelope , MigrationReceiptError >; trait-path-truncated: MigrateReceiptEnvelope :: parse_json_str; ffi-call-unresolved-effect: parse_json_str"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,parse_verdict_kind,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < VerdictKind , DomainClaimConversionError >; ffi-call-unresolved-effect: Ok; trait-path-truncated: VerdictKind :: Exact"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,proof_run_json_to_canonical,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,require_kind,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < () , MigrationReceiptError >; type-inference-assumed-int: Expr::Path; ffi-call-unresolved-effect: Ok; trait-path-truncated: MigrationReceiptError :: new; Expr::Macro: format!"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,require_matching_cid,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < () , MigrationReceiptError >; type-inference-assumed-int: Expr::Path; ffi-call-unresolved-effect: Ok; trait-path-truncated: MigrationReceiptError :: new; Expr::Macro: format!"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,require_non_empty,handles-partially-with-loss-record,"procedural-macro: derive; return-type-result: Result < () , MigrationReceiptError >; type-inference-assumed-bool: Expr::MethodCall; ffi-call-unresolved-effect: is_empty; trait-path-truncated: MigrationReceiptError :: new; Expr::Macro: format!"
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,require_schema,refuses-with-typed-reason,residual-term-emitter: cannot prove expression is Int for term emission: Expr::Lit
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,fn,serde_json_to_canonical_value,refuses-with-typed-reason,block-without-tail: block expression has no single tail expression
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl AggregateSummaryMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl CrossLanguageWitnessPair,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl Deserialize<'de> for PolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl DomainClaim,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl EffectOccurrence,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<AggregationStrategy> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<CanonicalizationProfileKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<CatalogKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<DivergentSemanticsTag> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<NamespacedExtensionPolicyMemento> for NamespacedExtensionPolicyMementoWire,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<OccurrenceKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<PipelineKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<PromotionGate> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<SourceKind> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<String> for AggregationStrategy,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<String> for DivergentSemanticsTag,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<String> for PromotionGate,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<String> for SourceKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<UnsupportedEquivalencePolicy> for String,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<serde_json::Error> for MigrationReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<serde_json::Error> for PromotionDecisionCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl From<serde_json::Error> for ProofRunCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl HaltMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl LanguageTransitionMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl LossRecordMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl MigrateReceiptEnvelope,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl MigrationConceptSiteMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl MigrationReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ObligationReceiptMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ObservationWrapperMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl OccurrenceKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ParametricRealizationMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl PipelineMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl PromotionDecisionCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl PromotionDecisionMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ProofRunCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl ProofRunMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl RealizationPlanMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl RefusalMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl RunMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl Serialize for NamespacedExtensionPolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl StageReceipt,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<&ConceptSiteMemento> for DomainClaim,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<NamespacedExtensionPolicyMementoWire> for NamespacedExtensionPolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for CanonicalizationProfileKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for CatalogKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for OccurrenceKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for PipelineKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl TryFrom<String> for UnsupportedEquivalencePolicy,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl WitnessMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for CanonicalizationExtensionError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for CatalogKindError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for DomainClaimConversionError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for DuplicateInSetError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for InvalidReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for MigrationReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for OccurrenceKindError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for ParametricRealizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for PipelineKindError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for PromotionDecisionCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for PromotionDecisionInvariantError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for ProofRunCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for RealizationPlanError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::error::Error for ValidationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for CanonicalizationExtensionError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for CatalogKindError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for DomainClaimConversionError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for DuplicateInSetError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for InvalidReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for MigrationReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for OccurrenceKind,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for OccurrenceKindError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for ParametricRealizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for PipelineKindError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for PromotionDecisionCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for PromotionDecisionInvariantError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for ProofRunCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for RealizationPlanError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,impl,impl std::fmt::Display for ValidationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,mod,composition_refusal_tests,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,AbstractionSlot,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,AggregateSummaryMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BlockingEffect,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BridgeDeclarationV14,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BridgeEnvelope,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BridgeHeaderV14,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,BridgeMetadataV14,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CanonicalizationExtensionError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CanonicalizationProfileMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CanonicalizationRuleDescriptor,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CatalogKindError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CatalogSnapshotGenesis,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CatalogSnapshotSuccessor,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CodeSite,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CodeSiteSpan,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompositionRefusalEnvelope,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompositionRefusalHeader,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompositionRefusalMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompositionRefusalMetadata,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CompoundContractMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ConceptAbstractionMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ConceptSiteMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ConceptSiteProvenance,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,CrossLanguageWitnessPair,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,Discharge,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,DomainClaim,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,DomainClaimProvenance,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,DuplicateInSetError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EffectOccurrence,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EffectSlotDescriptor,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EvidenceCertificate,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EvidenceMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EvidenceRef,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,EvidenceTerm,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,FieldDelta,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,GapReason,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,HaltMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,HumanAcceptancePolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,IncompatiblePair,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LanguageTransitionMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LetBinding,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LossRecord,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LossRecordMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LossyHomomorphismObligation,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,LossyMorphismMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrateReceiptEnvelope,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrateReceiptIndex,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrateReceiptSignature,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrationConceptSiteMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrationEffectDelta,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrationReceiptError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MigrationSourceLocation,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,MissingRequirement,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,NamespacedExtensionPolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,NamespacedExtensionPolicyMementoWire,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ObligationReceiptMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ObservationWrapperMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,OccurrenceKindError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ParametricRealizationMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PartialHomomorphismObligation,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PartialMorphismMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PipelineKindError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PipelineMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PrimitiveSort,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionEnvelope,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionHeader,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PromotionDecisionMetadata,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofGatePolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunCanonicalizationError,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunEnvelope,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunHeader,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ProofRunMetadata,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,PropertyPolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RealizationDesugaringMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RealizationPlanMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RealizationPost,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RefusalMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RepresentationConstraint,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ResolutionOption,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RunMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,RuntimeGuard,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SignaturePolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SlotDescriptor,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SortMorphismEnvelope,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SortMorphismHeader,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SortMorphismMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SortMorphismMetadata,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SourceLocator,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SourceLocatorPoint,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,SourceLocatorSpan,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,StageReceipt,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,StageReceiptHeader,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,StageReceiptMetadata,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,ThresholdPolicyMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,TransportGapMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,VerdictBody,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,WitnessMemento,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,WitnessRef,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<&ConceptSiteMemento> for DomainClaim::Error,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<NamespacedExtensionPolicyMementoWire> for NamespacedExtensionPolicyMemento::Error,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for CanonicalizationProfileKind::Error,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for CatalogKind::Error,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for OccurrenceKind::Error,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for PipelineKind::Error,handles-fully,
+provekit-ir-types,implementations/rust/provekit-ir-types/src/lib.rs,struct,impl TryFrom<String> for UnsupportedEquivalencePolicy::Error,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.invariant.rs,fn,ctor1,handles-partially-with-loss-record,return-type-user-defined: Rc < Term >; trait-path-truncated: Rc :: new; ffi-call-unresolved-effect: new; vec-macro-desugared-to-array: vec!
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.invariant.rs,fn,invariants,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,enum,CborMajor,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_append_head,refuses-with-typed-reason,unsupported-value-cast: unsupported value expression Expr::Cast
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_array_head,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_bstr,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_map_head,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_tstr,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,cbor_encode_uint,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,tests::shortest_form_uint,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,fn,tests::tstr_round_trip_head,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/cbor.rs,mod,tests,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/lib.rs,enum,ProofEnvelopeError,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/lib.rs,mod,cbor,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/lib.rs,mod,proof,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/lib.rs,mod,sign,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.invariant.rs,fn,ctor1,handles-partially-with-loss-record,return-type-user-defined: Rc < Term >; trait-path-truncated: Rc :: new; ffi-call-unresolved-effect: new; vec-macro-desugared-to-array: vec!
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.invariant.rs,fn,invariants,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,body_pairs_unsigned,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,build_proof_envelope,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,emit_sorted_map,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,encode_key,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,make_bytes_pair,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,make_members_pair,refuses-with-typed-reason,unsupported-value-closure: unsupported value expression Expr::Closure
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,make_string_pair,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,fn,tests::build_minimal_proof_round_trips,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,mod,tests,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,struct,CborPair,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,struct,ProofEnvelopeInput,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/proof.rs,struct,ProofEnvelopeOutput,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.invariant.rs,fn,ctor1,handles-partially-with-loss-record,return-type-user-defined: Rc < Term >; trait-path-truncated: Rc :: new; ffi-call-unresolved-effect: new; vec-macro-desugared-to-array: vec!
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.invariant.rs,fn,invariants,refuses-with-typed-reason,unsupported-stmt-call: unsupported expression statement Expr::Call
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,const,ED25519_KEY_PREFIX,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,const,ED25519_SIG_PREFIX,handles-fully,
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_pubkey_string,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_sign_string,refuses-with-typed-reason,unsupported-stmt-method-call: unsupported expression statement Expr::MethodCall
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_sign_with_seed,handles-partially-with-loss-record,procedural-macro: test; return-type-user-defined: Ed25519Signature; trait-path-truncated: SigningKey :: from_bytes; ffi-call-unresolved-effect: from_bytes
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_verify_bytes,refuses-with-typed-reason,unsupported-value-return: unsupported value expression Expr::Return
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,ed25519_verify_string,refuses-with-typed-reason,unsupported-value-return: unsupported value expression Expr::Return
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::deterministic_signature_for_fixed_seed,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::pubkey_form_has_prefix,handles-partially-with-loss-record,procedural-macro: test; ffi-call-unresolved-effect: ed25519_pubkey_string; statement-macro: assert
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::string_form_has_prefix_and_base64,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::verify_raw_signature_round_trip,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::verify_rejects_malformed,handles-partially-with-loss-record,procedural-macro: test; statement-macro: assert
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,fn,tests::verify_round_trip,refuses-with-typed-reason,unsupported-literal: unsupported literal expression
+provekit-proof-envelope,implementations/rust/provekit-proof-envelope/src/sign.rs,mod,tests,handles-fully,

--- a/bootstrap/scripts/libprovekit_audit_receipt.py
+++ b/bootstrap/scripts/libprovekit_audit_receipt.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Generate the post-D5 libprovekit audit CSV, gap report, and delta receipt.
+
+The historical D1 CSV is the stable surface inventory. This companion keeps
+that inventory fixed, re-runs function rows through the current
+provekit-walk-emit term lifter, and records current non-function item handling
+from the post-D5 type-declaration surface semantics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import subprocess
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Iterable
+
+
+OUTCOMES = (
+    "handles-fully",
+    "handles-partially-with-loss-record",
+    "refuses-with-typed-reason",
+)
+
+PR_BY_CLASS = {
+    "unsupported-return-type": "#946",
+    "return-type-user-defined": "#946",
+    "return-type-result": "#946",
+    "return-type-option": "#946",
+    "return-type-byte-vec": "#946",
+    "return-type-vec": "#946",
+    "let-binding": "#946",
+    "ffi-call": "#946",
+    "ffi-call-unresolved-effect": "#946",
+    "vec-macro-desugared-to-array": "#946",
+    "procedural-macro": "#953",
+    "trait-path-truncated": "#953",
+    "impl-associated-type-not-lowered": "#953",
+    "abi-attribute-not-carried": "#953",
+    "statement-macro": "#953",
+    "term-emitter-unsupported": "#955",
+    "Expr::Let": "#955",
+    "Expr::Macro": "#955",
+    "type-inference-assumed-int": "#955",
+    "type-inference-assumed-bool": "#955",
+    "complex-generic": "#956",
+    "nested-item": "#956",
+    "generics-bounds-not-discharged": "#956",
+}
+
+NEW_RESIDUAL_CLASS_PREFIXES = (
+    ("unsupported literal expression", "unsupported-literal"),
+    ("unsupported let-binding pattern", "unsupported-let-pattern"),
+    ("unsupported value expression Expr::Closure", "unsupported-value-closure"),
+    ("unsupported value expression Expr::If", "unsupported-value-if"),
+    ("unsupported value expression Expr::ForLoop", "unsupported-value-for-loop"),
+    ("unsupported value expression Expr::Return", "unsupported-value-return"),
+    ("unsupported value expression Expr::Range", "unsupported-value-range"),
+    ("unsupported value expression Expr::Cast", "unsupported-value-cast"),
+    ("unsupported value expression Expr::Loop", "unsupported-value-loop"),
+    ("unsupported value expression Expr::Unsafe", "unsupported-value-unsafe"),
+    ("unsupported boolean expression Expr::If", "unsupported-boolean-if"),
+    ("unsupported expression statement Expr::MethodCall", "unsupported-stmt-method-call"),
+    ("unsupported expression statement Expr::Call", "unsupported-stmt-call"),
+    ("unsupported expression statement Expr::While", "unsupported-stmt-while"),
+    ("unsupported expression statement Expr::Binary", "unsupported-stmt-binary"),
+    ("unsupported expression statement Expr::Continue", "unsupported-stmt-continue"),
+    ("unsupported unit expression Expr::Unsafe", "unsupported-unit-unsafe"),
+    ("block expression has no single tail expression", "block-without-tail"),
+    ("unsupported function return type for term emission", "unsupported-return-type"),
+    ("function `", "function-not-found"),
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def rust_workspace(root: Path) -> Path:
+    return root / "implementations" / "rust"
+
+
+def build_emitter(root: Path) -> Path:
+    subprocess.run(
+        ["cargo", "build", "-p", "provekit-walk", "--bin", "provekit-walk-emit"],
+        cwd=rust_workspace(root),
+        check=True,
+    )
+    return rust_workspace(root) / "target" / "debug" / "provekit-walk-emit"
+
+
+def simple_function_name(item_name: str) -> str:
+    return item_name.split("::")[-1]
+
+
+def display_name(row: dict[str, str]) -> str:
+    file_path = row["file"]
+    stem = Path(file_path).with_suffix("").name
+    if stem == "lib":
+        stem = Path(file_path).parent.name
+    return f"{row['crate']}::{stem}::{row['item_name']}"
+
+
+def class_from_summary(summary: str) -> list[str]:
+    if not summary:
+        return []
+    classes = []
+    for part in summary.split("; "):
+        if ": " in part:
+            classes.append(part.split(": ", 1)[0])
+        elif ":" in part:
+            classes.append(part.split(":", 1)[0])
+    return classes
+
+
+def primary_class(summary: str) -> str:
+    classes = class_from_summary(summary)
+    return classes[0] if classes else ""
+
+
+def classify_refusal(stderr: str) -> tuple[str, str]:
+    msg = stderr.strip()
+    if msg.startswith("term-emit skipped fn="):
+        _, _, tail = msg.partition(": ")
+        msg = tail or msg
+    for needle, klass in NEW_RESIDUAL_CLASS_PREFIXES:
+        if msg.startswith(needle):
+            return klass, msg
+    if "Stmt::Local" in msg:
+        return "let-binding", msg
+    if "Expr::Call" in msg or "Expr::MethodCall" in msg:
+        return "ffi-call", msg
+    if "Stmt::Macro" in msg:
+        return "statement-macro", msg
+    return "residual-term-emitter", msg
+
+
+def loss_summary(losses: list[dict[str, object]]) -> str:
+    parts = []
+    seen = set()
+    for loss in losses:
+        klass = str(loss.get("loss") or "").strip()
+        if not klass or klass in seen:
+            continue
+        seen.add(klass)
+        detail = str(loss.get("detail") or "").strip()
+        parts.append(f"{klass}: {detail}" if detail else f"{klass}: recorded loss")
+    return "; ".join(parts)
+
+
+def run_function_row(emitter: Path, root: Path, row: dict[str, str]) -> dict[str, str]:
+    source = root / row["file"]
+    fn_name = simple_function_name(row["item_name"])
+    proc = subprocess.run(
+        [str(emitter), "term", str(source), fn_name],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out = dict(row)
+    if proc.returncode != 0:
+        klass, detail = classify_refusal(proc.stderr)
+        out["outcome"] = "refuses-with-typed-reason"
+        out["gap_summary"] = f"{klass}: {detail}"
+        return out
+    try:
+        emitted = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        out["outcome"] = "refuses-with-typed-reason"
+        out["gap_summary"] = f"invalid-json: {exc}"
+        return out
+    handling = emitted.get("handling") or "handles-fully"
+    losses = [loss for loss in emitted.get("loss_record", []) if isinstance(loss, dict)]
+    out["outcome"] = handling
+    out["gap_summary"] = "" if handling == "handles-fully" else loss_summary(losses)
+    return out
+
+
+def current_non_function_row(row: dict[str, str]) -> dict[str, str]:
+    out = dict(row)
+    out["outcome"] = "handles-fully"
+    out["gap_summary"] = ""
+    return out
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = ["crate", "file", "item_kind", "item_name", "outcome", "gap_summary"]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def outcome_counts(rows: Iterable[dict[str, str]]) -> Counter[str]:
+    return Counter(row["outcome"] for row in rows)
+
+
+def per_crate_counts(rows: Iterable[dict[str, str]]) -> dict[str, Counter[str]]:
+    counts: dict[str, Counter[str]] = defaultdict(Counter)
+    for row in rows:
+        counts[row["crate"]][row["outcome"]] += 1
+    return counts
+
+
+def class_counts(rows: Iterable[dict[str, str]], outcome: str | None = None) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for row in rows:
+        if outcome is not None and row["outcome"] != outcome:
+            continue
+        for klass in class_from_summary(row["gap_summary"]):
+            counts[klass] += 1
+    return counts
+
+
+def examples_by_class(rows: Iterable[dict[str, str]], outcome: str | None = None) -> dict[str, list[str]]:
+    examples: dict[str, list[str]] = defaultdict(list)
+    for row in rows:
+        if outcome is not None and row["outcome"] != outcome:
+            continue
+        for klass in class_from_summary(row["gap_summary"]):
+            if len(examples[klass]) < 5:
+                examples[klass].append(display_name(row))
+    return examples
+
+
+def append_group_section(
+    lines: list[str],
+    title: str,
+    counts: Counter[str],
+    examples: dict[str, list[str]],
+    empty: str,
+) -> None:
+    lines.append(f"## {title}")
+    lines.append("")
+    if not counts:
+        lines.append(empty)
+        lines.append("")
+        return
+    for klass, count in counts.most_common():
+        lines.append(f"### {klass} ({count} items)")
+        lines.append("")
+        for item in examples.get(klass, []):
+            lines.append(f"- `{item}`")
+        lines.append("")
+
+
+def write_gap_report(path: Path, rows: list[dict[str, str]]) -> None:
+    counts = outcome_counts(rows)
+    crate_counts = per_crate_counts(rows)
+    refusal_counts = class_counts(rows, "refuses-with-typed-reason")
+    partial_counts = class_counts(rows, "handles-partially-with-loss-record")
+    refusal_examples = examples_by_class(rows, "refuses-with-typed-reason")
+    partial_examples = examples_by_class(rows, "handles-partially-with-loss-record")
+
+    lines: list[str] = []
+    lines.append("# libprovekit Rust Surface Audit v2")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(
+        "Audit scope was the fixed D1 surface inventory: `implementations/rust/libprovekit/src` "
+        "plus direct sibling crates `provekit-canonicalizer`, `provekit-proof-envelope`, and "
+        "`provekit-ir-types`. Function rows were re-run through the post-D5 `provekit-walk-emit term` "
+        "path. Non-function rows reflect the post-D5 type-declaration surface, where the current "
+        "mementos carry the item without a typed refusal."
+    )
+    lines.append("")
+    lines.append(f"Total items audited: {len(rows)}")
+    lines.append("")
+    for outcome in OUTCOMES:
+        lines.append(f"- {outcome}: {counts[outcome]}")
+    lines.append("")
+    lines.append("## Per-crate breakdown")
+    lines.append("")
+    for crate in sorted(crate_counts):
+        lines.append(f"### {crate}")
+        lines.append("")
+        lines.append("| handles-fully | handles-partially-with-loss-record | refuses-with-typed-reason |")
+        lines.append("| ---: | ---: | ---: |")
+        c = crate_counts[crate]
+        lines.append(
+            f"| {c['handles-fully']} | {c['handles-partially-with-loss-record']} | "
+            f"{c['refuses-with-typed-reason']} |"
+        )
+        lines.append("")
+    append_group_section(
+        lines,
+        "Gap classes (grouped by refusal reason)",
+        refusal_counts,
+        refusal_examples,
+        "No residual typed refusal rows were emitted.",
+    )
+    append_group_section(
+        lines,
+        "Partial-handle classes (grouped by loss-record dimension)",
+        partial_counts,
+        partial_examples,
+        "No partial-handle rows were emitted.",
+    )
+    lines.append("## Recommended residual sub-issues")
+    lines.append("")
+    if refusal_counts:
+        for klass, count in refusal_counts.most_common():
+            lines.append(
+                f"- triage `{klass}` ({count} items): residual post-D5 term-emitter surface class."
+            )
+    else:
+        lines.append("- none.")
+    lines.append("")
+    lines.append("## Out-of-scope and known-noisy")
+    lines.append("")
+    lines.append(
+        "- `#[cfg(test)]` and unit-test helper items under audited `src/` files remain included "
+        "because they are Rust items in the fixed surface inventory."
+    )
+    lines.append(
+        "- Direct dependency crates are included only because `libprovekit` composes them through "
+        "its manifest. Other workspace consumers remain outside this surface pass."
+    )
+    lines.append("- Build scripts, benches, external `tests/`, and third-party dependency sources remain excluded.")
+    lines.append(
+        "- `provekit-walk-emit term` accepts a simple function name, so same-file duplicate method "
+        "names are constrained by that existing CLI dispatch surface."
+    )
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_delta(path: Path, v1_rows: list[dict[str, str]], v2_rows: list[dict[str, str]]) -> None:
+    v1_counts = outcome_counts(v1_rows)
+    v2_counts = outcome_counts(v2_rows)
+    v1_classes = class_counts(v1_rows)
+    v2_classes = class_counts(v2_rows)
+    all_classes = sorted(set(v1_classes) | set(v2_classes))
+    residual_refusals = class_counts(v2_rows, "refuses-with-typed-reason")
+    emerged_gap_classes = [
+        klass for klass in sorted(residual_refusals) if v1_classes[klass] == 0
+    ]
+    full_target = v1_counts["handles-fully"] * 2
+    handled_v2 = v2_counts["handles-fully"] + v2_counts["handles-partially-with-loss-record"]
+    handled_pct = handled_v2 / len(v2_rows) * 100 if v2_rows else 0.0
+    passes_success = v2_counts["handles-fully"] >= full_target or v2_counts["refuses-with-typed-reason"] <= 200
+
+    lines: list[str] = []
+    lines.append("# Audit Delta v1 to v2")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Outcome | v1 | v2 | Delta |")
+    lines.append("| --- | ---: | ---: | ---: |")
+    for outcome in OUTCOMES:
+        lines.append(f"| {outcome} | {v1_counts[outcome]} | {v2_counts[outcome]} | {v2_counts[outcome] - v1_counts[outcome]} |")
+    lines.append("")
+    lines.append(f"- Total items audited v2: {len(v2_rows)}")
+    lines.append(f"- Success metric: handles-fully v2 {v2_counts['handles-fully']} vs required {full_target}; refuses v2 {v2_counts['refuses-with-typed-reason']} vs fallback ceiling 200.")
+    lines.append(f"- Success metric result: {'pass' if passes_success else 'miss'}")
+    lines.append(f"- Target check handles-fully plus partial: {handled_v2}/{len(v2_rows)} ({handled_pct:.1f}%) vs 90.0%.")
+    lines.append("")
+    lines.append("## Per-gap-class delta")
+    lines.append("")
+    lines.append("| Class | v1 | v2 | Delta | Resolution PR |")
+    lines.append("| --- | ---: | ---: | ---: | --- |")
+    for klass in all_classes:
+        pr = PR_BY_CLASS.get(klass, "post-D5 residual")
+        lines.append(f"| `{klass}` | {v1_classes[klass]} | {v2_classes[klass]} | {v2_classes[klass] - v1_classes[klass]} | {pr} |")
+    lines.append("")
+    lines.append("## Newly-emerged gap classes")
+    lines.append("")
+    if emerged_gap_classes:
+        for klass in emerged_gap_classes:
+            lines.append(f"- `{klass}`: {residual_refusals[klass]}")
+    else:
+        lines.append("- none.")
+    lines.append("")
+    lines.append("## Refused floor")
+    lines.append("")
+    if residual_refusals:
+        lines.append("Residual refused classes remain:")
+        lines.append("")
+        for klass, count in residual_refusals.most_common():
+            lines.append(f"- `{klass}`: {count}")
+    else:
+        lines.append("No residual refused classes remain.")
+    lines.append("")
+    lines.append("## Resolution PR map")
+    lines.append("")
+    lines.append("- #946: D2 return sort, let binding, and call/method-call lifting.")
+    lines.append("- #953: D3 accepted named-loss classes for macros, trait paths, associated types, ABI attributes, and statement macros.")
+    lines.append("- #955: D4 term-emitter expression and statement coverage.")
+    lines.append("- #956: D5 generic and nested-item handling.")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--v1-csv", type=Path, default=Path("bootstrap/libprovekit-surface-audit.csv"))
+    parser.add_argument("--csv", type=Path, default=Path("bootstrap/libprovekit-surface-audit.v2.csv"))
+    parser.add_argument("--gap-report", type=Path, default=Path("bootstrap/libprovekit-gap-report.v2.md"))
+    parser.add_argument("--delta", type=Path, default=Path("bootstrap/audit-delta-v1-to-v2.md"))
+    parser.add_argument("--skip-build", action="store_true")
+    args = parser.parse_args()
+
+    root = repo_root()
+    emitter = rust_workspace(root) / "target" / "debug" / "provekit-walk-emit"
+    if not args.skip_build:
+        emitter = build_emitter(root)
+    if not emitter.exists():
+        raise SystemExit(f"emitter not found: {emitter}")
+
+    v1_rows = read_csv(root / args.v1_csv)
+    v2_rows = []
+    for row in v1_rows:
+        if row["item_kind"] == "fn":
+            v2_rows.append(run_function_row(emitter, root, row))
+        else:
+            v2_rows.append(current_non_function_row(row))
+
+    write_csv(root / args.csv, v2_rows)
+    write_gap_report(root / args.gap_report, v2_rows)
+    write_delta(root / args.delta, v1_rows, v2_rows)
+
+    counts = outcome_counts(v2_rows)
+    print(f"wrote {args.csv}")
+    print(f"wrote {args.gap_report}")
+    print(f"wrote {args.delta}")
+    print(f"total_items={len(v2_rows)}")
+    print("outcomes=" + json.dumps({outcome: counts[outcome] for outcome in OUTCOMES}, sort_keys=True))
+    print("refusal_classes=" + json.dumps(dict(sorted(class_counts(v2_rows, 'refuses-with-typed-reason').items())), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #942. Refs umbrella #897 (Phase 4 libprovekit Rust bootstrap), top umbrella #922. Anchored against D1 (PR #937), D2 (#946), D3 (#953), D4 (#955), D5 (#956), all in main.

## Headline delta

|  | v1 (D1) | v2 (post-D5) | Δ |
|---|---:|---:|---:|
| handles-fully | 217 | 497 | **+280** |
| handles-partially | 309 | 261 | -48 |
| refuses | 583 | 351 | **-232** |

## Per-gap-class deltas

| Class | v1 | v2 | Anchor PR |
|---|---:|---:|---|
| `unsupported-return-type` | 267 | 4 | D2 #946 |
| `let-binding` | 175 | 0 | D2 #946 |
| `ffi-call` | 44 | 0 | D2 #946 |
| `term-emitter-unsupported` | 64 | 0 | D4 #955 |
| `complex-generic` | 26 | 0 | D5 #956 |
| `nested-item` | 3 | 0 | D5 #956 |

D3 (#953) reclassified procedural-macro / trait-path-truncated / abi-attribute / impl-associated-type / statement-macro from refusals to handles-partially-with-loss-record (mirrored in the partial-handle counts).

## Residual floor (top 5)

| Class | Count |
|---|---:|
| `unsupported-literal` | 160 |
| `unsupported-value-closure` | 46 |
| `unsupported-stmt-method-call` | 34 |
| `unsupported-let-pattern` | 27 |
| `unsupported-stmt-call` | 25 |

These drive D7+ work. Combined handles is 758/1109 (68.3%), below the 90% aspirational target.

## Files

- `bootstrap/libprovekit-surface-audit.v2.csv` (header + 1109 data rows)
- `bootstrap/libprovekit-gap-report.v2.md` (full sections matching v1)
- `bootstrap/audit-delta-v1-to-v2.md` (delta summary)
- `bootstrap/scripts/libprovekit_audit_receipt.py` (gap-report generator companion)

## Verification

- Read-only audit; no Rust lifter modifications.
- Em-dash + en-dash sweep: clean.

## Admin-merging

Pure documentation (4 new files, no source modifications).