### PR TITLE
feat(bootstrap D7-debt): retire method-chain receivers (a.b().c()) -- blake3_512_of NOW LIFTS

### DIFF
--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -733,12 +733,6 @@ fn lower_expr_to_stmt(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm,
                         .to_string(),
                 );
             }
-            if matches!(&*method.receiver, Expr::MethodCall(_)) {
-                return Err(
-                    "unsupported statement-position method call chain: receiver Expr::MethodCall"
-                        .to_string(),
-                );
-            }
             lower_method_call_expr_to_value_term(method, ctx)
         }
         Expr::Try(try_expr) => Ok(AlgebraTerm::op(

--- a/implementations/rust/provekit-walk/tests/term_emit_d2.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d2.rs
@@ -198,3 +198,26 @@ fn lowers_simple_method_call_expression_with_unresolved_call_loss() {
         .iter()
         .any(|loss| loss["loss"] == "ffi-call-unresolved-effect"));
 }
+
+#[test]
+fn lowers_statement_method_chain_receiver_as_nested_method_term() {
+    let parsed = term_json(
+        r#"
+            struct Receiver;
+            fn caller(expr: Receiver) {
+                expr.method1().method2();
+            }
+        "#,
+        "caller",
+    );
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("method:method2(method:method1(expr, []), [])")
+    );
+    assert_eq!(parsed["term"]["name"].as_str(), Some("method:method2"));
+    assert_eq!(
+        parsed["term"]["args"][0]["name"].as_str(),
+        Some("method:method1")
+    );
+    assert_eq!(parsed["term"]["args"][0]["args"][0]["name"], "expr");
+}


### PR DESCRIPTION
Empirical breakthrough: **blake3_512_of lifts cleanly via provekit-walk-emit.**

Removes the chain-reject guard that PR #1000 added as a safety net. The value-term recursion path already handles nested method-call receivers correctly; the guard was over-cautious.

## Empirical

```sh
./target/release/provekit-walk-emit term provekit-canonicalizer/src/hash.rs blake3_512_of /tmp/b3.json
# term CID: blake3-512:bac54cc60a11b0c902c1a00a7dcd0825fa1ded256401d2ea5170ef175d7c47d20d74539bab1952f3f62ef835482163e3233e753fb764d38fa75f07389ceb3494
# term bytes: 6238
```

## Unblocks

The libprovekit-py mechanical-lowering work (codex aff00ca7 stopped on this refusal). After this PR + the realize-python kit work landing tonight, libprovekit-py can be produced via the substrate's own CLI.

## Tests

- provekit-walk term_emit_d2: 9 passed
- libprovekit d7_v1 / d7_v4_widen / d7_v7_module_sweep: all 3 passed

Per-language kit only. No substrate. No new memento types.