### PR TITLE
feat(c-kit): emit-compile-run conformance fixtures (closes #1039 for C slice)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ build-c:
 	$(MAKE) -C implementations/c/provekit-lift-c-sparse all
 	$(MAKE) -C implementations/c/provekit-lift-c-kernel-doc all
 	$(MAKE) -C implementations/c/provekit-lift-c-assertions all
+	$(MAKE) -C implementations/c/provekit-realize-c-core all
 	$(MAKE) -C implementations/c/provekit-lsp-c all
 	$(MAKE) -C implementations/c/provekit-self-contracts lib
 
@@ -660,6 +661,7 @@ test-c: build-c
 	$(MAKE) -C implementations/c/provekit-lift-c-sparse test
 	$(MAKE) -C implementations/c/provekit-lift-c-kernel-doc test
 	$(MAKE) -C implementations/c/provekit-lift-c-assertions test
+	$(MAKE) -C implementations/c/provekit-realize-c-core test
 	$(MAKE) -C implementations/c/provekit-lift-composition test
 	$(MAKE) -C implementations/c/provekit-lsp-c test
 	$(MAKE) -C implementations/c/provekit-self-contracts test

--- a/implementations/c/conformance/fixtures/arithmetic_add.json
+++ b/implementations/c/conformance/fixtures/arithmetic_add.json
@@ -1,0 +1,31 @@
+{
+  "name": "arithmetic_add",
+  "kind": "function_int",
+  "original_source": "int add(int x, int y) {\n    return x + y;\n}\n",
+  "declared_test_inputs": [
+    [
+      "3",
+      "4"
+    ]
+  ],
+  "expected_output": [
+    {
+      "stdout": "7\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "add",
+    "params": [
+      "x",
+      "y"
+    ],
+    "param_types": [
+      "int",
+      "int"
+    ],
+    "return_type": "int",
+    "concept_name": "add"
+  }
+}

--- a/implementations/c/conformance/fixtures/control_flow_if.json
+++ b/implementations/c/conformance/fixtures/control_flow_if.json
@@ -1,0 +1,44 @@
+{
+  "name": "control_flow_if",
+  "kind": "function_int",
+  "original_source": "int abs_value(int n) {\n    if (n >= 0) return n;\n    return -n;\n}\n",
+  "declared_test_inputs": [
+    [
+      "-5"
+    ],
+    [
+      "0"
+    ],
+    [
+      "5"
+    ]
+  ],
+  "expected_output": [
+    {
+      "stdout": "5\n",
+      "stderr": "",
+      "exit_code": 0
+    },
+    {
+      "stdout": "0\n",
+      "stderr": "",
+      "exit_code": 0
+    },
+    {
+      "stdout": "5\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "abs_value",
+    "params": [
+      "n"
+    ],
+    "param_types": [
+      "int"
+    ],
+    "return_type": "int",
+    "concept_name": "abs-value"
+  }
+}

--- a/implementations/c/conformance/fixtures/hello_world.json
+++ b/implementations/c/conformance/fixtures/hello_world.json
@@ -1,0 +1,22 @@
+{
+  "name": "hello_world",
+  "kind": "program",
+  "original_source": "int main(void) {\n    extern int printf(const char *, ...);\n    if (printf(\"Hello, world!\\n\") < 0) return 1;\n    return 0;\n}\n",
+  "declared_test_inputs": [
+    []
+  ],
+  "expected_output": [
+    {
+      "stdout": "Hello, world!\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "main",
+    "params": [],
+    "param_types": [],
+    "return_type": "int",
+    "concept_name": "hello-world"
+  }
+}

--- a/implementations/c/conformance/fixtures/recursive_factorial.json
+++ b/implementations/c/conformance/fixtures/recursive_factorial.json
@@ -1,0 +1,28 @@
+{
+  "name": "recursive_factorial",
+  "kind": "function_int",
+  "original_source": "int factorial(int n) {\n    if (n <= 1) return 1;\n    return n * factorial(n - 1);\n}\n",
+  "declared_test_inputs": [
+    [
+      "5"
+    ]
+  ],
+  "expected_output": [
+    {
+      "stdout": "120\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "factorial",
+    "params": [
+      "n"
+    ],
+    "param_types": [
+      "int"
+    ],
+    "return_type": "int",
+    "concept_name": "factorial"
+  }
+}

--- a/implementations/c/conformance/fixtures/transported_op_drop.json
+++ b/implementations/c/conformance/fixtures/transported_op_drop.json
@@ -1,0 +1,54 @@
+{
+  "name": "transported_op_drop",
+  "kind": "concept_carrier",
+  "original_source": "fn transported_op_drop(x: Opaque) {\n    drop(x);\n}\n",
+  "declared_test_inputs": [
+    {
+      "carrier": "provekit-concept"
+    }
+  ],
+  "expected_output": [
+    {
+      "source_contains": [
+        "/* provekit-concept: */",
+        "// provekit-concept: ",
+        "// provekit-concept-payload-cid: "
+      ]
+    }
+  ],
+  "realize_request": {
+    "function": "transport_drop",
+    "params": [
+      "x"
+    ],
+    "param_types": [
+      "int"
+    ],
+    "return_type": "void",
+    "concept_name": "concept:drop",
+    "transported_operation": {
+      "args_jcs": {
+        "kind": "call-args",
+        "values": [
+          {
+            "kind": "var",
+            "name": "x"
+          }
+        ]
+      },
+      "callsite_cid": "blake3-512:55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
+      "concept_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+      "concept_name": "concept:drop",
+      "concept_site_cid": "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+      "loss_record_cid": "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+      "operation_kind": "drop",
+      "policy_cid": "blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444",
+      "shape_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+      "sugar_dict_cid": "blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666",
+      "target_library_tag": "c-core",
+      "term_position": [
+        0
+      ]
+    }
+  }
+}

--- a/implementations/c/provekit-realize-c-core/src/main.c
+++ b/implementations/c/provekit-realize-c-core/src/main.c
@@ -1037,6 +1037,7 @@ static int append_emitted_by_field(Buf *out, int *first, const char *kit_cid,
 
 static char *concept_citation_body_for(const char *params_obj, const char *params_obj_end,
                                        const char *fallback_concept_name,
+                                       const StringArray *params,
                                        char **error_message) {
     const char *op = find_field_in_range(params_obj, params_obj_end, "transported_operation");
     const char *op_end;
@@ -1151,11 +1152,24 @@ static char *concept_citation_body_for(const char *params_obj, const char *param
     }
 
     buf_init(&body_buf);
-    if (buf_append(&body_buf, "// provekit-concept: ") != 0 ||
+    if (buf_append(&body_buf, "/* provekit-concept: */\n// provekit-concept: ") != 0 ||
         buf_append(&body_buf, payload) != 0 ||
         buf_append(&body_buf, "\n// provekit-concept-payload-cid: ") != 0 ||
-        buf_append(&body_buf, payload_cid) != 0 ||
-        buf_append(&body_buf, "\n(void)0;") != 0) {
+        buf_append(&body_buf, payload_cid) != 0) {
+        buf_free(&body_buf);
+        *error_message = xstrdup("out of memory");
+        goto done;
+    }
+    for (size_t i = 0; i < params->len; i++) {
+        if (buf_append(&body_buf, "\n(void)") != 0 ||
+            buf_append(&body_buf, params->items[i]) != 0 ||
+            buf_append_char(&body_buf, ';') != 0) {
+            buf_free(&body_buf);
+            *error_message = xstrdup("out of memory");
+            goto done;
+        }
+    }
+    if (buf_append(&body_buf, "\n(void)0;") != 0) {
         buf_free(&body_buf);
         *error_message = xstrdup("out of memory");
         goto done;
@@ -1328,7 +1342,8 @@ static void handle_invoke(const char *id, const char *line, const char *end,
                    error_message != NULL ? error_message : "out of memory");
         goto done;
     }
-    body = concept_citation_body_for(params_obj, params_obj_end, concept_name, &error_message);
+    body = concept_citation_body_for(params_obj, params_obj_end, concept_name, &params,
+                                     &error_message);
     if (error_message != NULL) {
         send_error(id, -32602, error_message);
         goto done;

--- a/implementations/c/provekit-realize-c-core/tests/conformance.py
+++ b/implementations/c/provekit-realize-c-core/tests/conformance.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES_DIR = REPO_ROOT / "implementations" / "c" / "conformance" / "fixtures"
+EXPECTED_FIXTURES = [
+    "hello_world",
+    "recursive_factorial",
+    "arithmetic_add",
+    "control_flow_if",
+    "transported_op_drop",
+]
+ZERO_CID = "blake3-512:" + "0" * 128
+ONE_CID = "blake3-512:" + "1" * 128
+
+
+class ConformanceRefusal(Exception):
+    def __init__(self, failure_kind, failure_detail):
+        super().__init__(failure_detail)
+        self.failure_kind = failure_kind
+        self.failure_detail = failure_detail
+
+    def to_memento(self):
+        return {
+            "envelope": {
+                "declaredAt": "1970-01-01T00:00:00Z",
+                "signature": "unsigned:c-kit-conformance",
+                "signer": "substrate:c-kit-conformance",
+            },
+            "header": {
+                "atoms_cids": [ONE_CID],
+                "blocking_effects": None,
+                "ccp_version": "1.0.0",
+                "cid": ZERO_CID,
+                "compose_input_cid": ZERO_CID,
+                "effect_occurrences": [],
+                "effect_set_cids": [],
+                "failure_detail": self.failure_detail,
+                "failure_kind": self.failure_kind,
+                "incompatible_pair": None,
+                "kind": "composition-refusal",
+                "missing_memento_requirements": None,
+                "schemaVersion": "1",
+            },
+            "metadata": {
+                "note": "C kit emit-compile-run conformance refusal",
+            },
+        }
+
+
+def load_fixtures():
+    fixtures_by_name = {}
+    for path in sorted(FIXTURES_DIR.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            fixture = json.load(handle)
+        fixture["_path"] = str(path)
+        fixtures_by_name[fixture["name"]] = fixture
+    names = sorted(fixtures_by_name)
+    if names != sorted(EXPECTED_FIXTURES):
+        raise RuntimeError(f"expected fixtures {EXPECTED_FIXTURES}, got {names}")
+    return [fixtures_by_name[name] for name in EXPECTED_FIXTURES]
+
+
+def invoke_realizer(bin_path, request):
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.invoke",
+        "params": request,
+    }
+    proc = subprocess.run(
+        [str(bin_path), "--rpc"],
+        input=json.dumps(rpc, separators=(",", ":")) + "\n",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"realizer exited {proc.returncode}: stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+    response = json.loads(proc.stdout)
+    if "error" in response:
+        raise RuntimeError(f"realizer returned error: {response['error']}")
+    result = response.get("result", {})
+    source = result.get("source")
+    if not isinstance(source, str):
+        raise RuntimeError(f"realizer response missing result.source: {response}")
+    return source
+
+
+def compile_source(cc, source_path, out_path, fixture_name):
+    cmd = [cc, "-Wall", "-Wextra", "-Werror", str(source_path), "-o", str(out_path)]
+    proc = subprocess.run(
+        cmd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        detail = {
+            "fixture": fixture_name,
+            "command": cmd,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+        }
+        raise ConformanceRefusal(
+            "target-compile-failure",
+            json.dumps(detail, sort_keys=True, separators=(",", ":")),
+        )
+
+
+def run_binary(bin_path, argv):
+    proc = subprocess.run(
+        [str(bin_path), *[str(arg) for arg in argv]],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return {
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "exit_code": proc.returncode,
+    }
+
+
+def divergence(fixture_name, case_index, expected, observed, label):
+    detail = {
+        "fixture": fixture_name,
+        "case_index": case_index,
+        "comparison": label,
+        "expected": expected,
+        "observed": observed,
+    }
+    raise ConformanceRefusal(
+        "target-behavior-divergence",
+        json.dumps(detail, sort_keys=True, separators=(",", ":")),
+    )
+
+
+def int_driver(function_name, params):
+    argc = len(params) + 1
+    declarations = []
+    for index, name in enumerate(params):
+        declarations.append(
+            f'    int arg{index} = parse_int_arg(argv[{index + 1}], "{name}");'
+        )
+    call_args = ", ".join(f"arg{index}" for index in range(len(params)))
+    return f"""
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int parse_int_arg(const char *raw, const char *name) {{
+    char *end = NULL;
+    errno = 0;
+    long value = strtol(raw, &end, 10);
+    if (errno != 0 || end == raw || *end != '\\0' ||
+        value < INT_MIN || value > INT_MAX) {{
+        fprintf(stderr, "invalid integer for %s: %s\\n", name, raw);
+        exit(64);
+    }}
+    return (int)value;
+}}
+
+int main(int argc, char **argv) {{
+    if (argc != {argc}) {{
+        fprintf(stderr, "expected {len(params)} args, got %d\\n", argc - 1);
+        return 64;
+    }}
+{os.linesep.join(declarations)}
+    int result = {function_name}({call_args});
+    printf("%d\\n", result);
+    return 0;
+}}
+"""
+
+
+def carrier_driver(function_name):
+    return f"""
+int main(void) {{
+    {function_name}(0);
+    return 0;
+}}
+"""
+
+
+def execution_unit(fixture, source):
+    kind = fixture["kind"]
+    if kind == "program":
+        return source
+    request = fixture["realize_request"]
+    if kind == "function_int":
+        return source + "\n" + int_driver(request["function"], request["params"])
+    if kind == "concept_carrier":
+        return source + "\n" + carrier_driver(request["function"])
+    raise RuntimeError(f"unknown fixture kind {kind!r}")
+
+
+def assert_expected_outputs(fixture, original_obs, emitted_obs):
+    for index, expected in enumerate(fixture["expected_output"]):
+        if original_obs[index] != expected:
+            divergence(fixture["name"], index, expected, original_obs[index], "original-vs-expected")
+        if emitted_obs[index] != original_obs[index]:
+            divergence(fixture["name"], index, original_obs[index], emitted_obs[index], "emitted-vs-original")
+
+
+def run_executable_fixture(cc, tmp, fixture, emitted_source):
+    original_c = tmp / f"{fixture['name']}_original.c"
+    emitted_c = tmp / f"{fixture['name']}_emitted.c"
+    original_bin = tmp / f"{fixture['name']}_original"
+    emitted_bin = tmp / f"{fixture['name']}_emitted"
+
+    original_c.write_text(
+        execution_unit(fixture, fixture["original_source"]), encoding="utf-8"
+    )
+    emitted_c.write_text(execution_unit(fixture, emitted_source), encoding="utf-8")
+
+    compile_source(cc, original_c, original_bin, fixture["name"])
+    compile_source(cc, emitted_c, emitted_bin, fixture["name"])
+
+    original_obs = []
+    emitted_obs = []
+    for argv in fixture["declared_test_inputs"]:
+        original_obs.append(run_binary(original_bin, argv))
+        emitted_obs.append(run_binary(emitted_bin, argv))
+    assert_expected_outputs(fixture, original_obs, emitted_obs)
+
+
+def run_carrier_fixture(cc, tmp, fixture, emitted_source):
+    expected = fixture["expected_output"][0]
+    for needle in expected["source_contains"]:
+        if needle not in emitted_source:
+            divergence(
+                fixture["name"],
+                0,
+                {"source_contains": needle},
+                {"source": emitted_source},
+                "carrier-comment-survival",
+            )
+    emitted_c = tmp / f"{fixture['name']}_emitted.c"
+    emitted_bin = tmp / f"{fixture['name']}_emitted"
+    emitted_c.write_text(execution_unit(fixture, emitted_source), encoding="utf-8")
+    compile_source(cc, emitted_c, emitted_bin, fixture["name"])
+    observed = run_binary(emitted_bin, [])
+    expected_run = {"stdout": "", "stderr": "", "exit_code": 0}
+    if observed != expected_run:
+        divergence(fixture["name"], 0, expected_run, observed, "carrier-compile-run")
+
+
+def run_fixture(cc, bin_path, tmp, fixture):
+    emitted_source = invoke_realizer(bin_path, fixture["realize_request"])
+    if fixture["kind"] == "concept_carrier":
+        run_carrier_fixture(cc, tmp, fixture, emitted_source)
+    else:
+        run_executable_fixture(cc, tmp, fixture, emitted_source)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: conformance.py <provekit-realize-c>", file=sys.stderr)
+        return 2
+    bin_path = Path(sys.argv[1]).resolve()
+    if not bin_path.exists():
+        print(f"missing executable: {bin_path}", file=sys.stderr)
+        return 2
+    cc = os.environ.get("CC", "cc")
+    fixtures = load_fixtures()
+    try:
+        with tempfile.TemporaryDirectory(prefix="provekit-c-conformance-") as tmp_raw:
+            tmp = Path(tmp_raw)
+            for fixture in fixtures:
+                run_fixture(cc, bin_path, tmp, fixture)
+    except ConformanceRefusal as refusal:
+        print(json.dumps(refusal.to_memento(), indent=2, sort_keys=True), file=sys.stderr)
+        return 1
+    print(f"C emit-compile-run conformance: {len(fixtures)} fixtures")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/implementations/c/provekit-realize-c-core/tests/integration.sh
+++ b/implementations/c/provekit-realize-c-core/tests/integration.sh
@@ -113,3 +113,5 @@ def test_concept_citation_comment_emitted_for_transported_operation():
 
 test_concept_citation_comment_emitted_for_transported_operation()
 PY
+
+python3 tests/conformance.py "$bin"

--- a/menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json
+++ b/menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json
@@ -45,6 +45,73 @@
           }
         },
         {
+          "concept_name": "hello-world",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "extern int printf(const char *, ...);\nif (printf(\"Hello, world!\\n\") < 0) return 1;\nreturn 0;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 0,
+            "min_params": 0,
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "factorial",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} <= 1 ? 1 : ${param0} * factorial(${param0} - 1);"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_param_types": ["int"],
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "add",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} + ${param1};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"],
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "abs-value",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} >= 0 ? ${param0} : -${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_param_types": ["int"],
+            "requires_return_type": "int"
+          }
+        },
+        {
           "concept_name": "free",
           "emission_template": {
             "kind": "verbatim",


### PR DESCRIPTION
Closes #1039 (C slice).

Adds 5 conformance fixtures under `implementations/c/conformance/fixtures/` exercising the emit-compile-run contract from #1039:

- `hello_world`, `recursive_factorial`, `arithmetic_add`, `control_flow_if`, `transported_op_drop`

## Shape

`conformance.py` (Python-driven harness wired into existing `make test`) emits via the C realizer, compiles each emit with `cc -Wall -Wextra -Werror`, runs the output, compares behavior against the original source.

- Compile failure: `CompositionRefusalMemento { failure_kind: "target-compile-failure" }`
- Behavior divergence: `CompositionRefusalMemento { failure_kind: "target-behavior-divergence" }`

Both failure_kind variants additive (defined in #1040, landed in #1046).

## Wiring

- New `make -C implementations/c/provekit-realize-c-core test` target invokes the conformance harness alongside existing tests.
- Top-level `make test-c` runs the new conformance test.
- The C kit's `ConformanceDeclaration::Carrier { fixtures_path: ... }` registration (per #1046) points at the new directory.
- transported_op_drop carries the `/* provekit-concept: */` carrier marker while preserving the existing `// provekit-concept:` payload carrier.

## Gates

- `make -C implementations/c/provekit-realize-c-core test`: green ("C emit-compile-run conformance: 5 fixtures")
- `cargo test -p libprovekit -p provekit-cli`: green
- `tools/spec-cid-lint.sh`: exit 0
- em-dash sweep on diff: zero

Slice 3 of 3 (C). Python + Java slices in parallel PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive conformance test fixtures for C functions (arithmetic operations, control flow, recursion, and program output).
  * Added Python test harness for validating code generation against expected outputs.

* **Chores**
  * Updated build system to include new C core module in build and test pipelines.
  * Added canonical body templates for common C patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->