### PR TITLE
feat(libprovekit): per-callsite migration point-query producing effect chain receipt (closes #1147)

### DIFF
--- a/docs/audits/2026-05-18-stream-a-stage-4-status.md
+++ b/docs/audits/2026-05-18-stream-a-stage-4-status.md
@@ -1,0 +1,50 @@
+# Stream A Stage 4 status
+
+Issue: #1147
+Branch: kit/pk-1147-stream-a-stage-4
+
+## Progress
+
+- Added `DimensionValueMemento` carriers and op aliases to `PlatformSemanticsDeclaration`.
+- Added `PlatformSemanticsDeclaration::compare_op_with`, returning exact, divergent, or uncharacterizable comparison results.
+- Wired per-callsite platform semantic divergences into `ChangedCallsite.effect` using the target `DimensionValueMemento` CID as the effect name.
+- Added `--focus` to migration bind arguments and scoped changed callsites to the focused callsite.
+- Added `loss_dimensions` to `LossRecordMemento`, populated with `IrFormula::DivergenceBetween` for platform semantic divergences.
+- Preserved the existing async propagation and legacy sqlite `last_insert_rowid` loss path.
+
+## Passing checks
+
+- `cargo test -p libprovekit --test core_interface platform_semantics_compare_op -- --nocapture`
+- `cargo test -p provekit-cli point_query -- --nocapture`
+- `cargo test -p libprovekit --test core_interface`
+- `cargo test -p provekit-ir-types --test platform_semantics_mementos`
+- `cargo test -p provekit-realize-rust-core --test platform_semantics`
+- `cargo test -p provekit-cli --test migrate_async_rewrite_test -- --nocapture`
+- `cargo test -p provekit-cli --test stage3_cross_language_test -- --nocapture`
+
+## Stop condition
+
+The protected burned test command failed:
+
+```text
+cargo test -p provekit-cli --test slice2_java_realize_plugin_byte_identical --test mint_kit_integration --test trinity_roundtrip_test --test verb_composition --test cli_surface
+```
+
+Failure:
+
+```text
+cli_surface::lift_zig_shows_production_composes_but_unit_tests_conflict failed
+error: unable to update file from .../.zig-local-cache/.../provekit-lift-zig
+to .../implementations/zig/provekit-lift-zig/zig-out/bin/provekit-lift-zig:
+PermissionDenied
+```
+
+I stopped after this failure, per the burned-test rule. The failure is in the Zig install step writing `implementations/zig/provekit-lift-zig/zig-out/bin/provekit-lift-zig`, before the lift plugin can answer RPC.
+
+## Commit status
+
+Not committed in this pass. Earlier git metadata writes also failed in this linked worktree with:
+
+```text
+cannot lock ref 'ORIG_HEAD': Unable to create .../provekit/.git/worktrees/pk-1147-stream-a-stage-4/ORIG_HEAD.lock: Operation not permitted
+```

--- a/implementations/c/provekit-realize-c-core/platform_semantics.rs
+++ b/implementations/c/provekit-realize-c-core/platform_semantics.rs
@@ -90,7 +90,19 @@ pub fn declaration() -> PlatformSemanticsDeclaration {
                 )
             })
             .collect(),
+        dimension_values: dimension_values(),
+        op_aliases: BTreeMap::new(),
     }
+}
+
+pub fn dimension_values() -> Vec<DimensionValueMemento> {
+    vec![
+        dimension_value(ARITHMETIC_OVERFLOW, UNDEFINED_BEHAVIOR),
+        dimension_value(INTEGER_DIVISION_ROUNDING, TRUNCATE),
+        dimension_value(SHIFT_MODE, IMPLEMENTATION_DEFINED),
+        dimension_value(NULL_SEMANTICS, UNDEFINED_BEHAVIOR),
+        dimension_value(BITWISE_SEMANTICS, TWOS_COMPLEMENT),
+    ]
 }
 
 fn dimension_value(dimension_name: &str, value_name: &str) -> DimensionValueMemento {

--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -55,9 +55,10 @@ pub use traits::{
 };
 pub use types::{
     ArityShape, AritySlot, Attestation, Boundary, ChainIntegrityFailureWitness,
-    ChainIntegrityWitness, Cid, CidError, ConformanceDeclaration, Contract, Dialect, DomainClaim,
-    DomainKind, Formula, Input, LanguageSignature, OperationSignature, Path, PathAlgebra,
-    PathDocument, PathDocumentError, PathError, PathInputBinding, PathInputMaterial,
+    ChainIntegrityWitness, Cid, CidError, ConformanceDeclaration, Contract, Dialect,
+    DivergenceCharacterization, DomainClaim, DomainKind, Formula, Input, LanguageSignature,
+    OperationSignature, Path, PathAlgebra, PathDocument, PathDocumentError, PathError,
+    PathInputBinding, PathInputMaterial, PlatformSemanticComparisonError,
     PlatformSemanticsDeclaration, Refutation, SignatureCatalogError, SlotEvaluation, SlotSort,
     Term, Truth, Verb, Verdict, VerdictCoercionError, Witness,
 };

--- a/implementations/rust/libprovekit/src/core/platform_semantics.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::core::types::PlatformSemanticsDeclaration;
+use std::collections::BTreeMap;
 
-mod python_common;
 pub mod java;
+mod python_common;
 pub mod python_lift_source;
 pub mod python_realize_core;
 
@@ -33,6 +34,9 @@ pub fn platform_semantics_for_lower_target(target: &str) -> Option<PlatformSeman
             let declaration = provekit_realize_rust_core::platform_semantics::declaration();
             Some(PlatformSemanticsDeclaration {
                 tags: declaration.tags,
+                dimension_values: provekit_realize_rust_core::platform_semantics::dimension_values(
+                ),
+                op_aliases: rust_concept_op_aliases(),
             })
         }
         "java" => Some(java::declaration()),
