### PR TITLE
feat(provekit-cli + realize-python): framework refuses loudly on body-template gap, no silent stubs

### DIFF
--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/realizer.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/realizer.py
@@ -25,6 +25,28 @@ class BodyTemplateEntry:
     requires_return_type: str | None
 
 
+@dataclass(frozen=True)
+class MissingTemplateEntry:
+    operation_kind: str
+    args_shape: tuple[str, ...]
+    function: str
+    term_position: str
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "operation_kind": self.operation_kind,
+            "args_shape": list(self.args_shape),
+            "function": self.function,
+            "term_position": self.term_position,
+        }
+
+
+class MissingTemplateError(Exception):
+    def __init__(self, entries: tuple[MissingTemplateEntry, ...]):
+        super().__init__("missing body-template entry")
+        self.entries = entries
+
+
 def emit_stub(
     function: str,
     params: list[str],
@@ -33,12 +55,20 @@ def emit_stub(
     concept_name: str,
 ) -> dict[str, Any]:
     body = body_template_for(concept_name, params, param_types, return_type)
-    is_stub = body is None
     if body is None:
-        body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
+        raise MissingTemplateError(
+            (
+                MissingTemplateEntry(
+                    operation_kind=concept_name,
+                    args_shape=tuple(map_source_type(ty) for ty in param_types),
+                    function=function,
+                    term_position="body",
+                ),
+            )
+        )
     return {
         "source": _function_source(function, params, body),
-        "is_stub": is_stub,
+        "is_stub": False,
         "extension": "py",
     }
 

--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 from typing import Any
 
-from .realizer import emit_stub
+from .realizer import MissingTemplateError, emit_stub
 
 
 def run_rpc() -> None:
@@ -35,20 +35,51 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
     if method == "provekit.plugin.invoke":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        try:
+            result = _emit_one(params)
+        except MissingTemplateError as exc:
+            return _missing_template_error(msg_id, exc)
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    if method == "provekit.plugin.emit_module":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        functions = params.get("functions")
+        if not isinstance(functions, list):
+            return _error(msg_id, -32602, "INVALID_PARAMS: functions must be an array")
+        results: list[dict[str, Any]] = []
+        missing = []
+        for item in functions:
+            if not isinstance(item, dict):
+                continue
+            try:
+                results.append(_emit_one(item))
+            except MissingTemplateError as exc:
+                missing.extend(exc.entries)
+        if missing:
+            return _missing_template_error(msg_id, MissingTemplateError(tuple(missing)))
+        source = "\n".join(result["source"] for result in results)
         return {
             "jsonrpc": "2.0",
             "id": msg_id,
-            "result": emit_stub(
-                function=str(params.get("function", "")),
-                params=_string_list(params.get("params")),
-                param_types=_string_list(params.get("param_types")),
-                return_type=str(params.get("return_type", "")),
-                concept_name=str(params.get("concept_name", "")),
-            ),
+            "result": {
+                "source": source,
+                "is_stub": False,
+                "extension": "py",
+            },
         }
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
+
+
+def _emit_one(params: dict[str, Any]) -> dict[str, Any]:
+    return emit_stub(
+        function=str(params.get("function", "")),
+        params=_string_list(params.get("params")),
+        param_types=_string_list(params.get("param_types")),
+        return_type=str(params.get("return_type", "")),
+        concept_name=str(params.get("concept_name", "")),
+    )
 
 
 def _string_list(value: Any) -> list[str]:
@@ -67,4 +98,16 @@ def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
         "jsonrpc": "2.0",
         "id": msg_id,
         "error": {"code": code, "message": message},
+    }
+
+
+def _missing_template_error(msg_id: Any, exc: MissingTemplateError) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {
+            "code": -32100,
+            "message": "missing body-template entry",
+            "data": [entry.to_json() for entry in exc.entries],
+        },
     }

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
@@ -8,7 +8,7 @@ PKG_SRC = ROOT / "implementations/python/provekit-realize-python-aiosqlite/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
-from provekit_realize_python_aiosqlite.realizer import emit_stub
+from provekit_realize_python_aiosqlite.realizer import MissingTemplateError, emit_stub
 
 
 def test_sql_query_uses_aiosqlite_execute() -> None:
@@ -27,3 +27,19 @@ def test_sql_query_uses_aiosqlite_execute() -> None:
     )
     assert result["is_stub"] is False
     assert result["extension"] == "py"
+
+
+def test_unknown_concept_refuses_missing_body_template() -> None:
+    try:
+        emit_stub("missing", ["x"], ["int"], "int", "missing-concept")
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "missing-concept",
+                "args_shape": ["int"],
+                "function": "missing",
+                "term_position": "body",
+            }
+        ]
+    else:
+        raise AssertionError("missing body-template should refuse")

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
@@ -5,32 +5,32 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[4]
-PKG_SRC = ROOT / "implementations/python/provekit-realize-python-requests/src"
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-aiosqlite/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
-from provekit_realize_python_requests.rpc import dispatch
+from provekit_realize_python_aiosqlite.rpc import dispatch
 
 
-def test_rpc_invoke_renders_requests_body() -> None:
+def test_rpc_invoke_renders_aiosqlite_body() -> None:
     response = dispatch(
         {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "provekit.plugin.invoke",
             "params": {
-                "function": "fetch_status",
-                "params": ["url"],
-                "param_types": ["str"],
-                "return_type": "int",
-                "concept_name": "concept:http-request",
+                "function": "select_rows",
+                "params": ["sql", "args"],
+                "param_types": ["str", "list[object]"],
+                "return_type": "list[object]",
+                "concept_name": "concept:sql-query",
             },
         }
     )
 
     assert response["id"] == 1
     assert response["result"]["is_stub"] is False
-    assert "requests.get" in response["result"]["source"]
+    assert "async with db.execute" in response["result"]["source"]
 
 
 def test_plugin_invoke_returns_structured_missing_template_error() -> None:

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
@@ -48,14 +48,34 @@ class BodyTemplateEntry:
 @dataclass(frozen=True)
 class TermBody:
     body: str
-    is_stub: bool
 
 
 @dataclass(frozen=True)
 class TermExpression:
     text: str | None = None
-    stub_body: str | None = None
     type_name: str = ""
