### PR TITLE
feat(typescript-kit): implement provekit.plugin.platform_semantics RPC (#1270)

### DIFF
--- a/implementations/typescript/provekit-realize-typescript-core/package-lock.json
+++ b/implementations/typescript/provekit-realize-typescript-core/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "provekit-realize-typescript-core",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "provekit-realize-typescript-core",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noble/hashes": "^2.2.0"
+      },
+      "bin": {
+        "provekit-realize-typescript": "src/main.js"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    }
+  }
+}

--- a/implementations/typescript/provekit-realize-typescript-core/package.json
+++ b/implementations/typescript/provekit-realize-typescript-core/package.json
@@ -9,5 +9,8 @@
   },
   "scripts": {
     "test": "node --test tests/*.test.js"
+  },
+  "dependencies": {
+    "@noble/hashes": "^2.2.0"
   }
 }

--- a/implementations/typescript/provekit-realize-typescript-core/src/platform_semantics.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/platform_semantics.js
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// TypeScript kit platform semantics declaration.
+//
+// Implements the provekit.plugin.platform_semantics RPC method (PEP 1.7.0).
+// Returns the JSON payload for the "typescript" target.
+//
+// JavaScript/TypeScript arithmetic uses IEEE 754 double-precision floating
+// point for the Number type. There is no integer arithmetic type at the
+// language level; all arithmetic ops produce doubles. Bitwise operators
+// coerce their operands to signed 32-bit integers via the ToInt32 algorithm
+// before operating, then return a double whose value equals the 32-bit result.
+//
+// CID computation follows the substrate spec:
+//   DimensionValueMemento CID = blake3-512(JCS(memento WITHOUT cid + kit_cid))
+//   PlatformSemanticTag CID   = blake3-512(JCS(tag WITHOUT cid + kit_cid))
+
+"use strict";
+
+const { blake3 } = require("@noble/hashes/blake3.js");
+
+const KIT_ID = "provekit-realize-typescript-core@0.1.0";
+
+// kit_cid is provenance metadata only (elided from CID computation per substrate spec).
+// Computed as blake3-512(utf8(KIT_ID)) with dkLen=64.
+const KIT_CID = "blake3-512:" + _hexOf(blake3(
+  new TextEncoder().encode(KIT_ID),
+  { dkLen: 64 }
+));
+
+// Concept-op CIDs shared across all language kits (cross-kit hub CIDs).
+// Source of truth: menagerie/concept-shapes/cids.tsv.
+const OP_ADD    = "blake3-512:398980644a46039b0c2875ab36ccb61f52f284ccad5481593305ed3f10efe91e7863c00a3f2d673644430f691e6b5354f5d65f9da4fa23acdb13dc58f5b438f9";
+const OP_SUB    = "blake3-512:b6c62a64669ff12d0af45d9932c1ab5e08576f1cac97b4abe60392a9f02393dac9765514b024b1481ddc829d4b7fb97950ad648a9944dceafa194b8423923533";
+const OP_MUL    = "blake3-512:1df457dceb0ec7a6dc4596eb70be001be09180afc69fa3ff8121cd78a0daff5dd9606dbfd4fb9fcdc5d834939a6f19c52b80aace16dea6df5ffdce62d86bbfa2";
+const OP_DIV    = "blake3-512:d7403da8d2a8921b71170b5fc34c12022118d0c545f25c7ff89fe77bbed02419e3528479ded0e746535ee92d0e1801bce46608c15c3d6d2a5567bec811cbc75a";
+const OP_REM    = "blake3-512:235c6177611c2753a1c0d07d44391f5465ab50dc585372df52220118cb103ef19502192a07148bd2969d7f6f7ed0d134714d7745825f486768d0b0de8ac0b6dc";
+const OP_SHL    = "blake3-512:37af5330572cf08650e3b6d5fdfc2649d56c0bb2e019f9be3861082c9d1961c1808beca6f9dfc39742ade25f06bfb499da74c89d33f64decd0c70f0972d021e1";
+const OP_SHR    = "blake3-512:cb23fbc9d05a19b353e1fe85c77e241fdc8c58cde5a7c5cad008b721a51eaf682284d8bfe3b383d751cb58833e94beb6bd0dd4d330f9619f095c8b4daa8298da";
+const OP_BITAND = "blake3-512:fcc41d285a20dae6c2deb2a854665d5d43bc829a09a76107d929898b3b169d1abf53ed71f302b00ec2146bcec3b5fe732ca7ecd4354e7739e67feea3db9fd6a2";
+const OP_BITOR  = "blake3-512:5c455355a13fd97a872848613b34b2b56f9738c832f900558710af1cd053976157513f31a8feb123202557dc0a369b88bc7c946179fe817d6c2f80d4f318f824";
+const OP_BITXOR = "blake3-512:16ba612da4883e853dd18b08c8e7b1803e1e2b0a42ab83c261048a49cdfd9b20bc54e809b8f4e8e5c9af63cc7447dee039cb826c611dfec137855a11a502adb9";
+const OP_NEG    = "blake3-512:e0c3e13fd7e0d11fa3b78f4e083ab60b1166bdd905bc04e533e6dcc97d79330bd6a403caaf1265d8134ea3ccd5fe8cfd5a3e18f349ea7edcb6310c098e845c0f";
+const OP_BITNOT = "blake3-512:eeaaf14737f661b6bce03f23d281974502182fea83909eeaade25e510887b26e80dac1b10af3b1f2f496b53898051d63e8d250e78cfa8e88380c84809e5eabe0";
+
+// Cached result to avoid repeated computation.
+let _cached = null;
+
+/** Returns the platform_semantics declaration for the TypeScript kit. */
+function declaration() {
+  if (_cached !== null) return _cached;
+
+  const dimValues = dimensionValues();
+  const dimCids = {};
+  for (const dv of dimValues) {
+    dimCids[dv.dimension_name] = dv.cid;
+  }
+
+  const tags = [
+    // Arithmetic ops: IEEE 754 saturate on overflow (-> +/-Infinity, not wrap or panic)
+    _tag(OP_ADD, { ArithmeticOverflow: dimCids.ArithmeticOverflow }),
+    _tag(OP_SUB, { ArithmeticOverflow: dimCids.ArithmeticOverflow }),
+    _tag(OP_MUL, { ArithmeticOverflow: dimCids.ArithmeticOverflow }),
+    _tag(OP_NEG, { ArithmeticOverflow: dimCids.ArithmeticOverflow }),
+    // Division: always float (no integer truncation), div-by-zero gives NaN/Infinity
+    _tag(OP_DIV, {
+      IntegerDivisionRounding: dimCids.IntegerDivisionRounding,
+      NullSemantics: dimCids.NullSemantics,
+    }),
+    // Remainder: same float semantics, NaN/Infinity on zero
+    _tag(OP_REM, {
+      IntegerDivisionRounding: dimCids.IntegerDivisionRounding,
+      NullSemantics: dimCids.NullSemantics,
+    }),
+    // Bitwise shifts: ToInt32 coercion then wrapping shift
+    _tag(OP_SHL, { ShiftMode: dimCids.ShiftMode }),
+    _tag(OP_SHR, { ShiftMode: dimCids.ShiftMode }),
+    // Bitwise ops: ToInt32 coercion
+    _tag(OP_BITAND, { BitwiseSemantics: dimCids.BitwiseSemantics }),
+    _tag(OP_BITOR,  { BitwiseSemantics: dimCids.BitwiseSemantics }),
+    _tag(OP_BITXOR, { BitwiseSemantics: dimCids.BitwiseSemantics }),
+    _tag(OP_BITNOT, { BitwiseSemantics: dimCids.BitwiseSemantics }),
+  ];
+
+  _cached = { tags, dimension_values: dimValues };
+  return _cached;
+}
+
+/** Returns the dimension values for the TypeScript kit. */
+function dimensionValues() {
+  return [
+    // ArithmeticOverflow: IEEE 754 double saturates to +/-Infinity rather than wrapping
+    _dimValue("ArithmeticOverflow", "Ieee754Saturate"),
+    // IntegerDivisionRounding: JS `/` always performs float division, never truncates
+    _dimValue("IntegerDivisionRounding", "FloatDivision"),
+    // NullSemantics: division or remainder by zero returns NaN or Infinity, no exception
+    _dimValue("NullSemantics", "ReturnsNanOrInfinity"),
+    // ShiftMode: bitwise shift operands are coerced to Int32 with wrapping
+    _dimValue("ShiftMode", "Int32Wrapping"),
+    // BitwiseSemantics: bitwise operands are coerced to Int32 via ToInt32 algorithm
+    _dimValue("BitwiseSemantics", "Int32"),
+  ];
+}
+
+// --- Helpers ---
+
+function _dimValue(dimensionName, valueName) {
+  const compareTo = { kind: "atomic", name: `typescript:${valueName}`, args: [] };
+  const forCid = {
+    compare_to: compareTo,
+    dimension_name: dimensionName,
+    kind: "platform-dimension-value",
+    schemaVersion: "1.0.0",
+    value_name: valueName,
+  };
+  return {
+    compare_to: compareTo,
+    dimension_name: dimensionName,
+    kind: "platform-dimension-value",
+    kit_cid: KIT_CID,
+    schemaVersion: "1.0.0",
+    value_name: valueName,
+    cid: _cidOf(forCid),
+  };
+}
+
+function _tag(opCid, dimensions) {
+  const forCid = {
+    dimensions,
+    kind: "platform-semantic-tag",
+    op_cid: opCid,
+    schemaVersion: "1.0.0",
+  };
+  return {
+    dimensions,
+    kind: "platform-semantic-tag",
+    kit_cid: KIT_CID,
+    op_cid: opCid,
+    schemaVersion: "1.0.0",
+    cid: _cidOf(forCid),
+  };
+}
+
+function _cidOf(obj) {
+  const canonical = _jcs(obj);
+  const bytes = new TextEncoder().encode(canonical);
+  const hash = blake3(bytes, { dkLen: 64 });
+  return "blake3-512:" + _hexOf(hash);
+}
+
+function _jcs(obj) {
+  return JSON.stringify(_sortKeys(obj));
+}
+
+function _sortKeys(val) {
+  if (val === null || typeof val !== "object") return val;
+  if (Array.isArray(val)) return val.map(_sortKeys);
+  return Object.fromEntries(
+    Object.keys(val).sort().map((k) => [k, _sortKeys(val[k])])
+  );
+}
+
+function _hexOf(bytes) {
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+module.exports = { declaration, dimensionValues, KIT_CID };

--- a/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
@@ -1,6 +1,7 @@
 const readline = require("node:readline");
 
 const { emitStub } = require("./realizer");
+const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
 
 function runRpc() {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
@@ -39,6 +40,10 @@ function dispatch(request) {
         namedTermTree: params.namedTermTree ?? params.named_term_tree,
       }),
     };
