### PR TITLE
feat(realize-catalogs): mint concept:insert-and-get-id entries for ts-pg, python-sqlite3, python-aiosqlite (D5h / #1254)

### DIFF
--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-aiosqlite.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-aiosqlite.json
@@ -5,14 +5,14 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:519e4351e4e489cdd9a7609fc181ffe98caba19683886e39332a02ee25a1292cadee7320a66ddd22941964bf39582d9f8b0c07daeb8a46e5617a6d6207cb309a",
+    "cid": "blake3-512:0f3e314c2362259b34b62191dd34ae783defcaf697b53641d7a95935c11d338c0634ea43146e8b34bbcc8ee1425d9ddb88bb72331917aafb05b7e673bfab1a5b",
     "content": {
       "entries": [
         {
-          "concept_name": "concept:sql-query",
+          "concept_name": "concept:insert-and-get-id",
           "emission_template": {
             "kind": "verbatim",
-            "template": "async with db.execute(${param0}, tuple(${param1})) as cursor:\n    return await cursor.fetchall()"
+            "template": "cursor = await db.execute(${param0}, tuple(${param1}))\nawait db.commit()\nreturn int(cursor.lastrowid or 0)"
           },
           "loss_record_contribution": {
             "form": "literal",
@@ -21,11 +21,16 @@
                 "args": [
                   {
                     "kind": "const",
-                    "value": "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1"
+                    "value": "blake3-512:0a4f0a8d36d8dee96b8d5b32a18bb390f35877ecef611771048c6e10cfc3d25ad8f59de89b00c7794f62cabaf91dbd779244338393a8bb6ef5e8309b0929b3ca"
                   }
                 ],
                 "head": "atomic",
-                "name": "sql-query-cites-concept-cid"
+                "name": "insert-and-get-id-cites-concept-cid"
+              },
+              "last_insert_id_loss_claim": {
+                "args": [],
+                "head": "atomic",
+                "name": "aiosqlite-last-insert-id-from-lastrowid"
               }
             }
           },
@@ -57,6 +62,32 @@
                 "args": [],
                 "head": "atomic",
                 "name": "aiosqlite-last-insert-id-from-lastrowid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
+          "concept_name": "concept:sql-query",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "async with db.execute(${param0}, tuple(${param1})) as cursor:\n    return await cursor.fetchall()"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1"
+                  }
+                ],
+                "head": "atomic",
+                "name": "sql-query-cites-concept-cid"
               }
             }
           },

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
@@ -5,14 +5,14 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:111c182c3b04b3c04fec336e3db41961bb22c7e52c7a7f60cc9b1e0439eae82d6953a5bebf76f5b41a2ae22c7513afc36ca25170daf689fd11f62cf1004effb1",
+    "cid": "blake3-512:cf611a434c39c0c2e8d520f365a2899c73ea55f82fdc13b12648b21887207330cc2594758e1ce9f9d86fed28b56b81a3fe9a689073cccc54f3ac98cd8aa9f6c8",
     "content": {
       "entries": [
         {
-          "concept_name": "concept:sql-query",
+          "concept_name": "concept:insert-and-get-id",
           "emission_template": {
             "kind": "verbatim",
-            "template": "cursor = db.execute(${param0}, tuple(${param1}))\nreturn cursor.fetchall()"
+            "template": "cursor = db.execute(${param0}, tuple(${param1}))\ndb.commit()\nreturn int(cursor.lastrowid or 0)"
           },
           "loss_record_contribution": {
             "form": "literal",
@@ -21,11 +21,16 @@
                 "args": [
                   {
                     "kind": "const",
-                    "value": "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1"
+                    "value": "blake3-512:0a4f0a8d36d8dee96b8d5b32a18bb390f35877ecef611771048c6e10cfc3d25ad8f59de89b00c7794f62cabaf91dbd779244338393a8bb6ef5e8309b0929b3ca"
                   }
                 ],
                 "head": "atomic",
-                "name": "sql-query-cites-concept-cid"
+                "name": "insert-and-get-id-cites-concept-cid"
+              },
+              "last_insert_id_loss_claim": {
+                "args": [],
+                "head": "atomic",
+                "name": "sqlite3-last-insert-id-from-lastrowid"
               }
             }
           },
@@ -57,6 +62,32 @@
                 "args": [],
                 "head": "atomic",
                 "name": "sqlite3-last-insert-id-from-lastrowid"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
+          "concept_name": "concept:sql-query",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "cursor = db.execute(${param0}, tuple(${param1}))\nreturn cursor.fetchall()"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1"
+                  }
+                ],
+                "head": "atomic",
+                "name": "sql-query-cites-concept-cid"
               }
             }
           },

