### PR TITLE
[codex] fix Python root operand binding realization

### DIFF
--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
@@ -142,7 +142,9 @@ def emit_stub(
     if concept_lines:
         body = "\n".join([*concept_lines, "pass"])
     else:
-        use_term_shape = isinstance(term_shape, dict) and bool(term_shape)
+        use_term_shape = isinstance(term_shape, dict) and (
+            bool(term_shape) or bool(operand_bindings)
+        )
         if use_term_shape:
             missing = missing_templates_for_term_shape(
                 function,

--- a/implementations/python/provekit-realize-python-core/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realizer.py
@@ -573,6 +573,23 @@ def test_term_shape_sidecar_renders_safe_divide_then_double_source_symbols() -> 
     assert fn(-5, 2) == -1
 
 
+def test_empty_term_shape_uses_root_operand_binding_literal() -> None:
+    result = emit_stub(
+        function="",
+        params=[],
+        param_types=[],
+        return_type="str",
+        concept_name="UNNAMED-CONCEPT-1",
+        term_shape={},
+        operand_bindings=[{"position": [], "symbol": '"hello"'}],
+        source_function_name="hello",
+    )
+
+    assert result["source"] == "def hello():\n    return \"hello\"\n"
+    namespace = _compiled_namespace(result["source"])
+    assert namespace["hello"]() == "hello"
+
+
 def test_term_shape_sidecar_wins_over_lossy_named_tree_for_nested_unary_ops() -> None:
     lossy_tree = {
         "conceptName": "concept:seq",


### PR DESCRIPTION
## Summary

- treats an empty Python term shape as realizable when the lift sidecar carries root operand bindings
- adds a regression test for the root-binding literal case that was falling through to `UNNAMED-CONCEPT-1` body-template lookup

## Root cause

The merged Trinity CI fix handled structured term shapes, but the Python `hello` fixture lifts as `term_shape = {}` with a root operand binding for the literal. The realizer gated term-shape lowering on `bool(term_shape)`, so `{}` was treated as absent and the lower path tried to find a body-template for `UNNAMED-CONCEPT-1`.

## Validation

- git diff --check
- python3 -m pytest implementations/python/provekit-realize-python-core/tests/test_realizer.py implementations/python/provekit-realize-python-core/tests/test_emit_compile_run_conformance.py -q
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test python_emit_compile_run_conformance --features provekit-cli/slow-tests -- --nocapture
- cargo build --manifest-path implementations/rust/Cargo.toml -p provekit-walk -p provekit-realize-rust-core -p provekit-cli
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test trinity_composition_census --features provekit-cli/slow-tests -- --nocapture
