### PR TITLE
feat(lift+mint): substrate-honest three-speech-act wire (loss / observed_dimension / refusal-memento)

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -790,9 +790,16 @@ fn mint_from_ir_document(
     }
 
     for decl in ir {
-        if decl.get("kind").and_then(|v| v.as_str()) == Some("library-sugar-binding-entry") {
-            let (cid, bytes) = mint_library_sugar_binding_entry(decl)?;
-            members.entry(cid).or_insert(bytes);
+        match decl.get("kind").and_then(|v| v.as_str()) {
+            Some("library-sugar-binding-entry") => {
+                let (cid, bytes) = mint_library_sugar_binding_entry(decl)?;
+                members.entry(cid).or_insert(bytes);
+            }
+            Some("refusal-memento") => {
+                let (cid, bytes) = mint_refusal_memento(decl)?;
+                members.entry(cid).or_insert(bytes);
+            }
+            _ => {}
         }
     }
 
@@ -925,6 +932,39 @@ fn mint_library_sugar_binding_entry(decl: &Value) -> Result<(String, Vec<u8>), S
             "signatureShapeCid": signature_shape_cid,
             "targetLanguage": target_language,
             "targetLibraryTag": target_library_tag,
+        },
+        "schemaVersion": "1",
+    });
+    let canonical = encode_jcs(&json_to_cvalue(&envelope));
+    let cid = blake3_512_of(canonical.as_bytes());
+    Ok((cid, canonical.into_bytes()))
+}
+
+fn mint_refusal_memento(decl: &Value) -> Result<(String, Vec<u8>), String> {
+    let target_language = required_str(decl, "target_language", "refusal-memento")?;
+    let surface = required_str(decl, "surface", "refusal-memento")?;
+    let concept = required_str(decl, "concept", "refusal-memento")?;
+    let reason = required_str(decl, "reason", "refusal-memento")?;
+    let would_close_with_cluster =
+        required_str(decl, "would_close_with_cluster", "refusal-memento")?;
+
+    if reason.trim().is_empty() {
+        return Err("`refusal-memento` missing non-empty `reason`".to_string());
+    }
+    if would_close_with_cluster.trim().is_empty() {
+        return Err(
+            "`refusal-memento` missing non-empty `would_close_with_cluster`".to_string(),
+        );
+    }
+
+    let envelope = json!({
+        "body": decl,
+        "header": {
+            "concept": concept,
+            "kind": "refusal-memento",
+            "surface": surface,
+            "targetLanguage": target_language,
+            "wouldCloseWithCluster": would_close_with_cluster,
         },
         "schemaVersion": "1",
     });

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -424,6 +424,8 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
             let SugarTarget {
                 concept,
                 library,
+                loss,
+                observed_dimension,
                 item_fn,
             } = sugar_target;
             let param_names = fn_param_names(&item_fn);
@@ -454,7 +456,7 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
             ]);
             let signature_shape_cid = blake3_512_of(encode_jcs(&sig_shape).as_bytes());
 
