### PR TITLE
feat(libprovekit): mint PlatformSemanticTag + DimensionValueMemento types (Stream A Stage 2)

### DIFF
--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -45,10 +45,6 @@ pub use primitives::{
     address, compose, dropper, resolve, sign, verify_sig, ComposeError, SigningKey,
 };
 pub use prove_kit::ProveKit;
-pub use walks::{
-    assert_concept_tier, walk_premises_to_root, walk_premises_to_root_with_failure_steps,
-    ChainBreak, ChainWalkFailure, HubMissingNode,
-};
 pub use stubs::{CKit, FunctionContractDomain, NoopPortfolio, RustKit};
 pub use traits::{
     Canonical, Catalog, CoreError, Domain, DomainError, HashMapCatalog, HashMapInputCatalog,
@@ -58,8 +54,12 @@ pub use types::{
     ArityShape, AritySlot, Attestation, Boundary, ChainIntegrityFailureWitness,
     ChainIntegrityWitness, Cid, CidError, ConformanceDeclaration, Contract, Dialect, DomainClaim,
     DomainKind, Formula, Input, LanguageSignature, OperationSignature, Path, PathAlgebra,
-    PathDocument, PathDocumentError, PathError, PathInputBinding, PathInputMaterial, Refutation,
-    SignatureCatalogError, SlotEvaluation, SlotSort, Term, Truth, Verb, Verdict,
-    VerdictCoercionError, Witness,
+    PathDocument, PathDocumentError, PathError, PathInputBinding, PathInputMaterial,
+    PlatformSemanticsDeclaration, Refutation, SignatureCatalogError, SlotEvaluation, SlotSort,
+    Term, Truth, Verb, Verdict, VerdictCoercionError, Witness,
 };
 pub use verbs::{cross_compile, link, prove, realize, transform, verify};
+pub use walks::{
+    assert_concept_tier, walk_premises_to_root, walk_premises_to_root_with_failure_steps,
+    ChainBreak, ChainWalkFailure, HubMissingNode,
+};

--- a/implementations/rust/libprovekit/src/core/path_executor.rs
+++ b/implementations/rust/libprovekit/src/core/path_executor.rs
@@ -535,6 +535,7 @@ mod tests {
             },
             ConformanceDeclaration::Carrier {
                 fixtures_path: "fixtures/lower-fixture".into(),
+                platform_semantics: None,
             },
         );
         registry.register(

--- a/implementations/rust/libprovekit/src/core/types.rs
+++ b/implementations/rust/libprovekit/src/core/types.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
-use provekit_ir_types::{IrFormula, IrTerm, LetBinding, Sort};
+use provekit_ir_types::{IrFormula, IrTerm, LetBinding, PlatformSemanticTag, Sort};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
@@ -805,9 +805,18 @@ pub enum Dialect {
 /// data and require dialect-as-substrate-object architecture that the kit's
 /// own content-addressing already provides.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct PlatformSemanticsDeclaration {
+    pub tags: Vec<PlatformSemanticTag>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum ConformanceDeclaration {
     /// Kit emits target source and pins the fixture directory that proves it.
-    Carrier { fixtures_path: PathBuf },
+    Carrier {
+        fixtures_path: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        platform_semantics: Option<PlatformSemanticsDeclaration>,
+    },
     /// Kit does not emit target source; `reason` records the audit premise.
     NonCarrier { reason: &'static str },
 }

--- a/implementations/rust/libprovekit/src/core/walks.rs
+++ b/implementations/rust/libprovekit/src/core/walks.rs
@@ -722,8 +722,7 @@ mod tests {
             ],
         );
 
-        let err = assert_concept_tier(&term, &catalog)
-            .expect_err("missing op CID must be refused");
+        let err = assert_concept_tier(&term, &catalog).expect_err("missing op CID must be refused");
         assert_eq!(err.node_op_cid, missing_cid);
         assert_eq!(err.term_position, vec![1]);
     }

--- a/implementations/rust/libprovekit/src/wp.rs
+++ b/implementations/rust/libprovekit/src/wp.rs
@@ -676,6 +676,22 @@ fn reduce_formula<R: OpContractResolver + ?Sized>(
             };
             wp(slot_term, &arg, resolver)
         }
+        IrFormula::DivergenceBetween { source, target } => Ok(IrFormula::DivergenceBetween {
+            source: Box::new(reduce_formula(
+                *source,
+                q,
+                stmt_transformers,
+                op_name,
+                resolver,
+            )?),
+            target: Box::new(reduce_formula(
+                *target,
+                q,
+                stmt_transformers,
+                op_name,
+                resolver,
+            )?),
+        }),
     }
 }
 
@@ -818,6 +834,10 @@ pub fn substitute_in_formula(
                 .map(|f| substitute_in_formula(f, var_name, replacement))
                 .collect(),
             r#fn,
+        },
+        IrFormula::DivergenceBetween { source, target } => IrFormula::DivergenceBetween {
+            source: Box::new(substitute_in_formula(*source, var_name, replacement)),
+            target: Box::new(substitute_in_formula(*target, var_name, replacement)),
         },
     }
 }
