### PR TITLE
feat(concept-api): tagging primitives per language SDK

### DIFF
--- a/implementations/java/provekit-java-contract-annotations/pom.xml
+++ b/implementations/java/provekit-java-contract-annotations/pom.xml
@@ -10,4 +10,18 @@
     </parent>
     <artifactId>provekit-java-contract-annotations</artifactId>
     <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>com.provekit</groupId>
+            <artifactId>provekit-ir</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/implementations/java/provekit-java-contract-annotations/src/main/java/com/provekit/contract/RealizationTags.java
+++ b/implementations/java/provekit-java-contract-annotations/src/main/java/com/provekit/contract/RealizationTags.java
@@ -1,0 +1,151 @@
+package com.provekit.contract;
+
+import com.provekit.ir.Jcs;
+import java.util.Objects;
+
+/** Builder-style tagging primitives for per-concept realization metadata. */
+public final class RealizationTags {
+    private RealizationTags() {}
+
+    /** A tagged realization memento matching the substrate enum shape. */
+    public sealed interface RealizationMemento
+            permits FirstClass, Composition, Boundary, SugarCarrier {
+        Jcs.Json toJson();
+
+        default String toJcsString() {
+            return Jcs.encode(toJson());
+        }
+
+        default String recomputeCid() {
+            return Jcs.cid(toJson());
+        }
+    }
+
+    /** A first-class language-native concept realization. */
+    public record FirstClass(String syntacticPattern, String surfaceLocator)
+            implements RealizationMemento {
+        public FirstClass {
+            syntacticPattern = requireText(syntacticPattern, "syntacticPattern");
+            surfaceLocator = requireText(surfaceLocator, "surfaceLocator");
+        }
+
+        @Override
+        public Jcs.Json toJson() {
+            return Jcs.object(
+                    "kind", Jcs.string("first-class"),
+                    "surface_locator", Jcs.string(surfaceLocator),
+                    "syntactic_pattern", Jcs.string(syntacticPattern));
+        }
+    }
+
+    /** A realization expressed as a content-addressed concept composition tree. */
+    public record Composition(String compositionTreeCid) implements RealizationMemento {
+        public Composition {
+            compositionTreeCid = requireText(compositionTreeCid, "compositionTreeCid");
+        }
+
+        @Override
+        public Jcs.Json toJson() {
+            return Jcs.object(
+                    "composition_tree_cid", Jcs.string(compositionTreeCid),
+                    "kind", Jcs.string("composition"));
+        }
+    }
+
+    /** A library or API boundary realization. */
+    public record Boundary(String library, String api, String boundaryContractCid)
+            implements RealizationMemento {
+        public Boundary {
+            library = requireText(library, "library");
+            api = requireText(api, "api");
+            boundaryContractCid = requireText(boundaryContractCid, "boundaryContractCid");
+        }
+
+        @Override
+        public Jcs.Json toJson() {
+            return Jcs.object(
+                    "api", Jcs.string(api),
+                    "boundary_contract_cid", Jcs.string(boundaryContractCid),
+                    "kind", Jcs.string("boundary"),
+                    "library", Jcs.string(library));
+        }
+    }
+
+    /** A realization carried implicitly by concept-citation comment sugar. */
+    public record SugarCarrier() implements RealizationMemento {
+        @Override
+        public Jcs.Json toJson() {
+            return Jcs.object("kind", Jcs.string("sugar-carrier"));
+        }
+    }
+
+    /**
+     * Tag a concept op with a language-native syntactic form.
+     *
+     * <pre>{@code
+     * RealizationTags.RealizationMemento realization =
+     *         RealizationTags.tagFirstClass("concept:add", "${x} + ${y}", "binary-operator");
+     * // Returns RealizationTags.FirstClass
+     * }</pre>
+     */
+    public static RealizationMemento tagFirstClass(
+            String conceptOp, String syntacticPattern, String surfaceLocator) {
+        requireText(conceptOp, "conceptOp");
+        return new FirstClass(syntacticPattern, surfaceLocator);
+    }
+
+    /**
+     * Tag a concept op with a content-addressed composition tree.
+     *
+     * <pre>{@code
+     * RealizationTags.RealizationMemento realization =
+     *         RealizationTags.tagComposition("concept:list", compositionTreeCid);
+     * // Returns RealizationTags.Composition
+     * }</pre>
+     */
+    public static RealizationMemento tagComposition(String conceptOp, String compositionTree) {
+        requireText(conceptOp, "conceptOp");
+        return new Composition(compositionTree);
+    }
+
+    /**
+     * Tag a concept op with a library or API boundary contract.
+     *
+     * <pre>{@code
+     * RealizationTags.RealizationMemento realization =
+     *         RealizationTags.tagBoundary(
+     *                 "concept:http-request",
+     *                 "python-requests",
+     *                 "requests.get",
+     *                 boundaryContractCid);
+     * // Returns RealizationTags.Boundary
+     * }</pre>
+     */
+    public static RealizationMemento tagBoundary(
+            String conceptOp, String library, String api, String boundaryContractCid) {
+        requireText(conceptOp, "conceptOp");
+        return new Boundary(library, api, boundaryContractCid);
+    }
+
+    /**
+     * Tag a concept op as a concept-citation sugar carrier.
+     *
+     * <pre>{@code
+     * RealizationTags.RealizationMemento realization =
+     *         RealizationTags.tagSugarCarrier("concept:free");
+     * // Returns RealizationTags.SugarCarrier
+     * }</pre>
+     */
+    public static RealizationMemento tagSugarCarrier(String conceptOp) {
+        requireText(conceptOp, "conceptOp");
+        return new SugarCarrier();
+    }
+
+    private static String requireText(String value, String field) {
+        String text = Objects.requireNonNull(value, field);
+        if (text.isEmpty()) {
+            throw new IllegalArgumentException(field + " must be non-empty");
+        }
+        return text;
+    }
+}

