### PR TITLE
fix(typescript-kit): make _jcs BigInt-safe (prevent u64 truncation above 2^53)

### DIFF
--- a/implementations/typescript/provekit-realize-typescript-core/src/literal_encoding.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/literal_encoding.js
@@ -126,16 +126,17 @@ function _cidOf(obj) {
   return "blake3-512:" + _hexOf(hash);
 }
 
-function _jcs(obj) {
-  return JSON.stringify(_sortKeys(obj));
-}
-
-function _sortKeys(val) {
-  if (val === null || typeof val !== "object") return val;
-  if (Array.isArray(val)) return val.map(_sortKeys);
-  return Object.fromEntries(
-    Object.keys(val).sort().map((k) => [k, _sortKeys(val[k])])
-  );
+function _jcs(val) {
+  // RFC 8785: keys sorted by Unicode code-point, no whitespace, BigInt emitted
+  // as plain decimal digits (JSON.stringify throws on BigInt).
+  if (val === null) return "null";
+  if (typeof val === "boolean") return val ? "true" : "false";
+  if (typeof val === "bigint") return val.toString();
+  if (typeof val === "number") return JSON.stringify(val);
+  if (typeof val === "string") return JSON.stringify(val);
+  if (Array.isArray(val)) return "[" + val.map(_jcs).join(",") + "]";
+  const keys = Object.keys(val).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + _jcs(val[k])).join(",") + "}";
 }
 
 function _hexOf(bytes) {

--- a/implementations/typescript/provekit-realize-typescript-core/src/platform_semantics.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/platform_semantics.js
@@ -195,20 +195,26 @@ function _cidOf(obj) {
   return "blake3-512:" + _hexOf(hash);
 }
 
-function _jcs(obj) {
-  return JSON.stringify(_sortKeys(obj));
-}
-
-function _sortKeys(val) {
-  if (val === null || typeof val !== "object") return val;
-  if (Array.isArray(val)) return val.map(_sortKeys);
-  return Object.fromEntries(
-    Object.keys(val).sort().map((k) => [k, _sortKeys(val[k])])
-  );
+function _jcs(val) {
+  // RFC 8785: keys sorted by Unicode code-point, no whitespace, BigInt emitted
+  // as plain decimal digits (JSON.stringify throws on BigInt).
+  if (val === null) return "null";
+  if (typeof val === "boolean") return val ? "true" : "false";
+  if (typeof val === "bigint") return val.toString();
+  if (typeof val === "number") return JSON.stringify(val);
+  if (typeof val === "string") return JSON.stringify(val);
+  if (Array.isArray(val)) return "[" + val.map(_jcs).join(",") + "]";
+  // Object: sort keys by Unicode code-point order (String#localeCompare with
+  // sensitivity:"variant" + sort() gives byte-order for ASCII-only keys, which
+  // are the only keys this protocol produces; Object.keys().sort() uses the same
+  // Unicode code-unit order as the protocol spec requires for ASCII).
+  const keys = Object.keys(val).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + _jcs(val[k])).join(",") + "}";
 }
 
 function _hexOf(bytes) {
   return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-module.exports = { declaration, dimensionValues, KIT_CID, CONCEPT_LITERAL_CID };
+// _jcs exported for conformance tests; internal use only (not part of the public API).
+module.exports = { declaration, dimensionValues, KIT_CID, CONCEPT_LITERAL_CID, _jcs };

--- a/implementations/typescript/provekit-realize-typescript-core/tests/platform_semantics.test.js
+++ b/implementations/typescript/provekit-realize-typescript-core/tests/platform_semantics.test.js
@@ -3,7 +3,7 @@
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 
-const { declaration, dimensionValues, CONCEPT_LITERAL_CID } = require("../src/platform_semantics");
+const { declaration, dimensionValues, CONCEPT_LITERAL_CID, _jcs } = require("../src/platform_semantics");
 const { dispatch } = require("../src/rpc");
 
 // Golden CIDs for dimension values (kit_cid elided per substrate spec).
@@ -134,4 +134,25 @@ test("ts_rpc_dispatch_platform_semantics", () => {
   assert.deepStrictEqual(response.result.op_aliases, {});
   assert.ok(response.result.tags.length > 0);
   assert.ok(response.result.dimension_values.length > 0);
+});
+
+// JCS BigInt conformance: _jcs must emit large integers verbatim without truncation.
+// JSON.stringify() throws on BigInt; the old _sortKeys+JSON.stringify path silently
+// truncated u64 values above Number.MAX_SAFE_INTEGER (2^53 = 9007199254740992).
+test("ts_jcs_bigint_emitted_verbatim", () => {
+  // 4614253070214989087 == f64::to_bits(3.14), exceeds Number.MAX_SAFE_INTEGER.
+  // JSON.stringify(4614253070214989087) returns "4614253070214989000" (truncated);
+  // _jcs must emit all 19 digits.
+  const result = _jcs({ __float_bits__: 4614253070214989087n });
+  assert.strictEqual(result, '{"__float_bits__":4614253070214989087}',
+    "_jcs must not truncate BigInt values above Number.MAX_SAFE_INTEGER");
+});
+
+// Discrimination: confirm that JS Number truncation gives a different result,
+// proving the test would catch the regression if the BigInt path were removed.
+test("ts_jcs_number_truncates_but_bigint_does_not", () => {
+  const truncated = _jcs({ __float_bits__: 4614253070214989087 }); // JS Number
+  const exact     = _jcs({ __float_bits__: 4614253070214989087n }); // BigInt
+  assert.notStrictEqual(truncated, exact,
+    "JS Number truncates large u64; BigInt preserves all digits");
 });


### PR DESCRIPTION
## Summary

Replaces the `JSON.stringify(_sortKeys(obj))` implementation of `_jcs` in both `platform_semantics.js` and `literal_encoding.js` with a custom recursive serializer that handles `BigInt` values.

**The bug:** `JSON.stringify` throws a `TypeError` when given a `BigInt`, and silently truncates JS `Number` values above `Number.MAX_SAFE_INTEGER` (2^53 = 9007199254740992). For example:
- `JSON.stringify(4614253070214989087)` produces `"4614253070214989000"` (19 digits truncated to 16)
- `JSON.stringify(4614253070214989087n)` throws `TypeError: Do not know how to serialize a BigInt`

The `_mementoFloatBits` path in `literal_encoding.js` already worked around this for Float mementos by building JCS manually. This PR fixes the root cause so `_jcs` itself is correct for any caller.

**The fix:** A custom recursive serializer that:
- Emits `BigInt` as `val.toString()` (plain decimal digits, no truncation)
- Delegates `Number` and `String` to `JSON.stringify` (handles NaN, Infinity, escaping)
- Sorts object keys with `Object.keys(val).sort()` (byte-order for ASCII keys)

**Tests added** to `platform_semantics.test.js`:
- `ts_jcs_bigint_emitted_verbatim`: proves `_jcs({__float_bits__: 4614253070214989087n})` emits all 19 digits
- `ts_jcs_number_truncates_but_bigint_does_not`: discrimination test confirming JS `Number` and `BigInt` produce different output, so the test would catch a regression

## Test plan

- [ ] `npm test` passes (25/25 tests)
- [ ] `ts_jcs_bigint_emitted_verbatim` passes
- [ ] `ts_jcs_number_truncates_but_bigint_does_not` passes
- [ ] All existing golden CID tests still pass (no CID regression)
- [ ] No em-dashes in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)