### PR TITLE
feat(libprovekit): LiftKit wraps lifter machinery as a registered Kit (closes #1033, also closes executor-promotion half of #1025)

### DIFF
--- a/implementations/rust/libprovekit/src/core/lift_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lift_plugin.rs
@@ -28,6 +28,13 @@ pub struct LiftPluginKit {
     working_dir: Option<PathBuf>,
 }
 
+/// Source-shaped Lift Kit adapter over the existing lift-plugin transport.
+#[derive(Debug, Clone)]
+pub struct LiftKit {
+    dialect: Dialect,
+    transport: LiftPluginKit,
+}
+
 impl LiftPluginKit {
     /// Build a lift-plugin Kit from an already-resolved command.
     pub fn new(
@@ -80,6 +87,7 @@ impl LiftPluginKit {
             premises: vec![],
             to: response_cid,
             witness: None,
+            payload: Some(response_term),
             verdict: Verdict::Unresolved,
             attestation: None,
         })
@@ -182,6 +190,74 @@ impl LiftPluginKit {
         }
 
         Ok((initialize_response, response))
+    }
+}
+
+impl LiftKit {
+    /// Build a source Lift Kit from an already-resolved lift-plugin command.
+    pub fn new(
+        dialect: Dialect,
+        surface: impl Into<String>,
+        command: Vec<String>,
+        working_dir: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            dialect,
+            transport: LiftPluginKit::new(surface, command, working_dir),
+        }
+    }
+
+    fn lift_params_from_source(&self, input: &Input) -> Result<Value, LiftPluginKitError> {
+        let Input::Source { dialect, bytes } = input else {
+            return Err(LiftPluginKitError::Failed(
+                "lift kit expects Input::Source".to_string(),
+            ));
+        };
+        if dialect != &self.dialect {
+            return Err(LiftPluginKitError::Failed(format!(
+                "lift kit expected source dialect {:?}, got {:?}",
+                self.dialect, dialect
+            )));
+        }
+        serde_json::from_slice(bytes).map_err(|error| {
+            LiftPluginKitError::Failed(format!(
+                "lift source bytes must encode lift-plugin request JSON: {error}"
+            ))
+        })
+    }
+}
+
+impl Kit for LiftKit {
+    fn dialect(&self) -> Dialect {
+        self.dialect.clone()
+    }
+
+    fn transform(&self, input: &Input) -> Result<DomainClaim, KitError> {
+        let lift_params = self
+            .lift_params_from_source(input)
+            .map_err(|error| KitError::Transformation(error.to_string()))?;
+        let spec_input = Input::Spec(lift_params);
+        let mut claim = self
+            .transport
+            .parse_session(&spec_input)
+            .map(|session| session.claim)
+            .map_err(|error| KitError::Transformation(format!("lift plugin transport: {error}")))?;
+        claim.from = vec![address(input)];
+        Ok(claim)
+    }
+
+    fn prove(&self, claim: DomainClaim) -> Result<DomainClaim, KitError> {
+        Ok(claim)
+    }
+
+    fn parse(&self, input: &Input) -> Result<Term, KitError> {
+        self.transform(input)?
+            .payload
+            .ok_or_else(|| KitError::Serialization("lift claim missing term payload".to_string()))
+    }
+
+    fn serialize(&self, term: &Term) -> Result<Input, KitError> {
+        Ok(Input::Term(term.clone()))
     }
 }
 

--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -19,13 +19,15 @@
 //! `sign`.
 
 pub mod lift_plugin;
+pub mod path_executor;
 pub mod primitives;
 pub mod stubs;
 pub mod traits;
 pub mod types;
 pub mod verbs;
 
-pub use lift_plugin::{LiftPluginKit, LiftPluginKitError, LiftPluginKitSession};
+pub use lift_plugin::{LiftKit, LiftPluginKit, LiftPluginKitError, LiftPluginKitSession};
+pub use path_executor::{execute_path, KitRegistry, PathExecutionError};
 pub use primitives::{
     address, compose, dropper, resolve, sign, verify_sig, ComposeError, SigningKey,
 };

