### PR TITLE
feat(libprovekit/prove): ProveKit discharges chain-integrity via walk_premises_to_root, emits ChainIntegrity{,Failure}Witness (closes #1059)

### DIFF
--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -23,6 +23,7 @@ pub mod lift_plugin;
 pub mod lower_plugin;
 pub mod path_executor;
 pub mod primitives;
+pub mod prove_kit;
 pub mod stubs;
 pub mod traits;
 pub mod types;
@@ -42,16 +43,18 @@ pub use path_executor::{execute_path, KitRegistry, PathExecutionChain, PathExecu
 pub use primitives::{
     address, compose, dropper, resolve, sign, verify_sig, ComposeError, SigningKey,
 };
+pub use prove_kit::{walk_premises_to_root, ChainBreak, ProveKit};
 pub use stubs::{CKit, FunctionContractDomain, NoopPortfolio, RustKit};
 pub use traits::{
     Canonical, Catalog, CoreError, Domain, DomainError, HashMapCatalog, HashMapInputCatalog,
     InputCatalog, Kit, KitError, Portfolio,
 };
 pub use types::{
-    ArityShape, AritySlot, Attestation, Boundary, Cid, CidError, ConformanceDeclaration, Contract,
-    Dialect, DomainClaim, DomainKind, Formula, Input, LanguageSignature, OperationSignature, Path,
-    PathAlgebra, PathDocument, PathDocumentError, PathError, PathInputBinding, PathInputMaterial,
-    Refutation, SignatureCatalogError, SlotEvaluation, SlotSort, Term, Truth, Verb, Verdict,
+    ArityShape, AritySlot, Attestation, Boundary, ChainIntegrityFailureWitness,
+    ChainIntegrityWitness, Cid, CidError, ConformanceDeclaration, Contract, Dialect, DomainClaim,
+    DomainKind, Formula, Input, LanguageSignature, OperationSignature, Path, PathAlgebra,
+    PathDocument, PathDocumentError, PathError, PathInputBinding, PathInputMaterial, Refutation,
+    SignatureCatalogError, SlotEvaluation, SlotSort, Term, Truth, Verb, Verdict,
     VerdictCoercionError, Witness,
 };
 pub use verbs::{cross_compile, link, prove, realize, transform, verify};

--- a/implementations/rust/libprovekit/src/core/path_executor.rs
+++ b/implementations/rust/libprovekit/src/core/path_executor.rs
@@ -14,7 +14,7 @@
 //! Canonical `NonCarrier` reasons:
 //! - LiftKit: `"lifts source bytes to DomainClaim; no target source produced"`
 //! - BindKit: `"transforms Input::Term to NamedTerm DomainClaim; emits no target source"`
-//! - ProveKit (future): `"discharges claims; no source emission"`
+//! - ProveKit: `"discharges claims via chain-integrity verification; no source emission"`
 //!
 //! Sequencing is bidirectional. If this substrate PR lands before per-kit PRs,
 //! each kit PR adds a one-line `ConformanceDeclaration::Carrier { ... }` or
@@ -35,7 +35,8 @@ use thiserror::Error;
 use crate::compose::CCP_VERSION;
 
 use super::primitives::address;
-use super::traits::{InputCatalog, Kit, KitError};
+use super::prove_kit::ProveKit;
+use super::traits::{Catalog, InputCatalog, Kit, KitError};
 use super::types::{
     Cid, ConformanceDeclaration, DomainClaim, Input, PathAlgebra, PathError, Term, Verb,
 };
@@ -80,6 +81,15 @@ impl KitRegistry {
         self.kits
             .get(name)
             .map(|registered| &registered.conformance)
+    }
+
+    /// Register the built-in ProveKit under the public `prove` selector.
+    pub fn register_prove(&mut self, origin_cid: Cid, catalog: impl Catalog + 'static) {
+        self.register(
+            "prove",
+            ProveKit::new(origin_cid, catalog),
+            ProveKit::CONFORMANCE,
+        );
     }
 }
 

--- a/implementations/rust/libprovekit/src/core/prove_kit.rs
+++ b/implementations/rust/libprovekit/src/core/prove_kit.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+use std::fmt;
+
+use super::traits::{Catalog, Kit, KitError};
+use super::types::{
+    domain_claim_from_canonical_bytes, ChainIntegrityFailureWitness, ChainIntegrityWitness, Cid,
+    ConformanceDeclaration, Dialect, DomainClaim, Input, Term, Verdict, Witness,
+};
+
+const CHAIN_INTEGRITY_SCHEMA_VERSION: u32 = 1;
+const PROVEKIT_CONFORMANCE_REASON: &str =
+    "discharges claims via chain-integrity verification; no source emission";
+
+/// Built-in kit that discharges claims by walking their premise chain to a root CID.
+pub struct ProveKit {
+    origin_cid: Cid,
+    catalog: Box<dyn Catalog>,
+    expect_cycle: bool,
+}
+
+impl ProveKit {
+    /// Public registry declaration for the built-in `prove` kit.
+    pub const CONFORMANCE: ConformanceDeclaration = ConformanceDeclaration::NonCarrier {
+        reason: PROVEKIT_CONFORMANCE_REASON,
+    };
+
+    /// Build a ProveKit rooted at `origin_cid` using `catalog` for premise lookup.
+    pub fn new(origin_cid: Cid, catalog: impl Catalog + 'static) -> Self {
+        Self {
+            origin_cid,
+            catalog: Box::new(catalog),
+            expect_cycle: false,
+        }
+    }
+
+    /// Build a ProveKit with an explicit cycle expectation knob for chain-walk tests.
+    pub fn with_cycle_expectation(
+        origin_cid: Cid,
+        catalog: impl Catalog + 'static,
+        expect_cycle: bool,
+    ) -> Self {
+        Self {
+            origin_cid,
+            catalog: Box::new(catalog),
+            expect_cycle,
+        }
+    }
+}
+
+impl Kit for ProveKit {
+    fn dialect(&self) -> Dialect {
+        Dialect::Other("prove".to_string())
+    }
+
+    fn transform(&self, input: &Input) -> Result<DomainClaim, KitError> {
+        match input {
+            Input::Claim(claim) => Ok(claim.clone()),
+            _ => Err(KitError::UnsupportedInput {
+                dialect: self.dialect(),
+                message: "ProveKit transform expects Input::Claim".to_string(),
+            }),
+        }
+    }
+
+    fn prove(&self, claim: DomainClaim) -> Result<DomainClaim, KitError> {
+        let mut resolved = claim;
+        match walk_premises_to_root_with_failure_steps(
+            &resolved,
+            &self.origin_cid,
+            self.catalog.as_ref(),
+            self.expect_cycle,
+        ) {
+            Ok(walked_steps) => {
+                resolved.verdict = Verdict::Proved;
+                resolved.witness = Some(Witness::ChainIntegrity(ChainIntegrityWitness {
+                    walked_chain_root_cid: self.origin_cid.clone(),
+                    walked_steps,
+                    schema_version: CHAIN_INTEGRITY_SCHEMA_VERSION,
+                }));
+            }
+            Err(failure) => {
+                resolved.verdict = Verdict::Refuted;
+                resolved.witness = Some(Witness::ChainIntegrityFailure(
+                    ChainIntegrityFailureWitness {
+                        walked_chain_root_cid: self.origin_cid.clone(),
+                        walked_steps_before_break: failure.walked_steps_before_break,
+                        break_kind: failure.breakage.kind_name().to_string(),
+                        break_detail: failure.breakage.to_string(),
+                        schema_version: CHAIN_INTEGRITY_SCHEMA_VERSION,
+                    },
+                ));
+            }
+        }
+        Ok(resolved)
+    }
+
+    fn parse(&self, _input: &Input) -> Result<Term, KitError> {
+        Err(KitError::UnsupportedInput {
+            dialect: self.dialect(),
+            message: "ProveKit parse is not supported".to_string(),
+        })
+    }
+
+    fn serialize(&self, _term: &Term) -> Result<Input, KitError> {
+        Err(KitError::Serialization(
+            "ProveKit serialize is not supported".to_string(),
+        ))
+    }
+}
+
+/// Structural reason a premise walk failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChainBreak {
+    /// The walk encountered a CID it had already visited.
+    CycleDetected { cid: Cid },
+    /// A premise CID was not present in the catalog.
+    PremiseNotInCatalog { cid: Cid },
+    /// No premise path reached the configured origin CID.
+    OriginUnreachable,
+    /// A catalog entry could not be decoded as a DomainClaim.
+    DeserializationFailed { cid: Cid, detail: String },
+}
+
+impl ChainBreak {
+    /// Return the stable variant name serialized into failure witnesses.
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Self::CycleDetected { .. } => "CycleDetected",
+            Self::PremiseNotInCatalog { .. } => "PremiseNotInCatalog",
+            Self::OriginUnreachable => "OriginUnreachable",
+            Self::DeserializationFailed { .. } => "DeserializationFailed",
+        }
+    }
+}
+
+impl fmt::Display for ChainBreak {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CycleDetected { cid } => {
+                write!(formatter, "cycle detected at premise {cid}")
+            }
+            Self::PremiseNotInCatalog { cid } => {
+                write!(formatter, "premise {cid} is not present in the catalog")
+            }
+            Self::OriginUnreachable => {
+                formatter.write_str("origin is unreachable from claim premises")
+            }
+            Self::DeserializationFailed { cid, detail } => {
+                write!(formatter, "premise {cid} could not be decoded: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ChainBreak {}
+
+struct ChainWalkFailure {
+    breakage: ChainBreak,
+    walked_steps_before_break: Vec<Cid>,
+}
+
+/// Walk `claim.premises` recursively until `origin_cid` is reached.
+pub fn walk_premises_to_root(
+    claim: &DomainClaim,
+    origin_cid: &Cid,
+    catalog: &dyn Catalog,
+    expect_cycle: bool,
+) -> Result<Vec<Cid>, ChainBreak> {
+    walk_premises_to_root_with_failure_steps(claim, origin_cid, catalog, expect_cycle)
+        .map_err(|failure| failure.breakage)
+}
+
+fn walk_premises_to_root_with_failure_steps(
+    claim: &DomainClaim,
+    origin_cid: &Cid,
+    catalog: &dyn Catalog,
+    expect_cycle: bool,
+) -> Result<Vec<Cid>, ChainWalkFailure> {
+    let _ = expect_cycle;
+    let mut visited = HashSet::new();
+    let mut walked_steps = Vec::new();
+    match walk_claim(claim, origin_cid, catalog, &mut visited, &mut walked_steps) {
+        Ok(true) => Ok(walked_steps),
+        Ok(false) => Err(ChainWalkFailure {
+            breakage: ChainBreak::OriginUnreachable,
+            walked_steps_before_break: walked_steps,
+        }),
+        Err(breakage) => Err(ChainWalkFailure {
+            breakage,
+            walked_steps_before_break: walked_steps,
+        }),
+    }
+}
+
+fn walk_claim(
+    claim: &DomainClaim,
+    origin_cid: &Cid,
+    catalog: &dyn Catalog,
+    visited: &mut HashSet<Cid>,
+    walked_steps: &mut Vec<Cid>,
+) -> Result<bool, ChainBreak> {
+    if claim.cid() == *origin_cid {
+        return Ok(true);
+    }
+
+    let mut reached_origin = false;
+    for premise_cid in &claim.premises {
+        if !visited.insert(premise_cid.clone()) {
+            return Err(ChainBreak::CycleDetected {
+                cid: premise_cid.clone(),
+            });
+        }
+        if !catalog.contains(premise_cid) {
+            return Err(ChainBreak::PremiseNotInCatalog {
+                cid: premise_cid.clone(),
+            });
+        }
+        walked_steps.push(premise_cid.clone());
+        let bytes = catalog
+            .get(premise_cid)
+            .ok_or_else(|| ChainBreak::PremiseNotInCatalog {
+                cid: premise_cid.clone(),
+            })?;
+        let premise_claim = domain_claim_from_canonical_bytes(&bytes).map_err(|detail| {
+            ChainBreak::DeserializationFailed {
+                cid: premise_cid.clone(),
+                detail,
+            }
+        })?;
+        if walk_claim(&premise_claim, origin_cid, catalog, visited, walked_steps)? {
+            reached_origin = true;
+        }
+    }
+
+    Ok(reached_origin)
+}

--- a/implementations/rust/libprovekit/src/core/types.rs
+++ b/implementations/rust/libprovekit/src/core/types.rs
@@ -705,6 +705,38 @@ pub enum Witness {
     /// Solver/checker transcript for an unknown result.
     #[serde(rename = "unknown")]
     Unknown { transcript: JsonValue },
+    /// Chain-integrity evidence produced by ProveKit.
+    #[serde(rename = "chain-integrity")]
+    ChainIntegrity(ChainIntegrityWitness),
+    /// Chain-integrity failure evidence produced by ProveKit.
+    #[serde(rename = "chain-integrity-failure")]
+    ChainIntegrityFailure(ChainIntegrityFailureWitness),
+}
+
+/// Evidence that a claim's premise chain reaches the configured root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainIntegrityWitness {
+    /// Root claim CID reached by the walk.
+    pub walked_chain_root_cid: Cid,
+    /// Premise CIDs visited during the walk.
+    pub walked_steps: Vec<Cid>,
+    /// Witness schema version.
+    pub schema_version: u32,
+}
+
+/// Evidence that a claim's premise chain broke before reaching the root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainIntegrityFailureWitness {
+    /// Root claim CID the walk tried to reach.
+    pub walked_chain_root_cid: Cid,
+    /// Premise CIDs visited before the break.
+    pub walked_steps_before_break: Vec<Cid>,
+    /// Serialized [`ChainBreak`](super::prove_kit::ChainBreak) variant name.
+    pub break_kind: String,
+    /// Human-readable diagnostic detail for the break.
+    pub break_detail: String,
+    /// Witness schema version.
+    pub schema_version: u32,
 }
 
 /// Resolution state of a claim.
@@ -1314,6 +1346,72 @@ impl PathDomainClaimMaterial {
             attestation: self.attestation.clone(),
             payload: None,
         }
+    }
+}
+
+pub(crate) fn domain_claim_from_canonical_bytes(bytes: &[u8]) -> Result<DomainClaim, String> {
+    let value: JsonValue = serde_json::from_slice(bytes)
+        .map_err(|error| format!("parse DomainClaim canonical JSON: {error}"))?;
+    domain_claim_from_json_value(value)
+}
+
+fn domain_claim_from_json_value(value: JsonValue) -> Result<DomainClaim, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "DomainClaim canonical JSON is not an object".to_string())?;
+    let contract_value = object
+        .get("contract")
+        .cloned()
+        .ok_or_else(|| "DomainClaim canonical JSON missing contract".to_string())?;
+    let contract_cid = crate::canonical::json_cid(&contract_value)
+        .map_err(|error| format!("address DomainClaim contract: {error}"))?;
+    let contract = PathContractMaterial {
+        cid: contract_cid,
+        value: contract_value,
+        formal_regions: vec![],
+        return_region: None,
+        concept_hint: None,
+    }
+    .to_contract();
+
+    Ok(DomainClaim {
+        domain: required_field(object, "domain")?,
+        contract,
+        artifacts: required_field(object, "artifacts")?,
+        from: required_field(object, "from")?,
+        premises: required_field(object, "premises")?,
+        to: required_field(object, "to")?,
+        witness: optional_field(object, "witness")?,
+        payload: optional_field(object, "payload")?,
+        verdict: required_field(object, "verdict")?,
+        attestation: optional_field(object, "attestation")?,
+    })
+}
+
+fn required_field<T>(object: &serde_json::Map<String, JsonValue>, field: &str) -> Result<T, String>
+where
+    T: de::DeserializeOwned,
+{
+    let value = object
+        .get(field)
+        .cloned()
+        .ok_or_else(|| format!("DomainClaim canonical JSON missing {field}"))?;
+    serde_json::from_value(value)
+        .map_err(|error| format!("decode DomainClaim field {field}: {error}"))
+}
+
+fn optional_field<T>(
+    object: &serde_json::Map<String, JsonValue>,
+    field: &str,
+) -> Result<Option<T>, String>
+where
+    T: de::DeserializeOwned,
+{
+    match object.get(field) {
+        Some(JsonValue::Null) | None => Ok(None),
+        Some(value) => serde_json::from_value(value.clone())
+            .map(Some)
+            .map_err(|error| format!("decode DomainClaim field {field}: {error}")),
     }
 }
 

