### PR TITLE
feat(libprovekit): platform-semantics dispatcher API (Stream A Stage 2.5)

### DIFF
--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -22,6 +22,7 @@ pub mod bind;
 pub mod lift_plugin;
 pub mod lower_plugin;
 pub mod path_executor;
+pub mod platform_semantics;
 pub mod primitives;
 pub mod prove_kit;
 pub mod stubs;
@@ -41,6 +42,7 @@ pub use lower_plugin::{
     RealizedSource,
 };
 pub use path_executor::{execute_path, KitRegistry, PathExecutionChain, PathExecutionError};
+pub use platform_semantics::platform_semantics_for_lower_target;
 pub use primitives::{
     address, compose, dropper, resolve, sign, verify_sig, ComposeError, SigningKey,
 };

--- a/implementations/rust/libprovekit/src/core/path_executor.rs
+++ b/implementations/rust/libprovekit/src/core/path_executor.rs
@@ -24,6 +24,7 @@
 //! update per callsite.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use provekit_ir_types::{
     composition_refusal_compose_input_cid, composition_refusal_header_cid,
@@ -34,6 +35,7 @@ use thiserror::Error;
 
 use crate::compose::CCP_VERSION;
 
+use super::platform_semantics::platform_semantics_for_lower_target;
 use super::primitives::address;
 use super::prove_kit::ProveKit;
 use super::traits::{Catalog, InputCatalog, Kit, KitError};
@@ -65,6 +67,29 @@ impl KitRegistry {
             RegisteredKit {
                 kit: Box::new(kit),
                 conformance,
+            },
+        );
+    }
+
+    /// Register a kit by name with a carrier declaration whose platform
+    /// semantics are populated by the canonical lower-target dispatcher.
+    ///
+    /// This is equivalent to calling [`Self::register`] with a
+    /// [`ConformanceDeclaration::Carrier`] whose `platform_semantics` field is
+    /// `platform_semantics_for_lower_target(target)`.
+    pub fn register_with_platform_semantics(
+        &mut self,
+        name: impl Into<String>,
+        kit: impl Kit + 'static,
+        target: &str,
+        fixtures_path: PathBuf,
+    ) {
+        self.register(
+            name,
+            kit,
+            ConformanceDeclaration::Carrier {
+                fixtures_path,
+                platform_semantics: platform_semantics_for_lower_target(target),
             },
         );
     }

--- a/implementations/rust/libprovekit/src/core/platform_semantics.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::core::types::PlatformSemanticsDeclaration;
+
+/// Returns the PlatformSemanticsDeclaration for the given lower-target language,
+/// or None when no kit has declared semantics for that target.
+///
+/// Per the open-keyed schema ruling at
+/// `docs/plans/2026-05-16-platform-semantic-tag-schema-ruling.md`, kits mint
+/// their own dimension names and value mementos. This dispatcher is the
+/// CLI-side entry point that picks the right declaration to register with
+/// ConformanceDeclaration::Carrier at kit-registration time.
+///
+/// Stage 2.5 ships this dispatcher returning None for ALL targets. Stage 3.1
+/// per-kit dispatches will populate the match arms as each kit's
+/// PlatformSemanticsDeclaration lands.
+pub fn platform_semantics_for_lower_target(target: &str) -> Option<PlatformSemanticsDeclaration> {
+    let _ = target;
+    None
+}

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -10,12 +10,12 @@ use libprovekit::compose::{
     FunctionContractMemento, Locus,
 };
 use libprovekit::core::{
-    address, compose, execute_path, link, prove, transform, verify, ArityShape, AritySlot, CKit,
-    Canonical, Catalog, Cid, ConformanceDeclaration, Dialect, DomainClaim, DomainKind,
-    FunctionContractDomain, HashMapCatalog, HashMapInputCatalog, Input, InputCatalog, Kit,
-    KitRegistry, LanguageSignature, LiftKit, LiftPluginKit, Path, PathAlgebra, PathDocument,
-    PathDocumentError, PathError, PlatformSemanticsDeclaration, Refutation, SlotSort, Term, Truth,
-    Verb, Verdict, Witness,
+    address, compose, execute_path, link, platform_semantics_for_lower_target, prove, transform,
+    verify, ArityShape, AritySlot, CKit, Canonical, Catalog, Cid, ConformanceDeclaration, Dialect,
+    DomainClaim, DomainKind, FunctionContractDomain, HashMapCatalog, HashMapInputCatalog, Input,
+    InputCatalog, Kit, KitRegistry, LanguageSignature, LiftKit, LiftPluginKit, Path, PathAlgebra,
+    PathDocument, PathDocumentError, PathError, PlatformSemanticsDeclaration, Refutation, SlotSort,
+    Term, Truth, Verb, Verdict, Witness,
 };
 use provekit_canonicalizer::Value;
 use provekit_ir_types::{
@@ -1279,6 +1279,13 @@ fn carrier_registration_preserves_platform_semantics_declaration() {
         first_tag.dimensions.keys().collect::<Vec<_>>()
     );
     assert_eq!(decoded.to_jcs_string(), encoded);
+}
+
+#[test]
+fn dispatcher_returns_none_for_all_current_targets() {
+    for target in ["rust", "python", "java", "c", "unknown"] {
+        assert_eq!(platform_semantics_for_lower_target(target), None);
+    }
 }
 
 #[test]

