### PR TITLE
fix(lift-python): preserve operator op-CIDs as bind-IR atoms (closes #1076)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -258,18 +258,36 @@ def _shape_stmt(node: ast.stmt, *, top_level: bool) -> Json:
         }
     if isinstance(node, (ast.For, ast.AsyncFor)):
         return {"body": _shape_block(node.body), "kind": "for"}
-    if isinstance(node, (ast.Return, ast.Break, ast.Continue)):
+    if isinstance(node, ast.Return):
+        shaped: dict[str, Json] = {"kind": "exit"}
+        if node.value is not None:
+            _add_operator_child(shaped, "value", _shape_expr(node.value))
+        return shaped
+    if isinstance(node, (ast.Break, ast.Continue)):
         return {"kind": "exit"}
     if isinstance(node, ast.Assign):
+        kind = "assign"
         if top_level and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
-            return {"kind": "let"}
-        return {"kind": "assign"}
+            kind = "let"
+        shaped: dict[str, Json] = {"kind": kind}
+        _add_operator_child(shaped, "value", _shape_expr(node.value))
+        return shaped
     if isinstance(node, ast.AnnAssign):
+        kind = "assign"
         if top_level and isinstance(node.target, ast.Name):
-            return {"kind": "let"}
-        return {"kind": "assign"}
+            kind = "let"
+        shaped = {"kind": kind}
+        if node.value is not None:
+            _add_operator_child(shaped, "value", _shape_expr(node.value))
+        return shaped
     if isinstance(node, ast.AugAssign):
-        return {"kind": "assign"}
+        shaped = {"kind": "assign"}
+        op_shape = _bin_operator_shape(
+            node.op,
+            [_shape_expr(node.target), _shape_expr(node.value)],
+        )
+        _add_operator_child(shaped, "value", op_shape)
+        return shaped
     if isinstance(node, ast.Expr):
         return _shape_expr(node.value)
     return {"kind": "opaque"}
@@ -277,43 +295,116 @@ def _shape_stmt(node: ast.stmt, *, top_level: bool) -> Json:
 
 def _shape_expr(node: ast.expr) -> Json:
     if isinstance(node, ast.BinOp):
-        return {"kind": "bin", "op": _bin_op(node.op)}
+        return _bin_operator_shape(node.op, [_shape_expr(node.left), _shape_expr(node.right)])
+    if isinstance(node, ast.BoolOp):
+        op = _bool_op(node.op)
+        values = [_shape_expr(value) for value in node.values]
+        if op is None:
+            return {"kind": "opaque"}
+        return _operator_shape(op["kind"], op["op"], op["concept_name"], values)
+    if isinstance(node, ast.UnaryOp):
+        op = _unary_op(node.op)
+        if op is None:
+            return {"kind": "opaque"}
+        return _operator_shape(op["kind"], op["op"], op["concept_name"], [_shape_expr(node.operand)])
     if isinstance(node, ast.Compare):
-        op = _rel_op(node.ops[0]) if node.ops else "opaque-op"
-        return {"kind": "rel", "op": op}
+        op = _rel_op(node.ops[0]) if node.ops else None
+        args = [_shape_expr(node.left)]
+        args.extend(_shape_expr(comparator) for comparator in node.comparators[:1])
+        if op is None:
+            return {"kind": "rel", "op": "opaque-op"}
+        return _operator_shape("rel", op["op"], op["concept_name"], args)
     if isinstance(node, ast.Call):
         return {"kind": "call"}
     return {"kind": "opaque"}
 
 
