### PR TITLE
feat(python-kit): declare platform semantics for A10 primitives (Stream A Stage 3.1)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/platform_semantics.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/platform_semantics.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .canonical import cid_of_json
+
+Json = dict[str, Any]
+
+PYTHON_PLATFORM_KIT_CID = (
+    "blake3-512:"
+    "bc36b43fec1a80efcecb05f8c4de725f961295466530aec452763c6c479b67c"
+    "590c2e8062a3f46979383086ae80e6c0a917c443625d3474a7a89705e0a56ab8c"
+)
+
+PYTHON_PLATFORM_DIMENSIONS: tuple[tuple[str, str], ...] = (
+    ("ArithmeticOverflow", "ArbitraryPrecision"),
+    ("IntegerDivisionRounding", "Floor"),
+    ("ShiftMode", "Arithmetic"),
+    ("NullSemantics", "RaiseZeroDivisionError"),
+    ("BitwiseSemantics", "TwosComplement"),
+)
+
+PYTHON_PLATFORM_CONCEPT_OP_CIDS: tuple[str, ...] = (
+    "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468",
+    "blake3-512:b7c54558573348bb3a9297732547a8e6e9d152403d292df7426b6bb8a248f705b4b030bf2a22ba547a17d6f1bfaf8e75a6843e02e8f23a8226ebc09e2a8622af",
+    "blake3-512:46cd627de058c8d4f7d087ea33f4904af65ad4b2e3cfd3aff8f44bf27db96b33c2dae39cd30f53898c233c9465ba8d2701c69e5903d48935113103b4db00fd03",
+    "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839",
+    "blake3-512:92340897b43965e01454b00a6a43ec54b2bf0e01213a45fa2311f730dde18adf8da97a22458c1a2a0fb23ce85ef3ad9b22e704804c74f41997aba3ba02cefe0d",
+    "blake3-512:f9cdfcba8d0e223803126504a2a6ed10005fa61acb5c55b74b270bc66d963eb7648ab6763f0510760df93145c0f6670087a403417e8b3100c7142e121111807a",
+    "blake3-512:c90e3c159b25e4c4c7f9c899da5aa3ee048a548719ced7360f3e514450811096b21cd5473f22d7a05df088f92210bbc916e65970b9fa1e1511c193ed969f112b",
+    "blake3-512:9e96c2445bad6bb1e5a6f902ad7f733e3f4619829b9c0e232361fbf50b978c8332029212ed895762e604d1df009fce58848cda33524a697df798233eae30a14b",
+    "blake3-512:d57b54bffe698ed804a4a49486b73a1a8a3e7bd84fb12babaad01ce22d8b7bcb5a35f3476324063f8de9f8090846d0d4fbeb48d78475d07e16f7925b4f264de3",
+    "blake3-512:343b1f9faa98218467d810e0a2bb1b1eebeaf921c71a1bc52141f885220afff482c631c52e2157a6067640f4830f928add53ef7aa0386c6a27ee3c8bab6dc353",
+    "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f",
+    "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409",
+)
+
+
+def dimension_values() -> list[Json]:
+    return [
+        _with_cid(
+            {
+                "compare_to": _compare_atom(value_name),
+                "dimension_name": dimension_name,
+                "kind": "platform-dimension-value",
+                "kit_cid": PYTHON_PLATFORM_KIT_CID,
+                "schemaVersion": "1.0.0",
+                "value_name": value_name,
+            }
+        )
+        for dimension_name, value_name in PYTHON_PLATFORM_DIMENSIONS
+    ]
+
+
+def declaration() -> Json:
+    dimensions = {
+        value["dimension_name"]: value["cid"]
+        for value in dimension_values()
+        if isinstance(value["dimension_name"], str)
+    }
+    return {
+        "tags": [
+            _with_cid(
+                {
+                    "dimensions": dimensions,
+                    "kind": "platform-semantic-tag",
+                    "kit_cid": PYTHON_PLATFORM_KIT_CID,
+                    "op_cid": op_cid,
+                    "schemaVersion": "1.0.0",
+                }
+            )
+            for op_cid in PYTHON_PLATFORM_CONCEPT_OP_CIDS
+        ]
+    }
+
+
+def _compare_atom(value_name: str) -> Json:
+    return {"kind": "atomic", "name": f"python:{value_name}", "args": []}
+
+
+def _with_cid(memento: Json) -> Json:
+    result = dict(memento)
+    result["cid"] = cid_of_json(result)
+    return result

