### PR TITLE
Restore seam4 federation byte-identity (type-leak + term_shape alignment)

### DIFF
--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -635,6 +635,25 @@ pub fn strip_realize_sidecar_from_lift_term(term: Term) -> Term {
                 object.remove("realizeParamTypes");
                 object.remove("realize_return_type");
                 object.remove("realizeReturnType");
+                object.remove("realize_original_param_types");
+                object.remove("realizeOriginalParamTypes");
+                // #1075/A9 federation: the bind-lift-entry is the cross-language
+                // boundary surface and must hash to the SAME bytes whether
+                // lifted from typed Rust or untyped Python. The Python lifter
+                // emits only {kind, param_names, term_shape, term_shape_cid,
+                // operand_bindings, realize_*, source_function_name, witnesses};
+                // Rust additionally carries visibility/generic_params/doc_lines
+                // for the Java boundary realize path. Those are realize-only
+                // metadata (read off the UN-stripped lift IR by cmd_lower, never
+                // off this hashed term) so they ride CID-invisible here too,
+                // scoped to bind-lift-entry to leave sugar-entry CIDs untouched.
+                if object.get("kind").and_then(Json::as_str) == Some("bind-lift-entry") {
+                    object.remove("visibility");
+                    object.remove("generic_params");
+                    object.remove("genericParams");
+                    object.remove("doc_lines");
+                    object.remove("docLines");
+                }
             }
         }
     }

--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -543,6 +543,24 @@ fn bind_payload_wire_named_term_document(named: &NamedTermDocument) -> NamedTerm
         term.function.clear();
         // fn_name_sugar is preserved: it carries the source fn name as a
         // non-CID-affecting annotation on the citation (Option C sugar layer)
+        //
+        // #1075 federation: the wire op-tree is arg[1] of the federated
+        // concept:bind-result payload (the cross-language CID). Source-language
+        // realize-only metadata — visibility, generic_params, doc_lines, and the
+        // signature types — must NOT ride it, or typed-Rust (`pub fn add(x: i64,
+        // y: i64) -> i64`) and untyped-Python (`def add(x, y)`) bind to different
+        // CIDs. These fields are NOT lost: the full NamedTermDocument (with them
+        // intact) is addressed separately as the bind claim's `artifacts[0]`
+        // (named_cid) and is the canonical realize-input channel; cmd_lower's
+        // production path reconstructs from the ir-document, never from this wire
+        // op-tree. Parallel to the bind-lift-entry strip in
+        // strip_realize_sidecar_from_lift_term.
+        term.visibility.clear();
+        term.generic_params.clear();
+        term.doc_lines.clear();
+        term.param_types.clear();
+        term.return_type.clear();
+        term.original_param_types.clear();
     }
     wire
 }

--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -546,21 +546,29 @@ fn bind_payload_wire_named_term_document(named: &NamedTermDocument) -> NamedTerm
         //
         // #1075 federation: the wire op-tree is arg[1] of the federated
         // concept:bind-result payload (the cross-language CID). Source-language
-        // realize-only metadata — visibility, generic_params, doc_lines, and the
-        // signature types — must NOT ride it, or typed-Rust (`pub fn add(x: i64,
-        // y: i64) -> i64`) and untyped-Python (`def add(x, y)`) bind to different
-        // CIDs. These fields are NOT lost: the full NamedTermDocument (with them
-        // intact) is addressed separately as the bind claim's `artifacts[0]`
-        // (named_cid) and is the canonical realize-input channel; cmd_lower's
-        // production path reconstructs from the ir-document, never from this wire
-        // op-tree. Parallel to the bind-lift-entry strip in
+        // realize-only display metadata — visibility, generic_params, doc_lines
+        // — must NOT ride it, or typed-Rust (`pub fn add ...`) and untyped-Python
+        // (`def add ...`) bind to different CIDs. These are NOT lost: the full
+        // NamedTermDocument (with them intact) is addressed separately as the
+        // bind claim's `artifacts[0]` (named_cid) and is the canonical realize
+        // channel; cmd_lower's production path reconstructs from the ir-document,
+        // never from this wire op-tree. Parallel to the bind-lift-entry strip in
         // strip_realize_sidecar_from_lift_term.
