### PR TITLE
Feat: lift Python library sugar bindings

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable
 
-from provekit_lift_py_tests.canonicalizer import encode_jcs
+from provekit_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
 from provekit_lift_py_tests.decorators import _parse_expr_string
 from provekit_lift_py_tests.ir import formula_to_value
 
@@ -64,7 +64,7 @@ class _CommentOccurrence:
     surface: str
 
 
-def lift_source(source: str, source_path: str) -> BindLiftResult:
+def lift_source(source: str, source_path: str, layer: str = "all") -> BindLiftResult:
     result = BindLiftResult()
     try:
         tree = ast.parse(source, filename=source_path)
@@ -82,9 +82,17 @@ def lift_source(source: str, source_path: str) -> BindLiftResult:
     collector = _DefinitionCollector()
     collector.visit(tree)
     lines = source.splitlines()
+    source_lines = source.splitlines(keepends=True)
     rel_path = source_path.replace(os.sep, "/")
     for info in collector.definitions:
         try:
+            if layer == "library-bindings":
+                entry = _library_binding_entry_for_function(
+                    info.node, rel_path, lines, source_lines
+                )
+                if entry is not None:
+                    result.ir.append(entry)
+                continue
             result.ir.append(
                 _entry_for_function(info.node, rel_path, lines, result.diagnostics)
             )
@@ -100,7 +108,9 @@ def lift_source(source: str, source_path: str) -> BindLiftResult:
     return result
 
 
-def lift_paths(workspace_root: str, source_paths: Iterable[str]) -> BindLiftResult:
+def lift_paths(
+    workspace_root: str, source_paths: Iterable[str], layer: str = "all"
+) -> BindLiftResult:
     result = BindLiftResult()
     root = Path(workspace_root or ".").resolve()
     paths = list(source_paths) or ["."]
@@ -146,7 +156,7 @@ def lift_paths(workspace_root: str, source_paths: Iterable[str]) -> BindLiftResu
                 )
                 continue
             display_path = os.path.relpath(file_path, root).replace(os.sep, "/")
-            file_result = lift_source(source, display_path)
+            file_result = lift_source(source, display_path, layer=layer)
             result.ir.extend(file_result.ir)
             result.diagnostics.extend(file_result.diagnostics)
     return result
@@ -190,8 +200,83 @@ def _entry_for_function(
     }
 
 
-def _signature_param_names(args: ast.arguments) -> list[str]:
-    names: list[str] = []
+def _library_binding_entry_for_function(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    rel_path: str,
+    lines: list[str],
+    source_lines: list[str],
+) -> Json | None:
+    binding = _sugar_bind_decorator(node)
+    if binding is None:
+        return None
+
+    shape_result = _function_shape_with_bindings(node, lines)
+    term_shape = shape_result.shape
+    param_names = _signature_param_names(node.args)
+    param_types = [
+        _annotation_surface(arg.annotation) for arg in _ordered_signature_args(node.args)
+    ]
+    return_type = _annotation_surface(node.returns)
+    signature_shape = {
+        "param_names": param_names,
+        "param_types": param_types,
+        "return_type": return_type,
+    }
+    body_source = _body_source_locator(node, rel_path, source_lines)
+
+    return {
+        "body_source": body_source,
+        "concept_name": binding["concept_name"],
+        "kind": "library-sugar-binding-entry",
+        "loss_record_contribution": {
+            "form": "literal",
+            "value": {"entries": []},
+        },
+        "param_names": param_names,
+        "param_types": param_types,
+        "return_type": return_type,
+        "signature_shape_cid": cid_of_json(signature_shape),
+        "source_function_name": node.name,
+        "target_language": "python",
+        "target_library_tag": binding["target_library_tag"],
+        "term_shape": term_shape,
+        "term_shape_cid": cid_of_json(term_shape),
+    }
+
+
+def _sugar_bind_decorator(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> dict[str, str] | None:
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call) or not _is_sugar_bind_func(decorator.func):
+            continue
+        concept = _keyword_str(decorator, "concept")
+        library = _keyword_str(decorator, "library")
+        if concept and library:
+            return {"concept_name": concept, "target_library_tag": library}
+    return None
+
+
+def _is_sugar_bind_func(func: ast.expr) -> bool:
+    if not isinstance(func, ast.Attribute) or func.attr != "bind":
+        return False
+    value = func.value
+    if isinstance(value, ast.Name):
+        return value.id == "sugar"
+    if isinstance(value, ast.Attribute) and value.attr == "sugar":
+        return isinstance(value.value, ast.Name) and value.value.id == "provekit"
+    return False
+
+
+def _keyword_str(call: ast.Call, name: str) -> str | None:
+    for keyword in call.keywords:
+        if keyword.arg == name and isinstance(keyword.value, ast.Constant):
+            if isinstance(keyword.value.value, str) and keyword.value.value:
+                return keyword.value.value
+    return None
+
+
+def _ordered_signature_args(args: ast.arguments) -> list[ast.arg]:
     ordered_args: list[ast.arg] = []
     ordered_args.extend(args.posonlyargs)
     ordered_args.extend(args.args)
