### PR TITLE
feat(conformance): java emit-compile-run #1039

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -683,6 +683,7 @@ test-php:
 .PHONY: test-java
 test-java: build-java
 	mvn test -q -f implementations/java/provekit-lift-java-core/pom.xml
+	mvn test -q -f implementations/java/pom.xml -pl provekit-realize-java-core -am
 
 .PHONY: test-swift
 test-swift: build-swift

--- a/implementations/java/conformance/fixtures/arithmetic_add/fixture.json
+++ b/implementations/java/conformance/fixtures/arithmetic_add/fixture.json
@@ -1,0 +1,18 @@
+{
+  "name": "arithmetic_add",
+  "original_source": "original_source.java",
+  "original_main_class": "ArithmeticAdd",
+  "declared_test_inputs": [
+    ["3", "4"]
+  ],
+  "expected_output": [
+    "7\n"
+  ],
+  "emission": {
+    "function": "add",
+    "params": ["x", "y"],
+    "param_types": ["i32", "i32"],
+    "return_type": "i32",
+    "concept_name": "concept:arithmetic-add"
+  }
+}

--- a/implementations/java/conformance/fixtures/arithmetic_add/original_source.java
+++ b/implementations/java/conformance/fixtures/arithmetic_add/original_source.java
@@ -1,0 +1,10 @@
+final class ArithmeticAdd {
+    // concept: concept:arithmetic-add
+    public static int add(int x, int y) {
+        return x + y;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(add(Integer.parseInt(args[0]), Integer.parseInt(args[1])));
+    }
+}

--- a/implementations/java/conformance/fixtures/control_flow_if/fixture.json
+++ b/implementations/java/conformance/fixtures/control_flow_if/fixture.json
@@ -1,0 +1,22 @@
+{
+  "name": "control_flow_if",
+  "original_source": "original_source.java",
+  "original_main_class": "ControlFlowIf",
+  "declared_test_inputs": [
+    ["-5"],
+    ["0"],
+    ["5"]
+  ],
+  "expected_output": [
+    "5\n",
+    "0\n",
+    "5\n"
+  ],
+  "emission": {
+    "function": "absValue",
+    "params": ["n"],
+    "param_types": ["i32"],
+    "return_type": "i32",
+    "concept_name": "concept:control-flow-if"
+  }
+}

--- a/implementations/java/conformance/fixtures/control_flow_if/original_source.java
+++ b/implementations/java/conformance/fixtures/control_flow_if/original_source.java
@@ -1,0 +1,13 @@
+final class ControlFlowIf {
+    // concept: concept:control-flow-if
+    public static int absValue(int n) {
+        if (n >= 0) {
+            return n;
+        }
+        return -n;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(absValue(Integer.parseInt(args[0])));
+    }
+}

--- a/implementations/java/conformance/fixtures/hello_world/fixture.json
+++ b/implementations/java/conformance/fixtures/hello_world/fixture.json
@@ -1,0 +1,18 @@
+{
+  "name": "hello_world",
+  "original_source": "original_source.java",
+  "original_main_class": "HelloWorld",
+  "declared_test_inputs": [
+    []
+  ],
+  "expected_output": [
+    "hello\n"
+  ],
+  "emission": {
+    "function": "hello",
+    "params": [],
+    "param_types": [],
+    "return_type": "String",
+    "concept_name": "concept:hello-world"
+  }
+}

--- a/implementations/java/conformance/fixtures/hello_world/original_source.java
+++ b/implementations/java/conformance/fixtures/hello_world/original_source.java
@@ -1,0 +1,10 @@
+final class HelloWorld {
+    // concept: concept:hello-world
+    public static String hello() {
+        return "hello";
+    }
+
+    public static void main(String[] args) {
+        System.out.println(hello());
+    }
+}