+        //
+        // NOTE: the signature TYPES (param_types/return_type/original_param_types)
+        // are deliberately NOT cleared here. After the layer-1 sidecar migration
+        // the rust + python lifters both emit the bare types empty on
+        // bind-lift-entry, so NamedTerm.param_types is already [] for the
+        // federated `add` algebra — clearing it would be a CID no-op there. But
+        // the LEGACY bind-result lower path (named_term_document_from_bind_payload
+        // -> op-tree reconstruction, used by lower_plugin for Term inputs) reads
+        // the types back from this wire form to build the realize request; for a
+        // function that DID carry source types, clearing them here would degrade
+        // its emitted signature (i64 -> int int-inference fallback). Keeping them
+        // preserves that path's fidelity without affecting seam-4 byte-identity.
         term.visibility.clear();
         term.generic_params.clear();
         term.doc_lines.clear();
-        term.param_types.clear();
-        term.return_type.clear();
-        term.original_param_types.clear();
     }
     wire
 }

--- a/implementations/rust/libprovekit/tests/bind_kit.rs
+++ b/implementations/rust/libprovekit/tests/bind_kit.rs
@@ -154,6 +154,16 @@ fn bind_kit_transform_emits_bind_result_op_tree() {
             term.fn_name_sugar = Some(term.function.clone());
         }
         term.function.clear();
+        // #1075 federation: the wire op-tree (arg[1] of concept:bind-result, the
+        // cross-language CID) clears source-language realize-only DISPLAY metadata
+        // so typed-Rust and untyped-Python federate byte-identically. The full
+        // NamedTermDocument (with these fields) lives on artifacts[0]; the wire
+        // reconstruction recovered here legitimately lacks them. Signature types
+        // are preserved on the wire (legacy lower path reads them back). Mirror
+        // bind_payload_wire_named_term_document.
+        term.visibility.clear();
+        term.generic_params.clear();
+        term.doc_lines.clear();
     }
 
     let claim = BindKit::default()

