### PR TITLE
test(migrate): update stale stdout assertion to match post-#1201 diagnostic

### DIFF
--- a/implementations/rust/provekit-cli/tests/migrate_async_rewrite_test.rs
+++ b/implementations/rust/provekit-cli/tests/migrate_async_rewrite_test.rs
@@ -71,7 +71,7 @@ fn bind_migrates_better_sqlite3_to_pg_with_async_receipt() {
         "6 functions widened to async",
         "1 boundary handlers already async-capable",
         "1 refused exports because public API forbids promise return",
-        "1 lossy sites: sqlite-specific last_insert_rowid semantics",
+        "1 lossy callsites: kit-declared dimension divergence",
     ];
     for line in expected {
         assert!(


### PR DESCRIPTION
Single-line test-expectation fix.

PR #1201 changed the migrate diagnostic message from `"N lossy sites: sqlite-specific last_insert_rowid semantics"` to `"N lossy callsites: kit-declared dimension divergence"` when retiring the lastInsertRowid substring heuristic. The assertion in `migrate_async_rewrite_test.rs:74` was not updated, leaving a stale expectation that surfaced as a Cross-language conformance gate failure post-#1204.

This is the load-bearing antibody (Cross-language conformance gate) being red on main. Restoring it with a one-line string update.

## Verification

\`\`\`
test result: ok. 1 passed; 0 failed
\`\`\`

## Out of scope (filed separately)

The other slow-lane failure on main, `trinity_citation_comments_exhibit::fixture_01_*` (3 failures with "python bind missing expected fixture concept \`concept:add\`; saw [\"concept:bind-result\", \"concept:op-application\"]"), is caused by PR #1205's Shape A op-tree + McCarthy desugar substrate shape change. That requires updating the test's `EXPECTED_CONCEPTS` to track the new payload tree structure or walking deeper into the op-application children. Not in scope for this fix; PR #1205's author should own.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for a migration scenario validation.

---

*Note: This release contains no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->