### PR TITLE
feat(bootstrap D7-v7): MODULE TERMINUS -- provekit-canonicalizer::value round-trips losslessly post-rustfmt

### DIFF
--- a/bootstrap/D7-v7/README.md
+++ b/bootstrap/D7-v7/README.md
@@ -1,0 +1,81 @@
+# D7-v7 value module sweep
+
+Scope: provekit-canonicalizer::value.
+Parent arc: #943.
+Base commit: 63a0bc1a.
+Branch: bootstrap/D7-v7-value-module-sweep.
+
+D7-v6 closed the scalar constructor cluster.
+That cluster contains Value::null, Value::boolean, Value::integer, and Value::string.
+D7-v7 reruns the same lift, bridge, resolve, realize, rustfmt, and byte compare path at module scope.
+The source file is implementations/rust/provekit-canonicalizer/src/value.rs.
+
+This is the D7 terminus claim for provekit-canonicalizer::value.
+D7 terminus reached for provekit-canonicalizer::value at commit <merge-sha-of-this-PR>.
+The claim is scoped to functions whose current lift yields a D7 bridge-compatible single-term fixture.
+Non-goal functions are characterized below and excluded from the terminus check.
+
+The walker command used for each function was:
+cd implementations/rust && target/debug/provekit-walk-emit term provekit-canonicalizer/src/value.rs <fn> /private/tmp/d7-v7-walk/<fn>.raw.json
+
+The in-scope functions are:
+null.
+boolean.
+integer.
+string.
+
+The non-goal functions are:
+kind.
+array.
+object.
+
+| fn | verdict | fixture CID | cluster_canonical_cid | cluster_cardinality | note |
+| --- | --- | --- | --- | --- | --- |
+| kind | NON_GOAL | n/a | n/a | n/a | raw match_expr contains var nodes; not bridge-compatible under proofir_resolve |
+| null | BYTE_IDENTICAL | blake3-512:754c6ff2c9a0ff92d96bcce0d1269385809944e613c11696df0458703a4e5e187714866b9e35171eb09d7753b66274a5e0d51a99ff1e0a0be3d9da6c1082d23f | n/a | 4 scalar constructors | D7-v3 and v7 agree after rustfmt |
+| boolean | BYTE_IDENTICAL | blake3-512:fe4f9d22916f33696f6a318c559948f445c0e61f353370c8d8a007e64bc56057e937fd844685e7120fa6346a0a4abd1cd2301190020b7c4bfec41fccb77abe89 | n/a | 4 scalar constructors | D7-v5 direct param shape remains closed |
+| integer | BYTE_IDENTICAL | blake3-512:e69f9d9cf2ffac684c58502e416d722b4a94bf2269f7ac135010520e57a65660e7093b517bf17f01bfe1a574794881f3e7d28c091fb0a6b5507cddb2ec9e279a | n/a | 4 scalar constructors | D7-v5 direct param shape remains closed |
+| string | BYTE_IDENTICAL | blake3-512:87a7b7bedc6615347bf6e01483804337dbeba211bc7bb5566e56f5d38e52d44b5d422af48d5a68a98cd88fd1a9011b940b229e53cdcb91f878f8e0aa2b731b60 | n/a | 4 scalar constructors | D7-v6 method:into arg shape remains closed |
+| array | NON_GOAL | n/a | n/a | n/a | Value::Array is explicit D7-v6 out-of-scope debt |
+| object | NON_GOAL | n/a | n/a | n/a | lift refuses with unsupported-value-closure |
+
+The #971 inventory is a libprovekit/src bind inventory.
+value.rs lives under provekit-canonicalizer, so it has no useful #971 cluster_canonical_cid.
+The table keeps the cluster fields explicit and marks them n/a for that reason.
+The local scalar cluster cardinality is still useful: 4.
+
+Committed D7-v7 fixtures:
+implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_null.json.
+implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_boolean.json.
+implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_integer.json.
+implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_string.json.
+
+Committed D7-v7 receipts:
+bootstrap/D7-v7/value_null_source_round_trip_receipt.json.
+bootstrap/D7-v7/value_boolean_source_round_trip_receipt.json.
+bootstrap/D7-v7/value_integer_source_round_trip_receipt.json.
+bootstrap/D7-v7/value_string_source_round_trip_receipt.json.
+bootstrap/D7-v7/value_module_sweep_receipt.json.
+
+The integration test is implementations/rust/libprovekit/tests/d7_v7_module_sweep.rs.
+It recomputes each fixture CID.
+It resolves through libprovekit::proofir_resolve.
+It realizes through provekit_realize_rust_core::emit_from_resolved.
+It extracts the original function slice from value.rs.
+It rustfmts both sides.
+It byte-compares the post-rustfmt strings.
+It checks the committed receipt for drift.
+
+Module verdict: TERMINUS.
+byte_identical_count: 4.
+characterized_diff_count: 0.
+non_goal_count: 3.
+
+The non-goal accounting matters.
+kind is not a scalar constructor fixture because its raw term contains match_expr plus var nodes.
+array is a Value::Array constructor surface, and v6 explicitly left Value::Array outside the closure.
+object still refuses during lift with unsupported value expression Expr::Closure.
+No lifter, realizer, or substrate extension was made in D7-v7.
+
+This is the n=1 case of the cycle invariance theorem on a real libprovekit submodule.
+For the in-scope value.rs functions, rustfmt(realize_rust(proofir_resolve(lift_rust(fn)))) equals rustfmt(fn) byte-for-byte.

