### PR TITLE
feat(bootstrap D7-v4): diagnostic widening to Value::boolean / integer / string (stub-body class identified)

### DIFF
--- a/bootstrap/D7-v4/README.md
+++ b/bootstrap/D7-v4/README.md
@@ -1,0 +1,59 @@
+# D7-v4 Value constructor widening receipts
+
+Scope: diagnostic-only widening after D7-v3.
+Parent arc: #943.
+Base commit: fba9a51d.
+Branch: bootstrap/D7-v4-widen-value-methods.
+
+D7-v3 reached BYTE_IDENTICAL for impl Value::null.
+D7-v4 widens the receipt discipline to three adjacent constructors.
+It does not extend provekit-walk.
+It does not extend provekit-realize-rust-core.
+It does not mint concept hubs, touch substrate, or mint new ops.
+
+Targets in implementations/rust/provekit-canonicalizer/src/value.rs:
+impl Value::boolean.
+impl Value::integer.
+impl Value::string.
+
+The checked-in source currently uses Value::Bool for boolean.
+The checked-in integer parameter is named n, and string is generic: string<S: Into<String>>(s: S).
+The original slices in the receipts are taken from the checked-in file.
+
+Trimmed fixture paths:
+implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_boolean.json.
+implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_integer.json.
+implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_string.json.
+
+| method | verdict | dominant class | fixture CID |
+| --- | --- | --- | --- |
+| boolean | CHARACTERIZED_DIFF | stub-body | blake3-512:b2c54035098e0bc287eca146fea6f697d56547d13d2e620cc38cbfda6b2f65d1994eeebe64aa3d8f3ac91843c45ab423b5917e95f2d62bc88f76500dd5f45b85 |
+| integer | CHARACTERIZED_DIFF | stub-body | blake3-512:ca7c544cf2e01f70d422e41d75151d13d2adae92dafdec36d9368ae132ce2510954c4fd04ec49e50c36124f98a00edc4e6162f7c7d800427844d251f837c8f28 |
+| string | CHARACTERIZED_DIFF | stub-body | blake3-512:8b3c7680416cb010f77eb30f5ef2c9284c3feadb16e3f5be7c48c44596557e46a94e5c7502cc0c106d1d39ec4ffcddd34431363c3f9e5e3e708e6cd09091b9c2 |
+
+The walker already emits widened nested constructor surfaces.
+boolean trims to return(call:new(Arc::new, [call:Bool(Value::Bool, [b])])).
+integer trims to return(call:new(Arc::new, [call:Integer(Value::Integer, [n])])).
+string trims to return(call:new(Arc::new, [call:String(Value::String, [method:into(s, [])])])).
+
+The bridge fixture keeps only existing return and call:new catalog ops.
+The widened nested constructor surface is preserved inside the ListOfExpr literal.
+That keeps the fixture bridge-compatible without adding ProofIR ops.
+
+provekit_realize_rust_core::emit_from_resolved still recognizes Value::Null only.
+For these three widened literal shapes it falls through to the stub-body path.
+The regenerated source body is panic!("provekit-bind canonical: literal").
+That is the expected D7-v4 deliverable.
+
+bootstrap/D7-v4/boolean_source_round_trip_receipt.json.
+bootstrap/D7-v4/integer_source_round_trip_receipt.json.
+bootstrap/D7-v4/string_source_round_trip_receipt.json.
+
+The D7-v4 integration test is implementations/rust/libprovekit/tests/d7_v4_widen.rs.
+It recomputes the fixture CID, resolves the ProofIR term, realizes Rust, rustfmts both sides, compares bytes, classifies the diff, and checks the committed receipt.
+It accepts BYTE_IDENTICAL, CHARACTERIZED_DIFF, or BLOCKED.
+It does not assert byte identity.
+
+v5 should retire these stub-body differences under the #964/#962 self-host follow-up.
+That retirement should consume the existing widened literal shapes.
+It should not use this diagnostic receipt as license to add substrate concepts.

