### PR TITLE
feat(conformance): c emit-compile-run #1039

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 # Per-language targets:
 #   make build-rust: cargo build --release for workspace + tools
 #   make build-cpp: vendored-blake3 clang++ build of the C++ orchestrator
-#   make test-rust / test-go / test-ts / test-csharp / test-python / test-ruby / test-php
+#   make test-rust / test-go / test-ts / test-csharp / test-python / test-ruby / test-php / test-c
 #
 # Determinism:
 #   make ci is the local Linux-profile contract. If it's green, the non-Swift
@@ -197,6 +197,7 @@ build-c:
 	$(MAKE) -C implementations/c/provekit-lift-c-sparse all
 	$(MAKE) -C implementations/c/provekit-lift-c-kernel-doc all
 	$(MAKE) -C implementations/c/provekit-lift-c-assertions all
+	$(MAKE) -C implementations/c/provekit-realize-c-core all
 	$(MAKE) -C implementations/c/provekit-lsp-c all
 	$(MAKE) -C implementations/c/provekit-self-contracts lib
 
@@ -660,6 +661,7 @@ test-c: build-c
 	$(MAKE) -C implementations/c/provekit-lift-c-sparse test
 	$(MAKE) -C implementations/c/provekit-lift-c-kernel-doc test
 	$(MAKE) -C implementations/c/provekit-lift-c-assertions test
+	$(MAKE) -C implementations/c/provekit-realize-c-core test
 	$(MAKE) -C implementations/c/provekit-lift-composition test
 	$(MAKE) -C implementations/c/provekit-lsp-c test
 	$(MAKE) -C implementations/c/provekit-self-contracts test
@@ -719,7 +721,7 @@ build-zig:
 # NOTE: test-swift is intentionally excluded from test-all: it requires a
 # macOS host with the Swift toolchain. Use `make test-swift` on macOS.
 .PHONY: test-all
-test-all: test-rust test-go test-ts test-csharp test-python test-ruby test-php test-java
+test-all: test-rust test-go test-ts test-csharp test-python test-ruby test-php test-java test-c
 	@echo ""
 	@echo "==== test-all: PASS ===="
 

