### PR TITLE
Go onboarding: a Go library declares a boundary and gets a verifiable contract

### DIFF
--- a/examples/go-double/.provekit/config.toml
+++ b/examples/go-double/.provekit/config.toml
@@ -1,0 +1,19 @@
+# ProvekIt project config for the Go end-to-end example.
+#
+# `[authoring] surface = "go"` selects the Go lift surface (the manifest at
+# .provekit/lift/go/manifest.toml). `[solvers]` names z3 for the linear-
+# arithmetic class the body-obligation `(* 3 2) == 6` falls into; the
+# `-smt2 -in` flags mirror the verifier's default z3 invocation.
+[authoring]
+surface = "go"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]

--- a/examples/go-double/.provekit/lift/go/manifest.toml
+++ b/examples/go-double/.provekit/lift/go/manifest.toml
@@ -1,0 +1,15 @@
+# Go lift surface for `provekit mint` / `provekit verify`.
+#
+# `command` is the verify-facing Go lift binary (provekit-lift-go-verify),
+# launched in RPC mode. Build it first from the implementations/go module:
+#
+#     cd implementations/go && go build -o /tmp/provekit-lift-go-verify ./cmd/provekit-lift-go-verify
+#
+# then run the example with the binary on PATH or by editing `command[0]`
+# below to the built path. The integration test
+# (provekit-cli/tests/cmd_verify_go_production_bridge.rs) builds the binary and
+# rewrites this manifest's command to the built path in a tempdir copy, so the
+# in-repo example stays build-location-agnostic.
+name = "go"
+command = ["provekit-lift-go-verify", "--rpc"]
+working_dir = "."

--- a/examples/go-double/.provekit/realize/go/manifest.toml
+++ b/examples/go-double/.provekit/realize/go/manifest.toml
@@ -1,0 +1,15 @@
+# Go realize surface for `provekit materialize`: the SHIM that supplies the
+# native Go sugar for a contract's concept (provekit-realize-go-core).
+#
+# Build it first from the implementations/go/provekit-realize-go-core module:
+#
+#     cd implementations/go/provekit-realize-go-core && \
+#       go build -o /tmp/provekit-realize-go ./cmd/provekit-realize-go
+#
+# then edit `command[0]` to the built path or put it on PATH. The gating test
+# (provekit-cli/tests/go_realize_materialize.rs) builds the binary and installs
+# this manifest into a tempdir, so the in-repo example stays
+# build-location-agnostic.
+name = "go-realize"
+command = ["provekit-realize-go", "--rpc"]
+working_dir = "."

--- a/examples/go-double/README.md
+++ b/examples/go-double/README.md
@@ -1,0 +1,52 @@
+# Go end-to-end example: a Go library gets a contract, and the spine verifies it
+
+This is the Go analog of the Rust production-bridge gauntlet
+(`implementations/rust/provekit-cli/tests/cmd_verify_production_bridge.rs`). It
+demonstrates that ProvekIt's verification spine is LANGUAGE-NEUTRAL: a Go
+function's body-derived contract lifts to ProofIR
+(`post = result == <value-expr>` plus `formals`) and the verifier discharges
+the obligation through the body via weakest-precondition + z3, exactly as it
+does for Rust and Java.
+
+## The library
+
+```go
+func Double(x int) int { return x * 2 }
+```
+
+`double_test.go` carries the harvested assertion `assert.Equal(t, Double(3), 6)`.
+
+## The chain (no hand-bridging, no hand-written contracts)
+
+1. The **real Go lifter** (`provekit-lift-go-verify`, the verify-facing `go`
+   lift surface) lifts:
+   - `double.go` -> `function-contract` with `formals: ["x"]` and
+     `post = result == (* x 2)` (the verify-facing dialect normalizes Go's
+     `go:mul` to the SMT-LIB core symbol `*` so z3 can reduce it),
+   - `double_test.go` -> `contract` with `inv = =(Double(3), 6)` (the Go
+     Layer-0 leaf assertion harvester).
+2. `provekit mint` AUTO-WRITES the bridge `Double -> targetContractCid` for the
+   body-bearing function-contract (#1443). The bridge is TOOL-written, not
+   hand-built.
+3. `provekit verify`:
+   - **positive**: reduces `Double(3) == 6` through the body to
+     `(* 3 2) == 6` -> z3 discharges -> signed witness, exit 0.
+   - **negative** (break the body to `x * 3`): the obligation becomes
+     `(* 3 3) == 6` -> z3 refutes -> Unsatisfied, exit 1, no witness.
+
+## Run it
+
+```sh
+cd implementations/go
+go build -o /tmp/provekit-lift-go-verify ./cmd/provekit-lift-go-verify
+# point this example's .provekit/lift/go/manifest.toml command[0] at the binary
+# (or put it on PATH), then from the repo root:
+provekit mint   --project examples/go-double --out examples/go-double --no-attest
+provekit verify --project examples/go-double --emit-witnesses /tmp/go-witnesses
+```
+
+The gating integration test
+(`implementations/rust/provekit-cli/tests/cmd_verify_go_production_bridge.rs`)
+builds the binary, copies this example into a tempdir, and asserts both the
+positive discharge (signed witness, exit 0) and the honest negative
+(Unsatisfied, exit 1, no witness).

--- a/examples/go-double/double.go
+++ b/examples/go-double/double.go
@@ -1,0 +1,14 @@
+// Package sample is the Go library whose contract ProvekIt extracts and
+// verifies end-to-end. `Double` is a body-bearing function: the Go lifter
+// lifts its body `x * 2` to the verify-facing function-contract
+// `post = result == (* x 2)`. `provekit mint` auto-writes the
+// `Double -> targetContractCid` bridge (#1443); `provekit verify` reduces the
+// harvested `Double(3) == 6` assertion through the body via z3.
+package sample
+
+// Double returns twice its argument. The honest body is `x * 2`; the
+// integration test's negative case mutates it to `x * 3` to prove the spine
+// catches a real violation (Unsatisfied, exit 1, no witness).
+func Double(x int) int {
+	return x * 2
+}

--- a/examples/go-double/double_test.go
+++ b/examples/go-double/double_test.go
@@ -1,0 +1,15 @@
+package sample
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDouble is the harvested callsite. The Go Layer-0 leaf harvester lifts
+// `assert.Equal(t, Double(3), 6)` to a contract whose
+// `inv = =(Double(3), 6)` -- the `=(<call>, <expected>)` shape the verifier's
+// body-discharge seam enumerates and reduces through the body of `Double`.
+func TestDouble(t *testing.T) {
+	assert.Equal(t, Double(3), 6)
+}

--- a/examples/go-double/go.mod
+++ b/examples/go-double/go.mod
@@ -1,0 +1,12 @@
+// Standalone example module. It is intentionally NOT part of the
+// implementations/go module tree: the ProvekIt Go lifter consumes these
+// sources via go/parser (it lifts the AST, it does not compile them), so the
+// example demonstrates contract extraction without pulling testify into the
+// implementations/go build. `provekit verify` lifts `double.go` (the
+// function-contract) and `double_test.go` (the harvested `Double(3) == 6`
+// callsite) and discharges the body through z3.
+module example.com/go-double
+
+go 1.22
+
+require github.com/stretchr/testify v1.9.0

--- a/examples/go-identity/.provekit/config.toml
+++ b/examples/go-identity/.provekit/config.toml
@@ -1,0 +1,32 @@
+# Go AUTHORING surface, mirroring the rust authoring config:
+#
+#   [[plugins]] go-bind      (layer = "library-bindings")  -> emits the
+#       `library-sugar-binding-entry` DECLARATION catalog for each
+#       `//provekit:` annotated function.
+#   [[plugins]] go-contracts (emit = "ir-document")        -> emits the
+#       body-derived function-contracts + harvested callsites, gated on the
+#       declaration.
+#
+# Both plugins resolve to the same binary (provekit-lift-go-verify); it emits
+# different IR per surface (as rust's rust-bind / rust-contracts do), so a
+# function is not minted twice.
+[[plugins]]
+name = "go-sugar"
+surface = "go-bind"
+layer = "library-bindings"
+
+[[plugins]]
+name = "go-contracts"
+surface = "go-contracts"
+emit = "ir-document"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]

--- a/examples/go-identity/.provekit/lift/go-bind/manifest.toml
+++ b/examples/go-identity/.provekit/lift/go-bind/manifest.toml
@@ -1,0 +1,3 @@
+name = "go-bind"
+command = ["provekit-lift-go-verify", "--rpc"]
+working_dir = "."

--- a/examples/go-identity/.provekit/lift/go-contracts/manifest.toml
+++ b/examples/go-identity/.provekit/lift/go-contracts/manifest.toml
@@ -1,0 +1,3 @@
+name = "go-contracts"
+command = ["provekit-lift-go-verify", "--rpc"]
+working_dir = "."

--- a/examples/go-identity/.provekit/realize/go/manifest.toml
+++ b/examples/go-identity/.provekit/realize/go/manifest.toml
@@ -1,0 +1,6 @@
+# Go realize surface: the SHIM that materializes the `identity` concept back
+# into Go sugar (provekit-realize-go-core). Closes the loop: the boundary the
+# author declared above is realized here as `func Id(x int) int { return x }`.
+name = "go-realize"
+command = ["provekit-realize-go", "--rpc"]
+working_dir = "."

--- a/examples/go-identity/README.md
+++ b/examples/go-identity/README.md
@@ -1,0 +1,60 @@
+# Go authoring surface: a Go library DECLARES a boundary and GETS a contract
+
+This is the Go peer of the rust/java authoring surface. A Go library author
+marks a function with the `//provekit:` doc-comment directive (the idiomatic Go
+analog of rust's `#[provekit::sugar(...)]` attribute, in the family of
+`//go:generate` / `//go:build`), and that DECLARATION drives contract emission.
+
+It closes the loop the verify-side and realize-side examples opened: one
+function, `Id`, declares a boundary, GETS a contract, and that same contract
+both **discharges through the verifier spine** and **materializes back into Go**
+via `provekit-realize-go-core`.
+
+## The declaration
+
+```go
+//provekit:sugar(concept="identity", library="builtin", version="1")
+func Id(x int) int { return x }
+```
+
+`Unannotated` (no directive) is NOT lifted by the authoring surface: the author
+did not ask for a contract there.
+
+## The authoring surface (`.provekit/config.toml`)
+
+Two `[[plugins]]`, mirroring rust's `rust-bind` / `rust-contracts`:
+
+- `go-bind` (`layer = "library-bindings"`) emits the
+  `library-sugar-binding-entry` DECLARATION catalog for each annotated function.
+- `go-contracts` (`emit = "ir-document"`) emits the body-derived
+  function-contracts + harvested callsites, gated on the declaration.
+
+Both resolve to `provekit-lift-go-verify`, which emits different IR per surface
+(so a function is not minted twice).
+
+## The closed loop
+
+1. **Declare**: author writes `//provekit:sugar(concept="identity")` on `Id`.
+2. **Get a contract**: `provekit mint` lifts ONLY `Id` (declaration-gated),
+   emits its binding-entry + function-contract `post = result == x`, and
+   auto-writes the `Id -> targetContractCid` bridge.
+3. **Verify**: `provekit verify` reduces the harvested `Id(3) == 3` through the
+   body `x` -> `3 == 3` -> z3 discharges -> signed witness, exit 0.
+4. **Materialize**: `provekit-realize-go-core` realizes the same `identity`
+   concept back into Go: `func Id(x int) int { return x }`, which `go build`s.
+
+## Run it
+
+```sh
+cd implementations/go
+go build -o /tmp/provekit-lift-go-verify ./cmd/provekit-lift-go-verify
+cd provekit-realize-go-core && go build -o /tmp/provekit-realize-go ./cmd/provekit-realize-go
+# point the manifests' command[0] at the built binaries (or put them on PATH), then:
+provekit mint   --project examples/go-identity --out examples/go-identity --no-attest
+provekit verify --project examples/go-identity --emit-witnesses /tmp/go-id-witnesses
+```
+
+The gating tests
+(`provekit-cli/tests/cmd_authoring_surface_go.rs` for declare->contract->verify,
+and `provekit-cli/tests/go_realize_materialize.rs` for materialize) reproduce
+the loop.

--- a/examples/go-identity/go.mod
+++ b/examples/go-identity/go.mod
@@ -1,0 +1,7 @@
+// Standalone example module (parser-only; the Go lifter consumes these
+// sources via go/ast, it does not compile them). See README.md.
+module example.com/go-identity
+
+go 1.22
+
+require github.com/stretchr/testify v1.9.0

--- a/examples/go-identity/id.go
+++ b/examples/go-identity/id.go
@@ -1,0 +1,26 @@
+// Package sample is a Go library that DECLARES a ProvekIt boundary on one of
+// its functions, the way rust (`#[provekit::sugar(...)]`) and java authors do.
+// The `//provekit:sugar(...)` doc-comment directive is the Go authoring idiom
+// (analogous to `//go:generate` / `//go:build`). Running the authoring surface
+// (`provekit mint` with the go-bind / go-contracts plugins) lifts ONLY the
+// declared function and emits its contract -- the DECLARATION drives emission.
+package sample
+
+// Id is the boundary the author declares. The `identity` concept is realized
+// in Go as `return x`; the lifted contract `post = result == x` discharges
+// through the verifier spine AND the same `identity` concept materializes back
+// into Go via provekit-realize-go-core. One function, both directions: the
+// closed loop.
+//
+//provekit:sugar(concept="identity", library="builtin", version="1")
+func Id(x int) int {
+	return x
+}
+
+// Unannotated carries NO //provekit declaration, so the authoring surface does
+// NOT lift it: the author did not ask for a contract here. (The bare `go`
+// verify surface would still lift it; the authoring surface is declaration-
+// gated.)
+func Unannotated(y int) int {
+	return y + 1
+}

--- a/examples/go-identity/id_test.go
+++ b/examples/go-identity/id_test.go
@@ -1,0 +1,15 @@
+package sample
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestId is the harvested callsite for the declared boundary. The leaf
+// harvester lifts `assert.Equal(t, Id(3), 3)` to a contract whose
+// `inv = =(Id(3), 3)`, which the verifier reduces through the body-derived
+// contract for `Id` (`post = result == x`) -> `3 == 3` -> z3 discharges.
+func TestId(t *testing.T) {
+	assert.Equal(t, Id(3), 3)
+}

