### PR TITLE
feat(libprovekit/lower): claim_spec_value decomposes Term::Op { concept:bind-result } wrapper (closes #1069)

### DIFF
--- a/implementations/rust/libprovekit/src/core/lower_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lower_plugin.rs
@@ -6,6 +6,7 @@ use provekit_ir_types::Sort;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use super::bind::{concept_bind_result_cid, named_term_document_from_bind_payload, NamedTerm};
 use super::primitives::address;
 use super::traits::{Kit, KitError};
 use super::types::{
@@ -208,6 +209,11 @@ fn spec_value_from_input(input: &Input) -> Result<Value, String> {
 }
 
 fn claim_spec_value(claim: &DomainClaim) -> Result<Value, String> {
+    if let Some(Term::Op { op_cid, args, .. }) = &claim.payload {
+        if op_cid == &concept_bind_result_cid() {
+            return decompose_bind_result(args, claim);
+        }
+    }
     if let Some(Term::Const { value, .. }) = &claim.payload {
         return Ok(value.clone());
     }
@@ -224,6 +230,48 @@ fn claim_spec_value(claim: &DomainClaim) -> Result<Value, String> {
         "returnType": sort_name(&claim.contract.return_sort),
         "conceptName": claim.contract.concept_hint.clone().unwrap_or_else(|| claim.contract.fn_name.clone()),
         "termShapeCid": claim.to,
+    }))
+}
+
+fn decompose_bind_result(args: &[Term], _claim: &DomainClaim) -> Result<Value, String> {
+    if args.len() != 2 {
+        return Err(format!(
+            "bind-result wrapper expected 2 args, got {}",
+            args.len()
+        ));
+    }
+    let wrapper = Term::Op {
+        op_cid: concept_bind_result_cid(),
+        name: "concept:bind-result".to_string(),
+        args: args.to_vec(),
+    };
+    let named = named_term_document_from_bind_payload(&wrapper)
+        .map_err(|error| format!("decompose bind-result wrapper named form: {error}"))?;
+    let term_count = named.terms.len();
+    let [term] = named.terms.as_slice() else {
+        return Err(format!(
+            "bind-result wrapper expected exactly one named term, got {term_count}"
+        ));
+    };
+    realize_spec_from_named_term(term)
+}
+
+pub fn realize_spec_from_named_term(term: &NamedTerm) -> Result<Value, String> {
+    let named_term_tree = term
+        .named_term_tree
+        .as_ref()
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|error| format!("serialize namedTermTree for `{}`: {error}", term.function))?;
+    Ok(json!({
+        "kind": "RealizeRequest",
+        "function": term.function,
+        "params": term.params,
+        "paramTypes": term.param_types,
+        "returnType": term.return_type,
+        "conceptName": term.concept_name,
+        "namedTermTree": named_term_tree,
+        "termShapeCid": term.term_shape_cid,
     }))
 }
 

