### PR TITLE
ci(conformance): install libsqlite3-dev on Linux runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,7 @@ jobs:
             maven \
             nlohmann-json3-dev \
             php-cli \
+            libsqlite3-dev \
             sqlite3 \
             unzip \
             z3


### PR DESCRIPTION
## Summary

The Cross-language conformance gate failed at the **link step** (not a test failure):

```
rust-lld: error: unable to find library -lsqlite3
collect2: error: ld returned 1 exit status
```

`provekit-realize-rust` (release) links `rusqlite` (declared `rusqlite = "0.39"` in `examples/provekit-shim-rusqlite`, **no `bundled` feature**) against the system sqlite3 via `-lsqlite3`. The conformance job's apt block installed `sqlite3` (the CLI binary) but not **`libsqlite3-dev`** (the package that provides `libsqlite3.so` + headers for linking).

Prior green runs landed on warm self-hosted runners that already had the dev package; freshly-spawned autoscaler runners don't, so the gate failed at link before any test executed. This is pre-existing inherited red surfaced by a fresh runner — not introduced by recent merges.

## Fix

Add `libsqlite3-dev` to the conformance job's apt install list, beside `sqlite3`. No source/crate change — the shim builds byte-identically; only the runner filesystem gains the link library. (Considered enabling rusqlite's `bundled` feature instead, but that mutates the shim Cargo.toml and risks pinned-CID drift the gate is designed to catch; the env fix is the minimal correct change.)

## Scope

Only the conformance job builds the rusqlite-linking binary (the `prove` jobs were green and install no `sqlite3`), so the single apt block is the right place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline system dependencies to support project build requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->