### PR TITLE
fix(c-self-contracts): declare strdup via _POSIX_C_SOURCE; fixes proof-envelope segfault

### DIFF
--- a/implementations/c/provekit-self-contracts/tests/test_runner.c
+++ b/implementations/c/provekit-self-contracts/tests/test_runner.c
@@ -16,6 +16,15 @@
  * Run via `make test` in this directory or `make test-c` from repo root.
  */
 
+/* strdup is POSIX (since 2008) but not C11. Without this macro and the
+ * Makefile's -std=c11, <string.h> does not declare strdup; the resulting
+ * implicit-declaration warning means the int return is truncated when
+ * cast to a pointer on 64-bit hosts, the cross-kit byte-equivalence
+ * tests pass corrupt key/bytes pointers to proof_envelope_build, and
+ * the proof-envelope section segfaults. Must precede any include.
+ */
+#define _POSIX_C_SOURCE 200809L
+
 #include "provekit/self_contracts.h"
 
 #include <stdint.h>


### PR DESCRIPTION
## Summary

The C self-contracts test runner segfaulted in the \"Proof envelope\" section, causing `test-c` (and therefore `make test-all`) to fail. The CI logs show the compiler warnings that point directly at the cause:

\`\`\`
warning: implicit declaration of function 'strdup'
warning: assignment to 'char *' from 'int' makes pointer from integer without a cast
warning: cast to pointer from integer of different size
\`\`\`

\`strdup\` is POSIX (since 2008), not C11. With the Makefile's \`-std=c11\` and no feature-test macro, \`<string.h>\` doesn't declare it. The implicit declaration treats the return as \`int\`, the int is truncated when stored back into \`char *\`, and \`proof_envelope_build\` then dereferences corrupt pointers.

## Fix

Add \`#define _POSIX_C_SOURCE 200809L\` before any include in \`tests/test_runner.c\`. Standard idiom; matches what other POSIX-using test files do.

## Local verification

\`make -C implementations/c/provekit-self-contracts test\` -> 42/42 pass, including all 16 Proof envelope assertions that previously aborted the runner.

## Why now

Pre-existing red on main, masked behind the upstream test-rust failures (Java jar, ts-bind manifest, body-template CID drift). Once those layers cleared, test-c got far enough to surface this segfault.

## Test plan

- [x] Em-dash sweep clean
- [x] Commit identity: \`T Savo <evilgenius@nefariousplan.com>\`
- [x] Local: \`make -C implementations/c/provekit-self-contracts test\` -> 42/42 pass
- [ ] CI: \`Cross-language conformance gate\` green