### PR TITLE
feat(provekit-ir-types): RealizationMemento as 4-variant tagged enum

### DIFF
--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -736,6 +736,377 @@ pub struct RealizationDesugaringMemento {
     pub refines: Option<String>,
 }
 
+/// A first-class language-native concept realization.
+///
+/// Locked JCS key order: kind, surface_locator, syntactic_pattern.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FirstClassRealization {
+    #[serde(rename = "syntactic_pattern")]
+    pub syntactic_pattern: String,
+    #[serde(rename = "surface_locator")]
+    pub surface_locator: String,
+}
+
+/// A realization expressed as a content-addressed concept composition tree.
+///
+/// Locked JCS key order: composition_tree_cid, kind.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompositionRealization {
+    #[serde(rename = "composition_tree_cid")]
+    pub composition_tree_cid: String,
+}
+
+/// A library or API boundary realization.
+///
+/// Locked JCS key order: api, boundary_contract_cid, kind, library.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BoundaryRealization {
+    pub library: String,
+    pub api: String,
+    #[serde(rename = "boundary_contract_cid")]
+    pub boundary_contract_cid: String,
+}
+
+/// A realization carried implicitly by concept-citation comment sugar.
+///
+/// Locked JCS key order: kind.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct SugarCarrierRealization {}
+
+/// Per-(concept, language) realization metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RealizationMemento {
+    FirstClass(FirstClassRealization),
+    Composition(CompositionRealization),
+    Boundary(BoundaryRealization),
+    SugarCarrier(SugarCarrierRealization),
+}
+
+impl Serialize for RealizationMemento {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        match self {
+            RealizationMemento::FirstClass(realization) => {
+                let mut map = serializer.serialize_map(Some(3))?;
+                map.serialize_entry("kind", "first-class")?;
+                map.serialize_entry("surface_locator", &realization.surface_locator)?;
+                map.serialize_entry("syntactic_pattern", &realization.syntactic_pattern)?;
+                map.end()
+            }
+            RealizationMemento::Composition(realization) => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("composition_tree_cid", &realization.composition_tree_cid)?;
+                map.serialize_entry("kind", "composition")?;
+                map.end()
+            }
+            RealizationMemento::Boundary(realization) => {
+                let mut map = serializer.serialize_map(Some(4))?;
+                map.serialize_entry("api", &realization.api)?;
+                map.serialize_entry("boundary_contract_cid", &realization.boundary_contract_cid)?;
+                map.serialize_entry("kind", "boundary")?;
+                map.serialize_entry("library", &realization.library)?;
+                map.end()
+            }
+            RealizationMemento::SugarCarrier(_) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("kind", "sugar-carrier")?;
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RealizationMemento {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        realization_memento_from_json(value).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RealizationCanonicalizationError {
+    message: String,
+}
+
+impl RealizationCanonicalizationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for RealizationCanonicalizationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RealizationCanonicalizationError {}
+
+impl From<serde_json::Error> for RealizationCanonicalizationError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::new(err.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RealizationValidationError {
+    EmptySyntacticPattern,
+    InvalidCompositionTreeCid { composition_tree_cid: String },
+    EmptyBoundaryLibrary,
+    EmptyBoundaryApi,
+    EmptyBoundaryContractCid,
+    InvalidBoundaryContractCid { boundary_contract_cid: String },
+}
+
+impl std::fmt::Display for RealizationValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptySyntacticPattern => {
+                f.write_str("RealizationMemento: syntactic_pattern must be non-empty")
+            }
+            Self::InvalidCompositionTreeCid {
+                composition_tree_cid,
+            } => write!(
+                f,
+                "RealizationMemento: composition_tree_cid `{composition_tree_cid}` is not a valid blake3-512 CID"
+            ),
+            Self::EmptyBoundaryLibrary => {
+                f.write_str("RealizationMemento: library must be non-empty")
+            }
+            Self::EmptyBoundaryApi => {
+                f.write_str("RealizationMemento: api must be non-empty")
+            }
+            Self::EmptyBoundaryContractCid => {
+                f.write_str("RealizationMemento: boundary_contract_cid must be non-empty")
+            }
+            Self::InvalidBoundaryContractCid {
+                boundary_contract_cid,
+            } => write!(
+                f,
+                "RealizationMemento: boundary_contract_cid `{boundary_contract_cid}` is not a valid blake3-512 CID"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RealizationValidationError {}
+
+impl RealizationMemento {
+    pub fn to_jcs_string(&self) -> Result<String, RealizationCanonicalizationError> {
+        let json = serde_json::to_value(self)?;
+        let canonical = canonical_value_from_json(json);
+        Ok(provekit_canonicalizer::encode_jcs(&canonical))
+    }
+
+    pub fn recompute_cid(&self) -> Result<String, RealizationCanonicalizationError> {
+        let jcs = self.to_jcs_string()?;
+        Ok(provekit_canonicalizer::blake3_512_of(jcs.as_bytes()))
+    }
+
+    pub fn validate(&self) -> Result<(), RealizationValidationError> {
+        match self {
+            Self::FirstClass(realization) => {
+                if realization.syntactic_pattern.is_empty() {
+                    Err(RealizationValidationError::EmptySyntacticPattern)
+                } else {
+                    Ok(())
+                }
+            }
+            Self::Composition(realization) => {
+                if is_blake3_512_cid(&realization.composition_tree_cid) {
+                    Ok(())
+                } else {
+                    Err(RealizationValidationError::InvalidCompositionTreeCid {
+                        composition_tree_cid: realization.composition_tree_cid.clone(),
+                    })
+                }
+            }
+            Self::Boundary(realization) => {
+                if realization.library.is_empty() {
+                    return Err(RealizationValidationError::EmptyBoundaryLibrary);
+                }
+                if realization.api.is_empty() {
+                    return Err(RealizationValidationError::EmptyBoundaryApi);
+                }
+                if realization.boundary_contract_cid.is_empty() {
+                    return Err(RealizationValidationError::EmptyBoundaryContractCid);
+                }
+                if !is_blake3_512_cid(&realization.boundary_contract_cid) {
+                    return Err(RealizationValidationError::InvalidBoundaryContractCid {
+                        boundary_contract_cid: realization.boundary_contract_cid.clone(),
+                    });
+                }
+                Ok(())
+            }
+            Self::SugarCarrier(_) => Ok(()),
+        }
+    }
+}
+
+fn realization_memento_from_json(value: serde_json::Value) -> Result<RealizationMemento, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "RealizationMemento must deserialize from a JSON object".to_string())?;
+
+    if let Some(legacy_memento) = object.get("memento").and_then(serde_json::Value::as_object) {
+        return legacy_realization_from_object(legacy_memento, string_field(object, "cid"));
+    }
+
+    match object.get("kind").and_then(serde_json::Value::as_str) {
+        Some("first-class") => Ok(RealizationMemento::FirstClass(FirstClassRealization {
+            syntactic_pattern: required_string_field(object, "syntactic_pattern")?,
+            surface_locator: required_string_field(object, "surface_locator")?,
+        })),
+        Some("composition") => Ok(RealizationMemento::Composition(CompositionRealization {
+            composition_tree_cid: required_string_field(object, "composition_tree_cid")?,
+        })),
+        Some("boundary") => Ok(RealizationMemento::Boundary(BoundaryRealization {
+            library: required_string_field(object, "library")?,
+            api: required_string_field(object, "api")?,
+            boundary_contract_cid: required_string_field(object, "boundary_contract_cid")?,
+        })),
+        Some("sugar-carrier") => Ok(RealizationMemento::SugarCarrier(SugarCarrierRealization {})),
+        Some(_) | None => legacy_realization_from_object(object, string_field(object, "cid")),
+    }
+}
+
+fn legacy_realization_from_object(
+    object: &serde_json::Map<String, serde_json::Value>,
+    envelope_cid: Option<String>,
+) -> Result<RealizationMemento, String> {
+    if object.is_empty() {
+        return Ok(RealizationMemento::SugarCarrier(SugarCarrierRealization {}));
+    }
+
+    if let Some(composition_tree_cid) = first_string_field(
+        object,
+        &[
+            "composition_tree_cid",
+            "compositionTreeCid",
+            "composition_tree",
+        ],
+    ) {
+        return Ok(RealizationMemento::Composition(CompositionRealization {
+            composition_tree_cid,
+        }));
+    }
+
+    let library = first_string_field(
+        object,
+        &["library", "target_library", "target_lang", "source_lang"],
+    );
+    let api = first_string_field(object, &["api", "target_surface", "target_form", "fn_name"])
+        .or_else(|| nested_string_field(object, "morphism", "fn_name"))
+        .or_else(|| first_string_field(object, &["operator"]));
+    let boundary_contract_cid = first_valid_cid_field(
+        object,
+        &[
+            "boundary_contract_cid",
+            "boundaryContractCid",
+            "boundary_contract",
+            "contract_cid",
+            "cid",
+            "discharge_receipt",
+        ],
+    )
+    .or_else(|| envelope_cid.filter(|cid| is_blake3_512_cid(cid)));
+
+    if library.is_some() || api.is_some() || boundary_contract_cid.is_some() {
+        return Ok(RealizationMemento::Boundary(BoundaryRealization {
+            library: library.unwrap_or_else(|| "legacy-realization".to_string()),
+            api: api.unwrap_or_else(|| "legacy-realization".to_string()),
+            boundary_contract_cid: boundary_contract_cid.unwrap_or_default(),
+        }));
+    }
+
+    if let Some(syntactic_pattern) = first_string_field(
+        object,
+        &["syntactic_pattern", "syntactic_form", "syntactic-form"],
+    ) {
+        return Ok(RealizationMemento::FirstClass(FirstClassRealization {
+            syntactic_pattern,
+            surface_locator: first_string_field(
+                object,
+                &[
+                    "surface_locator",
+                    "surfaceLocator",
+                    "surface",
+                    "target_form",
+                ],
+            )
+            .unwrap_or_else(|| "expression".to_string()),
+        }));
+    }
+
+    if legacy_object_is_sugar_carrier(object) {
+        return Ok(RealizationMemento::SugarCarrier(SugarCarrierRealization {}));
+    }
+
+    Err("unrecognized RealizationMemento shape".to_string())
+}
+
+fn required_string_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<String, String> {
+    string_field(object, field)
+        .ok_or_else(|| format!("RealizationMemento field `{field}` must be present as a string"))
+}
+
+fn string_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Option<String> {
+    object
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+fn first_string_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    fields: &[&str],
+) -> Option<String> {
+    fields.iter().find_map(|field| string_field(object, field))
+}
+
+fn nested_string_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    object_field: &str,
+    nested_field: &str,
+) -> Option<String> {
+    object
+        .get(object_field)
+        .and_then(serde_json::Value::as_object)
+        .and_then(|nested| string_field(nested, nested_field))
+}
+
+fn first_valid_cid_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    fields: &[&str],
+) -> Option<String> {
+    fields
+        .iter()
+        .find_map(|field| string_field(object, field))
+        .filter(|cid| is_blake3_512_cid(cid))
+}
+
+fn legacy_object_is_sugar_carrier(object: &serde_json::Map<String, serde_json::Value>) -> bool {
+    object
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|kind| matches!(kind, "sugar-carrier" | "sugar_carrier"))
+}
+
 // ============================================================
 // End manual extension block -- abstraction layer (issue #71)
 // ============================================================

