### PR TITLE
fix(lift): canonicalize lift.to CID against realize-sidecar

### DIFF
--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -475,7 +475,12 @@ fn strip_bind_payload_source_function_from_value(value: &mut Json) {
     }
 }
 
-fn strip_realize_sidecar_from_lift_term(term: Term) -> Term {
+/// Strip realize-sidecar metadata (attr_pre, attr_post, concept_annotation,
+/// operand_bindings, proc_macro_invocations, source_function_name) from a
+/// lift-output `Term::Const`. Used to compute the canonical content CID that
+/// `lift.to` and `bind.from` both target, so adding a comment that shifts
+/// `fn_line` does not invalidate the proof chain.
+pub fn strip_realize_sidecar_from_lift_term(term: Term) -> Term {
     let Term::Const { mut value, sort } = term else {
         return term;
     };

--- a/implementations/rust/libprovekit/src/core/lift_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lift_plugin.rs
@@ -8,6 +8,7 @@ use provekit_ir_types::{IrFormula, IrTerm, Sort};
 use serde_json::{json, Value};
 use thiserror::Error;
 
+use super::bind::strip_realize_sidecar_from_lift_term;
 use super::primitives::address;
 use super::traits::{Kit, KitError};
 use super::types::{
@@ -76,7 +77,15 @@ impl LiftPluginKit {
                 ))
             }
         };
