### PR TITLE
feat(bootstrap D7-v2): extend realize-rust-core for return+call:new shape

### DIFF
--- a/bootstrap/D7-v2/README.md
+++ b/bootstrap/D7-v2/README.md
@@ -1,0 +1,60 @@
+# D7-v2 Value::null resolved-term realizer receipt
+
+Scope: one production function only.
+Target crate: provekit-canonicalizer.
+Target function: impl Value::null.
+Source path: implementations/rust/provekit-canonicalizer/src/value.rs.
+
+D7-v1 measured the source-layer gap after ProofIR resolution.
+That receipt showed a CHARACTERIZED_DIFF dominated by stub-body.
+The regenerator emitted panic!("provekit-bind canonical: return").
+The resolved body was return(call:new(literal("new"), literal(["Null"]))).
+The flat realizer API could not walk that body tree.
+
+D7-v2 adds one tight realizer extension in provekit-realize-rust-core.
+The new entrypoint is emit_from_resolved.
+It accepts the resolved term JSON used by the D7-v1 resolve step.
+It recognizes exactly the D7 Value::null body shape.
+It lowers return(<expr>) as a Rust trailing expression.
+It lowers call:new(literal("new"), literal(["Null"])) as new(Value::Null).
+It lowers literal(["Null"]) as Value::Null for this fixture.
+Every unsupported resolved concept or literal shape still falls back to the stub.
+
+The intended regenerated source body is:
+new(Value::Null)
+
+The original source body remains:
+Arc::new(Value::Null)
+
+The expected post-rustfmt diff shape is:
+-    Arc::new(Value::Null)
++    new(Value::Null)
+
+That diff is intentional for D7-v2.
+The missing Arc:: receiver prefix is not retired here.
+It is the next debt class tracked by #962.
+The empirical root cause is trait-path-truncated.
+The resolved call:new node carries the constructor call.
+It does not carry the receiver path needed to rebuild Arc::new.
+
+This is still a CHARACTERIZED_DIFF, not BYTE_IDENTICAL.
+The important change is the dominant class.
+D7-v1 was dominated by stub-body.
+D7-v2 is dominated by name-difference.
+That means the realizer now consumes the resolved body tree for this op family.
+The old panic stub no longer explains the Value::null source diff.
+
+This is progress because it narrows the remaining failure.
+Before D7-v2, source regeneration stopped at the root return concept.
+After D7-v2, regeneration reaches the constructor expression.
+The only visible body gap is the missing receiver name.
+That is the #962 trait-path-truncated issue.
+
+Out of scope for this receipt:
+Do not change provekit-walk.
+Do not change libprovekit::proofir_resolve.
+Do not add new concept ops.
+Do not generalize beyond return plus call:new plus literal.
+Do not claim source-layer byte identity for Value::null.
+
+The receipt is bootstrap/D7-v2/value_null_source_round_trip_receipt.json.

