### PR TITLE
feat(lifters): strip type annotations at lift boundary; realize kits reconstruct types (closes #1075)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -161,12 +161,7 @@ def _entry_for_function(
 ) -> Json:
     concept, attr_pre, attr_post = _extract_leading_annotations(lines, node.lineno)
     term_shape = _function_shape(node)
-    param_names, param_types = _signature_params(node.args)
-    return_type = _annotation_text(node.returns)
-    if return_type is None:
-        return_type = "Any"
-    elif return_type == "None":
-        return_type = "()"
+    param_names = _signature_param_names(node.args)
     witnesses = []
     witnesses.extend(_contract_comment_witnesses(lines, node, rel_path, diagnostics))
     witnesses.extend(_decorator_contract_witnesses(node, param_names, rel_path, diagnostics))
@@ -182,17 +177,14 @@ def _entry_for_function(
         "fn_name": node.name,
         "kind": "bind-lift-entry",
         "param_names": param_names,
-        "param_types": param_types,
-        "return_type": return_type,
         "term_shape": term_shape,
         "term_shape_cid": cid_of_json(term_shape),
         "witnesses": witnesses,
     }
 
 
-def _signature_params(args: ast.arguments) -> tuple[list[str], list[str]]:
+def _signature_param_names(args: ast.arguments) -> list[str]:
     names: list[str] = []
-    types: list[str] = []
     ordered_args: list[ast.arg] = []
     ordered_args.extend(args.posonlyargs)
     ordered_args.extend(args.args)
@@ -203,17 +195,7 @@ def _signature_params(args: ast.arguments) -> tuple[list[str], list[str]]:
         ordered_args.append(args.kwarg)
     for arg in ordered_args:
         names.append(arg.arg)