-        let response_cid = address(&response_term);
+        // Substrate identity rule: lift's `to` CID must be stable against
+        // realize-sidecar noise (attr_pre, attr_post, concept_annotation,
+        // operand_bindings, source_function_name, proc_macro_invocations).
+        // Adding a comment that shifts `fn_line` is irrelevant variation, so
+        // the canonical content address strips the sidecar before hashing.
+        // The `payload` field still carries the raw response (with sidecar)
+        // for downstream consumers that need realize-time metadata.
+        let canonical_term = strip_realize_sidecar_from_lift_term(response_term.clone());
+        let response_cid = address(&canonical_term);
         let contract = lift_response_contract(&self.surface, response, &response_cid);
 
         Ok(DomainClaim {

--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -34,9 +34,9 @@ pub mod walks;
 pub use crate::exam_manifest::ExamManifestKit;
 pub use bind::{
     bind_result_payload, bind_term_document, concept_bind_result_cid, named_term_document_cid,
-    named_term_document_from_bind_payload, BindContractWitness, BindError, BindKit, BindLiftEntry,
-    BindOptions, CandidateCluster, CandidateClusterManifest, NamedTerm, NamedTermDocument,
-    NamedTermTree, NamedWitness,
+    named_term_document_from_bind_payload, strip_realize_sidecar_from_lift_term,
+    BindContractWitness, BindError, BindKit, BindLiftEntry, BindOptions, CandidateCluster,
+    CandidateClusterManifest, NamedTerm, NamedTermDocument, NamedTermTree, NamedWitness,
 };
 pub use lift_plugin::{LiftKit, LiftPluginKit, LiftPluginKitError, LiftPluginKitSession};
 pub use lower_plugin::{

--- a/implementations/rust/libprovekit/tests/bind_kit.rs
+++ b/implementations/rust/libprovekit/tests/bind_kit.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use libprovekit::core::{
     address, bind_term_document, concept_bind_result_cid, named_term_document_from_bind_payload,
-    BindKit, BindOptions, Input, Kit, Term,
+    strip_realize_sidecar_from_lift_term, BindKit, BindOptions, Input, Kit, Term,
 };
 use libprovekit::proofir_bridge::CatalogIndex;
 use provekit_ir_types::{ExamManifestMemento, Sort};
@@ -130,14 +130,20 @@ fn bind_kit_transform_emits_bind_result_op_tree() {
         value: term_value.clone(),
         sort: primitive_sort("LiftPluginResponse"),
     };
-    let mut expected_payload_source_value = term_value.clone();
-    expected_payload_source_value["ir"][0]
-        .as_object_mut()
-        .expect("bind-lift-entry object")
-        .remove("fn_name");
-    let expected_payload_source = Term::Const {
-        value: expected_payload_source_value,
-        sort: primitive_sort("LiftPluginResponse"),
+    // The bind payload's `source` arg is `strip_fn_name(strip_realize_sidecar(input))`.
+    // The fn_name strip preserves the #1093 CID invariant; the realize-sidecar
+    // strip preserves canonical content identity (so the CID is stable against
+    // attr_pre/attr_post/concept_annotation/operand_bindings/proc_macro_invocations/
+    // source_function_name noise).
+    let expected_payload_source = {
+        let canonical = strip_realize_sidecar_from_lift_term(input_term.clone());
+        let Term::Const { mut value, sort } = canonical else {
+            unreachable!("input term is Term::Const");
+        };
+        if let Some(object) = value["ir"][0].as_object_mut() {
+            object.remove("fn_name");
+        }
+        Term::Const { value, sort }
     };
     let mut expected_named =
         bind_term_document(&term_value, &BindOptions::default()).expect("existing binder succeeds");
@@ -154,7 +160,10 @@ fn bind_kit_transform_emits_bind_result_op_tree() {
         .transform(&Input::Term(input_term.clone()))
         .expect("bind kit transforms term input");
 
-    assert_eq!(claim.from, vec![address(&input_term)]);
+    // Bind cites the canonical content CID of its input, which matches
+    // lift.to under the same canonicalization (strip realize sidecar).
+    let canonical_input = strip_realize_sidecar_from_lift_term(input_term.clone());
+    assert_eq!(claim.from, vec![address(&canonical_input)]);
     let payload = claim.payload.as_ref().expect("bind claim carries payload");
     assert_eq!(claim.to, address(payload));
     let Term::Op {

--- a/implementations/rust/provekit-cli/tests/bind_kit_path_integration.rs
+++ b/implementations/rust/provekit-cli/tests/bind_kit_path_integration.rs
@@ -6,9 +6,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use libprovekit::core::{
-    address, execute_path, named_term_document_cid, named_term_document_from_bind_payload, BindKit,
-    ConformanceDeclaration, Dialect, HashMapInputCatalog, Input, Kit, KitRegistry, LiftKit,
-    Path as CorePath, PathAlgebra, Term, Verb,
+    address, execute_path, named_term_document_cid, named_term_document_from_bind_payload,
+    strip_realize_sidecar_from_lift_term, BindKit, ConformanceDeclaration, Dialect,
+    HashMapInputCatalog, Input, Kit, KitRegistry, LiftKit, Path as CorePath, PathAlgebra, Term,
+    Verb,
 };
 
 const BIND_NONCARRIER: ConformanceDeclaration = ConformanceDeclaration::NonCarrier {
@@ -154,7 +155,9 @@ fn bind_path_executor_matches_cmd_bind_named_term_document_bytes() {
     let cli_cid = named_term_document_cid(&cli_named).expect("cmd_bind named terms cid");
 
     assert_eq!(claim.artifacts, vec![cli_cid]);
-    assert_eq!(claim.from, vec![address(&input_term)]);
+    // Bind cites the canonical content CID (strip realize sidecar) of its input.
+    let canonical_input = strip_realize_sidecar_from_lift_term(input_term.clone());
+    assert_eq!(claim.from, vec![address(&canonical_input)]);
     // bind_term_document's recovered named-term has empty `function` because
     // fn_name is stripped from the bind-result payload hash (closes #1093).
     assert!(cli_named.terms[0].function.is_empty());


### PR DESCRIPTION
## Summary

Lift's `to` CID becomes `address(strip_realize_sidecar(response_term))` instead of `address(response_term)`. The substrate's content-addressed identity must be stable against realize-sidecar noise: `attr_pre`, `attr_post`, `concept_annotation`, `operand_bindings`, `source_function_name`, `proc_macro_invocations`. Adding a comment to a source file shifts `fn_line`, which was shifting `lift.to`, which broke pin-all-three for the lift layer.

BindKit already canonicalizes its `from` the same way; this PR makes lift symmetric so the proof chain `bind.from == lift.to` holds end-to-end.

## Architect ruling

Sir, 2026-05-18: _"That means if the same source is re-lifted after adding a comment (shifts fn_line) the lift to CID changes. This is FUNDAMENTALLY broken."_

## Change set

- `lift_plugin.rs:79` — wrap `address` call with `strip_realize_sidecar_from_lift_term`.
- `bind.rs` — promote the strip function from `pub(crate)` to `pub` and add a doc comment.
- `core/mod.rs` — re-export `strip_realize_sidecar_from_lift_term`.
- `libprovekit/tests/bind_kit.rs` — update assertion to compare against canonical input CID; update `expected_payload_source` to apply the same canonicalization the bind kit applies.
- `provekit-cli/tests/bind_kit_path_integration.rs` — same canonical-input fix.

The lift's `payload` field still carries the raw response (with sidecar) for downstream consumers that need realize-time metadata. Only the content-address CID is canonical.

## What goes green

- `bind_kit_transform_emits_bind_result_op_tree` (was failing on main since #1194 added `concept_annotation` to the strip set).
- `bind_path_executor_matches_cmd_bind_named_term_document_bytes` (same root cause).
- Slow-lane `trinity_citation_comments_exhibit::fixture_01_*` (all three variants; line 407 panic `python bind claim must cite the lift payload CID in from`).

## Pre-existing main failures NOT addressed by this PR

These were already red on main directly (verified via checkout); not introduced here:

- `provekit_lift_processes_walk_crate_to_proof_catalog` (`expect@src/dropper/emit.rs:231:24` name collision in dogfood lift).
- `rust_canonical_bodies_cid_self_consistent` / `java_canonical_bodies_cid_self_consistent` (stale declared CIDs in body-template JSON files; substrate maintenance issue).
- `bind_migrates_better_sqlite3_to_pg_with_async_receipt` / `bind_migrates_better_sqlite3_to_python_with_cross_language_witness_pairs` (Stage 2/3 demo tests).
- Other test failures requiring external infrastructure (npm tarball, TS/C# lifter binaries).

## Test plan

- [x] cargo build workspace clean
- [x] bind_kit: 8/8 passed
- [x] bind_kit_path_integration: 3/3 passed
- [x] Workspace test diff: pre-existing main failures only; B fix introduces zero new failures
- [ ] CI slow-lane prove-trinity-citation-exhibit: needs CI's Java/Python lift+realize binaries; cannot validate locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed explanations for content identifier computation methods.

* **Bug Fixes**
  * Improved content identifier accuracy by refining canonicalization processes.
  * Ensured consistent identifier computation across operations.

* **Tests**
  * Updated verification tests to reflect improved canonicalization handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->