### PR TITLE
feat(realize-python-aiosqlite): body_template_for reads NTT for args_shape (closes #1246)

### DIFF
--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/realizer.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/realizer.py
@@ -53,14 +53,21 @@ def emit_stub(
     param_types: list[str],
     return_type: str,
     concept_name: str,
+    named_term_tree: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    body = body_template_for(concept_name, params, param_types, return_type)
+    body = body_template_for(
+        concept_name,
+        params,
+        param_types,
+        return_type,
+        named_term_tree=named_term_tree,
+    )
     if body is None:
         raise MissingTemplateError(
             (
                 MissingTemplateEntry(
                     operation_kind=concept_name,
-                    args_shape=tuple(map_source_type(ty) for ty in param_types),
+                    args_shape=args_shape_for(param_types, named_term_tree),
                     function=function,
                     term_position="body",
                 ),
@@ -78,30 +85,124 @@ def body_template_for(
     params: list[str],
     param_types: list[str],
     return_type: str,
+    named_term_tree: dict[str, Any] | None = None,
 ) -> str | None:
-    mapped_param_types = [map_source_type(ty) for ty in param_types]
+    tree_args_shape = _args_shape_from_named_term_tree(named_term_tree)
+    if tree_args_shape is None:
+        args_shape = tuple(map_source_type(ty) for ty in param_types)
+        template_params = params
+    else:
+        args_shape = tree_args_shape
+        template_params = _tree_template_params(named_term_tree, params, args_shape)
     mapped_return_type = map_source_type(return_type)
     candidate_names = (concept_name, concept_name.removeprefix("concept:"))
     for entry in entries():
         if entry.concept_name not in candidate_names:
             continue
-        if entry.min_params is not None and len(params) < entry.min_params:
+        if entry.min_params is not None and len(args_shape) < entry.min_params:
             continue
-        if entry.max_params is not None and len(params) > entry.max_params:
+        if entry.max_params is not None and len(args_shape) > entry.max_params:
             continue
         if entry.requires_param_types is not None:
-            if tuple(mapped_param_types) != entry.requires_param_types:
+            if args_shape != entry.requires_param_types:
                 continue
         if entry.requires_return_type is not None:
             if mapped_return_type != entry.requires_return_type:
                 continue
         if entry.template_kind != "verbatim":
             continue
-        rendered = render_template(entry.template, params, mapped_param_types, mapped_return_type)
+        rendered = render_template(
+            entry.template,
+            template_params,
+            list(args_shape),
+            mapped_return_type,
+        )
         if rendered is None:
             continue
         return rendered
     return None
+
+
+def args_shape_for(
+    param_types: list[str],
+    named_term_tree: dict[str, Any] | None = None,
+) -> tuple[str, ...]:
+    tree_args_shape = _args_shape_from_named_term_tree(named_term_tree)
+    if tree_args_shape is not None:
+        return tree_args_shape
+    return tuple(map_source_type(ty) for ty in param_types)
+
+
+def _args_shape_from_named_term_tree(
+    named_term_tree: dict[str, Any] | None,
+) -> tuple[str, ...] | None:
+    if not isinstance(named_term_tree, dict):
+        return None
+    args = named_term_tree.get("args")
+    if not isinstance(args, list):
+        return ()
+    return tuple(_tree_arg_shape(arg) for arg in args)
+
+
+def _tree_arg_shape(arg: Any) -> str:
+    if not isinstance(arg, dict):
+        return "arg"
+    for key in (
+        "sort",
+        "sortName",
+        "conceptName",
+        "concept_name",
+        "operationKind",
+        "operation_kind",
+        "kind",
+    ):
+        value = arg.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return "arg"
+
+
+def _tree_template_params(
+    named_term_tree: dict[str, Any] | None,
+    params: list[str],
+    args_shape: tuple[str, ...],
+) -> list[str]:
+    if len(params) == len(args_shape):
+        return params
+    if not isinstance(named_term_tree, dict):
+        return params
+    args = named_term_tree.get("args")
+    if not isinstance(args, list):
+        return []
+    out: list[str] = []
+    for index, arg in enumerate(args):
+        out.append(_tree_arg_name(arg, args_shape[index], index))
+    return out
+
+
+def _tree_arg_name(arg: Any, args_shape: str, index: int) -> str:
+    if isinstance(arg, dict):
+        for key in ("paramName", "param_name", "symbol", "name"):
+            value = arg.get(key)
+            if isinstance(value, str) and value.strip():
+                return _python_identifier(value, index)
+    return _python_identifier(args_shape, index)
+
+
+def _python_identifier(value: str, index: int) -> str:
+    stripped = value.strip()
+    if stripped in ("Sql", "concept:sql", "sql"):
+        return "sql"
+    if stripped in ("SqlArgs", "concept:sql-args", "sql-args", "sql_args"):
+        return "args"
+    if stripped.startswith("concept:"):
+        stripped = stripped.removeprefix("concept:")
+    candidate = re.sub(r"\W+", "_", stripped).strip("_").lower()
+    if not candidate:
+        return f"arg{index}"
+    if not (candidate[0].isalpha() or candidate[0] == "_"):
+        return f"arg{index}"
+    return candidate
 
 
 def map_source_type(src: str) -> str:

--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
@@ -79,6 +79,7 @@ def _emit_one(params: dict[str, Any]) -> dict[str, Any]:
         param_types=_string_list(params.get("param_types")),
         return_type=str(params.get("return_type", "")),
         concept_name=str(params.get("concept_name", "")),
+        named_term_tree=_dict_value(params, "named_term_tree", "namedTermTree"),
     )
 
 
@@ -86,6 +87,14 @@ def _string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return [str(item) for item in value]
+
+
+def _dict_value(params: dict[str, Any], *keys: str) -> dict[str, Any] | None:
+    for key in keys:
+        value = params.get(key)
+        if isinstance(value, dict):
+            return value
+    return None
 
 
 def _send(obj: dict[str, Any]) -> None:

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
@@ -11,6 +11,27 @@ if str(PKG_SRC) not in sys.path:
 from provekit_realize_python_aiosqlite.realizer import MissingTemplateError, emit_stub
 
 
+SQL_QUERY_NTT = {
+    "conceptName": "concept:sql-query",
+    "operationKind": "op-application",
+    "shapeCid": "blake3-512:sql-query",
+    "args": [
+        {
+            "conceptName": "Sql",
+            "operationKind": "const",
+            "shapeCid": "blake3-512:sql",
+            "args": [],
+        },
+        {
+            "conceptName": "SqlArgs",
+            "operationKind": "tuple",
+            "shapeCid": "blake3-512:sql-args",
+            "args": [],
+        },
+    ],
+}
+
+
 def test_sql_query_uses_aiosqlite_execute() -> None:
     result = emit_stub(
         function="select_rows",
@@ -27,6 +48,64 @@ def test_sql_query_uses_aiosqlite_execute() -> None:
     )
     assert result["is_stub"] is False
     assert result["extension"] == "py"
+
+
+def test_sql_query_uses_named_term_tree_args_shape() -> None:
+    result = emit_stub(
+        function="get_user_by_id",
+        params=["id"],
+        param_types=["int"],
+        return_type="User",
+        concept_name="concept:sql-query",
+        named_term_tree=SQL_QUERY_NTT,
+    )
+
+    assert result["source"] == (
+        "async def get_user_by_id(id):\n"
+        "    async with db.execute(sql, tuple(args)) as cursor:\n"
+        "        return await cursor.fetchall()\n"
+    )
+    assert result["is_stub"] is False
+    assert result["extension"] == "py"
+
+
+def test_sql_query_without_named_term_tree_uses_param_types_fallback() -> None:
+    try:
+        emit_stub("get_user_by_id", ["id"], ["int"], "User", "concept:sql-query")
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "concept:sql-query",
+                "args_shape": ["int"],
+                "function": "get_user_by_id",
+                "term_position": "body",
+            }
+        ]
+    else:
+        raise AssertionError("bare callsite signature should refuse")
+
+
+def test_missing_template_reports_named_term_tree_args_shape() -> None:
+    try:
+        emit_stub(
+            "missing",
+            ["id"],
+            ["int"],
+            "User",
+            "missing-concept",
+            named_term_tree=SQL_QUERY_NTT,
+        )
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "missing-concept",
+                "args_shape": ["Sql", "SqlArgs"],
+                "function": "missing",
+                "term_position": "body",
+            }
+        ]
+    else:
+        raise AssertionError("missing body-template should refuse")
 
 
 def test_unknown_concept_refuses_missing_body_template() -> None:

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
@@ -12,6 +12,27 @@ if str(PKG_SRC) not in sys.path:
 from provekit_realize_python_aiosqlite.rpc import dispatch
 
 