--- a/implementations/rust/provekit-ir-types/tests/realization_memento_tagged_enum.rs
+++ b/implementations/rust/provekit-ir-types/tests/realization_memento_tagged_enum.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tagged enum tests for RealizationMemento.
+
+use std::path::Path;
+
+use provekit_ir_types::{
+    BoundaryRealization, CompositionRealization, FirstClassRealization, RealizationMemento,
+    RealizationValidationError, SugarCarrierRealization,
+};
+
+const CID_1: &str = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+const CID_2: &str = "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+
+const FIRST_CLASS_JSON: &str =
+    r#"{"kind":"first-class","surface_locator":"expression","syntactic_pattern":"${x} + ${y}"}"#;
+const FIRST_CLASS_CID: &str = "blake3-512:acdf3eb35ee4650940aeacc8a98007a2d28c797e7ff2da361b74e31d0da23b34d0e2d285013f41890ff3b1a6e8f756b98832cb96e4331548988b32149a401205";
+
+const COMPOSITION_JSON: &str = r#"{"composition_tree_cid":"blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111","kind":"composition"}"#;
+const COMPOSITION_CID: &str = "blake3-512:0a20ad99956b4c18f0995dcd18f55b182838c1743708f95ec386b3dce25ee1b9e9c5b9feeb7bd472633b873b590b2fd27cd4d84573b5af15a5f7ef1bb376806e";
+
+const BOUNDARY_JSON: &str = r#"{"api":"requests.get","boundary_contract_cid":"blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222","kind":"boundary","library":"python-requests"}"#;
+const BOUNDARY_CID: &str = "blake3-512:f19a3b0940968d46c9db8d608534c5e66513e3d3c854bd48bbbbe7456f564630ab6adc5c42e88a2a310f361589b91ee538363aea581f8a8536132440860268e4";
+
+const SUGAR_CARRIER_JSON: &str = r#"{"kind":"sugar-carrier"}"#;
+const SUGAR_CARRIER_CID: &str = "blake3-512:9cad6b2857c8c51495787c2c91bdbf890af3c99656d7dac721dc5267445872ed369407e8ca36c05cc0b2ae93821ea2978ea04d18cb9fd7cb89190dafc85530ae";
+
+fn first_class() -> RealizationMemento {
+    RealizationMemento::FirstClass(FirstClassRealization {
+        syntactic_pattern: "${x} + ${y}".to_string(),
+        surface_locator: "expression".to_string(),
+    })
+}
+
+fn composition() -> RealizationMemento {
+    RealizationMemento::Composition(CompositionRealization {
+        composition_tree_cid: CID_1.to_string(),
+    })
+}
+
+fn boundary() -> RealizationMemento {
+    RealizationMemento::Boundary(BoundaryRealization {
+        library: "python-requests".to_string(),
+        api: "requests.get".to_string(),
+        boundary_contract_cid: CID_2.to_string(),
+    })
+}
+
+fn sugar_carrier() -> RealizationMemento {
+    RealizationMemento::SugarCarrier(SugarCarrierRealization {})
+}
+
+#[test]
+fn round_trips_first_class_realization() {
+    let memento = first_class();
+
+    let serialized = serde_json::to_string(&memento).expect("serialize");
+
+    assert_eq!(serialized, FIRST_CLASS_JSON);
+    assert_eq!(
+        serde_json::from_str::<RealizationMemento>(&serialized).expect("parse"),
+        memento
+    );
+}
+
+#[test]
+fn round_trips_composition_realization() {
+    let memento = composition();
+
+    let serialized = serde_json::to_string(&memento).expect("serialize");
+
+    assert_eq!(serialized, COMPOSITION_JSON);
+    assert_eq!(
+        serde_json::from_str::<RealizationMemento>(&serialized).expect("parse"),
+        memento
+    );
+}
+
+#[test]
+fn round_trips_boundary_realization() {
+    let memento = boundary();
+
+    let serialized = serde_json::to_string(&memento).expect("serialize");
+
+    assert_eq!(serialized, BOUNDARY_JSON);
+    assert_eq!(
+        serde_json::from_str::<RealizationMemento>(&serialized).expect("parse"),
+        memento
+    );
+}
+
+#[test]
+fn round_trips_sugar_carrier_realization() {
+    let memento = sugar_carrier();
+
+    let serialized = serde_json::to_string(&memento).expect("serialize");
+
+    assert_eq!(serialized, SUGAR_CARRIER_JSON);
+    assert_eq!(
+        serde_json::from_str::<RealizationMemento>(&serialized).expect("parse"),
+        memento
+    );
+}
+
+#[test]
+fn emits_jcs_canonical_bytes_per_variant() {
+    assert_eq!(
+        first_class().to_jcs_string().expect("first class JCS"),
+        FIRST_CLASS_JSON
+    );
+    assert_eq!(
+        composition().to_jcs_string().expect("composition JCS"),
+        COMPOSITION_JSON
+    );
+    assert_eq!(
+        boundary().to_jcs_string().expect("boundary JCS"),
+        BOUNDARY_JSON
+    );
+    assert_eq!(
+        sugar_carrier().to_jcs_string().expect("sugar carrier JCS"),
+        SUGAR_CARRIER_JSON
+    );
+}
+
+#[test]
+fn recomputes_pinned_cids_per_variant() {
+    assert_eq!(
+        first_class().recompute_cid().expect("first class cid"),
+        FIRST_CLASS_CID
+    );
+    assert_eq!(
+        composition().recompute_cid().expect("composition cid"),
+        COMPOSITION_CID
+    );
+    assert_eq!(
+        boundary().recompute_cid().expect("boundary cid"),
+        BOUNDARY_CID
+    );
+    assert_eq!(
+        sugar_carrier().recompute_cid().expect("sugar carrier cid"),
+        SUGAR_CARRIER_CID
+    );
+}
+
+#[test]
+fn kind_field_discriminates_overlapping_data() {
+    let first_class = RealizationMemento::FirstClass(FirstClassRealization {
+        syntactic_pattern: "requests.get".to_string(),
+        surface_locator: "python-requests".to_string(),
+    });
+    let boundary = RealizationMemento::Boundary(BoundaryRealization {
+        library: "python-requests".to_string(),
+        api: "requests.get".to_string(),
+        boundary_contract_cid: CID_2.to_string(),
+    });
+
+    assert_ne!(
+        first_class.recompute_cid().expect("first class cid"),
+        boundary.recompute_cid().expect("boundary cid")
+    );
+}
+
+#[test]
+fn legacy_catalog_realization_parses_as_boundary() {
+    let catalog_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .join("menagerie/concept-shapes/catalog/realizations");
+    let path = std::fs::read_dir(catalog_dir)
+        .expect("read realization catalog")
+        .map(|entry| entry.expect("read catalog entry").path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name.starts_with("concept:double-dispatch->c11:2d-fn-ptr-table.")
+                })
+        })
+        .expect("double-dispatch c11 realization fixture exists");
+    let text = std::fs::read_to_string(path).expect("read legacy fixture");
+
+    let parsed: RealizationMemento = serde_json::from_str(&text).expect("parse legacy fixture");
+
+    let RealizationMemento::Boundary(boundary) = parsed else {
+        panic!("legacy fixture should classify as Boundary");
+    };
+    assert_eq!(boundary.library, "c11");
+    assert_eq!(boundary.api, "concept:double-dispatch->c11:2d-fn-ptr-table");
+    assert!(boundary.boundary_contract_cid.starts_with("blake3-512:"));
+    assert_eq!(boundary.boundary_contract_cid.len(), 139);
+}
+
+#[test]
+fn validates_per_variant_rules() {
+    assert_eq!(
+        RealizationMemento::FirstClass(FirstClassRealization {
+            syntactic_pattern: String::new(),
+            surface_locator: "expression".to_string(),
+        })
+        .validate(),
+        Err(RealizationValidationError::EmptySyntacticPattern)
+    );
+    assert_eq!(
+        RealizationMemento::Composition(CompositionRealization {
+            composition_tree_cid: "not-a-cid".to_string(),
+        })
+        .validate(),
+        Err(RealizationValidationError::InvalidCompositionTreeCid {
+            composition_tree_cid: "not-a-cid".to_string(),
+        })
+    );
+    assert_eq!(
+        RealizationMemento::Boundary(BoundaryRealization {
+            library: String::new(),
+            api: "requests.get".to_string(),
+            boundary_contract_cid: CID_2.to_string(),
+        })
+        .validate(),
+        Err(RealizationValidationError::EmptyBoundaryLibrary)
+    );
+    assert_eq!(
+        RealizationMemento::Boundary(BoundaryRealization {
+            library: "python-requests".to_string(),
+            api: String::new(),
+            boundary_contract_cid: CID_2.to_string(),
+        })
+        .validate(),
+        Err(RealizationValidationError::EmptyBoundaryApi)
+    );
+    assert_eq!(
+        RealizationMemento::Boundary(BoundaryRealization {
+            library: "python-requests".to_string(),
+            api: "requests.get".to_string(),
+            boundary_contract_cid: String::new(),
+        })
+        .validate(),
+        Err(RealizationValidationError::EmptyBoundaryContractCid)
+    );
+    assert_eq!(
+        RealizationMemento::Boundary(BoundaryRealization {
+            library: "python-requests".to_string(),
+            api: "requests.get".to_string(),
+            boundary_contract_cid: "not-a-cid".to_string(),
+        })
+        .validate(),
+        Err(RealizationValidationError::InvalidBoundaryContractCid {
+            boundary_contract_cid: "not-a-cid".to_string(),
+        })
+    );
+
+    first_class().validate().expect("first class valid");
+    composition().validate().expect("composition valid");
+    boundary().validate().expect("boundary valid");
+    sugar_carrier().validate().expect("sugar carrier valid");
+}


### PR DESCRIPTION
Phase 1 sub-issue of migration umbrella #1119. Closes #1120. Implements R12 of the realization tag-kinds ruling (PR #1118).

RealizationMemento becomes tagged enum: FirstClass | Composition | Boundary | SugarCarrier. Per-variant serde + CID + validation + backward compat for existing realization JSON files (parse as Boundary). Tests cover round-trip, CID byte-stability, discrimination, sugar-carrier, validation failures, and double-dispatch fixture mapping.

`cargo test -p provekit-ir-types` passes. No em-dashes. No modifications outside provekit-ir-types/.