### PR TITLE
feat(bootstrap D7-v3): retire trait-path-truncated; Value::null hits BYTE_IDENTICAL (n=1 source-layer terminus)

### DIFF
--- a/bootstrap/D7-v0/README.md
+++ b/bootstrap/D7-v0/README.md
@@ -14,12 +14,12 @@ For this D7-v0 bridge smoke, that envelope was trimmed to one bridge-compatible 
 The fixture keeps the target, source, handling, term surface, op CIDs, and loss record from the raw lift.
 The fixture path is implementations/rust/libprovekit/tests/fixtures/proofir/d7_v0_value_null.json.
 
-The ProofIR term is return(call:new(new, [Null])).
+The ProofIR term is return(call:new(Arc::new, [Null])).
 The test resolves that term through libprovekit::proofir_resolve.
 The test then unresolves it through libprovekit::proofir_unresolve.
 The reassembled fixture is JCS-canonicalized and compared against the input fixture.
 
-The fixture CID is blake3-512:f78e468e6f80e305c8abb4f1b5ccbe54cdea54bf3d5104a63970be8500f7f0a5e7a467fa2cf3bcd2894502ff045c4aede5dbc83f3b76d5818a0aeb2fcacaca3e.
+The fixture CID is blake3-512:bcb10be48ad632abc71c406355b6d11b0191a959b523aa755ee00ad7496afa2270ce28821af4abcd5949427026fb16d8d8b38af702b1810dec3bdff810ec8f32.
 The round-trip output CID is the same CID.
 The byte-identity check passed.
 The loss-record preservation check passed.
@@ -27,14 +27,14 @@ The loss-record preservation check passed.
 The carried loss record is intentionally non-empty.
 It records procedural-macro detail derive.
 It records return-type-user-defined detail Arc < Value >.
