### PR TITLE
feat(typescript-kit): provekit.plugin.literal_encoding_answers (#1262)

### DIFF
--- a/implementations/typescript/provekit-realize-typescript-core/src/literal_encoding.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/literal_encoding.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// TypeScript kit literal-encoding answers.
+//
+// Implements the provekit.plugin.literal_encoding_answers RPC method.
+// Returns one LiteralEncodingMemento per sort the TypeScript kit admits
+// at literal positions per its SortAdmission declaration.
+//
+// TypeScript admits: Float, String, Bool, Null (no Int, no Bytes).
+// JS Number is IEEE 754 double; there is no distinct integer literal sort.
+// Buffers/Uint8Array are not a primitive literal sort at the JS/TS value layer.
+
+"use strict";
+
+const { blake3 } = require("@noble/hashes/blake3.js");
+const { KIT_CID } = require("./platform_semantics");
+
+// Canonical sort CIDs (from #1282)
+const SORT_BOOL_CID   = "blake3-512:0ee13bf3fd6b7ecfbee72dfbfc18a7c0ea7f1663de6cca43cefb36f5b4c03665452646094a7c296e819e75d683c6ce4821f3d7db3c3c78ae97f2d4e3451d2074";
+const SORT_NULL_CID   = "blake3-512:62f6040bd3f414c1e6c2b7bdf276669cd5613b33cb508a81170170064ca3ffba771a4b0002dc52e059fce5f9f63a1874ef71bd4ec89ae06e89c87a3e91aac3b5";
+const SORT_FLOAT_CID  = "blake3-512:b979e70c4d5e53d9bdf13d6f08330be3c5b0714b8c770d69bbd05946b86c36df5274be8145a2683cc29c278155c9c1ee65b6897913524eecb9e4c89c71862f57";
+const SORT_STRING_CID = "blake3-512:be8721d24849feb74c4721520bdba02d352a94f49253a627cd509127472aa1c47cbe99cb705cac4159b5365abcce0c9aaa4901fe67630827deb6be1f9daeea10";
+
+const CONCEPT_LITERAL_NAME = "concept:literal";
+
+/**
+ * Returns the set of LiteralEncodingMemento answers for the TypeScript kit.
+ * TypeScript admits: Float (3.14), String ("hello"), Bool (true), Null (null).
+ */
+function answers() {
+  return [
+    // TypeScript stores floats as JSON numbers (IEEE 754 double, not __float_bits__)
+    _memento(SORT_FLOAT_CID, "3.14", 3.14),
+    _memento(SORT_STRING_CID, '"hello"', "hello"),
+    _memento(SORT_BOOL_CID, "true", true),
+    _memento(SORT_NULL_CID, "null", null),
+  ];
+}
+
+function _memento(sortCid, sourceExample, decodedValue) {
+  const expectedTermShapeNode = {
+    concept_name: CONCEPT_LITERAL_NAME,
+    sort: sortCid,
+    value: decodedValue,
+  };
+  const forCid = {
+    expected_term_shape_node: expectedTermShapeNode,
+    kind: "literal-encoding-memento",
+    language: "typescript",
+    schemaVersion: "1.0.0",
+    sort_cid: sortCid,
+    source_example: sourceExample,
+  };
+  return {
+    cid: _cidOf(forCid),
+    expected_term_shape_node: expectedTermShapeNode,
+    kind: "literal-encoding-memento",
+    kit_cid: KIT_CID,
+    language: "typescript",
+    schemaVersion: "1.0.0",
+    sort_cid: sortCid,
+    source_example: sourceExample,
+  };
+}
+
+function _cidOf(obj) {
+  const canonical = _jcs(obj);
+  const bytes = new TextEncoder().encode(canonical);
+  const hash = blake3(bytes, { dkLen: 64 });
+  return "blake3-512:" + _hexOf(hash);
+}
+
+function _jcs(obj) {
+  return JSON.stringify(_sortKeys(obj));
+}
+
+function _sortKeys(val) {
+  if (val === null || typeof val !== "object") return val;
+  if (Array.isArray(val)) return val.map(_sortKeys);
+  return Object.fromEntries(
+    Object.keys(val).sort().map((k) => [k, _sortKeys(val[k])])
+  );
+}
+
+function _hexOf(bytes) {
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+module.exports = { answers };

--- a/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
@@ -1,6 +1,7 @@
 const readline = require("node:readline");
 
 const { emitStub } = require("./realizer");
+const { answers: literalEncodingAnswers } = require("./literal_encoding");
 const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
 
 function runRpc() {
@@ -44,6 +45,9 @@ function dispatch(request) {
   if (method === "provekit.plugin.platform_semantics") {
     const decl = platformSemanticsDeclaration();
     return { jsonrpc: "2.0", id: msgId, result: { tags: decl.tags, dimension_values: decl.dimension_values, op_aliases: {} } };
+  }
+  if (method === "provekit.plugin.literal_encoding_answers") {
+    return { jsonrpc: "2.0", id: msgId, result: { answers: literalEncodingAnswers() } };
   }
   if (method === "provekit.plugin.shutdown") {
     return { jsonrpc: "2.0", id: msgId, result: null };

--- a/implementations/typescript/provekit-realize-typescript-core/tests/literal_encoding.test.js
+++ b/implementations/typescript/provekit-realize-typescript-core/tests/literal_encoding.test.js
@@ -1,0 +1,86 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { answers } = require("../src/literal_encoding");
+const { dispatch } = require("../src/rpc");
+
+// Canonical sort CIDs (from #1282)
+const SORT_BOOL_CID   = "blake3-512:0ee13bf3fd6b7ecfbee72dfbfc18a7c0ea7f1663de6cca43cefb36f5b4c03665452646094a7c296e819e75d683c6ce4821f3d7db3c3c78ae97f2d4e3451d2074";
+const SORT_NULL_CID   = "blake3-512:62f6040bd3f414c1e6c2b7bdf276669cd5613b33cb508a81170170064ca3ffba771a4b0002dc52e059fce5f9f63a1874ef71bd4ec89ae06e89c87a3e91aac3b5";
+const SORT_FLOAT_CID  = "blake3-512:b979e70c4d5e53d9bdf13d6f08330be3c5b0714b8c770d69bbd05946b86c36df5274be8145a2683cc29c278155c9c1ee65b6897913524eecb9e4c89c71862f57";
+const SORT_STRING_CID = "blake3-512:be8721d24849feb74c4721520bdba02d352a94f49253a627cd509127472aa1c47cbe99cb705cac4159b5365abcce0c9aaa4901fe67630827deb6be1f9daeea10";
+
+// TypeScript admits: Float, String, Bool, Null (no Int, no Bytes) -- 4 answers.
+
+test("ts_literal_encoding_answers_count", () => {
+  const a = answers();
+  assert.strictEqual(a.length, 4, "TypeScript admits Float, String, Bool, Null (4 sorts)");
+});
+
+test("ts_literal_encoding_answers_sort_cids", () => {
+  const a = answers();
+  const sortCids = new Set(a.map((m) => m.sort_cid));
+  assert.ok(sortCids.has(SORT_FLOAT_CID), "must contain Float");
+  assert.ok(sortCids.has(SORT_STRING_CID), "must contain String");
+  assert.ok(sortCids.has(SORT_BOOL_CID), "must contain Bool");
+  assert.ok(sortCids.has(SORT_NULL_CID), "must contain Null");
+});
+
+test("ts_literal_encoding_answers_language", () => {
+  const a = answers();
+  for (const m of a) {
+    assert.strictEqual(m.language, "typescript", "language must be typescript");
+  }
+});
+
+test("ts_literal_encoding_answers_kind", () => {
+  const a = answers();
+  for (const m of a) {
+    assert.strictEqual(m.kind, "literal-encoding-memento");
+  }
+});
+
+test("ts_literal_encoding_answers_cid_format", () => {
+  const a = answers();
+  for (const m of a) {
+    assert.ok(m.cid.startsWith("blake3-512:"), "CID must start with blake3-512:");
+    assert.ok(m.cid.length > 20, "CID must not be empty");
+  }
+});
+
+// Golden LiteralEncodingMemento CIDs (kit_cid elided per #1262 / #1271)
+// TS uses _sortKeys + JSON.stringify (same as platform_semantics.js).
+const GOLDEN_CIDS = {
+  [SORT_FLOAT_CID]:  "blake3-512:9067386da3d0b0a951ac837ff1d1f9d48ae3688ed83b3640534bfc7929d59b1e2ac425303c1a3a08b7085c63dd6624da7c01a13201ecf6b77006f0ebd8629b15",
+  [SORT_STRING_CID]: "blake3-512:2afc602d467f858fb5c5e58138e1365be54f9a698a30ed823d5c5c5b966dc24a140c58ab5e1bd75a4a6239d7b934e8d1b7e78f8eb84a96b668f1f8dd3a7049f3",
+  [SORT_BOOL_CID]:   "blake3-512:784022d1f5e6a28447da659e347b009e2730b5ac0ab68a3d774e9b46cb59ed1bd07f76e9d6f48f40e123af93f2d65b89d5af4e0b57737694a0835c15405ab7e7",
+  [SORT_NULL_CID]:   "blake3-512:d58343632e0e01b35f866256148c90b529656ed22da8ab7e4a1b96e823f651ba5d27145470e514a71443aee432a5d98bb83c19eac9fefd4502d926dbbc62b75e",
+};
+
+test("ts_literal_encoding_answers_golden_cids", () => {
+  const a = answers();
+  const bySortCid = {};
+  for (const m of a) bySortCid[m.sort_cid] = m.cid;
+
+  for (const [sortCid, expectedCid] of Object.entries(GOLDEN_CIDS)) {
+    assert.strictEqual(
+      bySortCid[sortCid], expectedCid,
+      `Golden CID mismatch for sort ${sortCid.slice(0, 20)}`
+    );
+  }
+});
+
+test("ts_literal_encoding_answers_rpc_dispatch", () => {
+  const response = dispatch({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "provekit.plugin.literal_encoding_answers",
+    params: {},
+  });
+  assert.strictEqual(response.jsonrpc, "2.0");
+  assert.strictEqual(response.id, 1);
+  assert.ok(Array.isArray(response.result.answers));
+  assert.strictEqual(response.result.answers.length, 4);
+});


### PR DESCRIPTION
## Summary

- Adds `provekit.plugin.literal_encoding_answers` RPC dispatch arm to the TypeScript realize kit
- New `src/literal_encoding.js` returns 4 `LiteralEncodingMemento` answers: Float, String, Bool, Null (TypeScript does not admit Int or Bytes -- JS Number is IEEE 754 double with no distinct integer sort)
- Float stored as JSON number (3.14), consistent with how TS realizes float literals
- CIDs computed via `_sortKeys + JSON.stringify + blake3-512`, consistent with `platform_semantics.js`
- 7 tests with golden CID regression for all 4 sorts + RPC dispatch round-trip test

## Stacks on

PR #1296 (`pk-1262-substrate`) -- `LiteralEncodingMemento` substrate type.

## Test plan

- [x] `npm test` -- 23 tests pass (7 new + 16 existing)
- [x] Em-dash sweep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)