### PR TITLE
feat(realize): realization-fragment contract with imports flowing end-to-end (#1374)

### DIFF
--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -150,14 +150,57 @@ public final class RpcServer {
         String wrapperRecord = r.observationWrapperEmissionRecord() == null
                 ? ""
                 : ",\"observation_wrapper_emission_record\":" + r.observationWrapperEmissionRecord();
-        return "{\"source\":" + JsonUtil.quoted(r.source())
+        // #1374: extract FQN imports from the emitted source. Substrate-side
+        // assembly (Milestone C) deduplicates these and emits the idiomatic
+        // import block for the target language. The body itself can keep
+        // FQN-inline references (compiles either way); the imports field
+        // lets downstream tooling know what the fragment USES.
+        String importsJson = importsFromSource(r.source());
+        return "{\"kind\":\"realization-fragment\""
+                + ",\"source\":" + JsonUtil.quoted(r.source())
                 + ",\"emitted_artifact_cid\":"
                 + JsonUtil.quoted(Blake3.blake3_512(r.source().getBytes(StandardCharsets.UTF_8)))
                 + ",\"is_stub\":" + (r.isStub() ? "true" : "false")
                 + ",\"observed_loss_record\":" + r.observedLossRecord()
                 + ",\"used_sugars\":" + r.usedSugarsJson()
+                + ",\"imports\":" + importsJson
                 + wrapperRecord
                 + "}";
+    }
+
+    /**
+     * #1374: extract java FQN imports from the emitted source.
+     *
+     * Pattern: lowercase package segments separated by dots, then a
+     * PascalCase class name. Matches `com.fasterxml.jackson.databind.JsonNode`,
+     * `java.util.List`, `java.io.ByteArrayOutputStream`. Skips inner class
+     * suffixes (the matcher captures up to the FIRST PascalCase identifier;
+     * `JsonNode.NumberType` matches just `JsonNode`).
+     *
+     * Returns a JSON array of unique FQN strings sorted lexicographically.
+     */
+    private static String importsFromSource(String source) {
+        if (source == null || source.isEmpty()) return "[]";
+        java.util.regex.Pattern p = java.util.regex.Pattern.compile(
+            "\\b([a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)+\\.[A-Z][A-Za-z0-9_]*)"
+        );
+        java.util.regex.Matcher m = p.matcher(source);
+        java.util.TreeSet<String> imports = new java.util.TreeSet<>();
+        while (m.find()) {
+            String fqn = m.group(1);
+            // Skip java.lang.* — implicit in every compilation unit.
+            if (fqn.startsWith("java.lang.")) continue;
+            imports.add(fqn);
+        }
+        StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        for (String fqn : imports) {
+            if (!first) sb.append(',');
+            sb.append(JsonUtil.quoted(fqn));
+            first = false;
+        }
+        sb.append(']');
+        return sb.toString();
     }
 
     /**

--- a/implementations/rust/libprovekit/src/core/lower_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lower_plugin.rs
@@ -386,7 +386,17 @@ pub struct RealizeContractWitness {
     pub source_kind: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// #1374: structured realize-plugin response shape.
+///
+/// Realize plugins return a FRAGMENT — a per-site emission that says
+/// what the fragment IS plus what CONTEXT it needs (imports, helper
+/// declarations, dependencies, diagnostics, compile-unit requirements).
+/// Assembly (Milestone C, #1375) composes fragments into compilation
+/// units; the substrate doesn't bake file semantics into the CLI.
+///
+/// Backwards compatibility: legacy plugins return only `source` + `is_stub`
+/// (the other fields default to empty/None). New plugins populate them.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RealizedSource {
     pub extension: String,
     pub source: String,
@@ -395,6 +405,52 @@ pub struct RealizedSource {
     pub observed_loss_record: Value,
     pub used_sugars: Vec<Value>,
     pub observation_wrapper_emission_record: Option<Value>,
+
+    /// #1374: realization-fragment context.
+    ///
+    /// Symbols the fragment's emitted source uses from outside its own
+    /// body. Java: fully-qualified class names ("java.util.List",
+    /// "com.fasterxml.jackson.databind.JsonNode"). Rust: use-path strings
+    /// ("std::io::BufRead", "serde_json::Value"). Python: import names.
+    /// Assembly deduplicates these across fragments and emits the
+    /// import block(s) idiomatically for the target language.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub imports: Vec<String>,
+
+    /// Helper declarations the fragment needs in the surrounding
+    /// compilation unit. Each entry is a kit-specific shape with at
+    /// least a `name`, `kind` (static-field / static-init / function /
+    /// type-alias / module-private / etc.), and `source` (the helper's
+    /// declaration text). Assembly hoists these into the appropriate
+    /// scope (java: static fields in the class, static init blocks;
+    /// rust: const/lazy_static items; python: module-level).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub helpers: Vec<Value>,
+
+    /// Build-time dependencies the fragment requires. Each entry
+    /// declares (kind, coords): kind = "maven" / "cargo" / "pip" /
+    /// "npm" / "system"; coords = the kit's package-coordinate string
+    /// ("com.fasterxml.jackson.core:jackson-databind:2.17.0",
+    /// "serde_json = 1", ...). Assembly surfaces these to the user
+    /// (or auto-populates project files in future work).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<Value>,
+
+    /// Realize-side diagnostics — informational, warning, or error
+    /// notes the plugin wants to attach to the fragment. Each entry
+    /// is at least {severity: info/warn/error, message: string}.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<Value>,
+
+    /// Requirements the compilation unit must satisfy for this
+    /// fragment to compile cleanly. Kit-specific keys:
+    /// - java: `package`, `language_version`, `top_level` (class/interface/record)
+    /// - rust: `edition`, `module_path`
+    /// - python: `version`, `module`
+    /// Assembly reconciles requirements across fragments + materializes
+    /// the appropriate compilation-unit shell.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compile_unit_requirements: Option<Value>,
 }
 
 /// Transport boundary used by `LowerKit` to call the existing realize layer.

--- a/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
+++ b/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
@@ -164,6 +164,7 @@ impl RealizeTransport for CapturingTransport {
             observed_loss_record: json!({}),
             used_sugars: vec![],
             observation_wrapper_emission_record: None,
+            ..Default::default()
         })
     }
 }

--- a/implementations/rust/libprovekit/tests/recursive_composition_lower.rs
+++ b/implementations/rust/libprovekit/tests/recursive_composition_lower.rs
@@ -62,6 +62,7 @@ impl RealizeTransport for RecursiveTransport {
                 }),
                 used_sugars: vec![],
                 observation_wrapper_emission_record: None,
+                ..Default::default()
             }),
             "concept:log-emit" => {
                 let binding = request
@@ -101,6 +102,7 @@ impl RealizeTransport for RecursiveTransport {
                     }),
                     used_sugars: vec![],
                     observation_wrapper_emission_record: None,
+                    ..Default::default()
                 })
             }
             other => Err(format!("unexpected concept {other}")),

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -278,6 +278,44 @@ fn target_lang_file_extension(target_lang: &str) -> &'static str {
     }
 }
 
+/// #1374: wrap fragment-declared FQN imports as the target language's
+/// import-statement syntax. Stops here on substrate-side idiom — the rest
+/// (package declaration, class wrapping, helper placement) is Milestone C
+/// (target-owned assembly). Languages without a standard import-block
+/// syntax (or unsupported) get a comment-listing of the FQNs so the
+/// information isn't lost.
+fn format_imports_for(target_lang: &str, imports: &std::collections::BTreeSet<String>) -> String {
+    if imports.is_empty() { return String::new(); }
+    let lines: Vec<String> = match target_lang {
+        "java" => imports.iter().map(|fqn| format!("import {fqn};")).collect(),
+        "python" => imports.iter().map(|fqn| {
+            // Python convention: `import pkg.mod` for module-paths,
+            // `from pkg.mod import Name` when the FQN ends in a Class.
+            // Substrate-honest minimum: if the last segment starts with
+            // an uppercase letter, emit `from ... import Name`; else
+            // emit `import ...`.
+            let mut parts: Vec<&str> = fqn.split('.').collect();
+            if let Some(last) = parts.last().copied() {
+                if last.chars().next().is_some_and(|c| c.is_ascii_uppercase()) && parts.len() > 1 {
+                    parts.pop();
+                    return format!("from {} import {}", parts.join("."), last);
+                }
+            }
+            format!("import {}", fqn)
+        }).collect(),
+        "rust" => imports.iter().map(|fqn| format!("use {fqn};")).collect(),
+        "typescript" => imports.iter().map(|fqn| {
+            // TS imports require explicit named-bindings + module specifier;
+            // a bare FQN can't unambiguously become either ESM or CJS.
+            // Surface as a TODO comment until Milestone C's target-kit
+            // assembler decides.
+            format!("// TODO(#1375 assembly): import binding for `{}`", fqn)
+        }).collect(),
+        _ => imports.iter().map(|fqn| format!("// fragment import: {}", fqn)).collect(),
+    };
+    lines.join("\n")
+}
+
 /// Discrimated outcome of a cross-language discovery realize-probe.
 ///
 /// `None`-collapsed outcomes hide WHY the probe didn't succeed: a transport
@@ -287,8 +325,12 @@ fn target_lang_file_extension(target_lang: &str) -> &'static str {
 /// and skip without counting as a refuse; Preview → RESOLVE with emitted body.
 #[derive(Debug)]
 enum DiscoveryOutcome {
-    /// Realize plugin successfully emitted a body — full RESOLVE.
-    Preview(String),
+    /// Realize plugin successfully emitted a fragment — full RESOLVE.
+    /// #1374: carries the per-fragment context (imports) so materialize
+    /// can include realizer-declared imports in the emitted compilation
+    /// unit. `source` is the fragment body; `imports` is the
+    /// fully-qualified names the fragment uses from outside its own body.
+    Preview { source: String, imports: Vec<String> },
     /// Plugin ran but returned is_stub=true; the substrate has a real gap
     /// (no morphism for some sort CID, no body template for concept, etc.).
     SemanticGap,
@@ -331,7 +373,10 @@ fn invoke_target_realize_for_discovery(
     if response.is_stub {
         return DiscoveryOutcome::SemanticGap;
     }
-    DiscoveryOutcome::Preview(response.source)
+    DiscoveryOutcome::Preview {
+        source: response.source,
+        imports: response.imports,
+    }
 }
 
 /// #1361 chunk 2 part A / #1355: cross-language DISCOVERY mode.
@@ -443,7 +488,7 @@ fn run_cross_language_discovery(
                     // is REFUSE in the final tally — substrate surfaces
                     // gaps even when the family dispatch resolves.
                     match invoke_target_realize_for_discovery(project_root, target_lang, &matches[0], &carrier) {
-                        DiscoveryOutcome::Preview(body) => {
+                        DiscoveryOutcome::Preview { source: body, imports: fragment_imports } => {
                             resolves += 1;
                             eprintln!(
                                 "  {} {} @ {} → {} manifest `{}`",
@@ -461,6 +506,13 @@ fn run_cross_language_discovery(
                                     .entry(path.to_path_buf())
                                     .or_default();
                                 entry.bodies.push(body);
+                                // #1374: collect imports from both sources:
+                                //   1. fragment.imports (kit's per-fragment declaration)
+                                //   2. scope_bringings_for_realize (legacy manifest-level)
+                                // Both merge into the per-file deduplicated set.
+                                for imp in fragment_imports {
+                                    entry.imports.insert(imp);
+                                }
                                 let scope_imports = scope_bringings_for_realize(
                                     project_root,
                                     target_lang,
@@ -520,7 +572,7 @@ fn run_cross_language_discovery(
                         // actually emits; REFUSE only on substrate-gap (is_stub);
                         // WARN on transport failure (broken manifest/binary).
                         match invoke_target_realize_for_discovery(project_root, target_lang, &pick, &carrier) {
-                            DiscoveryOutcome::Preview(body) => {
+                            DiscoveryOutcome::Preview { source: body, imports: fragment_imports } => {
                                 resolves += 1;
                                 eprintln!(
                                     "  {} {} @ {} → {} manifest `{}` (disambiguated by --family-library)",
@@ -538,6 +590,10 @@ fn run_cross_language_discovery(
                                         .entry(path.to_path_buf())
                                         .or_default();
                                     entry.bodies.push(body);
+                                    // #1374: merge fragment.imports + scope_bringings.
+                                    for imp in fragment_imports {
+                                        entry.imports.insert(imp);
+                                    }
                                     let scope_imports = scope_bringings_for_realize(
                                         project_root,
                                         target_lang,
@@ -636,12 +692,11 @@ fn run_cross_language_discovery(
                     return EXIT_USER_ERROR;
                 }
             }
-            let imports_block = file
-                .imports
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>()
-                .join("\n");
+            // #1374: wrap raw FQN imports as the target language's import
+            // syntax. Substrate stops here on idiom; assembly (Milestone C
+            // / #1375) takes over deeper file-structure decisions (package
+            // declaration, class wrapping, package-level helpers).
+            let imports_block = format_imports_for(target_lang, &file.imports);
             let bodies_block = file.bodies.join("\n\n");
             let content = if imports_block.is_empty() {
                 format!("{bodies_block}\n")

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -1646,6 +1646,29 @@ fn invoke_realize(
     }
     let observation_wrapper_emission_record =
         result.get("observation_wrapper_emission_record").cloned();
+    // #1374: extract realization-fragment context if the realize plugin
+    // emitted it. Legacy plugins omit these fields; default-empty/None.
+    let imports = result
+        .get("imports")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(Value::as_str).map(String::from).collect())
+        .unwrap_or_default();
+    let helpers = result
+        .get("helpers")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let dependencies = result
+        .get("dependencies")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let diagnostics = result
+        .get("diagnostics")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let compile_unit_requirements = result.get("compile_unit_requirements").cloned();
     Ok(RealizedSource {
         extension,
         source,
@@ -1654,6 +1677,11 @@ fn invoke_realize(
         observed_loss_record,
         used_sugars,
         observation_wrapper_emission_record,
+        imports,
+        helpers,
+        dependencies,
+        diagnostics,
+        compile_unit_requirements,
     })
 }
 


### PR DESCRIPTION
## Summary

Closes #1374: realize-plugin response shape gains structured per-fragment context (imports/helpers/dependencies/diagnostics/compile_unit_requirements). Phase 1 (schema) + phase 2 (java extracts imports) + phase 3 (materialize wraps as language-appropriate import statements) all in this PR.

## What changed

**Schema extension (libprovekit + kit_dispatch):**

`RealizedSource` gains five new fields, all `#[serde(default)]` for backwards compatibility:
- `imports: Vec<String>` — FQN names the fragment uses from outside its body
- `helpers: Vec<Value>` — declarations needed in the surrounding compilation unit
- `dependencies: Vec<Value>` — build-time package coords
- `diagnostics: Vec<Value>` — realize-side info/warn/error notes
- `compile_unit_requirements: Option<Value>` — package/version/top-level kit-specific keys

**Java realize plugin populates imports:**

Regex-extract FQN-pattern matches from emitted source (`com.fasterxml.jackson.databind.JsonNode`), filter `java.lang.*` (implicit), sort, return as JSON array.

**Materialize wraps fragment imports as target-language syntax:**

`format_imports_for(target_lang, imports)` centralizes the wrapping:
- java: `import X;`
- python: `from pkg import Class` (uppercase last segment) / `import pkg.mod`
- rust: `use X;`
- typescript: TODO comment (needs Milestone C / #1375 assembly to resolve module specifiers)

**`DiscoveryOutcome::Preview` is now a struct variant** `{source, imports}` so the realize-side imports flow through to the substrate's per-file collector.

## Verification

Cross-language demo (rust → java):

```
materialize discovery: 9 site(s), 9 resolve + 0 ambiguous + 0 refused
EMIT wrote /tmp/rpc-1374d/lib.java (9 bodies, 1 imports)
```

Emitted java header:

```java
import com.fasterxml.jackson.databind.JsonNode;

final class StdinReadLineTransported { ... }
```

Was: bare `com.fasterxml.jackson.databind.JsonNode` text (neither valid java nor a valid import block).

## What's still missing for compilable output

The compile-check gate (#1376) will report what's still broken:
- No package declaration
- No top-level class wrapping (today's `lib.java` has multiple `final class` declarations at top level — only one public allowed)
- Helpers (e.g. static `ObjectMapper`) not yet emitted by realizers
- Static initializers not aggregated

Those all belong in **Milestone C (#1375) — target-owned assembly**, where each kit ships its own compilation-unit assembler.

## Out of scope (filed)

- #1375 Milestone C: target-owned assembly (kit ships assembler)
- Realize-plugin helpers/dependencies/diagnostics population — schema is there; realizers populate as they need it.

## Test plan

- [ ] Cross-language demo still 9/9 resolve
- [ ] /tmp/<out-dir>/lib.java starts with a valid `import X;` line
- [ ] Legacy realize plugins that don't emit `imports` field still work (serde default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)