### PR TITLE
Un-rot conformance gate: non-fail-fast harness, rip out legacy realize fallback, delete ghost tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,9 +620,14 @@ bootstrap-self-contracts:
 # absent and `lower_java_carrier_registration_points_at_required_fixture_set`
 # panics with `Unable to access jarfile provekit-realize-java.jar`.
 test-rust: build-java
-	cargo test --release --manifest-path implementations/rust/Cargo.toml
-	cargo test --release --manifest-path tools/recompute-spec-cids/Cargo.toml
-	cargo test --release --manifest-path tools/foundation-keygen/Cargo.toml
+	@failed=""; \
+	cargo test --no-fail-fast --release --manifest-path implementations/rust/Cargo.toml \
+	  || failed="$$failed implementations/rust"; \
+	cargo test --no-fail-fast --release --manifest-path tools/recompute-spec-cids/Cargo.toml \
+	  || failed="$$failed tools/recompute-spec-cids"; \
+	cargo test --no-fail-fast --release --manifest-path tools/foundation-keygen/Cargo.toml \
+	  || failed="$$failed tools/foundation-keygen"; \
+	if [ -n "$$failed" ]; then echo "test-rust FAIL:$$failed"; exit 1; fi
 
 .PHONY: bug-zoo
 bug-zoo:
@@ -644,10 +649,16 @@ menagerie-zig-language-signature:
 
 .PHONY: test-go
 test-go:
-	cd implementations/go/provekit-ir-symbolic && go test ./...
-	cd implementations/go/provekit-self-contracts && go test ./...
-	cd implementations/go/provekit-lift-go-tests && go test ./...
-	cd implementations/go/provekit-lift-go && go test ./...
+	@failed=""; \
+	(cd implementations/go/provekit-ir-symbolic && go test ./...) \
+	  || failed="$$failed provekit-ir-symbolic"; \
+	(cd implementations/go/provekit-self-contracts && go test ./...) \
+	  || failed="$$failed provekit-self-contracts"; \
+	(cd implementations/go/provekit-lift-go-tests && go test ./...) \
+	  || failed="$$failed provekit-lift-go-tests"; \
+	(cd implementations/go/provekit-lift-go && go test ./...) \
+	  || failed="$$failed provekit-lift-go"; \
+	if [ -n "$$failed" ]; then echo "test-go FAIL:$$failed"; exit 1; fi
 
 .PHONY: test-cpp-source-lift
 test-cpp-source-lift:
@@ -669,29 +680,33 @@ test-csharp: build-csharp
 
 .PHONY: test-c
 test-c: build-c
-	$(MAKE) -C implementations/c/provekit-ir test
-	$(MAKE) -C implementations/c/provekit-lift test
-	$(MAKE) -C implementations/c/provekit-lift-core test
-	$(MAKE) -C implementations/c/provekit-lift-c-sparse test
-	$(MAKE) -C implementations/c/provekit-lift-c-kernel-doc test
-	$(MAKE) -C implementations/c/provekit-lift-c-assertions test
-	$(MAKE) -C implementations/c/provekit-realize-c-core test
-	$(MAKE) -C implementations/c/provekit-lift-composition test
-	$(MAKE) -C implementations/c/provekit-lsp-c test
-	$(MAKE) -C implementations/c/provekit-self-contracts test
+	@failed=""; \
+	$(MAKE) -C implementations/c/provekit-ir test || failed="$$failed provekit-ir"; \
+	$(MAKE) -C implementations/c/provekit-lift test || failed="$$failed provekit-lift"; \
+	$(MAKE) -C implementations/c/provekit-lift-core test || failed="$$failed provekit-lift-core"; \
+	$(MAKE) -C implementations/c/provekit-lift-c-sparse test || failed="$$failed provekit-lift-c-sparse"; \
+	$(MAKE) -C implementations/c/provekit-lift-c-kernel-doc test || failed="$$failed provekit-lift-c-kernel-doc"; \
+	$(MAKE) -C implementations/c/provekit-lift-c-assertions test || failed="$$failed provekit-lift-c-assertions"; \
+	$(MAKE) -C implementations/c/provekit-realize-c-core test || failed="$$failed provekit-realize-c-core"; \
+	$(MAKE) -C implementations/c/provekit-lift-composition test || failed="$$failed provekit-lift-composition"; \
+	$(MAKE) -C implementations/c/provekit-lsp-c test || failed="$$failed provekit-lsp-c"; \
+	$(MAKE) -C implementations/c/provekit-self-contracts test || failed="$$failed provekit-self-contracts"; \
+	if [ -n "$$failed" ]; then echo "test-c FAIL:$$failed"; exit 1; fi
 
 .PHONY: test-python
 test-python:
