### PR TITLE
feat(cli): materialize concept carriers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Current catalog CID: `blake3-512:dd0cc79889ee67d2594f5cfa20a191bafed15196fb2c503
 | Protocol extensions | [reference/protocol-extensions.md](reference/protocol-extensions.md) |
 | Canonical IR bytes | [reference/ir/canonical-form.md](reference/ir/canonical-form.md) |
 | Diagnostic codes | [reference/error-codes.md](reference/error-codes.md) |
+| Materialize concept citations | [reference/materialize.md](reference/materialize.md) |
 | LSP helper protocol | [reference/lsp-plugin-protocol.md](reference/lsp-plugin-protocol.md) |
 
 ## Start here

--- a/docs/reference/materialize.md
+++ b/docs/reference/materialize.md
@@ -1,0 +1,87 @@
+# `provekit materialize`
+
+`provekit materialize` replaces ProvekIt concept-citation carrier comments in source files with source emitted by a selected realize kit.
+
+The command is an orchestration surface only. It does not contain host-language renderers in the Rust CLI: language and library behavior lives behind `.provekit/realize/<surface>/manifest.toml` JSON-RPC realize plugins.
+
+## Basic usage
+
+Dry-run to stdout:
+
+```bash
+provekit materialize \
+  --library typescript-better-sqlite3 \
+  --source-dir src \
+  --project .
+```
+
+Rewrite source files in place:
+
+```bash
+provekit materialize \
+  --library python-requests \
+  --source-dir src \
+  --project . \
+  --write
+```
+
+Write materialized copies under a separate tree:
+
+```bash
+provekit materialize \
+  --library rust-reqwest \
+  --source-dir src \
+  --project . \
+  --out-dir materialized-src
+```
+
+`--library` may be language-prefixed (`python-requests`, `rust-reqwest`, `typescript-better-sqlite3`). If it is not, pass `--target <language>` or provide project markers such as `Cargo.toml`, `pyproject.toml`, or `package.json` so the target language can be inferred.
+
+## Carrier comments
+
+A source file carries a JSON concept citation and, optionally, its payload CID:
+
+```python
+# provekit-concept: {"artifact_kind":"provekit-concept-citation-comment-sugar","concept_name":"concept:http-request","function":"fetch_status","params":["url"],"param_types":["str"],"return_type":"int"}
+# provekit-concept-payload-cid: blake3-512:<jcs-payload-cid>
+```
+
+The command accepts line comments (`//`, `#`) and single-line block comments (`/* ... */`). If a payload CID is present, `materialize` recomputes JCS+BLAKE3-512 over the payload and rejects mismatches before dispatching to a realize kit.
+
+## Examples
+
+### Python requests shim
+
+With `.provekit/realize/python-requests/manifest.toml` pointing at the Python requests realize kit:
+
+```bash
+provekit materialize --library python-requests --source-dir src --project .
+```
+
+A `concept:http-request` citation materializes through the Python requests shim and emits code using `requests.get(...)`. The Rust CLI does not know how to render Python or requests; it only selects the manifest surface and dispatches the request.
+
+### Rust reqwest shim
+
+With `.provekit/realize/rust/manifest.toml` pointing at `provekit-realize-rust`:
+
+```bash
+provekit materialize --library rust-reqwest --source-dir src --project .
+```
+
+A `concept:http-request` citation materializes through the Rust realizer and the `reqwest` library tag, emitting code using `reqwest::get(...)`.
+
+### TypeScript better-sqlite3 shim
+
+With `.provekit/realize/typescript-better-sqlite3/manifest.toml` pointing at the TypeScript better-sqlite3 realize kit:
+
+```bash
+provekit materialize --library typescript-better-sqlite3 --source-dir src --project .
+```
+
+A `concept:sql-query` citation materializes through the TypeScript better-sqlite3 shim and emits code using `db.prepare(sql).all(args)`.
+
+## Scan behavior
+
+`materialize` scans supported source extensions (`.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.rs`, `.java`) and prunes dependency/build directories such as `.git`, `node_modules`, `target`, `dist`, `build`, and `__pycache__`.
+
+Files without concept carriers are left untouched. If no carriers are found, the command exits successfully and reports `found 0 concept citation(s)` on stderr unless `--quiet` is set.

--- a/docs/reference/materialize.md
+++ b/docs/reference/materialize.md
@@ -2,7 +2,7 @@
 
 `provekit materialize` replaces ProvekIt concept-citation carrier comments in source files with source emitted by a selected realize kit.
 
-The command is an orchestration surface only. It does not contain host-language renderers in the Rust CLI: language and library behavior lives behind `.provekit/realize/<surface>/manifest.toml` JSON-RPC realize plugins.
+The command is an orchestration surface only. It does not contain host-language renderers in the Rust CLI: language and library behavior lives behind `.provekit/realize/<surface>/manifest.toml` JSON-RPC realize plugins and body-template entries that explicitly declare their `(target_language, target_library_tag, concept_name)` tuple.
 
 ## Basic usage
 