@@ -43,4 +47,57 @@ pub fn platform_semantics_for_lower_target(target: &str) -> Option<PlatformSeman
 
 pub fn python_kit_declaration() -> PlatformSemanticsDeclaration {
     python_realize_core::declaration()
+}
+
+fn rust_concept_op_aliases() -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (
+            "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468".to_string(),
+            "blake3-512:398980644a46039b0c2875ab36ccb61f52f284ccad5481593305ed3f10efe91e7863c00a3f2d673644430f691e6b5354f5d65f9da4fa23acdb13dc58f5b438f9".to_string(),
+        ),
+        (
+            "blake3-512:b7c54558573348bb3a9297732547a8e6e9d152403d292df7426b6bb8a248f705b4b030bf2a22ba547a17d6f1bfaf8e75a6843e02e8f23a8226ebc09e2a8622af".to_string(),
+            "blake3-512:b6c62a64669ff12d0af45d9932c1ab5e08576f1cac97b4abe60392a9f02393dac9765514b024b1481ddc829d4b7fb97950ad648a9944dceafa194b8423923533".to_string(),
+        ),
+        (
+            "blake3-512:46cd627de058c8d4f7d087ea33f4904af65ad4b2e3cfd3aff8f44bf27db96b33c2dae39cd30f53898c233c9465ba8d2701c69e5903d48935113103b4db00fd03".to_string(),
+            "blake3-512:1df457dceb0ec7a6dc4596eb70be001be09180afc69fa3ff8121cd78a0daff5dd9606dbfd4fb9fcdc5d834939a6f19c52b80aace16dea6df5ffdce62d86bbfa2".to_string(),
+        ),
+        (
+            "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839".to_string(),
+            "blake3-512:d7403da8d2a8921b71170b5fc34c12022118d0c545f25c7ff89fe77bbed02419e3528479ded0e746535ee92d0e1801bce46608c15c3d6d2a5567bec811cbc75a".to_string(),
+        ),
+        (
+            "blake3-512:92340897b43965e01454b00a6a43ec54b2bf0e01213a45fa2311f730dde18adf8da97a22458c1a2a0fb23ce85ef3ad9b22e704804c74f41997aba3ba02cefe0d".to_string(),
+            "blake3-512:235c6177611c2753a1c0d07d44391f5465ab50dc585372df52220118cb103ef19502192a07148bd2969d7f6f7ed0d134714d7745825f486768d0b0de8ac0b6dc".to_string(),
+        ),
+        (
+            "blake3-512:f9cdfcba8d0e223803126504a2a6ed10005fa61acb5c55b74b270bc66d963eb7648ab6763f0510760df93145c0f6670087a403417e8b3100c7142e121111807a".to_string(),
+            "blake3-512:37af5330572cf08650e3b6d5fdfc2649d56c0bb2e019f9be3861082c9d1961c1808beca6f9dfc39742ade25f06bfb499da74c89d33f64decd0c70f0972d021e1".to_string(),
+        ),
+        (
+            "blake3-512:c90e3c159b25e4c4c7f9c899da5aa3ee048a548719ced7360f3e514450811096b21cd5473f22d7a05df088f92210bbc916e65970b9fa1e1511c193ed969f112b".to_string(),
+            "blake3-512:cb23fbc9d05a19b353e1fe85c77e241fdc8c58cde5a7c5cad008b721a51eaf682284d8bfe3b383d751cb58833e94beb6bd0dd4d330f9619f095c8b4daa8298da".to_string(),
+        ),
+        (
+            "blake3-512:9e96c2445bad6bb1e5a6f902ad7f733e3f4619829b9c0e232361fbf50b978c8332029212ed895762e604d1df009fce58848cda33524a697df798233eae30a14b".to_string(),
+            "blake3-512:fcc41d285a20dae6c2deb2a854665d5d43bc829a09a76107d929898b3b169d1abf53ed71f302b00ec2146bcec3b5fe732ca7ecd4354e7739e67feea3db9fd6a2".to_string(),
+        ),
+        (
+            "blake3-512:d57b54bffe698ed804a4a49486b73a1a8a3e7bd84fb12babaad01ce22d8b7bcb5a35f3476324063f8de9f8090846d0d4fbeb48d78475d07e16f7925b4f264de3".to_string(),
+            "blake3-512:5c455355a13fd97a872848613b34b2b56f9738c832f900558710af1cd053976157513f31a8feb123202557dc0a369b88bc7c946179fe817d6c2f80d4f318f824".to_string(),
+        ),
+        (
+            "blake3-512:343b1f9faa98218467d810e0a2bb1b1eebeaf921c71a1bc52141f885220afff482c631c52e2157a6067640f4830f928add53ef7aa0386c6a27ee3c8bab6dc353".to_string(),
+            "blake3-512:16ba612da4883e853dd18b08c8e7b1803e1e2b0a42ab83c261048a49cdfd9b20bc54e809b8f4e8e5c9af63cc7447dee039cb826c611dfec137855a11a502adb9".to_string(),
+        ),
+        (
+            "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f".to_string(),
+            "blake3-512:eeaaf14737f661b6bce03f23d281974502182fea83909eeaade25e510887b26e80dac1b10af3b1f2f496b53898051d63e8d250e78cfa8e88380c84809e5eabe0".to_string(),
+        ),
+        (
+            "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409".to_string(),
+            "blake3-512:e0c3e13fd7e0d11fa3b78f4e083ab60b1166bdd905bc04e533e6dcc97d79330bd6a403caaf1265d8134ea3ccd5fe8cfd5a3e18f349ea7edcb6310c098e845c0f".to_string(),
+        ),
+    ])
 }