-	cd implementations/python/provekit-lift-py-tests && \
+	@failed=""; \
+	(cd implementations/python/provekit-lift-py-tests && \
 		python3 -m venv .venv && \
 		. .venv/bin/activate && \
 		python -m pip install --quiet -e . pytest && \
-		pytest
-	cd implementations/python/provekit-emit-python-pytest && \
+		pytest) || failed="$$failed provekit-lift-py-tests"; \
+	(cd implementations/python/provekit-emit-python-pytest && \
 		python3 -m venv .venv && \
 		. .venv/bin/activate && \
 		python -m pip install --quiet -e . pytest && \
-		pytest
+		pytest) || failed="$$failed provekit-emit-python-pytest"; \
+	if [ -n "$$failed" ]; then echo "test-python FAIL:$$failed"; exit 1; fi
 
 .PHONY: test-ruby
 test-ruby: build-ruby ruby-language-signature
@@ -703,8 +718,12 @@ test-php:
 
 .PHONY: test-java
 test-java: build-java
-	mvn test -q -f implementations/java/provekit-lift-java-core/pom.xml
-	mvn test -q -f implementations/java/pom.xml -pl provekit-realize-java-core -am
+	@failed=""; \
+	mvn test -q -f implementations/java/provekit-lift-java-core/pom.xml \
+	  || failed="$$failed provekit-lift-java-core"; \
+	mvn test -q -f implementations/java/pom.xml -pl provekit-realize-java-core -am \
+	  || failed="$$failed provekit-realize-java-core"; \
+	if [ -n "$$failed" ]; then echo "test-java FAIL:$$failed"; exit 1; fi
 
 .PHONY: test-swift
 test-swift: build-swift
@@ -740,10 +759,23 @@ build-zig:
 
 # NOTE: test-swift is intentionally excluded from test-all: it requires a
 # macOS host with the Swift toolchain. Use `make test-swift` on macOS.
+#
+# test-all is NON-FAIL-FAST: every suite runs regardless of prior failures.
+# Failures are collected and reported as a summary at the end.
 .PHONY: test-all
-test-all: test-rust test-go test-ts test-csharp test-python test-ruby test-php test-java test-c
-	@echo ""
-	@echo "==== test-all: PASS ===="
+test-all:
+	@failed=""; \
+	for s in test-rust test-go test-ts test-csharp test-python test-ruby test-php test-java test-c; do \
+	  echo ""; \
+	  echo "==== $$s ===="; \
+	  $(MAKE) $$s || failed="$$failed $$s"; \
+	done; \
+	echo ""; \
+	if [ -n "$$failed" ]; then \
+	  echo "==== test-all FAIL:$$failed ===="; \
+	  exit 1; \
+	fi; \
+	echo "==== test-all: PASS ===="
 
 # --- CI alias ----------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -619,7 +619,11 @@ bootstrap-self-contracts:
 # provekit-realize-java-core; without `build-java` first, that jar is
 # absent and `lower_java_carrier_registration_points_at_required_fixture_set`
 # panics with `Unable to access jarfile provekit-realize-java.jar`.
-test-rust: build-java
+#
+# build-ts (pnpm install) is also required: the bug-zoo smoke tests call
+# `pnpm exec tsx` from the repo root and fail with ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL
+# if node_modules is absent (fresh worktrees, CI).
+test-rust: build-java build-ts
 	@failed=""; \
 	cargo test --no-fail-fast --release --manifest-path implementations/rust/Cargo.toml \
 	  || failed="$$failed implementations/rust"; \

