### PR TITLE
verify: discharge harvested obligations through the function body (#1440)

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1985,6 +1985,7 @@ dependencies = [
 name = "provekit-lift-rust-tests"
 version = "0.1.0"
 dependencies = [
+ "libprovekit",
  "proc-macro2",
  "provekit-canonicalizer",
  "provekit-ir-symbolic",

--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -680,6 +680,154 @@ fn bind_response_contract(payload: &Json, payload_cid: &Cid) -> Contract {
     )
 }
 
+// ============================================================
+// Bridge writer (PR-22, #1440).
+// ============================================================
+//
+// A harvested call `double(3)` is dischargeable through verify ONLY when
+// three things are in the pool:
+//   1. a body-derived op-contract for `double` (post = result == *(x, 2)),
+//   2. a bridge `sourceSymbol "double" -> targetContractCid <op-contract>`,
+//   3. (transitively) the proof bundle the bridge pins.
+// The bridge's CID commits to the op-contract CID (it is in `inputCids`),
+// and the bundle commits to both; that is the proofchain rollup.
+//
+// This writer is the production source of (1) and (2): it takes the
+// `FunctionContractMemento` walk already builds for a function (which
+// carries `fn_name`, `formals`, `formal_sorts`, and the BODY-DERIVED
+// `post`), and emits both member envelopes in the v1.1-flat
+// `evidence.body` shape that `enumerate_callsites` / `resolve_target` /
+// `body_discharge::CatalogResolver` consume. The op-contract member CID is
+// the bridge's `targetContractCid`, so verify resolves the chain.
+
+/// One v1.1-flat member envelope plus its re-derivable member CID
+/// (`blake3_512(JCS(envelope))`, the same identity `load_all_proofs`
+/// recomputes for a member with no `cid` / `producerSignature` field).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgeMember {
+    /// The member CID = `blake3-512:<hex>`.
+    pub cid: Cid,
+    /// The member envelope JSON (no `cid` / `producerSignature` — those are
+    /// added by the proof-envelope builder when the bundle is assembled).
+    pub envelope: Json,
+}
+
+/// The pair of members a function bind produces for body-discharge: the
+/// body-derived op-contract and the bridge that points a harvested call at
+/// it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FunctionBridgeMembers {
+    /// The body-derived op-contract member (carries `formals` + `post`).
+    pub op_contract: BridgeMember,
+    /// The bridge member (`sourceSymbol -> targetContractCid`).
+    pub bridge: BridgeMember,
+}
+
+/// Re-derive a v1.1-flat member CID for an envelope, matching
+/// `provekit_verifier::load_all_proofs::compute_member_cid`: strip any
+/// `cid` / `producerSignature`, JCS-encode, BLAKE3-512.
+fn flat_member_cid(envelope: &Json) -> Cid {
+    let mut stripped = envelope.clone();
+    if let Json::Object(map) = &mut stripped {
+        map.remove("cid");
+        map.remove("producerSignature");
+    }
+    let canonical = provekit_canonicalizer::encode_jcs(&json_to_canonical_value(&stripped));
+    Cid::from_hash_output(blake3_512_of(canonical.as_bytes()))
+}
+
+/// Convert a `serde_json::Value` into the canonicalizer's `Value` so the
+/// JCS bytes line up with every other minter in the tree.
+fn json_to_canonical_value(j: &Json) -> std::sync::Arc<provekit_canonicalizer::Value> {
+    use provekit_canonicalizer::Value as CV;
+    match j {
+        Json::Null => CV::null(),
+        Json::Bool(b) => CV::boolean(*b),
+        Json::Number(n) => CV::integer(n.as_i64().unwrap_or(0)),
+        Json::String(s) => CV::string(s.clone()),
+        Json::Array(items) => CV::array(items.iter().map(json_to_canonical_value).collect()),
+        Json::Object(map) => CV::object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), json_to_canonical_value(v)))
+                .collect::<Vec<_>>(),
+        ),
+    }
+}
+
+/// Build the body-discharge members (op-contract + bridge) for a function
+/// contract. `target_proof_cid` is the `.proof` bundle CID the bridge pins
+/// (`BridgeDeclaration.targetProofCid`); pass the CID of the bundle these
+/// members will be assembled into. `source_layer` / `target_layer` name
+/// the language axes (e.g. `"rust"` -> `"rust-kit"`).
+///
+/// The op-contract carries the function's BODY-DERIVED `post` (the
+/// `FunctionContractMemento`'s `post`, which walk lifts from the body's
+/// trailing expression), plus `formals` / `formalSorts` so the resolver
+/// can name the value slots. This is the lift-half of walk (verification
+/// substrate); it does NOT touch the lower/cycle/carrier machinery.
+pub fn bind_function_bridge(
+    contract: &Contract,
+    source_layer: &str,
+    target_layer: &str,
+    target_proof_cid: Option<&str>,
+) -> Result<FunctionBridgeMembers, BindError> {
+    let post_json = serde_json::to_value(&contract.post)
+        .map_err(|e| BindError::Failed(format!("serialize body-derived post: {e}")))?;
+    let formals: Vec<Json> = contract
+        .formals
+        .iter()
+        .map(|f| Json::String(f.clone()))
+        .collect();
+    let formal_sorts: Vec<Json> = contract
+        .formal_sorts
+        .iter()
+        .map(|s| serde_json::to_value(s).unwrap_or(Json::Null))
+        .collect();
+
+    let op_contract_env = json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": contract.fn_name,
+                "formals": formals,
+                "formalSorts": formal_sorts,
+                "post": post_json
+            }
+        }
+    });
+    let op_contract_cid = flat_member_cid(&op_contract_env);
+
+    let mut bridge_body = serde_json::Map::new();
+    bridge_body.insert("sourceSymbol".into(), Json::String(contract.fn_name.clone()));
+    bridge_body.insert("sourceLayer".into(), Json::String(source_layer.to_string()));
+    bridge_body.insert(
+        "targetContractCid".into(),
+        Json::String(op_contract_cid.as_str().to_string()),
+    );
+    bridge_body.insert("targetLayer".into(), Json::String(target_layer.to_string()));
+    if let Some(tpc) = target_proof_cid {
+        bridge_body.insert("targetProofCid".into(), Json::String(tpc.to_string()));
+    }
+    let bridge_env = json!({
+        "evidence": {
+            "kind": "bridge",
+            "body": Json::Object(bridge_body)
+        }
+    });
+    let bridge_cid = flat_member_cid(&bridge_env);
+
+    Ok(FunctionBridgeMembers {
+        op_contract: BridgeMember {
+            cid: op_contract_cid,
+            envelope: op_contract_env,
+        },
+        bridge: BridgeMember {
+            cid: bridge_cid,
+            envelope: bridge_env,
+        },
+    })
+}
+
 fn bind_lift_entries(term_json: &Json) -> Result<Vec<BindLiftEntry>, BindError> {
     if term_json.get("kind").and_then(Json::as_str) == Some("named-term-document") {
         return Err(BindError::Failed(
@@ -1824,6 +1972,90 @@ fn primitive_sort(name: &str) -> Sort {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A `double(x) = x*2` function contract, as walk's
+    /// `build_function_contract` would produce: body-derived
+    /// `post = (result == *(x, 2))`, one formal `x`.
+    fn double_contract() -> Contract {
+        use crate::compose::{EffectSet, Locus};
+        let post = IrFormula::Atomic {
+            name: "=".to_string(),
+            args: vec![
+                IrTerm::Var {
+                    name: "result".to_string(),
+                },
+                IrTerm::Ctor {
+                    name: "*".to_string(),
+                    args: vec![
+                        IrTerm::Var {
+                            name: "x".to_string(),
+                        },
+                        IrTerm::Const {
+                            value: json!(2),
+                            sort: primitive_sort("Int"),
+                        },
+                    ],
+                },
+            ],
+        };
+        Contract {
+            fn_name: "double".to_string(),
+            formals: vec!["x".to_string()],
+            formal_sorts: vec![primitive_sort("Int")],
+            formal_regions: vec![],
+            return_sort: primitive_sort("Int"),
+            return_region: None,
+            pre: IrFormula::Atomic {
+                name: "true".to_string(),
+                args: vec![],
+            },
+            post,
+            body_cid: None,
+            effects: EffectSet::empty(),
+            locus: Locus::default(),
+            canonical_bytes: vec![],
+            cid: "blake3-512:test".to_string(),
+            auto_minted_mementos: vec![],
+            concept_hint: None,
+        }
+    }
+
+    #[test]
+    fn bind_function_bridge_emits_op_contract_and_pinned_bridge() {
+        let contract = double_contract();
+        let members =
+            bind_function_bridge(&contract, "rust", "rust-kit", Some("blake3-512:bundle"))
+                .expect("bind_function_bridge");
+
+        // Op-contract carries the body-derived post + formals.
+        let oc = members
+            .op_contract
+            .envelope
+            .pointer("/evidence/body")
+            .unwrap();
+        assert_eq!(oc.get("contractName").unwrap(), "double");
+        assert_eq!(oc.get("formals").unwrap(), &json!(["x"]));
+        // post is `result == *(x, 2)`.
+        let value_expr = oc.pointer("/post/args/1").unwrap();
+        assert_eq!(value_expr.get("name").unwrap(), "*");
+
+        // The bridge points at the op-contract member CID and pins the bundle.
+        let br = members.bridge.envelope.pointer("/evidence/body").unwrap();
+        assert_eq!(br.get("sourceSymbol").unwrap(), "double");
+        assert_eq!(
+            br.get("targetContractCid").unwrap().as_str().unwrap(),
+            members.op_contract.cid.as_str(),
+            "bridge.targetContractCid must equal the op-contract member CID (proofchain rollup)"
+        );
+        assert_eq!(br.get("targetProofCid").unwrap(), "blake3-512:bundle");
+
+        // CIDs are content-addressed and stable.
+        assert_eq!(
+            members.op_contract.cid,
+            super::flat_member_cid(&members.op_contract.envelope)
+        );
+        assert!(members.op_contract.cid.as_str().starts_with("blake3-512:"));
+    }
 
     #[test]
     fn bind_names_lifted_entries_without_plugin_dispatch() {

--- a/implementations/rust/provekit-cli/src/cmd_verify.rs
+++ b/implementations/rust/provekit-cli/src/cmd_verify.rs
@@ -464,6 +464,27 @@ fn verify_one_claim(
             // refinement obligation: instantiate the resolved pre with the
             // call's arg term (the same obligation the prover builds).
             let Some(_pre) = resolved.ir_formula.as_ref() else {
+                // HONESTY BOUNDARY (catches every body-bearing variant). The
+                // vacuous-discharge shortcut is legitimate ONLY for a
+                // genuinely non-body-bearing target. A target carrying
+                // `formals` is body-bearing by definition: its `post`
+                // describes a body whose obligation we reached here WITHOUT
+                // reducing (e.g. `extract_body_obligation` could not build the
+                // obligation because the body-derived `post` was not a
+                // `result == <expr>` equation, so the resolver dropped it).
+                // Vacuous-passing it would be a false green. Refuse instead:
+                // leave the default Undecidable verdict (not discharged, not
+                // pass, no witness).
+                if resolved.target_is_body_bearing {
+                    result.reason = format!(
+                        "body-discharge: refuse: target `{}` is body-bearing \
+                         (carries `formals`) but its obligation was not reduced \
+                         and it has no precondition; refusing rather than \
+                         reporting a vacuous pass",
+                        cs.bridge_ir_name
+                    );
+                    return result;
+                }
                 result.verdict = ObligationVerdict::Discharged;
                 result.reason = "vacuous: target carries no precondition".to_string();
                 result.obligation_class = "vacuous".to_string();

--- a/implementations/rust/provekit-cli/src/cmd_verify.rs
+++ b/implementations/rust/provekit-cli/src/cmd_verify.rs
@@ -480,9 +480,15 @@ fn verify_one_claim(
             }
         }
         Err(e) => {
-            // wp resolved the callee but refused/errored on a contract it
-            // DID see (e.g. arity mismatch) — a real, reportable gap, not a
-            // silent fall-through.
+            // The callee IS body-bearing (it has a body-derived op-contract)
+            // but the obligation could not be reduced through the body: an
+            // unrecognized assertion shape, an unconvertible operand, an
+            // arity mismatch, or a wp refusal on a nested call. The spine
+            // REFUSES rather than falling through to the refinement path,
+            // because that path would mis-read the body-derived op-contract
+            // (post/formals, no pre) as vacuous and report a FALSE pass.
+            // Refusal leaves the default verdict (Undecidable): not
+            // discharged, not pass, no witness, reason surfaced on the row.
             result.reason = format!("body-discharge: {e}");
             return result;
         }

--- a/implementations/rust/provekit-cli/src/cmd_verify.rs
+++ b/implementations/rust/provekit-cli/src/cmd_verify.rs
@@ -52,6 +52,7 @@ use owo_colors::OwoColorize;
 use provekit_canonicalizer::{blake3_512_of, encode_jcs};
 use provekit_proof_envelope::{ed25519_pubkey_string, ed25519_sign_string};
 use provekit_verifier::solvers::registry;
+use provekit_verifier::body_discharge;
 use provekit_verifier::{
     classify, enumerate_callsites, instantiate, load_all_proofs, resolve_target, run_plan,
     smt_emitter, DispatchConfig, FormulaTheory, MementoPool, ObligationVerdict, SolverHandle,
@@ -436,32 +437,53 @@ fn verify_one_claim(
         witness_cid: None,
     };
 
-    // Resolve the claim's target contract (its pre formula = the
-    // refinement target).
-    let resolved = match resolve_target::run(cs, pool) {
-        Ok(r) => r,
-        Err(e) => {
-            result.reason = format!("resolve-target: {e}");
-            return result;
+    // Body-discharge path (#1440): when the callsite names a callee with a
+    // body-derived op-contract AND its harvested assertion has the
+    // `=(<call>, <expected>)` shape, reduce the obligation THROUGH the
+    // body. wp inlines the callee's value-semantics (`double(x) = x*2`),
+    // so the solver sees a concrete formula (`*(3,2) == 6`) instead of an
+    // uninterpreted `double` symbol. This is the spine that turns a
+    // harvested body-obligation into a real, dischargeable / refutable
+    // claim. Anything outside the recognized shape falls through to the
+    // existing refinement path below.
+    let obligation = match body_discharge::extract_body_obligation(cs, pool) {
+        Ok(Some(body_discharge::BodyObligation::Reduced(reduced))) => reduced,
+        Ok(None) => {
+            // Not a body-bearing claim: resolve the target contract's pre
+            // and build the refinement obligation, exactly as before.
+            let resolved = match resolve_target::run(cs, pool) {
+                Ok(r) => r,
+                Err(e) => {
+                    result.reason = format!("resolve-target: {e}");
+                    return result;
+                }
+            };
+
+            // When the target has no precondition the claim is vacuously
+            // discharged (nothing to prove). Otherwise build the wp /
+            // refinement obligation: instantiate the resolved pre with the
+            // call's arg term (the same obligation the prover builds).
+            let Some(_pre) = resolved.ir_formula.as_ref() else {
+                result.verdict = ObligationVerdict::Discharged;
+                result.reason = "vacuous: target carries no precondition".to_string();
+                result.obligation_class = "vacuous".to_string();
+                result.discharging_solver = "none (vacuous)".to_string();
+                return result;
+            };
+
+            match instantiate::run(&resolved, &cs.arg_term) {
+                Ok(ob) => ob.ir_formula,
+                Err(e) => {
+                    result.reason = format!("instantiate: {e}");
+                    return result;
+                }
+            }
         }
-    };
-
-    // Build the obligation. When the target has no precondition the
-    // claim is vacuously discharged (nothing to prove). Otherwise build
-    // the wp / refinement obligation: instantiate the resolved pre with
-    // the call's arg term (the same obligation the prover builds).
-    let Some(_pre) = resolved.ir_formula.as_ref() else {
-        result.verdict = ObligationVerdict::Discharged;
-        result.reason = "vacuous: target carries no precondition".to_string();
-        result.obligation_class = "vacuous".to_string();
-        result.discharging_solver = "none (vacuous)".to_string();
-        return result;
-    };
-
-    let obligation = match instantiate::run(&resolved, &cs.arg_term) {
-        Ok(ob) => ob.ir_formula,
         Err(e) => {
-            result.reason = format!("instantiate: {e}");
+            // wp resolved the callee but refused/errored on a contract it
+            // DID see (e.g. arity mismatch) — a real, reportable gap, not a
+            // silent fall-through.
+            result.reason = format!("body-discharge: {e}");
             return result;
         }
     };
@@ -804,6 +826,7 @@ mod tests {
             property_name: "demo_property".into(),
             property_cid: "blake3-512:prop".into(),
             arg_term: None,
+            containing_atomic: None,
         };
         let obligation = json!({"kind":"atomic","name":"true","args":[]});
         let cid = mint_verification_witness(

--- a/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// End-to-end body-discharge proof for `provekit verify` (PR-22, #1440).
+//
+// THE LOAD-BEARING TEST. Unlike `cmd_verify_integration.rs` (whose claims
+// are body-INDEPENDENT tautologies `n >= n` / `n > n` that discharge in
+// pure LIA with no user symbol), this test proves the verification SPINE:
+// that `verify` reduces a harvested assertion THROUGH the callee function
+// BODY, so the solver sees the body's value-semantics instead of an
+// uninterpreted symbol.
+//
+// The example: `fn double(x) = x * 2`, harvested test `assert_eq!(double(3), 6)`.
+//
+//   POSITIVE: the body-derived op-contract for `double` carries
+//     `post = (result == *(x, 2))`. verify runs `wp(double(3), result==6)`
+//     -> `*(3, 2) == 6` -> z3 discharges -> pass, signed witness minted.
+//
+//   NEGATIVE: break the body to `x * 3` -> `post = (result == *(x, 3))` ->
+//     `wp(double(3), result==6)` -> `*(3, 3) == 6` -> z3 finds `9 != 6` SAT
+//     on the negation -> Unsatisfied, exit 1, NO witness. The negative case
+//     fails HONESTLY (Unsatisfied, not Undecidable) precisely because no
+//     uninterpreted symbol survives the body reduction.
+//
+// Requires `z3` on PATH; skips the solver-dependent asserts otherwise.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs};
+use provekit_proof_envelope::{
+    build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
+};
+use serde_json::{json, Value as Json};
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-verify-body-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+/// Compute the v1.1-flat member CID + canonical bytes, exactly as
+/// `provekit-verifier::load_all_proofs` re-derives it.
+fn flat_member(mut env: Json) -> (String, Vec<u8>) {
+    if let Json::Object(map) = &mut env {
+        map.remove("cid");
+        map.remove("producerSignature");
+    }
+    let canonical = json_to_canonical_jcs(&env);
+    let cid = blake3_512_of(canonical.as_bytes());
+    (cid, canonical.into_bytes())
+}
+
+fn json_to_canonical_jcs(j: &Json) -> String {
+    fn to_cv(j: &Json) -> std::sync::Arc<provekit_canonicalizer::Value> {
+        use provekit_canonicalizer::Value as CV;
+        match j {
+            Json::Null => CV::null(),
+            Json::Bool(b) => CV::boolean(*b),
+            Json::Number(n) => CV::integer(n.as_i64().unwrap_or(0)),
+            Json::String(s) => CV::string(s.clone()),
+            Json::Array(items) => CV::array(items.iter().map(to_cv).collect()),
+            Json::Object(map) => {
+                CV::object(map.iter().map(|(k, v)| (k.clone(), to_cv(v))).collect::<Vec<_>>())
+            }
+        }
+    }
+    encode_jcs(&to_cv(j))
+}
+
+/// An Int constant IR term.
+fn int_const(n: i64) -> Json {
+    json!({"kind": "const", "value": n, "sort": {"kind": "primitive", "name": "Int"}})
+}
+
+/// Publish a `.proof` catalog proving (or refuting) `double(3) == 6`,
+/// where `double`'s body is `x * <body_factor>`.
+///
+/// Three members, in the v1.1-flat `evidence.body` shape:
+///   - TARGET contract `double`: the body-derived op-contract. Its `post`
+///     is `result == *(x, <body_factor>)` (the lifted body) and it carries
+///     `formals: ["x"]`. This is what the catalog resolver projects into an
+///     `OpContractInfo` for wp.
+///   - SOURCE contract: carries the harvested assertion
+///     `=(double(3), 6)` in its `inv` slot (one bridged callsite).
+///   - BRIDGE: `sourceSymbol "double" -> targetContractCid <double>`.
+fn publish_double_project(suffix: &str, body_factor: i64) -> PathBuf {
+    let dir = unique_dir(suffix);
+    let proof_dir = dir.join(".provekit");
+    fs::create_dir_all(&proof_dir).expect("mkdir .provekit");
+
+    let signer_seed: Ed25519Seed = [0x42u8; 32];
+    let declared_at = "2026-05-23T00:00:00.000Z";
+
+    let mut members: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+
+    // The body-derived op-contract for `double`: post = result == *(x, k).
+    let target_env = json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": "double",
+                "formals": ["x"],
+                "formalSorts": [{"kind": "primitive", "name": "Int"}],
+                "post": {
+                    "kind": "atomic", "name": "=",
+                    "args": [
+                        {"kind": "var", "name": "result"},
+                        {"kind": "ctor", "name": "*", "args": [
+                            {"kind": "var", "name": "x"},
+                            int_const(body_factor)
+                        ]}
+                    ]
+                }
+            }
+        }
+    });
+    let (target_cid, target_bytes) = flat_member(target_env);
+    members.insert(target_cid.clone(), target_bytes);
+
+    // The harvested test assertion `assert_eq!(double(3), 6)` -> inv =(call, 6).
+    let source_env = json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": "double_test",
+                "inv": {
+                    "kind": "atomic", "name": "=",
+                    "args": [
+                        {"kind": "ctor", "name": "double", "args": [int_const(3)]},
+                        int_const(6)
+                    ]
+                }
+            }
+        }
+    });
+    let (source_cid, source_bytes) = flat_member(source_env);
+    members.insert(source_cid, source_bytes);
+
+    // The bridge: double (sourceSymbol) -> the body-derived contract.
+    let bridge_env = json!({
+        "evidence": {
+            "kind": "bridge",
+            "body": {
+                "sourceSymbol": "double",
+                "sourceLayer": "rust",
+                "targetContractCid": target_cid,
+                "targetLayer": "rust-kit"
+            }
+        }
+    });
+    let (bridge_cid, bridge_bytes) = flat_member(bridge_env);
+    members.insert(bridge_cid, bridge_bytes);
+
+    let signer_pubkey = ed25519_pubkey_string(&signer_seed);
+    let signer_cid = blake3_512_of(signer_pubkey.as_bytes());
+    let input = ProofEnvelopeInput {
+        name: format!("@test/verify-body-{suffix}"),
+        version: "1.0.0".into(),
+        binary_cid: None,
+        metadata: None,
+        members,
+        signer_cid,
+        signer_seed,
+        declared_at: declared_at.into(),
+    };
+    let built = build_proof_envelope(&input);
+    let hex = built.cid.strip_prefix("blake3-512:").unwrap();
+    fs::write(proof_dir.join(format!("{hex}.proof")), &built.bytes).expect("write proof");
+    dir
+}
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_verify_json_with_code(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .arg("verify")
+        .arg("--project")
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+/// POSITIVE: `double(x) = x*2`, `assert_eq!(double(3), 6)`. The body
+/// reduction yields `*(3, 2) == 6`; z3 discharges; a signed witness is
+/// minted. This is the proof that verify discharges a real BODY-obligation
+/// (not a body-independent tautology).
+#[test]
+fn verify_double_body_discharges_and_mints_witness() {
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping body-discharge positive test");
+        return;
+    }
+    let project = publish_double_project("pos", 2);
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["kind"], "verification-receipt");
+    assert_eq!(
+        receipt["totalClaims"], 1,
+        "exactly one body-bearing callsite enumerated; receipt: {receipt}"
+    );
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+
+    // The body reduction left a concrete LIA formula `*(3,2) == 6` — NO
+    // uninterpreted `double` symbol. So z3 discharges it.
+    assert_eq!(
+        claim["pass"], true,
+        "double(3)==6 must discharge through the body x*2; claim: {claim}"
+    );
+    assert_eq!(
+        claim["status"], "discharged",
+        "positive body-obligation must be discharged (not undecidable); claim: {claim}"
+    );
+
+    let solver = claim["dischargingSolver"].as_str().unwrap_or("");
+    assert!(
+        solver.starts_with("z3@"),
+        "discharging solver must be z3; got `{solver}`"
+    );
+
+    // A signed witness was minted. Capture its CID for the #1440 report:
+    //   cargo test verify_double_body_discharges -- --nocapture
+    let witness_cid = claim["witnessCid"].as_str().expect("witness minted");
+    assert!(witness_cid.starts_with("blake3-512:"));
+    eprintln!("POSITIVE_WITNESS_CID={witness_cid}");
+
+    let hex = witness_cid.trim_start_matches("blake3-512:");
+    let wpath = witnesses.join(format!("witness-{hex}.json"));
+    let bytes = fs::read_to_string(&wpath).expect("witness file written");
+    let witness: provekit_ir_types::WitnessMemento =
+        serde_json::from_str(&bytes).expect("witness re-parses");
+    assert_eq!(witness.outcome, "pass");
+    assert!(witness.signature.is_some(), "witness must be signed");
+
+    assert_eq!(receipt["ok"], true);
+    assert_eq!(code, 0, "positive run exits clean; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// NEGATIVE: break the body to `double(x) = x*3`. The body reduction
+/// yields `*(3, 3) == 6`; z3 finds `9 != 6` SAT on the negation ->
+/// Unsatisfied, exit 1, NO witness. This is THE load-bearing proof: the
+/// negative case must fail HONESTLY (Unsatisfied, not Undecidable),
+/// because no uninterpreted symbol survives the body reduction.
+#[test]
+fn verify_double_broken_body_fails_unsatisfied_no_witness() {
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping body-discharge negative test");
+        return;
+    }
+    let project = publish_double_project("neg", 3);
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+
+    // The decisive assertion: a BROKEN body makes the claim UNSATISFIED,
+    // not UNDECIDABLE. Undecidable here would mean the callee stayed an
+    // uninterpreted symbol (the #1440 bug); Unsatisfied means the body was
+    // reduced and z3 actually refuted `*(3,3) == 6`.
+    assert_eq!(
+        claim["status"], "unsatisfied",
+        "broken body x*3 must be UNSATISFIED (not undecidable); claim: {claim}"
+    );
+    assert_eq!(
+        claim["pass"], false,
+        "broken-body claim must not pass; claim: {claim}"
+    );
+
+    // No witness for a violated claim.
+    assert!(
+        claim["witnessCid"].is_null(),
+        "no witness may be minted for a violated claim; claim: {claim}"
+    );
+    assert_eq!(receipt["ok"], false);
+
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a violated claim; found {} files",
+        witness_files.len()
+    );
+
+    // Exit 1 = EXIT_VERIFY_FAIL (a hard violation, not a solver miss/exit 3).
+    assert_eq!(
+        code, 1,
+        "broken-body claim must exit 1 (EXIT_VERIFY_FAIL, not 3=undecidable); got {code}"
+    );
+    eprintln!("NEGATIVE_EXIT_CODE={code} STATUS={}", claim["status"]);
+
+    let _ = fs::remove_dir_all(&project);
+}

--- a/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
@@ -126,6 +126,28 @@ fn publish_double_project_with_inv(suffix: &str, body_factor: i64, inv: Json) ->
 /// false-green the reviewer found, where the resolver drops the contract
 /// and the claim falls through to the vacuous branch.
 fn publish_double_project_full(suffix: &str, post: Json, inv: Json) -> PathBuf {
+    publish_double_project_with_formals(
+        suffix,
+        json!(["x"]),
+        json!([{"kind": "primitive", "name": "Int"}]),
+        post,
+        inv,
+    )
+}
+
+/// Like `publish_double_project_full` but with an explicit `formals` /
+/// `formalSorts` on the target op-contract. Lets a test drive the zero-arg
+/// `formals: []` shape -- a body-derived contract for a zero-parameter
+/// function is STILL body-bearing (it has a body, just no parameters), and
+/// must not slip into the vacuous-discharge branch. The `double(3)` callsite
+/// from `inv` still enumerates regardless of the target's formals count.
+fn publish_double_project_with_formals(
+    suffix: &str,
+    formals: Json,
+    formal_sorts: Json,
+    post: Json,
+    inv: Json,
+) -> PathBuf {
     let dir = unique_dir(suffix);
     let proof_dir = dir.join(".provekit");
     fs::create_dir_all(&proof_dir).expect("mkdir .provekit");
@@ -142,8 +164,8 @@ fn publish_double_project_full(suffix: &str, post: Json, inv: Json) -> PathBuf {
             "kind": "contract",
             "body": {
                 "contractName": "double",
-                "formals": ["x"],
-                "formalSorts": [{"kind": "primitive", "name": "Int"}],
+                "formals": formals,
+                "formalSorts": formal_sorts,
                 "post": post
             }
         }
@@ -514,6 +536,84 @@ fn verify_body_bearing_non_equation_post_refuses_not_vacuous_pass() {
         "receipt must not be ok when a claim was refused; receipt: {receipt}"
     );
     eprintln!("FALSEGREEN2_STATUS={} EXIT={code}", claim["status"]);
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// FALSE-GREEN REGRESSION #3 (the empty-`formals` corner -- caught in the
+/// third-pass review as a writer-unreachable nit, closed on principle:
+/// honesty must hold for ALL inputs, not just what today's writer emits).
+///
+/// The `target_is_body_bearing` marker once gated on `!formals.is_empty()`,
+/// so a ZERO-ARG body-derived contract (`formals: []`) with a non-equation
+/// post and no `pre` was classified NON-body-bearing -> it slipped back into
+/// the vacuous-discharge branch -> GREEN PASS, exit 0. A zero-parameter
+/// function still has a body; its contract is body-bearing. The marker now
+/// gates on `formals` PRESENT (the key exists), not non-empty.
+///
+/// This test asserts the corner is closed: `formals: []` + non-equation post
+/// + no pre must REFUSE, exactly like the `formals: ["x"]` variants.
+#[test]
+fn verify_zero_arg_body_bearing_non_equation_post_refuses_not_vacuous_pass() {
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping false-green-3 (zero-arg) regression test");
+        return;
+    }
+    // Body-bearing op-contract with EMPTY formals + a non-equation post.
+    let post = json!({
+        "kind": "atomic", "name": "<=",
+        "args": [
+            {"kind": "var", "name": "result"},
+            int_const(10)
+        ]
+    });
+    // A normal `=(double(3), 6)` assertion, so exactly one callsite enumerates.
+    let inv = json!({
+        "kind": "atomic", "name": "=",
+        "args": [
+            {"kind": "ctor", "name": "double", "args": [int_const(3)]},
+            int_const(6)
+        ]
+    });
+    let project =
+        publish_double_project_with_formals("falsegreen3", json!([]), json!([]), post, inv);
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+
+    // THE BLOCKER ASSERTION: an empty-formals body-bearing contract must NOT
+    // vacuous-pass.
+    assert_ne!(
+        claim["status"], "discharged",
+        "zero-arg body-bearing contract must NOT be discharged; claim: {claim}"
+    );
+    assert_eq!(claim["pass"], false, "must NOT pass; claim: {claim}");
+    assert_ne!(
+        claim["obligationClass"], "vacuous",
+        "must NOT take the vacuous-discharge branch; claim: {claim}"
+    );
+
+    assert!(
+        claim["witnessCid"].is_null(),
+        "no witness for a refused claim; claim: {claim}"
+    );
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a refused claim; found {} files",
+        witness_files.len()
+    );
+
+    assert_ne!(code, 0, "a refused claim must not exit 0 (clean); got {code}");
+    assert_eq!(
+        receipt["ok"], false,
+        "receipt must not be ok when a claim was refused; receipt: {receipt}"
+    );
+    eprintln!("FALSEGREEN3_STATUS={} EXIT={code}", claim["status"]);
 
     let _ = fs::remove_dir_all(&project);
 }

--- a/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
@@ -90,6 +90,21 @@ fn int_const(n: i64) -> Json {
 ///     `=(double(3), 6)` in its `inv` slot (one bridged callsite).
 ///   - BRIDGE: `sourceSymbol "double" -> targetContractCid <double>`.
 fn publish_double_project(suffix: &str, body_factor: i64) -> PathBuf {
+    // The harvested test assertion `assert_eq!(double(3), 6)` -> inv =(call, 6).
+    let inv = json!({
+        "kind": "atomic", "name": "=",
+        "args": [
+            {"kind": "ctor", "name": "double", "args": [int_const(3)]},
+            int_const(6)
+        ]
+    });
+    publish_double_project_with_inv(suffix, body_factor, inv)
+}
+
+/// Like `publish_double_project` but with an explicit harvested `inv`
+/// formula, so a test can drive an assertion shape OTHER than
+/// `=(<call>, <expected>)` (the reviewer's `<=` false-green probe).
+fn publish_double_project_with_inv(suffix: &str, body_factor: i64, inv: Json) -> PathBuf {
     let dir = unique_dir(suffix);
     let proof_dir = dir.join(".provekit");
     fs::create_dir_all(&proof_dir).expect("mkdir .provekit");
@@ -123,19 +138,14 @@ fn publish_double_project(suffix: &str, body_factor: i64) -> PathBuf {
     let (target_cid, target_bytes) = flat_member(target_env);
     members.insert(target_cid.clone(), target_bytes);
 
-    // The harvested test assertion `assert_eq!(double(3), 6)` -> inv =(call, 6).
+    // The harvested test assertion in the source contract's `inv` slot
+    // (one bridged callsite). The default is `=(double(3), 6)`.
     let source_env = json!({
         "evidence": {
             "kind": "contract",
             "body": {
                 "contractName": "double_test",
-                "inv": {
-                    "kind": "atomic", "name": "=",
-                    "args": [
-                        {"kind": "ctor", "name": "double", "args": [int_const(3)]},
-                        int_const(6)
-                    ]
-                }
+                "inv": inv
             }
         }
     });
@@ -314,6 +324,91 @@ fn verify_double_broken_body_fails_unsatisfied_no_witness() {
         "broken-body claim must exit 1 (EXIT_VERIFY_FAIL, not 3=undecidable); got {code}"
     );
     eprintln!("NEGATIVE_EXIT_CODE={code} STATUS={}", claim["status"]);
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// FALSE-GREEN REGRESSION (PR-22 review blocker). The reviewer's exact
+/// probe: take the POSITIVE fixture and change the assertion predicate from
+/// `=` to `<=`. The callee `double` STILL has a body-derived op-contract,
+/// but `<=(double(3), 10)` is NOT the reducible `=(<call>, <expected>)`
+/// shape.
+///
+/// Before the fix, `extract_body_obligation` returned `Ok(None)` for the
+/// unrecognized shape, the claim fell through to `resolve_target` +
+/// `instantiate`, the body-derived op-contract (post/formals, NO `pre`) hit
+/// the "vacuous: target carries no precondition" branch, and verify
+/// reported `status:"discharged", pass:true, exit 0` -- a GREEN PASS for a
+/// claim it never checked. That is the one thing the verify spine must
+/// never do.
+///
+/// The fix: once a callee is body-bearing, an unreducible obligation
+/// REFUSES (not vacuous-pass). This test asserts the false green is closed:
+/// the claim must NOT be discharged and must NOT pass.
+#[test]
+fn verify_body_bearing_unrecognized_shape_refuses_not_vacuous_pass() {
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping false-green regression test");
+        return;
+    }
+    // `<=(double(3), 10)` -- a body-bearing callee, but not the `=` shape.
+    let inv = json!({
+        "kind": "atomic", "name": "<=",
+        "args": [
+            {"kind": "ctor", "name": "double", "args": [int_const(3)]},
+            int_const(10)
+        ]
+    });
+    let project = publish_double_project_with_inv("falsegreen", 2, inv);
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+
+    // THE BLOCKER ASSERTION: a body-bearing claim whose shape we cannot
+    // reduce must NOT report a green pass.
+    assert_ne!(
+        claim["status"], "discharged",
+        "unreducible body-bearing claim must NOT be discharged (no false green); claim: {claim}"
+    );
+    assert_eq!(
+        claim["pass"], false,
+        "unreducible body-bearing claim must NOT pass; claim: {claim}"
+    );
+    assert_ne!(
+        claim["obligationClass"], "vacuous",
+        "must NOT take the vacuous-discharge branch; claim: {claim}"
+    );
+
+    // It refuses with a body-discharge reason (the honest posture).
+    let reason = claim["reason"].as_str().unwrap_or("");
+    assert!(
+        reason.contains("body-discharge") && reason.contains("refuse"),
+        "refusal reason must be surfaced; got `{reason}`"
+    );
+
+    // No witness for a claim that was never discharged.
+    assert!(
+        claim["witnessCid"].is_null(),
+        "no witness for a refused claim; claim: {claim}"
+    );
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a refused claim; found {} files",
+        witness_files.len()
+    );
+
+    // Must NOT exit 0 (clean pass). Undecidable -> the receipt is not `ok`.
+    assert_ne!(code, 0, "a refused claim must not exit 0 (clean); got {code}");
+    assert_eq!(
+        receipt["ok"], false,
+        "receipt must not be ok when a claim was refused; receipt: {receipt}"
+    );
+    eprintln!("FALSEGREEN_STATUS={} EXIT={code}", claim["status"]);
 
     let _ = fs::remove_dir_all(&project);
 }

--- a/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
@@ -105,6 +105,27 @@ fn publish_double_project(suffix: &str, body_factor: i64) -> PathBuf {
 /// formula, so a test can drive an assertion shape OTHER than
 /// `=(<call>, <expected>)` (the reviewer's `<=` false-green probe).
 fn publish_double_project_with_inv(suffix: &str, body_factor: i64, inv: Json) -> PathBuf {
+    // The body-derived op-contract for `double`: post = result == *(x, k).
+    let post = json!({
+        "kind": "atomic", "name": "=",
+        "args": [
+            {"kind": "var", "name": "result"},
+            {"kind": "ctor", "name": "*", "args": [
+                {"kind": "var", "name": "x"},
+                int_const(body_factor)
+            ]}
+        ]
+    });
+    publish_double_project_full(suffix, post, inv)
+}
+
+/// Fully parameterized publisher: explicit body-derived op-contract `post`
+/// AND harvested `inv`. The target ALWAYS carries `formals: ["x"]` (it is a
+/// body-bearing op-contract) and NO `pre`. Lets a test drive a `post` that
+/// is not a `result == <expr>` equation -- the trigger for the second
+/// false-green the reviewer found, where the resolver drops the contract
+/// and the claim falls through to the vacuous branch.
+fn publish_double_project_full(suffix: &str, post: Json, inv: Json) -> PathBuf {
     let dir = unique_dir(suffix);
     let proof_dir = dir.join(".provekit");
     fs::create_dir_all(&proof_dir).expect("mkdir .provekit");
@@ -114,7 +135,8 @@ fn publish_double_project_with_inv(suffix: &str, body_factor: i64, inv: Json) ->
 
     let mut members: BTreeMap<String, Vec<u8>> = BTreeMap::new();
 
-    // The body-derived op-contract for `double`: post = result == *(x, k).
+    // The body-derived op-contract for `double`: carries `formals` (so it is
+    // body-bearing) and the supplied `post`; NO `pre`.
     let target_env = json!({
         "evidence": {
             "kind": "contract",
@@ -122,16 +144,7 @@ fn publish_double_project_with_inv(suffix: &str, body_factor: i64, inv: Json) ->
                 "contractName": "double",
                 "formals": ["x"],
                 "formalSorts": [{"kind": "primitive", "name": "Int"}],
-                "post": {
-                    "kind": "atomic", "name": "=",
-                    "args": [
-                        {"kind": "var", "name": "result"},
-                        {"kind": "ctor", "name": "*", "args": [
-                            {"kind": "var", "name": "x"},
-                            int_const(body_factor)
-                        ]}
-                    ]
-                }
+                "post": post
             }
         }
     });
@@ -409,6 +422,98 @@ fn verify_body_bearing_unrecognized_shape_refuses_not_vacuous_pass() {
         "receipt must not be ok when a claim was refused; receipt: {receipt}"
     );
     eprintln!("FALSEGREEN_STATUS={} EXIT={code}", claim["status"]);
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// FALSE-GREEN REGRESSION #2 (the false green MOVED, not closed -- caught
+/// in re-review). The first fix put the honesty boundary AFTER the resolver
+/// lookup gate. But `CatalogResolver::lookup` itself drops a body-bearing
+/// contract whose `post` is NOT a `result == <expr>` equation (the
+/// `value_expr()?` early-return), so it returns `None` -> `Ok(None)` ->
+/// fall-through -> the target has `formals` but no `pre` -> the
+/// vacuous-discharge branch fired -> GREEN PASS, exit 0. Same cardinal sin,
+/// narrower trigger.
+///
+/// The trigger: a body-bearing op-contract (`formals: ["x"]`, NO `pre`)
+/// whose `post` is a non-equation predicate `<=(result, x)`, with a
+/// harvested `=(double(3), 6)` assertion (so a callsite enumerates).
+///
+/// The consumer-side fix: `verify_one_claim` checks
+/// `resolved.target_is_body_bearing` BEFORE the vacuous branch and refuses.
+/// This test asserts the false green is closed for THIS variant too: the
+/// claim must NOT be discharged, must NOT pass, must NOT be vacuous.
+#[test]
+fn verify_body_bearing_non_equation_post_refuses_not_vacuous_pass() {
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping false-green-2 regression test");
+        return;
+    }
+    // Body-bearing op-contract whose post is NOT `result == <expr>` -- the
+    // resolver's `value_expr()` returns None and it drops the contract.
+    let post = json!({
+        "kind": "atomic", "name": "<=",
+        "args": [
+            {"kind": "var", "name": "result"},
+            {"kind": "var", "name": "x"}
+        ]
+    });
+    // A normal `=(double(3), 6)` assertion, so exactly one callsite enumerates.
+    let inv = json!({
+        "kind": "atomic", "name": "=",
+        "args": [
+            {"kind": "ctor", "name": "double", "args": [int_const(3)]},
+            int_const(6)
+        ]
+    });
+    let project = publish_double_project_full("falsegreen2", post, inv);
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+
+    // THE BLOCKER ASSERTION: a body-bearing claim that the resolver dropped
+    // must NOT slip through to a vacuous green pass.
+    assert_ne!(
+        claim["status"], "discharged",
+        "body-bearing contract dropped by the resolver must NOT be discharged; claim: {claim}"
+    );
+    assert_eq!(
+        claim["pass"], false,
+        "must NOT pass; claim: {claim}"
+    );
+    assert_ne!(
+        claim["obligationClass"], "vacuous",
+        "must NOT take the vacuous-discharge branch; claim: {claim}"
+    );
+
+    // The consumer-side refusal reason is surfaced.
+    let reason = claim["reason"].as_str().unwrap_or("");
+    assert!(
+        reason.contains("body-discharge") && reason.contains("refuse"),
+        "refusal reason must be surfaced; got `{reason}`"
+    );
+
+    assert!(
+        claim["witnessCid"].is_null(),
+        "no witness for a refused claim; claim: {claim}"
+    );
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a refused claim; found {} files",
+        witness_files.len()
+    );
+
+    assert_ne!(code, 0, "a refused claim must not exit 0 (clean); got {code}");
+    assert_eq!(
+        receipt["ok"], false,
+        "receipt must not be ok when a claim was refused; receipt: {receipt}"
+    );
+    eprintln!("FALSEGREEN2_STATUS={} EXIT={code}", claim["status"]);
 
     let _ = fs::remove_dir_all(&project);
 }

--- a/implementations/rust/provekit-lift-rust-tests/Cargo.toml
+++ b/implementations/rust/provekit-lift-rust-tests/Cargo.toml
@@ -19,3 +19,5 @@ serde_json = { workspace = true }
 [dev-dependencies]
 provekit-lift = { path = "../provekit-lift" }
 provekit-verifier = { path = "../provekit-verifier" }
+libprovekit = { path = "../libprovekit" }
+syn = { workspace = true, features = ["full", "extra-traits"] }

--- a/implementations/rust/provekit-lift-rust-tests/tests/round_trip.rs
+++ b/implementations/rust/provekit-lift-rust-tests/tests/round_trip.rs
@@ -143,6 +143,48 @@ fn fixture_lifts_4_skips_2_and_round_trips_through_verifier() {
         "expected 4 distinct mementos (one per lifted callsite assertion)"
     );
 
+    // REGRESSION (PR-22, #1440): the harvested proof alone yields ZERO
+    // callsites, because `enumerate_callsites` only emits a callsite when a
+    // harvested call ctor matches a BRIDGE `sourceSymbol`. Before this PR
+    // the round-trip test never asserted enumeration, so the
+    // bridge-is-required invariant was untested. Assert it both ways: empty
+    // before bind, non-empty after.
+    assert!(
+        provekit_verifier::enumerate_callsites::run(&pool).is_empty(),
+        "harvested proof with no bridge must enumerate zero callsites"
+    );
+
+    // After bind: a `bind_function_bridge` for `parse_int` makes the
+    // harvested `parse_int(\"42\")` call enumerate as a discharge callsite.
+    let mut pool = pool;
+    let item_fn: syn::ItemFn =
+        syn::parse_str("fn parse_int(s: &str) -> i64 { 42 }").expect("parse parse_int fixture");
+    let contract = provekit_walk::contract::build_function_contract(&item_fn, None);
+    let members =
+        libprovekit::core::bind::bind_function_bridge(&contract, "rust", "rust-kit", None)
+            .expect("bind_function_bridge");
+    pool.mementos.insert(
+        members.op_contract.cid.as_str().to_string(),
+        members.op_contract.envelope.clone(),
+    );
+    pool.mementos.insert(
+        members.bridge.cid.as_str().to_string(),
+        members.bridge.envelope.clone(),
+    );
+    pool.bridges_by_symbol
+        .insert("parse_int".to_string(), members.bridge.envelope.clone());
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    assert!(
+        !callsites.is_empty(),
+        "after harvest+bind, enumerate_callsites must be non-empty (the bridge wires the harvested call to a dischargeable target)"
+    );
+    assert!(
+        callsites.iter().any(|cs| cs.bridge_ir_name == "parse_int"),
+        "the parse_int callsite must enumerate; got {:?}",
+        callsites.iter().map(|c| &c.bridge_ir_name).collect::<Vec<_>>()
+    );
+
     println!("FIXTURE_PROOF_CID={}", minted.cid);
     let _ = std::fs::remove_dir_all(&td);
 }