-It records trait-path-truncated details Arc :: new and Value :: Null.
-It records ffi-call-unresolved-effect detail new.
+It records trait-path-truncated detail Value :: Null.
+It records ffi-call-unresolved-effect detail Arc::new.
 
 ## Loss-record framing
 
 Source-layer equivalence is evaluated in formatter-normal form. The contract is k(formatter(I)) = t(formatter(I) == formatter(I')), where formatter is the language's canonical formatter (rustfmt for Rust). The formatter is the canonicalizer, so whitespace, blank lines, trailing commas, and hex-vs-decimal literal rendering are NOT substrate concerns. The substrate carries concept:comment but NOT concept:formatting-hint.
 
-The v2 audit gap classes captured in this fixture's loss_record are engineering debt with named retirement tickets:
+The audit gap classes captured in this fixture's loss_record are engineering debt with named retirement tickets:
 
 - #961 procedural-macro -> concept:proc-macro-invocation + concept:derive-attribute
 - #962 trait-path-truncated -> concept:fully-qualified-path + rustc name resolution

--- a/bootstrap/D7-v0/value_null_round_trip_receipt.json
+++ b/bootstrap/D7-v0/value_null_round_trip_receipt.json
@@ -9,7 +9,7 @@
     "tool": "provekit-walk",
     "command": "cd implementations/rust && cargo run --bin provekit-walk-emit -- term provekit-canonicalizer/src/value.rs null /tmp/d7_v0_value_null.raw.json",
     "fixture_path": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v0_value_null.json",
-    "fixture_cid": "blake3-512:f78e468e6f80e305c8abb4f1b5ccbe54cdea54bf3d5104a63970be8500f7f0a5e7a467fa2cf3bcd2894502ff045c4aede5dbc83f3b76d5818a0aeb2fcacaca3e",
+    "fixture_cid": "blake3-512:bcb10be48ad632abc71c406355b6d11b0191a959b523aa755ee00ad7496afa2270ce28821af4abcd5949427026fb16d8d8b38af702b1810dec3bdff810ec8f32",
     "outcome": "handles-partially-with-loss-record",
     "loss_record": {
       "procedural_macro": [
@@ -19,16 +19,15 @@
         "Arc < Value >"
       ],
       "trait_path_truncated": [
-        "Arc :: new",
         "Value :: Null"
       ],
       "ffi_call_unresolved_effect": [
-        "new"
+        "Arc::new"
       ]
     }
   },
   "round_trip": {
-    "resolve_unresolve_output_cid": "blake3-512:f78e468e6f80e305c8abb4f1b5ccbe54cdea54bf3d5104a63970be8500f7f0a5e7a467fa2cf3bcd2894502ff045c4aede5dbc83f3b76d5818a0aeb2fcacaca3e",
+    "resolve_unresolve_output_cid": "blake3-512:bcb10be48ad632abc71c406355b6d11b0191a959b523aa755ee00ad7496afa2270ce28821af4abcd5949427026fb16d8d8b38af702b1810dec3bdff810ec8f32",
     "byte_identical_to_lift": true,
     "loss_record_preserved": true
   },

--- a/bootstrap/D7-v3/README.md
+++ b/bootstrap/D7-v3/README.md
@@ -1,0 +1,54 @@
+# D7-v3 Value::null source round-trip receipt
+
+Scope: one production function only.
+Target crate: provekit-canonicalizer.
+Target function: impl Value::null.
+Source path: implementations/rust/provekit-canonicalizer/src/value.rs.
+
+D7-v3 extends provekit-walk for the existing call:new op family.
+The lifter keeps the op name as call:new.
+It now threads the receiver-prefixed callee spelling through the first term argument.
+For Value::null, that argument changed from new to Arc::new.
+No substrate concept was minted.
+No concept:fully-qualified-path shape was introduced.
+
+The regenerated fixture is:
+implementations/rust/libprovekit/tests/fixtures/proofir/d7_v0_value_null.json.
+Its term surface is:
+return(call:new(Arc::new, [Null])).
+The fixture CID is:
+blake3-512:bcb10be48ad632abc71c406355b6d11b0191a959b523aa755ee00ad7496afa2270ce28821af4abcd5949427026fb16d8d8b38af702b1810dec3bdff810ec8f32.
+
+The D7-v2 source receipt showed a name-only source diff.
+The original body was Arc::new(Value::Null).
+The regenerated body was new(Value::Null).
+That diff existed because the lifted resolved term carried literal("new").
+The Arc:: receiver prefix was only present as a trait-path-truncated loss record.
+
+D7-v3 retires that loss for this call:new body shape.
+The new fixture no longer records trait-path-truncated detail Arc :: new.
+It still records trait-path-truncated detail Value :: Null.
+That remaining enum path loss is outside this chunk.
+The fixture still records ffi-call-unresolved-effect detail Arc::new.
+
+provekit-realize-rust-core now consumes the new resolved shape.
+It accepts call:new(literal("Arc::new"), literal(["Null"])).
+It emits Arc::new(Value::Null).
+It also keeps the old bare literal("new") path valid for older fixtures.
+
+The D7-v3 receipt is:
+bootstrap/D7-v3/value_null_source_round_trip_receipt.json.
+The verdict is BYTE_IDENTICAL.
+The post-rustfmt unified diff is empty.
+The regenerated source CID matches the original post-rustfmt slice CID.
+
+This reaches the D7 n=1 terminus for Value::null.
+The claim is empirical and narrow.
+It covers one real production function.
+It does not claim module-level source identity.
+It does not retire all trait-path-truncated debt.
+It does not generalize beyond the call:new receiver-prefix path used here.
+
+Next chunks widen from this single function to module-level source round trips.
+Those chunks should keep the same receipt discipline.
+They should report the next dominant diff class if byte identity fails.

--- a/bootstrap/D7-v3/value_null_source_round_trip_receipt.json
+++ b/bootstrap/D7-v3/value_null_source_round_trip_receipt.json
@@ -1,0 +1,34 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::null",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:bcb10be48ad632abc71c406355b6d11b0191a959b523aa755ee00ad7496afa2270ce28821af4abcd5949427026fb16d8d8b38af702b1810dec3bdff810ec8f32",
+    "step_2_resolve": "summary=return(call:new(literal(\"Arc::new\"), literal([\"Null\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"Null\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, \"null\", &[], &[], \"Arc < Value >\")",
+    "step_3_4_realize_input": {
+      "resolved_term_json": "{\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"Null\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+      "function": "null",
+      "params": [],
+      "param_types": [],
+      "return_type": "Arc < Value >"
+    },
+    "step_3_4_regenerated_source": "pub fn null() -> Arc < Value > {\n    Arc::new(Value::Null)\n}\n",
+    "step_5_original_slice_cid": "blake3-512:12832f678b924c4503c8d5e5839471bffa8051e2dfbc6f4d455b302dbbc7c649c56b5aec0d31fbd336c532111dbd46091b6efed10f288e68a511a32d08d29450",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_null_regenerated_v3.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_null_original.rs>",
+    "step_7_byte_identical_post_rustfmt": true,
+    "step_8_unified_diff": "",
+    "step_9_diff_classification": [],
+    "step_10_dominant_diff_class": "byte-identical",
+    "step_11_expected_diff_shape": "post-rustfmt byte-identical",
+    "step_12_empirical_root_cause": "#962 trait-path-truncated is retired for this call:new Value::null body because the resolved term now carries Arc::new.",
+    "regenerated_source_cid": "blake3-512:97ec24c86c7b920e7e13d80541e7ec5fd066bf3cbceb47bb8df5bb9ec88717558a04e8f605d180ae93730f1f42c9b4420060bcf80df0ff544c1ad4ef5369f670",
+    "original_slice_post_rustfmt_cid": "blake3-512:97ec24c86c7b920e7e13d80541e7ec5fd066bf3cbceb47bb8df5bb9ec88717558a04e8f605d180ae93730f1f42c9b4420060bcf80df0ff544c1ad4ef5369f670"
+  },
+  "verdict": "BYTE_IDENTICAL",
+  "dominant_diff_class": "byte-identical",
+  "next_action": "D7 single-function terminus reached for Value::null; next chunks widen the empirical claim to module-level source round trips."
+}

