### PR TITLE
fix(rusqlite-body-templates): declare target_library_tag on all 44 entries

### DIFF
--- a/menagerie/rust-language-signature/specs/body-templates/rust-canonical-bodies-rusqlite.json
+++ b/menagerie/rust-language-signature/specs/body-templates/rust-canonical-bodies-rusqlite.json
@@ -23,7 +23,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-connection-open",
@@ -43,7 +44,8 @@
           "signature_guard": {
             "min_params": 0,
             "max_params": 0
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-connection-open",
@@ -65,7 +67,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-connection-close",
@@ -84,7 +87,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -105,7 +109,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-batch-execute",
@@ -126,7 +131,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-query",
@@ -147,7 +153,8 @@
           "signature_guard": {
             "min_params": 4,
             "max_params": 4
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-query",
@@ -169,7 +176,8 @@
           "signature_guard": {
             "min_params": 4,
             "max_params": 4
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-prepare",
@@ -190,7 +198,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-prepare-cached",
@@ -211,7 +220,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-prepare-cached",
@@ -230,7 +240,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -251,7 +262,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-query",
@@ -271,7 +283,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-query",
@@ -292,7 +305,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-query",
@@ -314,7 +328,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-query",
@@ -335,7 +350,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:insert-and-get-id",
@@ -355,7 +371,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-query",
@@ -375,7 +392,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-transaction-begin",
@@ -396,7 +414,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-transaction-begin",
@@ -418,7 +437,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-transaction-begin",
@@ -439,7 +459,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-transaction-commit",
@@ -459,7 +480,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-transaction-rollback",
@@ -479,7 +501,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-savepoint",
@@ -499,7 +522,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-transaction-rollback",
@@ -518,7 +542,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-row-get-column",
@@ -538,7 +563,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-row-get-column",
@@ -559,7 +585,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-row-get-column",
@@ -579,7 +606,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:insert-and-get-id",
@@ -599,7 +627,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-changes-count",
@@ -619,7 +648,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-changes-count",
@@ -639,7 +669,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -657,7 +688,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "autocommit-mode"
+          "observed_dimension": "autocommit-mode",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -675,7 +707,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "pending-statement-presence"
+          "observed_dimension": "pending-statement-presence",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -693,7 +726,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "write-permission"
+          "observed_dimension": "write-permission",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -713,7 +747,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "cache-state"
+          "observed_dimension": "cache-state",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -731,7 +766,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "column-names"
+          "observed_dimension": "column-names",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -749,7 +785,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "column-count"
+          "observed_dimension": "column-count",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -767,7 +804,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "column-name-at-index"
+          "observed_dimension": "column-name-at-index",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -785,7 +823,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "column-index-of-name"
+          "observed_dimension": "column-index-of-name",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -803,7 +842,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "expanded-sql-text"
+          "observed_dimension": "expanded-sql-text",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -821,7 +861,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "parameter-count"
+          "observed_dimension": "parameter-count",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -839,7 +880,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "parameter-name-at-index"
+          "observed_dimension": "parameter-name-at-index",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -857,7 +899,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "parameter-index-of-name"
+          "observed_dimension": "parameter-index-of-name",
+          "target_library_tag": "rusqlite"
         },
         {
           "concept_name": "concept:sql-busy-timeout",
@@ -877,7 +920,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "rusqlite"
         }
       ]
     }


### PR DESCRIPTION
## Summary

PR #1330 added \`rust-canonical-bodies-rusqlite.json\` but did not stamp each entry with \`target_library_tag = \"rusqlite\"\`. The \`library_specific_body_template_entries_declare_target_tuple\` invariant in \`provekit-cli/tests/body_template_normalization.rs\` asserts that every library-specific body-template entry declares its \`(target_language, target_library_tag, concept_name)\` tuple. With 44 unstamped entries, this test fires 44 violations and \`test-rust\` exits.

Same fall-out chain: once the upstream test-c segfault (#1328) cleared, conformance gate got far enough to surface this.

## Fix

Added \`target_library_tag: \"rusqlite\"\` to all 44 entries. No other field changes. The tag matches what the test computes from the filename suffix.

## Test plan

- [x] Em-dash sweep clean
- [x] Commit identity: \`T Savo <evilgenius@nefariousplan.com>\`
- [x] Local: \`cargo test -p provekit-cli --test body_template_normalization library_specific_body_template_entries_declare_target_tuple\` -> 1 passed
- [ ] CI: \`Cross-language conformance gate\` green