--- a/implementations/java/provekit-java-contract-annotations/src/test/java/com/provekit/contract/RealizationTagsTest.java
+++ b/implementations/java/provekit-java-contract-annotations/src/test/java/com/provekit/contract/RealizationTagsTest.java
@@ -1,0 +1,77 @@
+package com.provekit.contract;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RealizationTagsTest {
+    private static final String COMPOSITION_TREE_CID =
+            "blake3-512:1111111111111111111111111111111111111111111111111111111111111111"
+                    + "1111111111111111111111111111111111111111111111111111111111111111";
+    private static final String BOUNDARY_CONTRACT_CID =
+            "blake3-512:2222222222222222222222222222222222222222222222222222222222222222"
+                    + "2222222222222222222222222222222222222222222222222222222222222222";
+
+    @Test
+    void tagFirstClassBuildsFirstClassRealization() {
+        RealizationTags.RealizationMemento realization =
+                RealizationTags.tagFirstClass("concept:add", "${x} + ${y}", "binary-operator");
+
+        RealizationTags.FirstClass firstClass =
+                assertInstanceOf(RealizationTags.FirstClass.class, realization);
+        assertEquals("${x} + ${y}", firstClass.syntacticPattern());
+        assertEquals("binary-operator", firstClass.surfaceLocator());
+    }
+
+    @Test
+    void tagCompositionBuildsCompositionRealization() {
+        RealizationTags.RealizationMemento realization =
+                RealizationTags.tagComposition("concept:list", COMPOSITION_TREE_CID);
+
+        RealizationTags.Composition composition =
+                assertInstanceOf(RealizationTags.Composition.class, realization);
+        assertEquals(COMPOSITION_TREE_CID, composition.compositionTreeCid());
+    }
+
+    @Test
+    void tagBoundaryBuildsBoundaryRealization() {
+        RealizationTags.RealizationMemento realization = RealizationTags.tagBoundary(
+                "concept:http-request",
+                "python-requests",
+                "requests.get",
+                BOUNDARY_CONTRACT_CID);
+
+        RealizationTags.Boundary boundary =
+                assertInstanceOf(RealizationTags.Boundary.class, realization);
+        assertEquals("python-requests", boundary.library());
+        assertEquals("requests.get", boundary.api());
+        assertEquals(BOUNDARY_CONTRACT_CID, boundary.boundaryContractCid());
+    }
+
+    @Test
+    void tagSugarCarrierBuildsSugarCarrierRealization() {
+        RealizationTags.RealizationMemento realization =
+                RealizationTags.tagSugarCarrier("concept:free");
+
+        assertInstanceOf(RealizationTags.SugarCarrier.class, realization);
+    }
+
+    @Test
+    void taggingPrimitivesHaveDistinctCids() {
+        Set<String> cids = Set.of(
+                RealizationTags.tagFirstClass("concept:add", "${x} + ${y}", "binary-operator")
+                        .recomputeCid(),
+                RealizationTags.tagComposition("concept:add", COMPOSITION_TREE_CID).recomputeCid(),
+                RealizationTags.tagBoundary(
+                                "concept:add",
+                                "python-requests",
+                                "requests.get",
+                                BOUNDARY_CONTRACT_CID)
+                        .recomputeCid(),
+                RealizationTags.tagSugarCarrier("concept:add").recomputeCid());
+
+        assertEquals(4, cids.size());
+    }
+}

