### PR TITLE
feat(java-kit): declare platform semantics for A10 primitives (Stream A Stage 3.1)

### DIFF
--- a/implementations/rust/libprovekit/src/core/platform_semantics.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics.rs
@@ -3,6 +3,7 @@
 use crate::core::types::PlatformSemanticsDeclaration;
 
 mod python_common;
+pub mod java;
 pub mod python_lift_source;
 pub mod python_realize_core;
 
@@ -27,6 +28,7 @@ pub fn platform_semantics_for_lower_target(target: &str) -> Option<PlatformSeman
                 tags: declaration.tags,
             })
         }
+        "java" => Some(java::declaration()),
         _ => None,
     }
 }

--- a/implementations/rust/libprovekit/src/core/platform_semantics/java.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics/java.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use provekit_canonicalizer::blake3_512_of;
+use provekit_ir_types::{DimensionValueMemento, IrFormula, PlatformSemanticTag};
+
+use crate::core::types::PlatformSemanticsDeclaration;
+
+const KIT_ID: &str = "provekit-realize-java-core@0.1.0";
+
+const CONCEPT_ADD_CID: &str = "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468";
+const CONCEPT_SUB_CID: &str = "blake3-512:b7c54558573348bb3a9297732547a8e6e9d152403d292df7426b6bb8a248f705b4b030bf2a22ba547a17d6f1bfaf8e75a6843e02e8f23a8226ebc09e2a8622af";
+const CONCEPT_MUL_CID: &str = "blake3-512:46cd627de058c8d4f7d087ea33f4904af65ad4b2e3cfd3aff8f44bf27db96b33c2dae39cd30f53898c233c9465ba8d2701c69e5903d48935113103b4db00fd03";
+const CONCEPT_NEG_CID: &str = "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409";
+const CONCEPT_DIV_CID: &str = "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839";
+const CONCEPT_MOD_CID: &str = "blake3-512:92340897b43965e01454b00a6a43ec54b2bf0e01213a45fa2311f730dde18adf8da97a22458c1a2a0fb23ce85ef3ad9b22e704804c74f41997aba3ba02cefe0d";
+const CONCEPT_SHL_CID: &str = "blake3-512:f9cdfcba8d0e223803126504a2a6ed10005fa61acb5c55b74b270bc66d963eb7648ab6763f0510760df93145c0f6670087a403417e8b3100c7142e121111807a";
+const CONCEPT_SHR_CID: &str = "blake3-512:c90e3c159b25e4c4c7f9c899da5aa3ee048a548719ced7360f3e514450811096b21cd5473f22d7a05df088f92210bbc916e65970b9fa1e1511c193ed969f112b";
+const CONCEPT_USHR_CID: &str = "blake3-512:5746cb4f8bb8d713624731661de51e851e7ca65dae10a88bae4727d1e0070525be77e9919d90939264acaf4c093b00808862e6d0d2c24ac05262ce95cd67c8ad";
+const CONCEPT_BITNOT_CID: &str = "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f";
+
+pub fn declaration() -> PlatformSemanticsDeclaration {
+    let kit_cid = blake3_512_of(KIT_ID.as_bytes());
+    let wrapping = dimension_value(&kit_cid, "ArithmeticOverflow", "Wrapping");
+    let truncate = dimension_value(&kit_cid, "IntegerDivisionRounding", "Truncate");
+    let arithmetic = dimension_value(&kit_cid, "ShiftMode", "Arithmetic");
+    let logical = dimension_value(&kit_cid, "ShiftMode", "Logical");
+    let throw_arithmetic = dimension_value(&kit_cid, "NullSemantics", "ThrowArithmeticException");
+    let twos_complement = dimension_value(&kit_cid, "BitwiseSemantics", "TwosComplement");
+
+    PlatformSemanticsDeclaration {
+        tags: vec![
+            tag(
+                &kit_cid,
+                CONCEPT_ADD_CID,
+                &[("ArithmeticOverflow", wrapping.cid.as_str())],
+            ),
+            tag(
+                &kit_cid,
+                CONCEPT_SUB_CID,
+                &[("ArithmeticOverflow", wrapping.cid.as_str())],
+            ),
+            tag(
+                &kit_cid,
+                CONCEPT_MUL_CID,
+                &[("ArithmeticOverflow", wrapping.cid.as_str())],
+            ),
+            tag(
+                &kit_cid,
+                CONCEPT_NEG_CID,
+                &[("ArithmeticOverflow", wrapping.cid.as_str())],
+            ),
+            tag(
+                &kit_cid,
+                CONCEPT_DIV_CID,
+                &[
+                    ("IntegerDivisionRounding", truncate.cid.as_str()),
+                    ("NullSemantics", throw_arithmetic.cid.as_str()),
+                ],
+            ),
+            tag(
+                &kit_cid,
+                CONCEPT_MOD_CID,
+                &[
+                    ("IntegerDivisionRounding", truncate.cid.as_str()),
+                    ("NullSemantics", throw_arithmetic.cid.as_str()),
+                ],
+            ),
+            tag(
+                &kit_cid,
+                CONCEPT_SHL_CID,
+                &[("BitwiseSemantics", twos_complement.cid.as_str())],
+            ),
+            tag(
+                &kit_cid,
+                CONCEPT_SHR_CID,
+                &[
+                    ("BitwiseSemantics", twos_complement.cid.as_str()),
+                    ("ShiftMode", arithmetic.cid.as_str()),
+                ],
+            ),
+            tag(
+                &kit_cid,
+                CONCEPT_USHR_CID,
+                &[
+                    ("BitwiseSemantics", twos_complement.cid.as_str()),
+                    ("ShiftMode", logical.cid.as_str()),
+                ],
+            ),
+            tag(
+                &kit_cid,
+                CONCEPT_BITNOT_CID,
+                &[("BitwiseSemantics", twos_complement.cid.as_str())],
+            ),
+        ],
+    }
+}
+
+fn dimension_value(kit_cid: &str, dimension_name: &str, value_name: &str) -> DimensionValueMemento {
+    DimensionValueMemento::new(
+        kit_cid.to_string(),
+        dimension_name.to_string(),
+        value_name.to_string(),
+        IrFormula::Atomic {
+            name: format!("java:{value_name}"),
+            args: vec![],
+        },
+    )
+}
+
+fn tag(kit_cid: &str, op_cid: &str, pairs: &[(&str, &str)]) -> PlatformSemanticTag {
+    let mut dimensions = BTreeMap::new();
+    for (dimension, cid) in pairs {
+        dimensions.insert((*dimension).to_string(), (*cid).to_string());
+    }
+
+    PlatformSemanticTag::new(kit_cid.to_string(), op_cid.to_string(), dimensions)
+}

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -17,7 +17,7 @@ use libprovekit::core::{
     PathDocument, PathDocumentError, PathError, PlatformSemanticsDeclaration, Refutation, SlotSort,
     Term, Truth, Verb, Verdict, Witness,
 };
