### PR TITLE
fix(realize-typescript-core): renderTemplate substitutes from NTT-derived values, not function params (D5f / #1252)

### DIFF
--- a/implementations/typescript/provekit-realize-typescript-better-sqlite3/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-better-sqlite3/src/rpc.js
@@ -35,6 +35,8 @@ function dispatch(request) {
         paramTypes: stringList(params.param_types),
         returnType: String(params.return_type ?? ""),
         conceptName: String(params.concept_name ?? ""),
+        mode: typeof params.mode === "string" ? params.mode : undefined,
+        namedTermTree: params.namedTermTree ?? params.named_term_tree,
       }),
     };
   }

--- a/implementations/typescript/provekit-realize-typescript-better-sqlite3/tests/realizer.test.js
+++ b/implementations/typescript/provekit-realize-typescript-better-sqlite3/tests/realizer.test.js
@@ -2,6 +2,7 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 
 const { emitStub } = require("../src/realizer");
+const { dispatch } = require("../src/rpc");
 
 test("sql query uses better-sqlite3 prepare all without await", () => {
   const result = emitStub({
@@ -30,4 +31,41 @@ test("sql execute returns better-sqlite3 row count and insert id", () => {
   assert.equal(result.is_stub, false);
   assert.match(result.source, /lastInsertRowid/);
   assert.match(result.source, /rows_affected/);
+});
+
+test("rpc forwards named term tree sources to better-sqlite3 template substitution", () => {
+  const response = dispatch({
+    id: 1,
+    method: "provekit.plugin.invoke",
+    params: {
+      function: "getUserById",
+      params: ["id"],
+      param_types: ["number"],
+      return_type: "User",
+      concept_name: "concept:sql-query",
+      namedTermTree: {
+        conceptName: "concept:sql-query",
+        operationKind: "op-application",
+        args: [
+          {
+            args: [],
+            conceptName: "Sql",
+            operationKind: "const",
+            sort: "Sql",
+            source: "\"SELECT id FROM users WHERE id = ?\"",
+          },
+          {
+            args: [],
+            conceptName: "SqlArgs",
+            operationKind: "args",
+            sort: "SqlArgs",
+            source: "[id]",
+          },
+        ],
+      },
+    },
+  });
+
+  assert.equal(response.result.is_stub, false);
+  assert.match(response.result.source, /db\.prepare\("SELECT id FROM users WHERE id = \?"\)\.all\(\[id\]\)/);
 });

--- a/implementations/typescript/provekit-realize-typescript-core/src/realizer.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/realizer.js
@@ -30,6 +30,7 @@ function createRealizer(bodyTemplateRel) {
     const mappedParamTypes = paramTypes.map(mapSourceType);
     const mappedReturnType = mapSourceType(returnType);
     const nttArgsShape = argsShapeFromNamedTermTree(namedTermTree, conceptName);
+    const templateSignature = templateLookupSignature(params, mappedParamTypes, namedTermTree, nttArgsShape);
     const candidateArgShapes = argShapeCandidates(nttArgsShape, mappedParamTypes, params.length);
     const candidateNames = [conceptName, conceptName.replace(/^concept:/, "")];
     for (const entry of entries()) {
@@ -40,7 +41,12 @@ function createRealizer(bodyTemplateRel) {
       if (typeof guard.requires_return_type === "string" && mappedReturnType !== guard.requires_return_type) continue;
       const emissionTemplate = entry.emission_template ?? {};
       if (emissionTemplate.kind !== "verbatim" || typeof emissionTemplate.template !== "string") continue;
-      const rendered = renderTemplate(emissionTemplate.template, params, mappedParamTypes, mappedReturnType);
+      const rendered = renderTemplate(
+        emissionTemplate.template,
+        templateSignature.params,
+        templateSignature.paramTypes,
+        mappedReturnType,
+      );
       if (rendered !== null) return rendered;
     }
     return null;
@@ -73,6 +79,84 @@ function argShapeCandidates(nttArgsShape, mappedParamTypes, paramCount) {
   }
   candidates.push({ count: paramCount, types: mappedParamTypes });
   return candidates;
+}
+
+function templateLookupSignature(params, mappedParamTypes, namedTermTree, nttArgsShape) {
+  if (!Array.isArray(nttArgsShape)) {
+    return { params, paramTypes: mappedParamTypes };
+  }
+  return {
+    params: nttTemplateParams(params, namedTermTree, nttArgsShape.length),
+    paramTypes: nttArgsShape,
+  };
+}
+
+function nttTemplateParams(params, namedTermTree, arity) {
+  const args = isPlainObject(namedTermTree) ? namedTermTree.args : null;
+  if (!Array.isArray(args)) {
+    if (params.length === arity) return params;
+    return Array.from({ length: arity }, (_, index) => `arg${index}`);
+  }
+
+  return Array.from({ length: arity }, (_, index) => {
+    const arg = args[index];
+    if (isPlainObject(arg)) return nttArgTemplateParam(arg, index);
+    return `arg${index}`;
+  });
+}
+
+function nttArgTemplateParam(arg, index) {
+  const source = stringField(arg, ["source"]);
+  if (source !== null) return source;
+
+  for (const key of ["name", "paramName", "param_name", "binding", "symbol"]) {
+    const value = stringField(arg, [key]);
+    if (value !== null) return typescriptIdentifierOrDefault(value, `arg${index}`);
+  }
+
+  const descriptor = nttArgDescriptor(arg);
+  if (descriptor === null) return `arg${index}`;
+  const name = normalizeConceptName(descriptor);
+  switch (name) {
+    case "sql":
+    case "sql-literal":
+      return "sql";
+    case "sqlargs":
+    case "sql-args":
+    case "sql_args":
+      return "args";
+    default:
+      return typescriptIdentifierOrDefault(descriptor.replace(/^concept:/, ""), `arg${index}`);
+  }
+}
+
+function nttArgDescriptor(arg) {
+  for (const key of [
+    "type",
+    "typeName",
+    "type_name",
+    "sort",
+    "sortName",
+    "sort_name",
+    "conceptName",
+    "concept_name",
+    "operationKind",
+    "operation_kind",
+  ]) {
+    const value = arg[key];
+    if (typeof value === "string" && value.trim() !== "") return value.trim();
+    if (isPlainObject(value)) {
+      const name = stringField(value, ["name", "sortName", "sort_name"]);
+      if (name !== null) return name;
+    }
+  }
+  return null;
+}
+
+function typescriptIdentifierOrDefault(value, fallback) {
+  const identifier = value.replace(/-/g, "_");
+  if (/^[A-Za-z_$][0-9A-Za-z_$]*$/.test(identifier)) return identifier;
+  return fallback;
 }
 
 function signatureGuardMatches(guard, candidateArgShapes) {

--- a/implementations/typescript/provekit-realize-typescript-core/tests/realizer.test.js
+++ b/implementations/typescript/provekit-realize-typescript-core/tests/realizer.test.js
@@ -132,6 +132,32 @@ test("named term tree request resolves the existing pg sql query body template",
   assert.match(result.source, /await pool\.query\(sql, args\)/);
 });
 
+test("named term tree source values drive pg sql query template substitution", () => {
+  const realizer = createRealizer(PG_BODY_TEMPLATE);
+  const result = realizer.emitStub({
+    functionName: "getUserById",
+    params: ["id"],
+    paramTypes: ["number"],
+    returnType: "User",
+    conceptName: "concept:sql-query",
+    namedTermTree: namedTermTree("concept:sql-query", [
+      {
+        ...namedTermTree("Sql"),
+        source: "\"SELECT id, name, email FROM users WHERE id = $1\"",
+        sort: "Sql",
+      },
+      {
+        ...namedTermTree("SqlArgs"),
+        source: "[id]",
+        sort: "SqlArgs",
+      },
+    ]),
+  });
+
+  assert.equal(result.is_stub, false);
+  assert.match(result.source, /await pool\.query\("SELECT id, name, email FROM users WHERE id = \$1", \[id\]\)/);
+});
+
 test("bare signature request still uses mapped param types without named term tree", () => {
   const realizer = createRealizer(SQL_GUARD_TEMPLATE);
   const result = realizer.emitStub({

--- a/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
@@ -35,6 +35,8 @@ function dispatch(request) {
         paramTypes: stringList(params.param_types),
         returnType: String(params.return_type ?? ""),
         conceptName: String(params.concept_name ?? ""),
+        mode: typeof params.mode === "string" ? params.mode : undefined,
+        namedTermTree: params.namedTermTree ?? params.named_term_tree,
       }),
     };
   }

--- a/implementations/typescript/provekit-realize-typescript-pg/tests/realizer.test.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/tests/realizer.test.js
@@ -2,6 +2,7 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 
 const { emitStub } = require("../src/realizer");
+const { dispatch } = require("../src/rpc");
 
 test("sql query uses pg pool query with await", () => {
   const result = emitStub({
@@ -30,4 +31,41 @@ test("sql execute appends returning id for pg insert id substitution", () => {
   assert.equal(result.is_stub, false);
   assert.match(result.source, /sql \+ " RETURNING id"/);
   assert.match(result.source, /last_insert_id/);
+});
+
+test("rpc forwards named term tree sources to pg template substitution", () => {
+  const response = dispatch({
+    id: 1,
+    method: "provekit.plugin.invoke",
+    params: {
+      function: "getUserById",
+      params: ["id"],
+      param_types: ["number"],
+      return_type: "User",
+      concept_name: "concept:sql-query",
+      namedTermTree: {
+        conceptName: "concept:sql-query",
+        operationKind: "op-application",
+        args: [
+          {
+            args: [],
+            conceptName: "Sql",
+            operationKind: "const",
+            sort: "Sql",
+            source: "\"SELECT id FROM users WHERE id = $1\"",
+          },
+          {
+            args: [],
+            conceptName: "SqlArgs",
+            operationKind: "args",
+            sort: "SqlArgs",
+            source: "[id]",
+          },
+        ],
+      },
+    },
+  });
+
+  assert.equal(response.result.is_stub, false);
+  assert.match(response.result.source, /await pool\.query\("SELECT id FROM users WHERE id = \$1", \[id\]\)/);
 });


### PR DESCRIPTION
## Summary

Closes audit row D5f (#1252).

PR #1248 added NTT-based args_shape derivation for the guard-match path in `bodyTemplateFor` but left `renderTemplate` substituting from the function's `params` array. For the migrate's typed callsites (e.g., `getUserById` has `params=["id"]`), the canonical 2-arg template's `${param1}` stays unresolved and `renderTemplate` returns null, so `emitStub` returns `is_stub=true` even though the guard match passed.

Fix mirrors the python plugins' `_template_lookup_signature` pattern: when NTT is present, derive substitution values from each arg's `source` field. Falls back to function params when NTT is absent.

Also threads `namedTermTree` through the `typescript-pg` and `typescript-better-sqlite3` RPC wrappers so the request reaches the core renderer. Added regression tests in core, pg, and better-sqlite3 packages.

## Verification

NTT-mode D5 verification harness:

- Baseline: `MATCHES=0 COSMETIC=0 SEMANTIC=6 MISSING=6`. All 4 ts-pg cells `Missing` (is_stub=true).
- After fix: `MATCHES=0 COSMETIC=0 SEMANTIC=9 MISSING=3`. `getUserById`, `getAllUsers`, and `countUsers` on `typescript-pg` flip to `Semantic`. `recordEvent/typescript-pg` remains `Missing` pending #1254 (D5h).

TS plugin unit tests: 8 passed (core), 3 passed (pg), 3 passed (better-sqlite3).

## Test plan
- [ ] CI green
- [ ] NTT-mode harness output matches the above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SQL template handling to support named parameter trees and improved parameter substitution across database implementations.
  * Added conditional mode metadata support for RPC operations.

* **Tests**
  * Added comprehensive test coverage for named-term-tree-driven SQL template substitution in multiple database adapters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->