--- a/bootstrap/D7-v2/value_null_source_round_trip_receipt.json
+++ b/bootstrap/D7-v2/value_null_source_round_trip_receipt.json
@@ -1,0 +1,40 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::null",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:f78e468e6f80e305c8abb4f1b5ccbe54cdea54bf3d5104a63970be8500f7f0a5e7a467fa2cf3bcd2894502ff045c4aede5dbc83f3b76d5818a0aeb2fcacaca3e",
+    "step_2_resolve": "summary=return(call:new(literal(\"new\"), literal([\"Null\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"Null\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, \"null\", &[], &[], \"Arc < Value >\")",
+    "step_3_4_realize_input": {
+      "resolved_term_json": "{\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"Null\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+      "function": "null",
+      "params": [],
+      "param_types": [],
+      "return_type": "Arc < Value >"
+    },
+    "step_3_4_regenerated_source": "pub fn null() -> Arc < Value > {\n    new(Value::Null)\n}\n",
+    "step_5_original_slice_cid": "blake3-512:12832f678b924c4503c8d5e5839471bffa8051e2dfbc6f4d455b302dbbc7c649c56b5aec0d31fbd336c532111dbd46091b6efed10f288e68a511a32d08d29450",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_null_regenerated_v2.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_null_original.rs>",
+    "step_7_byte_identical_post_rustfmt": false,
+    "step_8_unified_diff": "--- original_rustfmt\n+++ regenerated_rustfmt\n@@ -1,3 +1,3 @@\n pub fn null() -> Arc<Value> {\n-    Arc::new(Value::Null)\n+    new(Value::Null)\n }\n",
+    "step_9_diff_classification": [
+      {
+        "hunk": "@@ -1,3 +1,3 @@\n pub fn null() -> Arc<Value> {\n-    Arc::new(Value::Null)\n+    new(Value::Null)\n }",
+        "class": "name-difference",
+        "explanation": "provekit-realize-rust-core consumed the resolved body tree and emitted the constructor expression, but the resolved term lacks the receiver prefix recorded by #962 trait-path-truncated."
+      }
+    ],
+    "step_10_dominant_diff_class": "name-difference",
+    "step_11_expected_diff_shape": "-    Arc::new(Value::Null)\n+    new(Value::Null)",
+    "step_12_empirical_root_cause": "#962 trait-path-truncated: the resolved call:new body does not carry the Arc:: receiver prefix.",
+    "regenerated_source_cid": "blake3-512:792b3ac87dc00b54e3352d8157783af4bab98691b301f817d38c1bf75ce68a93777aea7c5ee08682d7bc48c2191679d9c062bb11ee6ce2ed8ef5d310a2190171",
+    "original_slice_post_rustfmt_cid": "blake3-512:97ec24c86c7b920e7e13d80541e7ec5fd066bf3cbceb47bb8df5bb9ec88717558a04e8f605d180ae93730f1f42c9b4420060bcf80df0ff544c1ad4ef5369f670"
+  },
+  "verdict": "CHARACTERIZED_DIFF",
+  "dominant_diff_class": "name-difference",
+  "next_action": "retire #962 trait-path-truncated by carrying the missing receiver path needed to restore Arc::new(Value::Null)."
+}

--- a/implementations/rust/libprovekit/tests/d7_v1_source_round_trip.rs
+++ b/implementations/rust/libprovekit/tests/d7_v1_source_round_trip.rs
@@ -40,10 +40,10 @@ fn source_path(repo_root: &Path) -> PathBuf {
         .join("value.rs")
 }
 
-fn receipt_path(repo_root: &Path) -> PathBuf {
+fn receipt_path(repo_root: &Path, phase: &str) -> PathBuf {
     repo_root
         .join("bootstrap")
-        .join("D7-v1")
+        .join(phase)
         .join("value_null_source_round_trip_receipt.json")
 }
 
@@ -306,6 +306,14 @@ fn classify_diff(diff: &str, realization_is_stub: bool, concept_name: &str) -> V
                         "provekit-realize-rust-core emitted its stub body because no body template matched the extracted root concept `{concept_name}`; the current flat API cannot consume the nested resolved body tree."
                     ),
                 })
+            } else if hunk.contains("-    Arc::new(Value::Null)")
+                && hunk.contains("+    new(Value::Null)")
+            {
+                json!({
+                    "hunk": hunk,
+                    "class": "name-difference",
+                    "explanation": "provekit-realize-rust-core consumed the resolved body tree and emitted the constructor expression, but the resolved term lacks the receiver prefix recorded by #962 trait-path-truncated.",
+                })
             } else {
                 json!({
                     "hunk": hunk,
@@ -315,6 +323,18 @@ fn classify_diff(diff: &str, realization_is_stub: bool, concept_name: &str) -> V
             }
         })
         .collect()
+}
+
+fn dominant_diff_class(byte_identical: bool, classification: &[JsonValue]) -> String {
+    if byte_identical {
+        "byte-identical".to_string()
+    } else {
+        classification
+            .iter()
+            .find_map(|item| item["class"].as_str())
+            .unwrap_or("unclassified")
+            .to_string()
+    }
 }
 
 #[test]
@@ -387,19 +407,19 @@ fn value_null_source_round_trip_receipt_is_complete() {
                 "provekit_realize_rust_core::emit_stub_with_mode({function:?}, &[], &[], {return_type:?}, {concept_name:?}, None)"
             ),
             "step_3_4_realize_input": {
-                "function": function,
-                "params": params,
-                "param_types": param_types,
-                "return_type": return_type,
-                "concept_name": concept_name,
+                "function": function.clone(),
+                "params": params.clone(),
+                "param_types": param_types.clone(),
+                "return_type": return_type.clone(),
+                "concept_name": concept_name.clone(),
                 "mode": JsonValue::Null,
             },