+SQL_QUERY_NTT = {
+    "conceptName": "concept:sql-query",
+    "operationKind": "op-application",
+    "shapeCid": "blake3-512:sql-query",
+    "args": [
+        {
+            "conceptName": "Sql",
+            "operationKind": "const",
+            "shapeCid": "blake3-512:sql",
+            "args": [],
+        },
+        {
+            "conceptName": "SqlArgs",
+            "operationKind": "tuple",
+            "shapeCid": "blake3-512:sql-args",
+            "args": [],
+        },
+    ],
+}
+
+
 def test_rpc_invoke_renders_aiosqlite_body() -> None:
     response = dispatch(
         {
@@ -31,6 +52,32 @@ def test_rpc_invoke_renders_aiosqlite_body() -> None:
     assert response["id"] == 1
     assert response["result"]["is_stub"] is False
     assert "async with db.execute" in response["result"]["source"]
+
+
+def test_rpc_invoke_threads_named_term_tree_for_template_lookup() -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "provekit.plugin.invoke",
+            "params": {
+                "function": "get_user_by_id",
+                "params": ["id"],
+                "param_types": ["int"],
+                "return_type": "User",
+                "concept_name": "concept:sql-query",
+                "named_term_tree": SQL_QUERY_NTT,
+            },
+        }
+    )
+
+    assert response["id"] == 9
+    assert response["result"]["is_stub"] is False
+    assert response["result"]["source"] == (
+        "async def get_user_by_id(id):\n"
+        "    async with db.execute(sql, tuple(args)) as cursor:\n"
+        "        return await cursor.fetchall()\n"
+    )
 
 
 def test_plugin_invoke_returns_structured_missing_template_error() -> None:
