### PR TITLE
refactor(cmd_materialize): implement MaterializeKit via SiteTransformKit (#1337 Phase C)

### DIFF
--- a/implementations/rust/libprovekit/src/core/source_transform.rs
+++ b/implementations/rust/libprovekit/src/core/source_transform.rs
@@ -498,31 +498,6 @@ impl From<&StubSignatureAndClose> for StubSignatureAndCloseClone {
     }
 }
 
-/// Splice a raw body string (the contents that go between the outermost
-/// braces, without surrounding braces) into the consumer's stub signature.
-/// This is the body-first sibling of
-/// `splice_realized_body_into_stub_signature`, which takes the realize
-/// plugin's full `fn ... { body }` source string. The kit-trait flow in
-/// Phase B returns the body directly (the trichotomy outcome carries
-/// `body: String`), so the splice path here avoids the round-trip through
-/// the realize-plugin source format.
-fn splice_body_into_stub_signature(stub: &StubSignatureAndClose, body: &str) -> String {
-    let body = body.trim_matches('\n');
-    let mut out = String::new();
-    out.push_str(&stub.signature_text);
-    if !stub.signature_text.ends_with('\n') {
-        out.push('\n');
-    }
-    for line in body.lines() {
-        out.push_str(line);
-        out.push('\n');
-    }
-    out.push_str(&stub.close_indent);
-    out.push('}');
-    out.push('\n');
-    out
-}
-
 /// Transform a source-file string by walking concept-citation carriers and
 /// replacing each carrier-plus-stub region with the kit's site outcome.
 /// Returns the rewritten source and the per-site outcomes in the order they
@@ -538,13 +513,15 @@ fn splice_body_into_stub_signature(stub: &StubSignatureAndClose, body: &str) -> 
 /// mirrors Phase A's `materialize_source_text` (which surfaces realize
 /// failures as `Err`).
 ///
