### PR TITLE
feat(libprovekit): BindKit wraps binder machinery as a registered Kit (closes #1037)

### DIFF
--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -1,0 +1,1086 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use provekit_canonicalizer::blake3_512_of;
+use provekit_ir_types::{
+    IrFormula, IrTerm, PromotionDecisionEnvelope, PromotionDecisionHeader,
+    PromotionDecisionMemento, PromotionDecisionMetadata, PromotionGate, PromotionResult, Sort,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as Json};
+use thiserror::Error;
+
+use super::primitives::address;
+use super::traits::{Kit, KitError};
+use super::types::{
+    memento_from_parts, Cid, Contract, Dialect, DomainClaim, DomainKind, Input, Term, Verdict,
+};
+
+/// Options for the substrate bind pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindOptions {
+    /// Source language hint for diagnostics and named-term metadata.
+    pub lang: String,
+}
+
+impl Default for BindOptions {
+    fn default() -> Self {
+        Self {
+            lang: "auto".to_string(),
+        }
+    }
+}
+
+/// Core Kit adapter for the existing substrate binder.
+#[derive(Debug, Clone, Default)]
+pub struct BindKit {
+    options: BindOptions,
+}
+
+impl BindKit {
+    /// Build a bind Kit using the supplied binder options.
+    pub fn new(options: BindOptions) -> Self {
+        Self { options }
+    }
+
+    fn bind_term_from_input(&self, input: &Input) -> Result<DomainClaim, BindError> {
+        let Input::Term(term) = input else {
+            return Err(BindError::Failed(
+                "bind kit expects Input::Term".to_string(),
+            ));
+        };
+        let term_json = term_json_from_term(term)?;
+        let named = bind_term_document(term_json, &self.options)?;
+        let named_value = serde_json::to_value(&named)
+            .map_err(|error| BindError::Failed(format!("serialize named term JSON: {error}")))?;
+        let named_cid = named_term_document_cid(&named)?;
+        let payload = Term::Const {
+            value: named_value.clone(),
+            sort: primitive_sort("NamedTermDocument"),
+        };
+        let contract = bind_response_contract(&named_value, &named_cid);
+
+        Ok(DomainClaim {
+            domain: DomainKind::Other("bind".to_string()),
+            contract,
+            artifacts: vec![named_cid.clone()],
+            from: vec![address(term)],
+            premises: vec![],
+            to: named_cid,
+            witness: None,
+            payload: Some(payload),
+            verdict: Verdict::Unresolved,
+            attestation: None,
+        })
+    }
+}
+
+impl Kit for BindKit {
+    fn dialect(&self) -> Dialect {
+        Dialect::Other("bind-default".to_string())
+    }
+
+    fn transform(&self, input: &Input) -> Result<DomainClaim, KitError> {
+        self.bind_term_from_input(input)
+            .map_err(|error| KitError::Transformation(error.to_string()))
+    }
+
+    fn prove(&self, claim: DomainClaim) -> Result<DomainClaim, KitError> {
+        Ok(claim)
+    }
+
+    fn parse(&self, input: &Input) -> Result<Term, KitError> {
+        self.transform(input)?
+            .payload
+            .ok_or_else(|| KitError::Serialization("bind claim missing term payload".to_string()))
+    }
+
+    fn serialize(&self, term: &Term) -> Result<Input, KitError> {
+        Ok(Input::Term(term.clone()))
+    }
+}
+
+/// Errors from the substrate bind Kit.
+#[derive(Debug, Error)]
+pub enum BindError {
+    /// Binding the term document failed.
+    #[error("{0}")]
+    Failed(String),
+}
+
+impl From<String> for BindError {
+    fn from(value: String) -> Self {
+        Self::Failed(value)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BindLiftEntry {
+    #[serde(default)]
+    pub kind: String,
+    pub file: String,
+    pub fn_name: String,
+    #[serde(default)]
+    pub fn_line: u64,
+    #[serde(default)]
+    pub attr_pre: Option<String>,
+    #[serde(default)]
+    pub attr_post: Option<String>,
+    #[serde(default)]
+    pub concept_annotation: Option<String>,
+    #[serde(default)]
+    pub param_names: Vec<String>,
+    #[serde(default)]
+    pub param_types: Vec<String>,
+    #[serde(default)]
+    pub return_type: String,
+    #[serde(default)]
+    pub term_shape: Json,
+    #[serde(default)]
+    pub term_shape_cid: String,
+    #[serde(default)]
+    pub witnesses: Vec<BindContractWitness>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BindContractWitness {
+    #[serde(default)]
+    pub role: String,
+    #[serde(default)]
+    pub predicate: Option<Json>,
+    #[serde(default)]
+    pub predicate_text: Option<String>,
+    #[serde(default)]
+    pub source_kind: String,
+    #[serde(default)]
+    pub confidence_basis_points: Option<u16>,
+    #[serde(default)]
+    pub line: Option<u64>,
+    #[serde(default)]
+    pub col: Option<u64>,
+    #[serde(default)]
+    pub extension_fields: BTreeMap<String, Json>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedTermDocument {
+    pub kind: String,
+    #[serde(rename = "promotionDecisionMementos")]
+    pub promotion_decision_mementos: Vec<PromotionDecisionMemento>,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "sourceLanguage")]
+    pub source_language: String,
+    pub terms: Vec<NamedTerm>,
+    #[serde(rename = "workspaceRoot", skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedTerm {
+    #[serde(rename = "conceptName")]
+    pub concept_name: String,
+    #[serde(rename = "dischargeVerdict")]
+    pub discharge_verdict: String,
+    pub file: String,
+    pub function: String,
+    pub name: String,
+    #[serde(
+        default,
+        rename = "namedTermTree",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub named_term_tree: Option<NamedTermTree>,
+    #[serde(rename = "paramTypes")]
+    pub param_types: Vec<String>,
+    pub params: Vec<String>,
+    #[serde(rename = "returnType")]
+    pub return_type: String,
+    #[serde(rename = "siteMementoCid")]
+    pub site_memento_cid: String,
+    #[serde(rename = "termShape")]
+    pub term_shape: Json,
+    #[serde(rename = "termShapeCid")]
+    pub term_shape_cid: String,
+    pub witnesses: Vec<NamedWitness>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedTermTree {
+    pub args: Vec<NamedTermTree>,
+    #[serde(rename = "conceptName")]
+    pub concept_name: String,
+    #[serde(rename = "operationKind")]
+    pub operation_kind: String,
+    #[serde(rename = "shapeCid")]
+    pub shape_cid: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedWitness {
+    pub predicate: Json,
+    #[serde(rename = "predicateText")]
+    pub predicate_text: String,
+    pub role: String,
+    #[serde(rename = "sourceKind")]
+    pub source_kind: String,
+}
+
+/// Bind a lifted ProofIR term document into a named-term document.
+pub fn bind_term_document(
+    term_json: &Json,
+    options: &BindOptions,
+) -> Result<NamedTermDocument, BindError> {
+    let entries = bind_lift_entries(term_json)?;
+    let source_language = source_language(term_json, options);
+    let workspace_root = workspace_root(term_json);
+
+    let catalog = seed_catalog();
+    let mut seen_names: BTreeSet<String> = BTreeSet::new();
+    let mut terms = Vec::with_capacity(entries.len());
+    let mut decisions = Vec::new();
+    let mut operation_namer = UnnamedConceptNamer::default();
+    for (idx, entry) in entries.into_iter().enumerate() {
+        let concept_name = concept_name_for(&entry, idx + 1, &catalog);
+        let name = unique_name(&concept_name, &mut seen_names);
+        let term_shape_cid = if entry.term_shape_cid.trim().is_empty() {
+            crate::canonical::json_cid(&entry.term_shape)
+                .map_err(|e| format!("cid term shape for {}: {e}", entry.fn_name))?
+        } else {
+            entry.term_shape_cid.clone()
+        };
+        let site_memento_cid = site_cid(&entry, &name, &term_shape_cid)?;
+        let witnesses = named_witnesses(&entry);
+        let promoted_cid = blake3_512_of(format!("provekit-bind/promoted/{name}").as_bytes());
+        let named_term_tree =
+            named_operation_tree(&entry.term_shape, &catalog, &mut operation_namer)?;
+        decisions.extend(promotion_decisions(
+            &term_shape_cid,
+            &promoted_cid,
+            &site_memento_cid,
+            &witnesses,
+        )?);
+        terms.push(NamedTerm {
+            concept_name,
+            discharge_verdict: if witnesses.is_empty() {
+                "loudly-bounded-lossy".to_string()
+            } else {
+                "exact".to_string()
+            },
+            file: entry.file,
+            function: entry.fn_name,
+            name,
+            named_term_tree,
+            param_types: entry.param_types,
+            params: entry.param_names,
+            return_type: if entry.return_type.is_empty() {
+                "()".to_string()
+            } else {
+                entry.return_type
+            },
+            site_memento_cid,
+            term_shape: entry.term_shape,
+            term_shape_cid,
+            witnesses,
+        });
+    }
+
+    Ok(NamedTermDocument {
+        kind: "named-term-document".to_string(),
+        promotion_decision_mementos: decisions,
+        schema_version: "1".to_string(),
+        source_language,
+        terms,
+        workspace_root,
+    })
+}
+
+/// Return the canonical named-term document CID emitted by `cmd_bind`.
+pub fn named_term_document_cid(named: &NamedTermDocument) -> Result<Cid, BindError> {
+    let cid = crate::canonical::serializable_cid(named)
+        .map_err(|error| BindError::Failed(format!("cid named term JSON: {error}")))?;
+    Cid::try_from(cid).map_err(|error| BindError::Failed(error.to_string()))
+}
+
+fn term_json_from_term(term: &Term) -> Result<&Json, BindError> {
+    match term {
+        Term::Const { value, .. } => Ok(value),
+        _ => Err(BindError::Failed(
+            "bind kit expects a ProofIR JSON const term".to_string(),
+        )),
+    }
+}
+
+fn bind_response_contract(named: &Json, named_cid: &Cid) -> Contract {
+    let pre = IrFormula::Atomic {
+        name: "true".to_string(),
+        args: vec![],
+    };
+    let post = IrFormula::Atomic {
+        name: "=".to_string(),
+        args: vec![
+            IrTerm::Var {
+                name: "result".to_string(),
+            },
+            IrTerm::Const {
+                value: named.clone(),
+                sort: primitive_sort("NamedTermDocument"),
+            },
+        ],
+    };
+
+    memento_from_parts(
+        "bind::default::named-term-document".to_string(),
+        vec!["term".to_string()],
+        vec![primitive_sort("LiftPluginResponse")],
+        primitive_sort("NamedTermDocument"),
+        pre,
+        post,
+        Some(named_cid.as_str().to_string()),
+    )
+}
+
+fn bind_lift_entries(term_json: &Json) -> Result<Vec<BindLiftEntry>, BindError> {
+    if term_json.get("kind").and_then(Json::as_str) == Some("named-term-document") {
+        return Err(BindError::Failed(
+            "input is already named; bind expects ProofIR term JSON from lift".to_string(),
+        ));
+    }
+    let ir = term_json
+        .get("ir")
+        .and_then(Json::as_array)
+        .ok_or_else(|| BindError::Failed("ProofIR document missing `ir` array".to_string()))?;
+    let mut out = Vec::new();
+    for item in ir {
+        if item.get("kind").and_then(Json::as_str) != Some("bind-lift-entry") {
+            continue;
+        }
+        let entry = serde_json::from_value::<BindLiftEntry>(item.clone())
+            .map_err(|e| BindError::Failed(format!("parse bind-lift-entry: {e}")))?;
+        out.push(entry);
+    }
+    Ok(out)
+}
+
+fn source_language(term_json: &Json, options: &BindOptions) -> String {
+    term_json
+        .get("sourceLanguage")
+        .or_else(|| term_json.get("surface"))
+        .and_then(Json::as_str)
+        .map(str::to_string)
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| {
+            if options.lang == "auto" {
+                "unknown".to_string()
+            } else {
+                options.lang.clone()
+            }
+        })
+}
+
+fn workspace_root(term_json: &Json) -> Option<String> {
+    term_json
+        .get("workspaceRoot")
+        .or_else(|| term_json.get("workspace_root"))
+        .and_then(Json::as_str)
+        .map(str::to_string)
+}
+
+fn concept_name_for(entry: &BindLiftEntry, ordinal: usize, catalog: &Catalog) -> String {
+    if let Some(annotation) = entry.concept_annotation.as_ref().map(|name| {
+        if name.starts_with("concept:") {
+            name.clone()
+        } else {
+            format!("concept:{name}")
+        }
+    }) {
+        return annotation;
+    }
+    let shape = TermShape::from_kit(entry.term_shape.clone(), entry.term_shape_cid.clone());
+    catalog
+        .match_shape(&shape.shape_cid(), &shape)
+        .map(|entry| entry.name.clone())
+        .unwrap_or_else(|| format!("UNNAMED-CONCEPT-{ordinal:x}"))
+}
+
+#[derive(Debug, Default)]
+struct UnnamedConceptNamer {
+    next: usize,
+}
+
+impl UnnamedConceptNamer {
+    fn next(&mut self) -> String {
+        self.next += 1;
+        format!("UNNAMED-CONCEPT-{:x}", self.next)
+    }
+}
+
+fn named_operation_tree(
+    value: &Json,
+    catalog: &Catalog,
+    namer: &mut UnnamedConceptNamer,
+) -> Result<Option<NamedTermTree>, BindError> {
+    let Some(operation_kind) = operation_kind(value) else {
+        return Ok(None);
+    };
+    let operation_shape = operation_lookup_shape(&operation_kind);
+    let shape_cid = crate::canonical::json_cid(&operation_shape)
+        .map_err(|e| format!("cid operation shape `{operation_kind}`: {e}"))?;
+    let shape = TermShape::from_kit(operation_shape, shape_cid.clone());
+    let concept_name = catalog
+        .match_shape(&shape.shape_cid(), &shape)
+        .map(|entry| entry.name.clone())
+        .unwrap_or_else(|| namer.next());
+    let args = child_operation_trees(value, catalog, namer)?;
+    Ok(Some(NamedTermTree {
+        args,
+        concept_name,
+        operation_kind,
+        shape_cid,
+    }))
+}
+
+fn child_operation_trees(
+    value: &Json,
+    catalog: &Catalog,
+    namer: &mut UnnamedConceptNamer,
+) -> Result<Vec<NamedTermTree>, BindError> {
+    let mut out = Vec::new();
+    collect_child_operation_trees(value, catalog, namer, &mut out)?;
+    Ok(out)
+}
+
+fn collect_child_operation_trees(
+    value: &Json,
+    catalog: &Catalog,
+    namer: &mut UnnamedConceptNamer,
+    out: &mut Vec<NamedTermTree>,
+) -> Result<(), BindError> {
+    match value {
+        Json::Array(values) => {
+            for child in values {
+                collect_operation_tree_or_descendants(child, catalog, namer, out)?;
+            }
+        }
+        Json::Object(object) => {
+            for (key, child) in object {
+                if key == "kind" || key == "op" {
+                    continue;
+                }
+                collect_operation_tree_or_descendants(child, catalog, namer, out)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn collect_operation_tree_or_descendants(
+    value: &Json,
+    catalog: &Catalog,
+    namer: &mut UnnamedConceptNamer,
+    out: &mut Vec<NamedTermTree>,
+) -> Result<(), BindError> {
+    if let Some(tree) = named_operation_tree(value, catalog, namer)? {
+        out.push(tree);
+        return Ok(());
+    }
+    collect_child_operation_trees(value, catalog, namer, out)
+}
+
+fn operation_kind(value: &Json) -> Option<String> {
+    let raw_kind = value.get("kind").and_then(Json::as_str)?.trim();
+    if raw_kind.is_empty() {
+        return None;
+    }
+    let raw_kind = raw_kind
+        .rsplit_once(':')
+        .map_or(raw_kind, |(_, suffix)| suffix);
+    let normalized = match raw_kind {
+        "body" | "block" => "seq",
+        "if" => "conditional",
+        "let" => "decl",
+        "bin" => value
+            .get("op")
+            .and_then(Json::as_str)
+            .and_then(binary_operator_kind)
+            .unwrap_or("bin"),
+        "rel" => value
+            .get("op")
+            .and_then(Json::as_str)
+            .and_then(binary_operator_kind)
+            .unwrap_or("rel"),
+        other => other,
+    };
+    Some(normalized.replace('_', "-"))
+}
+
+fn binary_operator_kind(op: &str) -> Option<&'static str> {
+    match op {
+        "+" => Some("add"),
+        "-" => Some("sub"),
+        "*" => Some("mul"),
+        "/" => Some("div"),
+        "%" => Some("mod"),
+        "==" => Some("eq"),
+        "!=" => Some("ne"),
+        "<" => Some("lt"),
+        "<=" => Some("le"),
+        ">" => Some("gt"),
+        ">=" => Some("ge"),
+        "&&" => Some("and"),
+        "||" => Some("or"),
+        _ => None,
+    }
+}
+
+fn operation_lookup_shape(operation_kind: &str) -> Json {
+    json!({
+        "kind": "operation-shape",
+        "operator": operation_kind,
+    })
+}
+
+fn unique_name(concept_name: &str, seen: &mut BTreeSet<String>) -> String {
+    let base = concept_name
+        .strip_prefix("concept:")
+        .unwrap_or(concept_name)
+        .to_string();
+    if seen.insert(base.clone()) {
+        return base;
+    }
+    for idx in 2usize.. {
+        let candidate = format!("{base}-{idx}");
+        if seen.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+    unreachable!("unbounded unique-name loop")
+}
+
+fn named_witnesses(entry: &BindLiftEntry) -> Vec<NamedWitness> {
+    let mut witnesses = Vec::new();
+    if entry.witnesses.is_empty() {
+        if let Some(pre) = entry.attr_pre.as_deref() {
+            witnesses.push(named_witness("pre", pre, "annotation"));
+        }
+        if let Some(post) = entry.attr_post.as_deref() {
+            witnesses.push(named_witness("post", post, "annotation"));
+        }
+        return witnesses;
+    }
+    entry
+        .witnesses
+        .iter()
+        .map(|witness| {
+            let predicate_text = witness
+                .predicate_text
+                .clone()
+                .or_else(|| witness.predicate.as_ref().map(Json::to_string))
+                .unwrap_or_else(|| "true".to_string());
+            NamedWitness {
+                predicate: witness
+                    .predicate
+                    .clone()
+                    .unwrap_or_else(|| json!({"kind": "text", "text": predicate_text})),
+                predicate_text,
+                role: if witness.role.trim().is_empty() {
+                    "unknown".to_string()
+                } else {
+                    witness.role.clone()
+                },
+                source_kind: if witness.source_kind.trim().is_empty() {
+                    "unspecified".to_string()
+                } else {
+                    witness.source_kind.clone()
+                },
+            }
+        })
+        .collect()
+}
+
+fn named_witness(role: &str, predicate_text: &str, source_kind: &str) -> NamedWitness {
+    NamedWitness {
+        predicate: json!({"kind": "text", "text": predicate_text}),
+        predicate_text: predicate_text.to_string(),
+        role: role.to_string(),
+        source_kind: source_kind.to_string(),
+    }
+}
+
+fn site_cid(entry: &BindLiftEntry, name: &str, term_shape_cid: &str) -> Result<String, BindError> {
+    let value = json!({
+        "file": entry.file,
+        "function": entry.fn_name,
+        "name": name,
+        "termShapeCid": term_shape_cid,
+    });
+    crate::canonical::json_cid(&value).map_err(|e| BindError::Failed(e.to_string()))
+}
+
+fn promotion_decisions(
+    candidate_cid: &str,
+    promoted_cid: &str,
+    site_memento_cid: &str,
+    witnesses: &[NamedWitness],
+) -> Result<Vec<PromotionDecisionMemento>, BindError> {
+    witnesses
+        .iter()
+        .enumerate()
+        .map(|(idx, witness)| {
+            let evidence_cid = crate::canonical::json_cid(&json!({
+                "predicate": witness.predicate,
+                "predicateText": witness.predicate_text,
+                "role": witness.role,
+                "siteMementoCid": site_memento_cid,
+                "sourceKind": witness.source_kind,
+            }))
+            .map_err(|e| BindError::Failed(e.to_string()))?;
+            let mut decision = PromotionDecisionMemento {
+                envelope: PromotionDecisionEnvelope {
+                    declared_at: "2026-05-15T00:00:00.000Z".to_string(),
+                    signature: String::new(),
+                    signer: "builtin:provekit-bind".to_string(),
+                },
+                header: PromotionDecisionHeader {
+                    candidate_cid: candidate_cid.to_string(),
+                    cid: String::new(),
+                    decider_cid: "builtin:provekit-bind".to_string(),
+                    decision_payload: json!({
+                        "evidence_count": 1,
+                        "ordinal": idx,
+                        "result": "admitted"
+                    }),
+                    evidence_cids: vec![evidence_cid],
+                    gate: PromotionGate::Proof,
+                    kind: "promotion-decision".to_string(),
+                    policy_cid: "builtin:provekit-bind/default-policy".to_string(),
+                    promoted_cid: promoted_cid.to_string(),
+                    result: PromotionResult::Admitted,
+                    schema_version: "1".to_string(),
+                },
+                metadata: PromotionDecisionMetadata {
+                    counterexample_cids: None,
+                    note: Some("bind admitted lifted evidence into named term".to_string()),
+                    source_url: None,
+                },
+            };
+            decision.header.cid = decision
+                .recompute_header_cid()
+                .map_err(|err| BindError::Failed(err.to_string()))?;
+            decision
+                .validate()
+                .map_err(|err| BindError::Failed(err.to_string()))?;
+            Ok(decision)
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+struct TermShape {
+    value: Json,
+    cid_cached: String,
+}
+
+impl TermShape {
+    fn from_kit(value: Json, cid: String) -> Self {
+        Self {
+            value,
+            cid_cached: cid,
+        }
+    }
+
+    fn shape_cid(&self) -> String {
+        self.cid_cached.clone()
+    }
+
+    fn classify(&self) -> &'static str {
+        classify_value(&self.value)
+    }
+}
+
+fn classify_value(value: &Json) -> &'static str {
+    let kind = value.get("kind").and_then(Json::as_str).unwrap_or("");
+    if kind != "body" {
+        return "unknown";
+    }
+    let stmts = value
+        .get("stmts")
+        .and_then(Json::as_array)
+        .map(|arr| arr.as_slice())
+        .unwrap_or(&[]);
+    let mut has_loop = false;
+    let mut has_if = false;
+    for stmt in stmts {
+        let kind = stmt.get("kind").and_then(Json::as_str).unwrap_or("");
+        match kind {
+            "while" | "for" => has_loop = true,
+            "if" => has_if = true,
+            _ => {}
+        }
+    }
+    if has_loop {
+        "retry-loop"
+    } else if has_if {
+        "guard-then-commit"
+    } else {
+        "unknown"
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CatalogEntry {
+    name: String,
+    shape_cid: String,
+    classification: &'static str,
+}
+
+#[derive(Debug, Clone)]
+struct Catalog {
+    entries: Vec<CatalogEntry>,
+}
+
+impl Catalog {
+    fn match_shape(&self, shape_cid: &str, shape: &TermShape) -> Option<&CatalogEntry> {
+        if let Some(entry) = self
+            .entries
+            .iter()
+            .find(|entry| entry.shape_cid == shape_cid)
+        {
+            return Some(entry);
+        }
+        let classification = shape.classify();
+        if classification == "unknown" {
+            return None;
+        }
+        self.entries
+            .iter()
+            .find(|entry| entry.classification == classification)
+    }
+}
+
+fn seed_catalog() -> Catalog {
+    let mut entries = Vec::new();
+    if let Some(root) = find_concept_shapes_root() {
+        entries.extend(load_catalog_abstractions(&root));
+        entries.extend(load_catalog_specs(&root));
+    }
+    entries.extend(legacy_classification_entries());
+    Catalog { entries }
+}
+
+fn legacy_classification_entries() -> Vec<CatalogEntry> {
+    vec![
+        CatalogEntry {
+            name: "concept:retry-with-bounded-attempts".to_string(),
+            shape_cid: String::new(),
+            classification: "retry-loop",
+        },
+        CatalogEntry {
+            name: "concept:guard-then-commit".to_string(),
+            shape_cid: String::new(),
+            classification: "guard-then-commit",
+        },
+    ]
+}
+
+fn find_concept_shapes_root() -> Option<PathBuf> {
+    let mut starts = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        starts.push(cwd);
+    }
+    if let Some(manifest_dir) = option_env!("CARGO_MANIFEST_DIR") {
+        starts.push(PathBuf::from(manifest_dir));
+    }
+    for start in starts {
+        for ancestor in start.ancestors() {
+            let candidate = ancestor.join("menagerie").join("concept-shapes");
+            if candidate.is_dir() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn load_catalog_abstractions(concept_shapes_root: &Path) -> Vec<CatalogEntry> {
+    let dir = concept_shapes_root.join("catalog").join("abstractions");
+    catalog_json_files(&dir, ".json")
+        .into_iter()
+        .filter_map(|path| load_catalog_abstraction(&path))
+        .collect()
+}
+
+fn load_catalog_abstraction(path: &Path) -> Option<CatalogEntry> {
+    let doc = read_json_file(path)?;
+    let name = doc
+        .get("memento")
+        .and_then(|memento| memento.get("operator"))
+        .and_then(Json::as_str)?
+        .to_string();
+    let shape_cid = doc
+        .get("cid")
+        .and_then(Json::as_str)
+        .map(str::to_string)
+        .or_else(|| shape_cid_from_abstraction_filename(path))?;
+    Some(CatalogEntry {
+        name,
+        shape_cid,
+        classification: "catalog-shape",
+    })
+}
+
+fn load_catalog_specs(concept_shapes_root: &Path) -> Vec<CatalogEntry> {
+    let dir = concept_shapes_root.join("specs");
+    catalog_json_files(&dir, ".spec.json")
+        .into_iter()
+        .flat_map(|path| load_catalog_spec(&path))
+        .collect()
+}
+
+fn load_catalog_spec(path: &Path) -> Vec<CatalogEntry> {
+    let Some(doc) = read_json_file(path) else {
+        return Vec::new();
+    };
+    let Some(name) = doc
+        .get("fn_name")
+        .and_then(Json::as_str)
+        .map(str::to_string)
+    else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    if let Ok(shape_cid) = crate::canonical::json_cid(&doc) {
+        entries.push(CatalogEntry {
+            name: name.clone(),
+            shape_cid,
+            classification: "catalog-shape",
+        });
+    }
+    if name.starts_with("concept:") {
+        if let Some(operator) = doc
+            .get("post")
+            .and_then(|post| post.get("operator"))
+            .and_then(Json::as_str)
+            .map(|operator| operator.replace('_', "-"))
+        {
+            if let Ok(shape_cid) = crate::canonical::json_cid(&operation_lookup_shape(&operator)) {
+                entries.push(CatalogEntry {
+                    name,
+                    shape_cid,
+                    classification: "catalog-shape",
+                });
+            }
+        }
+    }
+    entries
+}
+
+fn catalog_json_files(dir: &Path, suffix: &str) -> Vec<PathBuf> {
+    if !dir.is_dir() {
+        return Vec::new();
+    }
+    let mut paths = Vec::new();
+    collect_catalog_json_files(dir, suffix, &mut paths);
+    paths.sort();
+    paths
+}
+
+fn collect_catalog_json_files(dir: &Path, suffix: &str, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_catalog_json_files(&path, suffix, out);
+        } else if file_type.is_file()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(suffix))
+        {
+            out.push(path);
+        }
+    }
+}
+
+fn read_json_file(path: &Path) -> Option<Json> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn shape_cid_from_abstraction_filename(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_str()?;
+    let (_, cid_hex_with_suffix) = file_name.split_once(".blake3-512:")?;
+    let cid_hex = cid_hex_with_suffix.strip_suffix(".json")?;
+    Some(format!("blake3-512:{cid_hex}"))
+}
+
+fn primitive_sort(name: &str) -> Sort {
+    Sort::Primitive {
+        name: name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_names_lifted_entries_without_plugin_dispatch() {
+        let term = json!({
+            "kind": "ir-document",
+            "workspaceRoot": "/tmp/demo",
+            "ir": [{
+                "kind": "bind-lift-entry",
+                "file": "src/lib.rs",
+                "fn_name": "f",
+                "concept_annotation": "demo",
+                "param_names": ["x"],
+                "param_types": ["i64"],
+                "return_type": "i64",
+                "term_shape": {"kind": "op", "name": "demo"},
+                "witnesses": [{
+                    "role": "post",
+                    "predicate_text": "out == x",
+                    "source_kind": "annotation"
+                }]
+            }]
+        });
+        let named = bind_term_document(
+            &term,
+            &BindOptions {
+                lang: "rust".to_string(),
+            },
+        )
+        .expect("bind succeeds");
+        assert_eq!(named.kind, "named-term-document");
+        assert_eq!(named.terms[0].concept_name, "concept:demo");
+        assert_eq!(named.terms[0].function, "f");
+        assert_eq!(named.promotion_decision_mementos.len(), 1);
+    }
+
+    #[test]
+    fn seed_catalog_loads_real_concept_shape_catalog() {
+        let catalog = seed_catalog();
+        assert!(
+            catalog.entries.len() > 10,
+            "catalog should load real concept-shape entries, got {}",
+            catalog.entries.len()
+        );
+        assert!(
+            catalog
+                .entries
+                .iter()
+                .any(|entry| entry.name == "concept:identity"),
+            "catalog should include concept:identity"
+        );
+        assert!(
+            catalog
+                .entries
+                .iter()
+                .any(|entry| entry.name == "concept:new"),
+            "catalog should include algorithm-tier concept:new"
+        );
+    }
+
+    #[test]
+    fn catalog_matches_loaded_shape_cid_before_legacy_classification() {
+        let catalog = seed_catalog();
+        let identity_shape_cid = "blake3-512:6920f6e26184ca316f3dce6c02690b515c11b3d96d3b476bb5abe67cb55e1885031484c3add8a5f26b630e305ad3fe41eed10acca2e141898f9d6629c278867f";
+        let unknown_shape = TermShape::from_kit(
+            json!({
+                "kind": "body",
+                "stmts": []
+            }),
+            identity_shape_cid.to_string(),
+        );
+        let matched = catalog
+            .match_shape(identity_shape_cid, &unknown_shape)
+            .expect("identity CID should match before classify fallback");
+        assert_eq!(matched.name, "concept:identity");
+    }
+
+    #[test]
+    fn bind_names_blake3_512_of_operations_from_catalog() {
+        let term = json!({
+            "kind": "ir-document",
+            "sourceLanguage": "rust",
+            "workspaceRoot": "/tmp/provekit-bind-test",
+            "ir": [{
+                "kind": "bind-lift-entry",
+                "file": "implementations/rust/provekit-canonicalizer/src/hash.rs",
+                "fn_name": "blake3_512_of",
+                "param_names": ["bytes"],
+                "param_types": ["& [u8]"],
+                "return_type": "String",
+                "term_shape": {
+                    "kind": "body",
+                    "stmts": [
+                        {"kind": "let"},
+                        {"kind": "call"},
+                        {"kind": "let"},
+                        {"kind": "call"},
+                        {"kind": "let"},
+                        {"kind": "let"},
+                        {"kind": "call"},
+                        {"kind": "call"},
+                        {"kind": "opaque"}
+                    ]
+                },
+                "witnesses": []
+            }]
+        });
+
+        let named = bind_term_document(
+            &term,
+            &BindOptions {
+                lang: "rust".to_string(),
+            },
+        )
+        .expect("bind succeeds");
+        let named_json = serde_json::to_value(&named).expect("named term serializes");
+        let tree = named_json["terms"][0]
+            .get("namedTermTree")
+            .expect("operation-level named term tree is emitted");
+        let nested_names = serde_json::to_string(tree).expect("tree stringifies");
+        let mut operation_concepts = Vec::new();
+        collect_tree_concept_names(tree, &mut operation_concepts);
+        operation_concepts.sort();
+        operation_concepts.dedup();
+        eprintln!(
+            "operation-level matches for blake3_512_of: {}",
+            operation_concepts.join(", ")
+        );
+
+        assert!(
+            nested_names.contains("\"conceptName\":\"concept:call\""),
+            "blake3_512_of call operations should match catalog concept:call; tree={nested_names}"
+        );
+        assert!(
+            tree.get("args")
+                .and_then(Json::as_array)
+                .is_some_and(|args| !args.is_empty()),
+            "operation tree should retain recursive children; tree={tree}"
+        );
+    }
+
+    fn collect_tree_concept_names(tree: &Json, out: &mut Vec<String>) {
+        if let Some(name) = tree.get("conceptName").and_then(Json::as_str) {
+            if name.starts_with("concept:") {
+                out.push(name.to_string());
+            }
+        }
+        if let Some(args) = tree.get("args").and_then(Json::as_array) {
+            for arg in args {
+                collect_tree_concept_names(arg, out);
+            }
+        }
+    }
+}

--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -18,6 +18,7 @@
 //! composition obligations. `commit` is `compose(parent, change)` followed by
 //! `sign`.
 
+pub mod bind;
 pub mod lift_plugin;
 pub mod lower_plugin;
 pub mod path_executor;
@@ -27,6 +28,10 @@ pub mod traits;
 pub mod types;
 pub mod verbs;
 
+pub use bind::{
+    bind_term_document, named_term_document_cid, BindContractWitness, BindError, BindKit,
+    BindLiftEntry, BindOptions, NamedTerm, NamedTermDocument, NamedTermTree, NamedWitness,
+};
 pub use lift_plugin::{LiftKit, LiftPluginKit, LiftPluginKitError, LiftPluginKitSession};
 pub use lower_plugin::{
     LowerKit, RealizeContractPayload, RealizeContractWitness, RealizeRequest, RealizeTransport,

--- a/implementations/rust/libprovekit/src/core/path_executor.rs
+++ b/implementations/rust/libprovekit/src/core/path_executor.rs
@@ -53,7 +53,7 @@ pub fn execute_path(
             .get(&step.kit)
             .ok_or_else(|| PathExecutionError::Refused(Box::new(missing_kit_refusal(step))))?;
         let step_input = step_input(step, inputs, &materialized_inputs)?;
-        let claim = match step.verb {
+        let mut claim = match step.verb {
             Verb::Transform => kit
                 .transform(&step_input)
                 .map_err(PathExecutionError::Kit)?,
@@ -67,6 +67,7 @@ pub fn execute_path(
                 kit.prove(claim).map_err(|error| prove_error(step, error))?
             }
         };
+        claim.premises.extend(step_premises(step, &claims_by_step)?);
         if let Some(term) = claim.payload.clone() {
             materialized_inputs.insert(claim.to.clone(), Input::Term(term));
         }
@@ -110,6 +111,26 @@ fn step_input(
     Err(PathExecutionError::Refused(Box::new(
         missing_input_refusal(step, cid),
     )))
+}
+
+fn step_premises(
+    step: &PathAlgebra,
+    claims_by_step: &BTreeMap<String, DomainClaim>,
+) -> Result<Vec<Cid>, PathExecutionError> {
+    step.depends_on
+        .iter()
+        .map(|dependency| {
+            claims_by_step
+                .get(dependency)
+                .map(DomainClaim::cid)
+                .ok_or_else(|| {
+                    PathExecutionError::UnsupportedInput(format!(
+                        "path step `{}` dependency `{dependency}` did not execute",
+                        step.name
+                    ))
+                })
+        })
+        .collect()
 }
 
 /// Errors from path execution.

--- a/implementations/rust/libprovekit/tests/bind_kit.rs
+++ b/implementations/rust/libprovekit/tests/bind_kit.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use libprovekit::core::{address, bind_term_document, BindKit, BindOptions, Cid, Input, Kit, Term};
+use provekit_ir_types::Sort;
+use serde_json::{json, Value};
+
+fn primitive_sort(name: &str) -> Sort {
+    Sort::Primitive {
+        name: name.to_string(),
+    }
+}
+
+fn bind_input_value() -> Value {
+    json!({
+        "kind": "ir-document",
+        "sourceLanguage": "rust",
+        "workspaceRoot": "/tmp/provekit-bind-kit-test",
+        "ir": [{
+            "kind": "bind-lift-entry",
+            "file": "src/lib.rs",
+            "fn_name": "deposit",
+            "fn_line": 14,
+            "concept_annotation": "deposit-then-balance",
+            "param_names": ["balance", "amount"],
+            "param_types": ["i64", "i64"],
+            "return_type": "i64",
+            "term_shape": {
+                "kind": "body",
+                "stmts": [
+                    {"kind": "let"},
+                    {"kind": "bin", "op": "+"}
+                ]
+            },
+            "term_shape_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "witnesses": [{
+                "role": "post",
+                "predicate_text": "out == balance + amount",
+                "source_kind": "annotation"
+            }]
+        }]
+    })
+}
+
+#[test]
+fn bind_kit_transform_to_matches_existing_binder_named_term_document_cid() {
+    let term_value = bind_input_value();
+    let input_term = Term::Const {
+        value: term_value.clone(),
+        sort: primitive_sort("LiftPluginResponse"),
+    };
+    let expected_named =
+        bind_term_document(&term_value, &BindOptions::default()).expect("existing binder succeeds");
+    let expected_jcs = libprovekit::canonical::serializable_jcs(&expected_named)
+        .expect("named term canonicalizes");
+    let expected_cid = Cid::try_from(
+        libprovekit::canonical::serializable_cid(&expected_named).expect("named term cids"),
+    )
+    .expect("named term cid parses");
+
+    let claim = BindKit::default()
+        .transform(&Input::Term(input_term.clone()))
+        .expect("bind kit transforms term input");
+
+    assert_eq!(claim.to, expected_cid);
+    assert_eq!(claim.from, vec![address(&input_term)]);
+    let payload = claim.payload.as_ref().expect("bind claim carries payload");
+    let Term::Const { value, sort } = payload else {
+        panic!("bind payload should be a named term document const");
+    };
+    assert_eq!(sort, &primitive_sort("NamedTermDocument"));
+    assert_eq!(
+        libprovekit::canonical::json_jcs(&value).expect("payload canonicalizes"),
+        expected_jcs
+    );
+    assert!(
+        value["terms"][0].get("namedTermTree").is_some(),
+        "payload should retain namedTermTree"
+    );
+}

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -4,25 +4,25 @@
 //
 // Input is ProofIR term JSON, normally the `ir-document` emitted by
 // `provekit lift`. Output is JCS-canonical named-term JSON containing the
-// clustered names plus PromotionDecisionMementos. This module deliberately
-// does not import the per-language kit dispatch layer: source parsing belongs
-// to `lift`, and target source emission belongs to `lower`.
+// clustered names plus PromotionDecisionMementos. This command is now a thin
+// adapter over the core BindKit and Path executor; migration mode remains on
+// the legacy rewrite path.
 
-use std::collections::{BTreeMap, BTreeSet};
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::Parser;
-use owo_colors::OwoColorize;
-use provekit_canonicalizer::blake3_512_of;
-use provekit_ir_types::{
-    PromotionDecisionEnvelope, PromotionDecisionHeader, PromotionDecisionMemento,
-    PromotionDecisionMetadata, PromotionGate, PromotionResult,
+use libprovekit::core::{
+    address, execute_path, BindKit, BindOptions, HashMapInputCatalog, Input, KitRegistry,
+    Path as CorePath, PathAlgebra, PathExecutionError, Term, Verb,
 };
-use serde::{Deserialize, Serialize};
-use serde_json::{json, Value as Json};
+use owo_colors::OwoColorize;
+use provekit_ir_types::{CompositionRefusalMemento, Sort};
+use serde_json::Value as Json;
 
 use crate::{EXIT_OK, EXIT_USER_ERROR};
+
+pub use libprovekit::core::{NamedTerm, NamedTermDocument};
 
 #[derive(Parser, Debug, Clone)]
 pub struct BindArgs {
@@ -41,7 +41,7 @@ pub struct BindArgs {
     #[arg(long, default_value = "auto")]
     pub lang: String,
 
-    /// Legacy threshold hint. The substrate binder records it in metadata.
+    /// Legacy threshold hint. No effect in the four-verb model.
     #[arg(long, default_value = "1")]
     pub threshold: usize,
 
@@ -132,118 +132,6 @@ fn parse_mode(s: &str) -> Result<RuntimeMode, String> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BindLiftEntry {
-    #[serde(default)]
-    pub kind: String,
-    pub file: String,
-    pub fn_name: String,
-    #[serde(default)]
-    pub fn_line: u64,
-    #[serde(default)]
-    pub attr_pre: Option<String>,
-    #[serde(default)]
-    pub attr_post: Option<String>,
-    #[serde(default)]
-    pub concept_annotation: Option<String>,
-    #[serde(default)]
-    pub param_names: Vec<String>,
-    #[serde(default)]
-    pub param_types: Vec<String>,
-    #[serde(default)]
-    pub return_type: String,
-    #[serde(default)]
-    pub term_shape: Json,
-    #[serde(default)]
-    pub term_shape_cid: String,
-    #[serde(default)]
-    pub witnesses: Vec<BindContractWitness>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BindContractWitness {
-    #[serde(default)]
-    pub role: String,
-    #[serde(default)]
-    pub predicate: Option<Json>,
-    #[serde(default)]
-    pub predicate_text: Option<String>,
-    #[serde(default)]
-    pub source_kind: String,
-    #[serde(default)]
-    pub confidence_basis_points: Option<u16>,
-    #[serde(default)]
-    pub line: Option<u64>,
-    #[serde(default)]
-    pub col: Option<u64>,
-    #[serde(default)]
-    pub extension_fields: BTreeMap<String, Json>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NamedTermDocument {
-    pub kind: String,
-    #[serde(rename = "promotionDecisionMementos")]
-    pub promotion_decision_mementos: Vec<PromotionDecisionMemento>,
-    #[serde(rename = "schemaVersion")]
-    pub schema_version: String,
-    #[serde(rename = "sourceLanguage")]
-    pub source_language: String,
-    pub terms: Vec<NamedTerm>,
-    #[serde(rename = "workspaceRoot", skip_serializing_if = "Option::is_none")]
-    pub workspace_root: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NamedTerm {
-    #[serde(rename = "conceptName")]
-    pub concept_name: String,
-    #[serde(rename = "dischargeVerdict")]
-    pub discharge_verdict: String,
-    pub file: String,
-    pub function: String,
-    pub name: String,
-    #[serde(
-        default,
-        rename = "namedTermTree",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub named_term_tree: Option<NamedTermTree>,
-    #[serde(rename = "paramTypes")]
-    pub param_types: Vec<String>,
-    pub params: Vec<String>,
-    #[serde(rename = "returnType")]
-    pub return_type: String,
-    #[serde(rename = "siteMementoCid")]
-    pub site_memento_cid: String,
-    #[serde(rename = "termShape")]
-    pub term_shape: Json,
-    #[serde(rename = "termShapeCid")]
-    pub term_shape_cid: String,
-    pub witnesses: Vec<NamedWitness>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NamedTermTree {
-    pub args: Vec<NamedTermTree>,
-    #[serde(rename = "conceptName")]
-    pub concept_name: String,
-    #[serde(rename = "operationKind")]
-    pub operation_kind: String,
-    #[serde(rename = "shapeCid")]
-    pub shape_cid: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NamedWitness {
-    pub predicate: Json,
-    #[serde(rename = "predicateText")]
-    pub predicate_text: String,
-    pub role: String,
-    #[serde(rename = "sourceKind")]
-    pub source_kind: String,
-}
-
 pub fn run(args: BindArgs) -> u8 {
     if is_migration_request(&args) {
         return crate::cmd_bind_migrate::run(args);
@@ -263,14 +151,14 @@ pub fn run(args: BindArgs) -> u8 {
             return EXIT_USER_ERROR;
         }
     };
-    let named = match bind_term_document(&term_json, &args) {
+    let named = match run_bind_path(term_json, &args) {
         Ok(named) => named,
         Err(error) => {
             eprintln!("{}: {error}", "error".red().bold());
             return EXIT_USER_ERROR;
         }
     };
-    let jcs = match libprovekit::canonical::serializable_jcs(&named) {
+    let jcs = match libprovekit::canonical::json_jcs(&named) {
         Ok(jcs) => jcs,
         Err(error) => {
             eprintln!(
@@ -293,6 +181,75 @@ pub fn run(args: BindArgs) -> u8 {
         eprintln!("bind: wrote named-term JSON");
     }
     EXIT_OK
+}
+
+fn run_bind_path(term_json: Json, args: &BindArgs) -> Result<Json, BindCliError> {
+    let term = Term::Const {
+        value: term_json,
+        sort: Sort::Primitive {
+            name: "LiftPluginResponse".to_string(),
+        },
+    };
+    let term_cid = address(&term);
+    let mut inputs = HashMapInputCatalog::default();
+    inputs.put(term_cid.clone(), Input::Term(term));
+    let path_input = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "bind".to_string(),
+            kit: "bind-default".to_string(),
+            inputs: vec![term_cid],
+            depends_on: vec![],
+            verb: Verb::Transform,
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        "bind-default",
+        BindKit::new(BindOptions {
+            lang: args.lang.clone(),
+        }),
+    );
+    let claim = execute_path(&path_input, &registry, &inputs).map_err(BindCliError::from_path)?;
+    let payload = claim
+        .payload
+        .ok_or_else(|| BindCliError::Failed("bind claim missing term payload".to_string()))?;
+    match payload {
+        Term::Const { value, .. } => Ok(value),
+        _ => Err(BindCliError::Failed(
+            "bind claim payload was not a named term document".to_string(),
+        )),
+    }
+}
+
+#[derive(Debug)]
+enum BindCliError {
+    Refused(Box<CompositionRefusalMemento>),
+    Failed(String),
+}
+
+impl BindCliError {
+    fn from_path(error: PathExecutionError) -> Self {
+        match error {
+            PathExecutionError::Refused(refusal) => Self::Refused(refusal),
+            other => Self::Failed(other.to_string()),
+        }
+    }
+}
+
+impl std::fmt::Display for BindCliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Refused(refusal) => {
+                f.write_str(&serde_json::to_string(refusal).unwrap_or_else(|_| {
+                    format!(
+                        "{}: {}",
+                        refusal.header.failure_kind, refusal.header.failure_detail
+                    )
+                }))
+            }
+            Self::Failed(message) => f.write_str(message),
+        }
+    }
 }
 
 fn is_migration_request(args: &BindArgs) -> bool {
@@ -330,819 +287,6 @@ fn write_output(path: Option<&PathBuf>, bytes: &[u8]) -> Result<(), String> {
             stdout
                 .write_all(bytes)
                 .map_err(|e| format!("write stdout: {e}"))
-        }
-    }
-}
-
-fn bind_term_document(term_json: &Json, args: &BindArgs) -> Result<NamedTermDocument, String> {
-    let entries = bind_lift_entries(term_json)?;
-    let source_language = source_language(term_json, args);
-    let workspace_root = workspace_root(term_json);
-
-    let catalog = seed_catalog();
-    let mut seen_names: BTreeSet<String> = BTreeSet::new();
-    let mut terms = Vec::with_capacity(entries.len());
-    let mut decisions = Vec::new();
-    let mut operation_namer = UnnamedConceptNamer::default();
-    for (idx, entry) in entries.into_iter().enumerate() {
-        let concept_name = concept_name_for(&entry, idx + 1, &catalog);
-        let name = unique_name(&concept_name, &mut seen_names);
-        let term_shape_cid = if entry.term_shape_cid.trim().is_empty() {
-            libprovekit::canonical::json_cid(&entry.term_shape)
-                .map_err(|e| format!("cid term shape for {}: {e}", entry.fn_name))?
-        } else {
-            entry.term_shape_cid.clone()
-        };
-        let site_memento_cid = site_cid(&entry, &name, &term_shape_cid)?;
-        let witnesses = named_witnesses(&entry);
-        let promoted_cid = blake3_512_of(format!("provekit-bind/promoted/{name}").as_bytes());
-        let named_term_tree =
-            named_operation_tree(&entry.term_shape, &catalog, &mut operation_namer)?;
-        decisions.extend(promotion_decisions(
-            &term_shape_cid,
-            &promoted_cid,
-            &site_memento_cid,
-            &witnesses,
-        )?);
-        terms.push(NamedTerm {
-            concept_name,
-            discharge_verdict: if witnesses.is_empty() {
-                "loudly-bounded-lossy".to_string()
-            } else {
-                "exact".to_string()
-            },
-            file: entry.file,
-            function: entry.fn_name,
-            name,
-            named_term_tree,
-            param_types: entry.param_types,
-            params: entry.param_names,
-            return_type: if entry.return_type.is_empty() {
-                "()".to_string()
-            } else {
-                entry.return_type
-            },
-            site_memento_cid,
-            term_shape: entry.term_shape,
-            term_shape_cid,
-            witnesses,
-        });
-    }
-
-    Ok(NamedTermDocument {
-        kind: "named-term-document".to_string(),
-        promotion_decision_mementos: decisions,
-        schema_version: "1".to_string(),
-        source_language,
-        terms,
-        workspace_root,
-    })
-}
-
-fn bind_lift_entries(term_json: &Json) -> Result<Vec<BindLiftEntry>, String> {
-    if term_json.get("kind").and_then(Json::as_str) == Some("named-term-document") {
-        return Err("input is already named; bind expects ProofIR term JSON from lift".to_string());
-    }
-    let ir = term_json
-        .get("ir")
-        .and_then(Json::as_array)
-        .ok_or_else(|| "ProofIR document missing `ir` array".to_string())?;
-    let mut out = Vec::new();
-    for item in ir {
-        if item.get("kind").and_then(Json::as_str) != Some("bind-lift-entry") {
-            continue;
-        }
-        let entry = serde_json::from_value::<BindLiftEntry>(item.clone())
-            .map_err(|e| format!("parse bind-lift-entry: {e}"))?;
-        out.push(entry);
-    }
-    Ok(out)
-}
-
-fn source_language(term_json: &Json, args: &BindArgs) -> String {
-    term_json
-        .get("sourceLanguage")
-        .or_else(|| term_json.get("surface"))
-        .and_then(Json::as_str)
-        .map(str::to_string)
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| {
-            if args.lang == "auto" {
-                "unknown".to_string()
-            } else {
-                args.lang.clone()
-            }
-        })
-}
-
-fn workspace_root(term_json: &Json) -> Option<String> {
-    term_json
-        .get("workspaceRoot")
-        .or_else(|| term_json.get("workspace_root"))
-        .and_then(Json::as_str)
-        .map(str::to_string)
-}
-
-fn concept_name_for(entry: &BindLiftEntry, ordinal: usize, catalog: &Catalog) -> String {
-    if let Some(annotation) = entry.concept_annotation.as_ref().map(|name| {
-        if name.starts_with("concept:") {
-            name.clone()
-        } else {
-            format!("concept:{name}")
-        }
-    }) {
-        return annotation;
-    }
-    let shape = TermShape::from_kit(entry.term_shape.clone(), entry.term_shape_cid.clone());
-    catalog
-        .match_shape(&shape.shape_cid(), &shape)
-        .map(|entry| entry.name.clone())
-        .unwrap_or_else(|| format!("UNNAMED-CONCEPT-{ordinal:x}"))
-}
-
-#[derive(Debug, Default)]
-struct UnnamedConceptNamer {
-    next: usize,
-}
-
-impl UnnamedConceptNamer {
-    fn next(&mut self) -> String {
-        self.next += 1;
-        format!("UNNAMED-CONCEPT-{:x}", self.next)
-    }
-}
-
-fn named_operation_tree(
-    value: &Json,
-    catalog: &Catalog,
-    namer: &mut UnnamedConceptNamer,
-) -> Result<Option<NamedTermTree>, String> {
-    let Some(operation_kind) = operation_kind(value) else {
-        return Ok(None);
-    };
-    let operation_shape = operation_lookup_shape(&operation_kind);
-    let shape_cid = libprovekit::canonical::json_cid(&operation_shape)
-        .map_err(|e| format!("cid operation shape `{operation_kind}`: {e}"))?;
-    let shape = TermShape::from_kit(operation_shape, shape_cid.clone());
-    let concept_name = catalog
-        .match_shape(&shape.shape_cid(), &shape)
-        .map(|entry| entry.name.clone())
-        .unwrap_or_else(|| namer.next());
-    let args = child_operation_trees(value, catalog, namer)?;
-    Ok(Some(NamedTermTree {
-        args,
-        concept_name,
-        operation_kind,
-        shape_cid,
-    }))
-}
-
-fn child_operation_trees(
-    value: &Json,
-    catalog: &Catalog,
-    namer: &mut UnnamedConceptNamer,
-) -> Result<Vec<NamedTermTree>, String> {
-    let mut out = Vec::new();
-    collect_child_operation_trees(value, catalog, namer, &mut out)?;
-    Ok(out)
-}
-
-fn collect_child_operation_trees(
-    value: &Json,
-    catalog: &Catalog,
-    namer: &mut UnnamedConceptNamer,
-    out: &mut Vec<NamedTermTree>,
-) -> Result<(), String> {
-    match value {
-        Json::Array(values) => {
-            for child in values {
-                collect_operation_tree_or_descendants(child, catalog, namer, out)?;
-            }
-        }
-        Json::Object(object) => {
-            for (key, child) in object {
-                if key == "kind" || key == "op" {
-                    continue;
-                }
-                collect_operation_tree_or_descendants(child, catalog, namer, out)?;
-            }
-        }
-        _ => {}
-    }
-    Ok(())
-}
-
-fn collect_operation_tree_or_descendants(
-    value: &Json,
-    catalog: &Catalog,
-    namer: &mut UnnamedConceptNamer,
-    out: &mut Vec<NamedTermTree>,
-) -> Result<(), String> {
-    if let Some(tree) = named_operation_tree(value, catalog, namer)? {
-        out.push(tree);
-        return Ok(());
-    }
-    collect_child_operation_trees(value, catalog, namer, out)
-}
-
-fn operation_kind(value: &Json) -> Option<String> {
-    let raw_kind = value.get("kind").and_then(Json::as_str)?.trim();
-    if raw_kind.is_empty() {
-        return None;
-    }
-    let raw_kind = raw_kind
-        .rsplit_once(':')
-        .map_or(raw_kind, |(_, suffix)| suffix);
-    let normalized = match raw_kind {
-        "body" | "block" => "seq",
-        "if" => "conditional",
-        "let" => "decl",
-        "bin" => value
-            .get("op")
-            .and_then(Json::as_str)
-            .and_then(binary_operator_kind)
-            .unwrap_or("bin"),
-        "rel" => value
-            .get("op")
-            .and_then(Json::as_str)
-            .and_then(binary_operator_kind)
-            .unwrap_or("rel"),
-        other => other,
-    };
-    Some(normalized.replace('_', "-"))
-}
-
-fn binary_operator_kind(op: &str) -> Option<&'static str> {
-    match op {
-        "+" => Some("add"),
-        "-" => Some("sub"),
-        "*" => Some("mul"),
-        "/" => Some("div"),
-        "%" => Some("mod"),
-        "==" => Some("eq"),
-        "!=" => Some("ne"),
-        "<" => Some("lt"),
-        "<=" => Some("le"),
-        ">" => Some("gt"),
-        ">=" => Some("ge"),
-        "&&" => Some("and"),
-        "||" => Some("or"),
-        _ => None,
-    }
-}
-
-fn operation_lookup_shape(operation_kind: &str) -> Json {
-    json!({
-        "kind": "operation-shape",
-        "operator": operation_kind,
-    })
-}
-
-fn unique_name(concept_name: &str, seen: &mut BTreeSet<String>) -> String {
-    let base = concept_name
-        .strip_prefix("concept:")
-        .unwrap_or(concept_name)
-        .to_string();
-    if seen.insert(base.clone()) {
-        return base;
-    }
-    for idx in 2usize.. {
-        let candidate = format!("{base}-{idx}");
-        if seen.insert(candidate.clone()) {
-            return candidate;
-        }
-    }
-    unreachable!("unbounded unique-name loop")
-}
-
-fn named_witnesses(entry: &BindLiftEntry) -> Vec<NamedWitness> {
-    let mut witnesses = Vec::new();
-    if entry.witnesses.is_empty() {
-        if let Some(pre) = entry.attr_pre.as_deref() {
-            witnesses.push(named_witness("pre", pre, "annotation"));
-        }
-        if let Some(post) = entry.attr_post.as_deref() {
-            witnesses.push(named_witness("post", post, "annotation"));
-        }
-        return witnesses;
-    }
-    entry
-        .witnesses
-        .iter()
-        .map(|witness| {
-            let predicate_text = witness
-                .predicate_text
-                .clone()
-                .or_else(|| witness.predicate.as_ref().map(Json::to_string))
-                .unwrap_or_else(|| "true".to_string());
-            NamedWitness {
-                predicate: witness
-                    .predicate
-                    .clone()
-                    .unwrap_or_else(|| json!({"kind": "text", "text": predicate_text})),
-                predicate_text,
-                role: if witness.role.trim().is_empty() {
-                    "unknown".to_string()
-                } else {
-                    witness.role.clone()
-                },
-                source_kind: if witness.source_kind.trim().is_empty() {
-                    "unspecified".to_string()
-                } else {
-                    witness.source_kind.clone()
-                },
-            }
-        })
-        .collect()
-}
-
-fn named_witness(role: &str, predicate_text: &str, source_kind: &str) -> NamedWitness {
-    NamedWitness {
-        predicate: json!({"kind": "text", "text": predicate_text}),
-        predicate_text: predicate_text.to_string(),
-        role: role.to_string(),
-        source_kind: source_kind.to_string(),
-    }
-}
-
-fn site_cid(entry: &BindLiftEntry, name: &str, term_shape_cid: &str) -> Result<String, String> {
-    let value = json!({
-        "file": entry.file,
-        "function": entry.fn_name,
-        "name": name,
-        "termShapeCid": term_shape_cid,
-    });
-    libprovekit::canonical::json_cid(&value).map_err(|e| e.to_string())
-}
-
-fn promotion_decisions(
-    candidate_cid: &str,
-    promoted_cid: &str,
-    site_memento_cid: &str,
-    witnesses: &[NamedWitness],
-) -> Result<Vec<PromotionDecisionMemento>, String> {
-    witnesses
-        .iter()
-        .enumerate()
-        .map(|(idx, witness)| {
-            let evidence_cid = libprovekit::canonical::json_cid(&json!({
-                "predicate": witness.predicate,
-                "predicateText": witness.predicate_text,
-                "role": witness.role,
-                "siteMementoCid": site_memento_cid,
-                "sourceKind": witness.source_kind,
-            }))
-            .map_err(|e| e.to_string())?;
-            let mut decision = PromotionDecisionMemento {
-                envelope: PromotionDecisionEnvelope {
-                    declared_at: "2026-05-15T00:00:00.000Z".to_string(),
-                    signature: String::new(),
-                    signer: "builtin:provekit-bind".to_string(),
-                },
-                header: PromotionDecisionHeader {
-                    candidate_cid: candidate_cid.to_string(),
-                    cid: String::new(),
-                    decider_cid: "builtin:provekit-bind".to_string(),
-                    decision_payload: json!({
-                        "evidence_count": 1,
-                        "ordinal": idx,
-                        "result": "admitted"
-                    }),
-                    evidence_cids: vec![evidence_cid],
-                    gate: PromotionGate::Proof,
-                    kind: "promotion-decision".to_string(),
-                    policy_cid: "builtin:provekit-bind/default-policy".to_string(),
-                    promoted_cid: promoted_cid.to_string(),
-                    result: PromotionResult::Admitted,
-                    schema_version: "1".to_string(),
-                },
-                metadata: PromotionDecisionMetadata {
-                    counterexample_cids: None,
-                    note: Some("bind admitted lifted evidence into named term".to_string()),
-                    source_url: None,
-                },
-            };
-            decision.header.cid = decision
-                .recompute_header_cid()
-                .map_err(|err| err.to_string())?;
-            decision.validate().map_err(|err| err.to_string())?;
-            Ok(decision)
-        })
-        .collect()
-}
-
-#[derive(Debug, Clone)]
-struct TermShape {
-    value: Json,
-    cid_cached: String,
-}
-
-impl TermShape {
-    fn from_kit(value: Json, cid: String) -> Self {
-        Self {
-            value,
-            cid_cached: cid,
-        }
-    }
-
-    fn shape_cid(&self) -> String {
-        self.cid_cached.clone()
-    }
-
-    fn classify(&self) -> &'static str {
-        classify_value(&self.value)
-    }
-}
-
-fn classify_value(value: &Json) -> &'static str {
-    let kind = value.get("kind").and_then(Json::as_str).unwrap_or("");
-    if kind != "body" {
-        return "unknown";
-    }
-    let stmts = value
-        .get("stmts")
-        .and_then(Json::as_array)
-        .map(|arr| arr.as_slice())
-        .unwrap_or(&[]);
-    let mut has_loop = false;
-    let mut has_if = false;
-    for stmt in stmts {
-        let kind = stmt.get("kind").and_then(Json::as_str).unwrap_or("");
-        match kind {
-            "while" | "for" => has_loop = true,
-            "if" => has_if = true,
-            _ => {}
-        }
-    }
-    if has_loop {
-        "retry-loop"
-    } else if has_if {
-        "guard-then-commit"
-    } else {
-        "unknown"
-    }
-}
-
-#[derive(Debug, Clone)]
-struct CatalogEntry {
-    name: String,
-    shape_cid: String,
-    classification: &'static str,
-}
-
-#[derive(Debug, Clone)]
-struct Catalog {
-    entries: Vec<CatalogEntry>,
-}
-
-impl Catalog {
-    fn match_shape(&self, shape_cid: &str, shape: &TermShape) -> Option<&CatalogEntry> {
-        if let Some(entry) = self
-            .entries
-            .iter()
-            .find(|entry| entry.shape_cid == shape_cid)
-        {
-            return Some(entry);
-        }
-        let classification = shape.classify();
-        if classification == "unknown" {
-            return None;
-        }
-        self.entries
-            .iter()
-            .find(|entry| entry.classification == classification)
-    }
-}
-
-fn seed_catalog() -> Catalog {
-    let mut entries = Vec::new();
-    if let Some(root) = find_concept_shapes_root() {
-        entries.extend(load_catalog_abstractions(&root));
-        entries.extend(load_catalog_specs(&root));
-    }
-    entries.extend(legacy_classification_entries());
-    Catalog { entries }
-}
-
-fn legacy_classification_entries() -> Vec<CatalogEntry> {
-    vec![
-        CatalogEntry {
-            name: "concept:retry-with-bounded-attempts".to_string(),
-            shape_cid: String::new(),
-            classification: "retry-loop",
-        },
-        CatalogEntry {
-            name: "concept:guard-then-commit".to_string(),
-            shape_cid: String::new(),
-            classification: "guard-then-commit",
-        },
-    ]
-}
-
-fn find_concept_shapes_root() -> Option<PathBuf> {
-    let mut starts = Vec::new();
-    if let Ok(cwd) = std::env::current_dir() {
-        starts.push(cwd);
-    }
-    if let Some(manifest_dir) = option_env!("CARGO_MANIFEST_DIR") {
-        starts.push(PathBuf::from(manifest_dir));
-    }
-    for start in starts {
-        for ancestor in start.ancestors() {
-            let candidate = ancestor.join("menagerie").join("concept-shapes");
-            if candidate.is_dir() {
-                return Some(candidate);
-            }
-        }
-    }
-    None
-}
-
-fn load_catalog_abstractions(concept_shapes_root: &Path) -> Vec<CatalogEntry> {
-    let dir = concept_shapes_root.join("catalog").join("abstractions");
-    catalog_json_files(&dir, ".json")
-        .into_iter()
-        .filter_map(|path| load_catalog_abstraction(&path))
-        .collect()
-}
-
-fn load_catalog_abstraction(path: &Path) -> Option<CatalogEntry> {
-    let doc = read_json_file(path)?;
-    let name = doc
-        .get("memento")
-        .and_then(|memento| memento.get("operator"))
-        .and_then(Json::as_str)?
-        .to_string();
-    let shape_cid = doc
-        .get("cid")
-        .and_then(Json::as_str)
-        .map(str::to_string)
-        .or_else(|| shape_cid_from_abstraction_filename(path))?;
-    Some(CatalogEntry {
-        name,
-        shape_cid,
-        classification: "catalog-shape",
-    })
-}
-
-fn load_catalog_specs(concept_shapes_root: &Path) -> Vec<CatalogEntry> {
-    let dir = concept_shapes_root.join("specs");
-    catalog_json_files(&dir, ".spec.json")
-        .into_iter()
-        .flat_map(|path| load_catalog_spec(&path))
-        .collect()
-}
-
-fn load_catalog_spec(path: &Path) -> Vec<CatalogEntry> {
-    let Some(doc) = read_json_file(path) else {
-        return Vec::new();
-    };
-    let Some(name) = doc
-        .get("fn_name")
-        .and_then(Json::as_str)
-        .map(str::to_string)
-    else {
-        return Vec::new();
-    };
-    let mut entries = Vec::new();
-    if let Ok(shape_cid) = libprovekit::canonical::json_cid(&doc) {
-        entries.push(CatalogEntry {
-            name: name.clone(),
-            shape_cid,
-            classification: "catalog-shape",
-        });
-    }
-    if name.starts_with("concept:") {
-        if let Some(operator) = doc
-            .get("post")
-            .and_then(|post| post.get("operator"))
-            .and_then(Json::as_str)
-            .map(|operator| operator.replace('_', "-"))
-        {
-            if let Ok(shape_cid) =
-                libprovekit::canonical::json_cid(&operation_lookup_shape(&operator))
-            {
-                entries.push(CatalogEntry {
-                    name,
-                    shape_cid,
-                    classification: "catalog-shape",
-                });
-            }
-        }
-    }
-    entries
-}
-
-fn catalog_json_files(dir: &Path, suffix: &str) -> Vec<PathBuf> {
-    if !dir.is_dir() {
-        return Vec::new();
-    }
-    let mut paths: Vec<PathBuf> = walkdir::WalkDir::new(dir)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(|entry| entry.file_type().is_file())
-        .map(|entry| entry.into_path())
-        .filter(|path| {
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(suffix))
-        })
-        .collect();
-    paths.sort();
-    paths
-}
-
-fn read_json_file(path: &Path) -> Option<Json> {
-    let bytes = std::fs::read(path).ok()?;
-    serde_json::from_slice(&bytes).ok()
-}
-
-fn shape_cid_from_abstraction_filename(path: &Path) -> Option<String> {
-    let file_name = path.file_name()?.to_str()?;
-    let (_, cid_hex_with_suffix) = file_name.split_once(".blake3-512:")?;
-    let cid_hex = cid_hex_with_suffix.strip_suffix(".json")?;
-    Some(format!("blake3-512:{cid_hex}"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn bind_names_lifted_entries_without_plugin_dispatch() {
-        let term = json!({
-            "kind": "ir-document",
-            "workspaceRoot": "/tmp/demo",
-            "ir": [{
-                "kind": "bind-lift-entry",
-                "file": "src/lib.rs",
-                "fn_name": "f",
-                "concept_annotation": "demo",
-                "param_names": ["x"],
-                "param_types": ["i64"],
-                "return_type": "i64",
-                "term_shape": {"kind": "op", "name": "demo"},
-                "witnesses": [{
-                    "role": "post",
-                    "predicate_text": "out == x",
-                    "source_kind": "annotation"
-                }]
-            }]
-        });
-        let args = BindArgs {
-            input: None,
-            output: None,
-            root: PathBuf::from("."),
-            lang: "rust".to_string(),
-            threshold: 1,
-            rewrite: RewriteShape::Invisible,
-            mode: vec![RuntimeMode::Monitor],
-            target_language: None,
-            library_from: None,
-            library_to: None,
-            source_dir: None,
-            out_dir: None,
-            receipt: None,
-            witness_fixture: None,
-            write: false,
-            quiet: true,
-            plugins: crate::PluginFlags::default(),
-        };
-        let named = bind_term_document(&term, &args).expect("bind succeeds");
-        assert_eq!(named.kind, "named-term-document");
-        assert_eq!(named.terms[0].concept_name, "concept:demo");
-        assert_eq!(named.terms[0].function, "f");
-        assert_eq!(named.promotion_decision_mementos.len(), 1);
-    }
-
-    #[test]
-    fn seed_catalog_loads_real_concept_shape_catalog() {
-        let catalog = seed_catalog();
-        assert!(
-            catalog.entries.len() > 10,
-            "catalog should load real concept-shape entries, got {}",
-            catalog.entries.len()
-        );
-        assert!(
-            catalog
-                .entries
-                .iter()
-                .any(|entry| entry.name == "concept:identity"),
-            "catalog should include concept:identity"
-        );
-        assert!(
-            catalog
-                .entries
-                .iter()
-                .any(|entry| entry.name == "concept:new"),
-            "catalog should include algorithm-tier concept:new"
-        );
-    }
-
-    #[test]
-    fn catalog_matches_loaded_shape_cid_before_legacy_classification() {
-        let catalog = seed_catalog();
-        let identity_shape_cid = "blake3-512:6920f6e26184ca316f3dce6c02690b515c11b3d96d3b476bb5abe67cb55e1885031484c3add8a5f26b630e305ad3fe41eed10acca2e141898f9d6629c278867f";
-        let unknown_shape = TermShape::from_kit(
-            json!({
-                "kind": "body",
-                "stmts": []
-            }),
-            identity_shape_cid.to_string(),
-        );
-        let matched = catalog
-            .match_shape(identity_shape_cid, &unknown_shape)
-            .expect("identity CID should match before classify fallback");
-        assert_eq!(matched.name, "concept:identity");
-    }
-
-    #[test]
-    fn bind_names_blake3_512_of_operations_from_catalog() {
-        let term = json!({
-            "kind": "ir-document",
-            "sourceLanguage": "rust",
-            "workspaceRoot": "/tmp/provekit-bind-test",
-            "ir": [{
-                "kind": "bind-lift-entry",
-                "file": "implementations/rust/provekit-canonicalizer/src/hash.rs",
-                "fn_name": "blake3_512_of",
-                "param_names": ["bytes"],
-                "param_types": ["& [u8]"],
-                "return_type": "String",
-                "term_shape": {
-                    "kind": "body",
-                    "stmts": [
-                        {"kind": "let"},
-                        {"kind": "call"},
-                        {"kind": "let"},
-                        {"kind": "call"},
-                        {"kind": "let"},
-                        {"kind": "let"},
-                        {"kind": "call"},
-                        {"kind": "call"},
-                        {"kind": "opaque"}
-                    ]
-                },
-                "witnesses": []
-            }]
-        });
-        let args = BindArgs {
-            input: None,
-            output: None,
-            root: PathBuf::from("."),
-            lang: "rust".to_string(),
-            threshold: 1,
-            rewrite: RewriteShape::Invisible,
-            mode: vec![RuntimeMode::Monitor],
-            target_language: None,
-            library_from: None,
-            library_to: None,
-            source_dir: None,
-            out_dir: None,
-            receipt: None,
-            witness_fixture: None,
-            write: false,
-            quiet: true,
-            plugins: crate::PluginFlags::default(),
-        };
-
-        let named = bind_term_document(&term, &args).expect("bind succeeds");
-        let named_json = serde_json::to_value(&named).expect("named term serializes");
-        let tree = named_json["terms"][0]
-            .get("namedTermTree")
-            .expect("operation-level named term tree is emitted");
-        let nested_names = serde_json::to_string(tree).expect("tree stringifies");
-        let mut operation_concepts = Vec::new();
-        collect_tree_concept_names(tree, &mut operation_concepts);
-        operation_concepts.sort();
-        operation_concepts.dedup();
-        eprintln!(
-            "operation-level matches for blake3_512_of: {}",
-            operation_concepts.join(", ")
-        );
-
-        assert!(
-            nested_names.contains("\"conceptName\":\"concept:call\""),
-            "blake3_512_of call operations should match catalog concept:call; tree={nested_names}"
-        );
-        assert!(
-            tree.get("args")
-                .and_then(Json::as_array)
-                .is_some_and(|args| !args.is_empty()),
-            "operation tree should retain recursive children; tree={tree}"
-        );
-    }
-
-    fn collect_tree_concept_names(tree: &Json, out: &mut Vec<String>) {
-        if let Some(name) = tree.get("conceptName").and_then(Json::as_str) {
-            if name.starts_with("concept:") {
-                out.push(name.to_string());
-            }
-        }
-        if let Some(args) = tree.get("args").and_then(Json::as_array) {
-            for arg in args {
-                collect_tree_concept_names(arg, out);
-            }
         }
     }
 }

--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use chrono::{SecondsFormat, Utc};
 use libprovekit::core::{
     execute_path, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
+    Verb,
 };
 use libprovekit::effect_propagation::{
     propagate_effects, CallsiteEdge, ChangedCallsite, FunctionEffectInfo, PropagationDecision,
@@ -813,6 +814,7 @@ fn realize_probe_via_path(
             kit: kit_name.clone(),
             inputs: vec![input_cid],
             depends_on: vec![],
+            verb: Verb::Transform,
         }],
     }));
     let mut registry = KitRegistry::default();

--- a/implementations/rust/provekit-cli/src/cmd_lower.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lower.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 use clap::{Parser, ValueEnum};
 use libprovekit::core::{
     execute_path, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
+    Verb,
 };
 use owo_colors::OwoColorize;
 use serde_json::{json, Value as Json};
@@ -349,6 +350,7 @@ fn lower_named_spec_via_path(
             kit: kit_name.clone(),
             inputs: vec![input_cid],
             depends_on: vec![],
+            verb: Verb::Transform,
         }],
     }));
     let mut registry = KitRegistry::default();

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use clap::Parser;
 use libprovekit::core::{
     execute_path, Cid, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath,
-    PathAlgebra, Term,
+    PathAlgebra, Term, Verb,
 };
 use libprovekit::desugar::{load_desugaring_rules_from_dir, DesugaringSet};
 use libprovekit::transport::{transport_term, OperationTransport, TermTransport};
@@ -1470,6 +1470,7 @@ fn realize_spec_via_path(
             kit: kit_name.clone(),
             inputs: vec![input_cid],
             depends_on: vec![],
+            verb: Verb::Transform,
         }],
     }));
     let mut registry = KitRegistry::default();

--- a/implementations/rust/provekit-cli/tests/bind_kit_path_integration.rs
+++ b/implementations/rust/provekit-cli/tests/bind_kit_path_integration.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use libprovekit::core::{
+    address, execute_path, BindKit, Dialect, HashMapInputCatalog, Input, Kit, KitRegistry, LiftKit,
+    Path as CorePath, PathAlgebra, Term, Verb,
+};
+use provekit_ir_types::Sort;
+use serde_json::{json, Value};
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn primitive_sort(name: &str) -> Sort {
+    Sort::Primitive {
+        name: name.to_string(),
+    }
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod script");
+    }
+}
+
+fn fake_lifter(root: &Path) -> PathBuf {
+    let script = root.join("fake-rust-lifter.sh");
+    write_executable(
+        &script,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+  if [[ "$line" == *'"method":"initialize"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"fake-rust-lifter","protocol_version":"pep/1.7.0","capabilities":{"surfaces":["rust"]}}}'
+  elif [[ "$line" == *'"method":"lift"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"kind":"ir-document","sourceLanguage":"rust","ir":[{"kind":"bind-lift-entry","file":"src/lib.rs","fn_name":"id","fn_line":1,"concept_annotation":"identity","param_names":["x"],"param_types":["i64"],"return_type":"i64","term_shape":{"kind":"var","name":"x"},"term_shape_cid":"blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","witnesses":[]}]}}'
+  elif [[ "$line" == *'"method":"shutdown"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+    exit 0
+  fi
+done
+"#,
+    );
+    script
+}
+
+fn bind_input_value() -> Value {
+    json!({
+        "kind": "ir-document",
+        "sourceLanguage": "rust",
+        "workspaceRoot": "/tmp/provekit-bind-path-test",
+        "ir": [{
+            "kind": "bind-lift-entry",
+            "file": "src/lib.rs",
+            "fn_name": "deposit",
+            "fn_line": 14,
+            "concept_annotation": "deposit-then-balance",
+            "param_names": ["balance", "amount"],
+            "param_types": ["i64", "i64"],
+            "return_type": "i64",
+            "term_shape": {
+                "kind": "body",
+                "stmts": [
+                    {"kind": "let"},
+                    {"kind": "bin", "op": "+"}
+                ]
+            },
+            "term_shape_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+            "witnesses": [{
+                "role": "post",
+                "predicate_text": "out == balance + amount",
+                "source_kind": "annotation"
+            }]
+        }]
+    })
+}
+
+fn run_bind_cli(term_value: &Value) -> Vec<u8> {
+    let mut child = Command::new(provekit_bin())
+        .arg("bind")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bind");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(term_value.to_string().as_bytes())
+        .expect("write term");
+    let output = child.wait_with_output().expect("wait bind");
+    assert!(
+        output.status.success(),
+        "bind cli failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+#[test]
+fn bind_path_executor_matches_cmd_bind_named_term_document_bytes() {
+    let term_value = bind_input_value();
+    let input_term = Term::Const {
+        value: term_value.clone(),
+        sort: primitive_sort("LiftPluginResponse"),
+    };
+    let mut inputs = HashMapInputCatalog::default();
+    let term_cid = address(&input_term);
+    inputs.put(term_cid.clone(), Input::Term(input_term.clone()));
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "bind".to_string(),
+            kit: "bind-default".to_string(),
+            inputs: vec![term_cid],
+            depends_on: vec![],
+            verb: Verb::Transform,
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register("bind-default", BindKit::default());
+
+    let claim = execute_path(&path, &registry, &inputs).expect("bind path executes");
+    let cli_bytes = run_bind_cli(&term_value);
+    let cli_value: Value = serde_json::from_slice(&cli_bytes).expect("cmd_bind output parses");
+    let cli_cid = libprovekit::canonical::json_cid(&cli_value).expect("cmd_bind output cids");
+
+    assert_eq!(claim.to.as_str(), cli_cid);
+    assert_eq!(claim.from, vec![address(&input_term)]);
+    let payload = claim.payload.as_ref().expect("bind claim payload");
+    let Term::Const { value, .. } = payload else {
+        panic!("bind payload should be a named term document const");
+    };
+    assert_eq!(
+        libprovekit::canonical::json_jcs(&value)
+            .expect("payload canonicalizes")
+            .as_bytes(),
+        cli_bytes.as_slice()
+    );
+}
+
+#[test]
+fn lift_then_bind_path_carries_lift_output_and_claim_premise() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script = fake_lifter(temp.path());
+    let workspace_root = temp
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| temp.path().to_path_buf());
+    let request = json!({
+        "surface": "rust",
+        "workspace_root": workspace_root,
+        "config_path": ".provekit/config.toml",
+        "source_paths": ["."],
+        "options": {
+            "layer": "all",
+            "identifyOnly": false
+        }
+    });
+    let command = vec!["bash".to_string(), script.display().to_string()];
+    let source = Input::Source {
+        dialect: Dialect::Rust,
+        bytes: serde_json::to_vec(&request).expect("encode lift request"),
+    };
+    let lift_kit = LiftKit::new(
+        Dialect::Rust,
+        "rust",
+        command.clone(),
+        Some(temp.path().to_path_buf()),
+    );
+    let lift_claim = lift_kit
+        .transform(&source)
+        .expect("lift transform succeeds");
+
+    let mut inputs = HashMapInputCatalog::default();
+    let source_cid = inputs.insert(source);
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![
+            PathAlgebra {
+                name: "lift".to_string(),
+                kit: "lift-rust".to_string(),
+                inputs: vec![source_cid],
+                depends_on: vec![],
+                verb: Verb::Transform,
+            },
+            PathAlgebra {
+                name: "bind".to_string(),
+                kit: "bind-default".to_string(),
+                inputs: vec![lift_claim.to.clone()],
+                depends_on: vec!["lift".to_string()],
+                verb: Verb::Transform,
+            },
+        ],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        "lift-rust",
+        LiftKit::new(
+            Dialect::Rust,
+            "rust",
+            command,
+            Some(temp.path().to_path_buf()),
+        ),
+    );
+    registry.register("bind-default", BindKit::default());
+
+    let bind_claim = execute_path(&path, &registry, &inputs).expect("lift bind path executes");
+
+    assert_eq!(bind_claim.from, vec![lift_claim.to.clone()]);
+    assert_eq!(bind_claim.premises, vec![lift_claim.cid()]);
+}
+
+#[test]
+fn bind_path_refuses_unregistered_bind_variant_with_composition_refusal_memento() {
+    let term_value = bind_input_value();
+    let input_term = Term::Const {
+        value: term_value,
+        sort: primitive_sort("LiftPluginResponse"),
+    };
+    let mut inputs = HashMapInputCatalog::default();
+    let term_cid = address(&input_term);
+    inputs.put(term_cid.clone(), Input::Term(input_term));
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "bind".to_string(),
+            kit: "bind-missing".to_string(),
+            inputs: vec![term_cid],
+            depends_on: vec![],
+            verb: Verb::Transform,
+        }],
+    }));
+    let registry = KitRegistry::default();
+
+    let error = execute_path(&path, &registry, &inputs).expect_err("missing bind kit refuses");
+    let refusal = error
+        .composition_refusal()
+        .expect("missing bind kit emits refusal memento");
+    assert_eq!(refusal.header.failure_kind, "memento-required-missing");
+    assert_eq!(
+        refusal
+            .header
+            .missing_memento_requirements
+            .as_ref()
+            .unwrap()[0]
+            .role,
+        Some("kit-registry".to_string())
+    );
+}

--- a/implementations/rust/provekit-cli/tests/lower_kit_path_integration.rs
+++ b/implementations/rust/provekit-cli/tests/lower_kit_path_integration.rs
@@ -9,7 +9,7 @@ use libprovekit::compose::{
 };
 use libprovekit::core::{
     address, execute_path, Cid, DomainClaim, DomainKind, HashMapInputCatalog, Input, KitRegistry,
-    LowerKit, Path as CorePath, PathAlgebra, Term, Verdict,
+    LowerKit, Path as CorePath, PathAlgebra, Term, Verb, Verdict,
 };
 use provekit_cli::kit_dispatch::DispatchRealizeTransport;
 use provekit_ir_types::{IrFormula, Sort};
@@ -190,6 +190,7 @@ fn lower_python_path_claim_input_cites_from_premise_to_and_loss_cids() {
             kit: "lower-python".to_string(),
             inputs: vec![prior_input_cid],
             depends_on: vec![],
+            verb: Verb::Transform,
         }],
     }));
     let mut registry = KitRegistry::default();