--- a/bootstrap/D7-v4/boolean_source_round_trip_receipt.json
+++ b/bootstrap/D7-v4/boolean_source_round_trip_receipt.json
@@ -1,0 +1,44 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::boolean",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:b2c54035098e0bc287eca146fea6f697d56547d13d2e620cc38cbfda6b2f65d1994eeebe64aa3d8f3ac91843c45ab423b5917e95f2d62bc88f76500dd5f45b85",
+    "step_2_resolve": "summary=return(call:new(literal(\"Arc::new\"), literal([\"call:Bool(Value::Bool, [b])\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:Bool(Value::Bool, [b])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, \"boolean\", [\"b\"], [\"bool\"], \"Arc < Value >\")",
+    "step_3_4_realize_input": {
+      "resolved_term_json": "{\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:Bool(Value::Bool, [b])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+      "function": "boolean",
+      "params": [
+        "b"
+      ],
+      "param_types": [
+        "bool"
+      ],
+      "return_type": "Arc < Value >"
+    },
+    "step_3_4_regenerated_source": "pub fn boolean(b: bool) -> Arc < Value > {\n    panic!(\"provekit-bind canonical: literal\")\n}\n",
+    "step_5_original_slice_cid": "blake3-512:f6eaf0ebbb9589ce23cad273e29d19da6ddacf20d3c7d654a41ed3d718f8ec94f0793648808318b18a375da350a8d4de300594fe649d84ac260c5cab460d8c3d",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_boolean_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_boolean_original.rs>",
+    "step_7_byte_identical_post_rustfmt": false,
+    "step_8_unified_diff": "--- original_rustfmt\n+++ regenerated_rustfmt\n@@ -1,3 +1,3 @@\n pub fn boolean(b: bool) -> Arc<Value> {\n-    Arc::new(Value::Bool(b))\n+    panic!(\"provekit-bind canonical: literal\")\n }\n",
+    "step_9_diff_classification": [
+      {
+        "hunk": "@@ -1,3 +1,3 @@\n pub fn boolean(b: bool) -> Arc<Value> {\n-    Arc::new(Value::Bool(b))\n+    panic!(\"provekit-bind canonical: literal\")\n }",
+        "class": "stub-body",
+        "explanation": "provekit-realize-rust-core emitted its stub body because the existing D7 resolved body lowering does not consume this widened Value constructor literal shape; the realized fallback concept is `literal`. Retire in v5 under the #964/#962 self-host follow-up without minting new ops."
+      }
+    ],
+    "step_10_dominant_diff_class": "stub-body",
+    "step_11_expected_diff_shape": "BYTE_IDENTICAL or CHARACTERIZED_DIFF; D7-v4 is diagnostic-only widening",
+    "step_12_empirical_root_cause": "The existing D7 resolved body lowering does not consume widened Value constructor literal shapes beyond Value::Null, so realize-rust-core falls through to the stub-body path; retire under #964/#962 follow-up without extending this diagnostic chunk.",
+    "regenerated_source_cid": "blake3-512:2d1ca31ddb6ecd27e9cd0c2052df03d3eb93dfcc3b58447bc58217797e73e8d414ba60ad894a5425a74063d0e86fbeb8512a5a3236af27d4c07568ec81a3ff5a",
+    "original_slice_post_rustfmt_cid": "blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a"
+  },
+  "verdict": "CHARACTERIZED_DIFF",
+  "dominant_diff_class": "stub-body",
+  "next_action": "D7-v4 is diagnostic-only. v5 should retire any CHARACTERIZED_DIFF classes surfaced here without minting new ProofIR ops or substrate concepts."
+}

--- a/bootstrap/D7-v4/integer_source_round_trip_receipt.json
+++ b/bootstrap/D7-v4/integer_source_round_trip_receipt.json
@@ -1,0 +1,44 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::integer",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:ca7c544cf2e01f70d422e41d75151d13d2adae92dafdec36d9368ae132ce2510954c4fd04ec49e50c36124f98a00edc4e6162f7c7d800427844d251f837c8f28",
+    "step_2_resolve": "summary=return(call:new(literal(\"Arc::new\"), literal([\"call:Integer(Value::Integer, [n])\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:Integer(Value::Integer, [n])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, \"integer\", [\"n\"], [\"i64\"], \"Arc < Value >\")",
+    "step_3_4_realize_input": {
+      "resolved_term_json": "{\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:Integer(Value::Integer, [n])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+      "function": "integer",
+      "params": [
+        "n"
+      ],
+      "param_types": [
+        "i64"
+      ],
+      "return_type": "Arc < Value >"
+    },
+    "step_3_4_regenerated_source": "pub fn integer(n: i64) -> Arc < Value > {\n    panic!(\"provekit-bind canonical: literal\")\n}\n",
+    "step_5_original_slice_cid": "blake3-512:16fb069e21ea947daa7ab28932a6ac3e59a68b64db291a698212446b273d25892a14de2b9b4ee1cd046b3832236c5c414fe67159b1a7964804c8e97355628f42",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_integer_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_integer_original.rs>",
+    "step_7_byte_identical_post_rustfmt": false,
+    "step_8_unified_diff": "--- original_rustfmt\n+++ regenerated_rustfmt\n@@ -1,3 +1,3 @@\n pub fn integer(n: i64) -> Arc<Value> {\n-    Arc::new(Value::Integer(n))\n+    panic!(\"provekit-bind canonical: literal\")\n }\n",
+    "step_9_diff_classification": [
+      {
+        "hunk": "@@ -1,3 +1,3 @@\n pub fn integer(n: i64) -> Arc<Value> {\n-    Arc::new(Value::Integer(n))\n+    panic!(\"provekit-bind canonical: literal\")\n }",
+        "class": "stub-body",
+        "explanation": "provekit-realize-rust-core emitted its stub body because the existing D7 resolved body lowering does not consume this widened Value constructor literal shape; the realized fallback concept is `literal`. Retire in v5 under the #964/#962 self-host follow-up without minting new ops."
+      }
+    ],
+    "step_10_dominant_diff_class": "stub-body",
+    "step_11_expected_diff_shape": "BYTE_IDENTICAL or CHARACTERIZED_DIFF; D7-v4 is diagnostic-only widening",
+    "step_12_empirical_root_cause": "The existing D7 resolved body lowering does not consume widened Value constructor literal shapes beyond Value::Null, so realize-rust-core falls through to the stub-body path; retire under #964/#962 follow-up without extending this diagnostic chunk.",
+    "regenerated_source_cid": "blake3-512:8d5eec68ae8ab471a3e238482bb2964e5b35a4d0a3037af91083c4074d8690b24c239d2cfc5e3e66f9bc3cbf6e482a0ff28df4b576666f27e372ea0edf0a775a",
+    "original_slice_post_rustfmt_cid": "blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf"
+  },
+  "verdict": "CHARACTERIZED_DIFF",
+  "dominant_diff_class": "stub-body",
+  "next_action": "D7-v4 is diagnostic-only. v5 should retire any CHARACTERIZED_DIFF classes surfaced here without minting new ProofIR ops or substrate concepts."
+}