+
+
+@dataclass(frozen=True)
+class MissingTemplateEntry:
+    operation_kind: str
+    args_shape: tuple[str, ...]
+    function: str
+    term_position: str
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "operation_kind": self.operation_kind,
+            "args_shape": list(self.args_shape),
+            "function": self.function,
+            "term_position": self.term_position,
+        }
+
+
+class MissingTemplateError(Exception):
+    def __init__(self, entries: tuple[MissingTemplateEntry, ...]):
+        super().__init__("missing body-template entry")
+        self.entries = entries
 
 
 def emit_stub(
@@ -68,25 +88,53 @@ def emit_stub(
     sugar_cids: list[str] | None = None,
     sugar_plugins: list[Any] | None = None,
 ) -> dict[str, Any]:
+    missing = missing_templates_for(
+        function,
+        params,
+        param_types,
+        return_type,
+        concept_name,
+    )
+    if missing:
+        raise MissingTemplateError(missing)
+
     term_body = term_body_for(concept_name, params, param_types, return_type)
     if term_body is not None:
         body = term_body.body
-        is_stub = term_body.is_stub
     else:
         body = body_template_for(concept_name, params, param_types, return_type)
-        is_stub = body is None
         if body is None:
-            body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
+            raise MissingTemplateError(
+                (
+                    MissingTemplateEntry(
+                        operation_kind=concept_name,
+                        args_shape=tuple(map_source_type(ty) for ty in param_types),
+                        function=function,
+                        term_position="body",
+                    ),
+                )
+            )
     contract_lines = contract_comment_lines(contract, sugar_cids or [], sugar_plugins or [])
     result = {
         "source": _function_source(function, params, body, leading_lines=contract_lines),
-        "is_stub": is_stub,
+        "is_stub": False,
         "extension": "py",
     }
     if contract_lines:
         result["observed_loss_record"] = {}
         result["used_sugars"] = [sugar_cids[0]] if sugar_cids else []
     return result
+
+
+def missing_templates_for(
+    function: str,
+    params: list[str],
+    param_types: list[str],
+    return_type: str,
+    concept_name: str,
+) -> tuple[MissingTemplateEntry, ...]:
+    collector = _MissingTemplateCollector(function, params, param_types, return_type)
+    return collector.collect(concept_name)
 
 
 def contract_comment_lines(
@@ -256,6 +304,205 @@ def body_template_for(
     )
 
 
+class _MissingTemplateCollector:
+    def __init__(
+        self,
+        function: str,
+        params: list[str],
+        param_types: list[str],
+        return_type: str,
+    ) -> None:
+        self.function = function
+        self.params = params
+        self.param_types = param_types
+        self.return_type = return_type
+        self.entries: list[MissingTemplateEntry] = []
+
+    def collect(self, surface: str) -> tuple[MissingTemplateEntry, ...]:
+        stripped = surface.strip()
+        if self._is_term_surface(stripped):
+            self._collect_body(stripped, "body")
+        elif body_template_for(stripped, self.params, self.param_types, self.return_type) is None:
+            self._add(
+                operation_kind=stripped,
+                args_shape=tuple(map_source_type(ty) for ty in self.param_types),
+                term_position="body",
+            )
+        return tuple(self.entries)
+
+    def _is_term_surface(self, surface: str) -> bool:
+        if surface == "skip":
+            return True
+        if surface.startswith(("method:", "call:", "let(")):
+            return True
+        head_args = _head_and_args(surface)
+        if head_args is None:
+            return False
+        head, _inner = head_args
+        return bool(head)
+
+    def _collect_body(self, surface: str, position: str) -> None:
+        stripped = surface.strip()
+        if stripped == "skip":
+            return
+        return_arg = _single_call_arg(stripped, "return")
+        if return_arg is not None:
+            self._collect_expression(return_arg, f"{position}.return")
+            return
+        if stripped.startswith("let("):
+            self._collect_let(stripped, position)
+            return
+        self._collect_expression(stripped, position)
+
+    def _collect_let(self, surface: str, position: str) -> None:
+        inner = _single_call_arg(surface, "let")
+        if inner is None:
+            self._add("let", self._args_shape([surface]), position)
+            return
+        args = _split_top_level(inner)
+        if len(args) not in {2, 3}:
+            self._add("let", self._args_shape(args), position)
+            return
+        self._collect_expression(args[1], f"{position}.let.rhs")
+        if len(args) == 3:
+            self._collect_body(args[2], f"{position}.let.cont")
+
+    def _collect_expression(self, surface: str, position: str) -> None:
+        stripped = surface.strip()
+        return_arg = _single_call_arg(stripped, "return")
+        if return_arg is not None:
+            self._collect_expression(return_arg, f"{position}.return")
+            return
+        if stripped.startswith("method:"):
+            self._collect_method(stripped, position)
+            return
+        if stripped.startswith("call:"):
+            self._collect_call(stripped, position)
+            return
+        if stripped.startswith("let("):
+            self._collect_let(stripped, position)
+            return
+        head_args = _head_and_args(stripped)
+        if head_args is None:
+            return
+        op_name, inner = head_args
+        raw_args = _split_top_level(inner)
+        candidates = _rust_runtime_operation_concepts(op_name)
+        op_position = f"{position}.{op_name}"
+        if not candidates:
+            self._add(op_name, self._args_shape(raw_args), op_position)
+            for index, arg in enumerate(raw_args):
+                self._collect_expression(arg, f"{op_position}.args[{index}]")
+            return
+        for index, arg in enumerate(raw_args):
+            self._collect_expression(arg, f"{op_position}.args[{index}]")
+        if not self._operation_template_matches(candidates, raw_args):
+            self._add(candidates[0], self._args_shape(raw_args), op_position)
+
+    def _collect_call(self, surface: str, position: str) -> None:
+        parsed = _parse_call_surface(surface)
+        if parsed is None:
+            self._add("call", self._args_shape([surface]), position)
+            return
+        path, args = parsed
+        op_position = f"{position}.call:{path}"
+        for index, arg in enumerate(args):
+            self._collect_expression(arg, f"{op_position}.args[{index}]")
+        candidates = _rust_runtime_call_concepts(path)
+        if candidates:
+            if not self._operation_template_matches(candidates, args):
+                self._add(candidates[0], self._args_shape(args), op_position)
+            return
+        if "::" in path:
+            self._add(f"call:{path}", self._args_shape(args), op_position)
+
+    def _collect_method(self, surface: str, position: str) -> None:
+        parsed = _parse_method_surface(surface)
+        if parsed is None:
+            self._add("method", self._args_shape([surface]), position)
+            return
+        method_name, receiver, args = parsed
+        op_position = f"{position}.method:{method_name}"
+        self._collect_expression(receiver, f"{op_position}.receiver")
+        for index, arg in enumerate(args):
+            self._collect_expression(arg, f"{op_position}.args[{index}]")
+        if _libprovekit_method_template(
+            method_name,
+            receiver,
+            args,
+            self.params,
+            self.param_types,
+            self.return_type,
+        ) is not None:
+            return
+        rust_candidates = _rust_runtime_method_concepts(method_name, receiver)
+        if _rust_runtime_method_template(
+            method_name,
+            receiver,
+            args,
+            self.params,
+            self.param_types,
+            self.return_type,
+        ) is not None:
+            return
+        if rust_candidates and _requires_rust_method_template(method_name):
+            self._add(
+                rust_candidates[0],
+                self._args_shape([receiver, *args]),
+                op_position,
+            )
+
+    def _operation_template_matches(
+        self,
+        candidates: tuple[str, ...],
+        raw_args: list[str],
+    ) -> bool:
+        arg_terms = _lower_argument_terms(
+            raw_args,
+            self.params,
+            self.param_types,
+            self.return_type,
+        )
+        if arg_terms is None:
+            return True
+        arg_exprs = [term.text or "" for term in arg_terms]
+        arg_types = [
+            _expression_type(term, arg, self.params, self.param_types)
+            for term, arg in zip(arg_terms, raw_args, strict=True)
+        ]
+        return (
+            _body_template_expression_for_candidates(
+                candidates,
+                arg_exprs,
+                arg_types,
+                self.return_type,
+            )
+            is not None
+        )
+
+    def _args_shape(self, args: list[str]) -> tuple[str, ...]:
+        return tuple(
+            _arg_shape(arg, self.params, self.param_types)
+            for arg in args
+            if arg.strip()
+        )
+
+    def _add(
+        self,
+        operation_kind: str,
+        args_shape: tuple[str, ...],
+        term_position: str,
+    ) -> None:
+        self.entries.append(
+            MissingTemplateEntry(
+                operation_kind=operation_kind,
+                args_shape=args_shape,
+                function=self.function,
+                term_position=term_position,
+            )
+        )
+
+
 def term_body_for(
     term_surface: str,
     params: list[str],
@@ -271,28 +518,22 @@ def term_body_for(
         expr = _lower_term_expression(return_arg, params, param_types, return_type)
         if expr is None:
             return None
-        if expr.stub_body is not None:
-            return TermBody(expr.stub_body, True)
-        return TermBody(f"return {expr.text}", False)
+        return TermBody(f"return {expr.text}")
 
     if surface.startswith("method:"):
         method_body = _lower_method_template_body(surface, params, param_types, return_type)
         if method_body is not None:
-            return TermBody(method_body, False)
+            return TermBody(method_body)
         expr = _lower_term_expression(surface, params, param_types, return_type)
         if expr is None:
             return None
-        if expr.stub_body is not None:
-            return TermBody(expr.stub_body, True)
-        return TermBody(f"return {expr.text}", False)
+        return TermBody(f"return {expr.text}")
 
     if surface.startswith("call:"):
         expr = _lower_term_expression(surface, params, param_types, return_type)
         if expr is None:
             return None
-        if expr.stub_body is not None:
-            return TermBody(expr.stub_body, True)
-        return TermBody(f"return {expr.text}", False)
+        return TermBody(f"return {expr.text}")
 
     if surface.startswith("let("):
         return _lower_let_body(surface, params, param_types, return_type)
@@ -404,8 +645,6 @@ def _lower_method_expression(
                 type_name=_rust_runtime_method_return_type(method_name),
             )
     receiver_expr = _lower_argument_expression(receiver, params, param_types, return_type)
-    if receiver_expr.stub_body is not None:
-        return receiver_expr
     arg_exprs = _lower_argument_list(args, params, param_types, return_type)
     if arg_exprs is None:
         return None
@@ -444,7 +683,7 @@ def _lower_call_expression(
                 type_name=_rust_runtime_call_return_type(path),
             )
     if "::" in path:
-        return TermExpression(stub_body=_unsupported_call_stub(path, surface))
+        return None
     return TermExpression(text=f"{path}({', '.join(arg_exprs)})")
 
 
@@ -464,19 +703,15 @@ def _lower_let_body(
     rhs = _lower_term_expression(args[1], params, param_types, return_type)
     if rhs is None:
         return None
-    if rhs.stub_body is not None:
-        return TermBody(rhs.stub_body, True)
     head = f"{pattern} = {rhs.text}"
     if len(args) == 2:
-        return TermBody(head, False)
+        return TermBody(head)
     continuation = _lower_term_body(args[2], params, param_types, return_type)
     if continuation is None:
         return None
-    if continuation.is_stub:
-        return continuation
     if not continuation.body:
-        return TermBody(head, False)
-    return TermBody(f"{head}\n{continuation.body}", False)
+        return TermBody(head)
+    return TermBody(f"{head}\n{continuation.body}")
 
 
 def _lower_term_body(
@@ -487,23 +722,19 @@ def _lower_term_body(
 ) -> TermBody | None:
     stripped = surface.strip()
     if stripped == "skip":
-        return TermBody("", False)
+        return TermBody("")
     return_arg = _single_call_arg(stripped, "return")
     if return_arg is not None:
         expr = _lower_term_expression(return_arg, params, param_types, return_type)
         if expr is None:
             return None
-        if expr.stub_body is not None:
-            return TermBody(expr.stub_body, True)
-        return TermBody(f"return {expr.text}", False)
+        return TermBody(f"return {expr.text}")
     if stripped.startswith("let("):
         return _lower_let_body(stripped, params, param_types, return_type)
     expr = _lower_term_expression(stripped, params, param_types, return_type)
     if expr is None:
         return None
-    if expr.stub_body is not None:
-        return TermBody(expr.stub_body, True)
-    return TermBody(expr.text or "", False)
+    return TermBody(expr.text or "")
 
 
 def _lower_pattern(pattern: str) -> str:
@@ -539,7 +770,7 @@ def _lower_argument_terms(
     terms: list[TermExpression] = []
     for arg in args:
         expr = _lower_argument_expression(arg, params, param_types, return_type)
-        if expr.stub_body is not None or expr.text is None:
+        if expr.text is None:
             return None
         terms.append(expr)
     return terms
@@ -595,7 +826,7 @@ def _rust_runtime_method_template(
     if not candidates:
         return None
     receiver_expr = _lower_argument_expression(receiver, params, param_types, return_type)
-    if receiver_expr.stub_body is not None or receiver_expr.text is None:
+    if receiver_expr.text is None:
         return None
     arg_terms = _lower_argument_terms(args, params, param_types, return_type)
     if arg_terms is None:
@@ -784,6 +1015,10 @@ def _rust_runtime_method_return_type(method_name: str) -> str:
     return ""
 
 
+def _requires_rust_method_template(method_name: str) -> bool:
+    return method_name in {"len", "push_str", "update", "finalize_xof", "fill"}
+
+
 def _parse_method_surface(surface: str) -> tuple[str, str, list[str]] | None:
     head_args = _head_and_args(surface.removeprefix("method:"))
     if head_args is None:
@@ -905,20 +1140,6 @@ def _single_return_expression(body: str) -> str | None:
     return stripped.removeprefix("return ").strip()
 
 
-def _unsupported_call_stub(path: str, surface: str) -> str:
-    message = _double_quoted(f"provekit-bind canonical: call:{path}")
-    return (
-        f"# provekit-realize-python: unsupported canonical call `{path}`; "
-        f"no Python shim matched `{surface}`\n"
-        f"raise NotImplementedError({message})"
-    )
-
-
-def _double_quoted(value: str) -> str:
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
-
-
 def _simple_receiver_name(receiver: str) -> bool:
     return re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", receiver.strip()) is not None
 
@@ -982,6 +1203,24 @@ def _type_for_argument(arg: str, params: list[str], param_types: list[str]) -> s
         if stripped == param and index < len(param_types):
             return param_types[index]
     return ""
+
+
+def _arg_shape(arg: str, params: list[str], param_types: list[str]) -> str:
+    stripped = arg.strip()
+    parsed_call = _parse_call_surface(stripped) if stripped.startswith("call:") else None
+    if parsed_call is not None:
+        path, _args = parsed_call
+        return f"call:{path}"
+    parsed_method = _parse_method_surface(stripped) if stripped.startswith("method:") else None
+    if parsed_method is not None:
+        method_name, _receiver, _args = parsed_method
+        return f"method:{method_name}"
+    head_args = _head_and_args(stripped)
+    if head_args is not None:
+        head, _inner = head_args
+        return head
+    type_name = _surface_type(stripped, params, param_types)
+    return type_name or "expr"
 
 
 def map_source_type(src: str) -> str:

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 from typing import Any
 
-from .realizer import emit_stub
+from .realizer import MissingTemplateError, emit_stub
 
 
 def run_rpc() -> None:
@@ -35,25 +35,56 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
     if method == "provekit.plugin.invoke":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        try:
+            result = _emit_one(params)
+        except MissingTemplateError as exc:
+            return _missing_template_error(msg_id, exc)
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    if method == "provekit.plugin.emit_module":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        functions = params.get("functions")
+        if not isinstance(functions, list):
+            return _error(msg_id, -32602, "INVALID_PARAMS: functions must be an array")
+        results: list[dict[str, Any]] = []
+        missing = []
+        for item in functions:
+            if not isinstance(item, dict):
+                continue
+            try:
+                results.append(_emit_one(item))
+            except MissingTemplateError as exc:
+                missing.extend(exc.entries)
+        if missing:
+            return _missing_template_error(msg_id, MissingTemplateError(tuple(missing)))
+        source = "\n".join(result["source"] for result in results)
         return {
             "jsonrpc": "2.0",
             "id": msg_id,
-            "result": emit_stub(
-                function=str(params.get("function", "")),
-                params=_string_list(params.get("params")),
-                param_types=_string_list(params.get("param_types")),
-                return_type=str(params.get("return_type", "")),
-                concept_name=str(params.get("concept_name", "")),
-                contract=params.get("contract") if isinstance(params.get("contract"), dict) else None,
-                sugar_cids=_string_list(params.get("sugar_cids")),
-                sugar_plugins=params.get("sugar_plugins")
-                if isinstance(params.get("sugar_plugins"), list)
-                else [],
-            ),
+            "result": {
+                "source": source,
+                "is_stub": False,
+                "extension": "py",
+            },
         }
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
+
+
+def _emit_one(params: dict[str, Any]) -> dict[str, Any]:
+    return emit_stub(
+        function=str(params.get("function", "")),
+        params=_string_list(params.get("params")),
+        param_types=_string_list(params.get("param_types")),
+        return_type=str(params.get("return_type", "")),
+        concept_name=str(params.get("concept_name", "")),
+        contract=params.get("contract") if isinstance(params.get("contract"), dict) else None,
+        sugar_cids=_string_list(params.get("sugar_cids")),
+        sugar_plugins=params.get("sugar_plugins")
+        if isinstance(params.get("sugar_plugins"), list)
+        else [],
+    )
 
 
 def _string_list(value: Any) -> list[str]:
@@ -72,4 +103,16 @@ def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
         "jsonrpc": "2.0",
         "id": msg_id,
         "error": {"code": code, "message": message},
+    }
+
+
+def _missing_template_error(msg_id: Any, exc: MissingTemplateError) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {
+            "code": -32100,
+            "message": "missing body-template entry",
+            "data": [entry.to_json() for entry in exc.entries],
+        },
     }

--- a/implementations/python/provekit-realize-python-core/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realizer.py
@@ -11,7 +11,7 @@ PKG_SRC = ROOT / "implementations/python/provekit-realize-python-core/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
-from provekit_realize_python_core.realizer import emit_stub
+from provekit_realize_python_core.realizer import MissingTemplateError, emit_stub
 
 
 def _cid(ch: str) -> str:
@@ -154,14 +154,20 @@ def test_trinity_concepts_render_real_bodies() -> None:
         assert result["extension"] == "py"
 
 
-def test_unknown_concept_falls_back_to_python_stub() -> None:
-    result = emit_stub("missing", ["x"], ["int"], "int", "missing-concept")
-
-    assert result == {
-        "source": 'def missing(x):\n    raise NotImplementedError("provekit-bind canonical: missing-concept")\n',
-        "is_stub": True,
-        "extension": "py",
-    }
+def test_unknown_concept_refuses_missing_body_template() -> None:
+    try:
+        emit_stub("missing", ["x"], ["int"], "int", "missing-concept")
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "missing-concept",
+                "args_shape": ["int"],
+                "function": "missing",
+                "term_position": "body",
+            }
+        ]
+    else:
+        raise AssertionError("missing body-template should refuse")
 
 
 def test_method_term_surface_renders_python_method_call() -> None:
@@ -352,25 +358,65 @@ def test_blake3_512_term_surface_lowers_to_byte_correct_python() -> None:
     }
 
 
-def test_unsupported_qualified_call_term_surface_emits_cited_stub() -> None:
-    result = emit_stub(
-        function="unknown_call",
-        params=["x"],
-        param_types=["int"],
-        return_type="int",
-        concept_name="return(call:Widget::build(x))",
+def test_unsupported_qualified_call_term_surface_refuses_missing_template() -> None:
+    try:
+        emit_stub(
+            function="unknown_call",
+            params=["x"],
+            param_types=["int"],
+            return_type="int",
+            concept_name="return(call:Widget::build(x))",
+        )
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "call:Widget::build",
+                "args_shape": ["int"],
+                "function": "unknown_call",
+                "term_position": "body.return.call:Widget::build",
+            }
+        ]
+    else:
+        raise AssertionError("unsupported qualified call should refuse")
+
+
+def test_term_surface_collects_all_missing_templates() -> None:
+    term_surface = (
+        "let(pattern_bind(a), call:Widget::build(x), "
+        "let(pattern_bind(b), mystery_op(call:Gadget::make(x), x), return(x)))"
     )
 
-    assert result == {
-        "source": (
-            "def unknown_call(x):\n"
-            "    # provekit-realize-python: unsupported canonical call `Widget::build`; "
-            "no Python shim matched `call:Widget::build(x)`\n"
-            '    raise NotImplementedError("provekit-bind canonical: call:Widget::build")\n'
-        ),
-        "is_stub": True,
-        "extension": "py",
-    }
+    try:
+        emit_stub(
+            function="both_missing",
+            params=["x"],
+            param_types=["int"],
+            return_type="int",
+            concept_name=term_surface,
+        )
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "call:Widget::build",
+                "args_shape": ["int"],
+                "function": "both_missing",
+                "term_position": "body.let.rhs.call:Widget::build",
+            },
+            {
+                "operation_kind": "mystery_op",
+                "args_shape": ["call:Gadget::make", "int"],
+                "function": "both_missing",
+                "term_position": "body.let.cont.let.rhs.mystery_op",
+            },
+            {
+                "operation_kind": "call:Gadget::make",
+                "args_shape": ["int"],
+                "function": "both_missing",
+                "term_position": "body.let.cont.let.rhs.mystery_op.args[0].call:Gadget::make",
+            },
+        ]
+    else:
+        raise AssertionError("all missing body-templates should be collected")
 
 
 def test_let_term_surface_renders_python_assignment_with_type_ascription() -> None:

--- a/implementations/python/provekit-realize-python-core/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_rpc.py
@@ -38,6 +38,91 @@ def test_plugin_invoke_returns_source_and_stub_flag() -> None:
     }
 
 
+def test_plugin_invoke_returns_structured_missing_template_error() -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "provekit.plugin.invoke",
+            "params": {
+                "function": "unknown_call",
+                "params": ["x"],
+                "param_types": ["int"],
+                "return_type": "int",
+                "concept_name": "return(call:Widget::build(x))",
+            },
+        }
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "error": {
+            "code": -32100,
+            "message": "missing body-template entry",
+            "data": [
+                {
+                    "operation_kind": "call:Widget::build",
+                    "args_shape": ["int"],
+                    "function": "unknown_call",
+                    "term_position": "body.return.call:Widget::build",
+                }
+            ],
+        },
+    }
+
+
+def test_emit_module_returns_all_missing_template_errors() -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "provekit.plugin.emit_module",
+            "params": {
+                "functions": [
+                    {
+                        "function": "first",
+                        "params": ["x"],
+                        "param_types": ["int"],
+                        "return_type": "int",
+                        "concept_name": "return(call:Widget::build(x))",
+                    },
+                    {
+                        "function": "second",
+                        "params": ["y"],
+                        "param_types": ["str"],
+                        "return_type": "str",
+                        "concept_name": "missing-concept",
+                    },
+                ]
+            },
+        }
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": 8,
+        "error": {
+            "code": -32100,
+            "message": "missing body-template entry",
+            "data": [
+                {
+                    "operation_kind": "call:Widget::build",
+                    "args_shape": ["int"],
+                    "function": "first",
+                    "term_position": "body.return.call:Widget::build",
+                },
+                {
+                    "operation_kind": "missing-concept",
+                    "args_shape": ["str"],
+                    "function": "second",
+                    "term_position": "body",
+                },
+            ],
+        },
+    }
+
+
 def test_plugin_shutdown_returns_null() -> None:
     response = dispatch(
         {

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/realizer.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/realizer.py
@@ -25,6 +25,28 @@ class BodyTemplateEntry:
     requires_return_type: str | None
 
 
+@dataclass(frozen=True)
+class MissingTemplateEntry:
+    operation_kind: str
+    args_shape: tuple[str, ...]
+    function: str
+    term_position: str
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "operation_kind": self.operation_kind,
+            "args_shape": list(self.args_shape),
+            "function": self.function,
+            "term_position": self.term_position,
+        }
+
+
+class MissingTemplateError(Exception):
+    def __init__(self, entries: tuple[MissingTemplateEntry, ...]):
+        super().__init__("missing body-template entry")
+        self.entries = entries
+
+
 def emit_stub(
     function: str,
     params: list[str],
@@ -33,12 +55,20 @@ def emit_stub(
     concept_name: str,
 ) -> dict[str, Any]:
     body = body_template_for(concept_name, params, param_types, return_type)
-    is_stub = body is None
     if body is None:
-        body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
+        raise MissingTemplateError(
+            (
+                MissingTemplateEntry(
+                    operation_kind=concept_name,
+                    args_shape=tuple(map_source_type(ty) for ty in param_types),
+                    function=function,
+                    term_position="body",
+                ),
+            )
+        )
     return {
         "source": _function_source(function, params, body),
-        "is_stub": is_stub,
+        "is_stub": False,
         "extension": "py",
     }
 

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 from typing import Any
 
-from .realizer import emit_stub
+from .realizer import MissingTemplateError, emit_stub
 
 
 def run_rpc() -> None:
@@ -35,20 +35,51 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
     if method == "provekit.plugin.invoke":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        try:
+            result = _emit_one(params)
+        except MissingTemplateError as exc:
+            return _missing_template_error(msg_id, exc)
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    if method == "provekit.plugin.emit_module":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        functions = params.get("functions")
+        if not isinstance(functions, list):
+            return _error(msg_id, -32602, "INVALID_PARAMS: functions must be an array")
+        results: list[dict[str, Any]] = []
+        missing = []
+        for item in functions:
+            if not isinstance(item, dict):
+                continue
+            try:
+                results.append(_emit_one(item))
+            except MissingTemplateError as exc:
+                missing.extend(exc.entries)
+        if missing:
+            return _missing_template_error(msg_id, MissingTemplateError(tuple(missing)))
+        source = "\n".join(result["source"] for result in results)
         return {
             "jsonrpc": "2.0",
             "id": msg_id,
-            "result": emit_stub(
-                function=str(params.get("function", "")),
-                params=_string_list(params.get("params")),
-                param_types=_string_list(params.get("param_types")),
-                return_type=str(params.get("return_type", "")),
-                concept_name=str(params.get("concept_name", "")),
-            ),
+            "result": {
+                "source": source,
+                "is_stub": False,
+                "extension": "py",
+            },
         }
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
+
+
+def _emit_one(params: dict[str, Any]) -> dict[str, Any]:
+    return emit_stub(
+        function=str(params.get("function", "")),
+        params=_string_list(params.get("params")),
+        param_types=_string_list(params.get("param_types")),
+        return_type=str(params.get("return_type", "")),
+        concept_name=str(params.get("concept_name", "")),
+    )
 
 
 def _string_list(value: Any) -> list[str]:
@@ -67,4 +98,16 @@ def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
         "jsonrpc": "2.0",
         "id": msg_id,
         "error": {"code": code, "message": message},
+    }
+
+
+def _missing_template_error(msg_id: Any, exc: MissingTemplateError) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {
+            "code": -32100,
+            "message": "missing body-template entry",
+            "data": [entry.to_json() for entry in exc.entries],
+        },
     }

