### PR TITLE
Python onboarding to Go-parity: verify-discharge through the spine + @boundary authoring surface

### DIFF
--- a/docs/plans/2026-05-23-python-onboarding-parity-plan.md
+++ b/docs/plans/2026-05-23-python-onboarding-parity-plan.md
@@ -1,0 +1,57 @@
+# Python onboarding parity plan (mirror Go #1445)
+
+## STEP 1 empirical result (real python source lifter on `def double(x: int) -> int: return x * 2`)
+
+Driven via `python3 -m provekit_lift_python_source --rpc`, the real source lifter emits a
+`function-contract` for `double.double`:
+
+```
+post = (= (var return_value) (python:return (python:mul (var x) (const 2 Int))))
+formals = ["x"], formalSorts = [Value], returnSort = Value
+```
+
+Gaps vs the z3-dischargeable shape the verifier's `body_discharge::CatalogResolver` expects
+(`RESULT_VAR = "result"`, core SMT ops, `value_expr()` over `post`):
+
+1. **Result var**: emits `return_value`; verifier needs `result`. (Go emits `result`.)
+2. **`python:return` wrapper**: the value-expr is wrapped in `python:return(...)` inside the
+   post; verifier needs `result == <value-expr>` directly (bare op). Go has no wrapper.
+3. **Namespaced ops**: emits `python:mul` (like Go's `go:mul`); z3 needs core `*`. Needs a
+   `coreArithOp`-style normalization (mirror Go `NormalizeCoreArith`).
+4. **Sorts = `Value`**: z3 cannot discharge integer arith with sort `Value`; needs `Int`
+   from the `: int` annotation. Refuse when arithmetic body lacks an int annotation.
+
+Conclusion: python needs a verify-facing dialect transform (more gaps than Go's single
+op-normalization, but same KIND of work). Buildable; not a stop-and-call gap (advisor concurred).
+
+### Div soundness (Go lesson, applied preemptively)
+`python:div` (true div `/`), `python:floordiv` (`//`), `python:mod` (`%`) MUST stay
+namespaced (uninterpreted). Python `//`/`%` floor toward -inf (matches SMT-LIB `div`/`mod`
+on that axis) BUT python true `/` is float and `//` semantics still differ from truncation;
+to stay sound and mirror Go, leave ALL three uninterpreted -> Undecidable, never a false
+discharge. Regression mirrors `cmd_verify_go_division_unsound.rs`.
+
+## STEP 2 build
+- New verify-facing transform in `provekit_lift_python_source` (e.g. `verify_dialect.py`):
+  takes a lifted `function-contract`, returns the dischargeable form (result var, unwrap
+  return, core ops, Int sorts) or refuses (returns None / diagnostic) when not faithful.
+- New leaf-assertion harvester for pytest `assert double(3) == 6` -> `contract{inv = =(double(3), 6)}`
+  with `double(3)` a `ctor`. Mirror Go `LiftLeafAssertions` whitelist.
+- New binary `provekit-lift-python-verify` (`--rpc`): emits the verify-facing
+  function-contracts (+ `bridgeSourceSymbol`) from non-test .py + harvested callsites from
+  `*_test.py` / `test_*.py`. Modes: bare / bindings(library-bindings) / contracts(ir-document)
+  mirroring Go's `liftMode`.
+- `examples/python-double/` fixture: `double.py`, `test_double.py`, `.provekit/config.toml`,
+  `.provekit/lift/python/manifest.toml`.
+- Rust test `cmd_verify_python_production_bridge.rs` (mirror Go): real lifter -> mint
+  (auto-bridge, assert via `bridges_by_symbol`) -> verify positive (discharge, witness,
+  exit 0) + negative (broken body x*3 -> unsatisfied, exit 1, no witness).
+- Rust test `cmd_verify_python_division_unsound.rs`: `halve(x) = x // 2`, assert
+  `halve(-7) == expected` -> undecidable, no witness, exit 3.
+
+## STEP 3 authoring surface
+Python ALREADY has `@sugar.bind(concept=, library=)` -> `library-sugar-binding-entry` and
+`@contract(pre=,post=,inv=)` decorators (bind_lifter.py). Parity gap: gate the verify-facing
+function-contract emission on a `@provekit.boundary(...)` / `@provekit.sugar(...)` declaration
+(mirror Go `AnnotatedOnly`) so "declare -> get contract" holds. Close loop: declare -> contract
+-> discharge (STEP 2) -> realize back to python via existing realize kit.

--- a/examples/python-boundary/.provekit/config.toml
+++ b/examples/python-boundary/.provekit/config.toml
@@ -1,0 +1,32 @@
+# Python AUTHORING surface, mirroring the go-identity authoring config:
+#
+#   [[plugins]] python-bind      (layer = "library-bindings")  -> emits the
+#       `library-sugar-binding-entry` DECLARATION catalog for each
+#       `@provekit.boundary`/`@sugar.bind` annotated function.
+#   [[plugins]] python-contracts (emit = "ir-document")        -> emits the
+#       body-derived verify-facing function-contracts + harvested callsites,
+#       GATED on the `@provekit.boundary`/`@sugar` declaration.
+#
+# Both plugins resolve to the same binary (provekit-lift-python-verify); it
+# emits different IR per surface (as go's go-bind / go-contracts do), so a
+# function is not minted twice.
+[[plugins]]
+name = "python-sugar"
+surface = "python-bind"
+layer = "library-bindings"
+
+[[plugins]]
+name = "python-contracts"
+surface = "python-contracts"
+emit = "ir-document"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]

--- a/examples/python-boundary/.provekit/lift/python-bind/manifest.toml
+++ b/examples/python-boundary/.provekit/lift/python-bind/manifest.toml
@@ -1,0 +1,3 @@
+name = "python-bind"
+command = ["provekit-lift-python-verify", "--rpc"]
+working_dir = "."

--- a/examples/python-boundary/.provekit/lift/python-contracts/manifest.toml
+++ b/examples/python-boundary/.provekit/lift/python-contracts/manifest.toml
@@ -1,0 +1,3 @@
+name = "python-contracts"
+command = ["provekit-lift-python-verify", "--rpc"]
+working_dir = "."

--- a/examples/python-boundary/double.py
+++ b/examples/python-boundary/double.py
@@ -1,0 +1,11 @@
+import provekit
+
+
+# A library author DECLARES that this function's body is a boundary they want
+# a verifiable contract for. The verify-facing `python-contracts` surface gates
+# its body-derived function-contract emission on this declaration (mirroring
+# Go's `//provekit:boundary` pragma + AnnotatedOnly); the `python-bind` surface
+# emits the library-sugar-binding-entry declaration catalog for it.
+@provekit.boundary(concept="concept:mul")
+def double(x: int) -> int:
+    return x * 2

--- a/examples/python-boundary/test_double.py
+++ b/examples/python-boundary/test_double.py
@@ -1,0 +1,5 @@
+from double import double
+
+
+def test_double():
+    assert double(3) == 6

--- a/examples/python-double/.provekit/config.toml
+++ b/examples/python-double/.provekit/config.toml
@@ -1,0 +1,19 @@
+# ProvekIt project config for the Python end-to-end example.
+#
+# `[authoring] surface = "python"` selects the Python verify lift surface (the
+# manifest at .provekit/lift/python/manifest.toml). `[solvers]` names z3 for
+# the linear-arithmetic class the body-obligation `(* 3 2) == 6` falls into;
+# the `-smt2 -in` flags mirror the verifier's default z3 invocation.
+[authoring]
+surface = "python"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]

--- a/examples/python-double/double.py
+++ b/examples/python-double/double.py
@@ -1,0 +1,2 @@
+def double(x: int) -> int:
+    return x * 2

--- a/examples/python-double/test_double.py
+++ b/examples/python-double/test_double.py
@@ -1,0 +1,5 @@
+from double import double
+
+
+def test_double():
+    assert double(3) == 6

--- a/implementations/python/provekit-lift-python-source/pyproject.toml
+++ b/implementations/python/provekit-lift-python-source/pyproject.toml
@@ -19,6 +19,7 @@ test = ["pytest>=7"]
 [project.scripts]
 provekit-lift-python-source = "provekit_lift_python_source.rpc:main"
 provekit-bind-lift-python = "provekit_lift_python_source.bind_rpc:main"