@@ -1096,6 +1116,10 @@ fn free_vars_formula_into(f: &IrFormula, acc: &mut HashSet<String>) {
             for a in args {
                 free_vars_formula_into(a, acc);
             }
+        }
+        IrFormula::DivergenceBetween { source, target } => {
+            free_vars_formula_into(source, acc);
+            free_vars_formula_into(target, acc);
         }
     }
 }

--- a/implementations/rust/libprovekit/src/wp/tests.rs
+++ b/implementations/rust/libprovekit/src/wp/tests.rs
@@ -1076,5 +1076,8 @@ fn contains_schema_node(f: &IrFormula) -> bool {
         IrFormula::Forall { body, .. }
         | IrFormula::Exists { body, .. }
         | IrFormula::Choice { body, .. } => contains_schema_node(body),
+        IrFormula::DivergenceBetween { source, target } => {
+            contains_schema_node(source) || contains_schema_node(target)
+        }
     }
 }

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 
@@ -14,13 +14,15 @@ use libprovekit::core::{
     Canonical, Catalog, Cid, ConformanceDeclaration, Dialect, DomainClaim, DomainKind,
     FunctionContractDomain, HashMapCatalog, HashMapInputCatalog, Input, InputCatalog, Kit,
     KitRegistry, LanguageSignature, LiftKit, LiftPluginKit, Path, PathAlgebra, PathDocument,
-    PathDocumentError, PathError, Refutation, SlotSort, Term, Truth, Verb, Verdict, Witness,
+    PathDocumentError, PathError, PlatformSemanticsDeclaration, Refutation, SlotSort, Term, Truth,
+    Verb, Verdict, Witness,
 };
 use provekit_canonicalizer::Value;
 use provekit_ir_types::{
     composition_refusal_compose_input_cid, composition_refusal_header_cid,
     composition_refusal_signature, CompositionRefusalEnvelope, CompositionRefusalHeader,
-    CompositionRefusalMemento, CompositionRefusalMetadata, IrFormula, IrTerm, Sort,
+    CompositionRefusalMemento, CompositionRefusalMetadata, DimensionValueMemento, IrFormula,
+    IrTerm, PlatformSemanticTag, Sort,
 };
 use serde_json::json;
 