--- a/implementations/go/cmd/provekit-lift-go-verify/main.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/main.go
@@ -1,0 +1,291 @@
+// Command provekit-lift-go-verify is the VERIFY-FACING Go lift surface.
+//
+// It is the binary the kit-dispatch `go` lift surface resolves for the
+// `provekit verify` pipeline. It speaks the legacy-retained
+// `initialize` / `lift` / `shutdown` JSON-RPC the language-neutral
+// dispatcher drives (implementations/rust/provekit-cli/src/kit_dispatch.rs),
+// and returns ONE `ir-document` combining two real Go lift passes over the
+// workspace:
+//
+//  1. Body-derived function-contracts from the library's non-test `.go`
+//     files, lifted in the VERIFY-FACING dialect (liftgo.LiftSourceCore):
+//     arithmetic / comparison ops are emitted with their SMT-LIB core
+//     symbols (`*`, `+`, `<`, ...) so the body-derived
+//     `post = result == <body-expr>` is z3-dischargeable. This is the Go
+//     analog of Java's ProductionWalk vs JavaSourceLifter split — Go is
+//     wired INTO the language-neutral verifier spine by speaking the op
+//     vocabulary the spine already understands; the spine is NOT modified.
+//
+//  2. Harvested callsite assertions from the library's `_test.go` files,
+//     via the existing, tested Go Layer-0 assertion harvester
+//     (lifgotests.LiftFile): `assert.Equal(t, Double(3), 6)` lifts to a
+//     `contract` whose `inv = =(Double(3), 6)` — exactly the harvested
+//     `=(<call>, <expected>)` shape the verifier's body-discharge seam
+//     enumerates as a callsite.
+//
+// `provekit mint` then (#1443) auto-writes the `Double -> targetContractCid`
+// bridge for the body-bearing function-contract, and `provekit verify`
+// reduces `Double(3) == 6` through the body `(* x 2)` -> `(* 3 2) == 6` ->
+// z3 discharges (positive) / refutes (broken body, negative).
+//
+// HONEST: no contract or bridge is hand-written here; both halves are real
+// lifter output. Supra omnia, rectum.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	liftgo "github.com/tsavo/provekit/go/provekit-lift-go"
+	lifgotests "github.com/tsavo/provekit/go/provekit-lift-go-tests"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--rpc" {
+		if err := runRPC(os.Stdin, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "provekit-lift-go-verify rpc: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	fmt.Fprintln(os.Stderr, "usage: provekit-lift-go-verify --rpc")
+	os.Exit(1)
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type liftParams struct {
+	WorkspaceRoot string   `json:"workspace_root"`
+	SourcePaths   []string `json:"source_paths"`
+}
+
+func runRPC(stdin io.Reader, stdout io.Writer) error {
+	scanner := bufio.NewScanner(stdin)
+	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var req rpcRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			writeJSON(stdout, errorResponse(nil, -32700, "PARSE_ERROR"))
+			continue
+		}
+		switch req.Method {
+		case "initialize":
+			writeJSON(stdout, successResponse(req.ID, map[string]any{
+				"name":             "provekit-lift-go-verify",
+				"version":          "0.1.0",
+				"protocol_version": "pep/1.7.0",
+				"capabilities": map[string]any{
+					"authoring_surfaces": []string{"go"},
+					"ir_version":         liftgo.IRVersion,
+				},
+			}))
+		case "lift":
+			writeJSON(stdout, handleLift(req.ID, req.Params))
+		case "shutdown":
+			writeJSON(stdout, successResponse(req.ID, nil))
+			return nil
+		default:
+			writeJSON(stdout, errorResponse(req.ID, -32601, fmt.Sprintf("METHOD_NOT_FOUND: %s", req.Method)))
+		}
+	}
+	return scanner.Err()
+}
+
+func handleLift(id json.RawMessage, raw json.RawMessage) any {
+	var params liftParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return errorResponse(id, -32602, "invalid lift params")
+		}
+	}
+	root := params.WorkspaceRoot
+	if root == "" {
+		cwd, err := os.Getwd()
+		if err == nil {
+			root = cwd
+		} else {
+			root = "."
+		}
+	}
+
+	irItems, diagnostics, err := liftWorkspace(root)
+	if err != nil {
+		return errorResponse(id, -32603, fmt.Sprintf("lift failed: %v", err))
+	}
+	return successResponse(id, map[string]any{
+		"kind":        "ir-document",
+		"ir":          irItems,
+		"diagnostics": diagnostics,
+		"refusals":    []any{},
+	})
+}
+
+// liftWorkspace walks every `.go` file under root, splitting on the
+// `_test.go` suffix: non-test files feed the verify-facing body lifter,
+// test files feed the assertion harvester. Both halves land in one `ir[]`.
+func liftWorkspace(root string) ([]any, []map[string]any, error) {
+	var irItems []any
+	var diagnostics []map[string]any
+	seenFn := map[string]bool{}
+	seenContract := map[string]bool{}
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if info.IsDir() {
+			if info.Name() == "vendor" || info.Name() == ".git" || info.Name() == ".provekit" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+
+		if strings.HasSuffix(path, "_test.go") {
+			// Harvested callsite assertions (Layer-0 leaf harvester): each
+			// single top-level `assert.Equal(t, Fn(args), expected)` becomes a
+			// `contract` whose `inv = =(Fn(args), expected)` -- the harvested
+			// `=(<call>, <expected>)` callsite the verifier reduces through the
+			// body-derived function-contract.
+			decls, warnings, liftErr := lifgotests.LiftLeafAssertions(src, path)
+			if liftErr != nil {
+				diagnostics = append(diagnostics, map[string]any{"path": path, "message": liftErr.Error()})
+				return nil
+			}
+			for _, w := range warnings {
+				diagnostics = append(diagnostics, map[string]any{"path": w.SourcePath, "message": w.Reason})
+			}
+			for _, decl := range decls {
+				if seenContract[decl.Name] {
+					continue
+				}
+				seenContract[decl.Name] = true
+				irItems = append(irItems, decl)
+			}
+			return nil
+		}
+
+		// Body-derived function-contracts (verify-facing dialect).
+		rel := relPath(root, path)
+		lifted, liftErr := liftgo.LiftSourceCore("", rel, src)
+		if liftErr != nil {
+			diagnostics = append(diagnostics, map[string]any{"path": path, "message": liftErr.Error()})
+			return nil
+		}
+		for _, d := range lifted.Diagnostics {
+			diagnostics = append(diagnostics, map[string]any{"path": d.Path, "message": d.Message})
+		}
+		for _, fc := range lifted.Contracts {
+			if seenFn[fc.FnName] {
+				continue
+			}
+			seenFn[fc.FnName] = true
+			item, convErr := functionContractWithBridgeSymbol(fc)
+			if convErr != nil {
+				diagnostics = append(diagnostics, map[string]any{"path": rel, "message": convErr.Error()})
+				continue
+			}
+			irItems = append(irItems, item)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return irItems, diagnostics, nil
+}
+
+// functionContractWithBridgeSymbol serializes a FunctionContract to its
+// JSON object form and injects an explicit `bridgeSourceSymbol`: the bare
+// function symbol (`Double`) that the harvested call ctor uses and that the
+// auto-bridge writer in `provekit mint` (#1443) stamps as the bridge's
+// `sourceSymbol`.
+//
+// This is the protocol's first-class hook for it: `cmd_mint` reads
+// `bridgeSourceSymbol` directly (it otherwise derives the symbol from a
+// `name` / `symbol` / `fn_name` field, none of which is the lifter's
+// `fnName`). Setting it explicitly keeps the round-trip FunctionContract
+// shape untouched while making the body-discharge bridge resolve to `Double`,
+// so `enumerate_callsites` matches the harvested `=(Double(3), 6)` callsite.
+func functionContractWithBridgeSymbol(fc liftgo.FunctionContract) (map[string]any, error) {
+	raw, err := json.Marshal(fc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal function-contract: %w", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, fmt.Errorf("unmarshal function-contract: %w", err)
+	}
+	obj["bridgeSourceSymbol"] = bareSymbol(fc.FnName)
+	return obj, nil
+}
+
+// bareSymbol reduces a (possibly package-qualified) function name to the bare
+// identifier a harvested call ctor uses: `command-line-arguments.Double` ->
+// `Double`. Mirrors the verifier's `simple_function_symbol`.
+func bareSymbol(fnName string) string {
+	name := fnName
+	if i := strings.Index(name, "("); i >= 0 {
+		name = name[:i]
+	}
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	return name
+}
+
+func relPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.Base(path)
+	}
+	return rel
+}
+
+func successResponse(id json.RawMessage, result any) map[string]any {
+	return map[string]any{"jsonrpc": "2.0", "id": idValue(id), "result": result}
+}
+
+func errorResponse(id json.RawMessage, code int, message string) map[string]any {
+	return map[string]any{"jsonrpc": "2.0", "id": idValue(id), "error": map[string]any{"code": code, "message": message}}
+}
+
+func idValue(id json.RawMessage) any {
+	if len(id) == 0 {
+		return nil
+	}
+	var out any
+	if err := json.Unmarshal(id, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func writeJSON(w io.Writer, v any) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		fmt.Fprintf(w, `{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":%q}}`+"\n", err.Error())
+		return
+	}
+	fmt.Fprintln(w, string(b))
+}

--- a/implementations/go/cmd/provekit-lift-go-verify/main.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/main.go
@@ -41,6 +41,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
 	liftgo "github.com/tsavo/provekit/go/provekit-lift-go"
 	lifgotests "github.com/tsavo/provekit/go/provekit-lift-go-tests"
 )
@@ -65,8 +66,45 @@ type rpcRequest struct {
 }
 
 type liftParams struct {
-	WorkspaceRoot string   `json:"workspace_root"`
-	SourcePaths   []string `json:"source_paths"`
+	WorkspaceRoot string         `json:"workspace_root"`
+	SourcePaths   []string       `json:"source_paths"`
+	Options       map[string]any `json:"options"`
+}
+
+// liftMode is which of the three surfaces this call serves. The two authoring
+// surfaces (the `go-bind` / `go-contracts` plugins) emit DIFFERENT IR -- as
+// rust's `rust-bind` (library-sugar-binding-entry) and `rust-contracts`
+// (function-contract) do -- so the same function is not minted twice when both
+// plugins run in one `provekit mint`.
+type liftMode int
+
+const (
+	// modeBare: the standalone `go` verify surface (no authoring options).
+	// Emits function-contracts + harvested callsites for ALL functions.
+	modeBare liftMode = iota
+	// modeBindings: `go-bind`, layer = "library-bindings". Emits the
+	// `library-sugar-binding-entry` DECLARATION record for each annotated
+	// function (mint skips this kind -- it is the authoring catalog, not a
+	// contract).
+	modeBindings
+	// modeContracts: `go-contracts`, emit = "ir-document". Emits the
+	// body-derived function-contracts + harvested callsites, gated on the
+	// `//provekit:` declaration.
+	modeContracts
+)
+
+// modeFromOptions selects the surface mode from the dispatcher's lift options.
+func modeFromOptions(opts map[string]any) liftMode {
+	if opts == nil {
+		return modeBare
+	}
+	if layer, ok := opts["layer"].(string); ok && layer == "library-bindings" {
+		return modeBindings
+	}
+	if emit, ok := opts["emit"].(string); ok && emit == "ir-document" {
+		return modeContracts
+	}
+	return modeBare
 }
 
 func runRPC(stdin io.Reader, stdout io.Writer) error {
@@ -122,7 +160,7 @@ func handleLift(id json.RawMessage, raw json.RawMessage) any {
 		}
 	}
 
-	irItems, diagnostics, err := liftWorkspace(root)
+	irItems, diagnostics, err := liftWorkspace(root, modeFromOptions(params.Options))
 	if err != nil {
 		return errorResponse(id, -32603, fmt.Sprintf("lift failed: %v", err))
 	}
@@ -134,14 +172,22 @@ func handleLift(id json.RawMessage, raw json.RawMessage) any {
 	})
 }
 