@@ -79,6 +79,25 @@ provekit materialize --library typescript-better-sqlite3 --source-dir src --proj
 ```
 
 A `concept:sql-query` citation materializes through the TypeScript better-sqlite3 shim and emits code using `db.prepare(sql).all(args)`.
+
+## Body-template tuple normalization
+
+Library-specific body templates live at:
+
+```text
+menagerie/<language>-language-signature/specs/body-templates/<language>-canonical-bodies-<library-tag>.json
+```
+
+Every entry in those files must explicitly declare the sugar tuple it realizes:
+
+```json
+{
+  "target_library_tag": "requests",
+  "concept_name": "concept:http-request"
+}
+```
+
+The file-level `header.content.target_language` supplies the language component. Together, the normalized tuple is `(target_language, target_library_tag, concept_name)`. The selected `.provekit/realize/<surface>/manifest.toml` must agree with that tuple; the Rust CLI only selects the manifest and dispatches to the realize plugin.
 
 ## Scan behavior
 

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -256,10 +256,17 @@ fn concept_payload_cid_from_line(line: &str) -> Option<&str> {
 }
 
 fn strip_comment_prefix(line: &str) -> Option<&str> {
-    line.strip_prefix("//")
+    let body = line
+        .strip_prefix("//")
         .or_else(|| line.strip_prefix('#'))
-        .or_else(|| line.strip_prefix("/*"))
-        .map(str::trim_start)
+        .or_else(|| line.strip_prefix("/*"))?
+        .trim_start();
+    Some(
+        body.trim_end()
+            .strip_suffix("*/")
+            .map(str::trim_end)
+            .unwrap_or(body),
+    )
 }
 
 fn indent_realized_source(source: &str, indent: &str) -> String {

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -182,7 +182,8 @@ fn materialize_source_dir(
         let raw = std::fs::read_to_string(path)
             .map_err(|error| format!("read {}: {error}", path.display()))?;
         let (content, replacements) =
-            materialize_source_text(project_root, target_lang, library_tag, &raw)?;
+            materialize_source_text(project_root, target_lang, library_tag, &raw)
+                .map_err(|error| format!("{}: {error}", path.display()))?;
         if replacements == 0 {
             continue;
         }

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -216,11 +216,12 @@ fn materialize_source_text(
     let mut idx = 0usize;
     while idx < lines.len() {
         let line = lines[idx];
-        if let Some(payload) = concept_payload_from_line(line) {
+        if let Some((indent, payload)) = concept_payload_from_line(line) {
             let spec = realize_spec_from_payload(payload)?;
             let realized = realize_spec_via_path(project_root, target_lang, library_tag, spec)?;
-            out.push_str(&realized);
-            if !realized.ends_with('\n') {
+            let indented = indent_realized_source(&realized, indent);
+            out.push_str(&indented);
+            if !indented.ends_with('\n') {
                 out.push('\n');
             }
             replacements += 1;
@@ -237,9 +238,14 @@ fn materialize_source_text(
     Ok((out, replacements))
 }
 
-fn concept_payload_from_line(line: &str) -> Option<&str> {
+fn concept_payload_from_line(line: &str) -> Option<(&str, &str)> {
+    let indent_len = line.len() - line.trim_start().len();
+    let indent = &line[..indent_len];
     let normalized = strip_comment_prefix(line.trim_start())?;
-    normalized.strip_prefix("provekit-concept: ").map(str::trim)
+    normalized
+        .strip_prefix("provekit-concept: ")
+        .map(str::trim)
+        .map(|payload| (indent, payload))
 }
 
 fn concept_payload_cid_from_line(line: &str) -> Option<&str> {
@@ -254,6 +260,22 @@ fn strip_comment_prefix(line: &str) -> Option<&str> {
         .or_else(|| line.strip_prefix('#'))
         .or_else(|| line.strip_prefix("/*"))
         .map(str::trim_start)
+}
+
+fn indent_realized_source(source: &str, indent: &str) -> String {
+    if indent.is_empty() {
+        return source.to_string();
+    }
+    source
+        .split_inclusive('\n')
+        .map(|line| {
+            if line.trim().is_empty() {
+                line.to_string()
+            } else {
+                format!("{indent}{line}")
+            }
+        })
+        .collect()
 }
 
 fn realize_spec_from_payload(payload: &str) -> Result<Json, String> {

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `provekit materialize` turns concept-citation carriers in source files into
+// library-bound source by composing the existing LowerKit/realize path.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use libprovekit::core::{
+    execute_path, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
+    Verb,
+};
+use owo_colors::OwoColorize;
+use serde_json::Value as Json;
+use walkdir::WalkDir;
+
+use crate::kit_dispatch::DispatchRealizeTransport;
+use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
+
+#[derive(Parser, Debug, Clone)]
+pub struct MaterializeArgs {
+    /// Library surface to materialize, e.g. `typescript-better-sqlite3` or `better-sqlite3`.
+    #[arg(long)]
+    pub library: String,
+    /// Source directory to scan for `provekit-concept:` carriers.
+    #[arg(long = "source-dir")]
+    pub source_dir: PathBuf,
+    /// Project root containing `.provekit/realize/*/manifest.toml`. Defaults to source-dir parent/current.
+    #[arg(long)]
+    pub project: Option<PathBuf>,
+    /// Target language. Inferred from a language-prefixed --library or project markers when omitted.
+    #[arg(long, alias = "language")]
+    pub target: Option<String>,
+    /// Write files in place. Omitted means dry-run to stdout.
+    #[arg(long)]
+    pub write: bool,
+    /// Write materialized files under this directory, preserving paths relative to --source-dir.
+    #[arg(long = "out-dir", conflicts_with = "write")]
+    pub out_dir: Option<PathBuf>,
+    #[command(flatten)]
+    pub out: OutputFlags,
+}
+
+#[derive(Debug, Clone)]
+struct MaterializedFile {
+    source_path: PathBuf,
+    relative_path: PathBuf,
+    content: String,
+    replacements: usize,
+}
+
+pub fn run(args: MaterializeArgs) -> u8 {
+    let project_root = args.project.clone().unwrap_or_else(|| {
+        args.source_dir
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."))
+    });
+    if !project_root.exists() {
+        eprintln!(
+            "{}: project not found: {}",
+            "error".red().bold(),
+            project_root.display()
+        );
+        return EXIT_USER_ERROR;
+    }
+    if !args.source_dir.is_dir() {
+        eprintln!(
+            "{}: source-dir not found or not a directory: {}",
+            "error".red().bold(),
+            args.source_dir.display()
+        );
+        return EXIT_USER_ERROR;
+    }
+
+    let (target_lang, library_tag) =
+        match resolve_library_surface(&project_root, args.target.as_deref(), args.library.as_str())
+        {
+            Ok(surface) => surface,
+            Err(error) => {
+                eprintln!("{}: {error}", "error".red().bold());
+                return EXIT_USER_ERROR;
+            }
+        };
+
+    let files = match materialize_source_dir(
+        &project_root,
+        &args.source_dir,
+        &target_lang,
+        library_tag.as_deref(),
+    ) {
+        Ok(files) => files,
+        Err(error) => {
+            eprintln!("{}: {error}", "error".red().bold());
+            return EXIT_VERIFY_FAIL;
+        }
+    };
+
+    if let Some(out_dir) = args.out_dir.as_ref() {
+        if let Err(error) = write_out_dir(out_dir, &files) {
+            eprintln!("{}: {error}", "error".red().bold());
+            return EXIT_USER_ERROR;
+        }
+    } else if args.write {
+        if let Err(error) = write_in_place(&files) {
+            eprintln!("{}: {error}", "error".red().bold());
+            return EXIT_USER_ERROR;
+        }
+    } else if let Err(error) = print_dry_run(&files) {
+        eprintln!("{}: {error}", "error".red().bold());
+        return EXIT_USER_ERROR;
+    }
+
+    if !args.out.quiet && (args.write || args.out_dir.is_some()) {
+        let replacements: usize = files.iter().map(|file| file.replacements).sum();
+        println!(
+            "{} materialized {replacements} concept citation(s) across {} file(s)",
+            "materialize".green().bold(),
+            files.len()
+        );
+    }
+    EXIT_OK
+}
+
+fn resolve_library_surface(
+    project_root: &Path,
+    target: Option<&str>,
+    library: &str,
+) -> Result<(String, Option<String>), String> {
+    let library = library.trim();
+    if library.is_empty() {
+        return Err("--library must not be empty".to_string());
+    }
+    if let Some(target) = target {
+        return Ok((target.to_string(), Some(library.to_string())));
+    }
+    for language in ["typescript", "python", "rust", "java"] {
+        if let Some(tag) = library.strip_prefix(&format!("{language}-")) {
+            if tag.is_empty() {
+                return Err(format!("library surface `{library}` has empty library tag"));
+            }
+            return Ok((language.to_string(), Some(tag.to_string())));
+        }
+    }
+    let language = detect_project_language(project_root).ok_or_else(|| {
+        format!(
+            "could not infer target language for library `{library}`; pass --target=<language> or use a language-prefixed library surface"
+        )
+    })?;
+    Ok((language, Some(library.to_string())))
+}
+
+fn detect_project_language(project_root: &Path) -> Option<String> {
+    let markers = [
+        ("package.json", "typescript"),
+        ("Cargo.toml", "rust"),
+        ("pyproject.toml", "python"),
+        ("requirements.txt", "python"),
+        ("pom.xml", "java"),
+        ("build.gradle", "java"),
+        ("build.gradle.kts", "java"),
+    ];
+    markers
+        .iter()
+        .find(|(marker, _)| project_root.join(marker).exists())
+        .map(|(_, language)| (*language).to_string())
+}
+
+fn materialize_source_dir(
+    project_root: &Path,
+    source_dir: &Path,
+    target_lang: &str,
+    library_tag: Option<&str>,
+) -> Result<Vec<MaterializedFile>, String> {
+    let mut files = Vec::new();
+    for entry in WalkDir::new(source_dir).into_iter().filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_file() || !is_supported_source_file(path) {
+            continue;
+        }
+        let raw = std::fs::read_to_string(path)
+            .map_err(|error| format!("read {}: {error}", path.display()))?;
+        let (content, replacements) =
+            materialize_source_text(project_root, target_lang, library_tag, &raw)?;
+        if replacements == 0 {
+            continue;
+        }
+        let relative_path = path.strip_prefix(source_dir).unwrap_or(path).to_path_buf();
+        files.push(MaterializedFile {
+            source_path: path.to_path_buf(),
+            relative_path,
+            content,
+            replacements,
+        });
+    }
+    Ok(files)
+}
+
+fn is_supported_source_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("ts" | "tsx" | "js" | "jsx" | "py" | "rs" | "java")
+    )
+}
+
+fn materialize_source_text(
+    project_root: &Path,
+    target_lang: &str,
+    library_tag: Option<&str>,
+    raw: &str,
+) -> Result<(String, usize), String> {
+    let mut out = String::new();
+    let mut replacements = 0usize;
+    let lines = raw.split_inclusive('\n').collect::<Vec<_>>();
+    let mut idx = 0usize;
+    while idx < lines.len() {
+        let line = lines[idx];
+        if let Some(payload) = concept_payload_from_line(line) {
+            let spec = realize_spec_from_payload(payload)?;
+            let realized = realize_spec_via_path(project_root, target_lang, library_tag, spec)?;
+            out.push_str(&realized);
+            if !realized.ends_with('\n') {
+                out.push('\n');
+            }
+            replacements += 1;
+            if idx + 1 < lines.len() && concept_payload_cid_from_line(lines[idx + 1]).is_some() {
+                idx += 2;
+            } else {
+                idx += 1;
+            }
+            continue;
+        }
+        out.push_str(line);
+        idx += 1;
+    }
+    Ok((out, replacements))
+}
+
+fn concept_payload_from_line(line: &str) -> Option<&str> {
+    let normalized = strip_comment_prefix(line.trim_start())?;
+    normalized.strip_prefix("provekit-concept: ").map(str::trim)
+}
+
+fn concept_payload_cid_from_line(line: &str) -> Option<&str> {
+    let normalized = strip_comment_prefix(line.trim_start())?;
+    normalized
+        .strip_prefix("provekit-concept-payload-cid: ")
+        .map(str::trim)
+}
+
+fn strip_comment_prefix(line: &str) -> Option<&str> {
+    line.strip_prefix("//")
+        .or_else(|| line.strip_prefix('#'))
+        .or_else(|| line.strip_prefix("/*"))
+        .map(str::trim_start)
+}
+
+fn realize_spec_from_payload(payload: &str) -> Result<Json, String> {
+    let mut value: Json = serde_json::from_str(payload)
+        .map_err(|error| format!("parse provekit-concept payload JSON: {error}"))?;
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| "provekit-concept payload must be a JSON object".to_string())?;
+    let concept_name = object
+        .get("concept_name")
+        .or_else(|| object.get("conceptName"))
+        .and_then(Json::as_str)
+        .ok_or_else(|| "provekit-concept payload missing concept_name".to_string())?
+        .to_string();
+    object.insert(
+        "kind".to_string(),
+        Json::String("RealizeRequest".to_string()),
+    );
+    object.insert("concept_name".to_string(), Json::String(concept_name));
+    if !object.contains_key("function") {
+        object.insert(
+            "function".to_string(),
+            Json::String("provekit_materialized".to_string()),
+        );
+    }
+    if !object.contains_key("params") {
+        object.insert("params".to_string(), Json::Array(Vec::new()));
+    }
+    if !object.contains_key("param_types") {
+        if let Some(param_types) = object.remove("paramTypes") {
+            object.insert("param_types".to_string(), param_types);
+        } else {
+            let arity = object
+                .get("params")
+                .and_then(Json::as_array)
+                .map(Vec::len)
+                .unwrap_or(0);
+            object.insert(
+                "param_types".to_string(),
+                Json::Array(
+                    (0..arity)
+                        .map(|_| Json::String("unknown".to_string()))
+                        .collect(),
+                ),
+            );
+        }
+    }
+    if !object.contains_key("return_type") {
+        if let Some(return_type) = object.remove("returnType") {
+            object.insert("return_type".to_string(), return_type);
+        } else {
+            object.insert("return_type".to_string(), Json::String("void".to_string()));
+        }
+    }
+    if !object.contains_key("named_term_tree") {
+        if let Some(named_term_tree) = object.remove("namedTermTree") {
+            object.insert("named_term_tree".to_string(), named_term_tree);
+        }
+    }
+    Ok(value)
+}
+
+fn realize_spec_via_path(
+    project_root: &Path,
+    target_lang: &str,
+    library_tag: Option<&str>,
+    spec: Json,
+) -> Result<String, String> {
+    let mut inputs = HashMapInputCatalog::default();
+    let input_cid = inputs.insert(Input::Spec(spec));
+    let kit_name = library_tag
+        .map(|tag| format!("lower-{target_lang}-{tag}"))
+        .unwrap_or_else(|| format!("lower-{target_lang}"));
+    let path = Input::Path(Box::new(CorePath {
+        algebra: vec![PathAlgebra {
+            name: "lower".to_string(),
+            kit: kit_name.clone(),
+            inputs: vec![input_cid],
+            depends_on: vec![],
+            verb: Verb::Transform,
+        }],
+    }));
+    let mut registry = KitRegistry::default();
+    registry.register_with_platform_semantics(
+        kit_name,
+        LowerKit::new(
+            project_root.to_path_buf(),
+            target_lang.to_string(),
+            library_tag.map(str::to_string),
+            DispatchRealizeTransport,
+        ),
+        target_lang,
+        project_root.join(format!(
+            "implementations/{target_lang}/conformance/fixtures"
+        )),
+    );
+    let chain = execute_path(&path, &registry, &inputs).map_err(|error| {
+        error
+            .composition_refusal()
+            .and_then(|refusal| serde_json::to_string(refusal).ok())
+            .unwrap_or_else(|| error.to_string())
+    })?;
+    let realized =
+        LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(chain.terminal_claim())?;
+    if realized.is_stub {
+        return Err(format!(
+            "realize plugin for `{target_lang}` library `{}` returned a stub",
+            library_tag.unwrap_or("default")
+        ));
+    }
+    Ok(realized.source)
+}
+
+fn print_dry_run(files: &[MaterializedFile]) -> Result<(), String> {
+    let mut stdout = std::io::stdout().lock();
+    for file in files {
+        writeln!(stdout, "// file: {}", file.relative_path.display())
+            .map_err(|error| format!("write stdout: {error}"))?;
+        stdout
+            .write_all(file.content.as_bytes())
+            .map_err(|error| format!("write stdout: {error}"))?;
+        if !file.content.ends_with('\n') {
+            writeln!(stdout).map_err(|error| format!("write stdout: {error}"))?;
+        }
+    }
+    Ok(())
+}
+
+fn write_in_place(files: &[MaterializedFile]) -> Result<(), String> {
+    for file in files {
+        std::fs::write(&file.source_path, &file.content)
+            .map_err(|error| format!("write {}: {error}", file.source_path.display()))?;
+    }
+    Ok(())
+}
+
+fn write_out_dir(out_dir: &Path, files: &[MaterializedFile]) -> Result<(), String> {
+    for file in files {
+        let target = out_dir.join(&file.relative_path);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| format!("create {}: {error}", parent.display()))?;
+        }
+        std::fs::write(&target, &file.content)
+            .map_err(|error| format!("write {}: {error}", target.display()))?;
+    }
+    Ok(())
+}

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -145,7 +145,15 @@ fn resolve_library_surface(
         return Err("--library must not be empty".to_string());
     }
     if let Some(target) = target {
-        return Ok((target.to_string(), Some(library.to_string())));
+        let tag = library
+            .strip_prefix(&format!("{target}-"))
+            .unwrap_or(library);
+        if tag.is_empty() {
+            return Err(format!(
+                "library surface `{library}` has empty library tag after stripping `{target}-` prefix"
+            ));
+        }
+        return Ok((target.to_string(), Some(tag.to_string())));
     }
     for language in ["typescript", "python", "rust", "java"] {
         if let Some(tag) = library.strip_prefix(&format!("{language}-")) {
@@ -227,7 +235,20 @@ fn should_scan_entry(path: &Path) -> bool {
     };
     !matches!(
         name,
-        ".git" | "node_modules" | "target" | "dist" | "build" | "__pycache__"
+        ".git"
+            | ".mypy_cache"
+            | ".next"
+            | ".pytest_cache"
+            | ".ruff_cache"
+            | ".turbo"
+            | ".venv"
+            | ".vite"
+            | "__pycache__"
+            | "build"
+            | "dist"
+            | "node_modules"
+            | "target"
+            | "venv"
     )
 }
 
@@ -351,6 +372,14 @@ fn canonical_value_from_json(value: &Json) -> Result<Arc<CanonicalValue>, String
     }
 }
 
+// Permissive-defaults for carrier payloads. The materialize command synthesizes
+// defaults for missing carrier-payload fields (function, params, param_types,
+// return_type) to reduce friction during development. The substrate-honest
+// alternative is refuse-on-missing-fields: require each carrier author to
+// provide a complete payload. The permissive shape is intentional for the
+// build-pipeline ergonomics; the trade-off is that incomplete carriers may
+// produce stub-like realize output. A future strict mode (e.g., a
+// --strict-payloads flag) could refuse incomplete carriers up front.
 fn realize_spec_from_payload(payload: &str) -> Result<Json, String> {
     let mut value: Json = serde_json::from_str(payload)
         .map_err(|error| format!("parse provekit-concept payload JSON: {error}"))?;
@@ -381,19 +410,7 @@ fn realize_spec_from_payload(payload: &str) -> Result<Json, String> {
         if let Some(param_types) = object.remove("paramTypes") {
             object.insert("param_types".to_string(), param_types);
         } else {
-            let arity = object
-                .get("params")
-                .and_then(Json::as_array)
-                .map(Vec::len)
-                .unwrap_or(0);
-            object.insert(
-                "param_types".to_string(),
-                Json::Array(
-                    (0..arity)
-                        .map(|_| Json::String("unknown".to_string()))
-                        .collect(),
-                ),
-            );
+            object.insert("param_types".to_string(), Json::Array(Vec::new()));
         }
     }
     if !object.contains_key("return_type") {
@@ -453,6 +470,14 @@ fn realize_spec_via_path(
     })?;
     let realized =
         LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(chain.terminal_claim())?;
+    // String-formatted CLI error rather than a structured gap-record memento:
+    // materialize is a build-pipeline workflow that does not emit a receipt
+    // memento (unlike cmd_bind_migrate which produces MigrateReceiptEnvelope
+    // with refusal_mementos per `2026-05-18-refuse-leg-short-circuit-ruling`).
+    // The CLI surface is the consumer; a string error suffices. If a future
+    // caller needs structured refusal for build-pipeline consumption, extend
+    // materialize to optionally emit a refusal receipt and route through the
+    // existing RefusalMemento machinery.
     if realized.is_stub {
         return Err(format!(
             "realize plugin for `{target_lang}` library `{}` returned a stub",

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -174,7 +174,11 @@ fn materialize_source_dir(
     library_tag: Option<&str>,
 ) -> Result<Vec<MaterializedFile>, String> {
     let mut files = Vec::new();
-    for entry in WalkDir::new(source_dir).into_iter().filter_map(Result::ok) {
+    for entry in WalkDir::new(source_dir)
+        .into_iter()
+        .filter_entry(|entry| should_scan_entry(entry.path()))
+        .filter_map(Result::ok)
+    {
         let path = entry.path();
         if !path.is_file() || !is_supported_source_file(path) {
             continue;
@@ -202,6 +206,16 @@ fn is_supported_source_file(path: &Path) -> bool {
     matches!(
         path.extension().and_then(|ext| ext.to_str()),
         Some("ts" | "tsx" | "js" | "jsx" | "py" | "rs" | "java")
+    )
+}
+
+fn should_scan_entry(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return true;
+    };
+    !matches!(
+        name,
+        ".git" | "node_modules" | "target" | "dist" | "build" | "__pycache__"
     )
 }
 

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -5,6 +5,7 @@
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use clap::Parser;
 use libprovekit::core::{
@@ -12,6 +13,7 @@ use libprovekit::core::{
     Verb,
 };
 use owo_colors::OwoColorize;
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
 use serde_json::Value as Json;
 use walkdir::WalkDir;
 
@@ -232,6 +234,11 @@ fn materialize_source_text(
     while idx < lines.len() {
         let line = lines[idx];
         if let Some((indent, payload)) = concept_payload_from_line(line) {
+            if idx + 1 < lines.len() {
+                if let Some(declared_cid) = concept_payload_cid_from_line(lines[idx + 1]) {
+                    verify_payload_cid(payload, declared_cid)?;
+                }
+            }
             let spec = realize_spec_from_payload(payload)?;
             let realized = realize_spec_via_path(project_root, target_lang, library_tag, spec)?;
             let indented = indent_realized_source(&realized, indent);
@@ -298,6 +305,40 @@ fn indent_realized_source(source: &str, indent: &str) -> String {
             }
         })
         .collect()
+}
+
+fn verify_payload_cid(payload: &str, declared_cid: &str) -> Result<(), String> {
+    let parsed: Json = serde_json::from_str(payload)
+        .map_err(|error| format!("parse provekit-concept payload JSON: {error}"))?;
+    let canonical = canonical_value_from_json(&parsed)?;
+    let actual_cid = blake3_512_of(encode_jcs(canonical.as_ref()).as_bytes());
+    if actual_cid != declared_cid {
+        return Err(format!(
+            "provekit-concept-payload-cid mismatch: declared {declared_cid}, computed {actual_cid}"
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_value_from_json(value: &Json) -> Result<Arc<CanonicalValue>, String> {
+    match value {
+        Json::Null => Ok(CanonicalValue::null()),
+        Json::Bool(value) => Ok(CanonicalValue::boolean(*value)),
+        Json::Number(value) => value.as_i64().map(CanonicalValue::integer).ok_or_else(|| {
+            format!("provekit-concept payload contains non-integer number `{value}`")
+        }),
+        Json::String(value) => Ok(CanonicalValue::string(value)),
+        Json::Array(values) => values
+            .iter()
+            .map(canonical_value_from_json)
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::array),
+        Json::Object(entries) => entries
+            .iter()
+            .map(|(key, value)| canonical_value_from_json(value).map(|value| (key.clone(), value)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::object),
+    }
 }
 
 fn realize_spec_from_payload(payload: &str) -> Result<Json, String> {

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -99,6 +99,16 @@ pub fn run(args: MaterializeArgs) -> u8 {
         }
     };
 
+    if files.is_empty() {
+        if !args.out.quiet {
+            eprintln!(
+                "{} found 0 concept citation(s)",
+                "materialize".green().bold()
+            );
+        }
+        return EXIT_OK;
+    }
+
     if let Some(out_dir) = args.out_dir.as_ref() {
         if let Err(error) = write_out_dir(out_dir, &files) {
             eprintln!("{}: {error}", "error".red().bold());

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -33,6 +33,7 @@ mod cmd_init;
 mod cmd_lift;
 mod cmd_link;
 mod cmd_lower;
+mod cmd_materialize;
 mod cmd_mint;
 mod cmd_must;
 mod cmd_package;
@@ -164,6 +165,8 @@ enum Cmd {
     /// Implements the eight-verb pipeline (paper 20 §9) against arbitrary user code.
     /// --rewrite={annotate,canonical,invisible} --mode={witness,emitter,monitor,gate} --target-language=<lang>
     Bind(cmd_bind::BindArgs),
+    /// Materialize concept-citation carriers into library-bound source via substrate realize kits.
+    Materialize(cmd_materialize::MaterializeArgs),
     /// Load and inspect substrate exam manifests.
     Exam(cmd_exam::ExamArgs),
 }
@@ -426,6 +429,7 @@ fn main() -> ExitCode {
         Cmd::Transport(a) | Cmd::Migrate(a) => cmd_transport::run(a),
         Cmd::Compose(a) => cmd_compose::run(a),
         Cmd::Bind(a) => cmd_bind::run(a),
+        Cmd::Materialize(a) => cmd_materialize::run(a),
         Cmd::Exam(a) => cmd_exam::run(a),
     };
     ExitCode::from(code)

--- a/implementations/rust/provekit-cli/tests/body_template_normalization.rs
+++ b/implementations/rust/provekit-cli/tests/body_template_normalization.rs
@@ -1,0 +1,96 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("..")
+}
+
+fn library_specific_body_templates(root: &Path) -> Vec<(String, String, PathBuf)> {
+    let menagerie = root.join("menagerie");
+    let mut templates = Vec::new();
+    for language_dir in fs::read_dir(&menagerie).expect("read menagerie") {
+        let language_dir = language_dir.expect("read language dir");
+        let dirname = language_dir.file_name().to_string_lossy().into_owned();
+        let Some(language) = dirname.strip_suffix("-language-signature") else {
+            continue;
+        };
+        let template_dir = language_dir.path().join("specs").join("body-templates");
+        if !template_dir.exists() {
+            continue;
+        }
+        for entry in fs::read_dir(template_dir).expect("read body-template dir") {
+            let entry = entry.expect("read body-template");
+            let filename = entry.file_name().to_string_lossy().into_owned();
+            let Some(library_tag) = filename
+                .strip_prefix(&format!("{language}-canonical-bodies-"))
+                .and_then(|rest| rest.strip_suffix(".json"))
+            else {
+                continue;
+            };
+            templates.push((language.to_string(), library_tag.to_string(), entry.path()));
+        }
+    }
+    templates.sort_by(|a, b| a.2.cmp(&b.2));
+    templates
+}
+
+#[test]
+fn library_specific_body_template_entries_declare_target_tuple() {
+    let root = repo_root();
+    let templates = library_specific_body_templates(&root);
+    assert!(
+        !templates.is_empty(),
+        "expected library-specific body templates under menagerie"
+    );
+
+    let mut violations = Vec::new();
+    for (language, library_tag, path) in templates {
+        let raw = fs::read_to_string(&path).expect("read body-template json");
+        let json: Value = serde_json::from_str(&raw).expect("parse body-template json");
+        let content = json
+            .get("header")
+            .and_then(|header| header.get("content"))
+            .expect("body-template header.content exists");
+        let target_language = content
+            .get("target_language")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if target_language != language {
+            violations.push(format!(
+                "{} header.content.target_language={target_language:?}, expected {language:?}",
+                path.display()
+            ));
+        }
+        let entries = content
+            .get("entries")
+            .and_then(Value::as_array)
+            .expect("body-template entries array exists");
+        for (index, entry) in entries.iter().enumerate() {
+            let target_library_tag = entry
+                .get("target_library_tag")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if target_library_tag != library_tag {
+                let concept = entry
+                    .get("concept_name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("<missing concept_name>");
+                violations.push(format!(
+                    "{} entry[{index}] {concept} target_library_tag={target_library_tag:?}, expected {library_tag:?}",
+                    path.display()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "library-specific body-template entries must explicitly declare their (target_language, target_library_tag, concept_name) tuple:\n{}",
+        violations.join("\n")
+    );
+}

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -43,12 +43,10 @@ fn install_node_manifest(root: &Path, surface: &str, script: &Path, library_tag:
     fs::write(manifest, manifest_text).expect("write manifest");
 }
 
-#[test]
-fn materialize_dry_run_replaces_concept_citation_with_realized_library_source() {
-    let workspace = tempfile::tempdir().expect("tempdir");
+fn write_typescript_project_fixture(workspace: &Path) -> PathBuf {
     let repo = repo_root();
     install_node_manifest(
-        workspace.path(),
+        workspace,
         "typescript-better-sqlite3",
         &repo
             .join("implementations")
@@ -58,13 +56,14 @@ fn materialize_dry_run_replaces_concept_citation_with_realized_library_source() 
             .join("main.js"),
         "better-sqlite3",
     );
-    fs::write(
-        workspace.path().join("package.json"),
-        "{\"type\":\"module\"}\n",
-    )
-    .expect("write package marker");
-    let src_dir = workspace.path().join("src");
+    fs::write(workspace.join("package.json"), "{\"type\":\"module\"}\n")
+        .expect("write package marker");
+    let src_dir = workspace.join("src");
     fs::create_dir_all(&src_dir).expect("create src dir");
+    src_dir
+}
+
+fn write_concept_source(src_dir: &Path) -> PathBuf {
     let source_path = src_dir.join("queries.ts");
     fs::write(
         &source_path,
@@ -75,6 +74,14 @@ fn materialize_dry_run_replaces_concept_citation_with_realized_library_source() 
 "#,
     )
     .expect("write source");
+    source_path
+}
+
+#[test]
+fn materialize_dry_run_replaces_concept_citation_with_realized_library_source() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = write_typescript_project_fixture(workspace.path());
+    let source_path = write_concept_source(&src_dir);
 
     let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
         .arg("materialize")
@@ -108,5 +115,50 @@ fn materialize_dry_run_replaces_concept_citation_with_realized_library_source() 
             .expect("read original")
             .contains("provekit-concept:"),
         "dry run must not rewrite source files"
+    );
+}
+
+#[test]
+fn materialize_write_rewrites_source_file_in_place_and_reports_summary() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = write_typescript_project_fixture(workspace.path());
+    let source_path = write_concept_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--write")
+        .output()
+        .expect("spawn provekit materialize --write");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "materialize --write should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("materialized 1 concept citation(s) across 1 file(s)"),
+        "write mode should report replacement summary: {stdout}"
+    );
+    let rewritten = fs::read_to_string(&source_path).expect("read rewritten source");
+    assert!(rewritten.contains("// header stays"));
+    assert!(
+        rewritten.contains("db.prepare(sql).all(args)"),
+        "rewritten file should contain better-sqlite3 materialization:\n{rewritten}"
+    );
+    assert!(rewritten.contains("// footer stays"));
+    assert!(
+        !rewritten.contains("provekit-concept:"),
+        "write mode should remove concept citation carrier comments:\n{rewritten}"
+    );
+    assert!(
+        !rewritten.contains("provekit-concept-payload-cid:"),
+        "write mode should remove payload CID carrier comments:\n{rewritten}"
     );
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -186,6 +186,12 @@ fn write_mismatched_cid_concept_source(src_dir: &Path) -> PathBuf {
     source_path
 }
 
+fn write_no_carrier_source(src_dir: &Path) -> PathBuf {
+    let source_path = src_dir.join("plain.ts");
+    fs::write(&source_path, "export const untouched = 42;\n").expect("write plain source");
+    source_path
+}
+
 #[test]
 fn materialize_dry_run_replaces_concept_citation_with_realized_library_source() {
     let workspace = tempfile::tempdir().expect("tempdir");
@@ -474,5 +480,42 @@ fn materialize_rejects_payload_cid_mismatch() {
     assert!(
         stderr.contains("provekit-concept-payload-cid mismatch"),
         "CID mismatch error should explain the mismatch:\n{stderr}"
+    );
+}
+
+#[test]
+fn materialize_no_carriers_reports_zero_without_printing_dry_run_source() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = write_typescript_project_fixture(workspace.path());
+    let source_path = write_no_carrier_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .output()
+        .expect("spawn provekit materialize");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "no-carrier materialize should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        stdout, "",
+        "dry-run no-carrier mode should not print source"
+    );
+    assert!(
+        stderr.contains("found 0 concept citation(s)"),
+        "no-carrier mode should explain why no files were printed:\n{stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(source_path).expect("read plain source"),
+        "export const untouched = 42;\n"
     );
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -712,3 +712,43 @@ fn materialize_rust_reqwest_example_uses_rust_library_shim() {
     );
     assert!(!stdout.contains("provekit-concept:"));
 }
+
+#[test]
+fn materialize_explicit_target_strips_redundant_language_prefix_from_library() {
+    // N1 regression: --target python --library python-requests previously produced
+    // kit_name lower-python-python-requests, which no realize plugin matches.
+    // After the fix, resolve_library_surface strips the "python-" prefix and
+    // produces kit_name lower-python-requests, matching the installed plugin.
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let Some(src_dir) = write_python_requests_project_fixture(workspace.path()) else {
+        eprintln!("skipping N1 prefix-strip test: provekit-realize-python-requests binary is unavailable");
+        return;
+    };
+    write_python_http_request_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .env("PROVEKIT_REPO_ROOT", repo_root())
+        .arg("materialize")
+        .arg("--target")
+        .arg("python")
+        .arg("--library")
+        .arg("python-requests")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .output()
+        .expect("spawn provekit materialize with explicit target and prefixed library");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "explicit --target python --library python-requests should succeed after prefix strip\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("requests.get(url)"),
+        "result should route through the python-requests shim: {stdout}"
+    );
+    assert!(!stdout.contains("provekit-concept:"));
+}

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -47,6 +47,34 @@ fn install_node_manifest(root: &Path, surface: &str, script: &Path, library_tag:
     fs::write(manifest, manifest_text).expect("write manifest");
 }
 
+fn install_binary_manifest(
+    root: &Path,
+    surface: &str,
+    binary: &Path,
+    manifest_name: &str,
+    library_tag: &str,
+) {
+    let manifest = root
+        .join(".provekit")
+        .join("realize")
+        .join(surface)
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().expect("manifest path has parent"))
+        .expect("create manifest dir");
+    let binary = binary
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let manifest_text = format!(
+        "name = \"{manifest_name}\"\n\
+         library_tag = \"{library_tag}\"\n\
+         command = [\"{binary}\", \"--rpc\"]\n\
+         working_dir = \".\"\n",
+    );
+    fs::write(manifest, manifest_text).expect("write manifest");
+}
+
 fn write_typescript_project_fixture(workspace: &Path) -> PathBuf {
     let repo = repo_root();
     install_node_manifest(
@@ -67,6 +95,56 @@ fn write_typescript_project_fixture(workspace: &Path) -> PathBuf {
     src_dir
 }
 
+fn write_python_requests_project_fixture(workspace: &Path) -> Option<PathBuf> {
+    let repo = repo_root();
+    let binary = repo
+        .join("implementations")
+        .join("python")
+        .join("target")
+        .join("release")
+        .join("provekit-realize-python-requests");
+    if !binary.exists() {
+        return None;
+    }
+    install_binary_manifest(
+        workspace,
+        "python-requests",
+        &binary,
+        "python-realize-requests",
+        "requests",
+    );
+    fs::write(
+        workspace.join("pyproject.toml"),
+        "[project]\nname = \"materialize-python-example\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("write python project marker");
+    let src_dir = workspace.join("src");
+    fs::create_dir_all(&src_dir).expect("create python src dir");
+    Some(src_dir)
+}
+
+fn write_rust_reqwest_project_fixture(workspace: &Path) -> Option<PathBuf> {
+    let repo = repo_root();
+    let binary = repo
+        .join("implementations")
+        .join("rust")
+        .join("target")
+        .join("debug")
+        .join("provekit-realize-rust");
+    if !binary.exists() {
+        return None;
+    }
+    install_binary_manifest(workspace, "rust", &binary, "rust-realize", "reqwest");
+    fs::write(
+        workspace.join("Cargo.toml"),
+        "[package]\nname = \"materialize-rust-example\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write rust project marker");
+    let src_dir = workspace.join("src");
+    fs::create_dir_all(&src_dir).expect("create rust src dir");
+    Some(src_dir)
+}
+
 fn concept_carrier_lines(indent: &str) -> String {
     format!(
         "{indent}// provekit-concept: {}\n{indent}// provekit-concept-payload-cid: {}\n",
@@ -80,9 +158,26 @@ fn concept_payload_json() -> &'static str {
 }
 
 fn concept_payload_cid() -> String {
-    let json: Json = serde_json::from_str(concept_payload_json()).expect("payload json parses");
+    payload_cid(concept_payload_json())
+}
+
+fn payload_cid(payload: &str) -> String {
+    let json: Json = serde_json::from_str(payload).expect("payload json parses");
     let canonical = canonical_value_from_json(&json);
     blake3_512_of(encode_jcs(canonical.as_ref()).as_bytes())
+}
+
+fn http_payload_json(function: &str, param_type: &str, return_type: &str) -> String {
+    format!(
+        "{{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"concept:http-request\",\"function\":\"{function}\",\"params\":[\"url\"],\"param_types\":[\"{param_type}\"],\"return_type\":\"{return_type}\"}}"
+    )
+}
+
+fn carrier_lines(comment_prefix: &str, indent: &str, payload: &str) -> String {
+    format!(
+        "{indent}{comment_prefix} provekit-concept: {payload}\n{indent}{comment_prefix} provekit-concept-payload-cid: {}\n",
+        payload_cid(payload)
+    )
 }
 
 fn canonical_value_from_json(value: &Json) -> Arc<CanonicalValue> {
@@ -189,6 +284,34 @@ fn write_mismatched_cid_concept_source(src_dir: &Path) -> PathBuf {
 fn write_no_carrier_source(src_dir: &Path) -> PathBuf {
     let source_path = src_dir.join("plain.ts");
     fs::write(&source_path, "export const untouched = 42;\n").expect("write plain source");
+    source_path
+}
+
+fn write_python_http_request_source(src_dir: &Path) -> PathBuf {
+    let source_path = src_dir.join("client.py");
+    let payload = http_payload_json("fetch_status", "str", "int");
+    fs::write(
+        &source_path,
+        format!(
+            "# python materialize example\n{}# end\n",
+            carrier_lines("#", "", &payload)
+        ),
+    )
+    .expect("write python HTTP source");
+    source_path
+}
+
+fn write_rust_http_request_source(src_dir: &Path) -> PathBuf {
+    let source_path = src_dir.join("lib.rs");
+    let payload = http_payload_json("fetch_status", "&str", "i64");
+    fs::write(
+        &source_path,
+        format!(
+            "// rust materialize example\n{}// end\n",
+            carrier_lines("//", "", &payload)
+        ),
+    )
+    .expect("write rust HTTP source");
     source_path
 }
 
@@ -518,4 +641,74 @@ fn materialize_no_carriers_reports_zero_without_printing_dry_run_source() {
         fs::read_to_string(source_path).expect("read plain source"),
         "export const untouched = 42;\n"
     );
+}
+
+#[test]
+fn materialize_python_requests_example_uses_python_library_shim() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let Some(src_dir) = write_python_requests_project_fixture(workspace.path()) else {
+        eprintln!("skipping Python materialize example: provekit-realize-python-requests binary is unavailable");
+        return;
+    };
+    write_python_http_request_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .env("PROVEKIT_REPO_ROOT", repo_root())
+        .arg("materialize")
+        .arg("--library")
+        .arg("python-requests")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .output()
+        .expect("spawn provekit materialize for Python requests");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Python requests materialize example should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("// file: client.py"));
+    assert!(
+        stdout.contains("requests.get(url)"),
+        "Python requests example should route through the requests shim:\n{stdout}"
+    );
+    assert!(!stdout.contains("provekit-concept:"));
+}
+
+#[test]
+fn materialize_rust_reqwest_example_uses_rust_library_shim() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let Some(src_dir) = write_rust_reqwest_project_fixture(workspace.path()) else {
+        eprintln!("skipping Rust materialize example: provekit-realize-rust binary is unavailable; build with `cargo build -p provekit-realize-rust-core`");
+        return;
+    };
+    write_rust_http_request_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .env("PROVEKIT_REPO_ROOT", repo_root())
+        .arg("materialize")
+        .arg("--library")
+        .arg("rust-reqwest")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .output()
+        .expect("spawn provekit materialize for Rust reqwest");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Rust reqwest materialize example should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("// file: lib.rs"));
+    assert!(
+        stdout.contains("reqwest::get(url)"),
+        "Rust reqwest example should route through the Rust reqwest shim:\n{stdout}"
+    );
+    assert!(!stdout.contains("provekit-concept:"));
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -162,3 +162,43 @@ fn materialize_write_rewrites_source_file_in_place_and_reports_summary() {
         "write mode should remove payload CID carrier comments:\n{rewritten}"
     );
 }
+
+#[test]
+fn materialize_out_dir_writes_materialized_copy_and_leaves_source_unchanged() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = write_typescript_project_fixture(workspace.path());
+    let source_path = write_concept_source(&src_dir);
+    let out_dir = workspace.path().join("materialized");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .output()
+        .expect("spawn provekit materialize --out-dir");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "materialize --out-dir should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("materialized 1 concept citation(s) across 1 file(s)"),
+        "out-dir mode should report replacement summary: {stdout}"
+    );
+    let copied = fs::read_to_string(out_dir.join("queries.ts")).expect("read materialized copy");
+    assert!(copied.contains("db.prepare(sql).all(args)"));
+    assert!(!copied.contains("provekit-concept:"));
+    let original = fs::read_to_string(&source_path).expect("read original source");
+    assert!(
+        original.contains("provekit-concept:"),
+        "out-dir mode must not rewrite source file: {original}"
+    );
+}

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -63,17 +63,35 @@ fn write_typescript_project_fixture(workspace: &Path) -> PathBuf {
     src_dir
 }
 
+fn concept_carrier_lines(indent: &str) -> String {
+    format!(
+        "{indent}// provekit-concept: {{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"concept:sql-query\",\"function\":\"selectRows\",\"params\":[\"sql\",\"args\"],\"param_types\":[\"string\",\"unknown[]\"],\"return_type\":\"unknown[]\",\"named_term_tree\":{{\"conceptName\":\"concept:sql-query\",\"args\":[{{\"sort\":\"Sql\",\"source\":\"sql\"}},{{\"sort\":\"SqlArgs\",\"source\":\"args\"}}]}}}}\n{indent}// provekit-concept-payload-cid: blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+    )
+}
+
 fn write_concept_source(src_dir: &Path) -> PathBuf {
     let source_path = src_dir.join("queries.ts");
     fs::write(
         &source_path,
-        r#"// header stays
-// provekit-concept: {"artifact_kind":"provekit-concept-citation-comment-sugar","concept_name":"concept:sql-query","function":"selectRows","params":["sql","args"],"param_types":["string","unknown[]"],"return_type":"unknown[]","named_term_tree":{"conceptName":"concept:sql-query","args":[{"sort":"Sql","source":"sql"},{"sort":"SqlArgs","source":"args"}]}}
-// provekit-concept-payload-cid: blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-// footer stays
-"#,
+        format!(
+            "// header stays\n{}// footer stays\n",
+            concept_carrier_lines("")
+        ),
     )
     .expect("write source");
+    source_path
+}
+
+fn write_indented_concept_source(src_dir: &Path) -> PathBuf {
+    let source_path = src_dir.join("nested.ts");
+    fs::write(
+        &source_path,
+        format!(
+            "export function wrapper() {{\n{}  return true;\n}}\n",
+            concept_carrier_lines("  ")
+        ),
+    )
+    .expect("write indented source");
     source_path
 }
 
@@ -200,5 +218,44 @@ fn materialize_out_dir_writes_materialized_copy_and_leaves_source_unchanged() {
     assert!(
         original.contains("provekit-concept:"),
         "out-dir mode must not rewrite source file: {original}"
+    );
+}
+
+#[test]
+fn materialize_preserves_carrier_indentation_when_replacing_source() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = write_typescript_project_fixture(workspace.path());
+    let source_path = write_indented_concept_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--write")
+        .output()
+        .expect("spawn provekit materialize --write");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "materialize --write should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let rewritten = fs::read_to_string(&source_path).expect("read rewritten source");
+    assert!(
+        rewritten.contains("\n  function selectRows"),
+        "replacement should start at the carrier's indentation level:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains("\n    return db.prepare(sql).all(args);"),
+        "replacement body indentation should be offset from the carrier indentation:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains("\n  }\n  return true;"),
+        "replacement closing brace should preserve carrier indentation and following code:\n{rewritten}"
     );
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -3,6 +3,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
+use serde_json::Value as Json;
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -65,7 +69,9 @@ fn write_typescript_project_fixture(workspace: &Path) -> PathBuf {
 
 fn concept_carrier_lines(indent: &str) -> String {
     format!(
-        "{indent}// provekit-concept: {{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"concept:sql-query\",\"function\":\"selectRows\",\"params\":[\"sql\",\"args\"],\"param_types\":[\"string\",\"unknown[]\"],\"return_type\":\"unknown[]\",\"named_term_tree\":{{\"conceptName\":\"concept:sql-query\",\"args\":[{{\"sort\":\"Sql\",\"source\":\"sql\"}},{{\"sort\":\"SqlArgs\",\"source\":\"args\"}}]}}}}\n{indent}// provekit-concept-payload-cid: blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "{indent}// provekit-concept: {}\n{indent}// provekit-concept-payload-cid: {}\n",
+        concept_payload_json(),
+        concept_payload_cid()
     )
 }
 
@@ -73,10 +79,36 @@ fn concept_payload_json() -> &'static str {
     "{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"concept:sql-query\",\"function\":\"selectRows\",\"params\":[\"sql\",\"args\"],\"param_types\":[\"string\",\"unknown[]\"],\"return_type\":\"unknown[]\",\"named_term_tree\":{\"conceptName\":\"concept:sql-query\",\"args\":[{\"sort\":\"Sql\",\"source\":\"sql\"},{\"sort\":\"SqlArgs\",\"source\":\"args\"}]}}"
 }
 
+fn concept_payload_cid() -> String {
+    let json: Json = serde_json::from_str(concept_payload_json()).expect("payload json parses");
+    let canonical = canonical_value_from_json(&json);
+    blake3_512_of(encode_jcs(canonical.as_ref()).as_bytes())
+}
+
+fn canonical_value_from_json(value: &Json) -> Arc<CanonicalValue> {
+    match value {
+        Json::Null => CanonicalValue::null(),
+        Json::Bool(value) => CanonicalValue::boolean(*value),
+        Json::Number(value) => {
+            CanonicalValue::integer(value.as_i64().expect("test JSON uses integers only"))
+        }
+        Json::String(value) => CanonicalValue::string(value),
+        Json::Array(values) => {
+            CanonicalValue::array(values.iter().map(canonical_value_from_json).collect())
+        }
+        Json::Object(entries) => CanonicalValue::object(
+            entries
+                .iter()
+                .map(|(key, value)| (key.clone(), canonical_value_from_json(value))),
+        ),
+    }
+}
+
 fn block_comment_concept_carrier_lines(indent: &str) -> String {
     format!(
-        "{indent}/* provekit-concept: {} */\n{indent}/* provekit-concept-payload-cid: blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa */\n",
-        concept_payload_json()
+        "{indent}/* provekit-concept: {} */\n{indent}/* provekit-concept-payload-cid: {} */\n",
+        concept_payload_json(),
+        concept_payload_cid()
     )
 }
 
