### PR TITLE
fix(menagerie): regenerate canonical-bodies header CIDs for ts-pg / java / rust catalogs

### DIFF
--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -133,7 +133,7 @@ fn java_canonical_bodies_cid_self_consistent() {
         .join("menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json");
     assert_self_consistent(
         path,
-        "blake3-512:0a74f40c13bf4843b7afea6ee91e1b33ac026145a03c7da0be0b22e7667da8f4361f1dca95daedb0219f825139069096123f72f8df46ca1517a4b108e389f328",
+        "blake3-512:c1f42db4540bb0c6e4f132e81da5280b0f3a0fcad5b3c889ba8553295da7536123dcb6dea54861bf3dcb2f90ff92d001738cde4c51484f00e6a85fb504a63d0d",
     );
 }
 
@@ -198,7 +198,7 @@ fn typescript_pg_canonical_bodies_cid_self_consistent() {
     );
     assert_self_consistent(
         path,
-        "blake3-512:382f1ed59e3066d75c2f330f5ae007ab6726ccbe782bcac618bcade5e15ba80cc5e98c361a7d68500a01cba23f46e087442c1f86cb4b11d2a0abe5b82015927a",
+        "blake3-512:6c3b4df2a292388619b212b05c84e45ce94081750c2cfbeea473fe1a4b038ffd047224c740b55f2341758b418142c1b89c9f14d891e9462d1ac79231dcdd4d95",
     );
 }
 
@@ -227,6 +227,6 @@ fn rust_canonical_bodies_cid_self_consistent() {
         .join("menagerie/rust-language-signature/specs/body-templates/rust-canonical-bodies.json");
     assert_self_consistent(
         path,
-        "blake3-512:148269a6fa8da03d34618d575a252bb0152143af993453f153a48f4bb0b26adfa838c3b96e720428ee9b96147c4ba542966f9d48435842874c9ae67b0091f20c",
+        "blake3-512:29c2a7f4d73c583e30d7ee62a483dc702076488e902a56daa5e50dbf12b8131422a9a6e1c02a6009c12b1e4e4cd30789eee728083bd33753e23145fc6f924afe",
     );
 }

--- a/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
+++ b/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:f85399b05a7b6449158115ebedbdd53bba6d846e181a35d7e0e15d13c77d600ba30d588e1e0911402c832d423ea0484002b6d148f0b0449106c3e04a87edf175",
+    "cid": "blake3-512:c1f42db4540bb0c6e4f132e81da5280b0f3a0fcad5b3c889ba8553295da7536123dcb6dea54861bf3dcb2f90ff92d001738cde4c51484f00e6a85fb504a63d0d",
     "content": {
       "entries": [
         {
@@ -646,7 +646,9 @@
     },
     "critical": false,
     "kind": "body-template",
-    "protocol_versions": ["pep/1.7.0"],
+    "protocol_versions": [
+      "pep/1.7.0"
+    ],
     "provenance_cid": "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
     "schemaVersion": "1",
     "version": "1.0.0"

--- a/menagerie/rust-language-signature/specs/body-templates/rust-canonical-bodies.json
+++ b/menagerie/rust-language-signature/specs/body-templates/rust-canonical-bodies.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:148269a6fa8da03d34618d575a252bb0152143af993453f153a48f4bb0b26adfa838c3b96e720428ee9b96147c4ba542966f9d48435842874c9ae67b0091f20c",
+    "cid": "blake3-512:29c2a7f4d73c583e30d7ee62a483dc702076488e902a56daa5e50dbf12b8131422a9a6e1c02a6009c12b1e4e4cd30789eee728083bd33753e23145fc6f924afe",
     "content": {
       "entries": [
         {
@@ -103,7 +103,10 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["&dyn Fn(i64) -> i64", "i64"],
+            "requires_param_types": [
+              "&dyn Fn(i64) -> i64",
+              "i64"
+            ],
             "requires_return_type": "i64"
           },
           "target_library_tag": "rust-language-builtin"
@@ -154,7 +157,9 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1,
-            "requires_param_types": ["&[i64]"],
+            "requires_param_types": [
+              "&[i64]"
+            ],
             "requires_return_type": "i64"
           },
           "target_library_tag": "rust-stdlib"
@@ -205,7 +210,9 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1,
-            "requires_param_types": ["i64"],
+            "requires_param_types": [
+              "i64"
+            ],
             "requires_return_type": "i64"
           },
           "target_library_tag": "rust-language-builtin"
@@ -456,7 +463,9 @@
     },
     "critical": false,
     "kind": "body-template",
-    "protocol_versions": ["pep/1.7.0"],
+    "protocol_versions": [
+      "pep/1.7.0"
+    ],
     "provenance_cid": "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
     "schemaVersion": "1",
     "version": "1.0.0"

--- a/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-pg.json
+++ b/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-pg.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:9f88b3d48c3c85d2a6d382968e2f93ebc2f5e148ac7ec8adedd6db6b9a5cb1bd5f354fa363e9c4736c0b4dcc0f6c90329ad3039108b07fc300ad47306ce467b3",
+    "cid": "blake3-512:6c3b4df2a292388619b212b05c84e45ce94081750c2cfbeea473fe1a4b038ffd047224c740b55f2341758b418142c1b89c9f14d891e9462d1ac79231dcdd4d95",
     "content": {
       "entries": [
         {


### PR DESCRIPTION
## Summary

Three body-template catalogs had stale `header.cid` values that didn't match what `mint-plugin-cid` computes from `JCS(header.content)`, causing `substrate_default_cids` tests to fail on main:

- **typescript-canonical-bodies-pg.json**: introduced as stale by PR #1258 (D5h `concept:insert-and-get-id` mint). My Python wrapper around `compute_fixture_cid` produced a CID inconsistent with the Rust-side `mint-plugin-cid` binary. Updated to the mint-plugin-cid value.
- **java-canonical-bodies.json**: pre-existing drift on main.
- **rust-canonical-bodies.json**: pre-existing drift on main.

Each `header.cid` and corresponding test pin in `substrate_default_cids.rs` updated to the `mint-plugin-cid` output.

## CIDs updated

| Catalog | Old | New |
|---|---|---|
| typescript-canonical-bodies-pg | `382f1ed5...` / `9f88b3d4...` (PR #1258) | `6c3b4df2...` |
| java-canonical-bodies | `0a74f40c...` / `f85399b0...` | `c1f42db4...` |
| rust-canonical-bodies | `148269a6...` | `29c2a7f4...` |

## Verification

`cargo test -p provekit-plugin-loader --test substrate_default_cids`: **14 passed; 0 failed**.

## Test plan
- [ ] CI green
- [ ] Cross-language conformance gate (Linux) no longer reports these three failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin specification hashes and reformatted configuration documents for Java, TypeScript PostgreSQL, and Rust implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->