-            entries.push(json!({
+            let mut entry = json!({
                 "kind": "library-sugar-binding-entry",
                 "target_language": "rust",
                 "target_library_tag": library,
@@ -468,9 +470,30 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
                 "signature_shape_cid": signature_shape_cid,
                 "loss_record_contribution": {
                     "form": "literal",
-                    "value": { "entries": [] },
+                    "value": { "entries": loss },
                 },
                 "body_source": sugar_body_source(&rel, &src, &item_fn),
+            });
+            if let Some(observed) = observed_dimension {
+                entry["observed_dimension"] = json!(observed);
+            }
+            entries.push(entry);
+        }
+
+        for refuse_target in collect_refuse_targets(&file) {
+            let RefuseTarget {
+                surface,
+                concept,
+                reason,
+                would_close_with_cluster,
+            } = refuse_target;
+            entries.push(json!({
+                "kind": "refusal-memento",
+                "target_language": "rust",
+                "surface": surface,
+                "concept": concept,
+                "reason": reason,
+                "would_close_with_cluster": would_close_with_cluster,
             }));
         }
     }
@@ -531,7 +554,17 @@ struct BindLiftTarget {
 struct SugarTarget {
     concept: String,
     library: String,
+    loss: Vec<String>,
+    observed_dimension: Option<String>,
     item_fn: syn::ItemFn,
+}
+
+#[derive(Debug, Clone)]
+struct RefuseTarget {
+    surface: String,
+    concept: String,
+    reason: String,
+    would_close_with_cluster: String,
 }
 
 fn collect_bind_lift_targets(file: &syn::File) -> Vec<BindLiftTarget> {
@@ -601,10 +634,12 @@ fn collect_sugar_targets_in_items(items: &[syn::Item], targets: &mut Vec<SugarTa
     for item in items {
         match item {
             syn::Item::Fn(item_fn) => {
-                if let Some((concept, library)) = extract_sugar_attr(item_fn) {
+                if let Some(parsed) = extract_sugar_attr(item_fn) {
                     targets.push(SugarTarget {
-                        concept,
-                        library,
+                        concept: parsed.concept,
+                        library: parsed.library,
+                        loss: parsed.loss,
+                        observed_dimension: parsed.observed_dimension,
                         item_fn: item_fn.clone(),
                     });
                 }
@@ -619,57 +654,162 @@ fn collect_sugar_targets_in_items(items: &[syn::Item], targets: &mut Vec<SugarTa
     }
 }
 
-fn extract_sugar_attr(item_fn: &syn::ItemFn) -> Option<(String, String)> {
+fn collect_refuse_targets(file: &syn::File) -> Vec<RefuseTarget> {
+    let mut targets = Vec::new();
+    collect_refuse_targets_in_items(&file.items, &mut targets);
+    targets
+}
+
+fn collect_refuse_targets_in_items(items: &[syn::Item], targets: &mut Vec<RefuseTarget>) {
+    for item in items {
+        if let syn::Item::Mod(module) = item {
+            if let Some(parsed) = extract_refuse_attr(module) {
+                targets.push(parsed);
+            }
+            if let Some((_, nested_items)) = &module.content {
+                collect_refuse_targets_in_items(nested_items, targets);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct SugarAttrParsed {
+    concept: String,
+    library: String,
+    loss: Vec<String>,
+    observed_dimension: Option<String>,
+}
+
+fn extract_sugar_attr(item_fn: &syn::ItemFn) -> Option<SugarAttrParsed> {
     for attr in &item_fn.attrs {
         let path = attr.path();
         let segments: Vec<_> = path.segments.iter().collect();
         if segments.len() == 2 && segments[0].ident == "provekit" && segments[1].ident == "sugar" {
             if let Ok(meta_list) = attr.meta.require_list() {
-                let mut concept: Option<String> = None;
-                let mut library: Option<String> = None;
-                let tokens: Vec<_> = meta_list.tokens.clone().into_iter().collect();
-                let mut i = 0;
-                while i + 2 < tokens.len() {
-                    if let (
-                        proc_macro2::TokenTree::Ident(key),
-                        proc_macro2::TokenTree::Punct(eq),
-                        proc_macro2::TokenTree::Literal(val),
-                    ) = (&tokens[i], &tokens[i + 1], &tokens[i + 2])
-                    {
-                        if eq.as_char() == '=' {
-                            let val_str = val.to_string();
-                            if val_str.starts_with('"') && val_str.ends_with('"') {
-                                let inner = val_str[1..val_str.len() - 1].to_string();
-                                let key_name = key.to_string();
-                                if key_name == "concept" {
-                                    concept = Some(inner.clone());
-                                }
-                                if key_name == "library" {
-                                    library = Some(inner);
-                                }
-                            }
-                        }
-                        i += 3;
-                        if i < tokens.len() {
-                            if let proc_macro2::TokenTree::Punct(punct) = &tokens[i] {
-                                if punct.as_char() == ',' {
-                                    i += 1;
-                                }
-                            }
-                        }
-                    } else {
-                        i += 1;
-                    }
-                }
-                if let (Some(concept), Some(library)) = (concept, library) {
-                    if !concept.is_empty() && !library.is_empty() {
-                        return Some((concept, library));
-                    }
+                let args = parse_attr_named_args(&meta_list.tokens);
+                let concept = args.string("concept").unwrap_or_default();
+                let library = args.string("library").unwrap_or_default();
+                if !concept.is_empty() && !library.is_empty() {
+                    return Some(SugarAttrParsed {
+                        concept,
+                        library,
+                        loss: args.string_array("loss"),
+                        observed_dimension: args.string("observed_dimension"),
+                    });
                 }
             }
         }
     }
     None
+}
+
+fn extract_refuse_attr(item_mod: &syn::ItemMod) -> Option<RefuseTarget> {
+    for attr in &item_mod.attrs {
+        let path = attr.path();
+        let segments: Vec<_> = path.segments.iter().collect();
+        if segments.len() == 2 && segments[0].ident == "provekit" && segments[1].ident == "refuse" {
+            if let Ok(meta_list) = attr.meta.require_list() {
+                let args = parse_attr_named_args(&meta_list.tokens);
+                let surface = args.string("surface").unwrap_or_default();
+                let concept = args.string("concept").unwrap_or_default();
+                let reason = args.string("reason").unwrap_or_default();
+                let would_close_with_cluster =
+                    args.string("would_close_with_cluster").unwrap_or_default();
+                if !surface.is_empty()
+                    && !concept.is_empty()
+                    && !reason.is_empty()
+                    && !would_close_with_cluster.is_empty()
+                {
+                    return Some(RefuseTarget {
+                        surface,
+                        concept,
+                        reason,
+                        would_close_with_cluster,
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
+#[derive(Debug, Default)]
+struct ParsedAttrArgs {
+    strings: std::collections::BTreeMap<String, String>,
+    string_arrays: std::collections::BTreeMap<String, Vec<String>>,
+}
+
+impl ParsedAttrArgs {
+    fn string(&self, key: &str) -> Option<String> {
+        self.strings.get(key).cloned()
+    }
+
+    fn string_array(&self, key: &str) -> Vec<String> {
+        self.string_arrays.get(key).cloned().unwrap_or_default()
+    }
+}
+
+fn parse_attr_named_args(tokens: &proc_macro2::TokenStream) -> ParsedAttrArgs {
+    let mut out = ParsedAttrArgs::default();
+    let tokens: Vec<_> = tokens.clone().into_iter().collect();
+    let mut i = 0;
+    while i < tokens.len() {
+        let key = match &tokens[i] {
+            proc_macro2::TokenTree::Ident(ident) => ident.to_string(),
+            _ => {
+                i += 1;
+                continue;
+            }
+        };
+        let is_eq = matches!(tokens.get(i + 1), Some(proc_macro2::TokenTree::Punct(p)) if p.as_char() == '=');
+        if !is_eq {
+            i += 1;
+            continue;
+        }
+        match tokens.get(i + 2) {
+            Some(proc_macro2::TokenTree::Literal(lit)) => {
+                if let Some(unquoted) = unquote_string_literal(&lit.to_string()) {
+                    out.strings.insert(key, unquoted);
+                }
+                i += 3;
+            }
+            Some(proc_macro2::TokenTree::Group(group))
+                if group.delimiter() == proc_macro2::Delimiter::Bracket =>
+            {
+                let entries: Vec<String> = group
+                    .stream()
+                    .into_iter()
+                    .filter_map(|tt| match tt {
+                        proc_macro2::TokenTree::Literal(lit) => {
+                            unquote_string_literal(&lit.to_string())
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                out.string_arrays.insert(key, entries);
+                i += 3;
+            }
+            _ => {
+                i += 1;
+                continue;
+            }
+        }
+        if let Some(proc_macro2::TokenTree::Punct(p)) = tokens.get(i) {
+            if p.as_char() == ',' {
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+fn unquote_string_literal(raw: &str) -> Option<String> {
+    if raw.starts_with('"') && raw.ends_with('"') && raw.len() >= 2 {
+        Some(raw[1..raw.len() - 1].to_string())
+    } else {
+        None
+    }
 }
 
 fn concept_annotation_for_fn(source: &str, item_fn: &syn::ItemFn) -> Option<String> {
@@ -3622,5 +3762,268 @@ pub fn bitwise_not() -> i64 {
         std::fs::create_dir_all(dir.join("src")).expect("create src");
         std::fs::write(dir.join("src/lib.rs"), "fn broken(").expect("write source");
         dir
+    }
+
+    // ---- substrate-honest precursor wire tests (loss, observed_dimension, refusal-memento) ----
+
+    #[test]
+    fn sugar_attr_loss_array_populates_loss_record_entries() {
+        let root = temp_workspace("sugar_loss_array");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let src = r#"
+#[provekit::sugar(
+    concept = "concept:sql-query",
+    library = "rusqlite",
+    loss = ["sync-vs-async", "row-cardinality"],
+)]
+fn query(conn: String, sql: String) -> i64 { 0 }
+"#;
+        fs::write(src_dir.join("lib.rs"), src).expect("write source");
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."],
+        }))
+        .expect("bind lift should succeed");
+        let ir = out["ir"].as_array().expect("ir array");
+        let sugar: Vec<_> = ir
+            .iter()
+            .filter(|e| e["kind"] == "library-sugar-binding-entry")
+            .collect();
+        assert_eq!(sugar.len(), 1, "expected one sugar entry");
+        assert_eq!(
+            sugar[0]["loss_record_contribution"]["value"]["entries"],
+            json!(["sync-vs-async", "row-cardinality"])
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn sugar_attr_without_loss_still_emits_empty_entries() {
+        let root = temp_workspace("sugar_no_loss");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let src = r#"
+#[provekit::sugar(concept = "concept:sql-query", library = "rusqlite")]
+fn query(conn: String, sql: String) -> i64 { 0 }
+"#;
+        fs::write(src_dir.join("lib.rs"), src).expect("write source");
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."],
+        }))
+        .expect("bind lift should succeed");
+        let ir = out["ir"].as_array().expect("ir array");
+        let sugar: Vec<_> = ir
+            .iter()
+            .filter(|e| e["kind"] == "library-sugar-binding-entry")
+            .collect();
+        assert_eq!(sugar.len(), 1);
+        assert_eq!(
+            sugar[0]["loss_record_contribution"]["value"]["entries"],
+            json!([])
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn sugar_attr_observed_dimension_propagates_to_entry() {
+        let root = temp_workspace("sugar_observed_dim");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let src = r#"
+#[provekit::sugar(
+    concept = "concept:contract-observation",
+    library = "rusqlite",
+    observed_dimension = "autocommit-mode",
+)]
+fn is_autocommit(conn: String) -> bool { false }
+"#;
+        fs::write(src_dir.join("lib.rs"), src).expect("write source");
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."],
+        }))
+        .expect("bind lift should succeed");
+        let ir = out["ir"].as_array().expect("ir array");
+        let sugar: Vec<_> = ir
+            .iter()
+            .filter(|e| e["kind"] == "library-sugar-binding-entry")
+            .collect();
+        assert_eq!(sugar.len(), 1);
+        assert_eq!(sugar[0]["observed_dimension"], "autocommit-mode");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn refuse_attr_emits_refusal_memento_with_all_fields() {
+        let root = temp_workspace("refuse_full");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let src = r#"
+#[provekit::refuse(
+    surface = "rusqlite::Connection::backup",
+    concept = "concept:sql-physical-backup",
+    reason = "SQLite-binary-specific physical backup; N=1 cluster.",
+    would_close_with_cluster = "Connection-level physical-backup method on >=2 SQL drivers",
+)]
+pub mod refused_backup {}
+"#;
+        fs::write(src_dir.join("lib.rs"), src).expect("write source");
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."],
+        }))
+        .expect("bind lift should succeed");
+        let ir = out["ir"].as_array().expect("ir array");
+        let refusals: Vec<_> = ir
+            .iter()
+            .filter(|e| e["kind"] == "refusal-memento")
+            .collect();
+        assert_eq!(refusals.len(), 1, "expected one refusal-memento entry");
+        let r = &refusals[0];
+        assert_eq!(r["surface"], "rusqlite::Connection::backup");
+        assert_eq!(r["concept"], "concept:sql-physical-backup");
+        assert_eq!(
+            r["reason"],
+            "SQLite-binary-specific physical backup; N=1 cluster."
+        );
+        assert_eq!(
+            r["would_close_with_cluster"],
+            "Connection-level physical-backup method on >=2 SQL drivers"
+        );
+        assert_eq!(r["target_language"], "rust");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn refuse_attr_missing_field_produces_zero_memento() {
+        let root = temp_workspace("refuse_missing");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let src_missing_reason = r#"
+#[provekit::refuse(
+    surface = "rusqlite::Connection::backup",
+    concept = "concept:sql-physical-backup",
+    would_close_with_cluster = "Cross-driver analog",
+)]
+pub mod refused_backup {}
+"#;
+        fs::write(src_dir.join("lib.rs"), src_missing_reason).expect("write source");
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."],
+        }))
+        .expect("bind lift should succeed");
+        let ir = out["ir"].as_array().expect("ir array");
+        let refusals: Vec<_> = ir
+            .iter()
+            .filter(|e| e["kind"] == "refusal-memento")
+            .collect();
+        assert_eq!(
+            refusals.len(),
+            0,
+            "missing required field must produce zero refusal mementos"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn non_refuse_module_does_not_emit_memento() {
+        let root = temp_workspace("refuse_discrim");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let src = r#"
+pub mod plain_module {}
+"#;
+        fs::write(src_dir.join("lib.rs"), src).expect("write source");
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."],
+        }))
+        .expect("bind lift should succeed");
+        let ir = out["ir"].as_array().expect("ir array");
+        let refusals: Vec<_> = ir
+            .iter()
+            .filter(|e| e["kind"] == "refusal-memento")
+            .collect();
+        assert_eq!(refusals.len(), 0);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn three_speech_acts_compose_in_one_source_file() {
+        // The load-bearing test for PR A: a single Rust source file declares
+        // (1) a substrate-exact binding (sugar with loss = []), (2) a lossy
+        // binding (sugar with loss = ["sync-vs-async"]), and (3) a refusal
+        // (refuse module). One bind_lift call extracts all three.
+        let root = temp_workspace("three_speech_acts");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let src = r#"
+#[provekit::sugar(concept = "concept:sql-execute", library = "rusqlite", loss = [])]
+fn execute(conn: String, sql: String) -> i64 { 0 }
+
+#[provekit::sugar(
+    concept = "concept:sql-query",
+    library = "rusqlite",
+    loss = ["sync-vs-async", "row-cardinality"],
+)]
+fn query_row(conn: String, sql: String) -> String { String::new() }
+
+#[provekit::refuse(
+    surface = "rusqlite::Connection::backup",
+    concept = "concept:sql-physical-backup",
+    reason = "SQLite-specific; cluster N=1.",
+    would_close_with_cluster = "Cross-driver backup method on >=2 SQL drivers",
+)]
+pub mod refused_backup {}
+"#;
+        fs::write(src_dir.join("lib.rs"), src).expect("write source");
+        let out = bind_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."],
+        }))
+        .expect("bind lift should succeed");
+        let ir = out["ir"].as_array().expect("ir array");
+
+        let sugar: Vec<_> = ir
+            .iter()
+            .filter(|e| e["kind"] == "library-sugar-binding-entry")
+            .collect();
+        assert_eq!(sugar.len(), 2, "expected two sugar entries (exact + lossy)");
+
+        let exact = sugar
+            .iter()
+            .find(|e| e["source_function_name"] == "execute")
+            .expect("exact binding present");
+        assert_eq!(
+            exact["loss_record_contribution"]["value"]["entries"],
+            json!([])
+        );
+
+        let lossy = sugar
+            .iter()
+            .find(|e| e["source_function_name"] == "query_row")
+            .expect("lossy binding present");
+        assert_eq!(
+            lossy["loss_record_contribution"]["value"]["entries"],
+            json!(["sync-vs-async", "row-cardinality"])
+        );
+
+        let refusals: Vec<_> = ir
+            .iter()
+            .filter(|e| e["kind"] == "refusal-memento")
+            .collect();
+        assert_eq!(refusals.len(), 1, "expected one refusal-memento entry");
+        assert_eq!(refusals[0]["surface"], "rusqlite::Connection::backup");
+
+        let _ = fs::remove_dir_all(root);
     }
 }


### PR DESCRIPTION
## Summary

Precursor wire change so the substrate's three speech acts (materialize, loudly-bounded-lossy, refuse) all flow from kit source through the lift kit's JSON-RPC into cmd_mint's signed `.proof` envelope. Closes the sidecar-violation discovered while designing the rusqlite vendor-shim: every declaration the substrate signs must come from the source via JSON-RPC, not from a sidecar file.

This unblocks the rusqlite vendor-shim genesis-block .proof (PR B, queued).

## Wire changes

**walk_rpc.rs** (Rust lift kit):
- `extract_sugar_attr` extended to capture `loss = [<strings>]` array and `observed_dimension = "..."` string in addition to existing `concept`/`library`
- New `extract_refuse_attr` recognizes `#[provekit::refuse(surface, concept, reason, would_close_with_cluster)]` on modules
- New `RefuseTarget` struct + `collect_refuse_targets` walks `syn::File` collecting module-level refusals
- `bind_lift` populates `loss_record_contribution.value.entries` from the extracted array (previously hardcoded empty), threads `observed_dimension` into the entry when present, and emits new IR kind `refusal-memento` per refuse target

**cmd_mint.rs**:
- Dispatch loop branches on `"refusal-memento"` kind alongside existing `"library-sugar-binding-entry"`
- New `mint_refusal_memento` produces a signed envelope member with header `{surface, concept, kind, targetLanguage, wouldCloseWithCluster}` and body carrying the full IR record. Validates `reason` and `would_close_with_cluster` non-empty before signing.

## Tests

Six new tests in walk_rpc.rs cover every variant (three per speech act: positive / discrimination / structural):

- `sugar_attr_loss_array_populates_loss_record_entries` — positive: lossy binding survives lift+emit
- `sugar_attr_without_loss_still_emits_empty_entries` — backwards-compat: existing `#[sugar(concept, library)]` annotations still produce empty entries
- `sugar_attr_observed_dimension_propagates_to_entry` — observation binding's `observed_dimension` reaches the IR
- `refuse_attr_emits_refusal_memento_with_all_fields` — positive: refusal-memento with all four fields
- `refuse_attr_missing_field_produces_zero_memento` — discrimination: incomplete refuse attr is rejected
- `non_refuse_module_does_not_emit_memento` — discrimination: plain modules don't trigger refusal emission
- `three_speech_acts_compose_in_one_source_file` — load-bearing end-to-end: a single Rust file with exact-sugar + lossy-sugar + refuse-module emits all three IR record kinds in one lift call

Local: all 12 sugar+refuse tests in `provekit-walk-rpc` pass; em-dash sweep clean on the diff.

## Substrate-uniform discipline

This wire is the substrate-uniform pattern (paper 24): kit source is the truth, lift kit extracts via JSON-RPC, cmd_mint signs the envelope. No sidecar files. No second source of truth. The kit's signed claim equals what is in its annotated source.

## Test plan

- [ ] CI green on the 12 sugar/refuse tests + full provekit-walk + provekit-cli suite
- [ ] Backwards-compat: existing `#[provekit::sugar(concept, library)]` annotations (no `loss`, no `observed_dimension`) still produce identical IR shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for refusal-memento declarations and minting functionality
  * Extended sugar binding support to include loss records and observed dimensions

* **Tests**
  * Added comprehensive test coverage for refusal-memento emission and sugar attribute scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->