-// liftWorkspace walks every `.go` file under root, splitting on the
-// `_test.go` suffix: non-test files feed the verify-facing body lifter,
-// test files feed the assertion harvester. Both halves land in one `ir[]`.
-func liftWorkspace(root string) ([]any, []map[string]any, error) {
+// liftWorkspace walks every `.go` file under root and emits IR according to
+// the surface mode:
+//
+//   - modeBindings (go-bind): one `library-sugar-binding-entry` per annotated
+//     function -- the authoring DECLARATION catalog. mint skips this kind, so
+//     it does not double-mint the contracts the go-contracts surface emits.
+//   - modeContracts (go-contracts): body-derived function-contracts (gated on
+//     the annotation) + harvested callsites.
+//   - modeBare (standalone `go` surface): function-contracts for ALL functions
+//     + harvested callsites (the existing production-bridge behavior).
+func liftWorkspace(root string, mode liftMode) ([]any, []map[string]any, error) {
 	var irItems []any
 	var diagnostics []map[string]any
 	seenFn := map[string]bool{}
 	seenContract := map[string]bool{}
+	annotatedOnly := mode != modeBare
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
@@ -162,6 +208,11 @@ func liftWorkspace(root string) ([]any, []map[string]any, error) {
 		}
 
 		if strings.HasSuffix(path, "_test.go") {
+			// The bindings surface is the declaration catalog only -- it does
+			// not harvest callsites (those belong to the contracts surface).
+			if mode == modeBindings {
+				return nil
+			}
 			// Harvested callsite assertions (Layer-0 leaf harvester): each
 			// single top-level `assert.Equal(t, Fn(args), expected)` becomes a
 			// `contract` whose `inv = =(Fn(args), expected)` -- the harvested
@@ -185,9 +236,13 @@ func liftWorkspace(root string) ([]any, []map[string]any, error) {
 			return nil
 		}
 
-		// Body-derived function-contracts (verify-facing dialect).
+		// Body-derived function-contracts (verify-facing dialect). The
+		// authoring surfaces gate emission on the `//provekit:` declaration.
 		rel := relPath(root, path)
-		lifted, liftErr := liftgo.LiftSourceCore("", rel, src)
+		lifted, liftErr := liftgo.LiftSourceWithOptions("", rel, src, liftgo.LiftOptions{
+			NormalizeCoreArith: true,
+			AnnotatedOnly:      annotatedOnly,
+		})
 		if liftErr != nil {
 			diagnostics = append(diagnostics, map[string]any{"path": path, "message": liftErr.Error()})
 			return nil
@@ -195,15 +250,74 @@ func liftWorkspace(root string) ([]any, []map[string]any, error) {
 		for _, d := range lifted.Diagnostics {
 			diagnostics = append(diagnostics, map[string]any{"path": d.Path, "message": d.Message})
 		}
+		for _, r := range lifted.Refusals {
+			diagnostics = append(diagnostics, map[string]any{"path": rel, "message": fmt.Sprintf("%s: %s (%s)", r.Function, r.Reason, r.Kind)})
+		}
 		for _, fc := range lifted.Contracts {
 			if seenFn[fc.FnName] {
 				continue
 			}
 			seenFn[fc.FnName] = true
+			ann := lifted.Annotations[fc.FnName]
+
+			if mode == modeBindings {
+				// The DECLARATION catalog entry: WHICH boundary/sugar the
+				// library author declared on this function (mint skips this
+				// kind). This is the Go peer of rust's
+				// `library-sugar-binding-entry`.
+				if ann == nil {
+					continue
+				}
+				library := ann.Library
+				if library == "" {
+					library = "default"
+				}
+				paramTypes := goParamTypes(fc)
+				returnType := goReturnType(fc)
+				bodyText := extractGoFuncBody(string(src), bareSymbol(fc.FnName))
+				entry := map[string]any{
+					"kind":                 "library-sugar-binding-entry",
+					"target_language":      "go",
+					"target_library_tag":   library,
+					"concept_name":         ann.Concept,
+					"source_function_name": bareSymbol(fc.FnName),
+					"fnName":               fc.FnName,
+					"authoring_kind":       string(ann.Kind),
+					"param_names":          fc.Formals,
+					"param_types":          paramTypes,
+					"return_type":          returnType,
+					"visibility":           "",
+					"signature_shape_cid":  signatureShapeCID(bareSymbol(fc.FnName), fc.Formals, paramTypes, returnType),
+					"body_source": map[string]any{
+						"file":       rel,
+						"source_cid": cidOf([]byte(bodyText)),
+						"body_text":  bodyText,
+					},
+				}
+				if ann.Family != "" {
+					entry["family"] = ann.Family
+				}
+				if ann.Version != "" {
+					entry["version"] = ann.Version
+				}
+				irItems = append(irItems, entry)
+				continue
+			}
+
+			// modeContracts / modeBare: the function-contract.
 			item, convErr := functionContractWithBridgeSymbol(fc)
 			if convErr != nil {
 				diagnostics = append(diagnostics, map[string]any{"path": rel, "message": convErr.Error()})
 				continue
+			}
+			// Tag the contract with the authoring declaration so the emitted
+			// ir-document records WHICH concept the library declared.
+			if ann != nil {
+				item["conceptName"] = ann.Concept
+				item["authoringKind"] = string(ann.Kind)
+				if ann.Library != "" {
+					item["library"] = ann.Library
+				}
 			}
 			irItems = append(irItems, item)
 		}
@@ -252,6 +366,103 @@ func bareSymbol(fnName string) string {
 		name = name[i+1:]
 	}
 	return name
+}
+
+// goParamTypes maps each formal's IR sort to a Go type string for the
+// binding-entry catalog. The realize shim re-derives the actual Go types; this
+// is the declaration record, so a primitive-sort -> Go-type best-effort is
+// sufficient (Int -> int, others fall back to the sort name).
+func goParamTypes(fc liftgo.FunctionContract) []string {
+	out := make([]string, 0, len(fc.FormalSorts))
+	for _, s := range fc.FormalSorts {
+		out = append(out, goTypeForSort(s))
+	}
+	return out
+}
+
+func goReturnType(fc liftgo.FunctionContract) string {
+	if fc.ReturnSort == nil {
+		return ""
+	}
+	return goTypeForSort(fc.ReturnSort)
+}
+
+func goTypeForSort(sort any) string {
+	m, ok := sort.(map[string]any)
+	if !ok {
+		return "int"
+	}
+	name, _ := m["name"].(string)
+	switch name {
+	case "Int":
+		return "int"
+	case "Bool":
+		return "bool"
+	case "String":
+		return "string"
+	case "":
+		return "int"
+	default:
+		return name
+	}
+}
+
+// cidOf is the substrate's blake3-512 content address of raw bytes.
+func cidOf(b []byte) string {
+	return canonicalizer.ComputeCID(b)
+}
+
+// signatureShapeCID content-addresses the function's signature shape (name +
+// formal names + types + return type) -- the binding-entry's stable identity
+// for the declared boundary. Deterministic over the signature string.
+func signatureShapeCID(name string, formals, paramTypes []string, returnType string) string {
+	var b strings.Builder
+	b.WriteString("go-sig:")
+	b.WriteString(name)
+	b.WriteString("(")
+	for i, f := range formals {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(f)
+		b.WriteString(":")
+		if i < len(paramTypes) {
+			b.WriteString(paramTypes[i])
+		}
+	}
+	b.WriteString(")")
+	b.WriteString(returnType)
+	return cidOf([]byte(b.String()))
+}
+
+// extractGoFuncBody returns the text between the outermost `{` and matching
+// `}` of `func <name>(...)`, mirroring rust's `sugar_body_source` body_text.
+// Best-effort brace matching (does not parse strings/comments); sufficient for
+// the simple annotated bodies the authoring surface targets.
+func extractGoFuncBody(src, name string) string {
+	marker := "func " + name + "("
+	idx := strings.Index(src, marker)
+	if idx < 0 {
+		return ""
+	}
+	open := strings.IndexByte(src[idx:], '{')
+	if open < 0 {
+		return ""
+	}
+	open += idx
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(src[open+1 : i])
+			}
+		}
+	}
+	return ""
 }
 
 func relPath(root, path string) string {

--- a/implementations/go/go.mod
+++ b/implementations/go/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/tsavo/provekit/go/provekit-ir-symbolic v0.0.0
+	github.com/tsavo/provekit/go/provekit-lift-go v0.0.0
 	github.com/tsavo/provekit/go/provekit-lift-go-tests v0.0.0
 )
 

--- a/implementations/go/provekit-lift-go-tests/leaf.go
+++ b/implementations/go/provekit-lift-go-tests/leaf.go
@@ -35,11 +35,75 @@ package lifgotests
 import (
 	"fmt"
 	"go/ast"
+	"go/parser"
 	"go/token"
 	"strconv"
 
 	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 )
+
+// LiftLeafAssertions is the Layer-0 entry point: it harvests each single
+// top-level recognized assertion in a test file into its own `contract`
+// ContractDeclaration with `inv = <assertion-formula>`. This is the
+// single-assertion path the Layer-2 patterns RELEASE to (their warnings say
+// "releasing to layer 0"); it lifts shapes like
+//
+//	assert.Equal(t, Double(3), 6)  ->  contract{ inv = =(Double(3), 6) }
+//
+// where `Double(3)` is a `ctor` named `Double` — exactly the harvested
+// `=(<call>, <expected>)` callsite the verifier's body-discharge seam
+// enumerates and reduces through the body-derived function-contract for
+// `Double`. One contract per test function (Inv is the conjunction of that
+// test's recognized assertions; for the common single-assertion case this is
+// just the bare `=( ... )`), so a function-contract bridge can match it.
+//
+// Unlike LiftFile (Layer 2: bounded-loop / helper-inlining / multi-assert
+// characterization), this does NOT require >= 2 assertions and does NOT fold
+// into an opaque conjunction when there is exactly one — preserving the
+// clean `=(<call>, <expected>)` shape the body-discharge enumerator needs.
+func LiftLeafAssertions(src []byte, sourcePath string) ([]ir.ContractDeclaration, []LiftWarning, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, sourcePath, src, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse %s: %w", sourcePath, err)
+	}
+	var decls []ir.ContractDeclaration
+	var warnings []LiftWarning
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || !isTestFunc(fn) || fn.Body == nil {
+			continue
+		}
+		var atoms []ir.IrFormula
+		for _, stmt := range fn.Body.List {
+			call, ok := exprStmtCall(stmt)
+			if !ok || !isAssertionCall(call) {
+				continue
+			}
+			formula, err := liftAssertionCall(call)
+			if err != nil {
+				warnings = append(warnings, LiftWarning{
+					Adapter: ADAPTER, SourcePath: sourcePath, ItemName: fn.Name.Name, Reason: err.Error(),
+				})
+				continue
+			}
+			atoms = append(atoms, formula)
+		}
+		if len(atoms) == 0 {
+			continue
+		}
+		inv := atoms[0]
+		if len(atoms) > 1 {
+			inv = ir.And(atoms...)
+		}
+		decls = append(decls, ir.ContractDeclaration{
+			Name:       fn.Name.Name,
+			OutBinding: ir.DefaultOutBinding,
+			Inv:        inv,
+		})
+	}
+	return decls, warnings, nil
+}
 
 // isAssertionCall returns true if call is a recognized assertion-call
 // shape. Used by Pattern 2 / 3 to filter top-level statements before

