### PR TITLE
feat(libprovekit): LowerKit wraps realize machinery as a registered Kit (closes #1027)

### DIFF
--- a/implementations/rust/libprovekit/src/core/lower_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lower_plugin.rs
@@ -1,0 +1,491 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+
+use provekit_ir_types::Sort;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use super::primitives::address;
+use super::traits::{Kit, KitError};
+use super::types::{
+    formula_true, memento_from_parts, Cid, Dialect, DomainClaim, DomainKind, Input, Term, Verdict,
+};
+
+/// Request shape for the PEP 1.7.0 realize surface.
+///
+/// The transport serializes this directly as plugin params. Callers should not
+/// construct it while migrating to path execution; `LowerKit::transform`
+/// materializes this payload from `Input` and invokes the configured transport.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealizeRequest {
+    pub function: String,
+    pub params: Vec<String>,
+    pub param_types: Vec<String>,
+    pub return_type: String,
+    pub concept_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub named_term_tree: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub modes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract: Option<RealizeContractPayload>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub sugar_cids: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub sugar_plugins: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealizeContractPayload {
+    pub concept_site_cid: String,
+    pub object_fcm_cid: String,
+    pub local_contract_cid: String,
+    pub origin: String,
+    pub discharge_verdict: String,
+    pub witnesses: Vec<RealizeContractWitness>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealizeContractWitness {
+    pub role: String,
+    pub predicate: Value,
+    pub predicate_text: String,
+    pub source_kind: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealizedSource {
+    pub extension: String,
+    pub source: String,
+    pub is_stub: bool,
+    pub emitted_artifact_cid: Option<String>,
+    pub observed_loss_record: Value,
+    pub used_sugars: Vec<Value>,
+    pub observation_wrapper_emission_record: Option<Value>,
+}
+
+/// Transport boundary used by `LowerKit` to call the existing realize layer.
+pub trait RealizeTransport {
+    fn dispatch_realize(
+        &self,
+        workspace_root: &Path,
+        target_lang: &str,
+        library_tag: Option<&str>,
+        request: &RealizeRequest,
+    ) -> Result<RealizedSource, String>;
+}
+
+/// Core Kit adapter over the existing realize transport.
+#[derive(Debug, Clone)]
+pub struct LowerKit<T> {
+    workspace_root: PathBuf,
+    target_lang: String,
+    library_tag: Option<String>,
+    transport: T,
+}
+
+impl<T> LowerKit<T> {
+    pub fn new(
+        workspace_root: impl Into<PathBuf>,
+        target_lang: impl Into<String>,
+        library_tag: Option<String>,
+        transport: T,
+    ) -> Self {
+        Self {
+            workspace_root: workspace_root.into(),
+            target_lang: target_lang.into(),
+            library_tag,
+            transport,
+        }
+    }
+}
+
+impl<T: RealizeTransport> LowerKit<T> {
+    /// Recover the legacy transport response from a lower claim payload.
+    pub fn realized_source_from_claim(claim: &DomainClaim) -> Result<RealizedSource, String> {
+        let Some(Term::Const { value, .. }) = &claim.payload else {
+            return Err("lower claim missing realize response payload".to_string());
+        };
+        serde_json::from_value(value.clone())
+            .map_err(|error| format!("decode lower claim payload: {error}"))
+    }
+}
+
+impl<T: RealizeTransport + 'static> Kit for LowerKit<T> {
+    fn dialect(&self) -> Dialect {
+        Dialect::Other(self.target_lang.clone())
+    }
+
+    fn transform(&self, input: &Input) -> Result<DomainClaim, KitError> {
+        let invocation = RealizeInvocation::from_input(input, &self.target_lang, &self.library_tag)
+            .map_err(KitError::Transformation)?;
+        let realized = self
+            .transport
+            .dispatch_realize(
+                &self.workspace_root,
+                &self.target_lang,
+                invocation.effective_library_tag.as_deref(),
+                &invocation.request,
+            )
+            .map_err(|error| {
+                KitError::Transformation(format!("realize plugin transport: {error}"))
+            })?;
+        Ok(claim_from_realized(invocation, realized))
+    }
+
+    fn prove(&self, claim: DomainClaim) -> Result<DomainClaim, KitError> {
+        Ok(claim)
+    }
+
+    fn parse(&self, input: &Input) -> Result<Term, KitError> {
+        self.transform(input)?
+            .payload
+            .ok_or_else(|| KitError::Serialization("lower claim missing term payload".to_string()))
+    }
+
+    fn serialize(&self, term: &Term) -> Result<Input, KitError> {
+        Ok(Input::Term(term.clone()))
+    }
+}
+
+struct RealizeInvocation {
+    request: RealizeRequest,
+    from: Vec<Cid>,
+    premises: Vec<Cid>,
+    target_library_cid: Cid,
+    effective_library_tag: Option<String>,
+    policy_cid: Option<Cid>,
+    body_template_cids: Vec<Cid>,
+}
+
+impl RealizeInvocation {
+    fn from_input(
+        input: &Input,
+        target_lang: &str,
+        configured_library_tag: &Option<String>,
+    ) -> Result<Self, String> {
+        let spec = spec_value_from_input(input)?;
+        let fallback_from = fallback_from(input);
+        let request = request_from_spec(&spec)?;
+        let effective_library_tag =
+            string_field_optional(&spec, &["libraryTag", "library_tag", "library"])
+                .or_else(|| configured_library_tag.clone());
+        let target_library_cid = target_library_cid(
+            target_lang,
+            effective_library_tag.as_deref().unwrap_or("default"),
+        );
+        let from = from_cids(&spec, fallback_from)?;
+        let mut premises = explicit_cid_array(&spec, &["premises"])?;
+        if let Input::Claim(claim) = input {
+            premises.push(claim.cid());
+        }
+        dedup_cids(&mut premises);
+        let policy_cid = optional_cid_field(&spec, &["policyCid", "policy_cid"])?;
+        let body_template_cids =
+            explicit_cid_array(&spec, &["bodyTemplateCids", "body_template_cids"])?;
+        Ok(Self {
+            request,
+            from,
+            premises,
+            target_library_cid,
+            effective_library_tag,
+            policy_cid,
+            body_template_cids,
+        })
+    }
+}
+
+fn spec_value_from_input(input: &Input) -> Result<Value, String> {
+    match input {
+        Input::Spec(value) => Ok(value.clone()),
+        Input::Term(Term::Const { value, .. }) => Ok(value.clone()),
+        Input::Claim(claim) => claim_spec_value(claim),
+        _ => Err("lower kit expects Input::Spec, Input::Term, or Input::Claim".to_string()),
+    }
+}
+
+fn claim_spec_value(claim: &DomainClaim) -> Result<Value, String> {
+    if let Some(Term::Const { value, .. }) = &claim.payload {
+        return Ok(value.clone());
+    }
+    let param_types = claim
+        .contract
+        .formal_sorts
+        .iter()
+        .map(sort_name)
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "function": claim.contract.fn_name,
+        "params": claim.contract.formals,
+        "paramTypes": param_types,
+        "returnType": sort_name(&claim.contract.return_sort),
+        "conceptName": claim.contract.concept_hint.clone().unwrap_or_else(|| claim.contract.fn_name.clone()),
+        "termShapeCid": claim.to,
+    }))
+}
+
+fn fallback_from(input: &Input) -> Vec<Cid> {
+    match input {
+        Input::Claim(claim) if !claim.from.is_empty() => claim.from.clone(),
+        Input::Claim(claim) => vec![claim.to.clone()],
+        _ => vec![address(input)],
+    }
+}
+
+fn request_from_spec(spec: &Value) -> Result<RealizeRequest, String> {
+    let contract = match non_null_field(spec, &["contract"]) {
+        Some(value) => Some(
+            serde_json::from_value(value.clone())
+                .map_err(|error| format!("decode realize contract payload: {error}"))?,
+        ),
+        None => None,
+    };
+    Ok(RealizeRequest {
+        function: required_string_field(spec, &["function"])?,
+        params: string_array_field(spec, &["params"])?,
+        param_types: string_array_field(spec, &["paramTypes", "param_types"])?,
+        return_type: required_string_field(spec, &["returnType", "return_type"])?,
+        concept_name: required_string_field(spec, &["conceptName", "concept_name"])?,
+        named_term_tree: non_null_field(spec, &["namedTermTree", "named_term_tree"]).cloned(),
+        mode: string_field_optional(spec, &["mode"]),
+        modes: string_array_field(spec, &["modes"]).unwrap_or_default(),
+        contract,
+        sugar_cids: string_array_field(spec, &["sugarCids", "sugar_cids"]).unwrap_or_default(),
+        sugar_plugins: value_array_field(spec, &["sugarPlugins", "sugar_plugins"]),
+    })
+}
+
+fn claim_from_realized(invocation: RealizeInvocation, realized: RealizedSource) -> DomainClaim {
+    let response_term = realized_source_term(&realized);
+    let response_cid = address(&response_term);
+    let to = realized
+        .emitted_artifact_cid
+        .as_deref()
+        .and_then(|cid| Cid::parse(cid).ok())
+        .unwrap_or_else(|| response_cid.clone());
+    let mut artifacts = vec![
+        invocation.target_library_cid.clone(),
+        to.clone(),
+        response_cid,
+    ];
+    if let Some(policy_cid) = invocation.policy_cid {
+        artifacts.push(policy_cid);
+    }
+    artifacts.extend(invocation.body_template_cids);
+    artifacts.extend(
+        invocation
+            .request
+            .sugar_cids
+            .iter()
+            .filter_map(|cid| Cid::parse(cid.as_str()).ok()),
+    );
+    artifacts.extend(realized.used_sugars.iter().filter_map(cid_from_used_sugar));
+    if let Some(loss_cid) = loss_record_cid(&realized.observed_loss_record) {
+        artifacts.push(loss_cid);
+    }
+    dedup_cids(&mut artifacts);
+
+    let formal_sorts = invocation
+        .request
+        .param_types
+        .iter()
+        .map(|name| Sort::Primitive { name: name.clone() })
+        .collect();
+    let return_sort = Sort::Primitive {
+        name: invocation.request.return_type.clone(),
+    };
+    let contract = memento_from_parts(
+        invocation.request.function,
+        invocation.request.params,
+        formal_sorts,
+        return_sort,
+        formula_true(),
+        formula_true(),
+        Some(to.to_string()),
+    );
+
+    DomainClaim {
+        domain: DomainKind::Other("lower-realize".to_string()),
+        contract,
+        artifacts,
+        from: invocation.from,
+        premises: invocation.premises,
+        to,
+        witness: None,
+        payload: Some(response_term),
+        verdict: Verdict::Unresolved,
+        attestation: None,
+    }
+}
+
+fn realized_source_term(realized: &RealizedSource) -> Term {
+    Term::Const {
+        value: serde_json::to_value(realized).expect("realized source serializes"),
+        sort: Sort::Primitive {
+            name: "RealizePluginResponse".to_string(),
+        },
+    }
+}
+
+fn target_library_cid(target_lang: &str, library_tag: &str) -> Cid {
+    address(&Input::Spec(json!({
+        "targetLanguage": target_lang,
+        "libraryTag": library_tag,
+    })))
+}
+
+fn from_cids(spec: &Value, fallback: Vec<Cid>) -> Result<Vec<Cid>, String> {
+    let explicit = explicit_cid_array(spec, &["from"])?;
+    if !explicit.is_empty() {
+        return Ok(explicit);
+    }
+    if let Some(cid) = optional_cid_field(
+        spec,
+        &[
+            "termShapeCid",
+            "term_shape_cid",
+            "termTreeCid",
+            "term_tree_cid",
+            "namedTermTreeCid",
+            "named_term_tree_cid",
+            "inputCid",
+            "input_cid",
+        ],
+    )? {
+        return Ok(vec![cid]);
+    }
+    Ok(fallback)
+}
+
+fn field<'a>(spec: &'a Value, names: &[&str]) -> Option<&'a Value> {
+    names.iter().find_map(|name| spec.get(*name))
+}
+
+fn non_null_field<'a>(spec: &'a Value, names: &[&str]) -> Option<&'a Value> {
+    field(spec, names).filter(|value| !value.is_null())
+}
+
+fn required_string_field(spec: &Value, names: &[&str]) -> Result<String, String> {
+    string_field_optional(spec, names)
+        .ok_or_else(|| format!("realize spec missing string field `{}`", names[0]))
+}
+
+fn string_field_optional(spec: &Value, names: &[&str]) -> Option<String> {
+    field(spec, names)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn string_array_field(spec: &Value, names: &[&str]) -> Result<Vec<String>, String> {
+    let Some(value) = field(spec, names) else {
+        return Err(format!("realize spec missing array field `{}`", names[0]));
+    };
+    let items = value
+        .as_array()
+        .ok_or_else(|| format!("realize spec field `{}` must be an array", names[0]))?;
+    items
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .map(str::to_string)
+                .ok_or_else(|| format!("realize spec field `{}` must contain strings", names[0]))
+        })
+        .collect()
+}
+
+fn value_array_field(spec: &Value, names: &[&str]) -> Vec<Value> {
+    field(spec, names)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn optional_cid_field(spec: &Value, names: &[&str]) -> Result<Option<Cid>, String> {
+    let Some(value) = field(spec, names) else {
+        return Ok(None);
+    };
+    let Some(text) = value.as_str() else {
+        return Err(format!(
+            "realize spec field `{}` must be a CID string",
+            names[0]
+        ));
+    };
+    Cid::parse(text)
+        .map(Some)
+        .map_err(|error| format!("realize spec field `{}`: {error}", names[0]))
+}
+
+fn explicit_cid_array(spec: &Value, names: &[&str]) -> Result<Vec<Cid>, String> {
+    let Some(value) = field(spec, names) else {
+        return Ok(Vec::new());
+    };
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .map(|item| {
+                let Some(text) = item.as_str() else {
+                    return Err(format!(
+                        "realize spec field `{}` must contain CID strings",
+                        names[0]
+                    ));
+                };
+                Cid::parse(text)
+                    .map_err(|error| format!("realize spec field `{}`: {error}", names[0]))
+            })
+            .collect(),
+        Value::String(text) => Cid::parse(text)
+            .map(|cid| vec![cid])
+            .map_err(|error| format!("realize spec field `{}`: {error}", names[0])),
+        _ => Err(format!(
+            "realize spec field `{}` must be a CID string or array",
+            names[0]
+        )),
+    }
+}
+
+fn loss_record_cid(record: &Value) -> Option<Cid> {
+    match record {
+        Value::Null => None,
+        Value::Object(map) if map.is_empty() => None,
+        _ => cid_field_from_value(record).or_else(|| {
+            Some(address(&Term::Const {
+                value: record.clone(),
+                sort: Sort::Primitive {
+                    name: "ObservedLossRecord".to_string(),
+                },
+            }))
+        }),
+    }
+}
+
+fn cid_from_used_sugar(value: &Value) -> Option<Cid> {
+    value
+        .get("header")
+        .and_then(|header| header.get("cid"))
+        .and_then(Value::as_str)
+        .or_else(|| value.as_str())
+        .and_then(|cid| Cid::parse(cid).ok())
+}
+
+fn cid_field_from_value(value: &Value) -> Option<Cid> {
+    ["cid", "lossRecordCid", "loss_record_cid", "recordCid"]
+        .iter()
+        .filter_map(|name| value.get(*name))
+        .find_map(|value| value.as_str())
+        .and_then(|cid| Cid::parse(cid).ok())
+}
+
+fn dedup_cids(cids: &mut Vec<Cid>) {
+    cids.sort();
+    cids.dedup();
+}
+
+fn sort_name(sort: &Sort) -> String {
+    match sort {
+        Sort::Primitive { name } => name.clone(),
+        other => serde_json::to_string(other).expect("sort serializes"),
+    }
+}

