### PR TITLE
hotfix(provekit-walk): resolve merge conflict markers in term_emit_d7.rs (broke main from #1006+#1007)

### DIFF
--- a/implementations/rust/provekit-walk/tests/term_emit_d7.rs
+++ b/implementations/rust/provekit-walk/tests/term_emit_d7.rs
@@ -79,7 +79,6 @@ fn d7_lowers_wildcard_let_binding_with_path_call_rhs() {
 }
 
 #[test]
-<<<<<<< Updated upstream
 fn d7_lowers_closure_in_value_position_with_loss_record() {
     let parsed = term_json(
         r#"
@@ -88,7 +87,16 @@ fn d7_lowers_closure_in_value_position_with_loss_record() {
             }
         "#,
         "make_incrementer",
-=======
+    );
+
+    assert_eq!(
+        parsed["term_surface"].as_str(),
+        Some("let(pattern_bind(inc), closure([x], add(x, 1)), skip)")
+    );
+    assert_loss(&parsed, "closure-captures-environment");
+}
+
+#[test]
 fn d7_lowers_vec_macro_value_to_array_with_macro_loss() {
     let parsed = term_json(
         r#"
@@ -97,16 +105,10 @@ fn d7_lowers_vec_macro_value_to_array_with_macro_loss() {
             }
         "#,
         "make_vec",
->>>>>>> Stashed changes
     );
 
     assert_eq!(
         parsed["term_surface"].as_str(),
-<<<<<<< Updated upstream
-        Some("let(pattern_bind(inc), closure([x], add(x, 1)), skip)")
-    );
-    assert_loss(&parsed, "closure-captures-environment");
-=======
         Some("return(array([1, 2, 3]))")
     );
     assert_loss(&parsed, "macro-not-expanded");
@@ -146,5 +148,4 @@ fn d7_lowers_assert_statement_macro_to_opaque_macro_call() {
         Some("macro_call:assert(cond)")
     );
     assert_loss(&parsed, "macro-not-expanded");
->>>>>>> Stashed changes
 }


### PR DESCRIPTION
PRs #1006 and #1007 both added tests to term_emit_d7.rs. The macro-call rebase kept the conflict markers unresolved, breaking provekit-walk's tests on main. This PR resolves them. All 7 term_emit_d7 tests pass; d7_v1/v4/v7 tests pass. Em-dash sweep clean.