@@ -1203,6 +1205,7 @@ fn conformance_declaration_round_trips_through_json() {
 
     let carrier = ConformanceDeclaration::Carrier {
         fixtures_path: PathBuf::from("implementations/rust/conformance/fixtures"),
+        platform_semantics: None,
     };
     let non_carrier = ConformanceDeclaration::NonCarrier {
         reason: "lifts source bytes to DomainClaim; no target source produced",
@@ -1213,6 +1216,69 @@ fn conformance_declaration_round_trips_through_json() {
 
     assert_eq!(decode(carrier_json), carrier);
     assert_eq!(decode(non_carrier_json), non_carrier);
+}
+
+#[test]
+fn carrier_registration_preserves_platform_semantics_declaration() {
+    let wrapping = DimensionValueMemento::new(
+        "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111".to_string(),
+        "ArithmeticOverflowMode".to_string(),
+        "Wrapping".to_string(),
+        bool_true(),
+    );
+    let truncate = DimensionValueMemento::new(
+        "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111".to_string(),
+        "IntegerDivisionRoundingMode".to_string(),
+        "Truncate".to_string(),
+        bool_true(),
+    );
+    let arbitrary_precision = DimensionValueMemento::new(
+        "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111".to_string(),
+        "ArithmeticOverflowMode".to_string(),
+        "ArbitraryPrecision".to_string(),
+        bool_true(),
+    );
+    let first_tag = platform_tag(
+        "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        vec![
+            ("ArithmeticOverflowMode", wrapping.cid.clone()),
+            ("IntegerDivisionRoundingMode", truncate.cid.clone()),
+        ],
+    );
+    let second_tag = platform_tag(
+        "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        vec![("ArithmeticOverflowMode", arbitrary_precision.cid.clone())],
+    );
+    let declaration = PlatformSemanticsDeclaration {
+        tags: vec![first_tag.clone(), second_tag.clone()],
+    };
+    let mut registry = KitRegistry::default();
+
+    registry.register(
+        "semantic-kit",
+        LiftKit::new(Dialect::Rust, "rust", vec!["true".to_string()], None),
+        ConformanceDeclaration::Carrier {
+            fixtures_path: PathBuf::from("fixtures/semantic-kit"),
+            platform_semantics: Some(declaration.clone()),
+        },
+    );
+
+    let Some(ConformanceDeclaration::Carrier {
+        platform_semantics: Some(retrieved),
+        ..
+    }) = registry.conformance("semantic-kit")
+    else {
+        panic!("semantic-kit carrier declaration must preserve platform semantics");
+    };
+
+    assert_eq!(retrieved, &declaration);
+    let encoded = retrieved.tags[0].to_jcs_string();
+    let decoded: PlatformSemanticTag = serde_json::from_str(&encoded).expect("tag decodes");
+    assert_eq!(
+        decoded.dimensions.keys().collect::<Vec<_>>(),
+        first_tag.dimensions.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(decoded.to_jcs_string(), encoded);
 }
 
 #[test]
@@ -1236,21 +1302,27 @@ fn carrier_fixture_set_requirement_covers_c_emit_compile_run_fixtures() {
         CKit::default(),
         ConformanceDeclaration::Carrier {
             fixtures_path: fixtures_path.clone(),
+            platform_semantics: None,
         },
     );
 
-    assert_carrier_fixture_set(&registry, "lower-c", &[
-        "hello_world",
-        "recursive_factorial",
-        "arithmetic_add",
-        "arithmetic_multi_op",
-        "control_flow_if",
-        "transported_op_concept_comment",
-    ]);
+    assert_carrier_fixture_set(
+        &registry,
+        "lower-c",
+        &[
+            "hello_world",
+            "recursive_factorial",
+            "arithmetic_add",
+            "arithmetic_multi_op",
+            "control_flow_if",
+            "transported_op_concept_comment",
+        ],
+    );
 }
 
 fn assert_carrier_fixture_set(registry: &KitRegistry, kit: &str, required: &[&str]) {
-    let Some(ConformanceDeclaration::Carrier { fixtures_path }) = registry.conformance(kit) else {
+    let Some(ConformanceDeclaration::Carrier { fixtures_path, .. }) = registry.conformance(kit)
+    else {
         panic!("{kit} must be registered as a carrier kit");
     };
     let present = fixture_names(fixtures_path);
@@ -1265,6 +1337,18 @@ fn assert_carrier_fixture_set(registry: &KitRegistry, kit: &str, required: &[&st
         fixtures_path.display(),
         missing
     );
+}
+
+fn platform_tag(op_cid: &str, pairs: Vec<(&str, String)>) -> PlatformSemanticTag {
+    let mut dimensions = BTreeMap::new();
+    for (dimension, cid) in pairs {
+        dimensions.insert(dimension.to_string(), cid);
+    }
+    PlatformSemanticTag::new(
+        "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111".to_string(),
+        op_cid.to_string(),
+        dimensions,
+    )
 }
 
 fn fixture_names(path: &FsPath) -> BTreeSet<String> {

--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -829,6 +829,7 @@ fn realize_probe_via_path(
         ConformanceDeclaration::Carrier {
             fixtures_path: repo_root
                 .join(format!("implementations/{language}/conformance/fixtures")),
+            platform_semantics: None,
         },
     );
     let chain = execute_path(&path, &registry, &inputs).map_err(|error| error.to_string())?;

--- a/implementations/rust/provekit-cli/src/cmd_lower.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lower.rs
@@ -317,6 +317,7 @@ fn lower_named_spec_via_path(
         ConformanceDeclaration::Carrier {
             fixtures_path: project_root
                 .join(format!("implementations/{target}/conformance/fixtures")),
+            platform_semantics: None,
         },
     );
     let chain = execute_path(&path, &registry, &inputs).map_err(|error| {

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -1484,7 +1484,10 @@ fn realize_spec_via_path(
             None,
             DispatchRealizeTransport,
         ),
-        ConformanceDeclaration::Carrier { fixtures_path },
+        ConformanceDeclaration::Carrier {
+            fixtures_path,
+            platform_semantics: None,
+        },
     );
     let chain = execute_path(&path, &registry, &inputs).map_err(|error| error.to_string())?;
     LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(chain.terminal_claim())

--- a/implementations/rust/provekit-cli/tests/carrier_fixture_registry.rs
+++ b/implementations/rust/provekit-cli/tests/carrier_fixture_registry.rs
@@ -22,18 +22,16 @@ fn lower_java_carrier_registration_points_at_required_fixture_set() {
 
     registry.register(
         "lower-java",
-        LowerKit::new(
-            repo_root,
-            "java",
-            None,
-            DispatchRealizeTransport,
-        ),
+        LowerKit::new(repo_root, "java", None, DispatchRealizeTransport),
         ConformanceDeclaration::Carrier {
             fixtures_path: fixtures_path.clone(),
+            platform_semantics: None,
         },
     );
 
-    let Some(ConformanceDeclaration::Carrier { fixtures_path }) = registry.conformance("lower-java") else {
+    let Some(ConformanceDeclaration::Carrier { fixtures_path, .. }) =
+        registry.conformance("lower-java")
+    else {
         panic!("lower-java must register as a carrier");
     };
     assert_required_fixtures(fixtures_path);

--- a/implementations/rust/provekit-cli/tests/lower_kit_path_integration.rs
+++ b/implementations/rust/provekit-cli/tests/lower_kit_path_integration.rs
@@ -207,6 +207,7 @@ fn lower_python_path_claim_input_cites_from_premise_to_and_loss_cids() {
             fixtures_path: temp
                 .path()
                 .join("implementations/python/conformance/fixtures"),
+            platform_semantics: None,
         },
     );
 

--- a/implementations/rust/provekit-cli/tests/python_emit_compile_run_conformance.rs
+++ b/implementations/rust/provekit-cli/tests/python_emit_compile_run_conformance.rs
@@ -184,12 +184,13 @@ fn register_python_lower(registry: &mut KitRegistry, workspace_root: &Path) {
                 .join("python")
                 .join("conformance")
                 .join("fixtures"),
+            platform_semantics: None,
         },
     );
 }
 
 fn assert_python_carrier_fixture_set(registry: &KitRegistry) {
-    let Some(ConformanceDeclaration::Carrier { fixtures_path }) =
+    let Some(ConformanceDeclaration::Carrier { fixtures_path, .. }) =
         registry.conformance("lower-python")
     else {
         panic!("lower-python must register as a Carrier kit");

--- a/implementations/rust/provekit-cli/tests/trinity_composition_census.rs
+++ b/implementations/rust/provekit-cli/tests/trinity_composition_census.rs
@@ -57,7 +57,10 @@ fn repo_root() -> PathBuf {
 }
 
 fn rust_target_dir() -> PathBuf {
-    repo_root().join("implementations").join("rust").join("target")
+    repo_root()
+        .join("implementations")
+        .join("rust")
+        .join("target")
 }
 
 fn locate_binary(name: &str) -> PathBuf {
@@ -250,12 +253,15 @@ fn python_lift_source_input(workspace_root: &Path) -> Input {
 }
 
 fn register_rust_lift(registry: &mut KitRegistry, workspace_root: &Path) {
-    let command = vec![
-        provekit_walk_rpc().display().to_string(),
-    ];
+    let command = vec![provekit_walk_rpc().display().to_string()];
     registry.register(
         "lift-rust",
-        LiftKit::new(Dialect::Rust, "rust", command, Some(workspace_root.to_path_buf())),
+        LiftKit::new(
+            Dialect::Rust,
+            "rust",
+            command,
+            Some(workspace_root.to_path_buf()),
+        ),
         ConformanceDeclaration::NonCarrier {
             reason: "lifts rust source bytes to DomainClaim via provekit-walk-rpc",
         },
@@ -302,6 +308,7 @@ fn register_lower(registry: &mut KitRegistry, target_lang: &str, workspace_root:
                 .join(target_lang)
                 .join("conformance")
                 .join("fixtures"),
+            platform_semantics: None,
         },
     );
 }
@@ -377,7 +384,9 @@ fn seam1_discrimination_malformed_term_refuses_cleanly() {
     // shape unrelated to ir-document must refuse with a typed BindError, never panic.
     let malformed = Term::Const {
         value: json!({"kind": "not-an-ir-document", "noise": [1, 2, 3]}),
-        sort: Sort::Primitive { name: "Garbage".to_string() },
+        sort: Sort::Primitive {
+            name: "Garbage".to_string(),
+        },
     };
     let mut inputs = HashMapInputCatalog::default();
     let term_cid = address(&malformed);
@@ -810,9 +819,7 @@ fn seam6_positive_lower_to_rust_then_prove_chain_integrity_succeeds() {
     );
     match &terminal.witness {
         Some(Witness::ChainIntegrity(_)) => {}
-        other => panic!(
-            "seam 6 positive: terminal witness must be ChainIntegrity, got {other:?}"
-        ),
+        other => panic!("seam 6 positive: terminal witness must be ChainIntegrity, got {other:?}"),
     }
 }
 
@@ -849,11 +856,8 @@ fn seam6_discrimination_broken_premise_cid_refutes_with_chain_integrity_failure(
         .cid();
 
     // Tamper: replace lower's premises with a non-existent CID.
-    let bogus = libprovekit::core::Cid::parse(format!(
-        "blake3-512:{}",
-        "f".repeat(128)
-    ))
-    .expect("bogus CID parses");
+    let bogus = libprovekit::core::Cid::parse(format!("blake3-512:{}", "f".repeat(128)))
+        .expect("bogus CID parses");
     let mut tampered = lower_claim_real.clone();
     tampered.premises = vec![bogus.clone()];
 
@@ -898,9 +902,9 @@ fn seam6_discrimination_broken_premise_cid_refutes_with_chain_integrity_failure(
                 failure.break_kind, failure.break_detail
             );
         }
-        other => panic!(
-            "seam 6 discrimination: witness must be ChainIntegrityFailure, got {other:?}"
-        ),
+        other => {
+            panic!("seam 6 discrimination: witness must be ChainIntegrityFailure, got {other:?}")
+        }
     }
 }
 
@@ -1112,7 +1116,11 @@ fn run_lift_bind_capture_chain(
     }
     register_bind(&mut registry);
 
-    let lift_kit_name = if is_python { "lift-python" } else { "lift-rust" };
+    let lift_kit_name = if is_python {
+        "lift-python"
+    } else {
+        "lift-rust"
+    };
     let path = Input::Path(Box::new(CorePath {
         algebra: vec![
             PathAlgebra {

--- a/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
@@ -149,6 +149,12 @@ pub fn emit_formula(formula: &Formula) -> String {
                  must be reduced via libprovekit::wp first"
             )
         }
+        Formula::DivergenceBetween { .. } => {
+            unreachable!(
+                "platform divergence formula reached the Coq formula emitter; \
+                 stage 4 must lower it before backend compilation"
+            )
+        }
     }
 }
 fn emit_sort(sort: &Sort) -> String {
@@ -365,6 +371,10 @@ pub fn collect_free_vars_formula(
                 "wp-rule schema node reached the Coq free-var collector; \
                  must be reduced via libprovekit::wp first"
             )
+        }
+        Formula::DivergenceBetween { source, target } => {
+            collect_free_vars_formula(source, out, bound);
+            collect_free_vars_formula(target, out, bound);
         }
     }
 }

--- a/implementations/rust/provekit-ir-compiler-lean/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-lean/src/lib.rs
@@ -277,6 +277,13 @@ fn collect_formula(
                     .to_string(),
             ));
         }
+        Formula::DivergenceBetween { .. } => {
+            return Err(CompileError::Internal(
+                "platform divergence formula reached the Lean collector; \
+                 stage 4 must lower it before compilation"
+                    .to_string(),
+            ));
+        }
     }
     Ok(())
 }
@@ -411,6 +418,11 @@ fn emit_formula(formula: &Formula, ctx: &mut EmitContext) -> Result<String, Comp
         Formula::Substitute { .. } | Formula::Apply { .. } => Err(CompileError::Internal(
             "wp-rule schema node (substitute/apply) reached the Lean formula emitter; \
              it must be reduced via libprovekit::wp before compilation"
+                .to_string(),
+        )),
+        Formula::DivergenceBetween { .. } => Err(CompileError::Internal(
+            "platform divergence formula reached the Lean formula emitter; \
+             stage 4 must lower it before compilation"
                 .to_string(),
         )),
     }

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
@@ -183,6 +183,12 @@ pub fn emit_formula(formula: &Formula) -> String {
                  must be reduced via libprovekit::wp first"
             )
         }
