### PR TITLE
feat(libprovekit): PathAlgebra verb selector + Kit::prove default (closes #1038)

### DIFF
--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -40,7 +40,7 @@ pub use types::{
     ArityShape, AritySlot, Attestation, Boundary, Cid, CidError, Contract, Dialect, DomainClaim,
     DomainKind, Formula, Input, LanguageSignature, OperationSignature, Path, PathAlgebra,
     PathDocument, PathDocumentError, PathError, PathInputBinding, PathInputMaterial, Refutation,
-    SignatureCatalogError, SlotEvaluation, SlotSort, Term, Truth, Verdict, VerdictCoercionError,
-    Witness,
+    SignatureCatalogError, SlotEvaluation, SlotSort, Term, Truth, Verb, Verdict,
+    VerdictCoercionError, Witness,
 };
 pub use verbs::{cross_compile, link, prove, realize, transform, verify};

--- a/implementations/rust/libprovekit/src/core/path_executor.rs
+++ b/implementations/rust/libprovekit/src/core/path_executor.rs
@@ -11,8 +11,9 @@ use thiserror::Error;
 
 use crate::compose::CCP_VERSION;
 
+use super::primitives::address;
 use super::traits::{InputCatalog, Kit, KitError};
-use super::types::{Cid, DomainClaim, Input, PathAlgebra, PathError, Term};
+use super::types::{Cid, DomainClaim, Input, PathAlgebra, PathError, Verb};
 
 /// Registry of executable kits keyed by the `PathAlgebra.kit` selector.
 #[derive(Default)]
@@ -45,19 +46,34 @@ pub fn execute_path(
     };
     let ordered = path.ordered_steps().map_err(PathExecutionError::Path)?;
     let mut claims_by_step: BTreeMap<String, DomainClaim> = BTreeMap::new();
-    let mut materialized_terms: HashMap<Cid, Term> = HashMap::new();
+    let mut materialized_inputs: HashMap<Cid, Input> = HashMap::new();
 
     for step in ordered {
         let kit = registry
             .get(&step.kit)
             .ok_or_else(|| PathExecutionError::Refused(Box::new(missing_kit_refusal(step))))?;
-        let step_input = step_input(step, inputs, &materialized_terms)?;
-        let claim = kit
-            .transform(&step_input)
-            .map_err(PathExecutionError::Kit)?;
+        let step_input = step_input(step, inputs, &materialized_inputs)?;
+        let claim = match step.verb {
+            Verb::Transform => kit
+                .transform(&step_input)
+                .map_err(PathExecutionError::Kit)?,
+            Verb::Prove => {
+                let Input::Claim(claim) = step_input else {
+                    return Err(PathExecutionError::UnsupportedInput(format!(
+                        "path step `{}` Prove verb expects Input::Claim",
+                        step.name
+                    )));
+                };
+                kit.prove(claim).map_err(|error| prove_error(step, error))?
+            }
+        };
         if let Some(term) = claim.payload.clone() {
-            materialized_terms.insert(claim.to.clone(), term);
+            materialized_inputs.insert(claim.to.clone(), Input::Term(term));
         }
+        materialized_inputs.insert(
+            address(&Input::Claim(claim.clone())),
+            Input::Claim(claim.clone()),
+        );
         claims_by_step.insert(step.name.clone(), claim);
     }
 
@@ -76,7 +92,7 @@ pub fn execute_path(
 fn step_input(
     step: &PathAlgebra,
     inputs: &dyn InputCatalog,
-    materialized_terms: &HashMap<Cid, Term>,
+    materialized_inputs: &HashMap<Cid, Input>,
 ) -> Result<Input, PathExecutionError> {
     let [cid] = step.inputs.as_slice() else {
         return Err(PathExecutionError::UnsupportedInput(format!(
@@ -88,8 +104,8 @@ fn step_input(
     if let Some(input) = inputs.get_input(cid) {
         return Ok(input);
     }
-    if let Some(term) = materialized_terms.get(cid) {
-        return Ok(Input::Term(term.clone()));
+    if let Some(input) = materialized_inputs.get(cid) {
+        return Ok(input.clone());
     }
     Err(PathExecutionError::Refused(Box::new(
         missing_input_refusal(step, cid),
@@ -141,8 +157,29 @@ fn missing_input_refusal(step: &PathAlgebra, cid: &Cid) -> CompositionRefusalMem
         "input-catalog",
         "path-input",
         format!(
-            "path step `{}` input `{cid}` is not materialized and no prior term payload produced it",
+            "path step `{}` input `{cid}` is not materialized and no prior step output produced it",
             step.name
+        ),
+    )
+}
+
+fn prove_error(step: &PathAlgebra, error: KitError) -> PathExecutionError {
+    match error {
+        KitError::NotSupported => {
+            PathExecutionError::Refused(Box::new(prove_not_supported_refusal(step)))
+        }
+        other => PathExecutionError::Kit(other),
+    }
+}
+
+fn prove_not_supported_refusal(step: &PathAlgebra) -> CompositionRefusalMemento {
+    composition_refusal_for_missing_requirement(
+        step,
+        "kit-prove",
+        "kit-capability",
+        format!(
+            "path step `{}` kit `{}` does not support Prove",
+            step.name, step.kit
         ),
     )
 }

--- a/implementations/rust/libprovekit/src/core/traits.rs
+++ b/implementations/rust/libprovekit/src/core/traits.rs
@@ -108,7 +108,9 @@ pub trait Kit {
     fn transform(&self, input: &Input) -> Result<DomainClaim, KitError>;
 
     /// Primitive: attempt to prove or otherwise discharge a domain claim.
-    fn prove(&self, claim: DomainClaim) -> Result<DomainClaim, KitError>;
+    fn prove(&self, _claim: DomainClaim) -> Result<DomainClaim, KitError> {
+        Err(KitError::NotSupported)
+    }
 
     /// Deprecated term-level escape hatch.
     #[deprecated(note = "kits transform Input into DomainClaim; consume `transform` instead")]
@@ -169,6 +171,9 @@ pub enum SolverVerdict {
 /// Errors from dialect kits.
 #[derive(Debug, Error)]
 pub enum KitError {
+    /// The requested primitive is not implemented by this kit.
+    #[error("kit primitive not supported")]
+    NotSupported,
     /// The input belongs to another dialect or has no faithful term.
     #[error("kit {dialect:?}: unsupported input: {message}")]
     UnsupportedInput { dialect: Dialect, message: String },

--- a/implementations/rust/libprovekit/src/core/types.rs
+++ b/implementations/rust/libprovekit/src/core/types.rs
@@ -960,6 +960,28 @@ impl Path {
     }
 }
 
+/// Primitive selector for one path-algebra step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Verb {
+    /// Transform input material into a domain claim.
+    Transform,
+    /// Prove or otherwise discharge an existing domain claim.
+    Prove,
+}
+
+impl Verb {
+    /// Return whether this is the wire-default path verb.
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Transform)
+    }
+}
+
+impl Default for Verb {
+    fn default() -> Self {
+        Self::Transform
+    }
+}
+
 /// One algebra step inside a [`Path`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -968,6 +990,9 @@ pub struct PathAlgebra {
     pub name: String,
     /// Kit transform to apply.
     pub kit: String,
+    /// Kit primitive to dispatch for this step.
+    #[serde(default, skip_serializing_if = "Verb::is_default")]
+    pub verb: Verb,
     /// Input artifact CIDs to that transform.
     pub inputs: Vec<Cid>,
     /// Names of prerequisite algebra steps.
@@ -1787,7 +1812,7 @@ fn path_algebra_to_value(step: &PathAlgebra) -> Arc<CValue> {
     let mut inputs = step.inputs.clone();
     inputs.sort();
     inputs.dedup();
-    CValue::object([
+    let mut fields = vec![
         (
             "inputs",
             CValue::array(
@@ -1803,7 +1828,14 @@ fn path_algebra_to_value(step: &PathAlgebra) -> Arc<CValue> {
             "dependsOn",
             CValue::array(depends_on.into_iter().map(CValue::string).collect()),
         ),
-    ])
+    ];
+    if !step.verb.is_default() {
+        fields.push((
+            "verb",
+            json_to_cvalue(serde_json::to_value(step.verb).expect("verb serializes")),
+        ));
+    }
+    CValue::object(fields)
 }
 
 fn operation_name_cid(name: &str) -> Cid {

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -2,16 +2,17 @@
 
 use std::sync::Arc;
 
+use libprovekit::canonical::{json_cid, serializable_cid, serializable_jcs};
 use libprovekit::compose::{
     build_value, cid_of_value, compose_function_contracts, jcs_bytes_of_value, EffectSet,
     FunctionContractMemento, Locus,
 };
 use libprovekit::core::{
-    address, compose, execute_path, link, prove, transform, verify, ArityShape, AritySlot,
-    CKit, Canonical, Cid, Dialect, DomainClaim, DomainKind, FunctionContractDomain,
-    HashMapCatalog, HashMapInputCatalog, Input, InputCatalog, Kit, KitRegistry,
-    LanguageSignature, LiftKit, LiftPluginKit, Path, PathAlgebra, PathDocument,
-    PathDocumentError, PathError, Refutation, SlotSort, Term, Truth, Verdict, Witness,
+    address, compose, execute_path, link, prove, transform, verify, ArityShape, AritySlot, CKit,
+    Canonical, Cid, Dialect, DomainClaim, DomainKind, FunctionContractDomain, HashMapCatalog,
+    HashMapInputCatalog, Input, InputCatalog, Kit, KitRegistry, LanguageSignature, LiftKit,
+    LiftPluginKit, Path, PathAlgebra, PathDocument, PathDocumentError, PathError, Refutation,
+    SlotSort, Term, Truth, Verb, Verdict, Witness,
 };
 use provekit_canonicalizer::Value;
 use provekit_ir_types::{IrFormula, IrTerm, Sort};
@@ -135,6 +136,7 @@ fn one_step_path(name: &str, inputs: Vec<Cid>) -> Path {
             kit: format!("kit:{name}"),
             inputs,
             depends_on: vec![],
+            verb: Verb::Transform,
         }],
     }
 }
@@ -414,6 +416,7 @@ fn path_is_cidable_language_neutral_algebra() {
             "workspace_root": "/repo"
         })))],
         depends_on: vec![],
+        verb: Verb::Transform,
     };
     let mint_step = PathAlgebra {
         name: "mint".to_string(),
@@ -422,6 +425,7 @@ fn path_is_cidable_language_neutral_algebra() {
             "outDir": "/repo/out"
         })))],
         depends_on: vec!["lift".to_string()],
+        verb: Verb::Transform,
     };
 
     let path = Path {
@@ -439,6 +443,67 @@ fn path_is_cidable_language_neutral_algebra() {
     assert_eq!(
         path.step("mint").expect("mint step").depends_on,
         vec!["lift".to_string()]
+    );
+}
+
+#[test]
+fn path_algebra_default_verb_is_cid_stable_when_omitted() {
+    let source_cid = address(&Input::Spec(json!({"surface": "rust"})));
+    let step = PathAlgebra {
+        name: "lift".to_string(),
+        kit: "lift-rust".to_string(),
+        inputs: vec![source_cid.clone()],
+        depends_on: vec![],
+        verb: Verb::default(),
+    };
+    let without_verb = json!({
+        "dependsOn": [],
+        "inputs": [source_cid.as_str()],
+        "kit": "lift-rust",
+        "name": "lift"
+    });
+
+    let encoded = serializable_jcs(&step).expect("default verb step serializes");
+    assert!(
+        !encoded.contains("\"verb\""),
+        "default Transform verb must stay absent from canonical JSON: {encoded}"
+    );
+    assert_eq!(
+        serializable_cid(&step).expect("default verb step CID"),
+        json_cid(&without_verb).expect("legacy no-verb step CID")
+    );
+
+    let decoded: PathAlgebra =
+        serde_json::from_value(without_verb).expect("legacy no-verb step parses");
+    assert_eq!(decoded.verb, Verb::Transform);
+}
+
+#[test]
+fn path_algebra_prove_verb_round_trips_and_changes_cid() {
+    let claim_cid = address(&Input::Spec(json!({"claim": "input"})));
+    let transform_step = PathAlgebra {
+        name: "prove".to_string(),
+        kit: "prove-stub".to_string(),
+        inputs: vec![claim_cid],
+        depends_on: vec![],
+        verb: Verb::Transform,
+    };
+    let prove_step = PathAlgebra {
+        verb: Verb::Prove,
+        ..transform_step.clone()
+    };
+
+    let encoded = serializable_jcs(&prove_step).expect("Prove verb step serializes");
+    assert!(
+        encoded.contains("\"verb\":\"Prove\""),
+        "Prove verb must be present in canonical JSON: {encoded}"
+    );
+    let decoded: PathAlgebra = serde_json::from_str(&encoded).expect("Prove verb step round-trips");
+
+    assert_eq!(decoded.verb, Verb::Prove);
+    assert_ne!(
+        serializable_cid(&prove_step).expect("Prove verb step CID"),
+        serializable_cid(&transform_step).expect("Transform verb step CID")
     );
 }
 
@@ -464,12 +529,14 @@ fn path_document_round_trips_with_cid_checked_materialized_inputs() {
                 kit: "lift-plugin:rust-self-contracts".to_string(),
                 inputs: vec![lift_input_cid.clone()],
                 depends_on: vec![],
+                verb: Verb::Transform,
             },
             PathAlgebra {
                 name: "mint".to_string(),
                 kit: "provekit-mint".to_string(),
                 inputs: vec![mint_input_cid.clone()],
                 depends_on: vec!["lift".to_string()],
+                verb: Verb::Transform,
             },
         ],
     };