--- a/implementations/rust/libprovekit/src/core/platform_semantics/java.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics/java.rs
@@ -22,79 +22,102 @@ const CONCEPT_BITNOT_CID: &str = "blake3-512:5e788f0d551081f4e709e4418e01017fa9a
 
 pub fn declaration() -> PlatformSemanticsDeclaration {
     let kit_cid = blake3_512_of(KIT_ID.as_bytes());
-    let wrapping = dimension_value(&kit_cid, "ArithmeticOverflow", "Wrapping");
-    let truncate = dimension_value(&kit_cid, "IntegerDivisionRounding", "Truncate");
-    let arithmetic = dimension_value(&kit_cid, "ShiftMode", "Arithmetic");
-    let logical = dimension_value(&kit_cid, "ShiftMode", "Logical");
-    let throw_arithmetic = dimension_value(&kit_cid, "NullSemantics", "ThrowArithmeticException");
-    let twos_complement = dimension_value(&kit_cid, "BitwiseSemantics", "TwosComplement");
+    let values = dimension_values_for_kit(&kit_cid);
+    let value_cids = values
+        .iter()
+        .map(|value| (value.value_name.clone(), value.cid.clone()))
+        .collect::<BTreeMap<_, _>>();
 
     PlatformSemanticsDeclaration {
         tags: vec![
             tag(
                 &kit_cid,
                 CONCEPT_ADD_CID,
-                &[("ArithmeticOverflow", wrapping.cid.as_str())],
+                &[("ArithmeticOverflow", value_cids["Wrapping"].as_str())],
             ),
             tag(
                 &kit_cid,
                 CONCEPT_SUB_CID,
-                &[("ArithmeticOverflow", wrapping.cid.as_str())],
+                &[("ArithmeticOverflow", value_cids["Wrapping"].as_str())],
             ),
             tag(
                 &kit_cid,
                 CONCEPT_MUL_CID,
-                &[("ArithmeticOverflow", wrapping.cid.as_str())],
+                &[("ArithmeticOverflow", value_cids["Wrapping"].as_str())],
             ),
             tag(
                 &kit_cid,
                 CONCEPT_NEG_CID,
-                &[("ArithmeticOverflow", wrapping.cid.as_str())],
+                &[("ArithmeticOverflow", value_cids["Wrapping"].as_str())],
             ),
             tag(
                 &kit_cid,
                 CONCEPT_DIV_CID,
                 &[
-                    ("IntegerDivisionRounding", truncate.cid.as_str()),
-                    ("NullSemantics", throw_arithmetic.cid.as_str()),
+                    ("IntegerDivisionRounding", value_cids["Truncate"].as_str()),
+                    (
+                        "NullSemantics",
+                        value_cids["ThrowArithmeticException"].as_str(),
+                    ),
                 ],
             ),
             tag(
                 &kit_cid,
                 CONCEPT_MOD_CID,
                 &[
-                    ("IntegerDivisionRounding", truncate.cid.as_str()),
-                    ("NullSemantics", throw_arithmetic.cid.as_str()),
+                    ("IntegerDivisionRounding", value_cids["Truncate"].as_str()),
+                    (
+                        "NullSemantics",
+                        value_cids["ThrowArithmeticException"].as_str(),
+                    ),
                 ],
             ),
             tag(
                 &kit_cid,
                 CONCEPT_SHL_CID,
-                &[("BitwiseSemantics", twos_complement.cid.as_str())],
+                &[("BitwiseSemantics", value_cids["TwosComplement"].as_str())],
             ),
             tag(
                 &kit_cid,
                 CONCEPT_SHR_CID,
                 &[
-                    ("BitwiseSemantics", twos_complement.cid.as_str()),
-                    ("ShiftMode", arithmetic.cid.as_str()),
+                    ("BitwiseSemantics", value_cids["TwosComplement"].as_str()),
+                    ("ShiftMode", value_cids["Arithmetic"].as_str()),
                 ],
             ),
             tag(
                 &kit_cid,
                 CONCEPT_USHR_CID,
                 &[
-                    ("BitwiseSemantics", twos_complement.cid.as_str()),
-                    ("ShiftMode", logical.cid.as_str()),
+                    ("BitwiseSemantics", value_cids["TwosComplement"].as_str()),
+                    ("ShiftMode", value_cids["Logical"].as_str()),
                 ],
             ),
             tag(
                 &kit_cid,
                 CONCEPT_BITNOT_CID,
-                &[("BitwiseSemantics", twos_complement.cid.as_str())],
+                &[("BitwiseSemantics", value_cids["TwosComplement"].as_str())],
             ),
         ],
+        dimension_values: values,
+        op_aliases: BTreeMap::new(),
     }
+}
+
+pub fn dimension_values() -> Vec<DimensionValueMemento> {
+    let kit_cid = blake3_512_of(KIT_ID.as_bytes());
+    dimension_values_for_kit(&kit_cid)
+}
+
+fn dimension_values_for_kit(kit_cid: &str) -> Vec<DimensionValueMemento> {
+    vec![
+        dimension_value(kit_cid, "ArithmeticOverflow", "Wrapping"),
+        dimension_value(kit_cid, "IntegerDivisionRounding", "Truncate"),
+        dimension_value(kit_cid, "ShiftMode", "Arithmetic"),
+        dimension_value(kit_cid, "ShiftMode", "Logical"),
+        dimension_value(kit_cid, "NullSemantics", "ThrowArithmeticException"),
+        dimension_value(kit_cid, "BitwiseSemantics", "TwosComplement"),
+    ]
 }
 
 fn dimension_value(kit_cid: &str, dimension_name: &str, value_name: &str) -> DimensionValueMemento {

--- a/implementations/rust/libprovekit/src/core/platform_semantics/python_common.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics/python_common.rs
@@ -30,7 +30,8 @@ const PYTHON_PLATFORM_CONCEPT_OP_CIDS: &[&str] = &[
 ];
 
 pub(super) fn declaration() -> PlatformSemanticsDeclaration {
-    let dimensions = dimensions();
+    let dimension_values = dimension_values();
+    let dimensions = dimensions_from_values(&dimension_values);
     PlatformSemanticsDeclaration {
         tags: PYTHON_PLATFORM_CONCEPT_OP_CIDS
             .iter()
@@ -42,6 +43,8 @@ pub(super) fn declaration() -> PlatformSemanticsDeclaration {
                 )
             })
             .collect(),
+        dimension_values,
+        op_aliases: BTreeMap::new(),
     }
 }
 
@@ -59,10 +62,10 @@ pub(super) fn dimension_values() -> Vec<DimensionValueMemento> {
         .collect()
 }
 
