### PR TITLE
feat(bootstrap D7-debt): retire other Expr::* shapes in statement position

### DIFF
--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -739,12 +739,34 @@ fn lower_expr_to_stmt(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm,
             "try",
             vec![lower_expr_to_value_term(&try_expr.expr, ctx)?],
         )),
-        Expr::Tuple(tuple) if tuple.elems.is_empty() => Ok(AlgebraTerm::skip()),
+        Expr::Index(_) => lower_discarded_value_expr_to_stmt(expr, ctx),
+        Expr::Field(_) => lower_discarded_value_expr_to_stmt(expr, ctx),
+        Expr::Tuple(tuple) => {
+            if tuple.elems.is_empty() {
+                Ok(AlgebraTerm::skip())
+            } else {
+                lower_discarded_value_expr_to_stmt(expr, ctx)
+            }
+        }
+        Expr::Array(_) => lower_discarded_value_expr_to_stmt(expr, ctx),
+        Expr::Reference(_) => lower_discarded_value_expr_to_stmt(expr, ctx),
+        Expr::Path(_) => Ok(AlgebraTerm::skip()),
+        Expr::Lit(_) => Ok(AlgebraTerm::skip()),
         _ => Err(format!(
             "unsupported expression statement {}",
             expr_kind(expr)
         )),
     }
+}
+
+fn lower_discarded_value_expr_to_stmt(
+    expr: &Expr,
+    ctx: &LoweringContext,
+) -> Result<AlgebraTerm, String> {
+    Ok(AlgebraTerm::op(
+        "drop",
+        vec![lower_expr_to_value_term(expr, ctx)?],
+    ))
 }
 
 fn lower_assign_expr_to_stmt(

--- a/implementations/rust/provekit-walk/tests/term_emit_d7_stmt_expr_other.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d7_stmt_expr_other.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_walk::emit::rust_function_term_json_for_file;
+
+fn term_json(src: &str, name: &str) -> serde_json::Value {
+    let file: syn::File = syn::parse_str(src).unwrap();
+    let bytes = rust_function_term_json_for_file(&file, name, "d7_stmt_expr_other.rs").unwrap();
+    serde_json::from_slice(&bytes).expect("term JSON")
+}
+
+#[test]
+fn d7_lowers_index_expression_statement() {
+    let parsed = term_json(
+        r#"
+            fn touch_index(xs: [i32; 2], mut out: i32) {
+                xs[0];
+                out = 1;
+            }
+        "#,
+        "touch_index",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(drop(index(xs, 0)), assign(out, 1))")
+    );
+}
+
+#[test]
+fn d7_lowers_field_expression_statement() {
+    let parsed = term_json(
+        r#"
+            struct Point { x: i32 }
+            fn touch_field(p: Point, mut out: i32) {
+                p.x;
+                out = 1;
+            }
+        "#,
+        "touch_field",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(drop(field(p, x)), assign(out, 1))")
+    );
+}
+
+#[test]
+fn d7_lowers_tuple_expression_statement() {
+    let parsed = term_json(
+        r#"
+            fn touch_tuple(x: i32, mut out: i32) {
+                (x, 2);
+                out = 1;
+            }
+        "#,
+        "touch_tuple",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(drop(tuple([x, 2])), assign(out, 1))")
+    );
+}
+
+#[test]
+fn d7_lowers_array_expression_statement() {
+    let parsed = term_json(
+        r#"
+            fn touch_array(x: i32, mut out: i32) {
+                [x, 2];
+                out = 1;
+            }
+        "#,
+        "touch_array",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(drop(array([x, 2])), assign(out, 1))")
+    );
+}
+
+#[test]
+fn d7_lowers_reference_expression_statement() {
+    let parsed = term_json(
+        r#"
+            fn touch_reference(x: i32, mut out: i32) {
+                &x;
+                out = 1;
+            }
+        "#,
+        "touch_reference",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(drop(borrow(x)), assign(out, 1))")
+    );
+}
+
+#[test]
+fn d7_lowers_path_expression_statement_as_noop() {
+    let parsed = term_json(
+        r#"
+            fn touch_path(x: i32, mut out: i32) {
+                x;
+                out = 1;
+            }
+        "#,
+        "touch_path",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(skip, assign(out, 1))")
+    );
+}
+
+#[test]
+fn d7_lowers_literal_expression_statement_as_noop() {
+    let parsed = term_json(
+        r#"
+            fn touch_literal(mut out: i32) {
+                1;
+                out = 1;
+            }
+        "#,
+        "touch_literal",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("seq(skip, assign(out, 1))")
+    );
+}


### PR DESCRIPTION
Adds 7 new match-arms in provekit-walk-emit's statement-emitter: Expr::Index/Field/Tuple drop, Expr::Array/Reference reuse value-term, Expr::Path/Lit as skip. Each covered by a synthetic test. Existing D7 tests stay green. Per-language kit. No substrate.