--- a/implementations/rust/provekit-verifier/src/body_discharge.rs
+++ b/implementations/rust/provekit-verifier/src/body_discharge.rs
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Body-discharge: reduce a harvested-assertion obligation through the
+// CALLEE FUNCTION BODY, so the solver sees the body's value-semantics
+// (`double(x) = x*2`) instead of an uninterpreted symbol `double`.
+//
+// This is the verification spine the rest of the pipeline was missing
+// (#1440). The pieces it wires together already existed:
+//
+//   - `libprovekit::wp` — the weakest-precondition evaluator that inlines
+//     a callee's body value-expression into the postcondition. It is a
+//     REDUCTION (push the postcondition back through the body, extract the
+//     obligation), not a re-encoding of the body as ProofIR.
+//
+//   - the body-derived `post` carried on a contract memento: for
+//     `fn double(x) -> i64 { x * 2 }`, walk's `lift_function_postcondition`
+//     derives `post = (result == *(x, 2))` — the actual definition, lifted.
+//     (This is walk's lift-half, the verification substrate; NOT the
+//     lower/cycle/carrier machinery.)
+//
+//   - the bridge `sourceSymbol -> targetContractCid`, which names the
+//     body-derived op-contract for a harvested call.
+//
+// What this module adds:
+//
+//   1. `CatalogResolver` — the first non-test `OpContractResolver`. Given
+//      an op name it finds the bridge by symbol, follows
+//      `targetContractCid` to the contract memento, and projects its
+//      `formals` + `post` into an `OpContractInfo` wp can consume.
+//
+//   2. `extract_body_obligation` — for a body-bearing callsite whose
+//      harvested assertion has the shape `=(<call>, <expected>)`,
+//      reconstructs the call as a `core::Term::Op` (Ctor->Op, Delta 1),
+//      derives the postcondition `Q = (result == <expected>)`, and runs
+//      `wp(call, Q, resolver)`. The result is a body-reduced obligation
+//      (e.g. `*(3, 2) == 6`) with no uninterpreted callee symbol.
+//
+// Anything outside the recognized `=(<call>, <expected>)` shape returns
+// `None`: the caller falls through to the existing instantiate path. The
+// spine discharges a real body-obligation; it does not try to be the full
+// gauntlet.
+
+use serde_json::Value as Json;
+
+use libprovekit::core::types::Term;
+use libprovekit::wp::{self, OpContractInfo, OpContractResolver, SlotInfo, WpError};
+use provekit_ir_types::{IrFormula, IrTerm};
+
+use crate::types::{memento_body, memento_kind, CallSite, MementoPool};
+
+/// The variable name the derived postcondition equates the call's result
+/// with. Matches `libprovekit::wp::DEFAULT_RESULT_VAR` and the
+/// body-derived contract's `result = ...` shape.
+const RESULT_VAR: &str = "result";
+
+/// A catalog/pool-backed [`OpContractResolver`]. Resolves an op name to
+/// its body-derived op-contract by walking the bridge index:
+///
+///   op_name -> bridges_by_symbol[op_name].targetContractCid
+///           -> mementos[targetContractCid].body
+///           -> OpContractInfo { slots = formals, post }
+///
+/// This is the production resolver wp needs; the only other impl is the
+/// in-memory `MapResolver` used by wp's unit tests.
+pub struct CatalogResolver<'a> {
+    pool: &'a MementoPool,
+}
+
+impl<'a> CatalogResolver<'a> {
+    /// Build a resolver over a loaded memento pool.
+    pub fn new(pool: &'a MementoPool) -> Self {
+        Self { pool }
+    }
+
+    /// Find the contract memento body that the bridge for `op_name`
+    /// targets. Returns the contract body JSON object, or `None` if there
+    /// is no bridge for that symbol, the target CID is not in the pool, or
+    /// the target memento is not a contract.
+    fn target_contract_body(&self, op_name: &str) -> Option<&'a Json> {
+        let bridge = self.pool.bridges_by_symbol.get(op_name)?;
+        let bbody = bridge.get("evidence").and_then(|e| e.get("body"));
+        // v1.2-layered bridges carry the fields on `header`; v1.1-flat on
+        // `evidence.body`. Try flat first, then the header form.
+        let target_cid = bbody
+            .and_then(|b| b.get("targetContractCid"))
+            .or_else(|| bridge.pointer("/header/targetContractCid"))
+            .and_then(|v| v.as_str())?;
+        let env = self.pool.mementos.get(target_cid)?;
+        if memento_kind(env) != Some("contract") {
+            return None;
+        }
+        memento_body(env).filter(|v| v.is_object())
+    }
+}
+
+impl OpContractResolver for CatalogResolver<'_> {
+    fn lookup(&self, op_name: &str) -> Option<OpContractInfo> {
+        let body = self.target_contract_body(op_name)?;
+
+        // The body-derived op-contract carries the function's formals as a
+        // `formals` array (written by `core::bind`'s bridge writer). The
+        // slot names MUST match the free variables of `post` so wp can
+        // substitute the call's arg into the right formal. A contract with
+        // no `formals` is NOT a body-derived op-contract (e.g. the older
+        // cross-language refinement-target contracts that carry only a
+        // `pre` forall); return `None` so the caller falls through to the
+        // existing refinement path rather than mis-firing wp on it.
+        let formals: Vec<String> = body
+            .get("formals")
+            .and_then(|v| v.as_array())?
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+
+        // The body-derived postcondition (`result == <value_expr>`). A
+        // body-derived op-contract MUST carry one; without it there is
+        // nothing for wp to inline, so this is not a body-bearing target.
+        let post: IrFormula = serde_json::from_value(body.get("post")?.clone()).ok()?;
+
+        // A value-op has one value slot per formal; no Stmt slots (the body
+        // value-expression is a pure value, not a sub-statement).
+        let slots: Vec<SlotInfo> = formals.iter().map(SlotInfo::value).collect();
+
+        let mut info = OpContractInfo::new(slots);
+        info.post = Some(post);
+        // Require a recognizable `result == <value_expr>` shape; otherwise
+        // wp has no value expression to inline and would error. Falling
+        // through is the honest posture for a non-body-derived contract.
+        info.value_expr()?;
+        Some(info)
+    }
+}
+
+/// The kind of obligation `extract_body_obligation` produced, for the
+/// caller's receipt row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BodyObligation {
+    /// A body-reduced obligation formula, ready for the SMT emitter. The
+    /// callee symbol has been inlined; no uninterpreted constant remains.
+    Reduced(Json),
+}
+
+/// Try to build a body-reduced obligation for a body-bearing callsite.
+///
+/// Returns `Ok(Some(..))` when:
+///   - the callsite's harvested assertion is `=(<call>, <expected>)` with
+///     `<call>` the ctor whose name == the bridge's sourceSymbol, AND
+///   - the resolver knows the callee's body-derived op-contract.
+///
+/// Returns `Ok(None)` when the shape is not recognized or the callee has
+/// no body-derived contract: the caller falls through to the existing
+/// (instantiate-based) discharge path. Returns `Err` only when wp itself
+/// refuses or errors on a contract it DID resolve (a real, reportable gap,
+/// e.g. an arity mismatch).
+pub fn extract_body_obligation(
+    cs: &CallSite,
+    pool: &MementoPool,
+) -> Result<Option<BodyObligation>, String> {
+    let resolver = CatalogResolver::new(pool);
+
+    // The callee must have a body-derived contract; otherwise this is not
+    // a body-bearing claim (fall through).
+    if resolver.lookup(&cs.bridge_ir_name).is_none() {
+        return Ok(None);
+    }
+
+    // Recognize the `=(<call>, <expected>)` assertion shape. The callsite
+    // carries the containing atomic (the `=` predicate the call sits in),
+    // captured by `enumerate_callsites`.
+    let Some((call_json, expected_json)) = recognize_eq_call(cs) else {
+        return Ok(None);
+    };
+
+    // Ctor->Op (Delta 1): deserialize the harvested call as an `IrTerm`
+    // (a `ctor`), then convert into a `core::Term::Op` so wp's `wp_op`
+    // dispatches on it. The op CID is the deterministic name-derived CID.
+    let call_ir: IrTerm = match serde_json::from_value(call_json.clone()) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let call_term: Term = call_ir.into();
+    // Guard: the recognized call must actually be an op (a ctor with args).
+    if !matches!(call_term, Term::Op { .. }) {
+        return Ok(None);
+    }
+
+    // The expected value (RHS of the assertion) becomes the postcondition:
+    //   Q = (result == <expected>)
+    let expected_ir: IrTerm = match serde_json::from_value(expected_json.clone()) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let q = IrFormula::Atomic {
+        name: "=".to_string(),
+        args: vec![
+            IrTerm::Var {
+                name: RESULT_VAR.to_string(),
+            },
+            expected_ir,
+        ],
+    };
+
+    // Reduce: push Q back through the body. wp inlines `double`'s body
+    // value-expression, leaving e.g. `*(3, 2) == 6` (no `double` symbol).
+    match wp::wp(&call_term, &q, &resolver) {
+        Ok(reduced) => {
+            let reduced_json =
+                serde_json::to_value(&reduced).map_err(|e| format!("wp obligation serialize: {e}"))?;
+            Ok(Some(BodyObligation::Reduced(reduced_json)))
+        }
+        Err(WpError::Refused(_)) => {
+            // The callee resolved but a sub-term did not (an unresolved
+            // nested call). Not a body-bearing claim we can discharge; fall
+            // through honestly rather than forcing.
+            Ok(None)
+        }
+        Err(e) => Err(format!("wp body-reduction failed: {e}")),
+    }
+}
+
+/// Recognize the `=(<call>, <expected>)` harvested-assertion shape on a
+/// callsite. `<call>` is the ctor whose name == `cs.bridge_ir_name`.
+/// Returns `(call_json, expected_json)` — borrowing from the callsite's
+/// captured containing atomic — or `None` for any other shape.
+fn recognize_eq_call(cs: &CallSite) -> Option<(&Json, &Json)> {
+    let atomic = cs.containing_atomic.as_ref()?;
+    if atomic.get("kind").and_then(|v| v.as_str()) != Some("atomic") {
+        return None;
+    }
+    if atomic.get("name").and_then(|v| v.as_str()) != Some("=") {
+        return None;
+    }
+    let args = atomic.get("args").and_then(|v| v.as_array())?;
+    if args.len() != 2 {
+        return None;
+    }
+    // Find which side is the bridged call ctor; the other is the expected
+    // value. The harvester writes `=(call, expected)`, but accept either
+    // order defensively.
+    let is_call = |t: &Json| -> bool {
+        t.get("kind").and_then(|v| v.as_str()) == Some("ctor")
+            && t.get("name").and_then(|v| v.as_str()) == Some(cs.bridge_ir_name.as_str())
+    };
+    if is_call(&args[0]) && !is_call(&args[1]) {
+        Some((&args[0], &args[1]))
+    } else if is_call(&args[1]) && !is_call(&args[0]) {
+        Some((&args[1], &args[0]))
+    } else {
+        None
+    }
+}

