### PR TITLE
feat(realize-java): extend lower vocabulary (concept:while, for-each, field, method-call, ...)

### DIFF
--- a/.provekit/self-contracts-attestations/rust-bind.json
+++ b/.provekit/self-contracts-attestations/rust-bind.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "1",
+  "kind": "self-contracts-attestation",
+  "lang": "rust-bind",
+  "cid": "blake3-512:3d073f98389d5b0f74d231c0d72acf522100eac8958b9932e7b662b974982a6f6153129ca3cbf084e7d077276eccd4d542c5b6be6b42e21ccc6ebed52a0d9eaa",
+  "contractSetCid": "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+  "declaredAt": "2026-05-05T18:00:00Z",
+  "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+  "signature": "ed25519:XJXLX2mOgv2cdzruFNc7yR0ZXK4Tf7EK+EtK4IB3Qx+DaVL08X9wiayHuFpcf/R+sHlMD8AV47gfHb7IhVx/BQ=="
+}

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -1300,6 +1300,43 @@ final class SugarRealizer {
         if (conceptMatches("concept:skip", conceptName) && args.isEmpty()) {
             return Optional.of("");
         }
+        // Lift vocabulary parity: rust walk_rpc emits these concepts; java
+        // lower must accept them or translation bails on the first
+        // unrecognized construct in a body.
+        if (conceptMatches("concept:while", conceptName) && args.size() == 2) {
+            Optional<ShapeExpression> cond = lowerShapeExpression(args.get(0), context, appendPosition(position, 0));
+            Optional<String> body = lowerShapeBranchBody(args.get(1), context, appendPosition(position, 1));
+            if (cond.isEmpty() || body.isEmpty()) return Optional.empty();
+            return Optional.of("while (" + cond.get().text() + ") {\n"
+                    + indentBlock(body.get()) + "\n"
+                    + "}");
+        }
+        if (conceptMatches("concept:for-each", conceptName) && args.size() == 3) {
+            // args[0]: loop variable leaf (symbol). args[1]: iterable. args[2]: body.
+            String varName = args.get(0).stringFieldOrNull("text");
+            if (varName == null || varName.isBlank()) {
+                Optional<ShapeExpression> v = lowerShapeExpression(args.get(0), context, appendPosition(position, 0));
+                if (v.isEmpty()) return Optional.empty();
+                varName = v.get().text();
+            }
+            Optional<ShapeExpression> iter = lowerShapeExpression(args.get(1), context, appendPosition(position, 1));
+            if (iter.isEmpty()) return Optional.empty();
+            context.definedSymbols.add(varName);
+            Optional<String> body = lowerShapeBranchBody(args.get(2), context, appendPosition(position, 2));
+            if (body.isEmpty()) return Optional.empty();
+            return Optional.of("for (var " + varName + " : " + iter.get().text() + ") {\n"
+                    + indentBlock(body.get()) + "\n"
+                    + "}");
+        }
+        if (conceptMatches("concept:break", conceptName)) {
+            if (args.isEmpty()) return Optional.of("break;");
+            // break with value (rust's `break expr` in a loop) -> standard
+            // java has no equivalent at statement scope; emit a comment.
+            return Optional.of("break; // TODO: rust break-with-value not directly representable in java");
+        }
+        if (conceptMatches("concept:continue", conceptName)) {
+            return Optional.of("continue;");
+        }
         return Optional.empty();
     }
 