-use provekit_canonicalizer::Value;
+use provekit_canonicalizer::{blake3_512_of, Value};
 use provekit_ir_types::{
     composition_refusal_compose_input_cid, composition_refusal_header_cid,
     composition_refusal_signature, CompositionRefusalEnvelope, CompositionRefusalHeader,
@@ -1371,9 +1371,112 @@ fn dispatcher_returns_rust_platform_semantics_declaration() {
 
 #[test]
 fn dispatcher_still_returns_none_for_unclaimed_targets() {
-    for target in ["java", "c", "unknown"] {
+    for target in ["c", "unknown"] {
         assert_eq!(platform_semantics_for_lower_target(target), None);
     }
+}
+
+#[test]
+fn dispatcher_returns_java_platform_semantics_declaration() {
+    const ADD: &str = "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468";
+    const SUB: &str = "blake3-512:b7c54558573348bb3a9297732547a8e6e9d152403d292df7426b6bb8a248f705b4b030bf2a22ba547a17d6f1bfaf8e75a6843e02e8f23a8226ebc09e2a8622af";
+    const MUL: &str = "blake3-512:46cd627de058c8d4f7d087ea33f4904af65ad4b2e3cfd3aff8f44bf27db96b33c2dae39cd30f53898c233c9465ba8d2701c69e5903d48935113103b4db00fd03";
+    const NEG: &str = "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409";
+    const DIV: &str = "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839";
+    const MOD: &str = "blake3-512:92340897b43965e01454b00a6a43ec54b2bf0e01213a45fa2311f730dde18adf8da97a22458c1a2a0fb23ce85ef3ad9b22e704804c74f41997aba3ba02cefe0d";
+    const SHL: &str = "blake3-512:f9cdfcba8d0e223803126504a2a6ed10005fa61acb5c55b74b270bc66d963eb7648ab6763f0510760df93145c0f6670087a403417e8b3100c7142e121111807a";
+    const SHR: &str = "blake3-512:c90e3c159b25e4c4c7f9c899da5aa3ee048a548719ced7360f3e514450811096b21cd5473f22d7a05df088f92210bbc916e65970b9fa1e1511c193ed969f112b";
+    const USHR: &str = "blake3-512:5746cb4f8bb8d713624731661de51e851e7ca65dae10a88bae4727d1e0070525be77e9919d90939264acaf4c093b00808862e6d0d2c24ac05262ce95cd67c8ad";
+    const BITNOT: &str = "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f";
+
+    let declaration = platform_semantics_for_lower_target("java")
+        .expect("java lower target must declare platform semantics");
+    assert_eq!(
+        declaration,
+        libprovekit::core::platform_semantics::java::declaration()
+    );
+    let kit_cid = blake3_512_of(b"provekit-realize-java-core@0.1.0");
+    let wrapping = java_dimension_value(&kit_cid, "ArithmeticOverflow", "Wrapping");
+    let truncate = java_dimension_value(&kit_cid, "IntegerDivisionRounding", "Truncate");
+    let arithmetic = java_dimension_value(&kit_cid, "ShiftMode", "Arithmetic");
+    let logical = java_dimension_value(&kit_cid, "ShiftMode", "Logical");
+    let throw_arithmetic =
+        java_dimension_value(&kit_cid, "NullSemantics", "ThrowArithmeticException");
+    let twos_complement = java_dimension_value(&kit_cid, "BitwiseSemantics", "TwosComplement");
+
+    assert_eq!(declaration.tags.len(), 10);
+    assert_java_tag(
+        &declaration,
+        ADD,
+        &kit_cid,
+        &[("ArithmeticOverflow", &wrapping.cid)],
+    );
+    assert_java_tag(
+        &declaration,
+        SUB,
+        &kit_cid,
+        &[("ArithmeticOverflow", &wrapping.cid)],
+    );
+    assert_java_tag(
+        &declaration,
+        MUL,
+        &kit_cid,
+        &[("ArithmeticOverflow", &wrapping.cid)],
+    );
+    assert_java_tag(
+        &declaration,
+        NEG,
+        &kit_cid,
+        &[("ArithmeticOverflow", &wrapping.cid)],
+    );
+    assert_java_tag(
+        &declaration,
+        DIV,
+        &kit_cid,
+        &[
+            ("IntegerDivisionRounding", &truncate.cid),
+            ("NullSemantics", &throw_arithmetic.cid),
+        ],
+    );
+    assert_java_tag(
+        &declaration,
+        MOD,
+        &kit_cid,
+        &[
+            ("IntegerDivisionRounding", &truncate.cid),
+            ("NullSemantics", &throw_arithmetic.cid),
+        ],
+    );
+    assert_java_tag(
+        &declaration,
+        SHL,
+        &kit_cid,
+        &[("BitwiseSemantics", &twos_complement.cid)],
+    );
+    assert_java_tag(
+        &declaration,
+        SHR,
+        &kit_cid,
+        &[
+            ("BitwiseSemantics", &twos_complement.cid),
+            ("ShiftMode", &arithmetic.cid),
+        ],
+    );
+    assert_java_tag(
+        &declaration,
+        USHR,
+        &kit_cid,
+        &[
+            ("BitwiseSemantics", &twos_complement.cid),
+            ("ShiftMode", &logical.cid),
+        ],
+    );
+    assert_java_tag(
+        &declaration,
+        BITNOT,
+        &kit_cid,
+        &[("BitwiseSemantics", &twos_complement.cid)],
+    );
 }
 
 #[test]
@@ -1471,6 +1574,43 @@ fn assert_python_platform_semantics(declaration: &PlatformSemanticsDeclaration) 
         .copied()
         .collect::<BTreeSet<_>>();
     assert_eq!(actual_op_cids, expected_op_cids);
+}
+
+fn java_dimension_value(
+    kit_cid: &str,
+    dimension_name: &str,
+    value_name: &str,
+) -> DimensionValueMemento {
+    DimensionValueMemento::new(
+        kit_cid.to_string(),
+        dimension_name.to_string(),
+        value_name.to_string(),
+        IrFormula::Atomic {
+            name: format!("java:{value_name}"),
+            args: vec![],
+        },
+    )
+}
+
+fn assert_java_tag(
+    declaration: &PlatformSemanticsDeclaration,
+    op_cid: &str,
+    kit_cid: &str,
+    pairs: &[(&str, &str)],
+) {
+    let tag = declaration
+        .tags
+        .iter()
+        .find(|tag| tag.op_cid == op_cid)
+        .unwrap_or_else(|| panic!("missing Java platform semantic tag for {op_cid}"));
+    let expected = pairs
+        .iter()
+        .map(|(dimension, cid)| (dimension.to_string(), cid.to_string()))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(tag.kit_cid, kit_cid);
+    assert_eq!(tag.dimensions, expected);
+    assert_eq!(tag.cid, tag.recompute_cid());
 }
 
 fn fixture_names(path: &FsPath) -> BTreeSet<String> {


### PR DESCRIPTION
## Summary
- Adds Java-kit PlatformSemanticsDeclaration as sub-module `libprovekit/src/core/platform_semantics/java.rs`
- 10 tags spanning ArithmeticOverflow (Wrapping), IntegerDivisionRounding (Truncate), ShiftMode (Arithmetic + Logical), NullSemantics (ThrowArithmeticException), BitwiseSemantics (TwosComplement)
- Threads through \`platform_semantics_for_lower_target(\"java\")\` in the libprovekit dispatcher (Stage 2.5 API, locked in #1110)

## Composition with Python (#1112)
Dispatcher returns Some for both \`\"python\"\` and \`\"java\"\`. Remaining \`[\"rust\", \"c\", \"unknown\"]\` return None and are covered by \`dispatcher_still_returns_none_for_unclaimed_targets\`.

## Ruling adherence
Per the open-keyed schema ruling at \`docs/plans/2026-05-16-platform-semantic-tag-schema-ruling.md\`, dimensions and value mementos are kit-minted with \`kit_cid = blake3-512(provekit-realize-java-core@0.1.0)\`, not substrate-enumerated.

## Test plan
- [x] \`cargo test --manifest-path implementations/rust/Cargo.toml -p libprovekit --test core_interface\` (35/35 green locally)
- [ ] CI cross-language conformance gate green
- [ ] CI Trinity composition census slow lane green