@@ -138,6 +170,19 @@ fn write_malformed_dependency_source(src_dir: &Path) -> PathBuf {
         "// provekit-concept: {not json from dependency}\n",
     )
     .expect("write malformed dependency source");
+    source_path
+}
+
+fn write_mismatched_cid_concept_source(src_dir: &Path) -> PathBuf {
+    let source_path = src_dir.join("mismatch.ts");
+    fs::write(
+        &source_path,
+        format!(
+            "// provekit-concept: {}\n// provekit-concept-payload-cid: blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+            concept_payload_json()
+        ),
+    )
+    .expect("write mismatched CID source");
     source_path
 }
 
@@ -397,5 +442,37 @@ fn materialize_ignores_dependency_directories_when_scanning_sources() {
     assert!(
         !stdout.contains("node_modules"),
         "dependency files should not appear in materialize output:\n{stdout}"
+    );
+}
+
+#[test]
+fn materialize_rejects_payload_cid_mismatch() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = write_typescript_project_fixture(workspace.path());
+    write_mismatched_cid_concept_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .output()
+        .expect("spawn provekit materialize");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "CID mismatch should fail\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("mismatch.ts"),
+        "CID mismatch error should name the source file:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("provekit-concept-payload-cid mismatch"),
+        "CID mismatch error should explain the mismatch:\n{stderr}"
     );
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -129,6 +129,18 @@ fn write_malformed_concept_source(src_dir: &Path) -> PathBuf {
     source_path
 }
 