+provekit-lift-python-verify = "provekit_lift_python_source.verify_rpc:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/authoring.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/authoring.py
@@ -1,0 +1,60 @@
+"""Shared recognition of the verify-facing AUTHORING decorators.
+
+The Python peer of Go's `//provekit:boundary(...)` / `//provekit:sugar(...)`
+doc-comment pragma (PR #1445). A library author declares that a function's body
+is a contract they want discharged with::
+
+    @provekit.boundary(concept="concept:mul")   # or @boundary(...)
+    def double(x: int) -> int:
+        return x * 2
+
+These decorators are DECLARATIVE metadata (which concept/boundary the function
+realizes), NOT behavioral wrappers, so the source lifter SKIPS them when
+deciding whether a function is "decorated" -- it lifts the body underneath.
+This is distinct from `@sugar.bind(concept=, library=)` (the library-binding
+catalog decorator the bind lifter consumes); `@sugar`/`@boundary` here is the
+verify-facing authoring declaration.
+"""
+
+from __future__ import annotations
+
+import ast
+
+_AUTHORING_NAMES = {"boundary", "sugar"}
+
+
+def authoring_kind(decorator: ast.expr) -> str | None:
+    """Return "boundary"/"sugar" if `decorator` is a verify-facing authoring
+    declaration, else None. Matches `@boundary(...)`, `@sugar(...)`,
+    `@provekit.boundary(...)`, `@provekit.sugar(...)` and their bare
+    (non-call) forms. Does NOT match `@sugar.bind(...)` (the library-binding
+    decorator: its callee is `Attribute(attr="bind")`)."""
+    func = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if isinstance(func, ast.Name):
+        return func.id if func.id in _AUTHORING_NAMES else None
+    if isinstance(func, ast.Attribute) and func.attr in _AUTHORING_NAMES:
+        value = func.value
+        if isinstance(value, ast.Name) and value.id == "provekit":
+            return func.attr
+    return None
+
+
+def is_authoring_decorator(decorator: ast.expr) -> bool:
+    return authoring_kind(decorator) is not None
+
+
+def authoring_declaration(decorator: ast.expr) -> dict[str, str] | None:
+    """Parse `{kind, concept?, library?}` from a verify-facing authoring
+    decorator, or None if it is not one."""
+    kind = authoring_kind(decorator)
+    if kind is None:
+        return None
+    decl: dict[str, str] = {"kind": kind}
+    if isinstance(decorator, ast.Call):
+        for keyword in decorator.keywords:
+            if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+                if keyword.arg == "concept":
+                    decl["concept"] = keyword.value.value
+                elif keyword.arg == "library":
+                    decl["library"] = keyword.value.value
+    return decl

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/leaf_assertions.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/leaf_assertions.py
@@ -1,0 +1,148 @@
+"""Python Layer-0 leaf-assertion harvester (verify-facing).
+
+The Python analog of Go's ``lifgotests.LiftLeafAssertions`` (PR #1445). It
+harvests each single recognized ``assert`` statement in a pytest test function
+into its own ``contract`` declaration whose ``inv`` is the lifted
+``=(<call>, <expected>)`` formula::
+
+    def test_double():
+        assert double(3) == 6      ->  contract{ inv = =(double(3), 6) }
+
+where ``double(3)`` is a ``ctor`` named ``double`` -- exactly the harvested
+``=(<call>, <expected>)`` callsite the verifier's body-discharge seam
+enumerates and reduces through the body-derived ``function-contract`` for
+``double``. One contract per test function (``inv`` is the conjunction of that
+test's recognized assertions; the common single-assertion case is the bare
+``=( ... )``), so a function-contract bridge can match it.
+
+Whitelist (v0), each side an operand (identifier var / int literal / single-arg
+call ``f(arg)`` as a ctor / negative-int literal):
+
+    assert <lhs> == <rhs>   -> = (lhs, rhs)
+    assert <lhs> != <rhs>   -> ≠ (lhs, rhs)
+    assert <lhs> <  <rhs>   -> < (lhs, rhs)        (and <=, >, >=)
+
+Anything else is skipped (a diagnostic, not a contract) so the harvester never
+fabricates a callsite it cannot faithfully lift.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from typing import Any
+
+Json = dict[str, Any]
+
+_CMP: dict[type[ast.cmpop], str] = {
+    ast.Eq: "=",
+    ast.NotEq: "≠",
+    ast.Lt: "<",
+    ast.LtE: "≤",
+    ast.Gt: ">",
+    ast.GtE: "≥",
+}
+
+
+@dataclass
+class HarvestResult:
+    ir: list[Json] = field(default_factory=list)
+    diagnostics: list[Json] = field(default_factory=list)
+
+
+class _Unsupported(Exception):
+    pass
+
+
+def harvest_source(source: str, source_path: str) -> HarvestResult:
+    result = HarvestResult()
+    try:
+        tree = ast.parse(source, filename=source_path)
+    except SyntaxError as exc:
+        result.diagnostics.append(
+            {"kind": "parse-error", "message": exc.msg, "path": source_path, "line": exc.lineno}
+        )
+        return result
+
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if not node.name.startswith("test_") and not node.name.startswith("test"):
+            # Only pytest test functions harvest callsites. (Match `test*`.)
+            if not node.name.startswith("test"):
+                continue
+        atoms: list[Json] = []
+        for stmt in node.body:
+            if not isinstance(stmt, ast.Assert):
+                continue
+            try:
+                atoms.append(_lift_assert(stmt))
+            except _Unsupported as exc:
+                result.diagnostics.append(
+                    {
+                        "kind": "leaf-assertion-skipped",
+                        "message": str(exc),
+                        "path": source_path,
+                        "line": getattr(stmt, "lineno", node.lineno),
+                    }
+                )
+        if not atoms:
+            continue
+        inv = atoms[0] if len(atoms) == 1 else _and(atoms)
+        result.ir.append(
+            {
+                "schemaVersion": "1",
+                "kind": "contract",
+                "name": node.name,
+                "outBinding": "out",
+                "inv": inv,
+            }
+        )
+    return result
+
+
+def _lift_assert(stmt: ast.Assert) -> Json:
+    test = stmt.test
+    if not isinstance(test, ast.Compare):
+        raise _Unsupported("assert is not a comparison")
+    if len(test.ops) != 1 or len(test.comparators) != 1:
+        raise _Unsupported("only single-comparison asserts are harvested")
+    op = _CMP.get(type(test.ops[0]))
+    if op is None:
+        raise _Unsupported(f"comparison op {type(test.ops[0]).__name__} not in whitelist")
+    lhs = _translate_term(test.left)
+    rhs = _translate_term(test.comparators[0])
+    return {"kind": "atomic", "name": op, "args": [lhs, rhs]}
+
+
+def _translate_term(node: ast.expr) -> Json:
+    if isinstance(node, ast.Name):
+        return {"kind": "var", "name": node.id}
+    if isinstance(node, ast.Constant):
+        value = node.value
+        if isinstance(value, bool):
+            return {"kind": "const", "value": value, "sort": {"kind": "primitive", "name": "Bool"}}
+        if isinstance(value, int):
+            return {"kind": "const", "value": value, "sort": {"kind": "primitive", "name": "Int"}}
+        if isinstance(value, str):
+            return {"kind": "const", "value": value, "sort": {"kind": "primitive", "name": "String"}}
+        raise _Unsupported(f"unsupported constant {type(value).__name__}")
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        operand = node.operand
+        if isinstance(operand, ast.Constant) and isinstance(operand.value, int) and not isinstance(operand.value, bool):
+            return {"kind": "const", "value": -operand.value, "sort": {"kind": "primitive", "name": "Int"}}
+        raise _Unsupported("unary minus only on int literals")
+    if isinstance(node, ast.Call):
+        # Single-arg bare call f(arg) -> ctor("f", [<arg>]); the ctor name is
+        # the bare function symbol the auto-bridge sourceSymbol uses.
+        if not isinstance(node.func, ast.Name):
+            raise _Unsupported("call callee is not a bare identifier")
+        if node.keywords:
+            raise _Unsupported("call has keyword arguments")
+        args = [_translate_term(arg) for arg in node.args]
+        return {"kind": "ctor", "name": node.func.id, "args": args}
+    raise _Unsupported(f"operand {type(node).__name__} not supported")
+
+
+def _and(atoms: list[Json]) -> Json:
+    return {"kind": "and", "operands": atoms}

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -455,7 +455,15 @@ def _lift_function(
     try:
         if isinstance(node, ast.AsyncFunctionDef):
             raise _UnsupportedSyntax(node, "async functions are refused")
-        if node.decorator_list:
+        # Verify-facing AUTHORING decorators (@provekit.boundary / @boundary /
+        # @provekit.sugar / @sugar) are declarative metadata, not behavioral
+        # wrappers, so they do NOT make a function "decorated" for lift
+        # purposes -- the body underneath is lifted (mirrors Go stripping the
+        # //provekit: pragma). Any OTHER decorator still refuses.
+        from .authoring import is_authoring_decorator
+
+        non_authoring = [d for d in node.decorator_list if not is_authoring_decorator(d)]
+        if non_authoring:
             raise _UnsupportedSyntax(node, "decorated functions are refused")
         if node.args.vararg is not None or node.args.kwarg is not None:
             raise _UnsupportedSyntax(node, "*args and **kwargs are refused")

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/verify_dialect.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/verify_dialect.py
@@ -1,0 +1,310 @@
+"""Verify-facing dialect transform for the Python source lifter.
+
+This is the Python analog of Go's ``LiftSourceCore`` / ``NormalizeCoreArith``
+(PR #1445). The round-trip source lifter (``lifter.py``) emits a
+``function-contract`` whose ``post`` is::
+
+    (= (var return_value) (python:return (python:mul (var x) (const 2 Int))))
+
+with namespaced ops, the ``return_value`` result variable, a ``python:return``
+wrapper, and ``Value`` sorts. That form is byte-identical to what the
+round-trip / realize pipeline depends on and MUST NOT change on disk.
+
+The verifier's ``body_discharge::CatalogResolver`` instead needs a
+z3-dischargeable ``function-contract`` whose ``post`` is::
+
+    (= (var result) (* (var x) (const 2 Int)))
+
+i.e. the SMT result var ``result``, no ``python:return`` wrapper, SMT-core op
+symbols (``*``, ``+``, ``<`` ...), and ``Int`` formal/return sorts. This module
+performs exactly that transform and REFUSES (returns ``None`` with a reason)
+rather than emit an unsound contract.
+
+Supra omnia, rectum: the cardinal rule mirrored from the Go division lesson is
+that ``python:div`` / ``python:floordiv`` / ``python:mod`` are LEFT
+NAMESPACED (uninterpreted). SMT-LIB ``div``/``mod`` floor toward -inf and
+diverge from Python truncation / float semantics on negatives, so mapping them
+would let a Python-false assertion discharge with a signed witness. Leaving
+them uninterpreted makes the obligation Undecidable instead -- the honest
+refusal.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Any
+
+Json = dict[str, Any]
+
+# SMT result variable the verifier's body-discharge seam equates the call's
+# result with (matches libprovekit::wp::DEFAULT_RESULT_VAR == "result").
+RESULT_VAR = "result"
+
+# KEPT (faithful core): the SMT-LIB symbol for each namespaced arithmetic /
+# comparison / boolean op whose Int (or Bool) semantics coincide with the
+# SMT-LIB core theory for the value domain we model.
+#
+# EXCLUDED (deliberately absent -> stay namespaced -> Undecidable):
+#   python:div       true division `/`  (float result; not integer SMT div)
+#   python:floordiv  floor division `//`
+#   python:mod       modulo `%`
+#   python:pow, shifts, bitwise ops, is/in comparisons
+# All of these have no faithful core mapping for signed ints, so a contract
+# that uses them refuses to z3 rather than risk a false discharge.
+_CORE_ARITH_OP: dict[str, str] = {
+    "python:add": "+",
+    "python:sub": "-",
+    "python:mul": "*",
+    "python:neg": "-",
+    "python:not": "not",
+    "python:and": "and",
+    "python:or": "or",
+}
+
+# Comparison operators carried as the string head of a `python:compare` ctor.
+_CORE_CMP_OP: dict[str, str] = {
+    "==": "=",
+    "!=": "≠",
+    "<": "<",
+    "<=": "≤",
+    ">": ">",
+    ">=": "≥",
+}
+
+# Annotation surfaces that faithfully map to the SMT `Int` sort. Anything else
+# (no annotation, `float`, `str`, custom types) refuses for an arithmetic body.
+_INT_ANNOTATIONS = {"int"}
+_BOOL_ANNOTATIONS = {"bool"}
+
+
+class VerifyDialectRefusal(Exception):
+    """Raised when a lifted function-contract cannot be faithfully lowered to
+    the z3-dischargeable verify-facing dialect. The caller turns this into a
+    diagnostic and SKIPS emitting a contract -- never an unsound one."""
+
+    def __init__(self, fn_name: str, reason: str):
+        self.fn_name = fn_name
+        self.reason = reason
+        super().__init__(f"{fn_name}: {reason}")
+
+
+@dataclass(frozen=True)
+class _Sorts:
+    """SMT sorts for a function's formals + return, derived from the source
+    `: int` / `-> int` annotations (the round-trip lifter erases these to
+    `Value`)."""
+
+    formal_sorts: dict[str, str]  # formal name -> "Int" | "Bool"
+    return_sort: str | None  # "Int" | "Bool" | None
+
+
+def prim_sort(name: str) -> Json:
+    return {"kind": "primitive", "name": name}
+
+
+def collect_int_signatures(source: str) -> dict[str, _Sorts]:
+    """Parse `source` and return, per bare function name, the SMT sorts of its
+    annotated formals + return. Only `int` / `bool` annotations are recorded;
+    others are omitted (the transform refuses when a needed sort is missing)."""
+    out: dict[str, _Sorts] = {}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return out
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        formal_sorts: dict[str, str] = {}
+        for arg in node.args.args:
+            sort = _sort_for_annotation(arg.annotation)
+            if sort is not None:
+                formal_sorts[arg.arg] = sort
+        return_sort = _sort_for_annotation(node.returns)
+        out[node.name] = _Sorts(formal_sorts=formal_sorts, return_sort=return_sort)
+    return out
+
+
+def _sort_for_annotation(annotation: ast.expr | None) -> str | None:
+    if annotation is None:
+        return None
+    if isinstance(annotation, ast.Name):
+        if annotation.id in _INT_ANNOTATIONS:
+            return "Int"
+        if annotation.id in _BOOL_ANNOTATIONS:
+            return "Bool"
+    return None
+
+
+def to_verify_dialect(contract: Json, sorts: _Sorts) -> Json:
+    """Lower a round-trip `function-contract` to the z3-dischargeable
+    verify-facing dialect, or raise `VerifyDialectRefusal`.
+
+    Steps (mirroring Go LiftSourceCore + the result-var/return-unwrap that Go
+    did not need):
+      1. Strip the `python:return` wrapper from the post's value expression.
+      2. Rename the result var `return_value` -> `result`.
+      3. Normalize `python:*` ops to SMT-core symbols; refuse on any op with
+         no faithful core mapping (div/mod/floordiv/pow/shifts/...).
+      4. Replace the `Value` formal/return sorts with `Int`/`Bool` from the
+         source annotations; refuse if a formal touched by arithmetic lacks an
+         int/bool annotation.
+    """
+    fn_name = str(contract.get("fnName", "<unknown>"))
+    post = contract.get("post")
+    if not isinstance(post, dict) or post.get("name") != "=":
+        raise VerifyDialectRefusal(fn_name, "post is not an `=` atomic")
+    args = post.get("args")
+    if not isinstance(args, list) or len(args) != 2:
+        raise VerifyDialectRefusal(fn_name, "post `=` does not have exactly two args")
+    lhs, rhs = args[0], args[1]
+    if not (isinstance(lhs, dict) and lhs.get("kind") == "var" and lhs.get("name") == "return_value"):
+        raise VerifyDialectRefusal(fn_name, "post LHS is not the `return_value` result var")
+
+    # 1. Unwrap the single `python:return(<value>)` the body folds to. A body
+    #    that is anything other than exactly one bare return (e.g. a sequence,
+    #    a conditional, an assignment) does NOT produce a `result == value`
+    #    shape and is refused here -- the honest posture, not a mangle.
+    value_expr = _unwrap_return(rhs, fn_name)
+
+    # 2 + 3. Normalize the value expression's ops + literals to core SMT.
+    formal_sorts_map = sorts.formal_sorts
+    core_value = _normalize_term(value_expr, fn_name, formal_sorts_map)
+
+    # 4. Sorts: every formal must carry an Int/Bool annotation (the lifter
+    #    erased them to `Value`, which z3 cannot reason about for arithmetic).
+    formals = contract.get("formals")
+    if not isinstance(formals, list):
+        raise VerifyDialectRefusal(fn_name, "contract has no formals array")
+    new_formal_sorts: list[Json] = []
+    for formal in formals:
+        sort = formal_sorts_map.get(str(formal))
+        if sort is None:
+            raise VerifyDialectRefusal(
+                fn_name,
+                f"formal `{formal}` lacks an `int`/`bool` annotation; refusing "
+                f"rather than emit a `Value`-sorted obligation z3 cannot discharge",
+            )
+        new_formal_sorts.append(prim_sort(sort))
+    return_sort = sorts.return_sort
+    if return_sort is None:
+        raise VerifyDialectRefusal(
+            fn_name, "return lacks an `int`/`bool` annotation; refusing"
+        )
+
+    out = dict(contract)
+    out["formalSorts"] = new_formal_sorts
+    out["returnSort"] = prim_sort(return_sort)
+    out["post"] = {
+        "kind": "atomic",
+        "name": "=",
+        "args": [{"kind": "var", "name": RESULT_VAR}, core_value],
+    }
+    # The bridge-writer (#1443) keys the auto-bridge on `bridgeSourceSymbol`;
+    # the harvested callsite ctor uses the bare function name. Set it so
+    # `enumerate_callsites` matches `double(3)`.
+    out["bridgeSourceSymbol"] = _bare_symbol(fn_name)
+    return out
+
+
+def _unwrap_return(term: Json, fn_name: str) -> Json:
+    if isinstance(term, dict) and term.get("kind") == "ctor" and term.get("name") == "python:return":
+        inner = term.get("args")
+        if isinstance(inner, list) and len(inner) == 1:
+            return inner[0]
+        raise VerifyDialectRefusal(fn_name, "python:return wrapper is malformed")
+    # A body that did not fold to exactly one return is not a value-op.
+    raise VerifyDialectRefusal(
+        fn_name,
+        "body does not reduce to a single `return <expr>`; the verify-facing "
+        "dialect only discharges single-return value functions",
+    )
+
+
+def _normalize_term(term: Json, fn_name: str, formal_sorts: dict[str, str]) -> Json:
+    """Recursively rewrite a value-expression term into SMT-core form, or
+    refuse. Vars / int / bool consts pass through; `python:compare` becomes the
+    core comparison atomic-as-term; other `python:*` ctors map via
+    `_CORE_ARITH_OP` or refuse."""
+    if not isinstance(term, dict):
+        raise VerifyDialectRefusal(fn_name, "non-object term in value expression")
+    kind = term.get("kind")
+    if kind == "var":
+        return term
+    if kind == "const":
+        sort = term.get("sort")
+        sort_name = sort.get("name") if isinstance(sort, dict) else None
+        if sort_name in {"Int", "Bool"}:
+            return term
+        raise VerifyDialectRefusal(
+            fn_name, f"constant of sort `{sort_name}` is not Int/Bool; refusing"
+        )
+    if kind != "ctor":
+        raise VerifyDialectRefusal(fn_name, f"unexpected term kind `{kind}`")
+
+    name = term.get("name", "")
+    raw_args = term.get("args")
+    args = raw_args if isinstance(raw_args, list) else []
+
+    if name == "python:compare":
+        # python:compare(str_const(op), lhs, rhs) -> core comparison ctor.
+        if len(args) != 3:
+            raise VerifyDialectRefusal(fn_name, "python:compare arity != 3")
+        op_const = args[0]
+        op_str = op_const.get("value") if isinstance(op_const, dict) else None
+        core_op = _CORE_CMP_OP.get(str(op_str))
+        if core_op is None:
+            raise VerifyDialectRefusal(
+                fn_name, f"comparison op `{op_str}` has no faithful SMT-core mapping"
+            )
+        return {
+            "kind": "ctor",
+            "name": core_op,
+            "args": [
+                _normalize_term(args[1], fn_name, formal_sorts),
+                _normalize_term(args[2], fn_name, formal_sorts),
+            ],
+        }
+
+    core = _CORE_ARITH_OP.get(name)
+    if core is None:
+        # Includes python:div / python:floordiv / python:mod / python:pow /
+        # shifts / bitwise -- all deliberately UNINTERPRETED. We do NOT refuse
+        # the whole contract: instead the op stays NAMESPACED so the bridge is
+        # still written and wp hits an opaque symbol it cannot reduce, yielding
+        # `WpError::Refused` -> the verifier reports Undecidable (exit 3, no
+        # witness) via the proven-safe body-discharge refusal path. This
+        # mirrors Go's `coreArithOp` returning (_, false) for go:div and is the
+        # cardinal-sin guard: a division claim becomes Undecidable, NEVER a
+        # false discharge. (Refusing the contract entirely would drop the
+        # bridge and fall through to the refinement path, whose honesty for an
+        # unbound-ctor callsite is not guaranteed -- see body_discharge.rs.)
+        return {
+            "kind": "ctor",
+            "name": name,
+            "args": [_normalize_term_uninterpreted(a, fn_name, formal_sorts) for a in args],
+        }
+    return {
+        "kind": "ctor",
+        "name": core,
+        "args": [_normalize_term(a, fn_name, formal_sorts) for a in args],
+    }
+
+
+def _normalize_term_uninterpreted(term: Json, fn_name: str, formal_sorts: dict[str, str]) -> Json:
+    """Normalize the operands of an uninterpreted op. Core arith inside an
+    uninterpreted op is still normalized (so `(x + 1) // 2` keeps the `+`),
+    but the surrounding uninterpreted op is preserved by `_normalize_term`.
+    This is just `_normalize_term`; named separately for intent clarity."""
+    return _normalize_term(term, fn_name, formal_sorts)
+
+
+def _bare_symbol(fn_name: str) -> str:
+    """`double.double` / `pkg.mod.double` -> `double` (the bare ident the
+    harvested call ctor and the bridge sourceSymbol use)."""
+    name = fn_name
+    if "(" in name:
+        name = name[: name.index("(")]
+    if "." in name:
+        name = name[name.rindex(".") + 1 :]
+    return name

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/verify_rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/verify_rpc.py
@@ -1,0 +1,267 @@
+"""Verify-facing Python lift surface (`provekit-lift-python-verify --rpc`).
+
+The Python analog of `cmd/provekit-lift-go-verify` (PR #1445). It is the binary
+the kit-dispatch `python` lift surface resolves for the `provekit verify`
+pipeline. It speaks the `initialize`/`lift`/`shutdown` JSON-RPC the
+language-neutral dispatcher drives and returns ONE `ir-document` combining two
+real Python lift passes over the workspace:
+
+  1. Body-derived function-contracts from the library's non-test `.py` files,
+     lifted by the real source lifter (`lifter.lift_source`) then lowered to the
+     VERIFY-FACING dialect (`verify_dialect.to_verify_dialect`): arithmetic /
+     comparison ops are emitted with SMT-LIB core symbols (`*`, `+`, `<`),
+     the result var is `result`, the `python:return` wrapper is stripped, and
+     formal/return sorts come from the `: int` annotations -- so the
+     body-derived `post = result == <body-expr>` is z3-dischargeable. This is
+     the Python analog of Go's `LiftSourceCore`; the spine is NOT modified.
+
+  2. Harvested callsite assertions from the library's test files
+     (`leaf_assertions.harvest_source`): `assert double(3) == 6` lifts to a
+     `contract` whose `inv = =(double(3), 6)`.
+
+`provekit mint` then (#1443) auto-writes the `double -> targetContractCid`
+bridge for the body-bearing function-contract (keyed on `bridgeSourceSymbol`),
+and `provekit verify` reduces `double(3) == 6` through the body `(* x 2)` ->
+`(* 3 2) == 6` -> z3 discharges (positive) / refutes (broken body, negative) /
+refuses (division, undecidable).
+
+HONEST: no contract or bridge is hand-written; both halves are real lifter
+output, and any op with no faithful SMT-core mapping (div/mod/floordiv/...) is
+left uninterpreted -> Undecidable, never a false witness. Supra omnia, rectum.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+from .leaf_assertions import harvest_source
+from .lifter import lift_source
+from .verify_dialect import VerifyDialectRefusal, collect_int_signatures, to_verify_dialect
+
+SURFACE = "python"
+VERSION = "0.1.0"
+
+_IGNORED_DIRS = {".git", ".venv", "venv", "__pycache__", ".mypy_cache", ".pytest_cache", ".provekit"}
+
+
+def _is_test_file(name: str) -> bool:
+    return name.startswith("test_") and name.endswith(".py") or name.endswith("_test.py")
+
+
+def initialize_result() -> dict[str, Any]:
+    return {
+        "name": "provekit-lift-python-verify",
+        "version": VERSION,
+        "protocol_version": "provekit-lift/1",
+        "dialect": SURFACE,
+        "capabilities": {
+            "authoring_surfaces": [SURFACE],
+            "ir_version": "v1.1.0",
+            "emits_signed_mementos": False,
+        },
+    }
+
+
+def _mode_from_options(options: dict[str, Any] | None) -> str:
+    """bare | bindings | contracts, mirroring Go's liftMode. The two authoring
+    surfaces emit different IR so the same function is not minted twice when
+    both plugins run in one `provekit mint`."""
+    if not options:
+        return "bare"
+    if options.get("layer") == "library-bindings":
+        return "bindings"
+    if options.get("emit") == "ir-document":
+        return "contracts"
+    return "bare"
+
+
+def _iter_py_files(root: Path):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _IGNORED_DIRS]
+        for filename in sorted(filenames):
+            if filename.endswith(".py"):
+                yield Path(dirpath) / filename
+
+
+def lift_workspace(root: str, mode: str) -> tuple[list[Json], list[Json]]:
+    """Walk every `.py` under root, returning (ir_items, diagnostics).
+
+    mode == "bindings": `library-sugar-binding-entry` per annotated function
+      (declaration catalog; mint skips it). Delegates to the bind lifter.
+    mode == "contracts": verify-facing function-contracts gated on the
+      `@provekit.boundary`/`@provekit.sugar` declaration + harvested callsites.
+    mode == "bare": verify-facing function-contracts for ALL functions +
+      harvested callsites (the production-bridge behaviour).
+    """
+    Json = dict
+    root_path = Path(root or ".").resolve()
+    ir_items: list[Json] = []
+    diagnostics: list[Json] = []
+    seen_fn: set[str] = set()
+    seen_contract: set[str] = set()
+    annotated_only = mode != "bare"
+
+    # The bindings surface is the declaration catalog only -- delegate wholly
+    # to the existing bind lifter (it already emits library-sugar-binding-entry
+    # from @sugar.bind / @provekit.boundary). No callsite harvesting.
+    if mode == "bindings":
+        from . import bind_lifter
+
+        bind_result = bind_lifter.lift_paths(str(root_path), ["."], layer="library-bindings")
+        return bind_result.ir, bind_result.diagnostics
+
+    for path in _iter_py_files(root_path):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            diagnostics.append({"path": str(path), "message": f"cannot read: {exc}"})
+            continue
+        rel = os.path.relpath(path, root_path).replace(os.sep, "/")
+
+        if _is_test_file(path.name):
+            harvest = harvest_source(source, rel)
+            diagnostics.extend(harvest.diagnostics)
+            for decl in harvest.ir:
+                name = str(decl.get("name", ""))
+                if name in seen_contract:
+                    continue
+                seen_contract.add(name)
+                ir_items.append(decl)
+            continue
+
+        # Body-derived function-contracts (verify-facing dialect).
+        annotations = _boundary_annotations(source)
+        sorts_by_fn = collect_int_signatures(source)
+        lifted = lift_source(source, rel)
+        diagnostics.extend(lifted.diagnostics)
+        for refusal in lifted.refusals:
+            diagnostics.append({"path": rel, "message": json.dumps(refusal)})
+        for contract in lifted.ir:
+            if contract.get("kind") != "function-contract":
+                continue
+            fn_name = str(contract.get("fnName", ""))
+            if fn_name.startswith("<source-unit"):
+                continue
+            if fn_name in seen_fn:
+                continue
+            bare = fn_name.rsplit(".", 1)[-1]
+            declaration = annotations.get(bare)
+            if annotated_only and declaration is None:
+                continue
+            sorts = sorts_by_fn.get(bare)
+            if sorts is None:
+                diagnostics.append({"path": rel, "message": f"{fn_name}: no signature parsed"})
+                continue
+            try:
+                item = to_verify_dialect(contract, sorts)
+            except VerifyDialectRefusal as exc:
+                diagnostics.append(
+                    {"path": rel, "message": f"verify-dialect refusal: {exc.reason}", "function": fn_name}
+                )
+                continue
+            seen_fn.add(fn_name)
+            # Tag the contract with the authoring declaration so the emitted
+            # ir-document records WHICH concept the library declared (parallel
+            # to Go's conceptName/authoringKind tagging).
+            if declaration is not None:
+                item["conceptName"] = declaration.get("concept", "")
+                item["authoringKind"] = declaration.get("kind", "")
+                if declaration.get("library"):
+                    item["library"] = declaration["library"]
+            ir_items.append(item)
+
+    return ir_items, diagnostics
+
+
+def _boundary_annotations(source: str) -> dict[str, dict[str, str]]:
+    """Map bare function name -> {concept, kind, library} for functions
+    decorated with `@provekit.boundary(...)` / `@boundary(...)` /
+    `@provekit.sugar(...)` / `@sugar(...)`. This gates verify-facing contract
+    emission in the `contracts` surface, mirroring Go's `AnnotatedOnly`.
+
+    Note this is distinct from the existing `@sugar.bind(concept=, library=)`
+    library-binding decorator the bind lifter consumes; `@boundary`/`@sugar`
+    here is the verify-facing AUTHORING declaration: "this function's body is a
+    contract I want discharged"."""
+    import ast
+
+    from .authoring import authoring_declaration
+
+    out: dict[str, dict[str, str]] = {}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return out
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            decl = authoring_declaration(decorator)
+            if decl is not None:
+                out[node.name] = decl
+                break
+    return out
+
+
+def dispatch(request: dict[str, Any]) -> dict[str, Any]:
+    msg_id = request.get("id")
+    method = request.get("method", "")
+    params = request.get("params") or {}
+
+    if method == "initialize":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": initialize_result()}
+    if method == "lift":
+        root = str(params.get("workspace_root", "."))
+        mode = _mode_from_options(params.get("options"))
+        ir_items, diagnostics = lift_workspace(root, mode)
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {
+                "kind": "ir-document",
+                "ir": ir_items,
+                "callEdges": [],
+                "diagnostics": diagnostics,
+                "opacityReport": [],
+                "refusals": [],
+            },
+        }
+    if method == "shutdown":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": None}
+    return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32601, "message": f"METHOD_NOT_FOUND: {method}"}}
+
+
+def run_rpc() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+            response = dispatch(request)
+        except json.JSONDecodeError as exc:
+            response = {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": f"PARSE_ERROR: {exc}"}}
+        except Exception as exc:  # noqa: BLE001 -- surface as RPC error, never crash the loop
+            response = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32603, "message": f"{exc}\n{traceback.format_exc()}"},
+            }
+        sys.stdout.write(json.dumps(response, separators=(",", ":"), ensure_ascii=False) + "\n")
+        sys.stdout.flush()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rpc", action="store_true", help="run JSON-RPC over stdio")
+    args = parser.parse_args(argv)
+    if args.rpc:
+        run_rpc()
+    else:
+        parser.print_help()

