### PR TITLE
feat(citation): wire exam-question CIDs into TransportGap (#1126)

### DIFF
--- a/implementations/c/provekit-realize-c-core/src/main.c
+++ b/implementations/c/provekit-realize-c-core/src/main.c
@@ -9,6 +9,14 @@
 #include <string.h>
 #include <unistd.h>
 
+/* POSIX makes PATH_MAX optional in <limits.h>. On Linux glibc, it is
+ * typically only exposed via <linux/limits.h> or <sys/param.h>. Provide
+ * a portable fallback so the realize binary builds on a stock glibc
+ * toolchain without depending on cached object files masking the gap. */
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #include "blake3.h"
 
 #define BODY_TEMPLATE_REL "menagerie/c-language-signature/specs/body-templates/c-canonical-bodies.json"

--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaSourceLifter.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaSourceLifter.java
@@ -50,6 +50,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -68,6 +69,9 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
 
 public final class JavaSourceLifter {
+    static final String EXAM_MANIFEST_CID = "blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc";
+    private static final String EXAM_MANIFEST_BASENAME = "v1.1." + EXAM_MANIFEST_CID + ".json";
+
     public LiftResult liftSource(String path, String source) {
         List<Jcs.Json> declarations = new ArrayList<>();
         List<Jcs.Json> diagnosticsJson = new ArrayList<>();
@@ -141,7 +145,7 @@ public final class JavaSourceLifter {
     private static Parsed parse(String path, String source, List<Jcs.Json> diagnosticsJson, List<Refusal> refusals) {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         if (compiler == null) {
-            refusals.add(new Refusal("compiler-unavailable", null, null, "JDK compiler API is not available"));
+            refusals.add(citedRefusal("compiler-unavailable", null, null, "JDK compiler API is not available", "morphism", "concept:source-unit"));
             return null;
         }
         DiagnosticCollector<javax.tools.JavaFileObject> diagnostics = new DiagnosticCollector<>();
@@ -162,7 +166,7 @@ public final class JavaSourceLifter {
             }
             return new Parsed(task, Trees.instance(task), task.getTypes(), task.getElements(), units);
         } catch (IOException | RuntimeException e) {
-            refusals.add(new Refusal("parse-error", null, null, e.getMessage()));
+            refusals.add(citedRefusal("parse-error", null, null, e.getMessage(), "morphism", "concept:source-unit"));
             return null;
         }
     }
@@ -182,15 +186,84 @@ public final class JavaSourceLifter {
         }
     }
 
-    public record Refusal(String kind, String function, Integer line, String reason) {
+    public record Refusal(
+        String kind,
+        String function,
+        Integer line,
+        String reason,
+        String examQuestionCid,
+        String examManifestCid) {
+        public Refusal(String kind, String function, Integer line, String reason) {
+            this(kind, function, line, reason, null, null);
+        }
+
         public Jcs.Obj toJson() {
             List<Jcs.Field> fields = new ArrayList<>();
             fields.add(new Jcs.Field("kind", Jcs.string(kind)));
+            if (examManifestCid != null) fields.add(new Jcs.Field("exam_manifest_cid", Jcs.string(examManifestCid)));
+            if (examQuestionCid != null) fields.add(new Jcs.Field("exam_question_cid", Jcs.string(examQuestionCid)));
             fields.add(new Jcs.Field("function", function == null ? Jcs.nullValue() : Jcs.string(function)));
             fields.add(new Jcs.Field("line", line == null ? Jcs.nullValue() : Jcs.integer(line)));
             fields.add(new Jcs.Field("reason", Jcs.string(reason)));
             return new Jcs.Obj(fields);
         }
+    }
+
+    private static Refusal citedRefusal(String kind, String function, Integer line, String reason, String questionKind, String concept) {
+        return examQuestionCidFor(questionKind, concept, "java")
+            .map(cid -> new Refusal(kind, function, line, reason, cid, EXAM_MANIFEST_CID))
+            .orElseGet(() -> new Refusal(kind, function, line, reason));
+    }
+
+    static Optional<String> examQuestionCidFor(String kind, String concept, String language) {
+        Optional<Jcs.Obj> manifest = loadExamManifest();
+        if (manifest.isEmpty()) return Optional.empty();
+        Jcs.Arr questions = manifest.get()
+            .objectField("header")
+            .objectField("content")
+            .arrayField("questions");
+        for (Jcs.Json value : questions.values()) {
+            if (!(value instanceof Jcs.Obj question)) continue;
+            if (!kind.equals(question.stringFieldOrNull("kind"))) continue;
+            if (!concept.equals(question.stringFieldOrNull("concept"))) continue;
+            Jcs.Json parametersValue = question.get("parameters");
+            if (!(parametersValue instanceof Jcs.Obj parameters)) continue;
+            for (String languageKey : examLanguageKeys(kind)) {
+                if (language.equals(parameters.stringFieldOrNull(languageKey))) {
+                    return Optional.of(Jcs.cid(question));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static List<String> examLanguageKeys(String kind) {
+        return switch (kind) {
+            case "morphism" -> List.of("from_language");
+            case "boundary-realization", "realization" -> List.of("target_language");
+            case "concept-realization", "effect-classification", "sort-classification", "effect", "sort" -> List.of("language");
+            default -> List.of("language", "from_language", "target_language");
+        };
+    }
+
+    private static Optional<Jcs.Obj> loadExamManifest() {
+        List<Path> candidates = new ArrayList<>();
+        String env = System.getenv("PROVEKIT_EXAM_MANIFEST");
+        if (env != null && !env.isBlank()) candidates.add(Path.of(env));
+        Path start = Path.of("").toAbsolutePath().normalize();
+        for (Path current = start; current != null; current = current.getParent()) {
+            candidates.add(current.resolve("menagerie").resolve("concept-shapes").resolve("exams").resolve(EXAM_MANIFEST_BASENAME));
+        }
+        for (Path candidate : candidates) {
+            if (!Files.isRegularFile(candidate)) continue;
+            try {
+                Jcs.Json parsed = Jcs.parse(Files.readString(candidate, StandardCharsets.UTF_8));
+                if (parsed instanceof Jcs.Obj obj) return Optional.of(obj);
+            } catch (IOException | RuntimeException ignored) {
+                continue;
+            }
+        }
+        return Optional.empty();
     }
 
     private static final class JavaSourceFile extends SimpleJavaFileObject {
@@ -233,15 +306,15 @@ public final class JavaSourceLifter {
             String fnName = functionName(executable, parsed.types(), parsed.elements());
             int line = lineOf(parsed.trees(), getCurrentPath().getCompilationUnit(), method);
             if (executable.isVarArgs()) {
-                refusals.add(new Refusal("unsupported-varargs", fnName, line, "varargs methods are not in the java-source v1 slice"));
+                refusals.add(citedRefusal("unsupported-varargs", fnName, line, "varargs methods are not in the java-source v1 slice", "sort-classification", "concept:Term"));
                 return null;
             }
             if (!method.getTypeParameters().isEmpty()) {
-                refusals.add(new Refusal("unsupported-generics", fnName, line, "generic methods are not in the java-source v1 slice"));
+                refusals.add(citedRefusal("unsupported-generics", fnName, line, "generic methods are not in the java-source v1 slice", "sort-classification", "concept:Term"));
                 return null;
             }
             if (executable.getReturnType().getKind() == TypeKind.VOID) {
-                refusals.add(new Refusal("unsupported-return-sort", fnName, line, "java-source v1 emits value-returning function-contract mementos"));
+                refusals.add(citedRefusal("unsupported-return-sort", fnName, line, "java-source v1 emits value-returning function-contract mementos", "sort-classification", "concept:Term"));
                 return null;
             }
             try {
@@ -267,7 +340,7 @@ public final class JavaSourceLifter {
                 );
                 declarations.add(contract);
             } catch (RefuseException e) {
-                refusals.add(new Refusal(e.kind, fnName, e.line, e.getMessage()));
+                refusals.add(citedRefusal(e.kind, fnName, e.line, e.getMessage(), "sort-classification", "concept:Term"));
             } catch (RuntimeException e) {
                 refusals.add(new Refusal("analysis-error", fnName, line, e.getMessage()));
             }

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/JavaSourceLifterTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/JavaSourceLifterTest.java
@@ -77,11 +77,56 @@ class JavaSourceLifterTest {
         JavaSourceLifter.Refusal refusal = result.refusals().get(0);
         assertEquals("C.f(int)", refusal.function());
         assertTrue(refusal.reason().contains("LAMBDA"), refusal.toString());
+        assertEquals(
+            JavaSourceLifter.examQuestionCidFor("sort-classification", "concept:Term", "java").orElseThrow(),
+            refusal.examQuestionCid());
+        assertEquals(JavaSourceLifter.EXAM_MANIFEST_CID, refusal.examManifestCid());
         assertEquals(0, result.declarations().stream()
             .map(Jcs.Obj.class::cast)
             .filter(o -> "C.f(int)".equals(o.stringField("fnName")))
             .count());
         assertFalse(Jcs.encode(result.toJson()).contains("java:unknown"));
+    }
+
+    @Test
+    void unsupportedLambdaRefusalDoesNotFireReturnSortVariant() {
+        String source = """
+            import java.util.function.IntUnaryOperator;
+            class C {
+              int f(int x) {
+                IntUnaryOperator op = y -> y + 1;
+                return op.applyAsInt(x);
+              }
+            }
+            """;
+
+        JavaSourceLifter.LiftResult result = new JavaSourceLifter().liftSource("C.java", source);
+
+        assertEquals(1, result.refusals().size());
+        assertEquals("C.f(int)", result.refusals().get(0).function());
+        assertFalse(result.refusals().stream().anyMatch(r -> "unsupported-return-sort".equals(r.kind())));
+    }
+
+    @Test
+    void unsupportedLambdaRefusalCitesTermQuestionNotRelatedSort() {
+        String source = """
+            import java.util.function.IntUnaryOperator;
+            class C {
+              int f(int x) {
+                IntUnaryOperator op = y -> y + 1;
+                return op.applyAsInt(x);
+              }
+            }
+            """;
+
+        JavaSourceLifter.LiftResult result = new JavaSourceLifter().liftSource("C.java", source);
+
+        String refusalCid = result.refusals().get(0).examQuestionCid();
+        String related = JavaSourceLifter.examQuestionCidFor(
+            "sort-classification",
+            "concept:Formula",
+            "java").orElseThrow();
+        assertFalse(refusalCid.equals(related));
     }
 
     @Test

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -21,6 +22,12 @@ from .ir import (
     var,
 )
 
+EXAM_MANIFEST_CID = (
+    "blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc"
+)
+EXAM_MANIFEST_BASENAME = f"v1.1.{EXAM_MANIFEST_CID}.json"
+
+
 @dataclass
 class LiftResult:
     ir: list[Json] = field(default_factory=list)
@@ -37,10 +44,19 @@ class _FunctionInfo:
 
 
 class _UnsupportedSyntax(Exception):
-    def __init__(self, node: ast.AST, reason: str, kind: str = "unhandled-syntax"):
+    def __init__(
+        self,
+        node: ast.AST,
+        reason: str,
+        kind: str = "unhandled-syntax",
+        question_kind: str | None = None,
+        concept: str | None = None,
+    ):
         self.node = node
         self.reason = reason
         self.kind = kind
+        self.question_kind = question_kind
+        self.concept = concept
         super().__init__(reason)
 
 
@@ -87,12 +103,15 @@ def lift_source(source: str, source_path: str) -> LiftResult:
         tree = ast.parse(source, filename=source_path)
     except SyntaxError as exc:
         result.refusals.append(
-            {
-                "kind": "syntax-error",
-                "function": None,
-                "line": exc.lineno,
-                "reason": exc.msg,
-            }
+            _refusal(
+                "syntax-error",
+                None,
+                exc.lineno,
+                exc.msg,
+                result.diagnostics,
+                question_kind="morphism",
+                concept="concept:source-unit",
+            )
         )
         result.ir.append(
             source_unit_contract(
@@ -138,22 +157,24 @@ def lift_paths(workspace_root: str, source_paths: Iterable[str]) -> LiftResult:
             resolved = full.resolve()
         except OSError as exc:
             result.refusals.append(
-                {
-                    "kind": "io-error",
-                    "function": None,
-                    "line": None,
-                    "reason": f"cannot resolve path '{requested}': {exc}",
-                }
+                _refusal(
+                    "io-error",
+                    None,
+                    None,
+                    f"cannot resolve path '{requested}': {exc}",
+                    result.diagnostics,
+                )
             )
             continue
         if not _is_relative_to(resolved, root):
             result.refusals.append(
-                {
-                    "kind": "path-traversal",
-                    "function": None,
-                    "line": None,
-                    "reason": f"path '{requested}' escapes workspace root '{root}'",
-                }
+                _refusal(
+                    "path-traversal",
+                    None,
+                    None,
+                    f"path '{requested}' escapes workspace root '{root}'",
+                    result.diagnostics,
+                )
             )
             continue
         for file_path in _iter_python_files(resolved):
@@ -161,12 +182,13 @@ def lift_paths(workspace_root: str, source_paths: Iterable[str]) -> LiftResult:
                 source = file_path.read_text(encoding="utf-8")
             except OSError as exc:
                 result.refusals.append(
-                    {
-                        "kind": "io-error",
-                        "function": None,
-                        "line": None,
-                        "reason": f"cannot read '{file_path}': {exc}",
-                    }
+                    _refusal(
+                        "io-error",
+                        None,
+                        None,
+                        f"cannot read '{file_path}': {exc}",
+                        result.diagnostics,
+                    )
                 )
                 continue
             display_path = os.path.relpath(file_path, root)
@@ -364,7 +386,13 @@ class _Emitter:
             return ctor("python:attribute", self.expr(node.value), str_const(node.attr))
         if isinstance(node, ast.Subscript):
             return ctor("python:subscript", self.expr(node.value), self.subscript_index(node))
-        raise _UnsupportedSyntax(node, f"unhandled expression kind: {type(node).__name__}")
+        question_kind, concept = _citation_for_unhandled_expr(node)
+        raise _UnsupportedSyntax(
+            node,
+            f"unhandled expression kind: {type(node).__name__}",
+            question_kind=question_kind,
+            concept=concept,
+        )
 
     def constant(self, node: ast.Constant) -> Json:
         value = node.value
@@ -452,14 +480,110 @@ def _lift_function(
         )
     except _UnsupportedSyntax as exc:
         result.refusals.append(
-            {
-                "kind": exc.kind,
-                "function": info.fn_name,
-                "line": getattr(exc.node, "lineno", getattr(node, "lineno", None)),
-                "reason": exc.reason,
-            }
+            _refusal(
+                exc.kind,
+                info.fn_name,
+                getattr(exc.node, "lineno", getattr(node, "lineno", None)),
+                exc.reason,
+                result.diagnostics,
+                question_kind=exc.question_kind,
+                concept=exc.concept,
+            )
         )
         return None
+
+
+def _refusal(
+    kind: str,
+    function: str | None,
+    line: int | None,
+    reason: str,
+    diagnostics: list[Json],
+    *,
+    question_kind: str | None = None,
+    concept: str | None = None,
+) -> Json:
+    refusal: Json = {
+        "kind": kind,
+        "function": function,
+        "line": line,
+        "reason": reason,
+    }
+    if question_kind is None or concept is None:
+        diagnostics.append(
+            {
+                "kind": "exam-question-citation-missing",
+                "refusal_kind": kind,
+                "reason": "refusal is outside the v1.1 exam vocabulary",
+            }
+        )
+        return refusal
+    question_cid = _exam_question_cid_for(question_kind, concept, "python")
+    if question_cid is None:
+        diagnostics.append(
+            {
+                "kind": "exam-question-citation-missing",
+                "question_kind": question_kind,
+                "concept": concept,
+                "language": "python",
+            }
+        )
+        return refusal
+    refusal["exam_manifest_cid"] = EXAM_MANIFEST_CID
+    refusal["exam_question_cid"] = question_cid
+    return refusal
+
+
+def _citation_for_unhandled_expr(node: ast.AST) -> tuple[str, str]:
+    if isinstance(node, ast.ListComp):
+        return ("sort-classification", "concept:List<T>")
+    return ("sort-classification", "concept:Term")
+
+
+def _exam_question_cid_for(kind: str, concept: str, language: str) -> str | None:
+    manifest = _load_exam_manifest()
+    if manifest is None:
+        return None
+    for question in manifest.get("header", {}).get("content", {}).get("questions", []):
+        if question.get("kind") != kind or question.get("concept") != concept:
+            continue
+        parameters = question.get("parameters", {})
+        for language_key in _exam_language_keys(kind):
+            if parameters.get(language_key) == language:
+                return cid_of_json(question)
+    return None
+
+
+def _exam_language_keys(kind: str) -> tuple[str, ...]:
+    if kind == "morphism":
+        return ("from_language",)
+    if kind in {"boundary-realization", "realization"}:
+        return ("target_language",)
+    if kind in {
+        "concept-realization",
+        "effect-classification",
+        "sort-classification",
+        "effect",
+        "sort",
+    }:
+        return ("language",)
+    return ("language", "from_language", "target_language")
+
+
+def _load_exam_manifest() -> Json | None:
+    env_path = os.environ.get("PROVEKIT_EXAM_MANIFEST")
+    paths: list[Path] = []
+    if env_path:
+        paths.append(Path(env_path))
+    for base in [Path.cwd(), *Path(__file__).resolve().parents]:
+        paths.append(base / "menagerie" / "concept-shapes" / "exams" / EXAM_MANIFEST_BASENAME)
+    for path in paths:
+        try:
+            if path.is_file():
+                return json.loads(path.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+    return None
 
 
 def _contains_refused_control(fn: ast.FunctionDef) -> _UnsupportedSyntax | None:

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -16,7 +16,11 @@ from provekit_lift_py_tests.canonicalizer import jcs_hash, vobj, vstr
 
 from provekit_lift_python_source.canonical import canonical_json_bytes, cid_of_json
 from provekit_lift_python_source.compiler import compile_body_term, compile_ir_document
-from provekit_lift_python_source.lifter import lift_source
+from provekit_lift_python_source.lifter import (
+    EXAM_MANIFEST_CID,
+    _exam_question_cid_for,
+    lift_source,
+)
 from provekit_lift_python_source.rpc import initialize_result
 
 
@@ -90,6 +94,37 @@ def test_refuses_unhandled_syntax_without_unknown_ops() -> None:
     assert "ListComp" in refusal["reason"]
     assert "python:unknown" not in _canon(result.refusals)
     assert "python:skip" not in _canon(result.refusals)
+
+
+def test_unhandled_syntax_refusal_cites_v1_1_exam_question() -> None:
+    source = "def bad(xs):\n    return [x for x in xs]\n"
+
+    result = lift_source(source, "badmodule.py")
+
+    refusal = result.refusals[0]
+    expected = _exam_question_cid_for("sort-classification", "concept:List<T>", "python")
+    assert refusal["kind"] == "unhandled-syntax"
+    assert refusal["exam_manifest_cid"] == EXAM_MANIFEST_CID
+    assert refusal["exam_question_cid"] == expected
+
+
+def test_list_comprehension_refusal_does_not_fire_different_variant() -> None:
+    source = "def bad(xs):\n    return [x for x in xs]\n"
+
+    result = lift_source(source, "badmodule.py")
+
+    assert [refusal["kind"] for refusal in result.refusals] == ["unhandled-syntax"]
+    assert "syntax-error" not in _canon(result.refusals)
+
+
+def test_unhandled_syntax_refusal_cites_list_question_not_related_sort() -> None:
+    source = "def bad(xs):\n    return [x for x in xs]\n"
+
+    result = lift_source(source, "badmodule.py")
+
+    refusal_cid = result.refusals[0]["exam_question_cid"]
+    related = _exam_question_cid_for("sort-classification", "concept:Map<K,V>", "python")
+    assert refusal_cid != related
 
 
 def test_effects_are_sorted_and_loop_cid_is_blake3_512() -> None:

--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -5,8 +5,9 @@ use std::path::{Path, PathBuf};
 
 use provekit_canonicalizer::blake3_512_of;
 use provekit_ir_types::{
-    IrFormula, IrTerm, PromotionDecisionEnvelope, PromotionDecisionHeader,
-    PromotionDecisionMemento, PromotionDecisionMetadata, PromotionGate, PromotionResult, Sort,
+    ExamManifestMemento, GapKind, IrFormula, IrTerm, OptionStatus, PromotionDecisionEnvelope,
+    PromotionDecisionHeader, PromotionDecisionMemento, PromotionDecisionMetadata, PromotionGate,
+    PromotionResult, ResolutionOption, ResolutionOptionKind, Sort, TransportGapMemento,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as Json};
@@ -30,12 +31,15 @@ const CONCEPT_SEQ: &str = "concept:seq";
 pub struct BindOptions {
     /// Source language hint for diagnostics and named-term metadata.
     pub lang: String,
+    /// Optional exam manifest used to cite refusal questions in gap records.
+    pub exam_manifest: Option<ExamManifestMemento>,
 }
 
 impl Default for BindOptions {
     fn default() -> Self {
         Self {
             lang: "auto".to_string(),
+            exam_manifest: None,
         }
     }
 }
@@ -185,6 +189,12 @@ pub struct BindContractWitness {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NamedTermDocument {
+    #[serde(
+        default,
+        rename = "gapRecords",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub gap_records: Vec<Json>,
     pub kind: String,
     #[serde(rename = "promotionDecisionMementos")]
     pub promotion_decision_mementos: Vec<PromotionDecisionMemento>,
@@ -262,6 +272,7 @@ pub fn bind_term_document(
     let mut seen_names: BTreeSet<String> = BTreeSet::new();
     let mut terms = Vec::with_capacity(entries.len());
     let mut decisions = Vec::new();
+    let mut gap_records = Vec::new();
     let mut operation_namer = UnnamedConceptNamer::default();
     for (idx, entry) in entries.into_iter().enumerate() {
         let concept_name = concept_name_for(&entry, idx + 1, &catalog);
@@ -283,6 +294,14 @@ pub fn bind_term_document(
             &site_memento_cid,
             &witnesses,
         )?);
+        if witnesses.is_empty() {
+            gap_records.push(wp_rule_synthesis_gap_record(
+                &source_language,
+                &term_shape_cid,
+                &concept_name,
+                options.exam_manifest.as_ref(),
+            )?);
+        }
         terms.push(NamedTerm {
             concept_name,
             discharge_verdict: if witnesses.is_empty() {
@@ -309,6 +328,7 @@ pub fn bind_term_document(
     }
 
     Ok(NamedTermDocument {
+        gap_records,
         kind: "named-term-document".to_string(),
         promotion_decision_mementos: decisions,
         schema_version: "1".to_string(),
@@ -953,14 +973,19 @@ fn named_term_citation_term(
 }
 
 fn document_metadata_value(named: &NamedTermDocument) -> Result<Json, BindError> {
-    Ok(json!({
+    let mut value = json!({
         "kind": named.kind.clone(),
         "promotionDecisionMementos": serde_json::to_value(&named.promotion_decision_mementos)
             .map_err(|error| BindError::Failed(format!("serialize promotion decisions: {error}")))?,
         "schemaVersion": named.schema_version.clone(),
         "sourceLanguage": named.source_language.clone(),
         "workspaceRoot": named.workspace_root.clone(),
-    }))
+    });
+    if !named.gap_records.is_empty() {
+        value["gapRecords"] = serde_json::to_value(&named.gap_records)
+            .map_err(|error| BindError::Failed(format!("serialize gap records: {error}")))?;
+    }
+    Ok(value)
 }
 
 fn named_term_document_from_op_tree(term: &Term) -> Result<NamedTermDocument, BindError> {
@@ -980,6 +1005,13 @@ fn named_term_document_from_op_tree(term: &Term) -> Result<NamedTermDocument, Bi
         .transpose()
         .map_err(|error| BindError::Failed(format!("parse promotion decisions: {error}")))?
         .unwrap_or_default();
+    let gap_records = document
+        .get("gapRecords")
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| BindError::Failed(format!("parse gap records: {error}")))?
+        .unwrap_or_default();
     let terms = citations
         .into_iter()
         .map(|(_, citation)| {
@@ -992,6 +1024,7 @@ fn named_term_document_from_op_tree(term: &Term) -> Result<NamedTermDocument, Bi
         })
         .collect::<Result<Vec<_>, _>>()?;
     Ok(NamedTermDocument {
+        gap_records,
         kind: document
             .get("kind")
             .and_then(Json::as_str)
@@ -1108,6 +1141,67 @@ fn promotion_decisions(
             Ok(decision)
         })
         .collect()
+}
+
+fn wp_rule_synthesis_gap_record(
+    source_lang: &str,
+    source_op_cid: &str,
+    concept_name: &str,
+    exam_manifest: Option<&ExamManifestMemento>,
+) -> Result<Json, BindError> {
+    let target_concept_op = normalize_concept_name(concept_name);
+    let (exam_question_cid, exam_manifest_cid) = crate::exam_manifest::exam_question_citation(
+        exam_manifest,
+        "morphism",
+        &target_concept_op,
+        source_lang,
+        "bind",
+    );
+    let gap = TransportGapMemento {
+        exam_manifest_cid,
+        exam_question_cid,
+        fn_name: format!(
+            "gap:{}:bind:to:{}:wp-rule",
+            source_lang,
+            target_concept_op.trim_start_matches("concept:")
+        ),
+        gap_kind: GapKind::WpRuleMismatch,
+        kind: "TransportGapMemento".to_string(),
+        reason: None,
+        reason_note: Some(
+            "bind refused to synthesize a wp_rule without lifted contract evidence".to_string(),
+        ),
+        resolution_options: vec![ResolutionOption {
+            dual_view_cid: None,
+            loss: None,
+            loss_severity: None,
+            option_kind: ResolutionOptionKind::AcceptPermanent,
+            partial_morphism_cid: None,
+            precondition: None,
+            representation_map_delta: None,
+            respec_target_to: None,
+            split_targets: None,
+            status: OptionStatus::Deferred,
+            tradeoff: "provide source evidence or a catalog wp_rule before treating the bind as exact"
+                .to_string(),
+        }],
+        schema_version: "1".to_string(),
+        signature: None,
+        source_lang: source_lang.to_string(),
+        source_op_cid: source_op_cid.to_string(),
+        target_concept_op,
+        target_op_cid: None,
+    };
+    serde_json::to_value(gap)
+        .map_err(|error| BindError::Failed(format!("serialize wp_rule gap: {error}")))
+}
+
+fn normalize_concept_name(name: &str) -> String {
+    if name.starts_with("concept:") {
+        name.to_string()
+    } else {
+        format!("concept:{name}")
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1389,6 +1483,7 @@ mod tests {
             &term,
             &BindOptions {
                 lang: "rust".to_string(),
+                exam_manifest: None,
             },
         )
         .expect("bind succeeds");
@@ -1435,6 +1530,7 @@ mod tests {
             });
             BindKit::new(BindOptions {
                 lang: "rust".to_string(),
+                exam_manifest: None,
             })
             .bind_term_from_input(&input)
             .expect("bind succeeds")
@@ -1499,6 +1595,7 @@ mod tests {
 
         let kit = BindKit::new(BindOptions {
             lang: "rust".to_string(),
+            exam_manifest: None,
         });
 
         let add_claim = kit
@@ -1520,9 +1617,10 @@ mod tests {
 
     #[test]
     fn named_term_document_cid_ignores_source_function_name() {
-        fn document(function: &str) -> NamedTermDocument {
-            NamedTermDocument {
-                kind: "named-term-document".to_string(),
+            fn document(function: &str) -> NamedTermDocument {
+                NamedTermDocument {
+                    gap_records: vec![],
+                    kind: "named-term-document".to_string(),
                 promotion_decision_mementos: vec![],
                 schema_version: "1".to_string(),
                 source_language: "rust".to_string(),
@@ -1554,6 +1652,7 @@ mod tests {
     #[test]
     fn named_term_document_omits_empty_source_provenance_fields() {
         let document = NamedTermDocument {
+            gap_records: vec![],
             kind: "named-term-document".to_string(),
             promotion_decision_mementos: vec![],
             schema_version: "1".to_string(),
@@ -1677,6 +1776,7 @@ mod tests {
             &term,
             &BindOptions {
                 lang: "rust".to_string(),
+                exam_manifest: None,
             },
         )
         .expect("bind succeeds");

--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -63,6 +63,6 @@ pub use types::{
 };
 pub use verbs::{cross_compile, link, prove, realize, transform, verify};
 pub use walks::{
-    assert_concept_tier, walk_premises_to_root, walk_premises_to_root_with_failure_steps,
-    ChainBreak, ChainWalkFailure, HubMissingNode,
+    assert_concept_tier, assert_concept_tier_with_exam_manifest, walk_premises_to_root,
+    walk_premises_to_root_with_failure_steps, ChainBreak, ChainWalkFailure, HubMissingNode,
 };

--- a/implementations/rust/libprovekit/src/core/walks.rs
+++ b/implementations/rust/libprovekit/src/core/walks.rs
@@ -24,6 +24,7 @@ use std::fmt;
 
 use super::traits::Catalog;
 use super::types::{domain_claim_from_canonical_bytes, Cid, DomainClaim, Term};
+use provekit_ir_types::ExamManifestMemento;
 
 /// Structural reason a premise walk failed.
 ///
@@ -280,6 +281,10 @@ fn walk_inner(
 /// catalog's hub view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HubMissingNode {
+    /// CID of the exam manifest cited by this refusal, when it maps to one.
+    pub exam_manifest_cid: Option<String>,
+    /// CID of the specific exam question cited by this refusal, when it maps to one.
+    pub exam_question_cid: Option<String>,
     /// The operation CID that was absent from the catalog.
     pub node_op_cid: Cid,
     /// Slot path from the root term to the offending operation node, in the
@@ -306,15 +311,43 @@ impl std::error::Error for HubMissingNode {}
 /// the offending op CID and its term position. Constants, vars, and unit
 /// nodes are skipped because they carry no operation CID.
 pub fn assert_concept_tier(term: &Term, catalog: &dyn Catalog) -> Result<(), HubMissingNode> {
+    assert_concept_tier_with_exam_manifest(term, catalog, "unknown", None)
+}
+
+pub fn assert_concept_tier_with_exam_manifest(
+    term: &Term,
+    catalog: &dyn Catalog,
+    source_lang: &str,
+    manifest: Option<&ExamManifestMemento>,
+) -> Result<(), HubMissingNode> {
     for node in term.walk() {
         if !catalog.contains(node.op_cid) {
+            let concept = normalize_concept_name(node.op_name);
+            let (exam_question_cid, exam_manifest_cid) =
+                crate::exam_manifest::exam_question_citation(
+                    manifest,
+                    "morphism",
+                    &concept,
+                    source_lang,
+                    "concept-tier",
+                );
             return Err(HubMissingNode {
+                exam_manifest_cid,
+                exam_question_cid,
                 node_op_cid: node.op_cid.clone(),
                 term_position: node.term_position.clone(),
             });
         }
     }
     Ok(())
+}
+
+fn normalize_concept_name(name: &str) -> String {
+    if name.starts_with("concept:") {
+        name.to_string()
+    } else {
+        format!("concept:{name}")
+    }
 }
 
 #[cfg(test)]
@@ -725,5 +758,63 @@ mod tests {
         let err = assert_concept_tier(&term, &catalog).expect_err("missing op CID must be refused");
         assert_eq!(err.node_op_cid, missing_cid);
         assert_eq!(err.term_position, vec![1]);
+    }
+
+    #[test]
+    fn assert_concept_tier_gap_cites_v1_1_exam_question_when_op_is_absent() {
+        let manifest =
+            crate::exam_manifest::load_default_exam_manifest().expect("v1.1 manifest loads");
+        let missing_cid = address(&"op:add-missing");
+        let catalog = HashMapCatalog::default();
+        let term = make_op("add", missing_cid.clone(), vec![const_leaf()]);
+
+        let err =
+            assert_concept_tier_with_exam_manifest(&term, &catalog, "rust", Some(&manifest))
+                .expect_err("missing concept-tier op must be refused");
+
+        let expected =
+            crate::exam_manifest::exam_question_cid_for(&manifest, "morphism", "concept:add", "rust")
+                .expect("lookup succeeds")
+                .expect("add/rust question exists");
+        assert_eq!(err.node_op_cid, missing_cid);
+        assert_eq!(err.exam_manifest_cid.as_deref(), Some(manifest.header.cid.as_str()));
+        assert_eq!(err.exam_question_cid.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn assert_concept_tier_gap_does_not_fire_when_op_is_catalogued() {
+        let manifest =
+            crate::exam_manifest::load_default_exam_manifest().expect("v1.1 manifest loads");
+        let add_cid = address(&"op:add-present-for-citation");
+        let mut catalog = HashMapCatalog::default();
+        catalog.put(add_cid.clone(), b"add-op".to_vec());
+        let term = make_op("add", add_cid, vec![const_leaf()]);
+
+        assert_concept_tier_with_exam_manifest(&term, &catalog, "rust", Some(&manifest))
+            .expect("catalogued op is concept-tier");
+    }
+
+    #[test]
+    fn assert_concept_tier_gap_cites_exact_question_not_related_concept() {
+        let manifest =
+            crate::exam_manifest::load_default_exam_manifest().expect("v1.1 manifest loads");
+        let missing_cid = address(&"op:sub-missing");
+        let catalog = HashMapCatalog::default();
+        let term = make_op("sub", missing_cid, vec![const_leaf()]);
+
+        let err =
+            assert_concept_tier_with_exam_manifest(&term, &catalog, "rust", Some(&manifest))
+                .expect_err("missing concept-tier op must be refused");
+
+        let sub_question =
+            crate::exam_manifest::exam_question_cid_for(&manifest, "morphism", "concept:sub", "rust")
+                .expect("lookup succeeds")
+                .expect("sub/rust question exists");
+        let add_question =
+            crate::exam_manifest::exam_question_cid_for(&manifest, "morphism", "concept:add", "rust")
+                .expect("lookup succeeds")
+                .expect("add/rust question exists");
+        assert_eq!(err.exam_question_cid.as_deref(), Some(sub_question.as_str()));
+        assert_ne!(err.exam_question_cid.as_deref(), Some(add_question.as_str()));
     }
 }

--- a/implementations/rust/libprovekit/src/exam_manifest.rs
+++ b/implementations/rust/libprovekit/src/exam_manifest.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use provekit_ir_types::{ExamManifestMemento, IrFormula, IrTerm, Sort};
+use provekit_ir_types::{ExamManifestMemento, ExamQuestion, IrFormula, IrTerm, Sort};
 use serde_json::Value;
 
 use crate::core::primitives::address;
@@ -18,6 +18,10 @@ use crate::core::types::{
 
 const EXAM_MANIFEST_CONFORMANCE_REASON: &str =
     "loads exam-manifest mementos via PEP 1.7.0; no target source emission";
+pub const DEFAULT_EXAM_MANIFEST_CID: &str = "blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc";
+pub const DEFAULT_EXAM_MANIFEST_JSON: &str = include_str!(
+    "../../../../menagerie/concept-shapes/exams/v1.1.blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc.json"
+);
 
 pub struct ExamManifestKit {}
 
@@ -140,6 +144,69 @@ impl Kit for ExamManifestKit {
     }
 }
 
+pub fn load_default_exam_manifest() -> Result<ExamManifestMemento, KitError> {
+    let manifest: ExamManifestMemento = serde_json::from_str(DEFAULT_EXAM_MANIFEST_JSON)
+        .map_err(|error| KitError::Transformation(format!("parse default exam manifest: {error}")))?;
+    validate_manifest(&manifest)?;
+    if manifest.header.cid != DEFAULT_EXAM_MANIFEST_CID {
+        return Err(KitError::Transformation(format!(
+            "default exam manifest cid mismatch: declared {}, expected {}",
+            manifest.header.cid, DEFAULT_EXAM_MANIFEST_CID
+        )));
+    }
+    Ok(manifest)
+}
+
+pub fn exam_question_cid(question: &ExamQuestion) -> Result<String, KitError> {
+    crate::canonical::serializable_cid(question)
+        .map_err(|error| KitError::Transformation(format!("cid exam question: {error}")))
+}
+
+pub fn exam_question_cid_for(
+    manifest: &ExamManifestMemento,
+    kind: &str,
+    concept: &str,
+    language: &str,
+) -> Result<Option<String>, KitError> {
+    for question in &manifest.header.content.questions {
+        if question.kind.as_str() != kind || question.concept != concept {
+            continue;
+        }
+        if !question_matches_language(question, kind, language) {
+            continue;
+        }
+        return exam_question_cid(question).map(Some);
+    }
+    Ok(None)
+}
+
+pub fn exam_question_citation(
+    manifest: Option<&ExamManifestMemento>,
+    kind: &str,
+    concept: &str,
+    language: &str,
+    diagnostic_scope: &str,
+) -> (Option<String>, Option<String>) {
+    let Some(manifest) = manifest else {
+        return (None, None);
+    };
+    match exam_question_cid_for(manifest, kind, concept, language) {
+        Ok(Some(question_cid)) => (Some(question_cid), Some(manifest.header.cid.clone())),
+        Ok(None) => {
+            eprintln!(
+                "[{diagnostic_scope}] no exam question citation for kind={kind} concept={concept} language={language}"
+            );
+            (None, None)
+        }
+        Err(error) => {
+            eprintln!(
+                "[{diagnostic_scope}] exam question citation failed for kind={kind} concept={concept} language={language}: {error}"
+            );
+            (None, None)
+        }
+    }
+}
+
 fn validate_manifest(manifest: &ExamManifestMemento) -> Result<(), KitError> {
     manifest
         .validate()
@@ -154,6 +221,24 @@ fn validate_manifest(manifest: &ExamManifestMemento) -> Result<(), KitError> {
         )));
     }
     Ok(())
+}
+
+fn question_matches_language(question: &ExamQuestion, kind: &str, language: &str) -> bool {
+    let keys: &[&str] = match kind {
+        "morphism" => &["from_language"],
+        "boundary-realization" => &["target_language"],
+        "concept-realization" | "effect-classification" | "sort-classification" => &["language"],
+        "realization" => &["target_language"],
+        "effect" | "sort" => &["language"],
+        _ => &["language", "from_language", "target_language"],
+    };
+    keys.iter().any(|key| {
+        question
+            .parameters
+            .get(*key)
+            .and_then(serde_json::Value::as_str)
+            == Some(language)
+    })
 }
 
 fn exam_manifest_contract(manifest_value: &Value, manifest_cid: &Cid) -> crate::core::Contract {

--- a/implementations/rust/libprovekit/tests/bind_kit.rs
+++ b/implementations/rust/libprovekit/tests/bind_kit.rs
@@ -7,7 +7,7 @@ use libprovekit::core::{
     BindKit, BindOptions, Input, Kit, Term,
 };
 use libprovekit::proofir_bridge::CatalogIndex;
-use provekit_ir_types::Sort;
+use provekit_ir_types::{ExamManifestMemento, Sort};
 use serde_json::{json, Value};
 
 fn primitive_sort(name: &str) -> Sort {
@@ -30,6 +30,10 @@ fn repo_root() -> PathBuf {
 fn concept_catalog() -> CatalogIndex {
     CatalogIndex::from_catalog_root(repo_root().join("menagerie/concept-shapes/catalog"))
         .expect("concept-shapes catalog loads")
+}
+
+fn v1_1_exam_manifest() -> ExamManifestMemento {
+    libprovekit::exam_manifest::load_default_exam_manifest().expect("v1.1 exam manifest loads")
 }
 
 fn bind_input_value() -> Value {
@@ -61,6 +65,16 @@ fn bind_input_value() -> Value {
             }]
         }]
     })
+}
+
+fn witnessless_concept_input(concept: &str) -> Value {
+    let mut value = bind_input_value();
+    let entry = value["ir"][0]
+        .as_object_mut()
+        .expect("bind-lift-entry is object");
+    entry.insert("concept_annotation".to_string(), json!(concept));
+    entry.insert("witnesses".to_string(), json!([]));
+    value
 }
 
 #[test]
@@ -141,4 +155,83 @@ fn bind_kit_transform_emits_bind_result_op_tree() {
         libprovekit::canonical::serializable_jcs(second_payload)
             .expect("second payload canonicalizes")
     );
+}
+
+#[test]
+fn bind_gap_record_cites_exam_question_when_wp_rule_synthesis_refuses() {
+    let manifest = v1_1_exam_manifest();
+    let input = witnessless_concept_input("add");
+
+    let named = bind_term_document(
+        &input,
+        &BindOptions {
+            lang: "rust".to_string(),
+            exam_manifest: Some(manifest.clone()),
+        },
+    )
+    .expect("bind succeeds");
+    let named_json = serde_json::to_value(&named).expect("named term serializes");
+    let gap = named_json["gapRecords"]
+        .as_array()
+        .expect("gapRecords array")
+        .first()
+        .expect("gap record emitted");
+    let expected_question = libprovekit::exam_manifest::exam_question_cid_for(
+        &manifest,
+        "morphism",
+        "concept:add",
+        "rust",
+    )
+    .expect("lookup add/rust")
+    .expect("add/rust question exists");
+
+    assert_eq!(gap["kind"], "TransportGapMemento");
+    assert_eq!(gap["gap_kind"], "wp-rule-mismatch");
+    assert_eq!(gap["target_concept_op"], "concept:add");
+    assert_eq!(gap["exam_manifest_cid"], manifest.header.cid);
+    assert_eq!(gap["exam_question_cid"], expected_question);
+}
+
+#[test]
+fn bind_gap_record_not_emitted_for_exact_witnessed_entry() {
+    let named = bind_term_document(
+        &bind_input_value(),
+        &BindOptions {
+            lang: "rust".to_string(),
+            exam_manifest: Some(v1_1_exam_manifest()),
+        },
+    )
+    .expect("bind succeeds");
+    let named_json = serde_json::to_value(&named).expect("named term serializes");
+
+    assert!(named_json.get("gapRecords").is_none());
+}
+
+#[test]
+fn bind_gap_record_cites_exact_question_not_related_concept() {
+    let manifest = v1_1_exam_manifest();
+    let input = witnessless_concept_input("add");
+
+    let named = bind_term_document(
+        &input,
+        &BindOptions {
+            lang: "rust".to_string(),
+            exam_manifest: Some(manifest.clone()),
+        },
+    )
+    .expect("bind succeeds");
+    let named_json = serde_json::to_value(&named).expect("named term serializes");
+    let gap_question = named_json["gapRecords"][0]["exam_question_cid"]
+        .as_str()
+        .expect("gap cites question");
+    let related_question = libprovekit::exam_manifest::exam_question_cid_for(
+        &manifest,
+        "morphism",
+        "concept:sub",
+        "rust",
+    )
+    .expect("lookup sub/rust")
+    .expect("sub/rust question exists");
+
+    assert_ne!(gap_question, related_question);
 }

--- a/implementations/rust/libprovekit/tests/exam_manifest_smoke.rs
+++ b/implementations/rust/libprovekit/tests/exam_manifest_smoke.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use provekit_ir_types::ExamManifestMemento;
 
 const EXPECTED_EXAM_MANIFEST_CID: &str = "blake3-512:0e0dc132f3e8bf58da065d7fc237e85c225c5c87fbc690a19a42d594e9b1e46ed78e8f0f5a855fa1b75581745f588a4737adb17bc59e9a72b3bb9f6bcb665dd0";
+const EXPECTED_V1_1_EXAM_MANIFEST_CID: &str = "blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc";
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -33,4 +34,57 @@ fn exam_manifest_fixture_loads_and_pins_cid() {
         manifest.recompute_header_cid().expect("recompute cid"),
         EXPECTED_EXAM_MANIFEST_CID
     );
+}
+
+#[test]
+fn v1_1_manifest_loads_and_finds_question_cid_by_kind_concept_and_language() {
+    let manifest = libprovekit::exam_manifest::load_default_exam_manifest()
+        .expect("default v1.1 exam manifest loads");
+    assert_eq!(manifest.header.cid, EXPECTED_V1_1_EXAM_MANIFEST_CID);
+
+    let add_rust = libprovekit::exam_manifest::exam_question_cid_for(
+        &manifest,
+        "morphism",
+        "concept:add",
+        "rust",
+    )
+    .expect("lookup add/rust")
+    .expect("add/rust exists");
+    let sub_rust = libprovekit::exam_manifest::exam_question_cid_for(
+        &manifest,
+        "morphism",
+        "concept:sub",
+        "rust",
+    )
+    .expect("lookup sub/rust")
+    .expect("sub/rust exists");
+    let add_python = libprovekit::exam_manifest::exam_question_cid_for(
+        &manifest,
+        "morphism",
+        "concept:add",
+        "python",
+    )
+    .expect("lookup add/python")
+    .expect("add/python exists");
+
+    let expected = manifest
+        .header
+        .content
+        .questions
+        .iter()
+        .find(|question| {
+            question.kind.as_str() == "morphism"
+                && question.concept == "concept:add"
+                && question.parameters.get("from_language").and_then(|v| v.as_str())
+                    == Some("rust")
+        })
+        .expect("fixture has add/rust")
+        .to_owned();
+    assert_eq!(
+        add_rust,
+        libprovekit::exam_manifest::exam_question_cid(&expected)
+            .expect("question cid computes")
+    );
+    assert_ne!(add_rust, sub_rust);
+    assert_ne!(add_rust, add_python);
 }

--- a/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
+++ b/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
@@ -194,6 +194,7 @@ fn bind_claim() -> DomainClaim {
     };
     BindKit::new(BindOptions {
         lang: "rust".to_string(),
+        exam_manifest: None,
     })
     .transform(&Input::Term(input_term))
     .expect("bind kit transforms term input")

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -12,13 +12,19 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 
 use clap::Parser;
-use libprovekit::core::{bind_term_document, BindOptions};
+use libprovekit::core::{
+    address, bind_term_document, execute_path, BindKit, BindOptions, ConformanceDeclaration,
+    HashMapInputCatalog, Input, KitRegistry, Path as CorePath, PathAlgebra, PathExecutionError,
+    Term, Verb,
+};
 use owo_colors::OwoColorize;
+use provekit_ir_types::{CompositionRefusalMemento, Sort};
 use serde_json::Value as Json;
 
+use crate::kit_dispatch::dispatch_exam_manifest;
 use crate::{EXIT_OK, EXIT_USER_ERROR};
 
-pub use libprovekit::core::NamedTermDocument;
+pub use libprovekit::core::{NamedTerm, NamedTermDocument};
 
 #[derive(Parser, Debug, Clone)]
 pub struct BindArgs {
@@ -36,6 +42,14 @@ pub struct BindArgs {
     /// Source language hint for diagnostics and named-term metadata.
     #[arg(long, default_value = "auto")]
     pub lang: String,
+
+    /// Exam manifest path or CID used to cite bind refusal gap records.
+    #[arg(long)]
+    pub exam_manifest: Option<String>,
+
+    /// Exam-manifest plugin name. Falls back to the built-in loader when absent.
+    #[arg(long, default_value = "default")]
+    pub exam_manifest_plugin: String,
 
     /// Legacy threshold hint. No effect in the four-verb model.
     #[arg(long, default_value = "1")]
@@ -180,25 +194,79 @@ pub fn run(args: BindArgs) -> u8 {
 }
 
 fn run_bind_path(term_json: Json, args: &BindArgs) -> Result<Json, BindCliError> {
-    let named = bind_term_document(
-        &term_json,
-        &BindOptions {
-            lang: args.lang.clone(),
+    let exam_manifest = args
+        .exam_manifest
+        .as_deref()
+        .map(|target| {
+            dispatch_exam_manifest(&args.root, &args.exam_manifest_plugin, target)
+                .map_err(|error| BindCliError::Failed(error.to_string()))
+        })
+        .transpose()?;
+    let term = Term::Const {
+        value: term_json,
+        sort: Sort::Primitive {
+            name: "LiftPluginResponse".to_string(),
         },
-    )
-    .map_err(|error| BindCliError::Failed(error.to_string()))?;
-    serde_json::to_value(&named)
-        .map_err(|error| BindCliError::Failed(format!("serialize named terms: {error}")))
+    };
+    let term_cid = address(&term);
+    let mut inputs = HashMapInputCatalog::default();
+    inputs.put(term_cid.clone(), Input::Term(term));
+    let path_input = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "bind".to_string(),
+            kit: "bind-default".to_string(),
+            inputs: vec![term_cid],
+            depends_on: vec![],
+            verb: Verb::Transform,
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register(
+        "bind-default",
+        BindKit::new(BindOptions {
+            lang: args.lang.clone(),
+            exam_manifest,
+        }),
+        ConformanceDeclaration::NonCarrier {
+            reason: "transforms Input::Term to NamedTerm DomainClaim; emits no target source",
+        },
+    );
+    let chain = execute_path(&path_input, &registry, &inputs).map_err(BindCliError::from_path)?;
+    let claim = chain.terminal_claim();
+    let payload = claim
+        .payload
+        .as_ref()
+        .ok_or_else(|| BindCliError::Failed("bind claim missing term payload".to_string()))?;
+    serde_json::to_value(payload)
+        .map_err(|error| BindCliError::Failed(format!("serialize bind payload: {error}")))
 }
 
 #[derive(Debug)]
 enum BindCliError {
+    Refused(Box<CompositionRefusalMemento>),
     Failed(String),
+}
+
+impl BindCliError {
+    fn from_path(error: PathExecutionError) -> Self {
+        match error {
+            PathExecutionError::Refused(refusal) => Self::Refused(refusal),
+            other => Self::Failed(other.to_string()),
+        }
+    }
 }
 
 impl std::fmt::Display for BindCliError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Refused(refusal) => {
+                f.write_str(&serde_json::to_string(refusal).unwrap_or_else(|_| {
+                    format!(
+                        "{}: {}",
+                        refusal.header.failure_kind, refusal.header.failure_detail
+                    )
+                }))
+            }
             Self::Failed(message) => f.write_str(message),
         }
     }

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -1015,9 +1015,10 @@ fn java_home_from_maven() -> Option<String> {
 // ============================================================================
 
 const EXAM_MANIFEST_KIND: &str = "exam-manifest";
-const EXAM_MANIFEST_SCHEMA_VERSION: &str = "provekit-exam-manifest/v1";
+const EXAM_MANIFEST_SCHEMA_VERSION: &str = "provekit-exam-manifest/v1.1";
+const EXAM_MANIFEST_SCHEMA_VERSION_V1: &str = "provekit-exam-manifest/v1";
 const PEP_1_7_0: &str = "pep/1.7.0";
-pub const DEFAULT_EXAM_MANIFEST_CID: &str = "blake3-512:0e012db4ce35b235b8482344795ccbe8bccad51522825b5c495a862648736936497b11a940cf0ba9170ee6202849e9a8dc9eca5cb3021261ffa2f4ac4df6edc1";
+pub const DEFAULT_EXAM_MANIFEST_CID: &str = "blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc";
 #[allow(dead_code)]
 pub const EXAM_MANIFEST_MISMATCH_REASON: &str = "exam-manifest-mismatch";
 
@@ -1242,11 +1243,14 @@ fn validate_exam_manifest_plugin_manifest(
             EXAM_MANIFEST_KIND
         ));
     }
-    if parsed.exam_manifest_schema_version.as_deref() != Some(EXAM_MANIFEST_SCHEMA_VERSION) {
+    if parsed.exam_manifest_schema_version.as_deref() != Some(EXAM_MANIFEST_SCHEMA_VERSION)
+        && parsed.exam_manifest_schema_version.as_deref() != Some(EXAM_MANIFEST_SCHEMA_VERSION_V1)
+    {
         return Err(format!(
-            "manifest {} must declare [capabilities].exam_manifest_schema_version = \"{}\"",
+            "manifest {} must declare [capabilities].exam_manifest_schema_version = \"{}\" or \"{}\"",
             manifest.display(),
-            EXAM_MANIFEST_SCHEMA_VERSION
+            EXAM_MANIFEST_SCHEMA_VERSION,
+            EXAM_MANIFEST_SCHEMA_VERSION_V1
         ));
     }
     Ok(())

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -38,6 +38,38 @@ fn term_document() -> &'static [u8] {
 }"#
 }
 
+fn witnessless_add_term_document() -> &'static [u8] {
+    br#"{
+  "kind": "ir-document",
+  "sourceLanguage": "rust",
+  "workspaceRoot": "/tmp/provekit-bind-test",
+  "ir": [{
+    "kind": "bind-lift-entry",
+    "file": "src/lib.rs",
+    "fn_name": "add",
+    "fn_line": 4,
+    "concept_annotation": "add",
+    "param_names": ["x", "y"],
+    "param_types": ["i64", "i64"],
+    "return_type": "i64",
+    "term_shape": {"kind": "bin", "op": "+"},
+    "term_shape_cid": "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+    "witnesses": []
+  }]
+}"#
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
 fn assert_success(label: &str, output: &std::process::Output) {
     assert!(
         output.status.success(),
@@ -140,4 +172,47 @@ fn bind_does_not_require_or_invoke_language_lower_plugins() {
         .output()
         .expect("spawn bind");
     assert_success("bind ignores lower plugin", &output);
+}
+
+#[test]
+fn bind_cli_cites_v1_1_exam_question_for_wp_rule_refusal() {
+    let root = repo_root();
+    let manifest = root
+        .join("menagerie/concept-shapes/exams")
+        .join("v1.1.blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc.json");
+    let mut child = Command::new(provekit_bin())
+        .arg("bind")
+        .arg("--project")
+        .arg(&root)
+        .arg("--exam-manifest")
+        .arg(&manifest)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bind");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(witnessless_add_term_document())
+        .expect("write term");
+    let output = child.wait_with_output().expect("wait bind");
+    assert_success("bind stdin with exam manifest", &output);
+
+    let payload: Term = serde_json::from_slice(&output.stdout).expect("bind payload parses");
+    let named =
+        named_term_document_from_bind_payload(&payload).expect("bind payload recovers named term");
+    let named = serde_json::to_value(named).expect("named term serializes");
+    let gap = named["gapRecords"][0].as_object().expect("gap object");
+
+    assert_eq!(gap["target_concept_op"], "concept:add");
+    assert_eq!(
+        gap["exam_manifest_cid"],
+        "blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc"
+    );
+    assert!(gap["exam_question_cid"]
+        .as_str()
+        .expect("exam question cid")
+        .starts_with("blake3-512:"));
 }

--- a/implementations/rust/provekit-cli/tests/federation_handshake_test.rs
+++ b/implementations/rust/provekit-cli/tests/federation_handshake_test.rs
@@ -27,14 +27,16 @@ fn registry_memento_serializes_optional_exam_manifest_fields() {
         memento.header.exam_manifest_cid.as_deref(),
         Some(DEFAULT_EXAM_MANIFEST_CID)
     );
+    // exam_manifest_set is sorted lex-ascending for canonical CID determinism
+    // (federation requires byte-identical bytes regardless of caller insertion order).
+    let mut expected_set = vec![
+        DEFAULT_EXAM_MANIFEST_CID.to_string(),
+        OTHER_EXAM_MANIFEST_CID.to_string(),
+    ];
+    expected_set.sort();
     assert_eq!(
         memento.header.exam_manifest_set.as_deref(),
-        Some(
-            &[
-                DEFAULT_EXAM_MANIFEST_CID.to_string(),
-                OTHER_EXAM_MANIFEST_CID.to_string(),
-            ][..]
-        )
+        Some(&expected_set[..])
     );
 
     let json = serde_json::to_string(&memento).expect("serialize registry memento");

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -1342,13 +1342,20 @@ pub struct ResolutionOption {
 /// hub op at all; `target_op_cid` is absent in that case.
 ///
 /// Locked JCS key order (alphabetical):
-///   fn_name, gap_kind, kind, reason (omitted when absent),
-///   reason_note (omitted when absent), resolution_options,
-///   schema_version, signature (omitted when absent),
+///   exam_manifest_cid (omitted when absent),
+///   exam_question_cid (omitted when absent), fn_name, gap_kind, kind,
+///   reason (omitted when absent), reason_note (omitted when absent),
+///   resolution_options, schema_version, signature (omitted when absent),
 ///   source_lang, source_op_cid, target_concept_op,
 ///   target_op_cid (omitted when absent)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TransportGapMemento {
+    #[serde(rename = "exam_manifest_cid")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exam_manifest_cid: Option<String>,
+    #[serde(rename = "exam_question_cid")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exam_question_cid: Option<String>,
     #[serde(rename = "fn_name")]
     pub fn_name: String,
     #[serde(rename = "gap_kind")]
@@ -3173,7 +3180,8 @@ impl std::error::Error for PromotionDecisionInvariantError {}
 // Coverage state is intentionally outside this family.
 // ============================================================
 
-pub const EXAM_MANIFEST_SCHEMA_VERSION: &str = "provekit-exam-manifest/v1";
+pub const EXAM_MANIFEST_SCHEMA_VERSION: &str = "provekit-exam-manifest/v1.1";
+pub const EXAM_MANIFEST_SCHEMA_VERSION_V1: &str = "provekit-exam-manifest/v1";
 
 /// Envelope layer for an `ExamManifestMemento`.
 ///
@@ -3403,7 +3411,9 @@ impl ExamManifestMemento {
 
     /// Check shape-level invariants for loading an exam manifest.
     pub fn validate(&self) -> Result<(), ExamManifestValidationError> {
-        if self.metadata.schema_version != EXAM_MANIFEST_SCHEMA_VERSION {
+        if self.metadata.schema_version != EXAM_MANIFEST_SCHEMA_VERSION
+            && self.metadata.schema_version != EXAM_MANIFEST_SCHEMA_VERSION_V1
+        {
             return Err(ExamManifestValidationError::InvalidSchemaVersion {
                 schema_version: self.metadata.schema_version.clone(),
             });
@@ -3503,7 +3513,7 @@ impl std::fmt::Display for ExamManifestValidationError {
         match self {
             Self::InvalidSchemaVersion { schema_version } => write!(
                 f,
-                "ExamManifestMemento: schemaVersion must be {EXAM_MANIFEST_SCHEMA_VERSION:?}, got {schema_version:?}"
+                "ExamManifestMemento: schemaVersion must be {EXAM_MANIFEST_SCHEMA_VERSION:?} or {EXAM_MANIFEST_SCHEMA_VERSION_V1:?}, got {schema_version:?}"
             ),
             Self::EmptyQuestionKinds => f.write_str(
                 "ExamManifestMemento: question_kinds is empty, but at least one question kind is required",

--- a/implementations/rust/provekit-ir-types/tests/exam_manifest_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/exam_manifest_serde.rs
@@ -179,6 +179,29 @@ fn exam_manifest_accepts_future_question_kind_at_shape_level() {
         .expect("future kind validates at shape level");
 }
 
+#[test]
+fn exam_manifest_accepts_v1_1_schema_version() {
+    let mut manifest = example_manifest();
+    manifest.metadata.schema_version = "provekit-exam-manifest/v1.1".to_string();
+    manifest.header.content.question_kinds = vec![
+        "boundary-realization".to_string(),
+        "boundary-tag".to_string(),
+        "composition".to_string(),
+        "concept-realization".to_string(),
+        "effect-classification".to_string(),
+        "morphism".to_string(),
+        "sort-classification".to_string(),
+    ];
+    manifest.header.content.questions = vec![question(
+        ExamQuestionKind::Other("concept-realization".to_string()),
+        "concept:add",
+        json!({"language": "rust"}),
+        "RealizationMemento",
+    )];
+
+    manifest.validate().expect("v1.1 manifest validates");
+}
+
 fn example_manifest() -> ExamManifestMemento {
     ExamManifestMemento {
         envelope: ExamManifestEnvelope {

--- a/implementations/rust/provekit-ir-types/tests/transport_gap_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/transport_gap_serde.rs
@@ -85,6 +85,8 @@ fn python_add_gap_deserializes_from_spec_shape() {
         ResolutionOptionKind::AcceptPermanent
     );
     assert_eq!(m.resolution_options[1].status, OptionStatus::Deferred);
+    assert!(m.exam_manifest_cid.is_none());
+    assert!(m.exam_question_cid.is_none());
     assert!(m.signature.is_none());
 }
 
@@ -153,6 +155,50 @@ fn no_such_concept_op_omits_target_op_cid_when_none() {
         v.get("target_op_cid").is_none(),
         "target_op_cid must be absent in serialized JSON when None"
     );
+    assert!(
+        v.get("exam_manifest_cid").is_none(),
+        "exam_manifest_cid must be absent in serialized JSON when None"
+    );
+    assert!(
+        v.get("exam_question_cid").is_none(),
+        "exam_question_cid must be absent in serialized JSON when None"
+    );
+}
+
+#[test]
+fn gap_exam_question_citation_fields_round_trip() {
+    let raw = r#"{
+  "exam_manifest_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+  "exam_question_cid": "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+  "fn_name": "gap:rust:add:to:concept:add",
+  "gap_kind": "wp-rule-mismatch",
+  "kind": "TransportGapMemento",
+  "resolution_options": [
+    {
+      "option_kind": "accept-permanent",
+      "status": "deferred",
+      "tradeoff": "bind refused to synthesize a wp_rule without evidence"
+    }
+  ],
+  "schema_version": "1",
+  "source_lang": "rust",
+  "source_op_cid": "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+  "target_concept_op": "concept:add"
+}"#;
+
+    let m: TransportGapMemento = serde_json::from_str(raw).expect("parse cited gap");
+    assert_eq!(
+        m.exam_manifest_cid.as_deref(),
+        Some("blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
+    );
+    assert_eq!(
+        m.exam_question_cid.as_deref(),
+        Some("blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222")
+    );
+
+    let serialized = serde_json::to_string(&m).expect("serialize");
+    let reparsed: TransportGapMemento = serde_json::from_str(&serialized).expect("re-parse");
+    assert_eq!(m, reparsed);
 }
 
 // ================================================================

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -2183,11 +2183,15 @@ pub fn positive_id(x: i64) -> i64 {
         let payload_bytes =
             libprovekit::canonical::serializable_jcs(&payload).expect("payload canonicalizes");
 
+        // `fn_name` is allowed inside gap-record subtrees because TransportGapMemento's
+        // schema (see protocol/specs/2026-05-14-transport-gap-and-partial-morphism-protocol.md)
+        // names the gap by its own fn_name identifier (e.g., "gap:unknown:bind:...:wp-rule").
+        // That is legitimate citation, not a contract-attr leak. Walk the JSON tree and
+        // forbid `fn_name` everywhere EXCEPT under a `gapRecords` ancestor.
         for forbidden in [
             "attr_pre",
             "attr_post",
             "concept_annotation",
-            "fn_name",
             "operand_bindings",
             "source_function_name",
         ] {
@@ -2196,6 +2200,9 @@ pub fn positive_id(x: i64) -> i64 {
                 "bind payload hashed bytes contain forbidden field `{forbidden}`: {payload_bytes}"
             );
         }
+        let payload_json: Value =
+            serde_json::from_str(&payload_bytes).expect("payload bytes parse back to JSON");
+        assert_no_fn_name_outside_gap_records(&payload_json, &[]);
 
         let _ = fs::remove_dir_all(root);
     }
@@ -2353,6 +2360,31 @@ pub fn bitwise_not() -> i64 {
                 !object.contains_key(forbidden),
                 "bind lift entry contains forbidden field `{forbidden}` in {value:#?}"
             );
+        }
+    }
+
+    fn assert_no_fn_name_outside_gap_records(value: &Value, path: &[&str]) {
+        let under_gap_records = path.iter().any(|segment| *segment == "gapRecords");
+        match value {
+            Value::Object(map) => {
+                if !under_gap_records {
+                    assert!(
+                        !map.contains_key("fn_name"),
+                        "bind payload contains forbidden `fn_name` outside gap-record context at path {path:?}: {value:#?}"
+                    );
+                }
+                for (key, child) in map {
+                    let mut next_path: Vec<&str> = path.to_vec();
+                    next_path.push(key.as_str());
+                    assert_no_fn_name_outside_gap_records(child, &next_path);
+                }
+            }
+            Value::Array(items) => {
+                for child in items {
+                    assert_no_fn_name_outside_gap_records(child, path);
+                }
+            }
+            _ => {}
         }
     }
 

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -26,7 +26,7 @@ use std::sync::{Arc, OnceLock};
 
 use base64::Engine;
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
-use provekit_ir_types::{EvidenceMemento, IrFormula, IrTerm, SourceKind};
+use provekit_ir_types::{EvidenceMemento, ExamManifestMemento, IrFormula, IrTerm, SourceKind};
 use provekit_lift_contracts::lift_file_with_docstring_evidence;
 use provekit_walk::emit::{rust_function_term_json, shadow_proof_ir_cid, shadow_to_proof_ir};
 use provekit_walk::{
@@ -37,8 +37,10 @@ use serde_json::{json, Value};
 
 const CONCEPT_SHAPES_CATALOG_INDEX_JSON: &str =
     include_str!("../../../../../menagerie/concept-shapes/catalog/index.json");
+const EXAM_MANIFEST_CID: &str = libprovekit::exam_manifest::DEFAULT_EXAM_MANIFEST_CID;
 
 static CONCEPT_OP_CIDS: OnceLock<BTreeMap<String, String>> = OnceLock::new();
+static EXAM_MANIFEST: OnceLock<Option<ExamManifestMemento>> = OnceLock::new();
 
 fn main() -> io::Result<()> {
     let stdin = io::stdin();
@@ -325,22 +327,28 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
         let src = match std::fs::read_to_string(path) {
             Ok(s) => s,
             Err(e) => {
-                diagnostics.push(json!({
-                    "kind": "read-error",
-                    "path": path.display().to_string(),
-                    "detail": e.to_string()
-                }));
+                diagnostics.push(cited_diagnostic(
+                    "read-error",
+                    path.display().to_string(),
+                    e.to_string(),
+                    "morphism",
+                    "concept:source-unit",
+                    "rust",
+                ));
                 continue;
             }
         };
         let file = match syn::parse_file(&src) {
             Ok(f) => f,
             Err(e) => {
-                diagnostics.push(json!({
-                    "kind": "parse-error",
-                    "path": path.display().to_string(),
-                    "detail": e.to_string()
-                }));
+                diagnostics.push(cited_diagnostic(
+                    "parse-error",
+                    path.display().to_string(),
+                    e.to_string(),
+                    "morphism",
+                    "concept:source-unit",
+                    "rust",
+                ));
                 continue;
             }
         };
@@ -398,6 +406,43 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
         "ir": entries,
         "diagnostics": diagnostics,
     }))
+}
+
+fn cited_diagnostic(
+    kind: &str,
+    path: String,
+    detail: String,
+    question_kind: &str,
+    concept: &str,
+    language: &str,
+) -> Value {
+    let mut diagnostic = json!({
+        "kind": kind,
+        "path": path,
+        "detail": detail,
+    });
+    if let Some(question_cid) = exam_question_cid_for(question_kind, concept, language) {
+        diagnostic["exam_manifest_cid"] = json!(EXAM_MANIFEST_CID);
+        diagnostic["exam_question_cid"] = json!(question_cid);
+    } else {
+        diagnostic["exam_citation_diagnostic"] = json!({
+            "kind": "exam-question-citation-missing",
+            "question_kind": question_kind,
+            "concept": concept,
+            "language": language,
+        });
+    }
+    diagnostic
+}
+
+fn exam_question_cid_for(kind: &str, concept: &str, language: &str) -> Option<String> {
+    let manifest =
+        EXAM_MANIFEST.get_or_init(|| libprovekit::exam_manifest::load_default_exam_manifest().ok());
+    manifest.as_ref().and_then(|manifest| {
+        libprovekit::exam_manifest::exam_question_cid_for(manifest, kind, concept, language)
+            .ok()
+            .flatten()
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -2325,5 +2370,74 @@ pub fn bitwise_not() -> i64 {
         let root = std::env::temp_dir().join(format!("{name}_{nanos}"));
         fs::create_dir_all(&root).expect("create temp workspace");
         root
+    }
+
+    #[test]
+    fn rust_lifter_parse_refusal_cites_v1_1_exam_question() {
+        let dir = rust_lifter_parse_refusal_workspace("cites");
+
+        let result = bind_lift(&json!({
+            "workspace_root": dir,
+            "source_paths": ["."]
+        }))
+        .expect("bind lift returns document");
+        let diagnostic = result["diagnostics"][0].as_object().expect("diagnostic object");
+        let expected = exam_question_cid_for("morphism", "concept:source-unit", "rust")
+            .expect("source-unit rust question exists");
+
+        assert_eq!(diagnostic["kind"], "parse-error");
+        assert_eq!(diagnostic["exam_manifest_cid"], EXAM_MANIFEST_CID);
+        assert_eq!(diagnostic["exam_question_cid"], expected);
+    }
+
+    #[test]
+    fn rust_lifter_parse_refusal_does_not_fire_read_error_variant() {
+        let dir = rust_lifter_parse_refusal_workspace("discrim");
+
+        let result = bind_lift(&json!({
+            "workspace_root": dir,
+            "source_paths": ["."]
+        }))
+        .expect("bind lift returns document");
+
+        assert_eq!(result["diagnostics"][0]["kind"], "parse-error");
+        assert!(result["diagnostics"]
+            .as_array()
+            .expect("diagnostics array")
+            .iter()
+            .all(|item| item["kind"] != "read-error"));
+    }
+
+    #[test]
+    fn rust_lifter_parse_refusal_cites_source_unit_not_related_add() {
+        let dir = rust_lifter_parse_refusal_workspace("structural");
+
+        let result = bind_lift(&json!({
+            "workspace_root": dir,
+            "source_paths": ["."]
+        }))
+        .expect("bind lift returns document");
+        let refusal_cid = result["diagnostics"][0]["exam_question_cid"]
+            .as_str()
+            .expect("exam question cid");
+        let related =
+            exam_question_cid_for("morphism", "concept:add", "rust").expect("add rust exists");
+
+        assert_ne!(refusal_cid, related);
+    }
+
+    fn rust_lifter_parse_refusal_workspace(label: &str) -> PathBuf {
+        let unique = format!(
+            "provekit-walk-citation-{}-{}",
+            label,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        );
+        let dir = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(dir.join("src")).expect("create src");
+        std::fs::write(dir.join("src/lib.rs"), "fn broken(").expect("write source");
+        dir
     }
 }

--- a/menagerie/smoke-test-e2e/driver/src/cluster.rs
+++ b/menagerie/smoke-test-e2e/driver/src/cluster.rs
@@ -19,6 +19,10 @@
 //      we never accidentally fabricate semantics from a name match.
 
 use crate::algebra::TermShape;
+use provekit_ir_types::{
+    ExamManifestMemento, GapKind, OptionStatus, ResolutionOption, ResolutionOptionKind,
+    TransportGapMemento,
+};
 
 #[derive(Debug, Clone)]
 pub struct CatalogEntry {
@@ -65,5 +69,119 @@ pub fn seed_catalog() -> Catalog {
                 classification: "option-default",
             },
         ],
+    }
+}
+
+pub fn unknown_shape_gap_record(
+    shape_cid: &str,
+    concept: &str,
+    language: &str,
+    manifest: Option<&ExamManifestMemento>,
+) -> Result<serde_json::Value, String> {
+    let (exam_question_cid, exam_manifest_cid) = libprovekit::exam_manifest::exam_question_citation(
+        manifest,
+        "morphism",
+        concept,
+        language,
+        "cluster",
+    );
+    let gap = TransportGapMemento {
+        exam_manifest_cid,
+        exam_question_cid,
+        fn_name: format!(
+            "gap:{}:cluster:unknown-shape:to:{}",
+            language,
+            concept.trim_start_matches("concept:")
+        ),
+        gap_kind: GapKind::MissingTargetConstruct,
+        kind: "TransportGapMemento".to_string(),
+        reason: None,
+        reason_note: Some("cluster refused an unknown shape without a catalog concept".to_string()),
+        resolution_options: vec![ResolutionOption {
+            dual_view_cid: None,
+            loss: None,
+            loss_severity: None,
+            option_kind: ResolutionOptionKind::AcceptPermanent,
+            partial_morphism_cid: None,
+            precondition: None,
+            representation_map_delta: None,
+            respec_target_to: None,
+            split_targets: None,
+            status: OptionStatus::Deferred,
+            tradeoff: "name the concept or add a catalog shape before treating the cluster as exact"
+                .to_string(),
+        }],
+        schema_version: "1".to_string(),
+        signature: None,
+        source_lang: language.to_string(),
+        source_op_cid: shape_cid.to_string(),
+        target_concept_op: concept.to_string(),
+        target_op_cid: None,
+    };
+    serde_json::to_value(gap).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EXAM_MANIFEST_JSON: &str = include_str!(
+        "../../../concept-shapes/exams/v1.1.blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc.json"
+    );
+
+    #[test]
+    fn unknown_shape_gap_cites_v1_1_exam_question_when_concept_matches() {
+        let manifest = serde_json::from_str(EXAM_MANIFEST_JSON).expect("manifest parses");
+        let gap = unknown_shape_gap_record(
+            "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "concept:add",
+            "rust",
+            Some(&manifest),
+        )
+        .expect("gap serializes");
+        let expected =
+            libprovekit::exam_manifest::exam_question_cid_for(&manifest, "morphism", "concept:add", "rust")
+                .expect("lookup add/rust")
+                .expect("add/rust question exists");
+
+        assert_eq!(gap["target_concept_op"], "concept:add");
+        assert_eq!(gap["exam_manifest_cid"], manifest.header.cid);
+        assert_eq!(gap["exam_question_cid"], expected);
+    }
+
+    #[test]
+    fn unknown_shape_gap_does_not_emit_unrelated_gap_variant() {
+        let manifest = serde_json::from_str(EXAM_MANIFEST_JSON).expect("manifest parses");
+        let gap = unknown_shape_gap_record(
+            "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "concept:add",
+            "rust",
+            Some(&manifest),
+        )
+        .expect("gap serializes");
+
+        assert_eq!(gap["gap_kind"], "missing-target-construct");
+        assert_ne!(gap["gap_kind"], "wp-rule-mismatch");
+    }
+
+    #[test]
+    fn unknown_shape_gap_cites_exact_question_not_related_concept() {
+        let manifest = serde_json::from_str(EXAM_MANIFEST_JSON).expect("manifest parses");
+        let gap = unknown_shape_gap_record(
+            "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "concept:add",
+            "rust",
+            Some(&manifest),
+        )
+        .expect("gap serializes");
+        let related =
+            libprovekit::exam_manifest::exam_question_cid_for(&manifest, "morphism", "concept:sub", "rust")
+                .expect("lookup sub/rust")
+                .expect("sub/rust question exists");
+
+        assert_ne!(
+            gap["exam_question_cid"].as_str().expect("question cid"),
+            related
+        );
     }
 }

--- a/menagerie/smoke-test-e2e/driver/src/main.rs
+++ b/menagerie/smoke-test-e2e/driver/src/main.rs
@@ -38,7 +38,7 @@ use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
 use provekit_claim_envelope::{mint_contract, Authoring, MintContractArgs};
 use provekit_ir_types::{
     CodeSite, CodeSiteSpan, ConceptSiteMemento, ConceptSiteProvenance, Discharge, IrFormula,
-    LossRecord,
+    LossRecord, ExamManifestMemento,
 };
 use provekit_proof_envelope::Ed25519Seed;
 
@@ -52,6 +52,10 @@ mod synthesize;
 mod test_lift;
 
 use algebra::{FormulaShape, TermShape};
+
+const EXAM_MANIFEST_JSON: &str = include_str!(
+    "../../../concept-shapes/exams/v1.1.blake3-512:32af210992406289b0863d6f24ab3f05e6707034fd473fe7a8e323edda0376ce018f9ba8a31d00c4e3c4134140b1f3e06cfad6a0afde762778032035066475cc.json"
+);
 
 fn main() {
     let fixture_dir = locate_fixture_dir();
@@ -290,6 +294,7 @@ fn run_pass(source_root: &Path, pass_id: u32, read_concept_comments: bool) -> Pa
 
     let artifacts_dir = source_root.join("artifacts");
     let _ = fs::create_dir_all(&artifacts_dir);
+    let exam_manifest: Option<ExamManifestMemento> = serde_json::from_str(EXAM_MANIFEST_JSON).ok();
 
     let signer_seed: Ed25519Seed = [0x42; 32];
 
@@ -404,6 +409,26 @@ fn run_pass(source_root: &Path, pass_id: u32, read_concept_comments: bool) -> Pa
             } else {
                 name_pick
             };
+            if source == NameSource::Auto {
+                let target_concept = format!("concept:{final_name}");
+                if let Ok(gap) = cluster::unknown_shape_gap_record(
+                    &shape_cid,
+                    &target_concept,
+                    "rust",
+                    exam_manifest.as_ref(),
+                ) {
+                    if let Ok(bytes) = serde_json::to_vec_pretty(&gap) {
+                        let _ = fs::write(
+                            artifacts_dir.join(format!(
+                                "pass{}_cluster_gap_{}.json",
+                                pass_id,
+                                sanitize(&final_name)
+                            )),
+                            bytes,
+                        );
+                    }
+                }
+            }
 
             let abs_value = Value::object([
                 ("kind", Value::string("concept-abstraction-stub-0")),

--- a/protocol/provekit-ir.cddl
+++ b/protocol/provekit-ir.cddl
@@ -476,6 +476,10 @@ loss-record = LossRecord
 ; when a comparison is possible; it is absent only when neither an after_spec
 ; nor a concept_spec is available at gap-emit time.
 ;
+; Amendment 3: `exam_manifest_cid` and `exam_question_cid` are optional
+; citation fields. Emitters populate both when a gap answers a question in the
+; loaded exam manifest. Existing uncited gap records remain valid.
+;
 ; All three mementos are JCS-canonical (BTreeMap key order = alphabetical),
 ; BLAKE3-512-hashed, and live in menagerie/concept-shapes/gaps/.
 ;
@@ -559,11 +563,14 @@ resolution-option = {
 ; ----------------------------------------------------------------
 ;
 ; Locked key order (alphabetical):
-;   fn_name, gap_kind, kind, ? reason, ? reason_note,
-;   resolution_options, schema_version, ? signature, source_lang,
-;   source_op_cid, target_concept_op, ? target_op_cid
+;   ? exam_manifest_cid, ? exam_question_cid, fn_name, gap_kind,
+;   kind, ? reason, ? reason_note, resolution_options, schema_version,
+;   ? signature, source_lang, source_op_cid, target_concept_op,
+;   ? target_op_cid
 
 TransportGapMemento = {
+  ? exam_manifest_cid: cid,              ; the exam manifest version cited by this refusal
+  ? exam_question_cid: cid,              ; the specific exam question this refusal answers
   fn_name:           tstr,                ; e.g. "gap:python:add:to:concept:add"
   gap_kind:          gap-kind,
   kind:              "TransportGapMemento",
@@ -709,4 +716,3 @@ RealizationDesugaringMemento = {
   effects:           [* tstr],                 ; always [] for the equation itself; rhs term carries effects
   ? refines:         cid,
 }
-

--- a/protocol/specs/2026-05-14-transport-gap-and-partial-morphism-protocol.md
+++ b/protocol/specs/2026-05-14-transport-gap-and-partial-morphism-protocol.md
@@ -63,6 +63,8 @@ A `TransportGapMemento` records: operation `<lang>:op` (a CID) does not have an 
 transport-gap-memento = {
   schema_version:    "1",
   kind:              "TransportGapMemento",
+  ? exam_manifest_cid: cid,                  ; OPTIONAL; the exam manifest version whose question is cited
+  ? exam_question_cid: cid,                  ; OPTIONAL; the specific exam question this refusal answers
   fn_name:           tstr,                   ; canonical name, e.g. "gap:python:add:to:concept:add"
   source_op_cid:     cid,                    ; the lifter-emitted <lang>:op contract memento
   target_op_cid:     cid,                    ; the concept:op hub contract memento (or null when the gap is "no target op")
@@ -136,6 +138,12 @@ option-status = "recommended"      ; the generator's suggestion
 The `gap-reason` `*_delta` fields mirror exactly what `mint_language_morphisms.py`'s `diff_reason()` already computes: `formal_sorts` first, then `pre`, then `return_sort` / `effects`, then `post.wp` (post-WPF: `wp_rule`), then `post.arity_shape`. The generator already has the structured comparison; this spec moves it from a `json.dumps`-into-a-prose-sentence into the memento's `reason` field.
 
 The memento is JCS-canonical, BLAKE3-512-hashed, signed with the foundation v0 key (or a delegated project key when a project records a `chosen` / `rejected` status), and lives in the catalog alongside the morphisms it concerns (§4).
+
+### §1.1.1 Exam-question citations
+
+`TransportGapMemento` may carry two optional citation fields: `exam_question_cid` and `exam_manifest_cid`. They connect a refusal to the exam-administration substrate without changing the meaning of the gap. Existing gap records that omit both fields remain valid. New emitters populate both fields when the refusal answers a question in the loaded exam manifest. The question CID is the BLAKE3-512 CID of the canonical JSON bytes of the matched question entry, and the manifest CID is the CID of the manifest version that supplied that question.
+
+The lookup key is the refusal's question `kind`, target `concept:*`, and language-bearing parameter. `morphism` uses `from_language`; `boundary-realization` uses `target_language`; `concept-realization`, `effect-classification`, and `sort-classification` use `language`. Legacy v1 manifests retain the earlier `realization`, `effect`, and `sort` names with the same language keys. If no manifest question matches, the emitter omits both fields and logs a diagnostic that the gap is outside the exam vocabulary. Consumers must treat missing citation fields as an uncited gap, not as a parse error.
 
 ### §1.2 `PartialMorphismMemento`
 


### PR DESCRIPTION
## Summary

Closes Phase 4 of migration umbrella #1119. Wires the v1.1 exam manifest into the gap-record citation surface.

- `TransportGapMemento` gains optional `exam_question_cid` + `exam_manifest_cid` fields (backward-compat: legacy records without the fields still parse)
- Cluster (smoke-test driver), bind path (libprovekit + cmd_bind), and the three mature lifters (Rust + Python + Java) now populate citations when refusing
- Discrimination tests per refusal variant: positive + discrimination + structural
- Spec amendment §1.4 added to `2026-05-14-transport-gap-and-partial-morphism-protocol.md`

## Refs

- Refs #1126
- Closes Phase 4 of #1119
- v1.1 manifest from #1125 (PR #1133), CID `blake3-512:32af2109...066475cc`
- Builds on schema v1.1 from #1124 (PR #1132)

## Test plan

- [x] `cargo build --workspace --lib --bins` clean (2m 24s, one pre-existing unused-import warning unrelated to this change)
- [x] Duplicate `mod tests` in `walk_rpc.rs` resolved (sonnet agent merged into existing block at line 1743)
- [x] No em-dashes introduced (sweep clean; pre-existing instances in unrelated comments untouched)
- [x] Commit identity `T Savo <evilgenius@nefariousplan.com>`
- [ ] Pre-existing compile error in `provekit-walk/tests/end_to_end_demo.rs` (missing `IrFormula::DivergenceBetween` match arm) is unrelated; left for separate issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Refusal and gap records now include citations to specific exam questions for unsupported constructs and missing dependencies.
  * CLI bind command now accepts optional exam manifest parameters for enhanced diagnostics.

* **Improvements**
  * Error diagnostics enriched with linked exam question and manifest references.
  * Added support for v1.1 exam manifest schema format.

* **Bug Fixes**
  * Fixed missing `PATH_MAX` definition on certain platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->