### PR TITLE
feat(ts-pg-kit): implement provekit.plugin.platform_semantics RPC (#1270)

### DIFF
--- a/implementations/typescript/provekit-realize-typescript-pg/package-lock.json
+++ b/implementations/typescript/provekit-realize-typescript-pg/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "provekit-realize-typescript-pg",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "provekit-realize-typescript-pg",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noble/hashes": "^2.2.0"
+      },
+      "bin": {
+        "provekit-realize-typescript-pg": "src/main.js"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    }
+  }
+}

--- a/implementations/typescript/provekit-realize-typescript-pg/package.json
+++ b/implementations/typescript/provekit-realize-typescript-pg/package.json
@@ -9,5 +9,8 @@
   },
   "scripts": {
     "test": "node --test tests/*.test.js"
+  },
+  "dependencies": {
+    "@noble/hashes": "^2.2.0"
   }
 }

--- a/implementations/typescript/provekit-realize-typescript-pg/src/platform_semantics.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/src/platform_semantics.js
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binding-kit platform semantics declaration for the TypeScript pg library (node-postgres).
+//
+// Implements the provekit.plugin.platform_semantics RPC method (PEP 1.7.0).
+// Returns the JSON payload for the "typescript-pg" binding target.
+//
+// RowIdMechanism = ReturningClause: PostgreSQL requires appending a
+// `RETURNING id` (or equivalent) clause to the INSERT statement. The row id
+// is returned as a column in the result set, not as connection-global state.
+// This mechanism requires a structural rewrite of the INSERT SQL string
+// relative to better-sqlite3.
+//
+// CID computation follows the substrate spec:
+//   DimensionValueMemento CID = blake3-512(JCS(memento WITHOUT cid + kit_cid))
+//   PlatformSemanticTag CID   = blake3-512(JCS(tag WITHOUT cid + kit_cid))
+
+"use strict";
+
+const { blake3 } = require("@noble/hashes/blake3.js");
+
+const KIT_ID = "provekit-binding-pg@0.1.0";
+
+// CID for concept:insert-and-get-id, minted from its AlgorithmMemento via JCS+blake3-512.
+const CONCEPT_INSERT_AND_GET_ID_CID =
+  "blake3-512:0a4f0a8d36d8dee96b8d5b32a18bb390f35877ecef611771048c6e10cfc3d25ad8f59de89b00c7794f62cabaf91dbd779244338393a8bb6ef5e8309b0929b3ca";
+
+// kit_cid is provenance metadata only (elided from CID computation per substrate spec).
+const KIT_CID = "blake3-512:" + _hexOf(blake3(
+  new TextEncoder().encode(KIT_ID),
+  { dkLen: 64 }
+));
+
+// Cached result to avoid repeated computation.
+let _cached = null;
+
+/** Returns the platform_semantics declaration for the pg binding kit. */
+function declaration() {
+  if (_cached !== null) return _cached;
+
+  const dimValues = dimensionValues();
+  const rowIdCid = dimValues.find((d) => d.dimension_name === "RowIdMechanism").cid;
+
+  const tags = [
+    _tag(CONCEPT_INSERT_AND_GET_ID_CID, { RowIdMechanism: rowIdCid }),
+  ];
+
+  _cached = { tags, dimension_values: dimValues };
+  return _cached;
+}
+
+/** Returns the dimension values for the pg binding kit. */
+function dimensionValues() {
+  return [
+    // ReturningClause: row id is sourced from a server-side RETURNING clause
+    // appended to the INSERT SQL statement. The clause causes the server to
+    // return the specified columns (including the id) as a result row.
+    _dimValue("RowIdMechanism", "ReturningClause", {
+      kind: "atomic",
+      name: "row_id_source",
+      args: [
+        {
+          kind: "ctor",
+          name: "returning_clause_result",
+          args: [
+            { kind: "ctor", name: "insert_result_set_at_call_return", args: [] },
+          ],
+        },
+      ],
+    }),
+  ];
+}
+
+// --- Helpers ---
+
+function _dimValue(dimensionName, valueName, compareTo) {
+  const forCid = {
+    compare_to: compareTo,
+    dimension_name: dimensionName,
+    kind: "platform-dimension-value",
+    schemaVersion: "1.0.0",
+    value_name: valueName,
+  };
+  return {
+    compare_to: compareTo,
+    dimension_name: dimensionName,
+    kind: "platform-dimension-value",
+    kit_cid: KIT_CID,
+    schemaVersion: "1.0.0",
+    value_name: valueName,
+    cid: _cidOf(forCid),
+  };
+}
+
+function _tag(opCid, dimensions) {
+  const forCid = {
+    dimensions,
+    kind: "platform-semantic-tag",
+    op_cid: opCid,
+    schemaVersion: "1.0.0",
+  };
+  return {
+    dimensions,
+    kind: "platform-semantic-tag",
+    kit_cid: KIT_CID,
+    op_cid: opCid,
+    schemaVersion: "1.0.0",
+    cid: _cidOf(forCid),
+  };
+}
+
+function _cidOf(obj) {
+  const canonical = _jcs(obj);
+  const bytes = new TextEncoder().encode(canonical);
+  const hash = blake3(bytes, { dkLen: 64 });
+  return "blake3-512:" + _hexOf(hash);
+}
+
+function _jcs(obj) {
+  return JSON.stringify(_sortKeys(obj));
+}
+
+function _sortKeys(val) {
+  if (val === null || typeof val !== "object") return val;
+  if (Array.isArray(val)) return val.map(_sortKeys);
+  return Object.fromEntries(
+    Object.keys(val).sort().map((k) => [k, _sortKeys(val[k])])
+  );
+}
+
+function _hexOf(bytes) {
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+module.exports = { declaration, dimensionValues, CONCEPT_INSERT_AND_GET_ID_CID, KIT_CID };

--- a/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
@@ -1,6 +1,7 @@
 const readline = require("node:readline");
 
 const { emitStub } = require("./realizer");
+const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
 
 function runRpc() {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
@@ -39,6 +40,10 @@ function dispatch(request) {
         namedTermTree: params.namedTermTree ?? params.named_term_tree,
       }),
     };