--- a/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
@@ -1,0 +1,146 @@
+"""Unit tests for the verify-facing Python lift surface (Go-parity, PR #1445).
+
+Covers the three transform halves and the cardinal-sin division guard:
+  - to_verify_dialect lowers a `double` contract to `result == (* x 2)` / Int.
+  - division ops stay NAMESPACED (uninterpreted) so the bridge is still written
+    and wp refuses -> Undecidable, NEVER a false discharge.
+  - an unannotated arithmetic body refuses (no `Value`-sorted obligation).
+  - leaf harvester lifts `assert double(3) == 6` -> `=(double(3), 6)`.
+  - the `contracts` surface gates emission on `@provekit.boundary`/`@sugar`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from provekit_lift_python_source.leaf_assertions import harvest_source
+from provekit_lift_python_source.lifter import lift_source
+from provekit_lift_python_source.verify_dialect import (
+    VerifyDialectRefusal,
+    collect_int_signatures,
+    to_verify_dialect,
+)
+from provekit_lift_python_source.verify_rpc import lift_workspace
+
+
+def _fn_contract(source: str, source_path: str = "m.py"):
+    result = lift_source(source, source_path)
+    for item in result.ir:
+        if item.get("kind") == "function-contract" and not str(item["fnName"]).startswith(
+            "<source-unit"
+        ):
+            return item
+    raise AssertionError("no function-contract lifted")
+
+
+def test_double_lowers_to_dischargeable_core_form():
+    source = "def double(x: int) -> int:\n    return x * 2\n"
+    contract = _fn_contract(source)
+    sorts = collect_int_signatures(source)["double"]
+    out = to_verify_dialect(contract, sorts)
+
+    assert out["bridgeSourceSymbol"] == "double"
+    assert out["formalSorts"] == [{"kind": "primitive", "name": "Int"}]
+    assert out["returnSort"] == {"kind": "primitive", "name": "Int"}
+    post = out["post"]
+    assert post["name"] == "="
+    assert post["args"][0] == {"kind": "var", "name": "result"}
+    value = post["args"][1]
+    assert value["name"] == "*"  # python:mul normalized to SMT-core
+    assert value["args"][0] == {"kind": "var", "name": "x"}
+    assert value["args"][1]["value"] == 2
+
+
+def test_addition_and_comparison_normalize():
+    source = "def f(x: int, y: int) -> int:\n    return x + y\n"
+    contract = _fn_contract(source)
+    out = to_verify_dialect(contract, collect_int_signatures(source)["f"])
+    assert out["post"]["args"][1]["name"] == "+"
+
+
+def test_floordiv_stays_namespaced_not_refused():
+    # CARDINAL SIN GUARD: `//` has no faithful core mapping. It must STAY
+    # namespaced (so the bridge is written + wp refuses -> Undecidable), NOT be
+    # refused (which would drop the bridge and risk a vacuous-pass fall-through).
+    source = "def halve(x: int) -> int:\n    return x // 2\n"
+    contract = _fn_contract(source)
+    out = to_verify_dialect(contract, collect_int_signatures(source)["halve"])
+    assert out["bridgeSourceSymbol"] == "halve"
+    assert out["post"]["args"][1]["name"] == "python:floordiv"
+
+
+def test_truediv_and_mod_stay_namespaced():
+    for op, expected in (("/", "python:div"), ("%", "python:mod")):
+        source = f"def g(x: int) -> int:\n    return x {op} 2\n"
+        contract = _fn_contract(source)
+        out = to_verify_dialect(contract, collect_int_signatures(source)["g"])
+        assert out["post"]["args"][1]["name"] == expected
+
+
+def test_unannotated_arithmetic_body_refuses():
+    # No `: int` annotation -> a `Value`-sorted obligation z3 cannot discharge.
+    # Refuse rather than emit it.
+    source = "def double(x):\n    return x * 2\n"
+    contract = _fn_contract(source)
+    sorts = collect_int_signatures(source)["double"]
+    with pytest.raises(VerifyDialectRefusal):
+        to_verify_dialect(contract, sorts)
+
+
+def test_multistatement_body_refuses():
+    # A body that is not a single `return <expr>` is not a value-op.
+    source = "def f(x: int) -> int:\n    y = x + 1\n    return y * 2\n"
+    contract = _fn_contract(source)
+    with pytest.raises(VerifyDialectRefusal):
+        to_verify_dialect(contract, collect_int_signatures(source)["f"])
+
+
+def test_leaf_harvester_lifts_call_eq():
+    source = "def test_double():\n    assert double(3) == 6\n"
+    result = harvest_source(source, "test_m.py")
+    assert len(result.ir) == 1
+    contract = result.ir[0]
+    assert contract["kind"] == "contract"
+    assert contract["name"] == "test_double"
+    inv = contract["inv"]
+    assert inv["name"] == "="
+    call = inv["args"][0]
+    assert call == {
+        "kind": "ctor",
+        "name": "double",
+        "args": [{"kind": "const", "value": 3, "sort": {"kind": "primitive", "name": "Int"}}],
+    }
+    assert inv["args"][1]["value"] == 6
+
+
+def test_leaf_harvester_negative_int_literal():
+    source = "def test_halve():\n    assert halve(-7) == -4\n"
+    result = harvest_source(source, "test_m.py")
+    inv = result.ir[0]["inv"]
+    assert inv["args"][0]["args"][0]["value"] == -7
+    assert inv["args"][1]["value"] == -4
+
+
+def test_contracts_surface_gates_on_boundary_declaration(tmp_path):
+    # The `contracts` (ir-document) surface emits a function-contract ONLY for
+    # functions carrying a `@provekit.boundary`/`@boundary` declaration.
+    (tmp_path / "lib.py").write_text(
+        "import provekit\n\n\n"
+        "@provekit.boundary(concept='concept:mul')\n"
+        "def declared(x: int) -> int:\n    return x * 2\n\n\n"
+        "def undeclared(x: int) -> int:\n    return x + 1\n"
+    )
+    ir, _diag = lift_workspace(str(tmp_path), "contracts")
+    fn_names = [i["fnName"].rsplit(".", 1)[-1] for i in ir if i.get("kind") == "function-contract"]
+    assert "declared" in fn_names
+    assert "undeclared" not in fn_names
+    declared = next(i for i in ir if i.get("kind") == "function-contract")
+    assert declared["conceptName"] == "concept:mul"
+    assert declared["authoringKind"] == "boundary"
+
+
+def test_bare_surface_emits_all_functions(tmp_path):
+    (tmp_path / "lib.py").write_text("def double(x: int) -> int:\n    return x * 2\n")
+    ir, _diag = lift_workspace(str(tmp_path), "bare")
+    fn_names = [i["fnName"].rsplit(".", 1)[-1] for i in ir if i.get("kind") == "function-contract"]
+    assert fn_names == ["double"]

--- a/implementations/rust/provekit-cli/tests/cmd_verify_python_division_unsound.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_python_division_unsound.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CARDINAL-SIN REGRESSION (Python analog of `cmd_verify_go_division_unsound.rs`):
+// the verify-facing Python lifter must NEVER sign a witness for a Python-false
+// statement via an op whose SMT-LIB semantics diverge from Python.
+//
+// Python integer floor-division `//` and modulo `%` (and true division `/`,
+// which is float) have no faithful SMT-LIB-core mapping for signed ints:
+//   Python `-7 // 2 == -4` (floor toward -inf)
+//   SMT    `(div -7 2) == -4`  -- coincidentally agrees on THIS axis, but
+//          truncation/float semantics diverge elsewhere, and we refuse to
+//          model any of them.
+//
+// The verify-facing dialect (`verify_dialect.py`) therefore leaves
+// `python:floordiv` / `python:div` / `python:mod` UNINTERPRETED (namespaced).
+// The function-contract and its auto-bridge are STILL written, so the
+// body-discharge seam resolves the callee and runs wp -- which hits the opaque
+// op and returns a refusal, so verify reports Undecidable
+// (EXIT_SOLVER_FAIL = 3) with NO witness. That is the honest "I cannot prove
+// this", and it routes through the SAME proven-safe wp-refusal path Go's
+// `go:div` does (NOT a fall-through that risks a vacuous pass).
+//
+// This test drives the REAL Python lifter + REAL `provekit mint`/`verify` and
+// asserts: NO discharge, NO signed witness, exit 3. Both the Python-false
+// (`-4`) and Python-true (`-3`) assertions become Undecidable -- that is
+// correct; the cardinal point is that NEITHER false-discharges.
+//
+// Requires `python3` and `z3` on PATH; guards skip loudly otherwise.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value as Json;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn python_lift_src() -> PathBuf {
+    repo_root()
+        .join("implementations")
+        .join("python")
+        .join("provekit-lift-python-source")
+        .join("src")
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn python_available() -> bool {
+    Command::new("python3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-py-divunsound-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn build_python_lift_verify() -> PathBuf {
+    let src = python_lift_src();
+    let script =
+        std::env::temp_dir().join(format!("provekit-lift-python-verify-div-{}.sh", std::process::id()));
+    let body = format!(
+        "#!/bin/sh\nexec python3 -c \"import sys; sys.path.insert(0, '{}'); \
+         from provekit_lift_python_source.verify_rpc import run_rpc; run_rpc()\"\n",
+        src.display()
+    );
+    fs::write(&script, body).expect("write python lift wrapper");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&script).expect("stat wrapper").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).expect("chmod wrapper");
+    }
+    script
+}
+
+/// Stage a `halve(x) = x // 2` project whose harvested assertion is
+/// `halve(-7) == expected`. `expected = -4` is the value SMT floor-div would
+/// give; `-3` is truncation. Both must be Undecidable with `//` uninterpreted.
+fn stage_halve_project(suffix: &str, lift_script: &Path, expected: i64) -> PathBuf {
+    let example = repo_root().join("examples").join("python-double");
+    let project = unique_dir(suffix);
+
+    fs::write(
+        project.join("halve.py"),
+        "def halve(x: int) -> int:\n    return x // 2\n",
+    )
+    .expect("write halve.py");
+    fs::write(
+        project.join("test_halve.py"),
+        format!("from halve import halve\n\n\ndef test_halve():\n    assert halve(-7) == {expected}\n"),
+    )
+    .expect("write test_halve.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python")).expect("mkdir lift/python");
+    fs::copy(
+        example.join(".provekit").join("config.toml"),
+        provekit.join("config.toml"),
+    )
+    .expect("copy config.toml");
+    let manifest = format!(
+        "name = \"python\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+        lift_script.display()
+    );
+    fs::write(
+        provekit.join("lift").join("python").join("manifest.toml"),
+        manifest,
+    )
+    .expect("write manifest");
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .args(["mint", "--project"])
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .args(["--no-attest", "--quiet"])
+        .output()
+        .expect("spawn mint");
+    assert!(
+        out.status.success(),
+        "mint must succeed\n  stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_verify(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .args(["verify", "--project"])
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+/// Assert that the `halve(-7) == expected` claim does NOT discharge, writes NO
+/// witness, and exits 3 (Undecidable) -- never a false discharge.
+fn assert_undecidable_no_witness(suffix: &str, expected: i64) {
+    let lift_script = build_python_lift_verify();
+    let project = stage_halve_project(suffix, &lift_script, expected);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["pass"], false,
+        "an integer-division claim must NEVER discharge (// is uninterpreted); claim: {claim}"
+    );
+    assert_ne!(
+        claim["status"], "discharged",
+        "CARDINAL SIN: a division claim discharged -- inverted proof regression; claim: {claim}"
+    );
+    assert_eq!(
+        claim["status"], "undecidable",
+        "division claim must be Undecidable; claim: {claim}"
+    );
+    assert!(
+        claim["witnessCid"].is_null(),
+        "NO signed witness may exist for a division claim; claim: {claim}"
+    );
+
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a division claim; found {} files",
+        witness_files.len()
+    );
+
+    assert_eq!(
+        code, 3,
+        "division claim must exit 3 (EXIT_SOLVER_FAIL / undecidable), not 0 (discharged); got {code}"
+    );
+    eprintln!("PYTHON_DIV_UNSOUND_GUARD expected={expected} status=undecidable exit={code} witnesses=0");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// The Python-false-under-truncation assertion `halve(-7) == -4` must NOT
+/// discharge and must write NO witness -- the inverted-proof guard.
+#[test]
+fn python_division_floor_value_assertion_does_not_false_discharge() {
+    if !python_available() || !z3_available() {
+        eprintln!("python3/z3 not on PATH: skipping python division unsoundness regression");
+        return;
+    }
+    assert_undecidable_no_witness("floor-neg4", -4);
+}
+
+/// The truncation-value assertion `halve(-7) == -3` is ALSO Undecidable with
+/// `//` uninterpreted -- correct: we refuse rather than risk an unfaithful
+/// model.
+#[test]
+fn python_division_trunc_value_assertion_is_undecidable_not_discharged() {
+    if !python_available() || !z3_available() {
+        eprintln!("python3/z3 not on PATH: skipping");
+        return;
+    }
+    assert_undecidable_no_witness("trunc-neg3", -3);
+}

--- a/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// PYTHON end-to-end production-bridge gauntlet -- the Python analog of
+// `cmd_verify_go_production_bridge.rs`. Proves the verification spine is
+// LANGUAGE-NEUTRAL for Python: a Python function's body-derived contract lifts
+// to ProofIR (`post = result == (* x 2)` plus `formals`) and the verifier
+// discharges the obligation through the body via wp + z3, exactly as for Rust,
+// Java, and Go.
+//
+// This drives the REAL verify-facing Python lift surface
+// `provekit-lift-python-verify` (module
+// `provekit_lift_python_source.verify_rpc`). That surface lifts the real
+// Python sources in `examples/python-double`:
+//
+//   - `double.py`       -> function-contract `post = result == (* x 2)`
+//                          (verify-facing dialect: `python:mul` normalized to
+//                          `*`, `return_value` -> `result`, `python:return`
+//                          wrapper stripped, `Int` sorts from the `: int`
+//                          annotation).
+//   - `test_double.py`  -> contract `inv = =(double(3), 6)` (Python Layer-0
+//                          leaf-assertion harvester).
+//
+// `provekit mint` AUTO-WRITES the `double -> targetContractCid` bridge (#1443);
+// the bridge is TOOL-written, asserted by inspecting `pool.bridges_by_symbol`.
+// `provekit verify` then discharges both ways:
+//
+//   POSITIVE: `double(3) == 6` reduces through the body `(* 3 2) == 6` -> z3
+//     discharges -> pass, signed witness, exit 0.
+//   NEGATIVE: break the body to `x * 3` -> `(* 3 3) == 6` -> z3 refutes ->
+//     Unsatisfied, exit 1, NO witness.
+//
+// Requires `python3` and `z3` on PATH; skips the solver-dependent asserts if z3
+// is absent, and skips entirely (with a loud eprintln) if python3 is absent.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value as Json;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+/// CARGO_MANIFEST_DIR = .../implementations/rust/provekit-cli; three parents up
+/// is the repo root.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// The verify-facing Python lifter's source tree, prepended to `sys.path` so
+/// the binary resolves to THIS checkout's module (not a stale installed one).
+fn python_lift_src() -> PathBuf {
+    repo_root()
+        .join("implementations")
+        .join("python")
+        .join("provekit-lift-python-source")
+        .join("src")
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn python_available() -> bool {
+    Command::new("python3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-py-prod-bridge-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir project");
+    p
+}
+
+/// Write a small wrapper shell script that runs the verify-facing Python lift
+/// surface with THIS checkout's `src` on `sys.path`, and return its path. The
+/// Go test compiles a Go binary; Python is interpreted, so the analog is a
+/// stable wrapper invoking `python3 -c "...; run_rpc()"`.
+fn build_python_lift_verify() -> PathBuf {
+    let src = python_lift_src();
+    let script = std::env::temp_dir().join(format!(
+        "provekit-lift-python-verify-{}.sh",
+        std::process::id()
+    ));
+    let body = format!(
+        "#!/bin/sh\nexec python3 -c \"import sys; sys.path.insert(0, '{}'); \
+         from provekit_lift_python_source.verify_rpc import run_rpc; run_rpc()\"\n",
+        src.display()
+    );
+    fs::write(&script, body).expect("write python lift wrapper");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&script).expect("stat wrapper").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).expect("chmod wrapper");
+    }
+    script
+}
+
+/// Copy the in-repo `examples/python-double` into a fresh tempdir, write the
+/// `python` lift manifest pointing at the wrapper script, and (for the negative
+/// case) mutate the body multiplier. Returns the tempdir project.
+fn stage_python_project(suffix: &str, lift_script: &Path, body_factor: i64) -> PathBuf {
+    let example = repo_root().join("examples").join("python-double");
+    let project = unique_dir(suffix);
+
+    // double.py: the library, with the body multiplier (2 honest, 3 broken).
+    let double_src = format!("def double(x: int) -> int:\n    return x * {body_factor}\n");
+    fs::write(project.join("double.py"), double_src).expect("write double.py");
+
+    // test_double.py: copied verbatim (the harvested `double(3) == 6`).
+    fs::copy(
+        example.join("test_double.py"),
+        project.join("test_double.py"),
+    )
+    .expect("copy test_double.py");
+
+    // .provekit/config.toml: copied verbatim.
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python")).expect("mkdir .provekit/lift/python");
+    fs::copy(
+        example.join(".provekit").join("config.toml"),
+        provekit.join("config.toml"),
+    )
+    .expect("copy config.toml");
+
+    // .provekit/lift/python/manifest.toml: point command[0] at the wrapper.
+    let manifest = format!(
+        "name = \"python\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+        lift_script.display()
+    );
+    fs::write(
+        provekit.join("lift").join("python").join("manifest.toml"),
+        manifest,
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_verify_json_with_code(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .arg("verify")
+        .arg("--project")
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+/// THE bridge-writer assertion (language-neutral, runs without z3): the TOOL
+/// wrote a `bridge` member for `double` whose `targetContractCid` resolves to a
+/// `contract` member carrying the body-derived `formals` + `post`. No
+/// hand-bridging anywhere; the bridge came from `provekit mint`.
+#[test]
+fn python_mint_auto_writes_body_discharge_bridge() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping python production-bridge bridge-writer test");
+        return;
+    }
+    let lift_script = build_python_lift_verify();
+    let project = stage_python_project("bridge", &lift_script, 2);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "tool-minted bundle must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let bridge = pool
+        .bridges_by_symbol
+        .get("double")
+        .unwrap_or_else(|| {
+            panic!(
+                "mint must auto-write + index a bridge with sourceSymbol=double; indexed: {:?}",
+                pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+            )
+        });
+
+    let target_cid = provekit_verifier::types::memento_body_field(bridge, "targetContractCid")
+        .and_then(|v| v.as_str())
+        .expect("bridge must carry targetContractCid")
+        .to_string();
+
+    let target = pool.mementos.get(&target_cid).unwrap_or_else(|| {
+        panic!("bridge.targetContractCid {target_cid} must resolve to a member")
+    });
+    assert_eq!(
+        provekit_verifier::types::memento_kind(target),
+        Some("contract"),
+        "bridge target must be a contract memento"
+    );
+    let formals = provekit_verifier::types::memento_body_field(target, "formals")
+        .and_then(|v| v.as_array())
+        .expect("tool-written op-contract must carry formals");
+    assert_eq!(
+        formals.first().and_then(|v| v.as_str()),
+        Some("x"),
+        "op-contract formals must be [x]"
+    );
+    assert!(
+        provekit_verifier::types::memento_body_field(target, "post").is_some(),
+        "op-contract must carry the body-derived post"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// POSITIVE end-to-end: real Python lifter, tool-written bridge, verify
+/// discharges through the body `(* x 2)`, signed witness, exit 0.
+#[test]
+fn python_production_path_double_discharges_and_mints_witness() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping python production-bridge positive test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping python production-bridge positive test");
+        return;
+    }
+    let lift_script = build_python_lift_verify();
+    let project = stage_python_project("pos", &lift_script, 2);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["kind"], "verification-receipt", "receipt: {receipt}");
+    assert_eq!(
+        receipt["totalClaims"], 1,
+        "exactly one body-bearing callsite (the tool-written bridge made double(3) enumerate); receipt: {receipt}"
+    );
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["pass"], true,
+        "double(3)==6 must discharge through body (* x 2); claim: {claim}"
+    );
+    assert_eq!(claim["status"], "discharged", "claim: {claim}");
+
+    let solver = claim["dischargingSolver"].as_str().unwrap_or("");
+    assert!(
+        solver.starts_with("z3@"),
+        "discharging solver must be z3; got `{solver}`"
+    );
+
+    let witness_cid = claim["witnessCid"].as_str().expect("witness minted");
+    assert!(witness_cid.starts_with("blake3-512:"));
+    eprintln!("PYTHON_PRODUCTION_POSITIVE_WITNESS_CID={witness_cid}");
+
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(code, 0, "positive run exits clean; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// NEGATIVE end-to-end: broken body `x * 3`, verify Unsatisfied, exit 1, no
+/// witness. The decisive proof the tool-written bridge does not vacuously pass:
+/// a real violation is caught honestly.
+#[test]
+fn python_production_path_broken_body_fails_unsatisfied_no_witness() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping python production-bridge negative test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping python production-bridge negative test");
+        return;
+    }
+    let lift_script = build_python_lift_verify();
+    let project = stage_python_project("neg", &lift_script, 3);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["status"], "unsatisfied",
+        "broken body x*3 must be UNSATISFIED (not undecidable); claim: {claim}"
+    );
+    assert_eq!(claim["pass"], false, "claim: {claim}");
+    assert!(
+        claim["witnessCid"].is_null(),
+        "no witness for a violated claim; claim: {claim}"
+    );
+    assert_eq!(receipt["ok"], false, "receipt: {receipt}");
+
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a violated claim; found {} files",
+        witness_files.len()
+    );
+
+    assert_eq!(
+        code, 1,
+        "broken-body claim must exit 1 (EXIT_VERIFY_FAIL, not 3=undecidable); got {code}"
+    );
+    eprintln!(
+        "PYTHON_PRODUCTION_NEGATIVE_EXIT_CODE={code} STATUS={}",
+        claim["status"]
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}


### PR DESCRIPTION
## Summary

Brings **Python** to parity with the Go onboarding (#1445): a python library declares a boundary, GETS a verifiable contract (discharged through the spine via z3, with a signed witness), and materializes back into python. Built on the keystone spine (#1441), production bridge (#1443), and the python realize fixes from this session (#1448/#1451). Mirrors the proven Go procedure.

### STEP 1 — the python lift→verify gap (empirical)
The real python lifter emits a body-derived `function-contract`, but its shape diverged from the verifier's dischargeable expectation on **four** axes (Go diverged on one): result var `return_value` vs `result`; a `python:return` wrapper; **namespaced ops** (`python:mul`, like Go's `go:mul`); and `Value` sorts (the lifter erases `: int`) vs `Int`. All handled by a verify-facing dialect transform (`verify_dialect.py`), the python analog of Go's `NormalizeCoreArith`. The round-trip dialect is preserved.

### Div soundness (the cardinal axis — Go lesson applied preemptively)
`python:div`/`python:floordiv`/`python:mod` are left **namespaced/uninterpreted** — division goes Undecidable via the wp-refusal path, NEVER false-discharges. Empirically (real CLI):
| case | exit | status | witness |
|---|---|---|---|
| `double` x*2, `double(3)==6` | 0 | discharged (z3) | minted |
| `double` x*3 (broken) | 1 | unsatisfied | none |
| `halve` x//2, `halve(-7)==-4` (py-false) | 3 | undecidable | none |
| `halve` x//2, `halve(-7)==-3` (py-true) | 3 | undecidable | none |
(One mid-build correction: an early dialect refused the whole contract on a division op, dropping the bridge into an unproven path; fixed to keep the op namespaced so the bridge is written and wp refuses — identical to Go's stance.)

### STEP 2 — production-bridge verify-discharge
`cmd_verify_python_production_bridge.rs` (3) + `cmd_verify_python_division_unsound.rs` (2). Real lifter → `provekit mint` (tool-written bridge, asserted via `pool.bridges_by_symbol["double"]`) → `provekit verify`. All 5 green. Positive witness `blake3-512:5b9e0369…`.

### STEP 3 — `@provekit.boundary` authoring surface + closed loop
Added the verify-facing `@provekit.boundary(concept=...)` declaration gating function-contract emission (mirroring Go's `AnnotatedOnly`), taught the lifter to skip declarative decorators, three-mode verify binary. `examples/python-boundary` closes declare → contract (gated) → discharge end-to-end (signed witness, exit 0). Realize leg = the existing python realize kit (dispatch demonstrated, as with Go's `go_realize_materialize.rs`).

## Test plan
- [x] python production-bridge 3/3 + division-unsound 2/2
- [x] python lifter suite 87/87 (decorator change non-regressive)
- [x] #1441 body-discharge 5/5, #1443 rust bridge 3/3, #1445 Go bridge+division 5/5 untouched
- [x] `cargo build --workspace` green

Ref: #1436, #1445 (Go parity template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python source code verification support with verify-facing contract generation.
  * Added example Python projects demonstrating verification workflows and configuration patterns.

* **Documentation**
  * Added planning document for achieving Python verification parity.

* **Tests**
  * Added integration tests for Python production bridge verification and division operation unsoundness detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->