--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 
 use chrono::{SecondsFormat, Utc};
 use libprovekit::core::{
-    execute_path, ConformanceDeclaration, HashMapInputCatalog, Input, KitRegistry, LowerKit,
-    Path as CorePath, PathAlgebra, Verb,
+    execute_path, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
+    Verb,
 };
 use libprovekit::effect_propagation::{
     propagate_effects, CallsiteEdge, ChangedCallsite, FunctionEffectInfo, PropagationDecision,
@@ -818,7 +818,7 @@ fn realize_probe_via_path(
         }],
     }));
     let mut registry = KitRegistry::default();
-    registry.register(
+    registry.register_with_platform_semantics(
         kit_name,
         LowerKit::new(
             repo_root.to_path_buf(),
@@ -826,11 +826,8 @@ fn realize_probe_via_path(
             Some(tag.to_string()),
             DispatchRealizeTransport,
         ),
-        ConformanceDeclaration::Carrier {
-            fixtures_path: repo_root
-                .join(format!("implementations/{language}/conformance/fixtures")),
-            platform_semantics: None,
-        },
+        language,
+        repo_root.join(format!("implementations/{language}/conformance/fixtures")),
     );
     let chain = execute_path(&path, &registry, &inputs).map_err(|error| error.to_string())?;
     LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(chain.terminal_claim())

--- a/implementations/rust/provekit-cli/src/cmd_lower.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lower.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use clap::{Parser, ValueEnum};
 use libprovekit::core::lower_plugin::realize_spec_from_named_term;
 use libprovekit::core::{
-    execute_path, named_term_document_from_bind_payload, ConformanceDeclaration,
-    HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra, Term,
+    execute_path, named_term_document_from_bind_payload, HashMapInputCatalog, Input, KitRegistry,
+    LowerKit, Path as CorePath, PathAlgebra, Term,
 };
 use owo_colors::OwoColorize;
 use serde_json::{json, Value as Json};
@@ -306,7 +306,7 @@ fn lower_named_spec_via_path(
         }],
     }));
     let mut registry = KitRegistry::default();
