### PR TITLE
Feat: add library-bindings lift dispatch

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_lift.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lift.rs
@@ -71,6 +71,7 @@ pub fn run(args: LiftArgs) -> u8 {
         &surface,
         LiftPluginOptions {
             identify_only: args.identify_only,
+            library_bindings: args.library_bindings,
         },
         true,
     ) {
@@ -318,6 +319,7 @@ mod tests {
             project: Some(PathBuf::from("/provekit/no/such/lift/project")),
             output: None,
             identify_only: false,
+            library_bindings: false,
             out: OutputFlags::default(),
         };
         assert_eq!(run(args), crate::EXIT_USER_ERROR);

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -789,6 +789,13 @@ fn mint_from_ir_document(
         members.entry(m.cid.clone()).or_insert(m.canonical_bytes);
     }
 
+    for decl in ir {
+        if decl.get("kind").and_then(|v| v.as_str()) == Some("library-sugar-binding-entry") {
+            let (cid, bytes) = mint_library_sugar_binding_entry(decl)?;
+            members.entry(cid).or_insert(bytes);
+        }
+    }
+
     if members.is_empty() {
         return Err("no contracts to mint".to_string());
     }
@@ -895,6 +902,35 @@ fn mint_from_ir_document(
     let built = build_proof_envelope(&proof_input);
 
     Ok((built.bytes, built.cid, contract_set_cid))
+}
+
+fn mint_library_sugar_binding_entry(decl: &Value) -> Result<(String, Vec<u8>), String> {
+    let target_language = required_str(decl, "target_language", "library-sugar-binding-entry")?;
+    let target_library_tag =
+        required_str(decl, "target_library_tag", "library-sugar-binding-entry")?;
+    let concept_name = required_str(decl, "concept_name", "library-sugar-binding-entry")?;
+    let signature_shape_cid =
+        required_str(decl, "signature_shape_cid", "library-sugar-binding-entry")?;
+    let body_source = decl
+        .get("body_source")
+        .ok_or_else(|| "`library-sugar-binding-entry` missing `body_source`".to_string())?;
+    let source_cid = required_str(body_source, "source_cid", "body_source")?;
+
+    let envelope = json!({
+        "body": decl,
+        "header": {
+            "bodySourceCid": source_cid,
+            "conceptName": concept_name,
+            "kind": "library-sugar-binding-entry",
+            "signatureShapeCid": signature_shape_cid,
+            "targetLanguage": target_language,
+            "targetLibraryTag": target_library_tag,
+        },
+        "schemaVersion": "1",
+    });
+    let canonical = encode_jcs(&json_to_cvalue(&envelope));
+    let cid = blake3_512_of(canonical.as_bytes());
+    Ok((cid, canonical.into_bytes()))
 }
 
 fn optional_str<'a>(value: &'a Value, field: &str) -> Option<&'a str> {