@@ -510,6 +577,7 @@ fn path_document_rejects_materialized_input_cid_mismatch() {
                 kit: "lift-plugin:declared".to_string(),
                 inputs: vec![declared_cid],
                 depends_on: vec![],
+                verb: Verb::Transform,
             }],
         },
         inputs: vec![libprovekit::core::PathInputBinding {
@@ -689,12 +757,14 @@ fn path_derives_order_from_dependencies() {
             serde_json::json!({"surface": "rust"}),
         ))],
         depends_on: vec![],
+        verb: Verb::Transform,
     };
     let mint_step = PathAlgebra {
         name: "mint".to_string(),
         kit: "provekit-mint".to_string(),
         inputs: vec![address(&Input::Spec(serde_json::json!({"outDir": "out"})))],
         depends_on: vec!["lift".to_string()],
+        verb: Verb::Transform,
     };
     let path = Path {
         algebra: vec![mint_step, lift_step],
@@ -730,6 +800,7 @@ fn input_catalog_materializes_path_step_inputs_by_cid() {
             kit: "lift-plugin:jvm-bytecode".to_string(),
             inputs: vec![input_cid.clone()],
             depends_on: vec![],
+            verb: Verb::Transform,
         }],
     };
 
@@ -751,6 +822,7 @@ fn path_rejects_invalid_dependency_graphs() {
         kit: format!("kit:{name}"),
         inputs: vec![address(&format!("input:{name}"))],
         depends_on: depends_on.into_iter().map(str::to_string).collect(),
+        verb: Verb::Transform,
     };
 
     let duplicate = Path {
@@ -790,6 +862,7 @@ fn path_orders_cross_domain_link_after_shared_contract_proofs() {
             "contractCid": shared_contract.as_str()
         })))],
         depends_on: vec![],
