### PR TITLE
feat(bootstrap D7-v5): retire stub-body for Value::<Variant>(<param_ref>) -- boolean+integer BYTE_IDENTICAL, string surfaces method:into shape

### DIFF
--- a/bootstrap/D7-v4/README.md
+++ b/bootstrap/D7-v4/README.md
@@ -27,8 +27,8 @@ implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_string.json.
 
 | method | verdict | dominant class | fixture CID |
 | --- | --- | --- | --- |
-| boolean | CHARACTERIZED_DIFF | stub-body | blake3-512:b2c54035098e0bc287eca146fea6f697d56547d13d2e620cc38cbfda6b2f65d1994eeebe64aa3d8f3ac91843c45ab423b5917e95f2d62bc88f76500dd5f45b85 |
-| integer | CHARACTERIZED_DIFF | stub-body | blake3-512:ca7c544cf2e01f70d422e41d75151d13d2adae92dafdec36d9368ae132ce2510954c4fd04ec49e50c36124f98a00edc4e6162f7c7d800427844d251f837c8f28 |
+| boolean | BYTE_IDENTICAL | byte-identical | blake3-512:b2c54035098e0bc287eca146fea6f697d56547d13d2e620cc38cbfda6b2f65d1994eeebe64aa3d8f3ac91843c45ab423b5917e95f2d62bc88f76500dd5f45b85 |
+| integer | BYTE_IDENTICAL | byte-identical | blake3-512:ca7c544cf2e01f70d422e41d75151d13d2adae92dafdec36d9368ae132ce2510954c4fd04ec49e50c36124f98a00edc4e6162f7c7d800427844d251f837c8f28 |
 | string | CHARACTERIZED_DIFF | stub-body | blake3-512:8b3c7680416cb010f77eb30f5ef2c9284c3feadb16e3f5be7c48c44596557e46a94e5c7502cc0c106d1d39ec4ffcddd34431363c3f9e5e3e708e6cd09091b9c2 |
 
 The walker already emits widened nested constructor surfaces.
@@ -40,10 +40,8 @@ The bridge fixture keeps only existing return and call:new catalog ops.
 The widened nested constructor surface is preserved inside the ListOfExpr literal.
 That keeps the fixture bridge-compatible without adding ProofIR ops.
 
-provekit_realize_rust_core::emit_from_resolved still recognizes Value::Null only.
-For these three widened literal shapes it falls through to the stub-body path.
-The regenerated source body is panic!("provekit-bind canonical: literal").
-That is the expected D7-v4 deliverable.
+After D7-v5, provekit_realize_rust_core::emit_from_resolved recognizes Value::Null and the direct one-parameter Value::Bool and Value::Integer literal-list shapes.
+The string fixture still falls through to panic!("provekit-bind canonical: literal") because its argument surface is method:into(s, []), not a direct first-parameter reference.
 
 bootstrap/D7-v4/boolean_source_round_trip_receipt.json.
 bootstrap/D7-v4/integer_source_round_trip_receipt.json.
@@ -52,8 +50,8 @@ bootstrap/D7-v4/string_source_round_trip_receipt.json.
 The D7-v4 integration test is implementations/rust/libprovekit/tests/d7_v4_widen.rs.
 It recomputes the fixture CID, resolves the ProofIR term, realizes Rust, rustfmts both sides, compares bytes, classifies the diff, and checks the committed receipt.
 It accepts BYTE_IDENTICAL, CHARACTERIZED_DIFF, or BLOCKED.
-It does not assert byte identity.
+It does not assert byte identity for all three cases because string remains outside the D7-v5 direct-parameter shape.
 
-v5 should retire these stub-body differences under the #964/#962 self-host follow-up.
-That retirement should consume the existing widened literal shapes.
-It should not use this diagnostic receipt as license to add substrate concepts.
+v5 retired the direct one-parameter stub-body differences under the #964/#962 self-host follow-up.
+The remaining string method-call argument surface is recorded in bootstrap/D7-v5.
+It should not be used as license to add substrate concepts.

--- a/bootstrap/D7-v4/boolean_source_round_trip_receipt.json
+++ b/bootstrap/D7-v4/boolean_source_round_trip_receipt.json
@@ -20,25 +20,19 @@
       ],
       "return_type": "Arc < Value >"
     },