--- a/implementations/python/libprovekit-py/libprovekit_py/realization_tags.py
+++ b/implementations/python/libprovekit-py/libprovekit_py/realization_tags.py
@@ -1,0 +1,281 @@
+"""Concept API tagging primitives for realization mementos."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import shutil
+import subprocess
+from typing import Any, Callable, Mapping, Sequence, TypeAlias
+
+
+JsonValue: TypeAlias = None | bool | int | str | Sequence["JsonValue"] | Mapping[str, "JsonValue"]
+
+
+class RealizationTagError(ValueError):
+    """Raised when a realization tag cannot be built."""
+
+
+class _DecoratableRealization:
+    def __call__(self, target: Callable[..., Any]) -> Callable[..., Any]:
+        tags = list(getattr(target, "__provekit_realization_tags__", ()))
+        tags.append(self)
+        setattr(target, "__provekit_realization_tags__", tuple(tags))
+        return target
+
+
+@dataclass(frozen=True)
+class FirstClassRealization(_DecoratableRealization):
+    """A first-class language-native concept realization."""
+
+    syntactic_pattern: str
+    surface_locator: str
+
+    def to_json(self) -> dict[str, str]:
+        return {
+            "kind": "first-class",
+            "surface_locator": self.surface_locator,
+            "syntactic_pattern": self.syntactic_pattern,
+        }
+
+    def to_jcs_string(self) -> str:
+        return _encode_jcs(self.to_json())
+
+    def recompute_cid(self) -> str:
+        return _blake3_512_of(self.to_jcs_string().encode("utf-8"))
+
+
+@dataclass(frozen=True)
+class CompositionRealization(_DecoratableRealization):
+    """A realization expressed as a content-addressed concept composition tree."""
+
+    composition_tree_cid: str
+
+    def to_json(self) -> dict[str, str]:
+        return {
+            "composition_tree_cid": self.composition_tree_cid,
+            "kind": "composition",
+        }
+
+    def to_jcs_string(self) -> str:
+        return _encode_jcs(self.to_json())
+
+    def recompute_cid(self) -> str:
+        return _blake3_512_of(self.to_jcs_string().encode("utf-8"))
+
+
+@dataclass(frozen=True)
+class BoundaryRealization(_DecoratableRealization):
+    """A library or API boundary realization."""
+
+    library: str
+    api: str
+    boundary_contract_cid: str
+
+    def to_json(self) -> dict[str, str]:
+        return {
+            "api": self.api,
+            "boundary_contract_cid": self.boundary_contract_cid,
+            "kind": "boundary",
+            "library": self.library,
+        }
+
+    def to_jcs_string(self) -> str:
+        return _encode_jcs(self.to_json())
+
+    def recompute_cid(self) -> str:
+        return _blake3_512_of(self.to_jcs_string().encode("utf-8"))
+
+
+@dataclass(frozen=True)
+class SugarCarrierRealization(_DecoratableRealization):
+    """A realization carried implicitly by concept-citation comment sugar."""
+
+    def to_json(self) -> dict[str, str]:
+        return {"kind": "sugar-carrier"}
+
+    def to_jcs_string(self) -> str:
+        return _encode_jcs(self.to_json())
+
+    def recompute_cid(self) -> str:
+        return _blake3_512_of(self.to_jcs_string().encode("utf-8"))
+
+
+RealizationMemento: TypeAlias = (
+    FirstClassRealization
+    | CompositionRealization
+    | BoundaryRealization
+    | SugarCarrierRealization
+)
+
+
+def tag_first_class(
+    concept_op: str,
+    syntactic_pattern: str,
+    surface_locator: str,
+) -> FirstClassRealization:
+    """Tag a concept op with a language-native syntactic form.
+
+    Example:
+        >>> realization = tag_first_class(
+        ...     "concept:add",
+        ...     "${x} + ${y}",
+        ...     "binary-operator",
+        ... )
+        >>> realization.to_json()["kind"]
+        'first-class'
+
+        >>> @tag_first_class("concept:add", "${x} + ${y}", "binary-operator")
+        ... def add(x, y):
+        ...     return x + y
+    """
+    _require_text(concept_op, "concept_op")
+    return FirstClassRealization(
+        syntactic_pattern=_require_text(syntactic_pattern, "syntactic_pattern"),
+        surface_locator=_require_text(surface_locator, "surface_locator"),
+    )
+
+
+def tag_composition(concept_op: str, composition_tree: str) -> CompositionRealization:
+    """Tag a concept op with a content-addressed composition tree.
+
+    Example:
+        >>> realization = tag_composition("concept:list", "blake3-512:" + "1" * 128)
+        >>> realization.to_json()["kind"]
+        'composition'
+
+        >>> @tag_composition("concept:list", "blake3-512:" + "1" * 128)
+        ... def build_list(xs):
+        ...     return list(xs)
+    """
+    _require_text(concept_op, "concept_op")
+    return CompositionRealization(
+        composition_tree_cid=_require_text(composition_tree, "composition_tree"),
+    )
+
+
+def tag_boundary(
+    concept_op: str,
+    library: str,
+    api: str,
+    boundary_contract_cid: str,
+) -> BoundaryRealization:
+    """Tag a concept op with a library or API boundary contract.
+
+    Example:
+        >>> realization = tag_boundary(
+        ...     "concept:http-request",
+        ...     "python-requests",
+        ...     "requests.get",
+        ...     "blake3-512:" + "2" * 128,
+        ... )
+        >>> realization.to_json()["kind"]
+        'boundary'
+
+        >>> @tag_boundary("concept:http-request", "python-requests", "requests.get", "blake3-512:" + "2" * 128)
+        ... def get(url):
+        ...     return requests.get(url)
+    """
+    _require_text(concept_op, "concept_op")
+    return BoundaryRealization(
+        library=_require_text(library, "library"),
+        api=_require_text(api, "api"),
+        boundary_contract_cid=_require_text(boundary_contract_cid, "boundary_contract_cid"),
+    )
+
+
+def tag_sugar_carrier(concept_op: str) -> SugarCarrierRealization:
+    """Tag a concept op as a concept-citation sugar carrier.
+
+    Example:
+        >>> realization = tag_sugar_carrier("concept:free")
+        >>> realization.to_json()["kind"]
+        'sugar-carrier'
+
+        >>> @tag_sugar_carrier("concept:free")
+        ... def no_native_free(ptr):
+        ...     return ptr
+    """
+    _require_text(concept_op, "concept_op")
+    return SugarCarrierRealization()
+
+
+def _require_text(value: str, field: str) -> str:
+    if not isinstance(value, str):
+        raise RealizationTagError(f"{field} must be str")
+    if not value:
+        raise RealizationTagError(f"{field} must be non-empty")
+    return value
+
+
+def _encode_jcs(value: JsonValue) -> str:
+    out: list[str] = []
+    _encode_value(value, out)
+    return "".join(out)
+
+
+def _encode_value(value: JsonValue, out: list[str]) -> None:
+    if value is None:
+        out.append("null")
+    elif isinstance(value, bool):
+        out.append("true" if value else "false")
+    elif isinstance(value, int) and not isinstance(value, bool):
+        out.append(str(value))
+    elif isinstance(value, str):
+        _encode_string(value, out)
+    elif isinstance(value, Mapping):
+        out.append("{")
+        for index, key in enumerate(sorted(value.keys())):
+            if not isinstance(key, str):
+                raise TypeError("canonical JSON object keys must be str")
+            if index:
+                out.append(",")
+            _encode_string(key, out)
+            out.append(":")
+            _encode_value(value[key], out)
+        out.append("}")
+    elif isinstance(value, Sequence):
+        out.append("[")
+        for index, item in enumerate(value):
+            if index:
+                out.append(",")
+            _encode_value(item, out)
+        out.append("]")
+    else:
+        raise TypeError(f"unsupported canonical JSON value: {type(value).__name__}")
+
+
+def _encode_string(value: str, out: list[str]) -> None:
+    out.append('"')
+    for char in value:
+        codepoint = ord(char)
+        if char == '"':
+            out.append('\\"')
+        elif char == "\\":
+            out.append("\\\\")
+        elif codepoint < 0x20:
+            out.append("\\u00")
+            out.append("0123456789abcdef"[(codepoint >> 4) & 0xF])
+            out.append("0123456789abcdef"[codepoint & 0xF])
+        else:
+            out.append(char)
+    out.append('"')
+
+
+def _blake3_512_of(data: bytes) -> str:
+    try:
+        import blake3
+
+        digest = blake3.blake3(data).digest(length=64)
+        return "blake3-512:" + digest.hex()
+    except ModuleNotFoundError:
+        b3sum = shutil.which("b3sum")
+        if b3sum is None:
+            raise RuntimeError("BLAKE3 support requires the blake3 module or b3sum") from None
+        process = subprocess.run(
+            [b3sum, "--length", "64", "--no-names", "-"],
+            input=data,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        return "blake3-512:" + process.stdout.decode("utf-8").strip()

--- a/implementations/python/libprovekit-py/tests/test_realization_tags.py
+++ b/implementations/python/libprovekit-py/tests/test_realization_tags.py
@@ -1,0 +1,79 @@
+import unittest
+
+from libprovekit_py.realization_tags import (
+    BoundaryRealization,
+    CompositionRealization,
+    FirstClassRealization,
+    SugarCarrierRealization,
+    tag_boundary,
+    tag_composition,
+    tag_first_class,
+    tag_sugar_carrier,
+)
+
+COMPOSITION_TREE_CID = "blake3-512:" + "1" * 128
+BOUNDARY_CONTRACT_CID = "blake3-512:" + "2" * 128
+
+
+class RealizationTagsTest(unittest.TestCase):
+    def test_tag_first_class_builds_first_class_realization(self) -> None:
+        realization = tag_first_class("concept:add", "${x} + ${y}", "binary-operator")
+
+        self.assertEqual(
+            realization,
+            FirstClassRealization(
+                syntactic_pattern="${x} + ${y}",
+                surface_locator="binary-operator",
+            ),
+        )
+
+    def test_tag_composition_builds_composition_realization(self) -> None:
+        realization = tag_composition("concept:list", COMPOSITION_TREE_CID)
+
+        self.assertEqual(
+            realization,
+            CompositionRealization(
+                composition_tree_cid=COMPOSITION_TREE_CID,
+            ),
+        )
+
+    def test_tag_boundary_builds_boundary_realization(self) -> None:
+        realization = tag_boundary(
+            "concept:http-request",
+            "python-requests",
+            "requests.get",
+            BOUNDARY_CONTRACT_CID,
+        )
+
+        self.assertEqual(
+            realization,
+            BoundaryRealization(
+                library="python-requests",
+                api="requests.get",
+                boundary_contract_cid=BOUNDARY_CONTRACT_CID,
+            ),
+        )
+
+    def test_tag_sugar_carrier_builds_sugar_carrier_realization(self) -> None:
+        realization = tag_sugar_carrier("concept:free")
+
+        self.assertEqual(realization, SugarCarrierRealization())
+
+    def test_tagging_primitives_have_distinct_cids(self) -> None:
+        cids = {
+            tag_first_class("concept:add", "${x} + ${y}", "binary-operator").recompute_cid(),
+            tag_composition("concept:add", COMPOSITION_TREE_CID).recompute_cid(),
+            tag_boundary(
+                "concept:add",
+                "python-requests",
+                "requests.get",
+                BOUNDARY_CONTRACT_CID,
+            ).recompute_cid(),
+            tag_sugar_carrier("concept:add").recompute_cid(),
+        }
+
+        self.assertEqual(len(cids), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -6,6 +6,8 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod realization_tags;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum Declaration {

--- a/implementations/rust/provekit-ir-types/src/realization_tags.rs
+++ b/implementations/rust/provekit-ir-types/src/realization_tags.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    BoundaryRealization, CompositionRealization, FirstClassRealization, RealizationMemento,
+    SugarCarrierRealization,
+};
+
+/// Tag a concept op with a language-native syntactic form.
+///
+/// # Example
+///
+/// ```
+/// use provekit_ir_types::realization_tags::tag_first_class;
+///
+/// let realization = tag_first_class(
+///     "concept:add",
+///     "${x} + ${y}",
+///     "binary-operator",
+/// );
+/// // Returns RealizationMemento::FirstClass(...)
+/// ```
+pub fn tag_first_class(
+    concept_op: &str,
+    syntactic_pattern: &str,
+    surface_locator: &str,
+) -> RealizationMemento {
+    let _ = concept_op;
+    RealizationMemento::FirstClass(FirstClassRealization {
+        syntactic_pattern: syntactic_pattern.to_string(),
+        surface_locator: surface_locator.to_string(),
+    })
+}
+
+/// Tag a concept op with a content-addressed composition tree.
+///
+/// # Example
+///
+/// ```
+/// use provekit_ir_types::realization_tags::tag_composition;
+///
+/// let realization = tag_composition(
+///     "concept:list",
+///     "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+/// );
+/// // Returns RealizationMemento::Composition(...)
+/// ```
+pub fn tag_composition(concept_op: &str, composition_tree: &str) -> RealizationMemento {
+    let _ = concept_op;
+    RealizationMemento::Composition(CompositionRealization {
+        composition_tree_cid: composition_tree.to_string(),
+    })
+}
+
+/// Tag a concept op with a library or API boundary contract.
+///
+/// # Example
+///
+/// ```
+/// use provekit_ir_types::realization_tags::tag_boundary;
+///
+/// let realization = tag_boundary(
+///     "concept:http-request",
+///     "python-requests",
+///     "requests.get",
+///     "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+/// );
+/// // Returns RealizationMemento::Boundary(...)
+/// ```
+pub fn tag_boundary(
+    concept_op: &str,
+    library: &str,
+    api: &str,
+    boundary_contract_cid: &str,
+) -> RealizationMemento {
+    let _ = concept_op;
+    RealizationMemento::Boundary(BoundaryRealization {
+        library: library.to_string(),
+        api: api.to_string(),
+        boundary_contract_cid: boundary_contract_cid.to_string(),
+    })
+}
+
+/// Tag a concept op as a concept-citation sugar carrier.
+///
+/// # Example
+///
+/// ```
+/// use provekit_ir_types::realization_tags::tag_sugar_carrier;
+///
+/// let realization = tag_sugar_carrier("concept:free");
+/// // Returns RealizationMemento::SugarCarrier(...)
+/// ```
+pub fn tag_sugar_carrier(concept_op: &str) -> RealizationMemento {
+    let _ = concept_op;
+    RealizationMemento::SugarCarrier(SugarCarrierRealization {})
+}

--- a/implementations/rust/provekit-ir-types/tests/realization_tags.rs
+++ b/implementations/rust/provekit-ir-types/tests/realization_tags.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use provekit_ir_types::realization_tags::{
+    tag_boundary, tag_composition, tag_first_class, tag_sugar_carrier,
+};
+use provekit_ir_types::{
+    BoundaryRealization, CompositionRealization, FirstClassRealization, RealizationMemento,
+    SugarCarrierRealization,
+};
+
+const COMPOSITION_TREE_CID: &str = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+const BOUNDARY_CONTRACT_CID: &str = "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+
+#[test]
+fn tag_first_class_builds_first_class_realization() {
+    let realization = tag_first_class("concept:add", "${x} + ${y}", "binary-operator");
+
+    assert_eq!(
+        realization,
+        RealizationMemento::FirstClass(FirstClassRealization {
+            syntactic_pattern: "${x} + ${y}".to_string(),
+            surface_locator: "binary-operator".to_string(),
+        })
+    );
+}
+
+#[test]
+fn tag_composition_builds_composition_realization() {
+    let realization = tag_composition("concept:list", COMPOSITION_TREE_CID);
+
+    assert_eq!(
+        realization,
+        RealizationMemento::Composition(CompositionRealization {
+            composition_tree_cid: COMPOSITION_TREE_CID.to_string(),
+        })
+    );
+}
+
+#[test]
+fn tag_boundary_builds_boundary_realization() {
+    let realization = tag_boundary(
+        "concept:http-request",
+        "python-requests",
+        "requests.get",
+        BOUNDARY_CONTRACT_CID,
+    );
+
+    assert_eq!(
+        realization,
+        RealizationMemento::Boundary(BoundaryRealization {
+            library: "python-requests".to_string(),
+            api: "requests.get".to_string(),
+            boundary_contract_cid: BOUNDARY_CONTRACT_CID.to_string(),
+        })
+    );
+}
+
+#[test]
+fn tag_sugar_carrier_builds_sugar_carrier_realization() {
+    let realization = tag_sugar_carrier("concept:free");
+
+    assert_eq!(
+        realization,
+        RealizationMemento::SugarCarrier(SugarCarrierRealization {})
+    );
+}
+
+#[test]
+fn tagging_primitives_have_distinct_cids() {
+    let realizations = [
+        tag_first_class("concept:add", "${x} + ${y}", "binary-operator"),
+        tag_composition("concept:add", COMPOSITION_TREE_CID),
+        tag_boundary(
+            "concept:add",
+            "python-requests",
+            "requests.get",
+            BOUNDARY_CONTRACT_CID,
+        ),
+        tag_sugar_carrier("concept:add"),
+    ];
+    let cids = realizations
+        .iter()
+        .map(|realization| realization.recompute_cid().expect("cid"))
+        .collect::<HashSet<_>>();
+
+    assert_eq!(cids.len(), realizations.len());
+}


### PR DESCRIPTION
Phase 2 of #1119. Closes #1122. Rust + Java + Python SDKs each gain 4 tagging primitives returning RealizationMemento variants (from #1120).