+        verb: Verb::Transform,
     };
     let c_proof = PathAlgebra {
         name: "c-proof".to_string(),
@@ -799,6 +872,7 @@ fn path_orders_cross_domain_link_after_shared_contract_proofs() {
             "contractCid": shared_contract.as_str()
         })))],
         depends_on: vec![],
+        verb: Verb::Transform,
     };
     let link = PathAlgebra {
         name: "link".to_string(),
@@ -807,6 +881,7 @@ fn path_orders_cross_domain_link_after_shared_contract_proofs() {
             "sharedContractCid": shared_contract.as_str()
         })))],
         depends_on: vec!["ts-proof".to_string(), "c-proof".to_string()],
+        verb: Verb::Transform,
     };
     let path = Path {
         algebra: vec![link, ts_proof, c_proof],
@@ -1047,6 +1122,7 @@ fn execute_path_refuses_unregistered_lift_kit_with_composition_refusal_memento()
             kit: "lift-unknown".to_string(),
             inputs: vec![source_cid],
             depends_on: vec![],
+            verb: Verb::Transform,
         }],
     }));
     let registry = KitRegistry::default();

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -52,7 +52,7 @@ use serde_json::{json, Value};
 use libprovekit::core::{
     address, Boundary, Cid, Dialect, Domain, DomainClaim, DomainKind, FunctionContractDomain,
     HashMapInputCatalog, Input, InputCatalog, Kit, KitError, Path as CorePath, PathAlgebra,
-    PathDocument, Term, Verdict,
+    PathDocument, Term, Verb, Verdict,
 };
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_claim_envelope::{
@@ -402,12 +402,14 @@ fn mint_input(project_root: &Path, surface: &str, out_dir: &Path, quiet: bool) -
                     kit: format!("lift-plugin:{surface}"),
                     inputs: vec![lift_input_cid],
                     depends_on: vec![],
+                    verb: Verb::Transform,
                 },
                 PathAlgebra {
                     name: "mint".to_string(),
                     kit: "provekit-mint".to_string(),
                     inputs: vec![mint_input_cid],
                     depends_on: vec!["lift".to_string()],
+                    verb: Verb::Transform,
                 },
             ],
         })),
