### PR TITLE
Feat: prefer proof-backed requests bindings

### DIFF
--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/realizer.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/realizer.py
@@ -26,6 +26,17 @@ class BodyTemplateEntry:
 
 
 @dataclass(frozen=True)
+class ProofBindingCandidate:
+    admission_tier: str
+    body: str
+    concept_name: str
+    package_evidence: dict[str, Any]
+    signature_shape_cid: str
+    target_language: str
+    target_library_tag: str
+
+
+@dataclass(frozen=True)
 class MissingTemplateEntry:
     operation_kind: str
     args_shape: tuple[str, ...]
@@ -53,24 +64,125 @@ def emit_stub(
     param_types: list[str],
     return_type: str,
     concept_name: str,
+    *,
+    signature_shape_cid: str | None = None,
+    binding_candidates: list[dict[str, Any]] | None = None,
+    strict_proof_bindings: bool = False,
 ) -> dict[str, Any]:
+    proof_binding = proof_binding_for(
+        concept_name=concept_name,
+        signature_shape_cid=signature_shape_cid,
+        binding_candidates=binding_candidates or [],
+    )
+    if proof_binding is not None:
+        return {
+            "source": _function_source(function, params, proof_binding.body),
+            "is_stub": False,
+            "extension": "py",
+            "selection": {
+                "admission_tier": proof_binding.admission_tier,
+                "package_evidence": proof_binding.package_evidence,
+                "signature_shape_cid": proof_binding.signature_shape_cid,
+                "source": "proof-backed-library-binding",
+            },
+        }
+    if strict_proof_bindings:
+        raise _missing_template(function, params, param_types, concept_name)
     body = body_template_for(concept_name, params, param_types, return_type)
     if body is None:
-        raise MissingTemplateError(
-            (
-                MissingTemplateEntry(
-                    operation_kind=concept_name,
-                    args_shape=tuple(map_source_type(ty) for ty in param_types),
-                    function=function,
-                    term_position="body",
-                ),
-            )
-        )
+        raise _missing_template(function, params, param_types, concept_name)
     return {
         "source": _function_source(function, params, body),
         "is_stub": False,
         "extension": "py",
     }
+
+
+def proof_binding_for(
+    *,
+    concept_name: str,
+    signature_shape_cid: str | None,
+    binding_candidates: list[dict[str, Any]],
+) -> ProofBindingCandidate | None:
+    if not signature_shape_cid:
+        return None
+    matches: list[ProofBindingCandidate] = []
+    candidate_names = (concept_name, concept_name.removeprefix("concept:"))
+    for raw in binding_candidates:
+        candidate = _parse_proof_binding_candidate(raw)
+        if candidate is None:
+            continue
+        if candidate.target_language != "python":
+            continue
+        if candidate.target_library_tag != "requests":
+            continue
+        if candidate.concept_name not in candidate_names:
+            continue
+        if candidate.signature_shape_cid != signature_shape_cid:
+            continue
+        matches.append(candidate)
+    matches.sort(key=_proof_binding_sort_key)
+    return matches[0] if matches else None
+
+
+def _parse_proof_binding_candidate(raw: dict[str, Any]) -> ProofBindingCandidate | None:
+    body = raw.get("body")
+    concept_name = raw.get("concept_name")
+    signature_shape_cid = raw.get("signature_shape_cid")
+    target_language = raw.get("target_language")
+    target_library_tag = raw.get("target_library_tag")
+    if not isinstance(body, str):
+        return None
+    if not isinstance(concept_name, str):
+        return None
+    if not isinstance(signature_shape_cid, str):
+        return None
+    if not isinstance(target_language, str):
+        return None
+    if not isinstance(target_library_tag, str):
+        return None
+    package_evidence = raw.get("package_evidence")
+    if not isinstance(package_evidence, dict):
+        package_evidence = {}
+    admission_tier = raw.get("admission_tier")
+    if not isinstance(admission_tier, str):
+        admission_tier = "Third-party Inferred"
+    return ProofBindingCandidate(
+        admission_tier=admission_tier,
+        body=body,
+        concept_name=concept_name,
+        package_evidence=package_evidence,
+        signature_shape_cid=signature_shape_cid,
+        target_language=target_language,
+        target_library_tag=target_library_tag,
+    )
+
+
+def _proof_binding_sort_key(candidate: ProofBindingCandidate) -> tuple[int, str, str]:
+    tier_rank = {
+        "Self-Attested": 0,
+        "Third-party Inferred": 1,
+    }
+    return (
+        tier_rank.get(candidate.admission_tier, 2),
+        candidate.signature_shape_cid,
+        candidate.body,
+    )
+
+
+def _missing_template(
+    function: str, params: list[str], param_types: list[str], concept_name: str
+) -> MissingTemplateError:
+    return MissingTemplateError(
+        (
+            MissingTemplateEntry(
+                operation_kind=concept_name,
+                args_shape=tuple(map_source_type(ty) for ty in param_types),
+                function=function,
+                term_position="body",
+            ),
+        )
+    )
 
 
 def body_template_for(

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
@@ -79,7 +79,20 @@ def _emit_one(params: dict[str, Any]) -> dict[str, Any]:
         param_types=_string_list(params.get("param_types")),
         return_type=str(params.get("return_type", "")),
         concept_name=str(params.get("concept_name", "")),
+        signature_shape_cid=_optional_str(params.get("signature_shape_cid")),
+        binding_candidates=_dict_list(params.get("binding_candidates")),
+        strict_proof_bindings=bool(params.get("strict_proof_bindings", False)),
     )
+
+
+def _optional_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
 
 
 def _string_list(value: Any) -> list[str]:

