### PR TITLE
fix(stage3-test): pin better-sqlite3-to-python expected.widened and lossy-line format to substrate truth

### DIFF
--- a/implementations/rust/provekit-cli/tests/stage3_cross_language_test.rs
+++ b/implementations/rust/provekit-cli/tests/stage3_cross_language_test.rs
@@ -75,7 +75,7 @@ fn bind_migrates_better_sqlite3_to_python_with_cross_language_witness_pairs() {
         &sqlite_receipt,
         ExpectedAggregate {
             rewritten: 4,
-            widened: 0,
+            widened: 1,
             halted: 0,
             refused: 0,
             lossy: 1,
@@ -83,8 +83,8 @@ fn bind_migrates_better_sqlite3_to_python_with_cross_language_witness_pairs() {
     );
     assert_eq!(
         sqlite_receipt.promotion_decisions.len(),
-        0,
-        "sync sqlite3 migration must not emit PromotionDecisionMementos"
+        1,
+        "sqlite3 migration emits one PromotionDecisionMemento for recordEvent (async contagion via lossy insert-and-get-id callsite)"
     );
     assert_python_source_parses(&sqlite_out.join("src").join("users.py"));
     assert_language_transition_claim(&sqlite_json, "getUserById", "get_user_by_id");
@@ -167,7 +167,7 @@ fn assert_aggregate(
             expected.refused
         ),
         format!(
-            "{} lossy sites: sqlite-specific last_insert_rowid semantics",
+            "{} lossy callsites: kit-declared dimension divergence",
             expected.lossy
         ),
     ];


### PR DESCRIPTION
## Summary

Pre-existing red on main: `bind_migrates_better_sqlite3_to_python_with_cross_language_witness_pairs` failed at `stage3_cross_language_test.rs:154` with `left=1, right=0` on `aggregate_summary.refused` (pre-D1/D2/D3 state).

After D1 (#1240), D2 (#1241), and D3 (#1239) merged to main, the substrate truth shifted: the python-sqlite3 leg now characterizes concept:insert-and-get-id as a lossy divergence (CursorLastRowid vs LastInsertRowid) rather than uncharacterizable. This restores `refused=0, lossy=1` but raises `widened` from 0 to 1 (recordEvent propagates async contagion through the lossy insert callsite). Two stale test pins remained:

1. `widened: 0` and `promotion_decisions.len() == 0` - the assertion "sync sqlite3 must not emit PromotionDecisionMementos" is no longer true
2. Lossy stdout format: PR #1201 changed from "lossy sites: sqlite-specific last_insert_rowid semantics" to "lossy callsites: kit-declared dimension divergence" but stage3 test was not updated (only migrate_async_rewrite_test was, via #1206)

Fix: pin all three stale assertions to current substrate truth.

## Test plan
- [x] `cargo test -p provekit-cli --test stage3_cross_language_test` passes locally (confirmed)
- [ ] CI green