### PR TITLE
test(integration): close name-lifecycle loop bind -> edit -> relift -> substrate gains name (closes #979)

### DIFF
--- a/docs/audits/2026-05-18-979-name-lifecycle-status.md
+++ b/docs/audits/2026-05-18-979-name-lifecycle-status.md
@@ -1,0 +1,36 @@
+# #979 name lifecycle status
+
+Branch: `kit/pk-979-name-lifecycle`
+Worktree: `/Users/tsavo/provekit-worktrees/pk-979-name-lifecycle`
+
+## Implemented
+
+- Rust bind lift now reads an immediately preceding `// concept: NAME` comment and emits it as `concept_annotation` for the bind entry.
+- The bind result payload sanitizer consumes `concept_annotation`, `attr_pre`, and `attr_post` into the named result and strips those lift-side keys from the source-term half of `concept:bind-result`.
+- Added a CLI lifecycle integration test covering lift, bind, lower, edit `// concept: ...`, relift, and bind to `concept:my-thing`.
+- Documented the name lifecycle loop in `protocol/specs/2026-05-13-bind-ir-lift-result.md`.
+
+## Verification
+
+- `cargo test -p provekit-walk --bin provekit-walk-rpc`
+- `cargo test -p provekit-cli --test verb_composition`
+- `cargo test -p provekit-cli --test cmd_bind_integration`
+- `cargo test -p libprovekit core::bind`
+- `git diff --check`
+- Diff scan found no en dash or em dash characters in the patch.
+
+## Blocker
+
+Local commit is blocked by sandbox permissions on the main gitdir:
+
+```text
+fatal: Unable to create '/Users/tsavo/provekit/.git/worktrees/pk-979-name-lifecycle/index.lock': Operation not permitted
+```
+
+Direct write probes also fail with `Operation not permitted` under:
+
+- `/Users/tsavo/provekit/.git/worktrees/pk-979-name-lifecycle`
+- `/Users/tsavo/provekit/.git/objects`
+- `/Users/tsavo/provekit/.git/refs`
+
+The worktree files are writable, but this session cannot write Git metadata, so the local commit could not be created here.

--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -444,6 +444,12 @@ fn strip_realize_sidecar_from_lift_term(term: Term) -> Term {
     if let Some(entries) = value.get_mut("ir").and_then(Json::as_array_mut) {
         for entry in entries {
             if let Some(object) = entry.as_object_mut() {
+                object.remove("attr_pre");
+                object.remove("attrPre");
+                object.remove("attr_post");
+                object.remove("attrPost");
+                object.remove("concept_annotation");
+                object.remove("conceptAnnotation");
                 object.remove("operand_bindings");
                 object.remove("operandBindings");
                 object.remove("source_function_name");

--- a/implementations/rust/provekit-cli/tests/verb_composition.rs
+++ b/implementations/rust/provekit-cli/tests/verb_composition.rs
@@ -5,6 +5,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use libprovekit::core::{named_term_document_from_bind_payload, Term};
+
 fn provekit_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
 }
@@ -144,6 +146,151 @@ for line in sys.stdin:
     .expect("write lower manifest");
 }
 
+fn install_name_lifecycle_project(root: &Path) {
+    fs::create_dir_all(root.join("src")).expect("create src dir");
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn add_one(x: i64) -> i64 {\n    x + 1\n}\n",
+    )
+    .expect("write source");
+
+    let lift = root.join("lift-rust-lifecycle.py");
+    write_script(
+        &lift,
+        r##"#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).parent
+SOURCE = ROOT / "src" / "lib.rs"
+
+def concept_name():
+    concept = "add-one"
+    lines = SOURCE.read_text().splitlines()
+    for idx, line in enumerate(lines):
+        if "pub fn add_one" not in line:
+            continue
+        cursor = idx - 1
+        while cursor >= 0:
+            stripped = lines[cursor].strip()
+            if not stripped:
+                break
+            if stripped.startswith("#["):
+                cursor -= 1
+                continue
+            if stripped.startswith("//"):
+                body = stripped[2:].strip()
+                if body.startswith("concept:"):
+                    raw = body[len("concept:"):].strip().split()
+                    if raw:
+                        name = raw[0]
+                        if name.startswith("concept:"):
+                            name = name[len("concept:"):]
+                        if name:
+                            concept = name
+                    break
+                cursor -= 1
+                continue
+            break
+    return concept
+
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request.get("method")
+    request_id = request.get("id")
+    if method == "initialize":
+        result = {
+            "name": "test-rust-lift-lifecycle",
+            "protocol_version": "pep/1.7.0",
+            "capabilities": {"surfaces": ["rust"]},
+        }
+    elif method == "lift":
+        result = {
+            "kind": "ir-document",
+            "diagnostics": [],
+            "ir": [{
+                "kind": "bind-lift-entry",
+                "file": "src/lib.rs",
+                "fn_name": "add_one",
+                "fn_line": 1,
+                "concept_annotation": concept_name(),
+                "param_names": ["x"],
+                "param_types": ["i64"],
+                "return_type": "i64",
+                "term_shape": {"kind": "call", "op": "add-one"},
+                "term_shape_cid": "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "witnesses": []
+            }]
+        }
+    elif method == "shutdown":
+        result = {}
+    else:
+        print(json.dumps({"jsonrpc": "2.0", "id": request_id, "error": {"message": "unknown method"}}), flush=True)
+        continue
+    print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}), flush=True)
+    if method == "shutdown":
+        break
+"##,
+    );
+
+    let lower = root.join("lower-rust-lifecycle.py");
+    write_script(
+        &lower,
+        r##"#!/usr/bin/env python3
+import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    request_id = request.get("id")
+    params = request.get("params", {})
+    function = params.get("function", "add_one")
+    concept = params.get("concept_name", params.get("conceptName", ""))
+    source = f"// concept: {concept}\npub fn {function}(x: i64) -> i64 {{\n    x + 1\n}}\n"
+    print(json.dumps({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "source": source,
+            "is_stub": False,
+            "extension": "rs",
+            "observed_loss_record": {},
+            "used_sugars": []
+        }
+    }), flush=True)
+"##,
+    );
+
+    let lift_manifest = root.join(".provekit/lift/rust");
+    fs::create_dir_all(&lift_manifest).expect("create lift manifest dir");
+    fs::write(
+        lift_manifest.join("manifest.toml"),
+        format!(
+            "name = \"test-rust-lift-lifecycle\"\ncommand = [\"python3\", \"{}\"]\nworking_dir = \".\"\n",
+            manifest_command(&lift)
+        ),
+    )
+    .expect("write lift manifest");
+
+    fs::write(
+        root.join(".provekit/config.toml"),
+        "[authoring.lift]\nsurface = \"rust\"\n",
+    )
+    .expect("write config");
+
+    let lower_manifest = root.join(".provekit/realize/rust");
+    fs::create_dir_all(&lower_manifest).expect("create lower manifest dir");
+    fs::write(
+        lower_manifest.join("manifest.toml"),
+        format!(
+            "name = \"test-rust-lower-lifecycle\"\ncommand = [\"python3\", \"{}\"]\nlibrary_tag = \"default\"\nworking_dir = \".\"\n",
+            manifest_command(&lower)
+        ),
+    )
+    .expect("write lower manifest");
+}
+
 fn assert_success(label: &str, output: &std::process::Output) {
     assert!(
         output.status.success(),
@@ -151,6 +298,27 @@ fn assert_success(label: &str, output: &std::process::Output) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn run_provekit_stdin(label: &str, args: &[&str], input: &[u8]) -> Vec<u8> {
+    let mut child = Command::new(provekit_bin())
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|error| panic!("spawn {label}: {error}"));
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(input)
+        .unwrap_or_else(|error| panic!("write {label} stdin: {error}"));
+    let output = child
+        .wait_with_output()
+        .unwrap_or_else(|error| panic!("wait {label}: {error}"));
+    assert_success(label, &output);
+    output.stdout
 }
 
 #[test]
@@ -239,4 +407,45 @@ fn lift_bind_lower_pipe_and_file_forms_emit_byte_equivalent_python() {
         String::from_utf8_lossy(&file_bytes),
         "# concept: concept:add-one\ndef add_one(x):\n    raise NotImplementedError(\"provekit test lower\")\n"
     );
+}
+
+#[test]
+fn lift_bind_edit_comment_relift_bind_promotes_user_concept_name() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    install_name_lifecycle_project(&project);
+
+    let lift_initial = Command::new(provekit_bin())
+        .arg("lift")
+        .arg(&project)
+        .output()
+        .expect("spawn initial lift");
+    assert_success("initial lift", &lift_initial);
+    let bind_initial = run_provekit_stdin("initial bind", &["bind"], &lift_initial.stdout);
+    let lower_initial = run_provekit_stdin(
+        "initial lower",
+        &["lower", "--target", "rust"],
+        &bind_initial,
+    );
+
+    let bound_source = String::from_utf8(lower_initial).expect("lowered source utf8");
+    assert!(
+        bound_source.contains("// concept: concept:add-one"),
+        "initial lower must expose editable concept comment: {bound_source}"
+    );
+    let edited_source = bound_source.replace("// concept: concept:add-one", "// concept: my-thing");
+    fs::write(project.join("src/lib.rs"), edited_source).expect("write edited source");
+
+    let lift_edited = Command::new(provekit_bin())
+        .arg("lift")
+        .arg(&project)
+        .output()
+        .expect("spawn edited lift");
+    assert_success("edited lift", &lift_edited);
+    let bind_edited = run_provekit_stdin("edited bind", &["bind"], &lift_edited.stdout);
+
+    let payload: Term = serde_json::from_slice(&bind_edited).expect("bind payload parses");
+    let named = named_term_document_from_bind_payload(&payload)
+        .expect("bind payload recovers named term document");
+    assert_eq!(named.terms[0].concept_name, "concept:my-thing");
 }

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -361,7 +361,7 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
         let witnesses_by_symbol =
             contract_witnesses_by_function_symbol(&file, &rel, src.as_bytes());
 
