### PR TITLE
fix(realize-python-aiosqlite): NTT args_shape parity with python-sqlite3 (closes #1253)

### DIFF
--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/realizer.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/realizer.py
@@ -87,24 +87,22 @@ def body_template_for(
     return_type: str,
     named_term_tree: dict[str, Any] | None = None,
 ) -> str | None:
-    tree_args_shape = _args_shape_from_named_term_tree(named_term_tree)
-    if tree_args_shape is None:
-        args_shape = tuple(map_source_type(ty) for ty in param_types)
-        template_params = params
-    else:
-        args_shape = tree_args_shape
-        template_params = _tree_template_params(named_term_tree, params, args_shape)
+    template_params, lookup_param_types = _template_lookup_signature(
+        params,
+        param_types,
+        named_term_tree,
+    )
     mapped_return_type = map_source_type(return_type)
     candidate_names = (concept_name, concept_name.removeprefix("concept:"))
     for entry in entries():
         if entry.concept_name not in candidate_names:
             continue
-        if entry.min_params is not None and len(args_shape) < entry.min_params:
+        if entry.min_params is not None and len(lookup_param_types) < entry.min_params:
             continue
-        if entry.max_params is not None and len(args_shape) > entry.max_params:
+        if entry.max_params is not None and len(lookup_param_types) > entry.max_params:
             continue
         if entry.requires_param_types is not None:
-            if args_shape != entry.requires_param_types:
+            if tuple(lookup_param_types) != entry.requires_param_types:
                 continue
         if entry.requires_return_type is not None:
             if mapped_return_type != entry.requires_return_type:
@@ -114,7 +112,7 @@ def body_template_for(
         rendered = render_template(
             entry.template,
             template_params,
-            list(args_shape),
+            lookup_param_types,
             mapped_return_type,
         )
         if rendered is None:
@@ -127,82 +125,123 @@ def args_shape_for(
     param_types: list[str],
     named_term_tree: dict[str, Any] | None = None,
 ) -> tuple[str, ...]:
-    tree_args_shape = _args_shape_from_named_term_tree(named_term_tree)
-    if tree_args_shape is not None:
-        return tree_args_shape
+    ntt_args_shape = _ntt_args_shape(named_term_tree)
+    if ntt_args_shape is not None:
+        return ntt_args_shape
     return tuple(map_source_type(ty) for ty in param_types)
 
 
-def _args_shape_from_named_term_tree(
+# NTT (named_term_tree) helpers. Kept in lock-step with the python-sqlite3
+# kit's equivalents (#1253: latent inconsistency closed). Any change to NTT
+# derivation MUST be applied to both kits in the same PR; the test suite
+# guards this by pinning identical body_template_for outputs across the two
+# plugins for shared catalog entries.
+
+
+def _template_lookup_signature(
+    params: list[str],
+    param_types: list[str],
     named_term_tree: dict[str, Any] | None,
-) -> tuple[str, ...] | None:
+) -> tuple[list[str], list[str]]:
+    ntt_args_shape = _ntt_args_shape(named_term_tree)
+    if ntt_args_shape is None:
+        return params, [map_source_type(ty) for ty in param_types]
+    return (
+        _ntt_template_params(params, named_term_tree, len(ntt_args_shape)),
+        list(ntt_args_shape),
+    )
+
+
+def _ntt_args_shape(named_term_tree: dict[str, Any] | None) -> tuple[str, ...] | None:
     if not isinstance(named_term_tree, dict):
         return None
     args = named_term_tree.get("args")
     if not isinstance(args, list):
-        return ()
-    return tuple(_tree_arg_shape(arg) for arg in args)
+        return None
+    out: list[str] = []
+    for arg in args:
+        if not isinstance(arg, dict):
+            return None
+        descriptor = _ntt_arg_descriptor(arg)
+        if descriptor is None:
+            return None
+        out.append(_map_ntt_arg_descriptor(descriptor))
+    return tuple(out)
 
 
-def _tree_arg_shape(arg: Any) -> str:
-    if not isinstance(arg, dict):
-        return "arg"
+def _ntt_arg_descriptor(arg: dict[str, Any]) -> str | None:
     for key in (
+        "type",
+        "typeName",
+        "type_name",
         "sort",
         "sortName",
+        "sort_name",
         "conceptName",
         "concept_name",
         "operationKind",
         "operation_kind",
-        "kind",
     ):
         value = arg.get(key)
         if isinstance(value, str) and value.strip():
-            return value
-    return "arg"
+            return value.strip()
+    return None
 
 
-def _tree_template_params(
-    named_term_tree: dict[str, Any] | None,
+def _map_ntt_arg_descriptor(descriptor: str) -> str:
+    match descriptor:
+        case "Sql" | "sql" | "concept:sql":
+            return "str"
+        case "SqlArgs" | "sqlArgs" | "sql_args" | "sql-args" | "concept:sql-args":
+            return "list[object]"
+        case _:
+            return map_source_type(descriptor)
+
+
+def _ntt_template_params(
     params: list[str],
-    args_shape: tuple[str, ...],
+    named_term_tree: dict[str, Any] | None,
+    arity: int,
 ) -> list[str]:
-    if len(params) == len(args_shape):
+    if len(params) == arity:
         return params
-    if not isinstance(named_term_tree, dict):
-        return params
-    args = named_term_tree.get("args")
+    args = named_term_tree.get("args") if isinstance(named_term_tree, dict) else None
     if not isinstance(args, list):
-        return []
-    out: list[str] = []
+        return [f"arg{index}" for index in range(arity)]
+    names: list[str] = []
     for index, arg in enumerate(args):
-        out.append(_tree_arg_name(arg, args_shape[index], index))
-    return out
+        if isinstance(arg, dict):
+            names.append(_ntt_arg_name(arg, index))
+        else:
+            names.append(f"arg{index}")
+    return names
 
 
-def _tree_arg_name(arg: Any, args_shape: str, index: int) -> str:
-    if isinstance(arg, dict):
-        for key in ("paramName", "param_name", "symbol", "name"):
-            value = arg.get(key)
-            if isinstance(value, str) and value.strip():
-                return _python_identifier(value, index)
-    return _python_identifier(args_shape, index)
-
-
-def _python_identifier(value: str, index: int) -> str:
-    stripped = value.strip()
-    if stripped in ("Sql", "concept:sql", "sql"):
-        return "sql"
-    if stripped in ("SqlArgs", "concept:sql-args", "sql-args", "sql_args"):
-        return "args"
-    if stripped.startswith("concept:"):
-        stripped = stripped.removeprefix("concept:")
-    candidate = re.sub(r"\W+", "_", stripped).strip("_").lower()
-    if not candidate:
+def _ntt_arg_name(arg: dict[str, Any], index: int) -> str:
+    for key in ("name", "paramName", "param_name", "binding", "symbol"):
+        value = arg.get(key)
+        if isinstance(value, str) and value.strip():
+            return _python_identifier_or_default(value.strip(), f"arg{index}")
+    descriptor = _ntt_arg_descriptor(arg)
+    if descriptor is None:
         return f"arg{index}"
-    if not (candidate[0].isalpha() or candidate[0] == "_"):
-        return f"arg{index}"
-    return candidate
+    match descriptor:
+        case "Sql" | "sql" | "concept:sql":
+            return "sql"
+        case "SqlArgs" | "sqlArgs" | "sql_args" | "sql-args" | "concept:sql-args":
+            return "args"
+        case _:
+            return _python_identifier_or_default(
+                descriptor.removeprefix("concept:"),
+                f"arg{index}",
+            )
+
+
+def _python_identifier_or_default(value: str, default: str) -> str:
+    identifier = value.replace("-", "_")
+    if identifier.isidentifier():
+        return identifier
+    return default
 
 
 def map_source_type(src: str) -> str:

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
@@ -99,7 +99,7 @@ def test_missing_template_reports_named_term_tree_args_shape() -> None:
         assert [entry.to_json() for entry in exc.entries] == [
             {
                 "operation_kind": "missing-concept",
-                "args_shape": ["Sql", "SqlArgs"],
+                "args_shape": ["str", "list[object]"],
                 "function": "missing",
                 "term_position": "body",
             }

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
@@ -140,7 +140,7 @@ def test_plugin_invoke_missing_template_uses_named_term_tree_args_shape() -> Non
             "data": [
                 {
                     "operation_kind": "missing-concept",
-                    "args_shape": ["Sql", "SqlArgs"],
+                    "args_shape": ["str", "list[object]"],
                     "function": "missing",
                     "term_position": "body",
                 }


### PR DESCRIPTION
## Summary

Closes #1253 (D5g). Ports python-sqlite3's NTT (named_term_tree) derivation pattern into python-aiosqlite so both kits produce identical `args_shape` values for shared catalog entries.

## The divergence

- **python-sqlite3:** `_map_ntt_arg_descriptor` mapped semantic descriptors to Python types: `Sql → str`, `SqlArgs → list[object]`.
- **python-aiosqlite:** `_tree_arg_shape` returned raw sort names (`"Sql"`, `"SqlArgs"`).

Latent today (catalog body templates don't use `requires_param_types`), but real divergence that surfaces in `MissingTemplateError` reporting and would break when `requires_param_types`-using catalog entries land.

## Fix

Ported python-sqlite3's NTT helpers wholesale into python-aiosqlite. After this PR, both kits share an identical NTT-derivation surface:

- `_template_lookup_signature` returns `(template_params, lookup_param_types)` with `lookup_param_types` containing mapped Python types.
- `_ntt_args_shape` returns `None` when no NTT (falls back to param_types); otherwise mapped shape.
- `_ntt_arg_descriptor` scans `type / typeName / sort / sortName / conceptName / operationKind / ...` keys (matching sqlite3's wider set).
- `_map_ntt_arg_descriptor` does the `Sql → str`, `SqlArgs → list[object]` mapping.
- `_ntt_template_params`, `_ntt_arg_name`, `_python_identifier_or_default` match sqlite3's pattern.

Removed: aiosqlite's `_args_shape_from_named_term_tree`, `_tree_arg_shape`, `_tree_template_params`, `_tree_arg_name`, `_python_identifier` (the regex-based variant). All replaced by sqlite3-pattern equivalents.

A module-level comment documents the parity discipline: any future change to NTT derivation MUST land in both kits in the same PR.

## Test updates

Two assertions updated (they previously documented the divergence):

- `tests/test_realizer.py:102` — `args_shape: ["Sql", "SqlArgs"]` → `["str", "list[object]"]`.
- `tests/test_rpc.py:143` — same update.

After the fix, these tests confirm parity (assert the mapped Python types matching python-sqlite3's output).

## Validation

- aiosqlite tests: 17 passed (5 realizer + 6 platform_semantics + 6 rpc).
- sqlite3 tests: 15 passed (no regression).
- NTT harness (`cmd_bind_migrate::d5_realize_verification_harness_with_ntt`): `Totals: MATCHES=0 COSMETIC=0 SEMANTIC=8 MISSING=4` (same as before this PR; the 4 MISSING are typescript-pg PATH-dependency, unrelated to D5g).

## Cross-references

- Issue: #1253.
- Substrate-uniform pattern: `docs/explanation/substrate-uniform-pattern.md`.
- Audit row D5g: `docs/audits/2026-05-18-kit-as-substrate-participant-vision.md` (post-#1255 row).
- Pattern source: `implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/realizer.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)