### PR TITLE
feat(typescript-core): add SortAdmission for concept:literal (#1261)

### DIFF
--- a/implementations/typescript/provekit-realize-typescript-core/src/platform_semantics.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/platform_semantics.js
@@ -28,6 +28,17 @@ const KIT_CID = "blake3-512:" + _hexOf(blake3(
   { dkLen: 64 }
 ));
 
+// concept:literal CID (from #1282)
+const CONCEPT_LITERAL_CID = "blake3-512:02804a0bdbd2d5d541544451f41ee8d0d340baf28f70bd5abf5844e87a96aedd7b5ab3453962754a020679cc8c6b3d1f4cf0336a7ad8118128d42ac667abf2d6";
+
+// Canonical sort CIDs (from #1282)
+// TypeScript admits: Float, String, Bool, Null (JS Number is IEEE 754 double; no Int or Bytes at language level)
+// Args sorted alphabetically by CID string: BOOL (0ee1) < NULL (62f6) < FLOAT (b979) < STRING (be87)
+const SORT_BOOL_CID   = "blake3-512:0ee13bf3fd6b7ecfbee72dfbfc18a7c0ea7f1663de6cca43cefb36f5b4c03665452646094a7c296e819e75d683c6ce4821f3d7db3c3c78ae97f2d4e3451d2074";
+const SORT_NULL_CID   = "blake3-512:62f6040bd3f414c1e6c2b7bdf276669cd5613b33cb508a81170170064ca3ffba771a4b0002dc52e059fce5f9f63a1874ef71bd4ec89ae06e89c87a3e91aac3b5";
+const SORT_FLOAT_CID  = "blake3-512:b979e70c4d5e53d9bdf13d6f08330be3c5b0714b8c770d69bbd05946b86c36df5274be8145a2683cc29c278155c9c1ee65b6897913524eecb9e4c89c71862f57";
+const SORT_STRING_CID = "blake3-512:be8721d24849feb74c4721520bdba02d352a94f49253a627cd509127472aa1c47cbe99cb705cac4159b5365abcce0c9aaa4901fe67630827deb6be1f9daeea10";
+
 // Concept-op CIDs shared across all language kits (cross-kit hub CIDs).
 // Source of truth: menagerie/concept-shapes/cids.tsv.
 const OP_ADD    = "blake3-512:398980644a46039b0c2875ab36ccb61f52f284ccad5481593305ed3f10efe91e7863c00a3f2d673644430f691e6b5354f5d65f9da4fa23acdb13dc58f5b438f9";
@@ -80,6 +91,8 @@ function declaration() {
     _tag(OP_BITOR,  { BitwiseSemantics: dimCids.BitwiseSemantics }),
     _tag(OP_BITXOR, { BitwiseSemantics: dimCids.BitwiseSemantics }),
     _tag(OP_BITNOT, { BitwiseSemantics: dimCids.BitwiseSemantics }),
+    // concept:literal: only SortAdmission (Float, String, Bool, Null)
+    _tag(CONCEPT_LITERAL_CID, { SortAdmission: dimCids.SortAdmission }),
   ];
 
   _cached = { tags, dimension_values: dimValues };
@@ -99,6 +112,13 @@ function dimensionValues() {
     _dimValue("ShiftMode", "Int32Wrapping"),
     // BitwiseSemantics: bitwise operands are coerced to Int32 via ToInt32 algorithm
     _dimValue("BitwiseSemantics", "Int32"),
+    // concept:literal SortAdmission: TS admits Float, String, Bool, Null (no Int, no Bytes)
+    _dimValueAdmitsSorts("SortAdmission", "JsValueTier", [
+      SORT_BOOL_CID,   // 0ee1...
+      SORT_NULL_CID,   // 62f6...
+      SORT_FLOAT_CID,  // b979...
+      SORT_STRING_CID, // be87...
+    ]),
   ];
 }
 
