### PR TITLE
feat(java-kit): transported-op concept-citation carrier emit + relift (closes #1031)

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
@@ -42,9 +42,11 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -58,6 +60,7 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
 
 public final class JavaBindLifter {
+    private static final String CONCEPT_CITATION_COMMENT_KIND = "provekit-concept-citation-comment-sugar";
 
     /** Walk a workspace and emit one bind-lift-entry per method. */
     public Result liftPaths(String workspaceRoot, List<String> sourcePaths) {
@@ -133,7 +136,7 @@ public final class JavaBindLifter {
         }
         Trees trees = Trees.instance(task);
         for (CompilationUnitTree unit : units) {
-            new MethodScanner(trees, rel, source, entries).scan(unit, null);
+            new MethodScanner(trees, rel, source, entries, diagnostics).scan(unit, null);
         }
     }
 
@@ -143,12 +146,19 @@ public final class JavaBindLifter {
         private final String rel;
         private final String source;
         private final List<Jcs.Json> entries;
+        private final List<Jcs.Json> diagnostics;
 
-        MethodScanner(Trees trees, String rel, String source, List<Jcs.Json> entries) {
+        MethodScanner(
+                Trees trees,
+                String rel,
+                String source,
+                List<Jcs.Json> entries,
+                List<Jcs.Json> diagnostics) {
             this.trees = trees;
             this.rel = rel;
             this.source = source;
             this.entries = entries;
+            this.diagnostics = diagnostics;
         }
 
         @Override
@@ -209,11 +219,22 @@ public final class JavaBindLifter {
             List<Jcs.Json> surfaceWitnesses = new ArrayList<>();
             surfaceWitnesses.addAll(observationTagWitnesses(source, bodyStartLine, bodyEndLine));
             surfaceWitnesses.addAll(contractTagWitnesses(source, fnLine, bodyStartLine, bodyEndLine));
+            ConceptCitationScan conceptCitationScan = conceptCitationTags(
+                source,
+                rel,
+                fnLine,
+                bodyStartLine,
+                bodyEndLine,
+                diagnostics);
+            if (conceptCitationScan.refuseRelift()) {
+                return null;
+            }
 
             Jcs.Obj entry = Jcs.object(
                 "attr_post", Jcs.nullValue(),
                 "attr_pre", Jcs.nullValue(),
                 "concept_annotation", conceptAnnotation == null ? Jcs.nullValue() : Jcs.string(conceptAnnotation),
+                "concept_citations", Jcs.array(conceptCitationScan.citations()),
                 "file", Jcs.string(rel),
                 "fn_line", Jcs.integer(fnLine),
                 "fn_name", Jcs.string(fnName),
@@ -458,6 +479,401 @@ public final class JavaBindLifter {
         ));
     }
 
+    private static ConceptCitationScan conceptCitationTags(
+            String source,
+            String relPath,
+            int fnLine,
+            int startLine,
+            int endLine,
+            List<Jcs.Json> diagnostics) {
+        List<TagLine> tags = new ArrayList<>();
+        tags.addAll(scanPreMethodTags(source, fnLine));
+        tags.addAll(scanObservationTags(source, startLine, endLine));
+        List<Jcs.Json> citations = new ArrayList<>();
+        boolean refuseRelift = false;
+        int idx = 0;
+        while (idx < tags.size()) {
+            TagLine tag = tags.get(idx);
+            if ("provekit-concept-payload-cid".equals(tag.key())) {
+                conceptCitationDiag(
+                    diagnostics,
+                    relPath,
+                    tag.line(),
+                    "concept-citation:orphan-cid-line",
+                    "payload CID line has no preceding payload");
+                idx++;
+                continue;
+            }
+            if (!"provekit-concept".equals(tag.key())) {
+                idx++;
+                continue;
+            }
+            String payloadCid = null;
+            if (idx + 1 < tags.size()) {
+                TagLine next = tags.get(idx + 1);
+                if (next.line() == tag.line() + 1 && "provekit-concept-payload-cid".equals(next.key())) {
+                    payloadCid = next.value();
+                    idx++;
+                }
+            }
+            ConceptCitationValidation validation = conceptCitation(
+                tag.value(),
+                payloadCid,
+                relPath,
+                tag.line(),
+                diagnostics);
+            if (validation.refuseRelift()) {
+                refuseRelift = true;
+            }
+            if (validation.citation() != null) {
+                citations.add(validation.citation());
+            }
+            idx++;
+        }
+        return new ConceptCitationScan(citations, refuseRelift);
+    }
+
+    private static ConceptCitationValidation conceptCitation(
+            String payloadText,
+            String emittedPayloadCid,
+            String relPath,
+            int line,
+            List<Jcs.Json> diagnostics) {
+        Jcs.Json payloadJson;
+        try {
+            payloadJson = Jcs.parse(payloadText);
+        } catch (IllegalArgumentException e) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:malformed-json",
+                "malformed JSON: " + e.getMessage());
+            return ConceptCitationValidation.drop();
+        }
+        if (!(payloadJson instanceof Jcs.Obj payload)) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:malformed-json",
+                "payload is not an object");
+            return ConceptCitationValidation.drop();
+        }
+
+        if (!CONCEPT_CITATION_COMMENT_KIND.equals(payload.stringFieldOrNull("artifact_kind"))) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:unknown-schema-version",
+                "wrong artifact_kind");
+            return ConceptCitationValidation.drop();
+        }
+        if (!"1".equals(payload.stringFieldOrNull("schema_version"))) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:unknown-schema-version",
+                "unknown schema_version");
+            return ConceptCitationValidation.drop();
+        }
+        if (!validConceptEmittedBy(payload.get("emitted_by"))) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:malformed-cid",
+                "malformed emitted_by");
+            return ConceptCitationValidation.drop();
+        }
+
+        String operationKind = payload.stringFieldOrNull("operation_kind");
+        if (operationKind == null || operationKind.isBlank()) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:malformed-json",
+                "missing operation_kind");
+            return ConceptCitationValidation.drop();
+        }
+        Jcs.Json termPosition = payload.get("term_position");
+        if (!validTermPosition(termPosition)) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:malformed-json",
+                "malformed term_position");
+            return ConceptCitationValidation.drop();
+        }
+
+        String[] cidFields = {
+            "args_jcs_cid",
+            "concept_cid",
+            "concept_site_cid",
+            "loss_record_cid",
+            "shape_cid",
+            "sugar_dict_cid"
+        };
+        for (String key : cidFields) {
+            if (!validCid(payload.stringFieldOrNull(key))) {
+                conceptCitationDiag(
+                    diagnostics,
+                    relPath,
+                    line,
+                    "concept-citation:malformed-cid",
+                    "malformed " + key);
+                return ConceptCitationValidation.drop();
+            }
+        }
+        for (String key : List.of("callsite_cid", "policy_cid")) {
+            Jcs.Json value = payload.get(key);
+            if (value != null && (!(value instanceof Jcs.Str s) || !validCid(s.value()))) {
+                conceptCitationDiag(
+                    diagnostics,
+                    relPath,
+                    line,
+                    "concept-citation:malformed-cid",
+                    "malformed " + key);
+                return ConceptCitationValidation.drop();
+            }
+        }
+        if (emittedPayloadCid == null) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:payload-cid-mismatch",
+                "missing payload CID");
+            return ConceptCitationValidation.drop();
+        }
+        if (!validCid(emittedPayloadCid)) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:malformed-cid",
+                "malformed payload CID");
+            return ConceptCitationValidation.drop();
+        }
+        String payloadCid = Jcs.cid(payload);
+        if (!payloadCid.equals(emittedPayloadCid)) {
+            conceptCitationDiag(
+                diagnostics,
+                relPath,
+                line,
+                "concept-citation:payload-cid-mismatch",
+                "payload CID mismatch");
+            return ConceptCitationValidation.drop();
+        }
+
+        Jcs.Json argsJcs = payload.get("args_jcs");
+        if (argsJcs != null) {
+            if (!(argsJcs instanceof Jcs.Arr)) {
+                conceptCitationDiag(
+                    diagnostics,
+                    relPath,
+                    line,
+                    "concept-citation:malformed-json",
+                    "malformed args_jcs");
+                return ConceptCitationValidation.drop();
+            }
+            if (!Jcs.cid(argsJcs).equals(payload.stringField("args_jcs_cid"))) {
+                conceptCitationDiag(
+                    diagnostics,
+                    relPath,
+                    line,
+                    "concept-citation:args-cid-mismatch",
+                    "args CID mismatch");
+                return ConceptCitationValidation.drop();
+            }
+        }
+
+        Map<String, CatalogEntry> catalog = conceptShapeCatalog();
+        if (catalog != null) {
+            CatalogEntry catalogEntry = catalog.get(payload.stringField("concept_cid"));
+            if (catalogEntry == null) {
+                conceptCitationDiag(
+                    diagnostics,
+                    relPath,
+                    line,
+                    "concept-citation:unknown-concept",
+                    "concept not in local catalog");
+                return ConceptCitationValidation.drop();
+            }
+            if (!catalogEntry.shapeCid().equals(payload.stringField("shape_cid"))) {
+                conceptCitationDiag(
+                    diagnostics,
+                    relPath,
+                    line,
+                    "concept-citation:shape-mismatch",
+                    "shape CID mismatch");
+                return ConceptCitationValidation.refuse();
+            }
+            if (!catalogEntry.operationKind().equals(operationKind)) {
+                conceptCitationDiag(
+                    diagnostics,
+                    relPath,
+                    line,
+                    "concept-citation:operation-kind-mismatch",
+                    "operation_kind mismatch");
+                return ConceptCitationValidation.refuse();
+            }
+        }
+
+        List<Jcs.Field> extensionFieldList = new ArrayList<>();
+        extensionFieldList.add(new Jcs.Field("args_jcs_cid", Jcs.string(payload.stringField("args_jcs_cid"))));
+        extensionFieldList.add(new Jcs.Field("concept_site_cid", Jcs.string(payload.stringField("concept_site_cid"))));
+        extensionFieldList.add(new Jcs.Field("loss_record_cid", Jcs.string(payload.stringField("loss_record_cid"))));
+        extensionFieldList.add(new Jcs.Field("payload_cid", Jcs.string(payloadCid)));
+        extensionFieldList.add(new Jcs.Field("shape_cid", Jcs.string(payload.stringField("shape_cid"))));
+        extensionFieldList.add(new Jcs.Field("sugar_dict_cid", Jcs.string(payload.stringField("sugar_dict_cid"))));
+        extensionFieldList.add(new Jcs.Field("surface", Jcs.string("concept-citation-comment-sugar")));
+        if (payload.get("callsite_cid") instanceof Jcs.Str callsiteCid) {
+            extensionFieldList.add(new Jcs.Field("callsite_cid", Jcs.string(callsiteCid.value())));
+        }
+        if (payload.get("policy_cid") instanceof Jcs.Str policyCid) {
+            extensionFieldList.add(new Jcs.Field("policy_cid", Jcs.string(policyCid.value())));
+        }
+        if (argsJcs != null) {
+            extensionFieldList.add(new Jcs.Field("args_jcs", argsJcs));
+        }
+
+        return new ConceptCitationValidation(
+            Jcs.object(
+                "args_jcs_cid", Jcs.string(payload.stringField("args_jcs_cid")),
+                "artifact_kind", Jcs.string(CONCEPT_CITATION_COMMENT_KIND),
+                "col", Jcs.integer(0),
+                "confidence_basis_points", Jcs.integer(10000),
+                "concept_cid", Jcs.string(payload.stringField("concept_cid")),
+                "extension_fields", new Jcs.Obj(extensionFieldList),
+                "line", Jcs.integer(line),
+                "operation_kind", Jcs.string(operationKind),
+                "shape_cid", Jcs.string(payload.stringField("shape_cid")),
+                "source_kind", Jcs.string("native-surface"),
+                "term_position", termPosition
+            ),
+            false);
+    }
+
+    private static boolean validConceptEmittedBy(Jcs.Json value) {
+        if (!(value instanceof Jcs.Obj emittedByObj)) return false;
+        String kitId = emittedByObj.stringFieldOrNull("kit_id");
+        String targetLibraryTag = emittedByObj.stringFieldOrNull("target_library_tag");
+        return validCid(emittedByObj.stringFieldOrNull("kit_cid"))
+            && nonBlank(kitId)
+            && nonBlank(emittedByObj.stringFieldOrNull("kit_kind"))
+            && nonBlank(emittedByObj.stringFieldOrNull("target_language"))
+            && (targetLibraryTag == null || !targetLibraryTag.isBlank());
+    }
+
+    private static boolean validTermPosition(Jcs.Json value) {
+        if (!(value instanceof Jcs.Arr arr)) return false;
+        for (Jcs.Json item : arr.values()) {
+            if (!(item instanceof Jcs.Num number) || number.value() < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void conceptCitationDiag(
+            List<Jcs.Json> diagnostics,
+            String relPath,
+            int line,
+            String kind,
+            String message) {
+        diagnostics.add(Jcs.object(
+            "kind", Jcs.string(kind),
+            "line", Jcs.integer(line),
+            "message", Jcs.string(message),
+            "path", Jcs.string(relPath)
+        ));
+    }
+
+    private static Map<String, CatalogEntry> conceptShapeCatalog() {
+        Path root = repoRoot();
+        if (root == null) return null;
+        Path indexPath = root.resolve("menagerie/concept-shapes/catalog/index.json");
+        Jcs.Json indexJson;
+        try {
+            indexJson = Jcs.parse(Files.readString(indexPath, StandardCharsets.UTF_8));
+        } catch (IOException | IllegalArgumentException e) {
+            return null;
+        }
+        if (!(indexJson instanceof Jcs.Obj indexObj)) return null;
+        Jcs.Json entriesJson = indexObj.get("entries");
+        if (!(entriesJson instanceof Jcs.Obj entriesObj)) return null;
+        Map<String, CatalogEntry> catalog = new HashMap<>();
+        Path catalogRoot = indexPath.getParent();
+        for (Jcs.Field field : entriesObj.fields()) {
+            String cid = field.key();
+            if (!validCid(cid) || !(field.value() instanceof Jcs.Obj meta)) continue;
+            if (!"algorithm".equals(meta.stringFieldOrNull("kind"))) continue;
+            String name = meta.stringFieldOrNull("name");
+            String relative = meta.stringFieldOrNull("path");
+            if (name == null || !name.startsWith("concept:") || relative == null || relative.isBlank()) continue;
+            try {
+                Jcs.Json documentJson = Jcs.parse(Files.readString(catalogRoot.resolve(relative), StandardCharsets.UTF_8));
+                if (!(documentJson instanceof Jcs.Obj document)) continue;
+                String shapeCid = document.stringFieldOrNull("cid");
+                Jcs.Json mementoJson = document.get("memento");
+                if (!validCid(shapeCid) || !(mementoJson instanceof Jcs.Obj memento)) continue;
+                String operationKind = catalogOperationKind(name, memento);
+                if (operationKind != null && !operationKind.isBlank()) {
+                    catalog.put(cid, new CatalogEntry(shapeCid, operationKind));
+                }
+            } catch (IOException | IllegalArgumentException ignored) {
+            }
+        }
+        return catalog;
+    }
+
+    private static String catalogOperationKind(String name, Jcs.Obj memento) {
+        Jcs.Json post = memento.get("post");
+        if (post instanceof Jcs.Obj postObj) {
+            String operator = postObj.stringFieldOrNull("operator");
+            if (operator != null && !operator.isBlank()) {
+                return operator;
+            }
+        }
+        return name.startsWith("concept:") ? name.substring("concept:".length()) : null;
+    }
+
+    private static Path repoRoot() {
+        List<Path> candidates = new ArrayList<>();
+        Path cwd = Path.of("").toAbsolutePath().normalize();
+        candidates.add(cwd);
+        candidates.addAll(parentPaths(cwd));
+        try {
+            Path codeLocation = Path.of(JavaBindLifter.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+                .toAbsolutePath()
+                .normalize();
+            candidates.add(codeLocation);
+            candidates.addAll(parentPaths(codeLocation));
+        } catch (Exception ignored) {
+        }
+        for (Path candidate : candidates) {
+            if (Files.exists(candidate.resolve("menagerie/concept-shapes/catalog/index.json"))) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static List<Path> parentPaths(Path path) {
+        List<Path> parents = new ArrayList<>();
+        Path cursor = path.getParent();
+        while (cursor != null) {
+            parents.add(cursor);
+            cursor = cursor.getParent();
+        }
+        return parents;
+    }
+
     private static List<List<TagLine>> contractTagBlocks(List<TagLine> tags) {
         List<List<TagLine>> blocks = new ArrayList<>();
         List<TagLine> current = null;
@@ -610,6 +1026,20 @@ public final class JavaBindLifter {
             );
         }
     }
+
+    private record ConceptCitationScan(List<Jcs.Json> citations, boolean refuseRelift) {}
+
+    private record ConceptCitationValidation(Jcs.Json citation, boolean refuseRelift) {
+        static ConceptCitationValidation drop() {
+            return new ConceptCitationValidation(null, false);
+        }
+
+        static ConceptCitationValidation refuse() {
+            return new ConceptCitationValidation(null, true);
+        }
+    }
+
+    private record CatalogEntry(String shapeCid, String operationKind) {}
 
     private record TagLine(int line, String key, String value) {}
 

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
@@ -367,6 +367,159 @@ class TrinityRoundtripLiftTest {
         assertFalse(cidMismatchEncoded.contains("\"payload_cid\":\"" + LOSS_RECORD_CID + "\""), cidMismatchEncoded);
     }
 
+    @Test
+    void test_concept_citation_relift_recovers_identity() {
+        Jcs.Obj payload = conceptCitationPayload(ARGS_JCS_CID, "1", CONCEPT_SKIP_CID, "skip");
+        String source = conceptTaggedSource(payload, Jcs.cid(payload));
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertTrue(conceptDiagnostics(lift).isEmpty(), encoded);
+        Jcs.Obj entry = (Jcs.Obj) lift.entries().get(0);
+        Jcs.Arr citations = (Jcs.Arr) entry.get("concept_citations");
+        assertEquals(1, citations.values().size(), encoded);
+        Jcs.Obj citation = citations.objectAt(0);
+        assertEquals(CONCEPT_SKIP_CID, citation.stringField("concept_cid"));
+        assertEquals("skip", citation.stringField("operation_kind"));
+        assertEquals(CONCEPT_SKIP_CID, citation.stringField("shape_cid"));
+        assertEquals(ARGS_JCS_CID, citation.stringField("args_jcs_cid"));
+        assertEquals("native-surface", citation.stringField("source_kind"));
+        assertEquals(0, ((Jcs.Num) ((Jcs.Arr) citation.get("term_position")).get(0)).value());
+        Jcs.Obj extensionFields = (Jcs.Obj) citation.get("extension_fields");
+        assertEquals(Jcs.cid(payload), extensionFields.stringField("payload_cid"));
+        assertEquals(CONCEPT_SITE_CID, extensionFields.stringField("concept_site_cid"));
+        assertEquals(0, ((Jcs.Arr) entry.get("witnesses")).values().size());
+    }
+
+    @Test
+    void test_concept_citation_payload_cid_mismatch_refuses() {
+        Jcs.Obj payload = conceptCitationPayload(ARGS_JCS_CID, "1", CONCEPT_SKIP_CID, "skip");
+        String source = conceptTaggedSource(payload, LOSS_RECORD_CID);
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertEquals(0, conceptCitationCount(lift), encoded);
+        assertTrue(conceptDiagnostics(lift).contains("concept-citation:payload-cid-mismatch"), encoded);
+    }
+
+    @Test
+    void test_concept_citation_args_cid_mismatch_refuses() {
+        Jcs.Obj payload = conceptCitationPayload(LOSS_RECORD_CID, "1", CONCEPT_SKIP_CID, "skip");
+        String source = conceptTaggedSource(payload, Jcs.cid(payload));
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertEquals(0, conceptCitationCount(lift), encoded);
+        assertTrue(conceptDiagnostics(lift).contains("concept-citation:args-cid-mismatch"), encoded);
+    }
+
+    @Test
+    void test_concept_citation_unknown_schema_version_refuses() {
+        Jcs.Obj payload = conceptCitationPayload(ARGS_JCS_CID, "999", CONCEPT_SKIP_CID, "skip");
+        String source = conceptTaggedSource(payload, Jcs.cid(payload));
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertEquals(0, conceptCitationCount(lift), encoded);
+        assertTrue(conceptDiagnostics(lift).contains("concept-citation:unknown-schema-version"), encoded);
+    }
+
+    @Test
+    void test_concept_citation_malformed_json_refuses() {
+        String source = conceptSourceWithComments("// provekit-concept: {\"artifact_kind\":");
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertEquals(0, conceptCitationCount(lift), encoded);
+        assertTrue(conceptDiagnostics(lift).contains("concept-citation:malformed-json"), encoded);
+    }
+
+    @Test
+    void test_concept_citation_malformed_cid_refuses() {
+        Jcs.Obj payload = conceptCitationPayload("not-a-cid", ARGS_JCS_CID, "1", CONCEPT_SKIP_CID, "skip");
+        String source = conceptTaggedSource(payload, Jcs.cid(payload));
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertEquals(0, conceptCitationCount(lift), encoded);
+        assertTrue(conceptDiagnostics(lift).contains("concept-citation:malformed-cid"), encoded);
+    }
+
+    @Test
+    void test_concept_citation_unknown_concept_refuses() {
+        Jcs.Obj payload = conceptCitationPayload(_cid("7"), ARGS_JCS_CID, "1", CONCEPT_SKIP_CID, "skip");
+        String source = conceptTaggedSource(payload, Jcs.cid(payload));
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertEquals(0, conceptCitationCount(lift), encoded);
+        assertTrue(conceptDiagnostics(lift).contains("concept-citation:unknown-concept"), encoded);
+    }
+
+    @Test
+    void test_concept_citation_shape_mismatch_refuses_surrounding_relift() {
+        Jcs.Obj payload = conceptCitationPayload(ARGS_JCS_CID, "1", LOSS_RECORD_CID, "skip");
+        String source = conceptTaggedSource(payload, Jcs.cid(payload));
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(0, lift.entries().size(), encoded);
+        assertTrue(conceptDiagnostics(lift).contains("concept-citation:shape-mismatch"), encoded);
+    }
+
+    @Test
+    void test_concept_citation_operation_kind_mismatch_refuses_surrounding_relift() {
+        Jcs.Obj payload = conceptCitationPayload(ARGS_JCS_CID, "1", CONCEPT_SKIP_CID, "not-skip");
+        String source = conceptTaggedSource(payload, Jcs.cid(payload));
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(0, lift.entries().size(), encoded);
+        assertTrue(conceptDiagnostics(lift).contains("concept-citation:operation-kind-mismatch"), encoded);
+    }
+
+    @Test
+    void test_concept_citation_orphan_payload_cid_line_refuses() {
+        String source = conceptSourceWithComments("// provekit-concept-payload-cid: " + LOSS_RECORD_CID);
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("Concepts.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertEquals(0, conceptCitationCount(lift), encoded);
+        assertTrue(conceptDiagnostics(lift).contains("concept-citation:orphan-cid-line"), encoded);
+    }
+
+    @Test
+    void test_concept_citation_lower_java_relift_round_trip() {
+        Jcs.Obj payload = conceptCitationPayload(ARGS_JCS_CID, "1", CONCEPT_SKIP_CID, "skip");
+        String source = conceptTaggedSource(payload, Jcs.cid(payload));
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("RoundTrip.java", source);
+
+        Jcs.Obj citation = ((Jcs.Arr) ((Jcs.Obj) lift.entries().get(0)).get("concept_citations")).objectAt(0);
+        assertEquals(payload.stringField("concept_cid"), citation.stringField("concept_cid"));
+        assertEquals(payload.stringField("operation_kind"), citation.stringField("operation_kind"));
+        assertEquals(payload.stringField("shape_cid"), citation.stringField("shape_cid"));
+        assertEquals(payload.stringField("args_jcs_cid"), citation.stringField("args_jcs_cid"));
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
 
     private static final String CONTRACT_CID =
@@ -383,6 +536,15 @@ class TrinityRoundtripLiftTest {
         "blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666";
     private static final String PRE_FORMULA_CID = Jcs.cid(nonNullPredicate("name"));
     private static final String POST_FORMULA_CID = Jcs.cid(nonNullPredicate("out"));
+    private static final String CONCEPT_SKIP_CID =
+        "blake3-512:"
+        + "9a905548a44fce23882b17d857d275d7822bd235ab71dbf786cd991563cc1de9e"
+        + "610594f50ad3c89a3b7eeb43234a31b36caa8031914c85227158030669c63cb";
+    private static final Jcs.Arr ARGS_JCS = Jcs.array(Jcs.object(
+        "kind", Jcs.string("var"),
+        "name", Jcs.string("x")
+    ));
+    private static final String ARGS_JCS_CID = Jcs.cid(ARGS_JCS);
 
     private static String contractTaggedSource(
         String preFormulaCid,
@@ -455,6 +617,81 @@ class TrinityRoundtripLiftTest {
             "kind", Jcs.string("atomic"),
             "name", Jcs.string("neq")
         );
+    }
+
+    private static Jcs.Obj conceptCitationPayload(
+        String argsJcsCid,
+        String schemaVersion,
+        String shapeCid,
+        String operationKind) {
+        return conceptCitationPayload(CONCEPT_SKIP_CID, argsJcsCid, schemaVersion, shapeCid, operationKind);
+    }
+
+    private static Jcs.Obj conceptCitationPayload(
+        String conceptCid,
+        String argsJcsCid,
+        String schemaVersion,
+        String shapeCid,
+        String operationKind) {
+        return Jcs.object(
+            "args_jcs", ARGS_JCS,
+            "args_jcs_cid", Jcs.string(argsJcsCid),
+            "artifact_kind", Jcs.string("provekit-concept-citation-comment-sugar"),
+            "concept_cid", Jcs.string(conceptCid),
+            "concept_name", Jcs.string("concept:skip"),
+            "concept_site_cid", Jcs.string(CONCEPT_SITE_CID),
+            "emitted_by", Jcs.object(
+                "kit_cid", Jcs.string(KIT_CID),
+                "kit_id", Jcs.string("provekit-realize-java-core@0.1.0"),
+                "kit_kind", Jcs.string("realize"),
+                "target_language", Jcs.string("java"),
+                "target_library_tag", Jcs.string("java")
+            ),
+            "loss_record_cid", Jcs.string(LOSS_RECORD_CID),
+            "operation_kind", Jcs.string(operationKind),
+            "policy_cid", Jcs.string(POLICY_CID),
+            "schema_version", Jcs.string(schemaVersion),
+            "shape_cid", Jcs.string(shapeCid),
+            "sugar_dict_cid", Jcs.string(SUGAR_DICT_CID),
+            "term_position", Jcs.array(Jcs.integer(0))
+        );
+    }
+
+    private static String conceptTaggedSource(Jcs.Obj payload, String payloadCid) {
+        return conceptSourceWithComments(
+            "// provekit-concept: " + Jcs.encode(payload) + "\n"
+            + "// provekit-concept-payload-cid: " + payloadCid);
+    }
+
+    private static String conceptSourceWithComments(String comments) {
+        return """
+            final class ConceptTransported {
+                // concept: skip
+                public static void transport_skip(Object x) {
+__COMMENTS__
+                    ;
+                }
+            }
+            """
+            .replace("__COMMENTS__", comments);
+    }
+
+    private static String _cid(String ch) {
+        return "blake3-512:" + ch.repeat(128);
+    }
+
+    private static int conceptCitationCount(JavaBindLifter.Result lift) {
+        if (lift.entries().isEmpty()) return 0;
+        Jcs.Json citations = ((Jcs.Obj) lift.entries().get(0)).get("concept_citations");
+        return citations instanceof Jcs.Arr arr ? arr.values().size() : 0;
+    }
+
+    private static Set<String> conceptDiagnostics(JavaBindLifter.Result lift) {
+        return lift.diagnostics().stream()
+            .filter(d -> d instanceof Jcs.Obj obj && obj.stringFieldOrNull("kind") != null)
+            .map(d -> ((Jcs.Obj) d).stringField("kind"))
+            .filter(kind -> kind.startsWith("concept-citation:"))
+            .collect(Collectors.toSet());
     }
 
     private Set<String> declarationFnNames() {

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -91,11 +91,12 @@ public final class RpcServer {
         String mode = JsonUtil.decodeJsonStringField(paramsObj, "mode");
         List<String> modes = JsonUtil.decodeJsonStringArray(paramsObj, "modes");
         ContractPayload contract = ContractPayload.fromJson(JsonUtil.extractObjectField(paramsObj, "contract"));
+        TransportedOperation transportedOp = TransportedOperation.fromJson(JsonUtil.extractObjectField(paramsObj, "transported_op"));
         List<String> sugarPlugins = JsonUtil.decodeJsonObjectArray(paramsObj, "sugar_plugins");
         List<String> params = JsonUtil.decodeJsonStringArray(paramsObj, "params");
         List<String> paramTypes = JsonUtil.decodeJsonStringArray(paramsObj, "param_types");
         SugarRealizer.Realization r =
-                SugarRealizer.emitStub(function, params, paramTypes, returnType, conceptName, mode, modes, contract, sugarPlugins);
+                SugarRealizer.emitStub(function, params, paramTypes, returnType, conceptName, mode, modes, contract, sugarPlugins, transportedOp);
         String wrapperRecord = r.observationWrapperEmissionRecord() == null
                 ? ""
                 : ",\"observation_wrapper_emission_record\":" + r.observationWrapperEmissionRecord();

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -113,6 +113,20 @@ final class SugarRealizer {
             List<String> modes,
             ContractPayload contract,
             List<String> sugarPluginJson) {
+        return emitStub(function, params, paramTypes, returnType, conceptName, mode, modes, contract, sugarPluginJson, null);
+    }
+
+    static Realization emitStub(
+            String function,
+            List<String> params,
+            List<String> paramTypes,
+            String returnType,
+            String conceptName,
+            String mode,
+            List<String> modes,
+            ContractPayload contract,
+            List<String> sugarPluginJson,
+            TransportedOperation transportedOp) {
 
         String className = snakeToPascal(function) + "Transported";
         String mappedReturn = mapSourceType(returnType);
@@ -141,13 +155,19 @@ final class SugarRealizer {
                 + contractPrefix(contract)
                 + commentPrefix(contract, sugarEmissions);
 
-        Optional<RenderedBody> bodyTemplate = renderBodyTemplateFor(conceptName, params, mode);
-        boolean isStub = bodyTemplate.isEmpty();
-        String bodyContent = bodyTemplate.map(RenderedBody::body)
-                .orElse("throw new UnsupportedOperationException(\"provekit-bind canonical: " + conceptName + "\");");
+        String conceptCitationBlock = conceptCitationTagBlock(transportedOp, sugarPluginJson);
+        boolean hasConceptCitationCarrier = !conceptCitationBlock.isBlank();
+        Optional<RenderedBody> bodyTemplate = hasConceptCitationCarrier
+                ? Optional.empty()
+                : renderBodyTemplateFor(conceptName, params, mode);
+        boolean isStub = bodyTemplate.isEmpty() && !hasConceptCitationCarrier;
+        String bodyContent = hasConceptCitationCarrier
+                ? conceptCitationBlock + "\n;"
+                : bodyTemplate.map(RenderedBody::body)
+                    .orElse("throw new UnsupportedOperationException(\"provekit-bind canonical: " + conceptName + "\");");
         Jcs.Json bodyLossRecord = bodyTemplate.map(RenderedBody::lossRecord).orElse(Jcs.object());
         String observationWrapperEmissionRecord = null;
-        if (!isStub) {
+        if (!isStub && !hasConceptCitationCarrier) {
             Optional<ObservationComposition> observation = composeEmitterAfterReturn(
                     requestedModes,
                     bodyContent,
@@ -541,6 +561,115 @@ final class SugarRealizer {
         out.append("    // provekit-contract: ").append(Jcs.encode(payload)).append("\n");
         out.append("    // provekit-contract-payload-cid: ").append(Jcs.cid(payload)).append("\n");
         return out.toString();
+    }
+
+    private static String conceptCitationTagBlock(
+            TransportedOperation transportedOp,
+            List<String> sugarPluginJson) {
+        Jcs.Obj payload = conceptCitationPayload(transportedOp, sugarPluginJson);
+        if (payload == null) {
+            return "";
+        }
+        return "// provekit-concept: " + Jcs.encode(payload) + "\n"
+                + "// provekit-concept-payload-cid: " + Jcs.cid(payload);
+    }
+
+    private static Jcs.Obj conceptCitationPayload(
+            TransportedOperation transportedOp,
+            List<String> sugarPluginJson) {
+        if (transportedOp == null
+                || !validCid(transportedOp.conceptCid())
+                || !validCid(transportedOp.conceptSiteCid())
+                || !validCid(transportedOp.lossRecordCid())
+                || !validCid(transportedOp.shapeCid())
+                || transportedOp.operationKind().isBlank()) {
+            return null;
+        }
+
+        List<Jcs.Field> fields = new ArrayList<>();
+        if (transportedOp.argsJcs() != null) {
+            if (!(transportedOp.argsJcs() instanceof Jcs.Arr)) {
+                return null;
+            }
+            fields.add(new Jcs.Field("args_jcs", transportedOp.argsJcs()));
+            fields.add(new Jcs.Field("args_jcs_cid", Jcs.string(Jcs.cid(transportedOp.argsJcs()))));
+        } else if (validCid(transportedOp.argsJcsCid())) {
+            fields.add(new Jcs.Field("args_jcs_cid", Jcs.string(transportedOp.argsJcsCid())));
+        } else {
+            return null;
+        }
+
+        fields.add(new Jcs.Field("artifact_kind", Jcs.string("provekit-concept-citation-comment-sugar")));
+        if (validCid(transportedOp.callsiteCid())) {
+            fields.add(new Jcs.Field("callsite_cid", Jcs.string(transportedOp.callsiteCid())));
+        } else if (transportedOp.callsiteCid() != null && !transportedOp.callsiteCid().isBlank()) {
+            return null;
+        }
+        fields.add(new Jcs.Field("concept_cid", Jcs.string(transportedOp.conceptCid())));
+        if (!transportedOp.conceptName().isBlank()) {
+            fields.add(new Jcs.Field("concept_name", Jcs.string(transportedOp.conceptName())));
+        }
+        fields.add(new Jcs.Field("concept_site_cid", Jcs.string(transportedOp.conceptSiteCid())));
+        fields.add(new Jcs.Field("emitted_by", Jcs.object(
+                "kit_cid", Jcs.string(conceptCitationEmitterKitCid()),
+                "kit_id", Jcs.string(conceptCitationKitId()),
+                "kit_kind", Jcs.string("realize"),
+                "target_language", Jcs.string("java"),
+                "target_library_tag", Jcs.string(transportedOp.targetLibraryTag().isBlank()
+                        ? "java"
+                        : transportedOp.targetLibraryTag())
+        )));
+        fields.add(new Jcs.Field("loss_record_cid", Jcs.string(transportedOp.lossRecordCid())));
+        fields.add(new Jcs.Field("operation_kind", Jcs.string(transportedOp.operationKind())));
+        fields.add(new Jcs.Field("policy_cid", Jcs.string(conceptCitationPolicyCid(transportedOp))));
+        fields.add(new Jcs.Field("schema_version", Jcs.string("1")));
+        fields.add(new Jcs.Field("shape_cid", Jcs.string(transportedOp.shapeCid())));
+        fields.add(new Jcs.Field("sugar_dict_cid", Jcs.string(conceptCitationSugarDictCid(transportedOp, sugarPluginJson))));
+        fields.add(new Jcs.Field("term_position", Jcs.array(
+                transportedOp.termPosition().stream().map(Jcs::integer).toList()
+        )));
+        return new Jcs.Obj(fields);
+    }
+
+    private static String conceptCitationPolicyCid(TransportedOperation transportedOp) {
+        if (validCid(transportedOp.policyCid())) {
+            return transportedOp.policyCid();
+        }
+        return Blake3.blake3_512("provekit-realize-java-core/default-concept-citation-policy"
+                .getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String conceptCitationSugarDictCid(
+            TransportedOperation transportedOp,
+            List<String> sugarPluginJson) {
+        if (validCid(transportedOp.sugarDictCid())) {
+            return transportedOp.sugarDictCid();
+        }
+        if (sugarPluginJson != null) {
+            for (String rawPlugin : sugarPluginJson) {
+                try {
+                    Jcs.Json parsed = Jcs.parse(rawPlugin);
+                    if (!(parsed instanceof Jcs.Obj root)) continue;
+                    Jcs.Json headerJson = root.get("header");
+                    if (!(headerJson instanceof Jcs.Obj header)) continue;
+                    String cid = header.stringFieldOrNull("cid");
+                    if (validCid(cid)) {
+                        return cid;
+                    }
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+        }
+        return Blake3.blake3_512("provekit-realize-java-core/concept-citation-comment-sugar-v1"
+                .getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String conceptCitationKitId() {
+        return "provekit-realize-java-core@0.1.0";
+    }
+
+    private static String conceptCitationEmitterKitCid() {
+        return Blake3.blake3_512(conceptCitationKitId().getBytes(StandardCharsets.UTF_8));
     }
 
     private static Jcs.Obj contractCommentPayload(ContractPayload contract, SugarEmission emission) {
@@ -961,6 +1090,95 @@ final class SugarRealizer {
         if (!"literal".equals(contributionObj.stringFieldOrNull("form"))) return Jcs.object();
         Jcs.Json value = contributionObj.get("value");
         return value instanceof Jcs.Obj ? value : Jcs.object();
+    }
+}
+
+record TransportedOperation(
+        String conceptCid,
+        String conceptSiteCid,
+        String lossRecordCid,
+        String operationKind,
+        String policyCid,
+        String shapeCid,
+        List<Integer> termPosition,
+        Jcs.Json argsJcs,
+        String argsJcsCid,
+        String sugarDictCid,
+        String callsiteCid,
+        String conceptName,
+        String targetLibraryTag) {
+    TransportedOperation {
+        conceptCid = conceptCid == null ? "" : conceptCid;
+        conceptSiteCid = conceptSiteCid == null ? "" : conceptSiteCid;
+        lossRecordCid = lossRecordCid == null ? "" : lossRecordCid;
+        operationKind = operationKind == null ? "" : operationKind;
+        policyCid = policyCid == null ? "" : policyCid;
+        shapeCid = shapeCid == null ? "" : shapeCid;
+        termPosition = termPosition == null ? List.of() : List.copyOf(termPosition);
+        argsJcsCid = argsJcsCid == null ? "" : argsJcsCid;
+        sugarDictCid = sugarDictCid == null ? "" : sugarDictCid;
+        callsiteCid = callsiteCid == null ? "" : callsiteCid;
+        conceptName = conceptName == null ? "" : conceptName;
+        targetLibraryTag = targetLibraryTag == null ? "" : targetLibraryTag;
+    }
+
+    static TransportedOperation fromJson(String json) {
+        if (json == null || json.isBlank() || "{}".equals(json.trim())) {
+            return null;
+        }
+        Jcs.Json parsed;
+        try {
+            parsed = Jcs.parse(json);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        if (!(parsed instanceof Jcs.Obj obj)) {
+            return null;
+        }
+        return new TransportedOperation(
+                stringValue(obj, "concept_cid", "conceptCid"),
+                stringValue(obj, "concept_site_cid", "conceptSiteCid"),
+                stringValue(obj, "loss_record_cid", "lossRecordCid"),
+                stringValue(obj, "operation_kind", "operationKind"),
+                stringValue(obj, "policy_cid", "policyCid"),
+                stringValue(obj, "shape_cid", "shapeCid"),
+                termPosition(value(obj, "term_position", "termPosition")),
+                value(obj, "args_jcs", "argsJcs"),
+                stringValue(obj, "args_jcs_cid", "argsJcsCid"),
+                stringValue(obj, "sugar_dict_cid", "sugarDictCid"),
+                stringValue(obj, "callsite_cid", "callsiteCid"),
+                stringValue(obj, "concept_name", "conceptName"),
+                stringValue(obj, "target_library_tag", "targetLibraryTag")
+        );
+    }
+
+    private static Jcs.Json value(Jcs.Obj obj, String... keys) {
+        for (String key : keys) {
+            Jcs.Json value = obj.get(key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String stringValue(Jcs.Obj obj, String... keys) {
+        Jcs.Json value = value(obj, keys);
+        return value instanceof Jcs.Str s ? s.value() : "";
+    }
+
+    private static List<Integer> termPosition(Jcs.Json value) {
+        if (!(value instanceof Jcs.Arr arr)) {
+            return List.of();
+        }
+        List<Integer> out = new ArrayList<>();
+        for (Jcs.Json item : arr.values()) {
+            if (!(item instanceof Jcs.Num number) || number.value() < 0 || number.value() > Integer.MAX_VALUE) {
+                return List.of();
+            }
+            out.add((int) number.value());
+        }
+        return out;
     }
 }
 

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
@@ -199,6 +199,62 @@ public class JavaNullBoundaryRealizerTest {
     }
 
     @Test
+    public void test_concept_citation_comment_emitted_for_transported_operation() {
+        TransportedOperation transportedOp = transportedOperation();
+
+        SugarRealizer.Realization output = SugarRealizer.emitStub(
+            "transport_skip",
+            java.util.List.of("x"),
+            java.util.List.of("Object"),
+            "()",
+            "missing-java-skip-carrier",
+            "monitor",
+            java.util.List.of("monitor"),
+            null,
+            java.util.List.of(),
+            transportedOp
+        );
+
+        assertTrue(output.source().contains("// provekit-concept: {"), output.source());
+        assertTrue(output.source().contains("// provekit-concept-payload-cid: blake3-512:"), output.source());
+        assertTrue(output.source().contains("        ;\n"), output.source());
+        assertFalse(output.source().contains("UnsupportedOperationException"), output.source());
+        assertTrue(
+            output.source().indexOf("// provekit-concept:")
+                < output.source().indexOf("        ;"),
+            output.source()
+        );
+
+        String payloadText = conceptPayloadLine(output.source());
+        com.provekit.ir.Jcs.Obj payload = (com.provekit.ir.Jcs.Obj) com.provekit.ir.Jcs.parse(payloadText);
+        assertEquals("provekit-concept-citation-comment-sugar", payload.stringField("artifact_kind"));
+        assertEquals("1", payload.stringField("schema_version"));
+        assertEquals(transportedOp.conceptCid(), payload.stringField("concept_cid"));
+        assertEquals(transportedOp.conceptName(), payload.stringField("concept_name"));
+        assertEquals(transportedOp.conceptSiteCid(), payload.stringField("concept_site_cid"));
+        assertEquals(transportedOp.lossRecordCid(), payload.stringField("loss_record_cid"));
+        assertEquals(transportedOp.operationKind(), payload.stringField("operation_kind"));
+        assertEquals(transportedOp.policyCid(), payload.stringField("policy_cid"));
+        assertEquals(transportedOp.shapeCid(), payload.stringField("shape_cid"));
+        assertEquals(transportedOp.sugarDictCid(), payload.stringField("sugar_dict_cid"));
+        assertEquals(transportedOp.callsiteCid(), payload.stringField("callsite_cid"));
+        assertEquals(com.provekit.ir.Jcs.cid(transportedOp.argsJcs()), payload.stringField("args_jcs_cid"));
+
+        com.provekit.ir.Jcs.Arr termPosition = (com.provekit.ir.Jcs.Arr) payload.get("term_position");
+        assertEquals(1, termPosition.values().size());
+        assertEquals(0, ((com.provekit.ir.Jcs.Num) termPosition.get(0)).value());
+        com.provekit.ir.Jcs.Obj emittedBy = (com.provekit.ir.Jcs.Obj) payload.get("emitted_by");
+        assertTrue(emittedBy.stringField("kit_cid").startsWith("blake3-512:"));
+        assertEquals("provekit-realize-java-core@0.1.0", emittedBy.stringField("kit_id"));
+        assertEquals("realize", emittedBy.stringField("kit_kind"));
+        assertEquals("java", emittedBy.stringField("target_language"));
+        assertEquals("java", emittedBy.stringField("target_library_tag"));
+
+        String payloadCid = com.provekit.ir.Jcs.cid(payload);
+        assertTrue(output.source().contains("// provekit-concept-payload-cid: " + payloadCid), output.source());
+    }
+
+    @Test
     public void modeScopedJunitWitnessSugarDoesNotApplyToMonitor() {
         ContractPayload contract = new ContractPayload(
             "blake3-512:site",
@@ -539,6 +595,41 @@ public class JavaNullBoundaryRealizerTest {
             "\"cid\":\"java-function-comment\"",
             "\"cid\":\"blake3-512:574800417e6f4f57e561dbe9c437adc691b2cd2369d964cbc329348cb715b161f3b38f6f7ccfd41537d033741488c081ec01b6f7cb3f04ba724b7003fa05a7b6\""
         );
+    }
+
+    private static TransportedOperation transportedOperation() {
+        return new TransportedOperation(
+            cid("a"),
+            cid("b"),
+            cid("c"),
+            "skip",
+            cid("d"),
+            cid("e"),
+            java.util.List.of(0),
+            com.provekit.ir.Jcs.array(com.provekit.ir.Jcs.object(
+                "kind", com.provekit.ir.Jcs.string("var"),
+                "name", com.provekit.ir.Jcs.string("x")
+            )),
+            null,
+            cid("f"),
+            cid("0"),
+            "concept:skip",
+            "java"
+        );
+    }
+
+    private static String conceptPayloadLine(String source) {
+        for (String line : source.split("\\R")) {
+            String stripped = line.strip();
+            if (stripped.startsWith("// provekit-concept: ")) {
+                return stripped.substring("// provekit-concept: ".length());
+            }
+        }
+        throw new AssertionError("missing concept payload line:\n" + source);
+    }
+
+    private static String cid(String ch) {
+        return "blake3-512:" + ch.repeat(128);
     }
 
     private static String sugar(String cid, String name, String locator, String template, String loss) {


### PR DESCRIPTION
Closes #1031. Sibling pair to the just-merged Python carrier (#1022 / PR #1034). Implements `protocol/specs/2026-05-15-concept-citation-comment-sugar.md` (PR #1029) for the Java realize + lift kits.

## Realize side (provekit-realize-java-core)

- `SugarRealizer` extended with concept-citation comment emit, mirroring the contract-comment emit pattern.
- JCS-canonical payload via the kit's existing JSON canonicalizer + BLAKE3-512 via the kit's existing blake3 dep.
- Emits `// provekit-concept: {payload}` + `// provekit-concept-payload-cid:` pair followed by a no-op `;` statement at the transport site (NOT `throw new UnsupportedOperationException(...)` per #1018 non-lie rule).
- `RpcServer` threads the transported-op descriptor through the existing `provekit.plugin.invoke` boundary.

## Lift side (provekit-lift-java-source)

- `JavaBindLifter` extended with concept-citation comment scan. All 9 spec §6 fail-closed conditions with spec-correct diag tags:

| # | Tag | Mode |
|---|-----|------|
| 1 | `concept-citation:malformed-json` | drop |
| 2 | `concept-citation:unknown-schema-version` | drop |
| 3 | `concept-citation:malformed-cid` | drop |
| 4 | `concept-citation:payload-cid-mismatch` | drop, recomputes JCS+blake3 |
| 5 | `concept-citation:args-cid-mismatch` | drop |
| 6 | `concept-citation:unknown-concept` | drop |
| 7 | `concept-citation:shape-mismatch` | **REFUSE SURROUNDING RELIFT** |
| 8 | `concept-citation:operation-kind-mismatch` | **REFUSE SURROUNDING RELIFT** |
| 9 | `concept-citation:orphan-cid-line` | drop orphan |

- Conditions 7/8 raise a typed refusal exception caught at the per-function bind boundary, skipping the IR entry for that function while other functions continue lifting (matches Python sibling at PR #1034).
- Recovered citations emitted on a separate `concept_citations` channel alongside contract witnesses (spec §7: never mix).

## #1031 acceptance criteria — satisfied

- [x] Unit: Java realizer emits citation comment for synthetic transported op
- [x] Unit: Java lifter relifts → byte-equal `concept_cid`, `operation_kind`, `shape_cid`, `term_position`, `args_jcs_cid`
- [x] Unit: payload CID mismatch refuses
- [x] Unit: args CID mismatch refuses
- [x] Unit: unknown schema version refuses
- [x] Integration: lower→Java→relift round-trip via `TrinityRoundtripLiftTest`, concept_cid byte-equal hop-to-hop
- [x] No raw prose comment trusted as substrate operation

## Gates

- `mvn test` on `provekit-lift-java-source`: **BUILD SUCCESS, Tests run: 28, Failures: 0, Errors: 0** (5 in `JavaSourceLifterTest` + 23 in `TrinityRoundtripLiftTest`)
- `mvn test` on `provekit-realize-java-core`: Tests run: 19, Failures: 0, Errors: 4. **The 4 errors are pre-existing failures inherited from main** — `JavaNullBoundaryRealizerTest` fails with `NoClassDefFoundError com/github/javaparser/ast/expr/Expression` on `origin/main` too (confirmed by running mvn test on the freshly-cloned origin/main: identical 4-error output). Not introduced by this PR. Codex added 1 new test (bringing total 18 → 19); the new test passes.
- em/en-dash sweep on the 5 changed Java files: zero
- `tools/spec-cid-lint.sh`: exit 0

## Non-goals respected

- No new `provekit-realize-java-*` or `provekit-lift-java-*` modules. Extended existing.
- No hand-authored dict mapping operation names to Java source (#1017 lie pattern).
- No `throw new UnsupportedOperationException(...)` pretending it's the transported op (#1018 lie shape).
- No prose comment trusted as substrate evidence (spec §4).
- No mix of `provekit-concept:` and `provekit-contract:` handling (spec §7).
- No global sugar-selection policy decision (#889 owns that).
- No silent no-op Java surface without the citation comment.
- No new memento family (spec §10 — sugar, not memento family).

## Pre-existing test errors note

The 4 `NoClassDefFoundError` failures in `JavaNullBoundaryRealizerTest` exist on `origin/main` with the same shape (missing javaparser test-scope dependency in the maven workspace setup). They are **not** introduced by this PR and are out-of-scope for the carrier work. Tracked as a separate boy-scout cleanup if a future PR wants to add the javaparser test dependency to the realize-java-core pom.

Prerequisites: #1020 (PR #1028 merged), #1021 (PR #1029 merged), Python sibling PR #1034 merged for pattern reference.

## #1040 forward-compat

This PR does not add any `KitRegistry::register()` callsite (Java realize/lift are JSON-RPC subprocess plugins, not Rust `Kit` trait impls). When #1040 (substrate-side ConformanceDeclaration) lands, no rebase work needed on this branch's surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added concept-citation tagging support with automatic validation against schema, payload CID, and format requirements
  * Generated code now includes concept-citation comment blocks containing validated citation metadata
  * Implemented concept-citation validation diagnostics to identify schema mismatches, malformed payloads, and CID inconsistencies

* **Tests**
  * Added comprehensive test coverage for concept-citation validation, acceptance, and rejection scenarios across lift and realization pipelines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->