### PR TITLE
Migrate path loads body-templates from the shim .proof via RPC (shared enabler)

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_bind_migrate.rs
@@ -1050,8 +1050,22 @@ fn realize_probe_via_path(
     repo_root: &Path,
     language: &str,
     tag: &str,
-    spec: JsonValue,
+    mut spec: JsonValue,
 ) -> Result<libprovekit::core::RealizedSource, String> {
+    // `.proof`-load-via-RPC for the MIGRATE path: this is the single choke
+    // point every migrate realize dispatch funnels through (the binding probe,
+    // per-callsite body realization, and the MigrateKit's `realize_target`).
+    // Attaching the target shim's signed binding-entry templates here mirrors
+    // what `cmd_materialize` does for the materialize path, so a migrate into a
+    // target library no longer depends on that library's on-disk
+    // `<lang>-canonical-bodies-<tag>.json`: the @ProveKitSugar shim `.proof` is
+    // the authority, carried over RPC. Absent a `sugar_proof` pointer (or for a
+    // kit not yet preferring RPC), this is a no-op and the disk cache remains
+    // the fallback. `repo_root` is the project root; `(language, tag)` are the
+    // target lang/library tag.
+    crate::cmd_materialize::attach_body_templates_from_shim_proof(
+        &mut spec, repo_root, language, tag,
+    );
     let mut inputs = HashMapInputCatalog::default();
     let input_cid = inputs.insert(Input::Spec(spec));
     let kit_name = format!("lower-{language}");
@@ -3894,6 +3908,72 @@ mod tests {
             .and_then(|p| p.parent())
             .map(|p| p.to_path_buf())
             .expect("provekit-cli has rust/implementations/repo ancestry")
+    }
+
+    /// #1460 enabler plumbing: prove the MIGRATE realize path now attaches the
+    /// target shim's signed `.proof` body-templates to its realize spec via the
+    /// shared `attach_body_templates_from_shim_proof` helper factored out of the
+    /// materialize path. Verified against a real on-main java shim
+    /// (`examples/provekit-shim-java-sqlite-jdbc/*.proof`, library_tag
+    /// `sqlite-jdbc`), whose realize manifest declares `sugar_proof` and whose
+    /// canonical-bodies JSON was deleted in #1459 — so the templates can ONLY
+    /// come from the `.proof`. This is the choke point every migrate realize
+    /// dispatch (`probe_realize_binding`, `realize_callsite_bodies` via
+    /// `realize_request_for_callsite`, `MigrateKit::realize_target`) funnels
+    /// through, so wiring it here covers all of them.
+    #[test]
+    fn migrate_realize_spec_carries_shim_proof_body_templates() {
+        let repo = harness_repo_root();
+
+        // (1) The factored helper extracts library-sugar-binding-entry templates
+        // from the target shim `.proof` for (java, sqlite-jdbc).
+        let templates = crate::cmd_materialize::body_templates_from_shim_proof(
+            &repo,
+            "java",
+            "sqlite-jdbc",
+        );
+        assert!(
+            !templates.is_empty(),
+            "factored helper must extract body-templates from the on-main \
+             java sqlite-jdbc shim .proof (manifest declares sugar_proof; \
+             canonical-bodies JSON was deleted in #1459)"
+        );
+
+        // (2) The shared attach point inserts those templates into a realize
+        // spec under `bodyTemplates` — exactly what the migrate choke point
+        // `realize_probe_via_path` now does before RPC dispatch. Build a spec
+        // the same shape the migrate path builds (probe shape).
+        let mut spec = json!({
+            "kind": "RealizeRequest",
+            "function": "__provekit_migrate_probe",
+            "params": ["sql", "args"],
+            "paramTypes": ["string", "unknown[]"],
+            "returnType": "unknown[]",
+            "conceptName": "concept:sql-query",
+        });
+        crate::cmd_materialize::attach_body_templates_from_shim_proof(
+            &mut spec, &repo, "java", "sqlite-jdbc",
+        );
+        let attached = spec
+            .get("bodyTemplates")
+            .and_then(|v| v.as_array())
+            .expect("migrate realize spec must carry bodyTemplates after attach");
+        assert_eq!(
+            attached.len(),
+            templates.len(),
+            "attached bodyTemplates count must match the helper's extraction"
+        );
+
+        // (3) Negative control: empty library_tag is a no-op (back-compat — the
+        // kit then falls back to its on-disk canonical-bodies cache).
+        let mut bare = json!({ "kind": "RealizeRequest" });
+        crate::cmd_materialize::attach_body_templates_from_shim_proof(
+            &mut bare, &repo, "java", "",
+        );
+        assert!(
+            bare.get("bodyTemplates").is_none(),
+            "empty library_tag must not attach bodyTemplates (disk-cache fallback)"
+        );
     }
 
     fn harness_callsites() -> Vec<CallsiteProbe> {

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -1844,19 +1844,12 @@ impl SiteTransformKit for MaterializeKit<'_> {
         // @ProveKitSugar shim source is the authority. Absent pointer → empty
         // → kit uses its disk cache (back-compat for not-yet-migrated kits).
         if !carrier_library.is_empty() {
-            let templates = body_templates_from_shim_proof(
+            attach_body_templates_from_shim_proof(
+                &mut spec,
                 self.project_root,
                 &self.target_lang,
                 carrier_library,
             );
-            if !templates.is_empty() {
-                if let Some(obj) = spec.as_object_mut() {
-                    obj.insert(
-                        "bodyTemplates".to_string(),
-                        Json::Array(templates),
-                    );
-                }
-            }
         }
         let realized = self.realize_via_path(spec)?;
         // String-formatted refusal sentence rather than a structured
@@ -2032,7 +2025,39 @@ fn augment_spec_with_shim_term_shape(spec: &mut Json, project_root: &Path) {
 /// projector's shared `binding_entry_to_template_entry`. Returns an empty Vec
 /// when no pointer is declared, the file is unreadable, or no entries match —
 /// the realize kit then uses its disk cache (back-compat).
-fn body_templates_from_shim_proof(
+/// Attach the target shim's `.proof`-derived emission templates to a realize
+/// `spec` under the `bodyTemplates` key, in place. Shared by the materialize
+/// path (above) and the `bind`/MIGRATE path (`cmd_bind_migrate`) so both wire
+/// the @ProveKitSugar shim source as the body authority over RPC, with the
+/// on-disk `<lang>-canonical-bodies-<tag>.json` left as a back-compat fallback.
+///
+/// Behavior mirrors the materialize call site verbatim:
+/// - no-op when `library_tag` is empty (no library to resolve a shim for);
+/// - no-op when `body_templates_from_shim_proof` returns empty (no `sugar_proof`
+///   pointer, unreadable `.proof`, or no matching entries → kit uses disk cache);
+/// - no-op when `spec` is not a JSON object (all call sites build via `json!`,
+///   but the guard keeps the contract explicit);
+/// - otherwise inserts `bodyTemplates: [..]` (overwriting any prior key so the
+///   shim `.proof` is the single authority).
+pub(crate) fn attach_body_templates_from_shim_proof(
+    spec: &mut Json,
+    project_root: &Path,
+    target_lang: &str,
+    library_tag: &str,
+) {
+    if library_tag.is_empty() {
+        return;
+    }
+    let templates = body_templates_from_shim_proof(project_root, target_lang, library_tag);
+    if templates.is_empty() {
+        return;
+    }
+    if let Some(obj) = spec.as_object_mut() {
+        obj.insert("bodyTemplates".to_string(), Json::Array(templates));
+    }
+}
+
+pub(crate) fn body_templates_from_shim_proof(
     project_root: &Path,
     target_lang: &str,
     library_tag: &str,


### PR DESCRIPTION
## Summary

The shared enabler for killing every **migrate-consumed** shim's canonical-bodies JSON. PR #1458 wired `.proof`-load into `materialize`; this does the same for the `bind`/migrate path, which previously dispatched realize without the shim templates (so a migrate into a target library still depended on that library's on-disk JSON).

- Factored the `.proof`-load attach logic out of `cmd_materialize.rs` into shared `pub(crate)` helpers: `body_templates_from_shim_proof` (exposed) + new `attach_body_templates_from_shim_proof(spec, project_root, target_lang, library_tag)`. `cmd_materialize` calls the new helper; behavior unchanged.
- Wired it into `cmd_bind_migrate` at the single choke point `realize_probe_via_path` (before RPC dispatch). One attach point covers every migrate realize site: `probe_realize_binding`, `realize_callsite_bodies` (via `realize_request_for_callsite`), `MigrateKit::realize_target`, the d5 harness.

## Verification
- Unit test `migrate_realize_spec_carries_shim_proof_body_templates` runs against the **on-main java `sqlite-jdbc` shim `.proof`** — whose canonical-bodies JSON was deleted in #1459, so a non-empty template result can *only* come from the `.proof`. Asserts: helper extracts non-empty templates for `(java, sqlite-jdbc)`; the attach point inserts them under `bodyTemplates`; empty `library_tag` is a no-op (disk fallback preserved).
- No regression: `cmd_materialize_integration` 16/16, `cmd_materialize_proof_load` 6/6, `cross_platform_point_query_receipt_test` 6/6, all 154 provekit-cli bin unit tests (incl. both d5 migrate-realize harness tests), `cargo build --workspace` clean.
- **Back-compat verified, not assumed**: the d5 harness now gets `bodyTemplates` attached for python-sqlite3 and its output is unchanged — empirically confirming the python kit on main ignores them and falls back to its disk cache (until the python kit's prefer-RPC lands).

No JSON deleted (enabler only — per-kit deletions follow, rebased onto this).

Ref: #1436, #1458. Goal: no shim authored in JSON; `.proof` the only substrate disk artifact; all exchange RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)