### PR TITLE
feat(realize-python): body templates for concept:div + audit of A10-minted ops (closes #1086)

### DIFF
--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
@@ -1311,16 +1311,50 @@ def _rust_runtime_operation_concepts(op_name: str) -> tuple[str, ...]:
             return ("concept:array-repeat",)
         case "add":
             return ("concept:add",)
+        case "sub":
+            return ("concept:sub",)
         case "conditional":
             return ("concept:conditional",)
         case "decl":
             return ("concept:decl",)
         case "eq":
             return ("concept:eq",)
+        case "ne":
+            return ("concept:ne",)
         case "lt":
             return ("concept:lt",)
+        case "le":
+            return ("concept:le",)
+        case "gt":
+            return ("concept:gt",)
+        case "ge":
+            return ("concept:ge",)
         case "mul":
             return ("concept:mul",)
+        case "div":
+            return ("concept:div",)
+        case "and":
+            return ("concept:and",)
+        case "or":
+            return ("concept:or",)
+        case "not":
+            return ("concept:not",)
+        case "mod":
+            return ("concept:mod",)
+        case "shl":
+            return ("concept:shl",)
+        case "shr":
+            return ("concept:shr",)
+        case "bitand":
+            return ("concept:bitand",)
+        case "bitor":
+            return ("concept:bitor",)
+        case "bitxor":
+            return ("concept:bitxor",)
+        case "neg":
+            return ("concept:neg",)
+        case "bitnot":
+            return ("concept:bitnot",)
         case "borrow":
             return ("concept:borrow",)
     return ()
@@ -1330,12 +1364,39 @@ def _rust_runtime_operation_return_type(
     op_name: str, arg_terms: list[TermExpression]
 ) -> str:
     match op_name.strip():
-        case "add":
+        case (
+            "add"
+            | "sub"
+            | "mul"
+            | "div"
+            | "mod"
+            | "shl"
+            | "shr"
+            | "bitand"
+            | "bitor"
+            | "bitxor"
+        ):
             types = [term.type_name for term in arg_terms]
             if types and all(type_name == "int" for type_name in types):
                 return "int"
             if types and all(type_name == "str" for type_name in types):
                 return "str"
+        case "neg" | "bitnot":
+            types = [term.type_name for term in arg_terms]
+            if types and all(type_name == "int" for type_name in types):
+                return "int"
+        case "eq" | "ne" | "lt" | "le" | "gt" | "ge":
+            types = [term.type_name for term in arg_terms]
+            if types and all(type_name == "int" for type_name in types):
+                return "bool"
+        case "and" | "or":
+            types = [term.type_name for term in arg_terms]
+            if types and all(type_name == "bool" for type_name in types):
+                return "bool"
+        case "not":
+            types = [term.type_name for term in arg_terms]
+            if types and all(type_name == "bool" for type_name in types):
+                return "bool"
         case "borrow":
             return arg_terms[0].type_name if arg_terms else ""
     return ""

--- a/implementations/python/provekit-realize-python-core/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realizer.py
@@ -323,7 +323,7 @@ def test_rust_runtime_concepts_render_from_body_template_catalog() -> None:
             ["i64", "u32"],
             "i64",
             "concept:add",
-            "def checked_add(left, right):\n    return left + right\n",
+            "def checked_add(left, right):\n    return (left) + (right)\n",
         ),
         (
             "borrow_value",
@@ -443,6 +443,84 @@ def test_concept_mul_body_template_renders_valid_python_and_executes() -> None:
     namespace = _compiled_namespace(result["source"])
     product = namespace["product"]
     assert product(6, 7) == 42
+
+
+def test_a10_operator_body_templates_render_valid_python_and_execute() -> None:
+    cases = [
+        ("concept:add", ["left", "right"], ["i64", "i64"], "i64", "return (left) + (right)", (7, 3), 10),
+        ("concept:sub", ["left", "right"], ["i64", "i64"], "i64", "return (left) - (right)", (7, 3), 4),
+        ("concept:mul", ["left", "right"], ["i64", "i64"], "i64", "return (left) * (right)", (7, 3), 21),
+        ("concept:div", ["left", "right"], ["i64", "i64"], "i64", "return (left) // (right)", (7, 3), 2),
+        ("concept:eq", ["left", "right"], ["i64", "i64"], "bool", "return (left) == (right)", (7, 7), True),
+        ("concept:ne", ["left", "right"], ["i64", "i64"], "bool", "return (left) != (right)", (7, 3), True),
+        ("concept:lt", ["left", "right"], ["i64", "i64"], "bool", "return (left) < (right)", (3, 7), True),
+        ("concept:le", ["left", "right"], ["i64", "i64"], "bool", "return (left) <= (right)", (7, 7), True),
+        ("concept:gt", ["left", "right"], ["i64", "i64"], "bool", "return (left) > (right)", (7, 3), True),
+        ("concept:ge", ["left", "right"], ["i64", "i64"], "bool", "return (left) >= (right)", (7, 7), True),
+        ("concept:and", ["left", "right"], ["bool", "bool"], "bool", "return (left) and (right)", (True, False), False),
+        ("concept:or", ["left", "right"], ["bool", "bool"], "bool", "return (left) or (right)", (True, False), True),
+        ("concept:not", ["value"], ["bool"], "bool", "return not (value)", (False,), True),
+        ("concept:mod", ["left", "right"], ["i64", "i64"], "i64", "return (left) % (right)", (7, 3), 1),
+        ("concept:shl", ["left", "right"], ["i64", "i64"], "i64", "return (left) << (right)", (3, 2), 12),
+        ("concept:shr", ["left", "right"], ["i64", "i64"], "i64", "return (left) >> (right)", (8, 1), 4),
+        ("concept:bitand", ["left", "right"], ["i64", "i64"], "i64", "return (left) & (right)", (6, 3), 2),
+        ("concept:bitor", ["left", "right"], ["i64", "i64"], "i64", "return (left) | (right)", (4, 1), 5),
+        ("concept:bitxor", ["left", "right"], ["i64", "i64"], "i64", "return (left) ^ (right)", (6, 3), 5),
+        ("concept:neg", ["value"], ["i64"], "i64", "return -(value)", (7,), -7),
+        ("concept:bitnot", ["value"], ["i64"], "i64", "return ~(value)", (7,), -8),
+    ]
+
+    for index, (concept_name, params, param_types, return_type, body, args, expected) in enumerate(cases):
+        function = f"op_{index}"
+        result = emit_stub(
+            function=function,
+            params=params,
+            param_types=param_types,
+            return_type=return_type,
+            concept_name=concept_name,
+        )
+
+        assert result["source"] == f"def {function}({', '.join(params)}):\n    {body}\n"
+        namespace = _compiled_namespace(result["source"])
+        assert namespace[function](*args) == expected
+
+
+def test_a10_operator_templates_discriminate_distinct_ops() -> None:
+    add = emit_stub(
+        function="calc_add",
+        params=["left", "right"],
+        param_types=["i64", "i64"],
+        return_type="i64",
+        concept_name="concept:add",
+    )["source"]
+    sub = emit_stub(
+        function="calc_sub",
+        params=["left", "right"],
+        param_types=["i64", "i64"],
+        return_type="i64",
+        concept_name="concept:sub",
+    )["source"]
+
+    assert add == "def calc_add(left, right):\n    return (left) + (right)\n"
+    assert sub == "def calc_sub(left, right):\n    return (left) - (right)\n"
+    assert add != sub
+
+
+def test_a10_operator_term_surface_composes_nested_templates() -> None:
+    result = emit_stub(
+        function="composed",
+        params=["x", "y", "a", "b"],
+        param_types=["i64", "i64", "i64", "i64"],
+        return_type="i64",
+        concept_name="return(mul(add(x, y), sub(a, b)))",
+    )
+
+    assert result["source"] == (
+        "def composed(x, y, a, b):\n"
+        "    return ((x) + (y)) * ((a) - (b))\n"
+    )
+    namespace = _compiled_namespace(result["source"])
+    assert namespace["composed"](2, 3, 11, 4) == 35
 
 
 def test_core_concept_term_surface_composes_valid_python() -> None:

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-rust-runtime.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-rust-runtime.json
@@ -119,7 +119,23 @@
           "concept_name": "concept:add",
           "emission_template": {
             "kind": "verbatim",
-            "template": "return ${param0} + ${param1}"
+            "template": "return (${param0}) + (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:sub",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) - (${param1})"
           },
           "loss_record_contribution": {
             "form": "literal",
@@ -158,7 +174,24 @@
           },
           "signature_guard": {
             "max_params": 2,
-            "min_params": 2
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:ne",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) != (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
           }
         },
         {
@@ -188,7 +221,56 @@
           },
           "signature_guard": {
             "max_params": 2,
-            "min_params": 2
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:le",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) <= (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:gt",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) > (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:ge",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) >= (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
           }
         },
         {
@@ -203,7 +285,200 @@
           },
           "signature_guard": {
             "max_params": 2,
-            "min_params": 2
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:div",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) // (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:and",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) and (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["bool", "bool"]
+          }
+        },
+        {
+          "concept_name": "concept:or",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) or (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["bool", "bool"]
+          }
+        },
+        {
+          "concept_name": "concept:not",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return not (${param0})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_param_types": ["bool"]
+          }
+        },
+        {
+          "concept_name": "concept:mod",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) % (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:shl",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) << (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:shr",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) >> (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:bitand",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) & (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:bitor",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) | (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:bitxor",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return (${param0}) ^ (${param1})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"]
+          }
+        },
+        {
+          "concept_name": "concept:neg",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return -(${param0})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_param_types": ["int"]
+          }
+        },
+        {
+          "concept_name": "concept:bitnot",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ~(${param0})"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_param_types": ["int"]
           }
         },
         {


### PR DESCRIPTION
Closes #1086 (A16). Empirically surfaced by A14's local verification: after A14 closed the upstream operator-naming gap, the python lower stopped reporting UNNAMED-CONCEPT and started reporting `missing body-template entry: concept:div` — a strictly smaller residual confirming the convergence pattern.

## What changed

`menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-rust-runtime.json` adds body templates for the missing A10 operators. `realizer.py` adds term-surface routing + return typing for the A10 operator set. Tests in `test_realizer.py` cover positive + discrimination + structural shapes per operator.

## Audit table (all 21 A10-minted operators)

| Concept op | Python template |
|---|---|
| `concept:add` | `lhs + rhs` |
| `concept:sub` | `lhs - rhs` |
| `concept:mul` | `lhs * rhs` |
| `concept:div` | `lhs // rhs` (integer floor; matches i64 source semantics) |
| `concept:eq` | `lhs == rhs` |
| `concept:ne` | `lhs != rhs` |
| `concept:lt` | `lhs < rhs` |
| `concept:le` | `lhs <= rhs` |
| `concept:gt` | `lhs > rhs` |
| `concept:ge` | `lhs >= rhs` |
| `concept:and` | `lhs and rhs` |
| `concept:or` | `lhs or rhs` |
| `concept:not` | `not lhs` |
| `concept:mod` | `lhs % rhs` |
| `concept:shl` | `lhs << rhs` |
| `concept:shr` | `lhs >> rhs` |
| `concept:bitand` | `lhs & rhs` |
| `concept:bitor` | `lhs \| rhs` |
| `concept:bitxor` | `lhs ^ rhs` |
| `concept:neg` | `-lhs` |
| `concept:bitnot` | `~lhs` |

## Verification

- `python3 -m pytest -x`: **34/34 pass**
- Seam 3 slow lane: `missing body-template entry: concept:<A10-op>` is gone. The remaining seam-3 panic message contains only `UNNAMED-CONCEPT-1/2`, which closes when A14 γ-redesign (#1085-paused, redesign branch `1083-rust-term-shape-gamma`) lands.
- `cargo test --manifest-path implementations/rust/Cargo.toml`: pre-existing `provekit-bridgeworks` red (`realize spec missing string field function`) reproduces on clean `origin/main`; NOT introduced by this diff. Tracked separately at agent-task #70.
- em-dash sweep clean

## γ-safety check (per merge-order discipline)

A16's body templates read operand identity POSITIONALLY (function-level param names + slot index), NOT via per-operand-field traversal of namedTermTree. Confirmed γ-safe by inspection of `realizer.py`: each template uses positional `lhs`/`rhs` substitution against the operation's `args` array, regardless of args shape. Templates work whether args is `[{}]` (γ shape) or expanded (pre-γ shape).

This means A16 merges cleanly after A14 γ + A15 γ; no A17 re-author needed.

## Pipeline / merge order

1. A14 γ-redesign (`1083-rust-term-shape-gamma`) — Rust-side substrate primitive
2. A15 γ-redesign (PR #1087, branch `1084-python-term-shape-gamma`) — Python-side consumer
3. A16 (this PR) — body templates, γ-safe per inspection

After all three: antibody flip PR #1082 seam 4 federation goes byte-identical; seam 3 positive goes clean.

## Build-on-existing-kits clause

No new crate. No new public trait. No changes to BindKit, LowerKit, lift kits, or rust realize. No new concept op-CIDs (A10 already minted them). Pure body-template catalog work + the realize-side dispatch glue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)