--- a/implementations/rust/libprovekit/src/core/path_executor.rs
+++ b/implementations/rust/libprovekit/src/core/path_executor.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap};
+
+use provekit_ir_types::{
+    composition_refusal_compose_input_cid, composition_refusal_header_cid,
+    composition_refusal_signature, CompositionRefusalEnvelope, CompositionRefusalHeader,
+    CompositionRefusalMemento, CompositionRefusalMetadata, MissingRequirement,
+};
+use thiserror::Error;
+
+use crate::compose::CCP_VERSION;
+
+use super::traits::{InputCatalog, Kit, KitError};
+use super::types::{Cid, DomainClaim, Input, PathAlgebra, PathError, Term};
+
+/// Registry of executable kits keyed by the `PathAlgebra.kit` selector.
+#[derive(Default)]
+pub struct KitRegistry {
+    kits: HashMap<String, Box<dyn Kit>>,
+}
+
+impl KitRegistry {
+    /// Register a kit under the exact path selector.
+    pub fn register(&mut self, name: impl Into<String>, kit: impl Kit + 'static) {
+        self.kits.insert(name.into(), Box::new(kit));
+    }
+
+    /// Borrow a registered kit by selector.
+    pub fn get(&self, name: &str) -> Option<&dyn Kit> {
+        self.kits.get(name).map(Box::as_ref)
+    }
+}
+
+/// Execute a composed path by materializing step inputs and dispatching registered kits.
+pub fn execute_path(
+    input: &Input,
+    registry: &KitRegistry,
+    inputs: &dyn InputCatalog,
+) -> Result<DomainClaim, PathExecutionError> {
+    let Input::Path(path) = input else {
+        return Err(PathExecutionError::UnsupportedInput(
+            "execute_path expects Input::Path".to_string(),
+        ));
+    };
+    let ordered = path.ordered_steps().map_err(PathExecutionError::Path)?;
+    let mut claims_by_step: BTreeMap<String, DomainClaim> = BTreeMap::new();
+    let mut materialized_terms: HashMap<Cid, Term> = HashMap::new();
+
+    for step in ordered {
+        let kit = registry
+            .get(&step.kit)
+            .ok_or_else(|| PathExecutionError::Refused(Box::new(missing_kit_refusal(step))))?;
+        let step_input = step_input(step, inputs, &materialized_terms)?;
+        let claim = kit
+            .transform(&step_input)
+            .map_err(PathExecutionError::Kit)?;
+        if let Some(term) = claim.payload.clone() {
+            materialized_terms.insert(claim.to.clone(), term);
+        }
+        claims_by_step.insert(step.name.clone(), claim);
+    }
+
+    let terminals = path.terminal_steps();
+    let [terminal] = terminals.as_slice() else {
+        return Err(PathExecutionError::UnsupportedInput(format!(
+            "execute_path expects exactly one terminal step, got {}",
+            terminals.len()
+        )));
+    };
+    claims_by_step
+        .remove(&terminal.name)
+        .ok_or_else(|| PathExecutionError::UnsupportedInput("terminal step did not execute".into()))
+}
+
+fn step_input(
+    step: &PathAlgebra,
+    inputs: &dyn InputCatalog,
+    materialized_terms: &HashMap<Cid, Term>,
+) -> Result<Input, PathExecutionError> {
+    let [cid] = step.inputs.as_slice() else {
+        return Err(PathExecutionError::UnsupportedInput(format!(
+            "path step `{}` expects exactly one input CID, got {}",
+            step.name,
+            step.inputs.len()
+        )));
+    };
+    if let Some(input) = inputs.get_input(cid) {
+        return Ok(input);
+    }
+    if let Some(term) = materialized_terms.get(cid) {
+        return Ok(Input::Term(term.clone()));
+    }
+    Err(PathExecutionError::Refused(Box::new(
+        missing_input_refusal(step, cid),
+    )))
+}
+
+/// Errors from path execution.
+#[derive(Debug, Error)]
+pub enum PathExecutionError {
+    /// The path or step shape is outside the current executor contract.
+    #[error("{0}")]
+    UnsupportedInput(String),
+    /// The path algebra itself is invalid.
+    #[error(transparent)]
+    Path(#[from] PathError),
+    /// The target kit failed.
+    #[error(transparent)]
+    Kit(#[from] KitError),
+    /// Execution refused with a durable composition-refusal memento.
+    #[error("path execution refused")]
+    Refused(Box<CompositionRefusalMemento>),
+}
+
+impl PathExecutionError {
+    /// Borrow the durable refusal memento when this error is a refusal.
+    pub fn composition_refusal(&self) -> Option<&CompositionRefusalMemento> {
+        match self {
+            Self::Refused(refusal) => Some(refusal),
+            _ => None,
+        }
+    }
+}
+
+fn missing_kit_refusal(step: &PathAlgebra) -> CompositionRefusalMemento {
+    composition_refusal_for_missing_requirement(
+        step,
+        "kit-registry",
+        "plugin-registry",
+        format!(
+            "path step `{}` references unregistered kit `{}`",
+            step.name, step.kit
+        ),
+    )
+}
+
+fn missing_input_refusal(step: &PathAlgebra, cid: &Cid) -> CompositionRefusalMemento {
+    composition_refusal_for_missing_requirement(
+        step,
+        "input-catalog",
+        "path-input",
+        format!(
+            "path step `{}` input `{cid}` is not materialized and no prior term payload produced it",
+            step.name
+        ),
+    )
+}
+
+fn composition_refusal_for_missing_requirement(
+    step: &PathAlgebra,
+    role: &str,
+    memento_kind: &str,
+    reason: String,
+) -> CompositionRefusalMemento {
+    let atoms_cids: Vec<String> = step.inputs.iter().map(ToString::to_string).collect();
+    let effect_set_cids = Vec::new();
+    let compose_input_cid =
+        composition_refusal_compose_input_cid(&atoms_cids, &effect_set_cids, CCP_VERSION);
+    let mut header = CompositionRefusalHeader {
+        atoms_cids,
+        blocking_effects: None,
+        ccp_version: CCP_VERSION.to_string(),
+        cid: String::new(),
+        compose_input_cid,
+        effect_occurrences: Some(vec![]),
+        effect_set_cids,
+        failure_detail: reason.clone(),
+        failure_kind: "memento-required-missing".to_string(),
+        incompatible_pair: None,
+        kind: "composition-refusal".to_string(),
+        missing_memento_requirements: Some(vec![MissingRequirement {
+            expected_cid: None,
+            memento_kind: Some(memento_kind.to_string()),
+            reason,
+            role: Some(role.to_string()),
+        }]),
+        schema_version: "1".to_string(),
+    };
+    header.cid = composition_refusal_header_cid(&header);
+    let metadata = CompositionRefusalMetadata::default();
+    let signature = composition_refusal_signature(&header, &metadata);
+    CompositionRefusalMemento {
+        envelope: CompositionRefusalEnvelope {
+            declared_at: "1970-01-01T00:00:00Z".to_string(),
+            signature,
+            signer: "substrate:libprovekit".to_string(),
+        },
+        header,
+        metadata,
+    }
+}

--- a/implementations/rust/libprovekit/src/core/primitives.rs
+++ b/implementations/rust/libprovekit/src/core/primitives.rs
@@ -174,6 +174,7 @@ fn compose_function_contract_claims(
         premises,
         to,
         witness: None,
+        payload: None,
         verdict: compose_verdict(inner_claim.verdict, outer_claim.verdict),
         attestation: None,
     })

--- a/implementations/rust/libprovekit/src/core/stubs.rs
+++ b/implementations/rust/libprovekit/src/core/stubs.rs
@@ -199,6 +199,7 @@ fn transform_stub_input(expected: &Dialect, input: &Input) -> Result<DomainClaim
         premises: vec![],
         to,
         witness: None,
+        payload: Some(term),
         verdict: Verdict::Unresolved,
         attestation: None,
     })