--- a/implementations/python/provekit-lift-python-source/tests/test_lift_platform_semantics.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lift_platform_semantics.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-lift-python-source/src"
+PY_TESTS_SRC = ROOT / "implementations/python/provekit-lift-py-tests/src"
+if str(PY_TESTS_SRC) not in sys.path:
+    sys.path.insert(0, str(PY_TESTS_SRC))
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from provekit_lift_python_source.platform_semantics import declaration, dimension_values
+
+
+EXPECTED_DIMENSIONS = {
+    "ArithmeticOverflow": "ArbitraryPrecision",
+    "IntegerDivisionRounding": "Floor",
+    "ShiftMode": "Arithmetic",
+    "NullSemantics": "RaiseZeroDivisionError",
+    "BitwiseSemantics": "TwosComplement",
+}
+
+
+def test_python_lift_platform_semantics_declaration_shape() -> None:
+    values = dimension_values()
+    assert {item["dimension_name"]: item["value_name"] for item in values} == EXPECTED_DIMENSIONS
+    for item in values:
+        assert item["compare_to"] == {
+            "kind": "atomic",
+            "name": f"python:{item['value_name']}",
+            "args": [],
+        }
+        assert item["cid"].startswith("blake3-512:")
+
+    semantics = declaration()
+    assert semantics["tags"]
+    for tag in semantics["tags"]:
+        assert set(tag["dimensions"]) == set(EXPECTED_DIMENSIONS)
+        assert tag["op_cid"].startswith("blake3-512:")
+        assert tag["cid"].startswith("blake3-512:")

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/platform_semantics.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/platform_semantics.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .realizer import _cid_of_json
+
+Json = dict[str, Any]
+
+PYTHON_PLATFORM_KIT_CID = (
+    "blake3-512:"
+    "bc36b43fec1a80efcecb05f8c4de725f961295466530aec452763c6c479b67c"
+    "590c2e8062a3f46979383086ae80e6c0a917c443625d3474a7a89705e0a56ab8c"
+)
+
+PYTHON_PLATFORM_DIMENSIONS: tuple[tuple[str, str], ...] = (
+    ("ArithmeticOverflow", "ArbitraryPrecision"),
+    ("IntegerDivisionRounding", "Floor"),
+    ("ShiftMode", "Arithmetic"),
+    ("NullSemantics", "RaiseZeroDivisionError"),
+    ("BitwiseSemantics", "TwosComplement"),
+)
+
+PYTHON_PLATFORM_CONCEPT_OP_CIDS: tuple[str, ...] = (
+    "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468",
+    "blake3-512:b7c54558573348bb3a9297732547a8e6e9d152403d292df7426b6bb8a248f705b4b030bf2a22ba547a17d6f1bfaf8e75a6843e02e8f23a8226ebc09e2a8622af",
+    "blake3-512:46cd627de058c8d4f7d087ea33f4904af65ad4b2e3cfd3aff8f44bf27db96b33c2dae39cd30f53898c233c9465ba8d2701c69e5903d48935113103b4db00fd03",
+    "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839",
+    "blake3-512:92340897b43965e01454b00a6a43ec54b2bf0e01213a45fa2311f730dde18adf8da97a22458c1a2a0fb23ce85ef3ad9b22e704804c74f41997aba3ba02cefe0d",
+    "blake3-512:f9cdfcba8d0e223803126504a2a6ed10005fa61acb5c55b74b270bc66d963eb7648ab6763f0510760df93145c0f6670087a403417e8b3100c7142e121111807a",
+    "blake3-512:c90e3c159b25e4c4c7f9c899da5aa3ee048a548719ced7360f3e514450811096b21cd5473f22d7a05df088f92210bbc916e65970b9fa1e1511c193ed969f112b",
+    "blake3-512:9e96c2445bad6bb1e5a6f902ad7f733e3f4619829b9c0e232361fbf50b978c8332029212ed895762e604d1df009fce58848cda33524a697df798233eae30a14b",
+    "blake3-512:d57b54bffe698ed804a4a49486b73a1a8a3e7bd84fb12babaad01ce22d8b7bcb5a35f3476324063f8de9f8090846d0d4fbeb48d78475d07e16f7925b4f264de3",
+    "blake3-512:343b1f9faa98218467d810e0a2bb1b1eebeaf921c71a1bc52141f885220afff482c631c52e2157a6067640f4830f928add53ef7aa0386c6a27ee3c8bab6dc353",
+    "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f",
+    "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409",
+)
+
+
+def dimension_values() -> list[Json]:
+    return [
+        _with_cid(
+            {
+                "compare_to": _compare_atom(value_name),
+                "dimension_name": dimension_name,
+                "kind": "platform-dimension-value",
+                "kit_cid": PYTHON_PLATFORM_KIT_CID,
+                "schemaVersion": "1.0.0",
+                "value_name": value_name,
+            }
+        )
+        for dimension_name, value_name in PYTHON_PLATFORM_DIMENSIONS
+    ]
+
+
+def declaration() -> Json:
+    dimensions = {
+        value["dimension_name"]: value["cid"]
+        for value in dimension_values()
+        if isinstance(value["dimension_name"], str)
+    }
+    return {
+        "tags": [
+            _with_cid(
+                {
+                    "dimensions": dimensions,
+                    "kind": "platform-semantic-tag",
+                    "kit_cid": PYTHON_PLATFORM_KIT_CID,
+                    "op_cid": op_cid,
+                    "schemaVersion": "1.0.0",
+                }
+            )
+            for op_cid in PYTHON_PLATFORM_CONCEPT_OP_CIDS
+        ]
+    }
+
+
+def _compare_atom(value_name: str) -> Json:
+    return {"kind": "atomic", "name": f"python:{value_name}", "args": []}
+
+
+def _with_cid(memento: Json) -> Json:
+    result = dict(memento)
+    result["cid"] = _cid_of_json(result)
+    return result