--- a/implementations/java/conformance/fixtures/recursive_factorial/fixture.json
+++ b/implementations/java/conformance/fixtures/recursive_factorial/fixture.json
@@ -1,0 +1,18 @@
+{
+  "name": "recursive_factorial",
+  "original_source": "original_source.java",
+  "original_main_class": "RecursiveFactorial",
+  "declared_test_inputs": [
+    ["5"]
+  ],
+  "expected_output": [
+    "120\n"
+  ],
+  "emission": {
+    "function": "factorial",
+    "params": ["n"],
+    "param_types": ["i32"],
+    "return_type": "i32",
+    "concept_name": "concept:recursive-factorial"
+  }
+}

--- a/implementations/java/conformance/fixtures/recursive_factorial/original_source.java
+++ b/implementations/java/conformance/fixtures/recursive_factorial/original_source.java
@@ -1,0 +1,13 @@
+final class RecursiveFactorial {
+    // concept: concept:recursive-factorial
+    public static int factorial(int n) {
+        if (n == 0) {
+            return 1;
+        }
+        return n * factorial(n - 1);
+    }
+
+    public static void main(String[] args) {
+        System.out.println(factorial(Integer.parseInt(args[0])));
+    }
+}

--- a/implementations/java/conformance/fixtures/transported_op_via_concept_citation_comment/fixture.json
+++ b/implementations/java/conformance/fixtures/transported_op_via_concept_citation_comment/fixture.json
@@ -1,0 +1,43 @@
+{
+  "name": "transported_op_via_concept_citation_comment",
+  "original_source": "original_source.java",
+  "original_main_class": "TransportedOpViaConceptCitationComment",
+  "declared_test_inputs": [
+    ["resource"]
+  ],
+  "expected_output": [
+    ""
+  ],
+  "expected_emitted_source_contains": [
+    "// provekit-concept:",
+    "\"operation_kind\":\"skip\"",
+    "\"concept_name\":\"concept:skip\"",
+    "// provekit-concept-payload-cid: blake3-512:"
+  ],
+  "emission": {
+    "function": "transported_op_via_concept_citation_comment",
+    "params": ["x"],
+    "param_types": ["Object"],
+    "return_type": "()",
+    "concept_name": "concept:transported-op-via-concept-citation-comment",
+    "transported_operation": {
+      "concept_cid": "blake3-512:9a905548a44fce23882b17d857d275d7822bd235ab71dbf786cd991563cc1de9e610594f50ad3c89a3b7eeb43234a31b36caa8031914c85227158030669c63cb",
+      "concept_site_cid": "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+      "loss_record_cid": "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+      "operation_kind": "skip",
+      "policy_cid": "blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444",
+      "shape_cid": "blake3-512:9a905548a44fce23882b17d857d275d7822bd235ab71dbf786cd991563cc1de9e610594f50ad3c89a3b7eeb43234a31b36caa8031914c85227158030669c63cb",
+      "term_position": [0],
+      "args_jcs": [
+        {
+          "kind": "var",
+          "name": "x"
+        }
+      ],
+      "sugar_dict_cid": "blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666",
+      "callsite_cid": "blake3-512:77777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777",
+      "concept_name": "concept:skip",
+      "target_library_tag": "java"
+    }
+  }
+}

--- a/implementations/java/conformance/fixtures/transported_op_via_concept_citation_comment/original_source.java
+++ b/implementations/java/conformance/fixtures/transported_op_via_concept_citation_comment/original_source.java
@@ -1,0 +1,10 @@
+final class TransportedOpViaConceptCitationComment {
+    // concept: concept:transported-op-via-concept-citation-comment
+    public static void transported_op_via_concept_citation_comment(Object x) {
+        return;
+    }
+
+    public static void main(String[] args) {
+        transported_op_via_concept_citation_comment(args[0]);
+    }
+}

--- a/implementations/java/provekit-realize-java-core/pom.xml
+++ b/implementations/java/provekit-realize-java-core/pom.xml
@@ -29,6 +29,12 @@
         </dependency>
         <dependency>
             <groupId>com.provekit</groupId>