--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -19,6 +19,7 @@
 //! `sign`.
 
 pub mod lift_plugin;
+pub mod lower_plugin;
 pub mod path_executor;
 pub mod primitives;
 pub mod stubs;
@@ -27,6 +28,10 @@ pub mod types;
 pub mod verbs;
 
 pub use lift_plugin::{LiftKit, LiftPluginKit, LiftPluginKitError, LiftPluginKitSession};
+pub use lower_plugin::{
+    LowerKit, RealizeContractPayload, RealizeContractWitness, RealizeRequest, RealizeTransport,
+    RealizedSource,
+};
 pub use path_executor::{execute_path, KitRegistry, PathExecutionError};
 pub use primitives::{
     address, compose, dropper, resolve, sign, verify_sig, ComposeError, SigningKey,

--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -6,6 +6,9 @@ use std::process::Command;
 use std::sync::Arc;
 
 use chrono::{SecondsFormat, Utc};
+use libprovekit::core::{
+    execute_path, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
+};
 use libprovekit::effect_propagation::{
     propagate_effects, CallsiteEdge, ChangedCallsite, FunctionEffectInfo, PropagationDecision,
     PropagationInput,
@@ -21,6 +24,7 @@ use provekit_ir_types::{
 use serde_json::{json, Value as JsonValue};
 
 use crate::cmd_bind::BindArgs;
+use crate::kit_dispatch::DispatchRealizeTransport;
 use crate::{EXIT_OK, EXIT_USER_ERROR};
 
 const ASYNC_EFFECT: &str = "async";
@@ -773,31 +777,56 @@ fn probe_realize_binding(
     tag: &str,
     concept_name: &str,
 ) -> Result<(), String> {
-    let request = crate::kit_dispatch::RealizeRequest {
-        function: "__provekit_migrate_probe".to_string(),
-        params: vec!["sql".to_string(), "args".to_string()],
-        param_types: vec!["string".to_string(), "unknown[]".to_string()],
-        return_type: if concept_name == "concept:sql-execute" {
-            "{ rows_affected: number; last_insert_id: unknown }".to_string()
+    let spec = json!({
+        "kind": "RealizeRequest",
+        "function": "__provekit_migrate_probe",
+        "params": ["sql", "args"],
+        "paramTypes": ["string", "unknown[]"],
+        "returnType": if concept_name == "concept:sql-execute" {
+            "{ rows_affected: number; last_insert_id: unknown }"
         } else {
-            "unknown[]".to_string()
+            "unknown[]"
         },
-        concept_name: concept_name.to_string(),
-        named_term_tree: None,
-        mode: None,
-        modes: Vec::new(),
-        contract: None,
-        sugar_cids: Vec::new(),
-        sugar_plugins: Vec::new(),
-    };
-    let realized = crate::kit_dispatch::dispatch_realize(repo_root, language, Some(tag), &request)
-        .map_err(|e| format!("{e}"))?;
+        "conceptName": concept_name,
+    });
+    let realized = realize_probe_via_path(repo_root, language, tag, spec)?;
     if realized.is_stub {
         return Err(format!(
             "realize binding for {language}/{tag}/{concept_name} fell through to a stub"
         ));
     }
     Ok(())
+}
+
+fn realize_probe_via_path(
+    repo_root: &Path,
+    language: &str,
+    tag: &str,
+    spec: JsonValue,
+) -> Result<libprovekit::core::RealizedSource, String> {
+    let mut inputs = HashMapInputCatalog::default();
+    let input_cid = inputs.insert(Input::Spec(spec));
+    let kit_name = format!("lower-{language}");
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "lower".to_string(),
+            kit: kit_name.clone(),
+            inputs: vec![input_cid],
+            depends_on: vec![],
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        kit_name,
+        LowerKit::new(
+            repo_root.to_path_buf(),
+            language.to_string(),
+            Some(tag.to_string()),
+            DispatchRealizeTransport,
+        ),
+    );
+    let claim = execute_path(&path, &registry, &inputs).map_err(|error| error.to_string())?;
+    LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(&claim)
 }
 
 fn build_receipt(

--- a/implementations/rust/provekit-cli/src/cmd_lower.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lower.rs
@@ -11,6 +11,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use clap::{Parser, ValueEnum};
+use libprovekit::core::{
+    execute_path, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
+};
 use owo_colors::OwoColorize;
 use serde_json::{json, Value as Json};
 
@@ -21,6 +24,7 @@ use provekit_proof_envelope::{
 };
 
 use crate::cmd_bind::NamedTermDocument;
+use crate::kit_dispatch::DispatchRealizeTransport;
 use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
 
 const LOWER_PROTOCOL_VERSION: &str = "provekit-orp/1";
@@ -298,33 +302,16 @@ fn lower_named_document(
                     term.function
                 ))
             })?;
-        let request = crate::kit_dispatch::RealizeRequest {
-            function: term.function.clone(),
-            params: term.params.clone(),
-            param_types: term.param_types.clone(),
-            return_type: term.return_type.clone(),
-            concept_name: term.concept_name.clone(),
-            named_term_tree,
-            mode: None,
-            modes: Vec::new(),
-            contract: None,
-            sugar_cids: Vec::new(),
-            sugar_plugins: Vec::new(),
+        let spec = lower_named_spec(term, named_term_tree);
+        let source = match lower_named_spec_via_path(project_root, target, spec) {
+            Ok(source) => source,
+            Err(LowerNamedError::MissingTemplates(entries)) => {
+                missing_templates.extend(entries);
+                continue;
+            }
+            Err(error) => return Err(error),
         };
-        let realized =
-            match crate::kit_dispatch::dispatch_realize(project_root, target, None, &request) {
-                Ok(realized) => realized,
-                Err(error) => {
-                    if let Some(entries) = missing_templates_from_detail(&error.detail) {
-                        missing_templates.extend(entries);
-                        continue;
-                    }
-                    return Err(LowerNamedError::Message(format!(
-                        "lower plugin unavailable for `{target}`: {error}"
-                    )));
-                }
-            };
-        out.push_str(&realized.source);
+        out.push_str(&source);
         if !out.ends_with('\n') {
             out.push('\n');
         }
@@ -333,6 +320,58 @@ fn lower_named_document(
         return Err(LowerNamedError::MissingTemplates(missing_templates));
     }
     Ok(out)
+}
+
+fn lower_named_spec(term: &crate::cmd_bind::NamedTerm, named_term_tree: Option<Json>) -> Json {
+    json!({
+        "kind": "RealizeRequest",
+        "function": term.function,
+        "params": term.params,
+        "paramTypes": term.param_types,
+        "returnType": term.return_type,
+        "conceptName": term.concept_name,
+        "namedTermTree": named_term_tree,
+        "termShapeCid": term.term_shape_cid,
+    })
+}
+
+fn lower_named_spec_via_path(
+    project_root: &Path,
+    target: &str,
+    spec: Json,
+) -> Result<String, LowerNamedError> {
+    let mut inputs = HashMapInputCatalog::default();
+    let input_cid = inputs.insert(Input::Spec(spec));
+    let kit_name = format!("lower-{target}");
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "lower".to_string(),
+            kit: kit_name.clone(),
+            inputs: vec![input_cid],
+            depends_on: vec![],
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        kit_name,
+        LowerKit::new(
+            project_root.to_path_buf(),
+            target.to_string(),
+            None,
+            DispatchRealizeTransport,
+        ),
+    );
+    let claim = execute_path(&path, &registry, &inputs).map_err(|error| {
+        let detail = error.to_string();
+        if let Some(entries) = missing_templates_from_detail(&detail) {
+            LowerNamedError::MissingTemplates(entries)
+        } else {
+            LowerNamedError::Message(format!("lower plugin unavailable for `{target}`: {detail}"))
+        }
+    })?;
+    LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(&claim)
+        .map(|realized| realized.source)
+        .map_err(LowerNamedError::Message)
 }
 
 fn missing_templates_from_detail(detail: &str) -> Option<Vec<MissingTemplateEntry>> {

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -8,7 +8,10 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use clap::Parser;
-use libprovekit::core::{Cid, Term};
+use libprovekit::core::{
+    execute_path, Cid, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath,
+    PathAlgebra, Term,
+};
 use libprovekit::desugar::{load_desugaring_rules_from_dir, DesugaringSet};
 use libprovekit::transport::{transport_term, OperationTransport, TermTransport};
 use owo_colors::OwoColorize;
@@ -21,6 +24,7 @@ use provekit_ir_types::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use crate::kit_dispatch::DispatchRealizeTransport;
 use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
 
 #[derive(Parser, Debug, Clone)]
@@ -1409,7 +1413,7 @@ fn realize_function(
     let _ = body; // body emission is the kit's responsibility
     let workspace_root =
         repo_root().unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
-    let sugar_cids = sugar_plugins
+    let sugar_cids: Vec<String> = sugar_plugins
         .iter()
         .filter_map(|plugin| {
             plugin
@@ -1419,23 +1423,22 @@ fn realize_function(
                 .map(str::to_string)
         })
         .collect();
-    let request = crate::kit_dispatch::RealizeRequest {
-        function: function.to_string(),
-        params: params.to_vec(),
-        param_types: param_types.to_vec(),
-        return_type: return_type.to_string(),
-        concept_name: concept_name.to_string(),
-        named_term_tree: None,
-        mode: mode.map(str::to_string),
-        modes: mode.into_iter().map(str::to_string).collect(),
-        contract,
-        sugar_cids,
-        sugar_plugins,
-    };
-    let realized = crate::kit_dispatch::dispatch_realize(&workspace_root, language, None, &request)
-        .map_err(|e| {
-            TransportCliError::Refusal(format!("realize-time:kit-plugin-unavailable {e}"))
-        })?;
+    let spec = json!({
+        "kind": "RealizeRequest",
+        "function": function,
+        "params": params,
+        "paramTypes": param_types,
+        "returnType": return_type,
+        "conceptName": concept_name,
+        "mode": mode,
+        "modes": mode.into_iter().collect::<Vec<_>>(),
+        "contract": contract,
+        "sugarCids": sugar_cids,
+        "sugarPlugins": sugar_plugins,
+    });
+    let realized = realize_spec_via_path(&workspace_root, language, spec).map_err(|error| {
+        TransportCliError::Refusal(format!("realize-time:kit-plugin-unavailable {error}"))
+    })?;
     return Ok(RealizedSource {
         // The kit reports `extension`; fall back to a leak-free static
         // string MATCHING the kit's response. The Box::leak below converts
@@ -1453,25 +1456,54 @@ fn realize_function(
     });
 }
 
+fn realize_spec_via_path(
+    workspace_root: &Path,
+    language: &str,
+    spec: Value,
+) -> Result<libprovekit::core::RealizedSource, String> {
+    let mut inputs = HashMapInputCatalog::default();
+    let input_cid = inputs.insert(Input::Spec(spec));
+    let kit_name = format!("lower-{language}");
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "lower".to_string(),
+            kit: kit_name.clone(),
+            inputs: vec![input_cid],
+            depends_on: vec![],
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        kit_name,
+        LowerKit::new(
+            workspace_root.to_path_buf(),
+            language.to_string(),
+            None,
+            DispatchRealizeTransport,
+        ),
+    );
+    let claim = execute_path(&path, &registry, &inputs).map_err(|error| error.to_string())?;
+    LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(&claim)
+}
+
 #[cfg(test)]
 mod mint_realization_artifacts_tests {
     use super::*;
     use crate::kit_dispatch::RealizeRequest;
 
     fn make_request(mode: Option<&str>) -> RealizeRequest {
-        RealizeRequest {
-            function: "foo".to_string(),
-            params: vec!["x".to_string(), "y".to_string()],
-            param_types: vec!["int".to_string(), "int".to_string()],
-            return_type: "int".to_string(),
-            concept_name: "add".to_string(),
-            named_term_tree: None,
-            mode: mode.map(str::to_string),
-            modes: mode.into_iter().map(str::to_string).collect(),
-            contract: None,
-            sugar_cids: vec![],
-            sugar_plugins: vec![],
-        }
+        serde_json::from_value(serde_json::json!({
+            "function": "foo",
+            "params": ["x", "y"],
+            "param_types": ["int", "int"],
+            "return_type": "int",
+            "concept_name": "add",
+            "mode": mode,
+            "modes": mode.into_iter().collect::<Vec<_>>(),
+            "sugar_cids": [],
+            "sugar_plugins": []
+        }))
+        .expect("request decodes")
     }
 
     fn make_realized(wrapper_record: Option<serde_json::Value>) -> RealizedSource {

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -36,6 +36,27 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+#[allow(unused_imports)]
+pub use libprovekit::core::RealizeContractWitness;
+use libprovekit::core::RealizeTransport;
+pub use libprovekit::core::{RealizeContractPayload, RealizeRequest, RealizedSource};
+
+#[derive(Debug, Clone, Copy)]
+pub struct DispatchRealizeTransport;
+
+impl RealizeTransport for DispatchRealizeTransport {
+    fn dispatch_realize(
+        &self,
+        workspace_root: &Path,
+        target_lang: &str,
+        library_tag: Option<&str>,
+        request: &RealizeRequest,
+    ) -> Result<RealizedSource, String> {
+        dispatch_realize(workspace_root, target_lang, library_tag, request)
+            .map_err(|error| error.to_string())
+    }
+}
+
 // ============================================================================
 // Bind lift dispatch (PEP 1.7.0 kind = "lift", legacy-retained method `lift`)
 // ============================================================================
@@ -516,63 +537,6 @@ fn decode_bind_lift_response(response: Value) -> Result<BindLiftResult, String> 
 // ============================================================================
 // Realize dispatch (PEP 1.7.0 kind = "realize", method `provekit.plugin.invoke`)
 // ============================================================================
-
-/// Request shape for the realize surface. Mirrors what
-/// `body-template-memento.md` §3 specifies: the realize plugin receives a
-/// canonical clause + concept binding + signature info and returns a
-/// language-specific source string plus an `is_stub` flag.
-#[derive(Debug, Clone, Serialize)]
-pub struct RealizeRequest {
-    pub function: String,
-    pub params: Vec<String>,
-    pub param_types: Vec<String>,
-    pub return_type: String,
-    pub concept_name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub named_term_tree: Option<Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub modes: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub contract: Option<RealizeContractPayload>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub sugar_cids: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub sugar_plugins: Vec<Value>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct RealizeContractPayload {
-    pub concept_site_cid: String,
-    pub object_fcm_cid: String,
-    pub local_contract_cid: String,
-    pub origin: String,
-    pub discharge_verdict: String,
-    pub witnesses: Vec<RealizeContractWitness>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct RealizeContractWitness {
-    pub role: String,
-    pub predicate: Value,
-    pub predicate_text: String,
-    pub source_kind: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct RealizedSource {
-    pub extension: String,
-    pub source: String,
-    pub is_stub: bool,
-    pub emitted_artifact_cid: Option<String>,
-    pub observed_loss_record: Value,
-    pub used_sugars: Vec<Value>,
-    /// Raw `observation_wrapper_emission_record` from the kit response, present
-    /// when an observation mode emitted a wrapper FCM. Expected fields:
-    /// wrapper_fcm_cid, observer_effects, preservation_claim_cid.
-    pub observation_wrapper_emission_record: Option<Value>,
-}
 
 const DEFAULT_LIBRARY_TAG: &str = "default";
 
@@ -1090,38 +1054,38 @@ mod tests {
 
     #[test]
     fn realize_request_params_include_contract_mode_and_loss_payload() {
-        let request = RealizeRequest {
-            function: "lookup".to_string(),
-            params: vec!["name".to_string()],
-            param_types: vec!["String".to_string()],
-            return_type: "String".to_string(),
-            concept_name: "concept:lookup".to_string(),
-            named_term_tree: None,
-            mode: Some("monitor".to_string()),
-            modes: vec!["monitor".to_string(), "witness".to_string()],
-            contract: Some(RealizeContractPayload {
-                concept_site_cid: "blake3-512:site".to_string(),
-                object_fcm_cid: "blake3-512:object".to_string(),
-                local_contract_cid: "blake3-512:compound".to_string(),
-                origin: "evidence-lift[type-signature]".to_string(),
-                discharge_verdict: "exact".to_string(),
-                witnesses: vec![RealizeContractWitness {
-                    role: "pre".to_string(),
-                    predicate: json!({
+        let request: RealizeRequest = serde_json::from_value(json!({
+            "function": "lookup",
+            "params": ["name"],
+            "param_types": ["String"],
+            "return_type": "String",
+            "concept_name": "concept:lookup",
+            "mode": "monitor",
+            "modes": ["monitor", "witness"],
+            "contract": {
+                "concept_site_cid": "blake3-512:site",
+                "object_fcm_cid": "blake3-512:object",
+                "local_contract_cid": "blake3-512:compound",
+                "origin": "evidence-lift[type-signature]",
+                "discharge_verdict": "exact",
+                "witnesses": [{
+                    "role": "pre",
+                    "predicate": {
                         "args": [
                             {"kind": "var", "name": "name"},
                             {"kind": "const", "sort": {"kind": "primitive", "name": "Ref"}, "value": null}
                         ],
                         "kind": "atomic",
                         "name": "neq"
-                    }),
-                    predicate_text: "non_null(name)".to_string(),
-                    source_kind: "type-signature".to_string(),
-                }],
-            }),
-            sugar_cids: vec!["blake3-512:sugar".to_string()],
-            sugar_plugins: vec![json!({"header": {"kind": "sugar"}})],
-        };
+                    },
+                    "predicate_text": "non_null(name)",
+                    "source_kind": "type-signature"
+                }]
+            },
+            "sugar_cids": ["blake3-512:sugar"],
+            "sugar_plugins": [{"header": {"kind": "sugar"}}]
+        }))
+        .expect("request decodes");
 
         let params = realize_request_params(&request);
 
@@ -1145,13 +1109,13 @@ mod tests {
 
     #[test]
     fn realize_request_params_include_named_term_tree() {
-        let request = RealizeRequest {
-            function: "compose_tree".to_string(),
-            params: vec!["value".to_string()],
-            param_types: vec!["int".to_string()],
-            return_type: "int".to_string(),
-            concept_name: "UNNAMED-CONCEPT-1".to_string(),
-            named_term_tree: Some(json!({
+        let request: RealizeRequest = serde_json::from_value(json!({
+            "function": "compose_tree",
+            "params": ["value"],
+            "param_types": ["int"],
+            "return_type": "int",
+            "concept_name": "UNNAMED-CONCEPT-1",
+            "named_term_tree": {
                 "conceptName": "concept:seq",
                 "operationKind": "seq",
                 "shapeCid": "blake3-512:seq",
@@ -1161,13 +1125,12 @@ mod tests {
                     "shapeCid": "blake3-512:return",
                     "args": []
                 }]
-            })),
-            mode: None,
-            modes: Vec::new(),
-            contract: None,
-            sugar_cids: Vec::new(),
-            sugar_plugins: Vec::new(),
-        };
+            },
+            "modes": [],
+            "sugar_cids": [],
+            "sugar_plugins": []
+        }))
+        .expect("request decodes");
 
         let params = realize_request_params(&request);
 

--- a/implementations/rust/provekit-cli/tests/lower_kit_path_integration.rs
+++ b/implementations/rust/provekit-cli/tests/lower_kit_path_integration.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use libprovekit::compose::{
+    build_value, cid_of_value, jcs_bytes_of_value, EffectSet, FunctionContractMemento, Locus,
+};
+use libprovekit::core::{
+    address, execute_path, Cid, DomainClaim, DomainKind, HashMapInputCatalog, Input, KitRegistry,
+    LowerKit, Path as CorePath, PathAlgebra, Term, Verdict,
+};
+use provekit_cli::kit_dispatch::DispatchRealizeTransport;
+use provekit_ir_types::{IrFormula, Sort};
+use serde_json::json;
+
+fn valid_cid(fill: char) -> String {
+    format!("blake3-512:{}", fill.to_string().repeat(128))
+}
+
+fn parse_cid(fill: char) -> Cid {
+    Cid::parse(valid_cid(fill)).expect("valid CID")
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod script");
+    }
+}
+
+fn fake_realizer(root: &Path) -> PathBuf {
+    let script = root.join("fake-python-realizer.sh");
+    write_executable(
+        &script,
+        &format!(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+  if [[ "$line" == *'"method":"provekit.plugin.invoke"'* ]]; then
+    printf '%s\n' '{{"jsonrpc":"2.0","id":1,"result":{{"source":"def add(x, y):\n    return x + y\n","is_stub":false,"extension":"py","emitted_artifact_cid":"{}","observed_loss_record":{{"kind":"loss-record","cid":"{}"}},"used_sugars":[{{"header":{{"cid":"{}"}}}}]}}}}'
+    exit 0
+  fi
+done
+"#,
+            valid_cid('b'),
+            valid_cid('c'),
+            valid_cid('d')
+        ),
+    );
+    script
+}
+
+fn register_fake_realizer(project: &Path, script: &Path) {
+    let realize_dir = project.join(".provekit").join("realize").join("python");
+    fs::create_dir_all(&realize_dir).expect("create realize manifest dir");
+    fs::write(
+        realize_dir.join("manifest.toml"),
+        format!(
+            "name = \"fake-python-realizer\"\nlibrary_tag = \"default\"\ncommand = [\"bash\", \"{}\"]\n",
+            script.display()
+        ),
+    )
+    .expect("write manifest");
+}
+
+fn fake_missing_template_realizer(root: &Path) -> PathBuf {
+    let script = root.join("fake-missing-template-realizer.sh");
+    write_executable(
+        &script,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+  if [[ "$line" == *'"method":"provekit.plugin.invoke"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"error":{"code":-32100,"message":"missing body-template entry","data":[{"operation_kind":"call:Widget::build","args_shape":["int"],"function":"unknown_call","term_position":"body.return"}]}}'
+    exit 0
+  fi
+done
+"#,
+    );
+    script
+}
+
+fn minimal_contract() -> FunctionContractMemento {
+    let formals = vec!["x".to_string()];
+    let formal_sorts = vec![Sort::Primitive {
+        name: "int".to_string(),
+    }];
+    let return_sort = Sort::Primitive {
+        name: "int".to_string(),
+    };
+    let pre = IrFormula::Atomic {
+        name: "true".to_string(),
+        args: vec![],
+    };
+    let post = IrFormula::Atomic {
+        name: "true".to_string(),
+        args: vec![],
+    };
+    let effects = EffectSet::empty();
+    let locus = Locus::unknown();
+    let value = build_value(
+        "prior",
+        &formals,
+        &formal_sorts,
+        &return_sort,
+        &pre,
+        &post,
+        None,
+        &effects,
+        &locus,
+        &[],
+    );
+    FunctionContractMemento {
+        fn_name: "prior".to_string(),
+        formals,
+        formal_sorts,
+        formal_regions: vec![],
+        return_sort,
+        return_region: None,
+        pre,
+        post,
+        body_cid: None,
+        effects,
+        locus,
+        canonical_bytes: jcs_bytes_of_value(&value),
+        cid: cid_of_value(&value),
+        auto_minted_mementos: vec![],
+        concept_hint: None,
+    }
+}
+
+#[test]
+fn lower_python_path_claim_input_cites_from_premise_to_and_loss_cids() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script = fake_realizer(temp.path());
+    register_fake_realizer(temp.path(), &script);
+
+    let term_cid = parse_cid('a');
+    let policy_cid = parse_cid('e');
+    let sugar_cid = parse_cid('d');
+    let body_template_cid = parse_cid('f');
+    let spec = json!({
+        "kind": "RealizeRequest",
+        "function": "add",
+        "params": ["x", "y"],
+        "paramTypes": ["int", "int"],
+        "returnType": "int",
+        "conceptName": "concept:add",
+        "namedTermTree": {
+            "conceptName": "concept:add",
+            "operationKind": "add",
+            "shapeCid": term_cid,
+            "args": []
+        },
+        "termShapeCid": term_cid,
+        "policyCid": policy_cid,
+        "sugarCids": [sugar_cid],
+        "bodyTemplateCids": [body_template_cid]
+    });
+    let prior_claim = DomainClaim {
+        domain: DomainKind::Other("prior-step".to_string()),
+        contract: minimal_contract(),
+        artifacts: vec![],
+        from: vec![term_cid.clone()],
+        premises: vec![],
+        to: term_cid.clone(),
+        witness: None,
+        payload: Some(Term::Const {
+            value: spec,
+            sort: Sort::Primitive {
+                name: "LowerSpec".to_string(),
+            },
+        }),
+        verdict: Verdict::Unresolved,
+        attestation: None,
+    };
+    let prior_claim_cid = prior_claim.cid();
+    let mut inputs = HashMapInputCatalog::default();
+    let prior_input = Input::Claim(prior_claim);
+    let prior_input_cid = inputs.insert(prior_input);
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "lower".to_string(),
+            kit: "lower-python".to_string(),
+            inputs: vec![prior_input_cid],
+            depends_on: vec![],
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        "lower-python",
+        LowerKit::new(
+            temp.path().to_path_buf(),
+            "python",
+            None,
+            DispatchRealizeTransport,
+        ),
+    );
+
+    let claim = execute_path(&path, &registry, &inputs).expect("lower path executes");
+
+    assert_eq!(claim.from, vec![term_cid]);
+    assert_eq!(claim.premises, vec![prior_claim_cid]);
+    assert_eq!(claim.to, parse_cid('b'));
+    assert!(claim.artifacts.contains(&parse_cid('c')));
+    assert!(claim.artifacts.contains(&policy_cid));
+    assert!(claim.artifacts.contains(&sugar_cid));
+    assert!(claim.artifacts.contains(&body_template_cid));
+    assert_eq!(
+        claim.payload.as_ref().map(address),
+        Some(address(claim.payload.as_ref().expect("payload term")))
+    );
+}
+
+#[test]
+fn lower_cli_missing_body_template_refuses_without_partial_output() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script = fake_missing_template_realizer(temp.path());
+    register_fake_realizer(temp.path(), &script);
+    let input = temp.path().join("named-terms.json");
+    let output = temp.path().join("out.py");
+    fs::write(
+        &input,
+        serde_json::to_vec_pretty(&json!({
+            "kind": "NamedTermDocument",
+            "promotionDecisionMementos": [],
+            "schemaVersion": "1",
+            "sourceLanguage": "rust",
+            "workspaceRoot": temp.path(),
+            "terms": [{
+                "conceptName": "concept:add",
+                "dischargeVerdict": "exact",
+                "file": "src/lib.rs",
+                "function": "add",
+                "name": "add",
+                "namedTermTree": {
+                    "conceptName": "concept:add",
+                    "operationKind": "add",
+                    "shapeCid": valid_cid('a'),
+                    "args": []
+                },
+                "paramTypes": ["int", "int"],
+                "params": ["x", "y"],
+                "returnType": "int",
+                "siteMementoCid": valid_cid('e'),
+                "termShape": {"kind": "op", "name": "add"},
+                "termShapeCid": valid_cid('a'),
+                "witnesses": []
+            }]
+        }))
+        .expect("encode named terms"),
+    )
+    .expect("write named terms");
+
+    let output_result = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("lower")
+        .arg(&input)
+        .arg("--target")
+        .arg("python")
+        .arg("--project")
+        .arg(temp.path())
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("spawn provekit lower");
+
+    let stderr = String::from_utf8_lossy(&output_result.stderr);
+    assert!(
+        !output_result.status.success(),
+        "missing template must fail\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("missing body-template entry")
+            && stderr.contains("call:Widget::build")
+            && stderr.contains("unknown_call"),
+        "stderr should carry missing template receipt\nstderr:\n{stderr}"
+    );
+    assert!(
+        !output.exists(),
+        "missing template refusal must not leave a partial output file"
+    );
+}


### PR DESCRIPTION
feat(libprovekit): LowerKit wraps realize machinery as a registered Kit (closes #1027)

Sibling to LiftKit (#1033, PR #1036). Adapts the existing realize/lower dispatch machinery as a `Kit::transform(&Input) -> DomainClaim` registered with the public `libprovekit::core::path_executor::KitRegistry`.

## Substrate change

- New `lower_plugin.rs` module in `libprovekit::core` exports `LowerKit`.
- `LowerKit::transform(Input::Spec)` carries the existing `RealizeRequest` payload for compatibility; future PRs widen to `Input::Path` + `Input::Claim` per #1027 scope.
- Internally calls existing `kit_dispatch::dispatch_realize` (transport layer stays per #1027 implementation note).
- Returns `DomainClaim` citing `from` (input named-term/term-tree CID), `to` (emitted artifact CID), `premises` (prior step's claim CID when consumed as `Input::Claim` from a Path step), `artifacts`, and observed loss record CID when the realize plugin reports loss.

## CLI deletion (per hard-refuse "registry without teeth" rule)

- `cmd_lower.rs`, `cmd_transport.rs`, and `cmd_bind_migrate.rs` ALL now go through `LowerKit` via `execute_path`.
- Direct `RealizeRequest` construction REMOVED from all three production callers. No parallel-but-deprecated paths.
- The legacy `cmd_lower::run` / `cmd_transport::run` / `cmd_bind_migrate::run` entrypoints stay as compatibility shims (CLI argv parsing → adapter → executor → render result).

## PR #1018 refusal contract preserved

- `-32100 missing body-template entry` refusal flows through unchanged.
- No silent stubs. No partial output file on missing templates.
- LowerKit integration test asserts the refusal surfaces with the same `CompositionRefusalMemento` shape consumers depend on.

## Tests added

- `LowerKit::transform` unit tests for `from`/`premises`/`to` CID citation.
- Loss-record CID propagation test when realize plugin reports loss.
- Missing body-template refusal test asserting no-partial-output behavior.

## Gates

- `cargo test -p libprovekit`: passed.
- `cargo test -p provekit-cli`: passed.
- `tools/spec-cid-lint.sh`: exit 0.
- Change-scope em/en-dash sweep on the 7 dirty files: zero.

## Non-goals respected

- No new `provekit-realize-*` or `provekit-lower-*` crate. Extended existing.
- No parallel registry. Used `KitRegistry` from #1036.
- No parallel executor. Registered with `execute_path` from #1036.
- No new memento family.
- No broadening of Path semantics beyond #1025/#1026/#1033.
- No body-template catalog data changes.

## Forward-compat with #1040

This PR's `register("lower-default", LowerKit::new(...))` callsite uses the current two-arg signature. When #1040 (substrate ConformanceDeclaration) lands, this callsite adds `ConformanceDeclaration::Carrier { target_language: ..., fixtures_path: ... }` on rebase. Per #1040's bidirectional sequencing rule, conflict is mechanical.

Prerequisites: #1033 (PR #1036 merged for path_executor + KitRegistry).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