### PR DESCRIPTION
Sibling to LiftKit (#1036) and LowerKit (#1043). Adapts the binder machinery as a `Kit::transform(&Input) -> DomainClaim` registered with the public `KitRegistry`. Closes #1037.

## Substrate

- New `libprovekit::core::bind` module exports `BindKit` + per-operation `NamedTerm`/`NamedTermTree`/`NamedTermDocument`/`NamedWitness` types + `bind_term_document` entry point.
- `BindKit::transform(Input::Term)` walks the term tree, names each operation node using the loaded catalog, emits a `DomainClaim` carrying the `NamedTermDocument` as payload.
- Claim cites `from` (input Term CID), `to` (named-term-document CID), `premises` (prior step's claim CID when consumed as `Input::Claim`), and the named-term payload.

## CLI registry-without-teeth cleanup

- `cmd_bind::run` is now an adapter shim: argv parse → BindKit into KitRegistry → `execute_path` → render result.
- `cmd_bind.rs` shrinks from ~1100 lines to ~100 (`-1024 / +43`).
- No parallel-but-deprecated paths.

## Substrate addition: premise chain propagation

BindKit's multi-step binding assertion (lift then bind, where bind's claim must cite lift's claim CID in `premises`) requires the executor to walk `step.depends_on` and extend each step's claim premises with the prior steps' claim CIDs.

- Added `step_premises` helper in `path_executor.rs` + one line in the verb-dispatch arm (`claim.premises.extend(step_premises(step, &claims_by_step)?)`).
- Empty `depends_on` → empty premises, so single-step paths are byte-identical to current behavior.

## Boy-scout: #1044 verb-field oversight

PR #1044 (verb-selector) added `verb: Verb` as a required field on `PathAlgebra` but missed four construction sites:

- `cmd_transport.rs:1468`
- `cmd_lower.rs:347`
- `cmd_bind_migrate.rs:811`
- `tests/lower_kit_path_integration.rs:188`

Each gets `verb: Verb::Transform` + a `Verb` import. Without this, `cargo build -p provekit-cli` fails to compile on current main. CI on the #1044 merge has been in-progress for hours; the gap would surface there imminently. Bundled here under boy-scout-scoping (this PR is gated on main compiling).

## Tests

- `bind_kit` unit tests for `from`/`to`/`premises` citation.
- `bind_kit_path_integration::lift_then_bind_path_carries_lift_output_and_claim_premise` exercises the new `step_premises` premise-extension logic end-to-end.

## Gates

- `cargo test -p libprovekit`: 20 passed across 5 groups.
- `cargo test -p provekit-cli`: 10 groups passed (longest: `bind_migrates_better_sqlite3_to_python_with_cross_language_witness_pairs` at 174s).
- Em-dash sweep: zero.
- `git diff --check`: clean.

## Non-goals respected

- No new `provekit-bind-*` crate. Extended existing libprovekit modules.
- No parallel registry. Used `KitRegistry` from #1036.
- No parallel executor. Registered with `execute_path` from #1036.
- No new memento family.
- No body-template catalog data changes.

## Forward-compat with #1040

`register("bind-default", BindKit::new(...))` uses the current two-arg signature. When #1040 (ConformanceDeclaration) lands, this callsite adds `ConformanceDeclaration::NonCarrier { reason: "transforms Input::Term to NamedTerm DomainClaim; emits no target source" }` on rebase. Per #1040's bidirectional sequencing rule, conflict is mechanical.

Prereqs: #1033 (PR #1036), #1027 (PR #1043), #1038 (PR #1044).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bind document transformation functionality now available in libprovekit core module, enabling programmatic use alongside CLI tools.
  * Path executor now properly propagates step dependencies as claim premises in path execution.

* **Tests**
  * Added integration tests validating bind command behavior and path execution workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->