### PR TITLE
test(carrier-fixture-registry): expect java platform-semantic declaration

### DIFF
--- a/implementations/rust/provekit-cli/tests/carrier_fixture_registry.rs
+++ b/implementations/rust/provekit-cli/tests/carrier_fixture_registry.rs
@@ -34,7 +34,13 @@ fn lower_java_carrier_registration_points_at_required_fixture_set() {
     else {
         panic!("lower-java must register as a carrier");
     };
-    assert_eq!(platform_semantics, &None);
+    let semantics = platform_semantics
+        .as_ref()
+        .expect("java carrier registration populates platform-semantic declaration per Stage 3.1");
+    assert!(
+        !semantics.tags.is_empty(),
+        "java platform-semantic declaration must include per-op tags"
+    );
     assert_required_fixtures(fixtures_path);
 }
 


### PR DESCRIPTION
## Summary
Single-line test assertion update. After Stage 3.1 Java kit (#1116) landed, \`platform_semantics_for_lower_target(\"java\")\` now returns \`Some(declaration)\` instead of \`None\`. The carrier fixture registry test still asserted \`platform_semantics == &None\`, regressing CI on main.

## Change
Replace \`assert_eq!(platform_semantics, &None)\` with \`platform_semantics.as_ref().expect(...)\` + \`!semantics.tags.is_empty()\` check.

## Test plan
- [x] \`cargo test -p provekit-cli --test carrier_fixture_registry\` (1/1 green locally)
- [ ] CI Cross-language conformance gate green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for the `lower-java` carrier registration to verify that platform semantics are properly populated with per-operation tags, enhancing validation of the carrier fixture registry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->