--- a/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
+++ b/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use libprovekit::compose::{
+    build_value, cid_of_value, jcs_bytes_of_value, EffectSet, FunctionContractMemento, Locus,
+};
+use libprovekit::core::lower_plugin::realize_spec_from_named_term;
+use libprovekit::core::{
+    address, concept_bind_result_cid, named_term_document_from_bind_payload, BindKit, BindOptions,
+    Cid, DomainClaim, DomainKind, Input, Kit, LowerKit, RealizeRequest, RealizeTransport,
+    RealizedSource, Term, Verdict,
+};
+use provekit_ir_types::{IrFormula, Sort};
+use serde_json::{json, Value};
+
+fn primitive_sort(name: &str) -> Sort {
+    Sort::Primitive {
+        name: name.to_string(),
+    }
+}
+
+fn valid_cid(fill: char) -> String {
+    format!("blake3-512:{}", fill.to_string().repeat(128))
+}
+
+fn parse_cid(fill: char) -> Cid {
+    Cid::parse(valid_cid(fill)).expect("valid CID")
+}
+
+fn minimal_contract(fn_name: &str) -> FunctionContractMemento {
+    let formals = vec!["x".to_string()];
+    let formal_sorts = vec![primitive_sort("int")];
+    let return_sort = primitive_sort("int");
+    let pre = IrFormula::Atomic {
+        name: "true".to_string(),
+        args: vec![],
+    };
+    let post = IrFormula::Atomic {
+        name: "true".to_string(),
+        args: vec![],
+    };
+    let effects = EffectSet::empty();
+    let locus = Locus::unknown();
+    let value = build_value(
+        fn_name,
+        &formals,
+        &formal_sorts,
+        &return_sort,
+        &pre,
+        &post,
+        None,
+        &effects,
+        &locus,
+        &[],
+    );
+    FunctionContractMemento {
+        fn_name: fn_name.to_string(),
+        formals,
+        formal_sorts,
+        formal_regions: vec![],
+        return_sort,
+        return_region: None,
+        pre,
+        post,
+        body_cid: None,
+        effects,
+        locus,
+        canonical_bytes: jcs_bytes_of_value(&value),
+        cid: cid_of_value(&value),
+        auto_minted_mementos: vec![],
+        concept_hint: None,
+    }
+}
+
+fn bind_input_value() -> Value {
+    json!({
+        "kind": "ir-document",
+        "sourceLanguage": "rust",
+        "workspaceRoot": "/tmp/provekit-lower-claim-bind-result-test",
+        "ir": [{
+            "kind": "bind-lift-entry",
+            "file": "src/lib.rs",
+            "fn_name": "deposit",
+            "fn_line": 14,
+            "concept_annotation": "deposit-then-balance",
+            "param_names": ["balance", "amount"],
+            "param_types": ["i64", "i64"],
+            "return_type": "i64",
+            "term_shape": {
+                "kind": "body",
+                "stmts": [
+                    {"kind": "let"},
+                    {"kind": "bin", "op": "+"}
+                ]
+            },
+            "term_shape_cid": valid_cid('a'),
+            "witnesses": [{
+                "role": "post",
+                "predicate_text": "out == balance + amount",
+                "source_kind": "annotation"
+            }]
+        }]
+    })
+}
+
+#[derive(Clone, Default)]
+struct CapturingTransport {
+    requests: Arc<Mutex<Vec<RealizeRequest>>>,
+}
+
+impl CapturingTransport {
+    fn requests(&self) -> Vec<RealizeRequest> {
+        self.requests.lock().expect("requests lock").clone()
+    }
+}
+
+impl RealizeTransport for CapturingTransport {
+    fn dispatch_realize(
+        &self,
+        _workspace_root: &Path,
+        _target_lang: &str,
+        _library_tag: Option<&str>,
+        request: &RealizeRequest,
+    ) -> Result<RealizedSource, String> {
+        self.requests
+            .lock()
+            .expect("requests lock")
+            .push(request.clone());
+        Ok(RealizedSource {
+            extension: "txt".to_string(),
+            source: format!("realized {}", request.function),
+            is_stub: false,
+            emitted_artifact_cid: Some(valid_cid('b')),
+            observed_loss_record: json!({}),
+            used_sugars: vec![],
+            observation_wrapper_emission_record: None,
+        })
+    }
+}
+
+fn lower_with_capture(
+    claim: DomainClaim,
+    target: &str,
+) -> (
+    Result<DomainClaim, libprovekit::core::KitError>,
+    CapturingTransport,
+) {
+    let transport = CapturingTransport::default();
+    let lower = LowerKit::new(
+        PathBuf::from("/tmp/provekit-lower-claim-bind-result-test"),
+        target.to_string(),
+        None,
+        transport.clone(),
+    );
+    let result = lower.transform(&Input::Claim(claim));
+    (result, transport)
+}
+
+fn bind_claim() -> DomainClaim {
+    let term_value = bind_input_value();
+    let input_term = Term::Const {
+        value: term_value,
+        sort: primitive_sort("LiftPluginResponse"),
+    };
+    BindKit::new(BindOptions {
+        lang: "rust".to_string(),
+    })
+    .transform(&Input::Term(input_term))
+    .expect("bind kit transforms term input")
+}
+
+#[test]
+fn bind_result_claim_lower_uses_named_term_realize_request() {
+    let claim = bind_claim();
+    let payload = claim.payload.as_ref().expect("bind claim payload");
+    let named =
+        named_term_document_from_bind_payload(payload).expect("bind payload recovers named terms");
+    let expected_spec =
+        realize_spec_from_named_term(&named.terms[0]).expect("named term spec builds");
+
+    let (result, transport) = lower_with_capture(claim, "python");
+
+    result.expect("lower claim succeeds");
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1);
+    let request = &requests[0];
+    assert_eq!(request.function, "deposit");
+    assert_eq!(request.params, vec!["balance", "amount"]);
+    assert_eq!(request.param_types, vec!["i64", "i64"]);
+    assert_eq!(request.return_type, "i64");
+    assert_eq!(request.concept_name, "concept:deposit-then-balance");
+    assert_eq!(
+        request.named_term_tree,
+        expected_spec.get("namedTermTree").cloned()
+    );
+}
+
+#[test]
+fn term_const_claim_fast_path_is_preserved() {
+    let spec = json!({
+        "kind": "RealizeRequest",
+        "function": "const_path",
+        "params": ["x"],
+        "paramTypes": ["int"],
+        "returnType": "int",
+        "conceptName": "concept:const-path",
+        "termShapeCid": parse_cid('c')
+    });
+    let claim = DomainClaim {
+        domain: DomainKind::Other("prior".to_string()),
+        contract: minimal_contract("ignored_contract"),
+        artifacts: vec![],
+        from: vec![parse_cid('c')],
+        premises: vec![],
+        to: parse_cid('c'),
+        witness: None,
+        payload: Some(Term::Const {
+            value: spec,
+            sort: primitive_sort("LowerSpec"),
+        }),
+        verdict: Verdict::Unresolved,
+        attestation: None,
+    };
+
+    let (result, transport) = lower_with_capture(claim, "python");
+
+    result.expect("lower claim succeeds");
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].function, "const_path");
+    assert_eq!(requests[0].concept_name, "concept:const-path");
+}
+
+#[test]
+fn non_bind_result_op_claim_uses_existing_fallback() {
+    let payload = Term::Op {
+        op_cid: parse_cid('d'),
+        name: "concept:not-bind-result".to_string(),
+        args: vec![],
+    };
+    let claim = DomainClaim {
+        domain: DomainKind::Other("other-op".to_string()),
+        contract: minimal_contract("fallback_op"),
+        artifacts: vec![],
+        from: vec![parse_cid('d')],
+        premises: vec![],
+        to: address(&payload),
+        witness: None,
+        payload: Some(payload),
+        verdict: Verdict::Unresolved,
+        attestation: None,
+    };
+
+    let (result, transport) = lower_with_capture(claim, "python");
+
+    result.expect("lower claim succeeds");
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].function, "fallback_op");
+    assert_eq!(requests[0].params, vec!["x"]);
+    assert_eq!(requests[0].param_types, vec!["int"]);
+    assert_eq!(requests[0].return_type, "int");
+    assert_eq!(requests[0].named_term_tree, None);
+}
+
+#[test]
+fn malformed_bind_result_wrapper_refuses_before_transport() {
+    let payload = Term::Op {
+        op_cid: concept_bind_result_cid(),
+        name: "concept:bind-result".to_string(),
+        args: vec![Term::Const {
+            value: bind_input_value(),
+            sort: primitive_sort("LiftPluginResponse"),
+        }],
+    };
+    let claim = DomainClaim {
+        domain: DomainKind::Other("bind".to_string()),
+        contract: minimal_contract("bind::default::bind-result-op-tree"),
+        artifacts: vec![],
+        from: vec![parse_cid('e')],
+        premises: vec![],
+        to: address(&payload),
+        witness: None,
+        payload: Some(payload),
+        verdict: Verdict::Unresolved,
+        attestation: None,
+    };
+
+    let (result, transport) = lower_with_capture(claim, "python");
+
+    let error = result.expect_err("malformed bind-result wrapper refuses");
+    assert!(
+        error
+            .to_string()
+            .contains("bind-result wrapper expected 2 args, got 1"),
+        "unexpected error: {error}"
+    );
+    assert!(transport.requests().is_empty());
+}
+
+#[test]
+fn bind_result_request_shape_is_target_neutral_for_python_java_and_c() {
+    let mut requests = Vec::new();
+    for target in ["python", "java", "c"] {
+        let (result, transport) = lower_with_capture(bind_claim(), target);
+        result.expect("lower claim succeeds");
+        let captured = transport.requests();
+        assert_eq!(captured.len(), 1);
+        requests.push(serde_json::to_value(&captured[0]).expect("request serializes"));
+    }
+
+    assert_eq!(requests[0], requests[1]);
+    assert_eq!(requests[0], requests[2]);
+}