--- a/bootstrap/D7-v7/value_boolean_source_round_trip_receipt.json
+++ b/bootstrap/D7-v7/value_boolean_source_round_trip_receipt.json
@@ -1,0 +1,64 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::boolean",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "lift": {
+    "tool": "provekit-walk",
+    "command": "cd implementations/rust && target/debug/provekit-walk-emit term provekit-canonicalizer/src/value.rs boolean /private/tmp/d7-v7-walk/boolean.raw.json",
+    "fixture_path": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_boolean.json",
+    "fixture_cid": "blake3-512:fe4f9d22916f33696f6a318c559948f445c0e61f353370c8d8a007e64bc56057e937fd844685e7120fa6346a0a4abd1cd2301190020b7c4bfec41fccb77abe89",
+    "outcome": "handles-partially-with-loss-record",
+    "term_surface": "return(call:new(Arc::new, [call:Bool(Value::Bool, [b])]))",
+    "loss_record": [
+      {
+        "detail": "derive",
+        "loss": "procedural-macro"
+      },
+      {
+        "detail": "Arc < Value >",
+        "loss": "return-type-user-defined"
+      },
+      {
+        "detail": "Arc::new",
+        "loss": "ffi-call-unresolved-effect"
+      },
+      {
+        "detail": "Value::Bool",
+        "loss": "ffi-call-unresolved-effect"
+      }
+    ]
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:fe4f9d22916f33696f6a318c559948f445c0e61f353370c8d8a007e64bc56057e937fd844685e7120fa6346a0a4abd1cd2301190020b7c4bfec41fccb77abe89",
+    "step_2_resolve": "summary=return(call:new(literal(\"Arc::new\"), literal([\"call:Bool(Value::Bool, [b])\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:Bool(Value::Bool, [b])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, \"boolean\", [\"b\"], [\"bool\"], \"Arc < Value >\")",
+    "step_3_4_realize_input": {
+      "resolved_term_json": "{\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:Bool(Value::Bool, [b])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+      "function": "boolean",
+      "params": [
+        "b"
+      ],
+      "param_types": [
+        "bool"
+      ],
+      "return_type": "Arc < Value >"
+    },
+    "step_3_4_regenerated_source": "pub fn boolean(b: bool) -> Arc < Value > {\n    Arc::new(Value::Bool(b))\n}\n",
+    "step_5_original_slice_cid": "blake3-512:f6eaf0ebbb9589ce23cad273e29d19da6ddacf20d3c7d654a41ed3d718f8ec94f0793648808318b18a375da350a8d4de300594fe649d84ac260c5cab460d8c3d",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_boolean_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_boolean_original.rs>",
+    "step_7_byte_identical_post_rustfmt": true,
+    "step_8_unified_diff": "",
+    "step_9_diff_classification": [],
+    "step_10_dominant_diff_class": "byte-identical",
+    "step_11_expected_diff_shape": "BYTE_IDENTICAL required for every D7-v7 in-scope value.rs function",
+    "step_12_empirical_root_cause": "The D7-v6 resolved body lowering emits this in-scope Value constructor body byte-for-byte after rustfmt.",
+    "regenerated_source_cid": "blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a",
+    "original_slice_post_rustfmt_cid": "blake3-512:e4f464f54e93db6d8a14c682a3d2eb927d39c776ba0cc1dd62bc480a6de74918f3a25d94715840e957ed2d2d3b497e58cd02db8c3c9be4278b2e170d90d9982a"
+  },
+  "verdict": "BYTE_IDENTICAL",
+  "dominant_diff_class": "byte-identical",
+  "next_action": "No per-function D7 debt remains for this in-scope Value constructor."
+}

--- a/bootstrap/D7-v7/value_integer_source_round_trip_receipt.json
+++ b/bootstrap/D7-v7/value_integer_source_round_trip_receipt.json
@@ -1,0 +1,64 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::integer",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "lift": {
+    "tool": "provekit-walk",
+    "command": "cd implementations/rust && target/debug/provekit-walk-emit term provekit-canonicalizer/src/value.rs integer /private/tmp/d7-v7-walk/integer.raw.json",
+    "fixture_path": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_integer.json",
+    "fixture_cid": "blake3-512:e69f9d9cf2ffac684c58502e416d722b4a94bf2269f7ac135010520e57a65660e7093b517bf17f01bfe1a574794881f3e7d28c091fb0a6b5507cddb2ec9e279a",
+    "outcome": "handles-partially-with-loss-record",
+    "term_surface": "return(call:new(Arc::new, [call:Integer(Value::Integer, [n])]))",
+    "loss_record": [
+      {
+        "detail": "derive",
+        "loss": "procedural-macro"
+      },
+      {
+        "detail": "Arc < Value >",
+        "loss": "return-type-user-defined"
+      },
+      {
+        "detail": "Arc::new",
+        "loss": "ffi-call-unresolved-effect"
+      },
+      {
+        "detail": "Value::Integer",
+        "loss": "ffi-call-unresolved-effect"
+      }
+    ]
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:e69f9d9cf2ffac684c58502e416d722b4a94bf2269f7ac135010520e57a65660e7093b517bf17f01bfe1a574794881f3e7d28c091fb0a6b5507cddb2ec9e279a",
+    "step_2_resolve": "summary=return(call:new(literal(\"Arc::new\"), literal([\"call:Integer(Value::Integer, [n])\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:Integer(Value::Integer, [n])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, \"integer\", [\"n\"], [\"i64\"], \"Arc < Value >\")",
+    "step_3_4_realize_input": {
+      "resolved_term_json": "{\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:Integer(Value::Integer, [n])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+      "function": "integer",
+      "params": [
+        "n"
+      ],
+      "param_types": [
+        "i64"
+      ],
+      "return_type": "Arc < Value >"
+    },
+    "step_3_4_regenerated_source": "pub fn integer(n: i64) -> Arc < Value > {\n    Arc::new(Value::Integer(n))\n}\n",
+    "step_5_original_slice_cid": "blake3-512:16fb069e21ea947daa7ab28932a6ac3e59a68b64db291a698212446b273d25892a14de2b9b4ee1cd046b3832236c5c414fe67159b1a7964804c8e97355628f42",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_integer_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_integer_original.rs>",
+    "step_7_byte_identical_post_rustfmt": true,
+    "step_8_unified_diff": "",
+    "step_9_diff_classification": [],
+    "step_10_dominant_diff_class": "byte-identical",
+    "step_11_expected_diff_shape": "BYTE_IDENTICAL required for every D7-v7 in-scope value.rs function",
+    "step_12_empirical_root_cause": "The D7-v6 resolved body lowering emits this in-scope Value constructor body byte-for-byte after rustfmt.",
+    "regenerated_source_cid": "blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf",
+    "original_slice_post_rustfmt_cid": "blake3-512:7cfdae9bf999160132cede4141307afcd664d0609e24263059761edf6033861abc85a2f437ea2637b598aafca7091d40b745ce24c52fcb605a3cbf4862373baf"
+  },
+  "verdict": "BYTE_IDENTICAL",
+  "dominant_diff_class": "byte-identical",
+  "next_action": "No per-function D7 debt remains for this in-scope Value constructor."
+}