+  }
+  if (method === "provekit.plugin.platform_semantics") {
+    const decl = platformSemanticsDeclaration();
+    return { jsonrpc: "2.0", id: msgId, result: { tags: decl.tags, dimension_values: decl.dimension_values, op_aliases: {} } };
   }
   if (method === "provekit.plugin.shutdown") {
     return { jsonrpc: "2.0", id: msgId, result: null };

--- a/implementations/typescript/provekit-realize-typescript-core/tests/platform_semantics.test.js
+++ b/implementations/typescript/provekit-realize-typescript-core/tests/platform_semantics.test.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { declaration, dimensionValues } = require("../src/platform_semantics");
+const { dispatch } = require("../src/rpc");
+
+// Golden CIDs for dimension values (kit_cid elided per substrate spec).
+// Independently computed and cross-checked against Python core golden values.
+const GOLDEN_DIM_VALUE_CIDS = {
+  ArithmeticOverflow:       "blake3-512:f4997b8efc9565dbbd3e5339017b2c8ae097912e05a3d349ec7dbbd78deb2fe6e835e88086fd8802902d6208ba17d777bc4dcd27e904c5bf768d95010d09fef3",
+  IntegerDivisionRounding:  "blake3-512:12acb888fe27733082713413b587bc20e8437dc6ec1873516de9f9476f8cc3c76e0f7caaf0cb91d41d26f2e6ffa9873cf2a3786188ecd7fbd8f23ee77e2ed63a",
+  NullSemantics:            "blake3-512:2b6e67a5513cc768b1c59b9fdbf7fb7ef3f7d12235a4b8c1cd63fcbc52b0c23a8e43b88cbd3bd4c730f2f5f40751d3f1b8c6ba12f3c1307b7a0ff81f593d492f",
+  ShiftMode:                "blake3-512:31de26cc4a328f4a3817d5b9587fa67c0cc30b07e1109113e6727f5a553afb0e1f1dc8f01d10cec210f3c04956df2b062c4a127612d535cdbb018ecf4531f5fa",
+  BitwiseSemantics:         "blake3-512:de3c71b070d8e228ad2699a0013f95c4ec18a638a1b1e8c5d406737dddde297b738c38eed094f99d8d512ba1f9255ecac911191134f5bea228f68bb4cddde78a",
+};
+
+const EXPECTED_DIMENSIONS = {
+  ArithmeticOverflow:      "Ieee754Saturate",
+  IntegerDivisionRounding: "FloatDivision",
+  NullSemantics:           "ReturnsNanOrInfinity",
+  ShiftMode:               "Int32Wrapping",
+  BitwiseSemantics:        "Int32",
+};
+
+// Positive: declaration is non-empty
+test("ts_declaration_is_non_empty", () => {
+  const decl = declaration();
+  assert.ok(decl.tags.length > 0, "must declare at least one op tag");
+  assert.ok(decl.dimension_values.length > 0, "must declare dimension values");
+});
+
+// Positive: dimension values have correct dimension_name/value_name mappings
+test("ts_dimension_value_names", () => {
+  const dvs = dimensionValues();
+  const actual = {};
+  for (const dv of dvs) {
+    actual[dv.dimension_name] = dv.value_name;
+  }
+  assert.deepStrictEqual(actual, EXPECTED_DIMENSIONS);
+});
+
+// Positive: dimension value CIDs match goldens
+test("ts_dimension_value_cids_match_goldens", () => {
+  const dvs = dimensionValues();
+  for (const dv of dvs) {
+    const expected = GOLDEN_DIM_VALUE_CIDS[dv.dimension_name];
+    assert.strictEqual(
+      dv.cid, expected,
+      `${dv.dimension_name} CID mismatch`
+    );
+  }
+});
+
+// Positive: all tag CIDs start with blake3-512: and are 139 chars
+test("ts_tag_cids_are_valid_blake3_512", () => {
+  const decl = declaration();
+  for (const tag of decl.tags) {
+    assert.ok(tag.cid.startsWith("blake3-512:"), `tag ${tag.op_cid}: CID must start with blake3-512:`);
+    assert.strictEqual(tag.cid.length, 139, `tag ${tag.op_cid}: CID must be 139 chars`);
+  }
+});
+
+// Discrimination: TS uses Ieee754Saturate; Python uses ArbitraryPrecision.
+// They must produce different ArithmeticOverflow dimension value CIDs.
+test("ts_arithmetic_overflow_differs_from_python", () => {
+  const dvs = dimensionValues();
+  const tsOverflow = dvs.find((d) => d.dimension_name === "ArithmeticOverflow");
+  assert.ok(tsOverflow, "must have ArithmeticOverflow");
+  assert.strictEqual(tsOverflow.value_name, "Ieee754Saturate");
+  // Python ArbitraryPrecision golden CID (from python-core tests)
+  const pythonArbitraryPrecisionCid =
+    "blake3-512:d528ffa68485e200a65ac1119b3561aa28b56f52a04a31059ff41afeeff812843c4b9b12be9682445481b304e30d166baa64bc03fdb5f0fe40e07a0b1091d373";
+  assert.notStrictEqual(
+    tsOverflow.cid, pythonArbitraryPrecisionCid,
+    "Ieee754Saturate and ArbitraryPrecision must hash to different CIDs"
+  );
+});
+
+// Structural: compare_to for each dimension value is a proper atomic formula
+test("ts_dimension_value_compare_to_shapes", () => {
+  const dvs = dimensionValues();
+  for (const dv of dvs) {
+    assert.strictEqual(dv.compare_to.kind, "atomic");
+    assert.ok(dv.compare_to.name.startsWith("typescript:"), `compare_to.name must be 'typescript:...'`);
+    assert.deepStrictEqual(dv.compare_to.args, []);
+  }
+});
+
+// Positive: RPC dispatch returns correct shape for platform_semantics
+test("ts_rpc_dispatch_platform_semantics", () => {
+  const response = dispatch({ jsonrpc: "2.0", id: 42, method: "provekit.plugin.platform_semantics" });
+  assert.strictEqual(response.jsonrpc, "2.0");
+  assert.strictEqual(response.id, 42);
+  assert.ok(Array.isArray(response.result.tags));
+  assert.ok(Array.isArray(response.result.dimension_values));
+  assert.deepStrictEqual(response.result.op_aliases, {});
+  assert.ok(response.result.tags.length > 0);
+  assert.ok(response.result.dimension_values.length > 0);
+});


### PR DESCRIPTION
Implements `provekit.plugin.platform_semantics` for `provekit-realize-typescript-core`.

## Changes
- `src/platform_semantics.js`: IEEE 754 dimension values (ArithmeticOverflow=Ieee754Saturate, IntegerDivisionRounding=FloatDivision, NullSemantics=ReturnsNanOrInfinity, ShiftMode=Int32Wrapping, BitwiseSemantics=Int32) + 12 op tags computed at runtime via `@noble/hashes/blake3.js` with JCS canonicalization
- `src/rpc.js`: add `provekit.plugin.platform_semantics` dispatch case returning `{tags, dimension_values, op_aliases: {}}`
- `package.json`: add `@noble/hashes ^2.2.0` dependency (already pinned in root monorepo)
- `tests/platform_semantics.test.js`: 7 tests including 5 golden dimension-value CID assertions, discrimination test (Ieee754Saturate vs Python ArbitraryPrecision), and RPC dispatch shape test

All 15 tests pass (7 new + 8 existing).

Part of #1270 substrate-uniformity: TypeScript core kit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented platform semantics support for the TypeScript kit with a new RPC endpoint for semantic metadata queries.

* **Chores**
  * Added `@noble/hashes` library as a dependency.

* **Tests**
  * Added comprehensive test suite validating platform semantics outputs, cross-language compatibility, and RPC endpoint functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->