--- a/implementations/rust/provekit-cli/src/cmd_lower.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lower.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use clap::{Parser, ValueEnum};
+use libprovekit::core::lower_plugin::realize_spec_from_named_term;
 use libprovekit::core::{
     execute_path, named_term_document_from_bind_payload, ConformanceDeclaration,
     HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra, Term,
@@ -277,18 +278,7 @@ fn lower_named_document(
 ) -> Result<String, LowerNamedError> {
     let mut out = String::new();
     for term in &named.terms {
-        let named_term_tree = term
-            .named_term_tree
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()
-            .map_err(|e| {
-                LowerNamedError::Message(format!(
-                    "serialize namedTermTree for `{}`: {e}",
-                    term.function
-                ))
-            })?;
-        let spec = lower_named_spec(term, named_term_tree);
+        let spec = realize_spec_from_named_term(term).map_err(LowerNamedError::Message)?;
         let source = lower_named_spec_via_path(project_root, target, spec)?;
         out.push_str(&source);
         if !out.ends_with('\n') {
@@ -296,19 +286,6 @@ fn lower_named_document(
         }
     }
     Ok(out)
-}
-
-fn lower_named_spec(term: &crate::cmd_bind::NamedTerm, named_term_tree: Option<Json>) -> Json {
-    json!({
-        "kind": "RealizeRequest",
-        "function": term.function,
-        "params": term.params,
-        "paramTypes": term.param_types,
-        "returnType": term.return_type,
-        "conceptName": term.concept_name,
-        "namedTermTree": named_term_tree,
-        "termShapeCid": term.term_shape_cid,
-    })
 }
 
 fn lower_named_spec_via_path(


### PR DESCRIPTION
Closes #1069. A7 prereq for #1068 Path B. Closes the missed-integration gap A3 (#1065) introduced and surfaced by Path B's empirical probe.

## The gap

A3 changed BindKit's output to `Term::Op { op_cid: concept:bind-result, args: [original_term, named_form_binding] }`. `LowerKit::claim_spec_value` (`lower_plugin.rs:210-228` on main pre-A7) only fast-paths `Term::Const`; the new wrapper fell through to the default branch and synthesized a RealizeRequest with `function = bind::default::bind-result-op-tree`. Python realize plugin refused correctly: `missing body-template entry`.

Path B's empirical probe (branch `1068-trinity-exhibit-path-b`, SHA f2106ce5) confirmed: lift + bind composed cleanly, BindKit determinism passed, lower refused.

## What changed

- **`lower_plugin.rs:211`:** new match arm in `claim_spec_value` descends through `Term::Op { op_cid: concept_bind_result_cid(), args }` and calls into the shared spec builder. Term::Const fast path preserved. Other Term::Op variants continue taking the existing default fallback.
- **`cmd_lower.rs:281`:** CLI named-term lowering now uses the same shared spec builder so both code paths produce byte-identical RealizeRequest shapes. Single source of truth.
- **`tests/lower_claim_bind_result.rs`** (new, 174 LOC): five-partition test set.

## Test partition (the test-partition-is-spec discipline locked post-A2)

1. **Positive:** bind to lower with the wrapper succeeds; spec shape matches cmd_lower output for the same NamedTerm content.
2. **Regression:** Term::Const fast path still works.
3. **Discrimination:** a Term::Op with a DIFFERENT op_cid takes the existing fallback, not the new descent. **This is the load-bearing discrimination test A2's spec was missing.** If anyone tries to over-broaden the match arm, this test fails.
4. **Refusal:** malformed wrapper (wrong arg arity) refuses cleanly with a typed error. No panic. No silent fallthrough.
5. **Cross-target:** synthesized RealizeRequest is target-neutral; Python / Java / C plugins all receive the same shape.

## Gates

- `cargo test -p libprovekit -p provekit-cli`: green (every test partition passes).
- `tools/spec-cid-lint.sh`: exit 0.
- `git diff --check`: clean.
- em-dash / en-dash sweep on diff: zero.

## Build-on-existing-kits clause (held)

No new kits. No Kit trait surface changes. No algebra changes. No new concept op-CIDs. No modification to BindKit. One match arm + one private helper + one factored-out shared spec builder + five tests.

## Unblocks

- #1068 Path B (Trinity exhibit runnable command). After this lands, lift to bind to lower composes end-to-end against the Python realize plugin.
- Composition test census (`docs/plans/2026-05-16-trinity-composition-test-census.md`): seam 2 / seam 5 close with this PR.

## Cited prereqs

A1 #1064. A2 #1066. A3 #1065 (the gap-introducer). A4 #1061. A5 #1062. A6 #1063. Path A #1067.

## Parallel sibling

A8 #1070 (codex still in flight) locks the verdict-propagation policy in walks.rs. A8 touches walks.rs only; no file collision with this PR. A7 + A8 can land in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced handling of bind-result wrapper payloads with improved validation and decomposition logic.

* **Tests**
  * Added comprehensive test suite validating bind-result claim lowering across multiple target environments.

* **Refactor**
  * Improved code organization by consolidating payload serialization logic into a centralized helper.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->