@@ -106,6 +126,33 @@ function dimensionValues() {
 
 function _dimValue(dimensionName, valueName) {
   const compareTo = { kind: "atomic", name: `typescript:${valueName}`, args: [] };
+  const forCid = {
+    compare_to: compareTo,
+    dimension_name: dimensionName,
+    kind: "platform-dimension-value",
+    schemaVersion: "1.0.0",
+    value_name: valueName,
+  };
+  return {
+    compare_to: compareTo,
+    dimension_name: dimensionName,
+    kind: "platform-dimension-value",
+    kit_cid: KIT_CID,
+    schemaVersion: "1.0.0",
+    value_name: valueName,
+    cid: _cidOf(forCid),
+  };
+}
+
+// Build a DimensionValueMemento for an admits_sorts formula.
+// sortedCids must be pre-sorted alphabetically by CID string value.
+function _dimValueAdmitsSorts(dimensionName, valueName, sortedCids) {
+  const args = sortedCids.map((cid) => ({
+    kind: "const",
+    sort: { kind: "primitive", name: "cid" },
+    value: cid,
+  }));
+  const compareTo = { args, kind: "atomic", name: "admits_sorts" };
   const forCid = {
     compare_to: compareTo,
     dimension_name: dimensionName,
@@ -164,4 +211,4 @@ function _hexOf(bytes) {
   return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-module.exports = { declaration, dimensionValues, KIT_CID };
+module.exports = { declaration, dimensionValues, KIT_CID, CONCEPT_LITERAL_CID };

--- a/implementations/typescript/provekit-realize-typescript-core/tests/platform_semantics.test.js
+++ b/implementations/typescript/provekit-realize-typescript-core/tests/platform_semantics.test.js
@@ -3,7 +3,7 @@
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 
-const { declaration, dimensionValues } = require("../src/platform_semantics");
+const { declaration, dimensionValues, CONCEPT_LITERAL_CID } = require("../src/platform_semantics");
 const { dispatch } = require("../src/rpc");
 
 // Golden CIDs for dimension values (kit_cid elided per substrate spec).
@@ -14,7 +14,14 @@ const GOLDEN_DIM_VALUE_CIDS = {
   NullSemantics:            "blake3-512:2b6e67a5513cc768b1c59b9fdbf7fb7ef3f7d12235a4b8c1cd63fcbc52b0c23a8e43b88cbd3bd4c730f2f5f40751d3f1b8c6ba12f3c1307b7a0ff81f593d492f",
   ShiftMode:                "blake3-512:31de26cc4a328f4a3817d5b9587fa67c0cc30b07e1109113e6727f5a553afb0e1f1dc8f01d10cec210f3c04956df2b062c4a127612d535cdbb018ecf4531f5fa",
   BitwiseSemantics:         "blake3-512:de3c71b070d8e228ad2699a0013f95c4ec18a638a1b1e8c5d406737dddde297b738c38eed094f99d8d512ba1f9255ecac911191134f5bea228f68bb4cddde78a",
+  // concept:literal SortAdmission: TS admits Float, String, Bool, Null (no Int, no Bytes)
+  // value_name "JsValueTier" -- TS-specific, no cross-kit equivalence claim
+  SortAdmission:            "blake3-512:91bcbfd2eb398a5dbc614e4cb12595d59f750b752586e2f381e1c17e5e5e392f7884b9171f9cf3c753d9256c1621682bac07f119382509a72cc690619681d274",
 };
+
+// Golden concept:literal tag CID
+const GOLDEN_CONCEPT_LITERAL_TAG_CID =
+  "blake3-512:229156b2e5d513191b6a8acb1b26a7b00b11818e79d763403ce955f0e14024f4ca75814957be03a76830bb7fe6e473e5a9d98fd2996670745f3eb1cf3a2a565c";
 
 const EXPECTED_DIMENSIONS = {
   ArithmeticOverflow:      "Ieee754Saturate",
@@ -22,6 +29,7 @@ const EXPECTED_DIMENSIONS = {
   NullSemantics:           "ReturnsNanOrInfinity",
   ShiftMode:               "Int32Wrapping",
   BitwiseSemantics:        "Int32",
+  SortAdmission:           "JsValueTier",
 };
 
 // Positive: declaration is non-empty
@@ -78,14 +86,42 @@ test("ts_arithmetic_overflow_differs_from_python", () => {
   );
 });
 
-// Structural: compare_to for each dimension value is a proper atomic formula
+// Structural: compare_to for each dimension value is a proper atomic formula.
+// SortAdmission uses admits_sorts (not typescript:X) with non-empty CID args.
 test("ts_dimension_value_compare_to_shapes", () => {
   const dvs = dimensionValues();
   for (const dv of dvs) {
     assert.strictEqual(dv.compare_to.kind, "atomic");
-    assert.ok(dv.compare_to.name.startsWith("typescript:"), `compare_to.name must be 'typescript:...'`);
-    assert.deepStrictEqual(dv.compare_to.args, []);
+    if (dv.dimension_name === "SortAdmission") {
+      assert.strictEqual(dv.compare_to.name, "admits_sorts");
+      assert.ok(dv.compare_to.args.length > 0, "SortAdmission args must not be empty");
+      for (const arg of dv.compare_to.args) {
+        assert.strictEqual(arg.kind, "const");
+        assert.strictEqual(arg.sort.kind, "primitive");
+        assert.strictEqual(arg.sort.name, "cid");
+        assert.ok(arg.value.startsWith("blake3-512:"));
+      }
+    } else {
+      assert.ok(dv.compare_to.name.startsWith("typescript:"), `compare_to.name must be 'typescript:...'`);
+      assert.deepStrictEqual(dv.compare_to.args, []);
+    }
   }
+});
+
+// Positive: concept:literal tag has only SortAdmission dimension
+test("ts_concept_literal_has_sort_admission_only", () => {
+  const decl = declaration();
+  const literalTags = decl.tags.filter((t) => t.op_cid === CONCEPT_LITERAL_CID);
+  assert.strictEqual(literalTags.length, 1, "expected exactly one concept:literal tag");
+  const literalTag = literalTags[0];
+  const dimKeys = Object.keys(literalTag.dimensions);
+  assert.deepStrictEqual(dimKeys, ["SortAdmission"], "concept:literal must have only SortAdmission");
+  assert.strictEqual(
+    literalTag.dimensions.SortAdmission,
+    GOLDEN_DIM_VALUE_CIDS.SortAdmission,
+    "SortAdmission CID must match golden"
+  );
+  assert.strictEqual(literalTag.cid, GOLDEN_CONCEPT_LITERAL_TAG_CID, "tag CID must match golden");
 });
 
 // Positive: RPC dispatch returns correct shape for platform_semantics


### PR DESCRIPTION
## Summary

- Adds a `concept:literal` tag to `provekit-realize-typescript-core` with a `SortAdmission` dimension.
- TypeScript admission set: `{ Float, String, Bool, Null }` (no Int: JS `Number` is IEEE 754 double only; no Bytes: no native byte array literal type at the language level).
- The `compare_to` formula uses `admits_sorts` with `IrTerm::Const` args sorted alphabetically by CID string value, per the `#1271` encoding spec.
- value_name is `"JsValueTier"` (TS-specific; no cross-kit equivalence claim since the admission set differs from Java and Python).
- The `concept:literal` tag carries only `SortAdmission`.

## Golden CIDs

- `DV ("SortAdmission", "JsValueTier")`: `blake3-512:91bcbfd2eb398a5dbc614e4cb12595d59f750b752586e2f381e1c17e5e5e392f7884b9171f9cf3c753d9256c1621682bac07f119382509a72cc690619681d274`
- Tag CID for `concept:literal`: `blake3-512:229156b2e5d513191b6a8acb1b26a7b00b11818e79d763403ce955f0e14024f4ca75814957be03a76830bb7fe6e473e5a9d98fd2996670745f3eb1cf3a2a565c`

## Test plan

- [x] `node --test tests/platform_semantics.test.js`: 8 tests pass (includes new `ts_concept_literal_has_sort_admission_only`)
- [x] `ts_dimension_value_compare_to_shapes` updated to handle `SortAdmission` (admits_sorts formula) separately
- [x] Golden CID assertions cover the new SortAdmission DV and concept:literal tag

Closes #1261 (TypeScript core kit portion)