-def _bin_op(op: ast.operator) -> str:
-    if isinstance(op, ast.Add):
-        return "+"
-    if isinstance(op, ast.Sub):
-        return "-"
-    if isinstance(op, ast.Mult):
-        return "*"
-    if isinstance(op, ast.Div):
-        return "/"
-    if isinstance(op, ast.Mod):
-        return "%"
-    return "opaque-op"
+def _add_operator_child(parent: dict[str, Json], key: str, child: Json) -> None:
+    if _shape_has_operator_identity(child):
+        parent[key] = child
 
 
-def _rel_op(op: ast.cmpop) -> str:
-    if isinstance(op, ast.Eq):
-        return "=="
-    if isinstance(op, ast.NotEq):
-        return "!="
-    if isinstance(op, ast.Lt):
-        return "<"
-    if isinstance(op, ast.LtE):
-        return "<="
-    if isinstance(op, ast.Gt):
-        return ">"
-    if isinstance(op, ast.GtE):
-        return ">="
-    return "opaque-op"
+def _shape_has_operator_identity(value: Json) -> bool:
+    if isinstance(value, dict):
+        if "concept_name" in value or "op_cid" in value:
+            return True
+        return any(_shape_has_operator_identity(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_shape_has_operator_identity(child) for child in value)
+    return False
+
+
+def _bin_operator_shape(op: ast.operator, args: list[Json]) -> Json:
+    atom = _bin_op(op)
+    if atom is None:
+        return {"kind": "bin", "op": "opaque-op"}
+    return _operator_shape("bin", atom["op"], atom["concept_name"], args)
+
+
+def _operator_shape(kind: str, op: str, concept_name: str, args: list[Json]) -> Json:
+    shaped: dict[str, Json] = {
+        "concept_name": concept_name,
+        "kind": kind,
+        "op": op,
+    }
+    op_cid = _concept_op_cid(concept_name)
+    if op_cid is not None:
+        shaped["op_cid"] = op_cid
+    if args:
+        shaped["args"] = args
+    return shaped
+
+
+def _bin_op(op: ast.operator) -> dict[str, str] | None:
+    table: tuple[tuple[type[ast.operator], str, str], ...] = (
+        (ast.Add, "+", "concept:add"),
+        (ast.Sub, "-", "concept:sub"),
+        (ast.Mult, "*", "concept:mul"),
+        (ast.Div, "/", "concept:div"),
+        (ast.Mod, "%", "concept:mod"),
+        (ast.LShift, "<<", "concept:shl"),
+        (ast.RShift, ">>", "concept:shr"),
+        (ast.BitAnd, "&", "concept:bitand"),
+        (ast.BitOr, "|", "concept:bitor"),
+        (ast.BitXor, "^", "concept:bitxor"),
+    )
+    for cls, symbol, concept_name in table:
+        if isinstance(op, cls):
+            return {"concept_name": concept_name, "op": symbol}
+    return None
+
+
+def _bool_op(op: ast.boolop) -> dict[str, str] | None:
+    if isinstance(op, ast.And):
+        return {"concept_name": "concept:and", "kind": "and", "op": "&&"}
+    if isinstance(op, ast.Or):
+        return {"concept_name": "concept:or", "kind": "or", "op": "||"}
+    return None
+
+
+def _unary_op(op: ast.unaryop) -> dict[str, str] | None:
+    if isinstance(op, ast.Not):
+        return {"concept_name": "concept:not", "kind": "not", "op": "not"}
+    if isinstance(op, ast.USub):
+        return {"concept_name": "concept:neg", "kind": "neg", "op": "-"}
+    if isinstance(op, ast.Invert):
+        return {"concept_name": "concept:bitnot", "kind": "bitnot", "op": "~"}
+    return None
+
+
+def _rel_op(op: ast.cmpop) -> dict[str, str] | None:
+    table: tuple[tuple[type[ast.cmpop], str, str], ...] = (
+        (ast.Eq, "==", "concept:eq"),
+        (ast.NotEq, "!=", "concept:ne"),
+        (ast.Lt, "<", "concept:lt"),
+        (ast.LtE, "<=", "concept:le"),
+        (ast.Gt, ">", "concept:gt"),
+        (ast.GtE, ">=", "concept:ge"),
+    )
+    for cls, symbol, concept_name in table:
+        if isinstance(op, cls):
+            return {"concept_name": concept_name, "op": symbol}
+    return None
 
 
 def _extract_leading_annotations(
@@ -894,6 +985,40 @@ def _concept_citation_diag(
             "line": line_no,
         }
     )
+
+
+def _concept_op_cid(name: str) -> str | None:
+    return _concept_op_cids_by_name().get(name)
+
+
+@lru_cache(maxsize=1)
+def _concept_op_cids_by_name() -> dict[str, str]:
+    root = _repo_root()
+    if root is None:
+        return {}
+    index_path = root / "menagerie/concept-shapes/catalog/index.json"
+    try:
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    entries = index.get("entries")
+    if not isinstance(entries, dict):
+        return {}
+    cids: dict[str, str] = {}
+    for cid, meta in entries.items():
+        if not isinstance(cid, str) or CID_RE.fullmatch(cid) is None:
+            continue
+        if not isinstance(meta, dict) or meta.get("kind") != "algorithm":
+            continue
+        name = meta.get("name")
+        if isinstance(name, str) and name.startswith("concept:"):
+            meta_cid = meta.get("cid")
+            cids[name] = (
+                meta_cid
+                if isinstance(meta_cid, str) and CID_RE.fullmatch(meta_cid) is not None
+                else cid
+            )
+    return cids
 
 
 @lru_cache(maxsize=1)

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -135,6 +135,33 @@ def _concept_diagnostics(result: object) -> set[str]:
     return {diag["kind"] for diag in diagnostics}
 
 
+def _catalog_concept_cid(name: str) -> str:
+    index_path = ROOT / "menagerie/concept-shapes/catalog/index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    for entry in index["entries"].values():
+        if entry.get("kind") == "algorithm" and entry.get("name") == name:
+            cid = entry["cid"]
+            assert isinstance(cid, str)
+            return cid
+    raise AssertionError(f"missing catalog concept: {name}")
+
+
+def _walk_objects(value: object) -> list[dict]:
+    found: list[dict] = []
+    if isinstance(value, dict):
+        found.append(value)
+        for child in value.values():
+            found.extend(_walk_objects(child))
+    elif isinstance(value, list):
+        for child in value:
+            found.extend(_walk_objects(child))
+    return found
+
+
+def _operator_atoms(term_shape: dict) -> list[dict]:
+    return [node for node in _walk_objects(term_shape) if "op_cid" in node]
+
+
 def test_bind_lift_source_emits_language_neutral_entries() -> None:
     source = (
         "# concept: identity\n"
@@ -181,15 +208,32 @@ def test_bind_lift_source_emits_language_neutral_entries() -> None:
         "kind": "body",
         "stmts": [{"kind": "exit"}],
     }
+    eq_shape = {
+        "args": [{"kind": "call"}, {"kind": "opaque"}],
+        "concept_name": "concept:eq",
+        "kind": "rel",
+        "op": "==",
+        "op_cid": _catalog_concept_cid("concept:eq"),
+    }
+    neg_shape = {
+        "args": [{"kind": "opaque"}],
+        "concept_name": "concept:neg",
+        "kind": "neg",
+        "op": "-",
+        "op_cid": _catalog_concept_cid("concept:neg"),
+    }
     assert result.ir[2]["term_shape"] == {
         "kind": "body",
         "stmts": [
             {"kind": "let"},
             {
-                "cond": {"kind": "rel", "op": "=="},
+                "cond": eq_shape,
                 "else": {"kind": "block", "stmts": [{"kind": "exit"}]},
                 "kind": "if",
-                "then": {"kind": "block", "stmts": [{"kind": "exit"}]},
+                "then": {
+                    "kind": "block",
+                    "stmts": [{"kind": "exit", "value": neg_shape}],
+                },
             },
         ],
     }
@@ -198,6 +242,71 @@ def test_bind_lift_source_emits_language_neutral_entries() -> None:
         assert entry["file"] == "pkg/foo.py"
         assert entry["term_shape_cid"] == cid_of_json(entry["term_shape"])
     assert "python:" not in json.dumps(result.ir, sort_keys=True)
+
+
+def test_bind_lift_preserves_operator_concept_cid_atoms() -> None:
+    source = (
+        "def add(x, y):\n"
+        "    return x + y\n"
+        "\n"
+        "def sub(x, y):\n"
+        "    return x - y\n"
+        "\n"
+        "def mul(x, y):\n"
+        "    return x * y\n"
+        "\n"
+        "def div(x, y):\n"
+        "    return x / y\n"
+        "\n"
+        "def eq(x, y):\n"
+        "    return x == y\n"
+        "\n"
+        "def ne(x, y):\n"
+        "    return x != y\n"
+        "\n"
+        "def lt(x, y):\n"
+        "    return x < y\n"
+        "\n"
+        "def le(x, y):\n"
+        "    return x <= y\n"
+        "\n"
+        "def gt(x, y):\n"
+        "    return x > y\n"
+        "\n"
+        "def ge(x, y):\n"
+        "    return x >= y\n"
+        "\n"
+        "def logical_not(x):\n"
+        "    return not x\n"
+    )
+
+    result = lift_source(source, "pkg/operators.py")
+
+    assert result.diagnostics == []
+    expected = {
+        "add": ("concept:add", _catalog_concept_cid("concept:add")),
+        "sub": ("concept:sub", _catalog_concept_cid("concept:sub")),
+        "mul": ("concept:mul", _catalog_concept_cid("concept:mul")),
+        "div": ("concept:div", _catalog_concept_cid("concept:div")),
+        "eq": ("concept:eq", _catalog_concept_cid("concept:eq")),
+        "ne": ("concept:ne", _catalog_concept_cid("concept:ne")),
+        "lt": ("concept:lt", _catalog_concept_cid("concept:lt")),
+        "le": ("concept:le", _catalog_concept_cid("concept:le")),
+        "gt": ("concept:gt", _catalog_concept_cid("concept:gt")),
+        "ge": ("concept:ge", _catalog_concept_cid("concept:ge")),
+        "logical_not": ("concept:not", _catalog_concept_cid("concept:not")),
+    }
+    by_name = {entry["fn_name"]: entry for entry in result.ir}
+    for fn_name, (concept_name, op_cid) in expected.items():
+        atoms = _operator_atoms(by_name[fn_name]["term_shape"])
+        assert {"concept_name": concept_name, "op_cid": op_cid}.items() <= atoms[0].items()
+
+
+def test_bind_lift_operator_atoms_make_distinct_term_shape_cids() -> None:
+    add = lift_source("def f(x, y):\n    return x + y\n", "pkg/add.py").ir[0]
+    sub = lift_source("def f(x, y):\n    return x - y\n", "pkg/sub.py").ir[0]
+
+    assert add["term_shape_cid"] != sub["term_shape_cid"]
 
 
 def test_bind_lift_filters_unnamed_concepts_and_void_return() -> None:
@@ -217,7 +326,12 @@ def test_bind_lift_filters_unnamed_concepts_and_void_return() -> None:
     assert result.ir[0]["param_names"] == ["x"]
     assert result.ir[0]["param_types"] == ["Any"]
     assert result.ir[0]["return_type"] == "Any"
-    assert result.ir[0]["term_shape"]["stmts"][0] == {"kind": "assign"}
+    assign_shape = result.ir[0]["term_shape"]["stmts"][0]
+    assert assign_shape["kind"] == "assign"
+    assert {
+        "concept_name": "concept:add",
+        "op_cid": _catalog_concept_cid("concept:add"),
+    }.items() <= assign_shape["value"].items()
     assert result.ir[1]["return_type"] == "()"
 
 

--- a/implementations/rust/provekit-cli/tests/trinity_composition_census.rs
+++ b/implementations/rust/provekit-cli/tests/trinity_composition_census.rs
@@ -725,10 +725,7 @@ def add(x, y):
 /// bind-IR emission lacks operator-level resolution, OR BindKit drops
 /// operator atoms during named-term construction.
 ///
-/// Gated as #[should_panic] so the test suite passes; the panic message
-/// embeds the colliding CID so the empirical evidence remains inspectable.
 #[test]
-#[should_panic(expected = "seam 4 discrimination gap surfaced (deliverable for A10)")]
 fn seam4_discrimination_structural_diff_is_captured_when_present() {
     require_python_modules(&[
         "provekit_lift_py_tests",
@@ -745,23 +742,10 @@ def f(x, y):
 "#;
     let cid_add = run_lift_bind_capture_to(py_add, true);
     let cid_sub = run_lift_bind_capture_to(py_sub, true);
-    if cid_add == cid_sub {
-        let report = json!({
-            "seam": 4,
-            "property": "discrimination: distinct algebras must produce distinct bind CIDs",
-            "lifter": "lift-python (provekit-lift-python-source)",
-            "f_add_bind_cid": cid_add.as_str(),
-            "f_sub_bind_cid": cid_sub.as_str(),
-            "diagnosis": "Python source lift (and/or BindKit downstream) collides bind output for f(x,y)=x+y and f(x,y)=x-y. Operator atoms are not surfacing into the bind-IR entry. File as A10 prereq: Python bind-lifter must emit per-function term_shape that distinguishes body operator(s); or BindKit must refuse to canonicalize a bind-IR entry whose term_shape lacks operator resolution.",
-        });
-        panic!(
-            "seam 4 discrimination gap surfaced (deliverable for A10):\n{}",
-            serde_json::to_string_pretty(&report).unwrap()
-        );
-    }
-    // If distinct algebras ever start producing distinct CIDs, the should_panic
-    // will FAIL, alerting that A10 has been resolved and the antibody can be
-    // upgraded to assert_ne.
+    assert_ne!(
+        cid_add, cid_sub,
+        "seam 4 discrimination: python bind CIDs must differ for f(x,y)=x+y and f(x,y)=x-y"
+    );
 }
 
 // ============================================================================
@@ -1274,4 +1258,3 @@ fn run_lift_bind_capture_to(source: &str, is_python: bool) -> libprovekit::core:
         .to
         .clone()
 }
-


### PR DESCRIPTION
Closes #1076. A10. Closes the substrate correctness bug surfaced by census #1074 seam-4 discrimination test.

## What was wrong

Python source lift collapsed distinct operators (`x+y`, `x-y`, `x*y`, etc.) to the same bind CID because bind-IR entries omitted the operator's identity. Two semantically distinct algebras producing the same address.

## What changed

- `bind_lifter.py`: carries operator-bearing expression shapes into returns, assignments, annotated assignments, augmented assignments. Operator AST nodes attach catalog-backed `op_cid` atoms for existing concept ops (`concept:add`, `sub`, `mul`, `div`, `eq`, `ne`, `lt`, `le`, `gt`, `ge`, `and`, `or`, `not`).
- `test_bind_lifter.py`: structural walk tests + add-vs-sub term-shape CID distinctness.
- `trinity_composition_census.rs` seam 4 discrimination: promoted `#[should_panic]` to `assert_ne`. Antibody flips to passing assertion.

## Build-on-existing-kits clause

No new concept op-CIDs. No schema changes. No BindKit or LowerKit changes. No parallel `bind_lifter_v2.py`. Operators use existing concept ops in `menagerie/concept-shapes/catalog/algorithms/`.

## Gates

- `pytest implementations/python/provekit-lift-python-source/tests`: 30 passed.
- Focused slow seam 4 test with PYTHONPATH: passed.
- `cargo test -p libprovekit -p provekit-cli`: green.
- `tools/spec-cid-lint.sh`: exit 0.
- `git diff --check`: clean.
- em-dash / en-dash sweep: zero.

## Census antibody status after this PR

- Seam 4 discrimination: **CLOSED** by this PR.
- Seam 4 federation: still `#[should_panic]` pending A9 #1075.
- Seam 3 positive: still `#[should_panic]`; A11 #1077 covers 5 named concepts. The 2 UNNAMED-CONCEPT entries should resolve to named ops (likely `concept:sub` etc.) with this PR's operator-atom preservation; A11's follow-up commit confirms and templates them.

## Sequencing

Independent of A9 #1075 at file path (A9 touches type-emission; A10 touches operator-atoms in the same lifter package but different code paths). Either order works; whichever lands second rebases.

## Cited prereqs

A1 #1064. A2 #1066. A3 #1065. A4 #1061. A5 #1062. A6 #1063. Path A #1067. A7 #1071. A8 #1072. Census #1074.