@@ -1560,6 +1562,7 @@ mod tests {
                         "workspace_root": "."
                     })))],
                     depends_on: vec![],
+                    verb: Verb::Transform,
                 },
                 PathAlgebra {
                     name: "mint".to_string(),
@@ -1568,6 +1571,7 @@ mod tests {
                         "outDir": "out"
                     })))],
                     depends_on: vec!["lift".to_string(), "missing".to_string()],
+                    verb: Verb::Transform,
                 },
             ],
         }));

--- a/implementations/rust/provekit-cli/src/lift_plugin.rs
+++ b/implementations/rust/provekit-cli/src/lift_plugin.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 use libprovekit::core::{
     address, execute_path, Dialect, DomainClaim, HashMapInputCatalog, Input, KitRegistry, LiftKit,
     LiftPluginKit, LiftPluginKitError, Path as CorePath, PathAlgebra, PathExecutionError, Term,
+    Verb,
 };
 use owo_colors::OwoColorize;
 use provekit_ir_types::CompositionRefusalMemento;
@@ -172,6 +173,7 @@ pub(crate) fn dispatch_lift_path(
             kit: kit_name.clone(),
             inputs: vec![source_cid],
             depends_on: vec![],
+            verb: Verb::Transform,
         }],
     }));
     let mut registry = KitRegistry::default();

