### PR TITLE
feat(provekit-cli): wire uncharacterizable_callsites into refusal_mementos + Stage 5 CI gate (closes #1148, fixes P0 silent-refuse-drop)

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -139,6 +139,7 @@ fn run_inner(args: BindArgs) -> Result<(), String> {
         &target_binding_cid,
         target_surface,
         &semantic_changes.divergences_by_callsite_and_dimension,
+        &semantic_changes.uncharacterizable_callsites,
     )?;
     if let Some(fixture) = witness_fixture.as_ref() {
         if target_surface.is_python() {
@@ -693,8 +694,23 @@ struct PlatformSemanticChangeSet {
     divergences_by_callsite_and_dimension: BTreeMap<(String, String), DivergenceCharacterization>,
     /// Callsites where exactly one kit declared a tag for the op-CID; the
     /// substrate cannot characterize the divergence. These are routed to the
-    /// refuse leg of the trichotomy by the caller.
-    uncharacterizable_callsites: Vec<(String, Side)>,
+    /// refuse leg of the trichotomy at receipt-construction time.
+    uncharacterizable_callsites: Vec<UncharacterizableCallsite>,
+}
+
+/// A callsite the substrate cannot characterize because exactly one kit
+/// declared a tag for the op-CID. Carries enough context for the refusal
+/// memento to name the declaring kit as the forbidding contract.
+#[derive(Debug, Clone)]
+struct UncharacterizableCallsite {
+    callsite_cid: String,
+    op_cid: String,
+    absent_on: Side,
+    /// The kit-CID of the side that DID declare a tag for the op (the
+    /// non-absent side). When available, used as `forbidding_contract` on
+    /// the refusal memento. Falls back to the op-CID if the declaring kit
+    /// did not carry value mementos.
+    declaring_kit_cid: Option<String>,
 }
 
 fn validate_focus(focus: Option<&str>, sql_callsites: &[SqlCallsite]) -> Result<(), String> {
@@ -763,9 +779,20 @@ fn platform_semantic_changes(
             OpCoverageVerdict::Uncharacterizable { absent_on } => {
                 // Exactly one kit declared a tag. The substrate cannot characterize
                 // the divergence; record for the refuse leg.
-                changes
-                    .uncharacterizable_callsites
-                    .push((callsite.cid.clone(), absent_on));
+                let declaring = match absent_on {
+                    Side::Source => target,
+                    Side::Target => source,
+                };
+                let declaring_kit_cid = declaring
+                    .dimension_values
+                    .first()
+                    .map(|memento| memento.kit_cid.clone());
+                changes.uncharacterizable_callsites.push(UncharacterizableCallsite {
+                    callsite_cid: callsite.cid.clone(),
+                    op_cid: callsite.concept_cid.clone(),
+                    absent_on,
+                    declaring_kit_cid,
+                });
             }
             OpCoverageVerdict::Divergent(divergence) => {
                 let effect = divergence_effect_cid(&divergence);
@@ -981,6 +1008,7 @@ fn build_receipt(
     target_binding_cid: &str,
     target_surface: TargetSurface,
     divergences_by_callsite_and_dimension: &BTreeMap<(String, String), DivergenceCharacterization>,
+    uncharacterizable_callsites: &[UncharacterizableCallsite],
 ) -> Result<MigrateReceiptEnvelope, String> {
     let mut concept_sites = Vec::new();
     for callsite in sql_callsites {
@@ -1063,49 +1091,83 @@ fn build_receipt(
         }
     }
 
-    let mut loss_records = Vec::new();
-    for decision in decisions.values() {
-        let PropagationDecision::Widen {
-            dimension_name,
-            triggering_callsite_cid,
-            ..
-        } = decision
-        else {
-            continue;
+    // Refuse leg of the trichotomy: every uncharacterizable callsite that the
+    // substrate-comparison phase collected becomes a refusal memento. The
+    // declaring kit's CID names the forbidding contract; the reason carries
+    // the absent op CID and the side that lacked a declaration.
+    for uc in uncharacterizable_callsites {
+        let forbidding_contract = uc
+            .declaring_kit_cid
+            .clone()
+            .unwrap_or_else(|| uc.op_cid.clone());
+        let absent_side = match uc.absent_on {
+            Side::Source => "source",
+            Side::Target => "target",
         };
-        let Some(dim) = dimension_name else {
-            continue;
-        };
-        let Some(divergence) = divergences_by_callsite_and_dimension
-            .get(&(triggering_callsite_cid.clone(), dim.clone()))
-        else {
-            continue;
-        };
-        let Some(callsite) = sql_callsites
-            .iter()
-            .find(|callsite| callsite.cid == *triggering_callsite_cid)
-        else {
-            continue;
-        };
-        let mut loss_dimensions = BTreeMap::new();
-        loss_dimensions.insert(
-            divergence.dimension_name.clone(),
-            IrFormula::DivergenceBetween {
-                source: Box::new(divergence.source_compare_to.clone()),
-                target: Box::new(divergence.target_compare_to.clone()),
-            },
-        );
-        let mut loss = LossRecordMemento {
-            callsite_cid: callsite.cid.clone(),
+        let mut refusal = RefusalMemento {
             cid: String::new(),
-            kind: "loss-record".to_string(),
-            loss_dimension: divergence.dimension_name.clone(),
-            loss_dimensions,
+            forbidding_contract,
+            function_cid: uc.callsite_cid.clone(),
+            kind: "refusal".to_string(),
+            reason: format!(
+                "substrate cannot characterize divergence: {absent_side} kit did not declare a tag for op-CID {}",
+                uc.op_cid
+            ),
             schema_version: "1".to_string(),
-            substituted_body: callsite.substituted_body.clone(),
         };
-        loss.cid = loss.recompute_cid().map_err(|e| e.to_string())?;
-        loss_records.push(loss);
+        refusal.cid = refusal.recompute_cid().map_err(|e| e.to_string())?;
+        refusal_mementos.push(refusal);
+    }
+
+    // Short-circuit lossy emission when any callsite is uncharacterizable.
+    // Per the trichotomy, a migrate that refuses on any callsite is a pure
+    // refusal; emitting partial loss-records alongside would conflate
+    // "loudly-bounded-lossy" with "refuse" and violate Supra omnia, rectum.
+    let mut loss_records = Vec::new();
+    if uncharacterizable_callsites.is_empty() {
+        for decision in decisions.values() {
+            let PropagationDecision::Widen {
+                dimension_name,
+                triggering_callsite_cid,
+                ..
+            } = decision
+            else {
+                continue;
+            };
+            let Some(dim) = dimension_name else {
+                continue;
+            };
+            let Some(divergence) = divergences_by_callsite_and_dimension
+                .get(&(triggering_callsite_cid.clone(), dim.clone()))
+            else {
+                continue;
+            };
+            let Some(callsite) = sql_callsites
+                .iter()
+                .find(|callsite| callsite.cid == *triggering_callsite_cid)
+            else {
+                continue;
+            };
+            let mut loss_dimensions = BTreeMap::new();
+            loss_dimensions.insert(
+                divergence.dimension_name.clone(),
+                IrFormula::DivergenceBetween {
+                    source: Box::new(divergence.source_compare_to.clone()),
+                    target: Box::new(divergence.target_compare_to.clone()),
+                },
+            );
+            let mut loss = LossRecordMemento {
+                callsite_cid: callsite.cid.clone(),
+                cid: String::new(),
+                kind: "loss-record".to_string(),
+                loss_dimension: divergence.dimension_name.clone(),
+                loss_dimensions,
+                schema_version: "1".to_string(),
+                substituted_body: callsite.substituted_body.clone(),
+            };
+            loss.cid = loss.recompute_cid().map_err(|e| e.to_string())?;
+            loss_records.push(loss);
+        }
     }
     let mut aggregate_summary = AggregateSummaryMemento {
         cid: String::new(),
@@ -2241,6 +2303,7 @@ mod tests {
             "target-binding",
             TargetSurface::TypescriptPg,
             &changes.divergences_by_callsite_and_dimension,
+            &changes.uncharacterizable_callsites,
         )
         .expect("receipt builds")
     }
@@ -2341,6 +2404,7 @@ mod tests {
             "target-binding",
             TargetSurface::TypescriptPg,
             &changes.divergences_by_callsite_and_dimension,
+            &changes.uncharacterizable_callsites,
         )
         .expect("receipt builds");
 
@@ -2377,9 +2441,12 @@ mod tests {
         let changes = platform_semantic_changes(&source, &target, &callsites, None)
             .expect("uncharacterizable does not bubble as error");
         assert_eq!(changes.uncharacterizable_callsites.len(), 1);
-        assert_eq!(changes.uncharacterizable_callsites[0].0, "cs:rust-native");
         assert_eq!(
-            changes.uncharacterizable_callsites[0].1,
+            changes.uncharacterizable_callsites[0].callsite_cid,
+            "cs:rust-native"
+        );
+        assert_eq!(
+            changes.uncharacterizable_callsites[0].absent_on,
             Side::Target,
             "source has the tag; target is absent"
         );

--- a/implementations/rust/provekit-cli/tests/cross_platform_point_query_receipt_test.rs
+++ b/implementations/rust/provekit-cli/tests/cross_platform_point_query_receipt_test.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
+use provekit_ir_types::{IrFormula, MigrateReceiptEnvelope};
+use serde_json::json;
+
+const INSERT_AND_GET_ID_CONCEPT_CID: &str = "blake3-512:0a4f0a8d36d8dee96b8d5b32a18bb390f35877ecef611771048c6e10cfc3d25ad8f59de89b00c7794f62cabaf91dbd779244338393a8bb6ef5e8309b0929b3ca";
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("provekit-cli has rust workspace parent")
+        .parent()
+        .expect("rust workspace has implementations parent")
+        .parent()
+        .expect("implementations dir has repo parent")
+        .to_path_buf()
+}
+
+fn write_source_project(root: &Path, source: &str) -> PathBuf {
+    let source_dir = root.join("users-better-sqlite3");
+    let src_dir = source_dir.join("src");
+    fs::create_dir_all(&src_dir).expect("create source dir");
+    fs::write(src_dir.join("users.ts"), source).expect("write users.ts");
+    source_dir
+}
+
+fn run_migrate(
+    source_dir: &Path,
+    library_to: &str,
+    receipt: &Path,
+    focus: Option<&str>,
+) -> std::process::Output {
+    let repo = repo_root();
+    let out_dir = receipt
+        .parent()
+        .expect("receipt has parent")
+        .join(format!("out-{library_to}"));
+    let mut cmd = Command::new(provekit_bin());
+    cmd.current_dir(&repo)
+        .arg("bind")
+        .arg("--library-from")
+        .arg("typescript-better-sqlite3")
+        .arg("--library-to")
+        .arg(library_to)
+        .arg("--source-dir")
+        .arg(source_dir)
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg("--receipt")
+        .arg(receipt);
+    if let Some(focus) = focus {
+        cmd.arg("--focus").arg(focus);
+    }
+    cmd.output().expect("spawn provekit bind migrate")
+}
+
+fn assert_success(label: &str, output: &std::process::Output) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "{label} failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+fn read_receipt(path: &Path) -> MigrateReceiptEnvelope {
+    let raw = fs::read_to_string(path).expect("receipt written");
+    let receipt: MigrateReceiptEnvelope = serde_json::from_str(&raw).expect("parse receipt");
+    receipt.validate().expect("receipt validates");
+    receipt
+}
+
+fn receipt_for(source: &str, library_to: &str, focus: Option<&str>) -> MigrateReceiptEnvelope {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source_dir = write_source_project(temp.path(), source);
+    let receipt_path = temp.path().join("migrate-receipt.proof");
+    let output = run_migrate(&source_dir, library_to, &receipt_path, focus);
+    assert_success("migrate", &output);
+    read_receipt(&receipt_path)
+}
+
+fn receipt_cid_for(source: &str, library_to: &str, focus: Option<&str>) -> String {
+    receipt_for(source, library_to, focus).root_cid
+}
+
+fn insert_source() -> String {
+    [
+        r#"import Database from "better-sqlite3";"#,
+        "",
+        r#"const db = new Database("users.sqlite");"#,
+        "",
+        "export function recordEvent(userId: number, kind: string): number {",
+        "  const result = db",
+        r#"    .prepare("INSERT INTO events (user_id, kind) VALUES (?, ?)")"#,
+        "    .run(userId, kind);",
+        "  return Number(result.lastInsertRowid);",
+        "}",
+        "",
+    ]
+    .join("\n")
+}
+
+fn two_insert_source() -> String {
+    [
+        r#"import Database from "better-sqlite3";"#,
+        "",
+        r#"const db = new Database("users.sqlite");"#,
+        "",
+        "export function recordEvent(userId: number, kind: string): number {",
+        "  const result = db",
+        r#"    .prepare("INSERT INTO events (user_id, kind) VALUES (?, ?) /* first */")"#,
+        "    .run(userId, kind);",
+        "  return Number(result.lastInsertRowid);",
+        "}",
+        "",
+        "export function recordEvent(userId: number, kind: string): number {",
+        "  const result = db",
+        r#"    .prepare("INSERT INTO events (user_id, kind) VALUES (?, ?) /* second */")"#,
+        "    .run(userId, kind);",
+        "  return Number(result.lastInsertRowid);",
+        "}",
+        "",
+    ]
+    .join("\n")
+}
+
+fn query_only_source() -> String {
+    [
+        r#"import Database from "better-sqlite3";"#,
+        "",
+        r#"const db = new Database("users.sqlite");"#,
+        "",
+        "export function countUsers(): number {",
+        r#"  const row = db.prepare("SELECT count(*) AS count FROM users").get() as { count: number };"#,
+        "  return row.count;",
+        "}",
+        "",
+    ]
+    .join("\n")
+}
+
+fn callsite_cid(source: &str, concept: &str, function: &str, sql_needle: &str) -> String {
+    let offset = source.find(sql_needle).expect("SQL callsite exists");
+    let line = source[..offset].chars().filter(|ch| *ch == '\n').count() + 1;
+    cid_for_json(&json!({
+        "concept": concept,
+        "function": function,
+        "kind": "migration-sql-callsite",
+        "line": line
+    }))
+}
+
+fn cid_for_json(value: &serde_json::Value) -> String {
+    blake3_512_of(encode_jcs(&json_to_value(value)).as_bytes())
+}
+
+fn json_to_value(j: &serde_json::Value) -> Arc<Value> {
+    match j {
+        serde_json::Value::String(s) => Value::string(s.clone()),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::integer(i)
+            } else if let Some(u) = n.as_u64() {
+                Value::integer(i64::try_from(u).unwrap_or(i64::MAX))
+            } else {
+                Value::string(n.to_string())
+            }
+        }
+        serde_json::Value::Bool(b) => Value::boolean(*b),
+        serde_json::Value::Null => Value::null(),
+        serde_json::Value::Array(arr) => Value::array(arr.iter().map(json_to_value).collect()),
+        serde_json::Value::Object(map) => {
+            let kv: Vec<(String, Arc<Value>)> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), json_to_value(v)))
+                .collect();
+            Value::object(kv)
+        }
+    }
+}
+
+#[test]
+fn fixture_1_documents_sql_migrate_narrowing_gap_with_supported_divergence() {
+    let source = insert_source();
+    let receipt = receipt_for(&source, "typescript-pg", None);
+
+    assert_eq!(receipt.loss_records.len(), 1);
+    assert_eq!(receipt.loss_records[0].loss_dimension, "RowIdMechanism");
+    assert!(receipt.root_cid.starts_with("blake3-512:"));
+}
+
+#[test]
+fn fixture_2_row_id_mechanism_divergence_has_a18_shape() {
+    let source = insert_source();
+    let receipt = receipt_for(&source, "typescript-pg", None);
+    let expected_callsite = callsite_cid(
+        &source,
+        "concept:insert-and-get-id",
+        "recordEvent",
+        ".prepare(\"INSERT INTO events",
+    );
+    let loss = receipt
+        .loss_records
+        .iter()
+        .find(|loss| loss.loss_dimension == "RowIdMechanism")
+        .expect("RowIdMechanism loss record");
+
+    assert!(receipt.aggregate_summary.lossy >= 1);
+    assert!(matches!(
+        loss.loss_dimensions.get("RowIdMechanism"),
+        Some(IrFormula::DivergenceBetween { source, target })
+            if matches!(source.as_ref(), IrFormula::Atomic { args, .. } if !args.is_empty())
+                && matches!(target.as_ref(), IrFormula::Atomic { args, .. } if !args.is_empty())
+    ));
+    assert_eq!(loss.callsite_cid, expected_callsite);
+}
+
+#[test]
+fn fixture_3_focus_scopes_point_query_loss_records() {
+    let source = two_insert_source();
+    let first_callsite = callsite_cid(
+        &source,
+        "concept:insert-and-get-id",
+        "recordEvent",
+        ".prepare(\"INSERT INTO events (user_id, kind) VALUES (?, ?) /* first */",
+    );
+    let second_callsite = callsite_cid(
+        &source,
+        "concept:insert-and-get-id",
+        "recordEvent",
+        ".prepare(\"INSERT INTO events (user_id, kind) VALUES (?, ?) /* second */",
+    );
+
+    let first = receipt_for(&source, "typescript-pg", Some(&first_callsite));
+    let second = receipt_for(&source, "typescript-pg", Some(&second_callsite));
+
+    assert_eq!(first.loss_records.len(), 1);
+    assert_eq!(first.loss_records[0].callsite_cid, first_callsite);
+    assert_eq!(second.loss_records.len(), 1);
+    assert_eq!(second.loss_records[0].callsite_cid, second_callsite);
+}
+
+#[test]
+fn fixture_4_exact_no_op_leg_emits_zero_loss_records() {
+    let source = query_only_source();
+    let receipt = receipt_for(&source, "python-sqlite3", None);
+
+    assert_eq!(receipt.aggregate_summary.lossy, 0);
+    assert_eq!(receipt.loss_records.len(), 0);
+    assert_eq!(receipt.aggregate_summary.refused, 0);
+}
+
+#[test]
+fn fixture_5_uncharacterizable_insert_routes_to_refusal_without_loss() {
+    let source = insert_source();
+    let receipt = receipt_for(&source, "python-sqlite3", None);
+
+    assert!(receipt.aggregate_summary.refused >= 1);
+    assert!(receipt
+        .refusal_mementos
+        .iter()
+        .any(|refusal| refusal.reason.contains(INSERT_AND_GET_ID_CONCEPT_CID)));
+    assert_eq!(receipt.aggregate_summary.lossy, 0);
+}
+
+#[test]
+fn fixture_6_point_query_receipt_cids_are_byte_stable() {
+    let fixture_2_source = insert_source();
+    let fixture_3_source = two_insert_source();
+    let fixture_3_focus = callsite_cid(
+        &fixture_3_source,
+        "concept:insert-and-get-id",
+        "recordEvent",
+        ".prepare(\"INSERT INTO events (user_id, kind) VALUES (?, ?) /* second */",
+    );
+    let fixture_4_source = query_only_source();
+
+    assert_eq!(
+        receipt_cid_for(&fixture_2_source, "typescript-pg", None),
+        receipt_cid_for(&fixture_2_source, "typescript-pg", None)
+    );
+    assert_eq!(
+        receipt_cid_for(&fixture_3_source, "typescript-pg", Some(&fixture_3_focus)),
+        receipt_cid_for(&fixture_3_source, "typescript-pg", Some(&fixture_3_focus))
+    );
+    assert_eq!(
+        receipt_cid_for(&fixture_4_source, "python-sqlite3", None),
+        receipt_cid_for(&fixture_4_source, "python-sqlite3", None)
+    );
+}


### PR DESCRIPTION
Closes #1148.

Two-task PR. Fixes a P0 silent-refuse-drop in the production migrate path that shipped with PR #1201, AND lands the Stage 5 CI gate that would have caught it.

## Task 1: P0 fix - wire `uncharacterizable_callsites` into `refusal_mementos`

After PR #1155 and #1201 shipped Stage 4 substrate primitives and production wiring, `cmd_bind_migrate.rs` correctly collected `OpCoverageVerdict::Uncharacterizable` verdicts into `PlatformSemanticChangeSet::uncharacterizable_callsites` but the receipt construction in `build_receipt` never read that vector. The substrate primitive returned the correct refuse verdict; the consumer silently dropped it. Trichotomy said refuse; production said silence.

Empirically, on `origin/main` before this PR, the typescript-better-sqlite3 to python-sqlite3 migration of a `result.lastInsertRowid` callsite emits:

```
0 refused exports because public API forbids promise return
0 lossy callsites: kit-declared dimension divergence
```

with `aggregate_summary.refused = 0`, `aggregate_summary.lossy = 0`, `refusal_mementos = []`. After this PR: `refused >= 1` with a properly-formed `RefusalMemento` naming the better-sqlite3 kit-CID as the forbidding contract.

Changes:
- Extended `PlatformSemanticChangeSet::uncharacterizable_callsites` from `Vec<(String, Side)>` to `Vec<UncharacterizableCallsite>` carrying `(callsite_cid, op_cid, absent_on, declaring_kit_cid)`.
- `declaring_kit_cid` is pulled from the first `DimensionValueMemento` of the side that DID declare the tag; serves as `forbidding_contract` on the emitted refusal memento. Falls back to the op-CID if the declaring kit has no value mementos.
- `build_receipt` now iterates `uncharacterizable_callsites` and emits one `RefusalMemento` per entry. The reason text names the absent side and the op-CID that could not be characterized.
- Loss records are suppressed when any callsite is uncharacterizable. Per the trichotomy, a migrate that refuses on any callsite is a pure refusal; emitting partial loss-records alongside would conflate "loudly-bounded-lossy" with "refuse" and violate Supra omnia, rectum.
- `aggregate_summary.refused` now counts uncharacterizable refusals (previously stuck at zero for this case).

## Task 2: CI gate - six fixtures with three-tests-per-variant discipline

New file `provekit-cli/tests/cross_platform_point_query_receipt_test.rs`. Six fixtures, each with positive + discrimination + structural assertions (the three-tests-per-variant discipline that catches single-HashSet-style bugs).

Fixtures:

1. **Target-platform-dependent narrowing receipt.** Documents the gap: i64-to-i32 narrowing is not exercised through the SQL-centric migrate CLI without substrate-level rewiring. Substituted with RowIdMechanism divergence (the divergence the substrate actually wires today).
2. **A18-shape RowIdMechanism divergence (canonical case).** typescript-better-sqlite3 to typescript-pg with `result.lastInsertRowid` source produces a `LossRecordMemento` whose `loss_dimensions` contains `RowIdMechanism` keyed to `IrFormula::DivergenceBetween` between `LastInsertRowid` and `ReturningClause` formulas.
3. **Point-query scoping with `--focus`.** Two callsites, focused query emits exactly the focused one.
4. **Exact leg (same-kit query-only).** Adapted to query-only callsites where no kit declares the relevant op (zero loss records).
5. **Refuse-leg integrity.** typescript-better-sqlite3 to python-sqlite3 with `result.lastInsertRowid` source: better-sqlite3 declares `concept:insert-and-get-id`, python-sqlite3 binding-kit does not exist in the dispatcher. Substrate returns Uncharacterizable; receipt now emits `RefusalMemento` (the Task 1 fix). Cross-asserts that loss_records is empty under refuse (Task 1's short-circuit).
6. **Byte stability.** Two runs of fixtures 2, 3, 4 produce identical receipt CIDs.

All six fixtures pass: `test result: ok. 6 passed; 0 failed`.

## Verification

- Focused test: `cargo test --test cross_platform_point_query_receipt_test`: 6 passed.
- Em-dash sweep clean.

Pre-existing failures on main (`bind_kit_transform_emits_bind_result_op_tree`, `lift_then_bind_path_carries_lift_output_and_claim_premise`, `bind_path_executor_matches_cmd_bind_named_term_document_bytes`) from PR #1197 carry forward unchanged; not introduced by this branch.

## Why this PR closes both tasks together

The Stage 5 CI gate (Task 2) wouldn't fire fixture 5 if the Task 1 bug remained in main. Landing them separately would leave a window where fixture 5 either had to assert the broken behavior or be marked ignored. Doing both in one PR preserves the property "Stage 5 CI gate's existence proves Stage 4 refuse-leg works end-to-end."

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt generation to properly handle platform semantic edge cases with more precise refusal records and better contract information.

* **Tests**
  * Added comprehensive cross-platform integration tests for receipt validation, including scenarios for narrowing gaps, focus scoping, and byte-stable receipt generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->