### PR TITLE
feat(substrate): add literal-encoding question_kind + LiteralEncodingMemento (#1262 substrate half)

### DIFF
--- a/implementations/rust/provekit-ir-types/src/lib.rs
+++ b/implementations/rust/provekit-ir-types/src/lib.rs
@@ -625,6 +625,93 @@ impl PlatformSemanticTag {
     }
 }
 
+/// A kit-minted answer to a `literal-encoding` exam question.
+///
+/// For a given (language, substrate-canonical sort), declares the concrete
+/// `concept:literal { value, sort }` node the kit's bind-lift emits for a
+/// representative source-language literal of that sort. The exam consumer
+/// (filed as a follow-up) runs the kit's lift over `source_example` and
+/// asserts the resulting term_shape contains an equivalent
+/// `expected_term_shape_node`.
+///
+/// Locked JCS key order:
+///   cid, expected_term_shape_node, kind, kit_cid, language,
+///   schemaVersion, sort_cid, source_example.
+///
+/// Per the #1260 envelope-violation fix, `cid` and `kit_cid` are elided
+/// from the content-hash; two kits with byte-identical (language, sort_cid,
+/// source_example, expected_term_shape_node) tuples therefore produce
+/// byte-identical CIDs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiteralEncodingMemento {
+    /// DERIVED: BLAKE3-512 over JCS(memento) with `cid` + `kit_cid` elided.
+    pub cid: Cid,
+    #[serde(rename = "expected_term_shape_node")]
+    pub expected_term_shape_node: ExpectedLiteralNode,
+    pub kind: String,
+    #[serde(rename = "kit_cid")]
+    pub kit_cid: Cid,
+    pub language: String,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "sort_cid")]
+    pub sort_cid: Cid,
+    #[serde(rename = "source_example")]
+    pub source_example: String,
+}
+
+/// The concept:literal leaf shape the kit's bind-lift is expected to emit
+/// for the corresponding source_example.
+///
+/// Locked JCS key order: concept_name, sort, value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExpectedLiteralNode {
+    #[serde(rename = "concept_name")]
+    pub concept_name: String,
+    pub sort: Cid,
+    pub value: serde_json::Value,
+}
+
+impl LiteralEncodingMemento {
+    pub const KIND: &'static str = "literal-encoding-memento";
+    pub const SCHEMA_VERSION: &'static str = "1.0.0";
+    pub const CONCEPT_LITERAL_NAME: &'static str = "concept:literal";
+
+    pub fn new(
+        kit_cid: Cid,
+        language: String,
+        sort_cid: Cid,
+        source_example: String,
+        decoded_value: serde_json::Value,
+    ) -> Self {
+        let expected_term_shape_node = ExpectedLiteralNode {
+            concept_name: Self::CONCEPT_LITERAL_NAME.to_string(),
+            sort: sort_cid.clone(),
+            value: decoded_value,
+        };
+        let mut memento = Self {
+            cid: String::new(),
+            expected_term_shape_node,
+            kind: Self::KIND.to_string(),
+            kit_cid,
+            language,
+            schema_version: Self::SCHEMA_VERSION.to_string(),
+            sort_cid,
+            source_example,
+        };
+        memento.cid = memento.recompute_cid();
+        memento
+    }
+
+    pub fn to_jcs_string(&self) -> String {
+        platform_semantic_jcs_string(self)
+    }
+
+    pub fn recompute_cid(&self) -> Cid {
+        platform_semantic_cid_without_keys(self, &["cid", "kit_cid"])
+    }
+}
+
 fn platform_semantic_jcs_string<T: Serialize>(value: &T) -> String {
     let json = serde_json::to_value(value).expect("platform semantic memento serializes to JSON");
     let canonical = canonical_value_from_json(json);
@@ -3246,6 +3333,11 @@ pub enum ExamQuestionKind {
     Effect,
     BoundaryTag,
     Composition,
+    /// `literal-encoding`: per (language, sort), declares the concept:literal
+    /// node the kit's bind-lift emits for a representative source-language
+    /// literal of that sort. Added per #1262 alongside `LiteralEncodingMemento`
+    /// as the expected_answer_shape.
+    LiteralEncoding,
     Other(String),
 }
 
@@ -3258,6 +3350,7 @@ impl ExamQuestionKind {
             Self::Effect => "effect",
             Self::BoundaryTag => "boundary-tag",
             Self::Composition => "composition",
+            Self::LiteralEncoding => "literal-encoding",
             Self::Other(raw) => raw,
         }
     }
@@ -3272,6 +3365,7 @@ impl From<String> for ExamQuestionKind {
             "effect" => Self::Effect,
             "boundary-tag" => Self::BoundaryTag,
             "composition" => Self::Composition,
+            "literal-encoding" => Self::LiteralEncoding,
             _ => Self::Other(s),
         }
     }
