### PR TITLE
fix(cmd_materialize_integration): update stale summary assertions after #1345

### DIFF
--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -381,7 +381,7 @@ fn materialize_write_rewrites_source_file_in_place_and_reports_summary() {
         "materialize --write should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
-        stdout.contains("materialized 1 concept citation(s) across 1 file(s)"),
+        stdout.contains("materialized 1 exact + 0 lossy + 0 refused across 1 file(s)"),
         "write mode should report replacement summary: {stdout}"
     );
     let rewritten = fs::read_to_string(&source_path).expect("read rewritten source");
@@ -428,7 +428,7 @@ fn materialize_out_dir_writes_materialized_copy_and_leaves_source_unchanged() {
         "materialize --out-dir should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
-        stdout.contains("materialized 1 concept citation(s) across 1 file(s)"),
+        stdout.contains("materialized 1 exact + 0 lossy + 0 refused across 1 file(s)"),
         "out-dir mode should report replacement summary: {stdout}"
     );
     let copied = fs::read_to_string(out_dir.join("queries.ts")).expect("read materialized copy");


### PR DESCRIPTION
## Summary

PR #1345 (Phase E SourceTransformReceipt) replaced the materialize summary line \`\"materialized N concept citation(s) across M file(s)\"\` with the receipt-shaped \`\"materialized N exact + L lossy + R refused across M file(s)\"\`. Strictly more informative (separates the trichotomy verdicts) but two integration tests still matched the pre-#1345 string and panic on every CI run since.

## Failing tests

- \`materialize_write_rewrites_source_file_in_place_and_reports_summary\`
- \`materialize_out_dir_writes_materialized_copy_and_leaves_source_unchanged\`

## Fix

Update both \`assert!(stdout.contains(...))\` strings to the new shape.

## Test plan

- [x] Em-dash sweep clean
- [x] Commit identity: \`T Savo <evilgenius@nefariousplan.com>\`
- [x] Local: 1 passed
- [ ] CI: \`Cross-language conformance gate\` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `provekit materialize` command output to display a detailed breakdown of exact, lossy, and refused materializations across files, replacing the previous summary format in both `--write` and `--out-dir` modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->