### PR TITLE
fix(realize-python): catch sqlite3+aiosqlite tests up to sql-query cardinality

### DIFF
--- a/implementations/python/provekit-realize-python-aiosqlite/tests/conftest.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/conftest.py
@@ -31,14 +31,14 @@ from provekit_realize_python_aiosqlite.realizer import BODY_TEMPLATE_REL  # noqa
 
 # Minimal disk body-templates content. Only the concepts the tests probe, in
 # the 2-param `db.execute(sql, tuple(args))` shape the shim ships. A 1-param
-# `concept:sql-query` lookup MISSES this (no matching guard), which is exactly
+# lookup MISSES this (no matching guard), which is exactly
 # the "bare signature -> missing template" invariant the rpc tests assert.
 _DISK_FIXTURE = {
     "header": {
         "content": {
             "entries": [
                 {
-                    "concept_name": "concept:sql-query",
+                    "concept_name": "concept:sql-query-all",
                     "emission_template": {
                         "kind": "verbatim",
                         "template": (

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_realizer.py
@@ -20,10 +20,10 @@ from provekit_realize_python_aiosqlite.realizer import (
 # The kit resolves its shim proof from the installed/importable shim package.
 
 
-SQL_QUERY_NTT = {
-    "conceptName": "concept:sql-query",
+SQL_QUERY_ALL_NTT = {
+    "conceptName": "concept:sql-query-all",
     "operationKind": "op-application",
-    "shapeCid": "blake3-512:sql-query",
+    "shapeCid": "blake3-512:sql-query-all",
     "args": [
         {
             "conceptName": "Sql",
@@ -41,13 +41,13 @@ SQL_QUERY_NTT = {
 }
 
 
-def test_sql_query_uses_aiosqlite_execute(disk_fixture) -> None:
+def test_sql_query_all_uses_aiosqlite_execute(disk_fixture) -> None:
     result = emit_stub(
         function="select_rows",
         params=["sql", "args"],
         param_types=["str", "list[object]"],
         return_type="list[object]",
-        concept_name="concept:sql-query",
+        concept_name="concept:sql-query-all",
     )
 
     assert result["source"] == (
@@ -59,14 +59,14 @@ def test_sql_query_uses_aiosqlite_execute(disk_fixture) -> None:
     assert result["extension"] == "py"
 
 
-def test_sql_query_uses_named_term_tree_args_shape(disk_fixture) -> None:
+def test_sql_query_all_uses_named_term_tree_args_shape(disk_fixture) -> None:
     result = emit_stub(
         function="get_user_by_id",
         params=["id"],
         param_types=["int"],
         return_type="User",
-        concept_name="concept:sql-query",
-        named_term_tree=SQL_QUERY_NTT,
+        concept_name="concept:sql-query-all",
+        named_term_tree=SQL_QUERY_ALL_NTT,
     )
 
     assert result["source"] == (
@@ -78,9 +78,9 @@ def test_sql_query_uses_named_term_tree_args_shape(disk_fixture) -> None:
     assert result["extension"] == "py"
 
 
-def test_sql_query_self_resolves_from_shim_proof(disk_fixture) -> None:
+def test_sql_query_all_self_resolves_from_shim_proof(disk_fixture) -> None:
     body = body_template_for(
-        "concept:sql-query", ["sql", "args"], ["str", "list[object]"], "list[object]"
+        "concept:sql-query-all", ["sql", "args"], ["str", "list[object]"], "list[object]"
     )
     assert body == (
         "async with db.execute(sql, tuple(args)) as cursor:\n"
@@ -94,13 +94,15 @@ def test_unrelated_concept_resolves_from_same_shim_proof(disk_fixture) -> None:
     assert "close" in close_body
 
 
-def test_sql_query_without_named_term_tree_uses_param_types_fallback(disk_fixture) -> None:
+def test_missing_template_without_named_term_tree_uses_param_types_fallback(
+    disk_fixture,
+) -> None:
     try:
-        emit_stub("get_user_by_id", ["id"], ["int"], "User", "concept:sql-query")
+        emit_stub("get_user_by_id", ["id"], ["int"], "User", "missing-concept")
     except MissingTemplateError as exc:
         assert [entry.to_json() for entry in exc.entries] == [
             {
-                "operation_kind": "concept:sql-query",
+                "operation_kind": "missing-concept",
                 "args_shape": ["int"],
                 "function": "get_user_by_id",
                 "term_position": "body",
@@ -118,7 +120,7 @@ def test_missing_template_reports_named_term_tree_args_shape() -> None:
             ["int"],
             "User",
             "missing-concept",
-            named_term_tree=SQL_QUERY_NTT,
+            named_term_tree=SQL_QUERY_ALL_NTT,
         )
     except MissingTemplateError as exc:
         assert [entry.to_json() for entry in exc.entries] == [

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
@@ -12,10 +12,10 @@ if str(PKG_SRC) not in sys.path:
 from provekit_realize_python_aiosqlite.rpc import dispatch
 
 
-SQL_QUERY_NTT = {
-    "conceptName": "concept:sql-query",
+SQL_QUERY_ALL_NTT = {
+    "conceptName": "concept:sql-query-all",
     "operationKind": "op-application",
-    "shapeCid": "blake3-512:sql-query",
+    "shapeCid": "blake3-512:sql-query-all",
     "args": [
         {
             "conceptName": "Sql",
@@ -33,7 +33,7 @@ SQL_QUERY_NTT = {
 }
 
 
-def test_rpc_invoke_renders_aiosqlite_body(disk_fixture) -> None:
+def test_rpc_invoke_renders_aiosqlite_query_all_body(disk_fixture) -> None:
     response = dispatch(
         {
             "jsonrpc": "2.0",
@@ -44,7 +44,7 @@ def test_rpc_invoke_renders_aiosqlite_body(disk_fixture) -> None:
                 "params": ["sql", "args"],
                 "param_types": ["str", "list[object]"],
                 "return_type": "list[object]",
-                "concept_name": "concept:sql-query",
+                "concept_name": "concept:sql-query-all",
             },
         }
     )
@@ -65,8 +65,8 @@ def test_rpc_invoke_threads_named_term_tree_for_template_lookup(disk_fixture) ->
                 "params": ["id"],
                 "param_types": ["int"],
                 "return_type": "User",
-                "concept_name": "concept:sql-query",
-                "named_term_tree": SQL_QUERY_NTT,
+                "concept_name": "concept:sql-query-all",
+                "named_term_tree": SQL_QUERY_ALL_NTT,
             },
         }
     )
@@ -126,7 +126,7 @@ def test_plugin_invoke_missing_template_uses_named_term_tree_args_shape() -> Non
                 "param_types": ["int"],
                 "return_type": "User",
                 "concept_name": "missing-concept",
-                "named_term_tree": SQL_QUERY_NTT,
+                "named_term_tree": SQL_QUERY_ALL_NTT,
             },
         }
     )

--- a/implementations/python/provekit-realize-python-sqlite3/tests/conftest.py
+++ b/implementations/python/provekit-realize-python-sqlite3/tests/conftest.py
@@ -30,14 +30,14 @@ from provekit_realize_python_sqlite3.realizer import BODY_TEMPLATE_REL  # noqa: 
 
 # Minimal disk body-templates content. Only the concepts the tests probe, in
 # the 2-param `db.execute(sql, tuple(args))` shape the shim ships. A 1-param
-# `concept:sql-query` lookup MISSES this (no matching guard), which is exactly
+# lookup MISSES this (no matching guard), which is exactly
 # the "bare signature -> missing template" invariant the rpc tests assert.
 _DISK_FIXTURE = {
     "header": {
         "content": {
             "entries": [
                 {
-                    "concept_name": "concept:sql-query",
+                    "concept_name": "concept:sql-query-all",
                     "emission_template": {
                         "kind": "verbatim",
                         "template": (

--- a/implementations/python/provekit-realize-python-sqlite3/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-sqlite3/tests/test_realizer.py
@@ -20,13 +20,13 @@ from provekit_realize_python_sqlite3.realizer import (
 # The kit resolves its shim proof from the installed/importable shim package.
 
 
-def test_sql_query_uses_sqlite3_execute(disk_fixture) -> None:
+def test_sql_query_all_uses_sqlite3_execute(disk_fixture) -> None:
     result = emit_stub(
         function="select_rows",
         params=["sql", "args"],
         param_types=["str", "list[object]"],
         return_type="list[object]",
-        concept_name="concept:sql-query",
+        concept_name="concept:sql-query-all",
     )
 
     assert result["source"] == (
@@ -38,9 +38,9 @@ def test_sql_query_uses_sqlite3_execute(disk_fixture) -> None:
     assert result["extension"] == "py"
 
 
-def test_sql_query_self_resolves_from_shim_proof(disk_fixture) -> None:
+def test_sql_query_all_self_resolves_from_shim_proof(disk_fixture) -> None:
     body = body_template_for(
-        "concept:sql-query", ["sql", "args"], ["str", "list[object]"], "list[object]"
+        "concept:sql-query-all", ["sql", "args"], ["str", "list[object]"], "list[object]"
     )
     assert body == "cursor = db.execute(sql, tuple(args))\nreturn cursor.fetchall()"
 

--- a/implementations/python/provekit-realize-python-sqlite3/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/tests/test_rpc.py
@@ -12,7 +12,7 @@ if str(PKG_SRC) not in sys.path:
 from provekit_realize_python_sqlite3.rpc import dispatch
 
 
-def test_rpc_invoke_renders_sqlite3_body(disk_fixture) -> None:
+def test_rpc_invoke_renders_sqlite3_query_all_body(disk_fixture) -> None:
     response = dispatch(
         {
             "jsonrpc": "2.0",
@@ -23,7 +23,7 @@ def test_rpc_invoke_renders_sqlite3_body(disk_fixture) -> None:
                 "params": ["sql", "args"],
                 "param_types": ["str", "list[object]"],
                 "return_type": "list[object]",
-                "concept_name": "concept:sql-query",
+                "concept_name": "concept:sql-query-all",
             },
         }
     )
@@ -33,7 +33,7 @@ def test_rpc_invoke_renders_sqlite3_body(disk_fixture) -> None:
     assert "db.execute" in response["result"]["source"]
 
 
-def test_rpc_invoke_uses_named_term_tree_shape_for_sql_query(disk_fixture) -> None:
+def test_rpc_invoke_uses_named_term_tree_shape_for_sql_query_all(disk_fixture) -> None:
     response = dispatch(
         {
             "jsonrpc": "2.0",
@@ -44,11 +44,11 @@ def test_rpc_invoke_uses_named_term_tree_shape_for_sql_query(disk_fixture) -> No
                 "params": ["id"],
                 "param_types": ["int"],
                 "return_type": "list[object]",
-                "concept_name": "concept:sql-query",
+                "concept_name": "concept:sql-query-all",
                 "named_term_tree": {
-                    "conceptName": "concept:sql-query",
-                    "operationKind": "sql-query",
-                    "shapeCid": "blake3-512:sql-query",
+                    "conceptName": "concept:sql-query-all",
+                    "operationKind": "sql-query-all",
+                    "shapeCid": "blake3-512:sql-query-all",
                     "args": [
                         {
                             "conceptName": "Sql",
@@ -90,7 +90,7 @@ def test_rpc_invoke_without_named_term_tree_keeps_bare_signature_lookup(
                 "params": ["id"],
                 "param_types": ["int"],
                 "return_type": "list[object]",
-                "concept_name": "concept:sql-query",
+                "concept_name": "missing-concept",
             },
         }
     )
@@ -103,7 +103,7 @@ def test_rpc_invoke_without_named_term_tree_keeps_bare_signature_lookup(
             "message": "missing body-template entry",
             "data": [
                 {
-                    "operation_kind": "concept:sql-query",
+                    "operation_kind": "missing-concept",
                     "args_shape": ["int"],
                     "function": "select_by_id",
                     "term_position": "body",


### PR DESCRIPTION
## Summary

Last `test-python` red layer behind the long-red conformance gate. #1468 split flat `concept:sql-query` into cardinality members (`-all`/`-row`/`-iterate`) and re-minted the shim `.proof`s to carry only those. The python sqlite3 + aiosqlite **realize** kit tests still emitted the retired flat name → realizer's exact-name lookup misses → `MissingTemplateError` / RPC `KeyError: 'result'`.

## Fix (kit catches up to cardinality — the architect-chosen approach)

- Query cases asserting a `fetchall()` / list body → `concept:sql-query-all`, matched per-callsite to the shim's real entry (verified shim-side before editing).
- Missing-template probe tests → explicit `missing-concept` (no longer abusing the retired flat name to miss).

**Not done** (would defeat #1468 / violate Supra-omnia): no flat→`-all` alias (silently picks one of three distinct cardinalities), no `.proof` re-mint, no rust migrate change, no realizer fuzzy-match.

## Verification (exact Makefile fresh-venv recipe, with network)

- `provekit-realize-python-sqlite3`: **17 passed**
- `provekit-realize-python-aiosqlite`: **19 passed**

(Implemented by codex gpt-5.5 xhigh in an isolated worktree under hard constraints; diff reviewed + locally re-verified by the coordinator. The full conformance gate on main will confirm whether any further layers — e.g. test-java tests, previously unreachable because build-java failed at mkdir — remain.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)