+fn write_malformed_dependency_source(src_dir: &Path) -> PathBuf {
+    let dependency_dir = src_dir.join("node_modules").join("bad-package");
+    fs::create_dir_all(&dependency_dir).expect("create dependency dir");
+    let source_path = dependency_dir.join("index.js");
+    fs::write(
+        &source_path,
+        "// provekit-concept: {not json from dependency}\n",
+    )
+    .expect("write malformed dependency source");
+    source_path
+}
+
 #[test]
 fn materialize_dry_run_replaces_concept_citation_with_realized_library_source() {
     let workspace = tempfile::tempdir().expect("tempdir");
@@ -353,5 +365,37 @@ fn materialize_malformed_carrier_error_names_source_file() {
     assert!(
         stderr.contains("parse provekit-concept payload JSON"),
         "error should preserve the JSON parse detail:\n{stderr}"
+    );
+}
+
+#[test]
+fn materialize_ignores_dependency_directories_when_scanning_sources() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = write_typescript_project_fixture(workspace.path());
+    write_concept_source(&src_dir);
+    write_malformed_dependency_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .output()
+        .expect("spawn provekit materialize");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "materialize should ignore malformed carriers under dependency directories\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("// file: queries.ts"));
+    assert!(stdout.contains("db.prepare(sql).all(args)"));
+    assert!(
+        !stdout.contains("node_modules"),
+        "dependency files should not appear in materialize output:\n{stdout}"
     );
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -119,6 +119,16 @@ fn write_block_comment_concept_source(src_dir: &Path) -> PathBuf {
     source_path
 }
 
+fn write_malformed_concept_source(src_dir: &Path) -> PathBuf {
+    let source_path = src_dir.join("bad.ts");
+    fs::write(
+        &source_path,
+        "// provekit-concept: {not json}\n// provekit-concept-payload-cid: blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+    )
+    .expect("write malformed source");
+    source_path
+}
+
 #[test]
 fn materialize_dry_run_replaces_concept_citation_with_realized_library_source() {
     let workspace = tempfile::tempdir().expect("tempdir");
@@ -312,4 +322,36 @@ fn materialize_accepts_single_line_block_comment_carriers() {
     assert!(rewritten.contains("db.prepare(sql).all(args)"));
     assert!(!rewritten.contains("provekit-concept:"));
     assert!(!rewritten.contains("*/"));
+}
+
+#[test]
+fn materialize_malformed_carrier_error_names_source_file() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = write_typescript_project_fixture(workspace.path());
+    write_malformed_concept_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .output()
+        .expect("spawn provekit materialize");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "malformed carrier should fail\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("bad.ts"),
+        "error should identify the source file with the malformed carrier:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("parse provekit-concept payload JSON"),
+        "error should preserve the JSON parse detail:\n{stderr}"
+    );
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -69,6 +69,17 @@ fn concept_carrier_lines(indent: &str) -> String {
     )
 }
 
+fn concept_payload_json() -> &'static str {
+    "{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"concept:sql-query\",\"function\":\"selectRows\",\"params\":[\"sql\",\"args\"],\"param_types\":[\"string\",\"unknown[]\"],\"return_type\":\"unknown[]\",\"named_term_tree\":{\"conceptName\":\"concept:sql-query\",\"args\":[{\"sort\":\"Sql\",\"source\":\"sql\"},{\"sort\":\"SqlArgs\",\"source\":\"args\"}]}}"
+}
+
+fn block_comment_concept_carrier_lines(indent: &str) -> String {
+    format!(
+        "{indent}/* provekit-concept: {} */\n{indent}/* provekit-concept-payload-cid: blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa */\n",
+        concept_payload_json()
+    )
+}
+
 fn write_concept_source(src_dir: &Path) -> PathBuf {
     let source_path = src_dir.join("queries.ts");
     fs::write(
@@ -92,6 +103,19 @@ fn write_indented_concept_source(src_dir: &Path) -> PathBuf {
         ),
     )
     .expect("write indented source");
+    source_path
+}
+
+fn write_block_comment_concept_source(src_dir: &Path) -> PathBuf {
+    let source_path = src_dir.join("block.ts");
+    fs::write(
+        &source_path,
+        format!(
+            "// header stays\n{}// footer stays\n",
+            block_comment_concept_carrier_lines("")
+        ),
+    )
+    .expect("write block comment source");
     source_path
 }
 