+        Formula::DivergenceBetween { .. } => {
+            unreachable!(
+                "platform divergence formula reached the SMT-LIB formula emitter; \
+                 stage 4 must lower it before backend compilation"
+            )
+        }
     }
 }
 
@@ -356,6 +362,12 @@ fn emit_formula_with_opacities(formula: &Formula, opacities: &mut Vec<OpacityEnt
                  must be reduced via libprovekit::wp first"
             )
         }
+        Formula::DivergenceBetween { .. } => {
+            unreachable!(
+                "platform divergence formula reached the SMT-LIB opacity emitter; \
+                 stage 4 must lower it before backend compilation"
+            )
+        }
     }
 }
 
@@ -457,6 +469,10 @@ pub fn collect_free_vars_formula(
                 "wp-rule schema node reached the SMT-LIB free-var collector; \
                  must be reduced via libprovekit::wp first"
             )
+        }
+        Formula::DivergenceBetween { source, target } => {
+            collect_free_vars_formula(source, out, bound);
+            collect_free_vars_formula(target, out, bound);
         }
     }
 }
@@ -561,6 +577,10 @@ fn collect_ctor_decls_formula(formula: &Formula, out: &mut BTreeMap<String, Ctor
                 "wp-rule schema node reached the SMT-LIB ctor-decl collector; \
                  must be reduced via libprovekit::wp first"
             )