--- a/bootstrap/D7-v4/string_source_round_trip_receipt.json
+++ b/bootstrap/D7-v4/string_source_round_trip_receipt.json
@@ -1,0 +1,44 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::string",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:8b3c7680416cb010f77eb30f5ef2c9284c3feadb16e3f5be7c48c44596557e46a94e5c7502cc0c106d1d39ec4ffcddd34431363c3f9e5e3e708e6cd09091b9c2",
+    "step_2_resolve": "summary=return(call:new(literal(\"Arc::new\"), literal([\"call:String(Value::String, [method:into(s, [])])\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:String(Value::String, [method:into(s, [])])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, \"string<S: Into<String>>\", [\"s\"], [\"S\"], \"Arc < Value >\")",
+    "step_3_4_realize_input": {
+      "resolved_term_json": "{\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:String(Value::String, [method:into(s, [])])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+      "function": "string<S: Into<String>>",
+      "params": [
+        "s"
+      ],
+      "param_types": [
+        "S"
+      ],
+      "return_type": "Arc < Value >"
+    },
+    "step_3_4_regenerated_source": "pub fn string<S: Into<String>>(s: S) -> Arc < Value > {\n    panic!(\"provekit-bind canonical: literal\")\n}\n",
+    "step_5_original_slice_cid": "blake3-512:2326ad724a2dfd96c463b1a1ae71d025e953d35a850ecbdd6954a409e2f4c0b100174ca0a6a62121b15b3a2f374b891110750617dc2b9466e11533df286122a7",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_string_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_string_original.rs>",
+    "step_7_byte_identical_post_rustfmt": false,
+    "step_8_unified_diff": "--- original_rustfmt\n+++ regenerated_rustfmt\n@@ -1,3 +1,3 @@\n pub fn string<S: Into<String>>(s: S) -> Arc<Value> {\n-    Arc::new(Value::String(s.into()))\n+    panic!(\"provekit-bind canonical: literal\")\n }\n",
+    "step_9_diff_classification": [
+      {
+        "hunk": "@@ -1,3 +1,3 @@\n pub fn string<S: Into<String>>(s: S) -> Arc<Value> {\n-    Arc::new(Value::String(s.into()))\n+    panic!(\"provekit-bind canonical: literal\")\n }",
+        "class": "stub-body",
+        "explanation": "provekit-realize-rust-core emitted its stub body because the existing D7 resolved body lowering does not consume this widened Value constructor literal shape; the realized fallback concept is `literal`. Retire in v5 under the #964/#962 self-host follow-up without minting new ops."
+      }
+    ],
+    "step_10_dominant_diff_class": "stub-body",
+    "step_11_expected_diff_shape": "BYTE_IDENTICAL or CHARACTERIZED_DIFF; D7-v4 is diagnostic-only widening",
+    "step_12_empirical_root_cause": "The existing D7 resolved body lowering does not consume widened Value constructor literal shapes beyond Value::Null, so realize-rust-core falls through to the stub-body path; retire under #964/#962 follow-up without extending this diagnostic chunk.",
+    "regenerated_source_cid": "blake3-512:5a1eab3177aab96ca611d3a3ea7bf4284f3b7ffbdbe2e4cdf7e1c805ab2253fa0a7fae31b811df532deeed93660944c5dd4d769d0017e54146b34f160e933c48",
+    "original_slice_post_rustfmt_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43"
+  },
+  "verdict": "CHARACTERIZED_DIFF",
+  "dominant_diff_class": "stub-body",
+  "next_action": "D7-v4 is diagnostic-only. v5 should retire any CHARACTERIZED_DIFF classes surfaced here without minting new ProofIR ops or substrate concepts."
+}

--- a/implementations/rust/libprovekit/tests/d7_v4_widen.rs
+++ b/implementations/rust/libprovekit/tests/d7_v4_widen.rs
@@ -11,7 +11,49 @@ use provekit_canonicalizer::blake3_512_of;
 use provekit_ir_types::Term;
 use serde_json::{json, Value as JsonValue};
 
-const EXPECTED_FIXTURE_CID: &str = "blake3-512:bcb10be48ad632abc71c406355b6d11b0191a959b523aa755ee00ad7496afa2270ce28821af4abcd5949427026fb16d8d8b38af702b1810dec3bdff810ec8f32";
+struct MethodCase {
+    method: &'static str,
+    fixture_file: &'static str,
+    receipt_file: &'static str,
+    original_needle: &'static str,
+    realize_function: &'static str,
+    params: &'static [&'static str],
+    param_types: &'static [&'static str],
+    return_type: &'static str,
+}
+
+const CASES: &[MethodCase] = &[
+    MethodCase {
+        method: "boolean",
+        fixture_file: "d7_v4_value_boolean.json",
+        receipt_file: "boolean_source_round_trip_receipt.json",
+        original_needle: "pub fn boolean(",
+        realize_function: "boolean",
+        params: &["b"],
+        param_types: &["bool"],
+        return_type: "Arc < Value >",
+    },
+    MethodCase {
+        method: "integer",
+        fixture_file: "d7_v4_value_integer.json",
+        receipt_file: "integer_source_round_trip_receipt.json",
+        original_needle: "pub fn integer(",
+        realize_function: "integer",
+        params: &["n"],
+        param_types: &["i64"],
+        return_type: "Arc < Value >",
+    },
+    MethodCase {
+        method: "string",
+        fixture_file: "d7_v4_value_string.json",
+        receipt_file: "string_source_round_trip_receipt.json",
+        original_needle: "pub fn string<",
+        realize_function: "string<S: Into<String>>",
+        params: &["s"],
+        param_types: &["S"],
+        return_type: "Arc < Value >",
+    },
+];
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -20,7 +62,7 @@ fn repo_root() -> PathBuf {
         .expect("canonical repo root")
 }
 
