### PR TITLE
fix(loader): delete hardcoded kit-name table; resolve by convention (#1270 Tier 1.1)

### DIFF
--- a/implementations/rust/libprovekit/src/core/platform_semantics_loader.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics_loader.rs
@@ -35,27 +35,46 @@ pub enum PlatformSemanticsLoadError {
     ResultShape(String),
 }
 
-/// The canonical command for each lower-target kit. Hardcoded by-target rather
-/// than discovered because (a) this dispatcher must work in tests that have
-/// not registered a plugin registry, and (b) the kit binaries are themselves
-/// pinned by the workspace + plugin protocol; their command names are stable
-/// per CCP. Plugin-loader-based resolution remains available for callers that
-/// need it; for the platform-semantics specifically the canonical pinned name
-/// is enough.
-fn kit_command_for(target: &str) -> Option<Vec<String>> {
-    match target {
-        "rust" => Some(vec!["provekit-realize-rust-core".to_string()]),
-        "c" => Some(vec!["provekit-realize-c-core".to_string()]),
-        "java" => Some(vec!["provekit-realize-java-core".to_string()]),
-        "python" => Some(vec!["provekit-realize-python-core".to_string()]),
-        "typescript" => Some(vec!["provekit-realize-typescript-core".to_string()]),
-        // Binding-kit variants (per binding_semantics_for_tag dispatcher).
-        "aiosqlite" => Some(vec!["provekit-realize-python-aiosqlite".to_string()]),
-        "better-sqlite3" => Some(vec!["provekit-realize-typescript-better-sqlite3".to_string()]),
-        "pg" => Some(vec!["provekit-realize-typescript-pg".to_string()]),
-        "sqlite3" => Some(vec!["provekit-realize-python-sqlite3".to_string()]),
-        _ => None,
+/// Resolve a kit binary by convention. The substrate does NOT enumerate kits.
+///
+/// Convention:
+///   1. Try `provekit-realize-<kit_id>-core` on PATH (pure language-kit form)
+///   2. Try `provekit-realize-<kit_id>` on PATH (full kit-identity form,
+///      e.g., `python-aiosqlite`, `typescript-pg`)
+///
+/// Returns the first command that resolves on PATH. If neither candidate
+/// is on PATH, returns the language-kit form as a best-effort command so
+/// the loader's spawn produces a MissingBinary error citing the
+/// convention name, rather than collapsing two failure modes (unknown
+/// kit vs binary-missing) into the same None.
+///
+/// Adding a new kit requires nothing here: name the binary by convention
+/// and the substrate finds it. The previous hardcoded match table was
+/// substrate-uniform-pattern violation: kit enumeration inside libprovekit.
+fn kit_command_for(kit_id: &str) -> Vec<String> {
+    let lang_form = format!("provekit-realize-{kit_id}-core");
+    let identity_form = format!("provekit-realize-{kit_id}");
+    if which_on_path(&lang_form).is_some() {
+        return vec![lang_form];
     }
+    if which_on_path(&identity_form).is_some() {
+        return vec![identity_form];
+    }
+    // Best-effort: surface the language-kit-form name in MissingBinary.
+    vec![lang_form]
+}
+
+fn which_on_path(bin: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).find_map(|dir| {
+            let candidate = dir.join(bin);
+            if candidate.is_file() {
+                Some(candidate)
+            } else {
+                None
+            }
+        })
+    })
 }
 
 /// Load a kit's PlatformSemanticsDeclaration over JSON-RPC.
@@ -64,14 +83,20 @@ fn kit_command_for(target: &str) -> Option<Vec<String>> {
 /// `provekit.plugin.platform_semantics`, parses the result, and shuts the
 /// subprocess down.
 pub fn load_platform_semantics(
-    target: &str,
+    kit_id: &str,
 ) -> Result<PlatformSemanticsDeclaration, PlatformSemanticsLoadError> {
-    let Some(command) = kit_command_for(target) else {
-        return Err(PlatformSemanticsLoadError::Failed(format!(
-            "no kit command registered for target {target}"
-        )));
-    };
+    let command = kit_command_for(kit_id);
     load_platform_semantics_for_command(&command, None)
+}
+
+/// Load using an explicit binary command. The substrate's preferred API for
+/// callers that already know the kit's binary path (e.g., the CLI resolved
+/// it via `.provekit/realize/<kit>/manifest.toml`).
+pub fn load_platform_semantics_with_command(
+    command: &[String],
+    working_dir: Option<&PathBuf>,
+) -> Result<PlatformSemanticsDeclaration, PlatformSemanticsLoadError> {
+    load_platform_semantics_for_command(command, working_dir)
 }
 
 /// Same as `load_platform_semantics`, but caches the result per-target for


### PR DESCRIPTION
Tier 1.1 fix from the post-#1271 audit. PR #1271 shipped a loader with a hardcoded \`match target\` table mapping \"rust\", \"java\", \"python\", \"typescript\", \"c\", \"aiosqlite\", \"better-sqlite3\", \"pg\", \"sqlite3\" to their binary names. That table IS kit enumeration inside libprovekit, the exact substrate violation #1271 was supposed to eliminate. Two-hour-old embarrassment.

## Fix

\`kit_command_for(kit_id)\` resolves by **convention only**:
1. \`provekit-realize-<kit_id>-core\` (pure-language form)
2. \`provekit-realize-<kit_id>\` (full-identity form)

PATH selects whichever exists. New kit = name your binary by convention.

Also adds \`load_platform_semantics_with_command(command, working_dir)\` for callers that already resolved the binary path via the existing \`kit_dispatch\` registry.

## Test plan
- [x] \`cargo check -p libprovekit\` passes
- [x] \`cargo test -p libprovekit --lib\` passes (84/84)

Refs #1270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `load_platform_semantics_with_command` function for explicit command-based semantics loading with optional working directory configuration

* **Refactor**
  * Updated `load_platform_semantics` API: parameter changed from `target` to `kit_id`
  * Enhanced kit executable resolution using PATH-based convention discovery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->