### PR TITLE
feat(java-core): add SortAdmission for concept:literal (#1261)

### DIFF
--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/PlatformSemanticsDeclaration.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/PlatformSemanticsDeclaration.java
@@ -29,6 +29,27 @@ public final class PlatformSemanticsDeclaration {
 
     private static final String KIT_ID = "provekit-realize-java-core@0.1.0";
 
+    // concept:literal CID (from #1282)
+    private static final String CONCEPT_LITERAL_CID =
+        "blake3-512:02804a0bdbd2d5d541544451f41ee8d0d340baf28f70bd5abf5844e87a96aedd7b5ab3453962754a020679cc8c6b3d1f4cf0336a7ad8118128d42ac667abf2d6";
+
+    // Canonical sort CIDs (from #1282)
+    // Java admits: Int, Float, String, Bool, Bytes, Null (full primitive tier)
+    // Args sorted alphabetically by CID string value:
+    //   BOOL (0ee1...) < INT (30ff...) < NULL (62f6...) < BYTES (7116...) < FLOAT (b979...) < STRING (be87...)
+    private static final String SORT_BOOL_CID =
+        "blake3-512:0ee13bf3fd6b7ecfbee72dfbfc18a7c0ea7f1663de6cca43cefb36f5b4c03665452646094a7c296e819e75d683c6ce4821f3d7db3c3c78ae97f2d4e3451d2074";
+    private static final String SORT_INT_CID =
+        "blake3-512:30ffc51350121a7172f3e4064a33c45bbd345756979fccff6875cd2ab33e4964d098a99df80cfbdf1ec1a0738c5ac3476f0ff8f75589ea511d1acd82c74ecd58";
+    private static final String SORT_NULL_CID =
+        "blake3-512:62f6040bd3f414c1e6c2b7bdf276669cd5613b33cb508a81170170064ca3ffba771a4b0002dc52e059fce5f9f63a1874ef71bd4ec89ae06e89c87a3e91aac3b5";
+    private static final String SORT_BYTES_CID =
+        "blake3-512:7116ef6e62e6739b213a8394f975a53c771b89f08c36d27143827acfcfebc0e39e5b82c530be668c3cfd5ec6966ccaa42930b37fdb1f4ac25652a970be10fb6b";
+    private static final String SORT_FLOAT_CID =
+        "blake3-512:b979e70c4d5e53d9bdf13d6f08330be3c5b0714b8c770d69bbd05946b86c36df5274be8145a2683cc29c278155c9c1ee65b6897913524eecb9e4c89c71862f57";
+    private static final String SORT_STRING_CID =
+        "blake3-512:be8721d24849feb74c4721520bdba02d352a94f49253a627cd509127472aa1c47cbe99cb705cac4159b5365abcce0c9aaa4901fe67630827deb6be1f9daeea10";
+
     // Concept op CIDs (from provekit substrate hub)
     private static final String CONCEPT_ADD_CID =
         "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468";
@@ -79,6 +100,10 @@ public final class PlatformSemanticsDeclaration {
         DimValue logical = dimValue(kitCid, "ShiftMode", "Logical");
         DimValue throwArithEx = dimValue(kitCid, "NullSemantics", "ThrowArithmeticException");
         DimValue twosComplement = dimValue(kitCid, "BitwiseSemantics", "TwosComplement");
+        // concept:literal SortAdmission: Java admits full primitive tier (Int, Float, String, Bool, Bytes, Null).
+        // value_name "FullPrimitiveTier" matches Python for cross-kit substrate uniformity.
+        DimValue sortAdmission = dimValueAdmitsSorts(kitCid, "SortAdmission", "FullPrimitiveTier",
+            SORT_BOOL_CID, SORT_INT_CID, SORT_NULL_CID, SORT_BYTES_CID, SORT_FLOAT_CID, SORT_STRING_CID);
 
         // Build tags
         TagEntry addTag = tag(kitCid, CONCEPT_ADD_CID,
@@ -105,6 +130,9 @@ public final class PlatformSemanticsDeclaration {
             new String[]{"ShiftMode", logical.cid});
         TagEntry bitnotTag = tag(kitCid, CONCEPT_BITNOT_CID,
             new String[]{"BitwiseSemantics", twosComplement.cid});
+        // concept:literal tag: carries only the SortAdmission dimension
+        TagEntry literalTag = tag(kitCid, CONCEPT_LITERAL_CID,
+            new String[]{"SortAdmission", sortAdmission.cid});
 
         StringBuilder sb = new StringBuilder();
         sb.append("{\"tags\":[");
@@ -118,6 +146,7 @@ public final class PlatformSemanticsDeclaration {
         sb.append(','); appendTag(sb, shrTag);
         sb.append(','); appendTag(sb, ushrTag);
         sb.append(','); appendTag(sb, bitnotTag);
+        sb.append(','); appendTag(sb, literalTag);
         sb.append("],\"dimension_values\":[");
         appendDimValue(sb, wrapping);
         sb.append(','); appendDimValue(sb, truncate);
@@ -125,6 +154,7 @@ public final class PlatformSemanticsDeclaration {
         sb.append(','); appendDimValue(sb, logical);
         sb.append(','); appendDimValue(sb, throwArithEx);
         sb.append(','); appendDimValue(sb, twosComplement);
+        sb.append(','); appendDimValue(sb, sortAdmission);
         sb.append("]}");
         return sb.toString();
     }
@@ -162,6 +192,45 @@ public final class PlatformSemanticsDeclaration {
 
         // Full memento without cid + kit_cid for CID computation
         // JCS key order: compare_to < dimension_name < kind < schemaVersion < value_name
+        Value forCid = Value.object(
+            "compare_to", compareToVal,
+            "dimension_name", Value.string(dimensionName),
+            "kind", Value.string("platform-dimension-value"),
+            "schemaVersion", Value.string("1.0.0"),
+            "value_name", Value.string(valueName)
+        );
+
+        String cid = Jcs.blake3Cid(forCid);
+        return new DimValue(cid, kitCid, dimensionName, valueName, Jcs.encode(compareToVal));
+    }
+
+    // Construct a DimensionValueMemento for SortAdmission with an admits_sorts formula.
+    // compare_to = IrFormula::Atomic{name:"admits_sorts", args:[IrTerm::Const{kind:"const",sort:{kind:"primitive",name:"cid"},value:"<cid>"},...]}
+    // sortCids must already be sorted alphabetically by string value.
+    // JCS key order in IrTerm::Const: kind < sort < value (alphabetical)
+    // JCS key order in Sort::Primitive: kind < name (alphabetical)
+    // JCS key order in IrFormula::Atomic: args < kind < name (alphabetical)
+    private static DimValue dimValueAdmitsSorts(
+            String kitCid, String dimensionName, String valueName, String... sortCids) {
+        // Build args array
+        Value[] argValues = new Value[sortCids.length];
+        for (int i = 0; i < sortCids.length; i++) {
+            Value sortVal = Value.object(
+                "kind", Value.string("primitive"),
+                "name", Value.string("cid")
+            );
+            argValues[i] = Value.object(
+                "kind", Value.string("const"),
+                "sort", sortVal,
+                "value", Value.string(sortCids[i])
+            );
+        }
+        Value compareToVal = Value.object(
+            "args", Value.array(argValues),
+            "kind", Value.string("atomic"),
+            "name", Value.string("admits_sorts")
+        );
+
         Value forCid = Value.object(
             "compare_to", compareToVal,
             "dimension_name", Value.string(dimensionName),

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/RpcServerPlatformSemanticsTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/RpcServerPlatformSemanticsTest.java
@@ -17,6 +17,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class RpcServerPlatformSemanticsTest {
 
+    // Canonical concept:literal CID (from #1282)
+    private static final String CONCEPT_LITERAL_CID =
+        "blake3-512:02804a0bdbd2d5d541544451f41ee8d0d340baf28f70bd5abf5844e87a96aedd7b5ab3453962754a020679cc8c6b3d1f4cf0336a7ad8118128d42ac667abf2d6";
+
     // Golden dimension value CIDs (from Rust reference)
     private static final String CID_ARITHMETIC_OVERFLOW_WRAPPING =
         "blake3-512:a4aed351e390af2ca6b1076a8497aaba23717e09ebbb6354f30dc4c215d3250d50a35282f43eb520ed3dc8358541cb3edc33d728a10bdeff93fe1a05ba136569";
@@ -30,6 +34,10 @@ public class RpcServerPlatformSemanticsTest {
         "blake3-512:8c8ec297d6611af9634fe208bbcbae4ea65e12ebbdb290fa0aa044b0f3f21c796b674f0f113245c8cb4a39fcff2a2100c7435292b5fdf23eba6a2f34d4ead5cc";
     private static final String CID_BITWISE_SEMANTICS_TWOS_COMPLEMENT =
         "blake3-512:222818aea5033dc484fb3fa06d1c28a9f8693f7ff6cabcb73cee93ca6cff2598de137a4942203073e3ad6199a6609ebd149eb4d70c102a15c33a6a989c447e52";
+    // concept:literal SortAdmission: Java admits full primitive tier (Int, Float, String, Bool, Bytes, Null).
+    // DV CID matches Python ("FullPrimitiveTier", same admission set, kit_cid elided).
+    private static final String CID_SORT_ADMISSION_FULL_PRIMITIVE_TIER =
+        "blake3-512:cdec58a9736ce0d4efc81a73cde61e1776df742a67de9141e49cf6712ae580f948dc3ee7bfa136e7904cb6d579e50f9644845fe50f8d4ddfeb68902562f13f85";
 
     // Golden tag CIDs (from Rust reference)
     private static final String CID_TAG_ADD =
@@ -52,6 +60,9 @@ public class RpcServerPlatformSemanticsTest {
         "blake3-512:7693cb3b0eee68235f4845bb13408ee20847246f385608de1d0260bca6f23ad8974be005619db8228b2a2dc375fede9a554dee9df2b7929b5ceeadb6f2882228";
     private static final String CID_TAG_BITNOT =
         "blake3-512:6e2dd52738fdf5f8f6d78e7fa4c4f817b086e6946dfc3f4ddc8eb4540ae4bab7abb7361f5763951c30cadbf46bfd4aa720d24337351f778ea8b05369d3444cd6";
+    // concept:literal tag CID: matches Python (same DV CID, kit_cid elided, same op_cid)
+    private static final String CID_TAG_LITERAL =
+        "blake3-512:5523f7d24d51ff0a0d8ac96798946e4bc1722a7d1936918f4b9477b2246bde112d24f8043680fd22a5272e39d5bedbb2acc2d17590f6ff7afae140dd523c361d";
 
     @Test
     public void toJsonIsValidJson() {
@@ -64,17 +75,17 @@ public class RpcServerPlatformSemanticsTest {
     }
 
     @Test
-    public void toJsonContainsTenTags() {
+    public void toJsonContainsElevenTags() {
         Jcs.Json parsed = Jcs.parse(PlatformSemanticsDeclaration.toJson());
         Jcs.Arr tags = ((Jcs.Obj) parsed).arrayField("tags");
-        assertEquals(10, tags.values().size(), "expected 10 platform semantic tags");
+        assertEquals(11, tags.values().size(), "expected 11 platform semantic tags (10 operators + concept:literal)");
     }
 
     @Test
-    public void toJsonContainsSixDimensionValues() {
+    public void toJsonContainsSevenDimensionValues() {
         Jcs.Json parsed = Jcs.parse(PlatformSemanticsDeclaration.toJson());
         Jcs.Arr dimVals = ((Jcs.Obj) parsed).arrayField("dimension_values");
-        assertEquals(6, dimVals.values().size(), "expected 6 dimension values");
+        assertEquals(7, dimVals.values().size(), "expected 7 dimension values (6 original + SortAdmission)");
     }
 
     @Test
@@ -89,7 +100,8 @@ public class RpcServerPlatformSemanticsTest {
             new GoldenDimValue("ShiftMode",               "Arithmetic",               CID_SHIFT_MODE_ARITHMETIC),
             new GoldenDimValue("ShiftMode",               "Logical",                  CID_SHIFT_MODE_LOGICAL),
             new GoldenDimValue("NullSemantics",           "ThrowArithmeticException", CID_NULL_SEMANTICS_THROW_ARITHMETIC_EXCEPTION),
-            new GoldenDimValue("BitwiseSemantics",        "TwosComplement",           CID_BITWISE_SEMANTICS_TWOS_COMPLEMENT)
+            new GoldenDimValue("BitwiseSemantics",        "TwosComplement",           CID_BITWISE_SEMANTICS_TWOS_COMPLEMENT),
+            new GoldenDimValue("SortAdmission",           "FullPrimitiveTier",        CID_SORT_ADMISSION_FULL_PRIMITIVE_TIER)
         );
 
         assertEquals(goldens.size(), dimVals.values().size());
@@ -122,6 +134,8 @@ public class RpcServerPlatformSemanticsTest {
         String ushrOpCid   = "blake3-512:5746cb4f8bb8d713624731661de51e851e7ca65dae10a88bae4727d1e0070525be77e9919d90939264acaf4c093b00808862e6d0d2c24ac05262ce95cd67c8ad";
         String bitnotOpCid = "blake3-512:5e788f0d551081f4e709e4418e01017fa9ae1c04963e7be2862fadad8a8434fafa204629fbec53e2e44624c195ac2e32c0410df25cf8ff3a4be672582f89109f";
 
+        String literalOpCid = CONCEPT_LITERAL_CID;
+
         record GoldenTag(String opCid, String expectedCid) {}
         List<GoldenTag> goldens = List.of(
             new GoldenTag(addOpCid,    CID_TAG_ADD),
@@ -133,7 +147,8 @@ public class RpcServerPlatformSemanticsTest {
             new GoldenTag(shlOpCid,    CID_TAG_SHL),
             new GoldenTag(shrOpCid,    CID_TAG_SHR),
             new GoldenTag(ushrOpCid,   CID_TAG_USHR),
-            new GoldenTag(bitnotOpCid, CID_TAG_BITNOT)
+            new GoldenTag(bitnotOpCid, CID_TAG_BITNOT),
+            new GoldenTag(literalOpCid, CID_TAG_LITERAL)
         );
 
         assertEquals(goldens.size(), tags.values().size());
@@ -158,20 +173,51 @@ public class RpcServerPlatformSemanticsTest {
 
     @Test
     public void compareToIrFormulaAtomicShape() {
-        // Each dimension value's compare_to must be {args:[], kind:"atomic", name:"java:X"}
+        // Operator dimension values: compare_to is {args:[], kind:"atomic", name:"java:X"}
+        // SortAdmission: compare_to is {args:[...], kind:"atomic", name:"admits_sorts"}
         Jcs.Json parsed = Jcs.parse(PlatformSemanticsDeclaration.toJson());
         Jcs.Arr dimVals = ((Jcs.Obj) parsed).arrayField("dimension_values");
         for (Jcs.Json val : dimVals.values()) {
             Jcs.Obj obj = (Jcs.Obj) val;
+            String dimensionName = obj.stringField("dimension_name");
             Jcs.Obj compareTo = obj.objectField("compare_to");
             assertEquals("atomic", compareTo.stringField("kind"),
-                "compare_to.kind must be 'atomic'");
-            Jcs.Arr args = compareTo.arrayField("args");
-            assertTrue(args.isEmpty(), "compare_to.args must be empty");
+                "compare_to.kind must be 'atomic' for " + dimensionName);
             String name = compareTo.stringField("name");
-            assertTrue(name.startsWith("java:"),
-                "compare_to.name must start with 'java:' but was: " + name);
+            if ("SortAdmission".equals(dimensionName)) {
+                assertEquals("admits_sorts", name,
+                    "SortAdmission compare_to.name must be 'admits_sorts'");
+                Jcs.Arr args = compareTo.arrayField("args");
+                assertFalse(args.isEmpty(), "SortAdmission compare_to.args must not be empty");
+            } else {
+                Jcs.Arr args = compareTo.arrayField("args");
+                assertTrue(args.isEmpty(), "compare_to.args must be empty for " + dimensionName);
+                assertTrue(name.startsWith("java:"),
+                    "compare_to.name must start with 'java:' but was: " + name);
+            }
         }
+    }
+
+    @Test
+    public void conceptLiteralTagHasSortAdmissionOnly() {
+        Jcs.Json parsed = Jcs.parse(PlatformSemanticsDeclaration.toJson());
+        Jcs.Arr tags = ((Jcs.Obj) parsed).arrayField("tags");
+        Jcs.Obj literalTag = null;
+        for (Jcs.Json t : tags.values()) {
+            Jcs.Obj tagObj = (Jcs.Obj) t;
+            if (CONCEPT_LITERAL_CID.equals(tagObj.stringField("op_cid"))) {
+                literalTag = tagObj;
+                break;
+            }
+        }
+        assertNotNull(literalTag, "concept:literal tag must be present");
+        Jcs.Obj dims = literalTag.objectField("dimensions");
+        // Must have exactly one dimension: SortAdmission
+        assertEquals(CID_SORT_ADMISSION_FULL_PRIMITIVE_TIER,
+            dims.stringField("SortAdmission"),
+            "concept:literal SortAdmission must equal golden CID");
+        assertEquals(CID_TAG_LITERAL, literalTag.stringField("cid"),
+            "concept:literal tag CID must equal golden CID");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds a `concept:literal` tag to `provekit-realize-java-core` with a `SortAdmission` dimension.
- Java admission set: `{ Int, Float, String, Bool, Bytes, Null }` (full primitive tier).
- The `compare_to` formula uses `admits_sorts` with `IrTerm::Const` args sorted alphabetically by CID string value, per the `#1271` encoding spec.
- The `concept:literal` tag carries only `SortAdmission` (not the 6 operator-semantic dimensions).
- value_name is `"FullPrimitiveTier"` to match Python for cross-kit substrate uniformity: same admission set with `kit_cid` elided means Java and Python produce the same `DimensionValueMemento.cid` AND the same tag CID for `concept:literal`.

## Substrate uniformity verified

- `DV ("SortAdmission", "FullPrimitiveTier")` CID: `blake3-512:cdec58a...` (matches Python PR #1286)
- Tag CID for `concept:literal`: `blake3-512:5523f7d...` (matches Python PR #1286)

## Test plan

- [x] `mvn -pl provekit-lift-java-source,provekit-realize-java-core -am -DskipTests package` builds successfully
- [x] Test file updated: 11 tags, 7 dimension values, new `conceptLiteralTagHasSortAdmissionOnly` test
- [x] `compareToIrFormulaAtomicShape` updated to handle `SortAdmission` (admits_sorts formula) separately

Closes #1261 (Java kit portion)