-    "step_3_4_regenerated_source": "pub fn boolean(b: bool) -> Arc < Value > {\n    panic!(\"provekit-bind canonical: literal\")\n}\n",
+    "step_3_4_regenerated_source": "pub fn boolean(b: bool) -> Arc < Value > {\n    Arc::new(Value::Bool(b))\n}\n",
     "step_5_original_slice_cid": "blake3-512:f6eaf0ebbb9589ce23cad273e29d19da6ddacf20d3c7d654a41ed3d718f8ec94f0793648808318b18a375da350a8d4de300594fe649d84ac260c5cab460d8c3d",
     "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_boolean_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_boolean_original.rs>",
-    "step_7_byte_identical_post_rustfmt": false,
-    "step_8_unified_diff": "--- original_rustfmt\n+++ regenerated_rustfmt\n@@ -1,3 +1,3 @@\n pub fn boolean(b: bool) -> Arc<Value> {\n-    Arc::new(Value::Bool(b))\n+    panic!(\"provekit-bind canonical: literal\")\n }\n",
-    "step_9_diff_classification": [
-      {
-        "hunk": "@@ -1,3 +1,3 @@\n pub fn boolean(b: bool) -> Arc<Value> {\n-    Arc::new(Value::Bool(b))\n+    panic!(\"provekit-bind canonical: literal\")\n }",
-        "class": "stub-body",
-        "explanation": "provekit-realize-rust-core emitted its stub body because the existing D7 resolved body lowering does not consume this widened Value constructor literal shape; the realized fallback concept is `literal`. Retire in v5 under the #964/#962 self-host follow-up without minting new ops."
-      }
-    ],
-    "step_10_dominant_diff_class": "stub-body",
+    "step_7_byte_identical_post_rustfmt": true,
+    "step_8_unified_diff": "",
+    "step_9_diff_classification": [],
+    "step_10_dominant_diff_class": "byte-identical",
     "step_11_expected_diff_shape": "BYTE_IDENTICAL or CHARACTERIZED_DIFF; D7-v4 is diagnostic-only widening",
-    "step_12_empirical_root_cause": "The existing D7 resolved body lowering does not consume widened Value constructor literal shapes beyond Value::Null, so realize-rust-core falls through to the stub-body path; retire under #964/#962 follow-up without extending this diagnostic chunk.",
-    "regenerated_source_cid": "blake3-512:2d1ca31ddb6ecd27e9cd0c2052df03d3eb93dfcc3b58447bc58217797e73e8d414ba60ad894a5425a74063d0e86fbeb8512a5a3236af27d4c07568ec81a3ff5a",
+    "step_12_empirical_root_cause": "The existing D7 resolved body lowering emitted the checked-in Value constructor body byte-for-byte after rustfmt.",
+    "regenerated_source_cid": "blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a",
     "original_slice_post_rustfmt_cid": "blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a"
   },
-  "verdict": "CHARACTERIZED_DIFF",
-  "dominant_diff_class": "stub-body",
+  "verdict": "BYTE_IDENTICAL",
+  "dominant_diff_class": "byte-identical",
   "next_action": "D7-v4 is diagnostic-only. v5 should retire any CHARACTERIZED_DIFF classes surfaced here without minting new ProofIR ops or substrate concepts."
 }

--- a/bootstrap/D7-v4/integer_source_round_trip_receipt.json
+++ b/bootstrap/D7-v4/integer_source_round_trip_receipt.json
@@ -20,25 +20,19 @@
       ],
       "return_type": "Arc < Value >"
     },
-    "step_3_4_regenerated_source": "pub fn integer(n: i64) -> Arc < Value > {\n    panic!(\"provekit-bind canonical: literal\")\n}\n",
+    "step_3_4_regenerated_source": "pub fn integer(n: i64) -> Arc < Value > {\n    Arc::new(Value::Integer(n))\n}\n",
     "step_5_original_slice_cid": "blake3-512:16fb069e21ea947daa7ab28932a6ac3e59a68b64db291a698212446b273d25892a14de2b9b4ee1cd046b3832236c5c414fe67159b1a7964804c8e97355628f42",
     "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_integer_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_integer_original.rs>",