@@ -59,6 +106,41 @@ def test_plugin_invoke_returns_structured_missing_template_error() -> None:
                 {
                     "operation_kind": "missing-concept",
                     "args_shape": ["int"],
+                    "function": "missing",
+                    "term_position": "body",
+                }
+            ],
+        },
+    }
+
+
+def test_plugin_invoke_missing_template_uses_named_term_tree_args_shape() -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "provekit.plugin.invoke",
+            "params": {
+                "function": "missing",
+                "params": ["id"],
+                "param_types": ["int"],
+                "return_type": "User",
+                "concept_name": "missing-concept",
+                "named_term_tree": SQL_QUERY_NTT,
+            },
+        }
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": 10,
+        "error": {
+            "code": -32100,
+            "message": "missing body-template entry",
+            "data": [
+                {
+                    "operation_kind": "missing-concept",
+                    "args_shape": ["Sql", "SqlArgs"],
                     "function": "missing",
                     "term_position": "body",
                 }


### PR DESCRIPTION
Implements audit row D5d. Sibling to D5c (#1245), same NTT-canonicalization fix applied to aiosqlite plugin. 11 pytest tests pass. See [audit](docs/audits/2026-05-18-kit-as-substrate-participant-vision.md) row D5d.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for named term trees in stub generation, enabling dynamic argument shape computation and enhanced template matching.
  * Introduced new function to calculate argument shapes from parameter types and optional named term trees.

* **Tests**
  * Added comprehensive test coverage for named term tree integration, fallback behavior, and improved error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->