-            "step_3_4_regenerated_source": realization.source,
-            "step_5_original_slice_cid": original_slice_cid,
+            "step_3_4_regenerated_source": realization.source.clone(),
+            "step_5_original_slice_cid": original_slice_cid.clone(),
             "step_6_rustfmt_command": format!("{regenerated_rustfmt_command}\n{original_rustfmt_command}"),
             "step_7_byte_identical_post_rustfmt": byte_identical,
             "step_8_unified_diff": diff,
-            "step_9_diff_classification": classification,
+            "step_9_diff_classification": classification.clone(),
             "regenerated_source_cid": blake3_512_of(regenerated_rustfmt.as_bytes()),
             "original_slice_post_rustfmt_cid": blake3_512_of(original_rustfmt.as_bytes()),
         },
@@ -407,11 +427,11 @@ fn value_null_source_round_trip_receipt_is_complete() {
         "next_action": "if BYTE_IDENTICAL, D7 terminus reached for this fn; otherwise, file follow-up issue per dominant diff class (e.g., extend realize-rust-core to consume ResolvedTerm bodies for the stub-body class, retire concept:new ffi-effect-occurrence for the missing-concept class).",
     });
 
-    let receipt_path = receipt_path(&repo_root);
-    std::fs::create_dir_all(receipt_path.parent().expect("receipt parent"))
+    let v1_receipt_path = receipt_path(&repo_root, "D7-v1");
+    std::fs::create_dir_all(v1_receipt_path.parent().expect("receipt parent"))
         .expect("create D7-v1 receipt dir");
     std::fs::write(
-        &receipt_path,
+        &v1_receipt_path,
         format!(
             "{}\n",
             serde_json::to_string_pretty(&receipt).expect("pretty receipt")
@@ -420,13 +440,101 @@ fn value_null_source_round_trip_receipt_is_complete() {
     .expect("write D7-v1 receipt");
 
     let parsed: JsonValue = serde_json::from_str(
-        &std::fs::read_to_string(&receipt_path).expect("read written D7-v1 receipt"),
+        &std::fs::read_to_string(&v1_receipt_path).expect("read written D7-v1 receipt"),
     )
     .expect("parse written D7-v1 receipt");
     assert!(matches!(
         parsed["verdict"].as_str(),
         Some("BYTE_IDENTICAL" | "CHARACTERIZED_DIFF")
     ));
-    println!("receipt_path={}", receipt_path.display());
+
+    let v2_realization = provekit_realize_rust_core::emit_from_resolved(
+        &resolved_jcs,
+        &function,
+        &params,
+        &param_types,
+        &return_type,
+    );
+    let (v2_regenerated_rustfmt, v2_regenerated_rustfmt_command) = rustfmt_source(
+        &repo_root,
+        "value_null_regenerated_v2.rs",
+        &v2_realization.source,
+    );
+    let v2_byte_identical = v2_regenerated_rustfmt.as_bytes() == original_rustfmt.as_bytes();
+    let v2_diff = unified_diff(&repo_root, &original_rustfmt, &v2_regenerated_rustfmt);
+    let v2_classification = classify_diff(&v2_diff, v2_realization.is_stub, &concept_name);
+    let v2_verdict = if v2_byte_identical {
+        "BYTE_IDENTICAL"
+    } else {
+        "CHARACTERIZED_DIFF"
+    };
+    let v2_dominant_diff_class = dominant_diff_class(v2_byte_identical, &v2_classification);
+
+    assert_eq!(v2_verdict, "CHARACTERIZED_DIFF");
+    assert_eq!(v2_dominant_diff_class, "name-difference");
+    assert!(v2_diff.contains("-    Arc::new(Value::Null)"));
+    assert!(v2_diff.contains("+    new(Value::Null)"));
+
+    let v2_receipt = json!({
+        "version": "1",
+        "target": {
+            "crate": "provekit-canonicalizer",
+            "function": "impl Value::null",
+            "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs",
+        },
+        "pipeline": {
+            "step_1_fixture_cid": EXPECTED_FIXTURE_CID,
+            "step_2_resolve": format!("summary={resolved_summary}; jcs={resolved_jcs}"),
+            "step_3_4_realize_command": format!(
+                "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, {function:?}, &[], &[], {return_type:?})"
+            ),
+            "step_3_4_realize_input": {
+                "resolved_term_json": resolved_jcs,
+                "function": function,
+                "params": params,
+                "param_types": param_types,
+                "return_type": return_type,
+            },
+            "step_3_4_regenerated_source": v2_realization.source,
+            "step_5_original_slice_cid": original_slice_cid,
+            "step_6_rustfmt_command": format!("{v2_regenerated_rustfmt_command}\n{original_rustfmt_command}"),
+            "step_7_byte_identical_post_rustfmt": v2_byte_identical,
+            "step_8_unified_diff": v2_diff,
+            "step_9_diff_classification": v2_classification,
+            "step_10_dominant_diff_class": v2_dominant_diff_class.clone(),
+            "step_11_expected_diff_shape": "-    Arc::new(Value::Null)\n+    new(Value::Null)",
+            "step_12_empirical_root_cause": "#962 trait-path-truncated: the resolved call:new body does not carry the Arc:: receiver prefix.",
+            "regenerated_source_cid": blake3_512_of(v2_regenerated_rustfmt.as_bytes()),
+            "original_slice_post_rustfmt_cid": blake3_512_of(original_rustfmt.as_bytes()),
+        },
+        "verdict": v2_verdict,
+        "dominant_diff_class": v2_dominant_diff_class,
+        "next_action": "retire #962 trait-path-truncated by carrying the missing receiver path needed to restore Arc::new(Value::Null).",
+    });
+
+    let v2_receipt_path = receipt_path(&repo_root, "D7-v2");
+    std::fs::create_dir_all(v2_receipt_path.parent().expect("receipt parent"))
+        .expect("create D7-v2 receipt dir");
+    std::fs::write(
+        &v2_receipt_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&v2_receipt).expect("pretty v2 receipt")
+        ),
+    )
+    .expect("write D7-v2 receipt");
+
+    let v2_parsed: JsonValue = serde_json::from_str(
+        &std::fs::read_to_string(&v2_receipt_path).expect("read written D7-v2 receipt"),
+    )
+    .expect("parse written D7-v2 receipt");
+    assert_eq!(v2_parsed["verdict"].as_str(), Some("CHARACTERIZED_DIFF"));
+    assert_eq!(
+        v2_parsed["dominant_diff_class"].as_str(),
+        Some("name-difference")
+    );
+    println!("receipt_path={}", v1_receipt_path.display());
     println!("verdict={verdict}");
+    println!("v2_receipt_path={}", v2_receipt_path.display());
+    println!("v2_verdict={v2_verdict}");
 }