+  }
+  if (method === "provekit.plugin.platform_semantics") {
+    const decl = platformSemanticsDeclaration();
+    return { jsonrpc: "2.0", id: msgId, result: { tags: decl.tags, dimension_values: decl.dimension_values, op_aliases: {} } };
   }
   if (method === "provekit.plugin.shutdown") {
     return { jsonrpc: "2.0", id: msgId, result: null };

--- a/implementations/typescript/provekit-realize-typescript-pg/tests/platform_semantics.test.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/tests/platform_semantics.test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { declaration, dimensionValues, CONCEPT_INSERT_AND_GET_ID_CID } = require("../src/platform_semantics");
+const { dispatch } = require("../src/rpc");
+
+// Golden CIDs (kit_cid elided per substrate spec).
+const GOLDEN_RETURNING_CLAUSE_CID =
+  "blake3-512:8cd2692a556731b240b590ec2a194628f7db28a9f0816f4993677f64b18b72ac9591a6ae519c6e13fa2fe60dff3c6c0943b5bc8fd6ef00f298702def3d3e996e";
+const GOLDEN_INSERT_TAG_CID =
+  "blake3-512:51eb072fd0f9cf1b7056bff0c7f085d4f917e9964ef5511fcb8c726402cf765dc0607138671410335f2812f36bac1ff1b52a67d149b8b5a87d11cf329419cf7c";
+
+// Positive: declaration is non-empty
+test("pg_declaration_is_non_empty", () => {
+  const decl = declaration();
+  assert.ok(decl.tags.length > 0, "must declare at least one op tag");
+  assert.ok(decl.dimension_values.length > 0, "must declare dimension values");
+  assert.ok(
+    decl.tags.some((t) => t.op_cid === CONCEPT_INSERT_AND_GET_ID_CID),
+    "must declare concept:insert-and-get-id"
+  );
+});
+
+// Positive: ReturningClause dimension value CID matches golden
+test("pg_returning_clause_cid_matches_golden", () => {
+  const dvs = dimensionValues();
+  const rowId = dvs.find((d) => d.dimension_name === "RowIdMechanism");
+  assert.ok(rowId, "must have RowIdMechanism dimension");
+  assert.strictEqual(rowId.value_name, "ReturningClause");
+  assert.strictEqual(rowId.cid, GOLDEN_RETURNING_CLAUSE_CID);
+});
+
+// Positive: insert-and-get-id tag CID matches golden
+test("pg_insert_tag_cid_matches_golden", () => {
+  const decl = declaration();
+  const tag = decl.tags.find((t) => t.op_cid === CONCEPT_INSERT_AND_GET_ID_CID);
+  assert.ok(tag, "must have insert-and-get-id tag");
+  assert.strictEqual(tag.cid, GOLDEN_INSERT_TAG_CID);
+});
+
+// Discrimination: pg ReturningClause must differ from better-sqlite3 LastInsertRowid
+test("pg_returning_clause_differs_from_last_insert_rowid", () => {
+  const dvs = dimensionValues();
+  const rowId = dvs.find((d) => d.dimension_name === "RowIdMechanism");
+  // LastInsertRowid golden CID (better-sqlite3)
+  const lastInsertRowidCid =
+    "blake3-512:619f9cb06fa946350f9c8050f0be5281c6e7f67730be491bbe1223e549263ef6cb63751c1c3ea4f2df23a25a9d7307fcbb9634e58a13983e0900d40240fc2cf6";
+  assert.notStrictEqual(
+    rowId.cid, lastInsertRowidCid,
+    "ReturningClause and LastInsertRowid must hash to different CIDs"
+  );
+});
+
+// Structural: compare_to is a proper Atomic formula with IrTerm::Ctor args
+test("pg_dimension_value_compare_to_structure", () => {
+  const dvs = dimensionValues();
+  const rowId = dvs.find((d) => d.dimension_name === "RowIdMechanism");
+  assert.strictEqual(rowId.compare_to.kind, "atomic");
+  assert.strictEqual(rowId.compare_to.name, "row_id_source");
+  assert.strictEqual(rowId.compare_to.args.length, 1);
+  const arg = rowId.compare_to.args[0];
+  assert.strictEqual(arg.kind, "ctor");
+  assert.strictEqual(arg.name, "returning_clause_result");
+});
+
+// Positive: RPC dispatch returns correct shape
+test("pg_rpc_dispatch_platform_semantics", () => {
+  const response = dispatch({ jsonrpc: "2.0", id: 7, method: "provekit.plugin.platform_semantics" });
+  assert.strictEqual(response.jsonrpc, "2.0");
+  assert.strictEqual(response.id, 7);
+  assert.ok(Array.isArray(response.result.tags));
+  assert.ok(Array.isArray(response.result.dimension_values));
+  assert.deepStrictEqual(response.result.op_aliases, {});
+});


### PR DESCRIPTION
Implements `provekit.plugin.platform_semantics` for `provekit-realize-typescript-pg`.

## Changes
- `src/platform_semantics.js`: RowIdMechanism=ReturningClause binding declaration with IrTerm::Ctor compare_to formula; CID computed via `@noble/hashes/blake3.js` with JCS canonicalization
- `src/rpc.js`: add `provekit.plugin.platform_semantics` dispatch case
- `package.json`: add `@noble/hashes ^2.2.0` dependency
- `tests/platform_semantics.test.js`: 6 tests including golden CID assertions, discrimination vs LastInsertRowid, structural compare_to check, and RPC dispatch shape test

All 9 tests pass (6 new + 3 existing).

Part of #1270 substrate-uniformity: TypeScript pg binding kit.