### PR TITLE
feat(bootstrap D7-v1): source-layer round-trip diagnostic for Value::null

### DIFF
--- a/bootstrap/D7-v1/README.md
+++ b/bootstrap/D7-v1/README.md
@@ -1,0 +1,74 @@
+# D7-v1 Value::null source round-trip receipt
+
+Scope: one production function only.
+Target crate: provekit-canonicalizer.
+Target function: impl Value::null.
+Source path: implementations/rust/provekit-canonicalizer/src/value.rs.
+
+D7-v0 proved that this fixture round-trips byte-identically at the ProofIR layer.
+D7-v1 measures the next layer only.
+The measured equation is:
+rustfmt(realize_rust(proofir_resolve(fixture))) == rustfmt(original_source)
+
+The fixture is implementations/rust/libprovekit/tests/fixtures/proofir/d7_v0_value_null.json.
+The fixture CID is blake3-512:f78e468e6f80e305c8abb4f1b5ccbe54cdea54bf3d5104a63970be8500f7f0a5e7a467fa2cf3bcd2894502ff045c4aede5dbc83f3b76d5818a0aeb2fcacaca3e.
+The bridge resolves the term as return(call:new(literal("new"), literal(["Null"]))).
+The resolved root sort is Stmt.
+The nested call result sort is Expr.
+The literal callee sort is FnContract.
+The literal argument-list sort is ListOfExpr.
+
+The current Rust realizer surface is flat.
+It accepts function, params, param_types, return_type, concept_name, and mode.
+It does not accept a ResolvedTerm body tree.
+It does not walk nested ProofIR ops.
+It chooses one body template by concept name.
+If no template matches, it emits a panic stub.
+
+The D7-v1 extraction used the best fields available from the fixture and resolved term.
+function: null.
+params: [].
+param_types: [].
+return_type: Arc < Value >, carried by the D7-v0 loss record.
+concept_name: return, recovered from the resolved root op CID.
+mode: null.
+
+The library call was:
+provekit_realize_rust_core::emit_stub_with_mode("null", &[], &[], "Arc < Value >", "return", None)
+
+The regenerated source before rustfmt was:
+pub fn null() -> Arc < Value > {
+    panic!("provekit-bind canonical: return")
+}
+
+The original source slice was extracted from value.rs as just the method definition.
+The original body is Arc::new(Value::Null).
+Both sides were normalized with rustfmt --edition 2021 over stdin.
+No rustfmt.toml or .rustfmt.toml was present at the repository root.
+
+The post-rustfmt byte comparison is false.
+The verdict is CHARACTERIZED_DIFF.
+The unified diff has one hunk.
+The hunk class is stub-body.
+No formatter-noise hunk appeared.
+No name-difference hunk appeared independently of the stub.
+No structural-difference hunk appeared independently of the stub.
+
+The empirical body gap is the stub.
+The realizer emitted the stub because there is no template for the extracted root concept return.
+The realizer also has no term-tree input path that could lower return(call:new(...)).
+This is a source-layer realization gap, not a ProofIR bridge gap.
+The D7-v0 bridge receipt remains byte-identical at its layer.
+
+The dominant D7 debt ticket is #964.
+D7-v0 recorded ffi-call-unresolved-effect detail new.
+That is the operation needed to reconstitute Arc::new(Value::Null) as a body expression.
+#962 is secondary because D7-v0 also recorded trait-path-truncated for Arc :: new and Value :: Null.
+#963 is secondary because the return type Arc < Value > came from the loss record, not from resolved sort structure.
+#961 is not active for this method-level source diff because derive loss is outside the extracted null method.
+#965 is not active because the extracted method has no comments.
+
+For this single function, the source-layer terminus claim requires debt retirement.
+The immediate blocker is #964 plus a realizer path that can consume ResolvedTerm bodies.
+Byte identity should not be claimed from D7-v1.
+The receipt is bootstrap/D7-v1/value_null_source_round_trip_receipt.json.