-fn fixture_path(repo_root: &Path) -> PathBuf {
+fn fixture_path(repo_root: &Path, case: &MethodCase) -> PathBuf {
     repo_root
         .join("implementations")
         .join("rust")
@@ -28,7 +70,7 @@ fn fixture_path(repo_root: &Path) -> PathBuf {
         .join("tests")
         .join("fixtures")
         .join("proofir")
-        .join("d7_v0_value_null.json")
+        .join(case.fixture_file)
 }
 
 fn source_path(repo_root: &Path) -> PathBuf {
@@ -40,19 +82,20 @@ fn source_path(repo_root: &Path) -> PathBuf {
         .join("value.rs")
 }
 
-fn receipt_path(repo_root: &Path, phase: &str) -> PathBuf {
+fn receipt_path(repo_root: &Path, case: &MethodCase) -> PathBuf {
     repo_root
         .join("bootstrap")
-        .join(phase)
-        .join("value_null_source_round_trip_receipt.json")
+        .join("D7-v4")
+        .join(case.receipt_file)
 }
 
-fn scratch_path(repo_root: &Path, name: &str) -> PathBuf {
+fn scratch_path(repo_root: &Path, case: &MethodCase, name: &str) -> PathBuf {
     repo_root
         .join("implementations")
         .join("rust")
         .join("target")
-        .join("d7-v1")
+        .join("d7-v4")
+        .join(case.method)
         .join(name)
 }
 
@@ -84,7 +127,7 @@ fn op_name_for_cid(fixture: &JsonValue, cid: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-fn value_null_catalog(fixture: &JsonValue) -> CatalogIndex {
+fn value_constructor_catalog(fixture: &JsonValue) -> CatalogIndex {
     let mut catalog = CatalogIndex::new();
     catalog.insert_op(
         "return",
@@ -102,27 +145,6 @@ fn value_null_catalog(fixture: &JsonValue) -> CatalogIndex {
         Some(resolved_sort("Expr")),
     );
     catalog
-}
-
-fn function_name_from_target(fixture: &JsonValue) -> String {
-    fixture["target"]
-        .as_str()
-        .expect("target string")
-        .rsplit("::")
-        .next()
-        .expect("method name")
-        .to_string()
-}
-
-fn return_type_from_loss_record(fixture: &JsonValue) -> String {
-    fixture["loss_record"]
-        .as_array()
-        .expect("loss_record array")
-        .iter()
-        .find(|loss| loss["loss"] == "return-type-user-defined")
-        .and_then(|loss| loss["detail"].as_str())
-        .expect("return-type-user-defined detail")
-        .to_string()
 }
 
 fn root_concept_name(fixture: &JsonValue, resolved: &ResolvedTerm) -> String {
@@ -158,9 +180,8 @@ fn term_summary(fixture: &JsonValue, resolved: &ResolvedTerm) -> String {
     format!("{} -> sort {}", inner(fixture, resolved), resolved.sort)
 }
 
-fn extract_value_null_slice(source: &str) -> String {
-    let needle = "pub fn null(";
-    let method = source.find(needle).expect("find Value::null method");
+fn extract_method_slice(source: &str, needle: &str) -> String {
+    let method = source.find(needle).expect("find target Value method");
     let start = source[..method]
         .rfind('\n')
         .map(|index| index + 1)
@@ -188,7 +209,7 @@ fn extract_value_null_slice(source: &str) -> String {
         }
     }
 
-    panic!("unterminated Value::null body");
+    panic!("unterminated target Value method body");
 }
 
 fn rustfmt_config(repo_root: &Path) -> Option<PathBuf> {
@@ -245,9 +266,9 @@ fn rustfmt_source(repo_root: &Path, input_label: &str, source: &str) -> (String,
     )
 }
 
-fn unified_diff(repo_root: &Path, original: &str, regenerated: &str) -> String {
-    let original_path = scratch_path(repo_root, "value_null_original.rustfmt.rs");
-    let regenerated_path = scratch_path(repo_root, "value_null_regenerated.rustfmt.rs");
+fn unified_diff(repo_root: &Path, case: &MethodCase, original: &str, regenerated: &str) -> String {
+    let original_path = scratch_path(repo_root, case, "original.rustfmt.rs");
+    let regenerated_path = scratch_path(repo_root, case, "regenerated.rustfmt.rs");
     std::fs::create_dir_all(original_path.parent().expect("diff scratch parent"))
         .expect("create diff scratch dir");
     std::fs::write(&original_path, original).expect("write original rustfmt text");
@@ -303,22 +324,14 @@ fn classify_diff(diff: &str, realization_is_stub: bool, concept_name: &str) -> V
                     "hunk": hunk,
                     "class": "stub-body",
                     "explanation": format!(
-                        "provekit-realize-rust-core emitted its stub body because no body template matched the extracted root concept `{concept_name}`; the current flat API cannot consume the nested resolved body tree."
+                        "provekit-realize-rust-core emitted its stub body because the existing D7 resolved body lowering does not consume this widened Value constructor literal shape; the realized fallback concept is `{concept_name}`. Retire in v5 under the #964/#962 self-host follow-up without minting new ops."
                     ),
-                })
-            } else if hunk.contains("-    Arc::new(Value::Null)")
-                && hunk.contains("+    new(Value::Null)")
-            {
-                json!({
-                    "hunk": hunk,
-                    "class": "name-difference",
-                    "explanation": "provekit-realize-rust-core consumed the resolved body tree and emitted the constructor expression, but the resolved term lacks the receiver prefix recorded by #962 trait-path-truncated.",
                 })
             } else {
                 json!({
                     "hunk": hunk,
                     "class": "structural-difference",
-                    "explanation": "post-rustfmt text differs in AST shape rather than spelling-only identifier changes.",
+                    "explanation": "post-rustfmt text differs in AST shape rather than byte-only spelling.",
                 })
             }
         })
@@ -337,157 +350,187 @@ fn dominant_diff_class(byte_identical: bool, classification: &[JsonValue]) -> St
     }
 }
 
-#[test]
-fn value_null_source_round_trip_receipt_is_complete() {
-    let repo_root = repo_root();
+fn stub_concept_name(source: &str, fallback: &str) -> String {
+    let marker = "provekit-bind canonical: ";
+    source
+        .find(marker)
+        .and_then(|start| {
+            let value_start = start + marker.len();
+            source[value_start..]
+                .find('"')
+                .map(|end| source[value_start..value_start + end].to_string())
+        })
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+fn run_case(repo_root: &Path, case: &MethodCase) -> JsonValue {
     let fixture_text =
-        std::fs::read_to_string(fixture_path(&repo_root)).expect("read D7-v0 value null fixture");
-    let fixture: JsonValue = serde_json::from_str(&fixture_text).expect("parse D7-v0 fixture");
+        std::fs::read_to_string(fixture_path(repo_root, case)).expect("read D7-v4 fixture");
+    let fixture: JsonValue = serde_json::from_str(&fixture_text).expect("parse D7-v4 fixture");
     let fixture_cid = json_cid(&fixture).expect("fixture CID");
-    assert_eq!(fixture_cid, EXPECTED_FIXTURE_CID);
 
     let term: Term =
         serde_json::from_value(fixture["proofir_term"].clone()).expect("decode ProofIR term");
-    let catalog = value_null_catalog(&fixture);
-    let resolved = proofir_resolve(&term, &catalog).expect("resolve D7-v0 ProofIR term");
+    let catalog = value_constructor_catalog(&fixture);
+    let resolved = proofir_resolve(&term, &catalog).expect("resolve D7-v4 ProofIR term");
     let resolved_jcs = serializable_jcs(&resolved).expect("ResolvedTerm JCS");
     let resolved_summary = term_summary(&fixture, &resolved);
 
-    let function = function_name_from_target(&fixture);
-    let params: Vec<String> = Vec::new();
-    let param_types: Vec<String> = Vec::new();
-    let return_type = return_type_from_loss_record(&fixture);
+    let params: Vec<String> = case
+        .params
+        .iter()
+        .map(|param| (*param).to_string())
+        .collect();
+    let param_types: Vec<String> = case
+        .param_types
+        .iter()
+        .map(|ty| (*ty).to_string())
+        .collect();
     let concept_name = root_concept_name(&fixture, &resolved);
-    assert!(
-        !fixture["loss_record"]
-            .as_array()
-            .expect("loss_record array")
-            .iter()
-            .any(|loss| {
-                loss["loss"] == "trait-path-truncated" && loss["detail"] == "Arc :: new"
-            }),
-        "D7-v3 fixture must retire Arc::new trait-path-truncated loss"
-    );
 
     let source_text =
-        std::fs::read_to_string(source_path(&repo_root)).expect("read canonicalizer value.rs");
-    let original_slice = extract_value_null_slice(&source_text);
+        std::fs::read_to_string(source_path(repo_root)).expect("read canonicalizer value.rs");
+    let original_slice = extract_method_slice(&source_text, case.original_needle);
     let original_slice_cid = blake3_512_of(original_slice.as_bytes());
-    let (original_rustfmt, original_rustfmt_command) =
-        rustfmt_source(&repo_root, "value_null_original.rs", &original_slice);
+    let (original_rustfmt, original_rustfmt_command) = rustfmt_source(
+        repo_root,
+        &format!("value_{}_original.rs", case.method),
+        &original_slice,
+    );
 
-    let v3_realization = provekit_realize_rust_core::emit_from_resolved(
+    let realization = provekit_realize_rust_core::emit_from_resolved(
         &resolved_jcs,
-        &function,
+        case.realize_function,
         &params,
         &param_types,
-        &return_type,
+        case.return_type,
     );
-    let (v3_regenerated_rustfmt, v3_regenerated_rustfmt_command) = rustfmt_source(
-        &repo_root,
-        "value_null_regenerated_v3.rs",
-        &v3_realization.source,
+    let (regenerated_rustfmt, regenerated_rustfmt_command) = rustfmt_source(
+        repo_root,
+        &format!("value_{}_regenerated.rs", case.method),
+        &realization.source,
     );
-    let v3_byte_identical = v3_regenerated_rustfmt.as_bytes() == original_rustfmt.as_bytes();
-    let v3_diff = unified_diff(&repo_root, &original_rustfmt, &v3_regenerated_rustfmt);
-    let v3_classification = classify_diff(&v3_diff, v3_realization.is_stub, &concept_name);
-    let v3_verdict = if v3_byte_identical {
+    let byte_identical = regenerated_rustfmt.as_bytes() == original_rustfmt.as_bytes();
+    let diff = unified_diff(repo_root, case, &original_rustfmt, &regenerated_rustfmt);
+    let diff_concept_name = if realization.is_stub {
+        stub_concept_name(&realization.source, &concept_name)
+    } else {
+        concept_name
+    };
+    let classification = classify_diff(&diff, realization.is_stub, &diff_concept_name);
+    let verdict = if byte_identical {
         "BYTE_IDENTICAL"
     } else {
         "CHARACTERIZED_DIFF"
     };
-    let v3_dominant_diff_class = dominant_diff_class(v3_byte_identical, &v3_classification);
-    let v3_regenerated_source_cid = blake3_512_of(v3_regenerated_rustfmt.as_bytes());
+    let dominant_diff_class = dominant_diff_class(byte_identical, &classification);
+    let regenerated_source_cid = blake3_512_of(regenerated_rustfmt.as_bytes());
     let original_slice_post_rustfmt_cid = blake3_512_of(original_rustfmt.as_bytes());
 
-    if !v3_byte_identical {
+    if !byte_identical {
         assert!(
-            !v3_classification.is_empty(),
-            "non-identical source must have a classified diff hunk"
+            !classification.is_empty(),
+            "non-identical source must have a classified diff hunk for {}",
+            case.method
         );
     }
 
-    assert_eq!(v3_verdict, "BYTE_IDENTICAL");
-    assert_eq!(v3_dominant_diff_class, "byte-identical");
-    assert_eq!(v3_diff, "");
-    assert_eq!(v3_regenerated_source_cid, original_slice_post_rustfmt_cid);
-
-    let v3_receipt = json!({
+    json!({
         "version": "1",
         "target": {
             "crate": "provekit-canonicalizer",
-            "function": "impl Value::null",
+            "function": format!("impl Value::{}", case.method),
             "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs",
         },
         "pipeline": {
-            "step_1_fixture_cid": EXPECTED_FIXTURE_CID,
+            "step_1_fixture_cid": fixture_cid,
             "step_2_resolve": format!("summary={resolved_summary}; jcs={resolved_jcs}"),
             "step_3_4_realize_command": format!(
-                "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, {function:?}, &[], &[], {return_type:?})"
+                "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, {:?}, {:?}, {:?}, {:?})",
+                case.realize_function, params, param_types, case.return_type
             ),
             "step_3_4_realize_input": {
                 "resolved_term_json": resolved_jcs,
-                "function": function,
+                "function": case.realize_function,
                 "params": params,
                 "param_types": param_types,
-                "return_type": return_type,
+                "return_type": case.return_type,
             },
-            "step_3_4_regenerated_source": v3_realization.source,
+            "step_3_4_regenerated_source": realization.source,
             "step_5_original_slice_cid": original_slice_cid,
-            "step_6_rustfmt_command": format!("{v3_regenerated_rustfmt_command}\n{original_rustfmt_command}"),
-            "step_7_byte_identical_post_rustfmt": v3_byte_identical,
-            "step_8_unified_diff": v3_diff,
-            "step_9_diff_classification": v3_classification,
-            "step_10_dominant_diff_class": v3_dominant_diff_class.clone(),
-            "step_11_expected_diff_shape": "post-rustfmt byte-identical",
-            "step_12_empirical_root_cause": "#962 trait-path-truncated is retired for this call:new Value::null body because the resolved term now carries Arc::new.",
-            "regenerated_source_cid": v3_regenerated_source_cid,
+            "step_6_rustfmt_command": format!("{regenerated_rustfmt_command}\n{original_rustfmt_command}"),
+            "step_7_byte_identical_post_rustfmt": byte_identical,
+            "step_8_unified_diff": diff,
+            "step_9_diff_classification": classification,
+            "step_10_dominant_diff_class": dominant_diff_class.clone(),
+            "step_11_expected_diff_shape": "BYTE_IDENTICAL or CHARACTERIZED_DIFF; D7-v4 is diagnostic-only widening",
+            "step_12_empirical_root_cause": if byte_identical {
+                "The existing D7 resolved body lowering emitted the checked-in Value constructor body byte-for-byte after rustfmt.".to_string()
+            } else {
+                "The existing D7 resolved body lowering does not consume widened Value constructor literal shapes beyond Value::Null, so realize-rust-core falls through to the stub-body path; retire under #964/#962 follow-up without extending this diagnostic chunk.".to_string()
+            },
+            "regenerated_source_cid": regenerated_source_cid,
             "original_slice_post_rustfmt_cid": original_slice_post_rustfmt_cid,
         },
-        "verdict": v3_verdict,
-        "dominant_diff_class": v3_dominant_diff_class,
-        "next_action": "D7 single-function terminus reached for Value::null; next chunks widen the empirical claim to module-level source round trips.",
-    });
+        "verdict": verdict,
+        "dominant_diff_class": dominant_diff_class,
+        "next_action": "D7-v4 is diagnostic-only. v5 should retire any CHARACTERIZED_DIFF classes surfaced here without minting new ProofIR ops or substrate concepts.",
+    })
+}
 
-    if let Ok(out_dir) = std::env::var("D7_V3_RECEIPT_OUT_DIR") {
-        let v3_receipt_path =
-            PathBuf::from(out_dir).join("value_null_source_round_trip_receipt.json");
-        std::fs::create_dir_all(v3_receipt_path.parent().expect("receipt parent"))
-            .expect("create generated D7-v3 receipt dir");
-        std::fs::write(
-            &v3_receipt_path,
-            format!(
-                "{}\n",
-                serde_json::to_string_pretty(&v3_receipt).expect("pretty v3 receipt")
-            ),
-        )
-        .expect("write generated D7-v3 receipt");
-
-        let v3_parsed: JsonValue = serde_json::from_str(
-            &std::fs::read_to_string(&v3_receipt_path).expect("read generated D7-v3 receipt"),
-        )
-        .expect("parse generated D7-v3 receipt");
-        assert_eq!(v3_parsed["verdict"].as_str(), Some("BYTE_IDENTICAL"));
-        assert_eq!(
-            v3_parsed["dominant_diff_class"].as_str(),
-            Some("byte-identical")
+#[test]
+fn widened_value_constructor_receipts_are_produced() {
+    let repo_root = repo_root();
+    for case in CASES {
+        let receipt = run_case(&repo_root, case);
+        let verdict = receipt["verdict"].as_str().expect("receipt verdict");
+        assert!(
+            matches!(verdict, "BYTE_IDENTICAL" | "CHARACTERIZED_DIFF" | "BLOCKED"),
+            "unexpected verdict for {}: {verdict}",
+            case.method
         );
-        println!("v3_receipt_path={}", v3_receipt_path.display());
-        println!("v3_verdict={v3_verdict}");
-        return;
-    }
 
-    let v3_receipt_path = receipt_path(&repo_root, "D7-v3");
-    let v3_parsed: JsonValue = serde_json::from_str(
-        &std::fs::read_to_string(&v3_receipt_path).expect("read committed D7-v3 receipt"),
-    )
-    .expect("parse committed D7-v3 receipt");
-    assert_eq!(v3_parsed, v3_receipt, "committed D7-v3 receipt drifted");
-    assert_eq!(v3_parsed["verdict"].as_str(), Some("BYTE_IDENTICAL"));
-    assert_eq!(
-        v3_parsed["dominant_diff_class"].as_str(),
-        Some("byte-identical")
-    );
-    println!("v3_receipt_path={}", v3_receipt_path.display());
-    println!("v3_verdict={v3_verdict}");
+        if let Ok(out_dir) = std::env::var("D7_V4_RECEIPT_OUT_DIR") {
+            let path = PathBuf::from(out_dir).join(case.receipt_file);
+            std::fs::create_dir_all(path.parent().expect("receipt parent"))
+                .expect("create generated D7-v4 receipt dir");
+            std::fs::write(
+                &path,
+                format!(
+                    "{}\n",
+                    serde_json::to_string_pretty(&receipt).expect("pretty receipt")
+                ),
+            )
+            .expect("write generated D7-v4 receipt");
+            println!(
+                "d7_v4_{} verdict={} fixture_cid={} generated_receipt={}",
+                case.method,
+                verdict,
+                receipt["pipeline"]["step_1_fixture_cid"]
+                    .as_str()
+                    .expect("fixture cid"),
+                path.display()
+            );
+            continue;
+        }
+
+        let path = receipt_path(&repo_root, case);
+        let committed_text = std::fs::read_to_string(&path).expect("read committed D7-v4 receipt");
+        let committed: JsonValue =
+            serde_json::from_str(&committed_text).expect("parse committed D7-v4 receipt");
+        assert_eq!(
+            committed, receipt,
+            "committed D7-v4 receipt drifted for {}",
+            case.method
+        );
+        println!(
+            "d7_v4_{} verdict={} fixture_cid={} receipt={}",
+            case.method,
+            verdict,
+            receipt["pipeline"]["step_1_fixture_cid"]
+                .as_str()
+                .expect("fixture cid"),
+            path.display()
+        );
+    }
 }

--- a/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_boolean.json
+++ b/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_boolean.json
@@ -1,0 +1,66 @@
+{
+  "kind": "proofir-real-lift-fixture",
+  "target": "impl Value::boolean",
+  "source": "provekit-canonicalizer/src/value.rs",
+  "handling": "handles-partially-with-loss-record",
+  "loss_record": [
+    {
+      "detail": "derive",
+      "loss": "procedural-macro"
+    },
+    {
+      "detail": "Arc < Value >",
+      "loss": "return-type-user-defined"
+    },
+    {
+      "detail": "Arc::new",
+      "loss": "ffi-call-unresolved-effect"
+    },
+    {
+      "detail": "Value::Bool",
+      "loss": "ffi-call-unresolved-effect"
+    }
+  ],
+  "term_surface": "return(call:new(Arc::new, [call:Bool(Value::Bool, [b])]))",
+  "proofir_catalog_ops": [
+    {
+      "name": "return",
+      "op_cid": "blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6"
+    },
+    {
+      "name": "call:new",
+      "op_cid": "blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8"
+    }
+  ],
+  "proofir_term": {
+    "kind": "ctor",
+    "name": "return",
+    "args": [
+      {
+        "kind": "ctor",
+        "name": "call:new",
+        "args": [
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "FnContract"
+            },
+            "value": "Arc::new"
+          },
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "ListOfExpr"
+            },
+            "value": [
+              "call:Bool(Value::Bool, [b])"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "trim_note": "walk_emit term output was trimmed to one bridge-compatible ProofIR term; the raw rust-algebra envelope fields not consumed by proofir_resolve are represented by target, source, handling, term_surface, proofir_catalog_ops, and loss_record. The widened nested constructor surface is preserved inside the ListOfExpr literal without minting new ops."
+}

--- a/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_integer.json
+++ b/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_integer.json
@@ -1,0 +1,66 @@
+{
+  "kind": "proofir-real-lift-fixture",
+  "target": "impl Value::integer",
+  "source": "provekit-canonicalizer/src/value.rs",
+  "handling": "handles-partially-with-loss-record",
+  "loss_record": [
+    {
+      "detail": "derive",
+      "loss": "procedural-macro"
+    },
+    {
+      "detail": "Arc < Value >",
+      "loss": "return-type-user-defined"
+    },
+    {
+      "detail": "Arc::new",
+      "loss": "ffi-call-unresolved-effect"
+    },
+    {
+      "detail": "Value::Integer",
+      "loss": "ffi-call-unresolved-effect"
+    }
+  ],
+  "term_surface": "return(call:new(Arc::new, [call:Integer(Value::Integer, [n])]))",
+  "proofir_catalog_ops": [
+    {
+      "name": "return",
+      "op_cid": "blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6"
+    },
+    {
+      "name": "call:new",
+      "op_cid": "blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8"
+    }
+  ],
+  "proofir_term": {
+    "kind": "ctor",
+    "name": "return",
+    "args": [
+      {
+        "kind": "ctor",
+        "name": "call:new",
+        "args": [
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "FnContract"
+            },
+            "value": "Arc::new"
+          },
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "ListOfExpr"
+            },
+            "value": [
+              "call:Integer(Value::Integer, [n])"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "trim_note": "walk_emit term output was trimmed to one bridge-compatible ProofIR term; the raw rust-algebra envelope fields not consumed by proofir_resolve are represented by target, source, handling, term_surface, proofir_catalog_ops, and loss_record. The widened nested constructor surface is preserved inside the ListOfExpr literal without minting new ops."
+}

--- a/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_string.json
+++ b/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_string.json
@@ -1,0 +1,70 @@
+{
+  "kind": "proofir-real-lift-fixture",
+  "target": "impl Value::string",
+  "source": "provekit-canonicalizer/src/value.rs",
+  "handling": "handles-partially-with-loss-record",
+  "loss_record": [
+    {
+      "detail": "derive",
+      "loss": "procedural-macro"
+    },
+    {
+      "detail": "Arc < Value >",
+      "loss": "return-type-user-defined"
+    },
+    {
+      "detail": "Arc::new",
+      "loss": "ffi-call-unresolved-effect"
+    },
+    {
+      "detail": "Value::String",
+      "loss": "ffi-call-unresolved-effect"
+    },
+    {
+      "detail": "into",
+      "loss": "ffi-call-unresolved-effect"
+    }
+  ],
+  "term_surface": "return(call:new(Arc::new, [call:String(Value::String, [method:into(s, [])])]))",
+  "proofir_catalog_ops": [
+    {
+      "name": "return",
+      "op_cid": "blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6"
+    },
+    {
+      "name": "call:new",
+      "op_cid": "blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8"
+    }
+  ],
+  "proofir_term": {
+    "kind": "ctor",
+    "name": "return",
+    "args": [
+      {
+        "kind": "ctor",
+        "name": "call:new",
+        "args": [
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "FnContract"
+            },
+            "value": "Arc::new"
+          },
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "ListOfExpr"
+            },
+            "value": [
+              "call:String(Value::String, [method:into(s, [])])"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "trim_note": "walk_emit term output was trimmed to one bridge-compatible ProofIR term; the raw rust-algebra envelope fields not consumed by proofir_resolve are represented by target, source, handling, term_surface, proofir_catalog_ops, and loss_record. The widened nested constructor surface is preserved inside the ListOfExpr literal without minting new ops."
+}


### PR DESCRIPTION
Diagnostic widening of D7-v3's BYTE_IDENTICAL Value::null result to the three remaining simple Value constructors.

## Verdicts

| Method | Verdict | Dominant gap |
| --- | --- | --- |
| boolean | CHARACTERIZED_DIFF | stub-body |
| integer | CHARACTERIZED_DIFF | stub-body |
| string  | CHARACTERIZED_DIFF | stub-body |

Expected outcome -- the existing `emit_from_resolved` in `provekit-realize-rust-core` handles only the `Value::Null` unit-variant literal shape. Bool/Integer/String constructor literals fall through to the canonical panic stub.

## Fixture CIDs

- boolean: `blake3-512:b2c54035...`
- integer: `blake3-512:ca7c544c...`
- string : `blake3-512:8b3c7680...`

## Pipeline + tests

The d7_v4_widen integration test runs the v3-equivalent round-trip pipeline (lift_rust -> proofir_resolve -> realize_rust -> rustfmt -> byte-compare) for each method, produces a receipt, and asserts verdict in {BYTE_IDENTICAL, CHARACTERIZED_DIFF, BLOCKED}. All three are CHARACTERIZED_DIFF with consistent classification.

Existing tests (d7_v1, d7_v0 proofir_bridge_real_lift) stay green.

The d7_v1 test was minorly adjusted to compare against the committed receipt by default (opt-in generated-output path) so the test does not mutate bootstrap/ artifacts.

## Scope

Purely diagnostic. NO realizer extensions. NO lifter extensions. NO substrate changes.

## Next: D7-v5

Retires the stub-body class for `Value::<Variant>(arg)` shape by extending `provekit-realize-rust-core::emit_from_resolved` to handle constructor literals with one local-scope argument. Per-language kit only; admin-merge expected. After v5 lands, all three constructors should reach BYTE_IDENTICAL.

Refs #943.