+            <artifactId>provekit-lift-java-source</artifactId>
+            <version>0.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.provekit</groupId>
             <artifactId>provekit-lift-java-provekit-native</artifactId>
             <version>0.1.0</version>
         </dependency>

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaConformanceFixtureTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaConformanceFixtureTest.java
@@ -1,0 +1,489 @@
+package com.provekit.realize;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.provekit.ir.Jcs;
+import com.provekit.lift.java_source.JavaBindLifter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JavaConformanceFixtureTest {
+    private static final String TARGET_COMPILE_FAILURE = "target-compile-failure";
+    private static final String TARGET_BEHAVIOR_DIVERGENCE = "target-behavior-divergence";
+    private static final Set<String> REQUIRED_FIXTURES = Set.of(
+        "hello_world",
+        "recursive_factorial",
+        "arithmetic_add",
+        "control_flow_if",
+        "transported_op_via_concept_citation_comment"
+    );
+
+    @Test
+    void javaCarrierFixturesLiftEmitCompileAndRunAgainstOriginalBehavior(@TempDir Path tempDir)
+            throws Exception {
+        List<Fixture> fixtures = loadFixtures();
+
+        assertTrue(fixtures.size() >= REQUIRED_FIXTURES.size(), "Java conformance fixture set must have N>=5");
+        assertTrue(
+            fixtures.stream().map(Fixture::name).collect(Collectors.toSet()).containsAll(REQUIRED_FIXTURES),
+            "Java conformance fixture set must include " + REQUIRED_FIXTURES
+        );
+
+        for (Fixture fixture : fixtures) {
+            Path fixtureWork = tempDir.resolve(fixture.name());
+            Files.createDirectories(fixtureWork);
+
+            Path originalDir = fixtureWork.resolve("original");
+            Files.createDirectories(originalDir);
+            Path originalSource = originalDir.resolve(fixture.originalSourceFile());
+            Files.writeString(originalSource, fixture.originalSource(), StandardCharsets.UTF_8);
+
+            assertOriginalLiftsThroughBindLifter(fixture, originalDir);
+            compileJava(originalDir, originalSource.getFileName().toString());
+
+            SugarRealizer.Realization emitted = fixture.emission().emit();
+            Path emittedSource = writeEmittedSource(fixture, emitted.source(), fixtureWork.resolve("emitted"));
+            compileJava(emittedSource.getParent(), emittedSource.getFileName().toString());
+            assertEmittedSourceContains(fixture, emitted.source());
+            assertEmittedCarrierRelifts(fixture, emittedSource);
+
+            assertFalse(emitted.isStub(), fixture.name() + " must render from a template or transported carrier");
+            assertStdoutMatchesOriginal(fixture, originalDir, emittedSource);
+        }
+    }
+
+    @Test
+    void compileFailureRefusalUsesTargetCompileFailure(@TempDir Path tempDir) throws Exception {
+        Path broken = tempDir.resolve("Broken.java");
+        Files.writeString(broken, "final class Broken { static void f( }", StandardCharsets.UTF_8);
+
+        CompositionRefusalMemento refusal = compileJavaRefusal(tempDir, "Broken.java");
+
+        assertNotNull(refusal);
+        assertEquals(TARGET_COMPILE_FAILURE, refusal.failureKind());
+    }
+
+    @Test
+    void behaviorDivergenceRefusalUsesTargetBehaviorDivergence() {
+        CompositionRefusalMemento refusal = CompositionRefusalMemento.of(
+            TARGET_BEHAVIOR_DIVERGENCE,
+            "original output did not match emitted output"
+        );
+
+        assertEquals(TARGET_BEHAVIOR_DIVERGENCE, refusal.failureKind());
+        assertTrue(refusal.toJson().contains("\"failure_kind\":\"target-behavior-divergence\""));
+    }
+
+    private static List<Fixture> loadFixtures() throws IOException {
+        Path fixturesPath = repoRoot().resolve("implementations/java/conformance/fixtures");
+        assertTrue(Files.isDirectory(fixturesPath), "missing Java conformance fixture directory: " + fixturesPath);
+        try (Stream<Path> paths = Files.list(fixturesPath)) {
+            List<Path> fixtureJsons = paths
+                .filter(Files::isDirectory)
+                .map(path -> path.resolve("fixture.json"))
+                .filter(Files::isRegularFile)
+                .sorted(Comparator.comparing(path -> path.getParent().getFileName().toString()))
+                .toList();
+            List<Fixture> fixtures = new ArrayList<>();
+            for (Path fixtureJson : fixtureJsons) {
+                fixtures.add(readFixture(fixtureJson));
+            }
+            return fixtures;
+        }
+    }
+
+    private static Fixture readFixture(Path fixtureJson) throws IOException {
+        Jcs.Json parsed = Jcs.parse(Files.readString(fixtureJson, StandardCharsets.UTF_8));
+        if (!(parsed instanceof Jcs.Obj root)) {
+            throw new IllegalArgumentException(fixtureJson + " must be a JSON object");
+        }
+        Path fixtureDir = fixtureJson.getParent();
+        Path originalPath = fixtureDir.resolve(root.stringField("original_source"));
+        String originalSource = Files.readString(originalPath, StandardCharsets.UTF_8);
+        List<List<String>> declaredInputs = stringMatrix(root.arrayField("declared_test_inputs"));
+        List<String> expectedOutput = stringList(root.arrayField("expected_output"));
+        assertEquals(
+            declaredInputs.size(),
+            expectedOutput.size(),
+            root.stringField("name") + " input and output cardinality mismatch"
+        );
+        return new Fixture(
+            root.stringField("name"),
+            originalPath.getFileName().toString(),
+            originalSource,
+            root.stringField("original_main_class"),
+            declaredInputs,
+            expectedOutput,
+            optionalStringList(root.get("expected_emitted_source_contains")),
+            readEmission(root.objectField("emission"))
+        );
+    }
+
+    private static Emission readEmission(Jcs.Obj obj) {
+        return new Emission(
+            obj.stringField("function"),
+            stringList(obj.arrayField("params")),
+            stringList(obj.arrayField("param_types")),
+            obj.stringField("return_type"),
+            obj.stringField("concept_name"),
+            readTransportedOperation(obj.get("transported_operation"))
+        );
+    }
+
+    private static TransportedOperation readTransportedOperation(Jcs.Json json) {
+        if (!(json instanceof Jcs.Obj obj)) {
+            return null;
+        }
+        return new TransportedOperation(
+            obj.stringField("concept_cid"),
+            obj.stringField("concept_site_cid"),
+            obj.stringField("loss_record_cid"),
+            obj.stringField("operation_kind"),
+            obj.stringField("policy_cid"),
+            obj.stringField("shape_cid"),
+            intList(obj.arrayField("term_position")),
+            obj.get("args_jcs"),
+            obj.stringFieldOrNull("args_jcs_cid"),
+            obj.stringFieldOrNull("sugar_dict_cid"),
+            obj.stringFieldOrNull("callsite_cid"),
+            obj.stringFieldOrNull("concept_name"),
+            obj.stringFieldOrNull("target_library_tag")
+        );
+    }
+
+    private static void assertOriginalLiftsThroughBindLifter(Fixture fixture, Path originalDir) {
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPaths(
+            originalDir.toString(),
+            List.of(fixture.originalSourceFile())
+        );
+        String encoded = Jcs.encode(lift.toJson());
+        assertTrue(
+            lift.diagnostics().stream().noneMatch(JavaConformanceFixtureTest::isErrorDiagnostic),
+            encoded
+        );
+        Jcs.Obj entry = bindEntry(lift, fixture.emission().function());
+        assertNotNull(entry, encoded);
+        assertEquals(fixture.emission().conceptName(), entry.stringField("concept_annotation"), encoded);
+    }
+
+    private static boolean isErrorDiagnostic(Jcs.Json diagnostic) {
+        return diagnostic instanceof Jcs.Obj obj && "error".equals(obj.stringFieldOrNull("severity"));
+    }
+
+    private static void assertStdoutMatchesOriginal(Fixture fixture, Path originalDir, Path emittedSource)
+            throws Exception {
+        Path emittedDir = emittedSource.getParent();
+        Path harness = emittedDir.resolve("EmittedHarness.java");
+        Files.writeString(harness, emittedHarnessSource(fixture.emission()), StandardCharsets.UTF_8);
+        compileJava(emittedDir, "EmittedHarness.java", "-cp", ".");
+
+        for (int i = 0; i < fixture.declaredTestInputs().size(); i++) {
+            List<String> args = fixture.declaredTestInputs().get(i);
+            String expected = fixture.expectedOutput().get(i);
+            CommandResult original = runJava(originalDir, fixture.originalMainClass(), args);
+            assertBehavior(fixture, expected, original, "original source");
+
+            CommandResult emitted = runJava(emittedDir, "EmittedHarness", args);
+            if (!original.stdout().equals(emitted.stdout()) || emitted.exitCode() != 0) {
+                fail(CompositionRefusalMemento.of(
+                    TARGET_BEHAVIOR_DIVERGENCE,
+                    fixture.name() + " emitted output diverged for input " + args
+                        + "; original stdout=" + quote(original.stdout())
+                        + "; emitted stdout=" + quote(emitted.stdout())
+                        + "; emitted exit=" + emitted.exitCode()
+                        + "; emitted stderr=" + quote(emitted.stderr())
+                ).toJson());
+            }
+        }
+    }
+
+    private static void assertBehavior(Fixture fixture, String expected, CommandResult result, String side) {
+        if (result.exitCode() != 0 || !expected.equals(result.stdout())) {
+            fail(CompositionRefusalMemento.of(
+                TARGET_BEHAVIOR_DIVERGENCE,
+                fixture.name() + " " + side + " behavior mismatch"
+                    + "; expected stdout=" + quote(expected)
+                    + "; observed stdout=" + quote(result.stdout())
+                    + "; exit=" + result.exitCode()
+                    + "; stderr=" + quote(result.stderr())
+            ).toJson());
+        }
+    }
+
+    private static void assertEmittedSourceContains(Fixture fixture, String emittedSource) {
+        for (String marker : fixture.expectedEmittedSourceContains()) {
+            assertTrue(emittedSource.contains(marker), fixture.name() + " missing marker " + marker + "\n" + emittedSource);
+        }
+    }
+
+    private static void assertEmittedCarrierRelifts(Fixture fixture, Path emittedSource) {
+        if (fixture.expectedEmittedSourceContains().stream().noneMatch("// provekit-concept:"::equals)) {
+            return;
+        }
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPaths(
+            emittedSource.getParent().toString(),
+            List.of(emittedSource.getFileName().toString())
+        );
+        String encoded = Jcs.encode(lift.toJson());
+        Jcs.Obj entry = bindEntry(lift, fixture.emission().function());
+        assertNotNull(entry, encoded);
+        assertFalse(entry.arrayField("concept_citations").values().isEmpty(), encoded);
+    }
+
+    private static Jcs.Obj bindEntry(JavaBindLifter.Result lift, String functionName) {
+        for (Jcs.Json value : lift.entries()) {
+            if (value instanceof Jcs.Obj obj && functionName.equals(obj.stringFieldOrNull("fn_name"))) {
+                return obj;
+            }
+        }
+        return null;
+    }
+
+    private static Path writeEmittedSource(Fixture fixture, String source, Path emittedDir) throws IOException {
+        Files.createDirectories(emittedDir);
+        String className = SugarRealizer.snakeToPascal(fixture.emission().function()) + "Transported";
+        Path emittedSource = emittedDir.resolve(className + ".java");
+        Files.writeString(emittedSource, source, StandardCharsets.UTF_8);
+        return emittedSource;
+    }
+
+    private static void compileJava(Path workDir, String sourceFile, String... prefixArgs)
+            throws IOException, InterruptedException {
+        CompositionRefusalMemento refusal = compileJavaRefusal(workDir, sourceFile, prefixArgs);
+        if (refusal != null) {
+            fail(refusal.toJson());
+        }
+    }
+
+    private static CompositionRefusalMemento compileJavaRefusal(Path workDir, String sourceFile, String... prefixArgs)
+            throws IOException, InterruptedException {
+        List<String> command = new ArrayList<>();
+        command.add("javac");
+        command.addAll(List.of(prefixArgs));
+        command.add(sourceFile);
+        CommandResult result = run(workDir, command);
+        if (result.exitCode() == 0) {
+            return null;
+        }
+        return CompositionRefusalMemento.of(
+            TARGET_COMPILE_FAILURE,
+            String.join(" ", command) + " failed in " + workDir
+                + "; stdout=" + quote(result.stdout())
+                + "; stderr=" + quote(result.stderr())
+        );
+    }
+
+    private static CommandResult runJava(Path workDir, String mainClass, List<String> args)
+            throws IOException, InterruptedException {
+        List<String> command = new ArrayList<>();
+        command.add("java");
+        command.add("-cp");
+        command.add(".");
+        command.add(mainClass);
+        command.addAll(args);
+        return run(workDir, command);
+    }
+
+    private static CommandResult run(Path workDir, List<String> command) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder(command)
+            .directory(workDir.toFile())
+            .start();
+        boolean exited = process.waitFor(Duration.ofSeconds(20).toMillis(), TimeUnit.MILLISECONDS);
+        if (!exited) {
+            process.destroyForcibly();
+            fail(CompositionRefusalMemento.of(
+                TARGET_BEHAVIOR_DIVERGENCE,
+                String.join(" ", command) + " timed out in " + workDir
+            ).toJson());
+        }
+        return new CommandResult(
+            process.exitValue(),
+            new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8),
+            new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8)
+        );
+    }
+
+    private static String emittedHarnessSource(Emission emission) {
+        String className = SugarRealizer.snakeToPascal(emission.function()) + "Transported";
+        String mappedReturn = SugarRealizer.mapSourceType(emission.returnType());
+        String invocation = className + "." + emission.function() + "(" + invocationArgs(emission) + ")";
+        if ("void".equals(mappedReturn)) {
+            return """
+                final class EmittedHarness {
+                    public static void main(String[] args) {
+                        %s;
+                    }
+                }
+                """.formatted(invocation);
+        }
+        return """
+            final class EmittedHarness {
+                public static void main(String[] args) {
+                    System.out.println(%s);
+                }
+            }
+            """.formatted(invocation);
+    }
+
+    private static String invocationArgs(Emission emission) {
+        List<String> args = new ArrayList<>();
+        for (int i = 0; i < emission.params().size(); i++) {
+            String mapped = SugarRealizer.mapSourceType(i < emission.paramTypes().size()
+                ? emission.paramTypes().get(i)
+                : "String");
+            args.add(argumentExpression(mapped, i));
+        }
+        return String.join(", ", args);
+    }
+
+    private static String argumentExpression(String mappedType, int index) {
+        return switch (mappedType) {
+            case "int" -> "Integer.parseInt(args[" + index + "])";
+            case "long" -> "Long.parseLong(args[" + index + "])";
+            case "short" -> "Short.parseShort(args[" + index + "])";
+            case "byte" -> "Byte.parseByte(args[" + index + "])";
+            case "double" -> "Double.parseDouble(args[" + index + "])";
+            case "float" -> "Float.parseFloat(args[" + index + "])";
+            case "boolean" -> "Boolean.parseBoolean(args[" + index + "])";
+            case "String" -> "args[" + index + "]";
+            default -> "args[" + index + "]";
+        };
+    }
+
+    private static Path repoRoot() {
+        Path current = Path.of("").toAbsolutePath();
+        for (Path cursor = current; cursor != null; cursor = cursor.getParent()) {
+            if (Files.exists(cursor.resolve("implementations/java/pom.xml"))
+                    && Files.exists(cursor.resolve("implementations/rust"))) {
+                return cursor;
+            }
+            if (Files.exists(cursor.resolve("pom.xml"))
+                    && "java".equals(cursor.getFileName().toString())
+                    && cursor.getParent() != null
+                    && cursor.getParent().getParent() != null) {
+                Path root = cursor.getParent().getParent();
+                if (Files.exists(root.resolve("implementations/rust"))) {
+                    return root;
+                }
+            }
+        }
+        throw new IllegalStateException("could not locate provekit repo root from " + current);
+    }
+
+    private static List<String> stringList(Jcs.Arr arr) {
+        List<String> out = new ArrayList<>();
+        for (Jcs.Json value : arr.values()) {
+            if (!(value instanceof Jcs.Str string)) {
+                throw new IllegalArgumentException("expected string array");
+            }
+            out.add(string.value());
+        }
+        return out;
+    }
+
+    private static List<String> optionalStringList(Jcs.Json json) {
+        if (!(json instanceof Jcs.Arr arr)) {
+            return List.of();
+        }
+        return stringList(arr);
+    }
+
+    private static List<List<String>> stringMatrix(Jcs.Arr arr) {
+        List<List<String>> out = new ArrayList<>();
+        for (Jcs.Json value : arr.values()) {
+            if (!(value instanceof Jcs.Arr row)) {
+                throw new IllegalArgumentException("expected array of string arrays");
+            }
+            out.add(stringList(row));
+        }
+        return out;
+    }
+
+    private static List<Integer> intList(Jcs.Arr arr) {
+        List<Integer> out = new ArrayList<>();
+        for (Jcs.Json value : arr.values()) {
+            if (!(value instanceof Jcs.Num number)) {
+                throw new IllegalArgumentException("expected integer array");
+            }
+            out.add((int) number.value());
+        }
+        return out;
+    }
+
+    private static String quote(String raw) {
+        return raw == null ? "null" : raw.replace("\\", "\\\\").replace("\n", "\\n");
+    }
+
+    private record Fixture(
+        String name,
+        String originalSourceFile,
+        String originalSource,
+        String originalMainClass,
+        List<List<String>> declaredTestInputs,
+        List<String> expectedOutput,
+        List<String> expectedEmittedSourceContains,
+        Emission emission) {}
+
+    private record Emission(
+        String function,
+        List<String> params,
+        List<String> paramTypes,
+        String returnType,
+        String conceptName,
+        TransportedOperation transportedOperation) {
+        SugarRealizer.Realization emit() {
+            return SugarRealizer.emitStub(
+                function,
+                params,
+                paramTypes,
+                returnType,
+                conceptName,
+                "",
+                List.of(),
+                null,
+                List.of(),
+                transportedOperation
+            );
+        }
+    }
+
+    private record CommandResult(int exitCode, String stdout, String stderr) {}
+
+    private record CompositionRefusalMemento(String failureKind, String failureDetail) {
+        static CompositionRefusalMemento of(String failureKind, String failureDetail) {
+            return new CompositionRefusalMemento(failureKind, failureDetail);
+        }
+
+        String toJson() {
+            return "{"
+                + "\"kind\":\"CompositionRefusalMemento\","
+                + "\"failure_kind\":\"" + jsonEscape(failureKind) + "\","
+                + "\"failure_detail\":\"" + jsonEscape(failureDetail) + "\""
+                + "}";
+        }
+
+        private static String jsonEscape(String raw) {
+            return raw
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r");
+        }
+    }
+}