--- a/implementations/rust/provekit-cli/tests/cli_surface.rs
+++ b/implementations/rust/provekit-cli/tests/cli_surface.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use libprovekit::core::{address, Input, Path as CorePath, PathAlgebra, PathDocument};
+use libprovekit::core::{address, Input, Path as CorePath, PathAlgebra, PathDocument, Verb};
 use serde_json::json;
 
 fn provekit_bin() -> PathBuf {
@@ -52,7 +52,7 @@ fn write_executable(path: &Path, text: &str) {
             .unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
         f.sync_all()
             .unwrap_or_else(|e| panic!("sync {}: {e}", path.display()));
-        // f is dropped here — fd closed before chmod
+        // f is dropped here, fd closed before chmod
     }
     #[cfg(unix)]
     {
@@ -437,12 +437,14 @@ done
                 kit: "lift-plugin:path-lift".to_string(),
                 inputs: vec![lift_input_cid],
                 depends_on: vec![],
+                verb: Verb::Transform,
             },
             PathAlgebra {
                 name: "mint".to_string(),
                 kit: "provekit-mint".to_string(),
                 inputs: vec![mint_input_cid],
                 depends_on: vec!["lift".to_string()],
+                verb: Verb::Transform,
             },
         ],
     };

--- a/implementations/rust/provekit-cli/tests/lift_kit_path_integration.rs
+++ b/implementations/rust/provekit-cli/tests/lift_kit_path_integration.rs
@@ -5,8 +5,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use libprovekit::core::{
-    address, execute_path, Dialect, HashMapInputCatalog, Input, KitRegistry, LiftKit,
-    LiftPluginKit, Path as CorePath, PathAlgebra, Term,
+    address, execute_path, Dialect, DomainClaim, HashMapInputCatalog, Input, Kit, KitError,
+    KitRegistry, LiftKit, LiftPluginKit, Path as CorePath, PathAlgebra, Term, Verb, Verdict,
+    Witness,
 };
 use provekit_ir_types::Sort;
 use serde_json::json;
