### PR TITLE
fix(ci): add .provekit/lift/typescript-bind/manifest.toml

### DIFF
--- a/.provekit/lift/typescript-bind/manifest.toml
+++ b/.provekit/lift/typescript-bind/manifest.toml
@@ -1,0 +1,16 @@
+# PEP 1.7.0 `kind = "lift"` plugin manifest for the TypeScript bind-IR surface.
+# Walks .ts files via the TypeScript compiler API and returns `ir-document` with
+# `bind-lift-entry` records per `2026-05-13-bind-ir-lift-result.md`. cmd_bind
+# dispatches Verb 1 (Lift) here when --lang=typescript (or auto-detected as
+# typescript).
+#
+# The kit emits concepts via term_shape plus concept_annotation, not ts:* surface
+# ops. ProofIR is concept-language; this kit bridges TypeScript syntax to
+# concept-shaped records the bind dispatcher consumes.
+#
+# `npx tsx` resolves tsx from the repo-root node_modules populated by
+# `pnpm install --frozen-lockfile` (build-ts). working_dir = "." anchors
+# both the lookup and the relative script path at the workspace root.
+name = "typescript-bind-lift"
+command = ["npx", "tsx", "implementations/typescript/src/lift/typescript-source/bin.ts", "--rpc"]
+working_dir = "."


### PR DESCRIPTION
## Summary

`cross_platform_point_query_receipt_test` (six fixtures) panics with `kit-plugin-unavailable: no lift plugin for language typescript` because the resolver probes `.provekit/lift/typescript-bind/manifest.toml` at workspace root and only java-bind/c-bind/python-bind/rust-bind manifests existed.

This file was in commit `1bf832e27` on the same branch as #1315, but #1315 squash-merged before that commit was pushed, so only Layer 1 (Makefile) + Layer 2 (exam CID) landed. This PR brings the missing Layer 3 in.

Adds the typescript-bind manifest, modeled on the existing siblings. Invokes the existing typescript-source lift entrypoint (`implementations/typescript/src/lift/typescript-source/bin.ts`) via `npx tsx`, which resolves through the repo-root node_modules populated by `pnpm install --frozen-lockfile` in build-ts.

## Failing tests

- `cross_platform_point_query_receipt_test::fixture_1_documents_sql_migrate_narrowing_gap_with_supported_divergence`
- `cross_platform_point_query_receipt_test::fixture_2_row_id_mechanism_divergence_has_a18_shape`
- `cross_platform_point_query_receipt_test::fixture_3_focus_scopes_point_query_loss_records`
- `cross_platform_point_query_receipt_test::fixture_4_exact_no_op_leg_emits_zero_loss_records`
- `cross_platform_point_query_receipt_test::fixture_5_declared_insert_routes_to_loss_without_refusal`
- `cross_platform_point_query_receipt_test::fixture_6_point_query_receipt_cids_are_byte_stable`

All call `provekit bind --library-from typescript-better-sqlite3 --library-to <X>`; bind dispatches Verb 1 (lift) to typescript-bind which now resolves via this manifest.

## Test plan

- [x] Em-dash sweep clean
- [x] Commit identity: `T Savo <evilgenius@nefariousplan.com>`
- [x] Local verification: `cargo test -p provekit-cli --test cross_platform_point_query_receipt_test fixture_1` passes
- [ ] CI: `Cross-language conformance gate` green