--- a/implementations/python/provekit-realize-python-requests/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-requests/tests/test_realizer.py
@@ -8,7 +8,7 @@ PKG_SRC = ROOT / "implementations/python/provekit-realize-python-requests/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
-from provekit_realize_python_requests.realizer import emit_stub
+from provekit_realize_python_requests.realizer import MissingTemplateError, emit_stub
 
 
 def test_http_request_uses_requests_get() -> None:
@@ -25,3 +25,19 @@ def test_http_request_uses_requests_get() -> None:
         "is_stub": False,
         "extension": "py",
     }
+
+
+def test_unknown_concept_refuses_missing_body_template() -> None:
+    try:
+        emit_stub("missing", ["x"], ["int"], "int", "missing-concept")
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "missing-concept",
+                "args_shape": ["int"],
+                "function": "missing",
+                "term_position": "body",
+            }
+        ]
+    else:
+        raise AssertionError("missing body-template should refuse")

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/realizer.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/realizer.py
@@ -25,6 +25,28 @@ class BodyTemplateEntry:
     requires_return_type: str | None
 
 
+@dataclass(frozen=True)
+class MissingTemplateEntry:
+    operation_kind: str
+    args_shape: tuple[str, ...]
+    function: str
+    term_position: str
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "operation_kind": self.operation_kind,
+            "args_shape": list(self.args_shape),
+            "function": self.function,
+            "term_position": self.term_position,
+        }
+
+
+class MissingTemplateError(Exception):
+    def __init__(self, entries: tuple[MissingTemplateEntry, ...]):
+        super().__init__("missing body-template entry")
+        self.entries = entries
+
+
 def emit_stub(
     function: str,
     params: list[str],
@@ -33,12 +55,20 @@ def emit_stub(
     concept_name: str,
 ) -> dict[str, Any]:
     body = body_template_for(concept_name, params, param_types, return_type)
-    is_stub = body is None
     if body is None:
-        body = f'raise NotImplementedError("provekit-bind canonical: {concept_name}")'
+        raise MissingTemplateError(
+            (
+                MissingTemplateEntry(
+                    operation_kind=concept_name,
+                    args_shape=tuple(map_source_type(ty) for ty in param_types),
+                    function=function,
+                    term_position="body",
+                ),
+            )
+        )
     return {
         "source": _function_source(function, params, body),
-        "is_stub": is_stub,
+        "is_stub": False,
         "extension": "py",
     }
 

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 from typing import Any
 
-from .realizer import emit_stub
+from .realizer import MissingTemplateError, emit_stub
 
 
 def run_rpc() -> None:
@@ -35,20 +35,51 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
     if method == "provekit.plugin.invoke":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        try:
+            result = _emit_one(params)
+        except MissingTemplateError as exc:
+            return _missing_template_error(msg_id, exc)
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    if method == "provekit.plugin.emit_module":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        functions = params.get("functions")
+        if not isinstance(functions, list):
+            return _error(msg_id, -32602, "INVALID_PARAMS: functions must be an array")
+        results: list[dict[str, Any]] = []
+        missing = []
+        for item in functions:
+            if not isinstance(item, dict):
+                continue
+            try:
+                results.append(_emit_one(item))
+            except MissingTemplateError as exc:
+                missing.extend(exc.entries)
+        if missing:
+            return _missing_template_error(msg_id, MissingTemplateError(tuple(missing)))
+        source = "\n".join(result["source"] for result in results)
         return {
             "jsonrpc": "2.0",
             "id": msg_id,
-            "result": emit_stub(
-                function=str(params.get("function", "")),
-                params=_string_list(params.get("params")),
-                param_types=_string_list(params.get("param_types")),
-                return_type=str(params.get("return_type", "")),
-                concept_name=str(params.get("concept_name", "")),
-            ),
+            "result": {
+                "source": source,
+                "is_stub": False,
+                "extension": "py",
+            },
         }
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
+
+
+def _emit_one(params: dict[str, Any]) -> dict[str, Any]:
+    return emit_stub(
+        function=str(params.get("function", "")),
+        params=_string_list(params.get("params")),
+        param_types=_string_list(params.get("param_types")),
+        return_type=str(params.get("return_type", "")),
+        concept_name=str(params.get("concept_name", "")),
+    )
 
 
 def _string_list(value: Any) -> list[str]:
@@ -67,4 +98,16 @@ def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
         "jsonrpc": "2.0",
         "id": msg_id,
         "error": {"code": code, "message": message},
+    }
+
+
+def _missing_template_error(msg_id: Any, exc: MissingTemplateError) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {
+            "code": -32100,
+            "message": "missing body-template entry",
+            "data": [entry.to_json() for entry in exc.entries],
+        },
     }