--- a/implementations/rust/libprovekit/src/core/types.rs
+++ b/implementations/rust/libprovekit/src/core/types.rs
@@ -735,6 +735,8 @@ pub struct DomainClaim {
     pub to: Cid,
     /// Optional content-addressed witness.
     pub witness: Option<Witness>,
+    /// Optional faithful term payload materialized by transform kits.
+    pub payload: Option<Term>,
     /// Current discharge verdict.
     pub verdict: Verdict,
     /// Optional signer attestation, excluded from claim identity.
@@ -1180,6 +1182,7 @@ impl PathDomainClaimMaterial {
             witness: self.witness.clone(),
             verdict: self.verdict,
             attestation: self.attestation.clone(),
+            payload: None,
         }
     }
 }
@@ -1698,7 +1701,7 @@ fn domain_claim_to_value(claim: &DomainClaim) -> Arc<CValue> {
         None => CValue::null(),
     };
 
-    CValue::object([
+    let mut fields = vec![
         ("artifacts", CValue::array(artifact_values)),
         ("contract", contract_to_cvalue(&claim.contract)),
         (
@@ -1713,7 +1716,14 @@ fn domain_claim_to_value(claim: &DomainClaim) -> Arc<CValue> {
             json_to_cvalue(serde_json::to_value(claim.verdict).expect("verdict serializes")),
         ),
         ("witness", witness_value),
-    ])
+    ];
+    if let Some(payload) = &claim.payload {
+        fields.push((
+            "payload",
+            json_to_cvalue(serde_json::to_value(payload).expect("payload term serializes")),
+        ));
+    }
+    CValue::object(fields)
 }
 
 fn input_to_value(input: &Input) -> Arc<CValue> {

--- a/implementations/rust/libprovekit/src/core/verbs.rs
+++ b/implementations/rust/libprovekit/src/core/verbs.rs
@@ -125,6 +125,7 @@ fn link_by_shared_contract(claims: &[DomainClaim]) -> Result<DomainClaim, CoreEr
         premises,
         to: shared_contract,
         witness: None,
+        payload: None,
         verdict,
         attestation: None,
     })

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -7,9 +7,10 @@ use libprovekit::compose::{
     FunctionContractMemento, Locus,
 };
 use libprovekit::core::{
-    address, compose, link, prove, transform, verify, ArityShape, AritySlot, CKit, Canonical, Cid,
-    Dialect, DomainClaim, DomainKind, FunctionContractDomain, HashMapCatalog, HashMapInputCatalog,
-    Input, InputCatalog, Kit, LanguageSignature, LiftPluginKit, Path, PathAlgebra, PathDocument,
+    address, compose, execute_path, link, prove, transform, verify, ArityShape, AritySlot,
+    CKit, Canonical, Cid, Dialect, DomainClaim, DomainKind, FunctionContractDomain,
+    HashMapCatalog, HashMapInputCatalog, Input, InputCatalog, Kit, KitRegistry,
+    LanguageSignature, LiftKit, LiftPluginKit, Path, PathAlgebra, PathDocument,
     PathDocumentError, PathError, Refutation, SlotSort, Term, Truth, Verdict, Witness,
 };
 use provekit_canonicalizer::Value;