-        for target in collect_bind_lift_targets(&file) {
+        for target in collect_bind_lift_targets_with_source(&file, &src) {
             let item_fn = &target.item_fn;
             let fn_name = &target.fn_name;
             let term_shape = term_shape_for_fn(item_fn);
@@ -376,7 +376,7 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
                 .cloned()
                 .unwrap_or_default();
 
-            entries.push(json!({
+            let mut entry = json!({
                 "kind": "bind-lift-entry",
                 "param_names": param_names,
                 "term_shape": cvalue_to_json(&term_shape),
@@ -384,7 +384,11 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
                 "operand_bindings": operand_bindings,
                 "source_function_name": target.source_name,
                 "witnesses": witnesses,
-            }));
+            });
+            if let Some(concept_annotation) = &target.concept_annotation {
+                entry["concept_annotation"] = json!(concept_annotation);
+            }
+            entries.push(entry);
 
             for callsite in collect_bound_library_calls(item_fn, &library_bindings) {
                 let term_shape =
@@ -449,16 +453,25 @@ fn exam_question_cid_for(kind: &str, concept: &str, language: &str) -> Option<St
 struct BindLiftTarget {
     fn_name: String,
     source_name: String,
+    concept_annotation: Option<String>,
     item_fn: syn::ItemFn,
 }
 
 fn collect_bind_lift_targets(file: &syn::File) -> Vec<BindLiftTarget> {
+    collect_bind_lift_targets_with_source(file, "")
+}
+
+fn collect_bind_lift_targets_with_source(file: &syn::File, source: &str) -> Vec<BindLiftTarget> {
     let mut targets = Vec::new();
-    collect_bind_lift_targets_in_items(&file.items, &mut targets);
+    collect_bind_lift_targets_in_items(&file.items, source, &mut targets);
     targets
 }
 
-fn collect_bind_lift_targets_in_items(items: &[syn::Item], targets: &mut Vec<BindLiftTarget>) {
+fn collect_bind_lift_targets_in_items(
+    items: &[syn::Item],
+    source: &str,
+    targets: &mut Vec<BindLiftTarget>,
+) {
     for item in items {
         match item {
             syn::Item::Fn(item_fn) => {
@@ -466,6 +479,7 @@ fn collect_bind_lift_targets_in_items(items: &[syn::Item], targets: &mut Vec<Bin
                 targets.push(BindLiftTarget {
                     source_name: fn_name.clone(),
                     fn_name,
+                    concept_annotation: concept_annotation_for_fn(source, item_fn),
                     item_fn: item_fn.clone(),
                 });
             }
@@ -481,20 +495,80 @@ fn collect_bind_lift_targets_in_items(items: &[syn::Item], targets: &mut Vec<Bin
                         continue;
                     }
                     let source_name = method.sig.ident.to_string();
+                    let item_fn = item_fn_from_impl_method(method);
                     targets.push(BindLiftTarget {
                         fn_name: format!("{qualifier}::{source_name}"),
                         source_name,
-                        item_fn: item_fn_from_impl_method(method),
+                        concept_annotation: concept_annotation_for_fn(source, &item_fn),
+                        item_fn,
                     });
                 }
             }
             syn::Item::Mod(module) => {
                 if let Some((_, nested_items)) = &module.content {
-                    collect_bind_lift_targets_in_items(nested_items, targets);
+                    collect_bind_lift_targets_in_items(nested_items, source, targets);
                 }
             }
             _ => {}
         }
+    }
+}
+
+fn concept_annotation_for_fn(source: &str, item_fn: &syn::ItemFn) -> Option<String> {
+    if source.trim().is_empty() {
+        return None;
+    }
+    let fn_line = item_fn.sig.fn_token.span.start().line;
+    concept_annotation_before_line(source, fn_line)
+}
+
+fn concept_annotation_before_line(source: &str, fn_line: usize) -> Option<String> {
+    if fn_line <= 1 {
+        return None;
+    }
+    let lines = source.lines().collect::<Vec<_>>();
+    let mut idx = fn_line.checked_sub(2)?;
+    loop {
+        let trimmed = lines.get(idx)?.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if trimmed.starts_with("#[") {
+            if idx == 0 {
+                return None;
+            }
+            idx -= 1;
+            continue;
+        }
+        if let Some(comment_body) = rust_line_comment_body(trimmed) {
+            if let Some(name) = parse_concept_comment_body(comment_body) {
+                return Some(name);
+            }
+            if idx == 0 {
+                return None;
+            }
+            idx -= 1;
+            continue;
+        }
+        return None;
+    }
+}
+
+fn rust_line_comment_body(trimmed: &str) -> Option<&str> {
+    trimmed
+        .strip_prefix("///")
+        .or_else(|| trimmed.strip_prefix("//"))
+        .map(str::trim_start)
+}
+
+fn parse_concept_comment_body(body: &str) -> Option<String> {
+    let raw = body.strip_prefix("concept:")?.trim();
+    let token = raw.split_whitespace().next()?;
+    let bare = token.strip_prefix("concept:").unwrap_or(token);
+    if bare.is_empty() {
+        None
+    } else {
+        Some(bare.to_string())
     }
 }
 
@@ -2142,6 +2216,136 @@ pub fn add(x: i64, y: i64) -> i64 {
     }
 
     #[test]
+    fn bind_lift_relifts_edited_concept_comment_into_named_substrate_binding() {
+        let root = temp_workspace("bind_lift_concept_comment_lifecycle");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            src_dir.join("lib.rs"),
+            r#"
+// concept: my-thing
+pub fn shaped(x: i64) -> i64 {
+    (x * 7) + 3
+}
+"#,
+        )
+        .expect("write source");
+
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."]
+        }))
+        .expect("bind lift should succeed");
+
+        let entries = out["ir"].as_array().expect("ir array");
+        let entry = entries.first().expect("shaped entry");
+        assert_eq!(entry["concept_annotation"], "my-thing");
+
+        let named = bind_term_document(&out, &BindOptions::default())
+            .expect("bind term document builds from relifted source");
+        assert_eq!(named.terms[0].concept_name, "concept:my-thing");
+
+        let original_term = Term::Const {
+            value: out,
+            sort: primitive_sort("LiftPluginResponse"),
+        };
+        let payload = bind_result_payload(original_term, &named).expect("bind payload builds");
+        let payload_bytes =
+            libprovekit::canonical::serializable_jcs(&payload).expect("payload canonicalizes");
+        assert!(
+            !payload_bytes.contains("concept_annotation"),
+            "bind payload must not retain lift-side annotation scaffolding: {payload_bytes}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn bind_lift_concept_comment_survives_adjacent_attrs_and_metadata_comments() {
+        let root = temp_workspace("bind_lift_concept_comment_attrs");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            src_dir.join("lib.rs"),
+            r#"
+// concept: attr-backed-name
+// substrate-origin: annotation-lift
+#[cfg_attr(any(), requires(x > 0))]
+pub fn shaped(x: i64) -> i64 {
+    x
+}
+"#,
+        )
+        .expect("write source");
+
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."]
+        }))
+        .expect("bind lift should succeed");
+
+        let entries = out["ir"].as_array().expect("ir array");
+        let entry = entries.first().expect("shaped entry");
+        assert_eq!(entry["concept_annotation"], "attr-backed-name");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn bind_lift_discrimination_ignores_concept_comment_separated_by_blank_line() {
+        let entry = single_entry_for_source(
+            "concept_comment_blank_line",
+            r#"
+// concept: too-far-away
+
+pub fn shaped(x: i64) -> i64 {
+    x
+}
+"#,
+        );
+
+        assert!(
+            entry.get("concept_annotation").is_none(),
+            "blank-separated concept comment must not bind: {entry:#?}"
+        );
+    }
+
+    #[test]
+    fn bind_lift_discrimination_ignores_inline_trailing_concept_comment() {
+        let entry = single_entry_for_source(
+            "concept_comment_inline",
+            r#"
+pub fn shaped(x: i64) -> i64 { // concept: inline-name
+    x
+}
+"#,
+        );
+
+        assert!(
+            entry.get("concept_annotation").is_none(),
+            "inline trailing concept comment must not bind: {entry:#?}"
+        );
+    }
+
+    #[test]
+    fn bind_lift_discrimination_ignores_empty_concept_comment() {
+        let entry = single_entry_for_source(
+            "concept_comment_empty",
+            r#"
+// concept:
+pub fn shaped(x: i64) -> i64 {
+    x
+}
+"#,
+        );
+
+        assert!(
+            entry.get("concept_annotation").is_none(),
+            "empty concept comment must not bind: {entry:#?}"
+        );
+    }
+
+    #[test]
     fn bind_lift_contract_attrs_do_not_enter_hashed_bind_payload() {
         let root = temp_workspace("bind_lift_contract_attrs_payload");
         let src_dir = root.join("src");
@@ -2402,6 +2606,27 @@ pub fn bitwise_not() -> i64 {
         let root = std::env::temp_dir().join(format!("{name}_{nanos}"));
         fs::create_dir_all(&root).expect("create temp workspace");
         root
+    }
+
+    fn single_entry_for_source(name: &str, source: &str) -> Value {
+        let root = temp_workspace(name);
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(src_dir.join("lib.rs"), source).expect("write source");
+
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."]
+        }))
+        .expect("bind lift should succeed");
+        let entry = out["ir"]
+            .as_array()
+            .expect("ir array")
+            .first()
+            .expect("single entry")
+            .clone();
+        let _ = fs::remove_dir_all(root);
+        entry
     }
 
     #[test]