--- a/implementations/rust/provekit-realize-rust-core/src/lib.rs
+++ b/implementations/rust/provekit-realize-rust-core/src/lib.rs
@@ -8,6 +8,8 @@ use serde_json::Value;
 
 const BODY_TEMPLATE_REL: &str =
     "menagerie/rust-language-signature/specs/body-templates/rust-canonical-bodies.json";
+const RETURN_OP_CID: &str = "blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6";
+const CALL_NEW_OP_CID: &str = "blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Realization {
@@ -57,13 +59,158 @@ pub fn emit_stub_with_mode(
     let body = body_template_for(concept_name, params, param_types, return_type, mode);
     let is_stub = body.is_none();
     let body = body.unwrap_or_else(|| stub_body_for(concept_name));
-    let source = function_source(function, params, param_types, return_type, &body);
+    emit_function(function, params, param_types, return_type, &body, is_stub)
+}
+
+/// Emits Rust for exactly one D7-v2 resolved body shape:
+/// `return(call:new(literal("new"), literal(["Null"])))`.
+///
+/// The trailing `return` node is lowered as a Rust tail expression. The nested
+/// `call:new` shape lowers to `new(Value::Null)` because the resolved term
+/// records the constructor call but not the missing receiver prefix (`Arc::`).
+/// Unsupported resolved concepts or literal shapes fall back to the existing
+/// `panic!("provekit-bind canonical: <concept>")` stub body.
+pub fn emit_from_resolved(
+    resolved_term_json: &str,
+    function_name: &str,
+    params: &[String],
+    param_types: &[String],
+    return_type: &str,
+) -> Realization {
+    let resolved = match serde_json::from_str::<Value>(resolved_term_json) {
+        Ok(resolved) => resolved,
+        Err(_) => {
+            return emit_stub(
+                function_name,
+                params,
+                param_types,
+                return_type,
+                "malformed-resolved-term",
+            );
+        }
+    };
+
+    match lower_resolved_body(&resolved) {
+        Ok(body) => emit_function(
+            function_name,
+            params,
+            param_types,
+            return_type,
+            &body,
+            false,
+        ),
+        Err(concept_name) => emit_stub(
+            function_name,
+            params,
+            param_types,
+            return_type,
+            &concept_name,
+        ),
+    }
+}
+
+fn emit_function(
+    function: &str,
+    params: &[String],
+    param_types: &[String],
+    return_type: &str,
+    body: &str,
+    is_stub: bool,
+) -> Realization {
+    let source = function_source(function, params, param_types, return_type, body);
     let emitted_artifact_cid = blake3_512_of(source.as_bytes());
     Realization {
         source,
         is_stub,
         extension: "rs".to_string(),
         emitted_artifact_cid,
+    }
+}
+
+fn lower_resolved_body(term: &Value) -> Result<String, String> {
+    let concept_name = resolved_concept_name(term);
+    if concept_name != "return" {
+        return Err(concept_name);
+    }
+
+    let args = resolved_args(term).ok_or(concept_name)?;
+    if args.len() != 1 {
+        return Err("return".to_string());
+    }
+    lower_resolved_expr(&args[0])
+}
+
+fn lower_resolved_expr(term: &Value) -> Result<String, String> {
+    match resolved_concept_name(term).as_str() {
+        "call:new" => lower_call_new(term),
+        "literal" => lower_literal(term),
+        concept_name => Err(concept_name.to_string()),
+    }
+}
+
+fn lower_call_new(term: &Value) -> Result<String, String> {
+    let args = resolved_args(term).ok_or_else(|| "call:new".to_string())?;
+    if args.len() != 2 {
+        return Err("call:new".to_string());
+    }
+
+    let name = lower_literal(&args[0])?;
+    let lowered_args = lower_literal(&args[1])?;
+    if name != "new" {
+        return Err("call:new".to_string());
+    }
+
+    Ok(format!("new({lowered_args})"))
+}
+
+fn lower_literal(term: &Value) -> Result<String, String> {
+    let node = resolved_node(term).ok_or_else(|| "literal".to_string())?;
+    if node.get("kind").and_then(Value::as_str) != Some("literal") {
+        return Err(resolved_concept_name(term));
+    }
+
+    match node.get("value") {
+        Some(Value::String(value)) if value == "new" => Ok(value.to_string()),
+        Some(Value::Array(items)) if is_value_null_literal(items) => Ok("Value::Null".to_string()),
+        _ => Err("literal".to_string()),
+    }
+}
+
+fn is_value_null_literal(items: &[Value]) -> bool {
+    items.len() == 1 && items[0].as_str() == Some("Null")
+}
+
+fn resolved_args(term: &Value) -> Option<&[Value]> {
+    resolved_node(term)?
+        .get("args")?
+        .as_array()
+        .map(Vec::as_slice)
+}
+
+fn resolved_node(term: &Value) -> Option<&serde_json::Map<String, Value>> {
+    term.get("node")?.as_object()
+}
+
+fn resolved_concept_name(term: &Value) -> String {
+    let Some(node) = resolved_node(term) else {
+        return "malformed-resolved-term".to_string();
+    };
+    match node.get("kind").and_then(Value::as_str) {
+        Some("literal") => "literal".to_string(),
+        Some("concept:op-application") => node
+            .get("op_definition_cid")
+            .and_then(Value::as_str)
+            .map(op_concept_name)
+            .unwrap_or_else(|| "malformed-resolved-term".to_string()),
+        _ => "malformed-resolved-term".to_string(),
+    }
+}
+
+fn op_concept_name(op_definition_cid: &str) -> String {
+    match op_definition_cid {
+        RETURN_OP_CID => "return".to_string(),
+        CALL_NEW_OP_CID => "call:new".to_string(),
+        other => other.to_string(),
     }
 }
 
