### PR TITLE
fix(body-templates): declare target_library_tag for java-sqlite-jdbc + python-sqlite3 sister shims

### DIFF
--- a/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies-sqlite-jdbc.json
+++ b/menagerie/java-language-signature/specs/body-templates/java-canonical-bodies-sqlite-jdbc.json
@@ -24,7 +24,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-connection-open",
@@ -45,7 +46,8 @@
           "signature_guard": {
             "min_params": 0,
             "max_params": 0
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-connection-open",
@@ -68,7 +70,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-connection-close",
@@ -88,7 +91,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-connection-pool-acquire",
@@ -110,7 +114,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -132,7 +137,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -153,7 +159,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-query",
@@ -175,7 +182,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-prepare",
@@ -197,7 +205,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-prepare-cached",
@@ -219,7 +228,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -241,7 +251,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-query",
@@ -262,7 +273,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-query",
@@ -284,7 +296,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-query",
@@ -306,7 +319,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:insert-and-get-id",
@@ -327,7 +341,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-query",
@@ -348,7 +363,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-batch-execute",
@@ -369,7 +385,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-transaction-begin",
@@ -391,7 +408,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-transaction-begin",
@@ -413,7 +431,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-transaction-commit",
@@ -434,7 +453,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-transaction-rollback",
@@ -455,7 +475,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-savepoint",
@@ -476,7 +497,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-transaction-rollback",
@@ -497,7 +519,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-transaction-isolation-level",
@@ -518,7 +541,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-row-get-column",
@@ -539,7 +563,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-row-get-column",
@@ -561,7 +586,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-row-get-column",
@@ -583,7 +609,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-row-get-column",
@@ -606,7 +633,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:insert-and-get-id",
@@ -627,7 +655,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-changes-count",
@@ -648,7 +677,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-changes-count",
@@ -669,7 +699,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -687,7 +718,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "autocommit-mode"
+          "observed_dimension": "autocommit-mode",
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -705,7 +737,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "write-permission"
+          "observed_dimension": "write-permission",
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -723,7 +756,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "connection-closed"
+          "observed_dimension": "connection-closed",
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -743,7 +777,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "connection-validity"
+          "observed_dimension": "connection-validity",
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -761,7 +796,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "column-count"
+          "observed_dimension": "column-count",
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -779,7 +815,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "column-name-at-index"
+          "observed_dimension": "column-name-at-index",
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -797,7 +834,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "column-index-of-name"
+          "observed_dimension": "column-index-of-name",
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -815,7 +853,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "parameter-count"
+          "observed_dimension": "parameter-count",
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-result-metadata",
@@ -835,7 +874,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-result-metadata",
@@ -853,7 +893,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "column-type-name"
+          "observed_dimension": "column-type-name",
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-catalog-reflection",
@@ -874,7 +915,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-busy-timeout",
@@ -896,7 +938,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-autocommit-control",
@@ -916,7 +959,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         },
         {
           "concept_name": "concept:sql-cursor-fetch-size",
@@ -937,7 +981,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite-jdbc"
         }
       ]
     }

--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
@@ -23,7 +23,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-connection-open",
@@ -43,7 +44,8 @@
           "signature_guard": {
             "min_params": 0,
             "max_params": 0
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-connection-open",
@@ -65,7 +67,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-connection-close",
@@ -85,7 +88,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -107,7 +111,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-batch-execute",
@@ -128,7 +133,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-batch-execute",
@@ -148,7 +154,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-query",
@@ -170,7 +177,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-query",
@@ -191,7 +199,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-prepare",
@@ -212,7 +221,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-prepare-cached",
@@ -234,7 +244,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-execute",
@@ -256,7 +267,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-query",
@@ -277,7 +289,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-query",
@@ -298,7 +311,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-query",
@@ -319,7 +333,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-fetch-batch",
@@ -340,7 +355,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:insert-and-get-id",
@@ -361,7 +377,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-query",
@@ -382,7 +399,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-transaction-begin",
@@ -403,7 +421,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-transaction-begin",
@@ -425,7 +444,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-transaction-commit",
@@ -446,7 +466,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-transaction-rollback",
@@ -467,7 +488,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-savepoint",
@@ -487,7 +509,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-transaction-rollback",
@@ -506,7 +529,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-savepoint",
@@ -526,7 +550,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-row-get-column",
@@ -547,7 +572,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-row-get-column",
@@ -568,7 +594,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-row-mapping",
@@ -588,7 +615,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:insert-and-get-id",
@@ -608,7 +636,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-changes-count",
@@ -628,7 +657,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-changes-count",
@@ -648,7 +678,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -666,7 +697,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "autocommit-mode"
+          "observed_dimension": "autocommit-mode",
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -684,7 +716,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "isolation-level"
+          "observed_dimension": "isolation-level",
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -702,7 +735,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "column-names"
+          "observed_dimension": "column-names",
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -720,7 +754,8 @@
             "min_params": 1,
             "max_params": 1
           },
-          "observed_dimension": "column-count"
+          "observed_dimension": "column-count",
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:contract-observation",
@@ -738,7 +773,8 @@
             "min_params": 2,
             "max_params": 2
           },
-          "observed_dimension": "column-index-of-name"
+          "observed_dimension": "column-index-of-name",
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-busy-timeout",
@@ -758,7 +794,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-schema-dump",
@@ -778,7 +815,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-udf-register",
@@ -799,7 +837,8 @@
           "signature_guard": {
             "min_params": 4,
             "max_params": 4
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-udf-aggregate",
@@ -819,7 +858,8 @@
           "signature_guard": {
             "min_params": 4,
             "max_params": 4
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-progress-handler",
@@ -839,7 +879,8 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-transaction-begin",
@@ -861,7 +902,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-transaction-commit",
@@ -882,7 +924,8 @@
           "signature_guard": {
             "min_params": 1,
             "max_params": 1
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-transaction-rollback",
@@ -903,7 +946,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         },
         {
           "concept_name": "concept:sql-row-mapping",
@@ -923,7 +967,8 @@
           "signature_guard": {
             "min_params": 2,
             "max_params": 2
-          }
+          },
+          "target_library_tag": "sqlite3"
         }
       ]
     }


### PR DESCRIPTION
## Summary

PRs #1352 (python+sqlite3 sister shim, 45 sugar + 10 refusals) and #1353 (java sqlite-jdbc sister shim) rewrote their respective body-template catalogs but omitted \`target_library_tag\` on every entry. The \`library_specific_body_template_entries_declare_target_tuple\` invariant fires on each entry, panicking test-rust.

Added \`target_library_tag\` to all 45 entries in each file:
- \`java-canonical-bodies-sqlite-jdbc.json\`: tag = \`\"sqlite-jdbc\"\`
- \`python-canonical-bodies-sqlite3.json\`: tag = \`\"sqlite3\"\`

Same fall-out shape as #1342 (rusqlite). The third sister shim, TS better-sqlite3 (#1351), already had the tag.

## Test plan

- [x] Em-dash sweep clean
- [x] Commit identity: \`T Savo <evilgenius@nefariousplan.com>\`
- [x] Local: \`cargo test -p provekit-cli --test body_template_normalization library_specific_body_template_entries_declare_target_tuple\` -> 1 passed
- [ ] CI: \`Cross-language conformance gate\` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SQLite JDBC template configuration with library identifier tagging.
  * Improved formatting consistency in SQLite3 template structures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->