@@ -258,4 +282,34 @@ fn materialize_preserves_carrier_indentation_when_replacing_source() {
         rewritten.contains("\n  }\n  return true;"),
         "replacement closing brace should preserve carrier indentation and following code:\n{rewritten}"
     );
+}
+
+#[test]
+fn materialize_accepts_single_line_block_comment_carriers() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = write_typescript_project_fixture(workspace.path());
+    let source_path = write_block_comment_concept_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--write")
+        .output()
+        .expect("spawn provekit materialize --write");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "materialize should accept block-comment carriers\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let rewritten = fs::read_to_string(&source_path).expect("read rewritten source");
+    assert!(rewritten.contains("db.prepare(sql).all(args)"));
+    assert!(!rewritten.contains("provekit-concept:"));
+    assert!(!rewritten.contains("*/"));
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("provekit-cli has rust workspace parent")
+        .parent()
+        .expect("rust workspace has implementations parent")
+        .parent()
+        .expect("implementations dir has repo parent")
+        .to_path_buf()
+}
+
+fn node_bin() -> String {
+    std::env::var("NODE").unwrap_or_else(|_| "node".to_string())
+}
+
+fn install_node_manifest(root: &Path, surface: &str, script: &Path, library_tag: &str) {
+    let manifest = root
+        .join(".provekit")
+        .join("realize")
+        .join(surface)
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().expect("manifest path has parent"))
+        .expect("create manifest dir");
+    let script = script
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let manifest_text = format!(
+        "name = \"typescript-realize-{library_tag}\"\n\
+         library_tag = \"{library_tag}\"\n\
+         command = [\"{}\", \"{}\", \"--rpc\"]\n\
+         working_dir = \".\"\n",
+        node_bin().replace('\\', "\\\\").replace('"', "\\\""),
+        script,
+    );
+    fs::write(manifest, manifest_text).expect("write manifest");
+}
+
+#[test]
+fn materialize_dry_run_replaces_concept_citation_with_realized_library_source() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let repo = repo_root();
+    install_node_manifest(
+        workspace.path(),
+        "typescript-better-sqlite3",
+        &repo
+            .join("implementations")
+            .join("typescript")
+            .join("provekit-realize-typescript-better-sqlite3")
+            .join("src")
+            .join("main.js"),
+        "better-sqlite3",
+    );
+    fs::write(
+        workspace.path().join("package.json"),
+        "{\"type\":\"module\"}\n",
+    )
+    .expect("write package marker");
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+    let source_path = src_dir.join("queries.ts");
+    fs::write(
+        &source_path,
+        r#"// header stays
+// provekit-concept: {"artifact_kind":"provekit-concept-citation-comment-sugar","concept_name":"concept:sql-query","function":"selectRows","params":["sql","args"],"param_types":["string","unknown[]"],"return_type":"unknown[]","named_term_tree":{"conceptName":"concept:sql-query","args":[{"sort":"Sql","source":"sql"},{"sort":"SqlArgs","source":"args"}]}}
+// provekit-concept-payload-cid: blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+// footer stays
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .output()
+        .expect("spawn provekit materialize");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "materialize should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("// file: queries.ts"),
+        "stdout should name the file: {stdout}"
+    );
+    assert!(stdout.contains("// header stays"));
+    assert!(
+        stdout.contains("db.prepare(sql).all(args)"),
+        "stdout should contain better-sqlite3 materialization:\n{stdout}"
+    );
+    assert!(stdout.contains("// footer stays"));
+    assert!(
+        fs::read_to_string(&source_path)
+            .expect("read original")
+            .contains("provekit-concept:"),
+        "dry run must not rewrite source files"
+    );
+}

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-aiosqlite.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-aiosqlite.json
@@ -37,7 +37,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "aiosqlite"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -68,7 +69,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "aiosqlite"
         },
         {
           "concept_name": "concept:sql-query",
@@ -94,7 +96,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "aiosqlite"
         }
       ],
       "target_language": "python",

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-blake3.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-blake3.json
@@ -21,7 +21,8 @@
           "signature_guard": {
             "max_params": 0,
             "min_params": 0
-          }
+          },
+          "target_library_tag": "blake3"
         },
         {
           "concept_name": "rust-method:hasher-update",
@@ -36,7 +37,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "blake3"
         },
         {
           "concept_name": "rust-method:hasher-finalize-xof",
@@ -51,7 +53,8 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
-          }
+          },
+          "target_library_tag": "blake3"
         },
         {
           "concept_name": "rust-method:hasher-finalize-xof-fill",
@@ -66,7 +69,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "blake3"
         },
         {
           "concept_name": "rust-call:hex::encode",
@@ -81,7 +85,8 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
-          }
+          },
+          "target_library_tag": "blake3"
         }
       ],
       "target_language": "python",
