### PR TITLE
feat(memento): mint SugarSelectionPolicyMemento (closes #889)

### DIFF
--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -4140,6 +4140,348 @@ impl std::fmt::Display for PolicyProfileValidationError {
 
 impl std::error::Error for PolicyProfileValidationError {}
 
+// ============================================================
+// Manual extension: SugarSelectionPolicyMemento family (issue #889)
+// Source of truth:
+//   protocol/specs/2026-05-18-sugar-selection-policy-memento.md
+//
+// This is a content-addressed declaration of the sugar selection policy lane
+// cited by PolicyProfileMemento. It codifies the sugar-dict §4 emission
+// policy as a federated memento so vendors can ship policy CIDs alongside
+// sugar dict CIDs.
+// ============================================================
+
+/// The sugar emission mode selected by a sugar selection policy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub enum SugarSelectionMode {
+    BestOnly,
+    Inclusive,
+    Strict,
+}
+
+impl SugarSelectionMode {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::BestOnly => "best-only",
+            Self::Inclusive => "inclusive",
+            Self::Strict => "strict",
+        }
+    }
+}
+
+impl TryFrom<String> for SugarSelectionMode {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "best-only" => Ok(Self::BestOnly),
+            "inclusive" => Ok(Self::Inclusive),
+            "strict" => Ok(Self::Strict),
+            other => Err(format!("unknown sugar selection mode `{other}`")),
+        }
+    }
+}
+
+impl From<SugarSelectionMode> for String {
+    fn from(mode: SugarSelectionMode) -> String {
+        mode.as_str().to_string()
+    }
+}
+
+/// The deterministic tie-breaking strategy from sugar-dict §4.4.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub enum SugarSelectionTieBreaking {
+    LoadOrderThenEntryIndex,
+}
+
+impl SugarSelectionTieBreaking {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::LoadOrderThenEntryIndex => "load-order-then-entry-index",
+        }
+    }
+}
+
+impl TryFrom<String> for SugarSelectionTieBreaking {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "load-order-then-entry-index" => Ok(Self::LoadOrderThenEntryIndex),
+            other => Err(format!("unknown sugar selection tie_breaking `{other}`")),
+        }
+    }
+}
+
+impl From<SugarSelectionTieBreaking> for String {
+    fn from(tie_breaking: SugarSelectionTieBreaking) -> String {
+        tie_breaking.as_str().to_string()
+    }
+}
+
+/// Per-concept, per-language match criterion for a sugar selection policy.
+///
+/// Locked JCS key order: concept, language.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SugarSelectionAppliesTo {
+    pub concept: String,
+    pub language: String,
+}
+
+/// Content-addressed sugar selection policy.
+///
+/// Header fields are `cid`, `kind`, and `schemaVersion`; the remaining fields
+/// declare the policy content. Field order follows JCS key order:
+/// applies_to, cid, eligible_sugars, forbidden_sugars, kind, mode,
+/// schemaVersion, scoring, tie_breaking.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SugarSelectionPolicyMemento {
+    #[serde(rename = "applies_to")]
+    pub applies_to: Vec<SugarSelectionAppliesTo>,
+    /// DERIVED: BLAKE3-512 over JCS(memento) with `cid` elided.
+    pub cid: String,
+    #[serde(rename = "eligible_sugars")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eligible_sugars: Option<Vec<String>>,
+    #[serde(rename = "forbidden_sugars")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forbidden_sugars: Option<Vec<String>>,
+    /// MUST be "sugar-selection-policy".
+    pub kind: String,
+    pub mode: SugarSelectionMode,
+    /// MUST be "1".
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scoring: Option<String>,
+    #[serde(rename = "tie_breaking")]
+    pub tie_breaking: SugarSelectionTieBreaking,
+}
+
+impl SugarSelectionPolicyMemento {
+    pub fn from_jcs(jcs: &str) -> Result<Self, SugarSelectionPolicyValidationError> {
+        let policy: Self = serde_json::from_str(jcs)
+            .map_err(|err| SugarSelectionPolicyValidationError::Json(err.to_string()))?;
+        let rendered = policy.to_jcs_string()?;
+        if rendered != jcs {
+            return Err(SugarSelectionPolicyValidationError::NonCanonicalJcs);
+        }
+        policy.validate()?;
+        Ok(policy)
+    }
+
+    pub fn to_jcs_string(&self) -> Result<String, PromotionDecisionCanonicalizationError> {
+        let json = serde_json::to_value(self)?;
+        let canonical = serde_json_to_canonical_value(&json)?;
+        Ok(provekit_canonicalizer::encode_jcs(&canonical))
+    }
+
+    pub fn recompute_cid(&self) -> Result<String, PromotionDecisionCanonicalizationError> {
+        let mut policy = serde_json::to_value(self)?;
+        let serde_json::Value::Object(ref mut object) = policy else {
+            return Err(PromotionDecisionCanonicalizationError::new(
+                "sugar selection policy did not serialize as an object",
+            ));
+        };
+
+        object.remove("cid");
+        let canonical = serde_json_to_canonical_value(&policy)?;
+        let jcs = provekit_canonicalizer::encode_jcs(&canonical);
+        Ok(provekit_canonicalizer::blake3_512_of(jcs.as_bytes()))
+    }
+
+    pub fn validate(&self) -> Result<(), SugarSelectionPolicyValidationError> {
+        if self.kind != "sugar-selection-policy" {
+            return Err(SugarSelectionPolicyValidationError::InvalidKind {
+                kind: self.kind.clone(),
+            });
+        }
+        if self.schema_version != "1" {
+            return Err(SugarSelectionPolicyValidationError::InvalidSchemaVersion {
+                schema_version: self.schema_version.clone(),
+            });
+        }
+        if self.applies_to.is_empty() {
+            return Err(SugarSelectionPolicyValidationError::EmptyAppliesTo);
+        }
+        for (index, criterion) in self.applies_to.iter().enumerate() {
+            if criterion.concept.is_empty() {
+                return Err(SugarSelectionPolicyValidationError::EmptyApplyCriterion {
+                    index,
+                    field: "concept",
+                });
+            }
+            if criterion.language.is_empty() {
+                return Err(SugarSelectionPolicyValidationError::EmptyApplyCriterion {
+                    index,
+                    field: "language",
+                });
+            }
+        }
+
+        if let Some(scoring) = &self.scoring {
+            require_policy_cid("scoring", scoring)?;
+        }
+        validate_policy_cid_list("eligible_sugars", self.eligible_sugars.as_deref())?;
+        validate_policy_cid_list("forbidden_sugars", self.forbidden_sugars.as_deref())?;
+        reject_policy_cid_overlap(
+            self.eligible_sugars.as_deref(),
+            self.forbidden_sugars.as_deref(),
+        )?;
+
+        let actual = self.recompute_cid().map_err(|err| {
+            SugarSelectionPolicyValidationError::Canonicalization(err.to_string())
+        })?;
+        if actual != self.cid {
+            return Err(SugarSelectionPolicyValidationError::CidMismatch {
+                claimed: self.cid.clone(),
+                actual,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+impl std::str::FromStr for SugarSelectionPolicyMemento {
+    type Err = SugarSelectionPolicyValidationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_jcs(s)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SugarSelectionPolicyValidationError {
+    InvalidKind { kind: String },
+    InvalidSchemaVersion { schema_version: String },
+    EmptyAppliesTo,
+    EmptyApplyCriterion { index: usize, field: &'static str },
+    InvalidCid { field: &'static str, cid: String },
+    DuplicateSugarCid { field: &'static str, cid: String },
+    OverlappingSugarCid { cid: String },
+    CidMismatch { claimed: String, actual: String },
+    Canonicalization(String),
+    Json(String),
+    NonCanonicalJcs,
+}
+
+impl std::fmt::Display for SugarSelectionPolicyValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidKind { kind } => {
+                write!(f, "SugarSelectionPolicyMemento: invalid kind `{kind}`")
+            }
+            Self::InvalidSchemaVersion { schema_version } => write!(
+                f,
+                "SugarSelectionPolicyMemento: invalid schemaVersion `{schema_version}`"
+            ),
+            Self::EmptyAppliesTo => {
+                f.write_str("SugarSelectionPolicyMemento: applies_to must be non-empty")
+            }
+            Self::EmptyApplyCriterion { index, field } => write!(
+                f,
+                "SugarSelectionPolicyMemento: applies_to[{index}].{field} must be non-empty"
+            ),
+            Self::InvalidCid { field, cid } => write!(
+                f,
+                "SugarSelectionPolicyMemento: {field} contains invalid cid `{cid}`"
+            ),
+            Self::DuplicateSugarCid { field, cid } => write!(
+                f,
+                "SugarSelectionPolicyMemento: {field} contains duplicate cid `{cid}`"
+            ),
+            Self::OverlappingSugarCid { cid } => write!(
+                f,
+                "SugarSelectionPolicyMemento: sugar cid `{cid}` is both eligible and forbidden"
+            ),
+            Self::CidMismatch { claimed, actual } => write!(
+                f,
+                "SugarSelectionPolicyMemento: cid mismatch: claimed {claimed}, recomputed {actual}"
+            ),
+            Self::Canonicalization(message) => write!(
+                f,
+                "SugarSelectionPolicyMemento: canonicalization failed: {message}"
+            ),
+            Self::Json(message) => {
+                write!(
+                    f,
+                    "SugarSelectionPolicyMemento: JSON parse failed: {message}"
+                )
+            }
+            Self::NonCanonicalJcs => {
+                f.write_str("SugarSelectionPolicyMemento: input was not canonical JCS")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SugarSelectionPolicyValidationError {}
+
+impl From<PromotionDecisionCanonicalizationError> for SugarSelectionPolicyValidationError {
+    fn from(err: PromotionDecisionCanonicalizationError) -> Self {
+        Self::Canonicalization(err.to_string())
+    }
+}
+
+fn require_policy_cid(
+    field: &'static str,
+    cid: &str,
+) -> Result<(), SugarSelectionPolicyValidationError> {
+    if is_blake3_512_cid(cid) {
+        Ok(())
+    } else {
+        Err(SugarSelectionPolicyValidationError::InvalidCid {
+            field,
+            cid: cid.to_string(),
+        })
+    }
+}
+
+fn validate_policy_cid_list(
+    field: &'static str,
+    cids: Option<&[String]>,
+) -> Result<(), SugarSelectionPolicyValidationError> {
+    let Some(cids) = cids else {
+        return Ok(());
+    };
+    let mut seen = std::collections::BTreeSet::new();
+    for cid in cids {
+        require_policy_cid(field, cid)?;
+        if !seen.insert(cid.as_str()) {
+            return Err(SugarSelectionPolicyValidationError::DuplicateSugarCid {
+                field,
+                cid: cid.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn reject_policy_cid_overlap(
+    eligible: Option<&[String]>,
+    forbidden: Option<&[String]>,
+) -> Result<(), SugarSelectionPolicyValidationError> {
+    let (Some(eligible), Some(forbidden)) = (eligible, forbidden) else {
+        return Ok(());
+    };
+
+    let eligible = eligible
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    for cid in forbidden {
+        if eligible.contains(cid.as_str()) {
+            return Err(SugarSelectionPolicyValidationError::OverlappingSugarCid {
+                cid: cid.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn is_blake3_512_cid(s: &str) -> bool {
     let Some(hex) = s.strip_prefix("blake3-512:") else {
         return false;

--- a/implementations/rust/provekit-ir-types/tests/sugar_selection_policy_serde.rs
+++ b/implementations/rust/provekit-ir-types/tests/sugar_selection_policy_serde.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use provekit_ir_types::{
+    SugarSelectionMode, SugarSelectionPolicyMemento, SugarSelectionPolicyValidationError,
+    SugarSelectionTieBreaking,
+};
+
+#[test]
+fn sugar_selection_policy_round_trips_from_jcs_byte_identical() {
+    let mut policy: SugarSelectionPolicyMemento =
+        serde_json::from_str(&policy_json("")).expect("parse sugar selection policy");
+    policy.cid = policy
+        .recompute_cid()
+        .expect("recompute sugar selection policy cid");
+    let jcs = policy.to_jcs_string().expect("canonicalize policy");
+
+    let parsed =
+        SugarSelectionPolicyMemento::from_jcs(&jcs).expect("parse policy from canonical bytes");
+    let reserialized = parsed.to_jcs_string().expect("canonicalize parsed policy");
+
+    assert_eq!(reserialized, jcs);
+    assert_eq!(parsed.kind, "sugar-selection-policy");
+    assert_eq!(parsed.schema_version, "1");
+    assert_eq!(parsed.mode, SugarSelectionMode::Inclusive);
+    assert_eq!(
+        parsed.tie_breaking,
+        SugarSelectionTieBreaking::LoadOrderThenEntryIndex
+    );
+    assert_eq!(parsed.recompute_cid().unwrap(), parsed.cid);
+}
+
+#[test]
+fn sugar_selection_policy_requires_at_least_one_apply_match() {
+    let mut policy: SugarSelectionPolicyMemento =
+        serde_json::from_str(&policy_json("")).expect("parse sugar selection policy");
+    policy.applies_to.clear();
+    policy.cid = policy
+        .recompute_cid()
+        .expect("recompute sugar selection policy cid");
+
+    let err = policy.validate().expect_err("empty applies_to must reject");
+
+    assert_eq!(err, SugarSelectionPolicyValidationError::EmptyAppliesTo);
+}
+
+#[test]
+fn sugar_selection_policy_rejects_policy_profile_kind() {
+    let mut policy: SugarSelectionPolicyMemento =
+        serde_json::from_str(&policy_json("")).expect("parse sugar selection policy");
+    policy.kind = "policy-profile".to_string();
+    policy.cid = policy
+        .recompute_cid()
+        .expect("recompute sugar selection policy cid");
+
+    let err = policy
+        .validate()
+        .expect_err("policy-profile kind must not parse as sugar selection policy");
+
+    assert!(matches!(
+        err,
+        SugarSelectionPolicyValidationError::InvalidKind { .. }
+    ));
+}
+
+fn policy_json(cid_value: &str) -> String {
+    format!(
+        r#"{{
+  "applies_to": [
+    {{"concept": "concept:non-null", "language": "java"}}
+  ],
+  "cid": "{cid_value}",
+  "eligible_sugars": [
+    "{eligible_sugar}"
+  ],
+  "forbidden_sugars": [
+    "{forbidden_sugar}"
+  ],
+  "kind": "sugar-selection-policy",
+  "mode": "inclusive",
+  "schemaVersion": "1",
+  "scoring": "{scoring}",
+  "tie_breaking": "load-order-then-entry-index"
+}}"#,
+        cid_value = cid_value,
+        eligible_sugar = cid('a'),
+        forbidden_sugar = cid('b'),
+        scoring = cid('c')
+    )
+}
+
+fn cid(ch: char) -> String {
+    format!("blake3-512:{}", ch.to_string().repeat(128))
+}

--- a/protocol/specs/2026-05-12-sugar-dict-memento.md
+++ b/protocol/specs/2026-05-12-sugar-dict-memento.md
@@ -133,6 +133,8 @@ Additional sugar-specific flags:
 
 For each canonical contract clause C produced by the realizer:
 
+The emission policy described in this section is codified as a content-addressed artifact in `2026-05-18-sugar-selection-policy-memento.md`.
+
 ### §4.0 Emission policy
 
 A sugar consumer MUST apply one of these policies for a clause:

--- a/protocol/specs/2026-05-14-policy-profile-memento.md
+++ b/protocol/specs/2026-05-14-policy-profile-memento.md
@@ -2,11 +2,11 @@
 
 **Status:** v1.0.0 normative draft.
 **Date:** 2026-05-14
-**Related:** `2026-05-14-witness-consensus-promotion-v1.1-consensus-vector.md`, `2026-05-13-policy-memento.md`, `2026-05-12-sugar-dict-memento.md`, `2026-05-14-contract-comment-sugar.md`, `project_provekit_honesty_gradient.md` (#856).
+**Related:** `2026-05-14-witness-consensus-promotion-v1.1-consensus-vector.md`, `2026-05-13-policy-memento.md`, `2026-05-12-sugar-dict-memento.md`, `2026-05-18-sugar-selection-policy-memento.md`, `2026-05-14-contract-comment-sugar.md`, `project_provekit_honesty_gradient.md` (#856).
 
 ## Motivation
 
-Policy mementos define individual gates. A `ConsensusPolicyMemento` says how a witness consensus vector is judged. A sugar selection policy says how loss and mode coverage are judged. An emission policy says which runtime wrapper mode a realization may emit.
+Policy mementos define individual gates. A `ConsensusPolicyMemento` says how a witness consensus vector is judged. A `SugarSelectionPolicyMemento` says how loss and mode coverage are judged for the sugar selection lane. An emission policy says which runtime wrapper mode a realization may emit.
 
 A run, however, does not choose one gate in isolation. It chooses a profile: local smoke checks often want permissive witness floors and gate wrappers, while production deployment often wants stricter witness diversity and monitor wrappers. If those choices live in CLI defaults, the audit trail loses the policy input that made two runs differ.
 
@@ -68,7 +68,7 @@ Unknown bare decision kinds fail closed. Extension decision kinds MUST be namesp
 
 ## Field Discipline
 
-`policy_cid` points at the gate-local policy memento that owns detailed replay. The profile does not replace that policy. It gives a caller one content-addressed input that resolves to the policies used by all decisions in the run.
+`policy_cid` points at the gate-local policy memento that owns detailed replay. For `decision_kind = "sugar-selection"`, it points at `SugarSelectionPolicyMemento` as specified in `2026-05-18-sugar-selection-policy-memento.md`. The profile does not replace that policy. It gives a caller one content-addressed input that resolves to the policies used by all decisions in the run.
 
 `thresholds` is a query-friendly projection of the gate-local policy. A profile registry validates only the small predicate grammar (`metric>=N`, `metric<=N`, `metric==N`, `metric>N`, `metric<N`). Full policy replay remains the job of the referenced policy.
 
@@ -114,7 +114,7 @@ They are examples and stable test vectors. They are not universal truth. Consume
 
 This spec does not define a new consensus policy. It uses the consensus-policy surface from `witness-consensus/1.1`.
 
-This spec does not define sugar selection scoring. It cites the sugar-selection policy that owns that evaluation.
+This spec does not define sugar selection scoring. It cites `SugarSelectionPolicyMemento`, the sugar-selection policy that owns that evaluation.
 
 This spec does not make `smoke` or `prod` magic strings. They are ordinary profile mementos with ordinary content CIDs.
 

--- a/protocol/specs/2026-05-18-sugar-selection-policy-memento.md
+++ b/protocol/specs/2026-05-18-sugar-selection-policy-memento.md
@@ -1,0 +1,117 @@
+# Sugar Selection Policy Memento (`sugar-selection-policy/1`)
+
+**Status:** v1.0.0 normative draft.
+**Date:** 2026-05-18
+**Related:** `2026-05-12-sugar-dict-memento.md`, `2026-05-12-loss-function-memento.md`, `2026-05-14-policy-profile-memento.md`, `2026-05-13-promotion-decision-memento.md`, `2026-04-30-canonicalization-grammar.md`, `TSavo/provekit#889`.
+
+## Purpose
+
+`SugarSelectionPolicyMemento` is the content-addressed declaration of the sugar selection policy used by a realization consumer. Vendors can ship and federate their own sugar selection policies as mementos, then cite those CIDs from profiles, receipts, and promotion records.
+
+This memento does not define a new selection algorithm. It codifies the mechanism already specified in `2026-05-12-sugar-dict-memento.md` §4: enumerate matching sugar entries, score each candidate with a loaded loss function, rank candidates, apply the deterministic tie-break, and emit according to the selected mode.
+
+The policy is a sibling in the PolicyMemento family because it is policy input, not sugar content. A sugar dict declares surfaces. A sugar selection policy declares which loaded surfaces are eligible, which are forbidden, how candidates are scored, and which emission posture the consumer applies.
+
+## Wire Shape
+
+```cddl
+; Imports:
+;   cid
+
+; Locked JCS key order:
+;   applies_to, cid, eligible_sugars, forbidden_sugars, kind, mode,
+;   schemaVersion, scoring, tie_breaking
+sugar-selection-policy-memento = {
+  applies_to:        [+ sugar-selection-applies-to],
+  cid:               cid,
+  ? eligible_sugars: [+ cid],
+  ? forbidden_sugars: [+ cid],
+  kind:              "sugar-selection-policy",
+  mode:              sugar-selection-mode,
+  schemaVersion:     "1",
+  ? scoring:         cid,
+  tie_breaking:      sugar-selection-tie-breaking
+}
+
+sugar-selection-mode = "best-only" / "inclusive" / "strict"
+
+; v1.0.0 codifies the deterministic tie-break from sugar-dict §4.4.
+sugar-selection-tie-breaking = "load-order-then-entry-index"
+
+; Locked JCS key order: concept, language
+sugar-selection-applies-to = {
+  concept:  tstr,
+  language: tstr
+}
+```
+
+## Field Semantics
+
+`kind` is the memento discriminator and MUST be `sugar-selection-policy`.
+
+`schemaVersion` is the schema discriminator and MUST be `1`.
+
+`mode` selects the emission posture:
+
+| Mode | Meaning |
+|------|---------|
+| `best-only` | Emit exactly one selected candidate, the lowest-loss candidate after scoring and tie-breaking. |
+| `inclusive` | Emit every applicable candidate that survives enumeration, ordered by scoring and tie-breaking. |
+| `strict` | Apply the strict sugar refusal rule from `2026-05-12-sugar-dict-memento.md` §5 when no matching entry exists. |
+
+`scoring` is an optional CID reference to a `LossFunctionMemento`. When absent, the consumer uses the loaded default loss function for the run. When present, the consumer MUST score every sugar candidate through that loss function CID.
+
+`tie_breaking` declares the deterministic tie-breaking strategy. The v1.0.0 canonical value is `load-order-then-entry-index`, meaning:
+
+1. later sugar dicts in registry `load_order` win over earlier dicts;
+2. lower entry indexes within the same sugar dict win; and
+3. the final impossible ambiguity case follows the refusal or inclusion behavior in sugar-dict §4.4.
+
+`eligible_sugars` is an optional allow-list of sugar-dict CIDs. When present, a consumer MUST consider only candidates from those sugar dicts.
+
+`forbidden_sugars` is an optional deny-list of sugar-dict CIDs. A consumer MUST refuse to emit candidates from those sugar dicts even if they match and score well.
+
+`applies_to` is the non-empty set of per-(concept, language) match criteria for the policy. `concept` is the concept or concept family identifier the policy covers. `language` is the target language or surface family the policy covers.
+
+## Federation
+
+CID construction follows the `PolicyProfileMemento` pattern:
+
+```text
+cid_input = JCS(sugar-selection-policy-memento with cid elided)
+cid = "blake3-512:" ++ hex(BLAKE3-512(cid_input))
+```
+
+Changing the mode, scoring CID, tie-breaking strategy, allow-list, deny-list, or applicability criteria changes the policy CID.
+
+`PolicyProfileMemento` uses its `decision_kind = "sugar-selection"` lane to cite the applicable `SugarSelectionPolicyMemento` through `policy_cid`. A consumer that resolves a profile CID therefore gets the exact sugar selection policy CID alongside the witness consensus and emission gating policy CIDs.
+
+`PromotionDecisionMemento` MAY cite the `SugarSelectionPolicyMemento` CID applied at promotion time through its policy reference surface, either directly when the promotion decision is the sugar selection decision or through the cited `PolicyProfileMemento` when the decision is replayed as part of a profiled run.
+
+Vendors can federate policy mementos the same way they federate sugar dicts: publish the bytes, publish the CID, and let consumers decide whether to trust or load that policy. The CID names the exact policy input, not a marketplace label.
+
+## Relationship To Sugar Dict §4
+
+`2026-05-12-sugar-dict-memento.md` §4 defines the selection and emission algorithm. This memento turns that algorithm's policy inputs into content-addressed bytes:
+
+1. §4.1 enumeration is constrained by `eligible_sugars`, `forbidden_sugars`, and `applies_to`.
+2. §4.2 scoring is pinned by `scoring` when present.
+3. §4.3 selection is controlled by `mode`.
+4. §4.4 tie-breaking is pinned by `tie_breaking`.
+5. §4.5 emission records the selected candidates and can carry this policy CID in the audit trail or promotion record.
+
+The algorithm remains in the sugar dict spec. The selected policy becomes replayable because the consumer can cite this memento CID.
+
+## Validation
+
+Registries admitting a `SugarSelectionPolicyMemento` MUST:
+
+1. validate `kind = "sugar-selection-policy"` and `schemaVersion = "1"`;
+2. recompute `cid` with the `cid` field elided;
+3. require non-empty `applies_to`;
+4. reject malformed `scoring`, `eligible_sugars`, or `forbidden_sugars` CIDs;
+5. reject duplicate CIDs inside either sugar list;
+6. reject a sugar CID that appears in both `eligible_sugars` and `forbidden_sugars`; and
+7. reject unknown `mode` or `tie_breaking` values.
+
+The registry does not evaluate loss records. It resolves the policy input so the sugar selection consumer can replay the sugar-dict §4 mechanism against the loaded registry and loss function.


### PR DESCRIPTION
Architect ruling locked 2026-05-18: Path B from R14 reframe scope audit (PR #1160). SugarSelectionPolicyMemento as sibling memento in PolicyMemento family for marketplace federation (R4/R9).

Includes Rust type + JCS roundtrip + discrimination tests + spec doc + cross-refs in PolicyProfileMemento and sugar-dict-memento §4.

🤖