### PR TITLE
feat(py-sqlite3-kit): implement provekit.plugin.platform_semantics RPC (#1270)

### DIFF
--- a/implementations/python/provekit-realize-python-sqlite3/pyproject.toml
+++ b/implementations/python/provekit-realize-python-sqlite3/pyproject.toml
@@ -7,7 +7,7 @@ name = "provekit-realize-python-sqlite3"
 version = "0.1.0"
 description = "PEP 1.7.0 Python sqlite3 realize kit for ProvekIt bind canonical output"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = ["blake3>=1.0.0"]
 
 [project.scripts]
 provekit-realize-python-sqlite3 = "provekit_realize_python_sqlite3.__main__:main"

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/platform_semantics.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/platform_semantics.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import blake3 as _blake3
+
+Json = dict[str, Any]
+
+# CID for concept:insert-and-get-id, minted from its AlgorithmMemento via JCS+blake3-512.
+CONCEPT_INSERT_AND_GET_ID_CID = (
+    "blake3-512:"
+    "0a4f0a8d36d8dee96b8d5b32a18bb390f35877ecef611771048c6e10cfc3d25a"
+    "d8f59de89b00c7794f62cabaf91dbd779244338393a8bb6ef5e8309b0929b3ca"
+)
+
+KIT_ID = "provekit-binding-python-sqlite3@0.1.0"
+
+# kit_cid is provenance metadata only (elided from CID computation per substrate spec).
+SQLITE3_KIT_CID = (
+    "blake3-512:"
+    + _blake3.blake3(KIT_ID.encode("utf-8")).digest(length=64).hex()
+)
+
+
+def dimension_values() -> list[Json]:
+    return [
+        _with_cid(
+            {
+                # CursorLastRowid: row id is sourced from the cursor state after
+                # executing the INSERT. Accessed as cursor.lastrowid.
+                "compare_to": {
+                    "kind": "atomic",
+                    "name": "row_id_source",
+                    "args": [
+                        {
+                            "kind": "ctor",
+                            "name": "cursor_lastrowid",
+                            "args": [
+                                {
+                                    "kind": "ctor",
+                                    "name": "cursor_state_after_execute",
+                                    "args": [],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "dimension_name": "RowIdMechanism",
+                "kind": "platform-dimension-value",
+                "kit_cid": SQLITE3_KIT_CID,
+                "schemaVersion": "1.0.0",
+                "value_name": "CursorLastRowid",
+            }
+        )
+    ]
+
+
+def declaration() -> Json:
+    dim_vals = dimension_values()
+    row_id_cid = next(v["cid"] for v in dim_vals if v["dimension_name"] == "RowIdMechanism")
+    return {
+        "tags": [
+            _with_cid(
+                {
+                    "dimensions": {"RowIdMechanism": row_id_cid},
+                    "kind": "platform-semantic-tag",
+                    "kit_cid": SQLITE3_KIT_CID,
+                    "op_cid": CONCEPT_INSERT_AND_GET_ID_CID,
+                    "schemaVersion": "1.0.0",
+                }
+            )
+        ],
+        "dimension_values": dim_vals,
+    }
+
+
+def _with_cid(memento: Json) -> Json:
+    # CID is computed over JCS(memento) with "cid" and "kit_cid" elided,
+    # per substrate spec (DimensionValueMemento::recompute_cid +
+    # PlatformSemanticTag::recompute_cid in provekit-ir-types).
+    for_cid = {k: v for k, v in memento.items() if k not in ("cid", "kit_cid")}
+    result = dict(memento)
+    result["cid"] = _cid_of_json(for_cid)
+    return result
+
+
+def _cid_of_json(value: Any) -> str:
+    return (
+        "blake3-512:"
+        + _blake3.blake3(_canonical_json_bytes(value)).digest(length=64).hex()
+    )
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
@@ -5,6 +5,7 @@ import sys
 import traceback
 from typing import Any
 
+from .platform_semantics import declaration as _platform_semantics_declaration
 from .realizer import MissingTemplateError, emit_stub
 
 
@@ -67,6 +68,13 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
                 "extension": "py",
             },
         }
+    if method == "provekit.plugin.platform_semantics":
+        decl = _platform_semantics_declaration()
+        return {"jsonrpc": "2.0", "id": msg_id, "result": {
+            "tags": decl["tags"],
+            "dimension_values": decl["dimension_values"],
+            "op_aliases": {},
+        }}
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")

--- a/implementations/python/provekit-realize-python-sqlite3/tests/test_platform_semantics.py
+++ b/implementations/python/provekit-realize-python-sqlite3/tests/test_platform_semantics.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-sqlite3/src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from provekit_realize_python_sqlite3.platform_semantics import (
+    CONCEPT_INSERT_AND_GET_ID_CID,
+    declaration,
+    dimension_values,
+)
+from provekit_realize_python_sqlite3.rpc import dispatch
+
+# Golden CIDs verified by independent computation (kit_cid elided per substrate spec).
+GOLDEN_CURSOR_LASTROWID_CID = (
+    "blake3-512:"
+    "6fbe68f4eb8a7cf5e58bd5859f43ce9bff042e3b68f85d6576fd3055d08f9d2a"
+    "36bf9c316f6580111e178d82495b820b66414c934e5723d0e1c3a337df269933"
+)
+GOLDEN_INSERT_TAG_CID = (
+    "blake3-512:"
+    "2e2c882ac4c9b8a109b16a5645da75493eadaaa3f242a6169b36c7f3bb799b8a"
+    "12cf4315ed0c0fe2f9da742da555e642499a532104c946ea923971ced3d1b6c8"
+)
+
+
+def test_sqlite3_declaration_is_non_empty() -> None:
+    # Positive: declaration has at least one tag and one dimension value.
+    decl = declaration()
+    assert decl["tags"], "must declare at least one op tag"
+    assert decl["dimension_values"], "must declare dimension values"
+    assert any(t["op_cid"] == CONCEPT_INSERT_AND_GET_ID_CID for t in decl["tags"]), \
+        "must declare concept:insert-and-get-id"
+
+
+def test_sqlite3_cursor_lastrowid_cid_matches_golden() -> None:
+    # Positive: CursorLastRowid dimension value CID matches golden.
+    dvs = dimension_values()
+    row_id = next(d for d in dvs if d["dimension_name"] == "RowIdMechanism")
+    assert row_id["value_name"] == "CursorLastRowid"
+    assert row_id["cid"] == GOLDEN_CURSOR_LASTROWID_CID
+
+
+def test_sqlite3_insert_tag_cid_matches_golden() -> None:
+    # Positive: insert-and-get-id tag CID matches golden.
+    decl = declaration()
+    tag = next(t for t in decl["tags"] if t["op_cid"] == CONCEPT_INSERT_AND_GET_ID_CID)
+    assert tag["cid"] == GOLDEN_INSERT_TAG_CID
+
+
+def test_sqlite3_cursor_lastrowid_differs_from_last_insert_rowid() -> None:
+    # Discrimination: CursorLastRowid must differ from LastInsertRowid (better-sqlite3).
+    dvs = dimension_values()
+    row_id = next(d for d in dvs if d["dimension_name"] == "RowIdMechanism")
+    # LastInsertRowid golden CID (better-sqlite3)
+    last_insert_rowid_cid = (
+        "blake3-512:"
+        "619f9cb06fa946350f9c8050f0be5281c6e7f67730be491bbe1223e549263ef6"
+        "cb63751c1c3ea4f2df23a25a9d7307fcbb9634e58a13983e0900d40240fc2cf6"
+    )
+    assert row_id["cid"] != last_insert_rowid_cid, \
+        "CursorLastRowid and LastInsertRowid must hash to different CIDs"
+
+
+def test_sqlite3_dimension_value_compare_to_structure() -> None:
+    # Structural: compare_to is IrFormula::Atomic with IrTerm::Ctor args.
+    dvs = dimension_values()
+    row_id = next(d for d in dvs if d["dimension_name"] == "RowIdMechanism")
+    ct = row_id["compare_to"]
+    assert ct["kind"] == "atomic"
+    assert ct["name"] == "row_id_source"
+    assert len(ct["args"]) == 1
+    arg = ct["args"][0]
+    assert arg["kind"] == "ctor"
+    assert arg["name"] == "cursor_lastrowid"
+
+
+def test_sqlite3_rpc_dispatch_platform_semantics() -> None:
+    # Positive: RPC dispatch returns correct shape for platform_semantics.
+    response = dispatch({"jsonrpc": "2.0", "id": 3, "method": "provekit.plugin.platform_semantics"})
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] == 3
+    assert isinstance(response["result"]["tags"], list)
+    assert isinstance(response["result"]["dimension_values"], list)
+    assert response["result"]["op_aliases"] == {}
+    assert len(response["result"]["tags"]) > 0
+    assert len(response["result"]["dimension_values"]) > 0


### PR DESCRIPTION
Implements `provekit.plugin.platform_semantics` for `provekit-realize-python-sqlite3`.

## Changes
- `src/provekit_realize_python_sqlite3/platform_semantics.py`: RowIdMechanism=CursorLastRowid binding declaration with IrTerm::Ctor compare_to formula; CID computed via blake3+JCS canonicalization (same recipe as python-core)
- `src/provekit_realize_python_sqlite3/rpc.py`: add `provekit.plugin.platform_semantics` dispatch case
- `pyproject.toml`: add `blake3>=1.0.0` dependency
- `tests/test_platform_semantics.py`: 6 tests including golden CID assertions, discrimination vs LastInsertRowid, structural compare_to check, and RPC dispatch shape test

All 15 tests pass (6 new + 9 existing).

Part of #1270 substrate-uniformity: Python sqlite3 binding kit.