@@ -1343,12 +1380,86 @@ final class SugarRealizer {
             argTerms.add(term.get());
         }
         if (conceptMatches("concept:call", conceptName) && !argTerms.isEmpty()) {
+            // walk_rpc emits method calls AS concept:call with a method-leaf
+            // at args[1] (kind:"method", text:"<name>") and receiver at args[0].
+            // Plain calls have a path/symbol callee at args[0]. Distinguish
+            // by inspecting the raw shape, not the lowered ShapeExpression.
+            if (args.size() >= 2) {
+                Jcs.Json secondArg = args.get(1);
+                if (secondArg instanceof Jcs.Obj methodMaybe) {
+                    String kind = methodMaybe.stringFieldOrNull("kind");
+                    if ("method".equals(kind)) {
+                        String methodName = methodMaybe.stringFieldOrNull("text");
+                        if (methodName != null && !methodName.isBlank()) {
+                            String receiver = argTerms.get(0).text();
+                            String joined = argTerms.stream().skip(2)
+                                    .map(ShapeExpression::text)
+                                    .collect(Collectors.joining(", "));
+                            return Optional.of(new ShapeExpression(
+                                    receiver + "." + methodName + "(" + joined + ")",
+                                    mapSourceType(context.returnType)));
+                        }
+                    }
+                }
+            }
             String callee = argTerms.get(0).text();
             if (!isIdentifier(callee)) {
                 return Optional.empty();
             }
             String joined = argTerms.stream().skip(1).map(ShapeExpression::text).collect(Collectors.joining(", "));
             return Optional.of(new ShapeExpression(callee + "(" + joined + ")", mapSourceType(context.returnType)));
+        }
+        if (conceptMatches("concept:field", conceptName) && args.size() == 2) {
+            // args[0]: receiver expression. args[1]: field name leaf.
+            String fieldName = args.get(1).stringFieldOrNull("text");
+            if (fieldName == null || fieldName.isBlank()) return Optional.empty();
+            String receiver = argTerms.get(0).text();
+            return Optional.of(new ShapeExpression(
+                    receiver + "." + fieldName,
+                    mapSourceType(context.returnType)));
+        }
+        if (conceptMatches("concept:index", conceptName) && argTerms.size() == 2) {
+            // Java: array[idx] OR list.get(idx). Default to array form;
+            // collections use method-call concept instead.
+            String receiver = argTerms.get(0).text();
+            String idx = argTerms.get(1).text();
+            return Optional.of(new ShapeExpression(
+                    receiver + "[" + idx + "]",
+                    mapSourceType(context.returnType)));
+        }
+        if (conceptMatches("concept:cast", conceptName) && args.size() == 2) {
+            // args[0]: value. args[1]: type leaf.
+            String typeName = args.get(1).stringFieldOrNull("text");
+            if (typeName == null || typeName.isBlank()) {
+                Optional<ShapeExpression> t = lowerShapeExpression(args.get(1), context, appendPosition(position, 1));
+                if (t.isEmpty()) return Optional.empty();
+                typeName = t.get().text();
+            }
+            String value = argTerms.get(0).text();
+            return Optional.of(new ShapeExpression(
+                    "(" + mapSourceType(typeName) + ") (" + value + ")",
+                    mapSourceType(typeName)));
+        }
+        if (conceptMatches("concept:closure", conceptName) && !argTerms.isEmpty()) {
+            // Best-effort: emit a java lambda. Rust closures get lifted as
+            // concept:closure(param_leaf*, body). Java's lambda syntax is
+            // (a, b) -> body. Skip captured-state semantics; this only
+            // works for pure-function closures.
+            int bodyIdx = argTerms.size() - 1;
+            String params = argTerms.subList(0, bodyIdx).stream()
+                    .map(ShapeExpression::text)
+                    .collect(Collectors.joining(", "));
+            String body = argTerms.get(bodyIdx).text();
+            return Optional.of(new ShapeExpression(
+                    "(" + params + ") -> " + body,
+                    mapSourceType(context.returnType)));
+        }
+        // concept:reference (rust &x) and concept:deref (*x): java has neither
+        // explicit reference nor deref operators — references are implicit on
+        // objects; dereference is a no-op. Pass the inner expression through.
+        if ((conceptMatches("concept:reference", conceptName) || conceptMatches("concept:deref", conceptName))
+                && argTerms.size() == 1) {
+            return Optional.of(argTerms.get(0));
         }
         String expression = operationExpression(conceptName, argTerms);
         if (expression == null) {

--- a/implementations/rust/libprovekit-rpc-cross-platform/.provekit/config.toml
+++ b/implementations/rust/libprovekit-rpc-cross-platform/.provekit/config.toml
@@ -1,0 +1,15 @@
+[[plugins]]
+name = "rust-sugar"
+surface = "rust-bind"
+layer = "library-bindings"
+
+[[plugins]]
+name = "rust-contracts"
+surface = "rust-contracts"
+emit = "ir-document"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:cross-platform-rpc"
+library = "libprovekit-rpc-cross-platform"
+version = "rust-1"

--- a/implementations/rust/libprovekit-rpc-cross-platform/.provekit/lift/manifest.toml
+++ b/implementations/rust/libprovekit-rpc-cross-platform/.provekit/lift/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-bind-lift"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/implementations/rust/libprovekit-rpc-cross-platform/.provekit/lift/rust-bind/manifest.toml
+++ b/implementations/rust/libprovekit-rpc-cross-platform/.provekit/lift/rust-bind/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-bind-lift"
+command = ["../target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/implementations/rust/libprovekit-rpc-cross-platform/.provekit/lift/rust-contracts/manifest.toml
+++ b/implementations/rust/libprovekit-rpc-cross-platform/.provekit/lift/rust-contracts/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-contracts-lift"
+command = ["../target/debug/provekit-lift", "--rpc"]
+working_dir = "."


### PR DESCRIPTION
## Summary

Closes the rust→java vocabulary parity gap on the lower side.

Rust walk_rpc lifts the full AST with a rich ProofIR vocabulary (concept:while, concept:for-each, concept:match, concept:field, concept:index, concept:cast, concept:closure, concept:method-call shape, concept:break, concept:continue, concept:reference, concept:deref). Java SugarRealizer.lowerShapeBody / lowerShapeExpression previously only accepted (seq, assign, return, conditional, call, comment, skip + binary/comparison ops).

When materialize / lower tries to translate any non-trivial rust body, the unrecognized concept made the lowering bail to Empty → fallback to body-template lookup → no template → `is_stub=true` refuse.

## What this PR adds

**Statement-position handlers (`lowerShapeBody`):**

```
concept:while(cond, body)         → while (cond) { body }
concept:for-each(var, iter, body) → for (var v : iter) { body }
concept:break                      → break;
concept:continue                   → continue;
```

**Expression-position handlers (`lowerShapeExpression`):**

```
concept:field(receiver, name_leaf) → receiver.name
concept:index(receiver, idx)       → receiver[idx]
concept:cast(value, type_leaf)     → (type) value
concept:reference / concept:deref  → pass-through (java has no syntax)
concept:closure(params..., body)   → (a, b) -> body
concept:call with method-leaf at args[1] → receiver.method(args...)
```

The method-call shape detection inspects the raw shape's args[1] for `{kind: "method", text: "<name>"}` — that's how walk_rpc lifts `x.foo(y)`.

## Cross-platform crate now mints

Added `.provekit/config.toml` + lift manifests to `libprovekit-rpc-cross-platform/`. Minting produces 10 `library-sugar-binding-entry` records covering the RPC server's @sugar concepts (jsonrpc-ndjson-server-loop, jsonrpc-request-dispatch, lift-method-handler, ir-document-assembly, content-addressed-memento-name, ...).

## Verification

- 9/9 cross-lang demo still resolves
- javac still passes on the emitted Lib.java

## Remaining for end-to-end "lift libprovekit-rpc, lower it in java"

This PR makes the lower vocabulary capable; the final pipeline step (per-concept multi-library routing in `provekit lower`, equivalent to what `provekit materialize` already does) is separate work. Filed for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code transformation capabilities with support for loops, method calls, and type operations.
  * Added attestation and configuration files for Rust platform integration.
  * Added manifest definitions for cross-platform service handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->