### PR TITLE
feat(libprovekit-py): v0 honest refusal at first FFI shim gap

### DIFF
--- a/bootstrap/libprovekit-py-v1/gap-ticket.md
+++ b/bootstrap/libprovekit-py-v1/gap-ticket.md
@@ -1,0 +1,96 @@
+# libprovekit-py v0 -> v1: vendor-shim gap for blake3 FFI
+
+## Where v0 stopped
+
+End-to-end pipeline runs cleanly:
+
+1. `provekit-walk-emit term implementations/rust/provekit-canonicalizer/src/hash.rs blake3_512_of` emits a 6407-byte ProofIR with term CID `blake3-512:63306c27...`.
+2. `provekit-realize-python-core` consumes the term via JSON-RPC and returns:
+
+```python
+def blake3_512_of(bytes):
+    # provekit-realize-python: unsupported canonical call `blake3::Hasher::new`; no Python shim matched `call:new(blake3::Hasher::new, [])`
+    raise NotImplementedError("provekit-bind canonical: call:blake3::Hasher::new")
+```
+
+`is_stub=True`. The realize-kit honestly refuses at the first FFI call that has no Python shim.
+
+`implementations/python/libprovekit-py/libprovekit_py/canonical.py` is the verbatim text of the realize-kit's `source` field. No hand-editing, no decoration.
+
+## The gap class
+
+`no-python-shim-for-ffi-call:<symbol>` for the following Rust FFI symbols referenced in the term surface:
+
+- `blake3::Hasher::new` (call)
+- `update` (method)
+- `finalize_xof` (method)
+- `fill` (method)
+- `hex::encode` (call)
+- `String::with_capacity` (call)
+- `len` (method)
+- `push_str` (method)
+
+All map to library calls that have well-defined Python equivalents but no body-template entry in `menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-libprovekit.json`.
+
+## A separate, deeper gap: lifter statement-level effect loss
+
+The Rust body contains side-effecting statements that the lifter drops:
+
+```rust
+let mut hasher = blake3::Hasher::new();
+hasher.update(bytes);                          // dropped
+let mut out = [0u8; 64];
+hasher.finalize_xof().fill(&mut out);          // dropped
+let hex = hex::encode(out);
+```
+
+The lifter records these as `ffi-call-unresolved-effect` in the loss_record but they do not appear in the term tree. Even if every FFI shim were authored, the resulting Python would be wrong: `out` would always be `[0u8; 64]` and the digest would be the hash of zeros regardless of input.
+
+This is a lifter-level gap, distinct from the realize-kit's shim gap. It is substrate-gated and explicitly out of scope for per-language kit work.
+
+## Two paths to v1
+
+### Path A (per-language kit, no substrate)
+
+Author `python-canonical-bodies-libprovekit.json` entries that bind the eight FFI symbols above to Python equivalents:
+
+| Rust symbol | Python equivalent |
+| --- | --- |
+| `blake3::Hasher::new` | `blake3.blake3()` |
+| `Hasher.update` | `.update(...)` |
+| `Hasher.finalize_xof` | `(no-op; digest takes length=)` |
+| `OutputReader.fill` | `(use digest(length=64))` |
+| `hex::encode` | `bytes.hex()` |
+| `String::with_capacity` | `""` (Python strings are not preallocated) |
+| `str.len` | `len(...)` |
+| `String.push_str` | `+= ...` |
+
+This is body-template work; it follows the existing schema and signs the new entries with the libprovekit-py kit's key. It does NOT touch substrate.
+
+But: until the lifter gap is closed, the lowered Python is wrong even with full shim coverage. Path A produces a Python `blake3_512_of` that returns the same string regardless of input. That violates `k(I) = t` for any non-trivial `t`. Loudly characterize the loss in the receipt.
+
+### Path B (vendor absorption flow, issue #985)
+
+Run `bootstrap/scripts/absorb_vendor_library.sh <blake3-pyo3-source-path> blake3` to:
+
+1. Bind the blake3 vendor library (Rust crate) into the substrate via `provekit bind --rewrite annotate`.
+2. LLM auto-names each anonymous concept at the API edge per issue #980.
+3. Re-bind with `--rewrite invisible` to mint named PromotionDecisionMemento entries.
+4. Auto-mint concept hubs via `mint_from_promotion_decisions.py`.
+5. Generate `python-canonical-bodies-libprovekit.json` entries from the bind output.
+
+This produces the same body-template state as Path A but driven by the LLM-narrated cluster -> concept -> name pipeline. It is the canonical "absorption" pattern.
+
+Still gated by the lifter statement-level effect gap.
+
+### Path C (substrate work, not tonight)
+
+Extend `provekit-walk` to track statement-level method-call effects so `hasher.update(bytes)` appears in the lifted term and contributes to the output's data flow. This is the architectural fix that makes blake3_512_of's term faithful to its semantics. Substrate-gated.
+
+## Next chunk's brief
+
+Pick Path A (manual body-template entries) as the minimal forward motion. Write three entries: blake3::Hasher::new, hex::encode, String::push_str. Re-run the realize pipeline. Surface the next refusal class. Iterate.
+
+Defer Path B (#985 vendor absorption driver) until at least one manual Path A entry confirms the realize-kit's catalog-match logic finds new body-template entries correctly.
+
+Defer Path C indefinitely under the per-language kit constraint.

--- a/bootstrap/libprovekit-py-v1/receipt.json
+++ b/bootstrap/libprovekit-py-v1/receipt.json
@@ -1,0 +1,49 @@
+{
+  "artifact": "libprovekit-py",
+  "status": "refusal",
+  "version": "v0",
+  "function_under_test": "blake3_512_of",
+  "rust_source": "implementations/rust/provekit-canonicalizer/src/hash.rs",
+  "rust_term_cid": "blake3-512:63306c27eb2d5433a87a48e82bdf2cec1d48b155e5a47f9f4ab48a32d32de9dca7184fbba14fe86f82d6fa3e06f123057fcc9404ea9de9376ae7f432a7567723",
+  "rust_signature_cid": "blake3-512:6e96976ee181cc32de6dfb326b9b9a96e5f47b7ba8afef9606d93cee15984fc1c81de78491da094a788bf50725b26824e22b16d79a5b80dc76cd169c59aa844c",
+  "pipeline": {
+    "lift": {
+      "binary": "provekit-walk-emit",
+      "invocation": "provekit-walk-emit term implementations/rust/provekit-canonicalizer/src/hash.rs blake3_512_of /tmp/blake3_512_of.term.json",
+      "handling": "handles-partially-with-loss-record",
+      "loss_classes": [
+        "procedural-macro: test",
+        "return-type-user-defined: String",
+        "let-binding-mutability: hasher",
+        "ffi-call-unresolved-effect: blake3::Hasher::new",
+        "ffi-call-unresolved-effect: update",
+        "let-binding-mutability: out",
+        "ffi-call-unresolved-effect: fill",
+        "ffi-call-unresolved-effect: finalize_xof",
+        "ffi-call-unresolved-effect: hex::encode",
+        "let-binding-mutability: s",
+        "ffi-call-unresolved-effect: String::with_capacity",
+        "type-inference-assumed-int: Expr::MethodCall",
+        "ffi-call-unresolved-effect: len",
+        "ffi-call-unresolved-effect: push_str"
+      ]
+    },
+    "realize": {
+      "binary": "provekit-realize-python-core",
+      "method": "provekit.plugin.invoke",
+      "is_stub": true,
+      "stub_reason": "unsupported canonical call `blake3::Hasher::new`; no Python shim matched `call:new(blake3::Hasher::new, [])`",
+      "refusal_class": "no-python-shim-for-ffi-call:blake3::Hasher::new"
+    }
+  },
+  "claim": "v0 establishes the end-to-end pipeline (provekit-walk-emit -> provekit-realize-python-core) for libprovekit's first function. The Python output is the literal stdout of the realize-kit. The realize-kit emits an honest NotImplementedError stub because the term's first operation (call:new on blake3::Hasher::new) has no body-template entry in python-canonical-bodies-libprovekit.json. This is a vendor-shim gap, not a realizer term-shape gap.",
+  "what_v1_needs": "Either (a) author body-template entries for blake3, hex, and String FFI ops in python-canonical-bodies-libprovekit.json (per-library shim work, no substrate), OR (b) run the vendor-absorption flow (issue #985) to auto-mint concept hubs + body-template entries for the blake3 vendor library at its API edge.",
+  "out_of_scope_tonight": "Substrate changes: new concept hubs, lifter effect-tracking for statement-level method calls, RefusalMemento variants. Per the bootstrap arc rules, per-language kit work cannot mint new concept-shape specs.",
+  "gates": {
+    "no_substrate_changes": true,
+    "no_new_memento_types": true,
+    "no_new_specs": true,
+    "no_hand_authored_fallback_in_canonical_py": true,
+    "canonical_py_is_verbatim_realize_kit_output": true
+  }
+}

--- a/implementations/python/libprovekit-py/libprovekit_py/__init__.py
+++ b/implementations/python/libprovekit-py/libprovekit_py/__init__.py
@@ -1,0 +1,1 @@
+from .canonical import blake3_512_of

--- a/implementations/python/libprovekit-py/libprovekit_py/canonical.py
+++ b/implementations/python/libprovekit-py/libprovekit_py/canonical.py
@@ -1,0 +1,3 @@
+def blake3_512_of(bytes):
+    # provekit-realize-python: unsupported canonical call `blake3::Hasher::new`; no Python shim matched `call:new(blake3::Hasher::new, [])`
+    raise NotImplementedError("provekit-bind canonical: call:blake3::Hasher::new")

--- a/implementations/python/libprovekit-py/pyproject.toml
+++ b/implementations/python/libprovekit-py/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "libprovekit-py"
+version = "0.1.0"
+description = "Python realization of libprovekit, lowered via provekit-walk-emit + provekit-realize-python-core. v0: honest refusal at first FFI shim gap."
+
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
## Summary

First end-to-end run of `provekit-walk-emit` + `provekit-realize-python-core` against a libprovekit function. Result is an honest refusal at the first body-template gap, with a concrete plan for v1.

## What v0 establishes

- Pipeline works mechanically. Rust source -> term ProofIR (6407 bytes, CID `blake3-512:63306c27...`) -> Python via RPC.
- `canonical.py` is the LITERAL `source` field returned by the realize-kit. No hand-authoring, no decoration.
- The package installs and imports. The smoke test catches the `NotImplementedError` documented inside the stub.

## What v0 refuses

The realize-kit emits `is_stub=True` with `stub_reason: \"unsupported canonical call blake3::Hasher::new; no Python shim matched call:new(blake3::Hasher::new, [])\"`. This is a body-template gap, not a realizer term-shape gap.

The lift also drops statement-level method calls (`hasher.update(bytes)`, `hasher.finalize_xof().fill(&mut out)`) into the `loss_record` rather than the term tree. That is a separate substrate-level gap (lifter effect tracking) which is out of scope for this PR.

Both refusals are recorded verbatim in `bootstrap/libprovekit-py-v1/receipt.json` and the gap-ticket.

## What's NOT in this PR

- Substrate changes (no concept hubs, no spec edits, no new memento types).
- Hand-authored Python fallback (canonical.py is the verbatim realize-kit stdout).
- Special-case helpers in the realize-kit (the lie pattern stripped pre-merge in #1009).
- Body-template entries for blake3/hex/String (that's the v1 path; documented in gap-ticket).

## Path to v1

`bootstrap/libprovekit-py-v1/gap-ticket.md` enumerates three paths:

- **A**: author body-template entries in `python-canonical-bodies-libprovekit.json` for blake3, hex, String ops (per-language kit work, no substrate).
- **B**: run the vendor-absorption driver per issue #985 (LLM auto-naming + auto-minting).
- **C**: close the lifter statement-level effect gap (substrate, deferred).

Path A is the next concrete chunk after this PR lands.

## Verification

```
$ /tmp/realizevenv/bin/python3 -c \"
from libprovekit_py.canonical import blake3_512_of
try: blake3_512_of(b'hello')
except NotImplementedError as e: print(f'expected NotImplementedError: {e}')\"
expected NotImplementedError: provekit-bind canonical: call:blake3::Hasher::new
```

Em-dash sweep clean. Conflict-marker sweep clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `blake3_512_of` function interface to the `libprovekit-py` package.

* **Documentation**
  * Added comprehensive documentation identifying known implementation gaps and outlining multiple potential remediation approaches.

* **Chores**
  * Established Python package configuration and build system infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1010)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->