--- a/implementations/rust/provekit-cli/src/cmd_lower.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lower.rs
@@ -748,11 +748,19 @@ fn emit_java_module_preamble(
             .and_then(Json::as_array)
             .map(|a| a.iter().filter_map(Json::as_str).collect())
             .unwrap_or_default();
-        let param_types: Vec<&str> = entry.get("param_types")
+        // #1075/A9: signature types ride the CID-invisible realize sidecar on
+        // the bind-lift-entry (so federation byte-identity holds); the Java
+        // boundary emitter reads them from there. Fall back to the bare keys
+        // for any older/other entry shape that still emits them inline.
+        let param_types: Vec<&str> = entry.get("realize_param_types")
+            .or_else(|| entry.get("param_types"))
             .and_then(Json::as_array)
             .map(|a| a.iter().filter_map(Json::as_str).collect())
             .unwrap_or_default();
-        let return_type = entry.get("return_type").and_then(Json::as_str).unwrap_or("()");
+        let return_type = entry.get("realize_return_type")
+            .or_else(|| entry.get("return_type"))
+            .and_then(Json::as_str)
+            .unwrap_or("()");
         let java_return = map_rust_type_to_java(return_type);
         let java_params: Vec<String> = param_names.iter().zip(param_types.iter())
             .map(|(n, t)| format!("{} {}", map_rust_type_to_java(t), n))

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -402,12 +402,23 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
                 .unwrap_or_default();
 
             let doc_lines = sugar_doc_lines(item_fn);
+            // #1075/A9 federation invariant: the bind-lift-entry is a
+            // CID-bearing surface (it is embedded verbatim as arg[0] of the
+            // federated `concept:bind-result` payload and feeds NamedTerm via
+            // `bind_term_document`). Declared source signature types MUST NOT
+            // ride here, or typed-Rust and untyped-Python bind to DIFFERENT
+            // CIDs and seam-4 federation byte-identity breaks (regression
+            // 48b343a43). The Java boundary emitter genuinely needs these
+            // types to realize the interface signature, so they travel on the
+            // CID-INVISIBLE realize sidecar (`realize_*`, stripped by
+            // `strip_realize_sidecar_from_lift_term` before hashing) — the
+            // same channel #1448 already uses for the sugar/realizer path.
             let mut entry = json!({
                 "kind": "bind-lift-entry",
                 "param_names": param_names,
-                "param_types": param_types,
-                "original_param_types": original_param_types,
-                "return_type": return_type,
+                "realize_param_types": param_types,
+                "realize_original_param_types": original_param_types,
+                "realize_return_type": return_type,
                 "generic_params": generic_params,
                 "visibility": visibility,
                 "term_shape": cvalue_to_json(&term_shape),
@@ -3923,8 +3934,36 @@ pub fn add(left: i64, right: i64) -> i64 {
         let entry = entries.first().expect("add entry");
         assert_no_forbidden_bind_lift_entry_fields(entry);
         assert_eq!(entry["param_names"], json!(["left", "right"]));
-        assert!(entry.get("param_types").is_none());
-        assert!(entry.get("return_type").is_none());
+        // Federation invariant (#1075/A9): the bind-lift-entry is CID-bearing
+        // (embedded as arg[0] of the federated concept:bind-result payload and
+        // feeding NamedTerm), so declared signature types must NOT appear on it
+        // under the bare keys — typed-Rust would otherwise bind to a different
+        // CID than untyped-Python and seam-4 byte-identity would break.
+        assert!(
+            entry.get("param_types").is_none(),
+            "bare param_types must not ride the CID-bearing bind-lift-entry"
+        );
+        assert!(
+            entry.get("return_type").is_none(),
+            "bare return_type must not ride the CID-bearing bind-lift-entry"
+        );
+        assert!(
+            entry.get("original_param_types").is_none(),
+            "bare original_param_types must not ride the CID-bearing bind-lift-entry"
+        );
+        // The types are not LOST: they travel on the CID-invisible realize
+        // sidecar (stripped before hashing by strip_realize_sidecar_from_lift_term)
+        // so the Java boundary emitter can still realize the interface signature.
+        assert_eq!(
+            entry["realize_param_types"],
+            json!(["i64", "i64"]),
+            "signature types must be carried on the CID-invisible realize sidecar"
+        );
+        assert_eq!(
+            entry["realize_return_type"],
+            json!("i64"),
+            "return type must be carried on the CID-invisible realize sidecar"
+        );
         assert!(
             entry["witnesses"]
                 .as_array()

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -4485,21 +4485,56 @@ pub fn add(x: i64, y: i64) -> i64 {
 "#,
         );
 
-        // Substrate-canonical shape: free identifier args (x, y) lift as
-        // kind:"symbol" leaves carrying the name. (Previously emitted as
-        // non_operation_shape {} + supplemented by operand_bindings — the
-        // 2026-05-21 substrate-honest pass moved names into the shape so
-        // deeper consumers don't need position-threading to resolve them.)
+        // Substrate-canonical shape (#1075 federation): operand NAMES are
+        // sugar, so scoped param/local references lift as EMPTY structural
+        // leaves {}. The names travel on the CID-invisible operand_bindings
+        // sidecar (verified separately below), making the rust term_shape
+        // byte-identical to the python lifter's empty-leaf form so the same
+        // algebra federates cross-language. f(x)=x+y and f(a)=a+b share this
+        // shape. (Earlier the names rode the leaf, which made the shape
+        // name-dependent and broke seam-4 byte-identity.)
         assert_eq!(
             shape,
             json!({
                 "args": [
-                    {"kind": "symbol", "text": "x"},
-                    {"kind": "symbol", "text": "y"},
+                    {},
+                    {},
                 ],
                 "concept_name": "concept:add",
                 "op_cid": "blake3-512:95fc70e63a5550fd2e25142f13932919c59d085654ab387789c798886b0111c61d28fe533fc98b50df70eea9428a9af8aa75372c8b1c1deb3acc1a4094790468"
             })
+        );
+
+        // Names-are-sugar: the operand symbols are recovered from the
+        // operand_bindings sidecar (CID-invisible), not the leaves.
+        let out = bind_lift(&{
+            let root = temp_workspace("term_shape_add_bindings");
+            let src_dir = root.join("src");
+            fs::create_dir_all(&src_dir).expect("create src dir");
+            fs::write(
+                src_dir.join("lib.rs"),
+                "pub fn add(x: i64, y: i64) -> i64 {\n    x + y\n}\n",
+            )
+            .expect("write source");
+            let params = json!({
+                "workspace_root": root.to_string_lossy(),
+                "source_paths": ["."]
+            });
+            // leak the temp dir path via params; cleaned by OS temp reaper
+            params
+        })
+        .expect("bind lift should succeed");
+        let entry = out["ir"].as_array().expect("ir").first().expect("entry");
+        let bindings = entry["operand_bindings"]
+            .as_array()
+            .expect("operand_bindings array");
+        let symbols: Vec<&str> = bindings
+            .iter()
+            .filter_map(|b| b["symbol"].as_str())
+            .collect();
+        assert!(
+            symbols.contains(&"x") && symbols.contains(&"y"),
+            "operand symbols x,y must live on the operand_bindings sidecar, not the leaves: {bindings:#?}"
         );
     }
 
@@ -4797,37 +4832,39 @@ pub fn add_via_let(a: i64, b: i64) -> i64 {
 }
 "#,
         );
-        let seq_cid = concept_op_cid("concept:seq").expect("seq cid");
         let assign_cid = concept_op_cid("concept:assign").expect("assign cid");
         let add_cid = concept_op_cid("concept:add").expect("add cid");
 
-        // Substrate-canonical shape after 2026-05-21:
-        // - body is concept:seq containing [assign, tail-expression]
-        // - assign target is kind:symbol "q" (was {} relying on operand_bindings)
-        // - free identifier references (a, b, q) are kind:symbol leaves
+        // Substrate-canonical shape (#1075 federation):
+        // - assign TARGET is kind:symbol "q" — a let-binding NAME is structural
+        //   data (it declares a new name), so it stays in the shape.
+        // - SCOPED operand references (a, b) are EMPTY leaves {} — operand NAMES
+        //   are sugar, recovered from operand_bindings so the shape is
+        //   name-independent and federates cross-language.
+        // - The tail expression `q` is a bare scoped-variable return: it is now
+        //   an empty {} non-operation leaf and is dropped by
+        //   collapse_operation_shapes, so the body collapses from
+        //   seq([assign, q]) to just the assign. This is a CONSEQUENCE of
+        //   names-are-sugar: `{ let q = a+b; q }` and `{ let z = a+b; z }` carry
+        //   the same computation and now share a term_shape. The value-return
+        //   flows via operand_bindings; discharge (#1441 5/5) and the rust/go
+        //   production bridges round-trip unaffected.
         assert_eq!(
             shape,
             json!({
                 "args": [
+                    {"kind": "symbol", "text": "q"},
                     {
                         "args": [
-                            {"kind": "symbol", "text": "q"},
-                            {
-                                "args": [
-                                    {"kind": "symbol", "text": "a"},
-                                    {"kind": "symbol", "text": "b"},
-                                ],
-                                "concept_name": "concept:add",
-                                "op_cid": add_cid
-                            }
+                            {},
+                            {},
                         ],
-                        "concept_name": "concept:assign",
-                        "op_cid": assign_cid
-                    },
-                    {"kind": "symbol", "text": "q"}
+                        "concept_name": "concept:add",
+                        "op_cid": add_cid
+                    }
                 ],
-                "concept_name": "concept:seq",
-                "op_cid": seq_cid
+                "concept_name": "concept:assign",
+                "op_cid": assign_cid
             })
         );
         assert_no_forbidden_term_shape_fields(&shape);
@@ -4857,18 +4894,21 @@ pub fn f(a: i64, b: i64) -> i64 {
             json!("concept:add"),
             "top-level tail expression remains an add shape"
         );
-        // After 2026-05-21: let+tail-expression body is concept:seq
-        // ([assign, tail-symbol]) — both substrate-meaningful nodes.
-        // The assignment boundary is preserved INSIDE the seq, not at top.
+        // #1075 federation: `{ let q = a+b; q }` lifts as concept:assign(q, add).
+        // The trailing bare scoped-variable return `q` is now an empty {}
+        // non-operation leaf (operand NAMES are sugar), so collapse_operation_shapes
+        // drops it and the seq([assign, q]) collapses to the assign alone. The
+        // assignment boundary is still structurally distinct from a top-level
+        // operator (assign != add), which is what this test guards.
         assert_eq!(
             let_rhs["concept_name"],
-            json!("concept:seq"),
-            "let+tail body lifts as concept:seq with the assign as a child"
+            json!("concept:assign"),
+            "let+bare-tail-return body collapses to the concept:assign for the let-binding"
         );
         assert_eq!(
-            let_rhs["args"][0]["concept_name"],
-            json!("concept:assign"),
-            "seq's first child is the concept:assign for the let-binding"
+            let_rhs["args"][0],
+            json!({"kind": "symbol", "text": "q"}),
+            "assign's first child is the let-binding NAME leaf (structural, not sugar)"
         );
         assert_no_forbidden_term_shape_fields(&top_level);
         assert_no_forbidden_term_shape_fields(&let_rhs);

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -3343,10 +3343,27 @@ fn shape_of_expr(expr: &syn::Expr, ctx: &ShapeContext) -> Arc<CValue> {
         syn::Expr::Path(path) => {
             use quote::ToTokens;
             let text = path.to_token_stream().to_string().replace(' ', "");
-            CValue::object([
-                ("kind", CValue::string("symbol")),
-                ("text", CValue::string(text)),
-            ])
+            // #1075 federation: operand NAMES are sugar — the term_shape is
+            // structural identity, so `f(x)=x*2` and `f(y)=y*2` MUST share a
+            // term_shape. A scoped param/local reference therefore emits an
+            // EMPTY structural leaf `{}`; its symbol travels on the CID-invisible
+            // operand_bindings sidecar (same position, see bindings_of_expr's
+            // matching scoped_names check). This makes the rust term_shape
+            // byte-identical to the python lifter's empty-leaf + operand_bindings
+            // form (seam-4 federation). Discharge is unaffected: the realize
+            // binary's term_shape_leaf_expression checks operand_bindings.get(
+            // position) BEFORE kind=symbol, so it never read these leaves for
+            // scoped names. FREE identifiers (None, Some, Vec::new, enum paths)
+            // are NOT operands — they keep their symbol leaf so deeper consumers
+            // can lower them without operand_bindings position threading.
+            if ctx.scoped_names.contains(&text) {
+                non_operation_shape()
+            } else {
+                CValue::object([
+                    ("kind", CValue::string("symbol")),
+                    ("text", CValue::string(text)),
+                ])
+            }
         }
         _ => non_operation_shape(),
     }


### PR DESCRIPTION
## Summary

Restores the **federation byte-identity invariant** (`seam4_federation_rust_vs_python_lift_bind_byte_identity`), which has been RED on main since `48b343a43` (2026-05-22) — rust and python lifts of the same construct produced *different* bind CIDs, so contracts didn't actually federate across languages. This closes both layers of the divergence. seam4 is now GREEN: rust bind CID == python bind CID == `a212…`, byte-identical.

This is the "social" half of the substrate: code from different languages must arrive at the *same* CID for the same contract, or they don't recognize each other at the hub. That recognition was broken; this repairs it.

### Layer 1 — type-leak (`74f80c421`)
`48b343a43` put boundary signature types (`param_types`/`return_type`/`original_param_types`) as **bare keys on the CID-bearing `bind-lift-entry`** (to feed the Java boundary emitter), leaking them into the federated bind CID. Rust emits `["i64","i64"]`, untyped python emits none → divergent CIDs. Fix: migrate them to the CID-invisible `realize_*` sidecar (the channel `strip_realize_sidecar_from_lift_term` already strips before hashing — the same pattern #1448 uses). Java boundary consumer (`cmd_lower.rs` `emit_java_wrapper`) updated to read the sidecar. Java keeps its types; they just no longer touch federation.

### Layer 2 — term_shape alignment (`860472991`, `d49b18913`)
A second, deeper divergence: the rust lifter embedded operand names in leaves (`{"kind":"symbol","text":"x"}`) while python emitted empty `{}` leaves + an `operand_bindings` sidecar. **Operand names are sugar** — the term_shape is structural identity, so `f(x)=x*2` and `f(y)=y*2` must share a shape. Verified (not assumed) that python's empty-leaf form is canonical. Fix: a *scoped* param/local reference (`Expr::Path` in `shape_of_expr`) now emits an empty leaf (name travels on `operand_bindings`); *free* identifiers (None/Some/enum paths) keep their symbol leaf. Discharge is unaffected because the realize path already reads `operand_bindings` before `kind=symbol`.

### Discharge intact (the delicate part)
#1441 body-discharge **5/5** green throughout — `double(3)==6` still discharges + mints its witness after the term_shape change; operand info is read from the CID-invisible sidecar.

### Corrected mid-flight (documented honesty)
An initial wire-clear was over-broad and cleared signature *types* from the legacy bind-result lower path, regressing `i64`→`int` inference (`bind_result_claim_lower_uses_named_term_realize_request`). Narrowed to display-only metadata (visibility/generic_params/doc_lines) — seam4 green AND legacy signature fidelity preserved.

### Benign documented side-effect
`{ let q = a+b; q }` now lifts as `concept:assign(q, add)` rather than `seq([assign, q-leaf])` (the trailing bare scoped-var return is an empty leaf, dropped by the pre-existing `collapse_operation_shapes`). A direct consequence of names-are-sugar (`{let q=…}` and `{let z=…}` now share a term_shape). Discharge 5/5 and both production bridges round-trip unaffected; the two term_shape tests that pinned the old shape were updated with names-are-sugar comments + a positive assertion that operand names live on the sidecar.

## Test plan
- [x] **trinity census slow-lane 9/9 — seam4 federation GREEN (rust CID == python CID == `a212`)**
- [x] #1441 body-discharge 5/5; #1443 rust + #1445 Go production bridges round-trip
- [x] `bind_lift_erases_signature_types` passes; legacy bind-result lower path fidelity preserved
- [x] libprovekit (23 suites), walk_rpc (49), provekit-cli lib (36); `cargo build --workspace` green
- [x] No pinned CID literals on the broken rust forms; shape-pinned tests updated to canonical

Ref: #1436. Root regression: `48b343a43`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)