### PR TITLE
feat(python-kit): emit-compile-run conformance fixtures (closes #1039 for Python slice)

### DIFF
--- a/implementations/python/conformance/fixtures/arithmetic_add.json
+++ b/implementations/python/conformance/fixtures/arithmetic_add.json
@@ -1,0 +1,24 @@
+{
+  "name": "arithmetic_add",
+  "original_source": "def add(x, y):\n    return x + y\n",
+  "declared_test_inputs": [
+    {
+      "entrypoint": "add",
+      "args": [3, 4]
+    }
+  ],
+  "expected_output": [
+    {
+      "stdout": "",
+      "return_value": 7,
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "add",
+    "params": ["x", "y"],
+    "param_types": ["int", "int"],
+    "return_type": "int",
+    "concept_name": "concept:add"
+  }
+}

--- a/implementations/python/conformance/fixtures/control_flow_if.json
+++ b/implementations/python/conformance/fixtures/control_flow_if.json
@@ -1,0 +1,42 @@
+{
+  "name": "control_flow_if",
+  "original_source": "def abs_value(n):\n    if n >= 0:\n        return n\n    return -n\n",
+  "declared_test_inputs": [
+    {
+      "entrypoint": "abs_value",
+      "args": [-5]
+    },
+    {
+      "entrypoint": "abs_value",
+      "args": [0]
+    },
+    {
+      "entrypoint": "abs_value",
+      "args": [5]
+    }
+  ],
+  "expected_output": [
+    {
+      "stdout": "",
+      "return_value": 5,
+      "exit_code": 0
+    },
+    {
+      "stdout": "",
+      "return_value": 0,
+      "exit_code": 0
+    },
+    {
+      "stdout": "",
+      "return_value": 5,
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "abs_value",
+    "params": ["n"],
+    "param_types": ["int"],
+    "return_type": "int",
+    "concept_name": "abs-value"
+  }
+}

--- a/implementations/python/conformance/fixtures/hello_world.json
+++ b/implementations/python/conformance/fixtures/hello_world.json
@@ -1,0 +1,24 @@
+{
+  "name": "hello_world",
+  "original_source": "def hello_world():\n    print(\"Hello, world!\")\n",
+  "declared_test_inputs": [
+    {
+      "entrypoint": "hello_world",
+      "args": []
+    }
+  ],
+  "expected_output": [
+    {
+      "stdout": "Hello, world!\n",
+      "return_value": null,
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "hello_world",
+    "params": [],
+    "param_types": [],
+    "return_type": "()",
+    "concept_name": "hello-world"
+  }
+}

--- a/implementations/python/conformance/fixtures/recursive_factorial.json
+++ b/implementations/python/conformance/fixtures/recursive_factorial.json
@@ -1,0 +1,24 @@
+{
+  "name": "recursive_factorial",
+  "original_source": "def factorial(n):\n    if n <= 1:\n        return 1\n    return n * factorial(n - 1)\n",
+  "declared_test_inputs": [
+    {
+      "entrypoint": "factorial",
+      "args": [5]
+    }
+  ],
+  "expected_output": [
+    {
+      "stdout": "",
+      "return_value": 120,
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "factorial",
+    "params": ["n"],
+    "param_types": ["int"],
+    "return_type": "int",
+    "concept_name": "recursive-factorial"
+  }
+}

--- a/implementations/python/conformance/fixtures/transported_op_drop.json
+++ b/implementations/python/conformance/fixtures/transported_op_drop.json
@@ -1,0 +1,39 @@
+{
+  "name": "transported_op_drop",
+  "original_source": "def transported_op_drop(x):\n    return None\n",
+  "declared_test_inputs": [
+    {
+      "entrypoint": "transported_op_drop",
+      "args": ["resource"]
+    }
+  ],
+  "expected_output": {
+    "carrier_comment_contains": "# provekit-concept:"
+  },
+  "behavior_comparison": "carrier_comment",
+  "realize_request": {
+    "function": "transported_op_drop",
+    "params": ["x"],
+    "param_types": ["object"],
+    "return_type": "()",
+    "concept_name": "missing-python-drop-surface",
+    "transported_op": {
+      "args_jcs": [
+        {
+          "kind": "var",
+          "name": "x"
+        }
+      ],
+      "callsite_cid": "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "concept_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "concept_name": "concept:drop",
+      "concept_site_cid": "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "loss_record_cid": "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "operation_kind": "drop",
+      "policy_cid": "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "shape_cid": "blake3-512:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "sugar_dict_cid": "blake3-512:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "term_position": [3, 0]
+    }
+  }
+}

--- a/implementations/python/provekit-realize-python-core/tests/test_conformance_fixtures.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_conformance_fixtures.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-core/src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from provekit_realize_python_core.rpc import dispatch
+
+FIXTURES_DIR = ROOT / "implementations/python/conformance/fixtures"
+EXPECTED_FIXTURES = {
+    "arithmetic_add",
+    "control_flow_if",
+    "hello_world",
+    "recursive_factorial",
+    "transported_op_drop",
+}
+COMPILE_FAILURE = "target-compile-failure"
+BEHAVIOR_DIVERGENCE = "target-behavior-divergence"
+
+
+@dataclass(frozen=True)
+class RunResult:
+    stdout: str
+    return_value: Any
+    exit_code: int
+
+
+def _load_fixtures() -> list[dict[str, Any]]:
+    files = sorted(FIXTURES_DIR.glob("*.json"))
+    assert {path.stem for path in files} == EXPECTED_FIXTURES
+
+    fixtures = []
+    for path in files:
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+        assert fixture["name"] == path.stem
+        assert set(("original_source", "declared_test_inputs", "expected_output")).issubset(
+            fixture
+        )
+        assert isinstance(fixture["realize_request"], dict)
+        fixtures.append(fixture)
+    return fixtures
+
+
+def _composition_refusal(
+    fixture_name: str,
+    failure_kind: str,
+    failure_detail: str,
+) -> dict[str, Any]:
+    return {
+        "kind": "CompositionRefusalMemento",
+        "header": {
+            "kind": "composition-refusal",
+            "schema_version": "1",
+            "fixture": fixture_name,
+            "failure_kind": failure_kind,
+            "failure_detail": failure_detail,
+        },
+    }
+
+
+@pytest.mark.parametrize("fixture", _load_fixtures(), ids=lambda fixture: fixture["name"])
+def test_python_carrier_fixtures_emit_compile_and_match_behavior(
+    fixture: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": fixture["name"],
+            "method": "provekit.plugin.invoke",
+            "params": fixture["realize_request"],
+        }
+    )
+    assert "error" not in response, response
+    emitted_source = response["result"]["source"]
+    assert response["result"]["extension"] == "py"
+
+    emitted_file = tmp_path / f"{fixture['name']}_emitted.py"
+    emitted_file.write_text(emitted_source, encoding="utf-8")
+    refusal = _compile_emitted_python(fixture["name"], emitted_file)
+    assert refusal is None, json.dumps(refusal, sort_keys=True)
+
+    if fixture.get("behavior_comparison") == "carrier_comment":
+        expected = fixture["expected_output"]
+        assert isinstance(expected, dict)
+        needle = expected["carrier_comment_contains"]
+        if needle not in emitted_source:
+            pytest.fail(
+                json.dumps(
+                    _composition_refusal(
+                        fixture["name"],
+                        BEHAVIOR_DIVERGENCE,
+                        f"emitted source did not preserve carrier comment {needle!r}",
+                    ),
+                    sort_keys=True,
+                )
+            )
+        return
+
+    original_file = tmp_path / f"{fixture['name']}_original.py"
+    original_file.write_text(fixture["original_source"], encoding="utf-8")
+    original_results = _run_declared_inputs(original_file, fixture)
+    emitted_results = _run_declared_inputs(emitted_file, fixture)
+    expected_results = fixture["expected_output"]
+
+    assert [asdict(result) for result in original_results] == expected_results
+    if original_results != emitted_results:
+        pytest.fail(
+            json.dumps(
+                _composition_refusal(
+                    fixture["name"],
+                    BEHAVIOR_DIVERGENCE,
+                    (
+                        f"original output {[_jsonable(result) for result in original_results]!r} "
+                        f"did not match emitted output "
+                        f"{[_jsonable(result) for result in emitted_results]!r}"
+                    ),
+                ),
+                sort_keys=True,
+            )
+        )
+
+
+def test_compile_failure_refusal_uses_target_compile_failure(tmp_path: Path) -> None:
+    emitted_file = tmp_path / "broken.py"
+    emitted_file.write_text("def broken(:\n    pass\n", encoding="utf-8")
+
+    refusal = _compile_emitted_python("broken", emitted_file)
+
+    assert refusal is not None
+    assert refusal["header"]["failure_kind"] == COMPILE_FAILURE
+
+
+def test_behavior_divergence_refusal_uses_target_behavior_divergence() -> None:
+    refusal = _composition_refusal(
+        "mismatch",
+        BEHAVIOR_DIVERGENCE,
+        "original output did not match emitted output",
+    )
+
+    assert refusal["header"]["failure_kind"] == BEHAVIOR_DIVERGENCE
+
+
+def _compile_emitted_python(fixture_name: str, emitted_file: Path) -> dict[str, Any] | None:
+    proc = subprocess.run(
+        ["python3", "-m", "py_compile", str(emitted_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 0:
+        return None
+    return _composition_refusal(
+        fixture_name,
+        COMPILE_FAILURE,
+        (proc.stderr or proc.stdout).strip(),
+    )
+
+
+def _run_declared_inputs(path: Path, fixture: dict[str, Any]) -> list[RunResult]:
+    module = _load_module(path)
+    calls = fixture["declared_test_inputs"]
+    assert isinstance(calls, list)
+    results = []
+    for call in calls:
+        entrypoint = call["entrypoint"]
+        args = call.get("args", [])
+        stdout = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout):
+                return_value = getattr(module, entrypoint)(*args)
+        except SystemExit as exc:
+            results.append(
+                RunResult(
+                    stdout=stdout.getvalue(),
+                    return_value=None,
+                    exit_code=int(exc.code) if isinstance(exc.code, int) else 1,
+                )
+            )
+        except Exception as exc:
+            results.append(
+                RunResult(
+                    stdout=stdout.getvalue(),
+                    return_value=repr(exc),
+                    exit_code=1,
+                )
+            )
+        else:
+            results.append(
+                RunResult(
+                    stdout=stdout.getvalue(),
+                    return_value=return_value,
+                    exit_code=0,
+                )
+            )
+    return results
+
+
+def _load_module(path: Path) -> ModuleType:
+    module_name = f"provekit_conformance_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _jsonable(result: RunResult) -> dict[str, Any]:
+    return asdict(result)

--- a/implementations/python/pytest.ini
+++ b/implementations/python/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --import-mode=importlib

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -154,7 +154,7 @@ fn python_canonical_bodies_cid_self_consistent() {
     );
     assert_self_consistent(
         path,
-        "blake3-512:f211f2509d6a7deacc2d23d33f87d1259d2835ba7292231f377d7f234f3d22f56dbd2f348314f313accc62ec50ffcec40df6266ca9eb78ca2160a5b80468725e",
+        "blake3-512:5a06ad3425bae615c8b1cf88e0bbb827724f74257ed5f7df1d7d5eaa863666f2cfc5a044d9f4cc4acb6852740c96243061049b4a8ab199cfcc8b1c123169a904",
     );
 }
 

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:f211f2509d6a7deacc2d23d33f87d1259d2835ba7292231f377d7f234f3d22f56dbd2f348314f313accc62ec50ffcec40df6266ca9eb78ca2160a5b80468725e",
+    "cid": "blake3-512:5a06ad3425bae615c8b1cf88e0bbb827724f74257ed5f7df1d7d5eaa863666f2cfc5a044d9f4cc4acb6852740c96243061049b4a8ab199cfcc8b1c123169a904",
     "content": {
       "entries": [
         {
@@ -57,6 +57,67 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
+          }
+        },
+        {
+          "concept_name": "hello-world",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "print(\"Hello, world!\")"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "fixture_specific_stdout": {
+                "args": [],
+                "head": "atomic",
+                "name": "hello-world-stdout-is-fixture-specific"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 0,
+            "min_params": 0
+          }
+        },
+        {
+          "concept_name": "recursive-factorial",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "if ${param0} <= 1:\n    return 1\nreturn ${param0} * factorial(${param0} - 1)"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "fixture_specific_recursion": {
+                "args": [],
+                "head": "atomic",
+                "name": "recursive-factorial-body-names-factorial-fixture"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_param_types": ["int"],
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "abs-value",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} if ${param0} >= 0 else -${param0}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_param_types": ["int"],
+            "requires_return_type": "int"
           }
         },
         {


### PR DESCRIPTION
Closes #1039 (Python slice).

Adds 5 conformance fixtures under `implementations/python/conformance/fixtures/` exercising the emit-compile-run contract from #1039:

- `hello_world` — stdout match
- `recursive_factorial` — n=5 returns 120
- `arithmetic_add` — (3, 4) returns 7
- `control_flow_if` — abs_value over [-5, 0, 5]
- `transported_op_drop` — carrier-citation comment (`# provekit-concept:`) survives the emit verbatim

## Shape

`test_conformance_fixtures.py` (pytest) emits via `SugarRealizer`, compiles each emit with `python3 -m py_compile`, runs the fixture, compares behavior against the original source.

- Compile failure: `CompositionRefusalMemento { failure_kind: "target-compile-failure" }`
- Behavior divergence: `CompositionRefusalMemento { failure_kind: "target-behavior-divergence" }`

Both failure_kind variants additive (defined in #1040, landed in #1046).

## Wiring

- Python body-template CID recomputed; plugin-loader pin updated.
- New `implementations/python/pytest.ini` so `pytest implementations/python` collects sibling tests cleanly.
- The Python kit's `ConformanceDeclaration::Carrier { fixtures_path: ... }` registration (per #1046) points at the new directory.

## Gates

- `pytest implementations/python`: 233 passed, 3 skipped
- `cargo test -p libprovekit -p provekit-cli`: green
- `tools/spec-cid-lint.sh`: exit 0
- em-dash sweep on diff: zero

Slice 1 of 3 (Python). Java + C slices in parallel PRs.