### PR TITLE
feat(bootstrap D7-debt): retire Expr::Call in statement position

### DIFF
--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -738,6 +738,7 @@ fn lower_expr_to_stmt(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm,
             }
             lower_method_call_expr_to_value_term(method, ctx)
         }
+        Expr::Call(call) => lower_call_expr_to_value_term(call, ctx),
         Expr::Try(try_expr) => Ok(AlgebraTerm::op(
             "try",
             vec![lower_expr_to_value_term(&try_expr.expr, ctx)?],


### PR DESCRIPTION
One match-arm: Expr::Call statement -> call:<func-path>(<args>) via existing lower_call_expr_to_value_term. Targets String::with_capacity(capacity); in blake3_512_of. blake3_512_of now lifts with richer ProofIR (term CID blake3-512:d57caa58...; previously blake3-512:bac54cc6...). Existing D7 tests green.