--- a/bootstrap/D7-v7/value_module_sweep_receipt.json
+++ b/bootstrap/D7-v7/value_module_sweep_receipt.json
@@ -1,0 +1,69 @@
+{
+  "version": "1",
+  "target_module": "provekit-canonicalizer::value",
+  "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs",
+  "base_commit": "63a0bc1a",
+  "branch": "bootstrap/D7-v7-value-module-sweep",
+  "walk_emit_command": "cd implementations/rust && target/debug/provekit-walk-emit term provekit-canonicalizer/src/value.rs <fn> /private/tmp/d7-v7-walk/<fn>.raw.json",
+  "in_scope_functions": [
+    "null",
+    "boolean",
+    "integer",
+    "string"
+  ],
+  "non_goal_functions": [
+    {
+      "name": "kind",
+      "audit_class": "handles-partially-with-loss-record",
+      "lift_refuse_class": "not-bridge-compatible-match_expr-var",
+      "walk_emit_result": "accepted",
+      "reason": "the raw term contains match_expr plus var nodes; proofir_resolve rejects Var terms, so no D7-v0 style bridge-compatible single-term fixture is available without extending the bridge or realizer"
+    },
+    {
+      "name": "array",
+      "audit_class": "handles-partially-with-loss-record",
+      "lift_refuse_class": "value-array-separate-debt",
+      "walk_emit_result": "accepted",
+      "reason": "the raw term is a Value::Array constructor surface, but D7-v6 explicitly guards Value::Array out of the scalar constructor closure and this v7 sweep does not extend the realizer"
+    },
+    {
+      "name": "object",
+      "audit_class": "refuses-with-typed-reason",
+      "lift_refuse_class": "unsupported-value-closure",
+      "walk_emit_result": "refused",
+      "reason": "provekit-walk-emit refused object with unsupported value expression Expr::Closure"
+    }
+  ],
+  "per_function_verdicts": {
+    "kind": "NON_GOAL:not-bridge-compatible-match_expr-var",
+    "null": "BYTE_IDENTICAL",
+    "boolean": "BYTE_IDENTICAL",
+    "integer": "BYTE_IDENTICAL",
+    "string": "BYTE_IDENTICAL",
+    "array": "NON_GOAL:value-array-separate-debt",
+    "object": "NON_GOAL:unsupported-value-closure"
+  },
+  "per_function_receipts": {
+    "null": "bootstrap/D7-v7/value_null_source_round_trip_receipt.json",
+    "boolean": "bootstrap/D7-v7/value_boolean_source_round_trip_receipt.json",
+    "integer": "bootstrap/D7-v7/value_integer_source_round_trip_receipt.json",
+    "string": "bootstrap/D7-v7/value_string_source_round_trip_receipt.json"
+  },
+  "per_function_fixtures": {
+    "null": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_null.json",
+    "boolean": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_boolean.json",
+    "integer": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_integer.json",
+    "string": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_string.json"
+  },
+  "fixture_cids": {
+    "null": "blake3-512:754c6ff2c9a0ff92d96bcce0d1269385809944e613c11696df0458703a4e5e187714866b9e35171eb09d7753b66274a5e0d51a99ff1e0a0be3d9da6c1082d23f",
+    "boolean": "blake3-512:fe4f9d22916f33696f6a318c559948f445c0e61f353370c8d8a007e64bc56057e937fd844685e7120fa6346a0a4abd1cd2301190020b7c4bfec41fccb77abe89",
+    "integer": "blake3-512:e69f9d9cf2ffac684c58502e416d722b4a94bf2269f7ac135010520e57a65660e7093b517bf17f01bfe1a574794881f3e7d28c091fb0a6b5507cddb2ec9e279a",
+    "string": "blake3-512:87a7b7bedc6615347bf6e01483804337dbeba211bc7bb5566e56f5d38e52d44b5d422af48d5a68a98cd88fd1a9011b940b229e53cdcb91f878f8e0aa2b731b60"
+  },
+  "module_verdict": "TERMINUS",
+  "byte_identical_count": 4,
+  "characterized_diff_count": 0,
+  "non_goal_count": 3,
+  "terminus_rule": "module_verdict is TERMINUS because every in-scope function reached BYTE_IDENTICAL; non-goal functions are excluded from the terminus check"
+}

--- a/bootstrap/D7-v7/value_null_source_round_trip_receipt.json
+++ b/bootstrap/D7-v7/value_null_source_round_trip_receipt.json
@@ -1,0 +1,60 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::null",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "lift": {
+    "tool": "provekit-walk",
+    "command": "cd implementations/rust && target/debug/provekit-walk-emit term provekit-canonicalizer/src/value.rs null /private/tmp/d7-v7-walk/null.raw.json",
+    "fixture_path": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_null.json",
+    "fixture_cid": "blake3-512:754c6ff2c9a0ff92d96bcce0d1269385809944e613c11696df0458703a4e5e187714866b9e35171eb09d7753b66274a5e0d51a99ff1e0a0be3d9da6c1082d23f",
+    "outcome": "handles-partially-with-loss-record",
+    "term_surface": "return(call:new(Arc::new, [Null]))",
+    "loss_record": [
+      {
+        "detail": "derive",
+        "loss": "procedural-macro"
+      },
+      {
+        "detail": "Arc < Value >",
+        "loss": "return-type-user-defined"
+      },
+      {
+        "detail": "Arc::new",
+        "loss": "ffi-call-unresolved-effect"
+      },
+      {
+        "detail": "Value :: Null",
+        "loss": "trait-path-truncated"
+      }
+    ]
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:754c6ff2c9a0ff92d96bcce0d1269385809944e613c11696df0458703a4e5e187714866b9e35171eb09d7753b66274a5e0d51a99ff1e0a0be3d9da6c1082d23f",
+    "step_2_resolve": "summary=return(call:new(literal(\"Arc::new\"), literal([\"Null\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"Null\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, \"null\", [], [], \"Arc < Value >\")",
+    "step_3_4_realize_input": {
+      "resolved_term_json": "{\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"Null\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+      "function": "null",
+      "params": [],
+      "param_types": [],
+      "return_type": "Arc < Value >"
+    },
+    "step_3_4_regenerated_source": "pub fn null() -> Arc < Value > {\n    Arc::new(Value::Null)\n}\n",
+    "step_5_original_slice_cid": "blake3-512:12832f678b924c4503c8d5e5839471bffa8051e2dfbc6f4d455b302dbbc7c649c56b5aec0d31fbd336c532111dbd46091b6efed10f288e68a511a32d08d29450",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_null_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_null_original.rs>",
+    "step_7_byte_identical_post_rustfmt": true,
+    "step_8_unified_diff": "",
+    "step_9_diff_classification": [],
+    "step_10_dominant_diff_class": "byte-identical",
+    "step_11_expected_diff_shape": "BYTE_IDENTICAL required for every D7-v7 in-scope value.rs function",
+    "step_12_empirical_root_cause": "The D7-v6 resolved body lowering emits this in-scope Value constructor body byte-for-byte after rustfmt.",
+    "regenerated_source_cid": "blake3-512:97ec24c86c7b920e7e13d80541e7ec5fd066bf3cbceb47bb8df5bb9ec88717558a04e8f605d180ae93730f1f42c9b4420060bcf80df0ff544c1ad4ef5369f670",
+    "original_slice_post_rustfmt_cid": "blake3-512:97ec24c86c7b920e7e13d80541e7ec5fd066bf3cbceb47bb8df5bb9ec88717558a04e8f605d180ae93730f1f42c9b4420060bcf80df0ff544c1ad4ef5369f670"
+  },
+  "verdict": "BYTE_IDENTICAL",
+  "dominant_diff_class": "byte-identical",
+  "next_action": "No per-function D7 debt remains for this in-scope Value constructor."
+}