--- a/bootstrap/D7-v1/value_null_source_round_trip_receipt.json
+++ b/bootstrap/D7-v1/value_null_source_round_trip_receipt.json
@@ -1,0 +1,37 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::null",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:f78e468e6f80e305c8abb4f1b5ccbe54cdea54bf3d5104a63970be8500f7f0a5e7a467fa2cf3bcd2894502ff045c4aede5dbc83f3b76d5818a0aeb2fcacaca3e",
+    "step_2_resolve": "summary=return(call:new(literal(\"new\"), literal([\"Null\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"Null\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_stub_with_mode(\"null\", &[], &[], \"Arc < Value >\", \"return\", None)",
+    "step_3_4_realize_input": {
+      "function": "null",
+      "params": [],
+      "param_types": [],
+      "return_type": "Arc < Value >",
+      "concept_name": "return",
+      "mode": null
+    },
+    "step_3_4_regenerated_source": "pub fn null() -> Arc < Value > {\n    panic!(\"provekit-bind canonical: return\")\n}\n",
+    "step_5_original_slice_cid": "blake3-512:12832f678b924c4503c8d5e5839471bffa8051e2dfbc6f4d455b302dbbc7c649c56b5aec0d31fbd336c532111dbd46091b6efed10f288e68a511a32d08d29450",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_null_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_null_original.rs>",
+    "step_7_byte_identical_post_rustfmt": false,
+    "step_8_unified_diff": "--- original_rustfmt\n+++ regenerated_rustfmt\n@@ -1,3 +1,3 @@\n pub fn null() -> Arc<Value> {\n-    Arc::new(Value::Null)\n+    panic!(\"provekit-bind canonical: return\")\n }\n",
+    "step_9_diff_classification": [
+      {
+        "hunk": "@@ -1,3 +1,3 @@\n pub fn null() -> Arc<Value> {\n-    Arc::new(Value::Null)\n+    panic!(\"provekit-bind canonical: return\")\n }",
+        "class": "stub-body",
+        "explanation": "provekit-realize-rust-core emitted its stub body because no body template matched the extracted root concept `return`; the current flat API cannot consume the nested resolved body tree."
+      }
+    ],
+    "regenerated_source_cid": "blake3-512:6d7d743a4d10611e4d39c960715207a3af9cd57e2663a36667181019caa7f9531f2fc4aca2a544fd0a90ac97061cdf8e020ecc5c81021b622dbabed61e935b21",
+    "original_slice_post_rustfmt_cid": "blake3-512:97ec24c86c7b920e7e13d80541e7ec5fd066bf3cbceb47bb8df5bb9ec88717558a04e8f605d180ae93730f1f42c9b4420060bcf80df0ff544c1ad4ef5369f670"
+  },
+  "verdict": "CHARACTERIZED_DIFF",
+  "next_action": "if BYTE_IDENTICAL, D7 terminus reached for this fn; otherwise, file follow-up issue per dominant diff class (e.g., extend realize-rust-core to consume ResolvedTerm bodies for the stub-body class, retire concept:new ffi-effect-occurrence for the missing-concept class)."
+}

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1148,6 +1148,7 @@ dependencies = [
  "provekit-canonicalizer",
  "provekit-ir-types",
  "provekit-proof-envelope",
+ "provekit-realize-rust-core",
  "serde",
  "serde_json",
  "thiserror",

--- a/implementations/rust/libprovekit/Cargo.toml
+++ b/implementations/rust/libprovekit/Cargo.toml
@@ -21,3 +21,6 @@ provekit-ir-types = { path = "../provekit-ir-types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+provekit-realize-rust-core = { path = "../provekit-realize-rust-core" }

--- a/implementations/rust/libprovekit/tests/d7_v1_source_round_trip.rs
+++ b/implementations/rust/libprovekit/tests/d7_v1_source_round_trip.rs
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use libprovekit::canonical::{json_cid, serializable_jcs};
+use libprovekit::proofir_bridge::{CatalogIndex, ResolvedNode, ResolvedTerm};
+use libprovekit::proofir_resolve;
+use provekit_canonicalizer::blake3_512_of;
+use provekit_ir_types::Term;
+use serde_json::{json, Value as JsonValue};
+
+const EXPECTED_FIXTURE_CID: &str = "blake3-512:f78e468e6f80e305c8abb4f1b5ccbe54cdea54bf3d5104a63970be8500f7f0a5e7a467fa2cf3bcd2894502ff045c4aede5dbc83f3b76d5818a0aeb2fcacaca3e";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .expect("canonical repo root")
+}
+
+fn fixture_path(repo_root: &Path) -> PathBuf {
+    repo_root
+        .join("implementations")
+        .join("rust")
+        .join("libprovekit")
+        .join("tests")
+        .join("fixtures")
+        .join("proofir")
+        .join("d7_v0_value_null.json")
+}
+
+fn source_path(repo_root: &Path) -> PathBuf {
+    repo_root
+        .join("implementations")
+        .join("rust")
+        .join("provekit-canonicalizer")
+        .join("src")
+        .join("value.rs")
+}
+
+fn receipt_path(repo_root: &Path) -> PathBuf {
+    repo_root
+        .join("bootstrap")
+        .join("D7-v1")
+        .join("value_null_source_round_trip_receipt.json")
+}
+
+fn scratch_path(repo_root: &Path, name: &str) -> PathBuf {
+    repo_root
+        .join("implementations")
+        .join("rust")
+        .join("target")
+        .join("d7-v1")
+        .join(name)
+}
+
+fn resolved_sort(name: &str) -> JsonValue {
+    json!({
+        "args": [],
+        "kind": "ctor",
+        "name": name,
+    })
+}
+
+fn fixture_op_cid(fixture: &JsonValue, name: &str) -> String {
+    fixture["proofir_catalog_ops"]
+        .as_array()
+        .expect("proofir_catalog_ops array")
+        .iter()
+        .find(|op| op["name"] == name)
+        .and_then(|op| op["op_cid"].as_str())
+        .unwrap_or_else(|| panic!("fixture has op cid for {name}"))
+        .to_string()
+}
+
+fn op_name_for_cid(fixture: &JsonValue, cid: &str) -> Option<String> {
+    fixture["proofir_catalog_ops"]
+        .as_array()?
+        .iter()
+        .find(|op| op["op_cid"] == cid)
+        .and_then(|op| op["name"].as_str())
+        .map(str::to_string)
+}
+
+fn value_null_catalog(fixture: &JsonValue) -> CatalogIndex {
+    let mut catalog = CatalogIndex::new();
+    catalog.insert_op(
+        "return",
+        fixture_op_cid(fixture, "return"),
+        Some(vec![resolved_sort("Expr")]),
+        Some(resolved_sort("Stmt")),
+    );
+    catalog.insert_op(
+        "call:new",
+        fixture_op_cid(fixture, "call:new"),
+        Some(vec![
+            resolved_sort("FnContract"),
+            resolved_sort("ListOfExpr"),
+        ]),
+        Some(resolved_sort("Expr")),
+    );
+    catalog
+}
+
+fn function_name_from_target(fixture: &JsonValue) -> String {
+    fixture["target"]
+        .as_str()
+        .expect("target string")
+        .rsplit("::")
+        .next()
+        .expect("method name")
+        .to_string()
+}
+
+fn return_type_from_loss_record(fixture: &JsonValue) -> String {
+    fixture["loss_record"]
+        .as_array()
+        .expect("loss_record array")
+        .iter()
+        .find(|loss| loss["loss"] == "return-type-user-defined")
+        .and_then(|loss| loss["detail"].as_str())
+        .expect("return-type-user-defined detail")
+        .to_string()
+}
+
+fn root_concept_name(fixture: &JsonValue, resolved: &ResolvedTerm) -> String {
+    match &resolved.node {
+        ResolvedNode::OpApplication {
+            op_definition_cid, ..
+        } => op_name_for_cid(fixture, op_definition_cid)
+            .unwrap_or_else(|| op_definition_cid.to_string()),
+        ResolvedNode::Literal { .. } => "literal".to_string(),
+    }
+}
+
+fn term_summary(fixture: &JsonValue, resolved: &ResolvedTerm) -> String {
+    fn inner(fixture: &JsonValue, term: &ResolvedTerm) -> String {
+        match &term.node {
+            ResolvedNode::Literal { value } => format!("literal({value})"),
+            ResolvedNode::OpApplication {
+                op_definition_cid,
+                args,
+            } => {
+                let name = op_name_for_cid(fixture, op_definition_cid)
+                    .unwrap_or_else(|| op_definition_cid.to_string());
+                let args = args
+                    .iter()
+                    .map(|arg| inner(fixture, arg))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{name}({args})")
+            }
+        }
+    }
+
+    format!("{} -> sort {}", inner(fixture, resolved), resolved.sort)
+}
+
+fn extract_value_null_slice(source: &str) -> String {
+    let needle = "pub fn null(";
+    let method = source.find(needle).expect("find Value::null method");
+    let start = source[..method]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    let open_brace = source[method..]
+        .find('{')
+        .map(|index| method + index)
+        .expect("find method body");
+
+    let mut depth = 0usize;
+    for (offset, ch) in source[open_brace..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let mut end = open_brace + offset + ch.len_utf8();
+                    if source[end..].starts_with('\n') {
+                        end += 1;
+                    }
+                    return source[start..end].to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    panic!("unterminated Value::null body");
+}
+
+fn rustfmt_config(repo_root: &Path) -> Option<PathBuf> {
+    ["rustfmt.toml", ".rustfmt.toml"]
+        .iter()
+        .map(|name| repo_root.join(name))
+        .find(|path| path.is_file())
+}
+
+fn rustfmt_command_text(config: Option<&Path>, input_label: &str) -> String {
+    let mut parts = vec!["rustfmt".to_string(), "--edition 2021".to_string()];
+    if let Some(config) = config {
+        parts.push(format!("--config-path {}", config.display()));
+    }
+    parts.push("--emit stdout".to_string());
+    parts.push(format!("<stdin:{input_label}>"));
+    parts.join(" ")
+}
+
+fn rustfmt_source(repo_root: &Path, input_label: &str, source: &str) -> (String, String) {
+    let config = rustfmt_config(repo_root);
+    let mut command = Command::new("rustfmt");
+    command.arg("--edition").arg("2021");
+    if let Some(config) = &config {
+        command.arg("--config-path").arg(config);
+    }
+    let mut child = command
+        .arg("--emit")
+        .arg("stdout")
+        .current_dir(repo_root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rustfmt");
+    child
+        .stdin
+        .as_mut()
+        .expect("rustfmt stdin")
+        .write_all(source.as_bytes())
+        .expect("write rustfmt stdin");
+    let output = child.wait_with_output().expect("run rustfmt");
+
+    if !output.status.success() {
+        panic!(
+            "rustfmt failed for {input_label}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    (
+        String::from_utf8(output.stdout).expect("rustfmt stdout utf8"),
+        rustfmt_command_text(config.as_deref(), input_label),
+    )
+}
+
+fn unified_diff(repo_root: &Path, original: &str, regenerated: &str) -> String {
+    let original_path = scratch_path(repo_root, "value_null_original.rustfmt.rs");
+    let regenerated_path = scratch_path(repo_root, "value_null_regenerated.rustfmt.rs");
+    std::fs::create_dir_all(original_path.parent().expect("diff scratch parent"))
+        .expect("create diff scratch dir");
+    std::fs::write(&original_path, original).expect("write original rustfmt text");
+    std::fs::write(&regenerated_path, regenerated).expect("write regenerated rustfmt text");
+
+    let output = Command::new("diff")
+        .arg("--label")
+        .arg("original_rustfmt")
+        .arg("--label")
+        .arg("regenerated_rustfmt")
+        .arg("-u")
+        .arg(&original_path)
+        .arg(&regenerated_path)
+        .output()
+        .expect("run diff -u");
+
+    match output.status.code() {
+        Some(0) => String::new(),
+        Some(1) => String::from_utf8(output.stdout).expect("diff stdout utf8"),
+        _ => panic!("diff failed: {}", String::from_utf8_lossy(&output.stderr)),
+    }
+}
+
+fn diff_hunks(diff: &str) -> Vec<String> {
+    let mut hunks = Vec::new();
+    let mut current = Vec::new();
+
+    for line in diff.lines() {
+        if line.starts_with("@@") {
+            if !current.is_empty() {
+                hunks.push(current.join("\n"));
+                current.clear();
+            }
+            current.push(line.to_string());
+        } else if !current.is_empty() {
+            current.push(line.to_string());
+        }
+    }
+
+    if !current.is_empty() {
+        hunks.push(current.join("\n"));
+    }
+
+    hunks
+}
+
+fn classify_diff(diff: &str, realization_is_stub: bool, concept_name: &str) -> Vec<JsonValue> {
+    diff_hunks(diff)
+        .into_iter()
+        .map(|hunk| {
+            if realization_is_stub && hunk.contains("provekit-bind canonical:") {
+                json!({
+                    "hunk": hunk,
+                    "class": "stub-body",
+                    "explanation": format!(
+                        "provekit-realize-rust-core emitted its stub body because no body template matched the extracted root concept `{concept_name}`; the current flat API cannot consume the nested resolved body tree."
+                    ),
+                })
+            } else {
+                json!({
+                    "hunk": hunk,
+                    "class": "structural-difference",
+                    "explanation": "post-rustfmt text differs in AST shape rather than spelling-only identifier changes.",
+                })
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn value_null_source_round_trip_receipt_is_complete() {
+    let repo_root = repo_root();
+    let fixture_text =
+        std::fs::read_to_string(fixture_path(&repo_root)).expect("read D7-v0 value null fixture");
+    let fixture: JsonValue = serde_json::from_str(&fixture_text).expect("parse D7-v0 fixture");
+    let fixture_cid = json_cid(&fixture).expect("fixture CID");
+    assert_eq!(fixture_cid, EXPECTED_FIXTURE_CID);
+
+    let term: Term =
+        serde_json::from_value(fixture["proofir_term"].clone()).expect("decode ProofIR term");
+    let catalog = value_null_catalog(&fixture);
+    let resolved = proofir_resolve(&term, &catalog).expect("resolve D7-v0 ProofIR term");
+    let resolved_jcs = serializable_jcs(&resolved).expect("ResolvedTerm JCS");
+    let resolved_summary = term_summary(&fixture, &resolved);
+
+    let function = function_name_from_target(&fixture);
+    let params: Vec<String> = Vec::new();
+    let param_types: Vec<String> = Vec::new();
+    let return_type = return_type_from_loss_record(&fixture);
+    let concept_name = root_concept_name(&fixture, &resolved);
+    let realization = provekit_realize_rust_core::emit_stub_with_mode(
+        &function,
+        &params,
+        &param_types,
+        &return_type,
+        &concept_name,
+        None,
+    );
+
+    let source_text =
+        std::fs::read_to_string(source_path(&repo_root)).expect("read canonicalizer value.rs");
+    let original_slice = extract_value_null_slice(&source_text);
+    let original_slice_cid = blake3_512_of(original_slice.as_bytes());
+
+    let (regenerated_rustfmt, regenerated_rustfmt_command) =
+        rustfmt_source(&repo_root, "value_null_regenerated.rs", &realization.source);
+    let (original_rustfmt, original_rustfmt_command) =
+        rustfmt_source(&repo_root, "value_null_original.rs", &original_slice);
+
+    let byte_identical = regenerated_rustfmt.as_bytes() == original_rustfmt.as_bytes();
+    let diff = unified_diff(&repo_root, &original_rustfmt, &regenerated_rustfmt);
+    let classification = classify_diff(&diff, realization.is_stub, &concept_name);
+    let verdict = if byte_identical {
+        "BYTE_IDENTICAL"
+    } else {
+        "CHARACTERIZED_DIFF"
+    };
+
+    if !byte_identical {
+        assert!(
+            !classification.is_empty(),
+            "non-identical source must have a classified diff hunk"
+        );
+    }
+
+    let receipt = json!({
+        "version": "1",
+        "target": {
+            "crate": "provekit-canonicalizer",
+            "function": "impl Value::null",
+            "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs",
+        },
+        "pipeline": {
+            "step_1_fixture_cid": EXPECTED_FIXTURE_CID,
+            "step_2_resolve": format!("summary={resolved_summary}; jcs={resolved_jcs}"),
+            "step_3_4_realize_command": format!(
+                "provekit_realize_rust_core::emit_stub_with_mode({function:?}, &[], &[], {return_type:?}, {concept_name:?}, None)"
+            ),
+            "step_3_4_realize_input": {
+                "function": function,
+                "params": params,
+                "param_types": param_types,
+                "return_type": return_type,
+                "concept_name": concept_name,
+                "mode": JsonValue::Null,
+            },
+            "step_3_4_regenerated_source": realization.source,
+            "step_5_original_slice_cid": original_slice_cid,
+            "step_6_rustfmt_command": format!("{regenerated_rustfmt_command}\n{original_rustfmt_command}"),
+            "step_7_byte_identical_post_rustfmt": byte_identical,
+            "step_8_unified_diff": diff,
+            "step_9_diff_classification": classification,
+            "regenerated_source_cid": blake3_512_of(regenerated_rustfmt.as_bytes()),
+            "original_slice_post_rustfmt_cid": blake3_512_of(original_rustfmt.as_bytes()),
+        },
+        "verdict": verdict,
+        "next_action": "if BYTE_IDENTICAL, D7 terminus reached for this fn; otherwise, file follow-up issue per dominant diff class (e.g., extend realize-rust-core to consume ResolvedTerm bodies for the stub-body class, retire concept:new ffi-effect-occurrence for the missing-concept class).",
+    });
+
+    let receipt_path = receipt_path(&repo_root);
+    std::fs::create_dir_all(receipt_path.parent().expect("receipt parent"))
+        .expect("create D7-v1 receipt dir");
+    std::fs::write(
+        &receipt_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&receipt).expect("pretty receipt")
+        ),
+    )
+    .expect("write D7-v1 receipt");
+
+    let parsed: JsonValue = serde_json::from_str(
+        &std::fs::read_to_string(&receipt_path).expect("read written D7-v1 receipt"),
+    )
+    .expect("parse written D7-v1 receipt");
+    assert!(matches!(
+        parsed["verdict"].as_str(),
+        Some("BYTE_IDENTICAL" | "CHARACTERIZED_DIFF")
+    ));
+    println!("receipt_path={}", receipt_path.display());
+    println!("verdict={verdict}");
+}


### PR DESCRIPTION
Continues #943. Measures the source-layer gap on the D7-v0 fixture.

## Verdict

CHARACTERIZED_DIFF. Dominant gap class: stub-body. Empirical root cause: **#964** (ffi-call-unresolved-effect: new). Secondary: #962, #963.

## Diff

```diff
 pub fn null() -> Arc<Value> {
-    Arc::new(Value::Null)
+    panic!("provekit-bind canonical: return")
 }
```

## Why CHARACTERIZED_DIFF, not BYTE_IDENTICAL

`provekit-realize-rust-core` is a flat body-template realizer. The resolved root is the concept `return`, which has no template; the realizer falls through to `stub_body_for("return")` which is the canonical panic stub. The realizer cannot yet walk the nested `return(call:new(...))` body tree.

D7-v2 will tightly extend `provekit-realize-rust-core` to consume this exact tree shape (return + call:new + literal). v2's verdict is expected to shift the dominant class from `stub-body` to `name-difference` (Arc:: prefix missing, the trait-path-truncated loss class #962). v3 will retire #962.

## Acceptance

- Targeted test `value_null_source_round_trip_receipt_is_complete` green.
- Full libprovekit suite green.
- Em-dash sweep clean.
- Receipt complete and self-attesting (CIDs + full diff).

## Files

- `bootstrap/D7-v1/README.md`
- `bootstrap/D7-v1/value_null_source_round_trip_receipt.json`
- `implementations/rust/libprovekit/tests/d7_v1_source_round_trip.rs`
- `implementations/rust/libprovekit/Cargo.toml` (dev-dependency)