### PR TITLE
docs(libprovekit/walks): lock lenient verdict-propagation policy with antibody doc-comment + regression test (closes #1070)

### DIFF
--- a/implementations/rust/libprovekit/src/core/walks.rs
+++ b/implementations/rust/libprovekit/src/core/walks.rs
@@ -26,6 +26,12 @@ use super::traits::Catalog;
 use super::types::{domain_claim_from_canonical_bytes, Cid, DomainClaim, Term};
 
 /// Structural reason a premise walk failed.
+///
+/// Structural reason a premise walk failed. The four variants enumerate the
+/// failure modes of structural chain integrity. **Do not add verdict-shaped
+/// variants** (e.g., `NotProved { claim_cid, verdict }`). Verdict checks on
+/// intermediate claims belong in a verdict-aware verifier kit, not in this
+/// enum. See A8 / #1070 and the 2026-05-16 architect ruling for context.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChainBreak {
     /// The walk encountered a CID that is currently on the recursion stack,
@@ -103,6 +109,17 @@ pub struct ChainWalkFailure {
 ///   decode as `DomainClaim`.
 /// - `ChainBreak::OriginUnreachable` iff no leaf in the traversal equals
 ///   `origin_cid`.
+///
+/// Verifies structural chain integrity of `claim`'s premise graph back to
+/// `origin_cid`. The four failure modes are CycleDetected, PremiseNotInCatalog,
+/// OriginUnreachable, and DeserializationFailed.
+///
+/// **Verdict semantics on intermediate claims are out of scope for this walk.**
+/// Intermediate claims may carry any verdict (Pending, Inconclusive, Refuted,
+/// Proved). This walk does not propagate or check verdicts on visited claims.
+/// The substrate's first principle (Supra omnia rectum) applies: chain-walk
+/// proves chain integrity, not semantic correctness of intermediate transforms.
+/// Future verdict-aware verifiers belong in their own kits, not here.
 pub fn walk_premises_to_root(
     claim: &DomainClaim,
     origin_cid: &Cid,
@@ -430,6 +447,29 @@ mod tests {
         // Pre-order trace: mid is pushed first (descending from terminal),
         // then root is pushed when reached.
         assert_eq!(trace, vec![mid_cid, root_cid]);
+    }
+
+    #[test]
+    fn walk_premises_returns_ok_when_intermediate_claims_have_non_proved_verdicts() {
+        let origin = claim_fixture("verdict-policy-origin");
+        let origin_cid = origin.cid();
+
+        let mut intermediate = claim_fixture("verdict-policy-intermediate");
+        intermediate.premises = vec![origin_cid.clone()];
+        intermediate.verdict = Verdict::Unresolved;
+        let intermediate_cid = intermediate.cid();
+
+        let mut terminal = claim_fixture("verdict-policy-terminal");
+        terminal.premises = vec![intermediate_cid.clone()];
+
+        let mut catalog = HashMapCatalog::default();
+        insert_claim(&mut catalog, &origin);
+        insert_claim(&mut catalog, &intermediate);
+
+        let trace = walk_premises_to_root(&terminal, &origin_cid, &catalog, false)
+            .expect("intermediate non-Proved verdict is ignored by structural walk");
+
+        assert_eq!(trace, vec![intermediate_cid, origin_cid]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1070. A8 prereq for #1068 Path B. Locks the architect ruling on the verdict-propagation question (census seam 7).

## Architect ruling locked

The verdict-propagation question (raised in `docs/plans/2026-05-16-trinity-composition-test-census.md` seam 7) resolves to **option β: lenient verdict policy**.

`walk_premises_to_root` verifies structural chain integrity (cycle, premise CID resolution, origin reachable, deserialization). It does NOT check verdict on intermediate claims. The shipped Path A code (#1067) already implements β. A8 is documentation + one regression test that catches future α-shape drift (where intermediate kits would falsely claim Proved).

The locked architect reasoning: chain-walk proves chain integrity, not semantic correctness of intermediate transforms. Intermediate kits do not claim Verdict::Proved because they did not prove anything; they transformed. ProveKit's terminal claim IS Proved because its prove() ran the chain-walk and it succeeded.

## What changed

- **`walks.rs` ChainBreak doc-comment:** antibody note: "do not add verdict-shaped variants" (e.g., `NotProved`). Verdict-aware verifiers belong in their own kits, not in this enum.
- **`walks.rs` walk_premises_to_root doc-comment:** locked architect language verbatim. Explicitly enumerates the four failure modes and states the lenient policy: "Verdict semantics on intermediate claims are out of scope for this walk."
- **`walks.rs` regression test** `walk_premises_returns_ok_when_intermediate_claims_have_non_proved_verdicts`: 3-step chain with `Verdict::Pending` intermediate claim; assert walk returns Ok. If anyone adds an α-shape verdict check, this test fails red and points back to A8.

40 insertions, all in walks.rs. No algorithm changes. No new variants. No ProveKit changes.

## Test partition discipline

This is the test-partition-is-spec lesson from A2's discriminator bug applied to architectural rulings. The architect's words become a test that fails when the ruling is violated. Future contributors inherit the discipline without needing to re-read the architect's chat.

## Gates

- `cargo test -p libprovekit`: 70 passed (up from 69, with the new regression test).
- `cargo test -p libprovekit -p provekit-cli`: green.
- `tools/spec-cid-lint.sh`: exit 0.
- `git diff --check`: clean.
- em-dash / en-dash sweep on diff: zero.

## Build-on-existing-kits clause (held)

No new functions. No new variants. No algorithm changes. No new Verdict variants. No ProveKit changes. Just doc-comments + 1 test.

## Sibling

A7 #1071 (just merged at 1fab1a55). A7 touches lower_plugin.rs / cmd_lower.rs / new test file. A8 touches walks.rs only. No file collision; independent prereqs.

## Cited prereqs

A2 #1066 (the discriminator-bug lesson source). Path A #1067 (the walks module β-correct shape this PR documents).