@@ -47,6 +48,74 @@ done
     script
 }
 
+struct ProveStubKit;
+
+impl Kit for ProveStubKit {
+    fn dialect(&self) -> Dialect {
+        Dialect::Other("prove-stub".to_string())
+    }
+
+    fn transform(&self, _input: &Input) -> Result<DomainClaim, KitError> {
+        Err(KitError::Transformation(
+            "prove-stub transform must not be called".to_string(),
+        ))
+    }
+
+    fn prove(&self, claim: DomainClaim) -> Result<DomainClaim, KitError> {
+        let input_claim_cid = claim.cid();
+        let mut proved = claim;
+        let mut premises = proved.premises.clone();
+        premises.push(input_claim_cid.clone());
+        premises.sort();
+        premises.dedup();
+        proved.from = vec![input_claim_cid];
+        proved.premises = premises;
+        proved.verdict = Verdict::Proved;
+        proved.witness = Some(Witness::Proof {
+            tree: json!({"kit": "prove-stub"}),
+        });
+        Ok(proved)
+    }
+
+    fn parse(&self, _input: &Input) -> Result<Term, KitError> {
+        Err(KitError::Serialization(
+            "prove-stub parse is not supported".to_string(),
+        ))
+    }
+
+    fn serialize(&self, _term: &Term) -> Result<Input, KitError> {
+        Err(KitError::Serialization(
+            "prove-stub serialize is not supported".to_string(),
+        ))
+    }
+}
+
+struct TransformOnlyKit {
+    claim: DomainClaim,
+}
+
+impl Kit for TransformOnlyKit {
+    fn dialect(&self) -> Dialect {
+        Dialect::Other("transform-only".to_string())
+    }
+
+    fn transform(&self, _input: &Input) -> Result<DomainClaim, KitError> {
+        Ok(self.claim.clone())
+    }
+
+    fn parse(&self, _input: &Input) -> Result<Term, KitError> {
+        Err(KitError::Serialization(
+            "transform-only parse is not supported".to_string(),
+        ))
+    }
+
+    fn serialize(&self, _term: &Term) -> Result<Input, KitError> {
+        Err(KitError::Serialization(
+            "transform-only serialize is not supported".to_string(),
+        ))
+    }
+}
+
 #[test]
 fn lift_rust_path_executor_matches_existing_cmd_lift_transport_term_cid() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -82,6 +151,7 @@ fn lift_rust_path_executor_matches_existing_cmd_lift_transport_term_cid() {
             kit: "lift-rust".to_string(),
             inputs: vec![source_cid],
             depends_on: vec![],
+            verb: Verb::Transform,
         }],
     }));
     let mut registry = KitRegistry::default();
@@ -127,6 +197,132 @@ fn lift_rust_path_executor_matches_existing_cmd_lift_transport_term_cid() {
         claim.to,
         address(claim.payload.as_ref().expect("payload term"))
     );