@@ -92,6 +93,7 @@ fn claim_for_contract(contract: FunctionContractMemento) -> DomainClaim {
         premises: vec![],
         to,
         witness: None,
+        payload: None,
         verdict: Verdict::Unresolved,
         attestation: None,
     }
@@ -958,4 +960,107 @@ done
         Some("ir-document")
     );
     let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn lift_kit_transforms_source_through_lift_plugin_transport_and_carries_term_payload() {
+    let temp =
+        std::env::temp_dir().join(format!("provekit-lift-kit-source-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&temp);
+    std::fs::create_dir_all(&temp).expect("create temp dir");
+    let script = temp.join("fake-lifter.sh");
+    std::fs::write(
+        &script,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*) echo '{"jsonrpc":"2.0","id":1,"result":{"name":"fake-rust-lifter"}}' ;;
+    *'"method":"lift"'*) echo '{"jsonrpc":"2.0","id":2,"result":{"kind":"ir-document","ir":[{"kind":"bind-lift-entry","file":"src/lib.rs","fn_name":"id","fn_line":1,"param_names":["x"],"param_types":["i64"],"return_type":"i64","term_shape":{"kind":"var","name":"x"},"term_shape_cid":"blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","witnesses":[]}],"diagnostics":[]}}' ;;
+    *'"method":"shutdown"'*) exit 0 ;;
+  esac
+done
+"#,
+    )
+    .expect("write fake lifter");
+
+    let request = serde_json::json!({
+        "surface": "rust",
+        "workspace_root": temp,
+        "config_path": ".provekit/config.toml",
+        "source_paths": ["."],
+        "options": {"layer": "all", "identifyOnly": false}
+    });
+    let source = Input::Source {
+        dialect: libprovekit::core::Dialect::Rust,
+        bytes: serde_json::to_vec(&request).expect("source request JSON"),
+    };
+    let kit = LiftKit::new(
+        libprovekit::core::Dialect::Rust,
+        "rust",
+        vec!["sh".to_string(), script.display().to_string()],
+        Some(temp.clone()),
+    );
+
+    let claim = kit
+        .transform(&source)
+        .expect("source input lifts through the transport");
+    let expected_term = Term::Const {
+        value: serde_json::json!({
+            "kind": "ir-document",
+            "ir": [{
+                "kind": "bind-lift-entry",
+                "file": "src/lib.rs",
+                "fn_name": "id",
+                "fn_line": 1,
+                "param_names": ["x"],
+                "param_types": ["i64"],
+                "return_type": "i64",
+                "term_shape": {"kind": "var", "name": "x"},
+                "term_shape_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "witnesses": []
+            }],
+            "diagnostics": []
+        }),
+        sort: Sort::Primitive {
+            name: "LiftPluginResponse".to_string(),
+        },
+    };
+
+    assert_eq!(claim.to, address(&expected_term));
+    assert_eq!(claim.artifacts, vec![address(&expected_term)]);
+    assert_eq!(claim.payload.as_ref(), Some(&expected_term));
+    assert_eq!(claim.from, vec![address(&source)]);
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn execute_path_refuses_unregistered_lift_kit_with_composition_refusal_memento() {
+    let source = Input::Source {
+        dialect: libprovekit::core::Dialect::Other("unknown".to_string()),
+        bytes: b"fn id(x: i64) -> i64 { x }".to_vec(),
+    };
+    let mut inputs = HashMapInputCatalog::default();
+    let source_cid = inputs.insert(source);
+    let path = Input::Path(Box::new(Path {
+        algebra: vec![PathAlgebra {
+            name: "lift".to_string(),
+            kit: "lift-unknown".to_string(),
+            inputs: vec![source_cid],
+            depends_on: vec![],
+        }],
+    }));
+    let registry = KitRegistry::default();
+
+    let err = execute_path(&path, &registry, &inputs).expect_err("unknown lift kit refuses");
+    let refusal = err
+        .composition_refusal()
+        .expect("path executor error carries composition refusal");
+    assert_eq!(refusal.header.failure_kind, "memento-required-missing");
+    assert!(refusal
+        .header
+        .missing_memento_requirements
+        .as_ref()
+        .expect("missing requirements")
+        .iter()
+        .any(|requirement| requirement.role.as_deref() == Some("kit-registry")));
 }

