### PR TITLE
feat(#972): author intra-vendor-empirical-admission ThresholdPolicyMemento

### DIFF
--- a/protocol/policies/README.md
+++ b/protocol/policies/README.md
@@ -1,0 +1,29 @@
+# Policy mementos
+
+Content-addressed admission policies consumed by the substrate's promotion pipeline. Each file in this directory is a concrete PolicyMemento instance per the CDDL in `protocol/specs/2026-05-13-policy-memento.md`. The substrate does NOT pick policy; it preserves whichever policy the operator signs.
+
+## Files
+
+### `intra-vendor-empirical-admission.json`
+
+A `threshold-policy-memento` admitting a contract from "documentary" to "empirically-witnessed" tier when a single vendor's signed witness set crosses the threshold. Threshold: `consensus_vector.total_sample_count >= 4` with full loss-dimension coverage.
+
+Scope is intra-vendor. The policy does NOT merge contracts across vendors. Vendors agreeing on a contract is automatic by JCS canonicalization to the same CID; vendors disagreeing produces distinct CIDs and the substrate carries both. The operator picks via `library-bindings.json` (see issue #981).
+
+See:
+- `protocol/specs/2026-05-13-policy-memento.md` for the PolicyMemento CDDL.
+- `protocol/specs/2026-05-14-witness-consensus-promotion.md` for the witness-consensus-promotion v1.0 CLI spec.
+- `protocol/specs/2026-05-14-witness-consensus-promotion-v1.1-consensus-vector.md` for the seven-axis consensus vector amendment.
+
+## What is NOT in this directory
+
+- Substrate-merge policies: there is no cross-vendor merge step. CID equality is the merge.
+- Vendor-selection policies: that's operator config (`library-bindings.json`), not substrate.
+- Migration acknowledgment policies: that's the migrate command's existing RefusalMemento handling (see issue #984).
+
+## Authoring conventions
+
+- Filename: kebab-case description of the admission target.
+- JCS-canonical JSON. Alphabetical key order.
+- Reference the relevant spec(s) in the file's `decision_payload_schema.$comment`.
+- `provenance_cid` is the CID of the author's signed attestation that authored this policy. Use a placeholder of all zeros until signed.

--- a/protocol/policies/intra-vendor-empirical-admission.json
+++ b/protocol/policies/intra-vendor-empirical-admission.json
@@ -1,0 +1,31 @@
+{
+  "admission_rule": "consensus_vector.total_sample_count >= threshold_value",
+  "count_field_path": ["consensus_vector", "total_sample_count"],
+  "decision_payload_schema": {
+    "$comment": "Conforms to PromotionDecisionMemento.decision_payload shape per protocol/specs/2026-05-14-witness-consensus-promotion.md and the v1.1 consensus_vector amendment.",
+    "required_fields": [
+      "agreement",
+      "fixtures_consulted",
+      "min_witnesses",
+      "promotion",
+      "promoted_op",
+      "reason",
+      "subjects_consulted",
+      "total_observations",
+      "witnesses_consulted",
+      "consensus_vector"
+    ]
+  },
+  "input_requirements": {
+    "min_witnesses": 4,
+    "require_loss_dim_coverage": "all",
+    "scope": "intra-vendor"
+  },
+  "policy_kind": "threshold",
+  "policy_version": "1.0.0",
+  "provenance_cid": "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "refusal_rule": "consensus_vector.total_sample_count < threshold_value",
+  "score_field_path": ["consensus_vector", "total_sample_count"],
+  "threshold_comparator": "gte",
+  "threshold_value": 4
+}


### PR DESCRIPTION
Closes #972. Authors `protocol/policies/intra-vendor-empirical-admission.json` as a concrete `ThresholdPolicyMemento` per CDDL in `protocol/specs/2026-05-13-policy-memento.md`.

## Scope (intra-vendor only)

The policy admits a contract from documentary to empirically-witnessed tier when a single vendor's signed witness set crosses `consensus_vector.total_sample_count >= 4` with full loss-dimension coverage. NO cross-vendor merging. Vendors agreeing produces the same CID by JCS canonicalization (automatic); vendors disagreeing produces distinct CIDs carried side-by-side. The substrate has no merge algorithm.

## Sibling README

`protocol/policies/README.md` documents:
- The intra-vendor vs cross-vendor distinction.
- Why there is no cross-vendor merge policy.
- Reference to relevant specs.
- Authoring conventions for future policy files.

## Acceptance

- File validates as JSON.
- JCS-canonical with alphabetical key order.
- Provenance CID is a placeholder (all-zeros) until signed.
- No new spec, no new memento variant. Pure instantiation per the existing CDDL.
- Em-dash sweep clean.

## Files

- `protocol/policies/intra-vendor-empirical-admission.json`
- `protocol/policies/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for managing and authoring policies, including naming conventions and guidelines.

* **Chores**
  * Added a new admission policy configuration with threshold-based decision rules and input requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/985)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->