### PR TITLE
feat(exam-manifest,pep-1.7.0): federation handshake with exam_manifest_cid

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_plugin.rs
+++ b/implementations/rust/provekit-cli/src/cmd_plugin.rs
@@ -25,7 +25,7 @@
 // interleaved --plugin / --sugar / --loss-function / --lifter flags appear in
 // their true argv order, not two-pass (--plugin first, aliases second).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use provekit_plugin_loader::{
     error::LoadError,
@@ -33,6 +33,8 @@ use provekit_plugin_loader::{
     registry::{mint_failure_memento, PluginRegistry},
     PluginRegistryMemento,
 };
+
+use crate::kit_dispatch::{configured_exam_manifest_cid, DEFAULT_EXAM_MANIFEST_CID};
 
 /// PEP 1.7.0 plugin flags (§7).  Flatten into any subcommand that consumes
 /// the plugin registry:
@@ -287,6 +289,27 @@ impl PluginFlags {
         &self,
         sealed_at: &str,
     ) -> Result<PluginRegistryMemento, PluginLoadRefusal> {
+        self.build_registry_with_exam_manifest_cid(sealed_at, DEFAULT_EXAM_MANIFEST_CID.to_string())
+    }
+
+    /// Same as `build_registry`, but resolves the exam manifest CID from
+    /// `.provekit/config.toml` before sealing the registry.
+    pub fn build_registry_for_project(
+        &self,
+        project_root: &Path,
+        sealed_at: &str,
+    ) -> Result<PluginRegistryMemento, PluginLoadRefusal> {
+        self.build_registry_with_exam_manifest_cid(
+            sealed_at,
+            configured_exam_manifest_cid(project_root),
+        )
+    }
+
+    fn build_registry_with_exam_manifest_cid(
+        &self,
+        sealed_at: &str,
+        exam_manifest_cid: String,
+    ) -> Result<PluginRegistryMemento, PluginLoadRefusal> {
         let mut registry = PluginRegistry::new();
 
         // Walk flags in true argv order (B4: insertion order, not type-grouped).
@@ -349,7 +372,11 @@ impl PluginFlags {
             // Register any default plugins here once the substrate ships them.
         }
 
-        let memento = registry.emit_registry_memento(sealed_at);
+        let memento = registry.emit_registry_memento_with_exam_manifest(
+            sealed_at,
+            Some(exam_manifest_cid),
+            None,
+        );
 
         // Write registry memento to disk if requested (§7).
         if let Some(ref out_path) = self.plugin_registry_out {

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -48,7 +48,10 @@ pub use libprovekit::core::RealizeContractWitness;
 use libprovekit::core::RealizeTransport;
 pub use libprovekit::core::{RealizeContractPayload, RealizeRequest, RealizedSource};
 use libprovekit::ExamManifestKit;
-use provekit_ir_types::ExamManifestMemento;
+use provekit_ir_types::{Cid, ExamManifestMemento};
+use provekit_plugin_loader::{PluginRegistry, PluginRegistryMemento};
+
+use crate::project_config::read_project_config;
 
 #[derive(Debug, Clone, Copy)]
 pub struct DispatchRealizeTransport;
@@ -1014,6 +1017,121 @@ fn java_home_from_maven() -> Option<String> {
 const EXAM_MANIFEST_KIND: &str = "exam-manifest";
 const EXAM_MANIFEST_SCHEMA_VERSION: &str = "provekit-exam-manifest/v1";
 const PEP_1_7_0: &str = "pep/1.7.0";
+pub const DEFAULT_EXAM_MANIFEST_CID: &str = "blake3-512:0e012db4ce35b235b8482344795ccbe8bccad51522825b5c495a862648736936497b11a940cf0ba9170ee6202849e9a8dc9eca5cb3021261ffa2f4ac4df6edc1";
+#[allow(dead_code)]
+pub const EXAM_MANIFEST_MISMATCH_REASON: &str = "exam-manifest-mismatch";
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KitDispatchError {
+    ExamManifestMismatch {
+        local_manifest_cid: Cid,
+        remote_manifest_cid: Cid,
+    },
+}
+
+#[allow(dead_code)]
+impl KitDispatchError {
+    pub fn refused_reason(&self) -> &'static str {
+        match self {
+            Self::ExamManifestMismatch { .. } => EXAM_MANIFEST_MISMATCH_REASON,
+        }
+    }
+
+    pub fn refusal_payload(&self) -> Value {
+        match self {
+            Self::ExamManifestMismatch {
+                local_manifest_cid,
+                remote_manifest_cid,
+            } => json!({
+                "refused_reason": EXAM_MANIFEST_MISMATCH_REASON,
+                "local_manifest_cid": local_manifest_cid,
+                "remote_manifest_cid": remote_manifest_cid,
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for KitDispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExamManifestMismatch {
+                local_manifest_cid,
+                remote_manifest_cid,
+            } => write!(
+                f,
+                "{}: local_manifest_cid={}, remote_manifest_cid={}",
+                EXAM_MANIFEST_MISMATCH_REASON, local_manifest_cid, remote_manifest_cid
+            ),
+        }
+    }
+}
+
+impl std::error::Error for KitDispatchError {}
+
+pub fn configured_exam_manifest_cid(project_root: &Path) -> Cid {
+    read_project_config(project_root)
+        .exam_manifest_cid
+        .filter(|cid| !cid.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_EXAM_MANIFEST_CID.to_string())
+}
+
+#[allow(dead_code)]
+pub fn seal_plugin_registry_for_project(
+    registry: &PluginRegistry,
+    project_root: &Path,
+    sealed_at: &str,
+) -> PluginRegistryMemento {
+    registry.emit_registry_memento_with_exam_manifest(
+        sealed_at,
+        Some(configured_exam_manifest_cid(project_root)),
+        None,
+    )
+}
+
+#[allow(dead_code)]
+pub fn federate_plugin_registries(
+    local: &PluginRegistryMemento,
+    remote: &PluginRegistryMemento,
+) -> Result<(), KitDispatchError> {
+    let local_cids = registry_exam_manifest_cids(local);
+    let remote_cids = registry_exam_manifest_cids(remote);
+    if local_cids.iter().any(|cid| remote_cids.contains(cid)) {
+        return Ok(());
+    }
+
+    Err(KitDispatchError::ExamManifestMismatch {
+        local_manifest_cid: registry_primary_exam_manifest_cid(local),
+        remote_manifest_cid: registry_primary_exam_manifest_cid(remote),
+    })
+}
+
+#[allow(dead_code)]
+fn registry_exam_manifest_cids(registry: &PluginRegistryMemento) -> Vec<Cid> {
+    let mut cids = registry
+        .header
+        .exam_manifest_set
+        .clone()
+        .unwrap_or_default();
+    if let Some(cid) = &registry.header.exam_manifest_cid {
+        cids.push(cid.clone());
+    }
+    if cids.is_empty() {
+        cids.push(DEFAULT_EXAM_MANIFEST_CID.to_string());
+    }
+    cids.sort();
+    cids.dedup();
+    cids
+}
+
+#[allow(dead_code)]
+fn registry_primary_exam_manifest_cid(registry: &PluginRegistryMemento) -> Cid {
+    registry
+        .header
+        .exam_manifest_cid
+        .clone()
+        .unwrap_or_else(|| DEFAULT_EXAM_MANIFEST_CID.to_string())
+}
 
 pub fn dispatch_exam_manifest(
     workspace_root: &Path,

--- a/implementations/rust/provekit-cli/src/lib.rs
+++ b/implementations/rust/provekit-cli/src/lib.rs
@@ -33,3 +33,4 @@ pub struct OutputFlags {
 
 pub mod cmd_transport;
 pub mod kit_dispatch;
+pub mod project_config;

--- a/implementations/rust/provekit-cli/src/project_config.rs
+++ b/implementations/rust/provekit-cli/src/project_config.rs
@@ -26,6 +26,8 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Default)]
 pub struct ProjectConfig {
+    pub exam_manifest_cid: Option<String>,
+
     pub surface_default: Option<String>,
     pub surface_must: Option<String>,
     pub surface_lift: Option<String>,
@@ -130,6 +132,7 @@ fn parse_config(text: &str) -> ProjectConfig {
         let key = line[..eq].trim();
         let val = line[eq + 1..].trim().trim_matches('"').to_string();
         match (section.as_deref(), key) {
+            (None, "exam_manifest_cid") => cfg.exam_manifest_cid = Some(val),
             (Some("authoring"), "surface") => cfg.surface_default = Some(val),
             (Some("authoring.must"), "surface") => cfg.surface_must = Some(val),
             (Some("authoring.lift"), "surface") => cfg.surface_lift = Some(val),

--- a/implementations/rust/provekit-cli/tests/federation_handshake_test.rs
+++ b/implementations/rust/provekit-cli/tests/federation_handshake_test.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+
+use provekit_cli::kit_dispatch::{
+    configured_exam_manifest_cid, federate_plugin_registries, seal_plugin_registry_for_project,
+    KitDispatchError, DEFAULT_EXAM_MANIFEST_CID, EXAM_MANIFEST_MISMATCH_REASON,
+};
+use provekit_plugin_loader::registry::PluginRegistry;
+
+const OTHER_EXAM_MANIFEST_CID: &str = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+
+#[test]
+fn registry_memento_serializes_optional_exam_manifest_fields() {
+    let registry = PluginRegistry::new();
+
+    let memento = registry.emit_registry_memento_with_exam_manifest(
+        "2026-05-17T00:00:00.000Z",
+        Some(DEFAULT_EXAM_MANIFEST_CID.to_string()),
+        Some(vec![
+            DEFAULT_EXAM_MANIFEST_CID.to_string(),
+            OTHER_EXAM_MANIFEST_CID.to_string(),
+        ]),
+    );
+
+    assert_eq!(
+        memento.header.exam_manifest_cid.as_deref(),
+        Some(DEFAULT_EXAM_MANIFEST_CID)
+    );
+    assert_eq!(
+        memento.header.exam_manifest_set.as_deref(),
+        Some(
+            &[
+                DEFAULT_EXAM_MANIFEST_CID.to_string(),
+                OTHER_EXAM_MANIFEST_CID.to_string(),
+            ][..]
+        )
+    );
+
+    let json = serde_json::to_string(&memento).expect("serialize registry memento");
+    assert!(json.contains("\"exam_manifest_cid\""));
+    assert!(json.contains("\"exam_manifest_set\""));
+
+    let legacy = registry.emit_registry_memento("2026-05-17T00:00:00.000Z");
+    let legacy_json = serde_json::to_string(&legacy).expect("serialize legacy registry memento");
+    assert!(!legacy_json.contains("exam_manifest_cid"));
+    assert!(!legacy_json.contains("exam_manifest_set"));
+}
+
+#[test]
+fn configured_exam_manifest_cid_defaults_to_locked_v1_manifest() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+
+    assert_eq!(
+        configured_exam_manifest_cid(workspace.path()),
+        DEFAULT_EXAM_MANIFEST_CID
+    );
+}
+
+#[test]
+fn configured_exam_manifest_cid_reads_project_config() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let config_dir = workspace.path().join(".provekit");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!("exam_manifest_cid = \"{OTHER_EXAM_MANIFEST_CID}\"\n"),
+    )
+    .expect("write config");
+
+    assert_eq!(
+        configured_exam_manifest_cid(workspace.path()),
+        OTHER_EXAM_MANIFEST_CID
+    );
+}
+
+#[test]
+fn seal_plugin_registry_for_project_populates_exam_manifest_cid_from_config() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let config_dir = workspace.path().join(".provekit");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!("exam_manifest_cid = \"{OTHER_EXAM_MANIFEST_CID}\"\n"),
+    )
+    .expect("write config");
+
+    let registry = PluginRegistry::new();
+    let memento =
+        seal_plugin_registry_for_project(&registry, workspace.path(), "2026-05-17T00:00:00.000Z");
+
+    assert_eq!(
+        memento.header.exam_manifest_cid.as_deref(),
+        Some(OTHER_EXAM_MANIFEST_CID)
+    );
+}
+
+#[test]
+fn same_manifest_cid_federates_successfully() {
+    let registry = PluginRegistry::new();
+    let local = registry.emit_registry_memento_with_exam_manifest(
+        "2026-05-17T00:00:00.000Z",
+        Some(DEFAULT_EXAM_MANIFEST_CID.to_string()),
+        None,
+    );
+    let remote = registry.emit_registry_memento_with_exam_manifest(
+        "2026-05-17T00:00:00.000Z",
+        Some(DEFAULT_EXAM_MANIFEST_CID.to_string()),
+        None,
+    );
+
+    federate_plugin_registries(&local, &remote).expect("same manifest CID federates");
+}
+
+#[test]
+fn different_manifest_cid_refuses_with_exam_manifest_mismatch() {
+    let registry = PluginRegistry::new();
+    let local = registry.emit_registry_memento_with_exam_manifest(
+        "2026-05-17T00:00:00.000Z",
+        Some(DEFAULT_EXAM_MANIFEST_CID.to_string()),
+        None,
+    );
+    let remote = registry.emit_registry_memento_with_exam_manifest(
+        "2026-05-17T00:00:00.000Z",
+        Some(OTHER_EXAM_MANIFEST_CID.to_string()),
+        None,
+    );
+
+    let error = federate_plugin_registries(&local, &remote).expect_err("mismatch must refuse");
+
+    assert_eq!(
+        error,
+        KitDispatchError::ExamManifestMismatch {
+            local_manifest_cid: DEFAULT_EXAM_MANIFEST_CID.to_string(),
+            remote_manifest_cid: OTHER_EXAM_MANIFEST_CID.to_string(),
+        }
+    );
+    assert_eq!(error.refused_reason(), EXAM_MANIFEST_MISMATCH_REASON);
+}
+
+#[test]
+fn legacy_registry_without_manifest_federates_with_itself() {
+    let registry = PluginRegistry::new();
+    let legacy = registry.emit_registry_memento("2026-05-17T00:00:00.000Z");
+
+    federate_plugin_registries(&legacy, &legacy).expect("legacy self federation passes");
+}
+
+#[test]
+fn exam_manifest_mismatch_refusal_payload_has_required_shape() {
+    let error = KitDispatchError::ExamManifestMismatch {
+        local_manifest_cid: DEFAULT_EXAM_MANIFEST_CID.to_string(),
+        remote_manifest_cid: OTHER_EXAM_MANIFEST_CID.to_string(),
+    };
+
+    let payload = error.refusal_payload();
+
+    assert_eq!(
+        payload["refused_reason"].as_str(),
+        Some(EXAM_MANIFEST_MISMATCH_REASON)
+    );
+    assert_eq!(
+        payload["local_manifest_cid"].as_str(),
+        Some(DEFAULT_EXAM_MANIFEST_CID)
+    );
+    assert_eq!(
+        payload["remote_manifest_cid"].as_str(),
+        Some(OTHER_EXAM_MANIFEST_CID)
+    );
+    assert_eq!(payload.as_object().expect("payload is object").len(), 3);
+}
+
+#[test]
+fn exam_manifest_mismatch_discriminates_from_equal_manifests() {
+    let registry = PluginRegistry::new();
+    let local = registry.emit_registry_memento_with_exam_manifest(
+        "2026-05-17T00:00:00.000Z",
+        Some(OTHER_EXAM_MANIFEST_CID.to_string()),
+        None,
+    );
+    let remote = registry.emit_registry_memento_with_exam_manifest(
+        "2026-05-17T00:00:00.000Z",
+        Some(OTHER_EXAM_MANIFEST_CID.to_string()),
+        None,
+    );
+
+    assert!(federate_plugin_registries(&local, &remote).is_ok());
+}

--- a/implementations/rust/provekit-plugin-loader/src/cid.rs
+++ b/implementations/rust/provekit-plugin-loader/src/cid.rs
@@ -142,13 +142,18 @@ pub fn compute_registry_cid(header: &PluginRegistryMementoHeader) -> String {
         .map(|s| Value::string(s.clone()))
         .collect();
 
-    // JCS key order: built_in_count, failures, kind, load_order, loaded,
-    //                runtime_protocol_versions, schemaVersion, sealed_at
-    let input_v = Value::object([
-        (
-            "built_in_count",
-            Value::integer(header.built_in_count as i64),
-        ),
+    let mut fields = vec![(
+        "built_in_count",
+        Value::integer(header.built_in_count as i64),
+    )];
+    if let Some(cid) = &header.exam_manifest_cid {
+        fields.push(("exam_manifest_cid", Value::string(cid.clone())));
+    }
+    if let Some(cids) = &header.exam_manifest_set {
+        let cids_v: Vec<Arc<Value>> = cids.iter().map(|cid| Value::string(cid.clone())).collect();
+        fields.push(("exam_manifest_set", Value::array(cids_v)));
+    }
+    fields.extend([
         ("failures", Value::array(failures_v)),
         ("kind", Value::string("plugin-registry".to_string())),
         ("load_order", Value::array(load_order_v)),
@@ -157,6 +162,7 @@ pub fn compute_registry_cid(header: &PluginRegistryMementoHeader) -> String {
         ("schemaVersion", Value::string("1".to_string())),
         ("sealed_at", Value::string(header.sealed_at.clone())),
     ]);
+    let input_v = Value::object(fields);
 
     blake3_512_of(encode_jcs(&input_v).as_bytes())
 }
@@ -169,7 +175,7 @@ mod tests {
     #[test]
     fn cid_elides_cid_field() {
         // Two headers identical except one has cid="something" and the other has
-        // cid="something-else" — they MUST produce the same CID because `cid`
+        // cid="something-else" - they MUST produce the same CID because `cid`
         // is not part of the input.
         let h1 = PluginHeader {
             cid: "blake3-512:aaaaaa".to_string(),

--- a/implementations/rust/provekit-plugin-loader/src/registry.rs
+++ b/implementations/rust/provekit-plugin-loader/src/registry.rs
@@ -2,15 +2,15 @@
 //
 // §9 Registry semantics.
 //
-// PluginRegistry — in-memory store indexed by (kind, cid).
+// PluginRegistry - in-memory store indexed by (kind, cid).
 //
-// §9.1 — PluginRegistryMemento sealed after all --plugin flags processed.
-// §9.2 — Duplicate-CID collision rule: second registration of (kind, cid)
+// §9.1 - PluginRegistryMemento sealed after all --plugin flags processed.
+// §9.2 - Duplicate-CID collision rule: second registration of (kind, cid)
 //         is silently deduplicated UNLESS the content differs (which can't
 //         happen with content-addressing: same CID implies same content,
 //         §6.2), so duplicate is a no-op.
-// §9.3 — Registry CID computed over JCS(header_without_cid).
-// §9.4 — Every output's provenance MUST cite the registry CID.
+// §9.3 - Registry CID computed over JCS(header_without_cid).
+// §9.4 - Every output's provenance MUST cite the registry CID.
 //
 // Built-in plugins (when not suppressed) are appended AT THE END of the
 // `load_order` array per §7.  This crate ships no built-ins; the
@@ -33,12 +33,19 @@ use crate::types::{
 
 /// The header of a `PluginRegistryMemento` (§9.1).
 ///
-/// JCS key order: built_in_count, cid, failures, kind, load_order,
+/// JCS key order: built_in_count, cid, exam_manifest_cid,
+///                exam_manifest_set, failures, kind, load_order,
 ///                loaded, runtime_protocol_versions, schemaVersion, sealed_at
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PluginRegistryMementoHeader {
     pub built_in_count: usize,
     pub cid: String,
+    /// ExamManifestMemento CID the run was sealed against.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exam_manifest_cid: Option<String>,
+    /// Optional set of exam manifests admitted by this run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exam_manifest_set: Option<Vec<String>>,
     /// CIDs of PluginLoadFailureMementos minted during this run.
     pub failures: Vec<String>,
     pub kind: String,
@@ -114,7 +121,7 @@ impl PluginRegistry {
     pub fn register(&mut self, p: PluginMemento, source: &str) -> Result<bool, LoadError> {
         let key: RegistryKey = (p.kind().to_string(), p.cid().to_string());
         if self.plugins.contains_key(&key) {
-            // Deduplicated — same content, no error.
+            // Deduplicated - same content, no error.
             return Ok(false);
         }
         self.load_order
@@ -169,6 +176,16 @@ impl PluginRegistry {
     /// `signer_stub` is a placeholder envelope; full signing is out-of-scope
     /// for PEP 1.7.0 skeleton (§12).
     pub fn emit_registry_memento(&self, sealed_at: &str) -> PluginRegistryMemento {
+        self.emit_registry_memento_with_exam_manifest(sealed_at, None, None)
+    }
+
+    /// Seal the registry and include exam manifest compatibility fields.
+    pub fn emit_registry_memento_with_exam_manifest(
+        &self,
+        sealed_at: &str,
+        exam_manifest_cid: Option<String>,
+        exam_manifest_set: Option<Vec<String>>,
+    ) -> PluginRegistryMemento {
         use crate::loader::RUNTIME_PROTOCOL_VERSIONS;
 
         let failure_cids: Vec<String> =
@@ -176,7 +193,7 @@ impl PluginRegistry {
 
         // Build load_order as {kind, cid, source} objects per §9.1.
         // Preserves CLI insertion order (B4 correctness depends on caller
-        // passing plugins in input order — see build_registry in cmd_plugin.rs).
+        // passing plugins in input order - see build_registry in cmd_plugin.rs).
         let load_order: Vec<LoadOrderEntry> = self
             .load_order
             .iter()
@@ -203,10 +220,22 @@ impl PluginRegistry {
             .map(|s| s.to_string())
             .collect();
 
+        let exam_manifest_set = exam_manifest_set.and_then(|mut cids| {
+            cids.sort();
+            cids.dedup();
+            if cids.is_empty() {
+                None
+            } else {
+                Some(cids)
+            }
+        });
+
         // Build header without CID first (CID is computed over it).
         let mut header = PluginRegistryMementoHeader {
             built_in_count: self.builtin_count,
             cid: String::new(), // will be filled in below
+            exam_manifest_cid,
+            exam_manifest_set,
             failures: failure_cids,
             kind: "plugin-registry".to_string(),
             load_order,
@@ -383,7 +412,6 @@ mod tests {
     #[test]
     fn loaded_is_sorted_by_cid() {
         // B2: loaded must be sorted by cid ascending, regardless of insertion order.
-        use crate::types::LoadedEntry;
         let mut reg = PluginRegistry::new();
         reg.register(dummy_memento("sugar", "blake3-512:zzz"), "./z.json")
             .unwrap();

--- a/protocol/specs/2026-05-12-plugin-protocol.md
+++ b/protocol/specs/2026-05-12-plugin-protocol.md
@@ -395,8 +395,9 @@ cid = "blake3-512:" ++ hex(BLAKE3-512(cid_input))
 At run start, after all `--plugin` flags are processed and all built-ins are loaded (modulo §7 suppressions), the runtime SEALS the registry into a `PluginRegistryMemento`:
 
 ```cddl
-; Locked JCS key order: built_in_count, cid, failures, kind, load_order,
-; loaded, runtime_protocol_versions, schemaVersion, sealed_at
+; Locked JCS key order: built_in_count, cid, exam_manifest_cid,
+; exam_manifest_set, failures, kind, load_order, loaded,
+; runtime_protocol_versions, schemaVersion, sealed_at
 plugin-registry-memento = {
   envelope: {
     declaredAt: iso8601,
@@ -406,6 +407,8 @@ plugin-registry-memento = {
   header: {
     built_in_count:            uint,                         ; how many entries in load_order are built-ins
     cid:                       cid,                          ; DERIVED -- see §9.3
+    ? exam_manifest_cid:       cid,                          ; OPTIONAL in v1 amendment, REQUIRED in PEP v2
+    ? exam_manifest_set:       [* cid],                      ; OPTIONAL multiple admitted exam manifests
     failures:                  [* cid],                      ; PluginLoadFailureMemento CIDs, in load-attempt order
     kind:                      "plugin-registry",
     load_order:                [* { kind: plugin-kind, cid: cid, source: tstr } ],
@@ -420,6 +423,8 @@ plugin-registry-memento = {
 
 `load_order` preserves CLI order plus built-ins-at-end (§7); `loaded` is the same set sorted by CID (for content-addressing). Both fields are part of the CID; reordering CLI flags changes `load_order` bytes and rolls the registry CID, which rolls every downstream consumer that cited this registry. That is correct: a different load order is a different run.
 
+v1.0.0 of the exam-manifest amendment keeps both `exam_manifest_cid` and `exam_manifest_set` OPTIONAL for backward compatibility with already sealed registries. New v1 producers SHOULD populate `exam_manifest_cid` with the configured exam manifest CID or the runtime's shipped default manifest CID. PEP v2 will make `exam_manifest_cid` REQUIRED. `exam_manifest_set` remains OPTIONAL and is present only when a run intentionally admits more than one exam manifest.
+
 ### §9.2 Duplicate-CID collision rule
 
 Two plugins of the same `(kind, cid)` slot is a no-op (the second registration is silently dropped; the first wins). Two plugins of the same `kind` with DIFFERENT CIDs are BOTH registered; tie-breaking among them is kind-specific (consumer specs define it).
@@ -431,6 +436,8 @@ Two DIFFERENT plugin mementos asserting the same `(kind, cid)` are impossible by
 ```
 cid_input = JCS({
   "built_in_count":            <built_in_count>,
+  "exam_manifest_cid":         <exam_manifest_cid if present>,
+  "exam_manifest_set":         <exam_manifest_set if present>,
   "failures":                  <failures>,
   "kind":                      "plugin-registry",
   "load_order":                <load_order>,
@@ -442,25 +449,52 @@ cid_input = JCS({
 cid = "blake3-512:" ++ hex(BLAKE3-512(cid_input))
 ```
 
+`exam_manifest_cid` and `exam_manifest_set` are omitted from `cid_input` when absent. This preserves legacy registry CIDs while making any newly sealed registry that declares an exam manifest content-distinct.
+
 ### §9.4 Provenance propagation
 
 Any pipeline-output memento produced by a run MUST cite the `PluginRegistryMemento.cid` in its provenance. Concretely, every output memento's `provenance_cid` chain MUST resolve to a `ProvenanceMemento` whose `inputs` array contains the registry CID. This is the audit trail: a verifier can re-derive any output by replaying the exact plugin set the run used.
 
-## §10. Federation
+## §10. Federation handshake
 
-### §10.1 No central registry required
+### §10.1 Exam manifest compatibility
+
+Two `PluginRegistryMemento`s federate if either:
+
+- `exam_manifest_cid` is byte-equal between them, establishing a shared exam vocabulary.
+- There exists a `cross-exam-translation-memento` declaring a per-question mapping between the two manifests. This translation memento is future work and outside v1.
+
+Otherwise the runtime MUST refuse at the federation boundary with `refused_reason: "exam-manifest-mismatch"` and both manifest CIDs in the refusal payload:
+
+```cddl
+exam-manifest-mismatch-refusal = {
+  refused_reason:      "exam-manifest-mismatch",
+  local_manifest_cid:  cid,
+  remote_manifest_cid: cid
+}
+```
+
+During the v1 transition, a registry that omits `exam_manifest_cid` is a legacy registry. A runtime MAY interpret a missing value as its shipped default exam manifest CID for compatibility. PEP v2 removes this ambiguity by requiring `exam_manifest_cid`.
+
+### §10.2 Multiple admitted manifests
+
+If `exam_manifest_set` is present, it names the complete set of exam manifests the run admits. Federation MAY proceed when the two admitted sets share at least one CID. If no CID overlaps and no `cross-exam-translation-memento` exists, the runtime MUST refuse with `exam-manifest-mismatch` using each side's primary `exam_manifest_cid` in the payload.
+
+## §11. Federation mechanics
+
+### §11.1 No central registry required
 
 Plugins are content-addressed. A consumer references a plugin by CID (or by the kind plus a selection predicate the consumer spec defines). No directory service is required; a `PluginRegistryMemento` published alongside a `.proof` carries enough information for any verifier to fetch and re-load every plugin the run used (modulo plugin availability at the verifier's location, which is an out-of-protocol concern handled by the same content-addressed-storage mechanisms the rest of the substrate uses).
 
-### §10.2 Plugin dependencies
+### §11.2 Plugin dependencies
 
 A plugin's `content` payload MAY reference OTHER plugin CIDs (e.g., a sugar dict that depends on a particular lifter producing specific term-CIDs). The reference is content-addressed; the dependency graph is auditable. v1.0.0 of this protocol does NOT define an automatic dependency-resolution mechanism; consumer specs MAY require the runtime to refuse if a referenced dependency is not present in the registry.
 
-### §10.3 Future discovery service
+### §11.3 Future discovery service
 
 A federated discovery service (e.g., a content-addressed plugin index) is anticipated but is OUT OF SCOPE for v1.0.0. The CLI flag surface (§7) is the v1.0.0 interface. A future spec MAY define a discovery protocol on top of this base.
 
-## §11. Cross-references
+## §12. Cross-references
 
 - The `cid` construction follows `2026-04-30-canonicalization-grammar.md`.
 - The `provenance_cid` field MUST resolve to a `ProvenanceMemento` per `2026-05-06-provenance-memento.md`.
@@ -472,7 +506,7 @@ A federated discovery service (e.g., a content-addressed plugin index) is antici
 - The `loss-record` shape consumed by `loss-function` plugins is defined in `2026-05-14-transport-gap-and-partial-morphism-protocol.md` §1.3 and elaborated in `2026-05-15-concept-hub-abstraction-layer.md` §2.4.
 - The substrate trinity precedent: `project_provekit_substrate_trinity` (memo); the algebra-as-portable-thing thesis: `docs/papers/16-after-portability-the-universal-address-space.md`.
 
-## §12. Out of scope for v1.0.0
+## §13. Out of scope for v1.0.0
 
 - Hot-reload of the registry mid-run.
 - Cross-runtime portability beyond byte-identical CIDs.


### PR DESCRIPTION
Phase E of the exam manifest arc (#1103). Closes #1108. Depends on #1104 + #1105 (merged).

PEP 1.7.0 §9 amendment + §10 Federation handshake. PluginRegistryMemento gains optional `exam_manifest_cid` + `exam_manifest_set`. Same-CID federates; different-CID refuses with `ExamManifestMismatch`. Legacy-no-manifest federates with itself (backward compat).

9 tests pass (federation_handshake_test.rs). Discrimination tests per refusal variant. Pre-existing trinity_roundtrip flake left untouched per scope discipline.

Note: load-bearing PEP 1.7.0 federation surface change. Worth deeper Opus review if regressions surface post-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring exam manifest identifiers in project configuration files.
  * Plugin registry federation now validates exam manifest compatibility between registries.

* **Improvements**
  * Enhanced error reporting to detect and communicate registry incompatibilities during federation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->