### PR TITLE
ci(conformance): bump linux gate timeout 30->45 for teardown headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,13 @@ jobs:
     # macOS runner registered for #305 will pick up this Linux-only job
     # (apt-get) and fail.
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 30
+    # `make conformance` + `make test-all` run right up against ~30 min, leaving
+    # no room for teardown (the Rust-target cache save on push, or even the
+    # toolchain Post-steps on PRs) -> the job's last step gets clipped and the
+    # whole job is marked `cancelled`/fail despite both substantive steps
+    # passing. 45 (matching the macOS-swift conformance job) gives teardown
+    # headroom so a green run reports green.
+    timeout-minutes: 45
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Substantive gate steps (`make conformance` + `make test-all`) consume ~all 30 min, so teardown (Rust-target cache save on push; toolchain Post-steps on PRs) gets clipped and the job is stamped `cancelled`/fail despite both passing — verified on run 26429470259 @ `29c9dd6c0`. Bump to 45 (matches the macOS-swift conformance job) to give teardown headroom so a green run reports green. No test/build change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline timeout configuration for improved reliability during long-running conformance tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->