@@ -200,7 +285,44 @@ def _signature_param_names(args: ast.arguments) -> list[str]:
     ordered_args.extend(args.kwonlyargs)
     if args.kwarg is not None:
         ordered_args.append(args.kwarg)
-    for arg in ordered_args:
+    return ordered_args
+
+
+def _annotation_surface(annotation: ast.expr | None) -> str | None:
+    if annotation is None:
+        return None
+    return ast.unparse(annotation)
+
+
+def _body_source_locator(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    rel_path: str,
+    source_lines: list[str],
+) -> Json:
+    start_line = node.lineno
+    start_col = node.col_offset
+    if node.decorator_list:
+        first = min(node.decorator_list, key=lambda decorator: decorator.lineno)
+        start_line = first.lineno
+        start_col = 0
+    end_line = node.end_lineno or node.lineno
+    end_col = node.end_col_offset or 0
+    span_text = "".join(source_lines[start_line - 1 : end_line])
+    return {
+        "file": rel_path,
+        "source_cid": blake3_512_of(span_text.encode("utf-8")),
+        "span": {
+            "start_line": start_line,
+            "start_col": start_col,
+            "end_line": end_line,
+            "end_col": end_col,
+        },
+    }
+
+
+def _signature_param_names(args: ast.arguments) -> list[str]:
+    names: list[str] = []
+    for arg in _ordered_signature_args(args):
         names.append(arg.arg)
     return names
 

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_rpc.py
@@ -63,7 +63,10 @@ def _lift(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
     if not paths:
         paths = ["."]
 
-    result = lift_paths(str(params.get("workspace_root", ".")), paths)
+    options_value = params.get("options")
+    options = options_value if isinstance(options_value, dict) else {}
+    layer = str(options.get("layer") or "all")
+    result = lift_paths(str(params.get("workspace_root", ".")), paths, layer=layer)
     return {
         "jsonrpc": "2.0",
         "id": msg_id,

--- a/implementations/python/provekit-lift-python-source/tests/fixtures/library_bindings/requests_fetch_status.py
+++ b/implementations/python/provekit-lift-python-source/tests/fixtures/library_bindings/requests_fetch_status.py
@@ -1,0 +1,8 @@
+from provekit import sugar
+import requests
+
+
+@sugar.bind(concept="concept:http-request", library="requests")
+def fetch_status(url: str) -> int:
+    response = requests.get(url)
+    return response.status_code

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -19,6 +19,7 @@ if str(REALIZER_SRC) not in sys.path:
 
 from provekit_lift_python_source.bind_lifter import lift_source
 from provekit_lift_python_source.bind_rpc import dispatch, initialize_result
+from provekit_lift_py_tests.canonicalizer import blake3_512_of
 from provekit_lift_python_source.canonical import cid_of_json
 from provekit_realize_python_core.realizer import emit_stub
 
@@ -198,6 +199,73 @@ def _assert_absent_keys(value: object, forbidden: set[str]) -> None:
     elif isinstance(value, list):
         for child in value:
             _assert_absent_keys(child, forbidden)
+
+
+def test_library_bindings_layer_lifts_requests_shim_from_real_python_source() -> None:
+    fixture = Path(__file__).parent / "fixtures/library_bindings/requests_fetch_status.py"
+    source = fixture.read_text(encoding="utf-8")
+
+    result = lift_source(source, "src/shims/requests.py", layer="library-bindings")
+
+    assert result.diagnostics == []
+    assert len(result.ir) == 1
+    entry = result.ir[0]
+    assert entry["kind"] == "library-sugar-binding-entry"
+    assert entry["concept_name"] == "concept:http-request"
+    assert entry["target_language"] == "python"
+    assert entry["target_library_tag"] == "requests"
+    assert entry["source_function_name"] == "fetch_status"
+    assert entry["param_names"] == ["url"]
+    assert entry["param_types"] == ["str"]
+    assert entry["return_type"] == "int"
+    assert "emission_template" not in entry
+    assert entry["term_shape_cid"] == cid_of_json(entry["term_shape"])
+    assert entry["signature_shape_cid"] == cid_of_json(
+        {
+            "param_names": ["url"],
+            "param_types": ["str"],
+            "return_type": "int",
+        }
+    )
+    body_source = entry["body_source"]
+    assert body_source["file"] == "src/shims/requests.py"
+    assert body_source["span"] == {
+        "start_line": 5,
+        "start_col": 0,
+        "end_line": 8,
+        "end_col": 31,
+    }
+    expected_span = "".join(source.splitlines(keepends=True)[4:8])
+    assert body_source["source_cid"] == blake3_512_of(expected_span.encode("utf-8"))
+
+
+def test_library_bindings_rpc_passes_requested_layer(tmp_path: Path) -> None:
+    (tmp_path / "shim.py").write_text(
+        "from provekit import sugar\n"
+        "import requests\n"
+        "\n"
+        "@sugar.bind(concept=\"concept:http-request\", library=\"requests\")\n"
+        "def fetch_status(url: str) -> int:\n"
+        "    response = requests.get(url)\n"
+        "    return response.status_code\n",
+        encoding="utf-8",
+    )
+    request = {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "lift",
+        "params": {
+            "workspace_root": str(tmp_path),
+            "source_paths": ["shim.py"],
+            "options": {"layer": "library-bindings"},
+        },
+    }
+
+    response = dispatch(request)
+
+    assert response["id"] == 7
+    assert response["result"]["kind"] == "ir-document"
+    assert response["result"]["ir"][0]["kind"] == "library-sugar-binding-entry"
 
 
 def test_bind_lift_erases_signature_types_from_bind_ir_entries() -> None:


### PR DESCRIPTION
## Summary

- add `layer="library-bindings"` support to the existing Python bind lifter without adding a second AST walker
- lift real `@sugar.bind(concept=..., library=...)` Python functions into `library-sugar-binding-entry` records
- pass `options.layer` through the Python bind JSON-RPC shim
- add a real requests shim fixture that reauthors the legacy body-template path as Python source

## Details

The new layer reuses the existing AST collector and term-shape machinery. For decorated functions it emits:

- `kind = "library-sugar-binding-entry"`
- `target_language = "python"`
- `target_library_tag`
- `concept_name`
- source function name, params, param annotations, return annotation
- `body_source` with exact source span and BLAKE3-512 source CID
- term/signature CIDs

No `emission_template` string is emitted for the POC source path.

## Test Plan

- [x] `PYTHONPATH=implementations/python/provekit-lift-python-source/src:implementations/python/provekit-lift-py-tests/src:implementations/python/provekit-realize-python-core/src uv run --with pytest --with blake3 --with pynacl --with cbor2 python -m pytest implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py -q -k 'library_bindings'`
- [x] `PYTHONPATH=implementations/python/provekit-lift-python-source/src:implementations/python/provekit-lift-py-tests/src:implementations/python/provekit-realize-python-core/src uv run --with pytest --with blake3 --with pynacl --with cbor2 python -m pytest implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py -q`

Refs #1310