+        }
+        Formula::DivergenceBetween { source, target } => {
+            collect_ctor_decls_formula(source, out);
+            collect_ctor_decls_formula(target, out);
         }
     }
 }
@@ -729,5 +749,8 @@ fn has_outlives_predicate(formula: &Formula) -> bool {
         // TODO(wp-as-formula PR1+): teach provekit-ir-codegen to emit this arm.
         Formula::Substitute { target, .. } => has_outlives_predicate(target),
         Formula::Apply { args, .. } => args.iter().any(has_outlives_predicate),
+        Formula::DivergenceBetween { source, target } => {
+            has_outlives_predicate(source) || has_outlives_predicate(target)
+        }
     }
 }

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/lib.rs
@@ -126,6 +126,11 @@ fn validate_formula(formula: &provekit_ir_types::IrFormula) -> Result<(), String
              it must be reduced via libprovekit::wp before solving"
                 .to_string(),
         ),
+        provekit_ir_types::IrFormula::DivergenceBetween { .. } => Err(
+            "platform divergence formula reached the SMT-LIB validator; \
+             stage 4 must lower it before solving"
+                .to_string(),
+        ),
     }
 }
 

--- a/implementations/rust/provekit-ir-symbolic/src/convert.rs
+++ b/implementations/rust/provekit-ir-symbolic/src/convert.rs
@@ -290,5 +290,11 @@ pub fn formula_from_ir(f: ir::Formula) -> Formula {
                  must be reduced via libprovekit::wp first"
             )
         }
+        ir::Formula::DivergenceBetween { .. } => {
+            unreachable!(
+                "platform divergence formula reached ir-symbolic formula conversion; \
+                 stage 4 must lower it before symbolic conversion"
+            )
+        }
     }
 }

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -380,12 +380,15 @@ pub enum IrTerm {
 }
 
 // NOTE: The `IrFormula` enum below has been MANUALLY extended beyond the
-// codegen output to add the `Substitute` and `Apply` variants per the
-// wp-as-formula spec (protocol/specs/2026-05-13-wp-as-formula.md §2.3).
-// These two are the "wp-rule schema" nodes: they appear inside a
+// codegen output to add the `Substitute`, `Apply`, and `DivergenceBetween`
+// variants per the wp-as-formula spec
+// (protocol/specs/2026-05-13-wp-as-formula.md §2.3) and the platform
+// semantic tag ruling
+// (docs/plans/2026-05-16-platform-semantic-tag-schema-ruling.md §2).
+// `Substitute` and `Apply` are the "wp-rule schema" nodes: they appear inside a
 // `wp_rule` term and are reduced away by `libprovekit::wp` before any
 // formula reaches a solver backend. The codegen (`provekit-ir-codegen`)
