### PR TITLE
feat(bind): emit cluster cardinality view alongside output (closes #975)

### DIFF
--- a/docs/audits/2026-05-18-975-cluster-cardinality-status.md
+++ b/docs/audits/2026-05-18-975-cluster-cardinality-status.md
@@ -1,0 +1,34 @@
+# #975 Cluster Cardinality Status
+
+Status: implementation complete, local commit blocked by sandbox gitdir writes.
+
+## Change
+
+- Added `candidateClusterManifest` to the bind named-term document.
+- The manifest has `kind = "candidate-cluster-manifest"`, `schemaVersion = "1"`, `totalCandidates`, and per-cluster rows with `conceptCluster`, `candidateCount`, and `candidateCids`.
+- Bind computes the view from emitted named terms, grouping by `conceptName` and counting candidate terms per concept cluster.
+- Bind-result op-tree metadata carries the same manifest so `named_term_document_from_bind_payload` recovers it for CLI and path consumers.
+- Older bind-result payloads without the field derive the manifest during recovery.
+
+## Verification
+
+- `cargo test --manifest-path implementations/rust/Cargo.toml -p libprovekit --test bind_kit -- --nocapture`
+- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_bind_integration -- --nocapture`
+- `cargo test --manifest-path implementations/rust/Cargo.toml -p libprovekit --test lower_claim_bind_result -- --nocapture`
+- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test bind_kit_path_integration -- --nocapture`
+- `git diff --check`
+- added-line unicode dash check
+
+## Blocker
+
+Local commit is blocked because git cannot write the linked worktree index lock:
+
+```text
+fatal: Unable to create '/Users/tsavo/provekit/.git/worktrees/pk-975-cluster-cardinality/index.lock': Operation not permitted
+```
+
+Direct write probe to the same gitdir also fails:
+
+```text
+touch: /Users/tsavo/provekit/.git/worktrees/pk-975-cluster-cardinality/codex-write-test: Operation not permitted
+```

--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -189,11 +189,9 @@ pub struct BindContractWitness {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NamedTermDocument {
-    #[serde(
-        default,
-        rename = "gapRecords",
-        skip_serializing_if = "Vec::is_empty"
-    )]
+    #[serde(rename = "candidateClusterManifest", default)]
+    pub candidate_cluster_manifest: CandidateClusterManifest,
+    #[serde(default, rename = "gapRecords", skip_serializing_if = "Vec::is_empty")]
     pub gap_records: Vec<Json>,
     pub kind: String,
     #[serde(rename = "promotionDecisionMementos")]
@@ -205,6 +203,37 @@ pub struct NamedTermDocument {
     pub terms: Vec<NamedTerm>,
     #[serde(rename = "workspaceRoot", skip_serializing_if = "Option::is_none")]
     pub workspace_root: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CandidateClusterManifest {
+    pub clusters: Vec<CandidateCluster>,
+    pub kind: String,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "totalCandidates")]
+    pub total_candidates: u64,
+}
+
+impl Default for CandidateClusterManifest {
+    fn default() -> Self {
+        Self {
+            clusters: Vec::new(),
+            kind: "candidate-cluster-manifest".to_string(),
+            schema_version: "1".to_string(),
+            total_candidates: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CandidateCluster {
+    #[serde(rename = "candidateCids")]
+    pub candidate_cids: Vec<String>,
+    #[serde(rename = "candidateCount")]
+    pub candidate_count: u64,
+    #[serde(rename = "conceptCluster")]
+    pub concept_cluster: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -339,7 +368,10 @@ pub fn bind_term_document(
         });
     }
 
+    let candidate_cluster_manifest = candidate_cluster_manifest(&terms);
+
     Ok(NamedTermDocument {
+        candidate_cluster_manifest,
         gap_records,
         kind: "named-term-document".to_string(),
         promotion_decision_mementos: decisions,
@@ -1000,6 +1032,8 @@ fn named_term_citation_term(
 
 fn document_metadata_value(named: &NamedTermDocument) -> Result<Json, BindError> {
     let mut value = json!({
+        "candidateClusterManifest": serde_json::to_value(&named.candidate_cluster_manifest)
+            .map_err(|error| BindError::Failed(format!("serialize candidate cluster manifest: {error}")))?,
         "kind": named.kind.clone(),
         "promotionDecisionMementos": serde_json::to_value(&named.promotion_decision_mementos)
             .map_err(|error| BindError::Failed(format!("serialize promotion decisions: {error}")))?,
@@ -1012,6 +1046,33 @@ fn document_metadata_value(named: &NamedTermDocument) -> Result<Json, BindError>
             .map_err(|error| BindError::Failed(format!("serialize gap records: {error}")))?;
     }
     Ok(value)
+}
+
+fn candidate_cluster_manifest(terms: &[NamedTerm]) -> CandidateClusterManifest {
+    let mut by_concept: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for term in terms {
+        by_concept
+            .entry(term.concept_name.clone())
+            .or_default()
+            .push(term.term_shape_cid.clone());
+    }
+    let clusters = by_concept
+        .into_iter()
+        .map(|(concept_cluster, mut candidate_cids)| {
+            candidate_cids.sort();
+            CandidateCluster {
+                candidate_count: candidate_cids.len() as u64,
+                candidate_cids,
+                concept_cluster,
+            }
+        })
+        .collect();
+    CandidateClusterManifest {
+        clusters,
+        kind: "candidate-cluster-manifest".to_string(),
+        schema_version: "1".to_string(),
+        total_candidates: terms.len() as u64,
+    }
 }
 
 fn named_term_document_from_op_tree(term: &Term) -> Result<NamedTermDocument, BindError> {
@@ -1038,6 +1099,12 @@ fn named_term_document_from_op_tree(term: &Term) -> Result<NamedTermDocument, Bi
         .transpose()
         .map_err(|error| BindError::Failed(format!("parse gap records: {error}")))?
         .unwrap_or_default();
+    let parsed_candidate_cluster_manifest = document
+        .get("candidateClusterManifest")
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| BindError::Failed(format!("parse candidate cluster manifest: {error}")))?;
     let terms = citations
         .into_iter()
         .map(|(_, citation)| {
@@ -1049,7 +1116,10 @@ fn named_term_document_from_op_tree(term: &Term) -> Result<NamedTermDocument, Bi
                 .map_err(|error| BindError::Failed(format!("parse named term citation: {error}")))
         })
         .collect::<Result<Vec<_>, _>>()?;
+    let candidate_cluster_manifest =
+        parsed_candidate_cluster_manifest.unwrap_or_else(|| candidate_cluster_manifest(&terms));
     Ok(NamedTermDocument {
+        candidate_cluster_manifest,
         gap_records,
         kind: document
             .get("kind")
@@ -1208,8 +1278,9 @@ fn wp_rule_synthesis_gap_record(
             respec_target_to: None,
             split_targets: None,
             status: OptionStatus::Deferred,
-            tradeoff: "provide source evidence or a catalog wp_rule before treating the bind as exact"
-                .to_string(),
+            tradeoff:
+                "provide source evidence or a catalog wp_rule before treating the bind as exact"
+                    .to_string(),
         }],
         schema_version: "1".to_string(),
         signature: None,
@@ -1641,7 +1712,10 @@ mod tests {
         // Verify that the recovered named-term-document has function="" in both cases,
         // which is the load-bearing #1093 invariant.
         let add_payload = add_claim.payload.as_ref().expect("add claim has payload");
-        let adder_payload = adder_claim.payload.as_ref().expect("adder claim has payload");
+        let adder_payload = adder_claim
+            .payload
+            .as_ref()
+            .expect("adder claim has payload");
         let add_named = named_term_document_from_bind_payload(add_payload)
             .expect("recover add named term document");
         let adder_named = named_term_document_from_bind_payload(adder_payload)
@@ -1668,10 +1742,11 @@ mod tests {
 
     #[test]
     fn named_term_document_cid_ignores_source_function_name() {
-            fn document(function: &str) -> NamedTermDocument {
-                NamedTermDocument {
-                    gap_records: vec![],
-                    kind: "named-term-document".to_string(),
+        fn document(function: &str) -> NamedTermDocument {
+            NamedTermDocument {
+                candidate_cluster_manifest: CandidateClusterManifest::default(),
+                gap_records: vec![],
+                kind: "named-term-document".to_string(),
                 promotion_decision_mementos: vec![],
                 schema_version: "1".to_string(),
                 source_language: "rust".to_string(),
@@ -1704,6 +1779,7 @@ mod tests {
     #[test]
     fn named_term_document_omits_empty_source_provenance_fields() {
         let document = NamedTermDocument {
+            candidate_cluster_manifest: CandidateClusterManifest::default(),
             gap_records: vec![],
             kind: "named-term-document".to_string(),
             promotion_decision_mementos: vec![],

--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -35,7 +35,8 @@ pub use crate::exam_manifest::ExamManifestKit;
 pub use bind::{
     bind_result_payload, bind_term_document, concept_bind_result_cid, named_term_document_cid,
     named_term_document_from_bind_payload, BindContractWitness, BindError, BindKit, BindLiftEntry,
-    BindOptions, NamedTerm, NamedTermDocument, NamedTermTree, NamedWitness,
+    BindOptions, CandidateCluster, CandidateClusterManifest, NamedTerm, NamedTermDocument,
+    NamedTermTree, NamedWitness,
 };
 pub use lift_plugin::{LiftKit, LiftPluginKit, LiftPluginKitError, LiftPluginKitSession};
 pub use lower_plugin::{

--- a/implementations/rust/libprovekit/tests/bind_kit.rs
+++ b/implementations/rust/libprovekit/tests/bind_kit.rs
@@ -77,6 +77,52 @@ fn witnessless_concept_input(concept: &str) -> Value {
     value
 }
 
+fn cluster_input(entries: Vec<Value>) -> Value {
+    json!({
+        "kind": "ir-document",
+        "sourceLanguage": "rust",
+        "workspaceRoot": "/tmp/provekit-bind-kit-test",
+        "ir": entries
+    })
+}
+
+fn cluster_entry(fn_name: &str, concept: &str, cid_digit: char, witnesses: Vec<Value>) -> Value {
+    json!({
+        "kind": "bind-lift-entry",
+        "file": "src/lib.rs",
+        "fn_name": fn_name,
+        "fn_line": 14,
+        "concept_annotation": concept,
+        "param_names": ["x"],
+        "param_types": ["i64"],
+        "return_type": "i64",
+        "term_shape": {"kind": "bin", "op": "+"},
+        "term_shape_cid": format!(
+            "blake3-512:{}",
+            std::iter::repeat(cid_digit).take(128).collect::<String>()
+        ),
+        "witnesses": witnesses
+    })
+}
+
+fn candidate_cluster_manifest(named: &Value) -> &Value {
+    named
+        .get("candidateClusterManifest")
+        .expect("candidateClusterManifest emitted")
+}
+
+fn candidate_cluster_count(named: &Value, concept: &str) -> u64 {
+    candidate_cluster_manifest(named)["clusters"]
+        .as_array()
+        .expect("clusters array")
+        .iter()
+        .find(|cluster| cluster["conceptCluster"] == concept)
+        .unwrap_or_else(|| panic!("cluster {concept} missing"))
+        .get("candidateCount")
+        .and_then(Value::as_u64)
+        .expect("candidateCount is u64")
+}
+
 #[test]
 fn bind_kit_transform_emits_bind_result_op_tree() {
     let term_value = bind_input_value();
@@ -161,6 +207,86 @@ fn bind_kit_transform_emits_bind_result_op_tree() {
         libprovekit::canonical::serializable_jcs(second_payload)
             .expect("second payload canonicalizes")
     );
+}
+
+#[test]
+fn bind_emits_candidate_cluster_manifest_with_cardinality_per_concept() {
+    let input = cluster_input(vec![
+        cluster_entry("add_one", "add", '1', vec![]),
+        cluster_entry("add_two", "add", '2', vec![]),
+        cluster_entry("sub_one", "sub", '3', vec![]),
+        cluster_entry("mul_one", "concept:mul", '4', vec![]),
+    ]);
+
+    let named = bind_term_document(&input, &BindOptions::default()).expect("bind succeeds");
+    let named_json = serde_json::to_value(&named).expect("named term serializes");
+    let manifest = candidate_cluster_manifest(&named_json);
+
+    assert_eq!(manifest["kind"], "candidate-cluster-manifest");
+    assert_eq!(manifest["schemaVersion"], "1");
+    assert_eq!(manifest["totalCandidates"], 4);
+    assert_eq!(candidate_cluster_count(&named_json, "concept:add"), 2);
+    assert_eq!(candidate_cluster_count(&named_json, "concept:mul"), 1);
+    assert_eq!(candidate_cluster_count(&named_json, "concept:sub"), 1);
+}
+
+#[test]
+fn candidate_cluster_manifest_groups_by_concept_not_function_name() {
+    let input = cluster_input(vec![
+        cluster_entry("add_one", "add", '1', vec![]),
+        cluster_entry("add_two", "add", '1', vec![]),
+    ]);
+
+    let named = bind_term_document(&input, &BindOptions::default()).expect("bind succeeds");
+    let named_json = serde_json::to_value(&named).expect("named term serializes");
+    let clusters = candidate_cluster_manifest(&named_json)["clusters"]
+        .as_array()
+        .expect("clusters array");
+
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0]["conceptCluster"], "concept:add");
+    assert_eq!(clusters[0]["candidateCount"], 2);
+}
+
+#[test]
+fn candidate_cluster_manifest_groups_by_concept_not_shape_cid() {
+    let input = cluster_input(vec![
+        cluster_entry("add_one", "add", '1', vec![]),
+        cluster_entry("add_two", "add", '2', vec![]),
+    ]);
+
+    let named = bind_term_document(&input, &BindOptions::default()).expect("bind succeeds");
+    let named_json = serde_json::to_value(&named).expect("named term serializes");
+    let clusters = candidate_cluster_manifest(&named_json)["clusters"]
+        .as_array()
+        .expect("clusters array");
+
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0]["conceptCluster"], "concept:add");
+    assert_eq!(clusters[0]["candidateCount"], 2);
+}
+
+#[test]
+fn candidate_cluster_manifest_counts_candidates_not_witnesses() {
+    let witness = json!({
+        "role": "post",
+        "predicate_text": "out == x",
+        "source_kind": "annotation"
+    });
+    let input = cluster_input(vec![
+        cluster_entry("add_one", "add", '1', vec![witness.clone(), witness]),
+        cluster_entry("add_two", "add", '2', vec![]),
+    ]);
+
+    let named = bind_term_document(&input, &BindOptions::default()).expect("bind succeeds");
+    let named_json = serde_json::to_value(&named).expect("named term serializes");
+    let clusters = candidate_cluster_manifest(&named_json)["clusters"]
+        .as_array()
+        .expect("clusters array");
+
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0]["conceptCluster"], "concept:add");
+    assert_eq!(clusters[0]["candidateCount"], 2);
 }
 
 #[test]

--- a/implementations/rust/provekit-cli/src/cmd_bind.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind.rs
@@ -23,7 +23,7 @@ use serde_json::Value as Json;
 use crate::kit_dispatch::dispatch_exam_manifest;
 use crate::{EXIT_OK, EXIT_USER_ERROR};
 
-pub use libprovekit::core::{NamedTerm, NamedTermDocument};
+pub use libprovekit::core::NamedTermDocument;
 
 #[derive(Parser, Debug, Clone)]
 pub struct BindArgs {

--- a/implementations/rust/provekit-cli/tests/bind_kit_path_integration.rs
+++ b/implementations/rust/provekit-cli/tests/bind_kit_path_integration.rs
@@ -8,7 +8,7 @@ use std::process::{Command, Stdio};
 use libprovekit::core::{
     address, execute_path, named_term_document_cid, named_term_document_from_bind_payload, BindKit,
     ConformanceDeclaration, Dialect, HashMapInputCatalog, Input, Kit, KitRegistry, LiftKit,
-    NamedTermDocument, Path as CorePath, PathAlgebra, Term, Verb,
+    Path as CorePath, PathAlgebra, Term, Verb,
 };
 
 const BIND_NONCARRIER: ConformanceDeclaration = ConformanceDeclaration::NonCarrier {

--- a/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_bind_integration.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use libprovekit::core::{named_term_document_from_bind_payload, NamedTermDocument, Term};
+use libprovekit::core::{named_term_document_from_bind_payload, Term};
 
 fn provekit_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
@@ -59,6 +59,51 @@ fn witnessless_add_term_document() -> &'static [u8] {
 }"#
 }
 
+fn cluster_cardinality_term_document() -> &'static [u8] {
+    br#"{
+  "kind": "ir-document",
+  "sourceLanguage": "rust",
+  "workspaceRoot": "/tmp/provekit-bind-test",
+  "ir": [{
+    "kind": "bind-lift-entry",
+    "file": "src/lib.rs",
+    "fn_name": "add_one",
+    "fn_line": 4,
+    "concept_annotation": "add",
+    "param_names": ["x"],
+    "param_types": ["i64"],
+    "return_type": "i64",
+    "term_shape": {"kind": "bin", "op": "+"},
+    "term_shape_cid": "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+    "witnesses": []
+  }, {
+    "kind": "bind-lift-entry",
+    "file": "src/lib.rs",
+    "fn_name": "add_two",
+    "fn_line": 8,
+    "concept_annotation": "add",
+    "param_names": ["x"],
+    "param_types": ["i64"],
+    "return_type": "i64",
+    "term_shape": {"kind": "bin", "op": "+"},
+    "term_shape_cid": "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+    "witnesses": []
+  }, {
+    "kind": "bind-lift-entry",
+    "file": "src/lib.rs",
+    "fn_name": "sub_one",
+    "fn_line": 12,
+    "concept_annotation": "sub",
+    "param_names": ["x"],
+    "param_types": ["i64"],
+    "return_type": "i64",
+    "term_shape": {"kind": "bin", "op": "-"},
+    "term_shape_cid": "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+    "witnesses": []
+  }]
+}"#
+}
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -102,8 +147,8 @@ fn bind_from_stdin_emits_named_term_document_with_promotion_decisions() {
     // bind-result consumers use. fn_name is intentionally stripped from
     // the payload (#1093), so the recovered term has empty `function`.
     let payload: Term = serde_json::from_slice(&output.stdout).expect("bind payload parses");
-    let named = named_term_document_from_bind_payload(&payload)
-        .expect("bind payload recovers named term");
+    let named =
+        named_term_document_from_bind_payload(&payload).expect("bind payload recovers named term");
     let named = serde_json::to_value(named).expect("named term serializes");
     assert_eq!(named["sourceLanguage"], "rust");
     assert_eq!(
@@ -121,6 +166,42 @@ fn bind_from_stdin_emits_named_term_document_with_promotion_decisions() {
         named["promotionDecisionMementos"][0]["header"]["kind"],
         "promotion-decision"
     );
+}
+
+#[test]
+fn bind_from_stdin_emits_candidate_cluster_manifest() {
+    let mut child = Command::new(provekit_bin())
+        .arg("bind")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bind");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(cluster_cardinality_term_document())
+        .expect("write term");
+    let output = child.wait_with_output().expect("wait bind");
+    assert_success("bind stdin", &output);
+
+    let payload: Term = serde_json::from_slice(&output.stdout).expect("bind payload parses");
+    let named =
+        named_term_document_from_bind_payload(&payload).expect("bind payload recovers named term");
+    let named = serde_json::to_value(named).expect("named term serializes");
+    let manifest = named["candidateClusterManifest"]
+        .as_object()
+        .expect("candidateClusterManifest object");
+    let clusters = manifest["clusters"].as_array().expect("clusters array");
+
+    assert_eq!(manifest["kind"], "candidate-cluster-manifest");
+    assert_eq!(manifest["schemaVersion"], "1");
+    assert_eq!(manifest["totalCandidates"], 3);
+    assert_eq!(clusters[0]["conceptCluster"], "concept:add");
+    assert_eq!(clusters[0]["candidateCount"], 2);
+    assert_eq!(clusters[1]["conceptCluster"], "concept:sub");
+    assert_eq!(clusters[1]["candidateCount"], 1);
 }
 
 #[test]


### PR DESCRIPTION
Codex completed in isolated worktree; Kit committed on its behalf. Status report in worktree's `docs/audits/2026-05-18-*-status.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)