-    "step_7_byte_identical_post_rustfmt": false,
-    "step_8_unified_diff": "--- original_rustfmt\n+++ regenerated_rustfmt\n@@ -1,3 +1,3 @@\n pub fn integer(n: i64) -> Arc<Value> {\n-    Arc::new(Value::Integer(n))\n+    panic!(\"provekit-bind canonical: literal\")\n }\n",
-    "step_9_diff_classification": [
-      {
-        "hunk": "@@ -1,3 +1,3 @@\n pub fn integer(n: i64) -> Arc<Value> {\n-    Arc::new(Value::Integer(n))\n+    panic!(\"provekit-bind canonical: literal\")\n }",
-        "class": "stub-body",
-        "explanation": "provekit-realize-rust-core emitted its stub body because the existing D7 resolved body lowering does not consume this widened Value constructor literal shape; the realized fallback concept is `literal`. Retire in v5 under the #964/#962 self-host follow-up without minting new ops."
-      }
-    ],
-    "step_10_dominant_diff_class": "stub-body",
+    "step_7_byte_identical_post_rustfmt": true,
+    "step_8_unified_diff": "",
+    "step_9_diff_classification": [],
+    "step_10_dominant_diff_class": "byte-identical",
     "step_11_expected_diff_shape": "BYTE_IDENTICAL or CHARACTERIZED_DIFF; D7-v4 is diagnostic-only widening",
-    "step_12_empirical_root_cause": "The existing D7 resolved body lowering does not consume widened Value constructor literal shapes beyond Value::Null, so realize-rust-core falls through to the stub-body path; retire under #964/#962 follow-up without extending this diagnostic chunk.",
-    "regenerated_source_cid": "blake3-512:8d5eec68ae8ab471a3e238482bb2964e5b35a4d0a3037af91083c4074d8690b24c239d2cfc5e3e66f9bc3cbf6e482a0ff28df4b576666f27e372ea0edf0a775a",
+    "step_12_empirical_root_cause": "The existing D7 resolved body lowering emitted the checked-in Value constructor body byte-for-byte after rustfmt.",
+    "regenerated_source_cid": "blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf",
     "original_slice_post_rustfmt_cid": "blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf"
   },
-  "verdict": "CHARACTERIZED_DIFF",
-  "dominant_diff_class": "stub-body",
+  "verdict": "BYTE_IDENTICAL",
+  "dominant_diff_class": "byte-identical",
   "next_action": "D7-v4 is diagnostic-only. v5 should retire any CHARACTERIZED_DIFF classes surfaced here without minting new ProofIR ops or substrate concepts."
 }

--- a/bootstrap/D7-v5/README.md
+++ b/bootstrap/D7-v5/README.md
@@ -1,0 +1,35 @@
+# D7-v5 Value variant argument realizer receipt
+
+Scope: retire the direct one-parameter Value constructor stub-body class after D7-v4.
+Parent arc: #943.
+Base commit: 355ed128.
+Branch: bootstrap/D7-v5-retire-stub-body-variant-arg.
+
+D7-v5 extends implementations/rust/provekit-realize-rust-core/src/lib.rs.
+The only new realizer shape is:
+
+return(call:new(receiver, [call:<Variant>(Value::<Variant>, [first_param])]))
+
+The receiver must still be new or an ::new path.
+The literal-list payload must contain exactly one constructor surface.
+The constructor argument must exactly match the function's first formal parameter.
+The accepted Value variants are Value::Bool, Value::Integer, and Value::String.
+
+Unsupported shapes still fall through to the canonical literal stub.
+That includes multiple constructor args, nested calls inside the variant arg, computed-expression args, Value::Array, and Value::Object.
+
+| method | v5 verdict | dominant class | regenerated source CID | original post-rustfmt CID |
+| --- | --- | --- | --- | --- |
+| boolean | BYTE_IDENTICAL | byte-identical | blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a | blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a |
+| integer | BYTE_IDENTICAL | byte-identical | blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf | blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf |
+| string | CHARACTERIZED_DIFF | stub-body | blake3-512:5a1eab3177aab96ca611d3a3ea7bf4284f3b7ffbdbe2e4cdf7e1c805ab2253fa0a7fae31b811df532deeed93660944c5dd4d769d0017e54146b34f160e933c48 | blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43 |
+
+boolean and integer now reach BYTE_IDENTICAL from the D7-v4 fixtures.
+string does not: its actual v4 fixture is return(call:new(Arc::new, [call:String(Value::String, [method:into(s, [])])])).
+That is a nested method-call argument, so D7-v5 records it as CHARACTERIZED_DIFF and leaves it for the next step rather than broadening this patch.
+
+The D7-v4 receipt files were refreshed for the current realizer output.
+bootstrap/D7-v5/source_round_trip_receipt.json records the mixed v5 outcome.
+
+Next: D7-v6 should retire the string method:into(s, []) argument surface and then add the submodule-level source round-trip test for implementations/rust/provekit-canonicalizer/src/value.rs.
+That submodule-level test should cover the closed Value::null, Value::boolean, Value::integer, and Value::string cluster before Value::array or Value::object are attempted.