-// currently emits only the 8-way union without these arms; if you
+// currently emits only the generated union without these arms; if you
 // regenerate this file via `cargo run -p provekit-ir-codegen`, you WILL
 // clobber the manual extensions. Re-apply them from this comment block
 // through the closing `}` of the `IrFormula` enum, keeping the CDDL
@@ -454,6 +457,14 @@ pub enum IrFormula {
         #[serde(rename = "fn")]
         r#fn: String,
     },
+    /// `divergence-between` - characterizes a platform semantic difference
+    /// by carrying the source and target formulas being compared. JCS key
+    /// order: `kind`, `source`, `target`.
+    #[serde(rename = "divergence-between")]
+    DivergenceBetween {
+        source: Box<IrFormula>,
+        target: Box<IrFormula>,
+    },
 }
 
 pub type ConnectiveKind = String;
@@ -506,6 +517,135 @@ use std::collections::BTreeMap;
 /// mementos are NOT affected.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct LossRecord(pub BTreeMap<String, IrFormula>);
+
+// ============================================================
+// Manual extension block -- platform semantic tag mementos
+// Source of truth:
+//   docs/plans/2026-05-16-platform-semantic-tag-schema-ruling.md
+//   docs/plans/2026-05-16-platform-semantics-via-loss-records.md
+// ============================================================
+
+/// A kit-minted value for one open platform semantic dimension.
+///
+/// Locked JCS key order:
+///   cid, compare_to, dimension_name, kind, kit_cid, schemaVersion, value_name.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DimensionValueMemento {
+    /// DERIVED: BLAKE3-512 over JCS(memento) with `cid` elided.
+    pub cid: Cid,
+    pub compare_to: IrFormula,
+    #[serde(rename = "dimension_name")]
+    pub dimension_name: String,
+    pub kind: String,
+    #[serde(rename = "kit_cid")]
+    pub kit_cid: Cid,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "value_name")]
+    pub value_name: String,
+}
+
+impl DimensionValueMemento {
+    pub const KIND: &'static str = "platform-dimension-value";
+    pub const SCHEMA_VERSION: &'static str = "1.0.0";
+
+    pub fn new(
+        kit_cid: Cid,
+        dimension_name: String,
+        value_name: String,
+        compare_to: IrFormula,
+    ) -> Self {
+        let mut value = Self {
+            cid: String::new(),
+            compare_to,
+            dimension_name,
+            kind: Self::KIND.to_string(),
+            kit_cid,
+            schema_version: Self::SCHEMA_VERSION.to_string(),
+            value_name,
+        };
+        value.cid = value.recompute_cid();
+        value
+    }
+
+    pub fn to_jcs_string(&self) -> String {
+        platform_semantic_jcs_string(self)
+    }
+
+    pub fn recompute_cid(&self) -> Cid {
+        platform_semantic_cid_without_keys(self, &["cid"])
+    }
+}
+
+/// A flat per-kit, per-op platform semantic tag.
+///
+/// The `dimensions` map is intentionally open-keyed. Keys are kit-minted
+/// dimension names and values are CIDs of `DimensionValueMemento` objects.
+///
+/// Locked JCS key order: cid, dimensions, kind, kit_cid, op_cid, schemaVersion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlatformSemanticTag {
+    /// DERIVED: BLAKE3-512 over JCS(memento) with `cid` elided.
+    pub cid: Cid,
+    pub dimensions: BTreeMap<String, Cid>,
+    pub kind: String,
+    #[serde(rename = "kit_cid")]
+    pub kit_cid: Cid,
+    #[serde(rename = "op_cid")]
+    pub op_cid: Cid,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+}
+
+impl PlatformSemanticTag {
+    pub const KIND: &'static str = "platform-semantic-tag";
+    pub const SCHEMA_VERSION: &'static str = "1.0.0";
+
+    pub fn new(kit_cid: Cid, op_cid: Cid, dimensions: BTreeMap<String, Cid>) -> Self {
+        let mut tag = Self {
+            cid: String::new(),
+            dimensions,
+            kind: Self::KIND.to_string(),
+            kit_cid,
+            op_cid,
+            schema_version: Self::SCHEMA_VERSION.to_string(),
+        };
+        tag.cid = tag.recompute_cid();
+        tag
+    }
+
+    pub fn to_jcs_string(&self) -> String {
+        platform_semantic_jcs_string(self)
+    }
+
+    pub fn recompute_cid(&self) -> Cid {
+        platform_semantic_cid_without_keys(self, &["cid"])
+    }
+}
+
+fn platform_semantic_jcs_string<T: Serialize>(value: &T) -> String {
+    let json = serde_json::to_value(value).expect("platform semantic memento serializes to JSON");
+    let canonical = canonical_value_from_json(json);
+    provekit_canonicalizer::encode_jcs(&canonical)
+}
+
+fn platform_semantic_cid_without_keys<T: Serialize>(value: &T, keys: &[&str]) -> Cid {
+    let mut json =
+        serde_json::to_value(value).expect("platform semantic memento serializes to JSON");
+    let serde_json::Value::Object(ref mut map) = json else {
+        panic!("platform semantic memento did not serialize as object");
+    };
+    for key in keys {
+        map.remove(*key);
+    }
+    let canonical = canonical_value_from_json(json);
+    let jcs = provekit_canonicalizer::encode_jcs(&canonical);
+    provekit_canonicalizer::blake3_512_of(jcs.as_bytes())
+}
+
+// ============================================================
+// End manual extension block -- platform semantic tag mementos
+// ============================================================
 
 /// A single named slot in a `ConceptAbstractionMemento`.
 ///

