### PR TITLE
feat(bootstrap D7-debt): retire Expr::MethodCall in statement position (provekit-walk)

### DIFF
--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -726,6 +726,21 @@ fn lower_expr_to_stmt(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm,
         Expr::Block(block) => lower_stmts_to_stmt(&block.block.stmts, ctx),
         Expr::ForLoop(for_loop) => lower_for_loop_to_stmt(for_loop, ctx),
         Expr::Match(match_expr) => lower_match_to_stmt(match_expr, ctx),
+        Expr::MethodCall(method) => {
+            if method.turbofish.is_some() {
+                return Err(
+                    "unsupported statement-position method call with explicit turbofish"
+                        .to_string(),
+                );
+            }
+            if matches!(&*method.receiver, Expr::MethodCall(_)) {
+                return Err(
+                    "unsupported statement-position method call chain: receiver Expr::MethodCall"
+                        .to_string(),
+                );
+            }
+            lower_method_call_expr_to_value_term(method, ctx)
+        }
         Expr::Try(try_expr) => Ok(AlgebraTerm::op(
             "try",
             vec![lower_expr_to_value_term(&try_expr.expr, ctx)?],
@@ -1685,6 +1700,28 @@ mod tests {
             parsed["term_surface"].as_str(),
             Some("let(pattern_bind(y), add(x, 1), return(y))")
         );
+    }
+
+    #[test]
+    fn rust_term_json_lowers_statement_position_method_call() {
+        let src = r#"
+            struct Sink;
+            impl Sink {
+                fn write(&mut self, value: i32) {}
+            }
+            fn caller(mut sink: Sink, value: i32) {
+                sink.write(value);
+            }
+        "#;
+        let item_fn = parse_named(src, "caller");
+        let bytes = rust_function_term_json(&item_fn, "caller.rs").unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("valid JSON");
+
+        assert_eq!(
+            parsed["term_surface"].as_str(),
+            Some("method:write(sink, [value])")
+        );
+        assert_eq!(parsed["term"]["name"].as_str(), Some("method:write"));
     }
 
     #[test]


### PR DESCRIPTION
Per-language kit retirement: one new match-arm in provekit-walk's statement emitter for Expr::MethodCall as a statement. Closes the direct stmt method-call refusal class.

Chain-receiver case (a.b().c()) handled by sibling chunk; method-call in arg position handled by D7-v6.

Tests: d7_v3, d7_v4_widen, d7_v7_module_sweep, d7_v1, proofir_bridge_real_lift all green.

Per-language kit. No substrate. No new memento types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for method calls in statement position, with proper validation and handling of edge cases.

* **Tests**
  * Added test coverage for statement-position method call emission and verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1000)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->