### PR TITLE
Fix erased-signature int-reconstruction (conformance gate, layer 2)

### DIFF
--- a/implementations/rust/libprovekit/src/core/lower_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lower_plugin.rs
@@ -1192,18 +1192,25 @@ fn sidecar_entry_for_term<'a>(sidecar: &'a Value, term: &NamedTerm) -> Option<&'
 }
 
 fn realize_signature_from_named_term(term: &NamedTerm) -> (Vec<String>, String) {
-    // Erasure heuristic: legacy bind payloads sometimes omit type info
-    // entirely. Distinguish "no types declared" from "types declared as
-    // empty/unit". `return_type == ""` is absence; `return_type == "()"`
-    // is explicit unit. Functions with declared parameters or explicit
-    // return type are NOT erased.
-    let erased = term.param_types.is_empty()
-        && term.params.is_empty()
-        && term.return_type.trim().is_empty();
+    // Erasure heuristic: A9 strips declared types from the canonical lift term
+    // for seam-4 federation byte-identity, so a bind payload that round-trips
+    // through that path carries NO param_types and a unit/absent return even
+    // when the source function had real parameters (e.g. `identity(x)` lifts to
+    // params=["x"], param_types=[], return_type="()"). The erased signal is
+    // therefore "no declared param_types AND return is absent or unit" —
+    // INDEPENDENT of whether params exist. (Sidecar-carried real types override
+    // this guess later in merge_realize_sidecar; this is the fallback when the
+    // payload truly has nothing.)
+    let return_trimmed = term.return_type.trim();
+    let erased =
+        term.param_types.is_empty() && (return_trimmed.is_empty() || return_trimmed == "()");
     if !erased {
         return (term.param_types.clone(), term.return_type.clone());
     }
 
+    // Reconstruct one `int` per declared parameter; a zero-param function yields
+    // an empty vec (correct). The return is `()` only when the concept is unit;
+    // any other erased concept reconstructs to `int`.
     let param_types = term
         .params
         .iter()


### PR DESCRIPTION
## Summary

Closes `lower_claim_bind_result::bind_result_claim_lower_reconstructs_erased_signature_defaults`, the next failure in the Cross-language conformance gate's `make test-rust` step (surfaced after #1448's d7 fix peeled off the first layer).

**Confirmed pre-existing, not a regression**: the identical failure (`left: []`, `right: ["int"]`) reproduces on pristine `95b9632fd` — it predates this session's work, and #1448's sidecar change is a no-op on this erased path.

**Root cause**: `realize_signature_from_named_term` (lower_plugin.rs) gated the "erased signature" case on `term.params.is_empty()`. But A9 federation byte-identity strips declared *types*, not *params* — a function with real params round-trips as `params=["x"]`, `param_types=[]`, `return_type="()"`. That case was excluded by the `is_empty()` check, so the lower returned the empty `param_types` verbatim (`[]`) instead of reconstructing the `int` default.

**Fix**: the erased signal is now "no declared `param_types` AND return is absent-or-unit (`""`/`"()"`)" — independent of params. When erased, reconstruct one `int` per declared param (`int` return, `()` for unit concepts). Feeds only the realize REQUEST, never the bind CID.

## Test plan
- [x] `lower_claim_bind_result`: 6 passed (erased-defaults reconstructs `["int"]`; fully-typed path still green)
- [x] `python_emit_compile_run_conformance`: 2 passed (no regression)
- [x] seam4 federation byte-identity: python bind CID unchanged at `a212…` (heuristic feeds the realize request only)

## Note
The conformance gate is **not** fully green after this: the next failure underneath is `provekit_lift_processes_walk_crate_to_proof_catalog` (a provekit-lift self-lift name collision on an `expect` contract), which passes on `95b9632fd` and fails on current main — introduced in the `95b9632fd..HEAD` range, under separate investigation.

Ref: #1436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type handling logic for type erasure scenarios in the verification system. The system now more accurately determines when type information is erased and reconstructs appropriate type signatures accordingly, resulting in more robust type processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->