--- a/bootstrap/D7-v5/source_round_trip_receipt.json
+++ b/bootstrap/D7-v5/source_round_trip_receipt.json
@@ -1,0 +1,72 @@
+{
+  "version": "1",
+  "arc": "D7-v5",
+  "parent_arc": "#943",
+  "base_commit": "355ed128",
+  "branch": "bootstrap/D7-v5-retire-stub-body-variant-arg",
+  "implementation": {
+    "crate": "provekit-realize-rust-core",
+    "entrypoint": "emit_from_resolved",
+    "extended_file": "implementations/rust/provekit-realize-rust-core/src/lib.rs",
+    "retired_shape": "return(call:new(receiver, [call:<Variant>(Value::<Variant>, [first_param])]))",
+    "accepted_receiver": "new or *::new",
+    "accepted_variants": [
+      "Value::Bool",
+      "Value::Integer",
+      "Value::String"
+    ],
+    "scope_guard": [
+      "literal-list payload contains exactly one constructor surface",
+      "constructor argument exactly equals params[0]",
+      "no multiple variant args",
+      "no nested calls inside the variant arg",
+      "no computed-expression args",
+      "no Value::Array or Value::Object handling"
+    ]
+  },
+  "outcomes": [
+    {
+      "method": "impl Value::boolean",
+      "fixture": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_boolean.json",
+      "receipt": "bootstrap/D7-v4/boolean_source_round_trip_receipt.json",
+      "term_surface": "return(call:new(Arc::new, [call:Bool(Value::Bool, [b])]))",
+      "verdict": "BYTE_IDENTICAL",
+      "dominant_diff_class": "byte-identical",
+      "regenerated_source_cid": "blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a",
+      "original_slice_post_rustfmt_cid": "blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a"
+    },
+    {
+      "method": "impl Value::integer",
+      "fixture": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_integer.json",
+      "receipt": "bootstrap/D7-v4/integer_source_round_trip_receipt.json",
+      "term_surface": "return(call:new(Arc::new, [call:Integer(Value::Integer, [n])]))",
+      "verdict": "BYTE_IDENTICAL",
+      "dominant_diff_class": "byte-identical",
+      "regenerated_source_cid": "blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf",
+      "original_slice_post_rustfmt_cid": "blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf"
+    },
+    {
+      "method": "impl Value::string",
+      "fixture": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_string.json",
+      "receipt": "bootstrap/D7-v4/string_source_round_trip_receipt.json",
+      "term_surface": "return(call:new(Arc::new, [call:String(Value::String, [method:into(s, [])])]))",
+      "verdict": "CHARACTERIZED_DIFF",
+      "dominant_diff_class": "stub-body",
+      "regenerated_source_cid": "blake3-512:5a1eab3177aab96ca611d3a3ea7bf4284f3b7ffbdbe2e4cdf7e1c805ab2253fa0a7fae31b811df532deeed93660944c5dd4d769d0017e54146b34f160e933c48",
+      "original_slice_post_rustfmt_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43",
+      "unified_diff": "--- original_rustfmt\n+++ regenerated_rustfmt\n@@ -1,3 +1,3 @@\n pub fn string<S: Into<String>>(s: S) -> Arc<Value> {\n-    Arc::new(Value::String(s.into()))\n+    panic!(\"provekit-bind canonical: literal\")\n }\n",
+      "root_cause": "The fixture argument is method:into(s, []), not a direct first-parameter reference, so it stays outside the D7-v5 single-shape match."
+    }
+  ],
+  "summary": {
+    "stub_body_retired_for": [
+      "impl Value::boolean",
+      "impl Value::integer"
+    ],
+    "remaining_characterized_diff": [
+      "impl Value::string"
+    ],
+    "stop_condition": "String did not reach BYTE_IDENTICAL because the v4 fixture uses method:into(s, []) inside the Value::String constructor argument.",
+    "next_step": "D7-v6 should retire the string method:into(s, []) surface and then add the submodule-level source round-trip test for implementations/rust/provekit-canonicalizer/src/value.rs."
+  }
+}