--- a/protocol/specs/2026-05-13-bind-ir-lift-result.md
+++ b/protocol/specs/2026-05-13-bind-ir-lift-result.md
@@ -96,6 +96,24 @@ When `witnesses[]` is non-empty, it is the complete contract evidence set for th
 - **The full IR algebra term.** This entry is the BIND surface (clustering + naming + scoping); the full algebra term used by transport is requested separately via the realize-plugin protocol (`provekit.plugin.invoke` with `method: "lift"` on the realize side, see `2026-05-12-plugin-protocol.md` §4.2.2 and the body-template realize plugins).
 - **Concept-shape catalog matches.** The kit MUST emit `term_shape` + `term_shape_cid`; the catalog match is performed by cmd_bind (Verb 6: Identify), not the kit.
 
+### §1.4 Name lifecycle loop
+
+The authoring name loop is:
+
+1. A source file is lifted and bound.
+2. A realize or lower pass emits source with an editable `// concept: NAME` line.
+3. The user edits that line.
+4. The edited source is lifted again.
+5. The next bind result uses the edited name as the `NamedTerm.conceptName`.
+
+For this loop, lift kits MUST read an immediately preceding `// concept: NAME`
+comment as `concept_annotation`. The emitted field is a carrier from source
+surface into bind naming, not an extra proof term. Consumers use it to choose
+the named substrate binding, then MUST NOT retain the raw `concept_annotation`
+key in the source-term half of a `concept:bind-result` payload. The durable
+substrate fact is the resulting `conceptName`, not the comment syntax that
+carried the edit.
+
 ## §2. Term shape
 
 A term shape is a language-neutral fingerprint of the function body sufficient to cluster structurally-identical functions across languages.


### PR DESCRIPTION
Codex completed in isolated worktree; Kit committed on its behalf. Status report in worktree's `docs/audits/2026-05-18-*-status.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)