### PR TITLE
fix(#1472 fallout): supply-chain-npm-lifter missing emit_empty_formals

### DIFF
--- a/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-npm-lifter.rs
+++ b/menagerie/supply-chain-rails/authenticated-betrayal/kit-rpc/supply-chain-npm-lifter.rs
@@ -787,6 +787,7 @@ fn compute_contract_set_cid_for_ir(ir: &[Value]) -> Result<String, String> {
             signer_seed: [0x42u8; 32],
             formals: Vec::new(),
             formal_sorts: Vec::new(),
+            emit_empty_formals: false,
         };
         contract_cids.push(contract_cid(&args));
     }


### PR DESCRIPTION
#1472 added `emit_empty_formals` to `MintContractArgs` but missed `supply-chain-npm-lifter` — a runtime-spawned kit-rpc binary compiled on demand by the supply-chain smoke test (not by the workspace build, so `cargo test --no-run` didn't catch it). Its 5 smoke-test failures all stem from this single compile error (every `provekit package inspect` test spawns the lifter). Add `emit_empty_formals: false`.

Separately tracked: `provekit-walk --test lift_dogfood` fails with a #1472 *semantic* regression (lifter emits `expect@emit.rs:231:24` twice with different bodies → the lib.rs:577 name-collision guard). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated contract identifier computation to ensure consistent derivation across contract sets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->