@@ -3286,6 +3380,7 @@ impl From<ExamQuestionKind> for String {
             ExamQuestionKind::Effect => "effect".to_string(),
             ExamQuestionKind::BoundaryTag => "boundary-tag".to_string(),
             ExamQuestionKind::Composition => "composition".to_string(),
+            ExamQuestionKind::LiteralEncoding => "literal-encoding".to_string(),
             ExamQuestionKind::Other(raw) => raw,
         }
     }

--- a/implementations/rust/provekit-ir-types/tests/platform_semantics_mementos.rs
+++ b/implementations/rust/provekit-ir-types/tests/platform_semantics_mementos.rs
@@ -2,7 +2,10 @@
 
 use std::collections::BTreeMap;
 
-use provekit_ir_types::{DimensionValueMemento, IrFormula, PlatformSemanticTag};
+use provekit_ir_types::{
+    DimensionValueMemento, IrFormula, LiteralEncodingMemento, PlatformSemanticTag,
+};
+use serde_json::json;
 
 const KIT_CID: &str = "blake3-512:11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
 const OP_CID: &str = "blake3-512:22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
@@ -77,5 +80,69 @@ fn platform_semantic_tag_round_trips_and_recomputes_cid() {
             < encoded
                 .find("IntegerDivisionRoundingMode")
                 .expect("division key")
+    );
+}
+
+const SORT_INT_CID: &str = "blake3-512:30ffc51350121a7172f3e4064a33c45bbd345756979fccff6875cd2ab33e4964d098a99df80cfbdf1ec1a0738c5ac3476f0ff8f75589ea511d1acd82c74ecd58";
+
+/// LiteralEncodingMemento round-trips through JCS and recomputes its own
+/// CID. Per #1262, this is the kit-minted answer to a `literal-encoding`
+/// exam question: for (language, sort), what concept:literal node does the
+/// kit's bind-lift emit for a representative source-language literal?
+#[test]
+fn literal_encoding_memento_round_trips_and_recomputes_cid() {
+    let memento = LiteralEncodingMemento::new(
+        KIT_CID.to_string(),
+        "rust".to_string(),
+        SORT_INT_CID.to_string(),
+        "42".to_string(),
+        json!(42),
+    );
+
+    let encoded = memento.to_jcs_string();
+    let decoded: LiteralEncodingMemento =
+        serde_json::from_str(&encoded).expect("literal encoding decodes");
+
+    assert_eq!(decoded, memento);
+    assert_eq!(decoded.cid, decoded.recompute_cid());
+    assert_eq!(decoded.kind, LiteralEncodingMemento::KIND);
+    assert_eq!(decoded.schema_version, LiteralEncodingMemento::SCHEMA_VERSION);
+    assert_eq!(
+        decoded.expected_term_shape_node.concept_name,
+        LiteralEncodingMemento::CONCEPT_LITERAL_NAME
+    );
+    assert_eq!(decoded.expected_term_shape_node.sort, SORT_INT_CID);
+    assert_eq!(decoded.expected_term_shape_node.value, json!(42));
+}
+
+/// Substrate-uniform property (cross-kit equivalence): two kits with
+/// identical (language, sort_cid, source_example, decoded value) tuples
+/// produce byte-identical LiteralEncodingMemento CIDs even when kit_cid
+/// differs. Mirrors the post-#1271 kit_cid elision behavior already
+/// exercised by DimensionValueMemento + PlatformSemanticTag.
+#[test]
+fn literal_encoding_memento_cross_kit_equivalence_via_kit_cid_elision() {
+    let kit_a = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let kit_b = "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    let memento_a = LiteralEncodingMemento::new(
+        kit_a.to_string(),
+        "rust".to_string(),
+        SORT_INT_CID.to_string(),
+        "42".to_string(),
+        json!(42),
+    );
+    let memento_b = LiteralEncodingMemento::new(
+        kit_b.to_string(),
+        "rust".to_string(),
+        SORT_INT_CID.to_string(),
+        "42".to_string(),
+        json!(42),
+    );
+
+    assert_ne!(memento_a.kit_cid, memento_b.kit_cid);
+    assert_eq!(
+        memento_a.cid, memento_b.cid,
+        "kit_cid is elided from content-hash; identical (lang, sort, source, value) MUST collide"
     );
 }

--- a/menagerie/concept-shapes/specs/exam-manifest_shape.spec.json
+++ b/menagerie/concept-shapes/specs/exam-manifest_shape.spec.json
@@ -71,7 +71,8 @@
       "sort-classification",
       "effect-classification",
       "morphism",