--- a/implementations/rust/provekit-verifier/src/body_discharge.rs
+++ b/implementations/rust/provekit-verifier/src/body_discharge.rs
@@ -147,11 +147,19 @@ pub enum BodyObligation {
 ///     `<call>` the ctor whose name == the bridge's sourceSymbol, AND
 ///   - the resolver knows the callee's body-derived op-contract.
 ///
-/// Returns `Ok(None)` when the shape is not recognized or the callee has
-/// no body-derived contract: the caller falls through to the existing
-/// (instantiate-based) discharge path. Returns `Err` only when wp itself
-/// refuses or errors on a contract it DID resolve (a real, reportable gap,
-/// e.g. an arity mismatch).
+/// Returns `Ok(None)` ONLY when the callee has **no** body-derived
+/// op-contract: the claim is genuinely not body-bearing and the caller
+/// falls through to the existing (instantiate-based) refinement path.
+///
+/// Returns `Err` (a REFUSAL) when the callee **does** have a body-derived
+/// op-contract but the obligation cannot be reduced through it: the
+/// assertion shape is not the recognized `=(<call>, <expected>)`, an
+/// operand is unconvertible, or wp itself refuses/errors. This is the
+/// load-bearing honesty boundary: once a callee is body-bearing, the spine
+/// MUST either reduce the obligation or refuse it. It must NOT fall through
+/// to the refinement path, because that path treats a body-derived
+/// op-contract (which carries `post`/`formals` but no `pre`) as VACUOUS and
+/// reports a false `discharged`/`pass` for a claim it never checked.
 pub fn extract_body_obligation(
     cs: &CallSite,
     pool: &MementoPool,
@@ -159,37 +167,63 @@ pub fn extract_body_obligation(
     let resolver = CatalogResolver::new(pool);
 
     // The callee must have a body-derived contract; otherwise this is not
-    // a body-bearing claim (fall through).
+    // a body-bearing claim (fall through honestly).
     if resolver.lookup(&cs.bridge_ir_name).is_none() {
         return Ok(None);
     }
+
+    // From here on the callee IS body-bearing. Every failure to build the
+    // obligation is a REFUSAL (`Err`), never an `Ok(None)` fall-through —
+    // see the doc comment's honesty boundary.
 
     // Recognize the `=(<call>, <expected>)` assertion shape. The callsite
     // carries the containing atomic (the `=` predicate the call sits in),
     // captured by `enumerate_callsites`.
     let Some((call_json, expected_json)) = recognize_eq_call(cs) else {
-        return Ok(None);
+        let shape = cs
+            .containing_atomic
+            .as_ref()
+            .and_then(|a| a.get("name"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("<none>");
+        return Err(format!(
+            "refuse: callee `{}` has a body-derived contract but the harvested \
+             assertion is not the reducible `=(<call>, <expected>)` shape \
+             (containing predicate: `{shape}`); the body-discharge spine \
+             refuses rather than reporting a vacuous pass",
+            cs.bridge_ir_name
+        ));
     };
 
     // Ctor->Op (Delta 1): deserialize the harvested call as an `IrTerm`
     // (a `ctor`), then convert into a `core::Term::Op` so wp's `wp_op`
     // dispatches on it. The op CID is the deterministic name-derived CID.
-    let call_ir: IrTerm = match serde_json::from_value(call_json.clone()) {
-        Ok(t) => t,
-        Err(_) => return Ok(None),
-    };
+    let call_ir: IrTerm = serde_json::from_value(call_json.clone()).map_err(|e| {
+        format!(
+            "refuse: callee `{}` is body-bearing but its call term did not \
+             deserialize as an IR term: {e}",
+            cs.bridge_ir_name
+        )
+    })?;
     let call_term: Term = call_ir.into();
     // Guard: the recognized call must actually be an op (a ctor with args).
     if !matches!(call_term, Term::Op { .. }) {
-        return Ok(None);
+        return Err(format!(
+            "refuse: callee `{}` is body-bearing but its call term is not an \
+             op (no args to reduce through the body)",
+            cs.bridge_ir_name
+        ));
     }
 
     // The expected value (RHS of the assertion) becomes the postcondition:
     //   Q = (result == <expected>)
-    let expected_ir: IrTerm = match serde_json::from_value(expected_json.clone()) {
-        Ok(t) => t,
-        Err(_) => return Ok(None),
-    };
+    let expected_ir: IrTerm = serde_json::from_value(expected_json.clone()).map_err(|e| {
+        format!(
+            "refuse: callee `{}` is body-bearing but the assertion's expected \
+             value did not deserialize as an IR term: {e}",
+            cs.bridge_ir_name
+        )
+    })?;
     let q = IrFormula::Atomic {
         name: "=".to_string(),
         args: vec![
@@ -208,11 +242,18 @@ pub fn extract_body_obligation(
                 serde_json::to_value(&reduced).map_err(|e| format!("wp obligation serialize: {e}"))?;
             Ok(Some(BodyObligation::Reduced(reduced_json)))
         }
-        Err(WpError::Refused(_)) => {
-            // The callee resolved but a sub-term did not (an unresolved
-            // nested call). Not a body-bearing claim we can discharge; fall
-            // through honestly rather than forcing.
-            Ok(None)
+        Err(WpError::Refused(r)) => {
+            // The top-level callee resolved (we are past the lookup gate),
+            // but wp could not complete the reduction — e.g. a nested call
+            // whose contract has not landed. This is a body-bearing claim we
+            // cannot discharge, so we REFUSE: falling through to the
+            // refinement path would mis-read the body-derived op-contract as
+            // vacuous and report a false pass.
+            Err(format!(
+                "refuse: callee `{}` is body-bearing but wp could not reduce \
+                 the obligation: {r}",
+                cs.bridge_ir_name
+            ))
         }
         Err(e) => Err(format!("wp body-reduction failed: {e}")),
     }

--- a/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
+++ b/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
@@ -8,19 +8,20 @@
 
 use serde_json::Value as Json;
 
-use crate::types::{CallSite, MementoPool};
+use crate::types::{memento_body, memento_kind, CallSite, MementoPool};
 
 pub fn run(pool: &MementoPool) -> Vec<CallSite> {
     let mut out = Vec::new();
     for (cid, env) in &pool.mementos {
-        let ev = match env.get("evidence") {
-            Some(v) if v.is_object() => v,
-            _ => continue,
-        };
-        if ev.get("kind").and_then(|k| k.as_str()) != Some("contract") {
+        // Shape-agnostic (matches resolve_target): v1.2-layered contracts
+        // carry their kind on `header.kind` and pre/post/inv on `header`;
+        // v1.1-flat carry them on `evidence.kind` / `evidence.body`. The
+        // production harvest path (`mint_contract`) emits v1.2; reading
+        // only `evidence.body` here meant harvested calls never enumerated.
+        if memento_kind(env) != Some("contract") {
             continue;
         }
-        let body = match ev.get("body") {
+        let body = match memento_body(env) {
             Some(v) if v.is_object() => v,
             _ => continue,
         };
@@ -56,7 +57,11 @@ fn walk_formula(
         "atomic" => {
             if let Some(args) = f.get("args").and_then(|v| v.as_array()) {
                 for a in args {
-                    walk_term(a, property_name, property_cid, pool, out);
+                    // Pass the enclosing atomic down: when a bridged call
+                    // ctor is found as a direct argument of this atomic,
+                    // the body-discharge path needs the whole predicate
+                    // (e.g. `=(double(3), 6)`) to derive the postcondition.
+                    walk_term(a, property_name, property_cid, pool, Some(f), out);
                 }
             }
         }
@@ -83,6 +88,7 @@ fn walk_term(
     property_name: &str,
     property_cid: &str,
     pool: &MementoPool,
+    containing_atomic: Option<&Json>,
     out: &mut Vec<CallSite>,
 ) {
     if !t.is_object() {
@@ -97,9 +103,9 @@ fn walk_term(
         .unwrap_or_default()
         .to_string();
     if let Some(benv) = pool.bridges_by_symbol.get(&name) {
-        let bbody = benv
-            .get("evidence")
-            .and_then(|e| e.get("body"))
+        // Shape-agnostic: v1.2-layered bridges carry the fields on
+        // `header`; v1.1-flat on `evidence.body`.
+        let bbody = memento_body(benv)
             .cloned()
             .unwrap_or_else(|| serde_json::json!({}));
         // Forward pin: REQUIRED by the current BridgeDeclaration grammar
@@ -137,12 +143,16 @@ fn walk_term(
                 .get("args")
                 .and_then(|v| v.as_array())
                 .and_then(|arr| arr.first().cloned()),
+            containing_atomic: containing_atomic.cloned(),
         };
         out.push(cs);
     }
+    // Descend into the call's arguments. A nested call is no longer a
+    // direct argument of `containing_atomic`, so stop threading it: only a
+    // call DIRECTLY under an atomic carries that atomic as its `Q` source.
     if let Some(args) = t.get("args").and_then(|v| v.as_array()) {
         for a in args {
-            walk_term(a, property_name, property_cid, pool, out);
+            walk_term(a, property_name, property_cid, pool, None, out);
         }
     }
 }

--- a/implementations/rust/provekit-verifier/src/lib.rs
+++ b/implementations/rust/provekit-verifier/src/lib.rs
@@ -32,6 +32,7 @@
 // Stages 3-5 fan out per callsite via rayon (mirrors the C++
 // std::async fan-out and Go goroutines).
 
+pub mod body_discharge;
 pub mod call_edge_loader;
 pub mod cbor_decode;
 pub mod domain_claim_verifier;

--- a/implementations/rust/provekit-verifier/src/resolve_target.rs
+++ b/implementations/rust/provekit-verifier/src/resolve_target.rs
@@ -69,10 +69,17 @@ pub fn run(cs: &CallSite, pool: &MementoPool) -> Result<ResolvedProperty, String
     // (body-bearing). The caller must NOT vacuous-pass such a target if its
     // obligation was not reduced + discharged; it must refuse. Surface the
     // marker here, where the body is already in hand.
+    //
+    // PRESENCE, not non-emptiness, is the marker: a zero-arg body-derived
+    // contract carries `formals: []` (a body, no parameters) and is still
+    // body-bearing. Gating on `!is_empty()` would let `formals: []` + a
+    // non-equation post + no pre slip back into the vacuous-discharge branch.
+    // A genuinely non-body-bearing target (e.g. a LIA refinement contract)
+    // carries no `formals` key at all, so it stays on the legitimate path.
     let target_is_body_bearing = body
         .get("formals")
         .and_then(|v| v.as_array())
-        .is_some_and(|arr| !arr.is_empty());
+        .is_some();
     Ok(ResolvedProperty {
         cid: cs.bridge_target_cid.clone(),
         ir_formula,

--- a/implementations/rust/provekit-verifier/src/resolve_target.rs
+++ b/implementations/rust/provekit-verifier/src/resolve_target.rs
@@ -65,9 +65,18 @@ pub fn run(cs: &CallSite, pool: &MementoPool) -> Result<ResolvedProperty, String
     }
 
     let ir_formula = body.get("pre").cloned();
+    // A target carrying a `formals` array is a body-derived op-contract
+    // (body-bearing). The caller must NOT vacuous-pass such a target if its
+    // obligation was not reduced + discharged; it must refuse. Surface the
+    // marker here, where the body is already in hand.
+    let target_is_body_bearing = body
+        .get("formals")
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| !arr.is_empty());
     Ok(ResolvedProperty {
         cid: cs.bridge_target_cid.clone(),
         ir_formula,
         ir_kit_version: String::new(),
+        target_is_body_bearing,
     })
 }

--- a/implementations/rust/provekit-verifier/src/runner.rs
+++ b/implementations/rust/provekit-verifier/src/runner.rs
@@ -834,6 +834,27 @@ fn work_one(
     };
 
     if resolved.ir_formula.is_none() {
+        // HONESTY BOUNDARY (mirrors cmd_verify::verify_one_claim). The
+        // vacuous-discharge shortcut ("no precondition => nothing to prove")
+        // is legitimate ONLY for a genuinely non-body-bearing target. A
+        // target carrying `formals` is a body-derived op-contract: its `post`
+        // describes a body whose obligation the runner does NOT reduce here,
+        // so vacuous-passing it would be a false green. Refuse instead
+        // (Undecidable): not discharged, no witness.
+        if resolved.target_is_body_bearing {
+            n_residue.fetch_add(1, Ordering::Relaxed);
+            return (
+                cs.clone(),
+                ObligationVerdict::Undecidable,
+                format!(
+                    "body-discharge: refuse: target `{}` is body-bearing \
+                     (carries `formals`) but the runner did not reduce its \
+                     obligation and it has no precondition; refusing rather \
+                     than reporting a vacuous pass",
+                    cs.bridge_ir_name
+                ),
+            );
+        }
         n_vacuous.fetch_add(1, Ordering::Relaxed);
         return (
             cs.clone(),

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -684,6 +684,13 @@ pub struct CallSite {
     pub property_name: String,
     pub property_cid: String,
     pub arg_term: Option<Json>,
+    /// The atomic predicate the matched call ctor sits directly inside, if
+    /// the call was found as an argument of an atomic (e.g. the `=` in a
+    /// harvested `assert_eq!(double(3), 6)` -> `=(double(3), 6)`). Captured
+    /// so the body-discharge path can derive the postcondition `Q` (the
+    /// atomic with the call replaced by `result`). `None` when the call was
+    /// not directly under an atomic. Does not participate in any CID.
+    pub containing_atomic: Option<Json>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -698,6 +698,23 @@ pub struct ResolvedProperty {
     pub cid: String,
     pub ir_formula: Option<Json>,
     pub ir_kit_version: String,
+    /// True iff the resolved target contract is a body-derived op-contract
+    /// (body-bearing), not a plain refinement target.
+    ///
+    /// The canonical marker is a non-empty `formals` array on the contract
+    /// body: that is what `core::bind::bind_function_bridge` mints and what
+    /// body-bearing test fixtures construct. If a future contract shape
+    /// carries body markers under a different field, it MUST be recognized
+    /// here (`resolve_target::run` is the single setter) so the honesty
+    /// boundary stays complete.
+    ///
+    /// A body-bearing target whose obligation cannot be reduced and
+    /// discharged MUST be refused, never vacuous-passed -- the "no
+    /// precondition => vacuously true" shortcut is only legitimate for
+    /// genuinely non-body-bearing claims. Both consumers enforce this before
+    /// their vacuous-discharge branch: `cmd_verify::verify_one_claim` and
+    /// `runner::work_one`.
+    pub target_is_body_bearing: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/implementations/rust/provekit-verifier/tests/instantiate.rs
+++ b/implementations/rust/provekit-verifier/tests/instantiate.rs
@@ -32,6 +32,7 @@ fn resolved(formula: serde_json::Value) -> ResolvedProperty {
         cid: "blake3-512:00".into(),
         ir_formula: Some(formula),
         ir_kit_version: String::new(),
+        ..Default::default()
     }
 }
 
@@ -242,6 +243,7 @@ fn errors_when_resolved_has_no_ir_formula() {
         cid: "blake3-512:00".into(),
         ir_formula: None,
         ir_kit_version: String::new(),
+        ..Default::default()
     };
     let arg = Some(json!({"kind": "var", "name": "x"}));
     let r = instantiate::run(&rp, &arg);
@@ -296,6 +298,7 @@ fn obligation_carries_property_cid_and_kit_version() {
         cid: "blake3-512:abc".into(),
         ir_formula: Some(forall_n_gt_0()),
         ir_kit_version: "rust-kit@1.0".into(),
+        ..Default::default()
     };
     let r = instantiate::run(&rp, &arg).expect("instantiate");
     assert_eq!(r.property_cid, "blake3-512:abc");

--- a/implementations/rust/provekit-verifier/tests/round_trip_smt.rs
+++ b/implementations/rust/provekit-verifier/tests/round_trip_smt.rs
@@ -29,6 +29,7 @@ fn instantiate_then_smt_emit_basic() {
         cid: "blake3-512:00".into(),
         ir_formula: Some(pre),
         ir_kit_version: String::new(),
+        ..Default::default()
     };
     // Caller passed a var "x" as the argument.
     let arg = Some(json!({"kind": "var", "name": "x"}));


### PR DESCRIPTION
## Summary

Wires the **verification spine**: `verify` now proves a function BODY satisfies a harvested contract, both ways. Closes the #1440 gap where the wp evaluator existed but was unreachable, so z3 saw the user function as an uninterpreted `Ctor` -> "unknown constant" -> **Undecidable for both positive and negative**.

### The three deltas (NEW-BUILD on top of the existing `libprovekit::wp`)

1. **Ctor->Op at the wp boundary.** `verify` reconstructs a harvested call as a `core::Term::Op` (via `From<IrTerm>`) so wp's `wp_op` dispatches on it. The harvester and `enumerate_callsites` keep the JSON-ctor flow (the production path locked by the new regression test).
2. **Body-derived op-contract + catalog resolver.** `body_discharge::CatalogResolver` is the first non-test `OpContractResolver`: op name -> bridge by symbol -> `targetContractCid` -> contract memento -> projects its **body-derived `post`** (`result == *(x,2)`, lifted by walk's `lift_function_postcondition` -- the **lift-half**, NOT the cycle/lower/carrier machinery) + `formals` into an `OpContractInfo`. Non-body-derived contracts return `None` and fall through to the existing refinement path untouched.
3. **Bridge writer in `core::bind`.** `bind_function_bridge` takes a `FunctionContractMemento` and emits both the body-derived op-contract member and the bridge (`sourceSymbol -> targetContractCid -> targetProofCid`). The bridge CID commits to the op-contract CID (proofchain rollup).

### Load-bearing shape fix (flagged for review)

`enumerate_callsites` was **v1.1-flat only**, but the production harvest path (`mint_contract`) emits **v1.2-layered** mementos -- so harvested calls never enumerated. Made it shape-agnostic via `memento_kind`/`memento_body`, matching what `resolve_target` already does. Without this the spine can't see harvested contracts at all.

### The proof (committed, z3-gated: `cmd_verify_body_discharge.rs`)

- **Positive**: `double(x)=x*2`, `assert_eq!(double(3),6)` -> wp reduces to `*(3,2)==6` -> z3 discharges -> pass, signed witness minted.
- **Negative**: break body to `x*3` -> `*(3,3)==6` -> z3 finds `9!=6` SAT on the negation -> **Unsatisfied, exit 1, no witness**. Fails HONESTLY (Unsatisfied, not Undecidable) because no uninterpreted symbol survives the reduction.

Plus the regression the harvester round-trip test was missing: `enumerate_callsites` is empty before bind and **non-empty after harvest+bind**.

## Test plan

- [x] `cargo build --workspace` green
- [x] `cmd_verify_body_discharge`: positive discharges + signed witness; negative is Unsatisfied + exit 1 + no witness
- [x] `cmd_verify_integration` (the existing v1.1 LIA + violated tests) still pass (body path falls through cleanly)
- [x] `round_trip` regression: enumerate empty before bind, non-empty after
- [x] `bind_function_bridge` unit test (op-contract + pinned bridge, CID rollup)
- [x] libprovekit (101) + verifier suites green

## Pre-existing failure (not this branch)

`libprovekit` `d7_v1_source_round_trip::value_null_source_round_trip_receipt_is_complete` fails on the base commit `95b9632fd` too (byte-identical realize, the cycle machinery being retired). Verified by stashing this branch's changes.

ref #1440

Generated with Claude Opus 4.7 (1M context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fast-path verification for function contracts using body-discharge optimization. The verifier now efficiently handles claims about function calls when they match recognized contract patterns.

* **Tests**
  * Added comprehensive end-to-end tests validating body-discharge verification, including positive cases with successful verification and negative cases confirming proper failure handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->