--- a/implementations/go/provekit-lift-go/annotation.go
+++ b/implementations/go/provekit-lift-go/annotation.go
@@ -1,0 +1,174 @@
+// Go authoring-surface annotations: the idiom by which a Go library AUTHOR
+// declares a ProvekIt boundary / sugar on a function, so the library GETS a
+// contract the same way rust (`#[provekit::sugar(...)]`) and java authors do.
+//
+// Go has no attribute syntax, so the idiomatic analog is a comment-pragma
+// directive in the function's doc comment, mirroring the established
+// `//go:generate` / `//go:build` convention:
+//
+//	//provekit:boundary(concept="concept:X")
+//	//provekit:sugar(concept="concept:X", library="lib", version="1", family="concept:family:Y")
+//	func Foo(...) ... { ... }
+//
+// `go/ast` attaches such a directive (no space after `//`, directly above the
+// func) to the func's `Doc` field, so the parser reads `fn.Doc`. The
+// authoring surface (the `go-bind` / `go-contracts` plugins in
+// `.provekit/config.toml`) lifts ONLY annotated functions: the DECLARATION
+// drives emission, and the emitted contract is the same one that discharges
+// through the verifier spine and materializes via provekit-realize-go-core.
+package liftgo
+
+import (
+	"fmt"
+	"go/ast"
+	"strconv"
+	"strings"
+)
+
+// AnnotationKind is `boundary` or `sugar` -- the two authoring declarations.
+type AnnotationKind string
+
+const (
+	AnnotationBoundary AnnotationKind = "boundary"
+	AnnotationSugar    AnnotationKind = "sugar"
+)
+
+// Annotation is a parsed `//provekit:<kind>(key="value", ...)` directive.
+type Annotation struct {
+	Kind    AnnotationKind
+	Concept string
+	Library string
+	Version string
+	Family  string
+	// Raw holds every parsed key=value pair (including the ones promoted to
+	// typed fields) so downstream emission can carry through axes this struct
+	// does not name explicitly.
+	Raw map[string]string
+}
+
+const annotationPrefix = "//provekit:"
+
+// parseFuncAnnotation returns the ProvekIt authoring annotation declared in a
+// function's doc comment, or (nil, nil) if none is present. It refuses loudly
+// (returns an error) on a malformed `//provekit:` directive rather than
+// silently ignoring a typo'd declaration -- an author who wrote `//provekit:`
+// meant to declare something.
+func parseFuncAnnotation(fn *ast.FuncDecl) (*Annotation, error) {
+	if fn == nil || fn.Doc == nil {
+		return nil, nil
+	}
+	for _, c := range fn.Doc.List {
+		text := strings.TrimSpace(c.Text)
+		if !strings.HasPrefix(text, annotationPrefix) {
+			continue
+		}
+		return parseAnnotationDirective(text, fn.Name.Name)
+	}
+	return nil, nil
+}
+
+// parseAnnotationDirective parses one `//provekit:<kind>(...)` line.
+func parseAnnotationDirective(text, fnName string) (*Annotation, error) {
+	rest := strings.TrimPrefix(text, annotationPrefix)
+	open := strings.IndexByte(rest, '(')
+	if open < 0 || !strings.HasSuffix(rest, ")") {
+		return nil, fmt.Errorf("malformed //provekit annotation on %s: expected `kind(key=\"value\", ...)`, got %q", fnName, text)
+	}
+	kindStr := strings.TrimSpace(rest[:open])
+	var kind AnnotationKind
+	switch kindStr {
+	case string(AnnotationBoundary):
+		kind = AnnotationBoundary
+	case string(AnnotationSugar):
+		kind = AnnotationSugar
+	default:
+		return nil, fmt.Errorf("unknown //provekit annotation kind %q on %s (expected `boundary` or `sugar`)", kindStr, fnName)
+	}
+
+	body := rest[open+1 : len(rest)-1]
+	pairs, err := parseKeyValuePairs(body)
+	if err != nil {
+		return nil, fmt.Errorf("//provekit:%s on %s: %w", kindStr, fnName, err)
+	}
+
+	ann := &Annotation{Kind: kind, Raw: pairs}
+	ann.Concept = pairs["concept"]
+	ann.Library = pairs["library"]
+	ann.Version = pairs["version"]
+	ann.Family = pairs["family"]
+	if ann.Concept == "" {
+		return nil, fmt.Errorf("//provekit:%s on %s must declare a non-empty concept", kindStr, fnName)
+	}
+	return ann, nil
+}
+
+// parseKeyValuePairs parses `key="value", key2="value2"` (and bare-list
+// values like `loss=[]`, which are tolerated and stored verbatim). Quote-aware
+// so commas inside quoted values are not separators.
+func parseKeyValuePairs(body string) (map[string]string, error) {
+	out := map[string]string{}
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return out, nil
+	}
+	for _, segment := range splitTopLevelCommas(body) {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+		eq := strings.IndexByte(segment, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("expected key=value, got %q", segment)
+		}
+		key := strings.TrimSpace(segment[:eq])
+		val := strings.TrimSpace(segment[eq+1:])
+		// Quoted string value.
+		if strings.HasPrefix(val, "\"") {
+			unq, err := strconv.Unquote(val)
+			if err != nil {
+				return nil, fmt.Errorf("key %q has malformed quoted value %q", key, val)
+			}
+			val = unq
+		}
+		out[key] = val
+	}
+	return out, nil
+}
+
+// splitTopLevelCommas splits on commas not inside quotes or brackets.
+func splitTopLevelCommas(s string) []string {
+	var parts []string
+	var cur strings.Builder
+	inQuote := false
+	depth := 0
+	for _, r := range s {
+		switch r {
+		case '"':
+			inQuote = !inQuote
+			cur.WriteRune(r)
+		case '[', '(':
+			if !inQuote {
+				depth++
+			}
+			cur.WriteRune(r)
+		case ']', ')':
+			if !inQuote {
+				depth--
+			}
+			cur.WriteRune(r)
+		case ',':
+			if !inQuote && depth == 0 {
+				parts = append(parts, cur.String())
+				cur.Reset()
+			} else {
+				cur.WriteRune(r)
+			}
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if cur.Len() > 0 {
+		parts = append(parts, cur.String())
+	}
+	return parts
+}

--- a/implementations/go/provekit-lift-go/annotation_test.go
+++ b/implementations/go/provekit-lift-go/annotation_test.go
@@ -1,0 +1,146 @@
+package liftgo
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func parseFirstFunc(t *testing.T, src string) *ast.FuncDecl {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, d := range f.Decls {
+		if fn, ok := d.(*ast.FuncDecl); ok {
+			return fn
+		}
+	}
+	t.Fatal("no func decl")
+	return nil
+}
+
+func TestParseSugarAnnotation(t *testing.T) {
+	fn := parseFirstFunc(t, `package p
+
+//provekit:sugar(concept="identity", library="builtin", version="1", family="concept:family:core")
+func Id(x int) int { return x }
+`)
+	ann, err := parseFuncAnnotation(fn)
+	if err != nil {
+		t.Fatalf("parse annotation: %v", err)
+	}
+	if ann == nil {
+		t.Fatal("expected an annotation")
+	}
+	if ann.Kind != AnnotationSugar {
+		t.Fatalf("kind = %q, want sugar", ann.Kind)
+	}
+	if ann.Concept != "identity" {
+		t.Fatalf("concept = %q, want identity", ann.Concept)
+	}
+	if ann.Library != "builtin" || ann.Version != "1" || ann.Family != "concept:family:core" {
+		t.Fatalf("axes mismatch: %+v", ann)
+	}
+}
+
+func TestParseBoundaryAnnotation(t *testing.T) {
+	fn := parseFirstFunc(t, `package p
+
+//provekit:boundary(concept="concept:json-parse")
+func Parse(s string) int { return 0 }
+`)
+	ann, err := parseFuncAnnotation(fn)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if ann == nil || ann.Kind != AnnotationBoundary || ann.Concept != "concept:json-parse" {
+		t.Fatalf("boundary parse wrong: %+v", ann)
+	}
+}
+
+// Discrimination: a function with no //provekit directive yields no annotation.
+func TestNoAnnotationReturnsNil(t *testing.T) {
+	fn := parseFirstFunc(t, `package p
+
+// just a normal doc comment
+func Plain(x int) int { return x }
+`)
+	ann, err := parseFuncAnnotation(fn)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if ann != nil {
+		t.Fatalf("expected nil annotation, got %+v", ann)
+	}
+}
+
+// Discrimination: a malformed //provekit directive is refused loudly, never
+// silently ignored (the author meant to declare something).
+func TestMalformedAnnotationRefuses(t *testing.T) {
+	cases := []string{
+		`//provekit:sugar`,            // no parens
+		`//provekit:sugar()`,          // no concept
+		`//provekit:wat(concept="x")`, // unknown kind
+		`//provekit:sugar(concept=)`,  // malformed value
+	}
+	for _, directive := range cases {
+		src := "package p\n\n" + directive + "\nfunc F(x int) int { return x }\n"
+		fn := parseFirstFunc(t, src)
+		if _, err := parseFuncAnnotation(fn); err == nil {
+			t.Fatalf("directive %q must be refused", directive)
+		}
+	}
+}
+
+// AnnotatedOnly gates emission: only the annotated function is lifted.
+func TestLiftAnnotatedOnlyGatesEmission(t *testing.T) {
+	src := `package sample
+
+//provekit:sugar(concept="identity")
+func Id(x int) int { return x }
+
+func Other(y int) int { return y + 1 }
+`
+	result, err := LiftSourceWithOptions("example.com/sample", "s.go", []byte(src), LiftOptions{
+		NormalizeCoreArith: true,
+		AnnotatedOnly:      true,
+	})
+	if err != nil {
+		t.Fatalf("lift: %v", err)
+	}
+	contracts := result.FunctionContracts()
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, want 1 (only the annotated Id)", len(contracts))
+	}
+	if want := "example.com/sample.Id"; contracts[0].FnName != want {
+		t.Fatalf("fnName = %q, want %q", contracts[0].FnName, want)
+	}
+	if ann := result.Annotations[contracts[0].FnName]; ann == nil || ann.Concept != "identity" {
+		t.Fatalf("annotation not carried: %+v", result.Annotations)
+	}
+}
+
+// Discrimination: with AnnotatedOnly OFF, both functions are lifted (the bare
+// verify surface keeps its emit-all behavior).
+func TestLiftEmitAllWhenNotAnnotatedOnly(t *testing.T) {
+	src := `package sample
+
+//provekit:sugar(concept="identity")
+func Id(x int) int { return x }
+
+func Other(y int) int { return y + 1 }
+`
+	result, err := LiftSourceWithOptions("example.com/sample", "s.go", []byte(src), LiftOptions{
+		NormalizeCoreArith: true,
+	})
+	if err != nil {
+		t.Fatalf("lift: %v", err)
+	}
+	if len(result.FunctionContracts()) != 2 {
+		t.Fatalf("emit-all must lift both functions, got %d", len(result.FunctionContracts()))
+	}
+}

--- a/implementations/go/provekit-lift-go/cmd/provekit-lift-go/main.go
+++ b/implementations/go/provekit-lift-go/cmd/provekit-lift-go/main.go
@@ -8,13 +8,27 @@ import (
 )
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "--rpc" {
-		if err := liftgo.RunRPC(os.Stdin, os.Stdout); err != nil {
+	rpc := false
+	defaultOpts := liftgo.LiftOptions{}
+	for _, arg := range os.Args[1:] {
+		switch arg {
+		case "--rpc":
+			rpc = true
+		case "--dialect=core":
+			// Verify-facing dialect: emit SMT-LIB core op symbols so the
+			// body-derived postcondition discharges through the z3 verifier.
+			// The kit-dispatch `go` lift surface launches this binary with
+			// this flag (see implementations/go/.provekit/lift/go/manifest.toml).
+			defaultOpts.NormalizeCoreArith = true
+		}
+	}
+	if rpc {
+		if err := liftgo.RunRPCWithDefault(os.Stdin, os.Stdout, defaultOpts); err != nil {
 			fmt.Fprintf(os.Stderr, "provekit-lift-go-source rpc: %v\n", err)
 			os.Exit(1)
 		}
 		return
 	}
-	fmt.Fprintln(os.Stderr, "usage: provekit-lift-go --rpc")
+	fmt.Fprintln(os.Stderr, "usage: provekit-lift-go --rpc [--dialect=core]")
 	os.Exit(1)
 }

--- a/implementations/go/provekit-lift-go/lift.go
+++ b/implementations/go/provekit-lift-go/lift.go
@@ -46,11 +46,32 @@ type lifter struct {
 }
 
 // coreArithOp maps a namespaced Go op name to the SMT-LIB core-theory symbol
-// the z3-backed verifier discharges, when one exists. Only the operators whose
-// semantics are exactly an Int/Bool core operation are mapped; everything else
-// (bitwise ops, shifts, dereference, ...) keeps its namespaced form because it
-// has no faithful core-theory counterpart and must stay an uninterpreted /
-// loudly-bounded symbol rather than silently aliasing to the wrong theory.
+// the z3-backed verifier discharges, when (and ONLY when) the SMT-LIB Int/Bool
+// semantics are FAITHFUL to Go for every in-range input. An op whose SMT
+// meaning diverges from Go MUST NOT be mapped: it stays namespaced
+// (`go:<op>`), so the obligation retains an opaque uninterpreted symbol and
+// verify returns Undecidable (no witness) -- the honest "I cannot prove this"
+// rather than a false discharge. Supra omnia, rectum: refuse, never
+// false-discharge.
+//
+// Cardinal-sin guard (PR #1445 review): `go:div` / `go:mod` were previously
+// mapped to SMT-LIB `div` / `mod`, but the semantics DIVERGE on negatives:
+//
+//	Go `-7 / 2 == -3`   (truncates toward zero)
+//	SMT `(div -7 2) == -4` (floors toward -inf)
+//	Go `-7 % 2 == -1`   ;  SMT `(mod -7 2) == 1`
+//
+// That made `Halve(-7) == -4` (FALSE in Go) discharge with a SIGNED WITNESS --
+// an inverted proof. They are now left uninterpreted until faithful
+// truncation-toward-zero modeling lands (Euclidean correction / bitvector
+// theory; tracked follow-up). z3's `/` and `%` are NO better (real division /
+// floored remainder), so they are NOT substituted either.
+//
+// KEPT (faithful): `+` `-` `*` on Int (unbounded-Int overflow-modeling gap is
+// the accepted rust/java baseline, NOT introduced here); the signed
+// comparisons `<` `<=` `>` `>=` `=`; boolean `and` `or` `not`; unary `-`.
+// EXCLUDED (unfaithful / no faithful core form): div, mod/rem, shifts,
+// bitwise ops, unsigned comparisons, dereference -- all stay namespaced.
 func coreArithOp(name string) (string, bool) {
 	switch name {
 	case "go:add":
@@ -59,10 +80,9 @@ func coreArithOp(name string) (string, bool) {
 		return "-", true
 	case "go:mul":
 		return "*", true
-	case "go:div":
-		return "div", true
-	case "go:mod":
-		return "mod", true
+	// go:div and go:mod are DELIBERATELY NOT mapped: SMT-LIB div/mod (floor)
+	// diverge from Go (truncate) on negatives. Leaving them namespaced makes
+	// the obligation Undecidable instead of a false discharge.
 	case "go:eq":
 		return "=", true
 	case "go:lt":

--- a/implementations/go/provekit-lift-go/lift.go
+++ b/implementations/go/provekit-lift-go/lift.go
@@ -28,6 +28,74 @@ type lifter struct {
 	locals     map[types.Object]bool
 	knownFuncs map[string]bool
 	effects    *effectSet
+	// normalizeCoreArith selects the VERIFY-FACING op dialect: when true, the
+	// arithmetic / comparison operators that map onto SMT-LIB core theories
+	// (Int / Bool) are emitted with their core symbol (`*`, `+`, `<`, ...)
+	// instead of the namespaced round-trip form (`go:mul`, `go:add`, ...).
+	//
+	// This mirrors Java's two-lifter split: JavaSourceLifter emits `java:mul`
+	// (the round-trippable source dialect), ProductionWalk emits `*` (the
+	// verify-facing dialect the z3-backed verifier discharges). The default
+	// (false) keeps the byte-identical round-trip lift the existing tests and
+	// the Go source compiler depend on; the verify-facing entry points
+	// (LiftSourceCore / LiftPathsCore) set it true so the body-derived
+	// `post = result == (* x 2)` is something z3 can actually reduce. The
+	// verifier spine is NOT touched; Go is wired INTO it by speaking the op
+	// vocabulary the spine already understands.
+	normalizeCoreArith bool
+}
+
+// coreArithOp maps a namespaced Go op name to the SMT-LIB core-theory symbol
+// the z3-backed verifier discharges, when one exists. Only the operators whose
+// semantics are exactly an Int/Bool core operation are mapped; everything else
+// (bitwise ops, shifts, dereference, ...) keeps its namespaced form because it
+// has no faithful core-theory counterpart and must stay an uninterpreted /
+// loudly-bounded symbol rather than silently aliasing to the wrong theory.
+func coreArithOp(name string) (string, bool) {
+	switch name {
+	case "go:add":
+		return "+", true
+	case "go:sub":
+		return "-", true
+	case "go:mul":
+		return "*", true
+	case "go:div":
+		return "div", true
+	case "go:mod":
+		return "mod", true
+	case "go:eq":
+		return "=", true
+	case "go:lt":
+		return "<", true
+	case "go:le":
+		return "<=", true
+	case "go:gt":
+		return ">", true
+	case "go:ge":
+		return ">=", true
+	case "go:and":
+		return "and", true
+	case "go:or":
+		return "or", true
+	case "go:neg":
+		return "-", true
+	case "go:not":
+		return "not", true
+	default:
+		return "", false
+	}
+}
+
+// opForDialect returns the op name to emit for opName under this lifter's
+// dialect. In the verify-facing dialect a known core-arith op is normalized to
+// its SMT-LIB symbol; otherwise the namespaced name passes through unchanged.
+func (l *lifter) opForDialect(opName string) string {
+	if l.normalizeCoreArith {
+		if core, ok := coreArithOp(opName); ok {
+			return core
+		}
+	}
+	return opName
 }
 
 type exprResult struct {
@@ -42,7 +110,31 @@ type stmtResult struct {
 	hasReturn bool
 }
 
+// LiftOptions selects the op dialect a lift emits.
+type LiftOptions struct {
+	// NormalizeCoreArith emits the SMT-LIB core-theory symbol (`*`, `+`,
+	// `<`, ...) for arithmetic / comparison operators instead of the
+	// namespaced round-trip form (`go:mul`, ...). Set by the verify-facing
+	// entry points so the body-derived postcondition is z3-dischargeable.
+	NormalizeCoreArith bool
+}
+
+// LiftSource lifts a single Go source file in the round-trip dialect
+// (namespaced ops, byte-identical to the source compiler's expectation).
 func LiftSource(packagePath, sourcePath string, source []byte) (LiftResult, error) {
+	return LiftSourceWithOptions(packagePath, sourcePath, source, LiftOptions{})
+}
+
+// LiftSourceCore lifts a single Go source file in the VERIFY-FACING dialect:
+// arithmetic / comparison ops are normalized to their SMT-LIB core symbols so
+// the emitted `function-contract`'s `post = result == <body-expr>` discharges
+// through the z3-backed verifier. Mirrors Java's ProductionWalk.
+func LiftSourceCore(packagePath, sourcePath string, source []byte) (LiftResult, error) {
+	return LiftSourceWithOptions(packagePath, sourcePath, source, LiftOptions{NormalizeCoreArith: true})
+}
+
+// LiftSourceWithOptions lifts a single Go source file under the given dialect.
+func LiftSourceWithOptions(packagePath, sourcePath string, source []byte, opts LiftOptions) (LiftResult, error) {
 	if packagePath == "" {
 		packagePath = "command-line-arguments"
 	}
@@ -91,7 +183,7 @@ func LiftSource(packagePath, sourcePath string, source []byte) (LiftResult, erro
 		if !ok {
 			continue
 		}
-		contract, bodyTerm, refusals := liftFunc(fset, file, pkg, info, sourcePath, known, packagePath, fn)
+		contract, bodyTerm, refusals := liftFunc(fset, file, pkg, info, sourcePath, known, packagePath, fn, opts)
 		if len(refusals) > 0 {
 			result.Refusals = append(result.Refusals, refusals...)
 			continue
@@ -126,7 +218,7 @@ func LiftSource(packagePath, sourcePath string, source []byte) (LiftResult, erro
 	return result, nil
 }
 
-func liftFunc(fset *token.FileSet, file *ast.File, pkg *types.Package, info *types.Info, sourcePath string, known map[string]bool, packagePath string, fn *ast.FuncDecl) (FunctionContract, any, []Refusal) {
+func liftFunc(fset *token.FileSet, file *ast.File, pkg *types.Package, info *types.Info, sourcePath string, known map[string]bool, packagePath string, fn *ast.FuncDecl, opts LiftOptions) (FunctionContract, any, []Refusal) {
 	fnName := fallbackFuncName(packagePath, fn)
 	if obj, ok := info.Defs[fn.Name].(*types.Func); ok {
 		fnName = obj.FullName()
@@ -157,15 +249,16 @@ func liftFunc(fset *token.FileSet, file *ast.File, pkg *types.Package, info *typ
 	}
 
 	l := &lifter{
-		fset:       fset,
-		file:       file,
-		pkg:        pkg,
-		info:       info,
-		path:       sourcePath,
-		fnName:     fnName,
-		locals:     localObjects,
-		knownFuncs: known,
-		effects:    newEffectSet(),
+		fset:               fset,
+		file:               file,
+		pkg:                pkg,
+		info:               info,
+		path:               sourcePath,
+		fnName:             fnName,
+		locals:             localObjects,
+		knownFuncs:         known,
+		effects:            newEffectSet(),
+		normalizeCoreArith: opts.NormalizeCoreArith,
 	}
 	body, err := l.liftBlock(fn.Body.List)
 	if err != nil {
@@ -552,6 +645,7 @@ func (l *lifter) liftExpr(expr ast.Expr) (exprResult, error) {
 		if !ok {
 			return exprResult{}, errAt(e.OpPos, "binary operator %s is not modeled", e.Op)
 		}
+		opName = l.opForDialect(opName)
 		sort := irSort(l.info.Types[e].Type)
 		return exprResult{term: ir.MakeCtor(opName, []ir.IrTerm{left.term, right.term}, sort), alg: op(opName, left.alg, right.alg), sort: sort}, nil
 	case *ast.UnaryExpr:
@@ -563,6 +657,7 @@ func (l *lifter) liftExpr(expr ast.Expr) (exprResult, error) {
 		if !ok {
 			return exprResult{}, errAt(e.OpPos, "unary operator %s is not modeled", e.Op)
 		}
+		opName = l.opForDialect(opName)
 		sort := irSort(l.info.Types[e].Type)
 		return exprResult{term: ir.MakeCtor(opName, []ir.IrTerm{inner.term}, sort), alg: op(opName, inner.alg), sort: sort}, nil
 	case *ast.StarExpr:
@@ -1050,6 +1145,17 @@ func isIOCall(name string) bool {
 }
 
 func LiftPaths(workspaceRoot string, sourcePaths []string) (LiftResult, error) {
+	return LiftPathsWithOptions(workspaceRoot, sourcePaths, LiftOptions{})
+}
+
+// LiftPathsCore lifts the given Go sources in the VERIFY-FACING dialect
+// (core-arith op symbols). See LiftSourceCore.
+func LiftPathsCore(workspaceRoot string, sourcePaths []string) (LiftResult, error) {
+	return LiftPathsWithOptions(workspaceRoot, sourcePaths, LiftOptions{NormalizeCoreArith: true})
+}
+
+// LiftPathsWithOptions lifts the given Go sources under the given dialect.
+func LiftPathsWithOptions(workspaceRoot string, sourcePaths []string, opts LiftOptions) (LiftResult, error) {
 	modulePath := modulePathFor(workspaceRoot)
 	var merged LiftResult
 	for _, sourcePath := range sourcePaths {
@@ -1062,7 +1168,7 @@ func LiftPaths(workspaceRoot string, sourcePaths []string) (LiftResult, error) {
 			return LiftResult{}, err
 		}
 		pkgPath := packagePathFor(modulePath, workspaceRoot, path)
-		lifted, err := LiftSource(pkgPath, sourcePath, bytes)
+		lifted, err := LiftSourceWithOptions(pkgPath, sourcePath, bytes, opts)
 		if err != nil {
 			return LiftResult{}, err
 		}

--- a/implementations/go/provekit-lift-go/lift.go
+++ b/implementations/go/provekit-lift-go/lift.go
@@ -110,13 +110,23 @@ type stmtResult struct {
 	hasReturn bool
 }
 
-// LiftOptions selects the op dialect a lift emits.
+// LiftOptions selects the op dialect a lift emits and which functions it
+// emits contracts for.
 type LiftOptions struct {
 	// NormalizeCoreArith emits the SMT-LIB core-theory symbol (`*`, `+`,
 	// `<`, ...) for arithmetic / comparison operators instead of the
 	// namespaced round-trip form (`go:mul`, ...). Set by the verify-facing
 	// entry points so the body-derived postcondition is z3-dischargeable.
 	NormalizeCoreArith bool
+	// AnnotatedOnly gates contract emission on the AUTHORING declaration:
+	// when true, only functions carrying a `//provekit:boundary(...)` or
+	// `//provekit:sugar(...)` doc-comment directive are lifted. The
+	// authoring surface (`go-bind` / `go-contracts` plugins) sets this so
+	// the DECLARATION drives emission, mirroring rust's
+	// `#[provekit::sugar(...)]` / `#[provekit::boundary(...)]`. The default
+	// (false) keeps the emit-all behavior the bare `go` verify surface and
+	// the round-trip lift depend on.
+	AnnotatedOnly bool
 }
 
 // LiftSource lifts a single Go source file in the round-trip dialect
@@ -177,10 +187,29 @@ func LiftSourceWithOptions(packagePath, sourcePath string, source []byte, opts L
 
 	var result LiftResult
 	result.Diagnostics = diagnostics
+	result.Annotations = map[string]*Annotation{}
 	var bodyTerms []any
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok {
+			continue
+		}
+		// Authoring surface: the DECLARATION drives emission. A malformed
+		// `//provekit:` directive is refused loudly (an author who typed it
+		// meant to declare something), not silently dropped.
+		ann, annErr := parseFuncAnnotation(fn)
+		if annErr != nil {
+			result.Refusals = append(result.Refusals, Refusal{
+				Kind:     "malformed-annotation",
+				Function: fallbackFuncName(packagePath, fn),
+				Line:     fset.Position(fn.Pos()).Line,
+				Reason:   annErr.Error(),
+			})
+			continue
+		}
+		if opts.AnnotatedOnly && ann == nil {
+			// No boundary/sugar declared: the author did not ask the
+			// authoring surface to lift this function.
 			continue
 		}
 		contract, bodyTerm, refusals := liftFunc(fset, file, pkg, info, sourcePath, known, packagePath, fn, opts)
@@ -191,6 +220,9 @@ func LiftSourceWithOptions(packagePath, sourcePath string, source []byte, opts L
 		result.Contracts = append(result.Contracts, contract)
 		result.IR = append(result.IR, contract)
 		bodyTerms = append(bodyTerms, bodyTerm)
+		if ann != nil {
+			result.Annotations[contract.FnName] = ann
+		}
 	}
 
 	if len(bodyTerms) > 0 {
@@ -1177,6 +1209,12 @@ func LiftPathsWithOptions(workspaceRoot string, sourcePaths []string, opts LiftO
 		merged.SourceUnits = append(merged.SourceUnits, lifted.SourceUnits...)
 		merged.Refusals = append(merged.Refusals, lifted.Refusals...)
 		merged.Diagnostics = append(merged.Diagnostics, lifted.Diagnostics...)
+		for fnName, ann := range lifted.Annotations {
+			if merged.Annotations == nil {
+				merged.Annotations = map[string]*Annotation{}
+			}
+			merged.Annotations[fnName] = ann
+		}
 	}
 	return merged, nil
 }

--- a/implementations/go/provekit-lift-go/lift_test.go
+++ b/implementations/go/provekit-lift-go/lift_test.go
@@ -297,6 +297,83 @@ func TestRPCProtocolLiftsFixture(t *testing.T) {
 	}
 }
 
+const doubleSource = `package sample
+
+func Double(x int) int {
+	return x * 2
+}
+`
+
+// The round-trip dialect (default) keeps the namespaced op `go:mul`, which the
+// Go source compiler round-trips byte-identically.
+func TestRoundTripDialectKeepsNamespacedOp(t *testing.T) {
+	result, err := LiftSource("example.com/sample", "double.go", []byte(doubleSource))
+	if err != nil {
+		t.Fatalf("LiftSource: %v", err)
+	}
+	contracts := result.FunctionContracts()
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, want 1", len(contracts))
+	}
+	body, err := json.Marshal(contracts[0].Post)
+	if err != nil {
+		t.Fatalf("marshal post: %v", err)
+	}
+	if !strings.Contains(string(body), `"name":"go:mul"`) {
+		t.Fatalf("round-trip dialect must emit go:mul, got: %s", body)
+	}
+	if strings.Contains(string(body), `"name":"*"`) {
+		t.Fatalf("round-trip dialect must NOT normalize to core `*`: %s", body)
+	}
+}
+
+// The verify-facing dialect normalizes arithmetic to the SMT-LIB core symbol
+// `*`, so the body-derived postcondition is z3-dischargeable.
+func TestCoreDialectNormalizesArithToSmtSymbol(t *testing.T) {
+	result, err := LiftSourceCore("example.com/sample", "double.go", []byte(doubleSource))
+	if err != nil {
+		t.Fatalf("LiftSourceCore: %v", err)
+	}
+	contracts := result.FunctionContracts()
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, want 1", len(contracts))
+	}
+	body, err := json.Marshal(contracts[0].Post)
+	if err != nil {
+		t.Fatalf("marshal post: %v", err)
+	}
+	if !strings.Contains(string(body), `"name":"*"`) {
+		t.Fatalf("core dialect must emit `*`, got: %s", body)
+	}
+	// Discrimination: the namespaced form must be gone in the core dialect.
+	if strings.Contains(string(body), `"name":"go:mul"`) {
+		t.Fatalf("core dialect must NOT leave go:mul: %s", body)
+	}
+}
+
+// coreArithOp maps only the operators with a faithful Int/Bool core-theory
+// counterpart; structurally-unmappable ops (bitwise, shifts, deref) stay
+// namespaced so they cannot silently alias to the wrong theory.
+func TestCoreArithOpMappingIsBounded(t *testing.T) {
+	mapped := map[string]string{
+		"go:add": "+", "go:sub": "-", "go:mul": "*",
+		"go:eq": "=", "go:lt": "<", "go:le": "<=", "go:gt": ">", "go:ge": ">=",
+		"go:and": "and", "go:or": "or", "go:not": "not", "go:neg": "-",
+	}
+	for in, want := range mapped {
+		got, ok := coreArithOp(in)
+		if !ok || got != want {
+			t.Fatalf("coreArithOp(%q) = (%q, %v), want (%q, true)", in, got, ok, want)
+		}
+	}
+	// Discrimination: bitwise / shift / deref ops have NO core mapping.
+	for _, unmapped := range []string{"go:bitand", "go:bitor", "go:bitxor", "go:shl", "go:shr", "go:deref"} {
+		if got, ok := coreArithOp(unmapped); ok {
+			t.Fatalf("coreArithOp(%q) must be unmapped, got %q", unmapped, got)
+		}
+	}
+}
+
 func resultBodyTerm(t *testing.T, post any) any {
 	t.Helper()
 	generic, err := toGeneric(post)

--- a/implementations/go/provekit-lift-go/lift_test.go
+++ b/implementations/go/provekit-lift-go/lift_test.go
@@ -366,11 +366,54 @@ func TestCoreArithOpMappingIsBounded(t *testing.T) {
 			t.Fatalf("coreArithOp(%q) = (%q, %v), want (%q, true)", in, got, ok, want)
 		}
 	}
-	// Discrimination: bitwise / shift / deref ops have NO core mapping.
-	for _, unmapped := range []string{"go:bitand", "go:bitor", "go:bitxor", "go:shl", "go:shr", "go:deref"} {
+	// Discrimination: ops whose SMT-LIB semantics DIVERGE from Go (or have no
+	// faithful core form) must have NO core mapping, so they stay
+	// uninterpreted -> Undecidable, never a false discharge.
+	//
+	// `go:div` / `go:mod` are the cardinal-sin guard (PR #1445): SMT-LIB
+	// div/mod floor toward -inf while Go truncates toward zero, so mapping
+	// them signed a witness for `Halve(-7) == -4` (false in Go). They MUST
+	// stay namespaced until faithful truncation modeling lands.
+	for _, unmapped := range []string{
+		"go:div", "go:mod", // divergent semantics (truncate vs floor) — cardinal-sin guard
+		"go:bitand", "go:bitor", "go:bitxor", "go:bitnot", // no faithful Int core form
+		"go:shl", "go:shr", // shifts
+		"go:deref", "go:ne", // deref; ne intentionally conservative (left uninterpreted)
+	} {
 		if got, ok := coreArithOp(unmapped); ok {
-			t.Fatalf("coreArithOp(%q) must be unmapped, got %q", unmapped, got)
+			t.Fatalf("coreArithOp(%q) must be unmapped (unfaithful/no core form), got %q", unmapped, got)
 		}
+	}
+}
+
+// The verify-facing dialect must NOT normalize Go integer division to SMT-LIB
+// `div`: their rounding diverges on negatives, which would let a Go-false
+// equation discharge. The lifted body must keep the uninterpreted `go:div`.
+func TestCoreDialectLeavesDivisionUninterpreted(t *testing.T) {
+	src := `package sample
+
+func Halve(x int) int {
+	return x / 2
+}
+`
+	result, err := LiftSourceCore("example.com/sample", "halve.go", []byte(src))
+	if err != nil {
+		t.Fatalf("LiftSourceCore: %v", err)
+	}
+	contracts := result.FunctionContracts()
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, want 1", len(contracts))
+	}
+	body, err := json.Marshal(contracts[0].Post)
+	if err != nil {
+		t.Fatalf("marshal post: %v", err)
+	}
+	if !strings.Contains(string(body), `"name":"go:div"`) {
+		t.Fatalf("division must stay uninterpreted as go:div, got: %s", body)
+	}
+	// Decisive: it must NOT have been aliased to the floor-division SMT op.
+	if strings.Contains(string(body), `"name":"div"`) {
+		t.Fatalf("division must NOT normalize to SMT-LIB `div` (floor != Go truncate): %s", body)
 	}
 }
 

--- a/implementations/go/provekit-lift-go/rpc.go
+++ b/implementations/go/provekit-lift-go/rpc.go
@@ -17,11 +17,37 @@ type rpcRequest struct {
 }
 
 type liftParams struct {
-	WorkspaceRoot string   `json:"workspace_root"`
-	SourcePaths   []string `json:"source_paths"`
+	WorkspaceRoot string         `json:"workspace_root"`
+	SourcePaths   []string       `json:"source_paths"`
+	Options       map[string]any `json:"options"`
+}
+
+// dialectOptionsFromParams reads the verify-facing dialect selector from the
+// lift `options` bag. The verifier-driving caller (kit-dispatch) passes
+// `options.dialect = "core"` so the body-derived postcondition uses SMT-LIB
+// core op symbols and is z3-dischargeable. Absent / any other value keeps the
+// round-trip namespaced dialect.
+func dialectOptionsFromParams(opts map[string]any) LiftOptions {
+	if opts == nil {
+		return LiftOptions{}
+	}
+	if d, ok := opts["dialect"].(string); ok && d == "core" {
+		return LiftOptions{NormalizeCoreArith: true}
+	}
+	return LiftOptions{}
 }
 
 func RunRPC(stdin io.Reader, stdout io.Writer) error {
+	return RunRPCWithDefault(stdin, stdout, LiftOptions{})
+}
+
+// RunRPCWithDefault runs the lift RPC loop with a default op dialect applied
+// to every `lift` call that does not itself name a `dialect` in its options.
+// The kit-dispatch verify pipeline resolves the `go` lift surface to a binary
+// launched with `--dialect=core`, so the body-derived postconditions are
+// z3-dischargeable without the language-neutral dispatcher having to know
+// anything about Go.
+func RunRPCWithDefault(stdin io.Reader, stdout io.Writer, defaultOpts LiftOptions) error {
 	scanner := bufio.NewScanner(stdin)
 	for scanner.Scan() {
 		line := scanner.Bytes()
@@ -37,7 +63,7 @@ func RunRPC(stdin io.Reader, stdout io.Writer) error {
 		case "initialize":
 			writeRPC(stdout, successResponse(req.ID, InitializeResult()))
 		case "lift":
-			writeRPC(stdout, handleLift(req.ID, req.Params))
+			writeRPC(stdout, handleLift(req.ID, req.Params, defaultOpts))
 		case "compile":
 			writeRPC(stdout, handleCompile(req.ID, req.Params))
 		case "shutdown":
@@ -50,7 +76,7 @@ func RunRPC(stdin io.Reader, stdout io.Writer) error {
 	return scanner.Err()
 }
 
-func handleLift(id json.RawMessage, raw json.RawMessage) any {
+func handleLift(id json.RawMessage, raw json.RawMessage, defaultOpts LiftOptions) any {
 	var params liftParams
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &params); err != nil {
@@ -68,7 +94,11 @@ func handleLift(id json.RawMessage, raw json.RawMessage) any {
 	if len(params.SourcePaths) == 0 {
 		return errorResponse(id, -32602, "source_paths must be a non-empty array of strings")
 	}
-	result, err := LiftPaths(params.WorkspaceRoot, params.SourcePaths)
+	liftOpts := defaultOpts
+	if perCall := dialectOptionsFromParams(params.Options); perCall.NormalizeCoreArith {
+		liftOpts = perCall
+	}
+	result, err := LiftPathsWithOptions(params.WorkspaceRoot, params.SourcePaths, liftOpts)
 	if err != nil {
 		return errorResponse(id, -32603, fmt.Sprintf("Lift failed: %v", err))
 	}

--- a/implementations/go/provekit-lift-go/types.go
+++ b/implementations/go/provekit-lift-go/types.go
@@ -69,6 +69,11 @@ type LiftResult struct {
 	SourceUnits []SourceUnit
 	Refusals    []Refusal
 	Diagnostics []Diagnostic
+	// Annotations maps a lifted function's fnName to the authoring
+	// declaration (`//provekit:boundary` / `//provekit:sugar`) that drove
+	// its emission, when one was present. Empty under the bare verify/round-
+	// trip surfaces; populated by the authoring surface (AnnotatedOnly).
+	Annotations map[string]*Annotation
 }
 
 func (r LiftResult) FunctionContracts() []FunctionContract {

--- a/implementations/go/provekit-realize-go-core/cmd/provekit-realize-go/main.go
+++ b/implementations/go/provekit-realize-go-core/cmd/provekit-realize-go/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	realizego "github.com/tsavo/provekit/go/provekit-realize-go-core"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--rpc" {
+		if err := realizego.RunRPC(os.Stdin, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "provekit-realize-go rpc: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	fmt.Fprintln(os.Stderr, "usage: provekit-realize-go --rpc")
+	os.Exit(1)
+}

--- a/implementations/go/provekit-realize-go-core/go.mod
+++ b/implementations/go/provekit-realize-go-core/go.mod
@@ -1,0 +1,3 @@
+module github.com/tsavo/provekit/go/provekit-realize-go-core
+
+go 1.22

--- a/implementations/go/provekit-realize-go-core/realizer.go
+++ b/implementations/go/provekit-realize-go-core/realizer.go
@@ -1,0 +1,159 @@
+// Package realizego is the SHIM that supplies the native Go sugar for a
+// ProvekIt contract: the Go peer of provekit-realize-python-core.
+//
+// A contract, lifted to ProofIR (language-neutral), is MATERIALIZED into a Go
+// surface by this realize kit. `provekit materialize` (or a direct
+// dispatch_realize call) sends a `provekit.plugin.invoke` request naming a
+// cross-language `concept_name` plus the function signature; this kit returns
+// REAL Go source realizing that concept. Contract in -> Go sugar out.
+//
+// Minimal mirror (this session): ONE concept, `identity`, with its body
+// template inlined here. The PRODUCTION shape (Python pattern) loads templates
+// from a sealed JSON artifact under
+// `menagerie/go-language-signature/specs/body-templates/...`; that, plus the
+// broader concept set (addition, etc.), is deferred follow-up. The emitted
+// source is real Go that `go build`s -- never a stub for the supported
+// concept. Supra omnia, rectum.
+package realizego
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KitID identifies this realize kit in emitted provenance.
+const KitID = "provekit-realize-go-core@0.1.0"
+
+// bodyTemplate is the inline analog of one entry in Python's
+// `python-canonical-bodies.json`: a concept name, a `${paramN}`-placeholder
+// body template, and a signature guard (param-count bounds).
+type bodyTemplate struct {
+	conceptName string
+	template    string // Go statement(s); `${paramN}` substituted by argument names.
+	minParams   int
+	maxParams   int
+}
+
+// templates is the kit's supported-concept set. One concept for the minimal
+// mirror; adding rows (or loading a sealed JSON template file) is additive.
+var templates = []bodyTemplate{
+	{
+		// `identity`: a cross-language concept (also in Python's
+		// canonical-bodies). Go realization `return x` -- the same shape as
+		// Python's `return ${param0}`.
+		conceptName: "identity",
+		template:    "return ${param0}",
+		minParams:   1,
+		maxParams:   1,
+	},
+}
+
+// RealizeRequest mirrors the fields of the dispatcher's PEP 1.7.0 realize
+// request (libprovekit core::RealizeRequest) this kit consumes. Unused fields
+// are tolerated (the dispatcher serializes the full request).
+type RealizeRequest struct {
+	Function    string   `json:"function"`
+	Params      []string `json:"params"`
+	ParamTypes  []string `json:"param_types"`
+	ReturnType  string   `json:"return_type"`
+	ConceptName string   `json:"concept_name"`
+	Visibility  string   `json:"visibility"`
+}
+
+// RealizedSource is the `result` of a realize invoke: the native Go sugar.
+type RealizedSource struct {
+	Source    string `json:"source"`
+	IsStub    bool   `json:"is_stub"`
+	Extension string `json:"extension"`
+	KitID     string `json:"kit_id"`
+}
+
+// MissingTemplateError signals there is no body template for the requested
+// concept under the given signature -- the substrate-honest "this kit does
+// not cover that concept" refusal (NOT a silent stub).
+type MissingTemplateError struct {
+	ConceptName string
+	NumParams   int
+	Detail      string
+}
+
+func (e *MissingTemplateError) Error() string {
+	return fmt.Sprintf("missing body-template for concept %q (%d params): %s",
+		e.ConceptName, e.NumParams, e.Detail)
+}
+
+// Realize produces the Go sugar realizing the requested concept for the given
+// function signature. Returns *MissingTemplateError when the concept/signature
+// is uncovered.
+func Realize(req RealizeRequest) (RealizedSource, error) {
+	tpl, ok := lookupTemplate(req.ConceptName, len(req.Params))
+	if !ok {
+		return RealizedSource{}, &MissingTemplateError{
+			ConceptName: req.ConceptName,
+			NumParams:   len(req.Params),
+			Detail:      "no supported concept matches this name + param count",
+		}
+	}
+	body, err := substitute(tpl.template, req.Params)
+	if err != nil {
+		return RealizedSource{}, err
+	}
+	source := emitGoFunction(req, body)
+	return RealizedSource{
+		Source:    source,
+		IsStub:    false,
+		Extension: "go",
+		KitID:     KitID,
+	}, nil
+}
+
+func lookupTemplate(concept string, numParams int) (bodyTemplate, bool) {
+	for _, t := range templates {
+		if t.conceptName != concept {
+			continue
+		}
+		if numParams < t.minParams || numParams > t.maxParams {
+			continue
+		}
+		return t, true
+	}
+	return bodyTemplate{}, false
+}
+
+// substitute replaces `${paramN}` placeholders with the Nth argument name.
+func substitute(template string, params []string) (string, error) {
+	out := template
+	for i, name := range params {
+		out = strings.ReplaceAll(out, fmt.Sprintf("${param%d}", i), name)
+	}
+	if strings.Contains(out, "${param") {
+		return "", fmt.Errorf("template references a parameter not provided: %q", out)
+	}
+	return out, nil
+}
+
+// emitGoFunction assembles a real Go function declaration around the realized
+// body, reproducing the requested signature. `func <Fn>(<p0> <t0>, ...) <ret> {
+// <body> }`.
+func emitGoFunction(req RealizeRequest, body string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "func %s(", req.Function)
+	for i, name := range req.Params {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		typ := "int"
+		if i < len(req.ParamTypes) && req.ParamTypes[i] != "" {
+			typ = req.ParamTypes[i]
+		}
+		fmt.Fprintf(&b, "%s %s", name, typ)
+	}
+	b.WriteString(")")
+	if req.ReturnType != "" {
+		fmt.Fprintf(&b, " %s", req.ReturnType)
+	}
+	b.WriteString(" {\n\t")
+	b.WriteString(body)
+	b.WriteString("\n}")
+	return b.String()
+}

--- a/implementations/go/provekit-realize-go-core/realizer_test.go
+++ b/implementations/go/provekit-realize-go-core/realizer_test.go
@@ -1,0 +1,71 @@
+package realizego
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRealizeIdentityEmitsCompilableSignature(t *testing.T) {
+	got, err := Realize(RealizeRequest{
+		Function:    "Id",
+		Params:      []string{"x"},
+		ParamTypes:  []string{"int"},
+		ReturnType:  "int",
+		ConceptName: "identity",
+	})
+	if err != nil {
+		t.Fatalf("Realize identity: %v", err)
+	}
+	if got.IsStub {
+		t.Fatal("identity must not be a stub")
+	}
+	if got.Extension != "go" {
+		t.Fatalf("extension = %q, want go", got.Extension)
+	}
+	if !strings.Contains(got.Source, "func Id(x int) int") {
+		t.Fatalf("source missing signature: %s", got.Source)
+	}
+	if !strings.Contains(got.Source, "return x") {
+		t.Fatalf("identity body must be `return x`: %s", got.Source)
+	}
+}
+
+// Discrimination: an unsupported concept is refused with MissingTemplateError,
+// never silently stubbed.
+func TestRealizeUnsupportedConceptRefuses(t *testing.T) {
+	_, err := Realize(RealizeRequest{
+		Function:    "F",
+		Params:      []string{"x"},
+		ConceptName: "concept:not-supported",
+	})
+	if err == nil {
+		t.Fatal("unsupported concept must be refused")
+	}
+	if _, ok := err.(*MissingTemplateError); !ok {
+		t.Fatalf("want *MissingTemplateError, got %T: %v", err, err)
+	}
+}
+
+// Discrimination: identity's signature guard rejects a wrong param count
+// (2 params) rather than emitting a malformed body.
+func TestRealizeIdentityRejectsWrongArity(t *testing.T) {
+	_, err := Realize(RealizeRequest{
+		Function:    "Id2",
+		Params:      []string{"x", "y"},
+		ConceptName: "identity",
+	})
+	if err == nil {
+		t.Fatal("identity with 2 params must be refused (max_params=1)")
+	}
+}
+
+// Structural: substitute fills ${paramN} placeholders positionally.
+func TestSubstitutePositional(t *testing.T) {
+	out, err := substitute("return ${param0}", []string{"value"})
+	if err != nil {
+		t.Fatalf("substitute: %v", err)
+	}
+	if out != "return value" {
+		t.Fatalf("substitute = %q, want `return value`", out)
+	}
+}

--- a/implementations/go/provekit-realize-go-core/rpc.go
+++ b/implementations/go/provekit-realize-go-core/rpc.go
@@ -1,0 +1,107 @@
+package realizego
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+// RunRPC drives the PEP 1.7.0 realize protocol the dispatcher
+// (kit_dispatch.rs invoke_realize) speaks: a single `provekit.plugin.invoke`
+// line in, one JSON result line out. Also answers `provekit.plugin.shutdown`.
+func RunRPC(stdin io.Reader, stdout io.Writer) error {
+	scanner := bufio.NewScanner(stdin)
+	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var req rpcRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			writeJSON(stdout, errorResponse(nil, -32700, fmt.Sprintf("PARSE_ERROR: %v", err)))
+			continue
+		}
+		switch req.Method {
+		case "provekit.plugin.invoke":
+			writeJSON(stdout, handleInvoke(req.ID, req.Params))
+		case "provekit.plugin.shutdown":
+			writeJSON(stdout, successResponse(req.ID, nil))
+			return nil
+		default:
+			writeJSON(stdout, errorResponse(req.ID, -32601, fmt.Sprintf("METHOD_NOT_FOUND: %s", req.Method)))
+		}
+	}
+	return scanner.Err()
+}
+
+func handleInvoke(id json.RawMessage, raw json.RawMessage) any {
+	var req RealizeRequest
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &req); err != nil {
+			return errorResponse(id, -32602, fmt.Sprintf("INVALID_PARAMS: %v", err))
+		}
+	}
+	realized, err := Realize(req)
+	if err != nil {
+		var missing *MissingTemplateError
+		if asMissing(err, &missing) {
+			// Substrate-honest refusal: the concept is not covered.
+			return map[string]any{
+				"jsonrpc": "2.0",
+				"id":      idValue(id),
+				"error": map[string]any{
+					"code":    -32100,
+					"message": "missing body-template entry",
+					"data":    map[string]any{"concept_name": missing.ConceptName, "num_params": missing.NumParams},
+				},
+			}
+		}
+		return errorResponse(id, -32603, err.Error())
+	}
+	return successResponse(id, realized)
+}
+
+func asMissing(err error, target **MissingTemplateError) bool {
+	if m, ok := err.(*MissingTemplateError); ok {
+		*target = m
+		return true
+	}
+	return false
+}
+
+func successResponse(id json.RawMessage, result any) map[string]any {
+	return map[string]any{"jsonrpc": "2.0", "id": idValue(id), "result": result}
+}
+
+func errorResponse(id json.RawMessage, code int, message string) map[string]any {
+	return map[string]any{"jsonrpc": "2.0", "id": idValue(id), "error": map[string]any{"code": code, "message": message}}
+}
+
+func idValue(id json.RawMessage) any {
+	if len(id) == 0 {
+		return nil
+	}
+	var out any
+	if err := json.Unmarshal(id, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func writeJSON(w io.Writer, v any) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		fmt.Fprintf(w, `{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":%q}}`+"\n", err.Error())
+		return
+	}
+	fmt.Fprintln(w, string(b))
+}

--- a/implementations/rust/provekit-cli/tests/cmd_authoring_surface_go.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_authoring_surface_go.rs
@@ -124,11 +124,22 @@ fn stage_authoring_project(suffix: &str, lift_bin: &Path, broken: bool) -> PathB
         )
         .expect("write manifest");
     }
+
+    // HERMETIC: mint's body-template projection
+    // (project_body_templates_for_sugar_bindings) writes
+    // `<menagerie-root>/<lang>-language-signature/specs/body-templates/...`,
+    // locating the menagerie root by walking UP from the process CWD. Give the
+    // staged project its OWN menagerie/ dir and run mint with CWD set here (see
+    // run_mint), so the projection lands in the tempdir and NEVER clobbers the
+    // repo's tracked artifacts. (The non-hermetic walk-up is a tracked
+    // follow-up against the shared spine, out of scope for this fix.)
+    fs::create_dir_all(project.join("menagerie")).expect("mkdir menagerie");
     project
 }
 
 fn run_mint(project: &Path) {
     let out = Command::new(provekit_bin())
+        .current_dir(project) // hermetic projection: locate menagerie/ in the tempdir
         .args(["mint", "--project"])
         .arg(project)
         .arg("--out")

--- a/implementations/rust/provekit-cli/tests/cmd_authoring_surface_go.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_authoring_surface_go.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// GO AUTHORING SURFACE gauntlet: a Go library AUTHOR declares a boundary on a
+// function (`//provekit:sugar(concept="identity")`) and the library GETS a
+// contract -- the same way rust (`#[provekit::sugar(...)]`) and java authors
+// do. This is the central piece: today's verify-side proved "a Go library gets
+// a contract" by running the lifter internally; this proves the AUTHORING
+// surface -- the DECLARATION drives emission.
+//
+// The config mirrors rust's authoring shape: two `[[plugins]]` --
+//   go-bind      (layer = "library-bindings")  -> library-sugar-binding-entry
+//   go-contracts (emit = "ir-document")        -> function-contract + callsite
+// both resolving to provekit-lift-go-verify, which emits different IR per
+// surface so a function is not minted twice.
+//
+// Closed loop, asserted here:
+//   - DECLARE: only the annotated `Id` is lifted; `Unannotated` is NOT.
+//   - GET A CONTRACT: mint writes the binding-entry catalog (the declaration)
+//     AND the function-contract + auto-bridge (tool-written).
+//   - VERIFY: the harvested `Id(3) == 3` discharges through the body `x` ->
+//     `3 == 3` -> z3 -> signed witness, exit 0. Broken body -> Unsatisfied,
+//     exit 1, no witness.
+// The MATERIALIZE half of the loop (same `identity` concept -> Go sugar that
+// compiles) is gated by `go_realize_materialize.rs`.
+//
+// Requires `go` and `z3` on PATH; guards skip loudly otherwise.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value as Json;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-go-authoring-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn build_go_lift_verify() -> PathBuf {
+    let go_module = repo_root().join("implementations").join("go");
+    let out = std::env::temp_dir().join(format!("provekit-lift-go-verify-auth-{}", std::process::id()));
+    let built = Command::new("go")
+        .current_dir(&go_module)
+        .args(["build", "-o", out.to_str().unwrap(), "./cmd/provekit-lift-go-verify"])
+        .output()
+        .expect("spawn go build");
+    assert!(
+        built.status.success(),
+        "go build provekit-lift-go-verify failed\n  stderr: {}",
+        String::from_utf8_lossy(&built.stderr)
+    );
+    out
+}
+
+/// Stage the `examples/go-identity` authoring example into a tempdir, rewrite
+/// both lift manifests to the built binary, and (for the negative case) break
+/// the annotated body so `Id` no longer returns its argument.
+fn stage_authoring_project(suffix: &str, lift_bin: &Path, broken: bool) -> PathBuf {
+    let example = repo_root().join("examples").join("go-identity");
+    let project = unique_dir(suffix);
+
+    // id.go: keep the annotation; mutate the body for the negative case.
+    let body = if broken { "x + 1" } else { "x" };
+    let id_src = format!(
+        "package sample\n\n//provekit:sugar(concept=\"identity\", library=\"builtin\", version=\"1\")\nfunc Id(x int) int {{\n\treturn {body}\n}}\n\nfunc Unannotated(y int) int {{\n\treturn y + 1\n}}\n"
+    );
+    fs::write(project.join("id.go"), id_src).expect("write id.go");
+    fs::copy(example.join("id_test.go"), project.join("id_test.go")).expect("copy id_test.go");
+    fs::copy(example.join("go.mod"), project.join("go.mod")).expect("copy go.mod");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("go-bind")).unwrap();
+    fs::create_dir_all(provekit.join("lift").join("go-contracts")).unwrap();
+    fs::copy(
+        example.join(".provekit").join("config.toml"),
+        provekit.join("config.toml"),
+    )
+    .expect("copy config.toml");
+
+    for surface in ["go-bind", "go-contracts"] {
+        let manifest = format!(
+            "name = \"{surface}\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+            lift_bin.display()
+        );
+        fs::write(
+            provekit.join("lift").join(surface).join("manifest.toml"),
+            manifest,
+        )
+        .expect("write manifest");
+    }
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .args(["mint", "--project"])
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .args(["--no-attest", "--quiet"])
+        .output()
+        .expect("spawn mint");
+    assert!(
+        out.status.success(),
+        "mint must succeed\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_verify(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .args(["verify", "--project"])
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+/// DECLARE -> GET A CONTRACT: the authoring surface mints (a) the
+/// `library-sugar-binding-entry` declaration catalog for the annotated `Id`,
+/// and (b) the function-contract + auto-bridge. `Unannotated` is NOT minted.
+#[test]
+fn go_authoring_surface_emits_only_declared_boundary() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go authoring-surface test");
+        return;
+    }
+    let lift_bin = build_go_lift_verify();
+    let project = stage_authoring_project("declare", &lift_bin, false);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "tool-minted bundle must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    // (a) The DECLARATION catalog: a library-sugar-binding-entry for `Id`
+    // carrying the declared concept. (b) The auto-bridge for `Id`.
+    //
+    // The binding-entry envelope shape is the flat `{body, header,
+    // schemaVersion}` mint writes (mint_library_sugar_binding_entry); read its
+    // fields directly from the envelope (the verifier's `memento_kind` helper
+    // only handles the contract/bridge envelope shapes).
+    let mut saw_binding_entry_for_id = false;
+    for env in pool.mementos.values() {
+        let kind = env
+            .pointer("/header/kind")
+            .or_else(|| env.pointer("/body/kind"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if kind != "library-sugar-binding-entry" {
+            continue;
+        }
+        let body = env.pointer("/body").unwrap_or(env);
+        let concept = body
+            .get("concept_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let sfn = body
+            .get("source_function_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if sfn == "Id" && concept == "identity" {
+            saw_binding_entry_for_id = true;
+        }
+        // Discrimination: the unannotated function must NOT have a
+        // declaration entry.
+        assert_ne!(
+            sfn, "Unannotated",
+            "unannotated function must not get a binding-entry"
+        );
+    }
+    assert!(
+        saw_binding_entry_for_id,
+        "authoring surface must mint a library-sugar-binding-entry for the declared Id (concept=identity); indexed bridges: {:?}",
+        pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+    );
+
+    // The tool-written bridge for the declared boundary.
+    assert!(
+        pool.bridges_by_symbol.contains_key("Id"),
+        "mint must auto-write a bridge for the declared Id; got {:?}",
+        pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+    );
+    // Discrimination: no bridge for the undeclared function.
+    assert!(
+        !pool.bridges_by_symbol.contains_key("Unannotated"),
+        "the undeclared function must not get a bridge"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// VERIFY (positive): the declared boundary's contract discharges through the
+/// body, signed witness, exit 0.
+#[test]
+fn go_authoring_surface_declared_contract_discharges() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping");
+        return;
+    }
+    let lift_bin = build_go_lift_verify();
+    let project = stage_authoring_project("pos", &lift_bin, false);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(claim["pass"], true, "Id(3)==3 must discharge; claim: {claim}");
+    assert_eq!(claim["status"], "discharged", "claim: {claim}");
+    let witness_cid = claim["witnessCid"].as_str().expect("witness minted");
+    assert!(witness_cid.starts_with("blake3-512:"));
+    eprintln!("GO_AUTHORING_POSITIVE_WITNESS_CID={witness_cid}");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(code, 0, "positive run exits clean; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// VERIFY (negative): break the declared function's body so it no longer
+/// satisfies the harvested assertion -> Unsatisfied, exit 1, no witness.
+#[test]
+fn go_authoring_surface_broken_declared_body_fails() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping");
+        return;
+    }
+    let lift_bin = build_go_lift_verify();
+    let project = stage_authoring_project("neg", &lift_bin, true);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["status"], "unsatisfied",
+        "broken declared body must be UNSATISFIED; claim: {claim}"
+    );
+    assert_eq!(claim["pass"], false, "claim: {claim}");
+    assert!(claim["witnessCid"].is_null(), "no witness; claim: {claim}");
+    assert_eq!(receipt["ok"], false, "receipt: {receipt}");
+    assert_eq!(code, 1, "broken-body claim must exit 1; got {code}");
+    eprintln!("GO_AUTHORING_NEGATIVE_EXIT_CODE={code}");
+
+    let _ = fs::remove_dir_all(&project);
+}

--- a/implementations/rust/provekit-cli/tests/cmd_verify_go_division_unsound.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_go_division_unsound.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CARDINAL-SIN REGRESSION (PR #1445 review blocker): the verify-facing Go
+// lifter must NEVER sign a witness for a Go-false statement via an op whose
+// SMT-LIB semantics diverge from Go.
+//
+// The proven bug: `NormalizeCoreArith` mapped `go:div`/`go:mod` to SMT-LIB
+// `div`/`mod`, but they DIVERGE on negatives:
+//   Go  `-7 / 2 == -3` (truncate toward zero)
+//   SMT `(div -7 2) == -4` (floor toward -inf)
+// so on `func Halve(x int) int { return x / 2 }`, the assertion
+// `Halve(-7) == -4` (FALSE in Go) discharged with a SIGNED WITNESS, exit 0 --
+// an inverted proof.
+//
+// The fix leaves division/modulo UNINTERPRETED (`go:div` stays namespaced), so
+// the obligation retains an opaque symbol and verify returns Undecidable
+// (EXIT_SOLVER_FAIL = 3) with NO witness -- the honest "I cannot prove this".
+//
+// This test drives the REAL Go lifter + REAL `provekit mint`/`verify` on the
+// reviewer's exact probe and asserts: NO discharge, NO signed witness, exit 3.
+// Both the Go-false (`-4`) and Go-true (`-3`) assertions become Undecidable
+// with div uninterpreted -- that is correct; the cardinal point is that
+// neither false-discharges.
+//
+// Requires `go` and `z3` on PATH; guards skip loudly otherwise.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value as Json;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-go-divunsound-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn build_go_lift_verify() -> PathBuf {
+    let go_module = repo_root().join("implementations").join("go");
+    let out = std::env::temp_dir().join(format!("provekit-lift-go-verify-div-{}", std::process::id()));
+    let built = Command::new("go")
+        .current_dir(&go_module)
+        .args(["build", "-o", out.to_str().unwrap(), "./cmd/provekit-lift-go-verify"])
+        .output()
+        .expect("spawn go build");
+    assert!(
+        built.status.success(),
+        "go build provekit-lift-go-verify failed\n  stderr: {}",
+        String::from_utf8_lossy(&built.stderr)
+    );
+    out
+}
+
+/// Stage a `Halve(x) = x / 2` project whose harvested assertion is
+/// `Halve(-7) == expected`. `expected = -4` is the Go-FALSE/SMT-floor case;
+/// `-3` is the Go-TRUE case. Both must be Undecidable with div uninterpreted.
+fn stage_halve_project(suffix: &str, lift_bin: &Path, expected: i64) -> PathBuf {
+    let example = repo_root().join("examples").join("go-double");
+    let project = unique_dir(suffix);
+
+    fs::write(
+        project.join("halve.go"),
+        "package sample\n\nfunc Halve(x int) int {\n\treturn x / 2\n}\n",
+    )
+    .expect("write halve.go");
+    fs::write(
+        project.join("halve_test.go"),
+        format!(
+            "package sample\n\nimport (\n\t\"testing\"\n\n\t\"github.com/stretchr/testify/assert\"\n)\n\nfunc TestHalve(t *testing.T) {{\n\tassert.Equal(t, Halve(-7), {expected})\n}}\n"
+        ),
+    )
+    .expect("write halve_test.go");
+    // Reuse the example's go.mod (testify dep; parser-only, never compiled).
+    fs::copy(example.join("go.mod"), project.join("go.mod")).expect("copy go.mod");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("go")).expect("mkdir lift/go");
+    fs::copy(
+        example.join(".provekit").join("config.toml"),
+        provekit.join("config.toml"),
+    )
+    .expect("copy config.toml");
+    let manifest = format!(
+        "name = \"go\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+        lift_bin.display()
+    );
+    fs::write(
+        provekit.join("lift").join("go").join("manifest.toml"),
+        manifest,
+    )
+    .expect("write manifest");
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .args(["mint", "--project"])
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .args(["--no-attest", "--quiet"])
+        .output()
+        .expect("spawn mint");
+    assert!(
+        out.status.success(),
+        "mint must succeed\n  stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_verify(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .args(["verify", "--project"])
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+/// Assert that the `Halve(-7) == expected` claim does NOT discharge, writes NO
+/// witness, and exits 3 (Undecidable) -- never a false discharge.
+fn assert_undecidable_no_witness(suffix: &str, expected: i64) {
+    let lift_bin = build_go_lift_verify();
+    let project = stage_halve_project(suffix, &lift_bin, expected);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["pass"], false,
+        "an integer-division claim must NEVER discharge (div is uninterpreted); claim: {claim}"
+    );
+    assert_ne!(
+        claim["status"], "discharged",
+        "CARDINAL SIN: a division claim discharged -- inverted proof regression; claim: {claim}"
+    );
+    assert_eq!(
+        claim["status"], "undecidable",
+        "division claim must be Undecidable; claim: {claim}"
+    );
+    assert!(
+        claim["witnessCid"].is_null(),
+        "NO signed witness may exist for a division claim; claim: {claim}"
+    );
+
+    // No witness file may have been written for any /-containing contract.
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a division claim; found {} files",
+        witness_files.len()
+    );
+
+    assert_eq!(
+        code, 3,
+        "division claim must exit 3 (EXIT_SOLVER_FAIL / undecidable), not 0 (discharged); got {code}"
+    );
+    eprintln!("GO_DIV_UNSOUND_GUARD expected={expected} status=undecidable exit={code} witnesses=0");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// The Go-FALSE assertion `Halve(-7) == -4` (true only under SMT floor div)
+/// must NOT discharge and must write NO witness. This is the exact inverted
+/// proof PR #1445 review caught.
+#[test]
+fn go_division_go_false_assertion_does_not_false_discharge() {
+    if !go_available() || !z3_available() {
+        eprintln!("go/z3 not on PATH: skipping go division unsoundness regression");
+        return;
+    }
+    assert_undecidable_no_witness("false-neg4", -4);
+}
+
+/// The Go-TRUE assertion `Halve(-7) == -3` is ALSO Undecidable with div
+/// uninterpreted -- correct: we refuse rather than risk an unfaithful model.
+#[test]
+fn go_division_go_true_assertion_is_undecidable_not_discharged() {
+    if !go_available() || !z3_available() {
+        eprintln!("go/z3 not on PATH: skipping");
+        return;
+    }
+    assert_undecidable_no_witness("true-neg3", -3);
+}

--- a/implementations/rust/provekit-cli/tests/cmd_verify_go_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_go_production_bridge.rs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// GO end-to-end production-bridge gauntlet -- the Go analog of
+// `cmd_verify_production_bridge.rs`. Proves the verification spine is
+// LANGUAGE-NEUTRAL for a fourth language: a Go function's body-derived
+// contract lifts to ProofIR (`post = result == (* x 2)` plus `formals`) and
+// the verifier discharges the obligation through the body via wp + z3,
+// exactly as for Rust and Java.
+//
+// Unlike the Rust production-bridge test (which uses a mock lifter that emits
+// the ir-document directly), this drives the REAL Go lifter binary
+// `provekit-lift-go-verify` -- the verify-facing `go` lift surface -- built
+// from `implementations/go/cmd/provekit-lift-go-verify`. That binary lifts the
+// real Go sources in `examples/go-double`:
+//
+//   - `double.go`      -> function-contract `post = result == (* x 2)`
+//                         (verify-facing dialect: `go:mul` normalized to `*`).
+//   - `double_test.go` -> contract `inv = =(Double(3), 6)` (Go Layer-0 leaf
+//                         assertion harvester).
+//
+// `provekit mint` AUTO-WRITES the `Double -> targetContractCid` bridge (#1443);
+// the bridge is TOOL-written, asserted by inspecting `pool.bridges_by_symbol`.
+// `provekit verify` then discharges both ways:
+//
+//   POSITIVE: `Double(3) == 6` reduces through the body `(* 3 2) == 6` -> z3
+//     discharges -> pass, signed witness, exit 0.
+//   NEGATIVE: break the body to `x * 3` -> `(* 3 3) == 6` -> z3 refutes ->
+//     Unsatisfied, exit 1, NO witness.
+//
+// Requires `go` and `z3` on PATH; skips the solver-dependent asserts if z3 is
+// absent, and skips entirely (with a loud eprintln) if go is absent.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value as Json;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+/// CARGO_MANIFEST_DIR = .../implementations/rust/provekit-cli; three parents up
+/// is the repo root.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-go-prod-bridge-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir project");
+    p
+}
+
+/// Build the verify-facing Go lift binary once, into a stable per-process
+/// path, and return it. Panics on build failure (a real regression).
+fn build_go_lift_verify() -> PathBuf {
+    let go_module = repo_root().join("implementations").join("go");
+    let out = std::env::temp_dir().join(format!(
+        "provekit-lift-go-verify-{}",
+        std::process::id()
+    ));
+    let status = Command::new("go")
+        .current_dir(&go_module)
+        .args([
+            "build",
+            "-o",
+            out.to_str().expect("utf8 out path"),
+            "./cmd/provekit-lift-go-verify",
+        ])
+        .output()
+        .expect("spawn go build");
+    assert!(
+        status.status.success(),
+        "go build provekit-lift-go-verify failed\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
+    );
+    assert!(out.exists(), "go build produced no binary at {}", out.display());
+    out
+}
+
+/// Copy the in-repo `examples/go-double` into a fresh tempdir, rewrite the
+/// `go` lift manifest's `command` to the built binary path, and (for the
+/// negative case) mutate the body multiplier. Returns the tempdir project.
+fn stage_go_project(suffix: &str, lift_bin: &Path, body_factor: i64) -> PathBuf {
+    let example = repo_root().join("examples").join("go-double");
+    let project = unique_dir(suffix);
+
+    // double.go: the library, with the body multiplier (2 honest, 3 broken).
+    let double_src = format!(
+        "package sample\n\nfunc Double(x int) int {{\n\treturn x * {body_factor}\n}}\n"
+    );
+    fs::write(project.join("double.go"), double_src).expect("write double.go");
+
+    // double_test.go: copied verbatim (the harvested `Double(3) == 6`).
+    fs::copy(
+        example.join("double_test.go"),
+        project.join("double_test.go"),
+    )
+    .expect("copy double_test.go");
+    fs::copy(example.join("go.mod"), project.join("go.mod")).expect("copy go.mod");
+
+    // .provekit/config.toml: copied verbatim.
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("go")).expect("mkdir .provekit/lift/go");
+    fs::copy(
+        example.join(".provekit").join("config.toml"),
+        provekit.join("config.toml"),
+    )
+    .expect("copy config.toml");
+
+    // .provekit/lift/go/manifest.toml: rewrite command[0] to the built binary.
+    let manifest = format!(
+        "name = \"go\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+        lift_bin.display()
+    );
+    fs::write(
+        provekit.join("lift").join("go").join("manifest.toml"),
+        manifest,
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_verify_json_with_code(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .arg("verify")
+        .arg("--project")
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+/// THE bridge-writer assertion (language-neutral, runs without z3): the TOOL
+/// wrote a `bridge` member for `Double` whose `targetContractCid` resolves to
+/// a `contract` member carrying the body-derived `formals` + `post`. No
+/// hand-bridging anywhere; the bridge came from `provekit mint`.
+#[test]
+fn go_mint_auto_writes_body_discharge_bridge() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go production-bridge bridge-writer test");
+        return;
+    }
+    let lift_bin = build_go_lift_verify();
+    let project = stage_go_project("bridge", &lift_bin, 2);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "tool-minted bundle must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let bridge = pool
+        .bridges_by_symbol
+        .get("Double")
+        .unwrap_or_else(|| {
+            panic!(
+                "mint must auto-write + index a bridge with sourceSymbol=Double; indexed: {:?}",
+                pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+            )
+        });
+
+    let target_cid = provekit_verifier::types::memento_body_field(bridge, "targetContractCid")
+        .and_then(|v| v.as_str())
+        .expect("bridge must carry targetContractCid")
+        .to_string();
+
+    let target = pool.mementos.get(&target_cid).unwrap_or_else(|| {
+        panic!("bridge.targetContractCid {target_cid} must resolve to a member")
+    });
+    assert_eq!(
+        provekit_verifier::types::memento_kind(target),
+        Some("contract"),
+        "bridge target must be a contract memento"
+    );
+    let formals = provekit_verifier::types::memento_body_field(target, "formals")
+        .and_then(|v| v.as_array())
+        .expect("tool-written op-contract must carry formals");
+    assert_eq!(
+        formals.first().and_then(|v| v.as_str()),
+        Some("x"),
+        "op-contract formals must be [x]"
+    );
+    assert!(
+        provekit_verifier::types::memento_body_field(target, "post").is_some(),
+        "op-contract must carry the body-derived post"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// POSITIVE end-to-end: real Go lifter, tool-written bridge, verify discharges
+/// through the body `(* x 2)`, signed witness, exit 0.
+#[test]
+fn go_production_path_double_discharges_and_mints_witness() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go production-bridge positive test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping go production-bridge positive test");
+        return;
+    }
+    let lift_bin = build_go_lift_verify();
+    let project = stage_go_project("pos", &lift_bin, 2);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["kind"], "verification-receipt", "receipt: {receipt}");
+    assert_eq!(
+        receipt["totalClaims"], 1,
+        "exactly one body-bearing callsite (the tool-written bridge made Double(3) enumerate); receipt: {receipt}"
+    );
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["pass"], true,
+        "Double(3)==6 must discharge through body (* x 2); claim: {claim}"
+    );
+    assert_eq!(claim["status"], "discharged", "claim: {claim}");
+
+    let solver = claim["dischargingSolver"].as_str().unwrap_or("");
+    assert!(
+        solver.starts_with("z3@"),
+        "discharging solver must be z3; got `{solver}`"
+    );
+
+    let witness_cid = claim["witnessCid"].as_str().expect("witness minted");
+    assert!(witness_cid.starts_with("blake3-512:"));
+    eprintln!("GO_PRODUCTION_POSITIVE_WITNESS_CID={witness_cid}");
+
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(code, 0, "positive run exits clean; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// NEGATIVE end-to-end: broken body `x * 3`, verify Unsatisfied, exit 1, no
+/// witness. The decisive proof the tool-written bridge does not vacuously
+/// pass: a real violation is caught honestly.
+#[test]
+fn go_production_path_broken_body_fails_unsatisfied_no_witness() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go production-bridge negative test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping go production-bridge negative test");
+        return;
+    }
+    let lift_bin = build_go_lift_verify();
+    let project = stage_go_project("neg", &lift_bin, 3);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["status"], "unsatisfied",
+        "broken body x*3 must be UNSATISFIED (not undecidable); claim: {claim}"
+    );
+    assert_eq!(claim["pass"], false, "claim: {claim}");
+    assert!(
+        claim["witnessCid"].is_null(),
+        "no witness for a violated claim; claim: {claim}"
+    );
+    assert_eq!(receipt["ok"], false, "receipt: {receipt}");
+
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a violated claim; found {} files",
+        witness_files.len()
+    );
+
+    assert_eq!(
+        code, 1,
+        "broken-body claim must exit 1 (EXIT_VERIFY_FAIL, not 3=undecidable); got {code}"
+    );
+    eprintln!("GO_PRODUCTION_NEGATIVE_EXIT_CODE={code} STATUS={}", claim["status"]);
+
+    let _ = fs::remove_dir_all(&project);
+}

--- a/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
+++ b/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// GO MATERIALIZE/REALIZE gauntlet: a contract is materialized into a Go
+// surface by the Go SHIM that supplies the native Go sugar
+// (provekit-realize-go-core). This is the emit direction's Go peer of
+// provekit-realize-python-core, exercised through the substrate's
+// language-neutral realize dispatch (kit_dispatch::dispatch_realize, PEP
+// 1.7.0 `provekit.plugin.invoke`).
+//
+// HONEST claim (and its boundary): this drives the realize DISPATCH directly
+// (the same code path `provekit materialize` uses to invoke a target kit), NOT
+// the full `provekit materialize` carrier-rewrite pipeline. The latter needs a
+// Go `@sugar`/`@boundary` authoring surface (carrier annotations in source),
+// which is DEFERRED follow-up -- see this file's sibling report. What is proven
+// here: the substrate dispatches a contract's concept to the Go shim, the shim
+// supplies REAL Go sugar, and that sugar `go build`s. Supra omnia, rectum.
+//
+// The concept is `identity` -- a real cross-language concept (also in Python's
+// canonical-bodies), realized in Go as `return x`. Requires `go` on PATH.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use provekit_cli::kit_dispatch::{dispatch_realize, RealizeRequest};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-go-realize-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+/// Build the Go realize shim binary; panic on failure (a real regression).
+fn build_go_realize() -> PathBuf {
+    let module = repo_root()
+        .join("implementations")
+        .join("go")
+        .join("provekit-realize-go-core");
+    let out = std::env::temp_dir().join(format!("provekit-realize-go-{}", std::process::id()));
+    let built = Command::new("go")
+        .current_dir(&module)
+        .args([
+            "build",
+            "-o",
+            out.to_str().expect("utf8"),
+            "./cmd/provekit-realize-go",
+        ])
+        .output()
+        .expect("spawn go build");
+    assert!(
+        built.status.success(),
+        "go build provekit-realize-go failed\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&built.stdout),
+        String::from_utf8_lossy(&built.stderr)
+    );
+    assert!(out.exists(), "go build produced no binary at {}", out.display());
+    out
+}
+
+/// Register the Go realize shim as the `go` realize surface in `root`.
+fn install_go_realize_manifest(root: &Path, bin: &Path) {
+    let manifest = root
+        .join(".provekit")
+        .join("realize")
+        .join("go")
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().unwrap()).expect("mkdir manifest dir");
+    let text = format!(
+        "name = \"go-realize\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+        bin.display().to_string().replace('\\', "\\\\").replace('"', "\\\"")
+    );
+    fs::write(manifest, text).expect("write manifest");
+}
+
+fn identity_request() -> RealizeRequest {
+    RealizeRequest {
+        function: "Id".to_string(),
+        params: vec!["x".to_string()],
+        param_types: vec!["int".to_string()],
+        return_type: "int".to_string(),
+        concept_name: "identity".to_string(),
+        named_term_tree: None,
+        term_shape: None,
+        operand_bindings: Vec::new(),
+        source_function_name: None,
+        mode: None,
+        modes: Vec::new(),
+        contract: None,
+        sugar_cids: Vec::new(),
+        sugar_plugins: Vec::new(),
+        proc_macro_invocations: Vec::new(),
+        family: None,
+        library_version: None,
+        param_sort_cids: Vec::new(),
+        return_sort_cid: String::new(),
+        target_library_tag: String::new(),
+        visibility: String::new(),
+        generic_params: String::new(),
+        original_param_types: Vec::new(),
+        parametric_sort_expansions: Vec::new(),
+        function_return_types: std::collections::BTreeMap::new(),
+        doc_lines: Vec::new(),
+    }
+}
+
+/// The shim supplies REAL Go sugar (`func Id(x int) int { return x }`),
+/// dispatched through the substrate realize protocol, and that Go compiles.
+#[test]
+fn go_realize_shim_materializes_compilable_go_for_identity() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go realize materialize test");
+        return;
+    }
+    let bin = build_go_realize();
+    let workspace = unique_dir("ws");
+    install_go_realize_manifest(&workspace, &bin);
+
+    let realized = dispatch_realize(&workspace, "go", None, &identity_request())
+        .expect("go realize shim must materialize the identity concept");
+
+    assert!(
+        !realized.is_stub,
+        "realize must supply real sugar for a supported concept, not a stub"
+    );
+    assert_eq!(realized.extension, "go", "realized extension must be go");
+    eprintln!("GO_REALIZE_SOURCE=\n{}", realized.source);
+
+    // The supplied sugar must be the correct Go realization of `identity`.
+    assert!(
+        realized.source.contains("func Id(x int) int"),
+        "sugar must declare the requested signature; got:\n{}",
+        realized.source
+    );
+    assert!(
+        realized.source.contains("return x"),
+        "identity sugar body must be `return x`; got:\n{}",
+        realized.source
+    );
+
+    // The decisive bar: the supplied Go sugar COMPILES.
+    let proj = unique_dir("compile");
+    fs::write(proj.join("go.mod"), "module realized.test\n\ngo 1.22\n").expect("write go.mod");
+    fs::write(
+        proj.join("id.go"),
+        format!("package sample\n\n{}\n", realized.source),
+    )
+    .expect("write id.go");
+    let build = Command::new("go")
+        .current_dir(&proj)
+        .args(["build", "./..."])
+        .output()
+        .expect("spawn go build of realized sugar");
+    assert!(
+        build.status.success(),
+        "materialized Go sugar must compile\n  stdout: {}\n  stderr: {}\n  source:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr),
+        realized.source
+    );
+    eprintln!("GO_REALIZE_COMPILE_EXIT=0");
+
+    let _ = fs::remove_dir_all(&workspace);
+    let _ = fs::remove_dir_all(&proj);
+}
+
+/// Discrimination: an UNSUPPORTED concept is refused loudly (the shim does not
+/// silently stub). Proves the realize coverage is honest, not vacuous.
+#[test]
+fn go_realize_shim_refuses_unsupported_concept() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go realize refusal test");
+        return;
+    }
+    let bin = build_go_realize();
+    let workspace = unique_dir("refuse");
+    install_go_realize_manifest(&workspace, &bin);
+
+    let mut req = identity_request();
+    req.concept_name = "concept:unsupported-go-thing".to_string();
+
+    let result = dispatch_realize(&workspace, "go", None, &req);
+    assert!(
+        result.is_err(),
+        "unsupported concept must be refused, not silently stubbed; got {result:?}"
+    );
+
+    let _ = fs::remove_dir_all(&workspace);
+}

--- a/menagerie/go-language-signature/specs/body-templates/go-canonical-bodies-builtin.json
+++ b/menagerie/go-language-signature/specs/body-templates/go-canonical-bodies-builtin.json
@@ -1,0 +1,29 @@
+{
+  "header": {
+    "cid": "blake3-512:afafeff42be5ffe8bea4a0c73a4ae1a02750257a943783426f4e079edf38a4526be2b0f1b23ffa7bb564a0cf38a38749714a9f0c1d1889f72d36aa19c8afa15e",
+    "content": {
+      "target_language": "go",
+      "template_name": "go-canonical-bodies-builtin",
+      "entries": [
+        {
+          "concept_name": "identity",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "entries": []
+            }
+          },
+          "signature_guard": {
+            "min_params": 1,
+            "max_params": 1
+          },
+          "target_library_tag": "builtin"
+        }
+      ]
+    }
+  }
+}

--- a/menagerie/go-language-signature/specs/body-templates/go-canonical-bodies-default.json
+++ b/menagerie/go-language-signature/specs/body-templates/go-canonical-bodies-default.json
@@ -1,0 +1,29 @@
+{
+  "header": {
+    "cid": "blake3-512:2e8a93f86035f18c56981cf06107c760b09187dd9c22f1c01b4cd97da7accf6ce9cb5e8cd03d8bdb5d8c4988fc0671900d8b247b940a85ab8634b5f8af8e13cc",
+    "content": {
+      "target_language": "go",
+      "template_name": "go-canonical-bodies-default",
+      "entries": [
+        {
+          "concept_name": "identity",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "return ${param0}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "entries": []
+            }
+          },
+          "signature_guard": {
+            "min_params": 1,
+            "max_params": 1
+          },
+          "target_library_tag": "default"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Onboards **Go** as a first-class ProvekIt language, end-to-end and both directions, built on the keystone verification spine (#1441) and the production bridge-writer (#1443). A Go library author declares a boundary/sugar, the library **gets a contract**, and that contract both **verifies** through the spine and **materializes** back into Go via a sugar-supplying shim.

### The authoring surface (`@sugar`/`@boundary` for Go)
- Doc-comment pragma idiom (the Go analog of `#[provekit::sugar]`, in the `//go:generate`/`//go:build` family):
  ```go
  //provekit:sugar(concept="identity", library="builtin", version="1")
  func Id(x int) int { return x }
  ```
- Two-surface `.provekit/config.toml` (`go-bind` / `go-contracts`) mirroring rust's `rust-bind`/`rust-contracts`. Declaration-gated: only annotated funcs get contracts + auto-bridge; unannotated funcs get neither. Malformed directives refuse loudly.

### Verify side (Go library gets a verifiable contract)
- Java-style two-lifter split: `LiftOptions{NormalizeCoreArith}` emits SMT-LIB core ops (`*`, `+`, `<`) on the verify-facing path (resolving the `go:mul` `:`-reserved-char z3 error), while the round-trip dialect (`go:mul`) is preserved byte-identically. The verifier spine was NOT modified — Go was wired INTO it.
- Real Go lifter → `provekit mint` (tool-written auto-bridge, confirmed via `bridges_by_symbol`) → `provekit verify`: positive discharges through the body (z3, signed witness, exit 0); broken body → unsatisfied, exit 1, no witness.

### Realize side (contract materializes via a shim that supplies Go sugar)
- `provekit-realize-go-core`: PEP 1.7.0 plugin; maps a cross-language concept + signature to real Go via a body-template. Unsupported concept/arity refuses loudly (never stubbed).
- The authoring mint auto-projects the realize body-template registry (`menagerie/go-language-signature/specs/body-templates/go-canonical-bodies-*.json`) as a deterministic projection of the signed binding-entries.

### Closed loop
Same `Id` / `identity` concept: DECLARE (binding-entry + bridge) → VERIFY (z3 discharge + signed witness) → MATERIALIZE (realize back to Go). 

## Test plan
- [x] `cmd_authoring_surface_go.rs` — declare-gates-emission + positive discharge + negative (3 tests)
- [x] `cmd_verify_go_production_bridge.rs` — real lifter, tool-written bridge, positive/negative (3 tests)
- [x] `go_realize_materialize.rs` — substrate → Go shim → real sugar, `go build`, refusal (2 tests)
- [x] 6 Go annotation unit tests (parse, discrimination, AnnotatedOnly gating both ways)
- [x] Existing production-bridge tests still green (bare surface unaffected)
- [x] `cargo build --workspace` green; all touched Go modules `go test ./...` green

Deferred (tracked): full `provekit materialize` carrier-rewrite end-to-end (needs in-source carrier annotations); bridge-symbol `fnName` canonicalization (#1444).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Go end-to-end verification examples demonstrating function verification and concept authoring workflows
  * Introduced annotation directives (`//provekit:sugar`, `//provekit:boundary`) for declaring verified Go function boundaries
  * Implemented Go code lifting for verification and concept realization capabilities
  * Added integration tests for Go verification and materialization workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->