### PR TITLE
feat(libprovekit): SiteTransformKit trait + transform_source_text (#1336 Phase B)

### DIFF
--- a/implementations/rust/libprovekit/src/core/source_transform.rs
+++ b/implementations/rust/libprovekit/src/core/source_transform.rs
@@ -290,6 +290,316 @@ pub fn canonical_value_from_json(value: &Json) -> Result<Arc<CanonicalValue>, St
 // build-pipeline ergonomics; the trade-off is that incomplete carriers may
 // produce stub-like realize output. A future strict mode (e.g., a
 // --strict-payloads flag) could refuse incomplete carriers up front.
+// -----------------------------------------------------------------------------
+// Phase B (`#1336`): the unified site-transformation primitive.
+//
+// The materialize and migrate commands both walk a source file, find
+// `provekit-concept:` carrier comments, optionally consume the consumer's
+// stub function declaration that follows, dispatch to a kit-specific binding
+// resolver, and splice the realized body back into the consumer's signature.
+// Phase A extracted the mechanical primitives (carrier parsing, stub capture,
+// body splice). Phase B unifies the dispatch surface as `SiteTransformKit`
+// and the loop as `transform_source_text`. Phase C will reroute
+// `cmd_materialize::materialize_source_text` through this trait; Phase D will
+// do the same for `cmd_bind_migrate`; Phase E will unify the receipt
+// envelope so refusals carry through both flows by the same shape.
+//
+// This phase changes no CLI behavior. It adds the trait surface that the
+// existing commands will route through in subsequent phases.
+
+/// The trichotomy outcome of a single site transformation. Matches the
+/// substrate-honest first-principle: every site clears either with
+/// byte-exact realization, with declared bounded loss, or with refusal that
+/// names the concept hub whose minting would close the gap.
+#[derive(Debug, Clone)]
+pub enum SiteOutcome {
+    /// Site cleared with byte-exact realization. `body` is the spliced
+    /// function body (the contents between the outermost braces of the
+    /// realized function declaration); `binding_cid` pins the kit binding
+    /// that realized it; `loss_record` is the (possibly empty) loss-record
+    /// contribution carried by that binding.
+    Materialize {
+        body: String,
+        binding_cid: String,
+        loss_record: Json,
+    },
+
+    /// Site cleared with declared bounded loss. `body` is the spliced
+    /// function body; `binding_cid` pins the kit binding; `declared_loss`
+    /// is the list of dimensions where the realization is bounded-lossy.
+    LoudlyLossy {
+        body: String,
+        binding_cid: String,
+        declared_loss: Vec<String>,
+    },
+
+    /// Site cannot clear under the requested transformation. `reason` is a
+    /// substrate-honest sentence explaining why; `would_close_with_concept`
+    /// names the concept hub CID (or human-readable concept name) that, if
+    /// minted with an `N>=2` cross-library cluster, would close the
+    /// refusal.
+    Refuse {
+        reason: String,
+        would_close_with_concept: String,
+    },
+}
+
+/// A parsed `provekit-concept:` carrier comment in typed form. The
+/// materialize and migrate commands both consume this. Phase A moved the
+/// carrier-parsing primitive (`concept_payload_from_line`); this struct is
+/// the typed projection of the JSON payload that follows it.
+#[derive(Debug, Clone)]
+pub struct CarrierComment {
+    pub concept_name: String,
+    pub function: String,
+    pub params: Vec<String>,
+    pub param_types: Vec<String>,
+    pub return_type: String,
+    pub library_tag: Option<String>,
+    /// The raw JSON payload as it appeared in the source comment. Kept for
+    /// the carrier-payload-cid verification path that Phase A preserved
+    /// (`verify_payload_cid` recomputes JCS+blake3 over the same string the
+    /// consumer signed for).
+    pub raw_payload: String,
+}
+
+impl CarrierComment {
+    /// Parse the payload portion of a `provekit-concept: <JSON>` line.
+    /// The payload string is the value Phase A's `concept_payload_from_line`
+    /// returns; this function consumes it into typed fields with the same
+    /// permissive defaults that `realize_spec_from_payload` applies (missing
+    /// `function` becomes `provekit_materialized`, missing `params` becomes
+    /// `[]`, missing `return_type` becomes `"void"`).
+    pub fn parse(payload: &str) -> Result<Self, String> {
+        let raw_payload = payload.to_string();
+        let value: Json = serde_json::from_str(payload)
+            .map_err(|error| format!("parse provekit-concept payload JSON: {error}"))?;
+        let object = value
+            .as_object()
+            .ok_or_else(|| "provekit-concept payload must be a JSON object".to_string())?;
+
+        let concept_name = object
+            .get("concept_name")
+            .or_else(|| object.get("conceptName"))
+            .and_then(Json::as_str)
+            .ok_or_else(|| "provekit-concept payload missing concept_name".to_string())?
+            .to_string();
+
+        let function = object
+            .get("function")
+            .and_then(Json::as_str)
+            .unwrap_or("provekit_materialized")
+            .to_string();
+
+        let params = json_string_array_field(object.get("params"))
+            .map_err(|error| format!("provekit-concept payload `params`: {error}"))?;
+        let param_types = json_string_array_field(
+            object.get("param_types").or_else(|| object.get("paramTypes")),
+        )
+        .map_err(|error| format!("provekit-concept payload `param_types`: {error}"))?;
+
+        let return_type = object
+            .get("return_type")
+            .or_else(|| object.get("returnType"))
+            .and_then(Json::as_str)
+            .unwrap_or("void")
+            .to_string();
+
+        let library_tag = object
+            .get("library_tag")
+            .or_else(|| object.get("libraryTag"))
+            .or_else(|| object.get("library"))
+            .and_then(Json::as_str)
+            .map(str::to_string);
+
+        Ok(Self {
+            concept_name,
+            function,
+            params,
+            param_types,
+            return_type,
+            library_tag,
+            raw_payload,
+        })
+    }
+}
+
+fn json_string_array_field(value: Option<&Json>) -> Result<Vec<String>, String> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let array = value
+        .as_array()
+        .ok_or_else(|| "field must be a JSON array".to_string())?;
+    array
+        .iter()
+        .map(|entry| {
+            entry
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| "array entries must be strings".to_string())
+        })
+        .collect()
+}
+
+/// A kit that, given a concept-citation carrier, produces a site outcome
+/// (`Materialize`, `LoudlyLossy`, or `Refuse`). Both `provekit materialize`
+/// and `provekit bind migrate` will implement this in Phase C and Phase D
+/// respectively; the site-iteration, splice, and write-back machinery is
+/// shared by both via `transform_source_text`.
+pub trait SiteTransformKit: Send + Sync {
+    /// The target source language this kit emits (e.g., `"rust"`,
+    /// `"python"`). Used by callers that key per-language defaults off the
+    /// kit (e.g., file-extension filters in the file walker).
+    fn target_language(&self) -> &str;
+
+    /// Given a parsed carrier, dispatch to the kit's binding lookup and
+    /// produce a site outcome. The kit is responsible for any RPC,
+    /// path-composition, or binding-resolution it performs internally.
+    fn transform_site(&self, carrier: &CarrierComment) -> Result<SiteOutcome, String>;
+}
+
+/// A captured concept-citation site in a source file: the carrier plus the
+/// (optional) stub function block that followed it. Returned by the shared
+/// site-iteration loop for callers that want to introspect or aggregate
+/// outcomes before write-back. Held by `transform_source_text` internally;
+/// surfaced so future phases (the migrate receipt envelope, debug tooling)
+/// can consume the same captured shape.
+#[derive(Debug, Clone)]
+pub struct ConceptSite {
+    pub carrier: CarrierComment,
+    pub indent: String,
+    pub stub_line_count: usize,
+    pub stub_signature_and_close: Option<StubSignatureAndCloseClone>,
+    /// Inclusive starting line and exclusive ending line of the
+    /// carrier-plus-stub region in the source, as `split_inclusive('\n')`
+    /// indices. Used by callers that want to slice the source by line
+    /// range.
+    pub line_start: usize,
+    pub line_end_exclusive: usize,
+}
+
+/// Clone-friendly mirror of `StubSignatureAndClose`. The Phase A struct is
+/// owned by the capture step and consumed by the splice step in a single
+/// loop iteration; `ConceptSite` (Phase B) is meant to be cheap to clone
+/// for aggregation, so we carry the owned-string form.
+#[derive(Debug, Clone)]
+pub struct StubSignatureAndCloseClone {
+    pub signature_text: String,
+    pub close_indent: String,
+}
+
+impl From<&StubSignatureAndClose> for StubSignatureAndCloseClone {
+    fn from(value: &StubSignatureAndClose) -> Self {
+        Self {
+            signature_text: value.signature_text.clone(),
+            close_indent: value.close_indent.clone(),
+        }
+    }
+}
+
+/// Splice a raw body string (the contents that go between the outermost
+/// braces, without surrounding braces) into the consumer's stub signature.
+/// This is the body-first sibling of
+/// `splice_realized_body_into_stub_signature`, which takes the realize
+/// plugin's full `fn ... { body }` source string. The kit-trait flow in
+/// Phase B returns the body directly (the trichotomy outcome carries
+/// `body: String`), so the splice path here avoids the round-trip through
+/// the realize-plugin source format.
+fn splice_body_into_stub_signature(stub: &StubSignatureAndClose, body: &str) -> String {
+    let body = body.trim_matches('\n');
+    let mut out = String::new();
+    out.push_str(&stub.signature_text);
+    if !stub.signature_text.ends_with('\n') {
+        out.push('\n');
+    }
+    for line in body.lines() {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str(&stub.close_indent);
+    out.push('}');
+    out.push('\n');
+    out
+}
+
+/// Transform a source-file string by walking concept-citation carriers and
+/// replacing each carrier-plus-stub region with the kit's site outcome.
+/// Returns the rewritten source and the per-site outcomes in the order they
+/// appeared.
+///
+/// Refusals propagate as `Err(String)` carrying the refusal `reason`; the
+/// function does not continue past a site that returned `Refuse`, and does
+/// not continue past a site whose `transform_site` itself errored.  Phase D
+/// (`cmd_bind_migrate`) needs to accumulate refusals into a structured
+/// receipt envelope; that flow will sit above `transform_source_text` and
+/// catch the propagated `Err` (or, in Phase E, switch to an accumulating
+/// variant). For Phase B's narrow surface, the propagate-on-refuse shape
+/// mirrors Phase A's `materialize_source_text` (which surfaces realize
+/// failures as `Err`).
+///
+/// For `Materialize` and `LoudlyLossy` outcomes, the kit's returned `body`
+/// is spliced into the consumer's stub signature via
+/// `splice_realized_body_into_stub_signature` when a stub was captured.
+/// When no stub was captured (the carrier was not followed by a parseable
+/// stub function declaration), the returned `body` is wrapped in a thin
+/// `fn provekit_materialized() { ... }` skeleton to match the Phase A
+/// fallback path. The caller can then re-indent and append as before.
+pub fn transform_source_text(
+    source: &str,
+    kit: &dyn SiteTransformKit,
+) -> Result<(String, Vec<SiteOutcome>), String> {
+    let mut out = String::new();
+    let mut outcomes: Vec<SiteOutcome> = Vec::new();
+    let lines = source.split_inclusive('\n').collect::<Vec<_>>();
+    let mut idx = 0usize;
+    while idx < lines.len() {
+        let line = lines[idx];
+        if let Some((indent, payload)) = concept_payload_from_line(line) {
+            let mut consumed = 1usize;
+            if idx + consumed < lines.len()
+                && concept_payload_cid_from_line(lines[idx + consumed]).is_some()
+            {
+                let declared_cid = concept_payload_cid_from_line(lines[idx + consumed]).unwrap();
+                verify_payload_cid(payload, declared_cid)?;
+                consumed += 1;
+            }
+            let stub_block = capture_stub_function_block(&lines[idx + consumed..]);
+            consumed += stub_block.line_count;
+
+            let carrier = CarrierComment::parse(payload)?;
+            let outcome = kit.transform_site(&carrier)?;
+
+            let body_opt: Option<&str> = match &outcome {
+                SiteOutcome::Materialize { body, .. } => Some(body.as_str()),
+                SiteOutcome::LoudlyLossy { body, .. } => Some(body.as_str()),
+                SiteOutcome::Refuse { reason, .. } => {
+                    return Err(reason.clone());
+                }
+            };
+
+            if let Some(body) = body_opt {
+                let emitted = if let Some(stub) = stub_block.signature_and_close.as_ref() {
+                    splice_body_into_stub_signature(stub, body)
+                } else {
+                    body.to_string()
+                };
+                let indented = indent_realized_source(&emitted, indent);
+                out.push_str(&indented);
+                if !indented.ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+            outcomes.push(outcome);
+            idx += consumed;
+            continue;
+        }
+        out.push_str(line);
+        idx += 1;
+    }
+    Ok((out, outcomes))
+}
+
 pub fn realize_spec_from_payload(payload: &str) -> Result<Json, String> {
     let mut value: Json = serde_json::from_str(payload)
         .map_err(|error| format!("parse provekit-concept payload JSON: {error}"))?;
@@ -337,3 +647,95 @@ pub fn realize_spec_from_payload(payload: &str) -> Result<Json, String> {
     }
     Ok(value)
 }
+
+#[cfg(test)]
+mod phase_b_tests {
+    use super::*;
+    use serde_json::json;
+
+    struct MockMaterializeKit {
+        body: String,
+        binding_cid: String,
+    }
+
+    impl SiteTransformKit for MockMaterializeKit {
+        fn target_language(&self) -> &str {
+            "rust"
+        }
+
+        fn transform_site(&self, _carrier: &CarrierComment) -> Result<SiteOutcome, String> {
+            Ok(SiteOutcome::Materialize {
+                body: self.body.clone(),
+                binding_cid: self.binding_cid.clone(),
+                loss_record: json!([]),
+            })
+        }
+    }
+
+    struct RefusingKit {
+        reason: String,
+    }
+
+    impl SiteTransformKit for RefusingKit {
+        fn target_language(&self) -> &str {
+            "rust"
+        }
+
+        fn transform_site(&self, _carrier: &CarrierComment) -> Result<SiteOutcome, String> {
+            Ok(SiteOutcome::Refuse {
+                reason: self.reason.clone(),
+                would_close_with_concept: "concept:demo".to_string(),
+            })
+        }
+    }
+
+    const SAMPLE_SOURCE: &str = "fn before() {}\n\
+// provekit-concept: {\"concept_name\":\"concept:demo\",\"function\":\"do_thing\",\"params\":[\"x\"],\"param_types\":[\"u32\"],\"return_type\":\"u32\"}\n\
+fn do_thing(x: u32) -> u32 {\n\
+    unimplemented!()\n\
+}\n\
+fn after() {}\n";
+
+    #[test]
+    fn carrier_comment_parse_extracts_typed_fields() {
+        let payload = r#"{"concept_name":"concept:demo","function":"do_thing","params":["x"],"param_types":["u32"],"return_type":"u32","library_tag":"std"}"#;
+        let carrier = CarrierComment::parse(payload).expect("parses");
+        assert_eq!(carrier.concept_name, "concept:demo");
+        assert_eq!(carrier.function, "do_thing");
+        assert_eq!(carrier.params, vec!["x".to_string()]);
+        assert_eq!(carrier.param_types, vec!["u32".to_string()]);
+        assert_eq!(carrier.return_type, "u32");
+        assert_eq!(carrier.library_tag.as_deref(), Some("std"));
+        assert_eq!(carrier.raw_payload, payload);
+    }
+
+    #[test]
+    fn transform_source_text_splices_materialize_body_into_stub_signature() {
+        let kit = MockMaterializeKit {
+            body: "    x.wrapping_add(1)".to_string(),
+            binding_cid: "cid:mock".to_string(),
+        };
+        let (out, outcomes) =
+            transform_source_text(SAMPLE_SOURCE, &kit).expect("transform succeeds");
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(outcomes[0], SiteOutcome::Materialize { .. }));
+        // Carrier line is consumed; consumer signature is preserved; body is spliced.
+        assert!(out.contains("fn before() {}"));
+        assert!(out.contains("fn do_thing(x: u32) -> u32 {"));
+        assert!(out.contains("x.wrapping_add(1)"));
+        assert!(out.contains("fn after() {}"));
+        assert!(!out.contains("provekit-concept:"));
+        assert!(!out.contains("unimplemented!()"));
+    }
+
+    #[test]
+    fn transform_source_text_propagates_refusal_as_err() {
+        let kit = RefusingKit {
+            reason: "no binding for concept:demo".to_string(),
+        };
+        let error =
+            transform_source_text(SAMPLE_SOURCE, &kit).expect_err("refusal propagates as Err");
+        assert!(error.contains("no binding for concept:demo"));
+    }
+}
+


### PR DESCRIPTION
## Summary

Phase B of the umbrella refactor at #1334, filed as #1336.

Adds the trait surface that unifies the site-transformation primitive shared by `provekit materialize` (Phase C, upcoming) and `provekit bind migrate` (Phase D, upcoming). Trait surface only; no CLI behavior change in this PR.

What lands in `libprovekit::core::source_transform`:

- `SiteOutcome` enum — the substrate-honest trichotomy: `Materialize { body, binding_cid, loss_record }`, `LoudlyLossy { body, binding_cid, declared_loss }`, `Refuse { reason, would_close_with_concept }`.
- `CarrierComment` — typed projection of the `provekit-concept:` payload, with `parse` matching the permissive defaults of `realize_spec_from_payload` and preserving `raw_payload` for the carrier-payload-CID verification path Phase A retained.
- `SiteTransformKit` trait — `target_language()` plus `transform_site(&CarrierComment) -> Result<SiteOutcome, String>`.
- `ConceptSite` + `StubSignatureAndCloseClone` — clone-friendly captured shape surfaced for the Phase D migrate receipt envelope and future debug tooling.
- `transform_source_text` — the shared loop. Structurally identical to `cmd_materialize::materialize_source_text` (carrier line, optional payload-CID line, optional stub capture, splice, indent, write back); kit-driven via `transform_site`. Refusals propagate as `Err(String)` carrying the refusal `reason`, mirroring the materialize flow today; Phase E will unify into an accumulating receipt envelope.

Three trait-driven tests cover carrier parse, mock-materialize splice into the consumer signature, and refusal-as-Err propagation. Cmd modules are not touched.

## Test plan

- [x] `cargo build -p libprovekit -p provekit-cli` clean
- [x] `cargo test -p libprovekit` passes (3 new tests added under `phase_b_tests`)
- [x] `cargo doc -p libprovekit --no-deps` succeeds
- [x] em-dash sweep clean on diff

Closes #1336.
Builds toward #1334.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>