### PR TITLE
fix(body-templates): re-mint drifted CIDs (ts-better-sqlite3, ts-pg, py-requests)

### DIFF
--- a/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
+++ b/implementations/rust/provekit-plugin-loader/tests/substrate_default_cids.rs
@@ -165,7 +165,7 @@ fn python_requests_canonical_bodies_cid_self_consistent() {
     );
     assert_self_consistent(
         path,
-        "blake3-512:6612c844a35e288836a838e2a7615be2791eee36e159b3df333db0f63266cbe56db8754e33a8b33cce4fb89927f6e9236c2c5b0cc093eb6d80b1f1f124a2c52b",
+        "blake3-512:100f4c5b7ce1e21bbf63c942d696be3c19ce20c75f6c8be40fb8d7026428575d761e46f3cec9678396958dea2bffb41d1bd46dbc868595e31157bf289798ecaf",
     );
 }
 
@@ -187,7 +187,7 @@ fn typescript_better_sqlite3_canonical_bodies_cid_self_consistent() {
     );
     assert_self_consistent(
         path,
-        "blake3-512:5793dafda8c597efb885e89c8b9313fce75b1b10d08dee863a689e2867436a7173fa106abec67e8c6ee978c236c14ed87b33fc8566087ec95f5fde26e61cfe5a",
+        "blake3-512:3a6872e9b752177089832aba2d4f6cd413f9cf598d70502a6bd77fe3ef2ab0cc1ae07acdba14980afa97d3038278fe5b58d43b9a136af91077743705b99fbd7d",
     );
 }
 
@@ -198,7 +198,7 @@ fn typescript_pg_canonical_bodies_cid_self_consistent() {
     );
     assert_self_consistent(
         path,
-        "blake3-512:6c3b4df2a292388619b212b05c84e45ce94081750c2cfbeea473fe1a4b038ffd047224c740b55f2341758b418142c1b89c9f14d891e9462d1ac79231dcdd4d95",
+        "blake3-512:463dc2febd07836b54fca4f8e0c8ea20c66376cab9428fe1bb4f586fb4a57b332a0be4336fef1e4e1752c9340b57af618132e410050392c04667b9066fe783ad",
     );
 }
 

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-requests.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-requests.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:6612c844a35e288836a838e2a7615be2791eee36e159b3df333db0f63266cbe56db8754e33a8b33cce4fb89927f6e9236c2c5b0cc093eb6d80b1f1f124a2c52b",
+    "cid": "blake3-512:100f4c5b7ce1e21bbf63c942d696be3c19ce20c75f6c8be40fb8d7026428575d761e46f3cec9678396958dea2bffb41d1bd46dbc868595e31157bf289798ecaf",
     "content": {
       "entries": [
         {

--- a/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-better-sqlite3.json
+++ b/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-better-sqlite3.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:5793dafda8c597efb885e89c8b9313fce75b1b10d08dee863a689e2867436a7173fa106abec67e8c6ee978c236c14ed87b33fc8566087ec95f5fde26e61cfe5a",
+    "cid": "blake3-512:3a6872e9b752177089832aba2d4f6cd413f9cf598d70502a6bd77fe3ef2ab0cc1ae07acdba14980afa97d3038278fe5b58d43b9a136af91077743705b99fbd7d",
     "content": {
       "entries": [
         {

--- a/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-pg.json
+++ b/menagerie/typescript-language-signature/specs/body-templates/typescript-canonical-bodies-pg.json
@@ -5,7 +5,7 @@
     "signer": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   },
   "header": {
-    "cid": "blake3-512:6c3b4df2a292388619b212b05c84e45ce94081750c2cfbeea473fe1a4b038ffd047224c740b55f2341758b418142c1b89c9f14d891e9462d1ac79231dcdd4d95",
+    "cid": "blake3-512:463dc2febd07836b54fca4f8e0c8ea20c66376cab9428fe1bb4f586fb4a57b332a0be4336fef1e4e1752c9340b57af618132e410050392c04667b9066fe783ad",
     "content": {
       "entries": [
         {


### PR DESCRIPTION
## Summary

Main has been red on \`Cross-language conformance gate\` because three body-template catalogs' \`header.cid\` no longer matches the CID recomputed by \`compute_plugin_cid\` (§6.1 of plugin-protocol). The drift was masked behind the earlier Java jar / typescript-bind-manifest failures; once those cleared, the \`substrate_default_cids\` self-consistency checks surfaced this layer.

## Re-minted CIDs

| File | Old | New |
|------|-----|-----|
| \`typescript-canonical-bodies-better-sqlite3.json\` | \`5793dafd...\` | \`3a6872e9...\` |
| \`typescript-canonical-bodies-pg.json\` | \`6c3b4df2...\` | \`463dc2fe...\` |
| \`python-canonical-bodies-requests.json\` | \`6612c844...\` | \`100f4c5b...\` |

Re-ran \`mint-plugin-cid\` on each. Updated matching pinned values in \`provekit-plugin-loader/tests/substrate_default_cids.rs\` so the second \`assert_self_consistent\` assertion (declared == pinned) stays in sync.

## Test plan

- [x] Em-dash sweep clean
- [x] Commit identity: \`T Savo <evilgenius@nefariousplan.com>\`
- [x] Local: \`cargo test -p provekit-plugin-loader --test substrate_default_cids typescript_better_sqlite3 typescript_pg python_requests\` -> 3 passed
- [ ] CI: \`Cross-language conformance gate\` green