-      "composition"
+      "composition",
+      "literal-encoding"
     ],
     "question_parameter_schemas": {
       "boundary-realization": [
@@ -89,6 +90,9 @@
         "language"
       ],
       "effect-classification": [
+        "language"
+      ],
+      "literal-encoding": [
         "language"
       ],
       "morphism": [

--- a/menagerie/concept-shapes/specs/sort-instance_exam_question_kind.spec.json
+++ b/menagerie/concept-shapes/specs/sort-instance_exam_question_kind.spec.json
@@ -11,6 +11,7 @@
       "boundary-tag",
       "composition",
       "effect",
+      "literal-encoding",
       "morphism",
       "realization",
       "sort"

--- a/menagerie/concept-shapes/tests/test_exam_manifest_schema_v1_1.py
+++ b/menagerie/concept-shapes/tests/test_exam_manifest_schema_v1_1.py
@@ -22,6 +22,7 @@ QUESTION_KINDS = [
     "effect-classification",
     "morphism",
     "composition",
+    "literal-encoding",
 ]
 LIVE_V1_1_QUESTION_KINDS = sorted(set(QUESTION_KINDS) - {"composition"})
 LEGACY_V1_QUESTION_KINDS = [
@@ -48,6 +49,7 @@ PARAMETERS_BY_KIND = {
     "composition": set(),
     "concept-realization": {"language"},
     "effect-classification": {"language"},
+    "literal-encoding": {"language"},
     "morphism": {"from_language"},
     "sort-classification": {"language"},
 }
@@ -56,6 +58,7 @@ EXPECTED_ANSWER_SHAPE_BY_KIND = {
     "boundary-tag": "BoundaryTagMemento",
     "concept-realization": "RealizationMemento",
     "effect-classification": "EffectSignatureMemento",
+    "literal-encoding": "LiteralEncodingMemento",
     "morphism": "MorphismMemento",
     "sort-classification": "SortMorphismMemento",
 }
@@ -133,6 +136,14 @@ def _small_v1_1_manifest() -> dict[str, Any]:
                         "concept": "concept:Int",
                         "expected_answer_shape": "SortMorphismMemento",
                         "kind": "sort-classification",
+                        "parameters": {
+                            "language": "python",
+                        },
+                    },
+                    {
+                        "concept": "concept:Int",
+                        "expected_answer_shape": "LiteralEncodingMemento",
+                        "kind": "literal-encoding",
                         "parameters": {
                             "language": "python",
                         },


### PR DESCRIPTION
Substrate-canonical half of #1262.

The existing \`sort-classification\` exam verifies kits can MAP substrate-canonical sorts to native types. It does NOT verify that kits' bind-lift EMITS \`concept:literal { value, sort }\` nodes correctly for source-language literals. The new \`literal-encoding\` question kind closes that gap; without it, kits drift silently and Trinity cycle invariance breaks at runtime with no exam-time warning.

## What lands

- **\`LiteralEncodingMemento\`** (new type in \`provekit-ir-types\`): kit-minted answer shape. Fields: \`cid\`, \`expected_term_shape_node\`, \`kind\`, \`kit_cid\`, \`language\`, \`schemaVersion\`, \`sort_cid\`, \`source_example\`. CID elides \`cid\` + \`kit_cid\` per #1260 envelope-violation rule.
- **\`ExamQuestionKind::LiteralEncoding\`** variant with serde \`\"literal-encoding\"\` round-trip.
- **Schema specs extended**: \`exam-manifest_shape.spec.json\` (\`question_kinds\` + \`parameter_schemas\` add literal-encoding), \`sort-instance_exam_question_kind.spec.json\` (enum_values).
- **Python schema test** extended (\`QUESTION_KINDS\` + \`PARAMETERS_BY_KIND\` + \`EXPECTED_ANSWER_SHAPE_BY_KIND\` + fixture).
- **Memento tests** cover round-trip + CID recompute + cross-kit equivalence via \`kit_cid\` elision (substrate-uniform property: two kits with identical (lang, sort, source, value) tuples produce byte-identical CIDs).

## Out of this PR (Sonnet-agent cascade follow-on)

- Per-kit \`LiteralEncodingMemento\` answers: each kit ships one per (language, sort) it admits at literal positions per its SortAdmission declaration from #1283.
- Exam consumer that runs bind-lift and compares actual term_shape against \`expected_term_shape_node\`.
- Extending exam manifest v1.x with the actual literal-encoding question set (gated on per-kit answers).

## Test plan
- [x] \`cargo check -p provekit-ir-types\` passes
- [x] \`cargo test -p provekit-ir-types\` full suite passes (added 2 new LiteralEncodingMemento tests)
- [x] \`python3 -m pytest test_exam_manifest_schema_v1_1.py\`: 3/3 pass

Refs #1262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)