--- a/implementations/python/provekit-realize-python-requests/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-requests/tests/test_realizer.py
@@ -11,6 +11,108 @@ if str(PKG_SRC) not in sys.path:
 from provekit_realize_python_requests.realizer import MissingTemplateError, emit_stub
 
 
+def _proof_candidate(
+    *,
+    body: str,
+    signature_shape_cid: str = "blake3-512:" + "a" * 128,
+    admission_tier: str = "Self-Attested",
+    concept_name: str = "concept:http-request",
+) -> dict[str, object]:
+    return {
+        "admission_tier": admission_tier,
+        "body": body,
+        "concept_name": concept_name,
+        "package_evidence": {
+            "kind": "python-distribution",
+            "opaque_handle": "site-packages/provekit_shim_requests",
+        },
+        "signature_shape_cid": signature_shape_cid,
+        "target_language": "python",
+        "target_library_tag": "requests",
+    }
+
+
+def test_proof_backed_binding_wins_over_legacy_body_template() -> None:
+    sig = "blake3-512:" + "b" * 128
+
+    result = emit_stub(
+        function="fetch_status",
+        params=["url"],
+        param_types=["str"],
+        return_type="int",
+        concept_name="concept:http-request",
+        signature_shape_cid=sig,
+        binding_candidates=[
+            _proof_candidate(
+                signature_shape_cid=sig,
+                body="response = requests.request('GET', url)\nreturn response.status_code",
+            )
+        ],
+    )
+
+    assert result["source"] == (
+        "def fetch_status(url):\n"
+        "    response = requests.request('GET', url)\n"
+        "    return response.status_code\n"
+    )
+    assert result["selection"]["source"] == "proof-backed-library-binding"
+    assert result["selection"]["package_evidence"] == {
+        "kind": "python-distribution",
+        "opaque_handle": "site-packages/provekit_shim_requests",
+    }
+
+
+def test_proof_backed_binding_tie_breaks_by_admission_tier() -> None:
+    sig = "blake3-512:" + "c" * 128
+
+    result = emit_stub(
+        function="fetch_status",
+        params=["url"],
+        param_types=["str"],
+        return_type="int",
+        concept_name="concept:http-request",
+        signature_shape_cid=sig,
+        binding_candidates=[
+            _proof_candidate(
+                signature_shape_cid=sig,
+                admission_tier="Third-party Inferred",
+                body="return 599",
+            ),
+            _proof_candidate(
+                signature_shape_cid=sig,
+                admission_tier="Self-Attested",
+                body="return 200",
+            ),
+        ],
+    )
+
+    assert result["source"] == "def fetch_status(url):\n    return 200\n"
+    assert result["selection"]["admission_tier"] == "Self-Attested"
+
+
+def test_strict_mode_refuses_legacy_json_fallback() -> None:
+    try:
+        emit_stub(
+            function="fetch_status",
+            params=["url"],
+            param_types=["str"],
+            return_type="int",
+            concept_name="concept:http-request",
+            strict_proof_bindings=True,
+        )
+    except MissingTemplateError as exc:
+        assert [entry.to_json() for entry in exc.entries] == [
+            {
+                "operation_kind": "concept:http-request",
+                "args_shape": ["str"],
+                "function": "fetch_status",
+                "term_position": "body",
+            }
+        ]
+    else:
+        raise AssertionError("strict proof-backed mode should refuse JSON fallback")
+
+
 def test_http_request_uses_requests_get() -> None:
     result = emit_stub(
         function="fetch_status",

--- a/implementations/python/provekit-realize-python-requests/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-requests/tests/test_rpc.py
@@ -33,6 +33,40 @@ def test_rpc_invoke_renders_requests_body() -> None:
     assert "requests.get" in response["result"]["source"]
 
 
+def test_rpc_invoke_prefers_proof_backed_binding_candidate() -> None:
+    sig = "blake3-512:" + "d" * 128
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "provekit.plugin.invoke",
+            "params": {
+                "function": "fetch_status",
+                "params": ["url"],
+                "param_types": ["str"],
+                "return_type": "int",
+                "concept_name": "concept:http-request",
+                "signature_shape_cid": sig,
+                "binding_candidates": [
+                    {
+                        "admission_tier": "Self-Attested",
+                        "body": "return 204",
+                        "concept_name": "concept:http-request",
+                        "package_evidence": {"opaque_handle": "python-wheel"},
+                        "signature_shape_cid": sig,
+                        "target_language": "python",
+                        "target_library_tag": "requests",
+                    }
+                ],
+            },
+        }
+    )
+
+    assert response["id"] == 3
+    assert response["result"]["source"] == "def fetch_status(url):\n    return 204\n"
+    assert response["result"]["selection"]["source"] == "proof-backed-library-binding"
+
+
 def test_plugin_invoke_returns_structured_missing_template_error() -> None:
     response = dispatch(
         {


### PR DESCRIPTION
## Summary

- add a proof-backed binding selection seam to the Python `requests` realize kit
- pass normalized proof binding candidates through the realize RPC (`binding_candidates`, `signature_shape_cid`, `strict_proof_bindings`)
- prefer proof-backed candidates over legacy body-template JSON for matching `(python, requests, concept, signature_shape_cid)`
- deterministically sort multiple proof-backed matches by admission tier (`Self-Attested` before `Third-party Inferred`)
- preserve legacy JSON fallback unless strict proof-backed mode is requested

## Boundary

This keeps package/environment semantics in the Python realize kit. The candidate includes opaque `package_evidence`; generic Rust CLI code is not changed and does not inspect `site-packages`, `node_modules`, Cargo registries, Maven caches, etc.

## Test Plan

- [x] `PYTHONPATH=implementations/python/provekit-realize-python-requests/src uv run --with pytest python -m pytest implementations/python/provekit-realize-python-requests/tests -q`

Refs #1311