@@ -89,7 +94,9 @@
     },
     "critical": false,
     "kind": "body-template",
-    "protocol_versions": ["pep/1.7.0"],
+    "protocol_versions": [
+      "pep/1.7.0"
+    ],
     "provenance_cid": "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
     "schemaVersion": "1",
     "version": "1.0.0"

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-libprovekit.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-libprovekit.json
@@ -22,7 +22,8 @@
             "max_params": 0,
             "min_params": 0,
             "requires_return_type": "Value"
-          }
+          },
+          "target_library_tag": "libprovekit"
         },
         {
           "concept_name": "concept:value-boolean",
@@ -37,9 +38,12 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1,
-            "requires_param_types": ["bool"],
+            "requires_param_types": [
+              "bool"
+            ],
             "requires_return_type": "Value"
-          }
+          },
+          "target_library_tag": "libprovekit"
         },
         {
           "concept_name": "concept:value-integer",
@@ -54,9 +58,12 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1,
-            "requires_param_types": ["int"],
+            "requires_param_types": [
+              "int"
+            ],
             "requires_return_type": "Value"
-          }
+          },
+          "target_library_tag": "libprovekit"
         },
         {
           "concept_name": "concept:value-string",
@@ -71,9 +78,12 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1,
-            "requires_param_types": ["str"],
+            "requires_param_types": [
+              "str"
+            ],
             "requires_return_type": "Value"
-          }
+          },
+          "target_library_tag": "libprovekit"
         }
       ],
       "target_language": "python",
