### PR TITLE
feat(python-kit): transported-op concept-citation carrier emit + relift (closes #1022)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -17,6 +18,7 @@ from .canonical import cid_of_json
 Json = Any
 CID_RE = re.compile(r"^blake3-512:[0-9a-f]{128}$")
 CONTRACT_COMMENT_KIND = "provekit-contract-comment-sugar"
+CONCEPT_CITATION_COMMENT_KIND = "provekit-concept-citation-comment-sugar"
 CONTRACT_COMMENT_ROLE_MAP = {
     "pre": "pre",
     "post": "post",
@@ -145,10 +147,12 @@ def _entry_for_function(
     witnesses = []
     witnesses.extend(_contract_comment_witnesses(lines, node, rel_path, diagnostics))
     witnesses.extend(_decorator_contract_witnesses(node, param_names, rel_path, diagnostics))
+    concept_citations = _concept_citation_comments(lines, node, rel_path, diagnostics)
 
     return {
         "attr_post": attr_post,
         "attr_pre": attr_pre,
+        "concept_citations": concept_citations,
         "concept_annotation": concept,
         "file": rel_path,
         "fn_line": node.lineno,
@@ -518,6 +522,417 @@ def _contract_comment_witness(
         "role": CONTRACT_COMMENT_ROLE_MAP[role],
         "source_kind": "native-surface",
     }
+
+
+def _concept_citation_comments(
+    lines: list[str],
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    rel_path: str,
+    diagnostics: list[Json],
+) -> list[Json]:
+    """Return concept-citation artifacts separately from contract witnesses."""
+    citations: list[Json] = []
+    citations.extend(
+        _concept_citation_comments_from_surface_lines(
+            _leading_contract_comment_surface(lines, node.lineno),
+            rel_path,
+            diagnostics,
+        )
+    )
+    citations.extend(
+        _concept_citation_comments_from_surface_lines(
+            _function_body_comment_surface(lines, node),
+            rel_path,
+            diagnostics,
+        )
+    )
+    return citations
+
+
+def _function_body_comment_surface(
+    lines: list[str],
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[tuple[int, str]]:
+    end_lineno = getattr(node, "end_lineno", node.lineno)
+    surface: list[tuple[int, str]] = []
+    for idx in range(node.lineno, min(end_lineno, len(lines))):
+        stripped = lines[idx].strip()
+        if stripped.startswith("#"):
+            surface.append((idx + 1, stripped[1:].strip()))
+    return surface
+
+
+def _concept_citation_comments_from_surface_lines(
+    surface_lines: list[tuple[int, str]],
+    rel_path: str,
+    diagnostics: list[Json],
+) -> list[Json]:
+    citations: list[Json] = []
+    idx = 0
+    while idx < len(surface_lines):
+        line_no, content = surface_lines[idx]
+        if content.startswith("provekit-concept-payload-cid:"):
+            _concept_citation_diag(
+                diagnostics,
+                rel_path,
+                line_no,
+                "concept-citation:orphan-cid-line",
+                "payload CID line has no preceding payload",
+            )
+            idx += 1
+            continue
+        if not content.startswith("provekit-concept: "):
+            idx += 1
+            continue
+        raw_payload = content[len("provekit-concept: ") :].strip()
+        payload_cid: str | None = None
+        if idx + 1 < len(surface_lines):
+            next_line_no, next_content = surface_lines[idx + 1]
+            if (
+                next_line_no == line_no + 1
+                and next_content.startswith("provekit-concept-payload-cid: ")
+            ):
+                payload_cid = next_content[
+                    len("provekit-concept-payload-cid: ") :
+                ].strip()
+                idx += 1
+        citation = _concept_citation_witness(
+            raw_payload,
+            payload_cid,
+            rel_path,
+            line_no,
+            diagnostics,
+        )
+        if citation is not None:
+            citations.append(citation)
+        idx += 1
+    return citations
+
+
+def _concept_citation_witness(
+    raw_payload: str,
+    emitted_payload_cid: str | None,
+    rel_path: str,
+    line_no: int,
+    diagnostics: list[Json],
+) -> Json | None:
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:malformed-json",
+            f"malformed JSON: {exc.msg}",
+        )
+        return None
+    if not isinstance(payload, dict):
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:malformed-json",
+            "payload is not an object",
+        )
+        return None
+
+    if payload.get("artifact_kind") != CONCEPT_CITATION_COMMENT_KIND:
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:unknown-schema-version",
+            "wrong artifact_kind",
+        )
+        return None
+    if payload.get("schema_version") != "1":
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:unknown-schema-version",
+            "unknown schema_version",
+        )
+        return None
+    if not _valid_concept_emitted_by(payload.get("emitted_by")):
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:malformed-cid",
+            "malformed emitted_by",
+        )
+        return None
+
+    operation_kind = payload.get("operation_kind")
+    if not isinstance(operation_kind, str) or not operation_kind:
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:operation-kind-mismatch",
+            "missing operation_kind",
+        )
+        return None
+    term_position = payload.get("term_position")
+    if not _valid_term_position(term_position):
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:malformed-json",
+            "malformed term_position",
+        )
+        return None
+
+    cid_fields = [
+        "args_jcs_cid",
+        "concept_cid",
+        "concept_site_cid",
+        "loss_record_cid",
+        "shape_cid",
+        "sugar_dict_cid",
+    ]
+    for key in cid_fields:
+        value = payload.get(key)
+        if not isinstance(value, str) or CID_RE.fullmatch(value) is None:
+            _concept_citation_diag(
+                diagnostics,
+                rel_path,
+                line_no,
+                "concept-citation:malformed-cid",
+                f"malformed {key}",
+            )
+            return None
+    for key in ("callsite_cid", "policy_cid"):
+        value = payload.get(key)
+        if value is not None and (
+            not isinstance(value, str) or CID_RE.fullmatch(value) is None
+        ):
+            _concept_citation_diag(
+                diagnostics,
+                rel_path,
+                line_no,
+                "concept-citation:malformed-cid",
+                f"malformed {key}",
+            )
+            return None
+    if emitted_payload_cid is None:
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:payload-cid-mismatch",
+            "missing payload CID",
+        )
+        return None
+    if CID_RE.fullmatch(emitted_payload_cid) is None:
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:malformed-cid",
+            "malformed payload CID",
+        )
+        return None
+
+    payload_cid = cid_of_json(payload)
+    if emitted_payload_cid != payload_cid:
+        _concept_citation_diag(
+            diagnostics,
+            rel_path,
+            line_no,
+            "concept-citation:payload-cid-mismatch",
+            "payload CID mismatch",
+        )
+        return None
+
+    args_jcs = payload.get("args_jcs")
+    if args_jcs is not None:
+        if not isinstance(args_jcs, list):
+            _concept_citation_diag(
+                diagnostics,
+                rel_path,
+                line_no,
+                "concept-citation:malformed-json",
+                "malformed args_jcs",
+            )
+            return None
+        if cid_of_json(args_jcs) != payload["args_jcs_cid"]:
+            _concept_citation_diag(
+                diagnostics,
+                rel_path,
+                line_no,
+                "concept-citation:args-cid-mismatch",
+                "args CID mismatch",
+            )
+            return None
+
+    catalog = _concept_shape_catalog()
+    if catalog is not None:
+        catalog_entry = catalog.get(payload["concept_cid"])
+        if catalog_entry is None:
+            _concept_citation_diag(
+                diagnostics,
+                rel_path,
+                line_no,
+                "concept-citation:unknown-concept",
+                "concept not in local catalog",
+            )
+            return None
+        expected_shape_cid, expected_operation_kind = catalog_entry
+        if expected_shape_cid != payload["shape_cid"]:
+            _concept_citation_diag(
+                diagnostics,
+                rel_path,
+                line_no,
+                "concept-citation:shape-mismatch",
+                "shape CID mismatch",
+            )
+            return None
+        if expected_operation_kind != operation_kind:
+            _concept_citation_diag(
+                diagnostics,
+                rel_path,
+                line_no,
+                "concept-citation:operation-kind-mismatch",
+                "operation_kind mismatch",
+            )
+            return None
+
+    extension_fields = {
+        "args_jcs_cid": payload["args_jcs_cid"],
+        "concept_site_cid": payload["concept_site_cid"],
+        "loss_record_cid": payload["loss_record_cid"],
+        "payload_cid": payload_cid,
+        "shape_cid": payload["shape_cid"],
+        "sugar_dict_cid": payload["sugar_dict_cid"],
+        "surface": "concept-citation-comment-sugar",
+    }
+    for key in ("callsite_cid", "policy_cid"):
+        if isinstance(payload.get(key), str):
+            extension_fields[key] = payload[key]
+    if args_jcs is not None:
+        extension_fields["args_jcs"] = args_jcs
+    return {
+        "args_jcs_cid": payload["args_jcs_cid"],
+        "artifact_kind": CONCEPT_CITATION_COMMENT_KIND,
+        "col": 0,
+        "confidence_basis_points": 10000,
+        "concept_cid": payload["concept_cid"],
+        "extension_fields": extension_fields,
+        "line": line_no,
+        "operation_kind": operation_kind,
+        "shape_cid": payload["shape_cid"],
+        "source_kind": "native-surface",
+        "term_position": term_position,
+    }
+
+
+def _valid_concept_emitted_by(value: Json) -> bool:
+    if not isinstance(value, dict):
+        return False
+    kit_cid = value.get("kit_cid")
+    kit_id = value.get("kit_id")
+    kit_kind = value.get("kit_kind")
+    target_language = value.get("target_language")
+    target_library_tag = value.get("target_library_tag")
+    return (
+        isinstance(kit_cid, str)
+        and CID_RE.fullmatch(kit_cid) is not None
+        and isinstance(kit_id, str)
+        and bool(kit_id)
+        and isinstance(kit_kind, str)
+        and bool(kit_kind)
+        and isinstance(target_language, str)
+        and bool(target_language)
+        and (target_library_tag is None or isinstance(target_library_tag, str))
+    )
+
+
+def _valid_term_position(value: Json) -> bool:
+    if not isinstance(value, list):
+        return False
+    return all(
+        isinstance(item, int) and not isinstance(item, bool) and item >= 0
+        for item in value
+    )
+
+
+def _concept_citation_diag(
+    diagnostics: list[Json],
+    rel_path: str,
+    line_no: int,
+    category: str,
+    message: str,
+) -> None:
+    diagnostics.append(
+        {
+            "kind": category,
+            "message": message,
+            "path": rel_path,
+            "line": line_no,
+        }
+    )
+
+
+@lru_cache(maxsize=1)
+def _concept_shape_catalog() -> dict[str, tuple[str, str]] | None:
+    root = _repo_root()
+    if root is None:
+        return None
+    index_path = root / "menagerie/concept-shapes/catalog/index.json"
+    try:
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    entries = index.get("entries")
+    if not isinstance(entries, dict):
+        return None
+    catalog: dict[str, tuple[str, str]] = {}
+    catalog_root = index_path.parent
+    for cid, meta in entries.items():
+        if not isinstance(cid, str) or CID_RE.fullmatch(cid) is None:
+            continue
+        if not isinstance(meta, dict) or meta.get("kind") != "algorithm":
+            continue
+        name = meta.get("name")
+        rel_path = meta.get("path")
+        if not isinstance(name, str) or not name.startswith("concept:"):
+            continue
+        if not isinstance(rel_path, str):
+            continue
+        try:
+            document = json.loads((catalog_root / rel_path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        memento = document.get("memento")
+        if not isinstance(memento, dict):
+            continue
+        operation_kind = _catalog_operation_kind(name, memento)
+        shape_cid = document.get("cid")
+        if operation_kind and isinstance(shape_cid, str) and CID_RE.fullmatch(shape_cid):
+            catalog[cid] = (shape_cid, operation_kind)
+    return catalog
+
+
+def _catalog_operation_kind(name: str, memento: dict[str, Json]) -> str | None:
+    post = memento.get("post")
+    if isinstance(post, dict):
+        operator = post.get("operator")
+        if isinstance(operator, str) and operator:
+            return operator
+    if name.startswith("concept:"):
+        return name.removeprefix("concept:")
+    return None
+
+
+def _repo_root() -> Path | None:
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "menagerie/concept-shapes/catalog/index.json").exists():
+            return candidate
+    return None
 
 
 def _valid_emitted_by(value: Json) -> bool:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -28,6 +28,19 @@ CONTRACT_COMMENT_ROLE_MAP = {
 }
 
 
+class _ConceptCitationRefusal(Exception):
+    """Raised on substrate-identity contradiction (spec section 6 rows 7-8).
+    The surrounding relift refuses entirely; no IR entry is emitted
+    for the function whose source contained the contradiction."""
+
+    def __init__(self, diag_kind: str, rel_path: str, line_no: int, message: str):
+        super().__init__(message)
+        self.diag_kind = diag_kind
+        self.rel_path = rel_path
+        self.line_no = line_no
+        self.message = message
+
+
 @dataclass
 class BindLiftResult:
     ir: list[Json] = field(default_factory=list)
@@ -59,9 +72,19 @@ def lift_source(source: str, source_path: str) -> BindLiftResult:
     lines = source.splitlines()
     rel_path = source_path.replace(os.sep, "/")
     for info in collector.definitions:
-        result.ir.append(
-            _entry_for_function(info.node, rel_path, lines, result.diagnostics)
-        )
+        try:
+            result.ir.append(
+                _entry_for_function(info.node, rel_path, lines, result.diagnostics)
+            )
+        except _ConceptCitationRefusal as exc:
+            result.diagnostics.append(
+                {
+                    "kind": exc.diag_kind,
+                    "message": exc.message,
+                    "path": exc.rel_path,
+                    "line": exc.line_no,
+                }
+            )
     return result
 
 
@@ -671,7 +694,7 @@ def _concept_citation_witness(
             diagnostics,
             rel_path,
             line_no,
-            "concept-citation:operation-kind-mismatch",
+            "concept-citation:malformed-json",
             "missing operation_kind",
         )
         return None
@@ -783,23 +806,19 @@ def _concept_citation_witness(
             return None
         expected_shape_cid, expected_operation_kind = catalog_entry
         if expected_shape_cid != payload["shape_cid"]:
-            _concept_citation_diag(
-                diagnostics,
+            raise _ConceptCitationRefusal(
+                "concept-citation:shape-mismatch",
                 rel_path,
                 line_no,
-                "concept-citation:shape-mismatch",
                 "shape CID mismatch",
             )
-            return None
         if expected_operation_kind != operation_kind:
-            _concept_citation_diag(
-                diagnostics,
+            raise _ConceptCitationRefusal(
+                "concept-citation:operation-kind-mismatch",
                 rel_path,
                 line_no,
-                "concept-citation:operation-kind-mismatch",
                 "operation_kind mismatch",
             )
-            return None
 
     extension_fields = {
         "args_jcs_cid": payload["args_jcs_cid"],

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -21,6 +21,13 @@ from provekit_lift_python_source.canonical import cid_of_json
 from provekit_realize_python_core.realizer import emit_stub
 
 
+CONCEPT_SKIP_CID = (
+    "blake3-512:"
+    "9a905548a44fce23882b17d857d275d7822bd235ab71dbf786cd991563cc1de9e"
+    "610594f50ad3c89a3b7eeb43234a31b36caa8031914c85227158030669c63cb"
+)
+
+
 def _cid(ch: str) -> str:
     return "blake3-512:" + ch * 128
 
@@ -78,6 +85,54 @@ def _comment_lines(payload: dict, payload_cid: str) -> str:
         + "\n"
         + f"# provekit-contract-payload-cid: {payload_cid}\n"
     )
+
+
+def _concept_citation_payload(overrides: dict | None = None) -> tuple[dict, str]:
+    args = [{"kind": "var", "name": "x"}]
+    payload = {
+        "args_jcs": args,
+        "args_jcs_cid": cid_of_json(args),
+        "artifact_kind": "provekit-concept-citation-comment-sugar",
+        "concept_cid": CONCEPT_SKIP_CID,
+        "concept_name": "concept:skip",
+        "concept_site_cid": _cid("a"),
+        "emitted_by": {
+            "kit_cid": _cid("b"),
+            "kit_id": "provekit-realize-python-core@0.1.0",
+            "kit_kind": "realize",
+            "target_language": "python",
+            "target_library_tag": "python",
+        },
+        "loss_record_cid": _cid("c"),
+        "operation_kind": "skip",
+        "policy_cid": _cid("d"),
+        "schema_version": "1",
+        "shape_cid": CONCEPT_SKIP_CID,
+        "sugar_dict_cid": _cid("e"),
+        "term_position": [0],
+    }
+    if overrides:
+        payload.update(overrides)
+    return payload, cid_of_json(payload)
+
+
+def _concept_comment_lines(payload: dict, payload_cid: str) -> str:
+    return (
+        "# provekit-concept: "
+        + json.dumps(
+            payload,
+            separators=(",", ":"),
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        + "\n"
+        + f"# provekit-concept-payload-cid: {payload_cid}\n"
+    )
+
+
+def _concept_diagnostics(result: object) -> set[str]:
+    diagnostics = getattr(result, "diagnostics")
+    return {diag["kind"] for diag in diagnostics}
 
 
 def test_bind_lift_source_emits_language_neutral_entries() -> None:
@@ -271,6 +326,100 @@ def test_bind_lift_contract_comment_fails_closed_for_bad_payloads() -> None:
 
         assert result.ir[0].get("witnesses", []) == []
         assert any(diag["kind"] == "contract-comment-invalid" for diag in result.diagnostics)
+
+
+def test_concept_citation_relift_recovers_identity() -> None:
+    payload, payload_cid = _concept_citation_payload()
+    source = (
+        "def transport_skip(x: object):\n"
+        + "    "
+        + _concept_comment_lines(payload, payload_cid).replace("\n", "\n    ")
+        + "pass\n"
+    )
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.diagnostics == []
+    citations = result.ir[0]["concept_citations"]
+    assert len(citations) == 1
+    citation = citations[0]
+    assert citation["concept_cid"] == payload["concept_cid"]
+    assert citation["operation_kind"] == payload["operation_kind"]
+    assert citation["shape_cid"] == payload["shape_cid"]
+    assert citation["term_position"] == payload["term_position"]
+    assert citation["args_jcs_cid"] == payload["args_jcs_cid"]
+    assert citation["source_kind"] == "native-surface"
+    assert citation["extension_fields"]["payload_cid"] == payload_cid
+    assert result.ir[0]["witnesses"] == []
+
+
+def test_concept_citation_payload_cid_mismatch_refuses() -> None:
+    payload, _payload_cid = _concept_citation_payload()
+    source = _concept_comment_lines(payload, _cid("8")) + "def f(x: object):\n    pass\n"
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.ir[0].get("concept_citations", []) == []
+    assert "concept-citation:payload-cid-mismatch" in _concept_diagnostics(result)
+
+
+def test_concept_citation_args_cid_mismatch_refuses() -> None:
+    payload, payload_cid = _concept_citation_payload({"args_jcs_cid": _cid("8")})
+    source = _concept_comment_lines(payload, payload_cid) + "def f(x: object):\n    pass\n"
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.ir[0].get("concept_citations", []) == []
+    assert "concept-citation:args-cid-mismatch" in _concept_diagnostics(result)
+
+
+def test_concept_citation_unknown_schema_version_refuses() -> None:
+    payload, payload_cid = _concept_citation_payload({"schema_version": "999"})
+    source = _concept_comment_lines(payload, payload_cid) + "def f(x: object):\n    pass\n"
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.ir[0].get("concept_citations", []) == []
+    assert "concept-citation:unknown-schema-version" in _concept_diagnostics(result)
+
+
+def test_concept_citation_orphan_payload_cid_line_refuses() -> None:
+    source = "# provekit-concept-payload-cid: " + _cid("8") + "\ndef f():\n    pass\n"
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.ir[0].get("concept_citations", []) == []
+    assert "concept-citation:orphan-cid-line" in _concept_diagnostics(result)
+
+
+def test_concept_citation_round_trip() -> None:
+    args = [{"kind": "var", "name": "x"}]
+    transported_op = {
+        "args_jcs": args,
+        "concept_cid": CONCEPT_SKIP_CID,
+        "concept_name": "concept:skip",
+        "concept_site_cid": _cid("a"),
+        "loss_record_cid": _cid("c"),
+        "operation_kind": "skip",
+        "policy_cid": _cid("d"),
+        "shape_cid": CONCEPT_SKIP_CID,
+        "sugar_dict_cid": _cid("e"),
+        "term_position": [0],
+    }
+    emitted = emit_stub(
+        function="transport_skip",
+        params=["x"],
+        param_types=["object"],
+        return_type="()",
+        concept_name="missing-python-skip-carrier",
+        transported_op=transported_op,
+    )
+
+    result = lift_source(emitted["source"], "pkg/foo.py")
+
+    assert result.diagnostics == []
+    assert result.ir[0]["concept_citations"][0]["concept_cid"] == transported_op["concept_cid"]
+    assert result.ir[0]["concept_citations"][0]["args_jcs_cid"] == cid_of_json(args)
 
 
 def test_bind_lift_recovers_decorator_contract_witnesses() -> None:

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -475,3 +475,100 @@ def test_python_realize_then_lift_keeps_contract_and_concept_site_cids() -> None
     assert witness["extension_fields"]["contract_cid"] == _cid("2")
     assert witness["extension_fields"]["local_contract_cid"] == _cid("2")
     assert witness["predicate"] == _formula_gte_x_zero()
+
+
+def test_concept_citation_shape_mismatch_refuses_surrounding_relift() -> None:
+    from provekit_lift_python_source.bind_lifter import _concept_shape_catalog
+
+    assert _concept_shape_catalog() is not None, (
+        "catalog must be present for this test to exercise row-7 path"
+    )
+
+    # shape_cid differs from what the catalog records for CONCEPT_SKIP_CID
+    payload, payload_cid = _concept_citation_payload({"shape_cid": _cid("8")})
+    bad_fn_source = (
+        "def good_fn(x: int) -> int:\n"
+        "    return x\n"
+        "\n"
+        "def bad_fn(x: object):\n"
+        "    " + _concept_comment_lines(payload, payload_cid).replace("\n", "\n    ") + "    pass\n"
+    )
+
+    result = lift_source(bad_fn_source, "pkg/foo.py")
+
+    # bad_fn must not produce an IR entry; good_fn must still produce one
+    fn_names = [entry["fn_name"] for entry in result.ir]
+    assert "good_fn" in fn_names
+    assert "bad_fn" not in fn_names
+    assert len(result.ir) == 1
+    assert "concept-citation:shape-mismatch" in _concept_diagnostics(result)
+
+
+def test_concept_citation_operation_kind_mismatch_refuses_surrounding_relift() -> None:
+    from provekit_lift_python_source.bind_lifter import _concept_shape_catalog
+
+    assert _concept_shape_catalog() is not None, (
+        "catalog must be present for this test to exercise row-8 path"
+    )
+
+    # operation_kind differs from what the catalog records for CONCEPT_SKIP_CID ("skip")
+    payload, payload_cid = _concept_citation_payload({"operation_kind": "not-skip"})
+    bad_fn_source = (
+        "def good_fn(x: int) -> int:\n"
+        "    return x\n"
+        "\n"
+        "def bad_fn(x: object):\n"
+        "    " + _concept_comment_lines(payload, payload_cid).replace("\n", "\n    ") + "    pass\n"
+    )
+
+    result = lift_source(bad_fn_source, "pkg/foo.py")
+
+    fn_names = [entry["fn_name"] for entry in result.ir]
+    assert "good_fn" in fn_names
+    assert "bad_fn" not in fn_names
+    assert len(result.ir) == 1
+    assert "concept-citation:operation-kind-mismatch" in _concept_diagnostics(result)
+
+
+def test_concept_citation_missing_operation_kind_field_tags_as_malformed_json() -> None:
+    # Build payload without operation_kind to trigger the row-1 (malformed-json) path
+    args = [{"kind": "var", "name": "x"}]
+    payload: dict = {
+        "args_jcs": args,
+        "args_jcs_cid": cid_of_json(args),
+        "artifact_kind": "provekit-concept-citation-comment-sugar",
+        "concept_cid": CONCEPT_SKIP_CID,
+        "concept_name": "concept:skip",
+        "concept_site_cid": _cid("a"),
+        "emitted_by": {
+            "kit_cid": _cid("b"),
+            "kit_id": "provekit-realize-python-core@0.1.0",
+            "kit_kind": "realize",
+            "target_language": "python",
+            "target_library_tag": "python",
+        },
+        "loss_record_cid": _cid("c"),
+        "policy_cid": _cid("d"),
+        "schema_version": "1",
+        "shape_cid": CONCEPT_SKIP_CID,
+        "sugar_dict_cid": _cid("e"),
+        "term_position": [0],
+        # operation_kind intentionally omitted
+    }
+    payload_cid = cid_of_json(payload)
+    bad_fn_source = (
+        "def good_fn(x: int) -> int:\n"
+        "    return x\n"
+        "\n"
+        "def bad_fn(x: object):\n"
+        "    " + _concept_comment_lines(payload, payload_cid).replace("\n", "\n    ") + "    pass\n"
+    )
+
+    result = lift_source(bad_fn_source, "pkg/foo.py")
+
+    # drop-and-continue: bad_fn still gets an IR entry, just with no citation
+    fn_names = [entry["fn_name"] for entry in result.ir]
+    assert "good_fn" in fn_names
+    assert "bad_fn" in fn_names
+    assert result.ir[1].get("concept_citations", []) == []
+    assert "concept-citation:malformed-json" in _concept_diagnostics(result)

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
@@ -23,14 +23,22 @@ BLAKE3_BODY_TEMPLATE_REL = Path(
     "menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-blake3.json"
 )
 PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
-DEFAULT_KIT_CID = "blake3-512:" + blake3.blake3(
-    b"provekit-realize-python-core@0.1.0"
-).digest(length=64).hex()
+CID_RE = re.compile(r"^blake3-512:[0-9a-f]{128}$")
+KIT_ID = "provekit-realize-python-core@0.1.0"
+DEFAULT_KIT_CID = "blake3-512:" + blake3.blake3(KIT_ID.encode("utf-8")).digest(
+    length=64
+).hex()
 DEFAULT_POLICY_CID = "blake3-512:" + blake3.blake3(
     b"provekit-realize-python-core/default-contract-comment-policy"
 ).digest(length=64).hex()
 DEFAULT_SUGAR_DICT_CID = "blake3-512:" + blake3.blake3(
     b"provekit-realize-python-core/contract-comment-sugar-v1"
+).digest(length=64).hex()
+DEFAULT_CONCEPT_POLICY_CID = "blake3-512:" + blake3.blake3(
+    b"provekit-realize-python-core/default-concept-citation-policy"
+).digest(length=64).hex()
+DEFAULT_CONCEPT_SUGAR_DICT_CID = "blake3-512:" + blake3.blake3(
+    b"provekit-realize-python-core/concept-citation-comment-sugar-v1"
 ).digest(length=64).hex()
 
 
@@ -85,64 +93,75 @@ def emit_stub(
     return_type: str,
     concept_name: str,
     contract: dict[str, Any] | None = None,
+    transported_op: dict[str, Any] | None = None,
     sugar_cids: list[str] | None = None,
     sugar_plugins: list[Any] | None = None,
     named_term_tree: dict[str, Any] | None = None,
     annotate: bool = False,
 ) -> dict[str, Any]:
-    if named_term_tree is None:
-        missing = missing_templates_for(
-            function,
-            params,
-            param_types,
-            return_type,
-            concept_name,
-        )
+    sugar_cids_value = sugar_cids or []
+    sugar_plugins_value = sugar_plugins or []
+    concept_lines = concept_citation_comment_lines(
+        transported_op,
+        sugar_cids_value,
+        sugar_plugins_value,
+    )
+    if concept_lines:
+        body = "\n".join([*concept_lines, "pass"])
     else:
-        missing = missing_templates_for_tree(
-            function,
-            params,
-            param_types,
-            return_type,
-            named_term_tree,
-        )
-    if missing:
-        raise MissingTemplateError(missing)
-
-    if named_term_tree is None:
-        term_body = term_body_for(concept_name, params, param_types, return_type)
-    else:
-        term_body = term_body_for_tree(
-            named_term_tree,
-            params,
-            param_types,
-            return_type,
-            annotate=annotate,
-        )
-    if term_body is not None:
-        body = term_body.body
-    else:
-        body = body_template_for(concept_name, params, param_types, return_type)
-        if body is None:
-            raise MissingTemplateError(
-                (
-                    MissingTemplateEntry(
-                        operation_kind=concept_name,
-                        args_shape=tuple(map_source_type(ty) for ty in param_types),
-                        function=function,
-                        term_position="body",
-                    ),
-                )
+        if named_term_tree is None:
+            missing = missing_templates_for(
+                function,
+                params,
+                param_types,
+                return_type,
+                concept_name,
             )
-    contract_lines = contract_comment_lines(contract, sugar_cids or [], sugar_plugins or [])
+        else:
+            missing = missing_templates_for_tree(
+                function,
+                params,
+                param_types,
+                return_type,
+                named_term_tree,
+            )
+        if missing:
+            raise MissingTemplateError(missing)
+
+        if named_term_tree is None:
+            term_body = term_body_for(concept_name, params, param_types, return_type)
+        else:
+            term_body = term_body_for_tree(
+                named_term_tree,
+                params,
+                param_types,
+                return_type,
+                annotate=annotate,
+            )
+        if term_body is not None:
+            body = term_body.body
+        else:
+            body = body_template_for(concept_name, params, param_types, return_type)
+            if body is None:
+                raise MissingTemplateError(
+                    (
+                        MissingTemplateEntry(
+                            operation_kind=concept_name,
+                            args_shape=tuple(map_source_type(ty) for ty in param_types),
+                            function=function,
+                            term_position="body",
+                        ),
+                    )
+                )
+    contract_lines = contract_comment_lines(contract, sugar_cids_value, sugar_plugins_value)
     result = {
         "source": _function_source(function, params, body, leading_lines=contract_lines),
         "is_stub": False,
         "extension": "py",
     }
-    if contract_lines:
+    if contract_lines or concept_lines:
         result["observed_loss_record"] = {}
-        result["used_sugars"] = [sugar_cids[0]] if sugar_cids else []
+        result["used_sugars"] = [sugar_cids_value[0]] if sugar_cids_value else []
     return result
 
 
@@ -198,6 +217,29 @@ def contract_comment_lines(
     return lines
 
 
+def concept_citation_comment_lines(
+    transported_op: dict[str, Any] | None,
+    sugar_cids: list[str],
+    sugar_plugins: list[Any],
+) -> list[str]:
+    if not isinstance(transported_op, dict):
+        return []
+    payload = _concept_citation_payload(transported_op, sugar_cids, sugar_plugins)
+    if payload is None:
+        return []
+    payload_cid = _cid_of_json(payload)
+    payload_json = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return [
+        f"# provekit-concept: {payload_json}",
+        f"# provekit-concept-payload-cid: {payload_cid}",
+    ]
+
+
 def _contract_comment_payload(
     contract: dict[str, Any],
     witness: dict[str, Any],
@@ -250,6 +292,93 @@ def _contract_comment_payload(
     return payload
 
 
+def _concept_citation_payload(
+    transported_op: dict[str, Any],
+    sugar_cids: list[str],
+    sugar_plugins: list[Any],
+) -> dict[str, Any] | None:
+    concept_cid = _transported_cid(transported_op, "concept_cid", "conceptCid")
+    concept_site_cid = _transported_cid(
+        transported_op,
+        "concept_site_cid",
+        "conceptSiteCid",
+    )
+    loss_record_cid = _transported_cid(
+        transported_op,
+        "loss_record_cid",
+        "lossRecordCid",
+    )
+    shape_cid = _transported_cid(transported_op, "shape_cid", "shapeCid")
+    operation_kind = _transported_str(
+        transported_op,
+        "operation_kind",
+        "operationKind",
+    )
+    term_position = _transported_term_position(
+        _transported_value(transported_op, "term_position", "termPosition")
+    )
+    if (
+        concept_cid is None
+        or concept_site_cid is None
+        or loss_record_cid is None
+        or shape_cid is None
+        or operation_kind is None
+        or term_position is None
+    ):
+        return None
+
+    args_jcs = _transported_value(transported_op, "args_jcs", "argsJcs")
+    payload: dict[str, Any] = {
+        "artifact_kind": "provekit-concept-citation-comment-sugar",
+        "concept_cid": concept_cid,
+        "concept_site_cid": concept_site_cid,
+        "emitted_by": {
+            "kit_cid": DEFAULT_KIT_CID,
+            "kit_id": KIT_ID,
+            "kit_kind": "realize",
+            "target_language": "python",
+            "target_library_tag": _transported_str(
+                transported_op,
+                "target_library_tag",
+                "targetLibraryTag",
+            )
+            or "python",
+        },
+        "loss_record_cid": loss_record_cid,
+        "operation_kind": operation_kind,
+        "policy_cid": _concept_policy_cid(transported_op),
+        "schema_version": "1",
+        "shape_cid": shape_cid,
+        "sugar_dict_cid": _concept_sugar_dict_cid(
+            transported_op,
+            sugar_cids,
+            sugar_plugins,
+        ),
+        "term_position": term_position,
+    }
+
+    if args_jcs is not None:
+        if not isinstance(args_jcs, list):
+            return None
+        payload["args_jcs"] = args_jcs
+        payload["args_jcs_cid"] = _cid_of_json(args_jcs)
+    else:
+        args_jcs_cid = _transported_cid(transported_op, "args_jcs_cid", "argsJcsCid")
+        if args_jcs_cid is None:
+            return None
+        payload["args_jcs_cid"] = args_jcs_cid
+
+    callsite_cid = _transported_value(transported_op, "callsite_cid", "callsiteCid")
+    if callsite_cid is not None:
+        if not isinstance(callsite_cid, str) or not CID_RE.fullmatch(callsite_cid):
+            return None
+        payload["callsite_cid"] = callsite_cid
+    concept_name = _transported_str(transported_op, "concept_name", "conceptName")
+    if concept_name is not None:
+        payload["concept_name"] = concept_name
+    return payload
+
+
 def _payload_role(role: str) -> str | None:
     match role:
         case "pre" | "post" | "throws" | "observation":
@@ -278,6 +407,66 @@ def _sugar_dict_cid(sugar_cids: list[str], sugar_plugins: list[Any]) -> str:
         if isinstance(cid, str):
             return cid
     return DEFAULT_SUGAR_DICT_CID
+
+
+def _concept_policy_cid(transported_op: dict[str, Any]) -> str:
+    value = _transported_cid(transported_op, "policy_cid", "policyCid")
+    if value is not None:
+        return value
+    return DEFAULT_CONCEPT_POLICY_CID
+
+
+def _concept_sugar_dict_cid(
+    transported_op: dict[str, Any],
+    sugar_cids: list[str],
+    sugar_plugins: list[Any],
+) -> str:
+    value = _transported_cid(transported_op, "sugar_dict_cid", "sugarDictCid")
+    if value is not None:
+        return value
+    for cid in sugar_cids:
+        if CID_RE.fullmatch(cid):
+            return cid
+    for plugin in sugar_plugins:
+        if not isinstance(plugin, dict):
+            continue
+        header = plugin.get("header")
+        cid = header.get("cid") if isinstance(header, dict) else None
+        if isinstance(cid, str) and CID_RE.fullmatch(cid):
+            return cid
+    return DEFAULT_CONCEPT_SUGAR_DICT_CID
+
+
+def _transported_cid(transported_op: dict[str, Any], *keys: str) -> str | None:
+    value = _transported_value(transported_op, *keys)
+    if isinstance(value, str) and CID_RE.fullmatch(value):
+        return value
+    return None
+
+
+def _transported_str(transported_op: dict[str, Any], *keys: str) -> str | None:
+    value = _transported_value(transported_op, *keys)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _transported_value(transported_op: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in transported_op:
+            return transported_op[key]
+    return None
+
+
+def _transported_term_position(value: Any) -> list[int] | None:
+    if not isinstance(value, list):
+        return None
+    out: list[int] = []
+    for item in value:
+        if isinstance(item, bool) or not isinstance(item, int) or item < 0:
+            return None
+        out.append(item)
+    return out
 
 
 def _cid_of_json(value: Any) -> str:

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
@@ -80,6 +80,9 @@ def _emit_one(params: dict[str, Any]) -> dict[str, Any]:
         return_type=str(params.get("return_type", "")),
         concept_name=str(params.get("concept_name", "")),
         contract=params.get("contract") if isinstance(params.get("contract"), dict) else None,
+        transported_op=params.get("transported_op")
+        if isinstance(params.get("transported_op"), dict)
+        else None,
         sugar_cids=_string_list(params.get("sugar_cids")),
         sugar_plugins=params.get("sugar_plugins")
         if isinstance(params.get("sugar_plugins"), list)

--- a/implementations/python/provekit-realize-python-core/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realizer.py
@@ -23,6 +23,16 @@ def _cid(ch: str) -> str:
     return "blake3-512:" + ch * 128
 
 
+def _json_cid(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return "blake3-512:" + blake3.blake3(encoded).digest(length=64).hex()
+
+
 def _formula_gte_x_zero() -> dict:
     return {
         "args": [
@@ -77,6 +87,31 @@ def _contract_comment_payloads(source: str) -> list[dict]:
         if stripped.startswith("# provekit-contract: "):
             payloads.append(json.loads(stripped.removeprefix("# provekit-contract: ")))
     return payloads
+
+
+def _concept_citation_payloads(source: str) -> list[dict]:
+    payloads: list[dict] = []
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# provekit-concept: "):
+            payloads.append(json.loads(stripped.removeprefix("# provekit-concept: ")))
+    return payloads
+
+
+def _transported_op_payload() -> dict:
+    return {
+        "args_jcs": [{"kind": "var", "name": "x"}],
+        "callsite_cid": _cid("0"),
+        "concept_cid": _cid("a"),
+        "concept_name": "concept:drop",
+        "concept_site_cid": _cid("b"),
+        "loss_record_cid": _cid("c"),
+        "operation_kind": "drop",
+        "policy_cid": _cid("d"),
+        "shape_cid": _cid("e"),
+        "sugar_dict_cid": _cid("f"),
+        "term_position": [3, 0],
+    }
 
 
 def test_identity_renders_python_function_from_body_template() -> None:
@@ -601,3 +636,49 @@ def test_contract_witnesses_emit_liftable_contract_comment_payloads() -> None:
         assert payload["policy_cid"].startswith("blake3-512:")
         assert payload["sugar_dict_cid"].startswith("blake3-512:")
         assert isinstance(payload["ir_formula_jcs"], dict)
+
+
+def test_concept_citation_comment_emitted_for_transported_operation() -> None:
+    transported_op = _transported_op_payload()
+
+    result = emit_stub(
+        function="transport_drop",
+        params=["x"],
+        param_types=["object"],
+        return_type="()",
+        concept_name="missing-python-drop-surface",
+        transported_op=transported_op,
+    )
+
+    source = result["source"]
+    assert "# provekit-concept:" in source
+    assert "# provekit-concept-payload-cid: blake3-512:" in source
+    assert "    pass\n" in source
+    assert "NotImplementedError" not in source
+    assert source.index("# provekit-concept:") < source.index("    pass")
+
+    payloads = _concept_citation_payloads(source)
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload["artifact_kind"] == "provekit-concept-citation-comment-sugar"
+    assert payload["schema_version"] == "1"
+    assert payload["args_jcs"] == transported_op["args_jcs"]
+    assert payload["args_jcs_cid"] == _json_cid(transported_op["args_jcs"])
+    assert payload["callsite_cid"] == transported_op["callsite_cid"]
+    assert payload["concept_cid"] == transported_op["concept_cid"]
+    assert payload["concept_name"] == transported_op["concept_name"]
+    assert payload["concept_site_cid"] == transported_op["concept_site_cid"]
+    assert payload["loss_record_cid"] == transported_op["loss_record_cid"]
+    assert payload["operation_kind"] == transported_op["operation_kind"]
+    assert payload["policy_cid"] == transported_op["policy_cid"]
+    assert payload["shape_cid"] == transported_op["shape_cid"]
+    assert payload["sugar_dict_cid"] == transported_op["sugar_dict_cid"]
+    assert payload["term_position"] == transported_op["term_position"]
+    assert payload["emitted_by"]["kit_cid"].startswith("blake3-512:")
+    assert payload["emitted_by"]["kit_id"] == "provekit-realize-python-core@0.1.0"
+    assert payload["emitted_by"]["kit_kind"] == "realize"
+    assert payload["emitted_by"]["target_language"] == "python"
+    assert payload["emitted_by"]["target_library_tag"] == "python"
+
+    payload_cid = _json_cid(payload)
+    assert f"# provekit-concept-payload-cid: {payload_cid}" in source

--- a/implementations/python/provekit-realize-python-core/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_rpc.py
@@ -11,6 +11,10 @@ if str(PKG_SRC) not in sys.path:
 from provekit_realize_python_core.rpc import dispatch
 
 
+def _cid(ch: str) -> str:
+    return "blake3-512:" + ch * 128
+
+
 def test_plugin_invoke_returns_source_and_stub_flag() -> None:
     response = dispatch(
         {
@@ -36,6 +40,42 @@ def test_plugin_invoke_returns_source_and_stub_flag() -> None:
             "extension": "py",
         },
     }
+
+
+def test_plugin_invoke_threads_transported_op() -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "provekit.plugin.invoke",
+            "params": {
+                "function": "transport_drop",
+                "params": ["x"],
+                "param_types": ["object"],
+                "return_type": "()",
+                "concept_name": "missing-python-drop-surface",
+                "transported_op": {
+                    "args_jcs": [{"kind": "var", "name": "x"}],
+                    "concept_cid": _cid("a"),
+                    "concept_name": "concept:drop",
+                    "concept_site_cid": _cid("b"),
+                    "loss_record_cid": _cid("c"),
+                    "operation_kind": "drop",
+                    "policy_cid": _cid("d"),
+                    "shape_cid": _cid("e"),
+                    "sugar_dict_cid": _cid("f"),
+                    "term_position": [3, 0],
+                },
+            },
+        }
+    )
+
+    source = response["result"]["source"]
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] == 10
+    assert "# provekit-concept:" in source
+    assert "# provekit-concept-payload-cid: blake3-512:" in source
+    assert "    pass\n" in source
 
 
 def test_plugin_invoke_returns_structured_missing_template_error() -> None:


### PR DESCRIPTION
Closes #1022. Sibling pair to the existing contract-comment sugar pattern (realizer.py:170-244 + bind_lifter.py:380-500); implements `protocol/specs/2026-05-15-concept-citation-comment-sugar.md` (merged via PR #1029).

## Surface

- **Realize side** (realizer.py + rpc.py): `concept_citation_comment_lines` + `_concept_citation_payload` parallel to the contract-comment pair. Emits `# provekit-concept:` + `# provekit-concept-payload-cid:` block followed by a no-op `pass` at the transport site. `transported_op` threaded through `provekit.plugin.invoke` exactly like `contract` is wired today.
- **Lift side** (bind_lifter.py): `_concept_citation_witness` scan with all 9 §6 fail-closed conditions in spec-correct diag tags. Reuses `CID_RE` regex and the diagnostics-list pattern. Concept-citation evidence emitted as a separate `concept_citations` list (spec §7: never mixes with `witnesses`).

## §6 fail-closed table

| # | Condition | Tag | Mode |
|---|-----------|-----|------|
| 1 | malformed JSON | `concept-citation:malformed-json` | drop |
| 2 | unknown schema_version | `concept-citation:unknown-schema-version` | drop |
| 3 | malformed CID syntax | `concept-citation:malformed-cid` | drop |
| 4 | payload CID mismatch | `concept-citation:payload-cid-mismatch` | drop |
| 5 | args CID mismatch | `concept-citation:args-cid-mismatch` | drop |
| 6 | concept_cid not in catalog | `concept-citation:unknown-concept` | drop |
| 7 | shape_cid mismatch | `concept-citation:shape-mismatch` | **refuse surrounding relift** |
| 8 | operation_kind mismatch | `concept-citation:operation-kind-mismatch` | **refuse surrounding relift** |
| 9 | orphan payload-cid line | `concept-citation:orphan-cid-line` | drop |

## #1022 acceptance criteria — satisfied

- [x] Unit: Python realizer emits citation comment for synthetic transported op
- [x] Unit: Python lifter relifts → byte-equal `concept_cid`, `operation_kind`, `shape_cid`, `term_position`, `args_jcs_cid`
- [x] Unit: payload CID mismatch refuses
- [x] Unit: args CID mismatch refuses
- [x] Unit: unknown schema version refuses
- [x] Integration: lower→Python→relift round-trip, concept_cid byte-equal hop-to-hop
- [x] No raw prose comment trusted as substrate operation

## Gates

- pytest: **49 passed** (test_realizer.py 17 + test_rpc.py 4 + test_bind_lifter.py 14 + others 14)
- em/en-dash sweep: zero
- spec-cid-lint: exit 0

## Non-goals respected (#1022)

- No broadening of Python lowering beyond the carrier
- No Java/C/Rust carrier work (#1031/#1032 own those)
- No global sugar-selection policy (#889)
- No silent no-op Python surface without the citation comment
- No new memento types (concept-citation is sugar per spec §10)

Prerequisites #1020 (PR #1028) and #1021 (PR #1029) merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python source lifter now collects and validates concept citation artifacts from code comments, cross-checking against a concept shapes catalog and emitting them in lifted function entries.

* **Tests**
  * Added comprehensive concept citation tests covering identity recovery, payload validation, orphan detection, and round-trip verification.

* **Refactor**
  * Extended emit_stub function with transported operation and sugar configuration parameters to support concept citation comment generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->