--- a/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-pg.json
+++ b/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-pg.json
@@ -5,14 +5,14 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:382f1ed59e3066d75c2f330f5ae007ab6726ccbe782bcac618bcade5e15ba80cc5e98c361a7d68500a01cba23f46e087442c1f86cb4b11d2a0abe5b82015927a",
+    "cid": "blake3-512:9f88b3d48c3c85d2a6d382968e2f93ebc2f5e148ac7ec8adedd6db6b9a5cb1bd5f354fa363e9c4736c0b4dcc0f6c90329ad3039108b07fc300ad47306ce467b3",
     "content": {
       "entries": [
         {
-          "concept_name": "concept:sql-query",
+          "concept_name": "concept:insert-and-get-id",
           "emission_template": {
             "kind": "verbatim",
-            "template": "const result = await pool.query(${param0}, ${param1});\nreturn result.rows;"
+            "template": "const result = await pool.query<{ id: number }>(${param0} + \" RETURNING id\", ${param1});\nreturn Number(result.rows[0]?.id ?? 0);"
           },
           "loss_record_contribution": {
             "form": "literal",
@@ -21,11 +21,16 @@
                 "args": [
                   {
                     "kind": "const",
-                    "value": "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1"
+                    "value": "blake3-512:0a4f0a8d36d8dee96b8d5b32a18bb390f35877ecef611771048c6e10cfc3d25ad8f59de89b00c7794f62cabaf91dbd779244338393a8bb6ef5e8309b0929b3ca"
                   }
                 ],
                 "head": "atomic",
-                "name": "sql-query-cites-concept-cid"
+                "name": "insert-and-get-id-cites-concept-cid"
+              },
+              "last_insert_id_loss_claim": {
+                "args": [],
+                "head": "atomic",
+                "name": "pg-last-insert-id-from-returning-id"
               }
             }
           },
@@ -57,6 +62,32 @@
                 "args": [],
                 "head": "atomic",
                 "name": "pg-last-insert-id-from-returning-id"
+              }
+            }
+          },
+          "signature_guard": {
+            "max_params": 2,
+            "min_params": 2
+          }
+        },
+        {
+          "concept_name": "concept:sql-query",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "const result = await pool.query(${param0}, ${param1});\nreturn result.rows;"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "api_tier_concept_cid": {
+                "args": [
+                  {
+                    "kind": "const",
+                    "value": "blake3-512:dd0429a4d4276c076f5dde08a993a046afa15dd36433b1d89c4bc18831f63733788abef283ffb78b2b9f88c607593741367a35ebcbd36a88132c06d6ff233ed1"
+                  }
+                ],
+                "head": "atomic",
+                "name": "sql-query-cites-concept-cid"
               }
             }
           },


### PR DESCRIPTION
## Summary

Closes audit row D5h (#1254). Three target body-template catalogs gain a `concept:insert-and-get-id` entry. Each plugin's emission template owns its dialect's idiom internally per the scope-correction ruling:

- **typescript-canonical-bodies-pg.json**: `pool.query(${param0} + " RETURNING id", ${param1}); return Number(result.rows[0]?.id ?? 0)`. Mirrors the existing sql-execute entry's RETURNING-id append style.
- **python-canonical-bodies-sqlite3.json**: `cursor = db.execute(...); db.commit(); return int(cursor.lastrowid or 0)`. Native lastrowid retrieval.
- **python-canonical-bodies-aiosqlite.json**: `cursor = await db.execute(...); await db.commit(); return int(cursor.lastrowid or 0)`. Async sibling.

Each entry uses `signature_guard min/max_params=2` matching the canonical (sql, args) shape. `loss_record_contribution` mirrors the existing sql-execute entries: `api_tier_concept_cid` cites concept:insert-and-get-id; `last_insert_id_loss_claim` cites the per-binding mechanism (pg-returning-id, sqlite3-lastrowid, aiosqlite-lastrowid).

Header CIDs recomputed via `compute_fixture_cid` over JCS(header.content) using blake3-512.

## Verification

NTT-mode D5 verification harness on this branch (without #1257 applied): **MATCHES=0 COSMETIC=0 SEMANTIC=9 MISSING=3**. The 3 MISSING are ts-pg SELECT cells, blocked on #1257 landing. All 3 recordEvent cells flip from MISSING to SEMANTIC. With #1257 also landed, the harness should show 12 SEMANTIC and 0 MISSING.

## Test plan
- [ ] CI green