### PR TITLE
fix(python-lift): strip envelope fields + emit γ statement concepts (closes A19 + A20 Python)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -159,7 +159,6 @@ def _entry_for_function(
     lines: list[str],
     diagnostics: list[Json],
 ) -> Json:
-    concept, attr_pre, attr_post = _extract_leading_annotations(lines, node.lineno)
     term_shape = _function_shape(node)
     param_names = _signature_param_names(node.args)
     witnesses = []
@@ -168,10 +167,6 @@ def _entry_for_function(
     _concept_citation_comments(lines, node, rel_path, diagnostics)
 
     return {
-        "attr_post": attr_post,
-        "attr_pre": attr_pre,
-        "concept_annotation": concept,
-        "fn_name": node.name,
         "kind": "bind-lift-entry",
         "param_names": param_names,
         "term_shape": term_shape,
@@ -201,14 +196,14 @@ def _function_shape(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Json:
 
 
 def _shape_block(statements: list[ast.stmt]) -> Json:
-    shape: Json = {}
+    shapes: list[Json] = []
     for stmt in statements:
         if _is_docstring_stmt(stmt):
             continue
         candidate = _shape_stmt(stmt, top_level=False)
         if _shape_has_operator_identity(candidate):
-            shape = candidate
-    return shape
+            shapes.append(candidate)
+    return _collapse_operation_shapes(shapes)
 
 
 def _shape_stmt(node: ast.stmt, *, top_level: bool) -> Json:
@@ -222,23 +217,29 @@ def _shape_stmt(node: ast.stmt, *, top_level: bool) -> Json:
             ],
         )
     if isinstance(node, ast.While):
-        cond = _shape_expr(node.test)
-        if _shape_has_operator_identity(cond):
-            return cond
-        return _shape_block(node.body)
+        return _operator_shape(
+            "concept:while",
+            [_shape_expr(node.test), _shape_block(node.body)],
+        )
     if isinstance(node, (ast.For, ast.AsyncFor)):
-        return _shape_block(node.body)
+        return _operator_shape("concept:for", [_shape_block(node.body)])
     if isinstance(node, ast.Return):
         if node.value is None:
             return {}
         return _shape_expr(node.value)
-    if isinstance(node, (ast.Break, ast.Continue)):
-        return {}
+    if isinstance(node, ast.Break):
+        return _operator_shape("concept:break", [])
+    if isinstance(node, ast.Continue):
+        return _operator_shape("concept:continue", [])
     if isinstance(node, ast.Assign):
-        return _shape_expr(node.value)
+        target = _shape_expr(node.targets[0]) if node.targets else {}
+        return _operator_shape("concept:assign", [target, _shape_expr(node.value)])
     if isinstance(node, ast.AnnAssign):
         if node.value is not None:
-            return _shape_expr(node.value)
+            return _operator_shape(
+                "concept:assign",
+                [_shape_expr(node.target), _shape_expr(node.value)],
+            )
         return {}
     if isinstance(node, ast.AugAssign):
         return _bin_operator_shape(
@@ -272,7 +273,9 @@ def _shape_expr(node: ast.expr) -> Json:
             return {}
         return _operator_shape(op, args)
     if isinstance(node, ast.Call):
-        return {}
+        args = [_shape_expr(arg) for arg in node.args]
+        args.extend(_shape_expr(keyword.value) for keyword in node.keywords)
+        return _operator_shape("concept:call", args)
     return {}
 
 
@@ -284,6 +287,14 @@ def _shape_has_operator_identity(value: Json) -> bool:
     if isinstance(value, list):
         return any(_shape_has_operator_identity(child) for child in value)
     return False
+
+
+def _collapse_operation_shapes(shapes: list[Json]) -> Json:
+    if not shapes:
+        return {}
+    if len(shapes) == 1:
+        return shapes[0]
+    return _operator_shape("concept:seq", shapes)
 
 
 def _bin_operator_shape(op: ast.operator, args: list[Json]) -> Json:
@@ -365,42 +376,6 @@ def _rel_op(op: ast.cmpop) -> str | None:
         if isinstance(op, cls):
             return concept_name
     return None
-
-
-def _extract_leading_annotations(
-    lines: list[str],
-    fn_line: int,
-) -> tuple[str | None, str | None, str | None]:
-    concept: str | None = None
-    attr_pre: str | None = None
-    attr_post: str | None = None
-    idx = fn_line - 2
-    while idx >= 0:
-        line = lines[idx].strip()
-        if line.startswith("# concept:"):
-            if concept is None:
-                candidate = line[len("# concept:") :].strip()
-                if candidate.startswith("UNNAMED-CONCEPT-"):
-                    concept = None
-                    break
-                concept = candidate
-            idx -= 1
-            continue
-        if line.startswith("# @requires:"):
-            if attr_pre is None:
-                attr_pre = line[len("# @requires:") :].strip()
-            idx -= 1
-            continue
-        if line.startswith("# @ensures:"):
-            if attr_post is None:
-                attr_post = line[len("# @ensures:") :].strip()
-            idx -= 1
-            continue
-        if line == "" or line.startswith("#") or line.startswith("@"):
-            idx -= 1
-            continue
-        break
-    return concept, attr_pre, attr_post
 
 
 def _contract_comment_witnesses(

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -192,12 +192,13 @@ def test_bind_lift_erases_signature_types_from_bind_ir_entries() -> None:
     result = lift_source(source, "pkg/foo.py")
 
     assert result.diagnostics == []
-    entries = {entry["fn_name"]: entry for entry in result.ir}
-    assert entries["add"]["param_names"] == ["left", "right"]
-    assert "param_types" not in entries["add"]
-    assert "return_type" not in entries["add"]
-    assert "param_types" not in entries["generated"]
-    assert "return_type" not in entries["generated"]
+    assert len(result.ir) == 2
+    add, generated = result.ir
+    assert add["param_names"] == ["left", "right"]
+    assert "param_types" not in add
+    assert "return_type" not in add
+    assert "param_types" not in generated
+    assert "return_type" not in generated
 
 
 def test_bind_lift_source_emits_language_neutral_entries() -> None:
@@ -227,18 +228,11 @@ def test_bind_lift_source_emits_language_neutral_entries() -> None:
     result = lift_source(source, "pkg/foo.py")
 
     assert result.diagnostics == []
-    assert [entry["fn_name"] for entry in result.ir] == [
-        "wrap_identity",
-        "toggle",
-        "maybe_first",
-    ]
-    assert [entry["concept_annotation"] for entry in result.ir] == [
-        "identity",
-        "bool-cell",
-        "option",
-    ]
-    assert result.ir[0]["attr_pre"] == "x >= 0"
-    assert result.ir[0]["attr_post"] == "result >= 0"
+    assert len(result.ir) == 3
+    _assert_absent_keys(
+        result.ir,
+        {"attr_pre", "attr_post", "concept_annotation", "fn_name"},
+    )
     assert result.ir[0]["param_names"] == ["x"]
     assert "param_types" not in result.ir[0]
     assert "return_type" not in result.ir[0]
@@ -247,9 +241,37 @@ def test_bind_lift_source_emits_language_neutral_entries() -> None:
     for entry in result.ir:
         assert entry["kind"] == "bind-lift-entry"
         assert entry["term_shape_cid"] == cid_of_json(entry["term_shape"])
-        _assert_absent_keys(entry, {"file", "fn_line", "line", "column", "col"})
+        _assert_absent_keys(
+            entry,
+            {"file", "fn_line", "line", "column", "col"},
+        )
         _assert_absent_keys(entry["term_shape"], {"op", "kind"})
     assert "python:" not in json.dumps(result.ir, sort_keys=True)
+
+
+def test_bind_lift_contract_surfaces_do_not_emit_envelope_hash_fields() -> None:
+    sources = [
+        (
+            "# @requires: x > 0\n"
+            "def add(x, y):\n"
+            "    return x + y\n"
+        ),
+        (
+            "from provekit_lift_py_tests.decorators import contract\n"
+            "@contract(pre=\"x > 0\")\n"
+            "def add(x, y):\n"
+            "    return x + y\n"
+        ),
+    ]
+    forbidden = {"attr_pre", "attr_post", "concept_annotation", "fn_name"}
+
+    for source in sources:
+        result = lift_source(source, "pkg/add.py")
+
+        assert result.diagnostics == []
+        assert len(result.ir) == 1
+        assert forbidden.isdisjoint(result.ir[0])
+        _assert_absent_keys(result.ir[0], forbidden)
 
 
 def test_bind_lift_emits_gamma_shape_for_add_return() -> None:
@@ -278,6 +300,112 @@ def test_bind_lift_preserves_nested_gamma_composition() -> None:
     assert result.ir[0]["term_shape"] == _gamma_shape(
         "concept:add",
         [{}, _gamma_shape("concept:mul", [{}, {}])],
+    )
+
+
+def test_bind_lift_emits_gamma_shape_for_statement_concepts() -> None:
+    cases = [
+        (
+            "def f():\n"
+            "    while True:\n"
+            "        pass\n",
+            _gamma_shape("concept:while", [{}, {}]),
+        ),
+        (
+            "def f(items):\n"
+            "    for item in items:\n"
+            "        pass\n",
+            _gamma_shape("concept:for", [{}]),
+        ),
+        (
+            "def f():\n"
+            "    while True:\n"
+            "        break\n",
+            _gamma_shape("concept:while", [{}, _gamma_shape("concept:break")]),
+        ),
+        (
+            "def f():\n"
+            "    while True:\n"
+            "        continue\n",
+            _gamma_shape("concept:while", [{}, _gamma_shape("concept:continue")]),
+        ),
+        (
+            "def f(x, y):\n"
+            "    x = y\n",
+            _gamma_shape("concept:assign", [{}, {}]),
+        ),
+        (
+            "def f(g, x):\n"
+            "    g(x)\n",
+            _gamma_shape("concept:call", [{}]),
+        ),
+        (
+            "def f(g, x, y):\n"
+            "    x = y\n"
+            "    g(x)\n",
+            _gamma_shape(
+                "concept:seq",
+                [
+                    _gamma_shape("concept:assign", [{}, {}]),
+                    _gamma_shape("concept:call", [{}]),
+                ],
+            ),
+        ),
+    ]
+
+    for source, expected in cases:
+        result = lift_source(source, "pkg/statements.py")
+
+        assert result.diagnostics == []
+        assert result.ir[0]["term_shape"] == expected
+
+
+def test_bind_lift_discriminates_while_and_for_statement_concepts() -> None:
+    while_entry = lift_source(
+        "def f(items):\n"
+        "    while True:\n"
+        "        pass\n",
+        "pkg/while.py",
+    ).ir[0]
+    for_entry = lift_source(
+        "def f(items):\n"
+        "    for item in items:\n"
+        "        pass\n",
+        "pkg/for.py",
+    ).ir[0]
+
+    assert while_entry["term_shape"] == _gamma_shape("concept:while", [{}, {}])
+    assert for_entry["term_shape"] == _gamma_shape("concept:for", [{}])
+    assert while_entry["term_shape_cid"] != for_entry["term_shape_cid"]
+
+
+def test_bind_lift_preserves_nested_statement_gamma_composition() -> None:
+    result = lift_source(
+        "def f(x):\n"
+        "    if x > 0:\n"
+        "        while x > 0:\n"
+        "            x = x - 1\n"
+        "    return x\n",
+        "pkg/nested_statements.py",
+    )
+
+    assert result.diagnostics == []
+    assert result.ir[0]["term_shape"] == _gamma_shape(
+        "concept:conditional",
+        [
+            _gamma_shape("concept:gt", [{}, {}]),
+            _gamma_shape(
+                "concept:while",
+                [
+                    _gamma_shape("concept:gt", [{}, {}]),
+                    _gamma_shape(
+                        "concept:assign",
+                        [{}, _gamma_shape("concept:sub", [{}, {}])],
+                    ),
+                ],
+            ),
+            {},
+        ],
     )
 
 
@@ -340,9 +468,8 @@ def test_bind_lift_preserves_operator_concept_cid_atoms() -> None:
         "ge": ("concept:ge", _catalog_concept_cid("concept:ge")),
         "logical_not": ("concept:not", _catalog_concept_cid("concept:not")),
     }
-    by_name = {entry["fn_name"]: entry for entry in result.ir}
-    for fn_name, (concept_name, op_cid) in expected.items():
-        atoms = _operator_atoms(by_name[fn_name]["term_shape"])
+    for entry, (concept_name, op_cid) in zip(result.ir, expected.values(), strict=True):
+        atoms = _operator_atoms(entry["term_shape"])
         assert atoms[0]["concept_name"] == concept_name
         assert atoms[0]["op_cid"] == op_cid
         assert set(atoms[0]) == {"args", "concept_name", "op_cid"}
@@ -370,7 +497,7 @@ def test_bind_lift_filters_unnamed_concepts_and_void_return() -> None:
 
     result = lift_source(source, "foo.py")
 
-    assert [entry["concept_annotation"] for entry in result.ir] == [None, None]
+    _assert_absent_keys(result.ir, {"concept_annotation", "fn_name"})
     assert result.ir[0]["param_names"] == ["x"]
     assert "param_types" not in result.ir[0]
     assert "return_type" not in result.ir[0]
@@ -410,7 +537,8 @@ def test_bind_rpc_lift_returns_ir_document(tmp_path: Path) -> None:
     assert response["id"] == 7
     assert response["result"]["kind"] == "ir-document"
     assert response["result"]["diagnostics"] == []
-    assert response["result"]["ir"][0]["concept_annotation"] == "identity"
+    assert "concept_annotation" not in response["result"]["ir"][0]
+    assert "fn_name" not in response["result"]["ir"][0]
 
 
 def test_bind_lift_recovers_contract_comment_witness() -> None:
@@ -629,11 +757,9 @@ def test_concept_citation_shape_mismatch_refuses_surrounding_relift() -> None:
 
     result = lift_source(bad_fn_source, "pkg/foo.py")
 
-    # bad_fn must not produce an IR entry; good_fn must still produce one
-    fn_names = [entry["fn_name"] for entry in result.ir]
-    assert "good_fn" in fn_names
-    assert "bad_fn" not in fn_names
+    # bad_fn must not produce an IR entry; good_fn must still produce one.
     assert len(result.ir) == 1
+    assert "fn_name" not in result.ir[0]
     assert "concept-citation:shape-mismatch" in _concept_diagnostics(result)
 
 
@@ -656,10 +782,8 @@ def test_concept_citation_operation_kind_mismatch_refuses_surrounding_relift() -
 
     result = lift_source(bad_fn_source, "pkg/foo.py")
 
-    fn_names = [entry["fn_name"] for entry in result.ir]
-    assert "good_fn" in fn_names
-    assert "bad_fn" not in fn_names
     assert len(result.ir) == 1
+    assert "fn_name" not in result.ir[0]
     assert "concept-citation:operation-kind-mismatch" in _concept_diagnostics(result)
 
 
@@ -699,9 +823,8 @@ def test_concept_citation_missing_operation_kind_field_tags_as_malformed_json() 
 
     result = lift_source(bad_fn_source, "pkg/foo.py")
 
-    # drop-and-continue: bad_fn still gets an IR entry, just with no citation
-    fn_names = [entry["fn_name"] for entry in result.ir]
-    assert "good_fn" in fn_names
-    assert "bad_fn" in fn_names
+    # Drop and continue: bad_fn still gets an IR entry, just with no citation.
     assert "concept_citations" not in result.ir[1]
+    assert len(result.ir) == 2
+    assert all("fn_name" not in entry for entry in result.ir)
     assert "concept-citation:malformed-json" in _concept_diagnostics(result)


### PR DESCRIPTION
Closes A19 + A20 on the Python side per the post-merge audit.

A19: strips attr_pre/attr_post/concept_annotation/fn_name from Python bind IR emission.

A20: Python lift now emits γ canonical-form concepts for while/for/break/continue/assign/call/seq, matching the Rust lift's coverage. Federation now holds for algebras with loops/sequences/function-calls.

38/38 Python kit tests pass. Codex correctly refused to touch the new libprovekit-side function-field federation residual (filed as A23 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)