### PR TITLE
test: ignore/skip stale lower-era + broken-harness tests (reversible)

### DIFF
--- a/implementations/python/provekit-realize-python-core/tests/test_emit_compile_run_conformance.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_emit_compile_run_conformance.py
@@ -15,6 +15,18 @@ for path in (PY_TESTS_SRC, LIFT_SRC, REALIZER_SRC):
     if str(path) not in sys.path:
         sys.path.insert(0, str(path))
 
+import pytest
+
+# This cross-kit conformance test imports provekit-lift-python-source, which
+# transitively needs cbor2 (a dependency of provekit-lift-py-tests, not of this
+# realize kit). The Makefile runs it in the realize-python-core ISOLATED venv,
+# where cbor2 is absent -> collection error. Skip cleanly there; it still runs
+# in a full repo env. Pending conformance-harness rethink; do not delete.
+pytest.importorskip(
+    "cbor2",
+    reason="cross-kit conformance dep (cbor2 via provekit-lift-py-tests) absent in isolated venv",
+)
+
 from provekit_lift_python_source.bind_lifter import lift_source
 from provekit_realize_python_core.realizer import emit_stub
 

--- a/menagerie/bridgeworks/tests/smoke.rs
+++ b/menagerie/bridgeworks/tests/smoke.rs
@@ -358,6 +358,7 @@ fn walkthrough_binary_prep_ignores_test_only_cli_edits() {
 }
 
 #[test]
+#[ignore = "superseded: bridgeworks is a `lower`-era demo (lift -> lower to C witness); `provekit lower` retired in #1476. Pending redo-on-emit or retire; do not delete."]
 fn checked_add_exhibit_passes() {
     let _guard = shared_host_tool_lock();
     let _cli_env = CliEnvGuard::force_source_cli();
@@ -374,6 +375,7 @@ fn checked_add_exhibit_passes() {
 }
 
 #[test]
+#[ignore = "superseded: bridgeworks is a `lower`-era demo (lift -> lower to C witness); `provekit lower` retired in #1476. Pending redo-on-emit or retire; do not delete."]
 fn all_exhibits_reports_contract_and_implication_mementos() {
     let _guard = shared_host_tool_lock();
     let root = repo_root();

--- a/menagerie/supply-chain-rails/tests/smoke.rs
+++ b/menagerie/supply-chain-rails/tests/smoke.rs
@@ -129,6 +129,7 @@ fn all_mode_rejects_empty_specimen_root() {
 }
 
 #[test]
+#[ignore = "superseded: drives the retired `lower` JS-lowerer (#1476). Pending emit-era redesign; do not delete."]
 fn all_exhibits_show_conventional_green_then_provekit_red() {
     let root = repo_root();
     let provekit = build_provekit(&root);


### PR DESCRIPTION
## Summary

Quarantine (ignore/skip, **not delete**) tests that fail against the post-#1476 (`lower`->`emit`) and cardinality-split architecture, so they stay visible for a deliberate emit-era redesign. Part of draining the long-red conformance gate honestly.

- **bridgeworks** smoke: `#[ignore]` `checked_add_exhibit_passes` + `all_exhibits_reports_contract_and_implication_mementos`. Bridgeworks is a `lower`-era demo (lift → *lower* to a C witness); `provekit lower` retired in #1476. Demo preserved intact pending redo-on-emit-or-retire.
- **supply-chain-rails** smoke: `#[ignore]` `all_exhibits_show_conventional_green_then_provekit_red` (drives the retired `lower` JS-lowerer).
- **realize-python-core** `test_emit_compile_run_conformance.py`: module-level `pytest.importorskip("cbor2")` — pulls cross-kit deps (cbor2 via provekit-lift-py-tests) absent in the isolated venv; now skips cleanly there, still runs in a full env.

## Deliberately NOT done

- The **cross-language conformance suite** (C1-C8 `prove-*` jobs + byte-identical tests) is left untouched — it needs a deliberate redesign post-architecture-shift, not a piecemeal 1am retirement.
- **`package_inspection`'s `provekit mint` ORP-witness failure** (`package.no-install-side-effect`) is a **real regression**, not a stale test. Left visible / tracked, not ignored — Supra-omnia: we don't green the gate by burying a live bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)