--- a/implementations/rust/provekit-cli/src/cmd_lift.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lift.rs
@@ -66,7 +66,7 @@ pub fn run(args: LiftArgs) -> u8 {
         }
     };
 
-    match lift_plugin::dispatch_lift(
+    match lift_plugin::dispatch_lift_path(
         &project_root,
         &surface,
         LiftPluginOptions {
@@ -124,6 +124,19 @@ pub fn run(args: LiftArgs) -> u8 {
                 "error".red().bold()
             );
             EXIT_USER_ERROR
+        }
+        Err(LiftPluginError::Refused(refusal)) => {
+            eprintln!(
+                "{}: {}",
+                "error".red().bold(),
+                serde_json::to_string(&refusal).unwrap_or_else(|_| {
+                    format!(
+                        "{}: {}",
+                        refusal.header.failure_kind, refusal.header.failure_detail
+                    )
+                })
+            );
+            EXIT_VERIFY_FAIL
         }
         Err(LiftPluginError::Failed(error)) => {
             eprintln!("{}: {error}", "error".red().bold());

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -264,6 +264,12 @@ impl MintKit {
                     out_dir,
                 });
             }
+            Err(LiftPluginError::Refused(refusal)) => {
+                return Err(KitError::Transformation(format!(
+                    "{}: {}",
+                    refusal.header.failure_kind, refusal.header.failure_detail
+                )))
+            }
             Err(LiftPluginError::Failed(error)) => return Err(KitError::Transformation(error)),
         };
 
@@ -564,6 +570,7 @@ fn mint_result_claim(
         premises,
         to,
         witness: None,
+        payload: Some(term),
         verdict: Verdict::Unresolved,
         attestation: None,
     })

--- a/implementations/rust/provekit-cli/src/cmd_package.rs
+++ b/implementations/rust/provekit-cli/src/cmd_package.rs
@@ -101,6 +101,15 @@ fn run_inspect(args: PackageInspectArgs) -> u8 {
             );
             EXIT_USER_ERROR
         }
+        Err(LiftPluginError::Refused(refusal)) => {
+            eprintln!(
+                "{}: {}: {}",
+                "error".red().bold(),
+                refusal.header.failure_kind,
+                refusal.header.failure_detail
+            );
+            EXIT_VERIFY_FAIL
+        }
         Err(LiftPluginError::Failed(error)) => {
             eprintln!("{}: {error}", "error".red().bold());
             EXIT_VERIFY_FAIL

--- a/implementations/rust/provekit-cli/src/lift_plugin.rs
+++ b/implementations/rust/provekit-cli/src/lift_plugin.rs
@@ -10,8 +10,12 @@
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use libprovekit::core::{DomainClaim, Input, LiftPluginKit, LiftPluginKitError};
+use libprovekit::core::{
+    address, execute_path, Dialect, DomainClaim, HashMapInputCatalog, Input, KitRegistry, LiftKit,
+    LiftPluginKit, LiftPluginKitError, Path as CorePath, PathAlgebra, PathExecutionError, Term,
+};
 use owo_colors::OwoColorize;
+use provekit_ir_types::CompositionRefusalMemento;
 use serde_json::{json, Value};
 
 #[derive(Debug, Clone)]
@@ -34,13 +38,14 @@ impl LiftPluginSession {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct LiftPluginOptions {
+pub struct LiftPluginOptions {
     pub identify_only: bool,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) enum LiftPluginError {
     MissingBinary { binary: String },
+    Refused(Box<CompositionRefusalMemento>),
     Failed(String),
 }
 
@@ -60,6 +65,11 @@ impl std::fmt::Display for LiftPluginError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::MissingBinary { binary } => write!(f, "lifter binary `{binary}` not found"),
+            Self::Refused(refusal) => write!(
+                f,
+                "composition refused: {}: {}",
+                refusal.header.failure_kind, refusal.header.failure_detail
+            ),
             Self::Failed(message) => f.write_str(message),
         }
     }
@@ -117,6 +127,124 @@ pub(crate) fn dispatch_lift(
         legacy_response: core_session.legacy_response,
         claim: core_session.claim,
     })