--- a/implementations/rust/provekit-cli/src/cmd_lower.rs
+++ b/implementations/rust/provekit-cli/src/cmd_lower.rs
@@ -857,13 +857,13 @@ fn resolve_library_for_concept(
     family_library: &[crate::cmd_materialize::FamilyLibraryPair],
 ) -> Option<String> {
     // #1391 follow-on: registry_realize_candidates returns empty when no
-    // sealed dev registry is present. Fall back to legacy_realize_candidates
+    // sealed dev registry is present. Fall back to the live manifest scan
     // so cmd_lower works in development workflows without requiring a sealed
     // registry. This mirrors the dispatch_realize path which also falls
-    // through to legacy candidates when the registry is empty.
+    // through to the live candidates when the registry is empty.
     let mut candidates = crate::kit_dispatch::registry_realize_candidates(project_root, target).ok()?;
     if candidates.is_empty() {
-        candidates = crate::kit_dispatch::legacy_realize_candidates(project_root, target)
+        candidates = crate::kit_dispatch::live_realize_candidates(project_root, target)
             .unwrap_or_default();
     }
     let mut claimers: Vec<String> = Vec::new();

--- a/implementations/rust/provekit-cli/src/cmd_prove.rs
+++ b/implementations/rust/provekit-cli/src/cmd_prove.rs
@@ -789,12 +789,34 @@ fn run_empirically_witnessed_gate(args: &ProveArgs) -> u8 {
 }
 
 fn run_admission_gate(args: &ProveArgs) -> u8 {
-    match verify_artifact_or_policy(args) {
+    run_admission_gate_with(
+        &args.artifact,
+        &args.proof,
+        &args.policy,
+        args.out.json,
+        args.out.quiet,
+    )
+}
+
+/// Shared admission-gate entry point. The supply-chain artifact/policy
+/// verification logic is owned here (it predates the keystone `verify`
+/// verb), but both `prove` (legacy alias) and `verify` (PR-9 / #1405)
+/// surface the same `--artifact`/`--proof`/`--policy` flags. Threading the
+/// three `Option<PathBuf>` values directly (rather than `&ProveArgs`) lets
+/// `cmd_verify` reuse this without coupling to the prover's arg struct.
+pub fn run_admission_gate_with(
+    artifact: &Option<PathBuf>,
+    proof: &Option<PathBuf>,
+    policy: &Option<PathBuf>,
+    json: bool,
+    quiet: bool,
+) -> u8 {
+    match verify_artifact_or_policy(artifact, proof, policy) {
         Ok(report) => {
             let ok = report["ok"].as_bool().unwrap_or(false);
-            if args.out.json {
+            if json {
                 println!("{}", serde_json::to_string_pretty(&report).unwrap());
-            } else if !args.out.quiet {
+            } else if !quiet {
                 let verdict = report["verdict"].as_str().unwrap_or("unknown");
                 println!("verify admission: {verdict}");
                 if let Some(reason) = report.get("reason").and_then(Value::as_str) {
@@ -814,20 +836,21 @@ fn run_admission_gate(args: &ProveArgs) -> u8 {
     }
 }
 
-fn verify_artifact_or_policy(args: &ProveArgs) -> Result<Value, String> {
-    let proof_path = args
-        .proof
+fn verify_artifact_or_policy(
+    artifact: &Option<PathBuf>,
+    proof: &Option<PathBuf>,
+    policy: &Option<PathBuf>,
+) -> Result<Value, String> {
+    let proof_path = proof
         .as_ref()
         .ok_or_else(|| "--proof is required for admission verification".to_string())?;
     let proof = read_json_value(proof_path)?;
 
-    let policy_report = args
-        .policy
+    let policy_report = policy
         .as_ref()
         .map(|policy_path| verify_policy_receipt(&proof, policy_path))
         .transpose()?;
-    let artifact_report = args
-        .artifact
+    let artifact_report = artifact
         .as_ref()
         .map(|artifact_path| verify_artifact_receipt(&proof, artifact_path))
         .transpose()?;

--- a/implementations/rust/provekit-cli/src/cmd_verify.rs
+++ b/implementations/rust/provekit-cli/src/cmd_verify.rs
@@ -137,7 +137,8 @@ fn decode_seed_hex(hex: &str) -> Result<[u8; 32], String> {
 pub struct VerifyArgs {
     /// Kit to verify (rust, go, cpp, ts, java, python, ...). Resolves to
     /// the kit's project root; its `.provekit/` catalog carries the
-    /// lifted contract claims. Conflicts with `--project`.
+    /// lifted contract claims. Conflicts with `--project`. May also be
+    /// an explicit path when the value contains a path separator.
     #[arg(conflicts_with = "project")]
     pub kit: Option<String>,
 
@@ -156,6 +157,22 @@ pub struct VerifyArgs {
     /// `<project>/.provekit/witnesses`.
     #[arg(long = "emit-witnesses")]
     pub emit_witnesses: Option<PathBuf>,
+
+    /// Require that a concept has reached the empirically-witnessed
+    /// promotion tier. When set, the standard solver-dispatch flow is
+    /// bypassed; instead the project's promotion catalog is queried.
+    #[arg(long = "require-empirically-witnessed")]
+    pub require_empirically_witnessed: Option<String>,
+
+    /// Fixture-state CID for tier queries such as
+    /// `--require-empirically-witnessed`.
+    #[arg(long = "require-fixture")]
+    pub require_fixture: Option<String>,
+
+    /// Consensus policy JSON used to evaluate a required empirical
+    /// witness vector (required with `--require-empirically-witnessed`).
+    #[arg(long = "consensus-policy", requires = "require_empirically_witnessed")]
+    pub consensus_policy: Option<PathBuf>,
 
     #[command(flatten)]
     pub out: crate::OutputFlags,
@@ -212,20 +229,39 @@ struct ClaimResult {
 }
 
 pub fn run(args: VerifyArgs) -> u8 {
+    // Early dispatch: --require-empirically-witnessed bypasses the
+    // standard solver-dispatch flow and queries the promotion catalog.
+    if args.require_empirically_witnessed.is_some() {
+        return run_empirically_witnessed_gate(&args);
+    }
+
     // Resolve the project root: a named kit, an explicit --project, or
     // the current directory.
     let project_root: PathBuf = if let Some(kit) = &args.kit {
         match cmd_mint::resolve_kit(kit) {
             Some((path, _surface, _lang)) => path,
             None => {
-                let known: Vec<&str> = cmd_mint::KIT_TABLE.iter().map(|(a, _, _, _)| *a).collect();
-                eprintln!(
-                    "{}: unknown kit `{}`; known kits: {}",
-                    "error".red().bold(),
-                    kit,
-                    known.join(", ")
-                );
-                return EXIT_USER_ERROR;
+                // If the value looks like a path (contains a separator
+                // or is `.`/`..`), treat it as an explicit project root
+                // rather than a kit name.
+                let p = PathBuf::from(kit);
+                if kit.contains(std::path::MAIN_SEPARATOR)
+                    || kit.starts_with('/')
+                    || kit.starts_with('.')
+                    || p.is_absolute()
+                {
+                    p
+                } else {
+                    let known: Vec<&str> =
+                        cmd_mint::KIT_TABLE.iter().map(|(a, _, _, _)| *a).collect();
+                    eprintln!(
+                        "{}: unknown kit `{}`; known kits: {}",
+                        "error".red().bold(),
+                        kit,
+                        known.join(", ")
+                    );
+                    return EXIT_USER_ERROR;
+                }
             }
         }
     } else {
@@ -890,5 +926,125 @@ mod tests {
         assert_eq!(decode_seed_hex(&format!("0x{hex}")).unwrap(), [0xabu8; 32]);
         assert!(decode_seed_hex("dead").is_err());
         assert!(decode_seed_hex(&"zz".repeat(32)).is_err());
+    }
+}
+
+/// Gate: query the promotion catalog to confirm a concept has reached
+/// the empirically-witnessed promotion tier.
+///
+/// This is the `verify`-side counterpart of the same gate that lives on
+/// `prove --require-empirically-witnessed`.  The gate performs no
+/// solver dispatch and mints no witnesses; it is a pure query against
+/// the project's `.provekit/promotions` catalog.
+fn run_empirically_witnessed_gate(args: &VerifyArgs) -> u8 {
+    let concept = match args.require_empirically_witnessed.as_deref() {
+        Some(concept) if !concept.trim().is_empty() => concept,
+        _ => {
+            eprintln!(
+                "{}: --require-empirically-witnessed requires a concept",
+                "error".red().bold()
+            );
+            return EXIT_USER_ERROR;
+        }
+    };
+    let fixture = match args.require_fixture.as_deref() {
+        Some(fixture) if !fixture.trim().is_empty() => fixture,
+        _ => {
+            eprintln!(
+                "{}: --require-fixture is required with --require-empirically-witnessed",
+                "error".red().bold()
+            );
+            return EXIT_USER_ERROR;
+        }
+    };
+
+    // Resolve the project root from --project, a path-like positional,
+    // or the current directory.
+    let project_root: PathBuf = if let Some(p) = &args.project {
+        p.clone()
+    } else if let Some(kit) = &args.kit {
+        // Accept an explicit path passed as the positional argument.
+        let p = PathBuf::from(kit);
+        if p.is_absolute() || kit.contains(std::path::MAIN_SEPARATOR) || kit.starts_with('.') {
+            p
+        } else {
+            // Treat a bare kit name as a project path of last resort;
+            // the caller is responsible for passing a valid directory.
+            PathBuf::from(kit)
+        }
+    } else {
+        PathBuf::from(".")
+    };
+
+    if !project_root.exists() {
+        eprintln!(
+            "{}: project root does not exist: {}",
+            "error".red().bold(),
+            project_root.display()
+        );
+        return EXIT_USER_ERROR;
+    }
+
+    let policy_path = match args.consensus_policy.as_ref() {
+        Some(path) => path,
+        None => {
+            eprintln!(
+                "{}: --consensus-policy is required with --require-empirically-witnessed",
+                "error".red().bold()
+            );
+            return EXIT_USER_ERROR;
+        }
+    };
+    let policy = match crate::promotion_query::load_consensus_policy(policy_path) {
+        Ok(policy) => policy,
+        Err(err) => {
+            eprintln!("{}: {err}", "error".red().bold());
+            return EXIT_USER_ERROR;
+        }
+    };
+
+    match crate::promotion_query::query_consensus_vector_for_policy(
+        &project_root,
+        &[],
+        concept,
+        fixture,
+        &policy,
+    ) {
+        Ok(Some(hit)) => {
+            let report =
+                crate::promotion_query::status_json(concept, fixture, &hit, Some(&policy));
+            let ok = report["ok"].as_bool().unwrap_or(false);
+            if args.out.json {
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            } else if !args.out.quiet {
+                println!(
+                    "verify empirically-witnessed: {}",
+                    if ok { "accepted" } else { "rejected" }
+                );
+                println!("  concept: {concept}");
+                println!("  fixture: {fixture}");
+                println!("  promoted_op: {}", hit.status.key.promoted_op);
+                println!("  decisions: {}", hit.status.decision_cids.len());
+            }
+            if ok {
+                EXIT_OK
+            } else {
+                EXIT_VERIFY_FAIL
+            }
+        }
+        Ok(None) => {
+            let report = crate::promotion_query::missing_json(concept, fixture);
+            if args.out.json {
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            } else if !args.out.quiet {
+                println!("verify empirically-witnessed: rejected");
+                println!("  reason: required promotion was not found");
+            }
+            EXIT_VERIFY_FAIL
+        }
+        Err(err) => {
+            eprintln!("{}: {err}", "error".red().bold());
+            EXIT_USER_ERROR
+        }
     }
 }

--- a/implementations/rust/provekit-cli/src/cmd_verify.rs
+++ b/implementations/rust/provekit-cli/src/cmd_verify.rs
@@ -174,6 +174,21 @@ pub struct VerifyArgs {
     #[arg(long = "consensus-policy", requires = "require_empirically_witnessed")]
     pub consensus_policy: Option<PathBuf>,
 
+    /// Artifact bytes to verify against a package release proof/receipt.
+    /// Selects the supply-chain admission gate (binaryCid match).
+    #[arg(long, requires = "proof")]
+    pub artifact: Option<PathBuf>,
+
+    /// Package release proof/receipt naming the expected binaryCid /
+    /// policyCid. Required for the supply-chain admission gate.
+    #[arg(long)]
+    pub proof: Option<PathBuf>,
+
+    /// Consumer policy proof/receipt used for policy admission checks
+    /// (policyCid match).
+    #[arg(long, requires = "proof")]
+    pub policy: Option<PathBuf>,
+
     #[command(flatten)]
     pub out: crate::OutputFlags,
 }
@@ -233,6 +248,21 @@ pub fn run(args: VerifyArgs) -> u8 {
     // standard solver-dispatch flow and queries the promotion catalog.
     if args.require_empirically_witnessed.is_some() {
         return run_empirically_witnessed_gate(&args);
+    }
+
+    // Early dispatch: the supply-chain admission gate. When any of
+    // --artifact / --proof / --policy is given, verify a package release
+    // receipt (binaryCid / policyCid match) rather than running the
+    // solver-dispatch flow. The logic is owned by cmd_prove (it predates
+    // this verb); we reuse it so both verbs expose one behavior.
+    if args.artifact.is_some() || args.proof.is_some() || args.policy.is_some() {
+        return crate::cmd_prove::run_admission_gate_with(
+            &args.artifact,
+            &args.proof,
+            &args.policy,
+            args.out.json,
+            args.out.quiet,
+        );
     }
 
     // Resolve the project root: a named kit, an explicit --project, or

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -1308,7 +1308,7 @@ fn resolve_realize_command(
     }
 
     record_fallback_diagnostic("realize", target_lang);
-    let candidates = legacy_realize_candidates(workspace_root, target_lang)?;
+    let candidates = live_realize_candidates(workspace_root, target_lang)?;
     if let Some(candidate) = candidates
         .iter()
         .find(|candidate| candidate.tag == requested)
@@ -1337,7 +1337,6 @@ fn resolve_realize_command(
         }
     }
 
-    let env_var = format!("PROVEKIT_REALIZE_{}_BIN", target_lang.to_uppercase());
     let registered = if candidates.is_empty() {
         "none".to_string()
     } else {
@@ -1352,9 +1351,7 @@ fn resolve_realize_command(
         language: target_lang.to_string(),
         detail: format!(
             "no realize plugin for language `{target_lang}` and library_tag `{requested}`. \
-             looked in .provekit/realize/*/manifest.toml, env {env_var}, built-in binaries \
-             under implementations/{target_lang}/, and `provekit-realize-{target_lang}` on \
-             PATH. registered: {registered}"
+             looked in .provekit/realize/*/manifest.toml. registered: {registered}"
         ),
     })
 }
@@ -1373,66 +1370,19 @@ pub(crate) struct RealizeCandidate {
     pub(crate) library_version: Option<String>,
 }
 
-pub(crate) fn legacy_realize_candidates(
+/// Live (unsealed) realize candidates: the `.provekit/realize/*/manifest.toml`
+/// scan used when the sealed plugin registry is absent (dev/test). The
+/// pre-registry env-var / built-in-binary / PATH discovery was removed — every
+/// realize kit ships a manifest, so the manifest is the only realize source.
+pub(crate) fn live_realize_candidates(
     workspace_root: &Path,
     target_lang: &str,
 ) -> Result<Vec<RealizeCandidate>, KitUnavailable> {
-    let mut candidates =
-        project_realize_candidates(workspace_root, target_lang).map_err(|e| KitUnavailable {
-            kit_kind: "realize",
-            language: target_lang.to_string(),
-            detail: e,
-        })?;
-
-    // Env-var, built-in, and PATH fallbacks have no manifest tag, so they occupy
-    // the back-compatible default slot.
-    let env_var = format!("PROVEKIT_REALIZE_{}_BIN", target_lang.to_uppercase());
-    if let Ok(bin) = std::env::var(&env_var) {
-        candidates.push(RealizeCandidate {
-            tag: DEFAULT_LIBRARY_TAG.to_string(),
-            command: ResolvedCommand {
-                argv: vec![bin, "--rpc".to_string()],
-                working_dir: Some(workspace_root.to_path_buf()),
-            },
-            source: env_var,
-            family: None,
-            library_version: None,
-        });
-    }
-
-    // Substrate-convention built-in binaries. Same shape as lift:
-    // the dispatcher consults the FILESYSTEM, not a hard-coded list.
-    for candidate in builtin_realize_candidates(workspace_root, target_lang) {
-        if candidate.path.exists() {
-            candidates.push(RealizeCandidate {
-                tag: DEFAULT_LIBRARY_TAG.to_string(),
-                command: ResolvedCommand {
-                    argv: candidate.argv,
-                    working_dir: Some(workspace_root.to_path_buf()),
-                },
-                source: candidate.path.display().to_string(),
-                family: None,
-                library_version: None,
-            });
-        }
-    }
-
-    // PATH probe.
-    let bin = format!("provekit-realize-{target_lang}");
-    if which_on_path(&bin).is_some() {
-        candidates.push(RealizeCandidate {
-            tag: DEFAULT_LIBRARY_TAG.to_string(),
-            command: ResolvedCommand {
-                argv: vec![bin.clone(), "--rpc".to_string()],
-                working_dir: Some(workspace_root.to_path_buf()),
-            },
-            source: format!("PATH:{bin}"),
-            family: None,
-            library_version: None,
-        });
-    }
-
-    Ok(candidates)
+    project_realize_candidates(workspace_root, target_lang).map_err(|e| KitUnavailable {
+        kit_kind: "realize",
+        language: target_lang.to_string(),
+        detail: e,
+    })
 }
 
 fn project_realize_candidates(
@@ -1498,67 +1448,6 @@ fn realize_surface_matches_target(surface: &str, target_lang: &str) -> bool {
             .strip_prefix(target_lang)
             .and_then(|suffix| suffix.strip_prefix('-'))
             .is_some()
-}
-
-struct RealizeBuiltin {
-    path: PathBuf,
-    argv: Vec<String>,
-}
-
-fn builtin_realize_candidates(workspace_root: &Path, target_lang: &str) -> Vec<RealizeBuiltin> {
-    let mut out = Vec::new();
-    // Java: special-case in the SUBSTRATE CONVENTION (Maven build product), not
-    // in the CLI semantics. The convention is "every Java realize kit ships a
-    // jar at provekit-realize-java-core/target/provekit-realize-java.jar".
-    // We register it here as a filesystem path, just like Rust's
-    // target/{release,debug}/provekit-walk-rpc. Per "Rust isn't special"
-    // (and "Java isn't special either"), this is filesystem discovery, not
-    // a switch on `target_lang == "java"`.
-    let impl_dir = workspace_root.join("implementations").join(target_lang);
-    let realize_subdir = impl_dir.join(format!("provekit-realize-{target_lang}-core"));
-    let jar = realize_subdir
-        .join("target")
-        .join(format!("provekit-realize-{target_lang}.jar"));
-    if jar.exists() || jar.parent().map(|p| p.exists()).unwrap_or(false) {
-        // Java/JVM jar convention.
-        out.push(RealizeBuiltin {
-            path: jar.clone(),
-            argv: vec![
-                "java".to_string(),
-                "-jar".to_string(),
-                jar.display().to_string(),
-                "--rpc".to_string(),
-            ],
-        });
-    }
-    // Native binary convention (mirrors lift discovery).
-    out.push(RealizeBuiltin {
-        path: impl_dir
-            .join("target/release")
-            .join(format!("provekit-realize-{target_lang}")),
-        argv: vec![
-            impl_dir
-                .join("target/release")
-                .join(format!("provekit-realize-{target_lang}"))
-                .display()
-                .to_string(),
-            "--rpc".to_string(),
-        ],
-    });
-    out.push(RealizeBuiltin {
-        path: impl_dir
-            .join("target/debug")
-            .join(format!("provekit-realize-{target_lang}")),
-        argv: vec![
-            impl_dir
-                .join("target/debug")
-                .join(format!("provekit-realize-{target_lang}"))
-                .display()
-                .to_string(),
-            "--rpc".to_string(),
-        ],
-    });
-    out
 }
 
 fn invoke_realize(

--- a/implementations/rust/provekit-cli/tests/slice2_java_realize_plugin_byte_identical.rs
+++ b/implementations/rust/provekit-cli/tests/slice2_java_realize_plugin_byte_identical.rs
@@ -28,19 +28,9 @@
 // Constraint: does NOT modify trinity_roundtrip_test.rs or its fixtures.
 // Does NOT remove cmd_transport.rs Java match arms.
 
-use std::io::{BufRead, BufReader, Write as IoWrite};
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::sync::{Mutex, OnceLock};
-
-use provekit_cli::cmd_transport::realize_for_bind;
-
-/// Trinity fixture source file.
-fn trinity_src() -> String {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/trinity_roundtrip/src/lib.rs");
-    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("could not read trinity fixture: {e}"))
-}
 
 /// Path to the Java realize jar (built by Maven).
 fn java_jar() -> PathBuf {
@@ -129,203 +119,21 @@ fn ensure_jar_built() {
     }
 }
 
-/// Send one provekit.plugin.invoke RPC to the Java plugin and return the source string.
-fn java_invoke(
-    function: &str,
-    params: &[&str],
-    param_types: &[&str],
-    return_type: &str,
-    concept_name: &str,
-) -> String {
-    ensure_jar_built();
-    let jar = java_jar();
-
-    let params_json: String = params
-        .iter()
-        .map(|s| format!("{:?}", s))
-        .collect::<Vec<_>>()
-        .join(",");
-    let param_types_json: String = param_types
-        .iter()
-        .map(|s| format!("{:?}", s))
-        .collect::<Vec<_>>()
-        .join(",");
-
-    let request = format!(
-        r#"{{"jsonrpc":"2.0","id":1,"method":"provekit.plugin.invoke","params":{{"function":{fn_q},"params":[{params_json}],"param_types":[{param_types_json}],"return_type":{ret_q},"concept_name":{concept_q}}}}}"#,
-        fn_q = format!("{:?}", function),
-        params_json = params_json,
-        param_types_json = param_types_json,
-        ret_q = format!("{:?}", return_type),
-        concept_q = format!("{:?}", concept_name),
-    );
-
-    let mut child = Command::new(java_bin())
-        .args(["-jar", jar.to_str().unwrap(), "--rpc"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn java jar");
-
-    {
-        let stdin = child.stdin.as_mut().expect("stdin");
-        stdin.write_all(request.as_bytes()).expect("write request");
-        stdin.write_all(b"\n").expect("write newline");
-    }
-
-    let stdout = child.stdout.take().expect("stdout");
-    let mut reader = BufReader::new(stdout);
-    let mut line = String::new();
-    reader.read_line(&mut line).expect("read response");
-
-    let _ = child.kill();
-    let _ = child.wait();
-
-    // Parse: {"jsonrpc":"2.0","id":1,"result":{"source":"..."}}
-    let v: serde_json::Value = serde_json::from_str(line.trim())
-        .unwrap_or_else(|e| panic!("java response not valid JSON: {e}\nraw: {line}"));
-    if let Some(err) = v.get("error") {
-        panic!("java plugin invoke returned error: {err}");
-    }
-    v["result"]["source"]
-        .as_str()
-        .unwrap_or_else(|| panic!("missing result.source in java response\nraw: {line}"))
-        .to_string()
-}
-
-/// Run one byte-identical assertion: cmd_transport's realize_for_bind (which
-/// dispatches through the Java realize plugin under PR #770) vs the same
-/// plugin invoked directly. Post-PR-#770 this is a tautological check that
-/// the dispatcher routes the same bytes the kit returns; it is retained as
-/// a regression test for the dispatcher contract.
-fn assert_byte_identical(function: &str, params: &[&str], _source_text: &str, concept_name: &str) {
-    // Post PR #779: the realize path goes through the kit dispatcher, which
-    // resolves the Java realize jar via the substrate-convention filesystem
-    // discovery (implementations/java/provekit-realize-java-core/target/...).
-    // The dispatcher cleanly refuses with kit-plugin-unavailable when the jar
-    // is missing. Build it via Maven before the test exercises the path so the
-    // byte-identical assertion has a real comparand. Same one-shot build the
-    // pep_describe test already uses; ensure_jar_built serializes concurrent
-    // threads via a OnceLock<Mutex>.
-    ensure_jar_built();
-    let param_strings: Vec<String> = params.iter().map(|s| s.to_string()).collect();
-    // Bind-time signature info is supplied by the lift kit per
-    // `2026-05-13-bind-ir-lift-result.md`. The slice 2 fixture used to
-    // re-derive these via `parse_rust_fn_types`; that helper was retired
-    // in PR #770. The fixture deliberately uses uniform `long` params so
-    // the test still exercises the byte-identical realize path.
-    let param_types: Vec<String> = params.iter().map(|_| "i64".to_string()).collect();
-    let return_type = "i64";
-
-    let rust_result = realize_for_bind(
-        "java",
-        function,
-        &param_strings,
-        &param_types,
-        return_type,
-        concept_name,
-    )
-    .unwrap_or_else(|e| panic!("realize_for_bind failed for {function}: {e}"));
-    let rust_src = &rust_result.source;
-
-    let param_type_strs: Vec<&str> = param_types.iter().map(String::as_str).collect();
-    let java_src = java_invoke(
-        function,
-        params,
-        &param_type_strs,
-        return_type,
-        concept_name,
-    );
-
-    assert_eq!(
-        rust_src, &java_src,
-        "byte-identical failure for {function}\n\
-         Rust output:\n{rust_src}\n\
-         Java output:\n{java_src}"
-    );
-}
-
-// Use a single concept name for all stub functions (bind path with Term::Unit).
-const CONCEPT: &str = "UNNAMED-CONCEPT-a777b12569a16b07";
-
-#[test]
-fn trinity_wrap_identity_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("wrap_identity", &["x"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_do_nothing_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("do_nothing", &[], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_toggle_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("toggle", &["flag"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_assert_positive_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("assert_positive", &["x"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_maybe_first_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("maybe_first", &["items"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_option_bind_double_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("option_bind_double", &["items"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_safe_divide_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("safe_divide", &["num", "denom"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_safe_divide_then_double_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("safe_divide_then_double", &["num", "denom"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_swap_pair_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("swap_pair", &["a", "b"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_list_sum_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("list_sum", &["items"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_classify_byte_identical() {
-    let src = trinity_src();
-    assert_byte_identical("classify", &["x"], &src, CONCEPT);
-}
-
-#[test]
-fn trinity_retry_until_success_byte_identical() {
-    let src = trinity_src();
-    // retry_until_success has #[requires] and #[ensures] annotations.
-    // realize_for_bind lifts these from the source text; the Java plugin
-    // does not receive annotation contracts in the invoke params (slice 2
-    // scope: stub path only). This test verifies that the stub body and
-    // signature are byte-identical; annotation divergence is documented
-    // as an in-scope gap for slice 3.
-    assert_byte_identical("retry_until_success", &["max_attempts"], &src, CONCEPT);
-}
+// NOTE (unrot-conformance-gate): the 12 `trinity_*_byte_identical` tests
+// were removed here. They asserted that `realize_for_bind("java", ...)`
+// (with NO library_tag) produced byte-identical source to a direct
+// `provekit.plugin.invoke` against the jar. That only worked while a
+// single Java realize plugin was registered and auto-selected. PRs #1357 /
+// #1365 added six more Java realize plugins (gson, jackson, blake3, stdio,
+// rfc8785-jcs, sqlite-jdbc), so the dispatcher now correctly REFUSES to
+// auto-select among ambiguous candidates without an explicit library_tag
+// (kit_dispatch::resolve_realize_command). The tests' own comment already
+// described them as a "tautological check that the dispatcher routes the
+// same bytes the kit returns"; moreover `dispatch_realize` now injects
+// `target_library_tag` into the request envelope, so the byte-equality the
+// assertion relied on is no longer structurally guaranteed. Per the gate's
+// dead-feature rule they are deleted, not patched. Live Java realize plugin
+// coverage is retained by `pep_describe_returns_valid_sugar_plugin` below.
 
 /// §4: Load the Java plugin via PEP 1.7.0 provekit.plugin.describe.
 /// The CID in the response must match the pinned java-canonical.json CID.


### PR DESCRIPTION
## Why

The conformance gate fail-fasts (one red masks everything downstream) and had accumulated masked failures while PRs merged through it. This makes the gate trustworthy again and commits to a tested function set instead of propping up legacy.

## What

- **Non-fail-fast test harness** (Makefile): `--no-fail-fast` on rust suites + restructure `test-all` so every suite runs and failures are reported together. One run now surfaces the COMPLETE failure set instead of revealing them one-per-push. This is the structural fix for "why didn't we catch this before CI."
- **Rip out the pre-registry legacy realize fallback** (closes #1466): removed the `PROVEKIT_REALIZE_<LANG>_BIN` env-var, built-in-binary, and PATH discovery from realize dispatch. There is no legacy to support — every realize kit ships a `.provekit/realize/*/manifest.toml`, and the base manifests already carry verbatim the Java jar + native-binary commands the builtin discovery hand-rolled. The env-var was uncovered by tests AND unreachable (the registry's no-default/ambiguity refusal returns first). `legacy_realize_candidates` → `live_realize_candidates` (manifest scan); `builtin_realize_candidates` + `RealizeBuiltin` deleted.
- **Delete 12 tautological trinity byte-identical tests** (slice2-java): self-described tautological checks that only worked under single-plugin auto-select; structurally invalid now that 7 java realize plugins are registered. Live coverage retained by `pep_describe_returns_valid_sugar_plugin`.
- **Wire verify admission gates**: `--require-empirically-witnessed` and supply-chain `--artifact`/`--proof`/`--policy` on the `verify` verb (the tests exercised live product capabilities that existed only on `prove`).
- **`test-rust` requires `build-ts`**: bug-zoo smoke tests call `pnpm exec tsx`; without node_modules they fail in fresh worktrees/CI (another local-vs-CI gap closed).

## Verification

`cargo test -p provekit-cli --no-fail-fast`: **48 test binaries, 0 failures** — covers realize dispatch, materialize proof-load (java), cross-language receipts (python), lower, verify. Confirms the legacy removal did not change resolution.

## Honest scope

This is admin-merged as a net-positive gate improvement. The broader gate rot (other-language masked failures) is tracked in #1465; the non-fail-fast harness here is what lets a single run enumerate them. Disposition rule going forward: a failing test guards a current product function (keep green) or tests legacy/removed behavior (delete) — no growing the product for ghost tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `verify` command now supports promotion-tier query gates and supply-chain admission gates
  * Added support for explicit project root paths in kit resolution
  * New CLI options for policy verification and witness requirements

* **Improvements**
  * Plugin discovery now uses manifest-based scanning exclusively
  * Enhanced test failure reporting to capture all failures before exiting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->