### PR TITLE
feat(materialize): target-owned compilation-unit assembly (#1375 Milestone C)

### DIFF
--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -150,14 +150,57 @@ public final class RpcServer {
         String wrapperRecord = r.observationWrapperEmissionRecord() == null
                 ? ""
                 : ",\"observation_wrapper_emission_record\":" + r.observationWrapperEmissionRecord();
-        return "{\"source\":" + JsonUtil.quoted(r.source())
+        // #1374: extract FQN imports from the emitted source. Substrate-side
+        // assembly (Milestone C) deduplicates these and emits the idiomatic
+        // import block for the target language. The body itself can keep
+        // FQN-inline references (compiles either way); the imports field
+        // lets downstream tooling know what the fragment USES.
+        String importsJson = importsFromSource(r.source());
+        return "{\"kind\":\"realization-fragment\""
+                + ",\"source\":" + JsonUtil.quoted(r.source())
                 + ",\"emitted_artifact_cid\":"
                 + JsonUtil.quoted(Blake3.blake3_512(r.source().getBytes(StandardCharsets.UTF_8)))
                 + ",\"is_stub\":" + (r.isStub() ? "true" : "false")
                 + ",\"observed_loss_record\":" + r.observedLossRecord()
                 + ",\"used_sugars\":" + r.usedSugarsJson()
+                + ",\"imports\":" + importsJson
                 + wrapperRecord
                 + "}";
+    }
+
+    /**
+     * #1374: extract java FQN imports from the emitted source.
+     *
+     * Pattern: lowercase package segments separated by dots, then a
+     * PascalCase class name. Matches `com.fasterxml.jackson.databind.JsonNode`,
+     * `java.util.List`, `java.io.ByteArrayOutputStream`. Skips inner class
+     * suffixes (the matcher captures up to the FIRST PascalCase identifier;
+     * `JsonNode.NumberType` matches just `JsonNode`).
+     *
+     * Returns a JSON array of unique FQN strings sorted lexicographically.
+     */
+    private static String importsFromSource(String source) {
+        if (source == null || source.isEmpty()) return "[]";
+        java.util.regex.Pattern p = java.util.regex.Pattern.compile(
+            "\\b([a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)+\\.[A-Z][A-Za-z0-9_]*)"
+        );
+        java.util.regex.Matcher m = p.matcher(source);
+        java.util.TreeSet<String> imports = new java.util.TreeSet<>();
+        while (m.find()) {
+            String fqn = m.group(1);
+            // Skip java.lang.* — implicit in every compilation unit.
+            if (fqn.startsWith("java.lang.")) continue;
+            imports.add(fqn);
+        }
+        StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        for (String fqn : imports) {
+            if (!first) sb.append(',');
+            sb.append(JsonUtil.quoted(fqn));
+            first = false;
+        }
+        sb.append(']');
+        return sb.toString();
     }
 
     /**

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -48,6 +48,15 @@ public final class RpcServer {
                     String resultObj = handleInvoke(line);
                     sendResponse(id, resultObj);
                 }
+                // #1375 Milestone C: target-owned assembly. Substrate sends a
+                // batch of fragments + a destination hint; java decides file
+                // layout (package, imports, class wrapping, helper placement)
+                // and returns the files to write. Substrate stops baking
+                // java's file syntax.
+                case "provekit.plugin.assemble" -> {
+                    String resultObj = handleAssemble(line);
+                    sendResponse(id, resultObj);
+                }
                 case "provekit.plugin.shutdown" -> {
                     sendResponse(id, "null");
                     System.exit(0);
@@ -86,6 +95,146 @@ public final class RpcServer {
      * entry rendered a real body. cmd_bind uses this to emit accurate
      * per-concept `bind-stub-body-emitted` gap entries per body-template-memento.md §5.
      */
+    /**
+     * #1375 Milestone C: target-owned compilation-unit assembly.
+     *
+     * Substrate sends the kit the fragments it collected for one source
+     * file + a destination hint (file_basename, optional package_hint).
+     * The kit decides:
+     *   - file names (may split into multiple files)
+     *   - package declaration
+     *   - import block (dedupe across fragments)
+     *   - class wrapping (one or many)
+     *   - helper placement (static fields, init blocks)
+     *
+     * Returns a list of {path, content} pairs that the substrate writes
+     * verbatim to the out-dir. The substrate stops baking java's file
+     * syntax — that decision lives here now.
+     *
+     * Request shape:
+     *   {"target_lang":"java","file_basename":"lib","package_hint":"...",
+     *    "fragments":[{
+     *       "concept_name":"...",
+     *       "source":"...",
+     *       "imports":[...],
+     *       "helpers":[...],
+     *       "dependencies":[...],
+     *       "diagnostics":[...],
+     *       "compile_unit_requirements":{...}
+     *    }, ...]}
+     *
+     * Response shape:
+     *   {"files":[{"path":"Lib.java","content":"..."}]}
+     */
+    private String handleAssemble(String line) {
+        String paramsObj = JsonUtil.extractParamsObject(line);
+        String fileBasename = JsonUtil.decodeJsonStringField(paramsObj, "file_basename");
+        if (fileBasename == null || fileBasename.isBlank()) fileBasename = "lib";
+        String packageHint = JsonUtil.decodeJsonStringField(paramsObj, "package_hint");
+        String fragmentsJson = JsonUtil.extractArrayField(paramsObj, "fragments");
+
+        // Parse fragments + collect imports/sources.
+        java.util.TreeSet<String> mergedImports = new java.util.TreeSet<>();
+        java.util.List<String> bodies = new java.util.ArrayList<>();
+        try {
+            com.provekit.ir.Jcs.Json doc = com.provekit.ir.Jcs.parse(fragmentsJson);
+            if (doc instanceof com.provekit.ir.Jcs.Arr arr) {
+                for (com.provekit.ir.Jcs.Json item : arr.values()) {
+                    if (!(item instanceof com.provekit.ir.Jcs.Obj o)) continue;
+                    String src = o.stringFieldOrNull("source");
+                    if (src != null && !src.isBlank()) bodies.add(src);
+                    com.provekit.ir.Jcs.Json importsArr = o.get("imports");
+                    if (importsArr instanceof com.provekit.ir.Jcs.Arr ia) {
+                        for (com.provekit.ir.Jcs.Json v : ia.values()) {
+                            if (v instanceof com.provekit.ir.Jcs.Str s) {
+                                String fqn = s.value();
+                                if (!fqn.startsWith("java.lang.")) mergedImports.add(fqn);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (RuntimeException ignored) {
+            // Substrate-honest: malformed fragments → empty compilation unit.
+        }
+
+        // Class name: PascalCase from file basename.
+        String className = toPascalCase(fileBasename);
+        StringBuilder out = new StringBuilder();
+        if (packageHint != null && !packageHint.isBlank()) {
+            out.append("package ").append(packageHint).append(";\n\n");
+        }
+        for (String imp : mergedImports) {
+            out.append("import ").append(imp).append(";\n");
+        }
+        if (!mergedImports.isEmpty()) out.append('\n');
+        out.append("public final class ").append(className).append(" {\n");
+        for (int i = 0; i < bodies.size(); i++) {
+            String body = bodies.get(i);
+            // Strip outer wrapper class if the fragment came pre-wrapped.
+            // Realizers historically emit `final class FooTransported { method }`;
+            // the assembler peels that to get just the methods. Detected by
+            // a `class` keyword followed by `{` on the first non-comment line.
+            String unwrapped = stripWrappingClass(body);
+            for (String line2 : unwrapped.split("\n", -1)) {
+                if (line2.isEmpty()) {
+                    out.append('\n');
+                } else {
+                    out.append("    ").append(line2).append('\n');
+                }
+            }
+            if (i + 1 < bodies.size()) out.append('\n');
+        }
+        out.append("}\n");
+
+        // Single file response for now.
+        String filePath = className + ".java";
+        return "{\"files\":[{"
+            + "\"path\":" + JsonUtil.quoted(filePath)
+            + ",\"content\":" + JsonUtil.quoted(out.toString())
+            + "}]}";
+    }
+
+    /** PascalCase from snake-case or kebab-case file basename. */
+    private static String toPascalCase(String basename) {
+        StringBuilder sb = new StringBuilder();
+        boolean upNext = true;
+        for (int i = 0; i < basename.length(); i++) {
+            char c = basename.charAt(i);
+            if (c == '_' || c == '-' || c == '.') {
+                upNext = true;
+            } else if (upNext) {
+                sb.append(Character.toUpperCase(c));
+                upNext = false;
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.length() == 0 ? "Lib" : sb.toString();
+    }
+
+    /**
+     * Strip an outer `final class Foo { ... }` wrapper if present, returning
+     * just the inner body. Realizers historically wrap each method in a
+     * per-concept final class; the assembler collects them into one outer
+     * class, so the inner wrappers must be peeled.
+     *
+     * Returns the original body unchanged if no wrapper is detected.
+     */
+    private static String stripWrappingClass(String body) {
+        String trimmed = body.trim();
+        // Look for "final class <Name> {" near the start, optionally
+        // preceded by comments.
+        java.util.regex.Pattern p = java.util.regex.Pattern.compile(
+            "(?s)^\\s*(?://[^\\n]*\\n\\s*)*(?:final\\s+|public\\s+)?class\\s+\\w+\\s*\\{(.*)\\}\\s*$"
+        );
+        java.util.regex.Matcher m = p.matcher(trimmed);
+        if (m.matches()) {
+            return m.group(1).trim();
+        }
+        return body;
+    }
+
     private String handleInvoke(String line) {
         // Extract the inner params object to avoid ambiguity with the RPC "params" key.
         String paramsObj = JsonUtil.extractParamsObject(line);

--- a/implementations/rust/libprovekit/src/core/lower_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lower_plugin.rs
@@ -386,7 +386,17 @@ pub struct RealizeContractWitness {
     pub source_kind: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// #1374: structured realize-plugin response shape.
+///
+/// Realize plugins return a FRAGMENT — a per-site emission that says
+/// what the fragment IS plus what CONTEXT it needs (imports, helper
+/// declarations, dependencies, diagnostics, compile-unit requirements).
+/// Assembly (Milestone C, #1375) composes fragments into compilation
+/// units; the substrate doesn't bake file semantics into the CLI.
+///
+/// Backwards compatibility: legacy plugins return only `source` + `is_stub`
+/// (the other fields default to empty/None). New plugins populate them.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RealizedSource {
     pub extension: String,
     pub source: String,
@@ -395,6 +405,52 @@ pub struct RealizedSource {
     pub observed_loss_record: Value,
     pub used_sugars: Vec<Value>,
     pub observation_wrapper_emission_record: Option<Value>,
+
+    /// #1374: realization-fragment context.
+    ///
+    /// Symbols the fragment's emitted source uses from outside its own
+    /// body. Java: fully-qualified class names ("java.util.List",
+    /// "com.fasterxml.jackson.databind.JsonNode"). Rust: use-path strings
+    /// ("std::io::BufRead", "serde_json::Value"). Python: import names.
+    /// Assembly deduplicates these across fragments and emits the
+    /// import block(s) idiomatically for the target language.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub imports: Vec<String>,
+
+    /// Helper declarations the fragment needs in the surrounding
+    /// compilation unit. Each entry is a kit-specific shape with at
+    /// least a `name`, `kind` (static-field / static-init / function /
+    /// type-alias / module-private / etc.), and `source` (the helper's
+    /// declaration text). Assembly hoists these into the appropriate
+    /// scope (java: static fields in the class, static init blocks;
+    /// rust: const/lazy_static items; python: module-level).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub helpers: Vec<Value>,
+
+    /// Build-time dependencies the fragment requires. Each entry
+    /// declares (kind, coords): kind = "maven" / "cargo" / "pip" /
+    /// "npm" / "system"; coords = the kit's package-coordinate string
+    /// ("com.fasterxml.jackson.core:jackson-databind:2.17.0",
+    /// "serde_json = 1", ...). Assembly surfaces these to the user
+    /// (or auto-populates project files in future work).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<Value>,
+
+    /// Realize-side diagnostics — informational, warning, or error
+    /// notes the plugin wants to attach to the fragment. Each entry
+    /// is at least {severity: info/warn/error, message: string}.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<Value>,
+
+    /// Requirements the compilation unit must satisfy for this
+    /// fragment to compile cleanly. Kit-specific keys:
+    /// - java: `package`, `language_version`, `top_level` (class/interface/record)
+    /// - rust: `edition`, `module_path`
+    /// - python: `version`, `module`
+    /// Assembly reconciles requirements across fragments + materializes
+    /// the appropriate compilation-unit shell.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compile_unit_requirements: Option<Value>,
 }
 
 /// Transport boundary used by `LowerKit` to call the existing realize layer.

--- a/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
+++ b/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
@@ -164,6 +164,7 @@ impl RealizeTransport for CapturingTransport {
             observed_loss_record: json!({}),
             used_sugars: vec![],
             observation_wrapper_emission_record: None,
+            ..Default::default()
         })
     }
 }

--- a/implementations/rust/libprovekit/tests/recursive_composition_lower.rs
+++ b/implementations/rust/libprovekit/tests/recursive_composition_lower.rs
@@ -62,6 +62,7 @@ impl RealizeTransport for RecursiveTransport {
                 }),
                 used_sugars: vec![],
                 observation_wrapper_emission_record: None,
+                ..Default::default()
             }),
             "concept:log-emit" => {
                 let binding = request
@@ -101,6 +102,7 @@ impl RealizeTransport for RecursiveTransport {
                     }),
                     used_sugars: vec![],
                     observation_wrapper_emission_record: None,
+                    ..Default::default()
                 })
             }
             other => Err(format!("unexpected concept {other}")),

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -256,6 +256,17 @@ struct EmittedFile {
     bodies: Vec<String>,
     /// Scope-bringings deduplicated across all libraries used in this file.
     imports: std::collections::BTreeSet<String>,
+    /// #1375 Milestone C: per-fragment objects for target-owned assembly.
+    /// Each entry is the realize-fragment JSON shape (source + imports +
+    /// helpers + dependencies + diagnostics + compile_unit_requirements +
+    /// concept_name) that the target kit's assembler consumes to produce
+    /// a compilation unit. Substrate keeps these alongside the legacy
+    /// bodies+imports so it can fall back to concatenation if the kit
+    /// doesn't implement the assemble RPC.
+    fragments: Vec<serde_json::Value>,
+    /// Target manifest used for this file's emission (kept so the
+    /// substrate knows which kit to call for assemble).
+    target_manifest: Option<String>,
 }
 
 /// Map a target language to a file extension. Substrate-honest fallback
@@ -505,11 +516,15 @@ fn run_cross_language_discovery(
                                 let entry = emitted
                                     .entry(path.to_path_buf())
                                     .or_default();
+                                // #1375 Milestone C: record the fragment shape
+                                // so target-kit assemble can consume it.
+                                entry.fragments.push(serde_json::json!({
+                                    "concept_name": carrier.concept_name,
+                                    "source": body.clone(),
+                                    "imports": fragment_imports.clone(),
+                                }));
+                                entry.target_manifest = Some(matches[0].clone());
                                 entry.bodies.push(body);
-                                // #1374: collect imports from both sources:
-                                //   1. fragment.imports (kit's per-fragment declaration)
-                                //   2. scope_bringings_for_realize (legacy manifest-level)
-                                // Both merge into the per-file deduplicated set.
                                 for imp in fragment_imports {
                                     entry.imports.insert(imp);
                                 }
@@ -589,8 +604,15 @@ fn run_cross_language_discovery(
                                     let entry = emitted
                                         .entry(path.to_path_buf())
                                         .or_default();
+                                    // #1375 Milestone C: record fragment for
+                                    // target-kit assemble.
+                                    entry.fragments.push(serde_json::json!({
+                                        "concept_name": carrier.concept_name,
+                                        "source": body.clone(),
+                                        "imports": fragment_imports.clone(),
+                                    }));
+                                    entry.target_manifest = Some(pick.clone());
                                     entry.bodies.push(body);
-                                    // #1374: merge fragment.imports + scope_bringings.
                                     for imp in fragment_imports {
                                         entry.imports.insert(imp);
                                     }
@@ -692,10 +714,66 @@ fn run_cross_language_discovery(
                     return EXIT_USER_ERROR;
                 }
             }
-            // #1374: wrap raw FQN imports as the target language's import
-            // syntax. Substrate stops here on idiom; assembly (Milestone C
-            // / #1375) takes over deeper file-structure decisions (package
-            // declaration, class wrapping, package-level helpers).
+            // #1375 Milestone C: route compilation-unit assembly to the
+            // target kit. The kit decides file layout, package, imports,
+            // class wrapping. Fall back to substrate-side legacy concat
+            // when the kit doesn't implement assemble (method-not-found).
+            let file_basename = rel
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("lib");
+            let fragments_json = serde_json::to_string(&file.fragments)
+                .unwrap_or_else(|_| "[]".to_string());
+            let mut wrote_assembled = false;
+            if let Some(manifest) = file.target_manifest.as_deref() {
+                use crate::kit_dispatch::{dispatch_assemble, AssembleError};
+                match dispatch_assemble(
+                    project_root,
+                    target_lang,
+                    Some(manifest),
+                    &fragments_json,
+                    file_basename,
+                    None,
+                ) {
+                    Ok(assembled_files) => {
+                        for af in &assembled_files {
+                            let assembled_path = out_dir_path.join(&af.path);
+                            if let Some(parent) = assembled_path.parent() {
+                                let _ = std::fs::create_dir_all(parent);
+                            }
+                            if let Err(err) = std::fs::write(&assembled_path, &af.content) {
+                                eprintln!(
+                                    "{}: failed to write {}: {err}",
+                                    "error".red().bold(),
+                                    assembled_path.display()
+                                );
+                                return EXIT_USER_ERROR;
+                            }
+                            eprintln!(
+                                "  {} wrote {} (target-owned assembly via {} kit)",
+                                "EMIT".green().bold(),
+                                assembled_path.display(),
+                                target_lang,
+                            );
+                            files_written += 1;
+                        }
+                        wrote_assembled = true;
+                    }
+                    Err(AssembleError::MethodNotSupported) => {
+                        // Legacy kit — fall through to substrate concat.
+                    }
+                    Err(AssembleError::Failed(err)) => {
+                        eprintln!(
+                            "  {}: target-kit assemble failed (falling back to legacy concat): {err}",
+                            "WARN".yellow().bold(),
+                        );
+                    }
+                }
+            }
+            if wrote_assembled {
+                continue;
+            }
+            // Legacy concat path (substrate bakes language syntax).
             let imports_block = format_imports_for(target_lang, &file.imports);
             let bodies_block = file.bodies.join("\n\n");
             let content = if imports_block.is_empty() {

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -278,6 +278,44 @@ fn target_lang_file_extension(target_lang: &str) -> &'static str {
     }
 }
 
+/// #1374: wrap fragment-declared FQN imports as the target language's
+/// import-statement syntax. Stops here on substrate-side idiom — the rest
+/// (package declaration, class wrapping, helper placement) is Milestone C
+/// (target-owned assembly). Languages without a standard import-block
+/// syntax (or unsupported) get a comment-listing of the FQNs so the
+/// information isn't lost.
+fn format_imports_for(target_lang: &str, imports: &std::collections::BTreeSet<String>) -> String {
+    if imports.is_empty() { return String::new(); }
+    let lines: Vec<String> = match target_lang {
+        "java" => imports.iter().map(|fqn| format!("import {fqn};")).collect(),
+        "python" => imports.iter().map(|fqn| {
+            // Python convention: `import pkg.mod` for module-paths,
+            // `from pkg.mod import Name` when the FQN ends in a Class.
+            // Substrate-honest minimum: if the last segment starts with
+            // an uppercase letter, emit `from ... import Name`; else
+            // emit `import ...`.
+            let mut parts: Vec<&str> = fqn.split('.').collect();
+            if let Some(last) = parts.last().copied() {
+                if last.chars().next().is_some_and(|c| c.is_ascii_uppercase()) && parts.len() > 1 {
+                    parts.pop();
+                    return format!("from {} import {}", parts.join("."), last);
+                }
+            }
+            format!("import {}", fqn)
+        }).collect(),
+        "rust" => imports.iter().map(|fqn| format!("use {fqn};")).collect(),
+        "typescript" => imports.iter().map(|fqn| {
+            // TS imports require explicit named-bindings + module specifier;
+            // a bare FQN can't unambiguously become either ESM or CJS.
+            // Surface as a TODO comment until Milestone C's target-kit
+            // assembler decides.
+            format!("// TODO(#1375 assembly): import binding for `{}`", fqn)
+        }).collect(),
+        _ => imports.iter().map(|fqn| format!("// fragment import: {}", fqn)).collect(),
+    };
+    lines.join("\n")
+}
+
 /// Discrimated outcome of a cross-language discovery realize-probe.
 ///
 /// `None`-collapsed outcomes hide WHY the probe didn't succeed: a transport
@@ -287,8 +325,12 @@ fn target_lang_file_extension(target_lang: &str) -> &'static str {
 /// and skip without counting as a refuse; Preview → RESOLVE with emitted body.
 #[derive(Debug)]
 enum DiscoveryOutcome {
-    /// Realize plugin successfully emitted a body — full RESOLVE.
-    Preview(String),
+    /// Realize plugin successfully emitted a fragment — full RESOLVE.
+    /// #1374: carries the per-fragment context (imports) so materialize
+    /// can include realizer-declared imports in the emitted compilation
+    /// unit. `source` is the fragment body; `imports` is the
+    /// fully-qualified names the fragment uses from outside its own body.
+    Preview { source: String, imports: Vec<String> },
     /// Plugin ran but returned is_stub=true; the substrate has a real gap
     /// (no morphism for some sort CID, no body template for concept, etc.).
     SemanticGap,
@@ -331,7 +373,10 @@ fn invoke_target_realize_for_discovery(
     if response.is_stub {
         return DiscoveryOutcome::SemanticGap;
     }
-    DiscoveryOutcome::Preview(response.source)
+    DiscoveryOutcome::Preview {
+        source: response.source,
+        imports: response.imports,
+    }
 }
 
 /// #1361 chunk 2 part A / #1355: cross-language DISCOVERY mode.
@@ -443,7 +488,7 @@ fn run_cross_language_discovery(
                     // is REFUSE in the final tally — substrate surfaces
                     // gaps even when the family dispatch resolves.
                     match invoke_target_realize_for_discovery(project_root, target_lang, &matches[0], &carrier) {
-                        DiscoveryOutcome::Preview(body) => {
+                        DiscoveryOutcome::Preview { source: body, imports: fragment_imports } => {
                             resolves += 1;
                             eprintln!(
                                 "  {} {} @ {} → {} manifest `{}`",
@@ -461,6 +506,13 @@ fn run_cross_language_discovery(
                                     .entry(path.to_path_buf())
                                     .or_default();
                                 entry.bodies.push(body);
+                                // #1374: collect imports from both sources:
+                                //   1. fragment.imports (kit's per-fragment declaration)
+                                //   2. scope_bringings_for_realize (legacy manifest-level)
+                                // Both merge into the per-file deduplicated set.
+                                for imp in fragment_imports {
+                                    entry.imports.insert(imp);
+                                }
                                 let scope_imports = scope_bringings_for_realize(
                                     project_root,
                                     target_lang,
@@ -520,7 +572,7 @@ fn run_cross_language_discovery(
                         // actually emits; REFUSE only on substrate-gap (is_stub);
                         // WARN on transport failure (broken manifest/binary).
                         match invoke_target_realize_for_discovery(project_root, target_lang, &pick, &carrier) {
-                            DiscoveryOutcome::Preview(body) => {
+                            DiscoveryOutcome::Preview { source: body, imports: fragment_imports } => {
                                 resolves += 1;
                                 eprintln!(
                                     "  {} {} @ {} → {} manifest `{}` (disambiguated by --family-library)",
@@ -538,6 +590,10 @@ fn run_cross_language_discovery(
                                         .entry(path.to_path_buf())
                                         .or_default();
                                     entry.bodies.push(body);
+                                    // #1374: merge fragment.imports + scope_bringings.
+                                    for imp in fragment_imports {
+                                        entry.imports.insert(imp);
+                                    }
                                     let scope_imports = scope_bringings_for_realize(
                                         project_root,
                                         target_lang,
@@ -636,12 +692,11 @@ fn run_cross_language_discovery(
                     return EXIT_USER_ERROR;
                 }
             }
-            let imports_block = file
-                .imports
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>()
-                .join("\n");
+            // #1374: wrap raw FQN imports as the target language's import
+            // syntax. Substrate stops here on idiom; assembly (Milestone C
+            // / #1375) takes over deeper file-structure decisions (package
+            // declaration, class wrapping, package-level helpers).
+            let imports_block = format_imports_for(target_lang, &file.imports);
             let bodies_block = file.bodies.join("\n\n");
             let content = if imports_block.is_empty() {
                 format!("{bodies_block}\n")

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -1685,6 +1685,138 @@ fn invoke_realize(
     })
 }
 
+/// #1375 Milestone C: one file in a target-owned compilation-unit emission.
+#[derive(Debug, Clone)]
+pub struct AssembledFile {
+    pub path: String,
+    pub content: String,
+}
+
+/// Substrate-honest error from dispatch_assemble. Carries a discriminator so
+/// the caller can distinguish "plugin doesn't implement assemble" (fall back
+/// to legacy concat) from "plugin errored" (surface to user).
+#[derive(Debug)]
+pub enum AssembleError {
+    /// The plugin returned -32601 (method not found). Caller should fall
+    /// back to substrate's legacy concatenation logic.
+    MethodNotSupported,
+    /// Something else broke. Caller should treat as a transport error.
+    Failed(String),
+}
+
+/// #1375 Milestone C: route compilation-unit assembly to the target kit.
+///
+/// The substrate sends the kit a batch of fragments (one per @boundary site
+/// in a source file) + a destination hint, and the kit decides file
+/// layout (package, imports, class wrapping, helper placement).
+///
+/// `fragments_json` is the raw JSON array of fragment objects (one per
+/// site); each entry should have at least `source`, `imports`, etc., per
+/// the realization-fragment shape (#1374).
+pub fn dispatch_assemble(
+    workspace_root: &Path,
+    target_lang: &str,
+    library_tag: Option<&str>,
+    fragments_json: &str,
+    file_basename: &str,
+    package_hint: Option<&str>,
+) -> Result<Vec<AssembledFile>, AssembleError> {
+    let resolved = resolve_realize_command(workspace_root, target_lang, library_tag, None, None)
+        .map_err(|e| AssembleError::Failed(e.detail))?;
+    if resolved.argv.is_empty() {
+        return Err(AssembleError::Failed("empty command".to_string()));
+    }
+    let mut command = Command::new(&resolved.argv[0]);
+    if resolved.argv.len() > 1 {
+        command.args(&resolved.argv[1..]);
+    }
+    if let Some(wd) = &resolved.working_dir {
+        command.current_dir(wd);
+    }
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::null());
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| AssembleError::Failed(format!("spawn assemble kit: {e}")))?;
+
+    let fragments_value: Value = serde_json::from_str(fragments_json)
+        .map_err(|e| AssembleError::Failed(format!("fragments_json not valid JSON: {e}")))?;
+    let mut params = serde_json::Map::new();
+    params.insert("target_lang".to_string(), Value::String(target_lang.to_string()));
+    params.insert("file_basename".to_string(), Value::String(file_basename.to_string()));
+    if let Some(pkg) = package_hint {
+        params.insert("package_hint".to_string(), Value::String(pkg.to_string()));
+    }
+    params.insert("fragments".to_string(), fragments_value);
+
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.assemble",
+        "params": Value::Object(params),
+    });
+
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| AssembleError::Failed("assemble kit stdin unavailable".to_string()))?;
+        let req_str = serde_json::to_string(&req).expect("serialize assemble request");
+        stdin
+            .write_all(req_str.as_bytes())
+            .and_then(|()| stdin.write_all(b"\n"))
+            .map_err(|e| AssembleError::Failed(format!("write assemble request: {e}")))?;
+    }
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| AssembleError::Failed("assemble kit stdout unavailable".to_string()))?;
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .map_err(|e| AssembleError::Failed(format!("read assemble response: {e}")))?;
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let v: Value = serde_json::from_str(line.trim())
+        .map_err(|e| AssembleError::Failed(format!("assemble response not valid JSON: {e}")))?;
+    if let Some(err) = v.get("error") {
+        // -32601 is JSON-RPC's "method not found" — legacy kits without
+        // the assemble RPC return this. Caller falls back to legacy concat.
+        let code = err.get("code").and_then(Value::as_i64).unwrap_or(0);
+        if code == -32601 {
+            return Err(AssembleError::MethodNotSupported);
+        }
+        return Err(AssembleError::Failed(format!("assemble kit error: {err}")));
+    }
+    let result = v
+        .get("result")
+        .ok_or_else(|| AssembleError::Failed("assemble response missing result".to_string()))?;
+    let files_arr = result
+        .get("files")
+        .and_then(Value::as_array)
+        .ok_or_else(|| AssembleError::Failed("assemble response missing result.files".to_string()))?;
+    let mut out = Vec::with_capacity(files_arr.len());
+    for f in files_arr {
+        let path = f
+            .get("path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| AssembleError::Failed("assemble file missing path".to_string()))?
+            .to_string();
+        let content = f
+            .get("content")
+            .and_then(Value::as_str)
+            .ok_or_else(|| AssembleError::Failed("assemble file missing content".to_string()))?
+            .to_string();
+        out.push(AssembledFile { path, content });
+    }
+    Ok(out)
+}
+
 // Per #1270 Tier 1.4: configure_java_runtime + java_home_from_maven removed.
 // JVM-runtime discovery is the user's environment concern (set JAVA_HOME),
 // not the kit-agnostic dispatcher's job. The dispatcher does not know that

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -1646,6 +1646,29 @@ fn invoke_realize(
     }
     let observation_wrapper_emission_record =
         result.get("observation_wrapper_emission_record").cloned();
+    // #1374: extract realization-fragment context if the realize plugin
+    // emitted it. Legacy plugins omit these fields; default-empty/None.
+    let imports = result
+        .get("imports")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(Value::as_str).map(String::from).collect())
+        .unwrap_or_default();
+    let helpers = result
+        .get("helpers")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let dependencies = result
+        .get("dependencies")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let diagnostics = result
+        .get("diagnostics")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let compile_unit_requirements = result.get("compile_unit_requirements").cloned();
     Ok(RealizedSource {
         extension,
         source,
@@ -1654,6 +1677,11 @@ fn invoke_realize(
         observed_loss_record,
         used_sugars,
         observation_wrapper_emission_record,
+        imports,
+        helpers,
+        dependencies,
+        diagnostics,
+        compile_unit_requirements,
     })
 }
 


### PR DESCRIPTION
## Summary

Closes #1375 Milestone C: substrate stops baking target-language file syntax. Each kit owns the shape of its compilation units via a new RPC method `provekit.plugin.assemble`.

**Stacked on #1374** (realization-fragment contract). Merge that first.

## Demo

```
materialize discovery: 9 site(s), 9 resolve + 0 ambiguous + 0 refused
  EMIT wrote /tmp/rpc-1375/Lib.java (target-owned assembly via java kit)
materialize cross-language emission: 1 file(s) written to /tmp/rpc-1375
```

Emitted `Lib.java`:

```java
import com.fasterxml.jackson.databind.JsonNode;

public final class Lib {
    public static String stdin_read_line() { ... }
    public static void stdout_write_line(String line) { ... }
    ...
}
```

Was: 9 separate `final class FooTransported { method }` declarations with no outer wrapper. Substrate-side concat had no path to a compilable output.

## What changed

**RPC**: new `provekit.plugin.assemble` method.

**Request:**
```json
{
  "target_lang": "java",
  "file_basename": "lib",
  "package_hint": null,
  "fragments": [
    {"concept_name": "...", "source": "...", "imports": [...]},
    ...
  ]
}
```

**Response:**
```json
{"files": [{"path": "Lib.java", "content": "..."}]}
```

**Substrate (cmd_materialize):**
- `EmittedFile` gains `fragments` + `target_manifest` fields
- Resolve sites record fragment JSON
- Emission loop calls `dispatch_assemble` for each source file
- On `MethodNotSupported` (-32601, legacy kit), falls back to substrate concat

**Java assembler (RpcServer.handleAssemble):**
- Parses fragments + collects imports
- Emits package decl (optional), import block (deduped, java.lang.* filtered), `public final class Lib { ... }` wrapper
- Strips per-fragment `final class FooTransported` wrappers so methods compose cleanly

## What's still missing

- Helpers / static initializers (Jackson's ObjectMapper, etc.) — schema is there from #1374 but realizers don't yet populate
- Package declaration (currently nullable; future work: derive from project layout or accept via CLI flag)
- Single public class only — fragments referring to each other across the file are fine; cross-file references aren't yet a thing
- Compile-check (#1376) will reveal what's still broken

## Test plan

- [ ] Cross-language demo: 9/9 resolve + emit
- [ ] Output is a single `Lib.java` with `public final class Lib`, not 9 separate classes
- [ ] Legacy realize plugins without `assemble` method still get substrate-concat fallback (preserved old kits)
- [ ] `--compile-check` from #1376 should now have a fighting chance at javac success

## Depends on

- #1374 (realization-fragment contract — fragment.imports flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)