### PR TITLE
fix(test): cmd_bind_integration.rs missing Term + named_term_document_from_bind_payload imports

### DIFF
--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use libprovekit::core::NamedTermDocument;
+use libprovekit::core::{named_term_document_from_bind_payload, NamedTermDocument, Term};
 
 fn provekit_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_provekit"))


### PR DESCRIPTION
## Summary

The merged citation PR (#1134) added references to `Term` and `named_term_document_from_bind_payload` in `provekit-cli/tests/cmd_bind_integration.rs` without adding the imports. Caught by Linux CI on the post-merge run of main.

Fix: one-line import addition pulling both symbols from `libprovekit::core` alongside the existing `NamedTermDocument` import.

Verified locally: `cargo test --tests --no-run -p provekit-cli` builds clean.

## Refs

- Regression introduced by #1134 (admin-merged with red CI per architect call)
- Main HEAD that's broken: 89ec6ae04

🤖 Generated with [Claude Code](https://claude.com/claude-code)