### PR TITLE
feat(bootstrap D7-debt): extend provekit-realize-python-core for method/call/let terms

### DIFF
--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
@@ -13,6 +13,9 @@ import blake3
 BODY_TEMPLATE_REL = Path(
     "menagerie/python-language-signature/specs/body-templates/python-canonical-bodies.json"
 )
+LIBPROVEKIT_BODY_TEMPLATE_REL = Path(
+    "menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-libprovekit.json"
+)
 PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
 DEFAULT_KIT_CID = "blake3-512:" + blake3.blake3(
     b"provekit-realize-python-core@0.1.0"
@@ -36,6 +39,18 @@ class BodyTemplateEntry:
     requires_return_type: str | None
 
 
+@dataclass(frozen=True)
+class TermBody:
+    body: str
+    is_stub: bool
+
+
+@dataclass(frozen=True)
+class TermExpression:
+    text: str | None = None
+    stub_body: str | None = None
+
+
 def emit_stub(
     function: str,
     params: list[str],
@@ -46,10 +61,15 @@ def emit_stub(
     sugar_cids: list[str] | None = None,
     sugar_plugins: list[Any] | None = None,
 ) -> dict[str, Any]:
-    body = body_template_for(concept_name, params, param_types, return_type)
-    is_stub = body is None
-    if body is None:
-        body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
+    term_body = term_body_for(concept_name, params, param_types, return_type)
+    if term_body is not None:
+        body = term_body.body
+        is_stub = term_body.is_stub
+    else:
+        body = body_template_for(concept_name, params, param_types, return_type)
+        is_stub = body is None
+        if body is None:
+            body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
     contract_lines = contract_comment_lines(contract, sugar_cids or [], sugar_plugins or [])
     result = {
         "source": _function_source(function, params, body, leading_lines=contract_lines),
@@ -220,10 +240,69 @@ def body_template_for(
     param_types: list[str],
     return_type: str,
 ) -> str | None:
+    return _body_template_for_entries(
+        entries(),
+        (concept_name, concept_name.removeprefix("concept:")),
+        params,
+        param_types,
+        return_type,
+    )
+
+
+def term_body_for(
+    term_surface: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> TermBody | None:
+    surface = term_surface.strip()
+    if not surface:
+        return None
+
+    return_arg = _single_call_arg(surface, "return")
+    if return_arg is not None:
+        expr = _lower_term_expression(return_arg, params, param_types, return_type)
+        if expr is None:
+            return None
+        if expr.stub_body is not None:
+            return TermBody(expr.stub_body, True)
+        return TermBody(f"return {expr.text}", False)
+
+    if surface.startswith("method:"):
+        method_body = _lower_method_template_body(surface, params, param_types, return_type)
+        if method_body is not None:
+            return TermBody(method_body, False)
+        expr = _lower_term_expression(surface, params, param_types, return_type)
+        if expr is None:
+            return None
+        if expr.stub_body is not None:
+            return TermBody(expr.stub_body, True)
+        return TermBody(f"return {expr.text}", False)
+
+    if surface.startswith("call:"):
+        expr = _lower_term_expression(surface, params, param_types, return_type)
+        if expr is None:
+            return None
+        if expr.stub_body is not None:
+            return TermBody(expr.stub_body, True)
+        return TermBody(f"return {expr.text}", False)
+
+    if surface.startswith("let("):
+        return _lower_let_body(surface, params, param_types, return_type)
+
+    return None
+
+
+def _body_template_for_entries(
+    body_entries: tuple[BodyTemplateEntry, ...],
+    candidate_names: tuple[str, ...],
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> str | None:
     mapped_param_types = [map_source_type(ty) for ty in param_types]
     mapped_return_type = map_source_type(return_type)
-    candidate_names = (concept_name, concept_name.removeprefix("concept:"))
-    for entry in entries():
+    for entry in body_entries:
         if entry.concept_name not in candidate_names:
             continue
         if entry.min_params is not None and len(params) < entry.min_params:
@@ -243,6 +322,326 @@ def body_template_for(
             continue
         return rendered
     return None
+
+
+def _lower_term_expression(
+    term_surface: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> TermExpression | None:
+    surface = term_surface.strip()
+    return_arg = _single_call_arg(surface, "return")
+    if return_arg is not None:
+        return _lower_term_expression(return_arg, params, param_types, return_type)
+    if surface.startswith("method:"):
+        return _lower_method_expression(surface, params, param_types, return_type)
+    if surface.startswith("call:"):
+        return _lower_call_expression(surface, params, param_types, return_type)
+    if surface.startswith("let("):
+        return None
+    return TermExpression(text=surface)
+
+
+def _lower_method_template_body(
+    surface: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> str | None:
+    method = _parse_method_surface(surface)
+    if method is None:
+        return None
+    method_name, receiver, args = method
+    return _libprovekit_method_template(method_name, receiver, args, params, param_types, return_type)
+
+
+def _lower_method_expression(
+    surface: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> TermExpression | None:
+    method = _parse_method_surface(surface)
+    if method is None:
+        return None
+    method_name, receiver, args = method
+    template = _libprovekit_method_template(
+        method_name,
+        receiver,
+        args,
+        params,
+        param_types,
+        return_type,
+    )
+    if template is not None:
+        expression = _single_return_expression(template)
+        if expression is not None:
+            return TermExpression(text=expression)
+    receiver_expr = _lower_argument_expression(receiver, params, param_types, return_type)
+    if receiver_expr.stub_body is not None:
+        return receiver_expr
+    arg_exprs = _lower_argument_list(args, params, param_types, return_type)
+    if arg_exprs is None:
+        return None
+    return TermExpression(text=f"{receiver_expr.text}.{method_name}({', '.join(arg_exprs)})")
+
+
+def _lower_call_expression(
+    surface: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> TermExpression | None:
+    parsed = _parse_call_surface(surface)
+    if parsed is None:
+        return None
+    path, args = parsed
+    if path == "String::with_capacity":
+        return TermExpression(text="str()")
+    if "::" in path:
+        return TermExpression(stub_body=_unsupported_call_stub(path, surface))
+    arg_exprs = _lower_argument_list(args, params, param_types, return_type)
+    if arg_exprs is None:
+        return None
+    return TermExpression(text=f"{path}({', '.join(arg_exprs)})")
+
+
+def _lower_let_body(
+    surface: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> TermBody | None:
+    inner = _single_call_arg(surface, "let")
+    if inner is None:
+        return None
+    args = _split_top_level(inner)
+    if len(args) != 2:
+        return None
+    pattern = _lower_pattern(args[0])
+    rhs = _lower_term_expression(args[1], params, param_types, return_type)
+    if rhs is None:
+        return None
+    if rhs.stub_body is not None:
+        return TermBody(rhs.stub_body, True)
+    return TermBody(f"{pattern} = {rhs.text}", False)
+
+
+def _lower_pattern(pattern: str) -> str:
+    raw = pattern.strip()
+    bind_arg = _single_call_arg(raw, "pattern_bind")
+    if bind_arg is not None:
+        raw = bind_arg.strip()
+    ascription = _split_type_ascription(raw)
+    if ascription is None:
+        return raw
+    name, type_name = ascription
+    return f"{name}: {map_source_type(type_name)}"
+
+
+def _lower_argument_list(
+    args: list[str],
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> list[str] | None:
+    lowered: list[str] = []
+    for arg in args:
+        expr = _lower_argument_expression(arg, params, param_types, return_type)
+        if expr.stub_body is not None or expr.text is None:
+            return None
+        lowered.append(expr.text)
+    return lowered
+
+
+def _lower_argument_expression(
+    arg: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> TermExpression:
+    expr = _lower_term_expression(arg, params, param_types, return_type)
+    if expr is not None:
+        return expr
+    return TermExpression(text=arg.strip())
+
+
+def _libprovekit_method_template(
+    method_name: str,
+    receiver: str,
+    args: list[str],
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+) -> str | None:
+    if not _simple_receiver_name(receiver):
+        return None
+    receiver_key = _concept_key(receiver)
+    method_key = _concept_key(method_name)
+    candidates = (
+        f"concept:{receiver_key}-{method_key}",
+        f"{receiver_key}-{method_key}",
+    )
+    arg_types = [_type_for_argument(arg, params, param_types) for arg in args]
+    return _body_template_for_entries(
+        libprovekit_entries(),
+        candidates,
+        [arg.strip() for arg in args],
+        arg_types,
+        return_type,
+    )
+
+
+def _parse_method_surface(surface: str) -> tuple[str, str, list[str]] | None:
+    head_args = _head_and_args(surface.removeprefix("method:"))
+    if head_args is None:
+        return None
+    method_name, inner = head_args
+    args = _split_top_level(inner)
+    if len(args) != 2:
+        return None
+    method_args = _parse_bracket_list(args[1])
+    if method_args is None:
+        return None
+    return method_name.strip(), args[0].strip(), method_args
+
+
+def _parse_call_surface(surface: str) -> tuple[str, list[str]] | None:
+    head_args = _head_and_args(surface.removeprefix("call:"))
+    if head_args is None:
+        return None
+    path, inner = head_args
+    args = _split_top_level(inner)
+    if len(args) == 1 and args[0] == "":
+        return path.strip(), []
+    if len(args) == 2:
+        legacy_args = _parse_bracket_list(args[1])
+        if legacy_args is not None:
+            return args[0].strip(), legacy_args
+    return path.strip(), args
+
+
+def _single_call_arg(surface: str, head: str) -> str | None:
+    head_args = _head_and_args(surface)
+    if head_args is None:
+        return None
+    got_head, inner = head_args
+    if got_head != head:
+        return None
+    return inner
+
+
+def _head_and_args(surface: str) -> tuple[str, str] | None:
+    stripped = surface.strip()
+    if not stripped.endswith(")"):
+        return None
+    index = stripped.find("(")
+    if index <= 0:
+        return None
+    return stripped[:index], stripped[index + 1 : -1]
+
+
+def _parse_bracket_list(surface: str) -> list[str] | None:
+    stripped = surface.strip()
+    if not stripped.startswith("[") or not stripped.endswith("]"):
+        return None
+    inner = stripped[1:-1].strip()
+    if not inner:
+        return []
+    return _split_top_level(inner)
+
+
+def _split_top_level(text: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index, ch in enumerate(text):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+            continue
+        if ch in {"'", '"'}:
+            quote = ch
+            continue
+        if ch in "([{":
+            depth += 1
+            continue
+        if ch in ")]}":
+            depth -= 1
+            continue
+        if ch == "," and depth == 0:
+            parts.append(text[start:index].strip())
+            start = index + 1
+    parts.append(text[start:].strip())
+    return parts
+
+
+def _split_type_ascription(pattern: str) -> tuple[str, str] | None:
+    depth = 0
+    for index, ch in enumerate(pattern):
+        if ch in "([{":
+            depth += 1
+            continue
+        if ch in ")]}":
+            depth -= 1
+            continue
+        if ch != ":" or depth != 0:
+            continue
+        previous_ch = pattern[index - 1] if index > 0 else ""
+        next_ch = pattern[index + 1] if index + 1 < len(pattern) else ""
+        if previous_ch == ":" or next_ch == ":":
+            continue
+        name = pattern[:index].strip()
+        type_name = pattern[index + 1 :].strip()
+        if name and type_name:
+            return name, type_name
+    return None
+
+
+def _single_return_expression(body: str) -> str | None:
+    stripped = body.strip()
+    if "\n" in stripped:
+        return None
+    if not stripped.startswith("return "):
+        return None
+    return stripped.removeprefix("return ").strip()
+
+
+def _unsupported_call_stub(path: str, surface: str) -> str:
+    message = _double_quoted(f"provekit-bind canonical: call:{path}")
+    return (
+        f"# provekit-realize-python: unsupported canonical call `{path}`; "
+        f"no Python shim matched `{surface}`\n"
+        f"raise NotImplementedError({message})"
+    )
+
+
+def _double_quoted(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _simple_receiver_name(receiver: str) -> bool:
+    return re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", receiver.strip()) is not None
+
+
+def _concept_key(value: str) -> str:
+    return value.strip().replace("_", "-").lower()
+
+
+def _type_for_argument(arg: str, params: list[str], param_types: list[str]) -> str:
+    stripped = arg.strip()
+    for index, param in enumerate(params):
+        if stripped == param and index < len(param_types):
+            return param_types[index]
+    return ""
 
 
 def map_source_type(src: str) -> str:
@@ -281,7 +680,16 @@ def render_template(
 
 @lru_cache(maxsize=1)
 def entries() -> tuple[BodyTemplateEntry, ...]:
-    path = _find_repo_file(BODY_TEMPLATE_REL)
+    return _entries_from_file(BODY_TEMPLATE_REL)
+
+
+@lru_cache(maxsize=1)
+def libprovekit_entries() -> tuple[BodyTemplateEntry, ...]:
+    return _entries_from_file(LIBPROVEKIT_BODY_TEMPLATE_REL)
+
+
+def _entries_from_file(relative: Path) -> tuple[BodyTemplateEntry, ...]:
+    path = _find_repo_file(relative)
     if path is None:
         return ()
     raw = path.read_text(encoding="utf-8")

--- a/implementations/python/provekit-realize-python-core/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realizer.py
@@ -162,6 +162,91 @@ def test_unknown_concept_falls_back_to_python_stub() -> None:
     }
 
 
+def test_method_term_surface_renders_python_method_call() -> None:
+    result = emit_stub(
+        function="trim",
+        params=["value"],
+        param_types=["str"],
+        return_type="str",
+        concept_name="return(method:strip(value, []))",
+    )
+
+    assert result == {
+        "source": "def trim(value):\n    return value.strip()\n",
+        "is_stub": False,
+        "extension": "py",
+    }
+
+
+def test_method_term_surface_uses_libprovekit_body_template_binding() -> None:
+    result = emit_stub(
+        function="value_string",
+        params=["text"],
+        param_types=["str"],
+        return_type="Value",
+        concept_name="method:string(Value, [text])",
+    )
+
+    assert result == {
+        "source": "def value_string(text):\n    return Value.string(text)\n",
+        "is_stub": False,
+        "extension": "py",
+    }
+
+
+def test_call_term_surface_renders_python_call() -> None:
+    result = emit_stub(
+        function="reserve_text",
+        params=["capacity"],
+        param_types=["int"],
+        return_type="str",
+        concept_name="return(call:String::with_capacity(capacity))",
+    )
+
+    assert result == {
+        "source": "def reserve_text(capacity):\n    return str()\n",
+        "is_stub": False,
+        "extension": "py",
+    }
+
+
+def test_unsupported_qualified_call_term_surface_emits_cited_stub() -> None:
+    result = emit_stub(
+        function="unknown_call",
+        params=["x"],
+        param_types=["int"],
+        return_type="int",
+        concept_name="return(call:Widget::build(x))",
+    )
+
+    assert result == {
+        "source": (
+            "def unknown_call(x):\n"
+            "    # provekit-realize-python: unsupported canonical call `Widget::build`; "
+            "no Python shim matched `call:Widget::build(x)`\n"
+            '    raise NotImplementedError("provekit-bind canonical: call:Widget::build")\n'
+        ),
+        "is_stub": True,
+        "extension": "py",
+    }
+
+
+def test_let_term_surface_renders_python_assignment_with_type_ascription() -> None:
+    result = emit_stub(
+        function="bind_value",
+        params=["source"],
+        param_types=["int"],
+        return_type="None",
+        concept_name="let(result: i64, call:identity(source))",
+    )
+
+    assert result == {
+        "source": "def bind_value(source):\n    result: int = identity(source)\n",
+        "is_stub": False,
+        "extension": "py",
+    }
+
+
 def test_contract_witnesses_emit_liftable_contract_comment_payloads() -> None:
     result = emit_stub(
         function="wrap_identity",


### PR DESCRIPTION
Mirror of the Rust lifter retirements landing tonight (#1000-#1003). Adds Python-side emission for method/call/let terms so the round-trip can complete.

- method:<name>(<receiver>, [<args>]) -> <receiver>.<name>(<args>)
- call:<path>(<args>) -> <path>(<args>); String::with_capacity special-cased; other qualified calls emit citation-comment stubs
- let(<pattern>, <rhs>) -> <pattern> = <rhs>
- libprovekit method-template shims via python-canonical-bodies-libprovekit.json

11 pytest passes. Anything Python-related is in Python. No Rust changes. No substrate. Refs #943, #977.