### PR TITLE
feat(bootstrap D7-debt): retire Expr::Macro

### DIFF
--- a/implementations/rust/provekit-walk/src/emit.rs
+++ b/implementations/rust/provekit-walk/src/emit.rs
@@ -154,10 +154,6 @@ const LOSS_IMPL_ASSOCIATED_TYPE_NOT_LOWERED: &str = "impl-associated-type-not-lo
 /// are parsed on a function signature but not represented in the term.
 const LOSS_ABI_ATTRIBUTE_NOT_CARRIED: &str = "abi-attribute-not-carried";
 
-/// Accepted-loss dimension for statement-position macro invocations that are
-/// retained only as an opaque no-op in the emitted term.
-const LOSS_STATEMENT_MACRO: &str = "statement-macro";
-
 /// Accepted-loss dimension for `let mut` bindings whose mutability marker is
 /// not represented in the let pattern term.
 const LOSS_LET_BINDING_MUTABILITY: &str = "let-binding-mutability";
@@ -166,9 +162,9 @@ const LOSS_LET_BINDING_MUTABILITY: &str = "let-binding-mutability";
 /// kept but whose binding semantics are not fully represented during bootstrap.
 const LOSS_D4_EXPR_LET: &str = "Expr::Let";
 
-/// Accepted-loss dimension for expression-position macros that are retained as
-/// opaque macro-call terms because this lifter does not expand macro bodies.
-const LOSS_D4_EXPR_MACRO: &str = "Expr::Macro";
+/// Accepted-loss dimension for Rust macro invocations that are recorded without
+/// expanding their token streams.
+const LOSS_MACRO_NOT_EXPANDED: &str = "macro-not-expanded";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum AlgebraTerm {
@@ -614,11 +610,7 @@ fn lower_stmts_to_stmt(stmts: &[Stmt], ctx: &LoweringContext) -> Result<AlgebraT
             }
             Stmt::Item(_) => {}
             Stmt::Macro(mac) => {
-                ctx.add_loss(
-                    LOSS_STATEMENT_MACRO,
-                    mac.mac.path.to_token_stream().to_string(),
-                );
-                lowered.push(AlgebraTerm::skip());
+                lowered.push(lower_macro_to_value_term(&mac.mac, ctx)?);
             }
         }
     }
@@ -739,6 +731,7 @@ fn lower_expr_to_stmt(expr: &Expr, ctx: &LoweringContext) -> Result<AlgebraTerm,
             lower_method_call_expr_to_value_term(method, ctx)
         }
         Expr::Call(call) => lower_call_expr_to_value_term(call, ctx),
+        Expr::Macro(mac) => lower_macro_to_value_term(&mac.mac, ctx),
         Expr::Try(try_expr) => Ok(AlgebraTerm::op(
             "try",
             vec![lower_expr_to_value_term(&try_expr.expr, ctx)?],
@@ -883,7 +876,7 @@ fn lower_expr_to_bool_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebra
             lower_expr_to_value_term(expr, ctx)
         }
         Expr::Let(let_expr) => lower_let_expr_to_bool_term(let_expr, ctx),
-        Expr::Macro(mac) => lower_macro_to_value_term(mac, ctx),
+        Expr::Macro(mac) => lower_macro_to_value_term(&mac.mac, ctx),
         Expr::Match(match_expr) => lower_match_to_bool_term(match_expr, ctx),
         Expr::Paren(paren) => lower_expr_to_bool_term(&paren.expr, ctx),
         Expr::Block(block) => {
@@ -1165,8 +1158,7 @@ fn lower_expr_to_value_term(expr: &Expr, ctx: &LoweringContext) -> Result<Algebr
                 vec![lower_expr_to_value_term(&try_expr.expr, ctx)?],
             ))
         }