--- a/implementations/rust/provekit-ir-types/tests/platform_semantics_mementos.rs
+++ b/implementations/rust/provekit-ir-types/tests/platform_semantics_mementos.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use provekit_ir_types::{DimensionValueMemento, IrFormula, PlatformSemanticTag};
+
+const KIT_CID: &str = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+const OP_CID: &str = "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+const WRAPPING_CID: &str = "blake3-512:db0ba7a27a32c677aa59b79b8f9ba261f6568995ded6c4f68fc30539d6dedc7c1744f14acdb31c87f9ae75ef38bf519d7d0b7074f714b96a78ed359ac906cb2e";
+const TRUNCATE_CID: &str = "blake3-512:03d9358f650200c8c8682e0535a391013fc7750b33ca7f55b22f31714193a493d61e96a135a6dac7e522dd2b13715597fd3300d1532b65a091e07bdaa7953f13";
+const TAG_CID: &str = "blake3-512:6740c2388258930b896950b5cffd0c542a3f2ef4ba288fa422d57655f3488fd651b73de384485ea2f3dd08f64fe7d5c7572f29ca6f213b0118cc8da039afe992";
+
+fn true_formula() -> IrFormula {
+    IrFormula::Atomic {
+        name: "true".to_string(),
+        args: vec![],
+    }
+}
+
+#[test]
+fn dimension_value_memento_round_trips_and_recomputes_cid() {
+    let value = DimensionValueMemento::new(
+        KIT_CID.to_string(),
+        "ArithmeticOverflowMode".to_string(),
+        "Wrapping".to_string(),
+        true_formula(),
+    );
+
+    let encoded = value.to_jcs_string();
+    let decoded: DimensionValueMemento =
+        serde_json::from_str(&encoded).expect("dimension value decodes");
+
+    assert_eq!(decoded, value);
+    assert_eq!(decoded.cid, decoded.recompute_cid());
+    assert_eq!(decoded.cid, WRAPPING_CID);
+}
+
+#[test]
+fn platform_semantic_tag_round_trips_and_recomputes_cid() {
+    let wrapping = DimensionValueMemento::new(
+        KIT_CID.to_string(),
+        "ArithmeticOverflowMode".to_string(),
+        "Wrapping".to_string(),
+        true_formula(),
+    );
+    let truncate = DimensionValueMemento::new(
+        KIT_CID.to_string(),
+        "IntegerDivisionRoundingMode".to_string(),
+        "Truncate".to_string(),
+        true_formula(),
+    );
+    let mut dimensions = BTreeMap::new();
+    dimensions.insert(
+        "IntegerDivisionRoundingMode".to_string(),
+        truncate.cid.clone(),
+    );
+    dimensions.insert("ArithmeticOverflowMode".to_string(), wrapping.cid.clone());
+
+    let tag = PlatformSemanticTag::new(KIT_CID.to_string(), OP_CID.to_string(), dimensions);
+
+    let encoded = tag.to_jcs_string();
+    let decoded: PlatformSemanticTag = serde_json::from_str(&encoded).expect("tag decodes");
+
+    assert_eq!(wrapping.cid, WRAPPING_CID);
+    assert_eq!(truncate.cid, TRUNCATE_CID);
+    assert_eq!(decoded, tag);
+    assert_eq!(decoded.cid, decoded.recompute_cid());
+    assert_eq!(decoded.cid, TAG_CID);
+    assert!(
+        encoded
+            .find("ArithmeticOverflowMode")
+            .expect("overflow key")
+            < encoded
+                .find("IntegerDivisionRoundingMode")
+                .expect("division key")
+    );
+}

--- a/implementations/rust/provekit-lift-asm-aarch64/src/lib.rs
+++ b/implementations/rust/provekit-lift-asm-aarch64/src/lib.rs
@@ -1716,6 +1716,12 @@ fn predicate_term(formula: &IrFormula) -> IrTerm {
                  must be reduced via libprovekit::wp first"
             )
         }
+        IrFormula::DivergenceBetween { .. } => {
+            unreachable!(
+                "platform divergence formula reached the aarch64 predicate-term builder; \
+                 stage 4 must lower it before lifter predicate conversion"
+            )
+        }
     }
 }
 

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -1005,6 +1005,11 @@ fn ir_formula_to_text(formula: &IrFormula) -> String {
                 .join(", ");
             format!("{}({args})", r#fn)
         }
+        IrFormula::DivergenceBetween { source, target } => format!(
+            "divergence_between({}, {})",
+            ir_formula_to_text(source),
+            ir_formula_to_text(target)
+        ),
     }
 }
 