-/// For `Materialize` and `LoudlyLossy` outcomes, the kit's returned `body`
-/// is spliced into the consumer's stub signature via
-/// `splice_realized_body_into_stub_signature` when a stub was captured.
-/// When no stub was captured (the carrier was not followed by a parseable
-/// stub function declaration), the returned `body` is wrapped in a thin
-/// `fn provekit_materialized() { ... }` skeleton to match the Phase A
-/// fallback path. The caller can then re-indent and append as before.
+/// The kit's returned `body` is the realize plugin's full
+/// `fn ... { ... }` source declaration (the same shape the realize
+/// transport returns). When a stub was captured, the inner body is
+/// extracted from that source and spliced into the consumer's stub
+/// signature via `splice_realized_body_into_stub_signature`, preserving
+/// the consumer's signed signature exactly while filling its body from the
+/// kit binding. When no stub was captured, the kit's source is emitted as
+/// the materialized function, matching the Phase A fallback path. The
+/// caller can then re-indent and append as before.
 pub fn transform_source_text(
     source: &str,
     kit: &dyn SiteTransformKit,
@@ -580,7 +557,7 @@ pub fn transform_source_text(
 
             if let Some(body) = body_opt {
                 let emitted = if let Some(stub) = stub_block.signature_and_close.as_ref() {
-                    splice_body_into_stub_signature(stub, body)
+                    splice_realized_body_into_stub_signature(stub, body)
                 } else {
                     body.to_string()
                 };
@@ -711,8 +688,12 @@ fn after() {}\n";
 
     #[test]
     fn transform_source_text_splices_materialize_body_into_stub_signature() {
+        // Kit returns the realize plugin's full `fn ... { ... }` source; the
+        // stub-splice path extracts the inner body and wraps it in the
+        // consumer's signed signature. Same shape the realize transport
+        // returns and that `MaterializeKit` forwards.
         let kit = MockMaterializeKit {
-            body: "    x.wrapping_add(1)".to_string(),
+            body: "fn realized(x: u32) -> u32 {\n    x.wrapping_add(1)\n}".to_string(),
             binding_cid: "cid:mock".to_string(),
         };
         let (out, outcomes) =

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -9,11 +9,12 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 use libprovekit::core::{
     execute_path, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
-    Verb,
+    RealizedSource, Verb,
 };
 // Source-transform primitives live in libprovekit (#1335 Phase A). The glob
-// re-export keeps existing call sites (notably in `materialize_source_text`)
-// unchanged after the extract-and-move.
+// re-export keeps the carrier-parsing surface available to `materialize_source_text`
+// after the extract-and-move; Phase C reroutes the per-site loop through
+// `transform_source_text` + the `SiteTransformKit` trait (#1337).
 pub(crate) use libprovekit::core::source_transform::*;
 use owo_colors::OwoColorize;
 use serde_json::Value as Json;
@@ -260,112 +261,165 @@ fn materialize_source_text(
     library_tag: Option<&str>,
     raw: &str,
 ) -> Result<(String, usize), String> {
-    let mut out = String::new();
-    let mut replacements = 0usize;
-    let lines = raw.split_inclusive('\n').collect::<Vec<_>>();
-    let mut idx = 0usize;
-    while idx < lines.len() {
-        let line = lines[idx];
-        if let Some((indent, payload)) = concept_payload_from_line(line) {
-            // Consume the carrier comment, optional payload-cid line, and
-            // the following stub function declaration. The carrier+stub
-            // pair is replaced by a single materialized function whose
-            // signature comes from the consumer's stub (preserving the
-            // consumer's signed claim, including generic params, lifetimes,
-            // and where-clauses) and whose body comes from the realize
-            // plugin's emission of the shim's signed binding (#1331 +
-            // #1332). The consumer's signature is the trade anchor; the
-            // shim's body is the supply that fills it.
-            let mut consumed = 1usize;
-            if idx + consumed < lines.len()
-                && concept_payload_cid_from_line(lines[idx + consumed]).is_some()
-            {
-                let declared_cid = concept_payload_cid_from_line(lines[idx + consumed]).unwrap();
-                verify_payload_cid(payload, declared_cid)?;
-                consumed += 1;
-            }
-            let stub_block = capture_stub_function_block(&lines[idx + consumed..]);
-            consumed += stub_block.line_count;
-
-            let spec = realize_spec_from_payload(payload)?;
-            let realized = realize_spec_via_path(project_root, target_lang, library_tag, spec)?;
-            let emitted = if let Some(stub) = stub_block.signature_and_close.as_ref() {
-                splice_realized_body_into_stub_signature(stub, &realized)
-            } else {
-                realized
-            };
-            let indented = indent_realized_source(&emitted, indent);
-            out.push_str(&indented);
-            if !indented.ends_with('\n') {
-                out.push('\n');
-            }
-            replacements += 1;
-            idx += consumed;
-            continue;
-        }
-        out.push_str(line);
-        idx += 1;
-    }
-    Ok((out, replacements))
+    let kit = MaterializeKit::new(target_lang, library_tag, project_root);
+    let (rewritten, outcomes) = transform_source_text(raw, &kit)?;
+    // `transform_source_text` returns `Err(reason)` on any `SiteOutcome::Refuse`
+    // (per Phase B's propagate-on-refuse contract), so the outcomes vec
+    // contains only `Materialize` / `LoudlyLossy` variants here. Both count
+    // as successful site replacements for materialize's CLI summary; the
+    // distinction (loud-bounded-loss vs byte-exact) is recorded in the
+    // outcomes for future receipt-envelope consumers (#1334 Phase E) but
+    // does not alter the CLI's per-file replacement count today.
+    let count = outcomes.len();
+    Ok((rewritten, count))
 }
 
-fn realize_spec_via_path(
-    project_root: &Path,
-    target_lang: &str,
-    library_tag: Option<&str>,
-    spec: Json,
-) -> Result<String, String> {
-    let mut inputs = HashMapInputCatalog::default();
-    let input_cid = inputs.insert(Input::Spec(spec));
-    let kit_name = library_tag
-        .map(|tag| format!("lower-{target_lang}-{tag}"))
-        .unwrap_or_else(|| format!("lower-{target_lang}"));
-    let path = Input::Path(Box::new(CorePath {
-        algebra: vec![PathAlgebra {
-            name: "lower".to_string(),
-            kit: kit_name.clone(),
-            inputs: vec![input_cid],
-            depends_on: vec![],
-            verb: Verb::Transform,
-        }],
-    }));
-    let mut registry = KitRegistry::default();
-    registry.register_with_platform_semantics(
-        kit_name,
-        LowerKit::new(
-            project_root.to_path_buf(),
-            target_lang.to_string(),
-            library_tag.map(str::to_string),
-            DispatchRealizeTransport,
-        ),
-        target_lang,
-        project_root.join(format!(
-            "implementations/{target_lang}/conformance/fixtures"
-        )),
-    );
-    let chain = execute_path(&path, &registry, &inputs).map_err(|error| {
-        error
-            .composition_refusal()
-            .and_then(|refusal| serde_json::to_string(refusal).ok())
-            .unwrap_or_else(|| error.to_string())
-    })?;
-    let realized =
-        LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(chain.terminal_claim())?;
-    // String-formatted CLI error rather than a structured gap-record memento:
-    // materialize is a build-pipeline workflow that does not emit a receipt
-    // memento (unlike cmd_bind_migrate which produces MigrateReceiptEnvelope
-    // with refusal_mementos per `2026-05-18-refuse-leg-short-circuit-ruling`).
-    // The CLI surface is the consumer; a string error suffices. If a future
-    // caller needs structured refusal for build-pipeline consumption, extend
-    // materialize to optionally emit a refusal receipt and route through the
-    // existing RefusalMemento machinery.
-    if realized.is_stub {
-        return Err(format!(
-            "realize plugin for `{target_lang}` library `{}` returned a stub",
-            library_tag.unwrap_or("default")
-        ));
+/// `SiteTransformKit` implementation for `provekit materialize`. The
+/// materialize CLI is the N=1 specialization of the unified site-
+/// transformation primitive: for each `provekit-concept:` carrier, build
+/// a realize-request spec, dispatch through the LowerKit `execute_path`
+/// composition (same flow Phase A's `realize_spec_via_path` used), and
+/// map the realize transport's response onto the trichotomy outcome
+/// (`Materialize`, `LoudlyLossy`, `Refuse`) per the substrate-honest
+/// first-principle (#1334).
+pub struct MaterializeKit<'root> {
+    target_lang: String,
+    library_tag: Option<String>,
+    project_root: &'root Path,
+}
+
+impl<'root> MaterializeKit<'root> {
+    pub fn new(
+        target_lang: &str,
+        library_tag: Option<&str>,
+        project_root: &'root Path,
+    ) -> Self {
+        Self {
+            target_lang: target_lang.to_string(),
+            library_tag: library_tag.map(str::to_string),
+            project_root,
+        }
     }
-    Ok(realized.source)
+
+    /// Execute the lower-kit composition path that turns a realize-request
+    /// spec into a `RealizedSource`. This is the kit method that owns the
+    /// `execute_path`+`KitRegistry`+`DispatchRealizeTransport` wiring Phase A's
+    /// `realize_spec_via_path` free function did inline.
+    fn realize_via_path(&self, spec: Json) -> Result<RealizedSource, String> {
+        let mut inputs = HashMapInputCatalog::default();
+        let input_cid = inputs.insert(Input::Spec(spec));
+        let kit_name = self
+            .library_tag
+            .as_deref()
+            .map(|tag| format!("lower-{}-{tag}", self.target_lang))
+            .unwrap_or_else(|| format!("lower-{}", self.target_lang));
+        let path = Input::Path(Box::new(CorePath {
+            algebra: vec![PathAlgebra {
+                name: "lower".to_string(),
+                kit: kit_name.clone(),
+                inputs: vec![input_cid],
+                depends_on: vec![],
+                verb: Verb::Transform,
+            }],
+        }));
+        let mut registry = KitRegistry::default();
+        registry.register_with_platform_semantics(
+            kit_name,
+            LowerKit::new(
+                self.project_root.to_path_buf(),
+                self.target_lang.clone(),
+                self.library_tag.clone(),
+                DispatchRealizeTransport,
+            ),
+            &self.target_lang,
+            self.project_root.join(format!(
+                "implementations/{}/conformance/fixtures",
+                self.target_lang
+            )),
+        );
+        let chain = execute_path(&path, &registry, &inputs).map_err(|error| {
+            error
+                .composition_refusal()
+                .and_then(|refusal| serde_json::to_string(refusal).ok())
+                .unwrap_or_else(|| error.to_string())
+        })?;
+        LowerKit::<DispatchRealizeTransport>::realized_source_from_claim(chain.terminal_claim())
+    }
+}
+
+impl SiteTransformKit for MaterializeKit<'_> {
+    fn target_language(&self) -> &str {
+        &self.target_lang
+    }
+
+    fn transform_site(&self, carrier: &CarrierComment) -> Result<SiteOutcome, String> {
+        // Reuse Phase A's permissive-defaults spec builder (which lives in
+        // libprovekit) by re-serializing the carrier's raw payload. The
+        // typed CarrierComment fields are equivalent; routing through
+        // `realize_spec_from_payload` keeps a single permissive-defaults
+        // surface across both code paths and preserves byte-identical
+        // realize-request shape against Phase A.
+        let spec = realize_spec_from_payload(&carrier.raw_payload)?;
+        let realized = self.realize_via_path(spec)?;
+        // String-formatted refusal sentence rather than a structured
+        // gap-record memento: materialize is a build-pipeline workflow
+        // that does not emit a receipt memento (unlike cmd_bind_migrate
+        // which produces MigrateReceiptEnvelope with refusal_mementos per
+        // `2026-05-18-refuse-leg-short-circuit-ruling`). Phase B's
+        // `transform_source_text` propagates `SiteOutcome::Refuse` as
+        // `Err(reason)` to the CLI, which suffices for the consumer surface.
+        if realized.is_stub {
+            return Ok(SiteOutcome::Refuse {
+                reason: format!(
+                    "realize plugin for `{}` library `{}` returned a stub",
+                    self.target_lang,
+                    self.library_tag.as_deref().unwrap_or("default")
+                ),
+                would_close_with_concept: carrier.concept_name.clone(),
+            });
+        }
+        let binding_cid = realized.emitted_artifact_cid.clone().unwrap_or_default();
+        if has_loss(&realized.observed_loss_record) {
+            Ok(SiteOutcome::LoudlyLossy {
+                body: realized.source,
+                binding_cid,
+                declared_loss: extract_loss_dims(&realized.observed_loss_record),
+            })
+        } else {
+            Ok(SiteOutcome::Materialize {
+                body: realized.source,
+                binding_cid,
+                loss_record: realized.observed_loss_record,
+            })
+        }
+    }
+}
+
+/// A loss record is "loss-bearing" when it is neither JSON null nor an
+/// empty object. `lower_plugin::loss_record_cid` uses the same predicate
+/// shape for deciding whether to mint a loss-record CID; matching it here
+/// keeps the `LoudlyLossy` vs `Materialize` split aligned with the kit
+/// binding's own honesty gradient.
+fn has_loss(record: &Json) -> bool {
+    match record {
+        Json::Null => false,
+        Json::Object(map) => !map.is_empty(),
+        _ => true,
+    }
+}
+
+/// Project an `observed_loss_record` JSON value onto the list of declared
+/// loss dimensions. Object keys are the named dimensions (matching the
+/// shape `merge_observed_loss_records` builds in `lower_plugin`); non-object
+/// records degrade to a single-element vec carrying the value's JSON
+/// rendering, so consumers always get a non-empty `declared_loss` for
+/// loss-bearing records.
+fn extract_loss_dims(record: &Json) -> Vec<String> {
+    match record {
+        Json::Object(map) => map.keys().cloned().collect(),
+        Json::Null => Vec::new(),
+        other => vec![other.to_string()],
+    }
 }
 
 fn print_dry_run(files: &[MaterializedFile]) -> Result<(), String> {


### PR DESCRIPTION
## Summary

Phase C of the umbrella refactor #1334.

- `cmd_materialize.rs` now uses `transform_source_text` + a new `MaterializeKit` that implements `SiteTransformKit`, instead of its own site-iteration loop. The materialize CLI is the N=1 specialization of the unified source-transformation primitive.
- The new kit dispatches realize via `execute_path` (same flow Phase A's `realize_spec_via_path` used) and maps the realize transport's response onto the trichotomy outcome (`Materialize`, `LoudlyLossy`, `Refuse`) per the substrate-honest first-principle.
- Phase B's `transform_source_text` had a body-shape contract whose no-stub branch emitted the kit's body verbatim. To preserve byte-identical behavior against Phase A's no-stub fallback (which emits the full realize source), this PR routes the stub-splice case through Phase A's `splice_realized_body_into_stub_signature` (which extracts the inner body before splicing). `MaterializeKit` returns the realize plugin's full `fn ... { ... }` declaration as `body`, the same shape the realize transport returns. The Phase B mock test is updated to pass a full fn decl as `body`, matching the now-coherent contract.

## Verification

- `cargo build --manifest-path implementations/rust/Cargo.toml -p libprovekit -p provekit-cli` clean.
- `cargo test -p libprovekit --lib` 87 passed.
- `cargo test -p provekit-cli --lib` 18 passed.
- `cargo test -p provekit-cli --test cmd_materialize_integration` same pass/fail set as `main` (6 pass / 6 fail). The 6 failing tests are pre-existing TypeScript-realize-Node environment issues unrelated to this PR.
- Byte-identical materialize check on `examples/rusqlite-demo-consumer/`: `diff /tmp/before.txt /tmp/after.txt` empty.
- Em-dash sweep clean.

Closes #1337.
Builds toward #1334.

## Test plan

- [x] libprovekit lib tests pass
- [x] provekit-cli lib tests pass
- [x] provekit-cli materialize integration tests: pass/fail set unchanged vs main
- [x] Byte-identical materialize output on rusqlite-demo-consumer
- [x] Em-dash sweep clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>