### PR TITLE
feat(python-lift): canonical γ term_shape form (closes #1084 via redesign)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -165,15 +165,12 @@ def _entry_for_function(
     witnesses = []
     witnesses.extend(_contract_comment_witnesses(lines, node, rel_path, diagnostics))
     witnesses.extend(_decorator_contract_witnesses(node, param_names, rel_path, diagnostics))
-    concept_citations = _concept_citation_comments(lines, node, rel_path, diagnostics)
+    _concept_citation_comments(lines, node, rel_path, diagnostics)
 
     return {
         "attr_post": attr_post,
         "attr_pre": attr_pre,
-        "concept_citations": concept_citations,
         "concept_annotation": concept,
-        "file": rel_path,
-        "fn_line": node.lineno,
         "fn_name": node.name,
         "kind": "bind-lift-entry",
         "param_names": param_names,
@@ -200,79 +197,57 @@ def _signature_param_names(args: ast.arguments) -> list[str]:
 
 def _function_shape(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Json:
     statements = [stmt for stmt in node.body if not _is_docstring_stmt(stmt)]
-    return {
-        "kind": "body",
-        "stmts": [_shape_stmt(stmt, top_level=True) for stmt in statements],
-    }
+    return _shape_block(statements)
 
 
 def _shape_block(statements: list[ast.stmt]) -> Json:
-    return {
-        "kind": "block",
-        "stmts": [
-            _shape_stmt(stmt, top_level=False)
-            for stmt in statements
-            if not _is_docstring_stmt(stmt)
-        ],
-    }
+    shape: Json = {}
+    for stmt in statements:
+        if _is_docstring_stmt(stmt):
+            continue
+        candidate = _shape_stmt(stmt, top_level=False)
+        if _shape_has_operator_identity(candidate):
+            shape = candidate
+    return shape
 
 
 def _shape_stmt(node: ast.stmt, *, top_level: bool) -> Json:
     if isinstance(node, ast.If):
-        shaped: dict[str, Json] = {
-            "cond": _shape_expr(node.test),
-            "kind": "if",
-            "then": _shape_block(node.body),
-        }
-        if node.orelse:
-            shaped = {
-                "cond": shaped["cond"],
-                "else": _shape_block(node.orelse),
-                "kind": shaped["kind"],
-                "then": shaped["then"],
-            }
-        return shaped
+        return _operator_shape(
+            "concept:conditional",
+            [
+                _shape_expr(node.test),
+                _shape_block(node.body),
+                _shape_block(node.orelse),
+            ],
+        )
     if isinstance(node, ast.While):
-        return {
-            "body": _shape_block(node.body),
-            "cond": _shape_expr(node.test),
-            "kind": "while",
-        }
+        cond = _shape_expr(node.test)
+        if _shape_has_operator_identity(cond):
+            return cond
+        return _shape_block(node.body)
     if isinstance(node, (ast.For, ast.AsyncFor)):
-        return {"body": _shape_block(node.body), "kind": "for"}
+        return _shape_block(node.body)
     if isinstance(node, ast.Return):
-        shaped: dict[str, Json] = {"kind": "exit"}
-        if node.value is not None:
-            _add_operator_child(shaped, "value", _shape_expr(node.value))
-        return shaped
+        if node.value is None:
+            return {}
+        return _shape_expr(node.value)
     if isinstance(node, (ast.Break, ast.Continue)):
-        return {"kind": "exit"}
+        return {}
     if isinstance(node, ast.Assign):
-        kind = "assign"
-        if top_level and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
-            kind = "let"
-        shaped: dict[str, Json] = {"kind": kind}
-        _add_operator_child(shaped, "value", _shape_expr(node.value))
-        return shaped
+        return _shape_expr(node.value)
     if isinstance(node, ast.AnnAssign):
-        kind = "assign"
-        if top_level and isinstance(node.target, ast.Name):
-            kind = "let"
-        shaped = {"kind": kind}
         if node.value is not None:
-            _add_operator_child(shaped, "value", _shape_expr(node.value))
-        return shaped
+            return _shape_expr(node.value)
+        return {}
     if isinstance(node, ast.AugAssign):
-        shaped = {"kind": "assign"}
-        op_shape = _bin_operator_shape(
+        return _bin_operator_shape(
             node.op,
             [_shape_expr(node.target), _shape_expr(node.value)],
         )
-        _add_operator_child(shaped, "value", op_shape)
-        return shaped
     if isinstance(node, ast.Expr):
         return _shape_expr(node.value)
-    return {"kind": "opaque"}
+    return {}
 
 
 def _shape_expr(node: ast.expr) -> Json:
@@ -282,28 +257,23 @@ def _shape_expr(node: ast.expr) -> Json:
         op = _bool_op(node.op)
         values = [_shape_expr(value) for value in node.values]
         if op is None:
-            return {"kind": "opaque"}
-        return _operator_shape(op["kind"], op["op"], op["concept_name"], values)
+            return {}
+        return _operator_shape(op, values)
     if isinstance(node, ast.UnaryOp):
         op = _unary_op(node.op)
         if op is None:
-            return {"kind": "opaque"}
-        return _operator_shape(op["kind"], op["op"], op["concept_name"], [_shape_expr(node.operand)])
+            return {}
+        return _operator_shape(op, [_shape_expr(node.operand)])
     if isinstance(node, ast.Compare):
         op = _rel_op(node.ops[0]) if node.ops else None
         args = [_shape_expr(node.left)]
         args.extend(_shape_expr(comparator) for comparator in node.comparators[:1])
         if op is None:
-            return {"kind": "rel", "op": "opaque-op"}
-        return _operator_shape("rel", op["op"], op["concept_name"], args)
+            return {}
+        return _operator_shape(op, args)
     if isinstance(node, ast.Call):
-        return {"kind": "call"}
-    return {"kind": "opaque"}
-
-
-def _add_operator_child(parent: dict[str, Json], key: str, child: Json) -> None:
-    if _shape_has_operator_identity(child):
-        parent[key] = child
+        return {}
+    return {}
 
 
 def _shape_has_operator_identity(value: Json) -> bool:
@@ -319,73 +289,81 @@ def _shape_has_operator_identity(value: Json) -> bool:
 def _bin_operator_shape(op: ast.operator, args: list[Json]) -> Json:
     atom = _bin_op(op)
     if atom is None:
-        return {"kind": "bin", "op": "opaque-op"}
-    return _operator_shape("bin", atom["op"], atom["concept_name"], args)
+        return {}
+    return _operator_shape(atom, args)
 
 
-def _operator_shape(kind: str, op: str, concept_name: str, args: list[Json]) -> Json:
-    shaped: dict[str, Json] = {
-        "concept_name": concept_name,
-        "kind": kind,
-        "op": op,
-    }
+def _operator_shape(concept_name: str, args: list[Json]) -> Json:
     op_cid = _concept_op_cid(concept_name)
-    if op_cid is not None:
-        shaped["op_cid"] = op_cid
-    if args:
-        shaped["args"] = args
-    return shaped
+    if op_cid is None:
+        return {}
+    return {
+        "args": [_operand_slot(arg) for arg in args],
+        "concept_name": concept_name,
+        "op_cid": op_cid,
+    }
 
 
-def _bin_op(op: ast.operator) -> dict[str, str] | None:
-    table: tuple[tuple[type[ast.operator], str, str], ...] = (
-        (ast.Add, "+", "concept:add"),
-        (ast.Sub, "-", "concept:sub"),
-        (ast.Mult, "*", "concept:mul"),
-        (ast.Div, "/", "concept:div"),
-        (ast.Mod, "%", "concept:mod"),
-        (ast.LShift, "<<", "concept:shl"),
-        (ast.RShift, ">>", "concept:shr"),
-        (ast.BitAnd, "&", "concept:bitand"),
-        (ast.BitOr, "|", "concept:bitor"),
-        (ast.BitXor, "^", "concept:bitxor"),
+def _operand_slot(value: Json) -> Json:
+    if (
+        isinstance(value, dict)
+        and isinstance(value.get("concept_name"), str)
+        and isinstance(value.get("op_cid"), str)
+        and isinstance(value.get("args"), list)
+    ):
+        return value
+    return {}
+
+
+def _bin_op(op: ast.operator) -> str | None:
+    table: tuple[tuple[type[ast.operator], str], ...] = (
+        (ast.Add, "concept:add"),
+        (ast.Sub, "concept:sub"),
+        (ast.Mult, "concept:mul"),
+        (ast.Div, "concept:div"),
+        (ast.Mod, "concept:mod"),
+        (ast.LShift, "concept:shl"),
+        (ast.RShift, "concept:shr"),
+        (ast.BitAnd, "concept:bitand"),
+        (ast.BitOr, "concept:bitor"),
+        (ast.BitXor, "concept:bitxor"),
     )
-    for cls, symbol, concept_name in table:
+    for cls, concept_name in table:
         if isinstance(op, cls):
-            return {"concept_name": concept_name, "op": symbol}
+            return concept_name
     return None
 
 
-def _bool_op(op: ast.boolop) -> dict[str, str] | None:
+def _bool_op(op: ast.boolop) -> str | None:
     if isinstance(op, ast.And):
-        return {"concept_name": "concept:and", "kind": "and", "op": "&&"}
+        return "concept:and"
     if isinstance(op, ast.Or):
-        return {"concept_name": "concept:or", "kind": "or", "op": "||"}
+        return "concept:or"
     return None
 
 
-def _unary_op(op: ast.unaryop) -> dict[str, str] | None:
+def _unary_op(op: ast.unaryop) -> str | None:
     if isinstance(op, ast.Not):
-        return {"concept_name": "concept:not", "kind": "not", "op": "not"}
+        return "concept:not"
     if isinstance(op, ast.USub):
-        return {"concept_name": "concept:neg", "kind": "neg", "op": "-"}
+        return "concept:neg"
     if isinstance(op, ast.Invert):
-        return {"concept_name": "concept:bitnot", "kind": "bitnot", "op": "~"}
+        return "concept:bitnot"
     return None
 
 
-def _rel_op(op: ast.cmpop) -> dict[str, str] | None:
-    table: tuple[tuple[type[ast.cmpop], str, str], ...] = (
-        (ast.Eq, "==", "concept:eq"),
-        (ast.NotEq, "!=", "concept:ne"),
-        (ast.Lt, "<", "concept:lt"),
-        (ast.LtE, "<=", "concept:le"),
-        (ast.Gt, ">", "concept:gt"),
-        (ast.GtE, ">=", "concept:ge"),
+def _rel_op(op: ast.cmpop) -> str | None:
+    table: tuple[tuple[type[ast.cmpop], str], ...] = (
+        (ast.Eq, "concept:eq"),
+        (ast.NotEq, "concept:ne"),
+        (ast.Lt, "concept:lt"),
+        (ast.LtE, "concept:le"),
+        (ast.Gt, "concept:gt"),
+        (ast.GtE, "concept:ge"),
     )
-    for cls, symbol, concept_name in table:
+    for cls, concept_name in table:
         if isinstance(op, cls):
-            return {"concept_name": concept_name, "op": symbol}
+            return concept_name
     return None
 
 
@@ -609,10 +587,8 @@ def _contract_comment_witness(
     if isinstance(local_contract_cid, str):
         extension_fields["local_contract_cid"] = local_contract_cid
     return {
-        "col": 0,
         "confidence_basis_points": 10000,
         "extension_fields": extension_fields,
-        "line": line_no,
         "predicate": predicate,
         "predicate_text": fol_text,
         "role": CONTRACT_COMMENT_ROLE_MAP[role],
@@ -1151,13 +1127,11 @@ def _decorator_contract_witnesses(
                 continue
             witnesses.append(
                 {
-                    "col": getattr(decorator, "col_offset", 0),
                     "confidence_basis_points": 10000,
                     "extension_fields": {
                         "decorator": _decorator_name(decorator.func),
                         "surface": "python-decorator-contract",
                     },
-                    "line": getattr(decorator, "lineno", node.lineno),
                     "predicate": predicate,
                     "predicate_text": text,
                     "role": role,

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -162,6 +162,24 @@ def _operator_atoms(term_shape: dict) -> list[dict]:
     return [node for node in _walk_objects(term_shape) if "op_cid" in node]
 
 
+def _gamma_shape(concept_name: str, args: list[dict] | None = None) -> dict:
+    return {
+        "args": args or [],
+        "concept_name": concept_name,
+        "op_cid": _catalog_concept_cid(concept_name),
+    }
+
+
+def _assert_absent_keys(value: object, forbidden: set[str]) -> None:
+    if isinstance(value, dict):
+        assert forbidden.isdisjoint(value.keys())
+        for child in value.values():
+            _assert_absent_keys(child, forbidden)
+    elif isinstance(value, list):
+        for child in value:
+            _assert_absent_keys(child, forbidden)
+
+
 def test_bind_lift_erases_signature_types_from_bind_ir_entries() -> None:
     source = (
         "def add(left: int, right: int) -> int:\n"
@@ -224,44 +242,50 @@ def test_bind_lift_source_emits_language_neutral_entries() -> None:
     assert result.ir[0]["param_names"] == ["x"]
     assert "param_types" not in result.ir[0]
     assert "return_type" not in result.ir[0]
-    assert result.ir[0]["term_shape"] == {
-        "kind": "body",
-        "stmts": [{"kind": "exit"}],
-    }
-    eq_shape = {
-        "args": [{"kind": "call"}, {"kind": "opaque"}],
-        "concept_name": "concept:eq",
-        "kind": "rel",
-        "op": "==",
-        "op_cid": _catalog_concept_cid("concept:eq"),
-    }
-    neg_shape = {
-        "args": [{"kind": "opaque"}],
-        "concept_name": "concept:neg",
-        "kind": "neg",
-        "op": "-",
-        "op_cid": _catalog_concept_cid("concept:neg"),
-    }
-    assert result.ir[2]["term_shape"] == {
-        "kind": "body",
-        "stmts": [
-            {"kind": "let"},
-            {
-                "cond": eq_shape,
-                "else": {"kind": "block", "stmts": [{"kind": "exit"}]},
-                "kind": "if",
-                "then": {
-                    "kind": "block",
-                    "stmts": [{"kind": "exit", "value": neg_shape}],
-                },
-            },
-        ],
-    }
+    assert result.ir[0]["term_shape"] == {}
+    assert result.ir[1]["term_shape"] == _gamma_shape("concept:not", [{}])
     for entry in result.ir:
         assert entry["kind"] == "bind-lift-entry"
-        assert entry["file"] == "pkg/foo.py"
         assert entry["term_shape_cid"] == cid_of_json(entry["term_shape"])
+        _assert_absent_keys(entry, {"file", "fn_line", "line", "column", "col"})
+        _assert_absent_keys(entry["term_shape"], {"op", "kind"})
     assert "python:" not in json.dumps(result.ir, sort_keys=True)
+
+
+def test_bind_lift_emits_gamma_shape_for_add_return() -> None:
+    result = lift_source("def add(x, y):\n    return x + y\n", "pkg/add.py")
+
+    assert result.diagnostics == []
+    assert result.ir[0]["term_shape"] == _gamma_shape("concept:add", [{}, {}])
+
+
+def test_bind_lift_discriminates_sub_gamma_shape() -> None:
+    add = lift_source("def f(x, y):\n    return x + y\n", "pkg/add.py").ir[0]
+    sub = lift_source("def f(x, y):\n    return x - y\n", "pkg/sub.py").ir[0]
+
+    assert add["term_shape"] == _gamma_shape("concept:add", [{}, {}])
+    assert sub["term_shape"] == _gamma_shape("concept:sub", [{}, {}])
+    assert add["term_shape_cid"] != sub["term_shape_cid"]
+
+
+def test_bind_lift_preserves_nested_gamma_composition() -> None:
+    result = lift_source(
+        "def f(x, y, z):\n    return x + y * z\n",
+        "pkg/nested.py",
+    )
+
+    assert result.diagnostics == []
+    assert result.ir[0]["term_shape"] == _gamma_shape(
+        "concept:add",
+        [{}, _gamma_shape("concept:mul", [{}, {}])],
+    )
+
+
+def test_bind_lift_strips_source_location_keys_from_bind_payload() -> None:
+    result = lift_source("def add(x, y):\n    return x + y\n", "/tmp/work/pkg/add.py")
+
+    assert result.diagnostics == []
+    _assert_absent_keys(result.ir, {"file", "fn_line", "line", "column", "col"})
 
 
 def test_bind_lift_preserves_operator_concept_cid_atoms() -> None:
@@ -319,7 +343,11 @@ def test_bind_lift_preserves_operator_concept_cid_atoms() -> None:
     by_name = {entry["fn_name"]: entry for entry in result.ir}
     for fn_name, (concept_name, op_cid) in expected.items():
         atoms = _operator_atoms(by_name[fn_name]["term_shape"])
-        assert {"concept_name": concept_name, "op_cid": op_cid}.items() <= atoms[0].items()
+        assert atoms[0]["concept_name"] == concept_name
+        assert atoms[0]["op_cid"] == op_cid
+        assert set(atoms[0]) == {"args", "concept_name", "op_cid"}
+        assert all(arg == {} for arg in atoms[0]["args"])
+        _assert_absent_keys(atoms[0], {"kind", "op", "file", "fn_line", "line", "column"})
 
 
 def test_bind_lift_operator_atoms_make_distinct_term_shape_cids() -> None:
@@ -346,12 +374,8 @@ def test_bind_lift_filters_unnamed_concepts_and_void_return() -> None:
     assert result.ir[0]["param_names"] == ["x"]
     assert "param_types" not in result.ir[0]
     assert "return_type" not in result.ir[0]
-    assign_shape = result.ir[0]["term_shape"]["stmts"][0]
-    assert assign_shape["kind"] == "assign"
-    assert {
-        "concept_name": "concept:add",
-        "op_cid": _catalog_concept_cid("concept:add"),
-    }.items() <= assign_shape["value"].items()
+    assert result.ir[0]["term_shape"] == _gamma_shape("concept:add", [{}, {}])
+    assert "UNNAMED-CONCEPT" not in json.dumps(result.ir, sort_keys=True)
     assert "return_type" not in result.ir[1]
 
 
@@ -462,28 +486,33 @@ def test_bind_lift_contract_comment_fails_closed_for_bad_payloads() -> None:
         assert any(diag["kind"] == "contract-comment-invalid" for diag in result.diagnostics)
 
 
-def test_concept_citation_relift_recovers_identity() -> None:
-    payload, payload_cid = _concept_citation_payload()
-    source = (
-        "def transport_skip(x: object):\n"
-        + "    "
-        + _concept_comment_lines(payload, payload_cid).replace("\n", "\n    ")
-        + "pass\n"
+def test_bind_lift_omits_concept_citations_from_wire_payload() -> None:
+    args = [{"kind": "var", "name": "x"}]
+    concept_skip_cid = _catalog_concept_cid("concept:skip")
+    emitted = emit_stub(
+        function="transport_skip",
+        params=["x"],
+        param_types=["object"],
+        return_type="()",
+        concept_name="missing-python-skip-carrier",
+        transported_op={
+            "args_jcs": args,
+            "concept_cid": concept_skip_cid,
+            "concept_name": "concept:skip",
+            "concept_site_cid": _cid("a"),
+            "loss_record_cid": _cid("c"),
+            "operation_kind": "skip",
+            "policy_cid": _cid("d"),
+            "shape_cid": concept_skip_cid,
+            "sugar_dict_cid": _cid("e"),
+            "term_position": [0],
+        },
     )
 
-    result = lift_source(source, "pkg/foo.py")
+    result = lift_source(emitted["source"], "pkg/foo.py")
 
     assert result.diagnostics == []
-    citations = result.ir[0]["concept_citations"]
-    assert len(citations) == 1
-    citation = citations[0]
-    assert citation["concept_cid"] == payload["concept_cid"]
-    assert citation["operation_kind"] == payload["operation_kind"]
-    assert citation["shape_cid"] == payload["shape_cid"]
-    assert citation["term_position"] == payload["term_position"]
-    assert citation["args_jcs_cid"] == payload["args_jcs_cid"]
-    assert citation["source_kind"] == "native-surface"
-    assert citation["extension_fields"]["payload_cid"] == payload_cid
+    assert "concept_citations" not in result.ir[0]
     assert result.ir[0]["witnesses"] == []
 
 
@@ -493,7 +522,7 @@ def test_concept_citation_payload_cid_mismatch_refuses() -> None:
 
     result = lift_source(source, "pkg/foo.py")
 
-    assert result.ir[0].get("concept_citations", []) == []
+    assert "concept_citations" not in result.ir[0]
     assert "concept-citation:payload-cid-mismatch" in _concept_diagnostics(result)
 
 
@@ -503,7 +532,7 @@ def test_concept_citation_args_cid_mismatch_refuses() -> None:
 
     result = lift_source(source, "pkg/foo.py")
 
-    assert result.ir[0].get("concept_citations", []) == []
+    assert "concept_citations" not in result.ir[0]
     assert "concept-citation:args-cid-mismatch" in _concept_diagnostics(result)
 
 
@@ -513,7 +542,7 @@ def test_concept_citation_unknown_schema_version_refuses() -> None:
 
     result = lift_source(source, "pkg/foo.py")
 
-    assert result.ir[0].get("concept_citations", []) == []
+    assert "concept_citations" not in result.ir[0]
     assert "concept-citation:unknown-schema-version" in _concept_diagnostics(result)
 
 
@@ -522,38 +551,8 @@ def test_concept_citation_orphan_payload_cid_line_refuses() -> None:
 
     result = lift_source(source, "pkg/foo.py")
 
-    assert result.ir[0].get("concept_citations", []) == []
+    assert "concept_citations" not in result.ir[0]
     assert "concept-citation:orphan-cid-line" in _concept_diagnostics(result)
-
-
-def test_concept_citation_round_trip() -> None:
-    args = [{"kind": "var", "name": "x"}]
-    transported_op = {
-        "args_jcs": args,
-        "concept_cid": CONCEPT_SKIP_CID,
-        "concept_name": "concept:skip",
-        "concept_site_cid": _cid("a"),
-        "loss_record_cid": _cid("c"),
-        "operation_kind": "skip",
-        "policy_cid": _cid("d"),
-        "shape_cid": CONCEPT_SKIP_CID,
-        "sugar_dict_cid": _cid("e"),
-        "term_position": [0],
-    }
-    emitted = emit_stub(
-        function="transport_skip",
-        params=["x"],
-        param_types=["object"],
-        return_type="()",
-        concept_name="missing-python-skip-carrier",
-        transported_op=transported_op,
-    )
-
-    result = lift_source(emitted["source"], "pkg/foo.py")
-
-    assert result.diagnostics == []
-    assert result.ir[0]["concept_citations"][0]["concept_cid"] == transported_op["concept_cid"]
-    assert result.ir[0]["concept_citations"][0]["args_jcs_cid"] == cid_of_json(args)
 
 
 def test_bind_lift_recovers_decorator_contract_witnesses() -> None:
@@ -704,5 +703,5 @@ def test_concept_citation_missing_operation_kind_field_tags_as_malformed_json() 
     fn_names = [entry["fn_name"] for entry in result.ir]
     assert "good_fn" in fn_names
     assert "bad_fn" in fn_names
-    assert result.ir[1].get("concept_citations", []) == []
+    assert "concept_citations" not in result.ir[1]
     assert "concept-citation:malformed-json" in _concept_diagnostics(result)


### PR DESCRIPTION
Closes #1084 (A15) via redesign. Supersedes the locked-scope concept_citations deletion (which was correct but architecturally insufficient).

## Spec source

Implements [the canonical-form ruling at docs/plans/2026-05-16-canonical-term-shape-form.md](https://github.com/TSavo/provekit/blob/main/docs/plans/2026-05-16-canonical-term-shape-form.md) on the Python lift side.

## What changed

`implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py` now emits the canonical γ term_shape:

```json
{ "concept_name": "concept:<name>", "op_cid": "blake3-512:<hash>", "args": [{}, {}] }
```

Dropped (per the γ ruling's forbidden list):
- `kind: "bin"` and other lift-side kind tags
- `op: "+"` and other operator literals
- `exit:{value:...}` wrappers around tail expressions / return statements
- UNNAMED-CONCEPT-N wrappers in green state
- `concept_citations` field (incorporates the original A15 scope)
- Source-location metadata (`file`, `line`, `column`, `fn_line`) from bind payload

## Test partition added

Per test-partition-is-spec discipline (`tests/test_bind_lifter.py`):
- **Positive**: `def add(x, y): return x + y` emits γ with `concept:add` + op_cid + `args:[{}, {}]`
- **Discrimination**: `def sub(x, y): return x - y` emits γ with `concept:sub` (different op_cid)
- **Structural**: nested `def f(x, y, z): return x + y * z` emits γ with `concept:add` whose second arg is a nested `concept:mul`
- **Source-location absence**: bind payload contains no `file`/`line`/`column`/`fn_line` anywhere

## Verification

- `python3 -m pytest -q tests/test_bind_lifter.py`: **24/24 pass**
- `python3 -m pytest -x implementations/python/provekit-lift-python-source/tests/`: **34/34 pass**
- em-dash sweep clean

## Pipeline / merge order

This is the Python-side half of the γ ruling. A14 #1083 redesign (Rust-side γ, branch `1083-rust-term-shape-gamma`) is the parallel co-blocker. Merge order locked:

1. A14 γ-redesign first (Rust-side substrate primitive)
2. A15 γ-redesign (this PR — Python-side consumer)
3. A16 #1086 (body templates) after both — verified γ-safe by inspection (templates read operand identity positionally, not per-operand-field)

When (1) + (2) land, antibody flip PR #1082's seam 4 federation test transitions from `#[should_panic]` to clean `assert_eq!` empirically.

## Convergence note

Two empirical cycles surfaced this fix shape:
- Original A15 locked-scope (concept_citations deletion): closed 1 of 7 divergence axes
- γ ruling + redesign (this PR + A14 γ): closes the remaining axes by mandating concept-centered, surface-stripped canonical form

The original locked-scope was insufficient; the deeper architect diagnostic enumerated all 7 axes; γ closes them as a coherent ruling, not a per-axis chase. Recurring lesson: scope-locking based on first-axis diagnostic is structurally insufficient when the underlying property is byte-identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)