### PR TITLE
feat(java-kit): implement provekit.plugin.platform_semantics RPC (#1270)

### DIFF
--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/PlatformSemanticsDeclaration.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/PlatformSemanticsDeclaration.java
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Java kit platform semantics declaration.
+//
+// Implements the provekit.plugin.platform_semantics RPC method (PEP 1.7.0).
+// Returns the JSON payload that libprovekit deserializes into a
+// PlatformSemanticsDeclaration for the "java" target.
+//
+// CID computation follows the substrate spec:
+//   DimensionValueMemento CID = blake3-512(JCS(memento WITHOUT cid + kit_cid))
+//   PlatformSemanticTag CID   = blake3-512(JCS(tag WITHOUT cid + kit_cid))
+//
+// The golden CID values here are verified against the Rust reference
+// implementation (provekit-ir-types DimensionValueMemento::recompute_cid +
+// PlatformSemanticTag::recompute_cid).
+
+package com.provekit.realize;
+
+import com.provekit.ir.Blake3;
+import com.provekit.ir.Jcs;
+import com.provekit.ir.Jcs.Value;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+
+/** Builds and caches the platform_semantics JSON response for the Java kit. */
+public final class PlatformSemanticsDeclaration {
+    private PlatformSemanticsDeclaration() {}
+
+    private static final String KIT_ID = "provekit-realize-java-core@0.1.0";
+
+    // Concept op CIDs (from provekit substrate hub)
+    private static final String CONCEPT_ADD_CID =
+        "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468";
+    private static final String CONCEPT_SUB_CID =
+        "blake3-512:b7c54558573348bb3a9297732547a8e6e9d152403d292df7426b6bb8a248f705b4b030bf2a22ba547a17d6f1bfaf8e75a6843e02e8f23a8226ebc09e2a8622af";
+    private static final String CONCEPT_MUL_CID =
+        "blake3-512:46cd627de058c8d4f7d087ea33f4904af65ad4b2e3cfd3aff8f44bf27db96b33c2dae39cd30f53898c233c9465ba8d2701c69e5903d48935113103b4db00fd03";
+    private static final String CONCEPT_NEG_CID =
+        "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409";
+    private static final String CONCEPT_DIV_CID =
+        "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839";
+    private static final String CONCEPT_MOD_CID =
+        "blake3-512:92340897b43965e01454b00a6a43ec54b2bf0e01213a45fa2311f730dde18adf8da97a22458c1a2a0fb23ce85ef3ad9b22e704804c74f41997aba3ba02cefe0d";
+    private static final String CONCEPT_SHL_CID =
+        "blake3-512:f9cdfcba8d0e223803126504a2a6ed10005fa61acb5c55b74b270bc66d963eb7648ab6763f0510760df93145c0f6670087a403417e8b3100c7142e121111807a";
+    private static final String CONCEPT_SHR_CID =
+        "blake3-512:c90e3c159b25e4c4c7f9c899da5aa3ee048a548719ced7360f3e514450811096b21cd5473f22d7a05df088f92210bbc916e65970b9fa1e1511c193ed969f112b";
+    private static final String CONCEPT_USHR_CID =
+        "blake3-512:5746cb4f8bb8d713624731661de51e851e7ca65dae10a88bae4727d1e0070525be77e9919d90939264acaf4c093b00808862e6d0d2c24ac05262ce95cd67c8ad";
+    private static final String CONCEPT_BITNOT_CID =
+        "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f";
+
+    // Cached JSON response (built once on first call)
+    private static volatile String cachedJson = null;
+
+    /**
+     * Returns the complete JSON string for the provekit.plugin.platform_semantics result.
+     * Thread-safe via double-checked locking.
+     */
+    public static String toJson() {
+        if (cachedJson == null) {
+            synchronized (PlatformSemanticsDeclaration.class) {
+                if (cachedJson == null) {
+                    cachedJson = buildJson();
+                }
+            }
+        }
+        return cachedJson;
+    }
+
+    private static String buildJson() {
+        String kitCid = Blake3.blake3_512(KIT_ID.getBytes(StandardCharsets.UTF_8));
+
+        // Build dimension values
+        DimValue wrapping = dimValue(kitCid, "ArithmeticOverflow", "Wrapping");
+        DimValue truncate = dimValue(kitCid, "IntegerDivisionRounding", "Truncate");
+        DimValue arithmetic = dimValue(kitCid, "ShiftMode", "Arithmetic");
+        DimValue logical = dimValue(kitCid, "ShiftMode", "Logical");
+        DimValue throwArithEx = dimValue(kitCid, "NullSemantics", "ThrowArithmeticException");
+        DimValue twosComplement = dimValue(kitCid, "BitwiseSemantics", "TwosComplement");
+
+        // Build tags
+        TagEntry addTag = tag(kitCid, CONCEPT_ADD_CID,
+            new String[]{"ArithmeticOverflow", wrapping.cid});
+        TagEntry subTag = tag(kitCid, CONCEPT_SUB_CID,
+            new String[]{"ArithmeticOverflow", wrapping.cid});
+        TagEntry mulTag = tag(kitCid, CONCEPT_MUL_CID,
+            new String[]{"ArithmeticOverflow", wrapping.cid});
+        TagEntry negTag = tag(kitCid, CONCEPT_NEG_CID,
+            new String[]{"ArithmeticOverflow", wrapping.cid});
+        TagEntry divTag = tag(kitCid, CONCEPT_DIV_CID,
+            new String[]{"IntegerDivisionRounding", truncate.cid},
+            new String[]{"NullSemantics", throwArithEx.cid});
+        TagEntry modTag = tag(kitCid, CONCEPT_MOD_CID,
+            new String[]{"IntegerDivisionRounding", truncate.cid},
+            new String[]{"NullSemantics", throwArithEx.cid});
+        TagEntry shlTag = tag(kitCid, CONCEPT_SHL_CID,
+            new String[]{"BitwiseSemantics", twosComplement.cid});
+        TagEntry shrTag = tag(kitCid, CONCEPT_SHR_CID,
+            new String[]{"BitwiseSemantics", twosComplement.cid},
+            new String[]{"ShiftMode", arithmetic.cid});
+        TagEntry ushrTag = tag(kitCid, CONCEPT_USHR_CID,
+            new String[]{"BitwiseSemantics", twosComplement.cid},
+            new String[]{"ShiftMode", logical.cid});
+        TagEntry bitnotTag = tag(kitCid, CONCEPT_BITNOT_CID,
+            new String[]{"BitwiseSemantics", twosComplement.cid});
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"tags\":[");
+        appendTag(sb, addTag);
+        sb.append(','); appendTag(sb, subTag);
+        sb.append(','); appendTag(sb, mulTag);
+        sb.append(','); appendTag(sb, negTag);
+        sb.append(','); appendTag(sb, divTag);
+        sb.append(','); appendTag(sb, modTag);
+        sb.append(','); appendTag(sb, shlTag);
+        sb.append(','); appendTag(sb, shrTag);
+        sb.append(','); appendTag(sb, ushrTag);
+        sb.append(','); appendTag(sb, bitnotTag);
+        sb.append("],\"dimension_values\":[");
+        appendDimValue(sb, wrapping);
+        sb.append(','); appendDimValue(sb, truncate);
+        sb.append(','); appendDimValue(sb, arithmetic);
+        sb.append(','); appendDimValue(sb, logical);
+        sb.append(','); appendDimValue(sb, throwArithEx);
+        sb.append(','); appendDimValue(sb, twosComplement);
+        sb.append("]}");
+        return sb.toString();
+    }
+
+    // Internal records
+
+    private record DimValue(
+        String cid,
+        String kitCid,
+        String dimensionName,
+        String valueName,
+        String compareTo // JCS-encoded IrFormula::Atomic JSON string
+    ) {}
+
+    private record TagEntry(
+        String cid,
+        String kitCid,
+        String opCid,
+        LinkedHashMap<String, String> dimensions // sorted BTreeMap order (code-point)
+    ) {}
+
+    // Construct a DimensionValueMemento and compute its CID.
+    // compare_to = IrFormula::Atomic{name:"java:{valueName}",args:[]}
+    // JCS field order (code-point): args < kind < name
+    // CID = blake3-512(JCS(without cid + kit_cid))
+    //   = blake3-512(JCS({compare_to,dimension_name,kind,schemaVersion,value_name}))
+    // JCS field order: compare_to < dimension_name < kind < schemaVersion < value_name
+    private static DimValue dimValue(String kitCid, String dimensionName, String valueName) {
+        // compare_to object (IrFormula::Atomic): JCS keys: args, kind, name
+        Value compareToVal = Value.object(
+            "args", Value.array(),
+            "kind", Value.string("atomic"),
+            "name", Value.string("java:" + valueName)
+        );
+
+        // Full memento without cid + kit_cid for CID computation
+        // JCS key order: compare_to < dimension_name < kind < schemaVersion < value_name
+        Value forCid = Value.object(
+            "compare_to", compareToVal,
+            "dimension_name", Value.string(dimensionName),
+            "kind", Value.string("platform-dimension-value"),
+            "schemaVersion", Value.string("1.0.0"),
+            "value_name", Value.string(valueName)
+        );
+
+        String cid = Jcs.blake3Cid(forCid);
+        return new DimValue(cid, kitCid, dimensionName, valueName, Jcs.encode(compareToVal));
+    }
+
+    // Construct a PlatformSemanticTag and compute its CID.
+    // pairs: alternating dimension_name, value_cid strings (must be in sorted order)
+    // CID = blake3-512(JCS(without cid + kit_cid))
+    //   = blake3-512(JCS({dimensions,kind,op_cid,schemaVersion}))
+    // JCS field order: dimensions < kind < op_cid < schemaVersion
+    @SuppressWarnings("varargs")
+    private static TagEntry tag(String kitCid, String opCid, String[]... dimensionPairs) {
+        // dimensions object - keys must be sorted by code-point for JCS
+        LinkedHashMap<String, String> dims = new LinkedHashMap<>();
+        // Sort dimension keys (they come in already-sorted from caller)
+        java.util.TreeMap<String, String> sorted = new java.util.TreeMap<>(
+            java.util.Comparator.comparingInt(s -> s.codePointAt(0)));
+        // Use unicode code-point comparison for full correctness
+        sorted = new java.util.TreeMap<>((a, b) -> {
+            int i = 0, j = 0;
+            while (i < a.length() && j < b.length()) {
+                int ca = a.codePointAt(i);
+                int cb = b.codePointAt(j);
+                if (ca != cb) return Integer.compare(ca, cb);
+                i += Character.charCount(ca);
+                j += Character.charCount(cb);
+            }
+            return Integer.compare(a.length() - i, b.length() - j);
+        });
+        for (String[] pair : dimensionPairs) {
+            sorted.put(pair[0], pair[1]);
+        }
+        dims.putAll(sorted);
+
+        // Build dimensions Value object (keys already in JCS order via TreeMap)
+        Value[] dimKvs = new Value[dims.size() * 2];
+        int idx = 0;
+        // We need Object... for Value.object(), so rebuild
+        Object[] dimObjKvs = new Object[dims.size() * 2];
+        int oidx = 0;
+        for (java.util.Map.Entry<String, String> e : dims.entrySet()) {
+            dimObjKvs[oidx++] = e.getKey();
+            dimObjKvs[oidx++] = Value.string(e.getValue());
+        }
+        Value dimensionsVal = Value.object(dimObjKvs);
+
+        // Full tag without cid + kit_cid for CID computation
+        // JCS key order: dimensions < kind < op_cid < schemaVersion
+        Value forCid = Value.object(
+            "dimensions", dimensionsVal,
+            "kind", Value.string("platform-semantic-tag"),
+            "op_cid", Value.string(opCid),
+            "schemaVersion", Value.string("1.0.0")
+        );
+
+        String cid = Jcs.blake3Cid(forCid);
+        return new TagEntry(cid, kitCid, opCid, dims);
+    }
+
+    private static void appendDimValue(StringBuilder sb, DimValue v) {
+        // Wire JSON field order matches serde Rust struct field order:
+        // cid, compare_to, dimension_name, kind, kit_cid, schemaVersion, value_name
+        sb.append("{\"cid\":").append(JsonUtil.quoted(v.cid))
+          .append(",\"compare_to\":").append(v.compareTo)
+          .append(",\"dimension_name\":").append(JsonUtil.quoted(v.dimensionName))
+          .append(",\"kind\":\"platform-dimension-value\"")
+          .append(",\"kit_cid\":").append(JsonUtil.quoted(v.kitCid))
+          .append(",\"schemaVersion\":\"1.0.0\"")
+          .append(",\"value_name\":").append(JsonUtil.quoted(v.valueName))
+          .append("}");
+    }
+
+    private static void appendTag(StringBuilder sb, TagEntry t) {
+        // Wire JSON field order matches serde Rust struct field order:
+        // cid, dimensions, kind, kit_cid, op_cid, schemaVersion
+        sb.append("{\"cid\":").append(JsonUtil.quoted(t.cid))
+          .append(",\"dimensions\":{");
+        boolean first = true;
+        for (java.util.Map.Entry<String, String> e : t.dimensions.entrySet()) {
+            if (!first) sb.append(',');
+            first = false;
+            sb.append(JsonUtil.quoted(e.getKey())).append(':').append(JsonUtil.quoted(e.getValue()));
+        }
+        sb.append("}")
+          .append(",\"kind\":\"platform-semantic-tag\"")
+          .append(",\"kit_cid\":").append(JsonUtil.quoted(t.kitCid))
+          .append(",\"op_cid\":").append(JsonUtil.quoted(t.opCid))
+          .append(",\"schemaVersion\":\"1.0.0\"")
+          .append("}");
+    }
+}

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -39,6 +39,8 @@ public final class RpcServer {
             switch (method) {
                 // PEP 1.7.0 methods
                 case "provekit.plugin.describe" -> sendResponse(id, describeResult());
+                case "provekit.plugin.platform_semantics" ->
+                    sendResponse(id, PlatformSemanticsDeclaration.toJson());
                 case "provekit.plugin.invoke" -> {
                     // handleInvoke returns a full JSON object: {"source":..., "is_stub":...}
                     String resultObj = handleInvoke(line);

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/RpcServerPlatformSemanticsTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/RpcServerPlatformSemanticsTest.java
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fixture test for provekit.plugin.platform_semantics RPC handler.
+//
+// Golden CIDs are verified against the Rust reference implementation
+// (provekit-ir-types DimensionValueMemento::recompute_cid +
+//  PlatformSemanticTag::recompute_cid, KIT_ID="provekit-realize-java-core@0.1.0").
+
+package com.provekit.realize;
+
+import com.provekit.ir.Jcs;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RpcServerPlatformSemanticsTest {
+
+    // Golden dimension value CIDs (from Rust reference)
+    private static final String CID_ARITHMETIC_OVERFLOW_WRAPPING =
+        "blake3-512:a4aed351e390af2ca6b1076a8497aaba23717e09ebbb6354f30dc4c215d3250d50a35282f43eb520ed3dc8358541cb3edc33d728a10bdeff93fe1a05ba136569";
+    private static final String CID_INTEGER_DIVISION_ROUNDING_TRUNCATE =
+        "blake3-512:0bd40f590e54cda96d3da54526b027f40c2380f13840de5746aad47df54416dd0fe8949f4317a2363aa15032a22726b86896bf8a4d7cc7664cfd9cda726b78c9";
+    private static final String CID_SHIFT_MODE_ARITHMETIC =
+        "blake3-512:e6b118f0f19f0878db021c8332457adba51c6fe28943a306c88e168b8b69e724fd076a98a906e0cad7afa6e310543920b2efb9805c3eae74911c0cf534c30253";
+    private static final String CID_SHIFT_MODE_LOGICAL =
+        "blake3-512:d69d99f8502b0ee7dbbfe5a288de373a6f1a3f5fc2476f0ff88ea10e64947f90770d7cc673c8aec212fe4fd26672fa17004f6637def003b1eececae43ce1e95b";
+    private static final String CID_NULL_SEMANTICS_THROW_ARITHMETIC_EXCEPTION =
+        "blake3-512:8c8ec297d6611af9634fe208bbcbae4ea65e12ebbdb290fa0aa044b0f3f21c796b674f0f113245c8cb4a39fcff2a2100c7435292b5fdf23eba6a2f34d4ead5cc";
+    private static final String CID_BITWISE_SEMANTICS_TWOS_COMPLEMENT =
+        "blake3-512:222818aea5033dc484fb3fa06d1c28a9f8693f7ff6cabcb73cee93ca6cff2598de137a4942203073e3ad6199a6609ebd149eb4d70c102a15c33a6a989c447e52";
+
+    // Golden tag CIDs (from Rust reference)
+    private static final String CID_TAG_ADD =
+        "blake3-512:a51bc88e7819574c965522eaa2c4c18efc7e793e2a94e2c8eb23a9c7d0eb1487a2aa01a744d31157dcfa833b7720dfafe58dc02f5eca6e89a7b716e8889260af";
+    private static final String CID_TAG_SUB =
+        "blake3-512:c604a9489bafbfd60f06574adcb5e2351bbd29814d15157f7bb9502e233a770d545ec1b961855c4b2cd714686502960aae0dd54370f9ce9e0afdd7743a4e6065";
+    private static final String CID_TAG_MUL =
+        "blake3-512:b74c57dcaea98be23e04380c0f6a3940081e8f880602ead2a439449dea789d5fb808117b5e51cf52d6040d12edb26eb75b7f4cbbe191acb25abebe3915f2f818";
+    private static final String CID_TAG_NEG =
+        "blake3-512:8c6f6563b4bf636610d8772591636c2ebd3efe17481378e40d48b61afc598eae61d5aa9ce49e4c48a79c9dba2ffc51d0625bfa06f03de7e9a51cd66c7d5da72e";
+    private static final String CID_TAG_DIV =
+        "blake3-512:ab24257a81695821f3c68ee07c43554ad3b8c474302820f3a97aa029678eb727c2cf0f11dabf4e7ab423c3820da10a71e0300512c0d51fd2ddcaca17a501d55b";
+    private static final String CID_TAG_MOD =
+        "blake3-512:f6b292560aa19abc706fdcb80a0c3f6bc3555bd1eaba8895e07d5ee511aee97a9d2edfff1f751bd9e5b6322929cede4fb09a3265765aa9813e026ae6f1465667";
+    private static final String CID_TAG_SHL =
+        "blake3-512:87964ec9b6fd00c6881b2c164d6ba4c54e1cd92ed5c4ef474dc544afeda300d4e91927b76b51fb04af0c8640ebd122720410e472b7b945cf6a4d4842ba84f682";
+    private static final String CID_TAG_SHR =
+        "blake3-512:9203d2069cf8220e3b579e75c3f932930da0e9e60de8d3b8e1149da8a9550a665b05dd8cb53c587e94dbe1905fbbe1b07fc9474d7383a52bb2ce90a559ee072a";
+    private static final String CID_TAG_USHR =
+        "blake3-512:7693cb3b0eee68235f4845bb13408ee20847246f385608de1d0260bca6f23ad8974be005619db8228b2a2dc375fede9a554dee9df2b7929b5ceeadb6f2882228";
+    private static final String CID_TAG_BITNOT =
+        "blake3-512:6e2dd52738fdf5f8f6d78e7fa4c4f817b086e6946dfc3f4ddc8eb4540ae4bab7abb7361f5763951c30cadbf46bfd4aa720d24337351f778ea8b05369d3444cd6";
+
+    @Test
+    public void toJsonIsValidJson() {
+        String json = PlatformSemanticsDeclaration.toJson();
+        assertNotNull(json);
+        assertFalse(json.isBlank());
+        // Must parse without exception
+        Jcs.Json parsed = Jcs.parse(json);
+        assertNotNull(parsed);
+    }
+
+    @Test
+    public void toJsonContainsTenTags() {
+        Jcs.Json parsed = Jcs.parse(PlatformSemanticsDeclaration.toJson());
+        Jcs.Arr tags = ((Jcs.Obj) parsed).arrayField("tags");
+        assertEquals(10, tags.values().size(), "expected 10 platform semantic tags");
+    }
+
+    @Test
+    public void toJsonContainsSixDimensionValues() {
+        Jcs.Json parsed = Jcs.parse(PlatformSemanticsDeclaration.toJson());
+        Jcs.Arr dimVals = ((Jcs.Obj) parsed).arrayField("dimension_values");
+        assertEquals(6, dimVals.values().size(), "expected 6 dimension values");
+    }
+
+    @Test
+    public void dimensionValueCidsMatchGolden() {
+        Jcs.Json parsed = Jcs.parse(PlatformSemanticsDeclaration.toJson());
+        Jcs.Arr dimVals = ((Jcs.Obj) parsed).arrayField("dimension_values");
+
+        record GoldenDimValue(String dimensionName, String valueName, String expectedCid) {}
+        List<GoldenDimValue> goldens = List.of(
+            new GoldenDimValue("ArithmeticOverflow",      "Wrapping",                 CID_ARITHMETIC_OVERFLOW_WRAPPING),
+            new GoldenDimValue("IntegerDivisionRounding", "Truncate",                 CID_INTEGER_DIVISION_ROUNDING_TRUNCATE),
+            new GoldenDimValue("ShiftMode",               "Arithmetic",               CID_SHIFT_MODE_ARITHMETIC),
+            new GoldenDimValue("ShiftMode",               "Logical",                  CID_SHIFT_MODE_LOGICAL),
+            new GoldenDimValue("NullSemantics",           "ThrowArithmeticException", CID_NULL_SEMANTICS_THROW_ARITHMETIC_EXCEPTION),
+            new GoldenDimValue("BitwiseSemantics",        "TwosComplement",           CID_BITWISE_SEMANTICS_TWOS_COMPLEMENT)
+        );
+
+        assertEquals(goldens.size(), dimVals.values().size());
+        for (int i = 0; i < goldens.size(); i++) {
+            GoldenDimValue g = goldens.get(i);
+            Jcs.Obj obj = (Jcs.Obj) dimVals.get(i);
+            assertEquals(g.dimensionName(), obj.stringField("dimension_name"),
+                "dimension_name at index " + i);
+            assertEquals(g.valueName(), obj.stringField("value_name"),
+                "value_name at index " + i);
+            assertEquals(g.expectedCid(), obj.stringField("cid"),
+                "cid at index " + i + " (" + g.dimensionName() + "/" + g.valueName() + ")");
+        }
+    }
+
+    @Test
+    public void tagCidsMatchGoldenByOpCid() {
+        Jcs.Json parsed = Jcs.parse(PlatformSemanticsDeclaration.toJson());
+        Jcs.Arr tags = ((Jcs.Obj) parsed).arrayField("tags");
+
+        // Concept op CIDs from the Java kit data
+        String addOpCid    = "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468";
+        String subOpCid    = "blake3-512:b7c54558573348bb3a9297732547a8e6e9d152403d292df7426b6bb8a248f705b4b030bf2a22ba547a17d6f1bfaf8e75a6843e02e8f23a8226ebc09e2a8622af";
+        String mulOpCid    = "blake3-512:46cd627de058c8d4f7d087ea33f4904af65ad4b2e3cfd3aff8f44bf27db96b33c2dae39cd30f53898c233c9465ba8d2701c69e5903d48935113103b4db00fd03";
+        String negOpCid    = "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409";
+        String divOpCid    = "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839";
+        String modOpCid    = "blake3-512:92340897b43965e01454b00a6a43ec54b2bf0e01213a45fa2311f730dde18adf8da97a22458c1a2a0fb23ce85ef3ad9b22e704804c74f41997aba3ba02cefe0d";
+        String shlOpCid    = "blake3-512:f9cdfcba8d0e223803126504a2a6ed10005fa61acb5c55b74b270bc66d963eb7648ab6763f0510760df93145c0f6670087a403417e8b3100c7142e121111807a";
+        String shrOpCid    = "blake3-512:c90e3c159b25e4c4c7f9c899da5aa3ee048a548719ced7360f3e514450811096b21cd5473f22d7a05df088f92210bbc916e65970b9fa1e1511c193ed969f112b";
+        String ushrOpCid   = "blake3-512:5746cb4f8bb8d713624731661de51e851e7ca65dae10a88bae4727d1e0070525be77e9919d90939264acaf4c093b00808862e6d0d2c24ac05262ce95cd67c8ad";
+        String bitnotOpCid = "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f";
+
+        record GoldenTag(String opCid, String expectedCid) {}
+        List<GoldenTag> goldens = List.of(
+            new GoldenTag(addOpCid,    CID_TAG_ADD),
+            new GoldenTag(subOpCid,    CID_TAG_SUB),
+            new GoldenTag(mulOpCid,    CID_TAG_MUL),
+            new GoldenTag(negOpCid,    CID_TAG_NEG),
+            new GoldenTag(divOpCid,    CID_TAG_DIV),
+            new GoldenTag(modOpCid,    CID_TAG_MOD),
+            new GoldenTag(shlOpCid,    CID_TAG_SHL),
+            new GoldenTag(shrOpCid,    CID_TAG_SHR),
+            new GoldenTag(ushrOpCid,   CID_TAG_USHR),
+            new GoldenTag(bitnotOpCid, CID_TAG_BITNOT)
+        );
+
+        assertEquals(goldens.size(), tags.values().size());
+        for (int i = 0; i < goldens.size(); i++) {
+            GoldenTag g = goldens.get(i);
+            Jcs.Obj obj = (Jcs.Obj) tags.get(i);
+            assertEquals(g.opCid(), obj.stringField("op_cid"),
+                "op_cid at index " + i);
+            assertEquals(g.expectedCid(), obj.stringField("cid"),
+                "cid at index " + i + " (op=" + g.opCid().substring(0, 20) + "...)");
+        }
+    }
+
+    @Test
+    public void noOpAliasesField() {
+        // op_aliases is empty, serde skip_serializing_if means it should not appear in output
+        // The Java JSON output omits it (empty map = not emitted)
+        String json = PlatformSemanticsDeclaration.toJson();
+        assertFalse(json.contains("op_aliases"),
+            "op_aliases must not appear when empty");
+    }
+
+    @Test
+    public void compareToIrFormulaAtomicShape() {
+        // Each dimension value's compare_to must be {args:[], kind:"atomic", name:"java:X"}
+        Jcs.Json parsed = Jcs.parse(PlatformSemanticsDeclaration.toJson());
+        Jcs.Arr dimVals = ((Jcs.Obj) parsed).arrayField("dimension_values");
+        for (Jcs.Json val : dimVals.values()) {
+            Jcs.Obj obj = (Jcs.Obj) val;
+            Jcs.Obj compareTo = obj.objectField("compare_to");
+            assertEquals("atomic", compareTo.stringField("kind"),
+                "compare_to.kind must be 'atomic'");
+            Jcs.Arr args = compareTo.arrayField("args");
+            assertTrue(args.isEmpty(), "compare_to.args must be empty");
+            String name = compareTo.stringField("name");
+            assertTrue(name.startsWith("java:"),
+                "compare_to.name must start with 'java:' but was: " + name);
+        }
+    }
+
+    @Test
+    public void toJsonIsStable() {
+        // Must be deterministic across multiple calls
+        assertEquals(PlatformSemanticsDeclaration.toJson(),
+                     PlatformSemanticsDeclaration.toJson());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PlatformSemanticsDeclaration.java` implementing JCS + blake3-512 CID computation for 6 dimension values and 10 concept-op tags for the Java kit
- Wires `provekit.plugin.platform_semantics` case into `RpcServer.java` switch
- Adds `RpcServerPlatformSemanticsTest.java` with 8 tests asserting all 16 golden CIDs byte-identical to the Rust reference implementation (`provekit-ir-types` `DimensionValueMemento::recompute_cid` + `PlatformSemanticTag::recompute_cid`)

## Test plan

- [ ] `mvn test -pl provekit-realize-java-core --also-make` passes (53 tests, 0 failures)
- [ ] Em-dash sweep: `git diff --unified=0 origin/main | grep '^+' | grep -E '—|–'` returns nothing
- [ ] All 8 new CID fixture tests pass: `RpcServerPlatformSemanticsTest`
- [ ] 10 tag CIDs and 6 dimension value CIDs match Rust golden values verbatim

## Key notes

- `kit_cid = blake3_512("provekit-realize-java-core@0.1.0")` is elided from CID computation (per substrate spec)
- `op_aliases` is empty (omitted from wire JSON per `skip_serializing_if = "BTreeMap::is_empty"`)
- `compare_to` for each dimension value is `IrFormula::Atomic{name:"java:{valueName}",args:[]}` with JCS key order `args < kind < name`
- Data sourced from `git show 4fb8a68e9:implementations/rust/libprovekit/src/core/platform_semantics/java.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)