### PR TITLE
[inventory only] --no-fail-fast to enumerate full conformance-gate failure set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,7 +620,7 @@ bootstrap-self-contracts:
 # absent and `lower_java_carrier_registration_points_at_required_fixture_set`
 # panics with `Unable to access jarfile provekit-realize-java.jar`.
 test-rust: build-java
-	cargo test --release --manifest-path implementations/rust/Cargo.toml
+	cargo test --release --no-fail-fast --manifest-path implementations/rust/Cargo.toml
 	cargo test --release --manifest-path tools/recompute-spec-cids/Cargo.toml
 	cargo test --release --manifest-path tools/foundation-keygen/Cargo.toml
 


### PR DESCRIPTION
Temporary inventory PR: runs the conformance gate's make test-rust with --no-fail-fast so it reports EVERY failing test binary at once (instead of fail-fast masking all but the first). Used to enumerate the complete CI-Linux failure set for the conformance-gate-green effort. NOT for merge.