-fn dimensions() -> BTreeMap<String, String> {
-    dimension_values()
-        .into_iter()
-        .map(|value| (value.dimension_name, value.cid))
+fn dimensions_from_values(values: &[DimensionValueMemento]) -> BTreeMap<String, String> {
+    values
+        .iter()
+        .map(|value| (value.dimension_name.clone(), value.cid.clone()))
         .collect()
 }
 

--- a/implementations/rust/libprovekit/src/core/types.rs
+++ b/implementations/rust/libprovekit/src/core/types.rs
@@ -7,7 +7,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
-use provekit_ir_types::{IrFormula, IrTerm, LetBinding, PlatformSemanticTag, Sort};
+use provekit_ir_types::{
+    DimensionValueMemento, IrFormula, IrTerm, LetBinding, PlatformSemanticTag, Sort,
+};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
@@ -807,6 +809,106 @@ pub enum Dialect {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct PlatformSemanticsDeclaration {
     pub tags: Vec<PlatformSemanticTag>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dimension_values: Vec<DimensionValueMemento>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub op_aliases: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DivergenceCharacterization {
+    pub dimension_name: String,
+    pub source_value_cid: String,
+    pub target_value_cid: String,
+    pub source_compare_to: IrFormula,
+    pub target_compare_to: IrFormula,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PlatformSemanticComparisonError {
+    SourceOpAbsent {
+        op_cid: String,
+    },
+    TargetOpAbsent {
+        op_cid: String,
+    },
+    SourceDimensionAbsent {
+        op_cid: String,
+        dimension_name: String,
+    },
+    TargetDimensionAbsent {
+        op_cid: String,
+        dimension_name: String,
+    },
+    SourceValueAbsent {
+        value_cid: String,
+    },
+    TargetValueAbsent {
+        value_cid: String,
+    },
+}
+
+impl PlatformSemanticsDeclaration {
+    pub fn compare_op_with(
+        &self,
+        op_cid: &str,
+        target: &Self,
+    ) -> Result<Option<DivergenceCharacterization>, PlatformSemanticComparisonError> {
+        let source_tag = self.tag_for_op(op_cid).ok_or_else(|| {
+            PlatformSemanticComparisonError::SourceOpAbsent {
+                op_cid: op_cid.to_string(),
+            }
+        })?;
+        let target_tag = target.tag_for_op(op_cid).ok_or_else(|| {
+            PlatformSemanticComparisonError::TargetOpAbsent {
+                op_cid: op_cid.to_string(),
+            }
+        })?;
+
+        for (dimension_name, source_value_cid) in &source_tag.dimensions {
+            let Some(target_value_cid) = target_tag.dimensions.get(dimension_name) else {
+                continue;
+            };
+            if source_value_cid == target_value_cid {
+                continue;
+            }
+
+            let source_value = self.value_for_cid(source_value_cid).ok_or_else(|| {
+                PlatformSemanticComparisonError::SourceValueAbsent {
+                    value_cid: source_value_cid.clone(),
+                }
+            })?;
+            let target_value = target.value_for_cid(target_value_cid).ok_or_else(|| {
+                PlatformSemanticComparisonError::TargetValueAbsent {
+                    value_cid: target_value_cid.clone(),
+                }
+            })?;
+            return Ok(Some(DivergenceCharacterization {
+                dimension_name: dimension_name.clone(),
+                source_value_cid: source_value_cid.clone(),
+                target_value_cid: target_value_cid.clone(),
+                source_compare_to: source_value.compare_to.clone(),
+                target_compare_to: target_value.compare_to.clone(),
+            }));
+        }
+
+        Ok(None)
+    }
+
+    fn tag_for_op(&self, op_cid: &str) -> Option<&PlatformSemanticTag> {
+        let resolved = self
+            .op_aliases
+            .get(op_cid)
+            .map(String::as_str)
+            .unwrap_or(op_cid);
+        self.tags.iter().find(|tag| tag.op_cid == resolved)
+    }
+
+    fn value_for_cid(&self, value_cid: &str) -> Option<&DimensionValueMemento> {
+        self.dimension_values
+            .iter()
+            .find(|value| value.cid == value_cid)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -14,8 +14,8 @@ use libprovekit::core::{
     verify, ArityShape, AritySlot, CKit, Canonical, Catalog, Cid, ConformanceDeclaration, Dialect,
     DomainClaim, DomainKind, FunctionContractDomain, HashMapCatalog, HashMapInputCatalog, Input,
     InputCatalog, Kit, KitRegistry, LanguageSignature, LiftKit, LiftPluginKit, Path, PathAlgebra,
-    PathDocument, PathDocumentError, PathError, PlatformSemanticsDeclaration, Refutation, SlotSort,
-    Term, Truth, Verb, Verdict, Witness,
+    PathDocument, PathDocumentError, PathError, PlatformSemanticComparisonError,
+    PlatformSemanticsDeclaration, Refutation, SlotSort, Term, Truth, Verb, Verdict, Witness,
 };
 use provekit_canonicalizer::{blake3_512_of, Value};
 use provekit_ir_types::{
@@ -1274,6 +1274,8 @@ fn carrier_registration_preserves_platform_semantics_declaration() {
     );
     let declaration = PlatformSemanticsDeclaration {
         tags: vec![first_tag.clone(), second_tag.clone()],
+        dimension_values: vec![wrapping, truncate, arbitrary_precision],
+        op_aliases: BTreeMap::new(),
     };
     let mut registry = KitRegistry::default();
 
@@ -1522,6 +1524,71 @@ fn dispatcher_returns_c_platform_semantics_declaration() {
     ] {
         assert!(op_cids.contains(required), "missing C semantics tag for {required}");
     }
+}
+
+#[test]
+fn platform_semantics_compare_op_reports_open_keyed_dimension_divergence() {
+    let source = platform_semantics_for_lower_target("python")
+        .expect("python lower target declares platform semantics");
+    let target =
+        platform_semantics_for_lower_target("rust").expect("rust lower target declares semantics");
+    let div = PYTHON_PLATFORM_CONCEPT_OP_CIDS[3];
+
+    let divergence = source
+        .compare_op_with(div, &target)
+        .expect("comparison is characterizable")
+        .expect("python div to rust div diverges");
+
+    assert_eq!(divergence.dimension_name, "IntegerDivisionRounding");
+    assert_ne!(divergence.source_value_cid, divergence.target_value_cid);
+    assert_eq!(
+        divergence.source_compare_to,
+        IrFormula::Atomic {
+            name: "python:Floor".to_string(),
+            args: vec![],
+        }
+    );
+    assert_eq!(
+        divergence.target_compare_to,
+        IrFormula::Atomic {
+            name: "rust:Truncate".to_string(),
+            args: vec![],
+        }
+    );
+}
+
+#[test]
+fn platform_semantics_compare_op_preserves_exact_same_kit_leg() {
+    let source = platform_semantics_for_lower_target("python")
+        .expect("python lower target declares platform semantics");
+    let div = PYTHON_PLATFORM_CONCEPT_OP_CIDS[3];
+
+    assert_eq!(
+        source
+            .compare_op_with(div, &source)
+            .expect("same-kit comparison is characterizable"),
+        None
+    );
+}
+
+#[test]
+fn platform_semantics_compare_op_reports_uncharacterizable_absent_target_op() {
+    let source =
+        platform_semantics_for_lower_target("rust").expect("rust lower target declares semantics");
+    let target = platform_semantics_for_lower_target("java")
+        .expect("java lower target declares platform semantics");
+    let rust_only_op = source
+        .tags
+        .iter()
+        .map(|tag| tag.op_cid.as_str())
+        .find(|op_cid| target.compare_op_with(op_cid, &target).is_err())
+        .expect("fixture has a rust-only native op cid");
+
+    assert!(matches!(
+        source.compare_op_with(rust_only_op, &target),
+        Err(PlatformSemanticComparisonError::TargetOpAbsent { op_cid })
+            if op_cid == rust_only_op
+    ));
 }
 
 #[test]

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -74,6 +74,10 @@ pub struct BindArgs {
     #[arg(long)]
     pub library_to: Option<String>,
 
+    /// Scope migration effect propagation to one triggering callsite CID.
+    #[arg(long)]
+    pub focus: Option<String>,
+
     /// Source directory for migration rewrite.
     #[arg(long)]
     pub source_dir: Option<PathBuf>,
@@ -274,6 +278,7 @@ impl std::fmt::Display for BindCliError {
 fn is_migration_request(args: &BindArgs) -> bool {
     args.library_from.is_some()
         || args.library_to.is_some()
+        || args.focus.is_some()
         || args.source_dir.is_some()
         || args.out_dir.is_some()
         || args.receipt.is_some()

--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -7,8 +7,9 @@ use std::sync::Arc;
 
 use chrono::{SecondsFormat, Utc};
 use libprovekit::core::{
-    execute_path, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
-    Verb,
+    execute_path, platform_semantics_for_lower_target, DivergenceCharacterization,
+    HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
+    PlatformSemanticComparisonError, PlatformSemanticsDeclaration, Verb,
 };
 use libprovekit::effect_propagation::{
     propagate_effects, CallsiteEdge, ChangedCallsite, FunctionEffectInfo, PropagationDecision,
@@ -16,8 +17,8 @@ use libprovekit::effect_propagation::{
 };
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
 use provekit_ir_types::{
-    AggregateSummaryMemento, CrossLanguageWitnessPair, HaltMemento, LanguageTransitionMemento,
-    LossRecordMemento, MigrateReceiptEnvelope, MigrateReceiptSignature,
+    AggregateSummaryMemento, CrossLanguageWitnessPair, HaltMemento, IrFormula,
+    LanguageTransitionMemento, LossRecordMemento, MigrateReceiptEnvelope, MigrateReceiptSignature,
     MigrationConceptSiteMemento, MigrationEffectDelta, MigrationSourceLocation,
     PromotionDecisionEnvelope, PromotionDecisionHeader, PromotionDecisionMemento,
     PromotionDecisionMetadata, PromotionGate, PromotionResult, RefusalMemento, WitnessMemento,
@@ -85,6 +86,7 @@ fn run_inner(args: BindArgs) -> Result<(), String> {
     if sql_callsites.is_empty() {
         return Err("no better-sqlite3 SQL callsites found".to_string());
     }
+    validate_focus(args.focus.as_deref(), &sql_callsites)?;
 
     let source_binding_cid = body_template_cid(&repo_root, library_from)?;
     let target_binding_cid = body_template_cid(&repo_root, library_to)?;
@@ -93,8 +95,21 @@ fn run_inner(args: BindArgs) -> Result<(), String> {
     probe_realize_binding(&repo_root, &source_lang, &source_tag, "concept:sql-execute")?;
     probe_realize_binding(&repo_root, &target_lang, &target_tag, "concept:sql-execute")?;
 
-    let decisions = if target_surface.requires_async_delta() {
-        let graph = build_propagation_input(&functions, &sql_callsites);
+    let semantic_changes = platform_semantic_changes_for_targets(
+        &source_lang,
+        &target_lang,
+        &sql_callsites,
+        args.focus.as_deref(),
+    )?;
+    let mut changed_callsites = semantic_changes.changed_callsites.clone();
+    if target_surface.requires_async_delta() {
+        changed_callsites.extend(async_changed_callsites(
+            &sql_callsites,
+            args.focus.as_deref(),
+        ));
+    }
+    let decisions = if !changed_callsites.is_empty() {
+        let graph = build_propagation_input(&functions, &sql_callsites, changed_callsites);
         propagate_effects(&graph)
             .map_err(|e| format!("effect propagation: {e}"))?
             .decisions
@@ -114,6 +129,7 @@ fn run_inner(args: BindArgs) -> Result<(), String> {
         &source_binding_cid,
         &target_binding_cid,
         target_surface,
+        &semantic_changes.divergences_by_effect,
     )?;
     if let Some(fixture) = witness_fixture.as_ref() {
         if target_surface.is_python() {
@@ -655,9 +671,85 @@ fn parse_string_literal(arg: &str) -> Option<String> {
     Some(out)
 }
 
+#[derive(Debug, Clone, Default)]
+struct PlatformSemanticChangeSet {
+    changed_callsites: Vec<ChangedCallsite>,
+    divergences_by_effect: BTreeMap<String, DivergenceCharacterization>,
+}
+
+fn validate_focus(focus: Option<&str>, sql_callsites: &[SqlCallsite]) -> Result<(), String> {
+    let Some(focus) = focus else {
+        return Ok(());
+    };
+    if sql_callsites.iter().any(|callsite| callsite.cid == focus) {
+        Ok(())
+    } else {
+        Err(format!("--focus callsite {focus} was not found"))
+    }
+}
+
+fn async_changed_callsites(
+    sql_callsites: &[SqlCallsite],
+    focus: Option<&str>,
+) -> Vec<ChangedCallsite> {
+    sql_callsites
+        .iter()
+        .filter(|callsite| focus.map_or(true, |focus| focus == callsite.cid))
+        .map(|callsite| ChangedCallsite {
+            callsite_cid: callsite.cid.clone(),
+            effect: ASYNC_EFFECT.to_string(),
+        })
+        .collect()
+}
+
+fn platform_semantic_changes_for_targets(
+    source_lang: &str,
+    target_lang: &str,
+    sql_callsites: &[SqlCallsite],
+    focus: Option<&str>,
+) -> Result<PlatformSemanticChangeSet, String> {
+    let Some(source) = platform_semantics_for_lower_target(source_lang) else {
+        return Ok(PlatformSemanticChangeSet::default());
+    };
+    let Some(target) = platform_semantics_for_lower_target(target_lang) else {
+        return Ok(PlatformSemanticChangeSet::default());
+    };
+    platform_semantic_changes(&source, &target, sql_callsites, focus)
+        .map_err(|error| format!("platform semantic comparison: {error:?}"))
+}
+
+fn platform_semantic_changes(
+    source: &PlatformSemanticsDeclaration,
+    target: &PlatformSemanticsDeclaration,
+    sql_callsites: &[SqlCallsite],
+    focus: Option<&str>,
+) -> Result<PlatformSemanticChangeSet, PlatformSemanticComparisonError> {
+    let mut changes = PlatformSemanticChangeSet::default();
+    for callsite in sql_callsites
+        .iter()
+        .filter(|callsite| focus.map_or(true, |focus| focus == callsite.cid))
+    {
+        let Some(divergence) = source.compare_op_with(&callsite.concept_cid, target)? else {
+            continue;
+        };
+        let effect = divergence_effect_cid(&divergence);
+        changes.changed_callsites.push(ChangedCallsite {
+            callsite_cid: callsite.cid.clone(),
+            effect: effect.clone(),
+        });
+        changes.divergences_by_effect.insert(effect, divergence);
+    }
+    Ok(changes)
+}
+
+fn divergence_effect_cid(divergence: &DivergenceCharacterization) -> String {
+    divergence.target_value_cid.clone()
+}
+
 fn build_propagation_input(
     functions: &[TsFunction],
     sql_callsites: &[SqlCallsite],
+    changed_callsites: Vec<ChangedCallsite>,
 ) -> PropagationInput {
     let mut function_map = BTreeMap::new();
     for function in functions {
@@ -691,7 +783,6 @@ fn build_propagation_input(
     }
 
     let mut callsites = BTreeMap::new();
-    let mut changed_callsites = Vec::new();
     for callsite in sql_callsites {
         callsites.insert(
             callsite.cid.clone(),
@@ -701,10 +792,6 @@ fn build_propagation_input(
                 containing_fn: callsite.function.clone(),
             },
         );
-        changed_callsites.push(ChangedCallsite {
-            callsite_cid: callsite.cid.clone(),
-            effect: ASYNC_EFFECT.to_string(),
-        });
     }
 
     for caller in functions {
@@ -840,6 +927,7 @@ fn build_receipt(
     source_binding_cid: &str,
     target_binding_cid: &str,
     target_surface: TargetSurface,
+    divergences_by_effect: &BTreeMap<String, DivergenceCharacterization>,
 ) -> Result<MigrateReceiptEnvelope, String> {
     let mut concept_sites = Vec::new();
     for callsite in sql_callsites {
@@ -922,12 +1010,51 @@ fn build_receipt(
     }
 
     let mut loss_records = Vec::new();
+    for decision in decisions.values() {
+        let PropagationDecision::Widen {
+            effect,
+            triggering_callsite_cid,
+            ..
+        } = decision
+        else {
+            continue;
+        };
+        let Some(divergence) = divergences_by_effect.get(effect) else {
+            continue;
+        };
+        let Some(callsite) = sql_callsites
+            .iter()
+            .find(|callsite| callsite.cid == *triggering_callsite_cid)
+        else {
+            continue;
+        };
+        let mut loss_dimensions = BTreeMap::new();
+        loss_dimensions.insert(
+            divergence.dimension_name.clone(),
+            IrFormula::DivergenceBetween {
+                source: Box::new(divergence.source_compare_to.clone()),
+                target: Box::new(divergence.target_compare_to.clone()),
+            },
+        );
+        let mut loss = LossRecordMemento {
+            callsite_cid: callsite.cid.clone(),
+            cid: String::new(),
+            kind: "loss-record".to_string(),
+            loss_dimension: divergence.dimension_name.clone(),
+            loss_dimensions,
+            schema_version: "1".to_string(),
+            substituted_body: callsite.substituted_body.clone(),
+        };
+        loss.cid = loss.recompute_cid().map_err(|e| e.to_string())?;
+        loss_records.push(loss);
+    }
     for callsite in sql_callsites.iter().filter(|c| c.lossy) {
         let mut loss = LossRecordMemento {
             callsite_cid: callsite.cid.clone(),
             cid: String::new(),
             kind: "loss-record".to_string(),
             loss_dimension: "last_insert_rowid".to_string(),
+            loss_dimensions: BTreeMap::new(),
             schema_version: "1".to_string(),
             substituted_body: callsite.substituted_body.clone(),
         };
@@ -1990,6 +2117,232 @@ fn json_to_value(j: &serde_json::Value) -> Arc<Value> {
                 .map(|(k, v)| (k.clone(), json_to_value(v)))
                 .collect();
             Value::object(kv)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libprovekit::core::{platform_semantics_for_lower_target, PlatformSemanticComparisonError};
+    use provekit_ir_types::IrFormula;
+
+    const CONCEPT_ADD_CID: &str = "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468";
+    const CONCEPT_DIV_CID: &str = "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839";
+
+    fn function(name: &str) -> TsFunction {
+        TsFunction {
+            body: format!("return {name};"),
+            body_start: 0,
+            is_async: false,
+            line: 1,
+            name: name.to_string(),
+            public_sync_contract_cid: None,
+            return_type: "number".to_string(),
+            signature: format!("function {name}(): number"),
+        }
+    }
+
+    fn callsite(cid: &str, concept_cid: &str, function: &str) -> SqlCallsite {
+        SqlCallsite {
+            after: MigrationSourceLocation {
+                column: 1,
+                file: "after.rs".to_string(),
+                line: 1,
+            },
+            before: MigrationSourceLocation {
+                column: 1,
+                file: "before.rs".to_string(),
+                line: 1,
+            },
+            cid: cid.to_string(),
+            concept_cid: concept_cid.to_string(),
+            function: function.to_string(),
+            lossy: false,
+            sample_args: Vec::new(),
+            sql: String::new(),
+            substituted_body: format!("{function}:{cid}"),
+        }
+    }
+
+    fn receipt_for(
+        source: &str,
+        target: &str,
+        callsites: &[SqlCallsite],
+        focus: Option<&str>,
+    ) -> MigrateReceiptEnvelope {
+        let source_decl =
+            platform_semantics_for_lower_target(source).expect("source semantics declared");
+        let target_decl =
+            platform_semantics_for_lower_target(target).expect("target semantics declared");
+        let changes = platform_semantic_changes(&source_decl, &target_decl, callsites, focus)
+            .expect("semantic comparison is characterizable");
+        let functions = callsites
+            .iter()
+            .map(|callsite| function(&callsite.function))
+            .collect::<Vec<_>>();
+        let graph = build_propagation_input(&functions, callsites, changes.changed_callsites);
+        let decisions = propagate_effects(&graph)
+            .expect("propagation succeeds")
+            .decisions;
+        build_receipt(
+            &decisions,
+            callsites,
+            &functions,
+            "source-binding",
+            "target-binding",
+            TargetSurface::TypescriptPg,
+            &changes.divergences_by_effect,
+        )
+        .expect("receipt builds")
+    }
+
+    #[test]
+    fn point_query_receipt_populates_divergence_loss_dimensions_and_is_byte_stable() {
+        let callsites = vec![callsite("cs:add", CONCEPT_ADD_CID, "add")];
+
+        let java_receipt = receipt_for("python", "java", &callsites, None);
+        let java_receipt_again = receipt_for("python", "java", &callsites, None);
+        assert_eq!(java_receipt.root_cid, java_receipt_again.root_cid);
+        assert_eq!(java_receipt.aggregate_summary.lossy, 1);
+        assert_eq!(java_receipt.aggregate_summary.widened, 1);
+        let java_loss = &java_receipt.loss_records[0];
+        assert_eq!(java_loss.callsite_cid, "cs:add");
+        assert!(matches!(
+            java_loss.loss_dimensions.get("ArithmeticOverflow"),
+            Some(IrFormula::DivergenceBetween { source, target })
+                if **source == atom("python:ArbitraryPrecision")
+                    && **target == atom("java:Wrapping")
+        ));
+
+        let c_receipt = receipt_for("python", "c", &callsites, None);
+        let c_loss = &c_receipt.loss_records[0];
+        assert!(matches!(
+            c_loss.loss_dimensions.get("ArithmeticOverflow"),
+            Some(IrFormula::DivergenceBetween { source, target })
+                if **source == atom("python:ArbitraryPrecision")
+                    && **target == atom("c:UndefinedBehavior")
+        ));
+        assert_ne!(java_receipt.root_cid, c_receipt.root_cid);
+    }
+
+    #[test]
+    fn point_query_changed_callsite_effect_is_target_dimension_value_cid() {
+        let callsites = vec![callsite("cs:add", CONCEPT_ADD_CID, "add")];
+        let source = platform_semantics_for_lower_target("python").expect("python semantics");
+        let target = platform_semantics_for_lower_target("java").expect("java semantics");
+
+        let changes =
+            platform_semantic_changes(&source, &target, &callsites, None).expect("changes");
+        let changed = changes.changed_callsites.first().expect("changed callsite");
+        let divergence = changes
+            .divergences_by_effect
+            .get(&changed.effect)
+            .expect("effect indexes divergence");
+
+        assert_eq!(changed.effect, divergence.target_value_cid);
+        assert!(target
+            .dimension_values
+            .iter()
+            .any(|value| value.cid == changed.effect));
+    }
+
+    #[test]
+    fn point_query_focus_scopes_loss_records_to_the_focused_callsite() {
+        let callsites = vec![
+            callsite("cs:add", CONCEPT_ADD_CID, "add"),
+            callsite("cs:div", CONCEPT_DIV_CID, "divide"),
+        ];
+
+        let rust_receipt = receipt_for("python", "rust", &callsites, Some("cs:div"));
+        assert_eq!(rust_receipt.loss_records.len(), 1);
+        assert_eq!(rust_receipt.loss_records[0].callsite_cid, "cs:div");
+        assert!(rust_receipt.loss_records[0]
+            .loss_dimensions
+            .contains_key("IntegerDivisionRounding"));
+
+        let java_receipt = receipt_for("python", "java", &callsites, Some("cs:div"));
+        assert_eq!(java_receipt.loss_records.len(), 1);
+        assert_eq!(java_receipt.loss_records[0].callsite_cid, "cs:div");
+        assert_ne!(rust_receipt.root_cid, java_receipt.root_cid);
+    }
+
+    #[test]
+    fn point_query_same_kit_exact_leg_emits_zero_loss_records() {
+        let callsites = vec![callsite("cs:div", CONCEPT_DIV_CID, "divide")];
+
+        let receipt = receipt_for("python", "python", &callsites, None);
+        assert_eq!(receipt.aggregate_summary.lossy, 0);
+        assert_eq!(receipt.aggregate_summary.widened, 0);
+        assert!(receipt.loss_records.is_empty());
+    }
+
+    #[test]
+    fn point_query_refuse_decision_does_not_emit_partial_loss_records() {
+        let callsites = vec![callsite("cs:add", CONCEPT_ADD_CID, "add")];
+        let source = platform_semantics_for_lower_target("python").expect("python semantics");
+        let target = platform_semantics_for_lower_target("java").expect("java semantics");
+        let changes =
+            platform_semantic_changes(&source, &target, &callsites, None).expect("changes");
+        let effect = changes
+            .changed_callsites
+            .first()
+            .expect("changed callsite")
+            .effect
+            .clone();
+        let functions = vec![function("add")];
+        let decisions = BTreeMap::from([(
+            "add".to_string(),
+            PropagationDecision::Refuse {
+                forbidding_contract_cid: "contract:bounds-proof-required".to_string(),
+                function_cid: "function:add".to_string(),
+                reason: "contract forbids platform semantic widening".to_string(),
+                triggering_callsite_cid: "cs:add".to_string(),
+            },
+        )]);
+        assert!(changes.divergences_by_effect.contains_key(&effect));
+
+        let receipt = build_receipt(
+            &decisions,
+            &callsites,
+            &functions,
+            "source-binding",
+            "target-binding",
+            TargetSurface::TypescriptPg,
+            &changes.divergences_by_effect,
+        )
+        .expect("receipt builds");
+
+        assert_eq!(receipt.aggregate_summary.refused, 1);
+        assert_eq!(
+            receipt.refusal_mementos[0].forbidding_contract,
+            "contract:bounds-proof-required"
+        );
+        assert!(receipt.loss_records.is_empty());
+    }
+
+    #[test]
+    fn point_query_uncharacterizable_absent_op_routes_to_refuse_signal() {
+        let source = platform_semantics_for_lower_target("rust").expect("rust semantics");
+        let target = platform_semantics_for_lower_target("java").expect("java semantics");
+        let rust_only_op = source
+            .tags
+            .iter()
+            .map(|tag| tag.op_cid.as_str())
+            .find(|op_cid| target.compare_op_with(op_cid, &target).is_err())
+            .expect("rust-only op fixture exists");
+        let callsites = vec![callsite("cs:rust-native", rust_only_op, "native")];
+
+        assert!(matches!(
+            platform_semantic_changes(&source, &target, &callsites, None),
+            Err(PlatformSemanticComparisonError::TargetOpAbsent { .. })
+        ));
+    }
+
+    fn atom(name: &str) -> IrFormula {
+        IrFormula::Atomic {
+            name: name.to_string(),
+            args: vec![],
         }
     }
 }

--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -5653,6 +5653,9 @@ pub struct LossRecordMemento {
     pub kind: String,
     #[serde(rename = "loss_dimension")]
     pub loss_dimension: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(rename = "loss_dimensions")]
+    pub loss_dimensions: BTreeMap<String, IrFormula>,
     #[serde(rename = "schemaVersion")]
     pub schema_version: String,
     #[serde(rename = "substituted_body")]

--- a/implementations/rust/provekit-realize-rust-core/src/platform_semantics.rs
+++ b/implementations/rust/provekit-realize-rust-core/src/platform_semantics.rs
@@ -102,14 +102,39 @@ fn dimension_value_cids() -> DimensionValueCids {
     }
 }
 
-fn dimension_value_cid(dimension_name: &str, value_name: &str, compare_to: IrFormula) -> String {
+pub fn dimension_values() -> Vec<DimensionValueMemento> {
+    vec![
+        dimension_value("ArithmeticOverflow", "Wrapping", atom("rust:Wrapping")),
+        dimension_value("IntegerDivisionRounding", "Truncate", atom("rust:Truncate")),
+        dimension_value("ShiftMode", "Arithmetic", atom("rust:Arithmetic")),
+        dimension_value(
+            "NullSemantics",
+            "PanicOnDivByZero",
+            atom("rust:PanicOnDivByZero"),
+        ),
+        dimension_value(
+            "BitwiseSemantics",
+            "TwosComplement",
+            atom("rust:TwosComplement"),
+        ),
+    ]
+}
+
+fn dimension_value(
+    dimension_name: &str,
+    value_name: &str,
+    compare_to: IrFormula,
+) -> DimensionValueMemento {
     DimensionValueMemento::new(
         RUST_KIT_CID.to_string(),
         dimension_name.to_string(),
         value_name.to_string(),
         compare_to,
     )
-    .cid
+}
+
+fn dimension_value_cid(dimension_name: &str, value_name: &str, compare_to: IrFormula) -> String {
+    dimension_value(dimension_name, value_name, compare_to).cid
 }
 
 fn tag(op_cid: &str, dimensions: &[(&str, &str)]) -> PlatformSemanticTag {


### PR DESCRIPTION
Per-callsite migration point-query producing target-platform-dependent effect chain receipt. Bridges Stage 3.1's platform semantic dimension CIDs into ChangedCallsite.effect via DimensionValueMemento. Adds --focus scoping + LossRecordMemento.loss_dimensions with IrFormula::DivergenceBetween.

Codex completed in isolated worktree; Kit committed on its behalf.

Closes #1147. Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>

🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--focus` CLI option for migration mode to refine semantic validations.
  * Enhanced platform semantics comparison to characterize divergence between source and target operations.

* **Improvements**
  * Refined loss record tracking with dimension-specific loss representation for precise effect characterization across callsites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->