### PR TITLE
fix(libprovekit): strip source function name from bind payload hash (closes #1093)

### DIFF
--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -132,7 +132,7 @@ pub struct BindLiftEntry {
     pub kind: String,
     #[serde(default)]
     pub file: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub fn_name: String,
     #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub fn_line: u64,
@@ -198,6 +198,7 @@ pub struct NamedTerm {
     pub discharge_verdict: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub file: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub function: String,
     pub name: String,
     #[serde(
@@ -283,7 +284,7 @@ pub fn bind_term_document(
                 "exact".to_string()
             },
             file: entry.file,
-            function: entry.fn_name,
+            function: String::new(),
             name,
             named_term_tree,
             param_types: entry.param_types,
@@ -312,9 +313,18 @@ pub fn bind_term_document(
 
 /// Return the canonical named-term document CID emitted by `cmd_bind`.
 pub fn named_term_document_cid(named: &NamedTermDocument) -> Result<Cid, BindError> {
-    let cid = crate::canonical::serializable_cid(named)
+    let canonical = bind_payload_named_term_document(named);
+    let cid = crate::canonical::serializable_cid(&canonical)
         .map_err(|error| BindError::Failed(format!("cid named term JSON: {error}")))?;
     Cid::try_from(cid).map_err(|error| BindError::Failed(error.to_string()))
+}
+
+fn bind_payload_named_term_document(named: &NamedTermDocument) -> NamedTermDocument {
+    let mut canonical = named.clone();
+    for term in &mut canonical.terms {
+        term.function.clear();
+    }
+    canonical
 }
 
 pub fn concept_bind_result_cid() -> Cid {
@@ -326,12 +336,51 @@ pub fn bind_result_payload(
     named: &NamedTermDocument,
 ) -> Result<Term, BindError> {
     let catalog = ConceptOpCatalog::load()?;
-    let named_form_binding = named_term_document_op_tree(named, &catalog)?;
+    let canonical_named = bind_payload_named_term_document(named);
+    let named_form_binding = named_term_document_op_tree(&canonical_named, &catalog)?;
     Ok(Term::Op {
         op_cid: concept_bind_result_cid(),
         name: CONCEPT_BIND_RESULT.to_string(),
-        args: vec![original_term, named_form_binding],
+        args: vec![bind_payload_source_term(original_term), named_form_binding],
     })
+}
+
+fn bind_payload_source_term(mut term: Term) -> Term {
+    strip_bind_payload_source_function_from_term(&mut term);
+    term
+}
+
+fn strip_bind_payload_source_function_from_term(term: &mut Term) {
+    match term {
+        Term::Const { value, .. } => strip_bind_payload_source_function_from_value(value),
+        Term::Op { args, .. } => {
+            for arg in args {
+                strip_bind_payload_source_function_from_term(arg);
+            }
+        }
+        Term::Var { .. } | Term::Unit => {}
+    }
+}
+
+fn strip_bind_payload_source_function_from_value(value: &mut Json) {
+    match value {
+        Json::Array(values) => {
+            for value in values {
+                strip_bind_payload_source_function_from_value(value);
+            }
+        }
+        Json::Object(object) => {
+            if object.get("kind").and_then(Json::as_str) == Some("bind-lift-entry") {
+                object.remove("fn_name");
+                object.remove("fnName");
+                object.remove("function");
+            }
+            for value in object.values_mut() {
+                strip_bind_payload_source_function_from_value(value);
+            }
+        }
+        _ => {}
+    }
 }
 
 pub fn named_term_document_from_bind_payload(
@@ -945,9 +994,8 @@ fn term_position_from_citation(value: &Json) -> Vec<usize> {
         .unwrap_or_default()
 }
 
-fn site_cid(entry: &BindLiftEntry, name: &str, term_shape_cid: &str) -> Result<String, BindError> {
+fn site_cid(_entry: &BindLiftEntry, name: &str, term_shape_cid: &str) -> Result<String, BindError> {
     let value = json!({
-        "function": entry.fn_name,
         "name": name,
         "termShapeCid": term_shape_cid,
     });
@@ -1296,7 +1344,7 @@ mod tests {
         .expect("bind succeeds");
         assert_eq!(named.kind, "named-term-document");
         assert_eq!(named.terms[0].concept_name, "concept:demo");
-        assert_eq!(named.terms[0].function, "f");
+        assert!(named.terms[0].function.is_empty());
         assert_eq!(named.promotion_decision_mementos.len(), 1);
     }
 
@@ -1308,16 +1356,103 @@ mod tests {
         };
         let mut entry_with_file = entry.clone();
         entry_with_file.file = "src/lib.rs".to_string();
+        let mut entry_with_source_function = entry.clone();
+        entry_with_source_function.fn_name = "depositSource".to_string();
         let term_shape_cid = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
 
         assert_eq!(
             site_cid(&entry, "concept:deposit", term_shape_cid).expect("site cid"),
             site_cid(&entry_with_file, "concept:deposit", term_shape_cid).expect("site cid")
         );
+        assert_eq!(
+            site_cid(&entry, "concept:deposit", term_shape_cid).expect("site cid"),
+            site_cid(
+                &entry_with_source_function,
+                "concept:deposit",
+                term_shape_cid
+            )
+            .expect("site cid")
+        );
     }
 
     #[test]
-    fn named_term_document_omits_empty_file_fields() {
+    fn bind_payload_cid_ignores_source_function_name() {
+        fn lifted_add(fn_name: &str) -> Term {
+            Term::Const {
+                value: json!({
+                    "kind": "ir-document",
+                    "sourceLanguage": "rust",
+                    "ir": [{
+                        "kind": "bind-lift-entry",
+                        "fn_name": fn_name,
+                        "concept_annotation": "add",
+                        "param_names": ["x", "y"],
+                        "param_types": ["i64", "i64"],
+                        "return_type": "i64",
+                        "term_shape": {"kind": "bin", "op": "+"},
+                        "witnesses": []
+                    }]
+                }),
+                sort: primitive_sort("LiftPluginResponse"),
+            }
+        }
+
+        let kit = BindKit::new(BindOptions {
+            lang: "rust".to_string(),
+        });
+
+        let add_claim = kit
+            .transform(&Input::Term(lifted_add("add")))
+            .expect("bind add succeeds");
+        let adder_claim = kit
+            .transform(&Input::Term(lifted_add("adder")))
+            .expect("bind adder succeeds");
+
+        assert_eq!(
+            add_claim.to, adder_claim.to,
+            "source function name must not enter the bind payload CID"
+        );
+        assert_eq!(
+            add_claim.payload, adder_claim.payload,
+            "source function name must not enter the bind payload bytes"
+        );
+    }
+
+    #[test]
+    fn named_term_document_cid_ignores_source_function_name() {
+        fn document(function: &str) -> NamedTermDocument {
+            NamedTermDocument {
+                kind: "named-term-document".to_string(),
+                promotion_decision_mementos: vec![],
+                schema_version: "1".to_string(),
+                source_language: "rust".to_string(),
+                terms: vec![NamedTerm {
+                    concept_name: "concept:add".to_string(),
+                    discharge_verdict: "loudly-bounded-lossy".to_string(),
+                    file: String::new(),
+                    function: function.to_string(),
+                    name: "add".to_string(),
+                    named_term_tree: None,
+                    param_types: vec!["i64".to_string(), "i64".to_string()],
+                    params: vec!["x".to_string(), "y".to_string()],
+                    return_type: "i64".to_string(),
+                    site_memento_cid: "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222".to_string(),
+                    term_shape: json!({"kind": "bin", "op": "+"}),
+                    term_shape_cid: "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333".to_string(),
+                    witnesses: vec![],
+                }],
+                workspace_root: None,
+            }
+        }
+
+        assert_eq!(
+            named_term_document_cid(&document("add")).expect("add document cid"),
+            named_term_document_cid(&document("adder")).expect("adder document cid")
+        );
+    }
+
+    #[test]
+    fn named_term_document_omits_empty_source_provenance_fields() {
         let document = NamedTermDocument {
             kind: "named-term-document".to_string(),
             promotion_decision_mementos: vec![],
@@ -1327,7 +1462,7 @@ mod tests {
                 concept_name: "concept:deposit".to_string(),
                 discharge_verdict: "loudly-bounded-lossy".to_string(),
                 file: String::new(),
-                function: "deposit".to_string(),
+                function: String::new(),
                 name: "concept:deposit".to_string(),
                 named_term_tree: None,
                 param_types: vec!["i64".to_string()],
@@ -1346,6 +1481,10 @@ mod tests {
         assert!(
             value["terms"][0].get("file").is_none(),
             "empty file provenance should not serialize into named term JSON: {value}"
+        );
+        assert!(
+            value["terms"][0].get("function").is_none(),
+            "empty function provenance should not serialize into named term JSON: {value}"
         );
     }
 

--- a/implementations/rust/libprovekit/src/core/lower_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lower_plugin.rs
@@ -259,16 +259,17 @@ fn decompose_bind_result(args: &[Term], _claim: &DomainClaim) -> Result<Value, S
 }
 
 pub fn realize_spec_from_named_term(term: &NamedTerm) -> Result<Value, String> {
+    let function = realize_function_name(term).to_string();
     let named_term_tree = term
         .named_term_tree
         .as_ref()
         .map(serde_json::to_value)
         .transpose()
-        .map_err(|error| format!("serialize namedTermTree for `{}`: {error}", term.function))?;
+        .map_err(|error| format!("serialize namedTermTree for `{function}`: {error}"))?;
     let (param_types, return_type) = realize_signature_from_named_term(term);
     Ok(json!({
         "kind": "RealizeRequest",
-        "function": term.function,
+        "function": function,
         "params": term.params,
         "paramTypes": param_types,
         "returnType": return_type,
@@ -277,6 +278,14 @@ pub fn realize_spec_from_named_term(term: &NamedTerm) -> Result<Value, String> {
         "termShape": term.term_shape,
         "termShapeCid": term.term_shape_cid,
     }))
+}
+
+fn realize_function_name(term: &NamedTerm) -> &str {
+    if term.function.trim().is_empty() {
+        term.name.as_str()
+    } else {
+        term.function.as_str()
+    }
 }
 
 fn realize_signature_from_named_term(term: &NamedTerm) -> (Vec<String>, String) {

--- a/implementations/rust/libprovekit/tests/bind_kit.rs
+++ b/implementations/rust/libprovekit/tests/bind_kit.rs
@@ -70,6 +70,15 @@ fn bind_kit_transform_emits_bind_result_op_tree() {
         value: term_value.clone(),
         sort: primitive_sort("LiftPluginResponse"),
     };
+    let mut expected_payload_source_value = term_value.clone();
+    expected_payload_source_value["ir"][0]
+        .as_object_mut()
+        .expect("bind-lift-entry object")
+        .remove("fn_name");
+    let expected_payload_source = Term::Const {
+        value: expected_payload_source_value,
+        sort: primitive_sort("LiftPluginResponse"),
+    };
     let expected_named =
         bind_term_document(&term_value, &BindOptions::default()).expect("existing binder succeeds");
 
@@ -89,7 +98,7 @@ fn bind_kit_transform_emits_bind_result_op_tree() {
     assert_eq!(op_cid, &concept_bind_result_cid());
     assert_eq!(name, "concept:bind-result");
     assert_eq!(args.len(), 2);
-    assert_eq!(args[0], input_term);
+    assert_eq!(args[0], expected_payload_source);
     assert!(
         matches!(args[1], Term::Op { .. }),
         "named form binding should be represented as an op tree"
@@ -118,7 +127,7 @@ fn bind_kit_transform_emits_bind_result_op_tree() {
     let first_jcs =
         libprovekit::canonical::serializable_jcs(payload).expect("payload canonicalizes");
     let second_claim = BindKit::default()
-        .transform(&Input::Term(args[0].clone()))
+        .transform(&Input::Term(expected_payload_source.clone()))
         .expect("bind kit transforms term input again");
     let second_payload = second_claim
         .payload

--- a/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
+++ b/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
@@ -220,7 +220,7 @@ fn bind_result_claim_lower_uses_named_term_realize_request() {
     let requests = transport.requests();
     assert_eq!(requests.len(), 1);
     let request = &requests[0];
-    assert_eq!(request.function, "deposit");
+    assert_eq!(request.function, "deposit-then-balance");
     assert_eq!(request.params, vec!["balance", "amount"]);
     assert_eq!(request.param_types, vec!["i64", "i64"]);
     assert_eq!(request.return_type, "i64");
@@ -247,7 +247,7 @@ fn bind_result_claim_lower_reconstructs_erased_signature_defaults() {
     let requests = transport.requests();
     assert_eq!(requests.len(), 1);
     let request = &requests[0];
-    assert_eq!(request.function, "wrap_identity");
+    assert_eq!(request.function, "identity");
     assert_eq!(request.params, vec!["x"]);
     assert_eq!(request.param_types, vec!["int"]);
     assert_eq!(request.return_type, "int");

--- a/implementations/rust/provekit-cli/tests/bind_kit_path_integration.rs
+++ b/implementations/rust/provekit-cli/tests/bind_kit_path_integration.rs
@@ -158,7 +158,7 @@ fn bind_path_executor_matches_cmd_bind_named_term_document_bytes() {
     );
     let named =
         named_term_document_from_bind_payload(payload).expect("bind payload recovers named term");
-    assert_eq!(named.terms[0].function, "deposit");
+    assert!(named.terms[0].function.is_empty());
 }
 
 #[test]

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -79,7 +79,7 @@ fn bind_from_stdin_emits_bind_result_op_tree_with_promotion_decisions() {
         named["terms"][0]["conceptName"],
         "concept:deposit-then-balance"
     );
-    assert_eq!(named["terms"][0]["function"], "deposit");
+    assert!(named["terms"][0].get("function").is_none());
     assert_eq!(
         named["terms"][0]["witnesses"][0]["predicateText"],
         "out == balance + amount"


### PR DESCRIPTION
Closes A23 #1093. Completes the envelope-tier strip cascade started by A19 (lift envelope strip) + A21 (libprovekit source-location residuals).

## What changed

- BindLiftEntry::fn_name and NamedTerm::function get skip-if-empty handling so the hashed bytes contain no function-name residual
- realize_function_name() helper falls back to term.name when term.function is empty (in-place bridge; NOT a sidecar channel; that's A25's work)

## Why this matters

Per the canonical-form ruling: function names are surface syntax, not algebraic. Federation byte-identity for the same algebra must hold across languages with diverging function naming conventions (camelCase vs snake_case vs PascalCase). Before this PR, federation worked by accident when names happened to match.

## Empirical verification

- Red-before / green-after regression test: `add` vs `adder` produces byte-identical bind CIDs
- `cargo test -p libprovekit`: green
- `cargo test -p provekit-cli --test bind_kit_path_integration`: green
- `cargo test -p provekit-cli --test cmd_bind_integration`: green
- Pre-existing bridgeworks smoke red on origin/main is task #70, not introduced

## Scope discipline

The brief forbade "(c) Move function to a non-hashed sidecar (A25 follow-up territory)". The `realize_function_name` helper is NOT that; it's a fallback to `term.name` (the concept name) when `term.function` is empty, so realize emission doesn't break during the transition window before A25 introduces the proper `source_function_name` sidecar channel. A25-compatible: when sidecar arrives, fallback path is harmless backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)