--- a/implementations/python/provekit-realize-python-core/tests/test_realize_platform_semantics.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realize_platform_semantics.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-core/src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from provekit_realize_python_core.platform_semantics import declaration, dimension_values
+
+
+EXPECTED_DIMENSIONS = {
+    "ArithmeticOverflow": "ArbitraryPrecision",
+    "IntegerDivisionRounding": "Floor",
+    "ShiftMode": "Arithmetic",
+    "NullSemantics": "RaiseZeroDivisionError",
+    "BitwiseSemantics": "TwosComplement",
+}
+
+
+def test_python_realize_platform_semantics_declaration_shape() -> None:
+    values = dimension_values()
+    assert {item["dimension_name"]: item["value_name"] for item in values} == EXPECTED_DIMENSIONS
+    for item in values:
+        assert item["compare_to"] == {
+            "kind": "atomic",
+            "name": f"python:{item['value_name']}",
+            "args": [],
+        }
+        assert item["cid"].startswith("blake3-512:")
+
+    semantics = declaration()
+    assert semantics["tags"]
+    for tag in semantics["tags"]:
+        assert set(tag["dimensions"]) == set(EXPECTED_DIMENSIONS)
+        assert tag["op_cid"].startswith("blake3-512:")
+        assert tag["cid"].startswith("blake3-512:")

--- a/implementations/rust/libprovekit/src/core/platform_semantics.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics.rs
@@ -2,6 +2,10 @@
 
 use crate::core::types::PlatformSemanticsDeclaration;
 
+mod python_common;
+pub mod python_lift_source;
+pub mod python_realize_core;
+
 /// Returns the PlatformSemanticsDeclaration for the given lower-target language,
 /// or None when no kit has declared semantics for that target.
 ///
@@ -11,10 +15,16 @@ use crate::core::types::PlatformSemanticsDeclaration;
 /// CLI-side entry point that picks the right declaration to register with
 /// ConformanceDeclaration::Carrier at kit-registration time.
 ///
