### PR TITLE
feat(python-core): add SortAdmission for concept:literal (#1261)

### DIFF
--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/platform_semantics.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/platform_semantics.py
@@ -35,9 +35,37 @@ PYTHON_PLATFORM_CONCEPT_OP_CIDS: tuple[str, ...] = (
     "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409",
 )
 
+# concept:literal CID (from #1282)
+CONCEPT_LITERAL_CID = "blake3-512:02804a0bdbd2d5d541544451f41ee8d0d340baf28f70bd5abf5844e87a96aedd7b5ab3453962754a020679cc8c6b3d1f4cf0336a7ad8118128d42ac667abf2d6"
+
+# Canonical sort CIDs (from #1282)
+# Python admits: Int, Float, String, Bool, Bytes, Null (full primitive tier)
+# Args must be sorted alphabetically by CID string value:
+#   BOOL  (0ee1...) < INT (30ff...) < NULL (62f6...) < BYTES (7116...) < FLOAT (b979...) < STRING (be87...)
+_SORT_BOOL_CID = "blake3-512:0ee13bf3fd6b7ecfbee72dfbfc18a7c0ea7f1663de6cca43cefb36f5b4c03665452646094a7c296e819e75d683c6ce4821f3d7db3c3c78ae97f2d4e3451d2074"
+_SORT_INT_CID = "blake3-512:30ffc51350121a7172f3e4064a33c45bbd345756979fccff6875cd2ab33e4964d098a99df80cfbdf1ec1a0738c5ac3476f0ff8f75589ea511d1acd82c74ecd58"
+_SORT_NULL_CID = "blake3-512:62f6040bd3f414c1e6c2b7bdf276669cd5613b33cb508a81170170064ca3ffba771a4b0002dc52e059fce5f9f63a1874ef71bd4ec89ae06e89c87a3e91aac3b5"
+_SORT_BYTES_CID = "blake3-512:7116ef6e62e6739b213a8394f975a53c771b89f08c36d27143827acfcfebc0e39e5b82c530be668c3cfd5ec6966ccaa42930b37fdb1f4ac25652a970be10fb6b"
+_SORT_FLOAT_CID = "blake3-512:b979e70c4d5e53d9bdf13d6f08330be3c5b0714b8c770d69bbd05946b86c36df5274be8145a2683cc29c278155c9c1ee65b6897913524eecb9e4c89c71862f57"
+_SORT_STRING_CID = "blake3-512:be8721d24849feb74c4721520bdba02d352a94f49253a627cd509127472aa1c47cbe99cb705cac4159b5365abcce0c9aaa4901fe67630827deb6be1f9daeea10"
+
+# admits_sorts formula for Python (full primitive tier, sorted by CID string)
+_ADMITS_SORTS_FORMULA: Json = {
+    "args": [
+        {"kind": "const", "sort": {"kind": "primitive", "name": "cid"}, "value": _SORT_BOOL_CID},
+        {"kind": "const", "sort": {"kind": "primitive", "name": "cid"}, "value": _SORT_INT_CID},
+        {"kind": "const", "sort": {"kind": "primitive", "name": "cid"}, "value": _SORT_NULL_CID},
+        {"kind": "const", "sort": {"kind": "primitive", "name": "cid"}, "value": _SORT_BYTES_CID},
+        {"kind": "const", "sort": {"kind": "primitive", "name": "cid"}, "value": _SORT_FLOAT_CID},
+        {"kind": "const", "sort": {"kind": "primitive", "name": "cid"}, "value": _SORT_STRING_CID},
+    ],
+    "kind": "atomic",
+    "name": "admits_sorts",
+}
+
 
 def dimension_values() -> list[Json]:
-    return [
+    existing = [
         _with_cid(
             {
                 "compare_to": _compare_atom(value_name),
@@ -50,34 +78,64 @@ def dimension_values() -> list[Json]:
         )
         for dimension_name, value_name in PYTHON_PLATFORM_DIMENSIONS
     ]
+    # SortAdmission dimension value for concept:literal.
+    # value_name "FullPrimitiveTier" matches Java for cross-kit substrate uniformity.
+    sort_admission = _with_cid(
+        {
+            "compare_to": _ADMITS_SORTS_FORMULA,
+            "dimension_name": "SortAdmission",
+            "kind": "platform-dimension-value",
+            "kit_cid": PYTHON_PLATFORM_KIT_CID,
+            "schemaVersion": "1.0.0",
+            "value_name": "FullPrimitiveTier",
+        }
+    )
+    return existing + [sort_admission]
 
 
 def declaration() -> Json:
     dim_vals = dimension_values()
-    dimensions = {
+    # Existing five operator-semantic dimensions (shared across all arithmetic/shift/etc. tags)
+    op_dimensions = {
         value["dimension_name"]: value["cid"]
         for value in dim_vals
-        if isinstance(value["dimension_name"], str)
+        if value["dimension_name"] in {d for d, _ in PYTHON_PLATFORM_DIMENSIONS}
     }
+    # SortAdmission dimension value (used only by concept:literal tag)
+    sort_admission_dv = next(v for v in dim_vals if v["dimension_name"] == "SortAdmission")
+
+    op_tags = [
+        _with_cid(
+            {
+                "dimensions": op_dimensions,
+                "kind": "platform-semantic-tag",
+                "kit_cid": PYTHON_PLATFORM_KIT_CID,
+                "op_cid": op_cid,
+                "schemaVersion": "1.0.0",
+            }
+        )
+        for op_cid in PYTHON_PLATFORM_CONCEPT_OP_CIDS
+    ]
+
+    # concept:literal tag: only carries the SortAdmission dimension
+    literal_tag = _with_cid(
+        {
+            "dimensions": {"SortAdmission": sort_admission_dv["cid"]},
+            "kind": "platform-semantic-tag",
+            "kit_cid": PYTHON_PLATFORM_KIT_CID,
+            "op_cid": CONCEPT_LITERAL_CID,
+            "schemaVersion": "1.0.0",
+        }
+    )
+
     return {
-        "tags": [
-            _with_cid(
-                {
-                    "dimensions": dimensions,
-                    "kind": "platform-semantic-tag",
-                    "kit_cid": PYTHON_PLATFORM_KIT_CID,
-                    "op_cid": op_cid,
-                    "schemaVersion": "1.0.0",
-                }
-            )
-            for op_cid in PYTHON_PLATFORM_CONCEPT_OP_CIDS
-        ],
+        "tags": op_tags + [literal_tag],
         "dimension_values": dim_vals,
     }
 
 
 def _compare_atom(value_name: str) -> Json:
-    return {"kind": "atomic", "name": f"python:{value_name}", "args": []}
+    return {"args": [], "kind": "atomic", "name": f"python:{value_name}"}
 
 
 def _with_cid(memento: Json) -> Json:

--- a/implementations/python/provekit-realize-python-core/tests/test_realize_platform_semantics.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realize_platform_semantics.py
@@ -8,7 +8,11 @@ PKG_SRC = ROOT / "implementations/python/provekit-realize-python-core/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
-from provekit_realize_python_core.platform_semantics import declaration, dimension_values
+from provekit_realize_python_core.platform_semantics import (
+    CONCEPT_LITERAL_CID,
+    declaration,
+    dimension_values,
+)
 
 
 EXPECTED_DIMENSIONS = {
@@ -32,10 +36,14 @@ GOLDEN_DIM_VALUE_CIDS: dict[tuple[str, str], str] = {
         "blake3-512:676366cdedf3f53cdf4eade664dd570644217c86f596bb4a18d609723f43512ca100ca1903ef5cd9e2f10cb7309288054cafdcc22734439f9509b9bcad667628",
     ("BitwiseSemantics", "TwosComplement"):
         "blake3-512:01a8d218214a9344ac9f0a1a9b25d429eb8b0a72bd7d535a6377794f7769b3ded74f28b0073e5b64a5e5a64276d2cdeb4fb5ea64c2c5b007dfe5859b9cb13a45",
+    # concept:literal SortAdmission: Python admits full primitive tier (Int, Float, String, Bool, Bytes, Null)
+    # value_name "FullPrimitiveTier" matches Java for cross-kit substrate uniformity.
+    ("SortAdmission", "FullPrimitiveTier"):
+        "blake3-512:cdec58a9736ce0d4efc81a73cde61e1776df742a67de9141e49cf6712ae580f948dc3ee7bfa136e7904cb6d579e50f9644845fe50f8d4ddfeb68902562f13f85",
 }
 
-# Golden tag CIDs (all 12 tags share the same dimension map, so each has a unique CID
-# from the op_cid field).
+# Golden tag CIDs. The 12 operator tags share the same 5-dimension map; each has a unique
+# CID from its op_cid. The concept:literal tag carries only SortAdmission.
 GOLDEN_TAG_CIDS: dict[str, str] = {
     "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468":
         "blake3-512:63e60467c70e6b34af42c9b3ebbd3e4db9688714ecad57bf3e2376a7d36bfb7ac289474a8d0ddba754c2aede056106a6d5f0721307cf3fe676ec32a77b84a4d7",
@@ -61,28 +69,34 @@ GOLDEN_TAG_CIDS: dict[str, str] = {
         "blake3-512:210b62a4782185b311f8791e3886c6432e3a486250621398eb4f520f1b84b11f16c68908c9e2d9549b0937a4760f3e45e1d5fa386c119cf48646762af4f2216d",
     "blake3-512:ad958847b50cf07ddbb92d85ae488a5f983d5619e108476b42e519174cfcce883ecd637544a372b946bb45a1c22893c710bc9b08ea0569ad0e035b3babb6a409":
         "blake3-512:c75facd259c4e04eeb096c715c2507f0040a2043a3cb9f342d47923f069c1bde2c96d0b067b6b160fe5d9a07508d0f416ff1e3e7801d60fef77f271c959bc578",
+    # concept:literal tag (only SortAdmission dimension)
+    "blake3-512:02804a0bdbd2d5d541544451f41ee8d0d340baf28f70bd5abf5844e87a96aedd7b5ab3453962754a020679cc8c6b3d1f4cf0336a7ad8118128d42ac667abf2d6":
+        "blake3-512:5523f7d24d51ff0a0d8ac96798946e4bc1722a7d1936918f4b9477b2246bde112d24f8043680fd22a5272e39d5bedbb2acc2d17590f6ff7afae140dd523c361d",
 }
 
 
 def test_python_realize_platform_semantics_declaration_shape() -> None:
     values = dimension_values()
-    assert {item["dimension_name"]: item["value_name"] for item in values} == EXPECTED_DIMENSIONS
+    dim_map = {item["dimension_name"]: item["value_name"] for item in values}
+    # Existing 5 operator-semantic dimensions
+    for dim, val in EXPECTED_DIMENSIONS.items():
+        assert dim_map[dim] == val
+    # New SortAdmission dimension value
+    assert dim_map["SortAdmission"] == "FullPrimitiveTier"
     for item in values:
-        assert item["compare_to"] == {
-            "kind": "atomic",
-            "name": f"python:{item['value_name']}",
-            "args": [],
-        }
         assert item["cid"].startswith("blake3-512:")
 
     semantics = declaration()
     assert semantics["tags"]
     for tag in semantics["tags"]:
-        assert set(tag["dimensions"]) == set(EXPECTED_DIMENSIONS)
+        if tag["op_cid"] == CONCEPT_LITERAL_CID:
+            assert set(tag["dimensions"]) == {"SortAdmission"}
+        else:
+            assert set(tag["dimensions"]) == set(EXPECTED_DIMENSIONS)
         assert tag["op_cid"].startswith("blake3-512:")
         assert tag["cid"].startswith("blake3-512:")
     assert "dimension_values" in semantics
-    assert len(semantics["dimension_values"]) == 5
+    assert len(semantics["dimension_values"]) == 6
 
 
 def test_dimension_value_cids_match_golden() -> None:
@@ -106,6 +120,18 @@ def test_tag_cids_match_golden() -> None:
         )
 
 
+def test_concept_literal_has_sort_admission() -> None:
+    """concept:literal tag must carry only SortAdmission, with the golden DV CID."""
+    semantics = declaration()
+    literal_tags = [t for t in semantics["tags"] if t["op_cid"] == CONCEPT_LITERAL_CID]
+    assert len(literal_tags) == 1, "expected exactly one concept:literal tag"
+    literal_tag = literal_tags[0]
+    assert set(literal_tag["dimensions"]) == {"SortAdmission"}
+    golden_sort_admission_cid = GOLDEN_DIM_VALUE_CIDS[("SortAdmission", "FullPrimitiveTier")]
+    assert literal_tag["dimensions"]["SortAdmission"] == golden_sort_admission_cid
+    assert literal_tag["cid"] == GOLDEN_TAG_CIDS[CONCEPT_LITERAL_CID]
+
+
 def test_rpc_dispatch_platform_semantics() -> None:
     import sys
     from pathlib import Path
@@ -123,5 +149,5 @@ def test_rpc_dispatch_platform_semantics() -> None:
     result = response["result"]
     assert "tags" in result
     assert "dimension_values" in result
-    assert len(result["tags"]) == 12
-    assert len(result["dimension_values"]) == 5
+    assert len(result["tags"]) == 13
+    assert len(result["dimension_values"]) == 6


### PR DESCRIPTION
## Summary

- Adds a `concept:literal` tag to `provekit-realize-python-core` with a `SortAdmission` dimension.
- Python admission set: `{ Int, Float, String, Bool, Bytes, Null }` (full primitive tier).
- The `compare_to` formula uses `admits_sorts` with `IrTerm::Const` args sorted alphabetically by CID string value, per the `#1271` encoding spec.
- The `concept:literal` tag carries only `SortAdmission` (not the 5 operator-semantic dimensions).
- value_name is `"FullPrimitiveTier"` to match Java for cross-kit substrate uniformity: same admission set produces the same `DimensionValueMemento.cid`.

## Golden CIDs

- `DV ("SortAdmission", "FullPrimitiveTier")`: `blake3-512:cdec58a9736ce0d4efc81a73cde61e1776df742a67de9141e49cf6712ae580f948dc3ee7bfa136e7904cb6d579e50f9644845fe50f8d4ddfeb68902562f13f85`
- Tag CID for `concept:literal`: `blake3-512:5523f7d24d51ff0a0d8ac96798946e4bc1722a7d1936918f4b9477b2246bde112d24f8043680fd22a5272e39d5bedbb2acc2d17590f6ff7afae140dd523c361d`

## Test plan

- [x] `python -m pytest` in `provekit-realize-python-core`: 87 tests pass (includes new `test_concept_literal_has_sort_admission`)
- [x] RPC dispatch test updated: 13 tags, 6 dimension values
- [x] Golden CID assertions cover the new SortAdmission DV and concept:literal tag

Closes #1261 (Python kit portion)