-        Expr::Macro(mac) if mac.mac.path.is_ident("vec") => lower_vec_macro_to_value_term(mac, ctx),
-        Expr::Macro(mac) => lower_macro_to_value_term(mac, ctx),
+        Expr::Macro(mac) => lower_macro_to_value_term(&mac.mac, ctx),
         Expr::Match(match_expr) => lower_match_to_value_term(match_expr, ctx),
         Expr::Reference(reference) => {
             let op = if reference.mutability.is_some() {
@@ -1346,39 +1338,43 @@ fn lower_struct_expr_to_value_term(
 }
 
 fn lower_macro_to_value_term(
-    mac: &syn::ExprMacro,
+    mac: &syn::Macro,
     ctx: &LoweringContext,
 ) -> Result<AlgebraTerm, String> {
     let name = mac
-        .mac
         .path
         .segments
         .last()
         .map(|segment| segment.ident.to_string())
         .unwrap_or_else(|| "unknown".to_string());
-    ctx.add_loss(LOSS_D4_EXPR_MACRO, format!("{name}!"));
+    ctx.add_loss(LOSS_MACRO_NOT_EXPANDED, format!("{name}!"));
+    if mac.path.is_ident("vec") {
+        if let Some(term) = lower_vec_macro_to_value_term(mac, ctx)? {
+            return Ok(term);
+        }
+    }
     Ok(AlgebraTerm::op(
-        format!("call:macro:{name}"),
-        vec![AlgebraTerm::Symbol(name), AlgebraTerm::List(Vec::new())],
+        format!("macro_call:{name}"),
+        vec![AlgebraTerm::Symbol(mac.tokens.to_string())],
     ))
 }
 
 fn lower_vec_macro_to_value_term(
-    mac: &syn::ExprMacro,
+    mac: &syn::Macro,
     ctx: &LoweringContext,
-) -> Result<AlgebraTerm, String> {
-    ctx.add_loss("vec-macro-desugared-to-array", "vec!");
+) -> Result<Option<AlgebraTerm>, String> {
     let parser = syn::punctuated::Punctuated::<Expr, syn::Token![,]>::parse_terminated;
-    let items = match parser.parse2(mac.mac.tokens.clone()) {
+    let items = match parser.parse2(mac.tokens.clone()) {
         Ok(items) => items
             .iter()
             .map(|expr| lower_expr_to_value_term(expr, ctx))
             .collect::<Result<Vec<_>, _>>()?,
-        Err(err) => {
-            return Err(format!("unsupported vec! macro body: {err}"));
-        }
+        Err(_) => return Ok(None),
     };
-    Ok(AlgebraTerm::op("array", vec![AlgebraTerm::List(items)]))
+    Ok(Some(AlgebraTerm::op(
+        "array",
+        vec![AlgebraTerm::List(items)],
+    )))
 }
 
 fn expr_sort(expr: &Expr, ctx: &LoweringContext) -> Option<ExprSort> {

--- a/implementations/rust/provekit-walk/src/signature.rs
+++ b/implementations/rust/provekit-walk/src/signature.rs
@@ -49,6 +49,7 @@ pub fn canonical_operation_name(surface_name: &str) -> Option<&str> {
         "field" => Some("field"),
         name if name.starts_with("method:") => Some("method_call"),
         name if name.starts_with("call:") => Some("call_result"),
+        name if name.starts_with("macro_call:") => Some("call_result"),
         op @ ("skip" | "seq" | "if" | "while" | "for" | "switch" | "call" | "return" | "break"
         | "continue" | "deref" | "member" | "assign" | "neg" | "panic" | "try"
         | "try_option" | "match" | "match_expr" | "borrow" | "borrow_mut" | "deref_raw"

--- a/implementations/rust/provekit-walk/tests/term_emit_cli.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_cli.rs
@@ -45,7 +45,11 @@ fn term_emit_cli_writes_statement_macro_as_partial_loss_term_json() {
         .as_array()
         .unwrap()
         .iter()
-        .any(|loss| loss["loss"] == "statement-macro"));
+        .any(|loss| loss["loss"] == "macro-not-expanded"));
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("macro_call:println(\"not representable\")")
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("# rust term for function=bad"),

--- a/implementations/rust/provekit-walk/tests/term_emit_d3.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d3.rs
@@ -99,5 +99,5 @@ fn accepts_statement_macro_as_named_loss() {
         "#,
         "checked",
     );
-    assert_partial_loss(&parsed, "statement-macro");
+    assert_partial_loss(&parsed, "macro-not-expanded");
 }

--- a/implementations/rust/provekit-walk/tests/term_emit_d4.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d4.rs
@@ -117,9 +117,9 @@ fn d4_accepts_boolean_macro_expression_as_named_loss() {
     );
     assert_eq!(
         parsed["term_surface"].as_str(),
-        Some("return(call:macro:matches(matches, []))")
+        Some("return(macro_call:matches(x , 1))")
     );
-    assert_loss(&parsed, "Expr::Macro");
+    assert_loss(&parsed, "macro-not-expanded");
 }
 
 #[test]

--- a/implementations/rust/provekit-walk/tests/term_emit_d7.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d7.rs
@@ -79,6 +79,7 @@ fn d7_lowers_wildcard_let_binding_with_path_call_rhs() {
 }
 
 #[test]
+<<<<<<< Updated upstream
 fn d7_lowers_closure_in_value_position_with_loss_record() {
     let parsed = term_json(
         r#"
@@ -87,11 +88,63 @@ fn d7_lowers_closure_in_value_position_with_loss_record() {
             }
         "#,
         "make_incrementer",
+=======
+fn d7_lowers_vec_macro_value_to_array_with_macro_loss() {
+    let parsed = term_json(
+        r#"
+            fn make_vec() -> Vec<i32> {
+                vec![1, 2, 3]
+            }
+        "#,
+        "make_vec",
+>>>>>>> Stashed changes
     );
 
     assert_eq!(
         parsed["term_surface"].as_str(),
+<<<<<<< Updated upstream
         Some("let(pattern_bind(inc), closure([x], add(x, 1)), skip)")
     );
     assert_loss(&parsed, "closure-captures-environment");
+=======
+        Some("return(array([1, 2, 3]))")
+    );
+    assert_loss(&parsed, "macro-not-expanded");
+}
+
+#[test]
+fn d7_lowers_println_statement_macro_to_opaque_macro_call() {
+    let parsed = term_json(
+        r#"
+            fn log_hi() {
+                println!("hi");
+            }
+        "#,
+        "log_hi",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("macro_call:println(\"hi\")")
+    );
+    assert_loss(&parsed, "macro-not-expanded");
+}
+
+#[test]
+fn d7_lowers_assert_statement_macro_to_opaque_macro_call() {
+    let parsed = term_json(
+        r#"
+            fn check(cond: bool) {
+                assert!(cond);
+            }
+        "#,
+        "check",
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("macro_call:assert(cond)")
+    );
+    assert_loss(&parsed, "macro-not-expanded");
+>>>>>>> Stashed changes
 }


### PR DESCRIPTION
Macros -> macro_call:<name>(<tokens>) with macro-not-expanded loss. vec! special-cases to array(<elements>); other macros stay opaque. Synthetic D7 tests cover vec!/println!/assert!. Existing D7 tests green. Per-language kit. No substrate.