@@ -1583,6 +1619,58 @@ mod tests {
         assert!(
             error.contains("missing step `missing`"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn mint_from_ir_document_accepts_library_sugar_binding_without_contracts() {
+        let ir = vec![json!({
+            "body_source": {
+                "file": "src/shims/requests.py",
+                "source_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "span": {"start_line": 1, "start_col": 0, "end_line": 6, "end_col": 0}
+            },
+            "concept_name": "concept:http-request",
+            "kind": "library-sugar-binding-entry",
+            "loss_record_contribution": {"form": "literal", "value": {"entries": []}},
+            "param_names": ["url"],
+            "param_types": ["str"],
+            "return_type": "int",
+            "signature_shape_cid": "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "source_function_name": "fetch_status",
+            "target_language": "python",
+            "target_library_tag": "requests",
+            "term_shape": null,
+            "term_shape_cid": null
+        })];
+
+        let (bytes, filename_cid, contract_set_cid) =
+            mint_from_ir_document(&ir, None, None, None, Path::new("."), Path::new("."), true)
+                .expect("library-sugar-only ir-document must mint without contracts");
+
+        assert!(!bytes.is_empty());
+        assert!(filename_cid.starts_with("blake3-512:"));
+        assert_eq!(contract_set_cid, compute_contract_set_cid(vec![]));
+
+        let catalog = provekit_verifier::cbor_decode::decode(&bytes).expect("decode proof");
+        let members = catalog
+            .as_map()
+            .and_then(|m| m.get("members"))
+            .and_then(|v| v.as_map())
+            .expect("proof members");
+        assert_eq!(members.len(), 1);
+        let member = members.values().next().expect("library binding member");
+        let envelope: Value =
+            serde_json::from_slice(member.as_bstr().expect("member bytes")).expect("member JSON");
+        assert_eq!(
+            envelope.pointer("/header/kind").and_then(|v| v.as_str()),
+            Some("library-sugar-binding-entry")
+        );
+        assert_eq!(
+            envelope
+                .pointer("/body/target_library_tag")
+                .and_then(|v| v.as_str()),
+            Some("requests")
         );
     }
 

--- a/implementations/rust/provekit-cli/src/cmd_package.rs
+++ b/implementations/rust/provekit-cli/src/cmd_package.rs
@@ -68,6 +68,7 @@ fn run_inspect(args: PackageInspectArgs) -> u8 {
         &surface,
         LiftPluginOptions {
             identify_only: true,
+            library_bindings: false,
         },
         args.out.quiet,
     ) {

--- a/implementations/rust/provekit-cli/src/lift_plugin.rs
+++ b/implementations/rust/provekit-cli/src/lift_plugin.rs
@@ -41,6 +41,7 @@ impl LiftPluginSession {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LiftPluginOptions {
     pub identify_only: bool,
+    pub library_bindings: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -334,6 +335,8 @@ pub fn build_lift_params(project_root: &Path, surface: &str, options: LiftPlugin
         .unwrap_or_else(|_| project_root.to_path_buf());
     let layer = if options.identify_only {
         "identify-only"
+    } else if options.library_bindings {
+        "library-bindings"
     } else {
         "all"
     };
@@ -366,6 +369,24 @@ mod tests {
     use provekit_ir_types::Sort;
 
     #[test]
+    fn lift_plugin_options_select_library_bindings_layer() {
+        let request = build_lift_params(
+            Path::new("."),
+            "python",
+            LiftPluginOptions {
+                identify_only: false,
+                library_bindings: true,
+            },
+        );
+
+        assert_eq!(
+            request["options"]["layer"].as_str(),
+            Some("library-bindings")
+        );
+        assert_eq!(request["options"]["identifyOnly"].as_bool(), Some(false));
+    }
+
+    #[test]
     fn lift_session_is_domain_claim_first_and_legacy_response_round_trips() {
         let response = json!({
             "kind": "ir-document",
@@ -377,6 +398,7 @@ mod tests {
             "rust",
             LiftPluginOptions {
                 identify_only: false,
+                library_bindings: false,
             },
         );
 

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -305,8 +305,11 @@ pub struct LiftArgs {
     #[arg(short = 'o', long = "output")]
     pub output: Option<PathBuf>,
     /// Ask the configured lifter to report native contract identities without full ProofIR lowering.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "library_bindings")]
     pub identify_only: bool,
+    /// Ask the configured lifter for proof-producing host-language library-sugar bindings.
+    #[arg(long, conflicts_with = "identify_only")]
+    pub library_bindings: bool,
     #[command(flatten)]
     pub out: OutputFlags,
 }

--- a/implementations/rust/provekit-cli/tests/cli_surface.rs
+++ b/implementations/rust/provekit-cli/tests/cli_surface.rs
@@ -252,6 +252,69 @@ fn lift_identify_only_delegates_from_project_config() {
 }
 
 #[test]
+fn lift_library_bindings_delegates_layer_to_lifter() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let project = dir.path().join("project");
+    let manifest_dir = project.join(".provekit/lift/library-bindings");
+    fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+    fs::write(
+        project.join(".provekit/config.toml"),
+        "[authoring.lift]\nsurface = \"library-bindings\"\n",
+    )
+    .expect("write config");
+    let plugin = dir.path().join("library-bindings-plugin.sh");
+    write_executable(
+        &plugin,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+  if [[ "$line" == *'"method":"initialize"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"library-bindings","protocol_version":"pep/1.7.0","capabilities":{}}}'
+  elif [[ "$line" == *'"method":"lift"'* ]]; then
+    if [[ "$line" != *'"layer":"library-bindings"'* ]]; then
+      printf 'expected library-bindings layer, saw: %s\n' "$line" >&2
+      exit 42
+    fi
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"kind":"ir-document","ir":[{"body_source":{"file":"src/shims/requests.py","source_cid":"blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","span":{"start_line":1,"start_col":0,"end_line":6,"end_col":0}},"concept_name":"concept:http-request","kind":"library-sugar-binding-entry","loss_record_contribution":{"form":"literal","value":{"entries":[]}},"param_names":["url"],"param_types":["str"],"return_type":"int","signature_shape_cid":"blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","source_function_name":"fetch_status","target_language":"python","target_library_tag":"requests","term_shape":null,"term_shape_cid":null}],"diagnostics":[]}}'
+  elif [[ "$line" == *'"method":"shutdown"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+    exit 0
+  fi
+done
+"#,
+    );
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"library-bindings\"\ncommand = [\"{}\"]\n",
+            plugin.display()
+        ),
+    )
+    .expect("write manifest");
+
+    let output = output_retrying_etxtbsy(
+        Command::new(provekit_bin())
+            .arg("lift")
+            .arg(&project)
+            .arg("--library-bindings")
+            .arg("--json")
+            .arg("--quiet"),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "provekit lift --library-bindings failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let report: serde_json::Value =
+        serde_json::from_str(&stdout).expect("library-bindings lift JSON parses");
+    assert_eq!(report["kind"], "ir-document");
+    assert_eq!(report["ir"][0]["kind"], "library-sugar-binding-entry");
+    assert_eq!(report["ir"][0]["target_library_tag"], "requests");
+}
+
+#[test]
 fn lift_identify_only_rejects_non_identity_response() {
     let dir = tempfile::tempdir().expect("create tempdir");
     let project = dir.path().join("project");


### PR DESCRIPTION
## Summary

- add `provekit lift --library-bindings` and pass `options.layer = "library-bindings"` through lift-plugin RPC
- preserve existing `--identify-only` behavior and make the two lift modes mutually exclusive
- allow `mint` to bundle library-sugar-only `ir-document` results into `.proof` files even when they contain no function contracts
- add unit/integration coverage for the CLI/RPC layer handoff and empty-contract library-sugar proof bundling

## Tests

```text
CARGO_HOME=/opt/data/.cargo RUSTUP_HOME=/opt/data/.rustup PATH=/opt/data/.cargo/bin:$PATH cargo test -p provekit-cli library -- --nocapture
CARGO_HOME=/opt/data/.cargo RUSTUP_HOME=/opt/data/.rustup PATH=/opt/data/.cargo/bin:$PATH cargo test -p provekit-cli library_bindings -- --nocapture
CARGO_HOME=/opt/data/.cargo RUSTUP_HOME=/opt/data/.rustup PATH=/opt/data/.cargo/bin:$PATH cargo test -p provekit-cli mint_from_ir_document_accepts_library_sugar_binding_without_contracts -- --nocapture
```

Note: existing warning remains in `cmd_bind_migrate.rs` for unused `source_lang`.
