### PR TITLE
feat(bootstrap D7-v6): retire method:into arg-wrapper -- Value::string BYTE_IDENTICAL; n=1 cluster CLOSED

### DIFF
--- a/bootstrap/D7-v4/string_source_round_trip_receipt.json
+++ b/bootstrap/D7-v4/string_source_round_trip_receipt.json
@@ -20,25 +20,19 @@
       ],
       "return_type": "Arc < Value >"
     },
-    "step_3_4_regenerated_source": "pub fn string<S: Into<String>>(s: S) -> Arc < Value > {\n    panic!(\"provekit-bind canonical: literal\")\n}\n",
+    "step_3_4_regenerated_source": "pub fn string<S: Into<String>>(s: S) -> Arc < Value > {\n    Arc::new(Value::String(s.into()))\n}\n",
     "step_5_original_slice_cid": "blake3-512:2326ad724a2dfd96c463b1a1ae71d025e953d35a850ecbdd6954a409e2f4c0b100174ca0a6a62121b15b3a2f374b891110750617dc2b9466e11533df286122a7",
     "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_string_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_string_original.rs>",
-    "step_7_byte_identical_post_rustfmt": false,
-    "step_8_unified_diff": "--- original_rustfmt\n+++ regenerated_rustfmt\n@@ -1,3 +1,3 @@\n pub fn string<S: Into<String>>(s: S) -> Arc<Value> {\n-    Arc::new(Value::String(s.into()))\n+    panic!(\"provekit-bind canonical: literal\")\n }\n",
-    "step_9_diff_classification": [
-      {
-        "hunk": "@@ -1,3 +1,3 @@\n pub fn string<S: Into<String>>(s: S) -> Arc<Value> {\n-    Arc::new(Value::String(s.into()))\n+    panic!(\"provekit-bind canonical: literal\")\n }",
-        "class": "stub-body",
-        "explanation": "provekit-realize-rust-core emitted its stub body because the existing D7 resolved body lowering does not consume this widened Value constructor literal shape; the realized fallback concept is `literal`. Retire in v5 under the #964/#962 self-host follow-up without minting new ops."
-      }
-    ],
-    "step_10_dominant_diff_class": "stub-body",
+    "step_7_byte_identical_post_rustfmt": true,
+    "step_8_unified_diff": "",
+    "step_9_diff_classification": [],
+    "step_10_dominant_diff_class": "byte-identical",
     "step_11_expected_diff_shape": "BYTE_IDENTICAL or CHARACTERIZED_DIFF; D7-v4 is diagnostic-only widening",
-    "step_12_empirical_root_cause": "The existing D7 resolved body lowering does not consume widened Value constructor literal shapes beyond Value::Null, so realize-rust-core falls through to the stub-body path; retire under #964/#962 follow-up without extending this diagnostic chunk.",
-    "regenerated_source_cid": "blake3-512:5a1eab3177aab96ca611d3a3ea7bf4284f3b7ffbdbe2e4cdf7e1c805ab2253fa0a7fae31b811df532deeed93660944c5dd4d769d0017e54146b34f160e933c48",
+    "step_12_empirical_root_cause": "The existing D7 resolved body lowering emitted the checked-in Value constructor body byte-for-byte after rustfmt.",
+    "regenerated_source_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43",
     "original_slice_post_rustfmt_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43"
   },
-  "verdict": "CHARACTERIZED_DIFF",
-  "dominant_diff_class": "stub-body",
+  "verdict": "BYTE_IDENTICAL",
+  "dominant_diff_class": "byte-identical",
   "next_action": "D7-v4 is diagnostic-only. v5 should retire any CHARACTERIZED_DIFF classes surfaced here without minting new ProofIR ops or substrate concepts."
 }

--- a/bootstrap/D7-v6/README.md
+++ b/bootstrap/D7-v6/README.md
@@ -1,0 +1,56 @@
+# D7-v6 method into argument closure
+
+Scope: retire the single residual argument-wrapper shape from D7-v5.
+Parent arc: #943.
+Base commit: b3553412.
+Branch: bootstrap/D7-v6-retire-method-into-arg.
+
+D7-v5 closed the direct Value constructor argument shape.
+That covered Value::boolean and Value::integer.
+Value::null was already BYTE_IDENTICAL from D7-v3.
+Value::string stayed CHARACTERIZED_DIFF.
+
+The remaining string fixture is:
+implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_string.json.
+Its surface is:
+return(call:new(Arc::new, [call:String(Value::String, [method:into(s, [])])])).
+
+The original source is:
+implementations/rust/provekit-canonicalizer/src/value.rs.
+The checked body is:
+Arc::new(Value::String(s.into())).
+
+D7-v6 extends only provekit-realize-rust-core.
+The touched entrypoint is emit_from_resolved.
+The new accepted argument form is:
+method:<method_name>(<first_param>, []).
+
+For the real fixture, that means:
+method:into(s, []) becomes s.into().
+The shape composes under the existing Value::String constructor arm.
+The emitted body is:
+Arc::new(Value::String(s.into())).
+
+The guard is intentionally narrow.
+The method receiver must equal params[0].
+The method arg list must be empty.
+Non-param receivers are still rejected.
+Nested method receivers are still rejected.
+Method calls with one or more args are still rejected.
+Value::array and Value::object are not touched.
+
+bootstrap/D7-v4/string_source_round_trip_receipt.json is refreshed.
+Its verdict is now BYTE_IDENTICAL.
+The regenerated source CID equals the original post-rustfmt slice CID.
+Both are:
+blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43.
+
+bootstrap/D7-v6/n_1_cluster_closure_receipt.json records the cluster result.
+The closed constructors are Value::null, Value::boolean, Value::integer, and Value::string.
+All four are BYTE_IDENTICAL.
+
+The n=1 scalar constructor cluster is closed for the current fixtures.
+This is not a module-level source identity claim.
+It is the input for D7-v7.
+D7-v7 should sweep implementations/rust/provekit-canonicalizer/src/value.rs at module scope.
+That sweep should keep Value::array and Value::object as separate debt unless their fixtures close independently.