--- a/implementations/c/conformance/fixtures/arithmetic_add.json
+++ b/implementations/c/conformance/fixtures/arithmetic_add.json
@@ -1,0 +1,41 @@
+{
+  "name": "arithmetic_add",
+  "kind": "function_int",
+  "source_language": "c",
+  "original_source": "// concept: add\nint add(int x, int y) {\n    return x + y;\n}\n",
+  "declared_test_inputs": [
+    [
+      "3",
+      "4"
+    ],
+    [
+      "-3",
+      "9"
+    ]
+  ],
+  "expected_output": [
+    {
+      "stdout": "7\n",
+      "stderr": "",
+      "exit_code": 0
+    },
+    {
+      "stdout": "6\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "add",
+    "params": [
+      "x",
+      "y"
+    ],
+    "param_types": [
+      "int",
+      "int"
+    ],
+    "return_type": "int",
+    "concept_name": "add"
+  }
+}

--- a/implementations/c/conformance/fixtures/arithmetic_multi_op.json
+++ b/implementations/c/conformance/fixtures/arithmetic_multi_op.json
@@ -1,0 +1,41 @@
+{
+  "name": "arithmetic_multi_op",
+  "kind": "function_int",
+  "source_language": "c",
+  "original_source": "// concept: arithmetic-multi-op\nint arithmetic_multi_op(int x, int y) {\n    int sum = x + y;\n    int diff = x - y;\n    return sum * diff;\n}\n",
+  "declared_test_inputs": [
+    [
+      "7",
+      "2"
+    ],
+    [
+      "5",
+      "5"
+    ]
+  ],
+  "expected_output": [
+    {
+      "stdout": "45\n",
+      "stderr": "",
+      "exit_code": 0
+    },
+    {
+      "stdout": "0\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "arithmetic_multi_op",
+    "params": [
+      "x",
+      "y"
+    ],
+    "param_types": [
+      "int",
+      "int"
+    ],
+    "return_type": "int",
+    "concept_name": "arithmetic-multi-op"
+  }
+}

--- a/implementations/c/conformance/fixtures/control_flow_if.json
+++ b/implementations/c/conformance/fixtures/control_flow_if.json
@@ -1,0 +1,45 @@
+{
+  "name": "control_flow_if",
+  "kind": "function_int",
+  "source_language": "c",
+  "original_source": "// concept: abs-value\nint abs_value(int n) {\n    if (n >= 0) return n;\n    return -n;\n}\n",
+  "declared_test_inputs": [
+    [
+      "-5"
+    ],
+    [
+      "0"
+    ],
+    [
+      "5"
+    ]
+  ],
+  "expected_output": [
+    {
+      "stdout": "5\n",
+      "stderr": "",
+      "exit_code": 0
+    },
+    {
+      "stdout": "0\n",
+      "stderr": "",
+      "exit_code": 0
+    },
+    {
+      "stdout": "5\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "abs_value",
+    "params": [
+      "n"
+    ],
+    "param_types": [
+      "int"
+    ],
+    "return_type": "int",
+    "concept_name": "abs-value"
+  }
+}

--- a/implementations/c/conformance/fixtures/hello_world.json
+++ b/implementations/c/conformance/fixtures/hello_world.json
@@ -1,0 +1,23 @@
+{
+  "name": "hello_world",
+  "kind": "program",
+  "source_language": "c",
+  "original_source": "// concept: hello-world\nint main(void) {\n    extern int printf(const char *, ...);\n    if (printf(\"Hello, world!\\n\") < 0) return 1;\n    return 0;\n}\n",
+  "declared_test_inputs": [
+    []
+  ],
+  "expected_output": [
+    {
+      "stdout": "Hello, world!\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "main",
+    "params": [],
+    "param_types": [],
+    "return_type": "int",
+    "concept_name": "hello-world"
+  }
+}

--- a/implementations/c/conformance/fixtures/recursive_factorial.json
+++ b/implementations/c/conformance/fixtures/recursive_factorial.json
@@ -1,0 +1,37 @@
+{
+  "name": "recursive_factorial",
+  "kind": "function_int",
+  "source_language": "c",
+  "original_source": "// concept: factorial\nint factorial(int n) {\n    if (n <= 1) return 1;\n    return n * factorial(n - 1);\n}\n",
+  "declared_test_inputs": [
+    [
+      "5"
+    ],
+    [
+      "0"
+    ]
+  ],
+  "expected_output": [
+    {
+      "stdout": "120\n",
+      "stderr": "",
+      "exit_code": 0
+    },
+    {
+      "stdout": "1\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  ],
+  "realize_request": {
+    "function": "factorial",
+    "params": [
+      "n"
+    ],
+    "param_types": [
+      "int"
+    ],
+    "return_type": "int",
+    "concept_name": "factorial"
+  }
+}

--- a/implementations/c/conformance/fixtures/transported_op_concept_comment.json
+++ b/implementations/c/conformance/fixtures/transported_op_concept_comment.json
@@ -1,0 +1,56 @@
+{
+  "name": "transported_op_concept_comment",
+  "kind": "concept_carrier",
+  "source_language": "c",
+  "original_source": "/* concept: drop(x) */\nvoid transport_drop(int x) {\n    (void)x;\n}\n",
+  "declared_test_inputs": [
+    []
+  ],
+  "expected_output": [
+    {
+      "stdout": "",
+      "stderr": "",
+      "exit_code": 0,
+      "source_contains": [
+        "/* concept: drop(x) */",
+        "// provekit-concept: ",
+        "// provekit-concept-payload-cid: "
+      ]
+    }
+  ],
+  "realize_request": {
+    "function": "transport_drop",
+    "params": [
+      "x"
+    ],
+    "param_types": [
+      "int"
+    ],
+    "return_type": "void",
+    "concept_name": "concept:drop",
+    "transported_operation": {
+      "args_jcs": {
+        "kind": "call-args",
+        "values": [
+          {
+            "kind": "var",
+            "name": "x"
+          }
+        ]
+      },
+      "callsite_cid": "blake3-512:55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
+      "concept_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+      "concept_name": "concept:drop",
+      "concept_site_cid": "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+      "loss_record_cid": "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+      "operation_kind": "drop",
+      "policy_cid": "blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444",
+      "shape_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+      "sugar_dict_cid": "blake3-512:66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666",
+      "target_library_tag": "c-core",
+      "term_position": [
+        0
+      ]
+    }
+  }
+}

--- a/implementations/c/provekit-realize-c-core/Makefile
+++ b/implementations/c/provekit-realize-c-core/Makefile
@@ -10,6 +10,8 @@ B3_SRC = $(B3_DIR)/blake3.c $(B3_DIR)/blake3_dispatch.c $(B3_DIR)/blake3_portabl
 BIN = target/release/provekit-realize-c
 DISCOVERY_BIN = $(abspath ../target/release/provekit-realize-c)
 TEST_SH = tests/integration.sh
+CONFORMANCE_PY = tests/conformance.py
+BIND_LIFT_BIN = ../provekit-walk-c/provekit-bind-lift-c
 
 .PHONY: all clean test
 
@@ -20,7 +22,10 @@ $(BIN): $(SRC)
 	$(CC) $(CFLAGS) -o $@ $(SRC) $(B3_SRC)
 	cp $@ $(DISCOVERY_BIN)
 
-test: $(BIN) $(TEST_SH)
+$(BIND_LIFT_BIN):
+	$(MAKE) -C ../provekit-walk-c provekit-bind-lift-c
+
+test: $(BIN) $(BIND_LIFT_BIN) $(TEST_SH) $(CONFORMANCE_PY)
 	@chmod +x $(TEST_SH)
 	@$(TEST_SH)
 

--- a/implementations/c/provekit-realize-c-core/src/main.c
+++ b/implementations/c/provekit-realize-c-core/src/main.c
@@ -1035,8 +1035,32 @@ static int append_emitted_by_field(Buf *out, int *first, const char *kit_cid,
     return 0;
 }
 
+static const char *concept_display_name(const char *concept_name) {
+    const char *prefix = "concept:";
+    size_t prefix_len = strlen(prefix);
+    if (concept_name != NULL && strncmp(concept_name, prefix, prefix_len) == 0) {
+        return concept_name + prefix_len;
+    }
+    return concept_name != NULL ? concept_name : "unknown";
+}
+
+static int append_concept_shorthand(Buf *out, const char *concept_name,
+                                    const StringArray *params) {
+    if (buf_append(out, "/* concept: ") != 0 ||
+        buf_append(out, concept_display_name(concept_name)) != 0 ||
+        buf_append_char(out, '(') != 0) {
+        return -1;
+    }
+    for (size_t i = 0; i < params->len; i++) {
+        if (i > 0 && buf_append(out, ", ") != 0) return -1;
+        if (buf_append(out, params->items[i]) != 0) return -1;
+    }
+    return buf_append(out, ") */\n");
+}
+
 static char *concept_citation_body_for(const char *params_obj, const char *params_obj_end,
                                        const char *fallback_concept_name,
+                                       const StringArray *params,
                                        char **error_message) {
     const char *op = find_field_in_range(params_obj, params_obj_end, "transported_operation");
     const char *op_end;
@@ -1151,11 +1175,25 @@ static char *concept_citation_body_for(const char *params_obj, const char *param
     }
 
     buf_init(&body_buf);
-    if (buf_append(&body_buf, "// provekit-concept: ") != 0 ||
+    if (append_concept_shorthand(&body_buf, concept_name, params) != 0 ||
+        buf_append(&body_buf, "// provekit-concept: ") != 0 ||
         buf_append(&body_buf, payload) != 0 ||
         buf_append(&body_buf, "\n// provekit-concept-payload-cid: ") != 0 ||
-        buf_append(&body_buf, payload_cid) != 0 ||
-        buf_append(&body_buf, "\n(void)0;") != 0) {
+        buf_append(&body_buf, payload_cid) != 0) {
+        buf_free(&body_buf);
+        *error_message = xstrdup("out of memory");
+        goto done;
+    }
+    for (size_t i = 0; i < params->len; i++) {
+        if (buf_append(&body_buf, "\n(void)") != 0 ||
+            buf_append(&body_buf, params->items[i]) != 0 ||
+            buf_append_char(&body_buf, ';') != 0) {
+            buf_free(&body_buf);
+            *error_message = xstrdup("out of memory");
+            goto done;
+        }
+    }
+    if (buf_append(&body_buf, "\n(void)0;") != 0) {
         buf_free(&body_buf);
         *error_message = xstrdup("out of memory");
         goto done;
@@ -1328,7 +1366,8 @@ static void handle_invoke(const char *id, const char *line, const char *end,
                    error_message != NULL ? error_message : "out of memory");
         goto done;
     }
-    body = concept_citation_body_for(params_obj, params_obj_end, concept_name, &error_message);
+    body = concept_citation_body_for(params_obj, params_obj_end, concept_name, &params,
+                                     &error_message);
     if (error_message != NULL) {
         send_error(id, -32602, error_message);
         goto done;

--- a/implementations/c/provekit-realize-c-core/tests/conformance.py
+++ b/implementations/c/provekit-realize-c-core/tests/conformance.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES_DIR = REPO_ROOT / "implementations" / "c" / "conformance" / "fixtures"
+BIND_LIFT_BIN = REPO_ROOT / "implementations" / "c" / "provekit-walk-c" / "provekit-bind-lift-c"
+REQUIRED_FIXTURES = [
+    "hello_world",
+    "recursive_factorial",
+    "arithmetic_add",
+    "arithmetic_multi_op",
+    "control_flow_if",
+    "transported_op_concept_comment",
+]
+ZERO_CID = "blake3-512:" + "0" * 128
+ONE_CID = "blake3-512:" + "1" * 128
+
+
+class ConformanceRefusal(Exception):
+    def __init__(self, failure_kind, failure_detail):
+        super().__init__(failure_detail)
+        self.failure_kind = failure_kind
+        self.failure_detail = failure_detail
+
+    def to_memento(self):
+        return {
+            "envelope": {
+                "declaredAt": "1970-01-01T00:00:00Z",
+                "signature": "unsigned:c-kit-conformance",
+                "signer": "substrate:c-kit-conformance",
+            },
+            "header": {
+                "atoms_cids": [ONE_CID],
+                "blocking_effects": None,
+                "ccp_version": "1.0.0",
+                "cid": ZERO_CID,
+                "compose_input_cid": ZERO_CID,
+                "effect_occurrences": [],
+                "effect_set_cids": [],
+                "failure_detail": self.failure_detail,
+                "failure_kind": self.failure_kind,
+                "incompatible_pair": None,
+                "kind": "composition-refusal",
+                "missing_memento_requirements": None,
+                "schemaVersion": "1",
+            },
+            "metadata": {
+                "note": "C kit emit-compile-run conformance refusal",
+            },
+        }
+
+
+def load_fixtures():
+    fixtures_by_name = {}
+    for path in sorted(FIXTURES_DIR.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            fixture = json.load(handle)
+        fixture["_path"] = str(path)
+        fixtures_by_name[fixture["name"]] = fixture
+    missing = [name for name in REQUIRED_FIXTURES if name not in fixtures_by_name]
+    if missing:
+        raise RuntimeError(f"missing required C conformance fixtures: {missing}")
+    return [fixtures_by_name[name] for name in REQUIRED_FIXTURES]
+
+
+def rpc_lines(cmd, payload):
+    proc = subprocess.run(
+        cmd,
+        input=payload,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{cmd} exited {proc.returncode}: stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+    return [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+
+
+def lift_original_source(tmp, fixture):
+    if not BIND_LIFT_BIN.exists():
+        raise RuntimeError(f"missing C bind lifter: {BIND_LIFT_BIN}")
+    source_path = tmp / f"{fixture['name']}_lift.c"
+    source_path.write_text(fixture["original_source"], encoding="utf-8")
+    request = "\n".join(
+        [
+            json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "lift",
+                    "params": {
+                        "workspace_root": str(tmp),
+                        "source_paths": [source_path.name],
+                    },
+                }
+            ),
+            json.dumps({"jsonrpc": "2.0", "id": 3, "method": "shutdown", "params": {}}),
+        ]
+    )
+    responses = rpc_lines([str(BIND_LIFT_BIN)], request + "\n")
+    result = responses[1].get("result", {})
+    if result.get("kind") != "ir-document":
+        raise RuntimeError(f"C bind lifter returned non-ir document: {result}")
+    target_fn = fixture["realize_request"]["function"]
+    matches = [entry for entry in result.get("ir", []) if entry.get("fn_name") == target_fn]
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one lifted entry for {target_fn}, got {matches}")
+    return matches[0]
+
+
+def request_from_lift(fixture, entry):
+    request = dict(fixture["realize_request"])
+    expected = {
+        "function": entry.get("fn_name"),
+        "params": entry.get("param_names", []),
+        "param_types": entry.get("param_types", []),
+        "return_type": entry.get("return_type"),
+    }
+    for key, lifted in expected.items():
+        fixture_value = request.get(key)
+        if key == "return_type" and void_equivalent(fixture_value, lifted):
+            continue
+        if fixture_value != lifted:
+            raise RuntimeError(
+                f"{fixture['name']} {key} mismatch: fixture={fixture_value!r} lifted={lifted!r}"
+            )
+    if request.get("concept_name") in (None, ""):
+        concept = entry.get("concept_annotation")
+        if not concept:
+            raise RuntimeError(f"{fixture['name']} has no lifted concept annotation")
+        request["concept_name"] = concept
+    return request
+
+
+def void_equivalent(left, right):
+    return left in ("void", "()", "Unit") and right in ("void", "()", "Unit")
+
+
+def invoke_realizer(bin_path, request):
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.invoke",
+        "params": request,
+    }
+    responses = rpc_lines(
+        [str(bin_path), "--rpc"],
+        json.dumps(rpc, separators=(",", ":")) + "\n",
+    )
+    response = responses[0]
+    if "error" in response:
+        raise RuntimeError(f"realizer returned error: {response['error']}")
+    result = response.get("result", {})
+    source = result.get("source")
+    if not isinstance(source, str):
+        raise RuntimeError(f"realizer response missing result.source: {response}")
+    return source
+
+
+def compile_source(cc, source_path, out_path, fixture_name):
+    cmd = [cc, "-Wall", "-Wextra", "-Werror", str(source_path), "-o", str(out_path)]
+    proc = subprocess.run(
+        cmd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        detail = {
+            "fixture": fixture_name,
+            "command": cmd,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+        }
+        raise ConformanceRefusal(
+            "target-compile-failure",
+            json.dumps(detail, sort_keys=True, separators=(",", ":")),
+        )
+
+
+def run_binary(bin_path, argv):
+    proc = subprocess.run(
+        [str(bin_path), *[str(arg) for arg in argv]],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return {
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "exit_code": proc.returncode,
+    }
+
+
+def divergence(fixture_name, case_index, expected, observed, label):
+    detail = {
+        "fixture": fixture_name,
+        "case_index": case_index,
+        "comparison": label,
+        "expected": expected,
+        "observed": observed,
+    }
+    raise ConformanceRefusal(
+        "target-behavior-divergence",
+        json.dumps(detail, sort_keys=True, separators=(",", ":")),
+    )
+
+
+def int_driver(function_name, params):
+    argc = len(params) + 1
+    declarations = []
+    for index, name in enumerate(params):
+        declarations.append(
+            f'    int arg{index} = parse_int_arg(argv[{index + 1}], "{name}");'
+        )
+    call_args = ", ".join(f"arg{index}" for index in range(len(params)))
+    return f"""
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int parse_int_arg(const char *raw, const char *name) {{
+    char *end = NULL;
+    errno = 0;
+    long value = strtol(raw, &end, 10);
+    if (errno != 0 || end == raw || *end != '\\0' ||
+        value < INT_MIN || value > INT_MAX) {{
+        fprintf(stderr, "invalid integer for %s: %s\\n", name, raw);
+        exit(64);
+    }}
+    return (int)value;
+}}
+
+int main(int argc, char **argv) {{
+    if (argc != {argc}) {{
+        fprintf(stderr, "expected {len(params)} args, got %d\\n", argc - 1);
+        return 64;
+    }}
+{os.linesep.join(declarations)}
+    int result = {function_name}({call_args});
+    printf("%d\\n", result);
+    return 0;
+}}
+"""
+
+
+def void_driver(function_name):
+    return f"""
+int main(void) {{
+    {function_name}(0);
+    return 0;
+}}
+"""
+
+
+def execution_unit(fixture, source):
+    kind = fixture["kind"]
+    if kind == "program":
+        return source
+    request = fixture["realize_request"]
+    if kind == "function_int":
+        return source + "\n" + int_driver(request["function"], request["params"])
+    if kind == "concept_carrier":
+        return source + "\n" + void_driver(request["function"])
+    raise RuntimeError(f"unknown fixture kind {kind!r}")
+
+
+def assert_expected_outputs(fixture, original_obs, emitted_obs):
+    for index, expected in enumerate(fixture["expected_output"]):
+        expected_run = {
+            "stdout": expected.get("stdout", ""),
+            "stderr": expected.get("stderr", ""),
+            "exit_code": expected.get("exit_code", 0),
+        }
+        if original_obs[index] != expected_run:
+            divergence(
+                fixture["name"],
+                index,
+                expected_run,
+                original_obs[index],
+                "original-vs-expected",
+            )
+        if emitted_obs[index] != original_obs[index]:
+            divergence(
+                fixture["name"],
+                index,
+                original_obs[index],
+                emitted_obs[index],
+                "emitted-vs-original",
+            )
+
+
+def run_executable_fixture(cc, tmp, fixture, emitted_source):
+    original_c = tmp / f"{fixture['name']}_original.c"
+    emitted_c = tmp / f"{fixture['name']}_emitted.c"
+    original_bin = tmp / f"{fixture['name']}_original"
+    emitted_bin = tmp / f"{fixture['name']}_emitted"
+
+    original_c.write_text(
+        execution_unit(fixture, fixture["original_source"]), encoding="utf-8"
+    )
+    emitted_c.write_text(execution_unit(fixture, emitted_source), encoding="utf-8")
+
+    compile_source(cc, original_c, original_bin, fixture["name"])
+    compile_source(cc, emitted_c, emitted_bin, fixture["name"])
+
+    original_obs = []
+    emitted_obs = []
+    for argv in fixture["declared_test_inputs"]:
+        original_obs.append(run_binary(original_bin, argv))
+        emitted_obs.append(run_binary(emitted_bin, argv))
+    assert_expected_outputs(fixture, original_obs, emitted_obs)
+
+
+def run_carrier_fixture(cc, tmp, fixture, emitted_source):
+    expected = fixture["expected_output"][0]
+    for needle in expected["source_contains"]:
+        if needle not in emitted_source:
+            divergence(
+                fixture["name"],
+                0,
+                {"source_contains": needle},
+                {"source": emitted_source},
+                "carrier-comment-survival",
+            )
+    run_executable_fixture(cc, tmp, fixture, emitted_source)
+
+
+def run_fixture(cc, bin_path, tmp, fixture):
+    lifted = lift_original_source(tmp, fixture)
+    request = request_from_lift(fixture, lifted)
+    emitted_source = invoke_realizer(bin_path, request)
+    if fixture["kind"] == "concept_carrier":
+        run_carrier_fixture(cc, tmp, fixture, emitted_source)
+    else:
+        run_executable_fixture(cc, tmp, fixture, emitted_source)
+
+
+def verify_refusal_paths(cc, tmp):
+    bad_source = tmp / "compile_refusal_probe.c"
+    bad_source.write_text("int main(void) { return ; }\n", encoding="utf-8")
+    try:
+        compile_source(cc, bad_source, tmp / "compile_refusal_probe", "compile_refusal_probe")
+    except ConformanceRefusal as refusal:
+        if refusal.failure_kind != "target-compile-failure":
+            raise
+    else:
+        raise RuntimeError("compile refusal probe unexpectedly compiled")
+
+    try:
+        divergence(
+            "behavior_refusal_probe",
+            0,
+            {"stdout": "1\n", "stderr": "", "exit_code": 0},
+            {"stdout": "2\n", "stderr": "", "exit_code": 0},
+            "refusal-probe",
+        )
+    except ConformanceRefusal as refusal:
+        if refusal.failure_kind != "target-behavior-divergence":
+            raise
+    else:
+        raise RuntimeError("behavior refusal probe did not raise")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: conformance.py <provekit-realize-c>", file=sys.stderr)
+        return 2
+    bin_path = Path(sys.argv[1]).resolve()
+    if not bin_path.exists():
+        print(f"missing executable: {bin_path}", file=sys.stderr)
+        return 2
+    cc = os.environ.get("CC", "cc")
+    fixtures = load_fixtures()
+    try:
+        with tempfile.TemporaryDirectory(prefix="provekit-c-conformance-") as tmp_raw:
+            tmp = Path(tmp_raw)
+            verify_refusal_paths(cc, tmp)
+            for fixture in fixtures:
+                run_fixture(cc, bin_path, tmp, fixture)
+    except ConformanceRefusal as refusal:
+        print(json.dumps(refusal.to_memento(), indent=2, sort_keys=True), file=sys.stderr)
+        return 1
+    print(f"C emit-compile-run conformance: {len(fixtures)} fixtures")
+    print("C refusal probes: target-compile-failure target-behavior-divergence")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/implementations/c/provekit-realize-c-core/tests/integration.sh
+++ b/implementations/c/provekit-realize-c-core/tests/integration.sh
@@ -95,6 +95,7 @@ def test_concept_citation_comment_emitted_for_transported_operation():
         }
     )
     source = response["result"]["source"]
+    assert "/* concept: sql-execute(sql) */" in source, source
     assert "// provekit-concept: " in source, source
     assert "// provekit-concept-payload-cid: " in source, source
     assert "/* provekit-bind canonical:" not in source, source
@@ -113,3 +114,5 @@ def test_concept_citation_comment_emitted_for_transported_operation():
 
 test_concept_citation_comment_emitted_for_transported_operation()
 PY
+
+python3 tests/conformance.py "$bin"

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::collections::BTreeSet;
+use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 
 use libprovekit::canonical::{json_cid, serializable_cid, serializable_jcs};
@@ -1212,6 +1213,80 @@ fn conformance_declaration_round_trips_through_json() {
 
     assert_eq!(decode(carrier_json), carrier);
     assert_eq!(decode(non_carrier_json), non_carrier);
+}
+
+#[test]
+fn carrier_fixture_set_requirement_covers_c_emit_compile_run_fixtures() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("libprovekit has rust parent")
+        .parent()
+        .expect("rust has implementations parent")
+        .parent()
+        .expect("implementations has repo parent")
+        .to_path_buf();
+    let fixtures_path = repo_root
+        .join("implementations")
+        .join("c")
+        .join("conformance")
+        .join("fixtures");
+    let mut registry = KitRegistry::default();
+    registry.register(
+        "lower-c",
+        CKit::default(),
+        ConformanceDeclaration::Carrier {
+            fixtures_path: fixtures_path.clone(),
+        },
+    );
+
+    assert_carrier_fixture_set(&registry, "lower-c", &[
+        "hello_world",
+        "recursive_factorial",
+        "arithmetic_add",
+        "arithmetic_multi_op",
+        "control_flow_if",
+        "transported_op_concept_comment",
+    ]);
+}
+
+fn assert_carrier_fixture_set(registry: &KitRegistry, kit: &str, required: &[&str]) {
+    let Some(ConformanceDeclaration::Carrier { fixtures_path }) = registry.conformance(kit) else {
+        panic!("{kit} must be registered as a carrier kit");
+    };
+    let present = fixture_names(fixtures_path);
+    let missing = required
+        .iter()
+        .copied()
+        .filter(|name| !present.contains(*name))
+        .collect::<Vec<_>>();
+    assert!(
+        missing.is_empty(),
+        "{kit} carrier fixtures at {} missing required fixture(s): {:?}",
+        fixtures_path.display(),
+        missing
+    );
+}
+
+fn fixture_names(path: &FsPath) -> BTreeSet<String> {
+    let entries = std::fs::read_dir(path)
+        .unwrap_or_else(|error| panic!("read carrier fixture dir {}: {error}", path.display()));
+    entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.is_dir() {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .map(str::to_string)
+            } else if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+                path.file_stem()
+                    .and_then(|name| name.to_str())
+                    .map(str::to_string)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn refusal_for_failure_kind(failure_kind: &str, failure_detail: &str) -> CompositionRefusalMemento {

--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -217,7 +217,7 @@ fn c_canonical_bodies_cid_self_consistent() {
         .join("menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json");
     assert_self_consistent(
         path,
-        "blake3-512:f0948c8f4f00359bfdafb3c1bc19227ffc70f95807dcc53450f4c84be2d44bc77770aaa54f3058014febbad276a759ebcf8cc2acabf5e6e6bddada8167c684a2",
+        "blake3-512:74f655e44075901e6941049332618f96807b18bedf0381ad7edfb593a0ada8084d07ed2f848817574874e6ec52fa26ec493656e36ec4c66229d668b5bd9db181",
     );
 }
 

--- a/menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json
+++ b/menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:f0948c8f4f00359bfdafb3c1bc19227ffc70f95807dcc53450f4c84be2d44bc77770aaa54f3058014febbad276a759ebcf8cc2acabf5e6e6bddada8167c684a2",
+    "cid": "blake3-512:74f655e44075901e6941049332618f96807b18bedf0381ad7edfb593a0ada8084d07ed2f848817574874e6ec52fa26ec493656e36ec4c66229d668b5bd9db181",
     "content": {
       "entries": [
         {
@@ -42,6 +42,90 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
+          }
+        },
+        {
+          "concept_name": "hello-world",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "extern int printf(const char *, ...);\nif (printf(\"Hello, world!\\n\") < 0) return 1;\nreturn 0;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 0,
+            "min_params": 0,
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "factorial",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} <= 1 ? 1 : ${param0} * factorial(${param0} - 1);"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_param_types": ["int"],
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "add",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0} + ${param1};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"],
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "arithmetic-multi-op",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "int sum = ${param0} + ${param1};\nint diff = ${param0} - ${param1};\nreturn sum * diff;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2,
+            "requires_param_types": ["int", "int"],
+            "requires_return_type": "int"
+          }
+        },
+        {
+          "concept_name": "abs-value",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "if (${param0} >= 0) return ${param0};\nreturn -${param0};"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {}
+          },
+          "signature_guard": {
+            "max_params": 1,
+            "min_params": 1,
+            "requires_param_types": ["int"],
+            "requires_return_type": "int"
           }
         },
         {


### PR DESCRIPTION
Closes the C side of #1039. 6 fixtures (extra one!), emit-compile-run harness invoking cc -Wall -Wextra -Werror + binary behavior comparison. Refusal probes for target-compile-failure + target-behavior-divergence. Wires test-c into top-level test-all. C body templates with refreshed plugin CID. Concept citation comments preserved as /* concept: name(args) */.

🤖 Generated with [Claude Code](https://claude.com/claude-code)