--- a/implementations/rust/provekit-cli/tests/carrier_fixture_registry.rs
+++ b/implementations/rust/provekit-cli/tests/carrier_fixture_registry.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use libprovekit::core::{ConformanceDeclaration, KitRegistry, LowerKit};
+use provekit_cli::kit_dispatch::DispatchRealizeTransport;
+
+const REQUIRED_FIXTURES: &[&str] = &[
+    "arithmetic_add",
+    "control_flow_if",
+    "hello_world",
+    "recursive_factorial",
+    "transported_op_via_concept_citation_comment",
+];
+
+#[test]
+fn lower_java_carrier_registration_points_at_required_fixture_set() {
+    let repo_root = repo_root();
+    let fixtures_path = repo_root.join("implementations/java/conformance/fixtures");
+    let mut registry = KitRegistry::default();
+
+    registry.register(
+        "lower-java",
+        LowerKit::new(
+            repo_root,
+            "java",
+            None,
+            DispatchRealizeTransport,
+        ),
+        ConformanceDeclaration::Carrier {
+            fixtures_path: fixtures_path.clone(),
+        },
+    );
+
+    let Some(ConformanceDeclaration::Carrier { fixtures_path }) = registry.conformance("lower-java") else {
+        panic!("lower-java must register as a carrier");
+    };
+    assert_required_fixtures(fixtures_path);
+}
+
+fn assert_required_fixtures(fixtures_path: &Path) {
+    assert!(
+        fixtures_path.is_dir(),
+        "carrier fixtures_path must resolve to a directory: {}",
+        fixtures_path.display()
+    );
+
+    let present = std::fs::read_dir(fixtures_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", fixtures_path.display()))
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .collect::<BTreeSet<_>>();
+
+    for required in REQUIRED_FIXTURES {
+        assert!(
+            present.contains(*required),
+            "carrier fixture set at {} is missing `{required}`; present: {present:?}",
+            fixtures_path.display()
+        );
+        let fixture_json = fixtures_path.join(required).join("fixture.json");
+        assert!(
+            fixture_json.is_file(),
+            "carrier fixture `{required}` must include fixture.json at {}",
+            fixture_json.display()
+        );
+    }
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -133,7 +133,7 @@ fn java_canonical_bodies_cid_self_consistent() {
         .join("menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json");
     assert_self_consistent(
         path,
-        "blake3-512:265b192f573819b1814000f22efb1172e51ff83e0d127acdc0d31fb8dfce725e0aafe58b4f7b0f45469b969c4a561541e8d50e585fedd8056eefdd3e9cf5b7ff",
+        "blake3-512:0a74f40c13bf4843b7afea6ee91e1b33ac026145a03c7da0be0b22e7667da8f4361f1dca95daedb0219f825139069096123f72f8df46ca1517a4b108e389f328",
     );
 }
 

--- a/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
+++ b/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:265b192f573819b1814000f22efb1172e51ff83e0d127acdc0d31fb8dfce725e0aafe58b4f7b0f45469b969c4a561541e8d50e585fedd8056eefdd3e9cf5b7ff",
+    "cid": "blake3-512:0a74f40c13bf4843b7afea6ee91e1b33ac026145a03c7da0be0b22e7667da8f4361f1dca95daedb0219f825139069096123f72f8df46ca1517a4b108e389f328",
     "content": {
       "entries": [
         {
@@ -177,6 +177,70 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
+          }
+        },
+        {
+          "concept_name": "concept:hello-world",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return \"hello\";"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 0,
+            "min_params": 0,
+            "requires_return_type": "String"
+          }
+        },
+        {
+          "concept_name": "concept:recursive-factorial",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} == 0 ? 1 : ${param0} * factorial(${param0} - 1);"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "concept:arithmetic-add",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} + ${param1};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "concept:control-flow-if",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} >= 0 ? ${param0} : -${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_return_type": "int"
           }
         },
         {


### PR DESCRIPTION
Closes the Java side of #1039. 5 fixtures, JavaConformanceFixtureTest with javac/java happy-path + refusal checks (target-compile-failure, target-behavior-divergence). Wires Java realizer CI coverage into make test-java; Rust registry meta-test for lower-java carrier fixture registration; Java canonical body templates with refreshed CID pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)