--- a/bootstrap/D7-v6/n_1_cluster_closure_receipt.json
+++ b/bootstrap/D7-v6/n_1_cluster_closure_receipt.json
@@ -1,0 +1,79 @@
+{
+  "version": "1",
+  "arc": "D7-v6",
+  "parent_arc": "#943",
+  "base_commit": "b3553412",
+  "branch": "bootstrap/D7-v6-retire-method-into-arg",
+  "implementation": {
+    "crate": "provekit-realize-rust-core",
+    "entrypoint": "emit_from_resolved",
+    "extended_file": "implementations/rust/provekit-realize-rust-core/src/lib.rs",
+    "retired_shape": "method:<method_name>(<first_param>, []) as a Value::<Variant> constructor argument",
+    "composed_shape": "return(call:new(Arc::new, [call:String(Value::String, [method:into(s, [])])]))",
+    "emitted_surface": "Arc::new(Value::String(s.into()))",
+    "scope_guard": [
+      "constructor literal-list payload contains exactly one constructor surface",
+      "constructor path is one of Value::Bool, Value::Integer, or Value::String",
+      "method-call receiver exactly equals params[0]",
+      "method-call argument list is empty",
+      "method-call receiver is not nested",
+      "method calls with one or more args are not handled",
+      "Value::Array and Value::Object remain out of scope"
+    ]
+  },
+  "cluster": {
+    "name": "Arc::new(Value::<Variant>(<arg>))",
+    "status": "fully-closed",
+    "ready_for_v7_module_sweep": true,
+    "summary": "The Value scalar constructor cluster now reaches BYTE_IDENTICAL for null, boolean, integer, and string."
+  },
+  "outcomes": [
+    {
+      "method": "impl Value::null",
+      "fixture": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v0_value_null.json",
+      "receipt": "bootstrap/D7-v3/value_null_source_round_trip_receipt.json",
+      "term_surface": "return(call:new(Arc::new, [Null]))",
+      "verdict": "BYTE_IDENTICAL",
+      "dominant_diff_class": "byte-identical",
+      "regenerated_source_cid": "blake3-512:97ec24c86c7b920e7e13d80541e7ec5fd066bf3cbceb47bb8df5bb9ec88717558a04e8f605d180ae93730f1f42c9b4420060bcf80df0ff544c1ad4ef5369f670",
+      "original_slice_post_rustfmt_cid": "blake3-512:97ec24c86c7b920e7e13d80541e7ec5fd066bf3cbceb47bb8df5bb9ec88717558a04e8f605d180ae93730f1f42c9b4420060bcf80df0ff544c1ad4ef5369f670"
+    },
+    {
+      "method": "impl Value::boolean",
+      "fixture": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_boolean.json",
+      "receipt": "bootstrap/D7-v4/boolean_source_round_trip_receipt.json",
+      "term_surface": "return(call:new(Arc::new, [call:Bool(Value::Bool, [b])]))",
+      "verdict": "BYTE_IDENTICAL",
+      "dominant_diff_class": "byte-identical",
+      "regenerated_source_cid": "blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a",
+      "original_slice_post_rustfmt_cid": "blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a"
+    },
+    {
+      "method": "impl Value::integer",
+      "fixture": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_integer.json",
+      "receipt": "bootstrap/D7-v4/integer_source_round_trip_receipt.json",
+      "term_surface": "return(call:new(Arc::new, [call:Integer(Value::Integer, [n])]))",
+      "verdict": "BYTE_IDENTICAL",
+      "dominant_diff_class": "byte-identical",
+      "regenerated_source_cid": "blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf",
+      "original_slice_post_rustfmt_cid": "blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf"
+    },
+    {
+      "method": "impl Value::string",
+      "fixture": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v4_value_string.json",
+      "receipt": "bootstrap/D7-v4/string_source_round_trip_receipt.json",
+      "term_surface": "return(call:new(Arc::new, [call:String(Value::String, [method:into(s, [])])]))",
+      "verdict": "BYTE_IDENTICAL",
+      "dominant_diff_class": "byte-identical",
+      "regenerated_source_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43",
+      "original_slice_post_rustfmt_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43"
+    }
+  ],
+  "verification": {
+    "d7_v4_widen": "D7_V4_RECEIPT_OUT_DIR=/private/tmp/d7-v4-receipts cargo test -p libprovekit --test d7_v4_widen -- --nocapture",
+    "string_verdict": "BYTE_IDENTICAL",
+    "string_regenerated_source_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43",
+    "string_original_slice_post_rustfmt_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43"
+  },
+  "next_step": "D7-v7 should sweep implementations/rust/provekit-canonicalizer/src/value.rs at module scope before Value::array or Value::object are treated as closed."
+}