--- a/implementations/rust/libprovekit/tests/d7_v1_source_round_trip.rs
+++ b/implementations/rust/libprovekit/tests/d7_v1_source_round_trip.rs
@@ -11,7 +11,7 @@ use provekit_canonicalizer::blake3_512_of;
 use provekit_ir_types::Term;
 use serde_json::{json, Value as JsonValue};
 
-const EXPECTED_FIXTURE_CID: &str = "blake3-512:f78e468e6f80e305c8abb4f1b5ccbe54cdea54bf3d5104a63970be8500f7f0a5e7a467fa2cf3bcd2894502ff045c4aede5dbc83f3b76d5818a0aeb2fcacaca3e";
+const EXPECTED_FIXTURE_CID: &str = "blake3-512:bcb10be48ad632abc71c406355b6d11b0191a959b523aa755ee00ad7496afa2270ce28821af4abcd5949427026fb16d8d8b38af702b1810dec3bdff810ec8f32";
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -358,124 +358,61 @@ fn value_null_source_round_trip_receipt_is_complete() {
     let param_types: Vec<String> = Vec::new();
     let return_type = return_type_from_loss_record(&fixture);
     let concept_name = root_concept_name(&fixture, &resolved);
-    let realization = provekit_realize_rust_core::emit_stub_with_mode(
-        &function,
-        &params,
-        &param_types,
-        &return_type,
-        &concept_name,
-        None,
+    assert!(
+        !fixture["loss_record"]
+            .as_array()
+            .expect("loss_record array")
+            .iter()
+            .any(|loss| {
+                loss["loss"] == "trait-path-truncated" && loss["detail"] == "Arc :: new"
+            }),
+        "D7-v3 fixture must retire Arc::new trait-path-truncated loss"
     );
 
     let source_text =
         std::fs::read_to_string(source_path(&repo_root)).expect("read canonicalizer value.rs");
     let original_slice = extract_value_null_slice(&source_text);
     let original_slice_cid = blake3_512_of(original_slice.as_bytes());
-
-    let (regenerated_rustfmt, regenerated_rustfmt_command) =
-        rustfmt_source(&repo_root, "value_null_regenerated.rs", &realization.source);
     let (original_rustfmt, original_rustfmt_command) =
         rustfmt_source(&repo_root, "value_null_original.rs", &original_slice);
 
-    let byte_identical = regenerated_rustfmt.as_bytes() == original_rustfmt.as_bytes();
-    let diff = unified_diff(&repo_root, &original_rustfmt, &regenerated_rustfmt);
-    let classification = classify_diff(&diff, realization.is_stub, &concept_name);
-    let verdict = if byte_identical {
-        "BYTE_IDENTICAL"
-    } else {
-        "CHARACTERIZED_DIFF"
-    };
-
-    if !byte_identical {
-        assert!(
-            !classification.is_empty(),
-            "non-identical source must have a classified diff hunk"
-        );
-    }
-
-    let receipt = json!({
-        "version": "1",
-        "target": {
-            "crate": "provekit-canonicalizer",
-            "function": "impl Value::null",
-            "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs",
-        },
-        "pipeline": {
-            "step_1_fixture_cid": EXPECTED_FIXTURE_CID,
-            "step_2_resolve": format!("summary={resolved_summary}; jcs={resolved_jcs}"),
-            "step_3_4_realize_command": format!(
-                "provekit_realize_rust_core::emit_stub_with_mode({function:?}, &[], &[], {return_type:?}, {concept_name:?}, None)"
-            ),
-            "step_3_4_realize_input": {
-                "function": function.clone(),
-                "params": params.clone(),
-                "param_types": param_types.clone(),
-                "return_type": return_type.clone(),
-                "concept_name": concept_name.clone(),
-                "mode": JsonValue::Null,
-            },
-            "step_3_4_regenerated_source": realization.source.clone(),
-            "step_5_original_slice_cid": original_slice_cid.clone(),
-            "step_6_rustfmt_command": format!("{regenerated_rustfmt_command}\n{original_rustfmt_command}"),
-            "step_7_byte_identical_post_rustfmt": byte_identical,
-            "step_8_unified_diff": diff,
-            "step_9_diff_classification": classification.clone(),
-            "regenerated_source_cid": blake3_512_of(regenerated_rustfmt.as_bytes()),
-            "original_slice_post_rustfmt_cid": blake3_512_of(original_rustfmt.as_bytes()),
-        },
-        "verdict": verdict,
-        "next_action": "if BYTE_IDENTICAL, D7 terminus reached for this fn; otherwise, file follow-up issue per dominant diff class (e.g., extend realize-rust-core to consume ResolvedTerm bodies for the stub-body class, retire concept:new ffi-effect-occurrence for the missing-concept class).",
-    });
-
-    let v1_receipt_path = receipt_path(&repo_root, "D7-v1");
-    std::fs::create_dir_all(v1_receipt_path.parent().expect("receipt parent"))
-        .expect("create D7-v1 receipt dir");
-    std::fs::write(
-        &v1_receipt_path,
-        format!(
-            "{}\n",
-            serde_json::to_string_pretty(&receipt).expect("pretty receipt")
-        ),
-    )
-    .expect("write D7-v1 receipt");
-
-    let parsed: JsonValue = serde_json::from_str(
-        &std::fs::read_to_string(&v1_receipt_path).expect("read written D7-v1 receipt"),
-    )
-    .expect("parse written D7-v1 receipt");
-    assert!(matches!(
-        parsed["verdict"].as_str(),
-        Some("BYTE_IDENTICAL" | "CHARACTERIZED_DIFF")
-    ));
-
-    let v2_realization = provekit_realize_rust_core::emit_from_resolved(
+    let v3_realization = provekit_realize_rust_core::emit_from_resolved(
         &resolved_jcs,
         &function,
         &params,
         &param_types,
         &return_type,
     );
-    let (v2_regenerated_rustfmt, v2_regenerated_rustfmt_command) = rustfmt_source(
+    let (v3_regenerated_rustfmt, v3_regenerated_rustfmt_command) = rustfmt_source(
         &repo_root,
-        "value_null_regenerated_v2.rs",
-        &v2_realization.source,
+        "value_null_regenerated_v3.rs",
+        &v3_realization.source,
     );
-    let v2_byte_identical = v2_regenerated_rustfmt.as_bytes() == original_rustfmt.as_bytes();
-    let v2_diff = unified_diff(&repo_root, &original_rustfmt, &v2_regenerated_rustfmt);
-    let v2_classification = classify_diff(&v2_diff, v2_realization.is_stub, &concept_name);
-    let v2_verdict = if v2_byte_identical {
+    let v3_byte_identical = v3_regenerated_rustfmt.as_bytes() == original_rustfmt.as_bytes();
+    let v3_diff = unified_diff(&repo_root, &original_rustfmt, &v3_regenerated_rustfmt);
+    let v3_classification = classify_diff(&v3_diff, v3_realization.is_stub, &concept_name);
+    let v3_verdict = if v3_byte_identical {
         "BYTE_IDENTICAL"
     } else {
         "CHARACTERIZED_DIFF"
     };
-    let v2_dominant_diff_class = dominant_diff_class(v2_byte_identical, &v2_classification);
+    let v3_dominant_diff_class = dominant_diff_class(v3_byte_identical, &v3_classification);
+    let v3_regenerated_source_cid = blake3_512_of(v3_regenerated_rustfmt.as_bytes());
+    let original_slice_post_rustfmt_cid = blake3_512_of(original_rustfmt.as_bytes());
 
-    assert_eq!(v2_verdict, "CHARACTERIZED_DIFF");
-    assert_eq!(v2_dominant_diff_class, "name-difference");
-    assert!(v2_diff.contains("-    Arc::new(Value::Null)"));
-    assert!(v2_diff.contains("+    new(Value::Null)"));
+    if !v3_byte_identical {
+        assert!(
+            !v3_classification.is_empty(),
+            "non-identical source must have a classified diff hunk"
+        );
+    }
 
-    let v2_receipt = json!({
+    assert_eq!(v3_verdict, "BYTE_IDENTICAL");
+    assert_eq!(v3_dominant_diff_class, "byte-identical");
+    assert_eq!(v3_diff, "");
+    assert_eq!(v3_regenerated_source_cid, original_slice_post_rustfmt_cid);
+
+    let v3_receipt = json!({
         "version": "1",
         "target": {
             "crate": "provekit-canonicalizer",
@@ -495,46 +432,44 @@ fn value_null_source_round_trip_receipt_is_complete() {
                 "param_types": param_types,
                 "return_type": return_type,
             },
-            "step_3_4_regenerated_source": v2_realization.source,
+            "step_3_4_regenerated_source": v3_realization.source,
             "step_5_original_slice_cid": original_slice_cid,
-            "step_6_rustfmt_command": format!("{v2_regenerated_rustfmt_command}\n{original_rustfmt_command}"),
-            "step_7_byte_identical_post_rustfmt": v2_byte_identical,
-            "step_8_unified_diff": v2_diff,
-            "step_9_diff_classification": v2_classification,
-            "step_10_dominant_diff_class": v2_dominant_diff_class.clone(),
-            "step_11_expected_diff_shape": "-    Arc::new(Value::Null)\n+    new(Value::Null)",
-            "step_12_empirical_root_cause": "#962 trait-path-truncated: the resolved call:new body does not carry the Arc:: receiver prefix.",
-            "regenerated_source_cid": blake3_512_of(v2_regenerated_rustfmt.as_bytes()),
-            "original_slice_post_rustfmt_cid": blake3_512_of(original_rustfmt.as_bytes()),
+            "step_6_rustfmt_command": format!("{v3_regenerated_rustfmt_command}\n{original_rustfmt_command}"),
+            "step_7_byte_identical_post_rustfmt": v3_byte_identical,
+            "step_8_unified_diff": v3_diff,
+            "step_9_diff_classification": v3_classification,
+            "step_10_dominant_diff_class": v3_dominant_diff_class.clone(),
+            "step_11_expected_diff_shape": "post-rustfmt byte-identical",
+            "step_12_empirical_root_cause": "#962 trait-path-truncated is retired for this call:new Value::null body because the resolved term now carries Arc::new.",
+            "regenerated_source_cid": v3_regenerated_source_cid,
+            "original_slice_post_rustfmt_cid": original_slice_post_rustfmt_cid,
         },
-        "verdict": v2_verdict,
-        "dominant_diff_class": v2_dominant_diff_class,
-        "next_action": "retire #962 trait-path-truncated by carrying the missing receiver path needed to restore Arc::new(Value::Null).",
+        "verdict": v3_verdict,
+        "dominant_diff_class": v3_dominant_diff_class,
+        "next_action": "D7 single-function terminus reached for Value::null; next chunks widen the empirical claim to module-level source round trips.",
     });
 
-    let v2_receipt_path = receipt_path(&repo_root, "D7-v2");
-    std::fs::create_dir_all(v2_receipt_path.parent().expect("receipt parent"))
-        .expect("create D7-v2 receipt dir");
+    let v3_receipt_path = receipt_path(&repo_root, "D7-v3");
+    std::fs::create_dir_all(v3_receipt_path.parent().expect("receipt parent"))
+        .expect("create D7-v3 receipt dir");
     std::fs::write(
-        &v2_receipt_path,
+        &v3_receipt_path,
         format!(
             "{}\n",
-            serde_json::to_string_pretty(&v2_receipt).expect("pretty v2 receipt")
+            serde_json::to_string_pretty(&v3_receipt).expect("pretty v3 receipt")
         ),
     )
-    .expect("write D7-v2 receipt");
+    .expect("write D7-v3 receipt");
 
-    let v2_parsed: JsonValue = serde_json::from_str(
-        &std::fs::read_to_string(&v2_receipt_path).expect("read written D7-v2 receipt"),
+    let v3_parsed: JsonValue = serde_json::from_str(
+        &std::fs::read_to_string(&v3_receipt_path).expect("read written D7-v3 receipt"),
     )
-    .expect("parse written D7-v2 receipt");
-    assert_eq!(v2_parsed["verdict"].as_str(), Some("CHARACTERIZED_DIFF"));
+    .expect("parse written D7-v3 receipt");
+    assert_eq!(v3_parsed["verdict"].as_str(), Some("BYTE_IDENTICAL"));
     assert_eq!(
-        v2_parsed["dominant_diff_class"].as_str(),
-        Some("name-difference")
+        v3_parsed["dominant_diff_class"].as_str(),
+        Some("byte-identical")
     );
-    println!("receipt_path={}", v1_receipt_path.display());
-    println!("verdict={verdict}");
-    println!("v2_receipt_path={}", v2_receipt_path.display());
-    println!("v2_verdict={v2_verdict}");
+    println!("v3_receipt_path={}", v3_receipt_path.display());
+    println!("v3_verdict={v3_verdict}");
 }

--- a/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v0_value_null.json
+++ b/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v0_value_null.json
@@ -13,11 +13,7 @@
       "loss": "return-type-user-defined"
     },
     {
-      "detail": "Arc :: new",
-      "loss": "trait-path-truncated"
-    },
-    {
-      "detail": "new",
+      "detail": "Arc::new",
       "loss": "ffi-call-unresolved-effect"
     },
     {
@@ -25,7 +21,7 @@
       "loss": "trait-path-truncated"
     }
   ],
-  "term_surface": "return(call:new(new, [Null]))",
+  "term_surface": "return(call:new(Arc::new, [Null]))",
   "proofir_catalog_ops": [
     {
       "name": "return",
@@ -50,7 +46,7 @@
               "kind": "primitive",
               "name": "FnContract"
             },
-            "value": "new"
+            "value": "Arc::new"
           },
           {
             "kind": "const",

--- a/implementations/rust/libprovekit/tests/proofir_bridge_real_lift.rs
+++ b/implementations/rust/libprovekit/tests/proofir_bridge_real_lift.rs
@@ -8,6 +8,8 @@ use libprovekit::{proofir_resolve, proofir_unresolve};
 use provekit_ir_types::Term;
 use serde_json::{json, Value as JsonValue};
 
+const EXPECTED_FIXTURE_CID: &str = "blake3-512:bcb10be48ad632abc71c406355b6d11b0191a959b523aa755ee00ad7496afa2270ce28821af4abcd5949427026fb16d8d8b38af702b1810dec3bdff810ec8f32";
+
 fn fixture_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
@@ -86,6 +88,7 @@ fn value_null_lift_round_trips_byte_identical() {
 
     let fixture_cid = json_cid(&original_json).expect("fixture CID");
     let round_trip_cid = json_cid(&round_trip_json).expect("round-trip CID");
+    assert_eq!(fixture_cid, EXPECTED_FIXTURE_CID);
     assert_eq!(fixture_cid, round_trip_cid);
     println!("fixture_cid={fixture_cid}");
     println!("round_trip_cid={round_trip_cid}");

--- a/implementations/rust/provekit-realize-rust-core/src/lib.rs
+++ b/implementations/rust/provekit-realize-rust-core/src/lib.rs
@@ -62,12 +62,12 @@ pub fn emit_stub_with_mode(
     emit_function(function, params, param_types, return_type, &body, is_stub)
 }
 
-/// Emits Rust for exactly one D7-v2 resolved body shape:
-/// `return(call:new(literal("new"), literal(["Null"])))`.
+/// Emits Rust for the D7 resolved Value::null body shape:
+/// `return(call:new(literal("new" | "*::new"), literal(["Null"])))`.
 ///
 /// The trailing `return` node is lowered as a Rust tail expression. The nested
-/// `call:new` shape lowers to `new(Value::Null)` because the resolved term
-/// records the constructor call but not the missing receiver prefix (`Arc::`).
+/// `call:new` shape lowers to `<callee>(Value::Null)`. D7-v2 fixtures used a
+/// bare `new`; D7-v3 fixtures carry the receiver-prefixed `Arc::new` spelling.
 /// Unsupported resolved concepts or literal shapes fall back to the existing
 /// `panic!("provekit-bind canonical: <concept>")` stub body.
 pub fn emit_from_resolved(
@@ -156,11 +156,11 @@ fn lower_call_new(term: &Value) -> Result<String, String> {
 
     let name = lower_literal(&args[0])?;
     let lowered_args = lower_literal(&args[1])?;
-    if name != "new" {
+    if name != "new" && !name.ends_with("::new") {
         return Err("call:new".to_string());
     }
 
-    Ok(format!("new({lowered_args})"))
+    Ok(format!("{name}({lowered_args})"))
 }
 
 fn lower_literal(term: &Value) -> Result<String, String> {
@@ -170,7 +170,9 @@ fn lower_literal(term: &Value) -> Result<String, String> {
     }
 
     match node.get("value") {
-        Some(Value::String(value)) if value == "new" => Ok(value.to_string()),
+        Some(Value::String(value)) if value == "new" || value.ends_with("::new") => {
+            Ok(value.to_string())
+        }
         Some(Value::Array(items)) if is_value_null_literal(items) => Ok("Value::Null".to_string()),
         _ => Err("literal".to_string()),
     }
@@ -716,6 +718,55 @@ mod tests {
         assert_eq!(
             rendered.source,
             "pub fn null() -> Arc < Value > {\n    new(Value::Null)\n}\n"
+        );
+    }
+
+    #[test]
+    fn emits_value_null_from_resolved_call_new_with_receiver_prefix() {
+        let resolved = serde_json::json!({
+            "node": {
+                "args": [
+                    {
+                        "node": {
+                            "args": [
+                                {
+                                    "node": {
+                                        "kind": "literal",
+                                        "value": "Arc::new",
+                                    },
+                                    "sort": {"args": [], "kind": "ctor", "name": "FnContract"},
+                                },
+                                {
+                                    "node": {
+                                        "kind": "literal",
+                                        "value": ["Null"],
+                                    },
+                                    "sort": {"args": [], "kind": "ctor", "name": "ListOfExpr"},
+                                },
+                            ],
+                            "kind": "concept:op-application",
+                            "op_definition_cid": CALL_NEW_OP_CID,
+                        },
+                        "sort": {"args": [], "kind": "ctor", "name": "Expr"},
+                    },
+                ],
+                "kind": "concept:op-application",
+                "op_definition_cid": RETURN_OP_CID,
+            },
+            "sort": {"args": [], "kind": "ctor", "name": "Stmt"},
+        });
+        let rendered = emit_from_resolved(
+            &serde_json::to_string(&resolved).expect("resolved json"),
+            "null",
+            &[],
+            &[],
+            "Arc < Value >",
+        );
+
+        assert!(!rendered.is_stub);
+        assert_eq!(
+            rendered.source,
+            "pub fn null() -> Arc < Value > {\n    Arc::new(Value::Null)\n}\n"
         );
     }
 

--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -1173,14 +1173,15 @@ fn lower_call_expr_to_value_term(
     call: &syn::ExprCall,
     ctx: &LoweringContext,
 ) -> Result<AlgebraTerm, String> {
-    let callee = match &*call.func {
-        Expr::Path(path) => path_name_for_expr(path, ctx).unwrap_or_else(|| "unknown".to_string()),
+    let (op_name, callee) = match &*call.func {
+        Expr::Path(path) => path_call_name_for_expr(path)
+            .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string())),
         other => {
             ctx.add_loss(
                 "ffi-call-unresolved-callee",
                 format!("non-path callee {}", expr_kind(other)),
             );
-            "unknown".to_string()
+            ("unknown".to_string(), "unknown".to_string())
         }
     };
     ctx.add_loss("ffi-call-unresolved-effect", callee.clone());
@@ -1190,7 +1191,7 @@ fn lower_call_expr_to_value_term(
         .map(|arg| lower_expr_to_value_term(arg, ctx))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(AlgebraTerm::op(
-        format!("call:{callee}"),
+        format!("call:{op_name}"),
         vec![AlgebraTerm::Symbol(callee), AlgebraTerm::List(args)],
     ))
 }
@@ -1469,6 +1470,24 @@ fn path_name(path: &syn::ExprPath) -> Option<String> {
         .segments
         .last()
         .map(|segment| segment.ident.to_string())
+}
+
+fn path_call_name_for_expr(path: &syn::ExprPath) -> Option<(String, String)> {
+    if path.qself.is_some() {
+        return None;
+    }
+    let op_name = path.path.segments.last()?.ident.to_string();
+    let mut callee = path
+        .path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::");
+    if path.path.leading_colon.is_some() {
+        callee = format!("::{callee}");
+    }
+    Some((op_name, callee))
 }
 
 fn path_name_for_expr(path: &syn::ExprPath, ctx: &LoweringContext) -> Option<String> {

--- a/implementations/rust/provekit-walk/tests/term_emit_d2.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d2.rs
@@ -155,6 +155,28 @@ fn lowers_simple_call_expression_with_unresolved_call_loss() {
 }
 
 #[test]
+fn lowers_qualified_constructor_call_with_receiver_prefix() {
+    let parsed = term_json(
+        r#"
+            struct Arc<T>(T);
+            enum Value { Null }
+            fn null() -> Arc<Value> { Arc::new(Value::Null) }
+        "#,
+        "null",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("return(call:new(Arc::new, [Null]))")
+    );
+    assert_eq!(parsed["term"]["args"][0]["args"][0]["name"], "Arc::new");
+    assert!(!parsed["loss_record"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|loss| { loss["loss"] == "trait-path-truncated" && loss["detail"] == "Arc :: new" }));
+}
+
+#[test]
 fn lowers_simple_method_call_expression_with_unresolved_call_loss() {
     let parsed = term_json(
         r#"

--- a/implementations/rust/provekit-walk/tests/term_emit_d3.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d3.rs
@@ -39,11 +39,11 @@ fn accepts_trait_path_truncation_as_named_loss() {
     let parsed = term_json(
         r#"
             mod math {
-                pub fn id(x: i32) -> i32 { x }
+                pub const VALUE: i32 = 1;
             }
 
-            fn caller(x: i32) -> i32 {
-                math::id(x)
+            fn caller() -> i32 {
+                math::VALUE
             }
         "#,
         "caller",


### PR DESCRIPTION
**n=1 source-layer terminus reached on real libprovekit code.**

The pipeline lift_rust -> proofir_resolve -> realize_rust now produces byte-identical Rust source (post-rustfmt) for impl Value::null from provekit-canonicalizer.

## Verdict

`BYTE_IDENTICAL`. regenerated_source_cid == original_slice_post_rustfmt_cid == `blake3-512:97ec24c86c7b920e7e13d80541e7ec5fd066bf3cbceb47bb8df5bb9ec88717558a04e8f605d180ae93730f1f42c9b4420060bcf80df0ff544c1ad4ef5369f670`.

## The arc to here

| Chunk | Verdict | Dominant gap | Root cause |
| --- | --- | --- | --- |
| D7-v0 (#967) | ProofIR-layer round-trip | — | n/a (ProofIR-layer only) |
| D7-v1 (#968) | CHARACTERIZED_DIFF | stub-body | #964 ffi-call-unresolved-effect |
| D7-v2 (#969) | CHARACTERIZED_DIFF | name-difference | #962 trait-path-truncated |
| **D7-v3 (this PR)** | **BYTE_IDENTICAL** | **none** | **#962 retired** |

Three chunks, each retiring one debt class, converging to byte-identity.

## Changes

- `provekit-walk`: threads method-call receiver paths into call:new term emission. Now carries `Arc::new` verbatim instead of dropping the receiver.
- `provekit-realize-rust-core`: consumes the extended shape and emits `Arc::new(Value::Null)`.
- d7_v0 fixture regenerated to carry the new lift shape; fixture_cid updated to `blake3-512:bcb10be4...`.

#962 trait-path-truncated is retired for the call:new op family.

## Scope

Per-language kits only. No substrate touched. No new concept ops minted.

## Next

D7-v4 widens to Value::boolean / integer / string / array / object (5 more functions in the same module). On all-BYTE_IDENTICAL, the v5 chunk closes the full provekit-canonicalizer::value submodule. That's the D7 terminus; PushNotification fires and the chain transitions into Phase-5-Py.

## Refs

#943, #962, #964.