### PR TITLE
fix(java-kit): emit __float_bits__ for Float literals (bit-preserving)

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
@@ -377,6 +377,18 @@ public final class JavaBindLifter {
             literal = Jcs.object("kind", Jcs.string("literal"), "value", Jcs.nullValue());
         } else if (value instanceof Boolean b) {
             literal = Jcs.object("kind", Jcs.string("literal"), "value", Jcs.bool(b));
+        } else if (value instanceof Double d) {
+            // Bit-preserving: emit {"__float_bits__": <u64>} (IEEE 754 raw bits, substrate #1262).
+            // Double.doubleToRawLongBits preserves all bit patterns including NaN, +/-0, infinity.
+            long bits = Double.doubleToRawLongBits(d);
+            literal = Jcs.object("kind", Jcs.string("literal"), "value",
+                Jcs.object("__float_bits__", Jcs.integer(bits)));
+        } else if (value instanceof Float f) {
+            // Widen to double then preserve all 32 bits via doubleToRawLongBits of the widened form.
+            // Java float literals widen to double in the AST; raw float bits via Float.floatToRawIntBits.
+            long bits = Float.floatToRawIntBits(f) & 0xFFFFFFFFL;
+            literal = Jcs.object("kind", Jcs.string("literal"), "value",
+                Jcs.object("__float_bits__", Jcs.integer(bits)));
         } else if (value instanceof Number n) {
             literal = Jcs.object("kind", Jcs.string("literal"), "value", Jcs.integer(n.longValue()));
         } else if (value instanceof String s) {

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/LiteralEncodingAnswers.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/LiteralEncodingAnswers.java
@@ -14,9 +14,10 @@
 // JCS field order for expected_term_shape_node (alphabetical):
 //   concept_name, sort, value
 //
-// Float value: Java's Term.Value.Real(double) emits "String.valueOf(3.14)" = "3.14"
-// as a JSON number. We build the JCS string manually for the float case because
-// Jcs.Value only supports integer JSON numbers.
+// Float value: bit-preserving {"__float_bits__": <u64>} (IEEE 754 raw bits).
+// 4614253070214989087 == Double.doubleToRawLongBits(3.14) == 0x40091EB851EB851F.
+// We build the JCS string manually via buildMementoRaw because the value is an
+// integer object, not a primitive, and Jcs.Value supports integer JSON numbers.
 
 package com.provekit.realize;
 
@@ -74,7 +75,7 @@ public final class LiteralEncodingAnswers {
 
         // Java admits: Int, Float, String, Bool, Bytes, Null
         String intMemento     = buildMemento(kitCid, SORT_INT_CID,    "42",       intValue(42));
-        String floatMemento   = buildMementoRaw(kitCid, SORT_FLOAT_CID, "3.14",   "3.14");
+        String floatMemento   = buildMementoRaw(kitCid, SORT_FLOAT_CID, "3.14",   "{\"__float_bits__\":4614253070214989087}");
         String stringMemento  = buildMemento(kitCid, SORT_STRING_CID, "\"hello\"", stringValue("hello"));
         String boolMemento    = buildMemento(kitCid, SORT_BOOL_CID,   "true",     boolValue(true));
         String bytesMemento   = buildMemento(kitCid, SORT_BYTES_CID,  "\"abc\".getBytes()", stringValue("abc"));
@@ -132,12 +133,12 @@ public final class LiteralEncodingAnswers {
     }
 
     /**
-     * Builds a LiteralEncodingMemento JSON string for Float sort by constructing
-     * the JCS CID-input string manually (Jcs.Value doesn't support float numbers).
+     * Builds a LiteralEncodingMemento JSON string by constructing
+     * the JCS CID-input string manually from a raw JSON value literal.
      *
-     * The JCS for the forCid object is built manually with sorted keys and the
-     * float value emitted as a plain JSON number (no quotes), matching what
-     * Java's Term.Value.Real(double).toJson() produces.
+     * Used for Float sort: the value literal is the __float_bits__ object
+     * {"__float_bits__":4614253070214989087} (IEEE 754 raw bits of 3.14).
+     * Keys are in alphabetical order (JCS/RFC 8785 requirement).
      */
     private static String buildMementoRaw(String kitCid, String sortCid,
                                            String sourceExample, String valueJsonLiteral) {

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/LiteralEncodingAnswers.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/LiteralEncodingAnswers.java
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Java kit literal-encoding answers.
+//
+// Implements the provekit.plugin.literal_encoding_answers RPC method.
+// Returns one LiteralEncodingMemento per sort the Java kit admits at
+// literal positions per its SortAdmission declaration.
+//
+// Java admits: Int, Float, String, Bool, Bytes, Null (full primitive tier).
+//
+// CID computation: JCS(memento WITHOUT cid + kit_cid) -> blake3-512.
+// JCS field order for LiteralEncodingMemento (alphabetical):
+//   expected_term_shape_node, kind, language, schemaVersion, sort_cid, source_example
+// JCS field order for expected_term_shape_node (alphabetical):
+//   concept_name, sort, value
+//
+// Float value: Java's Term.Value.Real(double) emits "String.valueOf(3.14)" = "3.14"
+// as a JSON number. We build the JCS string manually for the float case because
+// Jcs.Value only supports integer JSON numbers.
+
+package com.provekit.realize;
+
+import com.provekit.ir.Blake3;
+import com.provekit.ir.Jcs;
+import com.provekit.ir.Jcs.Value;
+
+import java.nio.charset.StandardCharsets;
+
+/** Builds and caches the literal_encoding_answers JSON response for the Java kit. */
+public final class LiteralEncodingAnswers {
+    private LiteralEncodingAnswers() {}
+
+    // Canonical sort CIDs (from #1282)
+    // Java admits all 6 primitive sorts: Int, Float, String, Bool, Bytes, Null
+    private static final String SORT_INT_CID =
+        "blake3-512:30ffc51350121a7172f3e4064a33c45bbd345756979fccff6875cd2ab33e4964d098a99df80cfbdf1ec1a0738c5ac3476f0ff8f75589ea511d1acd82c74ecd58";
+    private static final String SORT_FLOAT_CID =
+        "blake3-512:b979e70c4d5e53d9bdf13d6f08330be3c5b0714b8c770d69bbd05946b86c36df5274be8145a2683cc29c278155c9c1ee65b6897913524eecb9e4c89c71862f57";
+    private static final String SORT_STRING_CID =
+        "blake3-512:be8721d24849feb74c4721520bdba02d352a94f49253a627cd509127472aa1c47cbe99cb705cac4159b5365abcce0c9aaa4901fe67630827deb6be1f9daeea10";
+    private static final String SORT_BOOL_CID =
+        "blake3-512:0ee13bf3fd6b7ecfbee72dfbfc18a7c0ea7f1663de6cca43cefb36f5b4c03665452646094a7c296e819e75d683c6ce4821f3d7db3c3c78ae97f2d4e3451d2074";
+    private static final String SORT_BYTES_CID =
+        "blake3-512:7116ef6e62e6739b213a8394f975a53c771b89f08c36d27143827acfcfebc0e39e5b82c530be668c3cfd5ec6966ccaa42930b37fdb1f4ac25652a970be10fb6b";
+    private static final String SORT_NULL_CID =
+        "blake3-512:62f6040bd3f414c1e6c2b7bdf276669cd5613b33cb508a81170170064ca3ffba771a4b0002dc52e059fce5f9f63a1874ef71bd4ec89ae06e89c87a3e91aac3b5";
+
+    private static final String CONCEPT_LITERAL_NAME = "concept:literal";
+    private static final String SCHEMA_VERSION = "1.0.0";
+    private static final String KIND = "literal-encoding-memento";
+    private static final String LANGUAGE = "java";
+
+    // Cached JSON response (built once on first call)
+    private static volatile String cachedJson = null;
+
+    /**
+     * Returns the complete JSON string for the provekit.plugin.literal_encoding_answers result.
+     * Thread-safe via double-checked locking.
+     */
+    public static String toJson() {
+        if (cachedJson == null) {
+            synchronized (LiteralEncodingAnswers.class) {
+                if (cachedJson == null) {
+                    cachedJson = buildJson();
+                }
+            }
+        }
+        return cachedJson;
+    }
+
+    private static String buildJson() {
+        String kitCid = Blake3.blake3_512(
+            "provekit-realize-java-core@0.1.0".getBytes(StandardCharsets.UTF_8));
+
+        // Java admits: Int, Float, String, Bool, Bytes, Null
+        String intMemento     = buildMemento(kitCid, SORT_INT_CID,    "42",       intValue(42));
+        String floatMemento   = buildMementoRaw(kitCid, SORT_FLOAT_CID, "3.14",   "3.14");
+        String stringMemento  = buildMemento(kitCid, SORT_STRING_CID, "\"hello\"", stringValue("hello"));
+        String boolMemento    = buildMemento(kitCid, SORT_BOOL_CID,   "true",     boolValue(true));
+        String bytesMemento   = buildMemento(kitCid, SORT_BYTES_CID,  "\"abc\".getBytes()", stringValue("abc"));
+        String nullMemento    = buildMemento(kitCid, SORT_NULL_CID,   "null",     nullValue());
+
+        return "{\"answers\":["
+            + intMemento + ","
+            + floatMemento + ","
+            + stringMemento + ","
+            + boolMemento + ","
+            + bytesMemento + ","
+            + nullMemento
+            + "]}";
+    }
+
+    /**
+     * Builds a LiteralEncodingMemento JSON string for sorts whose values
+     * can be represented in Jcs.Value (all sorts except Float).
+     *
+     * @param valueJson the JCS-encoded value fragment (e.g., "42", "\"hello\"", "true", "null")
+     */
+    private static String buildMemento(String kitCid, String sortCid,
+                                        String sourceExample, Value valueNode) {
+        // CID computation: JCS(memento WITHOUT cid + kit_cid)
+        // JCS field order for forCid (alphabetical):
+        //   expected_term_shape_node, kind, language, schemaVersion, sort_cid, source_example
+        // JCS field order for expected_term_shape_node (alphabetical):
+        //   concept_name, sort, value
+        Value expectedTermShapeNode = Value.object(
+            "concept_name", Value.string(CONCEPT_LITERAL_NAME),
+            "sort", Value.string(sortCid),
+            "value", valueNode
+        );
+        Value forCid = Value.object(
+            "expected_term_shape_node", expectedTermShapeNode,
+            "kind", Value.string(KIND),
+            "language", Value.string(LANGUAGE),
+            "schemaVersion", Value.string(SCHEMA_VERSION),
+            "sort_cid", Value.string(sortCid),
+            "source_example", Value.string(sourceExample)
+        );
+        String cid = Jcs.blake3Cid(forCid);
+        String etsnJson = Jcs.encode(expectedTermShapeNode);
+
+        // Wire JSON (fields in arbitrary order; libprovekit deserializes by key)
+        return "{\"cid\":" + JsonUtil.quoted(cid)
+            + ",\"expected_term_shape_node\":" + etsnJson
+            + ",\"kind\":" + JsonUtil.quoted(KIND)
+            + ",\"kit_cid\":" + JsonUtil.quoted(kitCid)
+            + ",\"language\":" + JsonUtil.quoted(LANGUAGE)
+            + ",\"schemaVersion\":" + JsonUtil.quoted(SCHEMA_VERSION)
+            + ",\"sort_cid\":" + JsonUtil.quoted(sortCid)
+            + ",\"source_example\":" + JsonUtil.quoted(sourceExample)
+            + "}";
+    }
+
+    /**
+     * Builds a LiteralEncodingMemento JSON string for Float sort by constructing
+     * the JCS CID-input string manually (Jcs.Value doesn't support float numbers).
+     *
+     * The JCS for the forCid object is built manually with sorted keys and the
+     * float value emitted as a plain JSON number (no quotes), matching what
+     * Java's Term.Value.Real(double).toJson() produces.
+     */
+    private static String buildMementoRaw(String kitCid, String sortCid,
+                                           String sourceExample, String valueJsonLiteral) {
+        // Manually build the JCS string for forCid (keys alphabetically sorted)
+        // expected_term_shape_node: {concept_name, sort, value}
+        // forCid: {expected_term_shape_node, kind, language, schemaVersion, sort_cid, source_example}
+        String etsnForCid = "{\"concept_name\":" + JsonUtil.quoted(CONCEPT_LITERAL_NAME)
+            + ",\"sort\":" + JsonUtil.quoted(sortCid)
+            + ",\"value\":" + valueJsonLiteral
+            + "}";
+        String forCidJcs = "{\"expected_term_shape_node\":" + etsnForCid
+            + ",\"kind\":" + JsonUtil.quoted(KIND)
+            + ",\"language\":" + JsonUtil.quoted(LANGUAGE)
+            + ",\"schemaVersion\":" + JsonUtil.quoted(SCHEMA_VERSION)
+            + ",\"sort_cid\":" + JsonUtil.quoted(sortCid)
+            + ",\"source_example\":" + JsonUtil.quoted(sourceExample)
+            + "}";
+        String cid = Blake3.blake3_512(forCidJcs.getBytes(StandardCharsets.UTF_8));
+
+        // The expected_term_shape_node in the wire response also contains the float value
+        String etsnJson = "{\"concept_name\":" + JsonUtil.quoted(CONCEPT_LITERAL_NAME)
+            + ",\"sort\":" + JsonUtil.quoted(sortCid)
+            + ",\"value\":" + valueJsonLiteral
+            + "}";
+        return "{\"cid\":" + JsonUtil.quoted(cid)
+            + ",\"expected_term_shape_node\":" + etsnJson
+            + ",\"kind\":" + JsonUtil.quoted(KIND)
+            + ",\"kit_cid\":" + JsonUtil.quoted(kitCid)
+            + ",\"language\":" + JsonUtil.quoted(LANGUAGE)
+            + ",\"schemaVersion\":" + JsonUtil.quoted(SCHEMA_VERSION)
+            + ",\"sort_cid\":" + JsonUtil.quoted(sortCid)
+            + ",\"source_example\":" + JsonUtil.quoted(sourceExample)
+            + "}";
+    }
+
+    // --- Value helpers ---
+
+    private static Value intValue(long n) {
+        return Value.integer(n);
+    }
+
+    private static Value stringValue(String s) {
+        return Value.string(s);
+    }
+
+    private static Value boolValue(boolean b) {
+        return Value.bool(b);
+    }
+
+    private static Value nullValue() {
+        return Value.NULL;
+    }
+}

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -41,6 +41,8 @@ public final class RpcServer {
                 case "provekit.plugin.describe" -> sendResponse(id, describeResult());
                 case "provekit.plugin.platform_semantics" ->
                     sendResponse(id, PlatformSemanticsDeclaration.toJson());
+                case "provekit.plugin.literal_encoding_answers" ->
+                    sendResponse(id, LiteralEncodingAnswers.toJson());
                 case "provekit.plugin.invoke" -> {
                     // handleInvoke returns a full JSON object: {"source":..., "is_stub":...}
                     String resultObj = handleInvoke(line);

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/LiteralEncodingAnswersTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/LiteralEncodingAnswersTest.java
@@ -92,8 +92,21 @@ public class LiteralEncodingAnswersTest {
     @Test
     public void toJsonContainsFloatValue() {
         String json = LiteralEncodingAnswers.toJson();
-        // Float memento must contain the float value 3.14 as a JSON number
-        assertTrue(json.contains("\"value\":3.14"), "must contain float value 3.14");
+        // Float memento must contain the bit-preserving __float_bits__ shape.
+        // 4614253070214989087 == Double.doubleToRawLongBits(3.14) == 0x40091EB851EB851F.
+        assertTrue(json.contains("\"value\":{\"__float_bits__\":4614253070214989087}"),
+            "must contain float __float_bits__ value");
+    }
+
+    @Test
+    public void toJsonFloatGoldenCid() {
+        // Regression: Float memento golden CID must not change.
+        // CID computed from JCS of forCid with __float_bits__ value.
+        String json = LiteralEncodingAnswers.toJson();
+        String expectedFloatCid =
+            "blake3-512:fa616d402e270631cd136b95d96f9038536c3b507bb736c35554ff41c7e21a20dca3b451d1ae9ee75b6632d5e58b96619c422ea38cab404f47241d471bf77766";
+        assertTrue(json.contains(expectedFloatCid),
+            "Float memento golden CID must match");
     }
 
     @Test

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/LiteralEncodingAnswersTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/LiteralEncodingAnswersTest.java
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for provekit.plugin.literal_encoding_answers RPC handler.
+//
+// Java admits: Int, Float, String, Bool, Bytes, Null (full primitive tier, 6 answers).
+// Golden CIDs verified on first run; hardcoded for regression protection.
+
+package com.provekit.realize;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LiteralEncodingAnswersTest {
+
+    // Canonical sort CIDs (from #1282)
+    private static final String SORT_INT_CID =
+        "blake3-512:30ffc51350121a7172f3e4064a33c45bbd345756979fccff6875cd2ab33e4964d098a99df80cfbdf1ec1a0738c5ac3476f0ff8f75589ea511d1acd82c74ecd58";
+    private static final String SORT_FLOAT_CID =
+        "blake3-512:b979e70c4d5e53d9bdf13d6f08330be3c5b0714b8c770d69bbd05946b86c36df5274be8145a2683cc29c278155c9c1ee65b6897913524eecb9e4c89c71862f57";
+    private static final String SORT_STRING_CID =
+        "blake3-512:be8721d24849feb74c4721520bdba02d352a94f49253a627cd509127472aa1c47cbe99cb705cac4159b5365abcce0c9aaa4901fe67630827deb6be1f9daeea10";
+    private static final String SORT_BOOL_CID =
+        "blake3-512:0ee13bf3fd6b7ecfbee72dfbfc18a7c0ea7f1663de6cca43cefb36f5b4c03665452646094a7c296e819e75d683c6ce4821f3d7db3c3c78ae97f2d4e3451d2074";
+    private static final String SORT_BYTES_CID =
+        "blake3-512:7116ef6e62e6739b213a8394f975a53c771b89f08c36d27143827acfcfebc0e39e5b82c530be668c3cfd5ec6966ccaa42930b37fdb1f4ac25652a970be10fb6b";
+    private static final String SORT_NULL_CID =
+        "blake3-512:62f6040bd3f414c1e6c2b7bdf276669cd5613b33cb508a81170170064ca3ffba771a4b0002dc52e059fce5f9f63a1874ef71bd4ec89ae06e89c87a3e91aac3b5";
+
+    @Test
+    public void toJsonIsNonEmpty() {
+        String json = LiteralEncodingAnswers.toJson();
+        assertNotNull(json);
+        assertFalse(json.isBlank());
+        // Must start with {"answers":[
+        assertTrue(json.startsWith("{\"answers\":["), "must start with {\"answers\":[");
+    }
+
+    @Test
+    public void toJsonContainsSixAnswers() {
+        // Java admits Int, Float, String, Bool, Bytes, Null -- 6 answers
+        // Count occurrences of "literal-encoding-memento" as a proxy for answer count
+        String json = LiteralEncodingAnswers.toJson();
+        int count = 0;
+        int idx = 0;
+        while ((idx = json.indexOf("literal-encoding-memento", idx)) != -1) {
+            count++;
+            idx++;
+        }
+        assertEquals(6, count,
+            "Java must emit exactly 6 literal-encoding-memento entries");
+    }
+
+    @Test
+    public void allAnswersHaveCorrectLanguage() {
+        String json = LiteralEncodingAnswers.toJson();
+        // Each answer must have "language":"java"
+        int count = 0;
+        int idx = 0;
+        while ((idx = json.indexOf("\"language\":\"java\"", idx)) != -1) {
+            count++;
+            idx++;
+        }
+        assertEquals(6, count, "must have 6 answers with language=java");
+    }
+
+    @Test
+    public void allAnswersHaveCidField() {
+        String json = LiteralEncodingAnswers.toJson();
+        // Each answer must have a "cid":"blake3-512:..." field
+        int count = 0;
+        int idx = 0;
+        while ((idx = json.indexOf("\"blake3-512:", idx)) != -1) {
+            count++;
+            idx++;
+        }
+        // 6 answers * 2 CIDs per answer (cid + kit_cid) + 6 sort_cids = 18 minimum
+        assertTrue(count >= 6, "must have at least 6 blake3-512: CID values in JSON");
+    }
+
+    @Test
+    public void answersCoversAllAdmittedSortCids() {
+        String json = LiteralEncodingAnswers.toJson();
+        assertTrue(json.contains(SORT_INT_CID), "must contain Int sort CID");
+        assertTrue(json.contains(SORT_FLOAT_CID), "must contain Float sort CID");
+        assertTrue(json.contains(SORT_STRING_CID), "must contain String sort CID");
+        assertTrue(json.contains(SORT_BOOL_CID), "must contain Bool sort CID");
+        assertTrue(json.contains(SORT_BYTES_CID), "must contain Bytes sort CID");
+        assertTrue(json.contains(SORT_NULL_CID), "must contain Null sort CID");
+    }
+
+    @Test
+    public void toJsonContainsFloatValue() {
+        String json = LiteralEncodingAnswers.toJson();
+        // Float memento must contain the float value 3.14 as a JSON number
+        assertTrue(json.contains("\"value\":3.14"), "must contain float value 3.14");
+    }
+
+    @Test
+    public void toJsonIsStable() {
+        // Regression: same output on every call
+        String first = LiteralEncodingAnswers.toJson();
+        String second = LiteralEncodingAnswers.toJson();
+        assertEquals(first, second, "toJson must return stable output");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the substrate-honesty violation in Java's `LiteralEncodingMemento` for the Float sort. JSON number `3.14` is silently lossy. Per substrate trichotomy: emit exact OR document loss OR refuse.

**Two coordinated changes (A: lift + B: realize):**

**A. Lift** (`JavaBindLifter.literalShape`): adds `Double` and `Float` arms before the generic `Number` arm. `Double.doubleToRawLongBits(d)` preserves all IEEE 754 bit patterns (NaN variants, `+0.0`/`-0.0`, infinities, denormals). The old `n.longValue()` silently truncated `3.14` to `3`.

**B. Realize** (`LiteralEncodingAnswers`): Float `buildMementoRaw` value literal changes from `"3.14"` to `"{\"__float_bits__\":4614253070214989087}"` (IEEE 754 raw bits of 3.14 as f64, `0x40091EB851EB851F`). Converges Java shape with Rust (#1298) and C (#1302).

**Float golden CID before:** (old java-answers PR value)
**Float golden CID after:** `blake3-512:fa616d402e270631cd136b95d96f9038536c3b507bb736c35554ff41c7e21a20dca3b451d1ae9ee75b6632d5e58b96619c422ea38cab404f47241d471bf77766`

## Files changed

- `implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java`: Added `Double`/`Float` arms in `literalShape` with bit-preserving encoding
- `implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/LiteralEncodingAnswers.java`: Float value changed to `__float_bits__` object; doc comments updated
- `implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/LiteralEncodingAnswersTest.java`: `toJsonContainsFloatValue` asserts `__float_bits__` shape; new `toJsonFloatGoldenCid` golden CID test added

## Test plan

- [x] `LiteralEncodingAnswersTest` (8 tests) pass with `-Dmaven.compiler.failOnError=false -Dtest=LiteralEncodingAnswersTest`
- [x] `mvn -DskipTests package` compiles cleanly for both `provekit-realize-java-core` and `provekit-lift-java-source`
- [x] Em-dash sweep clean
- [x] Commit identity: `T Savo <evilgenius@nefariousplan.com>`

**Note on pre-existing `JavaNullBoundaryRealizer` compile error:** `mvn test` for `provekit-realize-java-core` fails on `main` due to a pre-existing compile error in `JavaNullBoundaryRealizer.java` (unrelated to this PR). CI uses `-DskipTests` for Java. This PR does not introduce or worsen that error.