### PR TITLE
build(java): portable LOCAL_BIN default (/tmp not /private/tmp)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ RUBY ?= $(shell for p in /usr/local/opt/ruby/bin/ruby /opt/homebrew/opt/ruby/bin
 PYTHON ?= $(shell command -v python3 || echo python3)
 PIP ?= pip3 --python $(PYTHON)
 MVN ?= mvn
-LOCAL_BIN ?= /private/tmp/provekit-local-bin
+LOCAL_BIN ?= /tmp/provekit-local-bin
 JAVA_HOME ?= $(shell for d in /usr/local/opt/openjdk /opt/homebrew/opt/openjdk; do if [ -x "$$d/bin/java" ]; then echo "$$d"; exit; fi; done)
 export JAVA_HOME
 ifeq ($(strip $(JAVA_HOME)),)


### PR DESCRIPTION
## Summary

`build-java` (Makefile:239) copies `provekit-lsp-java` into `$(LOCAL_BIN)`. The default was `/private/tmp/provekit-local-bin` — a macOS-only path. On Linux, `/private` doesn't exist and can't be created by a non-root user:

```
mkdir: cannot create directory '/private': Permission denied
make[1]: *** [Makefile:239: build-java] Error 1
```

Masked on the conformance gate until #1478 fixed the earlier rust link failure; with the link fixed, the run reached build-java and hit this.

## Fix

Default `LOCAL_BIN ?= /tmp/provekit-local-bin`. `/tmp` exists on both Linux and macOS (on macOS it's a symlink to `/private/tmp`, so the effective location is unchanged). Still overridable.

One of the layers behind the long-red conformance gate (link → test-rust ✓ → test-python cardinality → build-java this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)