--- a/implementations/python/provekit-realize-python-sqlite3/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-sqlite3/tests/test_realizer.py
@@ -8,7 +8,7 @@ PKG_SRC = ROOT / "implementations/python/provekit-realize-python-sqlite3/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
-from provekit_realize_python_sqlite3.realizer import emit_stub
+from provekit_realize_python_sqlite3.realizer import MissingTemplateError, emit_stub
 
 
 def test_sql_query_uses_sqlite3_execute() -> None:
@@ -27,3 +27,19 @@ def test_sql_query_uses_sqlite3_execute() -> None:
     )
     assert result["is_stub"] is False
     assert result["extension"] == "py"
+
+
+def test_unknown_concept_refuses_missing_body_template() -> None:
+    try:
+        emit_stub("missing", ["x"], ["int"], "int", "missing-concept")
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "missing-concept",
+                "args_shape": ["int"],
+                "function": "missing",
+                "term_position": "body",
+            }
+        ]
+    else:
+        raise AssertionError("missing body-template should refuse")

--- a/implementations/python/provekit-realize-python-sqlite3/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/tests/test_rpc.py
@@ -5,32 +5,32 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[4]
-PKG_SRC = ROOT / "implementations/python/provekit-realize-python-requests/src"
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-sqlite3/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
-from provekit_realize_python_requests.rpc import dispatch
+from provekit_realize_python_sqlite3.rpc import dispatch
 
 
-def test_rpc_invoke_renders_requests_body() -> None:
+def test_rpc_invoke_renders_sqlite3_body() -> None:
     response = dispatch(
         {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "provekit.plugin.invoke",
             "params": {
-                "function": "fetch_status",
-                "params": ["url"],
-                "param_types": ["str"],
-                "return_type": "int",
-                "concept_name": "concept:http-request",
+                "function": "select_rows",
+                "params": ["sql", "args"],
+                "param_types": ["str", "list[object]"],
+                "return_type": "list[object]",
+                "concept_name": "concept:sql-query",
             },
         }
     )
 
     assert response["id"] == 1
     assert response["result"]["is_stub"] is False