--- a/implementations/rust/provekit-realize-rust-core/src/lib.rs
+++ b/implementations/rust/provekit-realize-rust-core/src/lib.rs
@@ -91,7 +91,7 @@ pub fn emit_from_resolved(
         }
     };
 
-    match lower_resolved_body(&resolved) {
+    match lower_resolved_body(&resolved, params) {
         Ok(body) => emit_function(
             function_name,
             params,
@@ -128,7 +128,7 @@ fn emit_function(
     }
 }
 
-fn lower_resolved_body(term: &Value) -> Result<String, String> {
+fn lower_resolved_body(term: &Value, params: &[String]) -> Result<String, String> {
     let concept_name = resolved_concept_name(term);
     if concept_name != "return" {
         return Err(concept_name);
@@ -138,30 +138,74 @@ fn lower_resolved_body(term: &Value) -> Result<String, String> {
     if args.len() != 1 {
         return Err("return".to_string());
     }
-    lower_resolved_expr(&args[0])
+    lower_resolved_expr(&args[0], params)
 }
 
-fn lower_resolved_expr(term: &Value) -> Result<String, String> {
+fn lower_resolved_expr(term: &Value, params: &[String]) -> Result<String, String> {
     match resolved_concept_name(term).as_str() {
-        "call:new" => lower_call_new(term),
+        "call:new" => lower_call_new(term, params),
         "literal" => lower_literal(term),
         concept_name => Err(concept_name.to_string()),
     }
 }
 
-fn lower_call_new(term: &Value) -> Result<String, String> {
+fn lower_call_new(term: &Value, params: &[String]) -> Result<String, String> {
     let args = resolved_args(term).ok_or_else(|| "call:new".to_string())?;
     if args.len() != 2 {
         return Err("call:new".to_string());
     }
 
     let name = lower_literal(&args[0])?;
-    let lowered_args = lower_literal(&args[1])?;
+    let lowered_args = lower_call_new_args_literal(&args[1], params)?;
     if name != "new" && !name.ends_with("::new") {
         return Err("call:new".to_string());
     }
 
     Ok(format!("{name}({lowered_args})"))
+}
+
+fn lower_call_new_args_literal(term: &Value, params: &[String]) -> Result<String, String> {
+    let node = resolved_node(term).ok_or_else(|| "literal".to_string())?;
+    if node.get("kind").and_then(Value::as_str) != Some("literal") {
+        return Err(resolved_concept_name(term));
+    }
+
+    match node.get("value") {
+        Some(Value::Array(items)) if is_value_null_literal(items) => Ok("Value::Null".to_string()),
+        Some(Value::Array(items)) => lower_single_value_variant_application(items, params)
+            .ok_or_else(|| "literal".to_string()),
+        _ => Err("literal".to_string()),
+    }
+}
+
+fn lower_single_value_variant_application(items: &[Value], params: &[String]) -> Option<String> {
+    if items.len() != 1 {
+        return None;
+    }
+
+    let surface = items[0].as_str()?;
+    let call = surface.strip_prefix("call:")?;
+    let (ctor_name, rest) = call.split_once('(')?;
+    let inner = rest.strip_suffix(')')?;
+    let (variant_path, arg_list) = inner.split_once(", [")?;
+    let arg = arg_list.strip_suffix(']')?;
+    let first_param = params.first()?;
+
+    if arg != first_param {
+        return None;
+    }
+
+    let variant_name = variant_path.rsplit("::").next()?;
+    if ctor_name != variant_name {
+        return None;
+    }
+
+    match variant_path {
+        "Value::Bool" | "Value::Integer" | "Value::String" => {
+            Some(format!("{variant_path}({arg})"))
+        }
+        _ => None,
+    }
 }
 
 fn lower_literal(term: &Value) -> Result<String, String> {
@@ -698,6 +742,41 @@ mod tests {
         items.iter().map(|item| item.to_string()).collect()
     }
 
+    fn resolved_return_call_new_with_literal_args(args: Vec<Value>) -> Value {
+        serde_json::json!({
+            "node": {
+                "args": [
+                    {
+                        "node": {
+                            "args": [
+                                {
+                                    "node": {
+                                        "kind": "literal",
+                                        "value": "Arc::new",
+                                    },
+                                    "sort": {"args": [], "kind": "ctor", "name": "FnContract"},
+                                },
+                                {
+                                    "node": {
+                                        "kind": "literal",
+                                        "value": args,
+                                    },
+                                    "sort": {"args": [], "kind": "ctor", "name": "ListOfExpr"},
+                                },
+                            ],
+                            "kind": "concept:op-application",
+                            "op_definition_cid": CALL_NEW_OP_CID,
+                        },
+                        "sort": {"args": [], "kind": "ctor", "name": "Expr"},
+                    },
+                ],
+                "kind": "concept:op-application",
+                "op_definition_cid": RETURN_OP_CID,
+            },
+            "sort": {"args": [], "kind": "ctor", "name": "Stmt"},
+        })
+    }
+
     #[test]
     fn renders_identity_from_body_template() {
         let rendered = emit_stub(
@@ -870,6 +949,66 @@ mod tests {
         assert_eq!(
             rendered.source,
             "pub fn null() -> Arc < Value > {\n    Arc::new(Value::Null)\n}\n"
+        );
+    }
+
+    #[test]
+    fn emits_value_bool_from_resolved_call_new_variant_arg_shape() {
+        let resolved = resolved_return_call_new_with_literal_args(vec![Value::String(
+            "call:Bool(Value::Bool, [b])".to_string(),
+        )]);
+        let rendered = emit_from_resolved(
+            &serde_json::to_string(&resolved).expect("resolved json"),
+            "boolean",
+            &strings(&["b"]),
+            &strings(&["bool"]),
+            "Arc < Value >",
+        );
+
+        assert!(!rendered.is_stub);
+        assert_eq!(
+            rendered.source,
+            "pub fn boolean(b: bool) -> Arc < Value > {\n    Arc::new(Value::Bool(b))\n}\n"
+        );
+    }
+
+    #[test]
+    fn emits_value_integer_from_resolved_call_new_variant_arg_shape() {
+        let resolved = resolved_return_call_new_with_literal_args(vec![Value::String(
+            "call:Integer(Value::Integer, [n])".to_string(),
+        )]);
+        let rendered = emit_from_resolved(
+            &serde_json::to_string(&resolved).expect("resolved json"),
+            "integer",
+            &strings(&["n"]),
+            &strings(&["i64"]),
+            "Arc < Value >",
+        );
+
+        assert!(!rendered.is_stub);
+        assert_eq!(
+            rendered.source,
+            "pub fn integer(n: i64) -> Arc < Value > {\n    Arc::new(Value::Integer(n))\n}\n"
+        );
+    }
+
+    #[test]
+    fn emits_value_string_from_resolved_call_new_variant_arg_shape() {
+        let resolved = resolved_return_call_new_with_literal_args(vec![Value::String(
+            "call:String(Value::String, [s])".to_string(),
+        )]);
+        let rendered = emit_from_resolved(
+            &serde_json::to_string(&resolved).expect("resolved json"),
+            "string",
+            &strings(&["s"]),
+            &strings(&["String"]),
+            "Arc < Value >",
+        );
+
+        assert!(!rendered.is_stub);
+        assert_eq!(
+            rendered.source,
+            "pub fn string(s: String) -> Arc < Value > {\n    Arc::new(Value::String(s))\n}\n"
         );
     }
 


### PR DESCRIPTION
Extends `provekit-realize-rust-core::emit_from_resolved` with one new match arm for single-arg constructor literals taking a direct parameter reference.

## Verdicts

| Method | Verdict | CIDs match |
| --- | --- | --- |
| boolean | BYTE_IDENTICAL | `blake3-512:e4f464f5...` |
| integer | BYTE_IDENTICAL | `blake3-512:7cfdae9b...` |
| string  | CHARACTERIZED_DIFF | new shape: `method:into(s, [])` |

Three of four constructors in the `Arc::new(Value::<Variant>(<arg>))` cluster are now BYTE_IDENTICAL. String surfaces a new sub-shape because the argument is wrapped in `.into()` (method call, not a direct param reference).

## Test results

- d7_v4_widen: boolean BYTE_IDENTICAL, integer BYTE_IDENTICAL, string CHARACTERIZED_DIFF (test passes; verdict-in-set still satisfied)
- d7_v1: v3_verdict BYTE_IDENTICAL preserved
- proofir_bridge_real_lift: Value::null round-trip preserved
- provekit-realize-rust-core: 12 unit tests passed

## Scope

Per-language kit only (`provekit-realize-rust-core`). NO substrate, NO lifter, NO concept op changes.

## Next: D7-v6

Retires the `method:into(<param_ref>, [])` argument-wrapper shape. After v6: all four constructors BYTE_IDENTICAL, n=1 cluster fully closed, ready for v7 module-level sweep.

Refs #943.