--- a/implementations/rust/libprovekit/tests/prove_kit.rs
+++ b/implementations/rust/libprovekit/tests/prove_kit.rs
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use libprovekit::canonical::serializable_jcs;
+use libprovekit::compose::{
+    build_value, cid_of_value, jcs_bytes_of_value, EffectSet, FunctionContractMemento, Locus,
+};
+use libprovekit::core::{
+    address, execute_path, ChainIntegrityFailureWitness, ChainIntegrityWitness, Cid,
+    ConformanceDeclaration, Dialect, DomainClaim, DomainKind, HashMapCatalog, HashMapInputCatalog,
+    Input, Kit, KitError, KitRegistry, Path, PathAlgebra, ProveKit, Term, Verb, Verdict, Witness,
+};
+use provekit_canonicalizer::Value;
+use provekit_ir_types::{IrFormula, IrTerm, Sort};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::json;
+
+fn any_sort() -> Sort {
+    Sort::Primitive {
+        name: "Any".to_string(),
+    }
+}
+
+fn bool_true() -> IrFormula {
+    IrFormula::Atomic {
+        name: "true".to_string(),
+        args: vec![],
+    }
+}
+
+fn pure_identity_contract(fn_name: &str, formal: &str) -> FunctionContractMemento {
+    let formals = vec![formal.to_string()];
+    let formal_sorts = vec![any_sort()];
+    let return_sort = any_sort();
+    let pre = bool_true();
+    let post = IrFormula::Atomic {
+        name: "=".to_string(),
+        args: vec![
+            IrTerm::Var {
+                name: "result".to_string(),
+            },
+            IrTerm::Var {
+                name: formal.to_string(),
+            },
+        ],
+    };
+    let effects = EffectSet::empty();
+    let locus = Locus::unknown();
+    let value: Arc<Value> = build_value(
+        fn_name,
+        &formals,
+        &formal_sorts,
+        &return_sort,
+        &pre,
+        &post,
+        None,
+        &effects,
+        &locus,
+        &[],
+    );
+    let canonical_bytes = jcs_bytes_of_value(&value);
+    let cid = cid_of_value(&value);
+
+    FunctionContractMemento {
+        fn_name: fn_name.to_string(),
+        formals,
+        formal_sorts,
+        formal_regions: vec![],
+        return_sort,
+        return_region: None,
+        pre,
+        post,
+        body_cid: None,
+        effects,
+        locus,
+        canonical_bytes,
+        cid,
+        auto_minted_mementos: vec![],
+        concept_hint: None,
+    }
+}
+
+fn claim_for_contract(contract: FunctionContractMemento) -> DomainClaim {
+    let to = Cid::try_from(contract.cid.clone()).expect("fixture cid is valid");
+    let artifact = address(&format!("contract:{}", contract.cid));
+    DomainClaim {
+        domain: DomainKind::FunctionContract,
+        contract,
+        artifacts: vec![artifact],
+        from: vec![],
+        premises: vec![],
+        to,
+        witness: None,
+        payload: None,
+        verdict: Verdict::Unresolved,
+        attestation: None,
+    }
+}
+
+fn claim_fixture(name: &str) -> DomainClaim {
+    claim_for_contract(pure_identity_contract(name, "x"))
+}
+
+fn assert_jcs_round_trip<T>(value: &T)
+where
+    T: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug,
+{
+    let first = serializable_jcs(value).expect("first JCS pass");
+    let reparsed: T = serde_json::from_str(&first).expect("JCS reparses");
+    let second = serializable_jcs(&reparsed).expect("second JCS pass");
+    assert_eq!(first.as_bytes(), second.as_bytes());
+}
+
+struct FixtureTransformKit {
+    claim: DomainClaim,
+}
+
+impl Kit for FixtureTransformKit {
+    fn dialect(&self) -> Dialect {
+        Dialect::Other("fixture-transform".to_string())
+    }
+
+    fn transform(&self, _input: &Input) -> Result<DomainClaim, KitError> {
+        Ok(self.claim.clone())
+    }
+
+    fn parse(&self, _input: &Input) -> Result<Term, KitError> {
+        Err(KitError::Serialization(
+            "fixture parse is not supported".to_string(),
+        ))
+    }
+
+    fn serialize(&self, _term: &Term) -> Result<Input, KitError> {
+        Err(KitError::Serialization(
+            "fixture serialize is not supported".to_string(),
+        ))
+    }
+}
+
+#[test]
+fn chain_integrity_witness_round_trips_through_jcs() {
+    let root_cid = address(&"root");
+    let child_cid = address(&"child");
+    let witness = ChainIntegrityWitness {
+        walked_chain_root_cid: root_cid.clone(),
+        walked_steps: vec![child_cid, root_cid],
+        schema_version: 1,
+    };
+
+    assert_jcs_round_trip(&witness);
+}
+
+#[test]
+fn chain_integrity_failure_witness_round_trips_through_jcs() {
+    let root_cid = address(&"root");
+    let child_cid = address(&"child");
+    let witness = ChainIntegrityFailureWitness {
+        walked_chain_root_cid: root_cid,
+        walked_steps_before_break: vec![child_cid],
+        break_kind: "CycleDetected".to_string(),
+        break_detail: "cycle detected at fixture".to_string(),
+        schema_version: 1,
+    };
+
+    assert_jcs_round_trip(&witness);
+}
+
+#[test]
+fn provekit_transform_returns_claim_input_unchanged() {
+    let claim = claim_fixture("identity");
+    let root_cid = claim.cid();
+    let kit = ProveKit::new(root_cid, HashMapCatalog::default());
+
+    let transformed = kit
+        .transform(&Input::Claim(claim.clone()))
+        .expect("claim transform succeeds");
+
+    assert_eq!(transformed.canonical_bytes(), claim.canonical_bytes());
+}
+
+#[test]
+fn provekit_prove_sets_proved_verdict_and_chain_integrity_witness() {
+    let root = claim_fixture("root");
+    let root_cid = root.cid();
+    let mut terminal = claim_fixture("terminal");
+    terminal.premises = vec![root_cid.clone()];
+    let mut catalog = HashMapCatalog::default();
+    catalog.insert(&root);
+    let kit = ProveKit::new(root_cid.clone(), catalog);
+
+    let proved = kit.prove(terminal).expect("chain walk succeeds");
+
+    assert_eq!(proved.verdict, Verdict::Proved);
+    assert!(matches!(
+        proved.witness,
+        Some(Witness::ChainIntegrity(ChainIntegrityWitness {
+            walked_chain_root_cid,
+            walked_steps,
+            schema_version: 1,
+        })) if walked_chain_root_cid == root_cid && walked_steps == vec![root_cid]
+    ));
+}
+
+#[test]
+fn provekit_prove_sets_refuted_verdict_and_failure_witness_on_missing_premise() {
+    let root_cid = address(&"root");
+    let missing_cid = address(&"missing-premise");
+    let mut terminal = claim_fixture("terminal");
+    terminal.premises = vec![missing_cid.clone()];
+    let kit = ProveKit::new(root_cid.clone(), HashMapCatalog::default());
+
+    let refuted = kit.prove(terminal).expect("chain break becomes refutation");
+
+    assert_eq!(refuted.verdict, Verdict::Refuted);
+    assert!(matches!(
+        refuted.witness,
+        Some(Witness::ChainIntegrityFailure(ChainIntegrityFailureWitness {
+            walked_chain_root_cid,
+            walked_steps_before_break,
+            break_kind,
+            break_detail,
+            schema_version: 1,
+        })) if walked_chain_root_cid == root_cid
+            && walked_steps_before_break.is_empty()
+            && break_kind == "PremiseNotInCatalog"
+            && break_detail.contains(missing_cid.as_str())
+    ));
+}
+
+#[test]
+fn provekit_prove_reflects_cycle_detected_in_failure_witness() {
+    let root_cid = address(&"root");
+    let cycle_cid = address(&"cycle");
+    let mut cycle_claim = claim_fixture("cycle-claim");
+    cycle_claim.premises = vec![cycle_cid.clone()];
+    let mut terminal = claim_fixture("terminal");
+    terminal.premises = vec![cycle_cid.clone()];
+    let mut catalog = HashMapCatalog::default();
+    catalog.put(cycle_cid.clone(), cycle_claim.canonical_bytes());
+    let kit = ProveKit::new(root_cid.clone(), catalog);
+
+    let refuted = kit.prove(terminal).expect("cycle becomes refutation");
+
+    assert_eq!(refuted.verdict, Verdict::Refuted);
+    assert!(matches!(
+        refuted.witness,
+        Some(Witness::ChainIntegrityFailure(ChainIntegrityFailureWitness {
+            walked_chain_root_cid,
+            walked_steps_before_break,
+            break_kind,
+            break_detail,
+            schema_version: 1,
+        })) if walked_chain_root_cid == root_cid
+            && walked_steps_before_break == vec![cycle_cid.clone()]
+            && break_kind == "CycleDetected"
+            && break_detail.contains(cycle_cid.as_str())
+    ));
+}
+
+#[test]
+fn kit_registry_registers_provekit_under_public_prove_name() {
+    let root_cid = address(&"root");
+    let mut registry = KitRegistry::default();
+
+    registry.register_prove(root_cid, HashMapCatalog::default());
+
+    assert!(registry.get("prove").is_some());
+    assert_eq!(
+        registry.conformance("prove"),
+        Some(&ConformanceDeclaration::NonCarrier {
+            reason: "discharges claims via chain-integrity verification; no source emission"
+        })
+    );
+}
+
+#[test]
+fn three_step_path_final_prove_produces_terminal_chain_integrity_witness() {
+    let root_input = Input::Spec(json!({"step": "root"}));
+    let child_input = Input::Spec(json!({"step": "child"}));
+    let mut inputs = HashMapInputCatalog::default();
+    let root_input_cid = inputs.insert(root_input);
+    let child_input_cid = inputs.insert(child_input);
+
+    let root_claim = claim_fixture("root");
+    let root_claim_cid = root_claim.cid();
+    let child_base_claim = claim_fixture("child");
+    let mut child_claim = child_base_claim.clone();
+    child_claim.premises = vec![root_claim_cid.clone()];
+    let child_claim_input_cid = address(&Input::Claim(child_claim.clone()));
+
+    let mut catalog = HashMapCatalog::default();
+    catalog.insert(&root_claim);
+
+    let path = Input::Path(Box::new(Path {
+        algebra: vec![
+            PathAlgebra {
+                name: "root".to_string(),
+                kit: "root-fixture".to_string(),
+                inputs: vec![root_input_cid],
+                depends_on: vec![],
+                verb: Verb::Transform,
+            },
+            PathAlgebra {
+                name: "child".to_string(),
+                kit: "child-fixture".to_string(),
+                inputs: vec![child_input_cid],
+                depends_on: vec!["root".to_string()],
+                verb: Verb::Transform,
+            },
+            PathAlgebra {
+                name: "prove".to_string(),
+                kit: "prove".to_string(),
+                inputs: vec![child_claim_input_cid],
+                depends_on: vec!["child".to_string()],
+                verb: Verb::Prove,
+            },
+        ],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        "root-fixture",
+        FixtureTransformKit {
+            claim: root_claim.clone(),
+        },
+        ConformanceDeclaration::NonCarrier {
+            reason: "test fixture transform; no source emission",
+        },
+    );
+    registry.register(
+        "child-fixture",
+        FixtureTransformKit {
+            claim: child_base_claim,
+        },
+        ConformanceDeclaration::NonCarrier {
+            reason: "test fixture transform; no source emission",
+        },
+    );
+    registry.register_prove(root_claim_cid.clone(), catalog);
+
+    let chain = execute_path(&path, &registry, &inputs).expect("path executes");
+    let terminal = chain.terminal_claim();
+
+    assert_eq!(terminal.verdict, Verdict::Proved);
+    assert!(terminal.witness.is_some());
+    assert!(matches!(
+        terminal.witness.as_ref(),
+        Some(Witness::ChainIntegrity(ChainIntegrityWitness {
+            walked_chain_root_cid,
+            walked_steps,
+            schema_version: 1,
+        })) if walked_chain_root_cid == &root_claim_cid && walked_steps == &vec![root_claim_cid]
+    ));
+}


### PR DESCRIPTION
Closes #1059. A2 prereq in the Trinity exhibit (#1024) queue. The last code prereq before the exhibit dispatch.

## What changed

Introduces the first registered `Kit` whose `prove()` produces a real `Verdict::Proved` with a substantive witness, by discharging chain-integrity over the claim's premises.

- `libprovekit::core::ProveKit`: identity `transform()`, real `prove()`.
- `walk_premises_to_root(claim, origin_cid, catalog, expect_cycle) -> Result<Vec<Cid>, ChainBreak>` with `HashSet<Cid>` visited tracking.
- `ChainBreak`: CycleDetected, PremiseNotInCatalog, OriginUnreachable, DeserializationFailed.
- Two new `Witness` variants in `provekit-ir-types`:
  - `Witness::ChainIntegrity(ChainIntegrityWitness)` on success.
  - `Witness::ChainIntegrityFailure(ChainIntegrityFailureWitness)` on refutation.
- `KitRegistry::register_prove` under name `"prove"` with `ConformanceDeclaration::NonCarrier`.

## Architect amendment to original spec

The original spec called for `Verdict::Refuted` + `witness: None` + a hypothetical `DomainClaim::failure_detail` field. The first codex dispatch correctly refused to fabricate `failure_detail` (the antibody pattern). Architect amendment: **every verdict produces evidence**. Refutation is positive evidence about why the chain broke, not the absence of a witness. The `ChainIntegrityFailureWitness` carries the failure detail directly.

Net surface change: zero new fields on `DomainClaim`. Two new `Witness` variants. The Trinity exhibit's assertion 5 (`verdict == Proved && witness.is_some()`) remains correct.

## Test coverage

8 prove_kit tests in `implementations/rust/libprovekit/tests/prove_kit.rs`:
- JCS byte-stability for `ChainIntegrityWitness`.
- JCS byte-stability for `ChainIntegrityFailureWitness`.
- Identity transform.
- Proved verdict on happy 3-step Path with terminating Verb::Prove.
- Refuted verdict + ChainIntegrityFailure witness on missing-premise.
- Refuted verdict on cyclic premises (`CycleDetected` reflected in failure witness's `break_kind`).
- Round-trip equivalence on both witness variants.
- 3-step path integration.

## Consumes

- #1024 Trinity exhibit binding assertion 5: `terminal_claim.verdict == Verdict::Proved && terminal_claim.witness.is_some()`.
- #1024 binding assertion 6: `walk_premises_to_root(&terminal_claim, &origin_cid, &catalog, false).is_ok()` (the canonical helper from #1024 may replace this PR's inline copy in a follow-up).

## Gates

- `cargo test -p libprovekit -p provekit-cli -p provekit-ir-types`: all green.
- `tools/spec-cid-lint.sh`: exit 0.
- `git diff --check`: clean.
- em-dash / en-dash sweep: zero.

## Non-goals (held)

No new Kit trait methods. No parallel registries. No solver backends. No modifications to other kits' `prove()` impls. No new fields on `DomainClaim`. No new `Verdict` variants.