+}
+
+#[test]
+fn lift_rust_then_prove_stub_path_routes_second_step_to_kit_prove() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script = fake_lifter(temp.path());
+    let workspace_root = temp
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| temp.path().to_path_buf());
+    let request = json!({
+        "surface": "rust",
+        "workspace_root": workspace_root,
+        "config_path": ".provekit/config.toml",
+        "source_paths": ["."],
+        "options": {
+            "layer": "all",
+            "identifyOnly": false,
+        }
+    });
+    let source = Input::Source {
+        dialect: Dialect::Rust,
+        bytes: serde_json::to_vec(&request).expect("encode lift request"),
+    };
+    let command = vec!["bash".to_string(), script.display().to_string()];
+    let expected_lift_claim = LiftKit::new(
+        Dialect::Rust,
+        "rust",
+        command.clone(),
+        Some(temp.path().to_path_buf()),
+    )
+    .transform(&source)
+    .expect("expected lift transform succeeds");
+    let mut inputs = HashMapInputCatalog::default();
+    let source_cid = inputs.insert(source);
+    let lift_claim_input_cid = address(&Input::Claim(expected_lift_claim.clone()));
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![
+            PathAlgebra {
+                name: "lift".to_string(),
+                kit: "lift-rust".to_string(),
+                inputs: vec![source_cid],
+                depends_on: vec![],
+                verb: Verb::Transform,
+            },
+            PathAlgebra {
+                name: "prove".to_string(),
+                kit: "prove-stub".to_string(),
+                inputs: vec![lift_claim_input_cid],
+                depends_on: vec!["lift".to_string()],
+                verb: Verb::Prove,
+            },
+        ],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        "lift-rust",
+        LiftKit::new(
+            Dialect::Rust,
+            "rust",
+            command,
+            Some(temp.path().to_path_buf()),
+        ),
+    );
+    registry.register("prove-stub", ProveStubKit);
+
+    let claim = execute_path(&path, &registry, &inputs).expect("lift then prove path executes");
+
+    assert_eq!(claim.verdict, Verdict::Proved);
+    assert_eq!(
+        claim.witness,
+        Some(Witness::Proof {
+            tree: json!({"kit": "prove-stub"})
+        })
+    );
+    assert_eq!(claim.from, vec![expected_lift_claim.cid()]);
+}
+
+#[test]
+fn default_kit_prove_refuses_prove_verb_step_with_composition_refusal_memento() {
+    let source = Input::Spec(json!({"fixture": "transform-only"}));
+    let mut inputs = HashMapInputCatalog::default();
+    let source_cid = inputs.insert(source);
+    let claim = libprovekit::core::RustKit::default()
+        .transform(&Input::Term(Term::Const {
+            value: json!({"fixture": "claim"}),
+            sort: Sort::Primitive {
+                name: "Fixture".to_string(),
+            },
+        }))
+        .expect("fixture transform claim");
+    let claim_input_cid = address(&Input::Claim(claim.clone()));
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![
+            PathAlgebra {
+                name: "transform".to_string(),
+                kit: "transform-only".to_string(),
+                inputs: vec![source_cid],
+                depends_on: vec![],
+                verb: Verb::Transform,
+            },
+            PathAlgebra {
+                name: "prove".to_string(),
+                kit: "prove-default".to_string(),
+                inputs: vec![claim_input_cid],
+                depends_on: vec!["transform".to_string()],
+                verb: Verb::Prove,
+            },
+        ],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        "transform-only",
+        TransformOnlyKit {
+            claim: claim.clone(),
+        },
+    );
+    registry.register("prove-default", TransformOnlyKit { claim });
+
+    let error = execute_path(&path, &registry, &inputs)
+        .expect_err("default Kit::prove must refuse Prove verb");
+    let refusal = error
+        .composition_refusal()
+        .expect("Prove verb NotSupported maps to composition refusal");
+
+    assert_eq!(refusal.header.failure_kind, "memento-required-missing");
 }
 
 #[test]


