### PR TITLE
fix(migrate): replace hardcoded source_lang check with substrate-availability probe (#1230 D6-D)

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -74,6 +74,15 @@ fn run_inner(args: BindArgs) -> Result<(), String> {
 
     let (source_lang, source_tag) = split_library_surface(library_from)?;
     let (target_lang, target_tag) = split_library_surface(library_to)?;
+
+    // Substrate-availability probe (#1230 D6-D): refuse loudly when no bind-lift
+    // kit exists for the source language. Replaces the previous hardcoded
+    // `source_lang != "typescript"` check inside TargetSurface::from_parts;
+    // the substrate's resolution chain (manifest, env-var, built-in, PATH)
+    // decides availability rather than an enumerated language list here.
+    crate::kit_dispatch::bind_lift_kit_available(&repo_root, &source_lang)
+        .map_err(|err| format!("migrate source: {err}"))?;
+
     let target_surface = TargetSurface::from_parts(
         library_from,
         library_to,
@@ -253,9 +262,15 @@ impl TargetSurface {
         target_lang: &str,
         target_tag: &str,
     ) -> Result<Self, String> {
-        if source_lang != "typescript" || source_tag != "better-sqlite3" {
+        // Per #1230 D6-D: the source_lang restriction is removed; substrate
+        // availability is now probed at the call site (run_inner) via
+        // kit_dispatch::bind_lift_kit_available so cmd_bind_migrate does not
+        // enumerate languages. The source_tag restriction remains until
+        // extract_sql_callsites is generalized off better-sqlite3 syntax
+        // (separate follow-up per the 2026-05-19 D6 decomposition).
+        if source_tag != "better-sqlite3" {
             return Err(format!(
-                "unsupported migration {library_from} to {library_to}; source must be typescript-better-sqlite3"
+                "unsupported migration {library_from} to {library_to}; source binding must be better-sqlite3 until extract_sql_callsites generalizes"
             ));
         }
         match (target_lang, target_tag) {

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -491,6 +491,21 @@ impl std::fmt::Display for KitUnavailable {
     }
 }
 
+/// Probe whether a bind-lift kit is resolvable for `source_lang` without
+/// actually invoking it. Cheap substrate-availability check for callers
+/// that want to refuse loudly before doing heavy work.
+///
+/// Returns `Ok(())` if the resolution chain (manifest, env-var, built-in
+/// convention, PATH) can locate a kit binary. Returns `Err(KitUnavailable)`
+/// otherwise. Per the substrate-uniform pattern, callers MUST NOT
+/// hardcode language-presence checks; they consult this probe instead.
+pub fn bind_lift_kit_available(
+    workspace_root: &Path,
+    source_lang: &str,
+) -> Result<(), KitUnavailable> {
+    resolve_lift_command(workspace_root, source_lang).map(|_| ())
+}
+
 /// Dispatch the bind-lift surface for `source_lang` and decode the response.
 ///
 /// Resolution order:
@@ -2121,5 +2136,23 @@ mod tests {
         assert!(validate_library_tag("Requests").is_err());
         assert!(validate_library_tag("urllib.request").is_err());
         assert!(validate_library_tag("1requests").is_err());
+    }
+
+    /// Probe behavior for an unknown source language. With no manifest,
+    /// no env-var override, no built-in entry, and no PATH binary, the
+    /// resolver must return KitUnavailable. This is the substrate-uniform
+    /// substitute (per #1230 D6-D) for the previously hardcoded
+    /// `source_lang != "typescript"` check in cmd_bind_migrate.
+    #[test]
+    fn bind_lift_kit_available_refuses_unknown_language() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let result = bind_lift_kit_available(tempdir.path(), "definitely_not_a_real_lang_xyz");
+        assert!(
+            result.is_err(),
+            "unknown language must produce KitUnavailable, got Ok"
+        );
+        let err = result.unwrap_err();
+        assert_eq!(err.kit_kind, "lift");
+        assert_eq!(err.language, "definitely_not_a_real_lang_xyz");
     }
 }


### PR DESCRIPTION
Audit row D6-D (per \`docs/audits/2026-05-19-d6-decomposition.md\`).

\`cmd_bind_migrate::TargetSurface::from_parts\` hardcoded \`source_lang != \"typescript\"\` as a gate. That enumerated languages inside the supposedly kit-agnostic migrate command. Per the substrate-uniform pattern, the dispatcher resolves kit availability via convention/manifest/env-var/PATH; cmd_bind_migrate must consult the resolver, not carry a kit list.

## Changes

- **\`kit_dispatch::bind_lift_kit_available(workspace_root, source_lang)\`**: new thin pub wrapper over \`resolve_lift_command\`. Cheap substrate-availability check; returns \`Err(KitUnavailable)\` when no kit binary resolves through the standard chain (manifest, env-var, built-in, PATH). Substrate-uniform substitute for caller-side language enumeration.

- **\`cmd_bind_migrate::run_inner\`**: calls the probe between \`split_library_surface\` and \`TargetSurface::from_parts\`. On \`Err\`, refuses with the \`KitUnavailable\` detail forwarded into the migrate error message.

- **\`TargetSurface::from_parts\`**: source_lang condition removed from the gate. \`source_tag\` remains as the narrow downstream gate until \`extract_sql_callsites\` is generalized off better-sqlite3 syntax (separate follow-up per the D6 decomposition).

- **Discrimination test** in \`kit_dispatch::tests\` asserts the probe returns \`Err(KitUnavailable)\` with \`kit_kind=\"lift\"\` and the language string echoed back, for a language that has no manifest / env-var / built-in / PATH binary.

## Out of this issue

Per the D6 decomposition:
- \`extract_functions\` / \`extract_sql_callsites\` source generalization (D6-B)
- \`source_file\` path convention (D6-C)
- \`TargetSurface\` enum residual uses (\`is_python\`, \`requires_async_delta\`, \`output_file\`)
- Per-target shell composition

## Boy-scout

The original audit was going to include rewriting 7 pre-existing-red \`cmd_bind_migrate\` tests, but #1291 (which landed during this work) already did that via synthetic fixtures. Remaining 2 failures are #1202-blocked (Uncharacterizable variant not yet consumed in migrate flow); that issue is in progress separately.

## Test plan

- [x] \`cargo check --workspace\` passes
- [x] \`cargo test -p provekit-cli --bin provekit\`: 102/104 pass (the 2 fails are pre-existing #1202 blocks, not introduced or addressable here)
- [x] New \`bind_lift_kit_available_refuses_unknown_language\` probe test passes

Refs #1230. Closes D6-D leaf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)