### PR TITLE
feat(bootstrap D7-debt): retire Expr::Closure in value position

### DIFF
--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -1040,6 +1040,80 @@ fn lower_expr_to_value_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebr
         }
         Expr::Call(call) => lower_call_expr_to_value_term(call, ctx),
         Expr::MethodCall(method) => lower_method_call_expr_to_value_term(method, ctx),
+        Expr::Closure(closure) => {
+            if closure.asyncness.is_some() {
+                return Err("unsupported async closure in value position".to_string());
+            }
+            if closure.capture.is_some() {
+                return Err("unsupported move closure in value position".to_string());
+            }
+            let mut params = Vec::new();
+            let mut closure_ctx = ctx.clone();
+            for input in &closure.inputs {
+                let mut bindings = match input {
+                    syn::Pat::Ident(ident) => vec![(ident.ident.to_string(), None)],
+                    syn::Pat::Type(pat_type) => match &*pat_type.pat {
+                        syn::Pat::Ident(ident) => {
+                            vec![(ident.ident.to_string(), sort_from_type(&pat_type.ty))]
+                        }
+                        _ => {
+                            return Err(
+                                "unsupported closure parameter destructuring pattern".to_string()
+                            );
+                        }
+                    },
+                    syn::Pat::Tuple(tuple) if closure.inputs.len() == 1 => {
+                        let mut tuple_bindings = Vec::new();
+                        for elem in &tuple.elems {
+                            match elem {
+                                syn::Pat::Ident(ident) => {
+                                    tuple_bindings.push((ident.ident.to_string(), None))
+                                }
+                                syn::Pat::Type(pat_type) => {
+                                    let syn::Pat::Ident(ident) = &*pat_type.pat else {
+                                        return Err(
+                                            "unsupported closure parameter destructuring pattern"
+                                                .to_string(),
+                                        );
+                                    };
+                                    tuple_bindings.push((
+                                        ident.ident.to_string(),
+                                        sort_from_type(&pat_type.ty),
+                                    ));
+                                }
+                                _ => {
+                                    return Err(
+                                        "unsupported closure parameter destructuring pattern"
+                                            .to_string(),
+                                    );
+                                }
+                            }
+                        }
+                        tuple_bindings
+                    }
+                    _ => {
+                        return Err(
+                            "unsupported closure parameter destructuring pattern".to_string()
+                        );
+                    }
+                };
+                for (name, sort) in bindings.drain(..) {
+                    closure_ctx = closure_ctx.with_var(name.clone(), sort);
+                    params.push(AlgebraTerm::Symbol(name));
+                }
+            }
+            ctx.add_loss(
+                "closure-captures-environment",
+                closure.to_token_stream().to_string(),
+            );
+            Ok(AlgebraTerm::op(
+                "closure",
+                vec![
+                    AlgebraTerm::List(params),
+                    lower_expr_to_value_term(&closure.body, &closure_ctx)?,
+                ],
+            ))
+        }
         Expr::Array(array) => {
             let items = array
                 .elems

--- a/implementations/rust/provekit-walk/tests/term_emit_d7.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d7.rs
@@ -77,3 +77,21 @@ fn d7_lowers_wildcard_let_binding_with_path_call_rhs() {
     );
     assert_loss(&parsed, "ffi-call-unresolved-effect");
 }
+
+#[test]
+fn d7_lowers_closure_in_value_position_with_loss_record() {
+    let parsed = term_json(
+        r#"
+            fn make_incrementer() {
+                let inc = |x| x + 1;
+            }
+        "#,
+        "make_incrementer",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("let(pattern_bind(inc), closure([x], add(x, 1)), skip)")
+    );
+    assert_loss(&parsed, "closure-captures-environment");
+}


### PR DESCRIPTION
One arm in lower_expr_to_value_term. |x| x + 1 -> closure([x], add(x, 1)) with closure-captures-environment loss record. Value::object now lifts via closure shape. Refuses async/move/destructuring (separate gaps). Existing D7 tests green. Per-language kit. No substrate.