--- a/implementations/rust/provekit-walk/src/dropper/predicate.rs
+++ b/implementations/rust/provekit-walk/src/dropper/predicate.rs
@@ -18,6 +18,10 @@ pub fn formula_contains_predicate(formula: &IrFormula, pred_name: &str) -> bool 
             formula_contains_predicate(body, pred_name)
         }
         IrFormula::Choice { body, .. } => formula_contains_predicate(body, pred_name),
+        IrFormula::DivergenceBetween { source, target } => {
+            formula_contains_predicate(source, pred_name)
+                || formula_contains_predicate(target, pred_name)
+        }
         // Substitute and Apply are higher-order / meta-level nodes that the
         // dropper does not interpret structurally; conservatively return false.
         IrFormula::Substitute { .. } | IrFormula::Apply { .. } => false,
@@ -48,6 +52,9 @@ pub fn predicate_var_arg(formula: &IrFormula, pred_name: &str) -> Option<String>
             predicate_var_arg(body, pred_name)
         }
         IrFormula::Choice { body, .. } => predicate_var_arg(body, pred_name),
+        IrFormula::DivergenceBetween { source, target } => {
+            predicate_var_arg(source, pred_name).or_else(|| predicate_var_arg(target, pred_name))
+        }
         // Substitute and Apply are higher-order / meta-level nodes; no var to extract.
         IrFormula::Substitute { .. } | IrFormula::Apply { .. } => None,
     }

--- a/implementations/rust/provekit-walk/src/dropper/predicates/not_null.rs
+++ b/implementations/rust/provekit-walk/src/dropper/predicates/not_null.rs
@@ -156,6 +156,10 @@ fn formula_contains_guard_for(formula: &IrFormula, var_name: &str) -> bool {
             formula_contains_guard_for(body, var_name)
         }
         IrFormula::Choice { body, .. } => formula_contains_guard_for(body, var_name),
+        IrFormula::DivergenceBetween { source, target } => {
+            formula_contains_guard_for(source, var_name)
+                || formula_contains_guard_for(target, var_name)
+        }
         // Substitute and Apply are meta-level; guard detection does not descend into them.
         IrFormula::Substitute { .. } | IrFormula::Apply { .. } => false,
     }

--- a/implementations/rust/provekit-walk/src/lift.rs
+++ b/implementations/rust/provekit-walk/src/lift.rs
@@ -228,7 +228,9 @@ fn formula_to_term(formula: IrFormula) -> Option<IrTerm> {
         IrFormula::Implies { operands } => formula_operands_to_term("implies", operands),
         IrFormula::Forall { .. } | IrFormula::Exists { .. } | IrFormula::Choice { .. } => None,
         // Substitute and Apply are meta-level; not reducible to a term here.
-        IrFormula::Substitute { .. } | IrFormula::Apply { .. } => None,
+        IrFormula::Substitute { .. }
+        | IrFormula::Apply { .. }
+        | IrFormula::DivergenceBetween { .. } => None,
     }
 }
 

--- a/implementations/rust/provekit-walk/src/marriage.rs
+++ b/implementations/rust/provekit-walk/src/marriage.rs
@@ -302,6 +302,9 @@ fn term_has_region_sort_in_formula(f: &IrFormula) -> bool {
         IrFormula::Forall { body, .. }
         | IrFormula::Exists { body, .. }
         | IrFormula::Choice { body, .. } => term_has_region_sort_in_formula(body),
+        IrFormula::DivergenceBetween { source, target } => {
+            term_has_region_sort_in_formula(source) || term_has_region_sort_in_formula(target)
+        }
         // Substitute and Apply are meta-level; no region sort to detect.
         IrFormula::Substitute { .. } | IrFormula::Apply { .. } => false,
     }


### PR DESCRIPTION
Implements the locked schema at [docs/plans/2026-05-16-platform-semantic-tag-schema-ruling.md](https://github.com/TSavo/provekit/blob/main/docs/plans/2026-05-16-platform-semantic-tag-schema-ruling.md). Substrate types only; no kit declaration data (Stage 3) and no comparison machinery (Stage 4).

## What lands

- PlatformSemanticTag { kit_cid, op_cid, dimensions: BTreeMap<String, Cid> }
- DimensionValueMemento { kit_cid, dimension_name, value_name, compare_to: IrFormula }
- IrFormula::DivergenceBetween variant (forward declaration; comparison machinery comes in Stage 4)
- ConformanceDeclaration::Carrier optional PlatformSemanticsDeclaration field
- JCS canonicalization + BLAKE3-512 CID derivation for both types
- Round-trip + CID-pin + determinism tests + synthetic-registration integration test

## Verification

- cargo test -p provekit-ir-types --test platform_semantics_mementos: 2 passed
- cargo test -p libprovekit --test core_interface (relevant): 2 passed
- cargo check --workspace: passed
- cargo fmt --check: passed
- em-dash sweep: clean

## Spec compliance

- BTreeMap (not HashMap) for deterministic key ordering
- compare_to: IrFormula (not string label, not closed enum)
- Open-keyed: substrate enumerates NO value names; kits mint both dimension names + value mementos
- Kit-attribution via kit_cid on both types

🤖 Generated with [Claude Code](https://claude.com/claude-code)