@@ -520,6 +667,80 @@ mod tests {
         assert_eq!(
             rendered.source,
             "pub fn unknown_cell(x: i64) -> i64 {\n    panic!(\"provekit-bind canonical: missing-cell\")\n}\n"
+        );
+    }
+
+    #[test]
+    fn emits_value_null_from_resolved_return_call_new_literal_shape() {
+        let resolved = serde_json::json!({
+            "node": {
+                "args": [
+                    {
+                        "node": {
+                            "args": [
+                                {
+                                    "node": {
+                                        "kind": "literal",
+                                        "value": "new",
+                                    },
+                                    "sort": {"args": [], "kind": "ctor", "name": "FnContract"},
+                                },
+                                {
+                                    "node": {
+                                        "kind": "literal",
+                                        "value": ["Null"],
+                                    },
+                                    "sort": {"args": [], "kind": "ctor", "name": "ListOfExpr"},
+                                },
+                            ],
+                            "kind": "concept:op-application",
+                            "op_definition_cid": CALL_NEW_OP_CID,
+                        },
+                        "sort": {"args": [], "kind": "ctor", "name": "Expr"},
+                    },
+                ],
+                "kind": "concept:op-application",
+                "op_definition_cid": RETURN_OP_CID,
+            },
+            "sort": {"args": [], "kind": "ctor", "name": "Stmt"},
+        });
+        let rendered = emit_from_resolved(
+            &serde_json::to_string(&resolved).expect("resolved json"),
+            "null",
+            &[],
+            &[],
+            "Arc < Value >",
+        );
+
+        assert!(!rendered.is_stub);
+        assert_eq!(
+            rendered.source,
+            "pub fn null() -> Arc < Value > {\n    new(Value::Null)\n}\n"
+        );
+    }
+
+    #[test]
+    fn unsupported_resolved_shape_falls_back_to_stub() {
+        let resolved = serde_json::json!({
+            "node": {
+                "args": [],
+                "kind": "concept:op-application",
+                "op_definition_cid": "unsupported-concept",
+            },
+            "sort": {"args": [], "kind": "ctor", "name": "Stmt"},
+        });
+        let rendered = emit_from_resolved(
+            &serde_json::to_string(&resolved).expect("resolved json"),
+            "unknown_cell",
+            &strings(&["x"]),
+            &strings(&["i64"]),
+            "i64",
+        );
+
+        assert!(rendered.is_stub);
+        assert_eq!(
+            rendered.source,
+            "pub fn unknown_cell(x: i64) -> i64 {\n    panic!(\"provekit-bind canonical: unsupported-concept\")\n}\n"
         );
     }
 