-/// Stage 2.5 ships this dispatcher returning None for ALL targets. Stage 3.1
-/// per-kit dispatches will populate the match arms as each kit's
+/// Stage 2.5 shipped this dispatcher returning None for all targets. Stage 3.1
+/// per-kit dispatches populate match arms as each kit's
 /// PlatformSemanticsDeclaration lands.
 pub fn platform_semantics_for_lower_target(target: &str) -> Option<PlatformSemanticsDeclaration> {
-    let _ = target;
-    None
+    match target {
+        "python" => Some(python_kit_declaration()),
+        _ => None,
+    }
+}
+
+pub fn python_kit_declaration() -> PlatformSemanticsDeclaration {
+    python_realize_core::declaration()
 }

--- a/implementations/rust/libprovekit/src/core/platform_semantics/python_common.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics/python_common.rs
@@ -1,0 +1,74 @@
+use std::collections::BTreeMap;
+
+use crate::core::types::PlatformSemanticsDeclaration;
+use provekit_ir_types::{DimensionValueMemento, IrFormula, PlatformSemanticTag};
+
+const PYTHON_PLATFORM_KIT_CID: &str =
+    "blake3-512:bc36b43fec1a80efcecb05f8c4de725f961295466530aec452763c6c479b67c590c2e8062a3f46979383086ae80e6c0a917c443625d3474a7a89705e0a56ab8c";
+
+const PYTHON_PLATFORM_DIMENSIONS: &[(&str, &str)] = &[
+    ("ArithmeticOverflow", "ArbitraryPrecision"),
+    ("IntegerDivisionRounding", "Floor"),
+    ("ShiftMode", "Arithmetic"),
+    ("NullSemantics", "RaiseZeroDivisionError"),
+    ("BitwiseSemantics", "TwosComplement"),
+];
+
+const PYTHON_PLATFORM_CONCEPT_OP_CIDS: &[&str] = &[
+    "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468",
+    "blake3-512:b7c54558573348bb3a9297732547a8e6e9d152403d292df7426b6bb8a248f705b4b030bf2a22ba547a17d6f1bfaf8e75a6843e02e8f23a8226ebc09e2a8622af",
+    "blake3-512:46cd627de058c8d4f7d087ea33f4904af65ad4b2e3cfd3aff8f44bf27db96b33c2dae39cd30f53898c233c9465ba8d2701c69e5903d48935113103b4db00fd03",
+    "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839",
+    "blake3-512:92340897b43965e01454b00a6a43ec54b2bf0e01213a45fa2311f730dde18adf8da97a22458c1a2a0fb23ce85ef3ad9b22e704804c74f41997aba3ba02cefe0d",
+    "blake3-512:f9cdfcba8d0e223803126504a2a6ed10005fa61acb5c55b74b270bc66d963eb7648ab6763f0510760df93145c0f6670087a403417e8b3100c7142e121111807a",
+    "blake3-512:c90e3c159b25e4c4c7f9c899da5aa3ee048a548719ced7360f3e514450811096b21cd5473f22d7a05df088f92210bbc916e65970b9fa1e1511c193ed969f112b",
+    "blake3-512:9e96c2445bad6bb1e5a6f902ad7f733e3f4619829b9c0e232361fbf50b978c8332029212ed895762e604d1df009fce58848cda33524a697df798233eae30a14b",
+    "blake3-512:d57b54bffe698ed804a4a49486b73a1a8a3e7bd84fb12babaad01ce22d8b7bcb5a35f3476324063f8de9f8090846d0d4fbeb48d78475d07e16f7925b4f264de3",
+    "blake3-512:343b1f9faa98218467d810e0a2bb1b1eebeaf921c71a1bc52141f885220afff482c631c52e2157a6067640f4830f928add53ef7aa0386c6a27ee3c8bab6dc353",
+    "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f",
+    "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409",
+];
+
+pub(super) fn declaration() -> PlatformSemanticsDeclaration {
+    let dimensions = dimensions();
+    PlatformSemanticsDeclaration {
+        tags: PYTHON_PLATFORM_CONCEPT_OP_CIDS
+            .iter()
+            .map(|op_cid| {
+                PlatformSemanticTag::new(
+                    PYTHON_PLATFORM_KIT_CID.to_string(),
+                    (*op_cid).to_string(),
+                    dimensions.clone(),
+                )
+            })
+            .collect(),
+    }
+}
+
+pub(super) fn dimension_values() -> Vec<DimensionValueMemento> {
+    PYTHON_PLATFORM_DIMENSIONS
+        .iter()
+        .map(|(dimension_name, value_name)| {
+            DimensionValueMemento::new(
+                PYTHON_PLATFORM_KIT_CID.to_string(),
+                (*dimension_name).to_string(),
+                (*value_name).to_string(),
+                compare_atom(value_name),
+            )
+        })
+        .collect()
+}
+
+fn dimensions() -> BTreeMap<String, String> {
+    dimension_values()
+        .into_iter()
+        .map(|value| (value.dimension_name, value.cid))
+        .collect()
+}
+
+fn compare_atom(value_name: &str) -> IrFormula {
+    IrFormula::Atomic {
+        name: format!("python:{value_name}"),
+        args: vec![],
+    }
+}

