### PR TITLE
feat(kit_dispatch): consult sealed PluginRegistryMemento as authority (closes #760)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ tools/blake3-vendored/*.o
 .provekit/graph.json
 .provekit/report.json
 .provekit/derivation.json
+.provekit/runs/
 .provekit/provekit.db
 .provekit/provekit.db-journal
 .provekit/provekit.db-wal

--- a/docs/audits/2026-05-18-760-registry-as-authority-status.md
+++ b/docs/audits/2026-05-18-760-registry-as-authority-status.md
@@ -1,0 +1,49 @@
+# Issue 760 Registry As Dispatch Authority Status
+
+Branch: `kit/pk-760-registry-as-dispatch-authority`
+Worktree: `/Users/tsavo/provekit-worktrees/pk-760-registry-as-dispatch-authority`
+
+## Completed
+
+- Added content-addressed `PluginRegistryMemento` persistence under `.provekit/runs/<registry-cid>/plugin-registry-memento.json`.
+- Added `.provekit/runs/` to `.gitignore` because run registries are generated run artifacts.
+- Added process-local `kit_dispatch` registry sealing and caching keyed by workspace root.
+- Made `dispatch_bind_lift`, `dispatch_realize`, and `dispatch_exam_manifest` try the sealed registry first.
+- Made registry dispatch authorize plugin records against `PluginRegistryMemento.header.load_order`.
+- Preserved the A2 filesystem fallback for unregistered kits and added the deprecation diagnostic.
+- Activated CID-first federation: byte-equal registry CIDs federate immediately, different registry CIDs fall through to exam manifest compatibility checks.
+- Added registry authority integration coverage for registered lift and realize dispatch, fallback diagnostics, structural CID determinism, and federation refusal.
+- Updated the stale Python canonical body-template declared CID and matching self-consistency pin so `provekit-plugin-loader` passes.
+
+## Verification
+
+- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test registry_authority_dispatch_test`
+- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-plugin-loader`
+- `cargo build --manifest-path implementations/rust/Cargo.toml --workspace`
+- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli`
+- `git diff --check`
+- Added-line scan found no U+2013 or U+2014 characters.
+
+Known warning:
+
+- `provekit-cli/src/cmd_bind.rs` still has the pre-existing unused `NamedTerm` import warning during CLI build/test.
+
+## Commit Blocker
+
+Local commit could not be created from this sandbox. Git can read the worktree state, but cannot create the linked worktree index lock:
+
+```text
+fatal: Unable to create '/Users/tsavo/provekit/.git/worktrees/pk-760-registry-as-dispatch-authority/index.lock': Operation not permitted
+```
+
+The changes are ready to commit outside this sandbox with:
+
+```text
+feat(kit_dispatch): consult sealed PluginRegistryMemento as authority (closes #760)
+```
+
+Requested identity:
+
+```text
+T Savo <evilgenius@nefariousplan.com>
+```

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -42,14 +42,19 @@ use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::{Mutex, OnceLock};
 
 #[allow(unused_imports)]
 pub use libprovekit::core::RealizeContractWitness;
 use libprovekit::core::RealizeTransport;
 pub use libprovekit::core::{RealizeContractPayload, RealizeRequest, RealizedSource};
 use libprovekit::ExamManifestKit;
+use provekit_canonicalizer::blake3_512_of;
 use provekit_ir_types::{Cid, ExamManifestMemento};
-use provekit_plugin_loader::{PluginRegistry, PluginRegistryMemento};
+use provekit_plugin_loader::{
+    cid::compute_plugin_cid, write_plugin_registry_memento, PluginEnvelope, PluginHeader,
+    PluginMemento, PluginMetadata, PluginRegistry, PluginRegistryMemento,
+};
 
 use crate::project_config::read_project_config;
 
@@ -67,6 +72,331 @@ impl RealizeTransport for DispatchRealizeTransport {
         dispatch_realize(workspace_root, target_lang, library_tag, request)
             .map_err(|error| error.to_string())
     }
+}
+
+const REGISTRY_SEALED_AT: &str = "1970-01-01T00:00:00.000Z";
+const REGISTRY_MANIFEST_KINDS: &[&str] = &["lift", "realize", "exam-manifest"];
+
+static RUN_PLUGIN_REGISTRIES: OnceLock<Mutex<BTreeMap<PathBuf, RunPluginRegistry>>> =
+    OnceLock::new();
+static KIT_DISPATCH_DIAGNOSTICS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct SealedPluginRegistry {
+    pub memento: PluginRegistryMemento,
+    pub path: PathBuf,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+struct RunPluginRegistry {
+    sealed: SealedPluginRegistry,
+    plugins: Vec<ManifestPluginRegistration>,
+}
+
+#[derive(Debug, Clone)]
+struct ManifestPluginRegistration {
+    kind: String,
+    surface: String,
+    source: String,
+    manifest_path: PathBuf,
+    parsed: ParsedManifest,
+    memento: PluginMemento,
+}
+
+#[allow(dead_code)]
+pub fn ensure_sealed_plugin_registry_for_project(
+    workspace_root: &Path,
+) -> Result<SealedPluginRegistry, String> {
+    run_plugin_registry_for_project(workspace_root).map(|registry| registry.sealed)
+}
+
+#[allow(dead_code)]
+pub fn reset_kit_dispatch_registry_cache_for_tests() {
+    if let Some(cache) = RUN_PLUGIN_REGISTRIES.get() {
+        cache.lock().expect("registry cache lock").clear();
+    }
+    let _ = drain_kit_dispatch_diagnostics();
+}
+
+#[allow(dead_code)]
+pub fn drain_kit_dispatch_diagnostics() -> Vec<String> {
+    let diagnostics = KIT_DISPATCH_DIAGNOSTICS.get_or_init(|| Mutex::new(Vec::new()));
+    let mut diagnostics = diagnostics.lock().expect("diagnostics lock");
+    std::mem::take(&mut *diagnostics)
+}
+
+fn run_plugin_registry_for_project(workspace_root: &Path) -> Result<RunPluginRegistry, String> {
+    let key = registry_cache_key(workspace_root);
+    let cache = RUN_PLUGIN_REGISTRIES.get_or_init(|| Mutex::new(BTreeMap::new()));
+    if let Some(registry) = cache
+        .lock()
+        .expect("registry cache lock")
+        .get(&key)
+        .cloned()
+    {
+        return Ok(registry);
+    }
+
+    let registry = build_run_plugin_registry(&key)?;
+    cache
+        .lock()
+        .expect("registry cache lock")
+        .insert(key, registry.clone());
+    Ok(registry)
+}
+
+fn registry_cache_key(workspace_root: &Path) -> PathBuf {
+    std::fs::canonicalize(workspace_root).unwrap_or_else(|_| {
+        if workspace_root.is_absolute() {
+            workspace_root.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(workspace_root)
+        }
+    })
+}
+
+fn build_run_plugin_registry(workspace_root: &Path) -> Result<RunPluginRegistry, String> {
+    let plugins = scan_manifest_plugins(workspace_root)?;
+    let mut registry = PluginRegistry::new();
+    for plugin in &plugins {
+        registry
+            .register(plugin.memento.clone(), &plugin.source)
+            .map_err(|error| format!("register {}: {error}", plugin.source))?;
+    }
+    let memento = registry.emit_registry_memento_with_exam_manifest(
+        REGISTRY_SEALED_AT,
+        Some(configured_exam_manifest_cid(workspace_root)),
+        None,
+    );
+    let path = write_plugin_registry_memento(workspace_root, &memento)
+        .map_err(|error| format!("write sealed PluginRegistryMemento: {error}"))?;
+    Ok(RunPluginRegistry {
+        sealed: SealedPluginRegistry { memento, path },
+        plugins,
+    })
+}
+
+fn scan_manifest_plugins(workspace_root: &Path) -> Result<Vec<ManifestPluginRegistration>, String> {
+    let mut plugins = Vec::new();
+    for kind in REGISTRY_MANIFEST_KINDS {
+        let kind_dir = workspace_root.join(".provekit").join(kind);
+        let Ok(entries) = std::fs::read_dir(&kind_dir) else {
+            continue;
+        };
+        let mut surfaces = entries
+            .flatten()
+            .filter_map(|entry| {
+                let path = entry.path();
+                if !path.is_dir() {
+                    return None;
+                }
+                let surface = path.file_name()?.to_str()?.to_string();
+                Some((surface, path))
+            })
+            .collect::<Vec<_>>();
+        surfaces.sort_by(|a, b| a.0.cmp(&b.0));
+        for (surface, path) in surfaces {
+            let manifest_path = path.join("manifest.toml");
+            if !manifest_path.exists() {
+                continue;
+            }
+            let parsed = parse_manifest(&manifest_path)?;
+            let source = registry_source(workspace_root, &manifest_path);
+            let memento = manifest_plugin_memento(
+                workspace_root,
+                *kind,
+                &surface,
+                &source,
+                &manifest_path,
+                &parsed,
+            )?;
+            plugins.push(ManifestPluginRegistration {
+                kind: (*kind).to_string(),
+                surface,
+                source,
+                manifest_path,
+                parsed,
+                memento,
+            });
+        }
+    }
+    Ok(plugins)
+}
+
+fn registry_source(workspace_root: &Path, path: &Path) -> String {
+    path.strip_prefix(workspace_root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn manifest_plugin_memento(
+    workspace_root: &Path,
+    kind: &str,
+    surface: &str,
+    source: &str,
+    manifest_path: &Path,
+    parsed: &ParsedManifest,
+) -> Result<PluginMemento, String> {
+    let manifest_bytes = std::fs::read(manifest_path)
+        .map_err(|error| format!("read {}: {error}", manifest_path.display()))?;
+    let working_dir = parsed
+        .working_dir
+        .as_ref()
+        .map(|path| path.display().to_string());
+    let content = json!({
+        "kind": "manifest-plugin",
+        "plugin_kind": kind,
+        "surface": surface,
+        "manifest_path": source,
+        "manifest_cid": blake3_512_of(&manifest_bytes),
+        "name": parsed.name.clone(),
+        "command": parsed.command.clone(),
+        "working_dir": working_dir,
+        "library_tag": parsed.library_tag.clone(),
+        "capability_kind": parsed.capability_kind.clone(),
+        "exam_manifest_schema_version": parsed.exam_manifest_schema_version.clone(),
+        "workspace_relative": manifest_path.starts_with(workspace_root),
+    });
+    let mut protocol_versions = parsed.protocol_versions.clone();
+    if protocol_versions.is_empty() {
+        protocol_versions.push(PEP_1_7_0.to_string());
+    }
+    protocol_versions.sort();
+    protocol_versions.dedup();
+    let mut header = PluginHeader {
+        cid: String::new(),
+        content,
+        critical: false,
+        kind: kind.to_string(),
+        protocol_versions,
+        provenance_cid: blake3_512_of(&manifest_bytes),
+        schema_version: "1".to_string(),
+        version: "0.1.0".to_string(),
+    };
+    header.cid = compute_plugin_cid(&header);
+    Ok(PluginMemento {
+        envelope: PluginEnvelope {
+            declared_at: REGISTRY_SEALED_AT.to_string(),
+            signature: "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+            signer: "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".to_string(),
+        },
+        header,
+        metadata: PluginMetadata::default(),
+    })
+}
+
+fn registry_authorizes_plugin(
+    registry: &RunPluginRegistry,
+    plugin: &ManifestPluginRegistration,
+) -> bool {
+    registry.sealed.memento.header.load_order.iter().any(|entry| {
+        entry.kind == plugin.kind
+            && entry.cid == plugin.memento.cid()
+            && entry.source == plugin.source
+    })
+}
+
+fn registry_lift_command(
+    workspace_root: &Path,
+    source_lang: &str,
+) -> Result<Option<(String, ResolvedCommand)>, String> {
+    let registry = run_plugin_registry_for_project(workspace_root)?;
+    for surface in [&format!("{source_lang}-bind"), source_lang] {
+        if let Some(plugin) = registry
+            .plugins
+            .iter()
+            .filter(|plugin| registry_authorizes_plugin(&registry, plugin))
+            .find(|plugin| plugin.kind == "lift" && plugin.surface == surface)
+        {
+            return Ok(Some((
+                plugin.surface.clone(),
+                resolved_command_from_manifest(workspace_root, &plugin.parsed),
+            )));
+        }
+    }
+    Ok(None)
+}
+
+fn registry_realize_candidates(
+    workspace_root: &Path,
+    target_lang: &str,
+) -> Result<Vec<RealizeCandidate>, String> {
+    let registry = run_plugin_registry_for_project(workspace_root)?;
+    let mut candidates = registry
+        .plugins
+        .iter()
+        .filter(|plugin| registry_authorizes_plugin(&registry, plugin))
+        .filter(|plugin| plugin.kind == "realize")
+        .filter(|plugin| realize_surface_matches_target(&plugin.surface, target_lang))
+        .map(|plugin| RealizeCandidate {
+            tag: plugin
+                .parsed
+                .library_tag
+                .clone()
+                .unwrap_or_else(|| DEFAULT_LIBRARY_TAG.to_string()),
+            command: resolved_command_from_manifest(workspace_root, &plugin.parsed),
+            source: plugin.source.clone(),
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|a, b| a.tag.cmp(&b.tag).then(a.source.cmp(&b.source)));
+    Ok(candidates)
+}
+
+fn registry_exam_manifest_command(
+    workspace_root: &Path,
+    plugin_name: &str,
+) -> Result<Option<ResolvedCommand>, String> {
+    let registry = run_plugin_registry_for_project(workspace_root)?;
+    let Some(plugin) = registry
+        .plugins
+        .iter()
+        .filter(|plugin| registry_authorizes_plugin(&registry, plugin))
+        .find(|plugin| plugin.kind == EXAM_MANIFEST_KIND && plugin.surface == plugin_name)
+    else {
+        return Ok(None);
+    };
+    validate_exam_manifest_plugin_manifest(&plugin.manifest_path, &plugin.parsed)?;
+    Ok(Some(resolved_command_from_manifest(
+        workspace_root,
+        &plugin.parsed,
+    )))
+}
+
+fn resolved_command_from_manifest(
+    workspace_root: &Path,
+    parsed: &ParsedManifest,
+) -> ResolvedCommand {
+    let working_dir = parsed
+        .working_dir
+        .clone()
+        .map(|wd| {
+            if wd.is_absolute() {
+                wd
+            } else {
+                workspace_root.join(wd)
+            }
+        })
+        .or_else(|| Some(workspace_root.to_path_buf()));
+    ResolvedCommand {
+        argv: parsed.command.clone(),
+        working_dir,
+    }
+}
+
+fn record_fallback_diagnostic(kind: &str, surface: &str) {
+    let message =
+        format!("deprecated kit_dispatch filesystem fallback: kind={kind} surface={surface}");
+    eprintln!("{message}");
+    KIT_DISPATCH_DIAGNOSTICS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .expect("diagnostics lock")
+        .push(message);
 }
 
 // ============================================================================
@@ -192,6 +522,18 @@ fn resolve_lift_command(
     workspace_root: &Path,
     source_lang: &str,
 ) -> Result<ResolvedCommand, KitUnavailable> {
+    match registry_lift_command(workspace_root, source_lang) {
+        Ok(Some((_surface, command))) => return Ok(command),
+        Ok(None) => record_fallback_diagnostic("lift", &format!("{source_lang}-bind")),
+        Err(detail) => {
+            return Err(KitUnavailable {
+                kit_kind: "lift",
+                language: source_lang.to_string(),
+                detail,
+            })
+        }
+    }
+
     // 1 + 2: project-local manifest under .provekit/lift/<surface>/manifest.toml.
     for surface in [&format!("{source_lang}-bind"), source_lang] {
         let manifest = workspace_root
@@ -201,20 +543,7 @@ fn resolve_lift_command(
             .join("manifest.toml");
         if manifest.exists() {
             if let Ok(parsed) = parse_manifest(&manifest) {
-                let working_dir = parsed
-                    .working_dir
-                    .map(|wd| {
-                        if wd.is_absolute() {
-                            wd
-                        } else {
-                            workspace_root.join(wd)
-                        }
-                    })
-                    .or_else(|| Some(workspace_root.to_path_buf()));
-                return Ok(ResolvedCommand {
-                    argv: parsed.command,
-                    working_dir,
-                });
+                return Ok(resolved_command_from_manifest(workspace_root, &parsed));
             }
         }
     }
@@ -610,8 +939,45 @@ fn resolve_realize_command(
         }
     }
 
-    let candidates = registered_realize_candidates(workspace_root, target_lang)?;
     let requested = library_tag.unwrap_or(DEFAULT_LIBRARY_TAG);
+    let registry_candidates =
+        registry_realize_candidates(workspace_root, target_lang).map_err(|detail| {
+            KitUnavailable {
+                kit_kind: "realize",
+                language: target_lang.to_string(),
+                detail,
+            }
+        })?;
+    if let Some(candidate) = registry_candidates
+        .iter()
+        .find(|candidate| candidate.tag == requested)
+    {
+        return Ok(candidate.command.clone());
+    }
+
+    if library_tag.is_none() {
+        if registry_candidates.len() == 1 {
+            return Ok(registry_candidates[0].command.clone());
+        }
+        if !registry_candidates.is_empty() {
+            let tags = registry_candidates
+                .iter()
+                .map(|candidate| format!("{} from {}", candidate.tag, candidate.source))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(KitUnavailable {
+                kit_kind: "realize",
+                language: target_lang.to_string(),
+                detail: format!(
+                    "multiple realize plugins registered for language `{target_lang}` but none \
+                     has library_tag `default`; pass an explicit library_tag. registered: {tags}"
+                ),
+            });
+        }
+    }
+
+    record_fallback_diagnostic("realize", target_lang);
+    let candidates = legacy_realize_candidates(workspace_root, target_lang)?;
     if let Some(candidate) = candidates
         .iter()
         .find(|candidate| candidate.tag == requested)
@@ -669,7 +1035,7 @@ struct RealizeCandidate {
     source: String,
 }
 
-fn registered_realize_candidates(
+fn legacy_realize_candidates(
     workspace_root: &Path,
     target_lang: &str,
 ) -> Result<Vec<RealizeCandidate>, KitUnavailable> {
@@ -1095,6 +1461,10 @@ pub fn federate_plugin_registries(
     local: &PluginRegistryMemento,
     remote: &PluginRegistryMemento,
 ) -> Result<(), KitDispatchError> {
+    if local.header.cid == remote.header.cid {
+        return Ok(());
+    }
+
     let local_cids = registry_exam_manifest_cids(local);
     let remote_cids = registry_exam_manifest_cids(remote);
     if local_cids.iter().any(|cid| remote_cids.contains(cid)) {
@@ -1170,6 +1540,18 @@ fn resolve_exam_manifest_command(
     workspace_root: &Path,
     plugin_name: &str,
 ) -> Result<Option<ResolvedCommand>, KitUnavailable> {
+    match registry_exam_manifest_command(workspace_root, plugin_name) {
+        Ok(Some(command)) => return Ok(Some(command)),
+        Ok(None) => record_fallback_diagnostic(EXAM_MANIFEST_KIND, plugin_name),
+        Err(detail) => {
+            return Err(KitUnavailable {
+                kit_kind: EXAM_MANIFEST_KIND,
+                language: plugin_name.to_string(),
+                detail,
+            })
+        }
+    }
+
     let project_manifest = workspace_root
         .join(".provekit")
         .join(EXAM_MANIFEST_KIND)
@@ -1205,20 +1587,10 @@ fn resolve_exam_manifest_command(
             detail,
         }
     })?;
-    let working_dir = parsed
-        .working_dir
-        .map(|wd| {
-            if wd.is_absolute() {
-                wd
-            } else {
-                workspace_root.join(wd)
-            }
-        })
-        .or_else(|| Some(workspace_root.to_path_buf()));
-    Ok(Some(ResolvedCommand {
-        argv: parsed.command,
-        working_dir,
-    }))
+    Ok(Some(resolved_command_from_manifest(
+        workspace_root,
+        &parsed,
+    )))
 }
 
 fn validate_exam_manifest_plugin_manifest(

--- a/implementations/rust/provekit-cli/tests/registry_authority_dispatch_test.rs
+++ b/implementations/rust/provekit-cli/tests/registry_authority_dispatch_test.rs
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use provekit_cli::kit_dispatch::{
+    dispatch_bind_lift, dispatch_realize, drain_kit_dispatch_diagnostics,
+    ensure_sealed_plugin_registry_for_project, federate_plugin_registries,
+    reset_kit_dispatch_registry_cache_for_tests, RealizeRequest, DEFAULT_EXAM_MANIFEST_CID,
+    EXAM_MANIFEST_MISMATCH_REASON,
+};
+use serial_test::serial;
+
+const OTHER_EXAM_MANIFEST_CID: &str = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+
+fn python_bin() -> String {
+    std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string())
+}
+
+fn write_realize_script(root: &Path, name: &str, source: &str) -> PathBuf {
+    let script = root.join(format!("{name}.py"));
+    fs::write(
+        &script,
+        format!(
+            r#"import json
+import sys
+
+for line in sys.stdin:
+    req = json.loads(line)
+    print(json.dumps({{
+        "jsonrpc": "2.0",
+        "id": req.get("id"),
+        "result": {{
+            "source": {source:?},
+            "is_stub": False,
+            "extension": "py"
+        }}
+    }}), flush=True)
+    break
+"#
+        ),
+    )
+    .expect("write realize script");
+    script
+}
+
+fn write_lift_script(root: &Path, name: &str, fn_name: &str) -> PathBuf {
+    let script = root.join(format!("{name}.py"));
+    fs::write(
+        &script,
+        format!(
+            r#"import json
+import sys
+
+for line in sys.stdin:
+    req = json.loads(line)
+    method = req.get("method")
+    if method == "initialize":
+        result = {{"name": "test-lift"}}
+    elif method == "lift":
+        result = {{
+            "kind": "ir-document",
+            "ir": [{{
+                "kind": "bind-lift-entry",
+                "file": "lib.rs",
+                "fn_name": {fn_name:?},
+                "fn_line": 1,
+                "param_names": [],
+                "param_types": [],
+                "return_type": "i32",
+                "term_shape": {{}},
+                "term_shape_cid": "blake3-512:test"
+            }}],
+            "diagnostics": []
+        }}
+    else:
+        result = {{}}
+    print(json.dumps({{
+        "jsonrpc": "2.0",
+        "id": req.get("id"),
+        "result": result
+    }}), flush=True)
+    if method == "shutdown":
+        break
+"#
+        ),
+    )
+    .expect("write lift script");
+    script
+}
+
+fn install_manifest(
+    root: &Path,
+    kind: &str,
+    surface: &str,
+    script: &Path,
+    library_tag: Option<&str>,
+) -> PathBuf {
+    let manifest = root
+        .join(".provekit")
+        .join(kind)
+        .join(surface)
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().expect("manifest parent")).expect("create manifest dir");
+    let tag = library_tag
+        .map(|tag| format!("library_tag = \"{tag}\"\n"))
+        .unwrap_or_default();
+    let manifest_text = format!(
+        "name = \"{surface}\"\n\
+         {tag}\
+         protocol_versions = [\"pep/1.7.0\"]\n\
+         command = [\"{}\", \"{}\", \"--rpc\"]\n\
+         working_dir = \".\"\n",
+        python_bin().replace('\\', "\\\\").replace('"', "\\\""),
+        script
+            .display()
+            .to_string()
+            .replace('\\', "\\\\")
+            .replace('"', "\\\""),
+    );
+    fs::write(&manifest, manifest_text).expect("write manifest");
+    manifest
+}
+
+fn realize_request() -> RealizeRequest {
+    RealizeRequest {
+        function: "make_value".to_string(),
+        params: Vec::new(),
+        param_types: Vec::new(),
+        return_type: "int".to_string(),
+        concept_name: "concept:test".to_string(),
+        named_term_tree: None,
+        term_shape: None,
+        operand_bindings: Vec::new(),
+        source_function_name: None,
+        mode: None,
+        modes: Vec::new(),
+        contract: None,
+        sugar_cids: Vec::new(),
+        sugar_plugins: Vec::new(),
+    }
+}
+
+#[test]
+#[serial]
+fn registered_realize_dispatch_uses_sealed_registry_after_manifest_removed() {
+    reset_kit_dispatch_registry_cache_for_tests();
+    let _ = drain_kit_dispatch_diagnostics();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let script = write_realize_script(
+        workspace.path(),
+        "realize_registered",
+        "from sealed registry",
+    );
+    let manifest = install_manifest(
+        workspace.path(),
+        "realize",
+        "python",
+        &script,
+        Some("urllib"),
+    );
+
+    let sealed =
+        ensure_sealed_plugin_registry_for_project(workspace.path()).expect("seal plugin registry");
+    assert!(sealed.path.exists());
+    assert_eq!(sealed.memento.header.load_order.len(), 1);
+
+    fs::remove_file(&manifest).expect("remove manifest after registry seal");
+    let realized = dispatch_realize(
+        workspace.path(),
+        "python",
+        Some("urllib"),
+        &realize_request(),
+    )
+    .expect("dispatch through sealed registry");
+
+    assert_eq!(realized.source, "from sealed registry");
+    assert!(
+        drain_kit_dispatch_diagnostics().is_empty(),
+        "registry hit should not emit fallback diagnostics"
+    );
+}
+
+#[test]
+#[serial]
+fn unregistered_realize_dispatch_falls_back_and_logs_deprecation() {
+    reset_kit_dispatch_registry_cache_for_tests();
+    let _ = drain_kit_dispatch_diagnostics();
+    let workspace = tempfile::tempdir().expect("tempdir");
+
+    ensure_sealed_plugin_registry_for_project(workspace.path()).expect("seal empty registry");
+    let script = write_realize_script(workspace.path(), "realize_legacy", "from legacy fallback");
+    install_manifest(
+        workspace.path(),
+        "realize",
+        "python",
+        &script,
+        Some("urllib"),
+    );
+
+    let realized = dispatch_realize(
+        workspace.path(),
+        "python",
+        Some("urllib"),
+        &realize_request(),
+    )
+    .expect("dispatch through legacy fallback");
+    let diagnostics = drain_kit_dispatch_diagnostics();
+
+    assert_eq!(realized.source, "from legacy fallback");
+    assert!(
+        diagnostics.iter().any(|line| {
+            line.contains("deprecated kit_dispatch filesystem fallback")
+                && line.contains("kind=realize")
+                && line.contains("surface=python")
+        }),
+        "missing fallback diagnostic: {diagnostics:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn registered_lift_dispatch_uses_sealed_registry_after_manifest_removed() {
+    reset_kit_dispatch_registry_cache_for_tests();
+    let _ = drain_kit_dispatch_diagnostics();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let script = write_lift_script(workspace.path(), "lift_registered", "lifted_by_registry");
+    let manifest = install_manifest(workspace.path(), "lift", "rust-bind", &script, None);
+
+    ensure_sealed_plugin_registry_for_project(workspace.path()).expect("seal lift registry");
+    fs::remove_file(&manifest).expect("remove manifest after registry seal");
+    let lifted =
+        dispatch_bind_lift(workspace.path(), "rust").expect("dispatch lift through registry");
+
+    assert_eq!(lifted.entries.len(), 1);
+    assert_eq!(lifted.entries[0].fn_name, "lifted_by_registry");
+    assert!(drain_kit_dispatch_diagnostics().is_empty());
+}
+
+#[test]
+#[serial]
+fn unregistered_lift_dispatch_falls_back_and_logs_deprecation() {
+    reset_kit_dispatch_registry_cache_for_tests();
+    let _ = drain_kit_dispatch_diagnostics();
+    let workspace = tempfile::tempdir().expect("tempdir");
+
+    ensure_sealed_plugin_registry_for_project(workspace.path()).expect("seal empty registry");
+    let script = write_lift_script(workspace.path(), "lift_legacy", "lifted_by_fallback");
+    install_manifest(workspace.path(), "lift", "rust-bind", &script, None);
+
+    let lifted = dispatch_bind_lift(workspace.path(), "rust").expect("dispatch lift fallback");
+    let diagnostics = drain_kit_dispatch_diagnostics();
+
+    assert_eq!(lifted.entries.len(), 1);
+    assert_eq!(lifted.entries[0].fn_name, "lifted_by_fallback");
+    assert!(
+        diagnostics.iter().any(|line| {
+            line.contains("deprecated kit_dispatch filesystem fallback")
+                && line.contains("kind=lift")
+                && line.contains("surface=rust-bind")
+        }),
+        "missing fallback diagnostic: {diagnostics:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn sealed_registry_cid_is_deterministic_for_same_plugin_set() {
+    reset_kit_dispatch_registry_cache_for_tests();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let script = write_realize_script(workspace.path(), "realize_stable", "stable");
+    install_manifest(
+        workspace.path(),
+        "realize",
+        "python",
+        &script,
+        Some("urllib"),
+    );
+
+    let first =
+        ensure_sealed_plugin_registry_for_project(workspace.path()).expect("first registry seal");
+    let first_bytes = fs::read(&first.path).expect("read first memento");
+
+    reset_kit_dispatch_registry_cache_for_tests();
+    let second =
+        ensure_sealed_plugin_registry_for_project(workspace.path()).expect("second registry seal");
+    let second_bytes = fs::read(&second.path).expect("read second memento");
+
+    assert_eq!(first.memento.header.cid, second.memento.header.cid);
+    assert_eq!(first.path, second.path);
+    assert_eq!(first_bytes, second_bytes);
+}
+
+#[test]
+#[serial]
+fn sealed_registry_federation_refuses_exam_manifest_mismatch() {
+    reset_kit_dispatch_registry_cache_for_tests();
+    let local = tempfile::tempdir().expect("local tempdir");
+    let remote = tempfile::tempdir().expect("remote tempdir");
+    let local_script = write_realize_script(local.path(), "realize_same", "same");
+    let remote_script = write_realize_script(remote.path(), "realize_same", "same");
+    install_manifest(
+        local.path(),
+        "realize",
+        "python",
+        &local_script,
+        Some("urllib"),
+    );
+    install_manifest(
+        remote.path(),
+        "realize",
+        "python",
+        &remote_script,
+        Some("urllib"),
+    );
+    let remote_config = remote.path().join(".provekit").join("config.toml");
+    fs::write(
+        &remote_config,
+        format!("exam_manifest_cid = \"{OTHER_EXAM_MANIFEST_CID}\"\n"),
+    )
+    .expect("write remote config");
+
+    let local_registry =
+        ensure_sealed_plugin_registry_for_project(local.path()).expect("local registry seal");
+    let remote_registry =
+        ensure_sealed_plugin_registry_for_project(remote.path()).expect("remote registry seal");
+    let error = federate_plugin_registries(&local_registry.memento, &remote_registry.memento)
+        .expect_err("different exam manifest CIDs must refuse");
+
+    assert_ne!(
+        local_registry.memento.header.cid,
+        remote_registry.memento.header.cid
+    );
+    assert_eq!(error.refused_reason(), EXAM_MANIFEST_MISMATCH_REASON);
+    assert_eq!(
+        error.refusal_payload()["local_manifest_cid"].as_str(),
+        Some(DEFAULT_EXAM_MANIFEST_CID)
+    );
+    assert_eq!(
+        error.refusal_payload()["remote_manifest_cid"].as_str(),
+        Some(OTHER_EXAM_MANIFEST_CID)
+    );
+}
+
+#[test]
+#[serial]
+fn sealed_registry_same_cid_federates_without_exam_check() {
+    reset_kit_dispatch_registry_cache_for_tests();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let script = write_realize_script(workspace.path(), "realize_federated", "same");
+    install_manifest(
+        workspace.path(),
+        "realize",
+        "python",
+        &script,
+        Some("urllib"),
+    );
+
+    let sealed =
+        ensure_sealed_plugin_registry_for_project(workspace.path()).expect("registry seal");
+
+    federate_plugin_registries(&sealed.memento, &sealed.memento)
+        .expect("byte-equal registry CIDs federate");
+}

--- a/implementations/rust/provekit-plugin-loader/src/lib.rs
+++ b/implementations/rust/provekit-plugin-loader/src/lib.rs
@@ -17,11 +17,16 @@
 pub mod cid;
 pub mod error;
 pub mod loader;
+pub mod persistence;
 pub mod registry;
 pub mod types;
 
 pub use error::LoadError;
 pub use loader::{load_plugin_from_file, load_plugin_from_rpc};
+pub use persistence::{
+    plugin_registry_memento_path, read_plugin_registry_memento, write_plugin_registry_memento,
+    PLUGIN_REGISTRY_MEMENTO_FILE,
+};
 pub use registry::{PluginRegistry, PluginRegistryMemento};
 pub use types::{
     LoadOrderEntry, LoadedEntry, PluginEnvelope, PluginHeader, PluginLoadFailureMemento,

--- a/implementations/rust/provekit-plugin-loader/src/persistence.rs
+++ b/implementations/rust/provekit-plugin-loader/src/persistence.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::PluginRegistryMemento;
+
+pub const PLUGIN_REGISTRY_MEMENTO_FILE: &str = "plugin-registry-memento.json";
+
+pub fn plugin_registry_memento_path(
+    project_root: &Path,
+    registry: &PluginRegistryMemento,
+) -> PathBuf {
+    project_root
+        .join(".provekit")
+        .join("runs")
+        .join(registry.cid())
+        .join(PLUGIN_REGISTRY_MEMENTO_FILE)
+}
+
+pub fn write_plugin_registry_memento(
+    project_root: &Path,
+    registry: &PluginRegistryMemento,
+) -> io::Result<PathBuf> {
+    let path = plugin_registry_memento_path(project_root, registry);
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "plugin registry memento path has no parent",
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+    let json = serde_json::to_string_pretty(registry).map_err(io::Error::other)?;
+    std::fs::write(&path, format!("{json}\n"))?;
+    Ok(path)
+}
+
+pub fn read_plugin_registry_memento(path: &Path) -> io::Result<PluginRegistryMemento> {
+    let raw = std::fs::read_to_string(path)?;
+    serde_json::from_str(&raw).map_err(io::Error::other)
+}

--- a/implementations/rust/provekit-plugin-loader/src/registry.rs
+++ b/implementations/rust/provekit-plugin-loader/src/registry.rs
@@ -463,4 +463,27 @@ mod tests {
         let m = reg.emit_registry_memento("2026-05-12T00:00:00.000Z");
         assert_eq!(m.header.built_in_count, 1);
     }
+
+    #[test]
+    fn write_registry_memento_uses_content_addressed_run_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut reg = PluginRegistry::new();
+        reg.register(dummy_memento("sugar", "blake3-512:aaa"), "./test.json")
+            .unwrap();
+        let m = reg.emit_registry_memento("2026-05-12T00:00:00.000Z");
+
+        let path =
+            crate::write_plugin_registry_memento(temp.path(), &m).expect("write registry memento");
+        let read_back = crate::read_plugin_registry_memento(&path).expect("read registry memento");
+
+        assert_eq!(read_back, m);
+        assert_eq!(
+            path,
+            temp.path()
+                .join(".provekit")
+                .join("runs")
+                .join(m.cid())
+                .join(crate::PLUGIN_REGISTRY_MEMENTO_FILE)
+        );
+    }
 }


### PR DESCRIPTION
Implements Sir's pin-all-three ruling: PluginRegistryMemento sealed at run start IS the pin of k in k(k'(k''(I)))=t.

- kit_dispatch seals + caches per run at `.provekit/runs/<cid>/plugin-registry-memento.json`
- A2 fallback for legacy kits with deprecation diagnostic
- Federation handshake activated: exam_manifest_cid compatibility checks now load-bearing
- Plugin-loader persistence helpers + unit test
- CLI integration tests: registered dispatch, fallback diagnostics, deterministic CID, federation refusal

Codex completed in 62 min isolated worktree run; Kit committed on its behalf.

🤖