### PR DESCRIPTION
Continues #943. Retires the **stub-body** loss class for the `return(call:new(literal, literal))` shape; diff narrows to exactly the trait-path-truncated debt (#962).

## Verdict

`CHARACTERIZED_DIFF`. Dominant: `name-difference`. Empirical root cause: **#962** (trait-path-truncated).

## Diff

```diff
 pub fn null() -> Arc<Value> {
-    Arc::new(Value::Null)
+    new(Value::Null)
 }
```

The stub-body class is now retired for this op family. The realizer walks the resolved tree correctly. The only remaining difference is the missing `Arc::` receiver prefix — exactly what #962 (trait-path-truncated) was filed to retire.

## Pipeline shift across v1 → v2

| | v1 | v2 |
| --- | --- | --- |
| Dominant class | stub-body | name-difference |
| Root cause | #964 (ffi-call-unresolved-effect) | #962 (trait-path-truncated) |
| Diff lines | 1 panic vs original body | 1 prefix difference |
| Verdict | CHARACTERIZED_DIFF | CHARACTERIZED_DIFF (narrower) |

## CIDs

- regenerated_source_cid: `blake3-512:792b3ac8...`
- original_slice_post_rustfmt_cid: `blake3-512:97ec24c8...`

## D7-v3 expectation

v3 retires #962 by extending `provekit-walk` to record the full FQN from `syn` path resolution. After v3 lands, the receipt for Value::null is expected to be **BYTE_IDENTICAL** post-rustfmt — the n=1 case of the cycle invariance theorem on a real production function.

## Scope

- Per-language kit only (`provekit-realize-rust-core`).
- No substrate changes (no concept ops minted, no specs touched).
- No lifter changes (`provekit-walk` untouched).
- One resolved-term shape only. Any other shape falls back to the existing stub.
- One function (Value::null).

## Acceptance

- All targeted tests green.
- Em-dash sweep clean.
- Receipt complete and self-attesting.
- The dominant-class assertion in the test (`name-difference`) holds.

## Files

- `implementations/rust/provekit-realize-rust-core/src/lib.rs` — new `emit_from_resolved` entrypoint + recursive walker for the supported shape.
- `implementations/rust/libprovekit/tests/d7_v1_source_round_trip.rs` — extended to also produce the v2 receipt.
- `bootstrap/D7-v2/value_null_source_round_trip_receipt.json` — structured receipt.
- `bootstrap/D7-v2/README.md` — receipt note framing the expected name-difference diff as #962 debt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced resolution and realization workflow for value type handling with improved pattern recognition and code generation capabilities.

* **Documentation**
  * Added comprehensive documentation for D7-v2 implementation details and workflow.

* **Tests**
  * Expanded test coverage with receipt fixtures and validation for resolution/realization pipeline verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/969)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->