### PR TITLE
fix(realize-python): body templates for concept:conditional, concept:eq, concept:decl, concept:lt, concept:mul (closes #1077)

### DIFF
--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
@@ -1311,6 +1311,16 @@ def _rust_runtime_operation_concepts(op_name: str) -> tuple[str, ...]:
             return ("concept:array-repeat",)
         case "add":
             return ("concept:add",)
+        case "conditional":
+            return ("concept:conditional",)
+        case "decl":
+            return ("concept:decl",)
+        case "eq":
+            return ("concept:eq",)
+        case "lt":
+            return ("concept:lt",)
+        case "mul":
+            return ("concept:mul",)
         case "borrow":
             return ("concept:borrow",)
     return ()

--- a/implementations/python/provekit-realize-python-core/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realizer.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import blake3
@@ -96,6 +98,21 @@ def _concept_citation_payloads(source: str) -> list[dict]:
         if stripped.startswith("# provekit-concept: "):
             payloads.append(json.loads(stripped.removeprefix("# provekit-concept: ")))
     return payloads
+
+
+def _compiled_namespace(source: str) -> dict[str, object]:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "rendered.py"
+        path.write_text(source, encoding="utf-8")
+        subprocess.run(
+            [sys.executable, "-m", "py_compile", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    namespace: dict[str, object] = {}
+    exec(source, namespace)
+    return namespace
 
 
 def _transported_op_payload() -> dict:
@@ -323,6 +340,129 @@ def test_rust_runtime_concepts_render_from_body_template_catalog() -> None:
         assert result["source"] == expected
         assert result["is_stub"] is False
         assert result["extension"] == "py"
+
+
+def test_concept_conditional_body_template_renders_valid_python_and_executes() -> None:
+    result = emit_stub(
+        function="pick",
+        params=["cond", "then_value", "else_value"],
+        param_types=["bool", "int", "int"],
+        return_type="int",
+        concept_name="concept:conditional",
+    )
+
+    assert result["source"] == (
+        "def pick(cond, then_value, else_value):\n"
+        "    return (then_value) if (cond) else (else_value)\n"
+    )
+    namespace = _compiled_namespace(result["source"])
+    pick = namespace["pick"]
+    assert pick(True, 11, 22) == 11
+    assert pick(False, 11, 22) == 22
+
+
+def test_concept_eq_body_template_renders_valid_python_and_executes() -> None:
+    result = emit_stub(
+        function="same",
+        params=["left", "right"],
+        param_types=["int", "int"],
+        return_type="bool",
+        concept_name="concept:eq",
+    )
+
+    assert result["source"] == "def same(left, right):\n    return (left) == (right)\n"
+    namespace = _compiled_namespace(result["source"])
+    same = namespace["same"]
+    assert same(3, 3) is True
+    assert same(3, 4) is False
+
+
+def test_concept_decl_body_template_renders_valid_python_and_executes() -> None:
+    body = realizer.body_template_for(
+        "concept:decl",
+        ["result", "value"],
+        ["str", "int"],
+        "None",
+    )
+    assert body == "result = value"
+    source = f"def assign(value):\n    {body}\n    return result\n"
+
+    namespace = _compiled_namespace(source)
+    assign = namespace["assign"]
+    assert assign(42) == 42
+
+
+def test_concept_decl_refuses_expression_position() -> None:
+    try:
+        emit_stub(
+            function="bad_decl_expr",
+            params=["value"],
+            param_types=["int"],
+            return_type="int",
+            concept_name="return(decl(result, value))",
+        )
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "concept:decl",
+                "args_shape": ["expr", "int"],
+                "function": "bad_decl_expr",
+                "term_position": "body.return.decl",
+            }
+        ]
+    else:
+        raise AssertionError("decl in expression position should refuse")
+
+
+def test_concept_lt_body_template_renders_valid_python_and_executes() -> None:
+    result = emit_stub(
+        function="less_than",
+        params=["left", "right"],
+        param_types=["int", "int"],
+        return_type="bool",
+        concept_name="concept:lt",
+    )
+
+    assert result["source"] == "def less_than(left, right):\n    return (left) < (right)\n"
+    namespace = _compiled_namespace(result["source"])
+    less_than = namespace["less_than"]
+    assert less_than(2, 5) is True
+    assert less_than(5, 2) is False
+
+
+def test_concept_mul_body_template_renders_valid_python_and_executes() -> None:
+    result = emit_stub(
+        function="product",
+        params=["left", "right"],
+        param_types=["int", "int"],
+        return_type="int",
+        concept_name="concept:mul",
+    )
+
+    assert result["source"] == "def product(left, right):\n    return (left) * (right)\n"
+    namespace = _compiled_namespace(result["source"])
+    product = namespace["product"]
+    assert product(6, 7) == 42
+
+
+def test_core_concept_term_surface_composes_valid_python() -> None:
+    result = emit_stub(
+        function="classify_or_double",
+        params=["value"],
+        param_types=["int"],
+        return_type="int",
+        concept_name="return(conditional(eq(value, 0), -1, conditional(lt(value, 0), 0, mul(value, 2))))",
+    )
+
+    assert result["source"] == (
+        "def classify_or_double(value):\n"
+        "    return (-1) if ((value) == (0)) else ((0) if ((value) < (0)) else ((value) * (2)))\n"
+    )
+    namespace = _compiled_namespace(result["source"])
+    classify_or_double = namespace["classify_or_double"]
+    assert classify_or_double(0) == -1
+    assert classify_or_double(-3) == 0
+    assert classify_or_double(4) == 8
 
 
 def test_call_term_surface_renders_python_call() -> None:

--- a/implementations/rust/provekit-cli/tests/trinity_composition_census.rs
+++ b/implementations/rust/provekit-cli/tests/trinity_composition_census.rs
@@ -414,20 +414,18 @@ fn seam1_discrimination_malformed_term_refuses_cleanly() {
 /// Seam 3 positive: lift -> bind -> lower (python target) -> relift via the
 /// Python source LiftKit must compose.
 ///
-/// EMPIRICAL OUTCOME (2026-05-16 first run): the lower step refuses with
+/// EMPIRICAL OUTCOME (2026-05-16 first run): the lower step refused with
 /// `missing body-template entry` for `concept:conditional`, `concept:eq`,
 /// `concept:decl`, `concept:lt`, `concept:mul`, and two UNNAMED-CONCEPT
-/// entries. The realize plugin lacks body-template coverage for the algebra
-/// shape `safe_divide_then_double` lifts to. Filed as A11 candidate: the
-/// Python realize plugin's body-template catalog must cover the concept ops
-/// the bind layer emits OR bind layer must mint a stub template per missing
-/// op rather than emitting an unbound `concept:*` op.
+/// entries. A11 covers the five named Python body templates. Until A10
+/// preserves operator atoms at lift time, the two UNNAMED-CONCEPT operator
+/// fallback entries still keep this antibody pinned.
 ///
-/// Until A11 lands, lower-back to Python on a non-trivial algebra refuses.
+/// Until A10 and A11 both land, lower-back to Python on a non-trivial algebra refuses.
 /// The test is pinned via #[should_panic] so the test suite passes while the
 /// gap remains visible in CI logs.
 #[test]
-#[should_panic(expected = "seam 3 positive gap surfaced (deliverable for A11)")]
+#[should_panic(expected = "seam 3 positive gap surfaced (awaiting A10 operator naming)")]
 fn seam3_positive_lower_then_relift_python_recovers_concept_citation() {
     require_python_modules(&[
         "provekit_lift_py_tests",
@@ -458,10 +456,10 @@ fn seam3_positive_lower_then_relift_python_recovers_concept_citation() {
                 "seam": 3,
                 "property": "positive composition: lift -> bind -> lower(python)",
                 "failure_detail": detail,
-                "diagnosis": "The python realize plugin reports `missing body-template entry` for one or more concept ops the bind layer emits for the safe_divide_then_double algebra. The lower step cannot proceed, so the relift step never runs. File as A11 prereq: extend the python realize plugin's body-template catalog to cover the algebra's concept ops, or have bind emit stub templates per missing op.",
+                "diagnosis": "The python realize plugin now covers the A11 named concept body templates for safe_divide_then_double. Remaining UNNAMED-CONCEPT refusals indicate the A10 operator-atom preservation fix is still needed before the relift step can run.",
             });
             panic!(
-                "seam 3 positive gap surfaced (deliverable for A11):\n{}",
+                "seam 3 positive gap surfaced (awaiting A10 operator naming):\n{}",
                 serde_json::to_string_pretty(&report).unwrap()
             );
         }
@@ -1274,4 +1272,3 @@ fn run_lift_bind_capture_to(source: &str, is_python: bool) -> libprovekit::core:
         .to
         .clone()
 }
-

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-rust-runtime.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-rust-runtime.json
@@ -132,6 +132,81 @@
           }
         },
         {
+          "concept_name": "concept:conditional",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param1}) if (${param0}) else (${param2})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 3,
+            "min_params": 3
+          }
+        },
+        {
+          "concept_name": "concept:eq",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) == (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
+          "concept_name": "concept:decl",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "${param0} = ${param1}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
+          "concept_name": "concept:lt",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) < (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
+          "concept_name": "concept:mul",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) * (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
           "concept_name": "concept:borrow",
           "emission_template": {
             "kind": "verbatim",


### PR DESCRIPTION
Closes #1077. A11. Closes the body-template coverage gap surfaced by census #1074 seam-3 positive test.

## What was wrong

Python realize plugin refused with `missing body-template entry` for 5 named concepts plus 2 UNNAMED-CONCEPT entries when lowering `safe_divide_then_double`. Coverage gap, not silent emission of garbage: refusal is the antibody.

## What changed

- `python-canonical-bodies-rust-runtime.json`: added templates for `concept:conditional`, `concept:eq`, `concept:decl`, `concept:lt`, `concept:mul`.
- `realizer.py`: routed `conditional`, `decl`, `eq`, `lt`, `mul` term surfaces to the corresponding templates.
- `test_realizer.py`: per-template `python3 -m py_compile` plus behavior tests, decl-in-expression-position refusal (`CompositionRefusalMemento`), composed term-surface coverage.
- `trinity_composition_census.rs`: seam 3 diagnosis updated. The `#[should_panic]` marker stays for now; flips in a follow-up commit when A10 #1076 lands and the 2 UNNAMED-CONCEPT entries resolve to named concept ops (likely `concept:sub` etc.) with existing templates.

## Template specs

- `concept:conditional(cond, then, else)` → Python ternary `then if cond else else`.
- `concept:eq(lhs, rhs)` → `lhs == rhs`.
- `concept:decl(name, value)` → Python assignment `name = value`. In expression-only context, refuses with typed `CompositionRefusalMemento` (Python lacks let-expression; refusal is substrate-correct).
- `concept:lt(lhs, rhs)` → `lhs < rhs`.
- `concept:mul(lhs, rhs)` → `lhs * rhs`.

## Build-on-existing-kits clause

No new concept op-CIDs. No schema change. No Python source lifter changes (that's A10). No BindKit/LowerKit changes. Refusal-on-missing-template antibody preserved for unsupported concepts.

## Gates

- `pytest implementations/python/provekit-realize-python-core/tests`: 31 passed.
- Slow seam 3 with PYTHONPATH + --features slow-tests: passes as `#[should_panic]`, now refusing only UNNAMED-CONCEPT-1 / UNNAMED-CONCEPT-2.
- `cargo test -p libprovekit -p provekit-cli`: green.
- `tools/spec-cid-lint.sh`: exit 0.
- `git diff --check`: clean.
- `python3 -m json.tool` on edited template JSON: exit 0.
- em-dash / en-dash sweep: zero.

## Census antibody status after this PR

- Seam 3 positive: 5 named concepts covered. The 2 UNNAMED entries flip after A10 lands.
- Seam 4 federation / discrimination: unchanged (A9 + A10 close those).

## Sequencing

Independent of A10 at file path. After A10 lands, a small follow-up commit on this PR or a separate one templates the 2 now-named concepts and flips the seam 3 `#[should_panic]` to a passing assertion.

## Cited prereqs

A1 #1064. A2 #1066. A3 #1065. A4 #1061. A5 #1062. A6 #1063. Path A #1067. A7 #1071. A8 #1072. Census #1074.