-    registry.register(
+    registry.register_with_platform_semantics(
         kit_name,
         LowerKit::new(
             project_root.to_path_buf(),
@@ -314,11 +314,8 @@ fn lower_named_spec_via_path(
             None,
             DispatchRealizeTransport,
         ),
-        ConformanceDeclaration::Carrier {
-            fixtures_path: project_root
-                .join(format!("implementations/{target}/conformance/fixtures")),
-            platform_semantics: None,
-        },
+        target,
+        project_root.join(format!("implementations/{target}/conformance/fixtures")),
     );
     let chain = execute_path(&path, &registry, &inputs).map_err(|error| {
         let detail = error

--- a/implementations/rust/provekit-cli/src/cmd_transport.rs
+++ b/implementations/rust/provekit-cli/src/cmd_transport.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 use clap::Parser;
 use libprovekit::core::{
-    execute_path, Cid, ConformanceDeclaration, HashMapInputCatalog, Input, KitRegistry, LowerKit,
-    Path as CorePath, PathAlgebra, Term, Verb,
+    execute_path, Cid, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath,
+    PathAlgebra, Term, Verb,
 };
 use libprovekit::desugar::{load_desugaring_rules_from_dir, DesugaringSet};
 use libprovekit::transport::{transport_term, OperationTransport, TermTransport};
@@ -1476,7 +1476,7 @@ fn realize_spec_via_path(
     let mut registry = KitRegistry::default();
     let fixtures_path =
         workspace_root.join(format!("implementations/{language}/conformance/fixtures"));
-    registry.register(
+    registry.register_with_platform_semantics(
         kit_name,
         LowerKit::new(
             workspace_root.to_path_buf(),
@@ -1484,10 +1484,8 @@ fn realize_spec_via_path(
             None,
             DispatchRealizeTransport,
         ),
-        ConformanceDeclaration::Carrier {
-            fixtures_path,
-            platform_semantics: None,
-        },
+        language,
+        fixtures_path,
     );
     let chain = execute_path(&path, &registry, &inputs).map_err(|error| error.to_string())?;
     LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(chain.terminal_claim())

--- a/implementations/rust/provekit-cli/tests/carrier_fixture_registry.rs
+++ b/implementations/rust/provekit-cli/tests/carrier_fixture_registry.rs
@@ -20,20 +20,21 @@ fn lower_java_carrier_registration_points_at_required_fixture_set() {
     let fixtures_path = repo_root.join("implementations/java/conformance/fixtures");
     let mut registry = KitRegistry::default();
 
-    registry.register(
+    registry.register_with_platform_semantics(
         "lower-java",
         LowerKit::new(repo_root, "java", None, DispatchRealizeTransport),
-        ConformanceDeclaration::Carrier {
-            fixtures_path: fixtures_path.clone(),
-            platform_semantics: None,
-        },
+        "java",
+        fixtures_path.clone(),
     );
 
-    let Some(ConformanceDeclaration::Carrier { fixtures_path, .. }) =
-        registry.conformance("lower-java")
+    let Some(ConformanceDeclaration::Carrier {
+        fixtures_path,
+        platform_semantics,
+    }) = registry.conformance("lower-java")
     else {
         panic!("lower-java must register as a carrier");
     };
+    assert_eq!(platform_semantics, &None);
     assert_required_fixtures(fixtures_path);
 }
 


### PR DESCRIPTION
Coordination-fix dispatch that locks the canonical dispatcher API BEFORE Stage 3.1's parallel per-kit dispatches land.

## Background

The original Stage 3 parallel attempt forked across four codex outputs on dispatcher function name + location (lower_platform_semantics / platform_semantics_for_target / platform_semantics_for_lower_target / platform_semantics_for_language). The fork was the parallel-dispatch protocol failure: shared API surfaces must be locked before parallel sub-dispatches.

## What lands

- libprovekit::core::platform_semantics::platform_semantics_for_lower_target(target: &str) -> Option<PlatformSemanticsDeclaration>
- KitRegistry::register_with_platform_semantics helper (optional convenience)
- cmd_lower / cmd_transport / cmd_bind_migrate use the canonical dispatcher (no inline literals)
- Returns None for all targets in this stage; Stage 3.1 populates match arms

## Verification

- cargo test -p libprovekit: 32 passed
- cargo test -p provekit-cli --test carrier_fixture_registry: 1 passed
- cargo fmt: clean
- em-dash sweep: clean

## Next

Stage 3.1 a-d parallel dispatches against this locked API. Each dispatch adds ONE match arm + ONE kit-specific module. Conflicts will be additive (independent arms) and trivially merge-resolvable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)