### PR TITLE
[codex] fix trinity CI and platform semantics loading

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
@@ -25,12 +25,16 @@ import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ForLoopTree;
 import com.sun.source.tree.IfTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.tree.WhileLoopTree;
 import com.sun.source.util.JavacTask;
@@ -202,7 +206,8 @@ public final class JavaBindLifter {
                 }
             }
 
-            Jcs.Obj termShape = shapeOfStatement(method.getBody());
+            ShapeResult shapeResult = shapeOfStatement(method.getBody());
+            Jcs.Json termShape = shapeResult.shape();
             String termShapeCid = Jcs.cid(termShape);
 
             String conceptAnnotation = extractConceptAnnotation(source, fnLine);
@@ -239,9 +244,11 @@ public final class JavaBindLifter {
                 "fn_line", Jcs.integer(fnLine),
                 "fn_name", Jcs.string(fnName),
                 "kind", Jcs.string("bind-lift-entry"),
+                "operand_bindings", Jcs.array(shapeResult.operandBindings()),
                 "param_names", Jcs.array(paramNames),
                 "param_types", Jcs.array(paramTypes),
                 "return_type", Jcs.string(returnType),
+                "source_function_name", Jcs.string(fnName),
                 "term_shape", termShape,
                 "term_shape_cid", Jcs.string(termShapeCid),
                 "witnesses", Jcs.array(surfaceWitnesses)
@@ -258,86 +265,147 @@ public final class JavaBindLifter {
     // `walk_rpc.rs::term_shape_for_fn` and `cmd_bind::TermShape::from_fn` on
     // the Rust side; same shape, same JCS bytes, same shape_cid.
 
-    private static Jcs.Obj shapeOfStatement(StatementTree stmt) {
-        if (stmt == null) return Jcs.object("kind", Jcs.string("opaque"));
+    private static ShapeResult shapeOfStatement(StatementTree stmt) {
+        if (stmt == null) return ShapeResult.empty();
         if (stmt instanceof BlockTree b) {
-            List<Jcs.Json> ss = new ArrayList<>();
-            for (StatementTree s : b.getStatements()) ss.add(shapeOfStatement(s));
-            return Jcs.object("kind", Jcs.string("body"), "stmts", Jcs.array(ss));
+            List<ShapeResult> children = new ArrayList<>();
+            for (StatementTree s : b.getStatements()) {
+                ShapeResult child = shapeOfStatement(s);
+                if (hasOperatorIdentity(child.shape()) || !child.operandBindings().isEmpty()) {
+                    children.add(child);
+                }
+            }
+            return operatorShapeResult("concept:seq", children);
         }
         if (stmt instanceof IfTree t) {
-            Jcs.Obj o = Jcs.object(
-                "cond", shapeOfExpression(t.getCondition()),
-                "kind", Jcs.string("if"),
-                "then", shapeOfStatement(t.getThenStatement())
-            );
-            if (t.getElseStatement() != null) {
-                o = withField(o, "else", shapeOfStatement(t.getElseStatement()));
-            }
-            return o;
+            List<ShapeResult> args = new ArrayList<>();
+            args.add(shapeOfExpression(t.getCondition()));
+            args.add(shapeOfStatement(t.getThenStatement()));
+            args.add(t.getElseStatement() == null ? operatorShapeResult("concept:skip", List.of()) : shapeOfStatement(t.getElseStatement()));
+            return operatorShapeResult("concept:conditional", args);
         }
-        if (stmt instanceof WhileLoopTree t) {
-            return Jcs.object(
-                "body", shapeOfStatement(t.getStatement()),
-                "cond", shapeOfExpression(t.getCondition()),
-                "kind", Jcs.string("while")
-            );
+        if (stmt instanceof ReturnTree t) {
+            if (t.getExpression() == null) return operatorShapeResult("concept:return", List.of());
+            return operatorShapeResult("concept:return", List.of(shapeOfExpression(t.getExpression())));
         }
-        if (stmt instanceof DoWhileLoopTree t) {
-            return Jcs.object(
-                "body", shapeOfStatement(t.getStatement()),
-                "cond", shapeOfExpression(t.getCondition()),
-                "kind", Jcs.string("while")
-            );
+        if (stmt instanceof VariableTree t) {
+            ShapeResult target = leafBinding(t.getName().toString());
+            ShapeResult init = t.getInitializer() == null ? literalShape(0) : shapeOfExpression(t.getInitializer());
+            return operatorShapeResult("concept:assign", List.of(target, init));
         }
-        if (stmt instanceof ForLoopTree t) {
-            return Jcs.object(
-                "body", shapeOfStatement(t.getStatement()),
-                "kind", Jcs.string("for")
-            );
-        }
-        if (stmt instanceof EnhancedForLoopTree t) {
-            return Jcs.object(
-                "body", shapeOfStatement(t.getStatement()),
-                "kind", Jcs.string("for")
-            );
-        }
-        if (stmt instanceof ReturnTree) return Jcs.object("kind", Jcs.string("exit"));
-        if (stmt instanceof com.sun.source.tree.BreakTree) return Jcs.object("kind", Jcs.string("exit"));
-        if (stmt instanceof com.sun.source.tree.ContinueTree) return Jcs.object("kind", Jcs.string("exit"));
-        if (stmt instanceof VariableTree) return Jcs.object("kind", Jcs.string("let"));
         if (stmt instanceof ExpressionStatementTree es) return shapeOfExpression(es.getExpression());
-        return Jcs.object("kind", Jcs.string("opaque"));
+        if (stmt instanceof com.sun.source.tree.BreakTree || stmt instanceof com.sun.source.tree.ContinueTree) {
+            return operatorShapeResult("concept:skip", List.of());
+        }
+        if (stmt instanceof WhileLoopTree || stmt instanceof DoWhileLoopTree || stmt instanceof ForLoopTree || stmt instanceof EnhancedForLoopTree) {
+            return ShapeResult.empty();
+        }
+        return ShapeResult.empty();
     }
 
-    private static Jcs.Obj shapeOfExpression(Tree expr) {
-        if (expr == null) return Jcs.object("kind", Jcs.string("opaque"));
-        if (expr instanceof AssignmentTree) return Jcs.object("kind", Jcs.string("assign"));
-        if (expr instanceof CompoundAssignmentTree) return Jcs.object("kind", Jcs.string("assign"));
-        if (expr instanceof BinaryTree b) {
-            String op = switch (b.getKind()) {
-                case PLUS -> "+";
-                case MINUS -> "-";
-                case MULTIPLY -> "*";
-                case DIVIDE -> "/";
-                case REMAINDER -> "%";
-                case EQUAL_TO -> "==";
-                case NOT_EQUAL_TO -> "!=";
-                case LESS_THAN -> "<";
-                case LESS_THAN_EQUAL -> "<=";
-                case GREATER_THAN -> ">";
-                case GREATER_THAN_EQUAL -> ">=";
-                default -> "opaque-op";
-            };
-            boolean isRel = switch (op) {
-                case "==", "!=", "<", "<=", ">", ">=" -> true;
-                default -> false;
-            };
-            return Jcs.object("kind", Jcs.string(isRel ? "rel" : "bin"), "op", Jcs.string(op));
+    private static ShapeResult shapeOfExpression(Tree expr) {
+        if (expr == null) return ShapeResult.empty();
+        if (expr instanceof ParenthesizedTree t) return shapeOfExpression(t.getExpression());
+        if (expr instanceof TypeCastTree t) return shapeOfExpression(t.getExpression());
+        if (expr instanceof AssignmentTree t) {
+            return operatorShapeResult("concept:assign", List.of(ShapeResult.empty(), shapeOfExpression(t.getExpression())));
         }
-        if (expr instanceof MethodInvocationTree) return Jcs.object("kind", Jcs.string("call"));
-        if (expr instanceof NewClassTree) return Jcs.object("kind", Jcs.string("call"));
-        return Jcs.object("kind", Jcs.string("opaque"));
+        if (expr instanceof CompoundAssignmentTree t) {
+            return operatorShapeResult("concept:assign", List.of(ShapeResult.empty(), shapeOfExpression(t.getExpression())));
+        }
+        if (expr instanceof BinaryTree b) {
+            String concept = switch (b.getKind()) {
+                case PLUS -> "concept:add";
+                case MINUS -> "concept:sub";
+                case MULTIPLY -> "concept:mul";
+                case DIVIDE -> "concept:div";
+                case REMAINDER -> "concept:mod";
+                case EQUAL_TO -> "concept:eq";
+                case NOT_EQUAL_TO -> "concept:ne";
+                case LESS_THAN -> "concept:lt";
+                case LESS_THAN_EQUAL -> "concept:le";
+                case GREATER_THAN -> "concept:gt";
+                case GREATER_THAN_EQUAL -> "concept:ge";
+                default -> "";
+            };
+            if (!concept.isEmpty()) {
+                return operatorShapeResult(concept, List.of(
+                    shapeOfExpression(b.getLeftOperand()),
+                    shapeOfExpression(b.getRightOperand())
+                ));
+            }
+        }
+        if (expr instanceof IdentifierTree t) return leafBinding(t.getName().toString());
+        if (expr instanceof LiteralTree t) return literalShape(t.getValue());
+        if (expr instanceof MethodInvocationTree || expr instanceof NewClassTree) return ShapeResult.empty();
+        return ShapeResult.empty();
+    }
+
+    private static ShapeResult operatorShapeResult(String conceptName, List<ShapeResult> args) {
+        String opCid = conceptCidForName(conceptName);
+        if (opCid == null || opCid.isBlank()) return ShapeResult.empty();
+        List<Jcs.Json> argShapes = args.stream().map(ShapeResult::shape).toList();
+        List<Jcs.Json> bindings = new ArrayList<>();
+        for (int i = 0; i < args.size(); i++) {
+            for (Jcs.Json binding : args.get(i).operandBindings()) {
+                bindings.add(prefixBinding(binding, i));
+            }
+        }
+        return new ShapeResult(
+            Jcs.object(
+                "args", Jcs.array(argShapes),
+                "concept_name", Jcs.string(conceptName),
+                "op_cid", Jcs.string(opCid)
+            ),
+            bindings
+        );
+    }
+
+    private static ShapeResult leafBinding(String symbol) {
+        return new ShapeResult(
+            Jcs.object(),
+            List.of(Jcs.object(
+                "position", Jcs.array(),
+                "symbol", Jcs.string(symbol)
+            ))
+        );
+    }
+
+    private static ShapeResult literalShape(Object value) {
+        Jcs.Json literal;
+        if (value == null) {
+            literal = Jcs.object("kind", Jcs.string("literal"), "value", Jcs.nullValue());
+        } else if (value instanceof Boolean b) {
+            literal = Jcs.object("kind", Jcs.string("literal"), "value", Jcs.bool(b));
+        } else if (value instanceof Number n) {
+            literal = Jcs.object("kind", Jcs.string("literal"), "value", Jcs.integer(n.longValue()));
+        } else if (value instanceof String s) {
+            literal = Jcs.object("kind", Jcs.string("literal"), "value", Jcs.string(s));
+        } else {
+            literal = Jcs.object();
+        }
+        return new ShapeResult(literal, List.of());
+    }
+
+    private static Jcs.Json prefixBinding(Jcs.Json binding, int prefix) {
+        if (!(binding instanceof Jcs.Obj obj)) return binding;
+        Jcs.Json rawPosition = obj.get("position");
+        String symbol = obj.stringFieldOrNull("symbol");
+        if (!(rawPosition instanceof Jcs.Arr position) || symbol == null) return binding;
+        List<Jcs.Json> prefixed = new ArrayList<>();
+        prefixed.add(Jcs.integer(prefix));
+        prefixed.addAll(position.values());
+        return Jcs.object(
+            "position", Jcs.array(prefixed),
+            "symbol", Jcs.string(symbol)
+        );
+    }
+
+    private static boolean hasOperatorIdentity(Jcs.Json value) {
+        if (value instanceof Jcs.Obj obj) {
+            return obj.stringFieldOrNull("concept_name") != null || obj.stringFieldOrNull("op_cid") != null;
+        }
+        return false;
     }
 
     // ---- Concept annotation extraction -------------------------------------
@@ -824,12 +892,23 @@ public final class JavaBindLifter {
                 if (!validCid(shapeCid) || !(mementoJson instanceof Jcs.Obj memento)) continue;
                 String operationKind = catalogOperationKind(name, memento);
                 if (operationKind != null && !operationKind.isBlank()) {
-                    catalog.put(cid, new CatalogEntry(shapeCid, operationKind));
+                    catalog.put(cid, new CatalogEntry(name, shapeCid, operationKind));
                 }
             } catch (IOException | IllegalArgumentException ignored) {
             }
         }
         return catalog;
+    }
+
+    private static String conceptCidForName(String conceptName) {
+        Map<String, CatalogEntry> catalog = conceptShapeCatalog();
+        if (catalog == null) return null;
+        for (Map.Entry<String, CatalogEntry> entry : catalog.entrySet()) {
+            if (conceptName.equals(entry.getValue().name())) {
+                return entry.getKey();
+            }
+        }
+        return null;
     }
 
     private static String catalogOperationKind(String name, Jcs.Obj memento) {
@@ -1039,7 +1118,13 @@ public final class JavaBindLifter {
         }
     }
 
-    private record CatalogEntry(String shapeCid, String operationKind) {}
+    private record ShapeResult(Jcs.Json shape, List<Jcs.Json> operandBindings) {
+        static ShapeResult empty() {
+            return new ShapeResult(Jcs.object(), List.of());
+        }
+    }
+
+    private record CatalogEntry(String name, String shapeCid, String operationKind) {}
 
     private record TagLine(int line, String key, String value) {}
 

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/TrinityRoundtripLiftTest.java
@@ -368,6 +368,33 @@ class TrinityRoundtripLiftTest {
     }
 
     @Test
+    void bindLifterKeepsOperatorsInsideLocalInitializersForTrinityRelift() {
+        String source = """
+            final class ComputeSumTransported {
+                // concept: UNNAMED-CONCEPT-1
+                public static int compute_sum(int a, int b) {
+                    int total = (a) + (b);
+                    int scaled = (total) * (2);
+                    int reduced = (scaled) - (1);
+                    return reduced;
+                }
+            }
+            """;
+
+        JavaBindLifter.Result lift = new JavaBindLifter().liftPathsFromSource("ComputeSum.java", source);
+        String encoded = Jcs.encode(lift.toJson());
+
+        assertEquals(1, lift.entries().size(), encoded);
+        assertTrue(encoded.contains("\"concept_name\":\"concept:assign\""), encoded);
+        assertTrue(encoded.contains("\"concept_name\":\"concept:add\""), encoded);
+        assertTrue(encoded.contains("\"concept_name\":\"concept:mul\""), encoded);
+        assertTrue(encoded.contains("\"concept_name\":\"concept:sub\""), encoded);
+        assertTrue(encoded.contains("\"operand_bindings\""), encoded);
+        assertTrue(encoded.contains("\"source_function_name\":\"compute_sum\""), encoded);
+        assertTrue(encoded.contains("\"symbol\":\"reduced\""), encoded);
+    }
+
+    @Test
     void test_concept_citation_relift_recovers_identity() {
         Jcs.Obj payload = conceptCitationPayload(ARGS_JCS_CID, "1", CONCEPT_SKIP_CID, "skip");
         String source = conceptTaggedSource(payload, Jcs.cid(payload));

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/JsonUtil.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/JsonUtil.java
@@ -125,6 +125,19 @@ final class JsonUtil {
         return extractObjectAt(json, pos);
     }
 
+    static String extractArrayField(String json, String field) {
+        String key = "\"" + field + "\"";
+        int ki = json.indexOf(key);
+        if (ki < 0) return "[]";
+        int pos = ki + key.length();
+        while (pos < json.length()
+            && (json.charAt(pos) == ':' || json.charAt(pos) == ' ' || json.charAt(pos) == '\t')) {
+            pos++;
+        }
+        if (pos >= json.length() || json.charAt(pos) != '[') return "[]";
+        return extractArrayAt(json, pos);
+    }
+
     private static String extractObjectAt(String json, int pos) {
         if (pos >= json.length() || json.charAt(pos) != '{') return "{}";
         int depth = 0;
@@ -133,6 +146,30 @@ final class JsonUtil {
             char c = json.charAt(pos);
             if (c == '{') depth++;
             else if (c == '}') {
+                depth--;
+                if (depth == 0) { pos++; break; }
+            } else if (c == '"') {
+                pos++;
+                while (pos < json.length()) {
+                    char sc = json.charAt(pos);
+                    if (sc == '\\') { pos += 2; continue; }
+                    if (sc == '"') break;
+                    pos++;
+                }
+            }
+            pos++;
+        }
+        return json.substring(start, pos);
+    }
+
+    private static String extractArrayAt(String json, int pos) {
+        if (pos >= json.length() || json.charAt(pos) != '[') return "[]";
+        int depth = 0;
+        int start = pos;
+        while (pos < json.length()) {
+            char c = json.charAt(pos);
+            if (c == '[') depth++;
+            else if (c == ']') {
                 depth--;
                 if (depth == 0) { pos++; break; }
             } else if (c == '"') {

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -88,6 +88,11 @@ public final class RpcServer {
         // Extract the inner params object to avoid ambiguity with the RPC "params" key.
         String paramsObj = JsonUtil.extractParamsObject(line);
         String function = JsonUtil.decodeJsonStringField(paramsObj, "function");
+        String sourceFunctionName = JsonUtil.decodeJsonStringField(paramsObj, "source_function_name");
+        if (sourceFunctionName.isBlank()) {
+            sourceFunctionName = JsonUtil.decodeJsonStringField(paramsObj, "sourceFunctionName");
+        }
+        String emittedFunction = sourceFunctionName.isBlank() ? function : sourceFunctionName;
         String returnType = JsonUtil.decodeJsonStringField(paramsObj, "return_type");
         String conceptName = JsonUtil.decodeJsonStringField(paramsObj, "concept_name");
         String mode = JsonUtil.decodeJsonStringField(paramsObj, "mode");
@@ -101,11 +106,19 @@ public final class RpcServer {
             }
             transportedOp = TransportedOperation.fromNamedTermTree(namedTermTree);
         }
+        String termShape = JsonUtil.extractObjectField(paramsObj, "term_shape");
+        if ("{}".equals(termShape)) {
+            termShape = JsonUtil.extractObjectField(paramsObj, "termShape");
+        }
+        String operandBindings = JsonUtil.extractArrayField(paramsObj, "operand_bindings");
+        if ("[]".equals(operandBindings)) {
+            operandBindings = JsonUtil.extractArrayField(paramsObj, "operandBindings");
+        }
         List<String> sugarPlugins = JsonUtil.decodeJsonObjectArray(paramsObj, "sugar_plugins");
         List<String> params = JsonUtil.decodeJsonStringArray(paramsObj, "params");
         List<String> paramTypes = JsonUtil.decodeJsonStringArray(paramsObj, "param_types");
         SugarRealizer.Realization r =
-                SugarRealizer.emitStub(function, params, paramTypes, returnType, conceptName, mode, modes, contract, sugarPlugins, transportedOp);
+                SugarRealizer.emitStub(emittedFunction, params, paramTypes, returnType, conceptName, mode, modes, contract, sugarPlugins, transportedOp, termShape, operandBindings);
         String wrapperRecord = r.observationWrapperEmissionRecord() == null
                 ? ""
                 : ",\"observation_wrapper_emission_record\":" + r.observationWrapperEmissionRecord();

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -127,6 +127,22 @@ final class SugarRealizer {
             ContractPayload contract,
             List<String> sugarPluginJson,
             TransportedOperation transportedOp) {
+        return emitStub(function, params, paramTypes, returnType, conceptName, mode, modes, contract, sugarPluginJson, transportedOp, null, null);
+    }
+
+    static Realization emitStub(
+            String function,
+            List<String> params,
+            List<String> paramTypes,
+            String returnType,
+            String conceptName,
+            String mode,
+            List<String> modes,
+            ContractPayload contract,
+            List<String> sugarPluginJson,
+            TransportedOperation transportedOp,
+            String termShapeJson,
+            String operandBindingsJson) {
 
         String className = snakeToPascal(function) + "Transported";
         String mappedReturn = mapSourceType(returnType);
@@ -157,9 +173,12 @@ final class SugarRealizer {
 
         String conceptCitationBlock = conceptCitationTagBlock(transportedOp, sugarPluginJson);
         boolean hasConceptCitationCarrier = !conceptCitationBlock.isBlank();
+        Optional<RenderedBody> termShapeBody = hasConceptCitationCarrier
+                ? Optional.empty()
+                : renderTermShapeBody(termShapeJson, operandBindingsJson, params, paramTypes, returnType);
         Optional<RenderedBody> bodyTemplate = hasConceptCitationCarrier
                 ? Optional.empty()
-                : renderBodyTemplateFor(conceptName, params, mode);
+                : termShapeBody.or(() -> renderBodyTemplateFor(conceptName, params, mode));
         boolean isStub = bodyTemplate.isEmpty() && !hasConceptCitationCarrier;
         String bodyContent = hasConceptCitationCarrier
                 ? conceptCitationBlock + "\n;"
@@ -835,6 +854,429 @@ final class SugarRealizer {
             if (part.length() > 1) sb.append(part.substring(1));
         }
         return sb.toString();
+    }
+
+    private record ShapeExpression(String text, String typeName) {}
+
+    private static final class ShapeContext {
+        final List<String> params;
+        final List<String> paramTypes;
+        final String returnType;
+        final Map<List<Integer>, String> operandBindings;
+        final Set<String> definedSymbols = new TreeSet<>();
+        int nextLeaf = 0;
+        int nextTemp = 0;
+        String lastAssignedSymbol = "";
+
+        ShapeContext(
+                List<String> params,
+                List<String> paramTypes,
+                String returnType,
+                Map<List<Integer>, String> operandBindings) {
+            this.params = params;
+            this.paramTypes = paramTypes;
+            this.returnType = returnType;
+            this.operandBindings = operandBindings;
+            this.definedSymbols.addAll(params);
+        }
+
+        ShapeExpression fallbackLeaf() {
+            if (!params.isEmpty()) {
+                int index = Math.min(nextLeaf, params.size() - 1);
+                nextLeaf += 1;
+                String type = index < paramTypes.size() ? mapSourceType(paramTypes.get(index)) : "";
+                return new ShapeExpression(params.get(index), type);
+            }
+            nextLeaf += 1;
+            return new ShapeExpression("0", "int");
+        }
+
+        String tempName() {
+            String name = "__provekit_v" + nextTemp;
+            nextTemp += 1;
+            return name;
+        }
+    }
+
+    private static Optional<RenderedBody> renderTermShapeBody(
+            String termShapeJson,
+            String operandBindingsJson,
+            List<String> params,
+            List<String> paramTypes,
+            String returnType) {
+        if (termShapeJson == null || termShapeJson.isBlank() || "{}".equals(termShapeJson.trim())) {
+            return Optional.empty();
+        }
+        Jcs.Json parsed;
+        try {
+            parsed = Jcs.parse(termShapeJson);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+        if (!(parsed instanceof Jcs.Obj shape)) {
+            return Optional.empty();
+        }
+        ShapeContext context = new ShapeContext(
+                params,
+                paramTypes,
+                returnType,
+                operandBindingMap(operandBindingsJson));
+        Optional<String> body = lowerShapeBody(shape, context, List.of());
+        if (body.isEmpty()) {
+            Optional<ShapeExpression> expression = lowerShapeExpression(shape, context, List.of());
+            if (expression.isEmpty() || expression.get().text().isBlank()) {
+                return Optional.empty();
+            }
+            body = Optional.of("return " + expression.get().text() + ";");
+        }
+        return Optional.of(new RenderedBody(body.get(), Jcs.object()));
+    }
+
+    private static Optional<String> lowerShapeBody(
+            Jcs.Obj shape,
+            ShapeContext context,
+            List<Integer> position) {
+        String conceptName = shapeConceptName(shape);
+        List<Jcs.Obj> args = shapeArgs(shape);
+        if (conceptMatches("concept:seq", conceptName) || "seq".equals(conceptName)) {
+            List<String> lines = new ArrayList<>();
+            for (int i = 0; i < args.size(); i++) {
+                Jcs.Obj child = args.get(i);
+                Optional<String> childBody = lowerShapeBody(child, context, appendPosition(position, i));
+                if (childBody.isPresent()) {
+                    if (!childBody.get().isBlank()) {
+                        lines.add(childBody.get());
+                    }
+                    continue;
+                }
+                Optional<ShapeExpression> expression = lowerShapeExpression(child, context, appendPosition(position, i));
+                if (expression.isEmpty() || expression.get().text().isBlank()) {
+                    return Optional.empty();
+                }
+                String temp = context.tempName();
+                context.definedSymbols.add(temp);
+                context.lastAssignedSymbol = temp;
+                lines.add(localDeclaration(context.returnType, temp, expression.get().text(), false));
+            }
+            if (!"void".equals(mapSourceType(context.returnType))
+                    && lines.stream().noneMatch(line -> line.strip().startsWith("return "))
+                    && !context.lastAssignedSymbol.isBlank()) {
+                lines.add("return " + context.lastAssignedSymbol + ";");
+            }
+            return Optional.of(String.join("\n", lines));
+        }
+        if (conceptMatches("concept:assign", conceptName) && args.size() == 2) {
+            Optional<ShapeExpression> target = lowerShapeExpression(args.get(0), context, appendPosition(position, 0));
+            Optional<ShapeExpression> value = lowerShapeExpression(args.get(1), context, appendPosition(position, 1));
+            if (target.isEmpty() || value.isEmpty() || !isIdentifier(target.get().text())) {
+                return Optional.empty();
+            }
+            String name = target.get().text();
+            boolean alreadyDefined = context.definedSymbols.contains(name);
+            context.definedSymbols.add(name);
+            context.lastAssignedSymbol = name;
+            return Optional.of(localDeclaration(context.returnType, name, value.get().text(), alreadyDefined));
+        }
+        if (conceptMatches("concept:return", conceptName)) {
+            if (args.isEmpty()) {
+                return Optional.of("return;");
+            }
+            Optional<ShapeExpression> value = lowerShapeExpression(args.get(0), context, appendPosition(position, 0));
+            return value.map(shapeExpression -> "return " + shapeExpression.text() + ";");
+        }
+        if (conceptMatches("concept:conditional", conceptName) && args.size() == 3) {
+            Optional<ShapeExpression> condition = lowerShapeExpression(args.get(0), context, appendPosition(position, 0));
+            Optional<String> thenBody = lowerShapeBranchBody(args.get(1), context, appendPosition(position, 1));
+            Optional<String> elseBody = lowerShapeBranchBody(args.get(2), context, appendPosition(position, 2));
+            if (condition.isEmpty() || thenBody.isEmpty() || elseBody.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of("if " + condition.get().text() + " {\n"
+                    + indentBlock(thenBody.get()) + "\n"
+                    + "} else {\n"
+                    + indentBlock(elseBody.get()) + "\n"
+                    + "}");
+        }
+        if (conceptMatches("concept:comment", conceptName) && !args.isEmpty()) {
+            Jcs.Json value = args.get(0).get("value");
+            if (value instanceof Jcs.Str s) {
+                return Optional.of("// " + s.value().replace("\n", "\n// "));
+            }
+        }
+        if (conceptMatches("concept:skip", conceptName) && args.isEmpty()) {
+            return Optional.of("");
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> lowerShapeBranchBody(
+            Jcs.Obj shape,
+            ShapeContext context,
+            List<Integer> position) {
+        Optional<String> body = lowerShapeBody(shape, context, position);
+        if (body.isPresent()) {
+            return body;
+        }
+        Optional<ShapeExpression> expression = lowerShapeExpression(shape, context, position);
+        return expression.map(shapeExpression -> "return " + shapeExpression.text() + ";");
+    }
+
+    private static Optional<ShapeExpression> lowerShapeExpression(
+            Jcs.Obj shape,
+            ShapeContext context,
+            List<Integer> position) {
+        String conceptName = shapeConceptName(shape);
+        if (conceptName.isBlank()) {
+            return Optional.of(shapeLeafExpression(shape, context, position));
+        }
+        List<Jcs.Obj> args = shapeArgs(shape);
+        if (conceptMatches("concept:seq", conceptName) || "seq".equals(conceptName)) {
+            Optional<String> body = lowerShapeBody(shape, context, position);
+            if (body.isEmpty()) {
+                return Optional.empty();
+            }
+            if (!context.lastAssignedSymbol.isBlank()) {
+                return Optional.of(new ShapeExpression(context.lastAssignedSymbol, mapSourceType(context.returnType)));
+            }
+            return Optional.empty();
+        }
+        List<ShapeExpression> argTerms = new ArrayList<>();
+        for (int i = 0; i < args.size(); i++) {
+            Optional<ShapeExpression> term = lowerShapeExpression(args.get(i), context, appendPosition(position, i));
+            if (term.isEmpty() || term.get().text().isBlank()) {
+                return Optional.empty();
+            }
+            argTerms.add(term.get());
+        }
+        if (conceptMatches("concept:call", conceptName) && !argTerms.isEmpty()) {
+            String callee = argTerms.get(0).text();
+            if (!isIdentifier(callee)) {
+                return Optional.empty();
+            }
+            String joined = argTerms.stream().skip(1).map(ShapeExpression::text).collect(Collectors.joining(", "));
+            return Optional.of(new ShapeExpression(callee + "(" + joined + ")", mapSourceType(context.returnType)));
+        }
+        String expression = operationExpression(conceptName, argTerms);
+        if (expression == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new ShapeExpression(expression, operationReturnType(conceptName, argTerms, context.returnType)));
+    }
+
+    private static ShapeExpression shapeLeafExpression(
+            Jcs.Obj shape,
+            ShapeContext context,
+            List<Integer> position) {
+        String bound = context.operandBindings.get(position);
+        if (bound != null && !bound.isBlank()) {
+            return symbolTerm(bound, context);
+        }
+        String kind = shape.stringFieldOrNull("kind");
+        if ("var".equals(kind)) {
+            String name = shape.stringFieldOrNull("name");
+            if (name != null && !name.isBlank()) {
+                return new ShapeExpression(name, typeForArgument(name, context));
+            }
+        }
+        Jcs.Json value = shape.get("value");
+        if ("const".equals(kind) || value != null) {
+            return literalTerm(value);
+        }
+        return context.fallbackLeaf();
+    }
+
+    private static String operationExpression(String conceptName, List<ShapeExpression> args) {
+        String op = conceptName.startsWith("concept:") ? conceptName.substring("concept:".length()) : conceptName;
+        if (args.size() == 2) {
+            String left = args.get(0).text();
+            String right = args.get(1).text();
+            return switch (op) {
+                case "add" -> "(" + left + ") + (" + right + ")";
+                case "sub" -> "(" + left + ") - (" + right + ")";
+                case "mul" -> "(" + left + ") * (" + right + ")";
+                case "div" -> "(" + left + ") / (" + right + ")";
+                case "mod" -> "(" + left + ") % (" + right + ")";
+                case "eq" -> "(" + left + ") == (" + right + ")";
+                case "ne" -> "(" + left + ") != (" + right + ")";
+                case "lt" -> "(" + left + ") < (" + right + ")";
+                case "le" -> "(" + left + ") <= (" + right + ")";
+                case "gt" -> "(" + left + ") > (" + right + ")";
+                case "ge" -> "(" + left + ") >= (" + right + ")";
+                case "and" -> "(" + left + ") && (" + right + ")";
+                case "or" -> "(" + left + ") || (" + right + ")";
+                default -> null;
+            };
+        }
+        if (args.size() == 1) {
+            String value = args.get(0).text();
+            return switch (op) {
+                case "neg" -> "-(" + value + ")";
+                case "not" -> "!(" + value + ")";
+                case "bitnot" -> "~(" + value + ")";
+                default -> null;
+            };
+        }
+        if ("skip".equals(op) && args.isEmpty()) {
+            return "null";
+        }
+        return null;
+    }
+
+    private static String operationReturnType(
+            String conceptName,
+            List<ShapeExpression> args,
+            String fallbackReturnType) {
+        String op = conceptName.startsWith("concept:") ? conceptName.substring("concept:".length()) : conceptName;
+        return switch (op) {
+            case "eq", "ne", "lt", "le", "gt", "ge", "and", "or", "not" -> "boolean";
+            case "call" -> mapSourceType(fallbackReturnType);
+            default -> args.isEmpty() ? mapSourceType(fallbackReturnType) : args.get(0).typeName();
+        };
+    }
+
+    private static String localDeclaration(String returnType, String name, String expression, boolean alreadyDefined) {
+        if (alreadyDefined) {
+            return name + " = " + expression + ";";
+        }
+        String type = mapSourceType(returnType);
+        if ("void".equals(type)) {
+            type = "Object";
+        }
+        return type + " " + name + " = " + expression + ";";
+    }
+
+    private static String shapeConceptName(Jcs.Obj shape) {
+        String value = shape.stringFieldOrNull("concept_name");
+        if (value == null || value.isBlank()) {
+            value = shape.stringFieldOrNull("conceptName");
+        }
+        return value == null ? "" : value.strip();
+    }
+
+    private static List<Jcs.Obj> shapeArgs(Jcs.Obj shape) {
+        Jcs.Json value = shape.get("args");
+        if (!(value instanceof Jcs.Arr arr)) {
+            return List.of();
+        }
+        List<Jcs.Obj> out = new ArrayList<>();
+        for (Jcs.Json child : arr.values()) {
+            if (child instanceof Jcs.Obj obj) {
+                out.add(obj);
+            }
+        }
+        return out;
+    }
+
+    private static Map<List<Integer>, String> operandBindingMap(String operandBindingsJson) {
+        Map<List<Integer>, String> out = new TreeMap<>(SugarRealizer::comparePosition);
+        if (operandBindingsJson == null || operandBindingsJson.isBlank() || "[]".equals(operandBindingsJson.trim())) {
+            return out;
+        }
+        Jcs.Json parsed;
+        try {
+            parsed = Jcs.parse(operandBindingsJson);
+        } catch (IllegalArgumentException e) {
+            return out;
+        }
+        if (!(parsed instanceof Jcs.Arr arr)) {
+            return out;
+        }
+        for (Jcs.Json item : arr.values()) {
+            if (!(item instanceof Jcs.Obj obj)) {
+                continue;
+            }
+            Jcs.Json rawPosition = obj.get("position");
+            String symbol = obj.stringFieldOrNull("symbol");
+            if (!(rawPosition instanceof Jcs.Arr parts) || symbol == null || symbol.isBlank()) {
+                continue;
+            }
+            List<Integer> position = new ArrayList<>();
+            boolean valid = true;
+            for (Jcs.Json part : parts.values()) {
+                if (part instanceof Jcs.Num n && n.value() >= 0 && n.value() <= Integer.MAX_VALUE) {
+                    position.add((int) n.value());
+                } else {
+                    valid = false;
+                    break;
+                }
+            }
+            if (valid) {
+                out.put(List.copyOf(position), symbol);
+            }
+        }
+        return out;
+    }
+
+    private static int comparePosition(List<Integer> left, List<Integer> right) {
+        int count = Math.min(left.size(), right.size());
+        for (int i = 0; i < count; i++) {
+            int cmp = Integer.compare(left.get(i), right.get(i));
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+        return Integer.compare(left.size(), right.size());
+    }
+
+    private static List<Integer> appendPosition(List<Integer> position, int next) {
+        List<Integer> out = new ArrayList<>(position);
+        out.add(next);
+        return List.copyOf(out);
+    }
+
+    private static ShapeExpression symbolTerm(String symbol, ShapeContext context) {
+        if ("true".equals(symbol) || "True".equals(symbol)) {
+            return new ShapeExpression("true", "boolean");
+        }
+        if ("false".equals(symbol) || "False".equals(symbol)) {
+            return new ShapeExpression("false", "boolean");
+        }
+        if ("None".equals(symbol) || "null".equals(symbol)) {
+            return new ShapeExpression("null", "Object");
+        }
+        if (symbol.matches("-?[0-9]+")) {
+            return new ShapeExpression(symbol, "int");
+        }
+        if (symbol.length() >= 2 && symbol.startsWith("\"") && symbol.endsWith("\"")) {
+            return new ShapeExpression(symbol, "String");
+        }
+        return new ShapeExpression(symbol, typeForArgument(symbol, context));
+    }
+
+    private static ShapeExpression literalTerm(Jcs.Json value) {
+        if (value instanceof Jcs.Bool b) {
+            return new ShapeExpression(Boolean.toString(b.value()), "boolean");
+        }
+        if (value instanceof Jcs.Num n) {
+            return new ShapeExpression(Long.toString(n.value()), "int");
+        }
+        if (value instanceof Jcs.Str s) {
+            return new ShapeExpression(JsonUtil.quoted(s.value()), "String");
+        }
+        if (value instanceof Jcs.Null || value == null) {
+            return new ShapeExpression("null", "Object");
+        }
+        return new ShapeExpression("null", "Object");
+    }
+
+    private static String typeForArgument(String symbol, ShapeContext context) {
+        for (int i = 0; i < context.params.size(); i++) {
+            if (context.params.get(i).equals(symbol)) {
+                return i < context.paramTypes.size() ? mapSourceType(context.paramTypes.get(i)) : "";
+            }
+        }
+        return mapSourceType(context.returnType);
+    }
+
+    private static boolean isIdentifier(String value) {
+        return value != null && value.matches("[A-Za-z_$][A-Za-z0-9_$]*");
+    }
+
+    private static String indentBlock(String body) {
+        if (body.isBlank()) {
+            return "    ;";
+        }
+        return body.lines().map(line -> "    " + line).collect(Collectors.joining("\n"));
     }
 
     // -----------------------------------------------------------------------

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/JavaNullBoundaryRealizerTest.java
@@ -639,6 +639,77 @@ public class JavaNullBoundaryRealizerTest {
         assertNull(output.observationWrapperEmissionRecord());
     }
 
+    @Test
+    public void termShapeRealizationRendersArithmeticSequenceDespiteUnnamedTopLevelConcept() {
+        String termShape = """
+            {
+              "concept_name": "concept:seq",
+              "op_cid": "%s",
+              "args": [
+                {
+                  "concept_name": "concept:assign",
+                  "op_cid": "%s",
+                  "args": [
+                    {},
+                    {"concept_name": "concept:add", "op_cid": "%s", "args": [{}, {}]}
+                  ]
+                },
+                {
+                  "concept_name": "concept:assign",
+                  "op_cid": "%s",
+                  "args": [
+                    {},
+                    {"concept_name": "concept:mul", "op_cid": "%s", "args": [{}, {}]}
+                  ]
+                },
+                {
+                  "concept_name": "concept:assign",
+                  "op_cid": "%s",
+                  "args": [
+                    {},
+                    {"concept_name": "concept:sub", "op_cid": "%s", "args": [{}, {}]}
+                  ]
+                }
+              ]
+            }
+            """.formatted(cid("a"), cid("b"), cid("c"), cid("d"), cid("e"), cid("f"), cid("1"));
+        String operandBindings = """
+            [
+              {"position":[0,0],"symbol":"total"},
+              {"position":[0,1,0],"symbol":"a"},
+              {"position":[0,1,1],"symbol":"b"},
+              {"position":[1,0],"symbol":"scaled"},
+              {"position":[1,1,0],"symbol":"total"},
+              {"position":[1,1,1],"symbol":"2"},
+              {"position":[2,0],"symbol":"reduced"},
+              {"position":[2,1,0],"symbol":"scaled"},
+              {"position":[2,1,1],"symbol":"1"}
+            ]
+            """;
+
+        SugarRealizer.Realization output = SugarRealizer.emitStub(
+            "compute_sum",
+            java.util.List.of("a", "b"),
+            java.util.List.of("int", "int"),
+            "int",
+            "UNNAMED-CONCEPT-1",
+            "",
+            java.util.List.of(),
+            null,
+            java.util.List.of(),
+            null,
+            termShape,
+            operandBindings
+        );
+
+        assertFalse(output.isStub(), output.source());
+        assertTrue(output.source().contains("int total = (a) + (b);"), output.source());
+        assertTrue(output.source().contains("int scaled = (total) * (2);"), output.source());
+        assertTrue(output.source().contains("int reduced = (scaled) - (1);"), output.source());
+        assertTrue(output.source().contains("return reduced;"), output.source());
+        assertFalse(output.source().contains("UnsupportedOperationException"), output.source());
+    }
+
     private static String modeScopedBeanValidationSugar(String mode) {
         return "{\"header\":{\"cid\":\"java-bean-validation\",\"content\":{\"entries\":[{\"emission_template\":{\"kind\":\"verbatim\",\"surface_locator\":\"annotation:before-parameter\",\"template\":\"@NotNull\"},\"loss_record_contribution\":{\"form\":\"literal\",\"value\":{}},\"mode\":\"" + mode + "\",\"predicate_pattern\":{\"args\":[{\"kind\":\"var\",\"name\":\"${symbol}\"},{\"kind\":\"const\",\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"},\"value\":null}],\"kind\":\"atomic\",\"name\":\"neq\"}}],\"sugar_name\":\"bean-validation\",\"target_language\":\"java\"},\"critical\":false,\"kind\":\"sugar\",\"protocol_versions\":[\"pep/1.7.0\"],\"provenance_cid\":\"blake3-512:0\",\"schemaVersion\":\"1\",\"version\":\"1.0.0\"}}";
     }

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
@@ -142,24 +142,24 @@ def emit_stub(
     if concept_lines:
         body = "\n".join([*concept_lines, "pass"])
     else:
-        if named_term_tree is None:
-            if term_shape is None:
-                missing = missing_templates_for(
-                    function,
-                    params,
-                    param_types,
-                    return_type,
-                    concept_name,
-                )
-            else:
-                missing = missing_templates_for_term_shape(
-                    function,
-                    params,
-                    param_types,
-                    return_type,
-                    term_shape,
-                    operand_bindings=operand_bindings,
-                )
+        use_term_shape = isinstance(term_shape, dict) and bool(term_shape)
+        if use_term_shape:
+            missing = missing_templates_for_term_shape(
+                function,
+                params,
+                param_types,
+                return_type,
+                term_shape,
+                operand_bindings=operand_bindings,
+            )
+        elif named_term_tree is None:
+            missing = missing_templates_for(
+                function,
+                params,
+                param_types,
+                return_type,
+                concept_name,
+            )
         else:
             missing = missing_templates_for_tree(
                 function,
@@ -171,17 +171,16 @@ def emit_stub(
         if missing:
             raise MissingTemplateError(missing)
 
-        if named_term_tree is None:
-            if term_shape is None:
-                term_body = term_body_for(concept_name, params, param_types, return_type)
-            else:
-                term_body = term_body_for_term_shape(
-                    term_shape,
-                    params,
-                    param_types,
-                    return_type,
-                    operand_bindings=operand_bindings,
-                )
+        if use_term_shape:
+            term_body = term_body_for_term_shape(
+                term_shape,
+                params,
+                param_types,
+                return_type,
+                operand_bindings=operand_bindings,
+            )
+        elif named_term_tree is None:
+            term_body = term_body_for(concept_name, params, param_types, return_type)
         else:
             term_body = term_body_for_tree(
                 named_term_tree,
@@ -193,8 +192,28 @@ def emit_stub(
         if term_body is not None:
             body = term_body.body
         else:
+            if use_term_shape:
+                missing = missing_templates_for_term_shape(
+                    function,
+                    params,
+                    param_types,
+                    return_type,
+                    term_shape,
+                    operand_bindings=operand_bindings,
+                )
+                if missing:
+                    raise MissingTemplateError(missing)
             body = body_template_for(concept_name, params, param_types, return_type)
             if body is None:
+                missing = missing_templates_for(
+                    function,
+                    params,
+                    param_types,
+                    return_type,
+                    concept_name,
+                )
+                if missing:
+                    raise MissingTemplateError(missing)
                 raise MissingTemplateError(
                     (
                         MissingTemplateEntry(
@@ -1038,10 +1057,16 @@ def _operand_binding_map(
             raise ValueError(f"duplicate operand_bindings position {position}")
         mapping[key] = symbol
 
-    leaf_positions = sorted(_term_shape_leaf_positions(term_shape, ()))
-    leaf_set = set(leaf_positions)
-    missing = [list(position) for position in leaf_positions if position not in mapping]
-    extra = [list(position) for position in sorted(mapping) if position not in leaf_set]
+    required_positions = sorted(_term_shape_leaf_positions(term_shape, ()))
+    allowed_positions = set(_term_shape_allowed_binding_positions(term_shape, ()))
+    missing = [
+        list(position) for position in required_positions if position not in mapping
+    ]
+    extra = [
+        list(position)
+        for position in sorted(mapping)
+        if position not in allowed_positions
+    ]
     if missing or extra:
         raise OperandBindingMisalignmentError(missing, extra)
     return mapping
@@ -1058,6 +1083,21 @@ def _term_shape_leaf_positions(shape: Any, position: tuple[int, ...]) -> list[tu
     out: list[tuple[int, ...]] = []
     for index, child in enumerate(_shape_args(shape)):
         out.extend(_term_shape_leaf_positions(child, (*position, index)))
+    return out
+
+
+def _term_shape_allowed_binding_positions(
+    shape: Any,
+    position: tuple[int, ...],
+) -> list[tuple[int, ...]]:
+    required = _term_shape_leaf_positions(shape, position)
+    if not isinstance(shape, dict):
+        return required
+    out = list(required)
+    if _shape_concept_name(shape) in {"concept:literal", "literal"} and "value" in shape:
+        out.append(position)
+    for index, child in enumerate(_shape_args(shape)):
+        out.extend(_term_shape_allowed_binding_positions(child, (*position, index)))
     return out
 
 
@@ -1092,6 +1132,7 @@ class _ShapeLoweringContext:
     next_leaf: int = 0
     next_temp: int = 0
     defined_symbols: set[str] = field(default_factory=set)
+    last_assigned_symbol: str | None = None
 
     def __post_init__(self) -> None:
         self.defined_symbols.update(self.params)
@@ -1197,12 +1238,39 @@ def _lower_shape_body(
         if tail is not None:
             if tail.body:
                 lines.append(tail.body)
+            if (
+                map_source_type(context.return_type) != "None"
+                and not any(line.lstrip().startswith("return ") for line in lines)
+                and context.last_assigned_symbol is not None
+            ):
+                lines.append(f"return {context.last_assigned_symbol}")
             return TermBody("\n".join(lines))
         expression = _lower_shape_expression(args[-1], context, (*position, len(args) - 1))
         if expression is None or expression.text is None:
             return None
         lines.append(f"return {expression.text}")
         return TermBody("\n".join(lines))
+    if concept_name in {"concept:assign", "assign"} and len(args) == 2:
+        target = _lower_shape_expression(args[0], context, (*position, 0))
+        value = _lower_shape_expression(args[1], context, (*position, 1))
+        if (
+            target is None
+            or target.text is None
+            or value is None
+            or value.text is None
+            or not _is_identifier_symbol(target.text)
+        ):
+            return None
+        context.defined_symbols.add(target.text)
+        context.last_assigned_symbol = target.text
+        return TermBody(f"{target.text} = {value.text}")
+    if concept_name in {"concept:return", "return"}:
+        if not args:
+            return TermBody("return")
+        value = _lower_shape_expression(args[0], context, (*position, 0))
+        if value is None or value.text is None:
+            return None
+        return TermBody(f"return {value.text}")
     if concept_name in {"concept:conditional", "conditional"} and len(args) == 3:
         condition = _lower_shape_expression(args[0], context, (*position, 0))
         if condition is None or condition.text is None:
@@ -1253,6 +1321,12 @@ def _lower_shape_expression(
     concept_name = _shape_concept_name(shape)
     if not concept_name:
         return _shape_leaf_expression(shape, context, position)
+    if concept_name in {"concept:literal", "literal"} and "value" in shape:
+        if context.operand_bindings is not None:
+            symbol = context.operand_bindings.get(position)
+            if symbol is not None:
+                return _symbol_term(symbol, context)
+        return _literal_term(shape.get("value"))
     args = _shape_args(shape)
     if concept_name in {"concept:seq", "seq"}:
         for index, child in enumerate(args[:-1]):
@@ -1293,8 +1367,9 @@ def _shape_leaf_expression(
     position: tuple[int, ...],
 ) -> TermExpression:
     if context.operand_bindings is not None:
-        symbol = context.operand_bindings[position]
-        return _symbol_term(symbol, context)
+        symbol = context.operand_bindings.get(position)
+        if symbol is not None:
+            return _symbol_term(symbol, context)
     kind = str(shape.get("kind", ""))
     if kind == "var":
         name = shape.get("name")

--- a/implementations/python/provekit-realize-python-core/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realizer.py
@@ -151,6 +151,10 @@ def _shape(concept_name: str, args: list[dict] | None = None) -> dict:
     return {"concept_name": concept_name, "args": args or []}
 
 
+def _literal_shape(value: object) -> dict:
+    return {"concept_name": "concept:literal", "args": [], "value": value}
+
+
 def _safe_divide_then_double_shape() -> dict:
     return _shape(
         "concept:conditional",
@@ -569,6 +573,39 @@ def test_term_shape_sidecar_renders_safe_divide_then_double_source_symbols() -> 
     assert fn(-5, 2) == -1
 
 
+def test_term_shape_sidecar_wins_over_lossy_named_tree_for_nested_unary_ops() -> None:
+    lossy_tree = {
+        "conceptName": "concept:seq",
+        "operationKind": "seq",
+        "shapeCid": _cid("a"),
+        "args": [
+            {
+                "conceptName": "concept:neg",
+                "operationKind": "op-application",
+                "shapeCid": _cid("b"),
+                "args": [],
+            }
+        ],
+    }
+
+    result = emit_stub(
+        function="",
+        params=["num", "denom"],
+        param_types=["int", "int"],
+        return_type="int",
+        concept_name="result-bind",
+        named_term_tree=lossy_tree,
+        term_shape=_safe_divide_then_double_shape(),
+        operand_bindings=_safe_divide_then_double_bindings(),
+        source_function_name="safe_divide_then_double",
+    )
+
+    source = result["source"]
+    assert "return -(1)" in source
+    namespace = _compiled_namespace(source)
+    assert namespace["safe_divide_then_double"](8, 2) == 8
+
+
 def test_term_shape_comment_emits_python_comment_surface() -> None:
     result = emit_stub(
         function="comment_only",
@@ -642,6 +679,76 @@ def test_term_shape_operand_bindings_resolve_nested_positions() -> None:
     assert result["source"] == (
         "def nested(a, b, c):\n"
         "    return ((a) * (b)) + (c)\n"
+    )
+
+
+def test_term_shape_operand_bindings_allow_concept_literal_positions() -> None:
+    result = emit_stub(
+        function="add_literal",
+        params=["x"],
+        param_types=["int"],
+        return_type="int",
+        concept_name="concept:add",
+        term_shape=_shape("concept:add", [{}, _literal_shape(2)]),
+        operand_bindings=[
+            {"position": [0], "symbol": "x"},
+            {"position": [1], "symbol": "2"},
+        ],
+    )
+
+    assert result["source"] == "def add_literal(x):\n    return (x) + (2)\n"
+
+
+def test_term_shape_concept_literal_does_not_require_operand_binding() -> None:
+    result = emit_stub(
+        function="add_literal",
+        params=["x"],
+        param_types=["int"],
+        return_type="int",
+        concept_name="concept:add",
+        term_shape=_shape("concept:add", [{}, _literal_shape(2)]),
+        operand_bindings=[{"position": [0], "symbol": "x"}],
+    )
+
+    assert result["source"] == "def add_literal(x):\n    return (x) + (2)\n"
+
+
+def test_term_shape_assignment_sequence_preserves_named_temps_and_return() -> None:
+    result = emit_stub(
+        function="compute_sum",
+        params=["a", "b"],
+        param_types=["int", "int"],
+        return_type="int",
+        concept_name="concept:seq",
+        term_shape=_shape(
+            "concept:seq",
+            [
+                _shape("concept:assign", [{}, _shape("concept:add", [{}, {}])]),
+                _shape("concept:assign", [{}, _shape("concept:mul", [{}, _literal_shape(2)])]),
+                _shape("concept:assign", [{}, _shape("concept:sub", [{}, _literal_shape(1)])]),
+                _shape("concept:return", [{}]),
+            ],
+        ),
+        operand_bindings=[
+            {"position": [0, 0], "symbol": "total"},
+            {"position": [0, 1, 0], "symbol": "a"},
+            {"position": [0, 1, 1], "symbol": "b"},
+            {"position": [1, 0], "symbol": "scaled"},
+            {"position": [1, 1, 0], "symbol": "total"},
+            {"position": [1, 1, 1], "symbol": "2"},
+            {"position": [2, 0], "symbol": "reduced"},
+            {"position": [2, 1, 0], "symbol": "scaled"},
+            {"position": [2, 1, 1], "symbol": "1"},
+            {"position": [3, 0], "symbol": "reduced"},
+        ],
+    )
+
+    assert result["source"] == (
+        "def compute_sum(a, b):\n"
+        "    total = (a) + (b)\n"
+        "    scaled = (total) * (2)\n"
+        "    reduced = (scaled) - (1)\n"
+        "    return reduced\n"
     )
 
 

--- a/implementations/rust/libprovekit/src/core/platform_semantics.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics.rs
@@ -56,7 +56,8 @@ pub fn platform_semantics_for_binding(
     binding_tag: &str,
 ) -> Option<PlatformSemanticsDeclaration> {
     let lang_decl = platform_semantics_for_lower_target(lang);
-    let binding_decl = platform_semantics_for_lower_target(binding_tag);
+    let binding_decl = platform_semantics_for_lower_target(&format!("{lang}-{binding_tag}"))
+        .or_else(|| platform_semantics_for_lower_target(binding_tag));
 
     match (lang_decl, binding_decl) {
         (None, None) => None,
@@ -85,7 +86,11 @@ fn merge_declarations(
 
     let mut seen_cids: BTreeMap<String, ()> = BTreeMap::new();
     let mut merged_values: Vec<DimensionValueMemento> = Vec::new();
-    for value in lang.dimension_values.into_iter().chain(binding.dimension_values) {
+    for value in lang
+        .dimension_values
+        .into_iter()
+        .chain(binding.dimension_values)
+    {
         if seen_cids.insert(value.cid.clone(), ()).is_none() {
             merged_values.push(value);
         }
@@ -125,11 +130,7 @@ mod binding_compose_tests {
     fn one_tag(op_cid: &str, dim: &str, value_cid: &str) -> PlatformSemanticTag {
         let mut dimensions = BTreeMap::new();
         dimensions.insert(dim.to_string(), value_cid.to_string());
-        PlatformSemanticTag::new(
-            TEST_KIT_CID.to_string(),
-            op_cid.to_string(),
-            dimensions,
-        )
+        PlatformSemanticTag::new(TEST_KIT_CID.to_string(), op_cid.to_string(), dimensions)
     }
 
     fn decl_with(op_cid: &str, dim: &str, value_name: &str) -> PlatformSemanticsDeclaration {
@@ -148,7 +149,10 @@ mod binding_compose_tests {
         let binding = decl_with(TEST_OP_B, "BindDim", "BindValue");
         let merged = merge_declarations(lang, binding);
         let op_cids: Vec<&str> = merged.tags.iter().map(|t| t.op_cid.as_str()).collect();
-        assert!(op_cids.contains(&TEST_OP_A), "language op must be in merged");
+        assert!(
+            op_cids.contains(&TEST_OP_A),
+            "language op must be in merged"
+        );
         assert!(op_cids.contains(&TEST_OP_B), "binding op must be in merged");
         assert_eq!(merged.dimension_values.len(), 2);
     }

--- a/implementations/rust/libprovekit/src/core/platform_semantics_loader.rs
+++ b/implementations/rust/libprovekit/src/core/platform_semantics_loader.rs
@@ -15,7 +15,7 @@
 // provekit-realize-c-core platform_semantics.rs files.
 
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
@@ -35,33 +35,186 @@ pub enum PlatformSemanticsLoadError {
     ResultShape(String),
 }
 
-/// Resolve a kit binary by convention. The substrate does NOT enumerate kits.
+#[derive(Debug, Clone)]
+struct ResolvedPlatformSemanticsCommand {
+    argv: Vec<String>,
+    working_dir: Option<PathBuf>,
+}
+
+/// Resolve kit commands by project manifest, workspace build convention, then
+/// PATH convention. The substrate does NOT enumerate kits.
 ///
 /// Convention:
-///   1. Try `provekit-realize-<kit_id>-core` on PATH (pure language-kit form)
-///   2. Try `provekit-realize-<kit_id>` on PATH (full kit-identity form,
+///   1. Try `.provekit/realize/<kit_id>/manifest.toml` from the current repo
+///   2. Try workspace-local build products under `implementations/<kit_id>/`
+///   3. Try `provekit-realize-<kit_id>-core` on PATH (pure language-kit form)
+///   4. Try `provekit-realize-<kit_id>` on PATH (full kit-identity form,
 ///      e.g., `python-aiosqlite`, `typescript-pg`)
 ///
-/// Returns the first command that resolves on PATH. If neither candidate
-/// is on PATH, returns the language-kit form as a best-effort command so
+/// If neither candidate is available, returns the language-kit form as a
+/// best-effort command so
 /// the loader's spawn produces a MissingBinary error citing the
 /// convention name, rather than collapsing two failure modes (unknown
 /// kit vs binary-missing) into the same None.
 ///
 /// Adding a new kit requires nothing here: name the binary by convention
-/// and the substrate finds it. The previous hardcoded match table was
-/// substrate-uniform-pattern violation: kit enumeration inside libprovekit.
-fn kit_command_for(kit_id: &str) -> Vec<String> {
+/// or register a manifest and the substrate finds it. The previous hardcoded
+/// match table was substrate-uniform-pattern violation: kit enumeration inside
+/// libprovekit.
+fn kit_command_candidates(kit_id: &str) -> Vec<ResolvedPlatformSemanticsCommand> {
+    let mut candidates = Vec::new();
+    if let Some(root) = find_workspace_root() {
+        if let Some(command) = manifest_command_for(&root, kit_id) {
+            candidates.push(command);
+        }
+        candidates.extend(workspace_build_candidates(&root, kit_id));
+    }
+
     let lang_form = format!("provekit-realize-{kit_id}-core");
     let identity_form = format!("provekit-realize-{kit_id}");
     if which_on_path(&lang_form).is_some() {
-        return vec![lang_form];
+        candidates.push(ResolvedPlatformSemanticsCommand {
+            argv: vec![lang_form.clone()],
+            working_dir: None,
+        });
     }
     if which_on_path(&identity_form).is_some() {
-        return vec![identity_form];
+        candidates.push(ResolvedPlatformSemanticsCommand {
+            argv: vec![identity_form],
+            working_dir: None,
+        });
     }
-    // Best-effort: surface the language-kit-form name in MissingBinary.
-    vec![lang_form]
+    if candidates.is_empty() {
+        // Best-effort: surface the language-kit-form name in MissingBinary.
+        candidates.push(ResolvedPlatformSemanticsCommand {
+            argv: vec![lang_form],
+            working_dir: None,
+        });
+    }
+    candidates
+}
+
+fn find_workspace_root() -> Option<PathBuf> {
+    let mut current = std::env::current_dir().ok()?;
+    loop {
+        if current.join(".provekit").join("realize").is_dir() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+fn manifest_command_for(root: &Path, kit_id: &str) -> Option<ResolvedPlatformSemanticsCommand> {
+    let manifest = root
+        .join(".provekit")
+        .join("realize")
+        .join(kit_id)
+        .join("manifest.toml");
+    if !manifest.exists() {
+        return None;
+    }
+    parse_manifest_command(&manifest, root).ok()
+}
+
+fn parse_manifest_command(
+    path: &Path,
+    root: &Path,
+) -> Result<ResolvedPlatformSemanticsCommand, PlatformSemanticsLoadError> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| PlatformSemanticsLoadError::Failed(format!("read {}: {e}", path.display())))?;
+    let mut command = Vec::new();
+    let mut working_dir = None;
+    let mut section = String::new();
+    for line in text.lines() {
+        let line = match line.find('#') {
+            Some(pos) => &line[..pos],
+            None => line,
+        }
+        .trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            section = line
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .trim()
+                .to_string();
+            continue;
+        }
+        let Some(eq) = line.find('=') else { continue };
+        let key = line[..eq].trim();
+        let value = line[eq + 1..].trim();
+        match (section.as_str(), key) {
+            ("", "command") => command = parse_toml_string_array(value),
+            ("", "working_dir") => {
+                let path = PathBuf::from(value.trim_matches('"'));
+                working_dir = Some(if path.is_absolute() {
+                    path
+                } else {
+                    root.join(path)
+                });
+            }
+            _ => {}
+        }
+    }
+    if command.is_empty() {
+        return Err(PlatformSemanticsLoadError::Failed(format!(
+            "manifest {} has no `command`",
+            path.display()
+        )));
+    }
+    Ok(ResolvedPlatformSemanticsCommand {
+        argv: command,
+        working_dir: working_dir.or_else(|| Some(root.to_path_buf())),
+    })
+}
+
+fn parse_toml_string_array(value: &str) -> Vec<String> {
+    let inner = value.trim().trim_matches(|c| c == '[' || c == ']');
+    inner
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn workspace_build_candidates(root: &Path, kit_id: &str) -> Vec<ResolvedPlatformSemanticsCommand> {
+    let impl_dir = root.join("implementations").join(kit_id);
+    let mut out = Vec::new();
+
+    let jar = impl_dir
+        .join(format!("provekit-realize-{kit_id}-core"))
+        .join("target")
+        .join(format!("provekit-realize-{kit_id}.jar"));
+    if jar.exists() {
+        out.push(ResolvedPlatformSemanticsCommand {
+            argv: vec![
+                "java".to_string(),
+                "-jar".to_string(),
+                jar.display().to_string(),
+                "--rpc".to_string(),
+            ],
+            working_dir: Some(root.to_path_buf()),
+        });
+    }
+
+    for profile in ["release", "debug"] {
+        let binary = impl_dir
+            .join("target")
+            .join(profile)
+            .join(format!("provekit-realize-{kit_id}"));
+        if binary.exists() {
+            out.push(ResolvedPlatformSemanticsCommand {
+                argv: vec![binary.display().to_string(), "--rpc".to_string()],
+                working_dir: Some(root.to_path_buf()),
+            });
+        }
+    }
+
+    out
 }
 
 fn which_on_path(bin: &str) -> Option<PathBuf> {
@@ -85,8 +238,18 @@ fn which_on_path(bin: &str) -> Option<PathBuf> {
 pub fn load_platform_semantics(
     kit_id: &str,
 ) -> Result<PlatformSemanticsDeclaration, PlatformSemanticsLoadError> {
-    let command = kit_command_for(kit_id);
-    load_platform_semantics_for_command(&command, None)
+    let mut last_error = None;
+    for command in kit_command_candidates(kit_id) {
+        match load_platform_semantics_for_command(&command.argv, command.working_dir.as_ref()) {
+            Ok(declaration) => return Ok(declaration),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(
+        last_error.unwrap_or_else(|| PlatformSemanticsLoadError::MissingBinary {
+            binary: format!("provekit-realize-{kit_id}-core"),
+        }),
+    )
 }
 
 /// Load using an explicit binary command. The substrate's preferred API for
@@ -179,10 +342,13 @@ fn load_platform_semantics_for_command(
             "protocol_version": "pep/1.7.0"
         }
     });
-    writeln!(stdin, "{init_req}").map_err(|e| {
-        PlatformSemanticsLoadError::Failed(format!("write initialize: {e}"))
-    })?;
-    let _ = read_response(&mut reader, 1)?;
+    writeln!(stdin, "{init_req}")
+        .map_err(|e| PlatformSemanticsLoadError::Failed(format!("write initialize: {e}")))?;
+    match read_response(&mut reader, 1) {
+        Ok(_) => {}
+        Err(error) if is_optional_handshake_error(&error) => {}
+        Err(error) => return Err(error),
+    }
 
     let req = json!({
         "jsonrpc": "2.0",
@@ -198,7 +364,7 @@ fn load_platform_semantics_for_command(
     let shutdown_req = json!({
         "jsonrpc": "2.0",
         "id": 3,
-        "method": "shutdown"
+        "method": "provekit.plugin.shutdown"
     });
     let _ = writeln!(stdin, "{shutdown_req}");
     drop(stdin);
@@ -239,4 +405,9 @@ fn read_response<R: BufRead>(
         )));
     }
     Ok(value)
+}
+
+fn is_optional_handshake_error(error: &PlatformSemanticsLoadError) -> bool {
+    matches!(error, PlatformSemanticsLoadError::Failed(message)
+        if message.contains("\"code\":-32601") || message.contains("METHOD_NOT_FOUND"))
 }

--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -2621,10 +2621,15 @@ fn json_to_value(j: &serde_json::Value) -> Arc<Value> {
 mod tests {
     use super::*;
 
-    use libprovekit::core::platform_semantics_for_lower_target;
+    use provekit_ir_types::{DimensionValueMemento, PlatformSemanticTag};
 
     const CONCEPT_ADD_CID: &str = "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468";
     const CONCEPT_DIV_CID: &str = "blake3-512:c6a13abbcafdf83edcff49d883a7c7440faadd8af896da0ad46e2bcb177ed0649d005b4ddecd4689cf565b10679219a07c784399bafe5c6174642e1b808d7839";
+    const CONCEPT_RUST_ONLY_CID: &str = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const TEST_PY_KIT_CID: &str = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+    const TEST_JAVA_KIT_CID: &str = "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+    const TEST_RUST_KIT_CID: &str = "blake3-512:33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333";
+    const TEST_C_KIT_CID: &str = "blake3-512:44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444";
 
     fn function(name: &str) -> TsFunction {
         TsFunction {
@@ -2660,16 +2665,122 @@ mod tests {
         }
     }
 
+    fn dim_value(
+        kit_cid: &str,
+        dimension_name: &str,
+        value_name: &str,
+        compare_to_name: &str,
+    ) -> DimensionValueMemento {
+        DimensionValueMemento::new(
+            kit_cid.to_string(),
+            dimension_name.to_string(),
+            value_name.to_string(),
+            atom(compare_to_name),
+        )
+    }
+
+    fn tag(
+        kit_cid: &str,
+        op_cid: &str,
+        dimension_name: &str,
+        value_cid: &str,
+    ) -> PlatformSemanticTag {
+        PlatformSemanticTag::new(
+            kit_cid.to_string(),
+            op_cid.to_string(),
+            BTreeMap::from([(dimension_name.to_string(), value_cid.to_string())]),
+        )
+    }
+
+    fn test_decl(kit_cid: &str, rows: &[(&str, &str, &str, &str)]) -> PlatformSemanticsDeclaration {
+        let mut values = Vec::new();
+        let mut tags = Vec::new();
+        for (op_cid, dimension_name, value_name, compare_to_name) in rows {
+            let value = dim_value(kit_cid, dimension_name, value_name, compare_to_name);
+            tags.push(tag(kit_cid, op_cid, dimension_name, &value.cid));
+            values.push(value);
+        }
+        PlatformSemanticsDeclaration {
+            tags,
+            dimension_values: values,
+            op_aliases: BTreeMap::new(),
+        }
+    }
+
+    fn test_platform_semantics_for_lower_target(target: &str) -> PlatformSemanticsDeclaration {
+        match target {
+            "python" => test_decl(
+                TEST_PY_KIT_CID,
+                &[
+                    (
+                        CONCEPT_ADD_CID,
+                        "ArithmeticOverflow",
+                        "ArbitraryPrecision",
+                        "python:ArbitraryPrecision",
+                    ),
+                    (
+                        CONCEPT_DIV_CID,
+                        "IntegerDivisionRounding",
+                        "Floor",
+                        "python:FloorDivision",
+                    ),
+                ],
+            ),
+            "java" => test_decl(
+                TEST_JAVA_KIT_CID,
+                &[
+                    (
+                        CONCEPT_ADD_CID,
+                        "ArithmeticOverflow",
+                        "Wrapping",
+                        "java:Wrapping",
+                    ),
+                    (
+                        CONCEPT_DIV_CID,
+                        "IntegerDivisionRounding",
+                        "TruncTowardZero",
+                        "java:TruncTowardZero",
+                    ),
+                ],
+            ),
+            "rust" => test_decl(
+                TEST_RUST_KIT_CID,
+                &[
+                    (
+                        CONCEPT_DIV_CID,
+                        "IntegerDivisionRounding",
+                        "TruncTowardZero",
+                        "rust:TruncTowardZero",
+                    ),
+                    (
+                        CONCEPT_RUST_ONLY_CID,
+                        "RustOnlySemantic",
+                        "NativeOnly",
+                        "rust:NativeOnly",
+                    ),
+                ],
+            ),
+            "c" => test_decl(
+                TEST_C_KIT_CID,
+                &[(
+                    CONCEPT_ADD_CID,
+                    "ArithmeticOverflow",
+                    "UndefinedBehavior",
+                    "c:UndefinedBehavior",
+                )],
+            ),
+            other => panic!("unknown test platform semantics target: {other}"),
+        }
+    }
+
     fn receipt_for(
         source: &str,
         target: &str,
         callsites: &[SqlCallsite],
         focus: Option<&str>,
     ) -> MigrateReceiptEnvelope {
-        let source_decl =
-            platform_semantics_for_lower_target(source).expect("source semantics declared");
-        let target_decl =
-            platform_semantics_for_lower_target(target).expect("target semantics declared");
+        let source_decl = test_platform_semantics_for_lower_target(source);
+        let target_decl = test_platform_semantics_for_lower_target(target);
         let changes = platform_semantic_changes(&source_decl, &target_decl, callsites, focus)
             .expect("semantic comparison is characterizable");
         let functions = callsites
@@ -2760,8 +2871,8 @@ mod tests {
     #[test]
     fn point_query_refuse_decision_does_not_emit_partial_loss_records() {
         let callsites = vec![callsite("cs:add", CONCEPT_ADD_CID, "add")];
-        let source = platform_semantics_for_lower_target("python").expect("python semantics");
-        let target = platform_semantics_for_lower_target("java").expect("java semantics");
+        let source = test_platform_semantics_for_lower_target("python");
+        let target = test_platform_semantics_for_lower_target("java");
         let changes =
             platform_semantic_changes(&source, &target, &callsites, None).expect("changes");
         let first_changed = changes.changed_callsites.first().expect("changed callsite");
@@ -2805,8 +2916,8 @@ mod tests {
 
     #[test]
     fn point_query_uncharacterizable_absent_op_routes_to_refuse_signal() {
-        let source = platform_semantics_for_lower_target("rust").expect("rust semantics");
-        let target = platform_semantics_for_lower_target("java").expect("java semantics");
+        let source = test_platform_semantics_for_lower_target("rust");
+        let target = test_platform_semantics_for_lower_target("java");
         // Find a rust-only op: present in source, absent in target.
         // After the OpCoverageVerdict refactor this returns Ok(Uncharacterizable)
         // rather than Err(TargetOpAbsent), so we match on the verdict directly.

--- a/implementations/rust/provekit-cli/tests/trinity_citation_comments_exhibit.rs
+++ b/implementations/rust/provekit-cli/tests/trinity_citation_comments_exhibit.rs
@@ -283,7 +283,7 @@ fn write_realize_manifest(root: &Path, target: &str) {
     .expect("write realize manifest");
 }
 
-fn lift_source_input(lang: &str, workspace_root: &Path) -> Input {
+fn lift_source_input(lang: &str, _workspace_root: &Path) -> Input {
     let source_paths = match lang {
         "python" => vec!["src/lib.py"],
         "java" => vec!["src/Lib.java"],
@@ -292,7 +292,7 @@ fn lift_source_input(lang: &str, workspace_root: &Path) -> Input {
     };
     let request = json!({
         "surface": lang,
-        "workspace_root": workspace_root,
+        "workspace_root": ".",
         "config_path": ".provekit/config.toml",
         "source_paths": source_paths,
         "options": { "layer": "all", "identifyOnly": false }
@@ -541,6 +541,16 @@ fn run_leg(
     source: &str,
     catalog: &HashMapCatalog,
 ) -> LegResult {
+    run_leg_with_expected_concepts(source_lang, target_lang, source, catalog, true)
+}
+
+fn run_leg_with_expected_concepts(
+    source_lang: &str,
+    target_lang: &str,
+    source: &str,
+    catalog: &HashMapCatalog,
+    require_expected_concepts: bool,
+) -> LegResult {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = temp.path();
     write_source_workspace(workspace, source_lang, source);
@@ -553,7 +563,9 @@ fn run_leg(
     assert_bind_payload_shape(&format!("{source_lang} bind"), &bind_claim);
     assert_claim_concept_tier(&format!("{source_lang} bind"), &bind_claim, catalog);
     let concept_cids = concept_cids_from_claim(&bind_claim);
-    assert_expected_concepts_present(&format!("{source_lang} bind"), &concept_cids);
+    if require_expected_concepts {
+        assert_expected_concepts_present(&format!("{source_lang} bind"), &concept_cids);
+    }
 
     let lower_claim = execute_lower(target_lang, workspace, &bind_claim);
     assert_claim_concept_tier(&format!("{target_lang} lower"), &lower_claim, catalog);
@@ -714,8 +726,10 @@ fn fixture_01_discrimination_middle_hop_mutation_changes_final_output() {
     let catalog = concept_catalog();
     let first_leg = run_leg("python", "java", &original, &catalog);
     let mutated_java = mutate_java_middle_hop(&first_leg.source);
-    let java_to_rust = run_leg("java", "rust", &mutated_java, &catalog);
-    let rust_to_python = run_leg("rust", "python", &java_to_rust.source, &catalog);
+    let java_to_rust =
+        run_leg_with_expected_concepts("java", "rust", &mutated_java, &catalog, false);
+    let rust_to_python =
+        run_leg_with_expected_concepts("rust", "python", &java_to_rust.source, &catalog, false);
 
     let original_stdout = python_function_stdout(&original, FIXTURE_FUNCTION, &[3, 4]);
     let mutated_stdout = python_function_stdout(&rust_to_python.source, FIXTURE_FUNCTION, &[3, 4]);

--- a/implementations/rust/provekit-realize-rust-core/src/lib.rs
+++ b/implementations/rust/provekit-realize-rust-core/src/lib.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -123,7 +124,26 @@ pub fn emit_from_term_shape(
     param_types: &[String],
     return_type: &str,
 ) -> Realization {
-    match lower_term_shape_body(term_shape) {
+    emit_from_term_shape_with_bindings(
+        term_shape,
+        &[],
+        function_name,
+        params,
+        param_types,
+        return_type,
+    )
+}
+
+pub fn emit_from_term_shape_with_bindings(
+    term_shape: &Value,
+    operand_bindings: &[Value],
+    function_name: &str,
+    params: &[String],
+    param_types: &[String],
+    return_type: &str,
+) -> Realization {
+    let mut context = ShapeLoweringContext::new(params, param_types, return_type, operand_bindings);
+    match lower_term_shape_body(term_shape, &mut context, &[]) {
         Some(body) => emit_function(
             function_name,
             params,
@@ -230,7 +250,75 @@ fn emit_function_with_evidence(
     }
 }
 
-fn lower_term_shape_body(shape: &Value) -> Option<String> {
+#[derive(Debug, Clone)]
+struct ShapeExpression {
+    text: String,
+    type_name: String,
+}
+
+#[derive(Debug)]
+struct ShapeLoweringContext {
+    params: Vec<String>,
+    param_types: Vec<String>,
+    return_type: String,
+    operand_bindings: BTreeMap<Vec<usize>, String>,
+    defined_symbols: BTreeSet<String>,
+    next_leaf: usize,
+    next_temp: usize,
+    last_assigned_symbol: Option<String>,
+}
+
+impl ShapeLoweringContext {
+    fn new(
+        params: &[String],
+        param_types: &[String],
+        return_type: &str,
+        operand_bindings: &[Value],
+    ) -> Self {
+        Self {
+            params: params.to_vec(),
+            param_types: param_types.to_vec(),
+            return_type: return_type.to_string(),
+            operand_bindings: operand_binding_map(operand_bindings),
+            defined_symbols: params.iter().cloned().collect(),
+            next_leaf: 0,
+            next_temp: 0,
+            last_assigned_symbol: None,
+        }
+    }
+
+    fn fallback_leaf(&mut self) -> ShapeExpression {
+        if self.params.is_empty() {
+            self.next_leaf += 1;
+            return ShapeExpression {
+                text: "0".to_string(),
+                type_name: "i64".to_string(),
+            };
+        }
+        let index = self.next_leaf.min(self.params.len() - 1);
+        self.next_leaf += 1;
+        ShapeExpression {
+            text: self.params[index].clone(),
+            type_name: self
+                .param_types
+                .get(index)
+                .map(|ty| map_source_type(ty))
+                .unwrap_or_default(),
+        }
+    }
+
+    fn temp_name(&mut self) -> String {
+        let name = format!("__provekit_v{}", self.next_temp);
+        self.next_temp += 1;
+        name
+    }
+}
+
+fn lower_term_shape_body(
+    shape: &Value,
+    context: &mut ShapeLoweringContext,
+    position: &[usize],
+) -> Option<String> {
     let concept_name = term_shape_concept_name(shape)?;
     if concept_name == "concept:comment" || concept_name == "comment" {
         return Some(rust_comment_body(term_shape_comment_surface(shape)?));
@@ -240,15 +328,320 @@ fn lower_term_shape_body(shape: &Value) -> Option<String> {
     }
     if concept_name == "concept:seq" || concept_name == "seq" {
         let mut lines = Vec::new();
-        for child in term_shape_args(shape) {
-            let child_body = lower_term_shape_body(child)?;
-            if !child_body.is_empty() {
-                lines.push(child_body);
+        for (index, child) in term_shape_args(shape).into_iter().enumerate() {
+            let child_position = append_position(position, index);
+            if let Some(child_body) = lower_term_shape_body(child, context, &child_position) {
+                if !child_body.is_empty() {
+                    lines.push(child_body);
+                }
+                continue;
+            }
+            let expression = lower_term_shape_expression(child, context, &child_position)?;
+            let temp = context.temp_name();
+            context.defined_symbols.insert(temp.clone());
+            context.last_assigned_symbol = Some(temp.clone());
+            lines.push(format!(
+                "let {temp}: {} = {};",
+                map_source_type(&context.return_type),
+                expression.text
+            ));
+        }
+        if map_source_type(&context.return_type) != "()"
+            && !lines
+                .iter()
+                .any(|line| line.trim_start().starts_with("return "))
+        {
+            if let Some(symbol) = context.last_assigned_symbol.as_deref() {
+                lines.push(format!("return {symbol};"));
             }
         }
         return Some(lines.join("\n"));
     }
+    if concept_name == "concept:assign" || concept_name == "assign" {
+        let args = term_shape_args(shape);
+        if args.len() != 2 {
+            return None;
+        }
+        let target = lower_term_shape_expression(args[0], context, &append_position(position, 0))?;
+        let value = lower_term_shape_expression(args[1], context, &append_position(position, 1))?;
+        if !is_rust_identifier(&target.text) {
+            return None;
+        }
+        let already_defined = context.defined_symbols.contains(&target.text);
+        context.defined_symbols.insert(target.text.clone());
+        context.last_assigned_symbol = Some(target.text.clone());
+        if already_defined {
+            return Some(format!("{} = {};", target.text, value.text));
+        }
+        return Some(format!(
+            "let {}: {} = {};",
+            target.text, value.type_name, value.text
+        ));
+    }
+    if concept_name == "concept:return" || concept_name == "return" {
+        let args = term_shape_args(shape);
+        if args.is_empty() {
+            return Some("return;".to_string());
+        }
+        let value = lower_term_shape_expression(args[0], context, &append_position(position, 0))?;
+        return Some(format!("return {};", value.text));
+    }
+    if concept_name == "concept:conditional" || concept_name == "conditional" {
+        let args = term_shape_args(shape);
+        if args.len() != 3 {
+            return None;
+        }
+        let condition =
+            lower_term_shape_expression(args[0], context, &append_position(position, 0))?;
+        let then_body =
+            lower_term_shape_branch_body(args[1], context, &append_position(position, 1))?;
+        let else_body =
+            lower_term_shape_branch_body(args[2], context, &append_position(position, 2))?;
+        return Some(format!(
+            "if {} {{\n{}\n}} else {{\n{}\n}}",
+            condition.text,
+            indent_block(&then_body),
+            indent_block(&else_body)
+        ));
+    }
     None
+}
+
+fn lower_term_shape_branch_body(
+    shape: &Value,
+    context: &mut ShapeLoweringContext,
+    position: &[usize],
+) -> Option<String> {
+    if let Some(body) = lower_term_shape_body(shape, context, position) {
+        return Some(body);
+    }
+    let expression = lower_term_shape_expression(shape, context, position)?;
+    Some(format!("return {};", expression.text))
+}
+
+fn lower_term_shape_expression(
+    shape: &Value,
+    context: &mut ShapeLoweringContext,
+    position: &[usize],
+) -> Option<ShapeExpression> {
+    let Some(concept_name) = term_shape_concept_name(shape) else {
+        return Some(term_shape_leaf_expression(shape, context, position));
+    };
+    let args = term_shape_args(shape);
+    if concept_name == "concept:seq" || concept_name == "seq" {
+        lower_term_shape_body(shape, context, position)?;
+        return context
+            .last_assigned_symbol
+            .as_ref()
+            .map(|symbol| ShapeExpression {
+                text: symbol.clone(),
+                type_name: map_source_type(&context.return_type),
+            });
+    }
+    let mut arg_terms = Vec::new();
+    for (index, arg) in args.iter().enumerate() {
+        arg_terms.push(lower_term_shape_expression(
+            arg,
+            context,
+            &append_position(position, index),
+        )?);
+    }
+    let expression = operation_expression(&concept_name, &arg_terms)?;
+    Some(ShapeExpression {
+        text: expression,
+        type_name: operation_return_type(&concept_name, &arg_terms, &context.return_type),
+    })
+}
+
+fn term_shape_leaf_expression(
+    shape: &Value,
+    context: &mut ShapeLoweringContext,
+    position: &[usize],
+) -> ShapeExpression {
+    if let Some(symbol) = context.operand_bindings.get(position) {
+        return symbol_term(symbol, context);
+    }
+    if shape.get("kind").and_then(Value::as_str) == Some("var") {
+        if let Some(name) = shape.get("name").and_then(Value::as_str) {
+            return ShapeExpression {
+                text: name.to_string(),
+                type_name: type_for_argument(name, context),
+            };
+        }
+    }
+    if shape.get("kind").and_then(Value::as_str) == Some("literal") || shape.get("value").is_some()
+    {
+        return literal_term(shape.get("value").unwrap_or(&Value::Null));
+    }
+    context.fallback_leaf()
+}
+
+fn operation_expression(concept_name: &str, args: &[ShapeExpression]) -> Option<String> {
+    let op = concept_name
+        .strip_prefix("concept:")
+        .unwrap_or(concept_name);
+    if args.len() == 2 {
+        let left = &args[0].text;
+        let right = &args[1].text;
+        return match op {
+            "add" => Some(format!("({left}) + ({right})")),
+            "sub" => Some(format!("({left}) - ({right})")),
+            "mul" => Some(format!("({left}) * ({right})")),
+            "div" => Some(format!("({left}) / ({right})")),
+            "mod" => Some(format!("({left}) % ({right})")),
+            "eq" => Some(format!("({left}) == ({right})")),
+            "ne" => Some(format!("({left}) != ({right})")),
+            "lt" => Some(format!("({left}) < ({right})")),
+            "le" => Some(format!("({left}) <= ({right})")),
+            "gt" => Some(format!("({left}) > ({right})")),
+            "ge" => Some(format!("({left}) >= ({right})")),
+            "and" => Some(format!("({left}) && ({right})")),
+            "or" => Some(format!("({left}) || ({right})")),
+            _ => None,
+        };
+    }
+    if args.len() == 1 {
+        let value = &args[0].text;
+        return match op {
+            "neg" => Some(format!("-({value})")),
+            "not" => Some(format!("!({value})")),
+            "bitnot" => Some(format!("!({value})")),
+            _ => None,
+        };
+    }
+    None
+}
+
+fn operation_return_type(
+    concept_name: &str,
+    args: &[ShapeExpression],
+    fallback_return_type: &str,
+) -> String {
+    match concept_name
+        .strip_prefix("concept:")
+        .unwrap_or(concept_name)
+    {
+        "eq" | "ne" | "lt" | "le" | "gt" | "ge" | "and" | "or" | "not" => "bool".to_string(),
+        _ => args
+            .first()
+            .map(|arg| arg.type_name.clone())
+            .unwrap_or_else(|| map_source_type(fallback_return_type)),
+    }
+}
+
+fn operand_binding_map(operand_bindings: &[Value]) -> BTreeMap<Vec<usize>, String> {
+    let mut out = BTreeMap::new();
+    for binding in operand_bindings {
+        let Some(position) = binding.get("position").and_then(Value::as_array) else {
+            continue;
+        };
+        let Some(symbol) = binding.get("symbol").and_then(Value::as_str) else {
+            continue;
+        };
+        let mut parts = Vec::new();
+        let mut valid = true;
+        for part in position {
+            if let Some(value) = part.as_u64().and_then(|value| usize::try_from(value).ok()) {
+                parts.push(value);
+            } else {
+                valid = false;
+                break;
+            }
+        }
+        if valid {
+            out.insert(parts, symbol.to_string());
+        }
+    }
+    out
+}
+
+fn symbol_term(symbol: &str, context: &ShapeLoweringContext) -> ShapeExpression {
+    if matches!(symbol, "true" | "True") {
+        return ShapeExpression {
+            text: "true".to_string(),
+            type_name: "bool".to_string(),
+        };
+    }
+    if matches!(symbol, "false" | "False") {
+        return ShapeExpression {
+            text: "false".to_string(),
+            type_name: "bool".to_string(),
+        };
+    }
+    if symbol.parse::<i64>().is_ok() {
+        return ShapeExpression {
+            text: symbol.to_string(),
+            type_name: "i64".to_string(),
+        };
+    }
+    if symbol.starts_with('"') && symbol.ends_with('"') {
+        return ShapeExpression {
+            text: symbol.to_string(),
+            type_name: "String".to_string(),
+        };
+    }
+    ShapeExpression {
+        text: symbol.to_string(),
+        type_name: type_for_argument(symbol, context),
+    }
+}
+
+fn literal_term(value: &Value) -> ShapeExpression {
+    match value {
+        Value::Bool(value) => ShapeExpression {
+            text: value.to_string(),
+            type_name: "bool".to_string(),
+        },
+        Value::Number(value) => ShapeExpression {
+            text: value.to_string(),
+            type_name: "i64".to_string(),
+        },
+        Value::String(value) => ShapeExpression {
+            text: format!("{:?}.to_string()", value),
+            type_name: "String".to_string(),
+        },
+        _ => ShapeExpression {
+            text: "()".to_string(),
+            type_name: "()".to_string(),
+        },
+    }
+}
+
+fn type_for_argument(symbol: &str, context: &ShapeLoweringContext) -> String {
+    context
+        .params
+        .iter()
+        .position(|param| param == symbol)
+        .and_then(|index| context.param_types.get(index))
+        .map(|ty| map_source_type(ty))
+        .unwrap_or_else(|| map_source_type(&context.return_type))
+}
+
+fn append_position(position: &[usize], next: usize) -> Vec<usize> {
+    let mut out = position.to_vec();
+    out.push(next);
+    out
+}
+
+fn is_rust_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn indent_block(body: &str) -> String {
+    let lines = body.lines().collect::<Vec<_>>();
+    if lines.is_empty() {
+        return "    ()".to_string();
+    }
+    lines
+        .into_iter()
+        .map(|line| format!("    {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn term_shape_concept_name(shape: &Value) -> Option<String> {
@@ -705,18 +1098,33 @@ pub fn dispatch(request: &Value) -> Value {
                 .get("concept_name")
                 .and_then(Value::as_str)
                 .unwrap_or("");
+            let source_function = params
+                .get("source_function_name")
+                .or_else(|| params.get("sourceFunctionName"))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .unwrap_or(function);
             let mode = params.get("mode").and_then(Value::as_str);
             let param_names = string_array(params.get("params"));
             let param_types = string_array(params.get("param_types"));
+            let operand_bindings = value_array(
+                params
+                    .get("operand_bindings")
+                    .or_else(|| params.get("operandBindings")),
+            );
             let proc_macro_invocations = value_array(
                 params
                     .get("procMacroInvocations")
                     .or_else(|| params.get("proc_macro_invocations")),
             );
-            let realized = if let Some(term_shape) = params.get("term_shape") {
-                let r = emit_from_term_shape(
+            let realized = if let Some(term_shape) =
+                params.get("term_shape").or_else(|| params.get("termShape"))
+            {
+                let r = emit_from_term_shape_with_bindings(
                     term_shape,
-                    function,
+                    &operand_bindings,
+                    source_function,
                     &param_names,
                     &param_types,
                     return_type,
@@ -724,7 +1132,7 @@ pub fn dispatch(request: &Value) -> Value {
                 apply_proc_macro_invocations(r, &proc_macro_invocations)
             } else {
                 emit_stub_with_mode_and_invocations(
-                    function,
+                    source_function,
                     &param_names,
                     &param_types,
                     return_type,
@@ -1395,6 +1803,98 @@ mod tests {
     }
 
     #[test]
+    fn rpc_term_shape_bindings_render_arithmetic_sequence_despite_unnamed_concept() {
+        let term_shape = serde_json::json!({
+            "concept_name": "concept:seq",
+            "op_cid": "blake3-512:seq",
+            "args": [
+                {
+                    "concept_name": "concept:assign",
+                    "op_cid": "blake3-512:assign-total",
+                    "args": [
+                        {},
+                        {
+                            "concept_name": "concept:add",
+                            "op_cid": "blake3-512:add",
+                            "args": [{}, {}]
+                        }
+                    ]
+                },
+                {
+                    "concept_name": "concept:assign",
+                    "op_cid": "blake3-512:assign-scaled",
+                    "args": [
+                        {},
+                        {
+                            "concept_name": "concept:mul",
+                            "op_cid": "blake3-512:mul",
+                            "args": [{}, {}]
+                        }
+                    ]
+                },
+                {
+                    "concept_name": "concept:assign",
+                    "op_cid": "blake3-512:assign-reduced",
+                    "args": [
+                        {},
+                        {
+                            "concept_name": "concept:sub",
+                            "op_cid": "blake3-512:sub",
+                            "args": [{}, {}]
+                        }
+                    ]
+                }
+            ]
+        });
+        let operand_bindings = serde_json::json!([
+            {"position": [0, 0], "symbol": "total"},
+            {"position": [0, 1, 0], "symbol": "a"},
+            {"position": [0, 1, 1], "symbol": "b"},
+            {"position": [1, 0], "symbol": "scaled"},
+            {"position": [1, 1, 0], "symbol": "total"},
+            {"position": [1, 1, 1], "symbol": "2"},
+            {"position": [2, 0], "symbol": "reduced"},
+            {"position": [2, 1, 0], "symbol": "scaled"},
+            {"position": [2, 1, 1], "symbol": "1"}
+        ]);
+        let response = dispatch(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "provekit.plugin.invoke",
+            "params": {
+                "function": "UNNAMED-CONCEPT-1",
+                "source_function_name": "compute_sum",
+                "params": ["a", "b"],
+                "param_types": ["int", "int"],
+                "return_type": "int",
+                "concept_name": "UNNAMED-CONCEPT-1",
+                "term_shape": term_shape,
+                "operand_bindings": operand_bindings
+            }
+        }));
+
+        assert_eq!(response["result"]["is_stub"], false);
+        let source = response["result"]["source"]
+            .as_str()
+            .expect("realized source");
+        assert!(
+            source.contains("pub fn compute_sum(a: i64, b: i64) -> i64"),
+            "{source}"
+        );
+        assert!(source.contains("let total: i64 = (a) + (b);"), "{source}");
+        assert!(
+            source.contains("let scaled: i64 = (total) * (2);"),
+            "{source}"
+        );
+        assert!(
+            source.contains("let reduced: i64 = (scaled) - (1);"),
+            "{source}"
+        );
+        assert!(source.contains("return reduced;"), "{source}");
+        assert!(!source.contains("panic!"), "{source}");
+    }
+
+    #[test]
     fn falls_back_to_deterministic_stub_for_missing_template() {
         let rendered = emit_stub(
             "unknown_cell",
@@ -1818,7 +2318,9 @@ mod tests {
 
         assert!(!rendered.is_stub);
         assert!(rendered.source.contains("let mut iter = items.iter();"));
-        assert!(rendered.source.contains("iter.next().copied().unwrap_or_default()"));
+        assert!(rendered
+            .source
+            .contains("iter.next().copied().unwrap_or_default()"));
     }
 
     #[test]
@@ -1865,7 +2367,9 @@ mod tests {
         let rendered = boundary_render("generic_id", "concept:generic-instantiation");
 
         assert!(!rendered.is_stub);
-        assert!(rendered.source.contains("std::convert::identity::<i64>(arg)"));
+        assert!(rendered
+            .source
+            .contains("std::convert::identity::<i64>(arg)"));
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -1506,11 +1506,18 @@ fn collapse_binding_groups(groups: Vec<Vec<OperandBinding>>) -> BindingResult {
 fn bindings_of_stmt(stmt: &syn::Stmt, ctx: &ShapeContext) -> BindingResult {
     match stmt {
         syn::Stmt::Expr(e, _) => bindings_of_expr(e, ctx),
-        syn::Stmt::Local(local) => local
-            .init
-            .as_ref()
-            .map(|init| bindings_of_expr(&init.expr, ctx))
-            .unwrap_or_default(),
+        syn::Stmt::Local(local) => {
+            let Some(init) = local.init.as_ref() else {
+                return BindingResult::default();
+            };
+            let Some(symbol) = local_binding_symbol(local) else {
+                return bindings_of_expr(&init.expr, ctx);
+            };
+            operation_binding_result(vec![
+                binding_result_for_symbol(symbol),
+                bindings_of_expr(&init.expr, ctx),
+            ])
+        }
         _ => BindingResult::default(),
     }
 }
@@ -1534,11 +1541,14 @@ fn bindings_of_expr(expr: &syn::Expr, ctx: &ShapeContext) -> BindingResult {
             bindings_of_block(&e.body, ctx),
         ]),
         syn::Expr::ForLoop(e) => operation_binding_result(vec![bindings_of_block(&e.body, ctx)]),
-        syn::Expr::Return(e) => e
-            .expr
-            .as_ref()
-            .map(|expr| bindings_of_expr(expr, ctx))
-            .unwrap_or_default(),
+        syn::Expr::Return(e) => {
+            let args = e
+                .expr
+                .as_ref()
+                .map(|expr| vec![bindings_of_expr(expr, ctx)])
+                .unwrap_or_default();
+            operation_binding_result(args)
+        }
         syn::Expr::Break(e) => {
             let args = e
                 .expr
@@ -1585,14 +1595,18 @@ fn bindings_of_expr(expr: &syn::Expr, ctx: &ShapeContext) -> BindingResult {
         syn::Expr::Paren(e) => bindings_of_expr(&e.expr, ctx),
         syn::Expr::Group(e) => bindings_of_expr(&e.expr, ctx),
         _ => operand_symbol(expr)
-            .map(|symbol| BindingResult {
-                has_operator: false,
-                bindings: vec![OperandBinding {
-                    position: Vec::new(),
-                    symbol,
-                }],
-            })
+            .map(binding_result_for_symbol)
             .unwrap_or_default(),
+    }
+}
+
+fn binding_result_for_symbol(symbol: String) -> BindingResult {
+    BindingResult {
+        has_operator: false,
+        bindings: vec![OperandBinding {
+            position: Vec::new(),
+            symbol,
+        }],
     }
 }
 
@@ -1690,6 +1704,19 @@ fn update_context_from_stmt(stmt: &syn::Stmt, ctx: &mut ShapeContext) {
     }
 }
 
+fn local_binding_symbol(local: &syn::Local) -> Option<String> {
+    match &local.pat {
+        syn::Pat::Ident(ident) => Some(ident.ident.to_string()),
+        syn::Pat::Type(pat_type) => {
+            let syn::Pat::Ident(ident) = &*pat_type.pat else {
+                return None;
+            };
+            Some(ident.ident.to_string())
+        }
+        _ => None,
+    }
+}
+
 fn local_binding_sort(
     local: &syn::Local,
     ctx: &ShapeContext,
@@ -1716,11 +1743,18 @@ fn local_binding_sort(
 fn shape_of_stmt(stmt: &syn::Stmt, ctx: &ShapeContext) -> Arc<CValue> {
     match stmt {
         syn::Stmt::Expr(e, _) => shape_of_expr(e, ctx),
-        syn::Stmt::Local(local) => local
-            .init
-            .as_ref()
-            .map(|init| shape_of_expr(&init.expr, ctx))
-            .unwrap_or_else(non_operation_shape),
+        syn::Stmt::Local(local) => {
+            let Some(init) = local.init.as_ref() else {
+                return non_operation_shape();
+            };
+            if local_binding_symbol(local).is_some() {
+                return gamma_operation(
+                    "concept:assign",
+                    vec![non_operation_shape(), shape_of_expr(&init.expr, ctx)],
+                );
+            }
+            shape_of_expr(&init.expr, ctx)
+        }
         _ => non_operation_shape(),
     }
 }
@@ -1747,11 +1781,14 @@ fn shape_of_expr(expr: &syn::Expr, ctx: &ShapeContext) -> Arc<CValue> {
             vec![shape_of_expr(&e.cond, ctx), shape_of_block(&e.body, ctx)],
         ),
         syn::Expr::ForLoop(e) => gamma_operation("concept:for", vec![shape_of_block(&e.body, ctx)]),
-        syn::Expr::Return(e) => e
-            .expr
-            .as_ref()
-            .map(|expr| shape_of_expr(expr, ctx))
-            .unwrap_or_else(non_operation_shape),
+        syn::Expr::Return(e) => {
+            let args = e
+                .expr
+                .as_ref()
+                .map(|expr| vec![shape_of_expr(expr, ctx)])
+                .unwrap_or_default();
+            gamma_operation("concept:return", args)
+        }
         syn::Expr::Break(e) => {
             let args = e
                 .expr
@@ -2535,7 +2572,7 @@ pub fn commented() -> &'static str {
     }
 
     #[test]
-    fn term_shape_let_rhs_operator_is_canonical_gamma() {
+    fn term_shape_let_binding_preserves_assignment_boundary() {
         let shape = term_shape_json(
             r#"
 pub fn add_via_let(a: i64, b: i64) -> i64 {
@@ -2544,20 +2581,29 @@ pub fn add_via_let(a: i64, b: i64) -> i64 {
 }
 "#,
         );
+        let assign_cid = concept_op_cid("concept:assign").expect("assign cid");
+        let add_cid = concept_op_cid("concept:add").expect("add cid");
 
         assert_eq!(
             shape,
             json!({
-                "args": [{}, {}],
-                "concept_name": "concept:add",
-                "op_cid": "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468"
+                "args": [
+                    {},
+                    {
+                        "args": [{}, {}],
+                        "concept_name": "concept:add",
+                        "op_cid": add_cid
+                    }
+                ],
+                "concept_name": "concept:assign",
+                "op_cid": assign_cid
             })
         );
         assert_no_forbidden_term_shape_fields(&shape);
     }
 
     #[test]
-    fn term_shape_top_level_operator_matches_let_rhs_gamma() {
+    fn term_shape_top_level_operator_differs_from_let_assignment_boundary() {
         let top_level = term_shape_json(
             r#"
 pub fn f(a: i64, b: i64) -> i64 {
@@ -2574,8 +2620,33 @@ pub fn f(a: i64, b: i64) -> i64 {
 "#,
         );
 
-        assert_eq!(top_level, let_rhs);
+        assert_ne!(top_level, let_rhs);
+        assert_eq!(
+            top_level["concept_name"],
+            json!("concept:add"),
+            "top-level tail expression remains an add shape"
+        );
+        assert_eq!(
+            let_rhs["concept_name"],
+            json!("concept:assign"),
+            "let binding preserves its assignment boundary"
+        );
         assert_no_forbidden_term_shape_fields(&top_level);
+        assert_no_forbidden_term_shape_fields(&let_rhs);
+    }
+
+    #[test]
+    fn term_shape_explicit_return_preserves_return_boundary() {
+        let shape = term_shape_json(
+            r#"
+pub fn f(a: i64) -> i64 {
+    return a;
+}
+"#,
+        );
+
+        assert_eq!(shape["concept_name"], json!("concept:return"));
+        assert_no_forbidden_term_shape_fields(&shape);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- fixes Trinity slow-lane realization by carrying term-shape and operand bindings through Java, Python, Rust, and walk relift paths
- fixes platform semantics discovery/loading so full kit identities resolve before bare binding tags and workspace build products are found reliably
- keeps bind-migrate receipt tests synthetic where they test receipt behavior rather than ambient kit discovery

## Root cause

Main CI was red in the Trinity slow-lane jobs and in the cross-language conformance gate. The failures came from losing structured term-shape/binding data across language realization plus platform semantics lookup falling back to the wrong kit identity/path behavior.

## Validation

- git diff --check --cached
- python3 -m pytest implementations/python/provekit-realize-python-core/tests/test_realizer.py -q
- mvn -q -pl provekit-lift-java-source -am -Dtest=TrinityRoundtripLiftTest#bindLifterKeepsOperatorsInsideLocalInitializersForTrinityRelift test
- mvn -q -pl provekit-realize-java-core -am -Dtest=JavaNullBoundaryRealizerTest#termShapeRealizationRendersArithmeticSequenceDespiteUnnamedTopLevelConcept test
- cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --bin provekit -- --nocapture
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test trinity_composition_census --features provekit-cli/slow-tests -- --nocapture
- JAVA_HOME=/usr/local/Cellar/openjdk/25.0.2/libexec/openjdk.jdk/Contents/Home cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test trinity_citation_comments_exhibit --features provekit-cli/slow-tests -- --nocapture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced code lifting to preserve operator structure and track operand bindings throughout the transformation pipeline.
  * Added code realization from term-shape representations, enabling more accurate generation of code in target languages.
  * Improved platform semantics resolution to support multi-candidate kit binary discovery and optional initialization handshakes.

* **Tests**
  * Added comprehensive test coverage for term-shape driven code generation across Java, Python, and Rust implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->