@@ -81,7 +91,9 @@
     },
     "critical": false,
     "kind": "body-template",
-    "protocol_versions": ["pep/1.7.0"],
+    "protocol_versions": [
+      "pep/1.7.0"
+    ],
     "provenance_cid": "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
     "schemaVersion": "1",
     "version": "1.0.0"

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-requests.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-requests.json
@@ -37,7 +37,8 @@
             "max_params": 1,
             "min_params": 1,
             "requires_return_type": "int"
-          }
+          },
+          "target_library_tag": "requests"
         },
         {
           "concept_name": "concept:http-request",
@@ -68,7 +69,8 @@
             "max_params": 2,
             "min_params": 2,
             "requires_return_type": "int"
-          }
+          },
+          "target_library_tag": "requests"
         },
         {
           "concept_name": "concept:http-response",
@@ -95,7 +97,8 @@
             "max_params": 1,
             "min_params": 1,
             "requires_return_type": "int"
-          }
+          },
+          "target_library_tag": "requests"
         },
         {
           "concept_name": "concept:http-response",
@@ -122,7 +125,8 @@
             "max_params": 1,
             "min_params": 1,
             "requires_return_type": "dict"
-          }
+          },
+          "target_library_tag": "requests"
         }
       ],
       "target_language": "python",