### PR DESCRIPTION
feat(libprovekit): PathAlgebra verb selector + Kit::prove default (closes #1038)

Adds `Verb::{Transform, Prove}` as a first-class field on `PathAlgebra`, makes `Kit::prove` defaulted, and extends `execute_path` to dispatch by verb. CID-stable by construction: existing PathDocument CIDs round-trip byte-identical.

## Substrate changes

### `Verb` enum + `PathAlgebra.verb` field

```rust
pub enum Verb { Transform, Prove }
impl Verb {
    pub fn is_default(&self) -> bool { matches!(self, Verb::Transform) }
}

pub struct PathAlgebra {
    // existing fields ...
    #[serde(default, skip_serializing_if = "Verb::is_default")]
    pub verb: Verb,
}
```

The `skip_serializing_if = "Verb::is_default"` is load-bearing: a `PathAlgebra { verb: Transform }` serializes WITHOUT the `verb` key, so existing PathDocument CIDs round-trip byte-identical. `#[serde(default)]` lets pre-existing PathDocuments deserialize cleanly (missing field = Transform).

### `Kit::prove` defaulted

```rust
fn prove(&self, _claim: DomainClaim) -> Result<DomainClaim, KitError> {
    Err(KitError::NotSupported)
}
```

Was required-no-default. Existing kits that already implement `prove` keep their impls (no regression). Future Transform-only kits (LiftKit, BindKit, LowerKit, future MintKit-transform-path) inherit the default.

### Executor verb dispatch

`execute_path` now matches on `step.verb`:
- `Verb::Transform` → existing `Kit::transform(&input)` path (unchanged).
- `Verb::Prove` → new `Kit::prove(claim)` path. Input materialized as `Input::Claim` from the prior step.

A kit dispatched on Prove that returns `KitError::NotSupported` surfaces as `CompositionRefusalMemento { failure_kind: memento-required-missing }` with non-zero exit. No silent fallback to Transform.

## CID-stability proof

Unit test: a `PathAlgebra` with default verb serialized via JCS produces a CID byte-identical to the same struct serialized with no `verb` field at all:

```
default-Transform CID: blake3-512:01ef83488d1d485abc02a1c421b09abf0b7ef1776a4a8dd05efa10b470a404827a6bc19a83f2fb2479c7e467f3522061d89b3a2a84403c19734acf6bf64bb575
no-verb-field    CID: blake3-512:01ef83488d1d485abc02a1c421b09abf0b7ef1776a4a8dd05efa10b470a404827a6bc19a83f2fb2479c7e467f3522061d89b3a2a84403c19734acf6bf64bb575
```

Same hash → `skip_serializing_if` does its job → existing PathDocuments aren't affected.

A separate test confirms a `PathAlgebra { verb: Prove }` produces a DIFFERENT CID (proving the field is real and CID-affecting when non-default).

## Tests added

- `verb_round_trip_cid_stability`: default Transform CID byte-equals no-verb-field JSON CID.
- `verb_prove_produces_different_cid`: `Prove` verb changes the CID.
- `lift_then_prove_integration`: two-step path `[{verb: Transform, kit: lift-rust}, {verb: Prove, kit: prove-stub}]` routes step 2 to `Kit::prove`, asserts terminal claim's verdict is set.
- `prove_default_refusal_integration`: a kit using the default `Kit::prove` impl on a Prove-verb step surfaces `CompositionRefusalMemento { failure_kind: memento-required-missing }` with non-zero exit.

## Gates

- `cargo test -p libprovekit`: passed.
- `cargo test -p provekit-cli`: passed (mint tests, lift_kit_path_integration, trinity_roundtrip_test all byte-identical).
- `tools/spec-cid-lint.sh`: exit 0.
- Change-scope em/en-dash sweep on the 9 dirty files: zero.

## Non-goals respected

- No new path executor or registry. Extended the one in `libprovekit::core::path_executor`.
- No verb arms beyond Transform/Prove (no verify, link, compose — those are future).
- No change to `DomainClaim` semantics.
- No CLI command migration.
- No body-template catalog data changes.
- No new memento family.

## Forward-compat with #1040

This PR's libprovekit changes don't add a new `register()` callsite (verb-selector is an enum + match arm + trait default; the existing kit registration is unchanged). When #1040 (substrate ConformanceDeclaration) lands, no rebase work needed on this branch's surface.

Prerequisites: #1033 (PR #1036 merged for path_executor).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
