### PR TITLE
Conformance gate green: 2-param SQL sugar shims for python-sqlite3 realize kit

### DIFF
--- a/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
+++ b/menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json
@@ -116,6 +116,51 @@
           "target_library_tag": "sqlite3"
         },
         {
+          "concept_name": "concept:sql-execute",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "cursor = db.execute(${param0}, tuple(${param1}))\ndb.commit()\nreturn {\"rows_affected\": cursor.rowcount, \"last_insert_id\": cursor.lastrowid}"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "entries": [
+                "sync-vs-async",
+                "last-insert-id",
+                "transaction-isolation",
+                "row-typing-mode"
+              ]
+            }
+          },
+          "signature_guard": {
+            "min_params": 2,
+            "max_params": 2
+          },
+          "target_library_tag": "sqlite3"
+        },
+        {
+          "concept_name": "concept:insert-and-get-id",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "cursor = db.execute(${param0}, tuple(${param1}))\ndb.commit()\nreturn int(cursor.lastrowid or 0)"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "entries": [
+                "sync-vs-async",
+                "id-column-discovery",
+                "row-typing-mode"
+              ]
+            }
+          },
+          "signature_guard": {
+            "min_params": 2,
+            "max_params": 2
+          },
+          "target_library_tag": "sqlite3"
+        },
+        {
           "concept_name": "concept:sql-batch-execute",
           "emission_template": {
             "kind": "verbatim",
@@ -155,6 +200,28 @@
           "signature_guard": {
             "min_params": 3,
             "max_params": 3
+          },
+          "target_library_tag": "sqlite3"
+        },
+        {
+          "concept_name": "concept:sql-query",
+          "emission_template": {
+            "kind": "verbatim",
+            "template": "cursor = db.execute(${param0}, tuple(${param1}))\nreturn cursor.fetchall()"
+          },
+          "loss_record_contribution": {
+            "form": "literal",
+            "value": {
+              "entries": [
+                "sync-vs-async",
+                "row-typing-mode",
+                "cursor-lifetime"
+              ]
+            }
+          },
+          "signature_guard": {
+            "min_params": 2,
+            "max_params": 2
           },
           "target_library_tag": "sqlite3"
         },


### PR DESCRIPTION
## Summary

Closes the last real blocker on the Cross-language conformance gate (Linux). Using CI ground truth (run 26366342614 at main HEAD), the gate's `make test-rust` step failed on **exactly 3 tests, one root cause** — and this fixes it.

### Root cause
`cross_platform_point_query_receipt_test.rs` fixtures 4/5/6 migrate `typescript-better-sqlite3 → python-sqlite3`. better-sqlite3's `db.prepare(q).all(p)` lifts to a **2-param** `concept:sql-query` (args_shape `["string","unknown[]"]`). The migrate's substrate-availability probe (`cmd_bind_migrate.rs:107`) probed `concept:sql-query`/`concept:sql-execute` at that 2-param arity, but the sqlite3 body-template spec only carried 1-param (fetch) and 3-param (cursor) tiers — no 2-param — so the python-sqlite3 realize kit honestly refused (`-32100 missing body-template`) and migrate failed.

### Fix
Added the missing 2-param tier to `menagerie/python-language-signature/specs/body-templates/python-canonical-bodies-sqlite3.json`, mirroring the sibling aiosqlite spec's trio, with synchronous sqlite3 templates emitting real native SQL:
- `concept:sql-query` → `cursor = db.execute(${param0}, tuple(${param1}))` / `return cursor.fetchall()`
- `concept:sql-execute` → `db.execute(...)` + `db.commit()` + rows_affected/last_insert_id
- `concept:insert-and-get-id` → `db.execute(...)` + `db.commit()` + `int(cursor.lastrowid or 0)`

This is the "kit ships its own sugar" path — the realize kit gains the shim so it can realize the concept, rather than migrate punting to refusal.

### CID-safety
The sqlite3 realizer reads only `header.content.entries` (no `header.cid` validation); `substrate_default_cids.rs` does not pin this spec; the probe output is a discardable capability check (never fed to a receipt or CID). So the edit trips no CID gate and does not affect federation byte-identity.

## Test plan
- [x] `cross_platform_point_query_receipt_test`: 6 passed; 0 failed (was 3 failed). Trichotomy honored: fixture_4 zero-loss no-op, fixture_5 declared-insert routes to loss without refusal, fixture_6 byte-stable receipt CIDs.
- [x] Invariants intact: `cmd_verify_body_discharge` 5/5, `cmd_verify_production_bridge` 3/3; seam4 + body-discharge spine green on CI at HEAD.
- [x] d7 (#1448) + erased-signature (#1449) confirmed green on CI — not in the failure set.
- Note: the ~41 other failures in a local Mac `--no-fail-fast` run are Mac-only artifacts (rustfmt generic-spacing + java manifest `default` tag) proven green on CI's Linux runner; not touched. The next CI run on this branch confirms the gate fully green.

Ref: #1436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parameterized SQLite3 query operations with enhanced result structures.

* **Improvements**
  * Updated SQLite3 execute and insert operations to provide richer return values, including row-affected counts and last-insert IDs.
  * Simplified parameter handling for database operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->