+}
+
+pub(crate) fn dispatch_lift_path(
+    project_root: &Path,
+    surface: &str,
+    options: LiftPluginOptions,
+    quiet: bool,
+) -> Result<LiftPluginSession, LiftPluginError> {
+    let started = Instant::now();
+    let manifest = find_manifest(project_root, surface);
+    if !quiet {
+        match &manifest {
+            Ok(manifest) => println!(
+                "{}: surface=`{}` plugin=`{}` command={:?}",
+                "dispatch".green().bold(),
+                surface,
+                manifest.name,
+                manifest.command
+            ),
+            Err(error) => println!(
+                "{}: surface=`{}` registry miss: {}",
+                "dispatch".yellow().bold(),
+                surface,
+                error
+            ),
+        }
+    }
+
+    let lift_params = build_lift_params(project_root, surface, options);
+    let dialect = dialect_for_surface(surface);
+    let kit_name = lift_kit_name(surface);
+    let source = Input::Source {
+        dialect: dialect.clone(),
+        bytes: serde_json::to_vec(&lift_params)
+            .map_err(|error| LiftPluginError::Failed(format!("encode lift request: {error}")))?,
+    };
+    let source_cid = address(&source);
+    let mut inputs = HashMapInputCatalog::default();
+    inputs.put(source_cid.clone(), source);
+    let path_input = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "lift".to_string(),
+            kit: kit_name.clone(),
+            inputs: vec![source_cid],
+            depends_on: vec![],
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    if let Ok(manifest) = &manifest {
+        registry.register(
+            kit_name,
+            LiftKit::new(
+                dialect,
+                surface,
+                manifest.command.clone(),
+                resolved_working_dir(project_root, manifest),
+            ),
+        );
+    }
+
+    trace_log(format!("lift path execute surface={surface}"));
+    let claim = execute_path(&path_input, &registry, &inputs).map_err(lift_error_from_path)?;
+    trace_log(format!(
+        "lift path executed surface={surface} elapsed={:?}",
+        started.elapsed()
+    ));
+    let legacy_response = claim
+        .payload
+        .as_ref()
+        .ok_or_else(|| LiftPluginError::Failed("lift claim missing term payload".to_string()))
+        .and_then(response_from_payload_term)?;
+
+    Ok(LiftPluginSession {
+        legacy_response,
+        claim,
+    })
+}
+
+fn response_from_payload_term(term: &Term) -> Result<Value, LiftPluginError> {
+    match term {
+        Term::Const { value, .. } => Ok(value.clone()),
+        _ => Err(LiftPluginError::Failed(
+            "lift claim payload was not a lift response term".to_string(),
+        )),
+    }
+}
+
+fn lift_error_from_path(error: PathExecutionError) -> LiftPluginError {
+    match error {
+        PathExecutionError::Refused(refusal) => LiftPluginError::Refused(refusal),
+        PathExecutionError::Kit(error) => match error {
+            libprovekit::core::KitError::Transformation(message)
+                if message.starts_with("lift plugin transport: lifter binary `") =>
+            {
+                LiftPluginError::Failed(message)
+            }
+            other => LiftPluginError::Failed(other.to_string()),
+        },
+        other => LiftPluginError::Failed(other.to_string()),
+    }
+}
+
+fn dialect_for_surface(surface: &str) -> Dialect {
+    match surface {
+        "rust" => Dialect::Rust,
+        "c" => Dialect::C,
+        "x86-64" | "x86_64" => Dialect::X86_64,
+        "aarch64" => Dialect::AArch64,
+        "wasm" => Dialect::Wasm,
+        "jvm-bytecode" => Dialect::JvmBytecode,
+        "coq" => Dialect::Coq,
+        "smt-lib" => Dialect::SmtLib,
+        other => Dialect::Other(other.to_string()),
+    }
+}
+
+fn lift_kit_name(surface: &str) -> String {
+    format!("lift-{surface}")
 }
 
 fn parse_manifest(path: &Path) -> Result<LiftPluginManifest, String> {
@@ -194,11 +322,7 @@ fn resolved_working_dir(project_root: &Path, manifest: &LiftPluginManifest) -> O
     })
 }
 