@@ -130,7 +134,9 @@
     },
     "critical": false,
     "kind": "body-template",
-    "protocol_versions": ["pep/1.7.0"],
+    "protocol_versions": [
+      "pep/1.7.0"
+    ],
     "provenance_cid": "blake3-512:0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
     "schemaVersion": "1",
     "version": "1.0.0"

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-rust-runtime.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-rust-runtime.json
@@ -21,7 +21,8 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
-          }
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:return",
@@ -36,7 +37,8 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
-          }
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:string-with-capacity",
@@ -51,8 +53,11 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1,
-            "requires_param_types": ["int"]
-          }
+            "requires_param_types": [
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:string-push-str",
@@ -67,8 +72,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["str", "str"]
-          }
+            "requires_param_types": [
+              "str",
+              "str"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:array-repeat",
@@ -83,7 +92,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:str-len",
@@ -98,7 +108,8 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
-          }
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:method-len",
@@ -113,7 +124,8 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
-          }
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:add",
@@ -128,8 +140,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:sub",
@@ -144,8 +160,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:conditional",
@@ -160,7 +180,8 @@
           "signature_guard": {
             "max_params": 3,
             "min_params": 3
-          }
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:eq",
@@ -175,8 +196,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:ne",
@@ -191,8 +216,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:decl",
@@ -207,7 +236,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:lt",
@@ -222,8 +252,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:le",
@@ -238,8 +272,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:gt",
@@ -254,8 +292,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:ge",
@@ -270,8 +312,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:mul",
@@ -286,8 +332,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:div",
@@ -302,8 +352,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:and",
@@ -318,8 +372,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["bool", "bool"]
-          }
+            "requires_param_types": [
+              "bool",
+              "bool"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:or",
@@ -334,8 +392,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["bool", "bool"]
-          }
+            "requires_param_types": [
+              "bool",
+              "bool"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:not",
@@ -350,8 +412,11 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1,
-            "requires_param_types": ["bool"]
-          }
+            "requires_param_types": [
+              "bool"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:mod",
@@ -366,8 +431,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:shl",
@@ -382,8 +451,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:shr",
@@ -398,8 +471,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:bitand",
@@ -414,8 +491,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:bitor",
@@ -430,8 +511,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:bitxor",
@@ -446,8 +531,12 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2,
-            "requires_param_types": ["int", "int"]
-          }
+            "requires_param_types": [
+              "int",
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:neg",
@@ -462,8 +551,11 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1,
-            "requires_param_types": ["int"]
-          }
+            "requires_param_types": [
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:bitnot",
@@ -478,8 +570,11 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1,
-            "requires_param_types": ["int"]
-          }
+            "requires_param_types": [
+              "int"
+            ]
+          },
+          "target_library_tag": "rust-runtime"
         },
         {
           "concept_name": "concept:borrow",
@@ -494,7 +589,8 @@
           "signature_guard": {
             "max_params": 1,
             "min_params": 1
-          }
+          },
+          "target_library_tag": "rust-runtime"
         }
       ],
       "target_language": "python",
@@ -502,7 +598,9 @@
     },
     "critical": false,
     "kind": "body-template",
-    "protocol_versions": ["pep/1.7.0"],
+    "protocol_versions": [
+      "pep/1.7.0"
+    ],
     "provenance_cid": "blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
     "schemaVersion": "1",
     "version": "1.0.0"

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
@@ -37,7 +37,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -68,7 +69,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-query",
@@ -94,7 +96,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         }
       ],
       "target_language": "python",

--- a/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-better-sqlite3.json
+++ b/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-better-sqlite3.json
@@ -32,7 +32,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "better-sqlite3"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -63,7 +64,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "better-sqlite3"
         }
       ],
       "target_language": "typescript",

--- a/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-pg.json
+++ b/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-pg.json
@@ -37,7 +37,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "pg"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -68,7 +69,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "pg"
         },
         {
           "concept_name": "concept:sql-query",
@@ -94,7 +96,8 @@
           "signature_guard": {
             "max_params": 2,
             "min_params": 2
-          }
+          },
+          "target_library_tag": "pg"
         }
       ],
       "target_language": "typescript",


### PR DESCRIPTION
## Summary
- Add `provekit materialize` for concept-citation carrier comments with dry-run, `--write`, and `--out-dir` modes.
- Harden carrier handling: indentation preservation, block-comment carriers, source-file diagnostics, dependency/build directory pruning, no-carrier UX, and adjacent payload CID verification.
- Exercise materialization through real realize shims for TypeScript better-sqlite3, Python requests, and Rust reqwest without embedding language/library renderers in the Rust CLI.
- Normalize library-specific body-template sugars so entries explicitly declare their `(target_language, target_library_tag, concept_name)` tuple, and document the materialize workflow.

## Test Plan
- [x] `cargo test -p provekit-cli --test cmd_materialize_integration -- --nocapture`
- [x] `cargo test -p provekit-cli --test library_tag_dispatch_test -- --nocapture`
- [x] `cargo test -p provekit-cli --test body_template_normalization -- --nocapture`
- [x] `cargo test -p provekit-cli` attempted; current branch reaches the known unrelated Java carrier registry failure (`lower_java_carrier_registration_points_at_required_fixture_set`) after CLI unit tests pass. Python `blake3` import noise is also still present in the broad run but not the terminal failure.

## Notes
- The Rust CLI remains orchestration-only: it scans/verifies carriers, selects `.provekit/realize/<surface>/manifest.toml`, and dispatches through the existing kit registry/path execution machinery.
- Python SQL examples remain scoped to Python SQL-specific library surfaces; Python requests examples use the requests surface only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `provekit materialize` command to automatically generate code from concept citation markers, with support for dry-run previews, in-place file rewriting, and separate output directory modes.

* **Documentation**
  * Added comprehensive guide for the `materialize` command, including usage examples for Python, Rust, and TypeScript projects.

* **Chores**
  * Updated body template specifications with explicit library targeting information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->