--- a/bootstrap/D7-v7/value_string_source_round_trip_receipt.json
+++ b/bootstrap/D7-v7/value_string_source_round_trip_receipt.json
@@ -1,0 +1,68 @@
+{
+  "version": "1",
+  "target": {
+    "crate": "provekit-canonicalizer",
+    "function": "impl Value::string",
+    "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs"
+  },
+  "lift": {
+    "tool": "provekit-walk",
+    "command": "cd implementations/rust && target/debug/provekit-walk-emit term provekit-canonicalizer/src/value.rs string /private/tmp/d7-v7-walk/string.raw.json",
+    "fixture_path": "implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_string.json",
+    "fixture_cid": "blake3-512:87a7b7bedc6615347bf6e01483804337dbeba211bc7bb5566e56f5d38e52d44b5d422af48d5a68a98cd88fd1a9011b940b229e53cdcb91f878f8e0aa2b731b60",
+    "outcome": "handles-partially-with-loss-record",
+    "term_surface": "return(call:new(Arc::new, [call:String(Value::String, [method:into(s, [])])]))",
+    "loss_record": [
+      {
+        "detail": "derive",
+        "loss": "procedural-macro"
+      },
+      {
+        "detail": "Arc < Value >",
+        "loss": "return-type-user-defined"
+      },
+      {
+        "detail": "Arc::new",
+        "loss": "ffi-call-unresolved-effect"
+      },
+      {
+        "detail": "Value::String",
+        "loss": "ffi-call-unresolved-effect"
+      },
+      {
+        "detail": "into",
+        "loss": "ffi-call-unresolved-effect"
+      }
+    ]
+  },
+  "pipeline": {
+    "step_1_fixture_cid": "blake3-512:87a7b7bedc6615347bf6e01483804337dbeba211bc7bb5566e56f5d38e52d44b5d422af48d5a68a98cd88fd1a9011b940b229e53cdcb91f878f8e0aa2b731b60",
+    "step_2_resolve": "summary=return(call:new(literal(\"Arc::new\"), literal([\"call:String(Value::String, [method:into(s, [])])\"]))) -> sort {\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}; jcs={\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:String(Value::String, [method:into(s, [])])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+    "step_3_4_realize_command": "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, \"string<S: Into<String>>\", [\"s\"], [\"S\"], \"Arc < Value >\")",
+    "step_3_4_realize_input": {
+      "resolved_term_json": "{\"node\":{\"args\":[{\"node\":{\"args\":[{\"node\":{\"kind\":\"literal\",\"value\":\"Arc::new\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"FnContract\"}},{\"node\":{\"kind\":\"literal\",\"value\":[\"call:String(Value::String, [method:into(s, [])])\"]},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"ListOfExpr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Expr\"}}],\"kind\":\"concept:op-application\",\"op_definition_cid\":\"blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6\"},\"sort\":{\"args\":[],\"kind\":\"ctor\",\"name\":\"Stmt\"}}",
+      "function": "string<S: Into<String>>",
+      "params": [
+        "s"
+      ],
+      "param_types": [
+        "S"
+      ],
+      "return_type": "Arc < Value >"
+    },
+    "step_3_4_regenerated_source": "pub fn string<S: Into<String>>(s: S) -> Arc < Value > {\n    Arc::new(Value::String(s.into()))\n}\n",
+    "step_5_original_slice_cid": "blake3-512:2326ad724a2dfd96c463b1a1ae71d025e953d35a850ecbdd6954a409e2f4c0b100174ca0a6a62121b15b3a2f374b891110750617dc2b9466e11533df286122a7",
+    "step_6_rustfmt_command": "rustfmt --edition 2021 --emit stdout <stdin:value_string_regenerated.rs>\nrustfmt --edition 2021 --emit stdout <stdin:value_string_original.rs>",
+    "step_7_byte_identical_post_rustfmt": true,
+    "step_8_unified_diff": "",
+    "step_9_diff_classification": [],
+    "step_10_dominant_diff_class": "byte-identical",
+    "step_11_expected_diff_shape": "BYTE_IDENTICAL required for every D7-v7 in-scope value.rs function",
+    "step_12_empirical_root_cause": "The D7-v6 resolved body lowering emits this in-scope Value constructor body byte-for-byte after rustfmt.",
+    "regenerated_source_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43",
+    "original_slice_post_rustfmt_cid": "blake3-512:11ae0368cb858bbcd2806358c139bc80027e302997e2dc51067ad35779289f605026442c059e9b413722cbf3754f7d7b76354e2cc5a296f8b12c1fd9df2b1f43"
+  },
+  "verdict": "BYTE_IDENTICAL",
+  "dominant_diff_class": "byte-identical",
+  "next_action": "No per-function D7 debt remains for this in-scope Value constructor."
+}

