### PR TITLE
fix(supply-chain-js-lowerer): use cwd, not workspace_root param, as artifact base

### DIFF
--- a/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-js-lowerer.rs
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-js-lowerer.rs
@@ -52,11 +52,12 @@ fn run_rpc() {
                 }),
             ),
             "realize" => {
-                let workspace = request
-                    .pointer("/params/workspace_root")
-                    .and_then(Value::as_str)
-                    .map(PathBuf::from)
-                    .unwrap_or_else(|| PathBuf::from("."));
+                // The kit dispatcher sets the plugin's cwd to the project root
+                // (workspace_root in the JSON-RPC params). Treating workspace_root
+                // as a path to read from would join it onto cwd, doubling up the
+                // project segment and reading the wrong file. Read relative to
+                // cwd directly.
+                let workspace = PathBuf::from(".");
                 let plan = request
                     .pointer("/params/plan")
                     .cloned()


### PR DESCRIPTION
## Summary
Single-line fix to the supply-chain-rails JS lowerer plugin. Surfaced by the assert_str diagnostic patch in #1129 (now merged).

## Root cause
The kit dispatcher in libprovekit::core sets the plugin subprocess's cwd to the project root (the workspace_root). The plugin was then taking the workspace_root string from the initialize JSON-RPC params and joining the artifact filename onto it, which doubles up the project segment relative to the plugin's cwd. On Linux conformance, this manifested as:

\`\`\`
read menagerie/supply-chain-rails/authenticated-betrayal/packages/
     safe-json-1.4.2-lie/index.js: No such file or directory (os error 2)
\`\`\`

because the plugin tried to read \`<cwd=lie>/menagerie/.../lie/index.js\` instead of \`<cwd=lie>/index.js\`.

## Change
\`menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-js-lowerer.rs\` — replace \`workspace_root\` param path use with \`PathBuf::from(".")\`. Kit dispatcher already placed us at the right project root.

## Test plan
- [x] \`cargo test -p provekit-supply-chain-rails --test smoke all_exhibits_show_conventional_green_then_provekit_red\` (passes locally)
- [ ] CI Cross-language conformance gate green