--- a/implementations/rust/provekit-realize-rust-core/src/lib.rs
+++ b/implementations/rust/provekit-realize-rust-core/src/lib.rs
@@ -191,21 +191,40 @@ fn lower_single_value_variant_application(items: &[Value], params: &[String]) ->
     let arg = arg_list.strip_suffix(']')?;
     let first_param = params.first()?;
 
-    if arg != first_param {
-        return None;
-    }
-
     let variant_name = variant_path.rsplit("::").next()?;
     if ctor_name != variant_name {
         return None;
     }
 
+    let lowered_arg = lower_value_variant_arg(arg, first_param)?;
     match variant_path {
         "Value::Bool" | "Value::Integer" | "Value::String" => {
-            Some(format!("{variant_path}({arg})"))
+            Some(format!("{variant_path}({lowered_arg})"))
         }
         _ => None,
     }
+}
+
+fn lower_value_variant_arg(arg: &str, first_param: &str) -> Option<String> {
+    if arg == first_param {
+        return Some(arg.to_string());
+    }
+
+    let method_call = arg.strip_prefix("method:")?;
+    let (method_name, rest) = method_call.split_once('(')?;
+    if method_name.is_empty() {
+        return None;
+    }
+    let inner = rest.strip_suffix(')')?;
+    let (receiver, method_args) = inner.split_once(", [")?;
+    if receiver != first_param {
+        return None;
+    }
+    if !method_args.strip_suffix(']')?.is_empty() {
+        return None;
+    }
+
+    Some(format!("{first_param}.{method_name}()"))
 }
 
 fn lower_literal(term: &Value) -> Result<String, String> {
@@ -1009,6 +1028,26 @@ mod tests {
         assert_eq!(
             rendered.source,
             "pub fn string(s: String) -> Arc < Value > {\n    Arc::new(Value::String(s))\n}\n"
+        );
+    }
+
+    #[test]
+    fn emits_value_string_from_resolved_call_new_variant_method_arg_shape() {
+        let resolved = resolved_return_call_new_with_literal_args(vec![Value::String(
+            "call:String(Value::String, [method:into(s, [])])".to_string(),
+        )]);
+        let rendered = emit_from_resolved(
+            &serde_json::to_string(&resolved).expect("resolved json"),
+            "string<S: Into<String>>",
+            &strings(&["s"]),
+            &strings(&["S"]),
+            "Arc < Value >",
+        );
+
+        assert!(!rendered.is_stub);
+        assert_eq!(
+            rendered.source,
+            "pub fn string<S: Into<String>>(s: S) -> Arc < Value > {\n    Arc::new(Value::String(s.into()))\n}\n"
         );
     }
 


### PR DESCRIPTION
Adds the final emit_from_resolved match arm for the `method:<name>(params[0], [])` argument-wrapper shape.

## Verdicts after v6

| Method | Verdict | CIDs |
| --- | --- | --- |
| Value::null    | BYTE_IDENTICAL | (v3, preserved) |
| Value::boolean | BYTE_IDENTICAL | (v5, preserved) |
| Value::integer | BYTE_IDENTICAL | (v5, preserved) |
| Value::string  | **BYTE_IDENTICAL (v6, new)** | `blake3-512:11ae0368...` |

**The n=1 cluster `Arc::new(Value::<Variant>(<arg>))` is fully closed.** All four scalar constructors round-trip lossless through the lift -> proofir_resolve -> realize_rust -> rustfmt pipeline on real libprovekit code.

## Test results

- d7_v4_widen: all three BYTE_IDENTICAL (the test now asserts byte-identity rather than just verdict-in-set)
- d7_v1: v3 BYTE_IDENTICAL preserved
- proofir_bridge_real_lift: Value::null bridge round-trip preserved
- provekit-realize-rust-core: 14 unit tests green (added test for the new method-call-arg shape)

## Scope

Per-language kit only (`provekit-realize-rust-core`). NO substrate, NO lifter, NO concept ops.

## Next: D7-v7 module sweep

Lift the entire `provekit-canonicalizer/src/value.rs` module via provekit-walk, run the round-trip pipeline per function, verdict per fn. Terminus when every function in the module is BYTE_IDENTICAL (excluding genuine non-goals like `array()` / `object()` which refuse at lift via unsupported-value-closure / unsupported-value-if -- separate debt class).

On v7 BYTE_IDENTICAL whole submodule: D7 TERMINUS PushNotification + transition to Phase-5-Py.

Refs #943.