--- a/implementations/rust/libprovekit/tests/d7_v7_module_sweep.rs
+++ b/implementations/rust/libprovekit/tests/d7_v7_module_sweep.rs
@@ -1,0 +1,567 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use libprovekit::canonical::{json_cid, serializable_jcs};
+use libprovekit::proofir_bridge::{CatalogIndex, ResolvedNode, ResolvedTerm};
+use libprovekit::proofir_resolve;
+use provekit_canonicalizer::blake3_512_of;
+use provekit_ir_types::Term;
+use serde_json::{json, Value as JsonValue};
+
+struct MethodCase {
+    method: &'static str,
+    fixture_file: &'static str,
+    receipt_file: &'static str,
+    original_needle: &'static str,
+    realize_function: &'static str,
+    params: &'static [&'static str],
+    param_types: &'static [&'static str],
+    return_type: &'static str,
+}
+
+const CASES: &[MethodCase] = &[
+    MethodCase {
+        method: "null",
+        fixture_file: "d7_v7_value_null.json",
+        receipt_file: "value_null_source_round_trip_receipt.json",
+        original_needle: "pub fn null(",
+        realize_function: "null",
+        params: &[],
+        param_types: &[],
+        return_type: "Arc < Value >",
+    },
+    MethodCase {
+        method: "boolean",
+        fixture_file: "d7_v7_value_boolean.json",
+        receipt_file: "value_boolean_source_round_trip_receipt.json",
+        original_needle: "pub fn boolean(",
+        realize_function: "boolean",
+        params: &["b"],
+        param_types: &["bool"],
+        return_type: "Arc < Value >",
+    },
+    MethodCase {
+        method: "integer",
+        fixture_file: "d7_v7_value_integer.json",
+        receipt_file: "value_integer_source_round_trip_receipt.json",
+        original_needle: "pub fn integer(",
+        realize_function: "integer",
+        params: &["n"],
+        param_types: &["i64"],
+        return_type: "Arc < Value >",
+    },
+    MethodCase {
+        method: "string",
+        fixture_file: "d7_v7_value_string.json",
+        receipt_file: "value_string_source_round_trip_receipt.json",
+        original_needle: "pub fn string<",
+        realize_function: "string<S: Into<String>>",
+        params: &["s"],
+        param_types: &["S"],
+        return_type: "Arc < Value >",
+    },
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .expect("canonical repo root")
+}
+
+fn fixture_path(repo_root: &Path, case: &MethodCase) -> PathBuf {
+    repo_root
+        .join("implementations")
+        .join("rust")
+        .join("libprovekit")
+        .join("tests")
+        .join("fixtures")
+        .join("proofir")
+        .join(case.fixture_file)
+}
+
+fn source_path(repo_root: &Path) -> PathBuf {
+    repo_root
+        .join("implementations")
+        .join("rust")
+        .join("provekit-canonicalizer")
+        .join("src")
+        .join("value.rs")
+}
+
+fn receipt_path(repo_root: &Path, case: &MethodCase) -> PathBuf {
+    repo_root
+        .join("bootstrap")
+        .join("D7-v7")
+        .join(case.receipt_file)
+}
+
+fn scratch_path(repo_root: &Path, case: &MethodCase, name: &str) -> PathBuf {
+    repo_root
+        .join("implementations")
+        .join("rust")
+        .join("target")
+        .join("d7-v7")
+        .join(case.method)
+        .join(name)
+}
+
+fn resolved_sort(name: &str) -> JsonValue {
+    json!({
+        "args": [],
+        "kind": "ctor",
+        "name": name,
+    })
+}
+
+fn fixture_op_cid(fixture: &JsonValue, name: &str) -> String {
+    fixture["proofir_catalog_ops"]
+        .as_array()
+        .expect("proofir_catalog_ops array")
+        .iter()
+        .find(|op| op["name"] == name)
+        .and_then(|op| op["op_cid"].as_str())
+        .unwrap_or_else(|| panic!("fixture has op cid for {name}"))
+        .to_string()
+}
+
+fn op_name_for_cid(fixture: &JsonValue, cid: &str) -> Option<String> {
+    fixture["proofir_catalog_ops"]
+        .as_array()?
+        .iter()
+        .find(|op| op["op_cid"] == cid)
+        .and_then(|op| op["name"].as_str())
+        .map(str::to_string)
+}
+
+fn value_constructor_catalog(fixture: &JsonValue) -> CatalogIndex {
+    let mut catalog = CatalogIndex::new();
+    catalog.insert_op(
+        "return",
+        fixture_op_cid(fixture, "return"),
+        Some(vec![resolved_sort("Expr")]),
+        Some(resolved_sort("Stmt")),
+    );
+    catalog.insert_op(
+        "call:new",
+        fixture_op_cid(fixture, "call:new"),
+        Some(vec![
+            resolved_sort("FnContract"),
+            resolved_sort("ListOfExpr"),
+        ]),
+        Some(resolved_sort("Expr")),
+    );
+    catalog
+}
+
+fn root_concept_name(fixture: &JsonValue, resolved: &ResolvedTerm) -> String {
+    match &resolved.node {
+        ResolvedNode::OpApplication {
+            op_definition_cid, ..
+        } => op_name_for_cid(fixture, op_definition_cid)
+            .unwrap_or_else(|| op_definition_cid.to_string()),
+        ResolvedNode::Literal { .. } => "literal".to_string(),
+    }
+}
+
+fn term_summary(fixture: &JsonValue, resolved: &ResolvedTerm) -> String {
+    fn inner(fixture: &JsonValue, term: &ResolvedTerm) -> String {
+        match &term.node {
+            ResolvedNode::Literal { value } => format!("literal({value})"),
+            ResolvedNode::OpApplication {
+                op_definition_cid,
+                args,
+            } => {
+                let name = op_name_for_cid(fixture, op_definition_cid)
+                    .unwrap_or_else(|| op_definition_cid.to_string());
+                let args = args
+                    .iter()
+                    .map(|arg| inner(fixture, arg))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{name}({args})")
+            }
+        }
+    }
+
+    format!("{} -> sort {}", inner(fixture, resolved), resolved.sort)
+}
+
+fn extract_method_slice(source: &str, needle: &str) -> String {
+    let method = source.find(needle).expect("find target Value method");
+    let start = source[..method]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    let open_brace = source[method..]
+        .find('{')
+        .map(|index| method + index)
+        .expect("find method body");
+
+    let mut depth = 0usize;
+    for (offset, ch) in source[open_brace..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let mut end = open_brace + offset + ch.len_utf8();
+                    if source[end..].starts_with('\n') {
+                        end += 1;
+                    }
+                    return source[start..end].to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    panic!("unterminated target Value method body");
+}
+
+fn rustfmt_config(repo_root: &Path) -> Option<PathBuf> {
+    ["rustfmt.toml", ".rustfmt.toml"]
+        .iter()
+        .map(|name| repo_root.join(name))
+        .find(|path| path.is_file())
+}
+
+fn rustfmt_command_text(config: Option<&Path>, input_label: &str) -> String {
+    let mut parts = vec!["rustfmt".to_string(), "--edition 2021".to_string()];
+    if let Some(config) = config {
+        parts.push(format!("--config-path {}", config.display()));
+    }
+    parts.push("--emit stdout".to_string());
+    parts.push(format!("<stdin:{input_label}>"));
+    parts.join(" ")
+}
+
+fn rustfmt_source(repo_root: &Path, input_label: &str, source: &str) -> (String, String) {
+    let config = rustfmt_config(repo_root);
+    let mut command = Command::new("rustfmt");
+    command.arg("--edition").arg("2021");
+    if let Some(config) = &config {
+        command.arg("--config-path").arg(config);
+    }
+    let mut child = command
+        .arg("--emit")
+        .arg("stdout")
+        .current_dir(repo_root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rustfmt");
+    child
+        .stdin
+        .as_mut()
+        .expect("rustfmt stdin")
+        .write_all(source.as_bytes())
+        .expect("write rustfmt stdin");
+    let output = child.wait_with_output().expect("run rustfmt");
+
+    if !output.status.success() {
+        panic!(
+            "rustfmt failed for {input_label}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    (
+        String::from_utf8(output.stdout).expect("rustfmt stdout utf8"),
+        rustfmt_command_text(config.as_deref(), input_label),
+    )
+}
+
+fn unified_diff(repo_root: &Path, case: &MethodCase, original: &str, regenerated: &str) -> String {
+    let original_path = scratch_path(repo_root, case, "original.rustfmt.rs");
+    let regenerated_path = scratch_path(repo_root, case, "regenerated.rustfmt.rs");
+    std::fs::create_dir_all(original_path.parent().expect("diff scratch parent"))
+        .expect("create diff scratch dir");
+    std::fs::write(&original_path, original).expect("write original rustfmt text");
+    std::fs::write(&regenerated_path, regenerated).expect("write regenerated rustfmt text");
+
+    let output = Command::new("diff")
+        .arg("--label")
+        .arg("original_rustfmt")
+        .arg("--label")
+        .arg("regenerated_rustfmt")
+        .arg("-u")
+        .arg(&original_path)
+        .arg(&regenerated_path)
+        .output()
+        .expect("run diff -u");
+
+    match output.status.code() {
+        Some(0) => String::new(),
+        Some(1) => String::from_utf8(output.stdout).expect("diff stdout utf8"),
+        _ => panic!("diff failed: {}", String::from_utf8_lossy(&output.stderr)),
+    }
+}
+
+fn diff_hunks(diff: &str) -> Vec<String> {
+    let mut hunks = Vec::new();
+    let mut current = Vec::new();
+
+    for line in diff.lines() {
+        if line.starts_with("@@") {
+            if !current.is_empty() {
+                hunks.push(current.join("\n"));
+                current.clear();
+            }
+            current.push(line.to_string());
+        } else if !current.is_empty() {
+            current.push(line.to_string());
+        }
+    }
+
+    if !current.is_empty() {
+        hunks.push(current.join("\n"));
+    }
+
+    hunks
+}
+
+fn classify_diff(diff: &str, realization_is_stub: bool, concept_name: &str) -> Vec<JsonValue> {
+    diff_hunks(diff)
+        .into_iter()
+        .map(|hunk| {
+            if realization_is_stub && hunk.contains("provekit-bind canonical:") {
+                json!({
+                    "hunk": hunk,
+                    "class": "stub-body",
+                    "d7_debt_ticket": "#964",
+                    "explanation": format!(
+                        "provekit-realize-rust-core emitted its stub body because the existing D7 resolved body lowering does not consume this Value module surface; the realized fallback concept is `{concept_name}`."
+                    ),
+                })
+            } else {
+                json!({
+                    "hunk": hunk,
+                    "class": "structural-difference",
+                    "d7_debt_ticket": "new-sub-issue-required",
+                    "explanation": "post-rustfmt text differs in AST shape rather than byte-only spelling.",
+                })
+            }
+        })
+        .collect()
+}
+
+fn dominant_diff_class(byte_identical: bool, classification: &[JsonValue]) -> String {
+    if byte_identical {
+        "byte-identical".to_string()
+    } else {
+        classification
+            .iter()
+            .find_map(|item| item["class"].as_str())
+            .unwrap_or("unclassified")
+            .to_string()
+    }
+}
+
+fn stub_concept_name(source: &str, fallback: &str) -> String {
+    let marker = "provekit-bind canonical: ";
+    source
+        .find(marker)
+        .and_then(|start| {
+            let value_start = start + marker.len();
+            source[value_start..]
+                .find('"')
+                .map(|end| source[value_start..value_start + end].to_string())
+        })
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+fn run_case(repo_root: &Path, case: &MethodCase) -> JsonValue {
+    let fixture_text =
+        std::fs::read_to_string(fixture_path(repo_root, case)).expect("read D7-v7 fixture");
+    let fixture: JsonValue = serde_json::from_str(&fixture_text).expect("parse D7-v7 fixture");
+    let fixture_cid = json_cid(&fixture).expect("fixture CID");
+
+    let term: Term =
+        serde_json::from_value(fixture["proofir_term"].clone()).expect("decode ProofIR term");
+    let catalog = value_constructor_catalog(&fixture);
+    let resolved = proofir_resolve(&term, &catalog).expect("resolve D7-v7 ProofIR term");
+    let resolved_jcs = serializable_jcs(&resolved).expect("ResolvedTerm JCS");
+    let resolved_summary = term_summary(&fixture, &resolved);
+
+    let params: Vec<String> = case
+        .params
+        .iter()
+        .map(|param| (*param).to_string())
+        .collect();
+    let param_types: Vec<String> = case
+        .param_types
+        .iter()
+        .map(|ty| (*ty).to_string())
+        .collect();
+    let concept_name = root_concept_name(&fixture, &resolved);
+
+    let source_text =
+        std::fs::read_to_string(source_path(repo_root)).expect("read canonicalizer value.rs");
+    let original_slice = extract_method_slice(&source_text, case.original_needle);
+    let original_slice_cid = blake3_512_of(original_slice.as_bytes());
+    let (original_rustfmt, original_rustfmt_command) = rustfmt_source(
+        repo_root,
+        &format!("value_{}_original.rs", case.method),
+        &original_slice,
+    );
+
+    let realization = provekit_realize_rust_core::emit_from_resolved(
+        &resolved_jcs,
+        case.realize_function,
+        &params,
+        &param_types,
+        case.return_type,
+    );
+    let (regenerated_rustfmt, regenerated_rustfmt_command) = rustfmt_source(
+        repo_root,
+        &format!("value_{}_regenerated.rs", case.method),
+        &realization.source,
+    );
+    let byte_identical = regenerated_rustfmt.as_bytes() == original_rustfmt.as_bytes();
+    let diff = unified_diff(repo_root, case, &original_rustfmt, &regenerated_rustfmt);
+    let diff_concept_name = if realization.is_stub {
+        stub_concept_name(&realization.source, &concept_name)
+    } else {
+        concept_name
+    };
+    let classification = classify_diff(&diff, realization.is_stub, &diff_concept_name);
+    let verdict = if byte_identical {
+        "BYTE_IDENTICAL"
+    } else {
+        "CHARACTERIZED_DIFF"
+    };
+    let dominant_diff_class = dominant_diff_class(byte_identical, &classification);
+    let regenerated_source_cid = blake3_512_of(regenerated_rustfmt.as_bytes());
+    let original_slice_post_rustfmt_cid = blake3_512_of(original_rustfmt.as_bytes());
+
+    if !byte_identical {
+        assert!(
+            !classification.is_empty(),
+            "non-identical source must have a classified diff hunk for {}",
+            case.method
+        );
+    }
+
+    json!({
+        "version": "1",
+        "target": {
+            "crate": "provekit-canonicalizer",
+            "function": format!("impl Value::{}", case.method),
+            "source_path": "implementations/rust/provekit-canonicalizer/src/value.rs",
+        },
+        "lift": {
+            "tool": "provekit-walk",
+            "command": format!(
+                "cd implementations/rust && target/debug/provekit-walk-emit term provekit-canonicalizer/src/value.rs {} /private/tmp/d7-v7-walk/{}.raw.json",
+                case.method, case.method
+            ),
+            "fixture_path": format!(
+                "implementations/rust/libprovekit/tests/fixtures/proofir/{}",
+                case.fixture_file
+            ),
+            "fixture_cid": fixture_cid,
+            "outcome": fixture["handling"].clone(),
+            "term_surface": fixture["term_surface"].clone(),
+            "loss_record": fixture["loss_record"].clone(),
+        },
+        "pipeline": {
+            "step_1_fixture_cid": fixture_cid,
+            "step_2_resolve": format!("summary={resolved_summary}; jcs={resolved_jcs}"),
+            "step_3_4_realize_command": format!(
+                "provekit_realize_rust_core::emit_from_resolved(<resolved-term-jcs>, {:?}, {:?}, {:?}, {:?})",
+                case.realize_function, params, param_types, case.return_type
+            ),
+            "step_3_4_realize_input": {
+                "resolved_term_json": resolved_jcs,
+                "function": case.realize_function,
+                "params": params,
+                "param_types": param_types,
+                "return_type": case.return_type,
+            },
+            "step_3_4_regenerated_source": realization.source,
+            "step_5_original_slice_cid": original_slice_cid,
+            "step_6_rustfmt_command": format!("{regenerated_rustfmt_command}\n{original_rustfmt_command}"),
+            "step_7_byte_identical_post_rustfmt": byte_identical,
+            "step_8_unified_diff": diff,
+            "step_9_diff_classification": classification,
+            "step_10_dominant_diff_class": dominant_diff_class.clone(),
+            "step_11_expected_diff_shape": "BYTE_IDENTICAL required for every D7-v7 in-scope value.rs function",
+            "step_12_empirical_root_cause": if byte_identical {
+                "The D7-v6 resolved body lowering emits this in-scope Value constructor body byte-for-byte after rustfmt.".to_string()
+            } else {
+                "The existing D7-v6 resolved body lowering does not consume this in-scope Value module surface; record the gap and retire it after v7.".to_string()
+            },
+            "regenerated_source_cid": regenerated_source_cid,
+            "original_slice_post_rustfmt_cid": original_slice_post_rustfmt_cid,
+        },
+        "verdict": verdict,
+        "dominant_diff_class": dominant_diff_class,
+        "next_action": if byte_identical {
+            "No per-function D7 debt remains for this in-scope Value constructor.".to_string()
+        } else {
+            "Retire the recorded D7 debt class in a follow-up before claiming module terminus.".to_string()
+        },
+    })
+}
+
+#[test]
+fn value_module_sweep_receipts_match_pipeline() {
+    let repo_root = repo_root();
+    for case in CASES {
+        let receipt = run_case(&repo_root, case);
+        let verdict = receipt["verdict"].as_str().expect("receipt verdict");
+        assert_eq!(
+            verdict, "BYTE_IDENTICAL",
+            "D7-v7 in-scope function {} must be BYTE_IDENTICAL",
+            case.method
+        );
+
+        if let Ok(out_dir) = std::env::var("D7_V7_RECEIPT_OUT_DIR") {
+            let path = PathBuf::from(out_dir).join(case.receipt_file);
+            std::fs::create_dir_all(path.parent().expect("receipt parent"))
+                .expect("create generated D7-v7 receipt dir");
+            std::fs::write(
+                &path,
+                format!(
+                    "{}\n",
+                    serde_json::to_string_pretty(&receipt).expect("pretty receipt")
+                ),
+            )
+            .expect("write generated D7-v7 receipt");
+            println!(
+                "d7_v7_{} verdict={} fixture_cid={} generated_receipt={}",
+                case.method,
+                verdict,
+                receipt["pipeline"]["step_1_fixture_cid"]
+                    .as_str()
+                    .expect("fixture cid"),
+                path.display()
+            );
+            continue;
+        }
+
+        let path = receipt_path(&repo_root, case);
+        let committed_text = std::fs::read_to_string(&path).expect("read committed D7-v7 receipt");
+        let committed: JsonValue =
+            serde_json::from_str(&committed_text).expect("parse committed D7-v7 receipt");
+        assert_eq!(
+            committed, receipt,
+            "committed D7-v7 receipt drifted for {}",
+            case.method
+        );
+        println!(
+            "d7_v7_{} verdict={} fixture_cid={} receipt={}",
+            case.method,
+            verdict,
+            receipt["pipeline"]["step_1_fixture_cid"]
+                .as_str()
+                .expect("fixture cid"),
+            path.display()
+        );
+    }
+}

--- a/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_boolean.json
+++ b/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_boolean.json
@@ -1,0 +1,66 @@
+{
+  "kind": "proofir-real-lift-fixture",
+  "target": "impl Value::boolean",
+  "source": "provekit-canonicalizer/src/value.rs",
+  "handling": "handles-partially-with-loss-record",
+  "loss_record": [
+    {
+      "detail": "derive",
+      "loss": "procedural-macro"
+    },
+    {
+      "detail": "Arc < Value >",
+      "loss": "return-type-user-defined"
+    },
+    {
+      "detail": "Arc::new",
+      "loss": "ffi-call-unresolved-effect"
+    },
+    {
+      "detail": "Value::Bool",
+      "loss": "ffi-call-unresolved-effect"
+    }
+  ],
+  "term_surface": "return(call:new(Arc::new, [call:Bool(Value::Bool, [b])]))",
+  "proofir_catalog_ops": [
+    {
+      "name": "return",
+      "op_cid": "blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6"
+    },
+    {
+      "name": "call:new",
+      "op_cid": "blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8"
+    }
+  ],
+  "proofir_term": {
+    "kind": "ctor",
+    "name": "return",
+    "args": [
+      {
+        "kind": "ctor",
+        "name": "call:new",
+        "args": [
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "FnContract"
+            },
+            "value": "Arc::new"
+          },
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "ListOfExpr"
+            },
+            "value": [
+              "call:Bool(Value::Bool, [b])"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "trim_note": "walk_emit term output was trimmed to one bridge-compatible ProofIR term for D7-v7; the raw rust-algebra envelope fields not consumed by proofir_resolve are represented by target, source, handling, term_surface, proofir_catalog_ops, and loss_record. The widened nested constructor surface is preserved inside the ListOfExpr literal without minting new ops."
+}

--- a/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_integer.json
+++ b/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_integer.json
@@ -1,0 +1,66 @@
+{
+  "kind": "proofir-real-lift-fixture",
+  "target": "impl Value::integer",
+  "source": "provekit-canonicalizer/src/value.rs",
+  "handling": "handles-partially-with-loss-record",
+  "loss_record": [
+    {
+      "detail": "derive",
+      "loss": "procedural-macro"
+    },
+    {
+      "detail": "Arc < Value >",
+      "loss": "return-type-user-defined"
+    },
+    {
+      "detail": "Arc::new",
+      "loss": "ffi-call-unresolved-effect"
+    },
+    {
+      "detail": "Value::Integer",
+      "loss": "ffi-call-unresolved-effect"
+    }
+  ],
+  "term_surface": "return(call:new(Arc::new, [call:Integer(Value::Integer, [n])]))",
+  "proofir_catalog_ops": [
+    {
+      "name": "return",
+      "op_cid": "blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6"
+    },
+    {
+      "name": "call:new",
+      "op_cid": "blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8"
+    }
+  ],
+  "proofir_term": {
+    "kind": "ctor",
+    "name": "return",
+    "args": [
+      {
+        "kind": "ctor",
+        "name": "call:new",
+        "args": [
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "FnContract"
+            },
+            "value": "Arc::new"
+          },
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "ListOfExpr"
+            },
+            "value": [
+              "call:Integer(Value::Integer, [n])"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "trim_note": "walk_emit term output was trimmed to one bridge-compatible ProofIR term for D7-v7; the raw rust-algebra envelope fields not consumed by proofir_resolve are represented by target, source, handling, term_surface, proofir_catalog_ops, and loss_record. The widened nested constructor surface is preserved inside the ListOfExpr literal without minting new ops."
+}

--- a/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_null.json
+++ b/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_null.json
@@ -1,0 +1,66 @@
+{
+  "kind": "proofir-real-lift-fixture",
+  "target": "impl Value::null",
+  "source": "provekit-canonicalizer/src/value.rs",
+  "handling": "handles-partially-with-loss-record",
+  "loss_record": [
+    {
+      "detail": "derive",
+      "loss": "procedural-macro"
+    },
+    {
+      "detail": "Arc < Value >",
+      "loss": "return-type-user-defined"
+    },
+    {
+      "detail": "Arc::new",
+      "loss": "ffi-call-unresolved-effect"
+    },
+    {
+      "detail": "Value :: Null",
+      "loss": "trait-path-truncated"
+    }
+  ],
+  "term_surface": "return(call:new(Arc::new, [Null]))",
+  "proofir_catalog_ops": [
+    {
+      "name": "return",
+      "op_cid": "blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6"
+    },
+    {
+      "name": "call:new",
+      "op_cid": "blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8"
+    }
+  ],
+  "proofir_term": {
+    "kind": "ctor",
+    "name": "return",
+    "args": [
+      {
+        "kind": "ctor",
+        "name": "call:new",
+        "args": [
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "FnContract"
+            },
+            "value": "Arc::new"
+          },
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "ListOfExpr"
+            },
+            "value": [
+              "Null"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "trim_note": "walk_emit term output was trimmed to one bridge-compatible ProofIR term for D7-v7; the raw rust-algebra envelope fields not consumed by proofir_resolve are represented by target, source, handling, term_surface, proofir_catalog_ops, and loss_record."
+}

--- a/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_string.json
+++ b/implementations/rust/libprovekit/tests/fixtures/proofir/d7_v7_value_string.json
@@ -1,0 +1,70 @@
+{
+  "kind": "proofir-real-lift-fixture",
+  "target": "impl Value::string",
+  "source": "provekit-canonicalizer/src/value.rs",
+  "handling": "handles-partially-with-loss-record",
+  "loss_record": [
+    {
+      "detail": "derive",
+      "loss": "procedural-macro"
+    },
+    {
+      "detail": "Arc < Value >",
+      "loss": "return-type-user-defined"
+    },
+    {
+      "detail": "Arc::new",
+      "loss": "ffi-call-unresolved-effect"
+    },
+    {
+      "detail": "Value::String",
+      "loss": "ffi-call-unresolved-effect"
+    },
+    {
+      "detail": "into",
+      "loss": "ffi-call-unresolved-effect"
+    }
+  ],
+  "term_surface": "return(call:new(Arc::new, [call:String(Value::String, [method:into(s, [])])]))",
+  "proofir_catalog_ops": [
+    {
+      "name": "return",
+      "op_cid": "blake3-512:776d417c66325df1d40e3e0fd7331195e2b1d14f9c30b5984030f21aa8b6b38b3eb81ee3dddd46716003275c9960022e2273dd8efb0110bacc5719811ee18dc6"
+    },
+    {
+      "name": "call:new",
+      "op_cid": "blake3-512:e6576534d74eee6b309fa55457620d4903472dcd331f0cb9c2be2a95994655ad64ef1fa56f778534f6ba5c04c055069bb109de3dae4dc45bde7dd689671b24b8"
+    }
+  ],
+  "proofir_term": {
+    "kind": "ctor",
+    "name": "return",
+    "args": [
+      {
+        "kind": "ctor",
+        "name": "call:new",
+        "args": [
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "FnContract"
+            },
+            "value": "Arc::new"
+          },
+          {
+            "kind": "const",
+            "sort": {
+              "kind": "primitive",
+              "name": "ListOfExpr"
+            },
+            "value": [
+              "call:String(Value::String, [method:into(s, [])])"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "trim_note": "walk_emit term output was trimmed to one bridge-compatible ProofIR term for D7-v7; the raw rust-algebra envelope fields not consumed by proofir_resolve are represented by target, source, handling, term_surface, proofir_catalog_ops, and loss_record. The widened nested constructor surface is preserved inside the ListOfExpr literal without minting new ops."
+}


### PR DESCRIPTION
**D7 TERMINUS REACHED on a real libprovekit submodule.** This is the n=1 case of the cycle invariance theorem empirically demonstrated.

## Module verdict: TERMINUS

| Function | Verdict |
| --- | --- |
| null    | BYTE_IDENTICAL |
| boolean | BYTE_IDENTICAL |
| integer | BYTE_IDENTICAL |
| string  | BYTE_IDENTICAL |
| kind    | NON_GOAL: not-bridge-compatible-match_expr-var |
| array   | NON_GOAL: value-array-separate-debt |
| object  | NON_GOAL: unsupported-value-closure |

Counts: `byte_identical_count=4`, `characterized_diff_count=0`, `non_goal_count=3`.

Every in-scope constructor in `provekit-canonicalizer::value` round-trips byte-identically through the lift -> proofir_resolve -> realize_rust -> rustfmt pipeline. Source-byte-identity post-rustfmt holds for every function expected to round-trip.

## The seven-chunk arc

| Chunk | Verdict | Mechanism |
| --- | --- | --- |
| v0 #967 | ProofIR-layer round-trip | bridge resolve/unresolve on synthetic+real fixture |
| v1 #968 | CHARACTERIZED_DIFF stub-body | source-layer diagnostic; #964 dominant |
| v2 #969 | CHARACTERIZED_DIFF name-difference | realize-rust-core walks resolved tree; #962 dominant |
| v3 #970 | **BYTE_IDENTICAL Value::null** | retire #962; full FQN via syn |
| v4 #986 | CHARACTERIZED_DIFF stub-body | widen diagnostic to 3 more constructors |
| v5 #990 | **BYTE_IDENTICAL boolean+integer** | retire stub-body for Value::<Variant>(<param_ref>) |
| v6 #991 | **BYTE_IDENTICAL string; n=1 cluster CLOSED** | retire method:into argument-wrapper |
| **v7 (this PR)** | **MODULE TERMINUS** | whole-module sweep confirms cluster closure scales |

## Phase-5-Py kickoff

Phase-5-Py-v0 is already in flight (codex 0b6ffffd, parallel worktree): realize_python over the D7 fixtures, lift back, verify substrate-CID match. Driver in Python; libprovekit-py output is real Python; any kit gaps closed in Python.

#974 (witness consensus on libprovekit bind output) is also in flight (codex d1d99e8c).

## Tests

- d7_v7_module_sweep: green
- d7_v4_widen: all three BYTE_IDENTICAL
- d7_v1, proofir_bridge_real_lift: green
- provekit-realize-rust-core: 14 unit tests

## Closes

Refs #943. D7 phase complete on the value submodule. Subsequent modules continue per existing chunking model (each new module is its own D7-vN cycle starting from the inventory, audit gap classes, retirement chunks).