### PR TITLE
[codex] Fix zero-arg body bridge promotion

### DIFF
--- a/implementations/rust/examples/cross_lang_consume.rs
+++ b/implementations/rust/examples/cross_lang_consume.rs
@@ -127,6 +127,7 @@ fn run() -> Result<(), String> {
     for d in &decls {
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: d.name.clone(),
             pre: d.pre.as_deref().map(formula_to_value),

--- a/implementations/rust/examples/parseInt_publish.rs
+++ b/implementations/rust/examples/parseInt_publish.rs
@@ -61,6 +61,7 @@ fn main() -> ExitCode {
     for d in &contract_decls {
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: d.name.clone(),
             pre: d.pre.as_deref().map(formula_to_value),

--- a/implementations/rust/provekit-agent/src/lib.rs
+++ b/implementations/rust/provekit-agent/src/lib.rs
@@ -334,6 +334,7 @@ pub fn mint_validated(
 
     let args = MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: v.name.clone(),
         pre: v.pre_value.clone(),

--- a/implementations/rust/provekit-baseline-rust-std/src/lib.rs
+++ b/implementations/rust/provekit-baseline-rust-std/src/lib.rs
@@ -351,6 +351,7 @@ pub fn mint_baseline(out_dir: &Path) -> Result<MintResult, String> {
         for d in &slab.contracts {
             let args = MintContractArgs {
                 formals: Vec::new(),
+                emit_empty_formals: false,
                 formal_sorts: Vec::new(),
                 contract_name: d.name.clone(),
                 pre: d.pre.as_deref().map(formula_to_value),

--- a/implementations/rust/provekit-baseline-std/src/bin/mint_all_baselines.rs
+++ b/implementations/rust/provekit-baseline-std/src/bin/mint_all_baselines.rs
@@ -220,6 +220,7 @@ fn mint_baseline(config: &BaselineConfig, out_dir: &Path) -> String {
 
             let args = MintContractArgs {
                 formals: Vec::new(),
+                emit_empty_formals: false,
                 formal_sorts: Vec::new(),
                 contract_name: cname,
                 pre: None,

--- a/implementations/rust/provekit-claim-envelope/src/bin/emit_c_fixtures.rs
+++ b/implementations/rust/provekit-claim-envelope/src/bin/emit_c_fixtures.rs
@@ -67,6 +67,7 @@ fn main() {
     // --- 4. mint_contract canonical_bytes + CID ---
     let args = MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: "parseInt".into(),
         pre: Some(pre_n_gt_0()),

--- a/implementations/rust/provekit-claim-envelope/src/lib.rs
+++ b/implementations/rust/provekit-claim-envelope/src/lib.rs
@@ -252,6 +252,12 @@ pub struct MintContractArgs {
     /// cross-language refinement targets); the field is then omitted from
     /// the header so those mementos keep their current bytes/CIDs.
     pub formals: Vec<String>,
+    /// Emit `formals: []` (and `formalSorts: []`) when the vector is
+    /// empty. Presence is load-bearing for zero-arg body-derived
+    /// op-contracts: absent `formals` means "not body-derived", while
+    /// present empty `formals` means "body-bearing function with no
+    /// parameters".
+    pub emit_empty_formals: bool,
     /// Sorts of the formals, parallel to `formals`. Carried alongside
     /// `formals` so the resolver can name the value slots; omitted from the
     /// header when empty.
@@ -373,9 +379,10 @@ pub fn contract_cid(args: &MintContractArgs) -> String {
     // Body-derived op-contracts carry their formals as part of contract
     // identity: two functions with the same `post` but different formal
     // names are different contracts (the resolver substitutes by formal
-    // name). Omitted when empty so non-function contracts keep their
+    // name). Omitted when empty unless `emit_empty_formals` marks the
+    // zero-arg body-derived case, so non-function contracts keep their
     // existing content CIDs unchanged.
-    if !args.formals.is_empty() {
+    if !args.formals.is_empty() || args.emit_empty_formals {
         let formals_arr: Vec<Arc<Value>> = args
             .formals
             .iter()
@@ -383,7 +390,7 @@ pub fn contract_cid(args: &MintContractArgs) -> String {
             .collect();
         kvs.push(("formals".into(), Value::array(formals_arr)));
     }
-    if !args.formal_sorts.is_empty() {
+    if !args.formal_sorts.is_empty() || args.emit_empty_formals {
         kvs.push((
             "formalSorts".into(),
             Value::array(args.formal_sorts.clone()),
@@ -480,9 +487,10 @@ pub fn mint_contract(args: &MintContractArgs) -> Result<MintedEnvelope, ClaimEnv
     // Body-derived op-contract slots: `formals` (+ `formalSorts`) ride in
     // the header so `body_discharge::CatalogResolver` (which reads the
     // header via `memento_body` for v1.2-layered mementos) can project them
-    // into `OpContractInfo` value slots. Omitted when empty so non-function
-    // contracts are byte-identical to their pre-#1436 form.
-    if !args.formals.is_empty() {
+    // into `OpContractInfo` value slots. Omitted when empty unless
+    // `emit_empty_formals` marks a zero-arg body-derived op-contract, so
+    // non-function contracts are byte-identical to their pre-#1436 form.
+    if !args.formals.is_empty() || args.emit_empty_formals {
         let formals_arr: Vec<Arc<Value>> = args
             .formals
             .iter()
@@ -490,7 +498,7 @@ pub fn mint_contract(args: &MintContractArgs) -> Result<MintedEnvelope, ClaimEnv
             .collect();
         kind_specific.push(("formals".into(), Value::array(formals_arr)));
     }
-    if !args.formal_sorts.is_empty() {
+    if !args.formal_sorts.is_empty() || args.emit_empty_formals {
         kind_specific.push((
             "formalSorts".into(),
             Value::array(args.formal_sorts.clone()),
@@ -1036,6 +1044,7 @@ mod tests {
     fn empty_contract_rejected() {
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: "x".into(),
             pre: None,
@@ -1080,6 +1089,7 @@ mod tests {
         ]);
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: "parseInt".into(),
             pre: Some(pre),
@@ -1109,6 +1119,7 @@ mod tests {
         ]);
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: "checked_add_u8.postcondition".into(),
             pre: None,

--- a/implementations/rust/provekit-claim-envelope/tests/cross_kit_pin.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/cross_kit_pin.rs
@@ -100,6 +100,7 @@ fn post_out_eq_0() -> Arc<Value> {
 fn fixture_args() -> MintContractArgs {
     MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: "demo".into(),
         pre: Some(pre_n_gt_0()),

--- a/implementations/rust/provekit-claim-envelope/tests/layered_shape.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/layered_shape.rs
@@ -80,6 +80,7 @@ fn pre_n_gt_0() -> Arc<Value> {
 fn contract_args() -> MintContractArgs {
     MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: "demo".into(),
         pre: Some(pre_n_gt_0()),

--- a/implementations/rust/provekit-claim-envelope/tests/mint_contract.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/mint_contract.rs
@@ -107,6 +107,7 @@ fn args_with(
 ) -> MintContractArgs {
     MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: "demo".into(),
         pre,

--- a/implementations/rust/provekit-cli/src/cmd_link.rs
+++ b/implementations/rust/provekit-cli/src/cmd_link.rs
@@ -163,6 +163,7 @@ fn lift_rust_contracts(rust_dir: &Path) -> Result<Vec<LinkerContract>, String> {
 
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: decl.name.clone(),
             pre: pre_v.clone(),

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -1012,9 +1012,8 @@ fn mint_from_ir_document(
         // `body_discharge::CatalogResolver` can resolve the body-obligation.
         // Non-function `contract` decls have no formals; the vecs stay empty
         // and the minted bytes are unchanged.
-        let formals: Vec<String> = decl
-            .get("formals")
-            .and_then(|v| v.as_array())
+        let formals_json = decl.get("formals").and_then(|v| v.as_array());
+        let formals: Vec<String> = formals_json
             .map(|arr| {
                 arr.iter()
                     .filter_map(|v| v.as_str().map(|s| s.to_string()))
@@ -1028,25 +1027,25 @@ fn mint_from_ir_document(
             .map(|arr| arr.iter().map(json_to_cvalue).collect())
             .unwrap_or_default();
         // A bridge is written only when this contract is a body-bearing
-        // function target: it carries a `post` AND formals (the resolver
-        // needs both). The bridge's `sourceSymbol` is the function's bare
-        // name as it appears in harvested call ctors. For a v1 function
-        // contract the harvested ctor uses the bare ident, so prefer the
-        // explicit `bridgeSourceSymbol` if the lifter set one, else the
-        // function's simple name.
-        let bridge_source_symbol: Option<String> = if kind == "function-contract"
-            && post.is_some()
-            && !formals.is_empty()
-        {
-            Some(
-                decl.get("bridgeSourceSymbol")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| simple_function_symbol(&name)),
-            )
-        } else {
-            None
-        };
+        // function target: it carries a `post` AND an explicit `formals`
+        // field. Presence is the marker, not non-emptiness: zero-arg
+        // functions carry `formals: []` and are still body-bearing. The
+        // bridge's `sourceSymbol` is the function's bare name as it appears
+        // in harvested call ctors. For a v1 function contract the harvested
+        // ctor uses the bare ident, so prefer the explicit
+        // `bridgeSourceSymbol` if the lifter set one, else the function's
+        // simple name.
+        let bridge_source_symbol: Option<String> =
+            if kind == "function-contract" && post.is_some() && formals_json.is_some() {
+                Some(
+                    decl.get("bridgeSourceSymbol")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| simple_function_symbol(&name)),
+                )
+            } else {
+                None
+            };
         let authority = optional_str(decl, "authority")
             .map(|authority_id| {
                 authorities_by_id.get(authority_id).ok_or_else(|| {
@@ -1061,6 +1060,8 @@ fn mint_from_ir_document(
         if let Some(authority) = authority {
             input_cids.push(authority.cid.clone());
         }
+        let emit_empty_formals =
+            kind == "function-contract" && formals_json.is_some() && formals.is_empty();
         let signer_seed = authority
             .map(|authority| authority.seed)
             .unwrap_or(default_signer_seed);
@@ -1084,6 +1085,7 @@ fn mint_from_ir_document(
             },
             signer_seed,
             formals,
+            emit_empty_formals,
             formal_sorts,
         };
 

--- a/implementations/rust/provekit-cli/src/cmd_proof.rs
+++ b/implementations/rust/provekit-cli/src/cmd_proof.rs
@@ -560,6 +560,7 @@ fn build_fixture_proof(name: &str, seed_byte: u8) -> BuiltProof {
     let declared_at = "2026-05-06T00:00:00.000Z";
     let member = mint_contract(&MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: format!("{name}/contract"),
         pre: Some(CValue::boolean(true)),

--- a/implementations/rust/provekit-cli/tests/cmd_verify_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_production_bridge.rs
@@ -115,20 +115,58 @@ fn ir_document(body_factor: i64) -> Json {
     })
 }
 
+/// Build the zero-arg `ir-document` variant: a body-derived
+/// `function-contract` for `answer()` plus a harvested source assertion
+/// carrying `assert_eq!(answer(), 42)`. This is the empty-formals corner of
+/// the same production bridge-writer seam: zero parameters still means
+/// body-bearing, so mint must promote it into a bridge member.
+fn zero_arg_ir_document(body_value: i64) -> Json {
+    json!({
+        "kind": "ir-document",
+        "diagnostics": [],
+        "ir": [
+            {
+                "kind": "function-contract",
+                "fn_name": "answer",
+                "formals": [],
+                "formalSorts": [],
+                "returnSort": {"kind": "primitive", "name": "Int"},
+                "outBinding": "result",
+                "post": {
+                    "kind": "atomic", "name": "=",
+                    "args": [
+                        {"kind": "var", "name": "result"},
+                        int_const(body_value)
+                    ]
+                }
+            },
+            {
+                "kind": "contract",
+                "symbol": "answer_test",
+                "outBinding": "out",
+                "inv": {
+                    "kind": "atomic", "name": "=",
+                    "args": [
+                        {"kind": "ctor", "name": "answer", "args": []},
+                        int_const(42)
+                    ]
+                }
+            }
+        ]
+    })
+}
+
 /// Generate a mock lift-plugin RPC: a POSIX shell script that speaks the
 /// newline-delimited JSON-RPC `LiftPluginKit` drives. It replies to
 /// `initialize` (id 1) and `lift` (id 2, result = the ir-document), then
 /// exits on `shutdown`. The ir-document is baked into the script body so
 /// the lifter is fully self-contained.
-fn write_mock_lifter(project: &Path, surface: &str, body_factor: i64) -> PathBuf {
+fn write_mock_lifter_with_ir(project: &Path, surface: &str, ir_doc: Json) -> PathBuf {
     let lift_dir = project.join(".provekit").join("lift").join(surface);
     fs::create_dir_all(&lift_dir).expect("mkdir lift surface dir");
 
     // The lift `result` is the ir-document. Embed it as a single JSON line.
-    let ir_doc = ir_document(body_factor);
-    let result_line = serde_json::to_string(&ir_doc).expect("serialize ir-document");
-
-    // The mock RPC: read each JSON-RPC line; on `initialize` emit an
+    // The mock RPC reads each JSON-RPC line; on `initialize` emit an
     // initialize result, on `lift` emit the ir-document result, on
     // `shutdown` exit. Newline-delimited, exactly what `read_response`
     // parses (one JSON object per line, matching the request `id`).
@@ -143,8 +181,6 @@ fn write_mock_lifter(project: &Path, surface: &str, body_factor: i64) -> PathBuf
     lift_obj.insert("result".into(), ir_doc.clone());
     let lift_line = serde_json::to_string(&Json::Object(lift_obj)).expect("serialize lift result");
     let init_line = serde_json::to_string(&init_result).expect("serialize init result");
-    // result_line retained for clarity of intent; lift_line is what we emit.
-    let _ = result_line;
 
     let script = format!(
         r#"#!/bin/sh
@@ -190,7 +226,7 @@ done
 /// Build a project whose lift produces the body-derived double contract,
 /// run the REAL `provekit mint` CLI, and return (project_dir, proof_path).
 /// `body_factor` is the body multiplier (2 = honest, 3 = broken).
-fn mint_double_project(suffix: &str, body_factor: i64) -> (PathBuf, PathBuf) {
+fn mint_project_from_ir(suffix: &str, ir_doc: Json) -> (PathBuf, PathBuf) {
     let surface = "mock";
     let project = unique_dir(suffix);
     fs::create_dir_all(project.join(".provekit")).expect("mkdir .provekit");
@@ -212,7 +248,7 @@ fn mint_double_project(suffix: &str, body_factor: i64) -> (PathBuf, PathBuf) {
         ),
     )
     .expect("write config.toml");
-    write_mock_lifter(&project, surface, body_factor);
+    write_mock_lifter_with_ir(&project, surface, ir_doc);
 
     let out = Command::new(provekit_bin())
         .arg("mint")
@@ -239,6 +275,10 @@ fn mint_double_project(suffix: &str, body_factor: i64) -> (PathBuf, PathBuf) {
         .find(|p| p.extension().map(|x| x == "proof").unwrap_or(false))
         .unwrap_or_else(|| panic!("mint must write a .proof into {}", project.display()));
     (project, proof)
+}
+
+fn mint_double_project(suffix: &str, body_factor: i64) -> (PathBuf, PathBuf) {
+    mint_project_from_ir(suffix, ir_document(body_factor))
 }
 
 /// Load the tool-minted bundle through the verifier's stage-1 loader. The
@@ -322,6 +362,66 @@ fn mint_auto_writes_body_discharge_bridge() {
         provekit_verifier::types::memento_body_field(target, "post").is_some(),
         "op-contract must carry the body-derived post"
     );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+/// Empty `formals` is still body-bearing. The production bridge writer must
+/// promote a zero-arg `function-contract` into the same bridge index that
+/// `enumerate_callsites` uses; otherwise verify reports `totalClaims: 0`
+/// for a real harvested `answer()` assertion.
+#[test]
+fn mint_auto_writes_zero_arg_body_discharge_bridge() {
+    let (project, _proof) = mint_project_from_ir("zeroarg-bridge", zero_arg_ir_document(42));
+    let pool = pool_of_project(&project);
+
+    let bridge = pool.bridges_by_symbol.get("answer").unwrap_or_else(|| {
+        panic!(
+            "mint must auto-write + index a bridge with sourceSymbol=answer; indexed symbols: {:?}",
+            pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+        )
+    });
+
+    let target_cid = provekit_verifier::types::memento_body_field(bridge, "targetContractCid")
+        .and_then(|v| v.as_str())
+        .expect("bridge must carry targetContractCid")
+        .to_string();
+    let target = pool.mementos.get(&target_cid).unwrap_or_else(|| {
+        panic!(
+            "bridge.targetContractCid {target_cid} must resolve to a member; member CIDs: {:?}",
+            pool.mementos.keys().collect::<Vec<_>>()
+        )
+    });
+    let formals = provekit_verifier::types::memento_body_field(target, "formals")
+        .and_then(|v| v.as_array())
+        .expect("zero-arg op-contract must carry an explicit formals array");
+    assert!(
+        formals.is_empty(),
+        "zero-arg op-contract formals must stay empty; got {formals:?}"
+    );
+    assert!(
+        provekit_verifier::types::memento_body_field(target, "post").is_some(),
+        "zero-arg op-contract must carry the body-derived post"
+    );
+
+    if z3_available() {
+        let witnesses = project.join("witnesses-out");
+        let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+        assert_eq!(
+            receipt["totalClaims"], 1,
+            "zero-arg harvested answer() assertion must enumerate; receipt: {receipt}"
+        );
+        let claim = &receipt["claims"].as_array().expect("claims")[0];
+        assert_eq!(
+            claim["pass"], true,
+            "answer()==42 must discharge through zero-arg body; claim: {claim}"
+        );
+        assert_eq!(claim["status"], "discharged", "claim: {claim}");
+        assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+        assert_eq!(code, 0, "zero-arg positive run exits clean; got {code}");
+    } else {
+        eprintln!("z3 not on PATH: skipping zero-arg production-bridge verify assertion");
+    }
 
     let _ = fs::remove_dir_all(&project);
 }

--- a/implementations/rust/provekit-cli/tests/proof_check.rs
+++ b/implementations/rust/provekit-cli/tests/proof_check.rs
@@ -42,6 +42,7 @@ fn fixture_proof_file_with_metadata(
     let declared_at = "2026-05-06T00:00:00.000Z";
     let member = mint_contract(&MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: declaration.name.clone(),
         pre: declaration.pre.as_deref().map(formula_to_value),

--- a/implementations/rust/provekit-lift/src/lib.rs
+++ b/implementations/rust/provekit-lift/src/lib.rs
@@ -444,6 +444,7 @@ pub fn lift_path(root: &Path) -> LiftReport {
             // signer_seed, produced_at, etc. do not affect the CID per spec #94).
             let args = MintContractArgs {
                 formals: Vec::new(),
+                emit_empty_formals: false,
                 formal_sorts: Vec::new(),
                 contract_name: d.name.clone(),
                 pre: d.pre.as_deref().map(formula_to_value),
@@ -592,6 +593,7 @@ pub fn mint_proof(decls: &[ContractDecl], opts: &LiftOptions) -> Result<MintOutp
     for d in decls {
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: d.name.clone(),
             pre: d.pre.as_deref().map(formula_to_value),

--- a/implementations/rust/provekit-lift/tests/call_edges.rs
+++ b/implementations/rust/provekit-lift/tests/call_edges.rs
@@ -47,6 +47,7 @@ fn b(n: i64) -> i64 { a(n) }
         .map(|d| {
             let args = MintContractArgs {
                 formals: Vec::new(),
+                emit_empty_formals: false,
                 formal_sorts: Vec::new(),
                 contract_name: d.name.clone(),
                 pre: d.pre.as_deref().map(formula_to_value),
@@ -129,6 +130,7 @@ fn b(x: i64) -> i64 {
         .map(|d| {
             let args = MintContractArgs {
                 formals: Vec::new(),
+                emit_empty_formals: false,
                 formal_sorts: Vec::new(),
                 contract_name: d.name.clone(),
                 pre: d.pre.as_deref().map(formula_to_value),
@@ -200,6 +202,7 @@ fn b(n: i64) -> i64 { a(n) }
             .map(|d| {
                 let args = MintContractArgs {
                     formals: Vec::new(),
+                    emit_empty_formals: false,
                     formal_sorts: Vec::new(),
                     contract_name: d.name.clone(),
                     pre: d.pre.as_deref().map(formula_to_value),
@@ -298,6 +301,7 @@ pub extern "C" fn foo(n: i32) -> i32 {
     // Verify it round-trips through the CID computation without panic.
     let args = MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: foo_contract.name.clone(),
         pre: foo_contract.pre.as_deref().map(formula_to_value),

--- a/implementations/rust/provekit-linkerd/src/methods.rs
+++ b/implementations/rust/provekit-linkerd/src/methods.rs
@@ -789,6 +789,7 @@ async fn lift_rust_source(
 
             let args = MintContractArgs {
                 formals: Vec::new(),
+                emit_empty_formals: false,
                 formal_sorts: Vec::new(),
                 contract_name: decl.name.clone(),
                 pre: pre_v.clone(),

--- a/implementations/rust/provekit-self-contracts/src/lib.rs
+++ b/implementations/rust/provekit-self-contracts/src/lib.rs
@@ -360,6 +360,7 @@ pub fn lift_plugin_protocol_contract_cids() -> Result<BTreeMap<String, String>, 
     for d in &slab.contracts {
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: d.name.clone(),
             pre: d.pre.as_deref().map(formula_to_value),
@@ -467,6 +468,7 @@ pub fn mint_self_proof(out_dir: &Path) -> Result<MintResult, String> {
         for d in &slab.contracts {
             let args = MintContractArgs {
                 formals: Vec::new(),
+                emit_empty_formals: false,
                 formal_sorts: Vec::new(),
                 contract_name: d.name.clone(),
                 pre: d.pre.as_deref().map(formula_to_value),

--- a/implementations/rust/provekit-showcase/src/fixture.rs
+++ b/implementations/rust/provekit-showcase/src/fixture.rs
@@ -314,6 +314,7 @@ fn mint_one_contract(root_seed: u64, idx: u64) -> ContractRow {
 
     let mint = mint_contract(&MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: format!("synthContract_{idx}"),
         pre: Some(pre.clone()),

--- a/implementations/rust/provekit-verifier/tests/load_all_proofs.rs
+++ b/implementations/rust/provekit-verifier/tests/load_all_proofs.rs
@@ -50,6 +50,7 @@ fn publish_parseint_proof(dir: &Path) -> String {
     for d in &decls {
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: d.name.clone(),
             pre: d.pre.as_deref().map(formula_to_value),
@@ -273,6 +274,7 @@ fn multiple_proofs_in_one_dir_all_loaded() {
     for d in &decls {
         let args = MintContractArgs {
             formals: Vec::new(),
+            emit_empty_formals: false,
             formal_sorts: Vec::new(),
             contract_name: d.name.clone(),
             pre: d.pre.as_deref().map(formula_to_value),

--- a/implementations/rust/provekit-verifier/tests/proof_conformance.rs
+++ b/implementations/rust/provekit-verifier/tests/proof_conformance.rs
@@ -37,6 +37,7 @@ fn fixture_proof_bytes() -> (String, Vec<u8>) {
     let declared_at = "2026-05-06T00:00:00.000Z";
     let member = mint_contract(&MintContractArgs {
         formals: Vec::new(),
+        emit_empty_formals: false,
         formal_sorts: Vec::new(),
         contract_name: declaration.name.clone(),
         pre: declaration.pre.as_deref().map(formula_to_value),

--- a/implementations/rust/provekit-walk/src/envelope.rs
+++ b/implementations/rust/provekit-walk/src/envelope.rs
@@ -148,6 +148,7 @@ pub fn mint_args(
         },
         signer_seed: *signer_seed,
         formals,
+        emit_empty_formals: contract.formals.is_empty(),
         formal_sorts,
     }
 }


### PR DESCRIPTION
## Summary
- Preserve explicit empty `formals` on zero-arg body-derived contracts so they remain body-bearing to the verifier.
- Promote `function-contract` declarations into bridge members based on `formals` field presence, not non-empty parameter lists.
- Add a production bridge regression for a zero-arg `answer()` assertion that must enumerate and discharge as one claim.

## Root Cause
`cmd_mint` only wrote auto-bridges when `formals` was non-empty, and `mint_contract` omitted empty `formals` from the contract header. A zero-arg body-derived function could therefore be harvested and minted without the bridge/member shape verify needs, producing the dangerous `totalClaims: 0` path.

## Validation
- `cargo test -p provekit-cli --test cmd_verify_production_bridge -- --nocapture`
- `cargo test -p provekit-claim-envelope`
- `pnpm test`
- `git diff --check`

Closes #1440.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated contract generation logic to provide more consistent handling of zero-argument contracts across proof generation and minting operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->