### PR TITLE
feat(libprovekit/catalog): contains predicate with default impl + HashMapCatalog override (closes #1056)

### DIFF
--- a/implementations/rust/libprovekit/src/core/traits.rs
+++ b/implementations/rust/libprovekit/src/core/traits.rs
@@ -28,6 +28,18 @@ pub trait Canonical {
 pub trait Catalog {
     /// Return the canonical bytes stored at `cid`, or `None` when absent.
     fn get(&self, cid: &Cid) -> Option<Vec<u8>>;
+
+    /// Returns true iff `get(cid)` would return `Some(_)`.
+    ///
+    /// Default impl performs the full `get` and discards the bytes. Impls that
+    /// can answer presence cheaply (in-memory HashMaps via `contains_key`,
+    /// filesystem-backed impls via `stat()` rather than `read()`) should
+    /// override. When a filesystem-backed `Catalog` impl is minted in
+    /// libprovekit::core, override `contains` to use `exists()` so verifier-side
+    /// hot paths don't pay full-read I/O cost.
+    fn contains(&self, cid: &Cid) -> bool {
+        self.get(cid).is_some()
+    }
 }
 
 /// In-memory content-addressed byte catalog used by unit tests and small examples.
@@ -56,6 +68,10 @@ impl HashMapCatalog {
 impl Catalog for HashMapCatalog {
     fn get(&self, cid: &Cid) -> Option<Vec<u8>> {
         self.entries.get(cid).cloned()
+    }
+
+    fn contains(&self, cid: &Cid) -> bool {
+        self.entries.contains_key(cid)
     }
 }
 

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -10,7 +10,7 @@ use libprovekit::compose::{
 };
 use libprovekit::core::{
     address, compose, execute_path, link, prove, transform, verify, ArityShape, AritySlot, CKit,
-    Canonical, Cid, ConformanceDeclaration, Dialect, DomainClaim, DomainKind,
+    Canonical, Catalog, Cid, ConformanceDeclaration, Dialect, DomainClaim, DomainKind,
     FunctionContractDomain, HashMapCatalog, HashMapInputCatalog, Input, InputCatalog, Kit,
     KitRegistry, LanguageSignature, LiftKit, LiftPluginKit, Path, PathAlgebra, PathDocument,
     PathDocumentError, PathError, Refutation, SlotSort, Term, Truth, Verb, Verdict, Witness,
@@ -975,6 +975,26 @@ fn resolve_reads_canonical_bytes_from_hash_map_catalog() {
 
     let bytes = libprovekit::core::resolve(&cid, &catalog).expect("claim bytes resolve");
     assert_eq!(bytes, claim.canonical_bytes());
+}
+
+#[test]
+fn hash_map_catalog_contains_reports_membership_without_get_fetch() {
+    let claim = claim_for_contract(pure_identity_contract("catalog_contains", "x"));
+    let mut catalog = HashMapCatalog::default();
+    let present = catalog.insert(&claim);
+    let absent = address(&"missing catalog entry");
+
+    assert!(<HashMapCatalog as Catalog>::contains(&catalog, &present));
+    assert!(!<HashMapCatalog as Catalog>::contains(&catalog, &absent));
+
+    let traits_source = include_str!("../src/core/traits.rs");
+    let impl_body = traits_source
+        .split("impl Catalog for HashMapCatalog {")
+        .nth(1)
+        .and_then(|tail| tail.split("/// Typed resolver").next())
+        .expect("HashMapCatalog Catalog impl is present");
+    assert!(impl_body.contains("self.entries.contains_key(cid)"));
+    assert!(!impl_body.contains("self.get(cid)"));
 }
 
 #[test]


### PR DESCRIPTION
Phase 1 of the #1024 Trinity exhibit prereq queue (parallel with #1055 A4 already merged via #1061).

Adds `Catalog::contains(&Cid) -> bool` as a trait method with default impl `self.get(cid).is_some()`. `HashMapCatalog` overrides to use `entries.contains_key()` so verifier-side hot-paths do not pay the unused `Vec<u8>` clone.

## Architect ruling (locked)

Doc-comment on the trait method records the future-fs-impl directive verbatim:

```
/// Returns true iff get(cid) would return Some(_).
///
/// Default impl performs the full get and discards the bytes. Impls that
/// can answer presence cheaply (in-memory HashMaps via contains_key,
/// filesystem-backed impls via stat() rather than read()) should
/// override. When a filesystem-backed Catalog impl is minted in
/// libprovekit::core, override contains to use exists() so verifier-side
/// hot paths do not pay full-read I/O cost.
```

## Trimmed-scope note

The original draft of #1056 assumed an fs-backed `Catalog` impl exists in libprovekit. Repo survey showed only `HashMapCatalog` impls the trait; fs-named structs in other crates are different types. The fs-backed override is deferred until a real fs-backed Catalog impl is minted; the trait method + HashMapCatalog override is the entire scope. The trimming was the antibody from codex's first dispatch (refused to fabricate fs-impl that did not exist).

## Tests

- HashMapCatalog membership round-trip (insert X, contains(X) == true, contains(Y) == false).
- Source assertion: the override calls `contains_key`, not `self.get` (compile-time argument).

## Gates

- `cargo test -p libprovekit`: green
- `tools/spec-cid-lint.sh`: exit 0
- `git diff --check`: clean
- em-dash sweep: zero

Consumed by future `assert_concept_tier` helper in #1024.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized internal membership verification to deliver improved lookup performance across library operations while maintaining full API compatibility.

* **Tests**
  * Added comprehensive test coverage validating the efficiency and correctness of the optimized membership verification implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->