### PR TITLE
fix(materialize): --library is a default, not a hard filter (#34)

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -560,17 +560,36 @@ fn run_cross_language_discovery(
                     .iter()
                     .any(|p| family_matches_override(family, &p.family))
             });
+            // #34: --library precedence rule. --library is the DEFAULT for
+            // multi-candidate sites without a more specific override, NOT a
+            // hard filter on the whole site set. Order:
+            //   1. Per-family override (--family-library): most specific. Keep
+            //      all candidates so the ambiguous-site handler resolves via
+            //      family.
+            //   2. --library: if the requested library tag is among the
+            //      candidates, pick it; otherwise leave the full set so the
+            //      site resolves via its own structure (single-candidate
+            //      concepts must not be filtered out by a top-level
+            //      --library that doesn't apply to them).
+            //   3. No hint: leave candidates intact; AMBIGUOUS if >1.
+            //
+            // Pre-#1383 behavior was case 3 only (--library was ignored at
+            // this layer). #1383 added case 2 as a HARD filter which broke
+            // every single-candidate concept whose manifest didn't match
+            // --library. This restores case 2 as a SOFT preference.
             let matches = if has_family_override {
-                // Per-family overrides are more specific than top-level
-                // --library. Leave the full candidate set intact so the
-                // ambiguous-site handler below can resolve or loudly report
-                // a bad/conflicting family override.
                 matches
             } else if let Some(target_library_tag) = target_library_tag {
-                matches
-                    .into_iter()
-                    .filter(|candidate| candidate == target_library_tag)
-                    .collect()
+                let preferred: Vec<String> = matches
+                    .iter()
+                    .filter(|candidate| *candidate == target_library_tag)
+                    .cloned()
+                    .collect();
+                if preferred.is_empty() {
+                    matches
+                } else {
+                    preferred
+                }
             } else {
                 matches
             };


### PR DESCRIPTION
## Summary

Closes #34. Fixes a demo-breaking regression from #1383.

## Problem

#1383 added \`--library\` as a HARD filter on candidate manifests for every site without a family override. That broke every single-candidate concept whose only java manifest didn't match \`--library\`. With strict-resolution semantics (#1373) now in place, the rust → java demo regressed from 9/9 RESOLVE to 2/9 RESOLVE + non-zero exit.

## Substrate-honest precedence rule

1. Per-site \`--family-library\` override: **most specific**. Family resolves.
2. Top-level \`--library\`: **PREFERENCE, not filter**. If the requested library is in the candidates, pick it. If not, leave the candidates intact (single-candidate concepts resolve through their unique manifest; multi-candidate sites without a family override become AMBIGUOUS as before).
3. No hint: candidates intact.

## Verification

\`provekit materialize --library java-io --family-library json=jackson --target java --source-lang rust ...\` restored to **9/9 RESOLVE**.

Compile-check now exposes the next-layer substrate-honesty gap (body templates use short class names because file-level imports got dropped during lift — separate issue).

## Test plan

- [ ] Demo: 9/9 resolve preserved
- [ ] \`--library X\` with no matching candidates does not silently filter all sites
- [ ] AMBIGUOUS sites where multiple candidates exist + \`--library\` matches one → pick that one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted library selection behavior in cross-language discovery: the `--library` flag now functions as a soft preference instead of a strict filter, allowing the system to fall back to available candidates when filtering yields no results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->