--- a/implementations/rust/libprovekit/src/core/platform_semantics/python_lift_source.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics/python_lift_source.rs
@@ -1,0 +1,12 @@
+use crate::core::types::PlatformSemanticsDeclaration;
+use provekit_ir_types::DimensionValueMemento;
+
+use super::python_common;
+
+pub fn declaration() -> PlatformSemanticsDeclaration {
+    python_common::declaration()
+}
+
+pub fn dimension_values() -> Vec<DimensionValueMemento> {
+    python_common::dimension_values()
+}

--- a/implementations/rust/libprovekit/src/core/platform_semantics/python_realize_core.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics/python_realize_core.rs
@@ -1,0 +1,12 @@
+use crate::core::types::PlatformSemanticsDeclaration;
+use provekit_ir_types::DimensionValueMemento;
+
+use super::python_common;
+
+pub fn declaration() -> PlatformSemanticsDeclaration {
+    python_common::declaration()
+}
+
+pub fn dimension_values() -> Vec<DimensionValueMemento> {
+    python_common::dimension_values()
+}

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -39,6 +39,29 @@ fn bool_true() -> IrFormula {
     }
 }
 
+const PYTHON_PLATFORM_DIMENSIONS: &[(&str, &str)] = &[
+    ("ArithmeticOverflow", "ArbitraryPrecision"),
+    ("IntegerDivisionRounding", "Floor"),
+    ("ShiftMode", "Arithmetic"),
+    ("NullSemantics", "RaiseZeroDivisionError"),
+    ("BitwiseSemantics", "TwosComplement"),
+];
+
+const PYTHON_PLATFORM_CONCEPT_OP_CIDS: &[&str] = &[
+    "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468",
+    "blake3-512:b7c54558573348bb3a9297732547a8e6e9d152403d292df7426b6bb8a248f705b4b030bf2a22ba547a17d6f1bfaf8e75a6843e02e8f23a8226ebc09e2a8622af",
+    "blake3-512:46cd627de058c8d4f7d087ea33f4904af65ad4b2e3cfd3aff8f44bf27db96b33c2dae39cd30f53898c233c9465ba8d2701c69e5903d48935113103b4db00fd03",
+    "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839",
+    "blake3-512:92340897b43965e01454b00a6a43ec54b2bf0e01213a45fa2311f730dde18adf8da97a22458c1a2a0fb23ce85ef3ad9b22e704804c74f41997aba3ba02cefe0d",
+    "blake3-512:f9cdfcba8d0e223803126504a2a6ed10005fa61acb5c55b74b270bc66d963eb7648ab6763f0510760df93145c0f6670087a403417e8b3100c7142e121111807a",
+    "blake3-512:c90e3c159b25e4c4c7f9c899da5aa3ee048a548719ced7360f3e514450811096b21cd5473f22d7a05df088f92210bbc916e65970b9fa1e1511c193ed969f112b",
+    "blake3-512:9e96c2445bad6bb1e5a6f902ad7f733e3f4619829b9c0e232361fbf50b978c8332029212ed895762e604d1df009fce58848cda33524a697df798233eae30a14b",
+    "blake3-512:d57b54bffe698ed804a4a49486b73a1a8a3e7bd84fb12babaad01ce22d8b7bcb5a35f3476324063f8de9f8090846d0d4fbeb48d78475d07e16f7925b4f264de3",
+    "blake3-512:343b1f9faa98218467d810e0a2bb1b1eebeaf921c71a1bc52141f885220afff482c631c52e2157a6067640f4830f928add53ef7aa0386c6a27ee3c8bab6dc353",
+    "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f",
+    "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409",
+];
+
 fn pure_identity_contract(fn_name: &str, formal: &str) -> FunctionContractMemento {
     let formals = vec![formal.to_string()];
     let formal_sorts = vec![any_sort()];
@@ -1282,8 +1305,45 @@ fn carrier_registration_preserves_platform_semantics_declaration() {
 }
 
 #[test]
-fn dispatcher_returns_none_for_all_current_targets() {
-    for target in ["rust", "python", "java", "c", "unknown"] {
+fn dispatcher_returns_python_platform_semantics_declaration() {
+    let declaration = platform_semantics_for_lower_target("python")
+        .expect("python lower target declares platform semantics");
+    assert_eq!(
+        declaration,
+        libprovekit::core::platform_semantics::python_realize_core::declaration()
+    );
+    assert_python_platform_semantics(&declaration);
+}
+
+#[test]
+fn python_platform_semantics_wrappers_share_locked_dimension_values() {
+    let lift = libprovekit::core::platform_semantics::python_lift_source::declaration();
+    let realize = libprovekit::core::platform_semantics::python_realize_core::declaration();
+    assert_eq!(lift, realize);
+    assert_python_platform_semantics(&lift);
+
+    let values = libprovekit::core::platform_semantics::python_realize_core::dimension_values();
+    assert_eq!(values.len(), PYTHON_PLATFORM_DIMENSIONS.len());
+    for (dimension, value_name) in PYTHON_PLATFORM_DIMENSIONS {
+        let value = values
+            .iter()
+            .find(|candidate| {
+                candidate.dimension_name == *dimension && candidate.value_name == *value_name
+            })
+            .unwrap_or_else(|| panic!("missing Python dimension value {dimension}:{value_name}"));
+        assert_eq!(
+            value.compare_to,
+            IrFormula::Atomic {
+                name: format!("python:{value_name}"),
+                args: vec![],
+            }
+        );
+    }
+}
+
+#[test]
+fn dispatcher_still_returns_none_for_non_python_targets() {
+    for target in ["rust", "java", "c", "unknown"] {
         assert_eq!(platform_semantics_for_lower_target(target), None);
     }
 }
@@ -1356,6 +1416,33 @@ fn platform_tag(op_cid: &str, pairs: Vec<(&str, String)>) -> PlatformSemanticTag
         op_cid.to_string(),
         dimensions,
     )
+}
+
+fn assert_python_platform_semantics(declaration: &PlatformSemanticsDeclaration) {
+    assert_eq!(
+        declaration.tags.len(),
+        PYTHON_PLATFORM_CONCEPT_OP_CIDS.len()
+    );
+    let expected_dimensions = PYTHON_PLATFORM_DIMENSIONS
+        .iter()
+        .map(|(dimension, _)| dimension.to_string())
+        .collect::<BTreeSet<_>>();
+    let actual_op_cids = declaration
+        .tags
+        .iter()
+        .map(|tag| {
+            assert_eq!(
+                tag.dimensions.keys().cloned().collect::<BTreeSet<_>>(),
+                expected_dimensions
+            );
+            tag.op_cid.as_str()
+        })
+        .collect::<BTreeSet<_>>();
+    let expected_op_cids = PYTHON_PLATFORM_CONCEPT_OP_CIDS
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual_op_cids, expected_op_cids);
 }
 
 fn fixture_names(path: &FsPath) -> BTreeSet<String> {


### PR DESCRIPTION
Python language family's PlatformSemanticsDeclaration entries against the locked Stage 2.5 dispatcher (PR #1110).

## Values

- ArithmeticOverflow: ArbitraryPrecision
- IntegerDivisionRounding: Floor (// semantics)
- ShiftMode: Arithmetic
- NullSemantics: RaiseZeroDivisionError
- BitwiseSemantics: TwosComplement

## Verification

- cargo test -p libprovekit --test core_interface: 34 passed
- pytest implementations/python/*: 84 passed
- cargo fmt: clean
- em-dash sweep: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)