-        types.append(_annotation_text(arg.annotation) or "Any")
-    return names, types
-
-
-def _annotation_text(annotation: ast.expr | None) -> str | None:
-    if annotation is None:
-        return None
-    try:
-        return ast.unparse(annotation)
-    except Exception:
-        return "Any"
+    return names
 
 
 def _function_shape(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Json:

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -162,6 +162,26 @@ def _operator_atoms(term_shape: dict) -> list[dict]:
     return [node for node in _walk_objects(term_shape) if "op_cid" in node]
 
 
+def test_bind_lift_erases_signature_types_from_bind_ir_entries() -> None:
+    source = (
+        "def add(left: int, right: int) -> int:\n"
+        "    return left + right\n"
+        "\n"
+        "def generated(value):\n"
+        "    return value\n"
+    )
+
+    result = lift_source(source, "pkg/foo.py")
+
+    assert result.diagnostics == []
+    entries = {entry["fn_name"]: entry for entry in result.ir}
+    assert entries["add"]["param_names"] == ["left", "right"]
+    assert "param_types" not in entries["add"]
+    assert "return_type" not in entries["add"]
+    assert "param_types" not in entries["generated"]
+    assert "return_type" not in entries["generated"]
+
+
 def test_bind_lift_source_emits_language_neutral_entries() -> None:
     source = (
         "# concept: identity\n"
@@ -202,8 +222,8 @@ def test_bind_lift_source_emits_language_neutral_entries() -> None:
     assert result.ir[0]["attr_pre"] == "x >= 0"
     assert result.ir[0]["attr_post"] == "result >= 0"
     assert result.ir[0]["param_names"] == ["x"]
-    assert result.ir[0]["param_types"] == ["int"]
-    assert result.ir[0]["return_type"] == "int"
+    assert "param_types" not in result.ir[0]
+    assert "return_type" not in result.ir[0]
     assert result.ir[0]["term_shape"] == {
         "kind": "body",
         "stmts": [{"kind": "exit"}],
@@ -324,15 +344,15 @@ def test_bind_lift_filters_unnamed_concepts_and_void_return() -> None:
 
     assert [entry["concept_annotation"] for entry in result.ir] == [None, None]
     assert result.ir[0]["param_names"] == ["x"]
-    assert result.ir[0]["param_types"] == ["Any"]
-    assert result.ir[0]["return_type"] == "Any"
+    assert "param_types" not in result.ir[0]
+    assert "return_type" not in result.ir[0]
     assign_shape = result.ir[0]["term_shape"]["stmts"][0]
     assert assign_shape["kind"] == "assign"
     assert {
         "concept_name": "concept:add",
         "op_cid": _catalog_concept_cid("concept:add"),
     }.items() <= assign_shape["value"].items()
-    assert result.ir[1]["return_type"] == "()"
+    assert "return_type" not in result.ir[1]
 
 
 def test_bind_rpc_initialize_declares_bind_ir_surface() -> None:

--- a/implementations/rust/libprovekit/src/core/lower_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lower_plugin.rs
@@ -263,16 +263,41 @@ pub fn realize_spec_from_named_term(term: &NamedTerm) -> Result<Value, String> {
         .map(serde_json::to_value)
         .transpose()
         .map_err(|error| format!("serialize namedTermTree for `{}`: {error}", term.function))?;
+    let (param_types, return_type) = realize_signature_from_named_term(term);
     Ok(json!({
         "kind": "RealizeRequest",
         "function": term.function,
         "params": term.params,
-        "paramTypes": term.param_types,
-        "returnType": term.return_type,
+        "paramTypes": param_types,
+        "returnType": return_type,
         "conceptName": term.concept_name,
         "namedTermTree": named_term_tree,
         "termShapeCid": term.term_shape_cid,
     }))
+}
+
+fn realize_signature_from_named_term(term: &NamedTerm) -> (Vec<String>, String) {
+    let erased = term.param_types.is_empty() && matches!(term.return_type.trim(), "" | "()");
+    if !erased {
+        return (term.param_types.clone(), term.return_type.clone());
+    }
+
+    let param_types = term
+        .params
+        .iter()
+        .map(|_| "int".to_string())
+        .collect::<Vec<_>>();
+    let return_type = if is_unit_concept(&term.concept_name) {
+        "()".to_string()
+    } else {
+        "int".to_string()
+    };
+    (param_types, return_type)
+}
+
+fn is_unit_concept(concept_name: &str) -> bool {
+    let trimmed = concept_name.trim();
+    trimmed == "unit" || trimmed == "concept:unit"
 }
 
 fn fallback_from(input: &Input) -> Vec<Cid> {

--- a/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
+++ b/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
@@ -105,6 +105,29 @@ fn bind_input_value() -> Value {
     })
 }
 
+fn erased_bind_input_value() -> Value {
+    json!({
+        "kind": "ir-document",
+        "workspaceRoot": "/tmp/provekit-lower-claim-bind-result-test",
+        "ir": [{
+            "kind": "bind-lift-entry",
+            "file": "src/lib.rs",
+            "fn_name": "wrap_identity",
+            "fn_line": 7,
+            "concept_annotation": "identity",
+            "param_names": ["x"],
+            "term_shape": {
+                "kind": "body",
+                "stmts": [
+                    {"kind": "exit"}
+                ]
+            },
+            "term_shape_cid": valid_cid('d'),
+            "witnesses": []
+        }]
+    })
+}
+
 #[derive(Clone, Default)]
 struct CapturingTransport {
     requests: Arc<Mutex<Vec<RealizeRequest>>>,
@@ -171,6 +194,17 @@ fn bind_claim() -> DomainClaim {
     .expect("bind kit transforms term input")
 }
 
+fn erased_bind_claim() -> DomainClaim {
+    let term_value = erased_bind_input_value();
+    let input_term = Term::Const {
+        value: term_value,
+        sort: primitive_sort("LiftPluginResponse"),
+    };
+    BindKit::default()
+        .transform(&Input::Term(input_term))
+        .expect("bind kit transforms erased term input")
+}
+
 #[test]
 fn bind_result_claim_lower_uses_named_term_realize_request() {
     let claim = bind_claim();
@@ -195,6 +229,28 @@ fn bind_result_claim_lower_uses_named_term_realize_request() {
         request.named_term_tree,
         expected_spec.get("namedTermTree").cloned()
     );
+}
+
+#[test]
+fn bind_result_claim_lower_reconstructs_erased_signature_defaults() {
+    let claim = erased_bind_claim();
+    let payload = claim.payload.as_ref().expect("bind claim payload");
+    let named =
+        named_term_document_from_bind_payload(payload).expect("bind payload recovers named terms");
+    assert_eq!(named.terms[0].param_types, Vec::<String>::new());
+    assert_eq!(named.terms[0].return_type, "()");
+
+    let (result, transport) = lower_with_capture(claim, "rust");
+
+    result.expect("lower claim succeeds");
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 1);
+    let request = &requests[0];
+    assert_eq!(request.function, "wrap_identity");
+    assert_eq!(request.params, vec!["x"]);
+    assert_eq!(request.param_types, vec!["int"]);
+    assert_eq!(request.return_type, "int");
+    assert_eq!(request.concept_name, "concept:identity");
 }
 
 #[test]

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -26,7 +26,7 @@ use std::path::{Path, PathBuf};
 use base64::Engine;
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_ir_types::{EvidenceMemento, IrFormula, IrTerm, SourceKind};
-use provekit_lift_contracts::{lift_file_with_docstring_evidence, lift_file_with_sig_evidence};
+use provekit_lift_contracts::lift_file_with_docstring_evidence;
 use provekit_walk::emit::{rust_function_term_json, shadow_proof_ir_cid, shadow_to_proof_ir};
 use provekit_walk::{
     build_function_contract_with_file, build_shadow_source, lift_function_postcondition,
@@ -356,7 +356,7 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
             let concept_annotation = extract_concept_annotation(&src, &target.source_name);
             let term_shape = term_shape_for_fn(item_fn);
             let term_shape_cid = blake3_512_of(encode_jcs(&term_shape).as_bytes());
-            let (param_names, param_types, return_type) = fn_signature(item_fn);
+            let param_names = fn_param_names(item_fn);
             let function_symbol = format!("{fn_name}@{rel}");
             let fallback_function_symbol = format!("{}@{rel}", target.source_name);
             let witnesses = witnesses_by_symbol
@@ -374,8 +374,6 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
                 "attr_post": attr_post,
                 "concept_annotation": concept_annotation,
                 "param_names": param_names,
-                "param_types": param_types,
-                "return_type": return_type,
                 "term_shape": cvalue_to_json(&term_shape),
                 "term_shape_cid": term_shape_cid,
                 "witnesses": witnesses,
@@ -397,8 +395,6 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
                     "attr_post": Value::Null,
                     "concept_annotation": concept_annotation_name(&callsite.pattern.concept_name),
                     "param_names": callsite.resolved_args,
-                    "param_types": vec!["unknown"; callsite.arity],
-                    "return_type": "unknown",
                     "term_shape": cvalue_to_json(&term_shape),
                     "term_shape_cid": term_shape_cid,
                     "witnesses": [],
@@ -548,7 +544,6 @@ struct LibraryCallPattern {
 struct BoundLibraryCall {
     pattern: LibraryCallPattern,
     resolved_args: Vec<String>,
-    arity: usize,
     line: usize,
 }
 
@@ -854,7 +849,6 @@ impl BoundCallCollector<'_> {
         self.calls.push(BoundLibraryCall {
             pattern: pattern.clone(),
             resolved_args,
-            arity,
             line,
         });
     }
@@ -908,14 +902,9 @@ fn contract_witnesses_by_function_symbol(
     source_bytes: &[u8],
 ) -> BTreeMap<String, Vec<Value>> {
     let mut by_symbol: BTreeMap<String, Vec<(String, Value)>> = BTreeMap::new();
-    for evidence in lift_file_with_sig_evidence(file, rel, source_bytes)
+    for evidence in lift_file_with_docstring_evidence(file, rel, source_bytes)
         .evidences
         .into_iter()
-        .chain(
-            lift_file_with_docstring_evidence(file, rel, source_bytes)
-                .evidences
-                .into_iter(),
-        )
     {
         let Some(symbol) = evidence_function_symbol(&evidence) else {
             continue;
@@ -1131,37 +1120,23 @@ fn collect_rs_files_shallow(dir: &Path, visited: &mut std::collections::BTreeSet
     }
 }
 
-fn fn_signature(item_fn: &syn::ItemFn) -> (Vec<String>, Vec<String>, String) {
+fn fn_param_names(item_fn: &syn::ItemFn) -> Vec<String> {
     let mut names = Vec::new();
-    let mut types = Vec::new();
     for (i, arg) in item_fn.sig.inputs.iter().enumerate() {
         match arg {
             syn::FnArg::Receiver(_) => {
                 names.push("__self".to_string());
-                types.push("Self".to_string());
             }
             syn::FnArg::Typed(pt) => {
                 let name = match &*pt.pat {
                     syn::Pat::Ident(p) => p.ident.to_string(),
                     _ => format!("__arg{}", i),
                 };
-                let ty_str = type_to_string(&pt.ty);
                 names.push(name);
-                types.push(ty_str);
             }
         }
     }
-    let return_type = match &item_fn.sig.output {
-        syn::ReturnType::Default => "()".to_string(),
-        syn::ReturnType::Type(_, t) => type_to_string(t),
-    };
-    (names, types, return_type)
-}
-
-fn type_to_string(ty: &syn::Type) -> String {
-    use quote::ToTokens;
-    let s = ty.to_token_stream().to_string();
-    normalize_ws(&s)
+    names
 }
 
 fn normalize_ws(s: &str) -> String {
@@ -1417,7 +1392,48 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn bind_lift_marries_docstring_and_type_signature_evidence_as_witnesses() {
+    fn bind_lift_erases_signature_types_from_bind_ir_entries() {
+        let root = temp_workspace("bind_lift_type_erasure");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            src_dir.join("lib.rs"),
+            r#"
+pub fn add(left: i64, right: i64) -> i64 {
+    left + right
+}
+"#,
+        )
+        .expect("write source");
+
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."]
+        }))
+        .expect("bind lift should succeed");
+
+        let entries = out["ir"].as_array().expect("ir array");
+        let entry = entries
+            .iter()
+            .find(|entry| entry["fn_name"] == "add")
+            .expect("add entry");
+        assert_eq!(entry["param_names"], json!(["left", "right"]));
+        assert!(entry.get("param_types").is_none());
+        assert!(entry.get("return_type").is_none());
+        assert!(
+            entry["witnesses"]
+                .as_array()
+                .expect("witnesses array")
+                .iter()
+                .all(|witness| witness["source_kind"] != "type-signature"),
+            "signature type evidence must not cross the bind lift boundary"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn bind_lift_marries_docstring_evidence_as_witnesses() {
         assert_eq!(
             initialize_result()["capabilities"]["ir_version"],
             "bind-ir/1.0.0",
@@ -1474,25 +1490,8 @@ pub fn wrap_positive(amount: usize) -> Option<usize> {
         assert!(
             witnesses
                 .iter()
-                .any(|w| w["source_kind"] == "type-signature"
-                    && w["extension_fields"]["signature_position"] == "param:0"),
-            "expected parameter type-signature evidence witness: {witnesses:#?}"
-        );
-        let return_type_witness = witnesses
-            .iter()
-            .find(|w| {
-                w["source_kind"] == "type-signature"
-                    && w["extension_fields"]["signature_position"] == "return"
-            })
-            .expect("return type-signature evidence witness");
-        let predicate_text = return_type_witness["predicate_text"]
-            .as_str()
-            .expect("type-signature witnesses must carry predicate_text");
-        assert!(
-            predicate_text.contains("is_some(result)")
-                && predicate_text.contains("is_none(result)")
-                && !predicate_text.contains("\"kind\""),
-            "type-signature predicate_text must be readable predicate text, not raw JSON: {predicate_text}"
+                .all(|w| w["source_kind"] != "type-signature"),
+            "type-signature witnesses must not cross the bind lift boundary: {witnesses:#?}"
         );
         assert!(
             witnesses.iter().all(|w| {
@@ -1624,7 +1623,8 @@ pub fn fetch_status(url: &str) -> i64 {
         assert_eq!(bound["file"], "src/lib.rs");
         assert_eq!(bound["fn_name"], "fetch_status__bound_call_1");
         assert_eq!(bound["param_names"], json!(["url"]));
-        assert_eq!(bound["param_types"], json!(["unknown"]));
+        assert!(bound.get("param_types").is_none());
+        assert!(bound.get("return_type").is_none());
         assert_eq!(bound["term_shape"], cvalue_to_json(&expected_shape));
         assert_eq!(bound["term_shape_cid"], expected_cid);
 


### PR DESCRIPTION
Closes #1075. A9. Implements architect-locked option (a) for the verdict-propagation question (census #1074 seam-4 federation gap).

## Architect ruling (locked, from issue #1075 comment 4467318644)

**Option (a):** lifters strip type annotations at the lift boundary. The hub carries algebra shape only (untyped). Realize kits reconstruct types from concept-tier shape + target language type system defaults.

Architect reasoning verbatim: *"The substrate's 'algebra is the portable thing' claim is structurally about shape, not types. Paper 16's colimit argument is structural; types are not in the universal property."*

The type-system asymmetry between languages belongs IN the realize kit, where language-specific knowledge already lives. The hub stays universal.

## What changed

- **Python source bind lifter** (`bind_lifter.py`): emits `param_names` only; no `param_types` or `return_type` fields.
- **Rust `provekit-walk-rpc` bind lift** (`walk_rpc.rs`): omits `param_types` and `return_type` from emitted NamedTerm entries, including bound callsite entries. Bind lift no longer forwards type-signature evidence as bind witnesses.
- **LowerKit** (`lower_plugin.rs`): reconstructs erased signature defaults for realize requests. Neutral `int` params/return as Rust convention; preserves `unit` for `unit` concepts.
- Regression coverage added for both lifters and lower reconstruction (test_bind_lifter.py + lower_claim_bind_result.rs).

## Build-on-existing-kits clause

No new Kit trait method. No bind-IR schema change. No new concept op-CID. No algebra change. No silent fallthrough; refusals are typed.

## Gates

- `pytest implementations/python/provekit-lift-python-source/tests`: 29 passed.
- `pytest implementations/python/provekit-realize-python-core/tests`: 24 passed.
- `cargo test -p provekit-walk --bin provekit-walk-rpc`: 6 passed.
- `cargo test -p libprovekit -p provekit-cli`: green.
- `tools/spec-cid-lint.sh`: exit 0.
- `git diff --check`: clean.
- em-dash / en-dash sweep: zero.

## Census antibody status after this PR + A10

After A9 (this PR) plus A10 #1076 both land, the seam-4 federation antibody can flip from `#[should_panic]` to `assert_eq` via a small follow-up commit. Both fixes are needed simultaneously:

- **A9 erases types** so bind CIDs can match across languages (this PR).
- **A10 preserves operator atoms** so distinct operators don't collide within either language (#1076).

If only A9 lands without A10: the federation antibody still fails because `x+y` and `x-y` collide in Python lift, so equating Rust's `add` and Python's "ambiguous binary op" is meaningless.

If only A10 lands without A9: the federation antibody still fails because Rust types persist and Python types don't.

## Sequencing

Touches the Python lifter package at a different code path than A10 #1076 (type-emission vs operator-atoms). File-path collision on `bind_lifter.py` and `test_bind_lifter.py`: whichever PR merges second rebases. Independent semantically.

## Cited prereqs

A1 #1064. A2 #1066. A3 #1065. A4 #1061. A5 #1062. A6 #1063. Path A #1067. A7 #1071. A8 #1072. Census #1074.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified bind-lift output to exclude signature type information from function entries while preserving parameter names.
  * Updated the system to reconstruct default types (`int` for parameters, `()` or `int` for return values) when signature data is unavailable, ensuring downstream compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->