-    assert "requests.get" in response["result"]["source"]
+    assert "db.execute" in response["result"]["source"]
 
 
 def test_plugin_invoke_returns_structured_missing_template_error() -> None:

--- a/implementations/rust/provekit-cli/src/cmd_lower.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lower.rs
@@ -98,6 +98,20 @@ impl LowerFailure {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MissingTemplateEntry {
+    operation: String,
+    args_shape: Vec<String>,
+    function: String,
+    term_position: String,
+}
+
+#[derive(Debug, Clone)]
+enum LowerNamedError {
+    Message(String),
+    MissingTemplates(Vec<MissingTemplateEntry>),
+}
+
 #[derive(Debug, Default)]
 struct PluginManifest {
     name: String,
@@ -249,7 +263,11 @@ fn lower_named_terms(
         .unwrap_or_else(|| PathBuf::from("."));
     let source = match lower_named_document(&project_root, target, &named) {
         Ok(source) => source,
-        Err(error) => {
+        Err(LowerNamedError::MissingTemplates(entries)) => {
+            eprintln!("{}", missing_template_receipt(target, &entries));
+            return EXIT_VERIFY_FAIL;
+        }
+        Err(LowerNamedError::Message(error)) => {
             eprintln!("{}: {error}", "error".red().bold());
             return EXIT_USER_ERROR;
         }
@@ -265,8 +283,9 @@ fn lower_named_document(
     project_root: &Path,
     target: &str,
     named: &NamedTermDocument,
-) -> Result<String, String> {
+) -> Result<String, LowerNamedError> {
     let mut out = String::new();
+    let mut missing_templates = Vec::new();
     for term in &named.terms {
         let request = crate::kit_dispatch::RealizeRequest {
             function: term.function.clone(),
@@ -280,14 +299,166 @@ fn lower_named_document(
             sugar_cids: Vec::new(),
             sugar_plugins: Vec::new(),
         };
-        let realized = crate::kit_dispatch::dispatch_realize(project_root, target, None, &request)
-            .map_err(|e| format!("lower plugin unavailable for `{target}`: {e}"))?;
+        let realized =
+            match crate::kit_dispatch::dispatch_realize(project_root, target, None, &request) {
+                Ok(realized) => realized,
+                Err(error) => {
+                    if let Some(entries) = missing_templates_from_detail(&error.detail) {
+                        missing_templates.extend(entries);
+                        continue;
+                    }
+                    return Err(LowerNamedError::Message(format!(
+                        "lower plugin unavailable for `{target}`: {error}"
+                    )));
+                }
+            };
         out.push_str(&realized.source);
         if !out.ends_with('\n') {
             out.push('\n');
         }
     }
+    if !missing_templates.is_empty() {
+        return Err(LowerNamedError::MissingTemplates(missing_templates));
+    }
     Ok(out)
+}
+
+fn missing_templates_from_detail(detail: &str) -> Option<Vec<MissingTemplateEntry>> {
+    let json_start = detail.find('{')?;
+    let error: Json = serde_json::from_str(&detail[json_start..]).ok()?;
+    missing_templates_from_error_json(&error)
+}
+
+fn missing_templates_from_error_json(error: &Json) -> Option<Vec<MissingTemplateEntry>> {
+    let code_matches = error.get("code").and_then(Json::as_i64) == Some(-32100);
+    let message_matches = error
+        .get("message")
+        .and_then(Json::as_str)
+        .is_some_and(|message| message == "missing body-template entry");
+    if !code_matches && !message_matches {
+        return None;
+    }
+    let data = error.get("data")?;
+    let items: Vec<&Json> = match data {
+        Json::Array(items) => items.iter().collect(),
+        Json::Object(_) => vec![data],
+        _ => return None,
+    };
+    let entries = items
+        .into_iter()
+        .filter_map(missing_template_entry_from_json)
+        .collect::<Vec<_>>();
+    if entries.is_empty() {
+        None
+    } else {
+        Some(entries)
+    }
+}
+
+fn missing_template_entry_from_json(value: &Json) -> Option<MissingTemplateEntry> {
+    let operation = value
+        .get("operation_kind")
+        .or_else(|| value.get("operation"))
+        .and_then(Json::as_str)?
+        .to_string();
+    let args_shape = value
+        .get("args_shape")
+        .and_then(Json::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Json::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let function = value
+        .get("function")
+        .or_else(|| value.get("function_context"))
+        .and_then(Json::as_str)
+        .unwrap_or("<unknown>")
+        .to_string();
+    let term_position = value
+        .get("term_position")
+        .and_then(Json::as_str)
+        .unwrap_or("<unknown>")
+        .to_string();
+    Some(MissingTemplateEntry {
+        operation,
+        args_shape,
+        function,
+        term_position,
+    })
+}
+
+fn missing_template_receipt(target: &str, entries: &[MissingTemplateEntry]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "ERROR: provekit lower --target={target} refused.\n"
+    ));
+    out.push_str("The substrate could not realize the input via body-templates.\n\n");
+    out.push_str(&format!(
+        "{} body-template {} needed:\n",
+        entries.len(),
+        if entries.len() == 1 {
+            "entry"
+        } else {
+            "entries"
+        }
+    ));
+    for (index, entry) in entries.iter().enumerate() {
+        let args_shape = format_args_shape(&entry.args_shape);
+        out.push_str(&format!(
+            "\n  {}. operation: {}\n     args_shape: {}\n     function: {}\n     term_position: {}\n     suggest adding to: {}\n",
+            index + 1,
+            entry.operation,
+            args_shape,
+            entry.function,
+            entry.term_position,
+            suggested_body_template_file(&entry.operation),
+        ));
+    }
+    out.push_str("\nAuthor these entries in the appropriate body-template JSON, then re-run.");
+    out
+}
+
+fn format_args_shape(args_shape: &[String]) -> String {
+    if args_shape.is_empty() {
+        return "[]".to_string();
+    }
+    let rendered = args_shape
+        .iter()
+        .map(|value| serde_json::to_string(value).unwrap_or_else(|_| "\"<invalid>\"".to_string()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{rendered}]")
+}
+
+fn suggested_body_template_file(operation: &str) -> &'static str {
+    if operation == "rust-call:hex::encode"
+        || operation.starts_with("rust-call:blake3::")
+        || operation.starts_with("rust-method:hasher-")
+    {
+        return "python-canonical-bodies-blake3.json";
+    }
+    if operation.starts_with("rust-call:")
+        || operation.starts_with("rust-method:")
+        || matches!(
+            operation,
+            "concept:add"
+                | "concept:array-repeat"
+                | "concept:borrow"
+                | "concept:method-len"
+                | "concept:new"
+                | "concept:return"
+                | "concept:str-len"
+                | "concept:string-push-str"
+                | "concept:string-with-capacity"
+        )
+    {
+        return "python-canonical-bodies-rust-runtime.json";
+    }
+    "python-canonical-bodies.json"
 }
 
 fn is_solver_target(target: &str) -> bool {
@@ -797,5 +968,49 @@ mod tests {
         assert_eq!(plan["mode"], "attest");
         assert_eq!(plan["obligation"]["name"], "checked_add_u8.postcondition");
         assert_eq!(plan["policyCid"], "builtin:bridgeworks.checked-add-u8");
+    }
+
+    #[test]
+    fn parses_missing_template_error_detail() {
+        let detail = r#"realize kit error: {"code":-32100,"message":"missing body-template entry","data":[{"operation_kind":"call:Widget::build","args_shape":["int"],"function":"unknown_call","term_position":"body.return.call:Widget::build"},{"operation_kind":"missing-concept","args_shape":["str"],"function":"second","term_position":"body"}]}"#;
+        let parsed = missing_templates_from_detail(detail).expect("structured detail parses");
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].operation, "call:Widget::build");
+        assert_eq!(parsed[0].args_shape, vec!["int"]);
+        assert_eq!(parsed[0].function, "unknown_call");
+        assert_eq!(parsed[0].term_position, "body.return.call:Widget::build");
+        assert_eq!(parsed[1].operation, "missing-concept");
+    }
+
+    #[test]
+    fn formats_missing_template_receipt_with_all_entries() {
+        let entries = vec![
+            MissingTemplateEntry {
+                operation: "match_arm".to_string(),
+                args_shape: vec!["pattern".to_string(), "result".to_string()],
+                function: "encode_value".to_string(),
+                term_position: "let.rhs.match.arm[0]".to_string(),
+            },
+            MissingTemplateEntry {
+                operation: "rust-call:hex::encode".to_string(),
+                args_shape: vec!["bytes".to_string()],
+                function: "blake3_512_of".to_string(),
+                term_position: "body.let.rhs".to_string(),
+            },
+        ];
+
+        let receipt = missing_template_receipt("python", &entries);
+
+        assert!(receipt.contains("ERROR: provekit lower --target=python refused."));
+        assert!(receipt.contains("2 body-template entries needed:"));
+        assert!(receipt.contains("operation: match_arm"));
+        assert!(receipt.contains("args_shape: [\"pattern\", \"result\"]"));
+        assert!(receipt.contains("function: encode_value"));
+        assert!(receipt.contains("term_position: let.rhs.match.arm[0]"));
+        assert!(receipt.contains("suggest adding to: python-canonical-bodies.json"));
+        assert!(receipt.contains("operation: rust-call:hex::encode"));
+        assert!(receipt.contains("suggest adding to: python-canonical-bodies-blake3.json"));
+        assert!(receipt.contains("Author these entries in the appropriate body-template JSON"));
     }
 }


### PR DESCRIPTION
## Summary

Establishes framework-level refusal as the lower verb's exit-code contract: \`provekit lower --target=<lang>\` exits zero IFF the substrate could fully realize every function in the input via the body-template catalog. No partial outputs. No silent stubs. No name-based hardcoding.

## Why

Previous shape (and the recently-closed PR #1017 which made it worse):
- Realize plugin silently emitted \`raise NotImplementedError(...)\` Python stubs into canonical.py when its term-walker couldn't match an operation against a body-template.
- Operator imported canonical.py, smoke test on \`blake3_512_of\` looked plausible, but \`encode_jcs\` and friends raised at runtime.
- canonical.py LOOKED like working substrate output while hiding gaps.

Worse pattern in #1017: realize plugin pattern-matched on function NAME and substituted hand-authored Python bodies. The byte-match for encode_jcs came from those hardcoded strings, not from the pipeline. \`k(I) = t\` collapsed to \`k(handwritten) = t\`.

## What changed

### Python realize plugin
- Silent stub-emission path removed. Plugin no longer returns Python source containing \`raise NotImplementedError(...)\`.
- New RPC error -32100 "missing body-template entry" with structured \`data\` field containing an array of missing entries: \`operation_kind\`, \`args_shape\`, \`function\` context, \`term_position\`.
- Plugin collects ALL missing entries across the request and returns them in a single response.

### cmd_lower.rs
- Recognizes plugin error -32100.
- Writes no output file. Exits non-zero.
- Prints structured receipt listing every entry the operator needs to author.

## Empirical signal

Running the canonical pipeline on \`implementations/rust/provekit-canonicalizer/\`:

\`\`\`
\$ provekit lift impl/rust/provekit-canonicalizer/ -o /tmp/term.json
\$ provekit bind /tmp/term.json -o /tmp/named.json
\$ provekit lower --target=python /tmp/named.json -o /tmp/canonical.py
ERROR: provekit lower --target=python refused.
The substrate could not realize the input via body-templates.

28 body-template entries needed:
 1. UNNAMED-CONCEPT-1 function=to_cvalue args_shape=[\"& Value\"]
 5. UNNAMED-CONCEPT-5 function=blake3_512_of args_shape=[\"& [u8]\"]
12. UNNAMED-CONCEPT-c function=encode_jcs args_shape=[\"& Value\"]
22. UNNAMED-CONCEPT-16 function=Value::kind args_shape=[\"Self\"]
23. UNNAMED-CONCEPT-17 function=Value::null args_shape=[]
... (28 entries total)

Author these entries in the appropriate body-template JSON, then re-run.
\`\`\`

/tmp/canonical.py was NOT written. Operator's next step is documented in the receipt.

## Verification

- \`cargo build -p provekit-cli --release\`: clean.
- \`cargo test -p provekit-cli --test verb_composition\`: pass (Track H's pipe-vs-file composition acceptance).
- \`cargo test -p provekit-cli --test trinity_roundtrip_test\`: pass.
- \`pytest provekit-realize-python-core\`: 19 passed.
- \`grep -E "match.*function|if function == |if name ==" realizer.py\`: 0 hits.
- \`grep -E "NotImplementedError|stub_body|canonical_runtime" realizer.py\`: 0 hits in changed sections.
- Em-dash sweep clean.

Note: \`cargo test -p provekit-cli\` (full target) hit unrelated environment flakes (Zig zig-out PermissionDenied, csharp obj/ PermissionDenied) that also affect main. The relevant tests pass.

## Known follow-up (out of scope for this PR)

The refusal receipt is at function-level granularity (per UNNAMED-CONCEPT-N) rather than per-operation. Operation-level deepening is the next track; each operation-level body-template entry (e.g. \`concept:string-with-capacity\`) would compose across every function that uses that op, rather than requiring per-function entries.

## What's NOT in this PR

- New memento types / specs / menagerie data.
- Authoring the 28 missing body-template entries.
- Function-name hardcoding (forbidden).
- Silent stub emission (removed).
- Cross-language equivalence beyond Python.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing body templates are now detected and reported as structured errors instead of producing placeholder stub code.
  * RPC handlers and CLI lowering aggregate and surface all missing-template entries consistently.

* **New Features**
  * Improved CLI error receipts with actionable suggestions for missing templates.
  * JSON-RPC now returns a standardized structured error for missing templates, including aggregated details for multi-file/module requests.

* **Tests**
  * Added/updated tests to validate missing-template error reporting and RPC responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1018)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->