-pub(crate) fn build_lift_params(
-    project_root: &Path,
-    surface: &str,
-    options: LiftPluginOptions,
-) -> Value {
+pub fn build_lift_params(project_root: &Path, surface: &str, options: LiftPluginOptions) -> Value {
     let workspace_root = project_root
         .canonicalize()
         .unwrap_or_else(|_| project_root.to_path_buf());

--- a/implementations/rust/provekit-cli/tests/lift_kit_path_integration.rs
+++ b/implementations/rust/provekit-cli/tests/lift_kit_path_integration.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use libprovekit::core::{
+    address, execute_path, Dialect, HashMapInputCatalog, Input, KitRegistry, LiftKit,
+    LiftPluginKit, Path as CorePath, PathAlgebra, Term,
+};
+use provekit_ir_types::Sort;
+use serde_json::json;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod script");
+    }
+}
+
+fn fake_lifter(root: &Path) -> PathBuf {
+    let script = root.join("fake-rust-lifter.sh");
+    write_executable(
+        &script,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+  if [[ "$line" == *'"method":"initialize"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"fake-rust-lifter","protocol_version":"pep/1.7.0","capabilities":{"surfaces":["rust"]}}}'
+  elif [[ "$line" == *'"method":"lift"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"kind":"ir-document","sourceLanguage":"rust","ir":[{"kind":"bind-lift-entry","file":"src/lib.rs","fn_name":"id","fn_line":1,"param_names":["x"],"param_types":["i64"],"return_type":"i64","term_shape":{"kind":"var","name":"x"},"term_shape_cid":"blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","witnesses":[]}],"diagnostics":[]}}'
+  elif [[ "$line" == *'"method":"shutdown"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+    exit 0
+  fi
+done
+"#,
+    );
+    script
+}
+
+#[test]
+fn lift_rust_path_executor_matches_existing_cmd_lift_transport_term_cid() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script = fake_lifter(temp.path());
+    let workspace_root = temp
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| temp.path().to_path_buf());
+    let request = json!({
+        "surface": "rust",
+        "workspace_root": workspace_root,
+        "config_path": ".provekit/config.toml",
+        "source_paths": ["."],
+        "options": {
+            "layer": "all",
+            "identifyOnly": false,
+        }
+    });
+    let command = vec!["bash".to_string(), script.display().to_string()];
+    let existing = LiftPluginKit::new("rust", command.clone(), Some(temp.path().to_path_buf()))
+        .parse_session(&Input::Spec(request.clone()))
+        .expect("existing lift plugin transport succeeds");
+
+    let source = Input::Source {
+        dialect: Dialect::Rust,
+        bytes: serde_json::to_vec(&request).expect("encode lift request"),
+    };
+    let mut inputs = HashMapInputCatalog::default();
+    let source_cid = inputs.insert(source);
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "lift".to_string(),
+            kit: "lift-rust".to_string(),
+            inputs: vec![source_cid],
+            depends_on: vec![],
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        "lift-rust",
+        LiftKit::new(
+            Dialect::Rust,
+            "rust",
+            command,
+            Some(temp.path().to_path_buf()),
+        ),
+    );
+
+    let claim = execute_path(&path, &registry, &inputs).expect("lift path executes");
+    assert_eq!(claim.to, existing.claim.to);
+    assert_eq!(claim.artifacts, existing.claim.artifacts);
+    assert_eq!(
+        claim.payload.as_ref(),
+        Some(&Term::Const {
+            value: json!({
+                "kind": "ir-document",
+                "sourceLanguage": "rust",
+                "ir": [{
+                    "kind": "bind-lift-entry",
+                    "file": "src/lib.rs",
+                    "fn_name": "id",
+                    "fn_line": 1,
+                    "param_names": ["x"],
+                    "param_types": ["i64"],
+                    "return_type": "i64",
+                    "term_shape": {"kind": "var", "name": "x"},
+                    "term_shape_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "witnesses": []
+                }],
+                "diagnostics": []
+            }),
+            sort: Sort::Primitive {
+                name: "LiftPluginResponse".to_string(),
+            },
+        })
+    );
+    assert_eq!(
+        claim.to,
+        address(claim.payload.as_ref().expect("payload term"))
+    );
+}
+
+#[test]
+fn lift_cli_refuses_unregistered_dialect_with_composition_refusal_memento() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    fs::create_dir_all(project.join(".provekit")).expect("create project config dir");
+    fs::write(
+        project.join(".provekit/config.toml"),
+        "[authoring.lift]\nsurface = \"neverlang\"\n",
+    )
+    .expect("write config");
+
+    let output = Command::new(provekit_bin())
+        .arg("lift")
+        .arg(&project)
+        .arg("--json")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit lift");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "unknown lift dialect must fail\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("composition-refusal")
+            && stderr.contains("memento-required-missing")
+            && stderr.contains("kit-registry"),
+        "stderr should carry the registry refusal memento\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Closes #1033. Wraps the existing lifter machinery as a `LiftKit` registered with a shared generic `KitRegistry`, exposing `libprovekit::core::execute_path` as the public substrate-spine verb.

## Two halves in one PR

**#1033 half (LiftKit):** Adapter shim in `cmd_lift` builds `Input::Source` + one-step `Path` + invokes the executor. `LiftKit::transform(Input::Source) -> DomainClaim` with `to` CID byte-equal to the existing lifter's Term CID and `payload: Option<Term>` carrying the lifted Term for downstream Path consumption via `Input::Term` (the #1026 closure work).

**Executor-promotion half of #1025 (side-effect):** `libprovekit::core::path_executor` ships as a generic reusable module. `KitRegistry` is `HashMap<String, Box<dyn Kit>>` — string-keyed, type-parameterized, ZERO `lift`/`Lift`/`LIFT` matches in the 192-LOC module. `execute_path(path, &registry, &inputs)` walks `PathAlgebra` steps, resolves each step's kit by name, calls `Kit::transform`, stores returned `DomainClaim`s by step name. Future BindKit, LowerKit (#1027), and the existing MintKit can register with the same registry instead of building their own dispatch.

## #1033 acceptance criteria — satisfied

- [x] Unit test: `LiftKit::transform(Input::Source { dialect: "rust", bytes })` returns `DomainClaim` whose `to` CID byte-equals the existing lifter's term CID for the same input
- [x] Integration test (`tests/lift_kit_path_integration.rs`): `execute_path(path)` with a one-step lift produces a `DomainClaim` byte-identical to `cmd_lift` output for the same source
- [x] Registry refuses unknown dialect with `CompositionRefusalMemento { failure_kind: memento-required-missing }`
- [x] No private template path, no silent fallback
- [x] Agent-driven `run_lift_loop` test surface unchanged

## Files

- `implementations/rust/libprovekit/src/core/path_executor.rs` (new, 192 LOC): generic `KitRegistry` + `execute_path` verb
- `implementations/rust/libprovekit/src/core/lift_plugin.rs`: `LiftKit` impl
- `implementations/rust/libprovekit/src/core/types.rs`: `DomainClaim.payload: Option<Term>` field for downstream consumption
- `implementations/rust/libprovekit/src/core/{mod,primitives,stubs,verbs}.rs`: re-exports + trait wiring
- `implementations/rust/libprovekit/tests/core_interface.rs`: LiftKit unit tests
- `implementations/rust/provekit-cli/src/cmd_lift.rs`: adapter shim, `run_lift_loop` unchanged
- `implementations/rust/provekit-cli/src/{cmd_mint,cmd_package,lift_plugin}.rs`: minor type wiring
- `implementations/rust/provekit-cli/tests/lift_kit_path_integration.rs` (new): `execute_path` + registry integration test

## Architectural impact on the trinity arc

After this lands:
- **#1024 Trinity exhibit binding assertion** becomes a single `execute_path(&trinity_path, &registry, &inputs)` call instead of shell-out + hand-assembly
- **#1025 spine work** shrinks to mechanical migration: replace `cmd_mint`'s in-place `transform_session`/`dispatch_path` with calls to `execute_path`, DELETE the duplicates (per hard-refuse rule on registry-without-teeth)
- **Two follow-up issues to file** for the Trinity prereq set:
  1. BindKit registers with the Path executor (mirrors this PR's shape for bind; needed for Trinity step 2). Draft pre-staged.
  2. `PathAlgebra` verb selector (`Verb::{Transform, Prove}` field + executor match arm + `Kit::prove` trait method with default `NotSupported` impl; needed for Trinity step 6). Draft pre-staged.

## Gates

- `cargo test -p libprovekit`: passed
- `cargo test -p provekit-cli`: passed
- `tools/spec-cid-lint.sh`: exit 0
- Change-scope em/en-dash sweep on the 13 modified/new files: zero

## Non-goals respected

- No modification of `run_lift_loop` in `cmd_lift.rs`
- No broadening of `Path` semantics beyond #1025/#1026/#1027
- No new lift dialects
- No new memento family (reuses `CompositionRefusalMemento`)

## Pre-existing em-dash note

Directory-wide em-dash sweep would surface pre-existing em-dashes in `wp.rs`, `wp/tests.rs`, three test files, and the signed `protocol-catalog.json`. The catalog em-dashes are baked into the catalog CID — touching them breaks foundation key attestation; they MUST NOT be edited. The doc-comment em-dashes are out-of-scope boy-scout work; this PR touches them not.

## Note for downstream consumers: mint claim CID drift

Opus review surfaced one non-blocking side-effect worth surfacing here so future readers don't trip over it:

`DomainClaim.payload: Option<Term>` participates in the canonical CValue when `Some(_)` (`types.rs:1370` + `Canonical for DomainClaim` at `:1207`). `cmd_mint::mint_result_claim` already opts in to `payload: Some(term)`, so **mint claim CIDs change post-PR**.

What this means concretely:

- The `to` CID and the lossy contract-projection contract are **unaffected** — the substrate primitive itself is correct, and all current pinned snapshot CIDs (which are Term CIDs or no-payload claims) still pass.
- Pre-existing pinned snapshot CIDs in tests are not broken.
- BUT: any downstream consumer that stored a mint claim CID **before this PR** will see a different CID after. There are no known such consumers today (no external pin we're aware of), so this is documentation, not a regression.
- The #1025 spine PR (which migrates `cmd_mint::transform_session`/`dispatch_path` onto `execute_path`) will land into a world where mint claim identities have already shifted; that work should NOT chase the old identities.

If any future consumer pins a mint claim CID, do so after this PR's commit lands, not before. The new identities are the canonical ones going forward.
