### PR TITLE
feat(lsp): shared protocol-catalog artifact + reference protocol_catalog_cid

### DIFF
--- a/docs/lsp/diagnostic-shape-v1.md
+++ b/docs/lsp/diagnostic-shape-v1.md
@@ -8,7 +8,7 @@ The check is:
 current_post implies callee_pre
 ```
 
-When the verifier rejects that implication, the LSP plugin emits one `implication-failed` diagnostic at the callsite.
+When the verifier rejects that implication, the LSP plugin emits one `provekit.lsp.implication_failed` diagnostic at the callsite.
 
 ## Scope
 
@@ -24,7 +24,7 @@ Forward-propagation precondition failures always use:
 |---|---|
 | `severity` | `1` |
 | `source` | `"provekit"` |
-| `code` | `"implication-failed"` |
+| `code` | `"provekit.lsp.implication_failed"` |
 
 Severity `1` is the LSP Error severity.
 
@@ -34,7 +34,7 @@ The diagnostic MUST preserve the v1.6.2 CID separation:
 
 | Field | Meaning |
 |---|---|
-| `protocol_catalog_cid` | The active protocol catalog CID. For the current tree this is v1.6.2. |
+| `protocol_catalog_cid` | The active shared LSP protocol catalog CID from `protocol/catalogs/provekit-lsp-shared-1.catalog.json`. |
 | `baseline_catalog_cid` | The CID of the verified `.proof` baseline catalog artifact used for lookup. This is the artifact CID, not a friendly filename. |
 | `baseline_contract_set_cid` | The signer-independent content set CID for the baseline contracts, when present or derivable. |
 | `baseline_index_cid` | The CID of the LSP callsite index artifact described in [callsite-resolution-v1.md](callsite-resolution-v1.md). |
@@ -58,7 +58,7 @@ The LSP diagnostic object is:
   },
   "severity": 1,
   "source": "provekit",
-  "code": "implication-failed",
+  "code": "provekit.lsp.implication_failed",
   "message": "callee precondition not established at this callsite",
   "data": {
     "schema_version": 1,
@@ -77,7 +77,7 @@ The LSP diagnostic object is:
     "baseline_catalog_cid": "blake3-512:...",
     "baseline_contract_set_cid": "blake3-512:...",
     "baseline_index_cid": "blake3-512:...",
-    "protocol_catalog_cid": "blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f"
+    "protocol_catalog_cid": "blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c"
   }
 }
 ```
@@ -99,7 +99,7 @@ An LSP plugin emits this diagnostic only when all of the following hold:
 
 If the accumulated post is `top`, the plugin suppresses this diagnostic. The floor spec treats `top` as a loss of precision, not as a user-visible contract violation.
 
-If lookup, verification, or trust-policy evaluation fails before the implication query can run, the plugin emits a more specific ProvekIt diagnostic code instead of `implication-failed`.
+If lookup, verification, or trust-policy evaluation fails before the implication query can run, the plugin emits a more specific ProvekIt diagnostic code instead of `provekit.lsp.implication_failed`.
 
 ## Hover Content
 

--- a/docs/reference/lsp-plugin-protocol.md
+++ b/docs/reference/lsp-plugin-protocol.md
@@ -3,6 +3,10 @@
 This page is the short operational reference for kit-local editor helpers.
 The shared editor protocol is defined in
 [`2026-05-25-lsp-shared-protocol.md`](../../protocol/specs/2026-05-25-lsp-shared-protocol.md).
+Its canonical machine-readable catalog is
+[`protocol/catalogs/provekit-lsp-shared-1.catalog.json`](../../protocol/catalogs/provekit-lsp-shared-1.catalog.json),
+whose `protocol_catalog_cid` is
+`blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c`.
 
 ProvekIt editor plugins speak a small line-delimited JSON protocol to kit-local helpers. The editor owns Language Server Protocol wiring; the helper owns ProvekIt parsing, lifting, and handshake checks.
 

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -2300,6 +2300,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-lsp-protocol-catalog"
+version = "0.1.0"
+dependencies = [
+ "provekit-canonicalizer",
+ "serde_json",
+]
+
+[[package]]
 name = "provekit-lsp-rust"
 version = "0.1.0"
 dependencies = [

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "provekit-lift-native-surfaces",
     "provekit-linker",
     "provekit-lsp",
+    "provekit-lsp-protocol-catalog",
     "provekit-lsp-rust",
     "provekit-build",
     "provekit-agent",

--- a/implementations/rust/provekit-canonicalizer/Cargo.toml
+++ b/implementations/rust/provekit-canonicalizer/Cargo.toml
@@ -6,6 +6,10 @@ license.workspace = true
 authors.workspace = true
 description = "ProvekIt: JCS-JSON encoder (RFC 8785) + BLAKE3-512 self-identifying hash helper."
 
+[features]
+default = []
+pure-blake3 = ["blake3/pure"]
+
 [dependencies]
 blake3 = { workspace = true }
 hex = { workspace = true }

--- a/implementations/rust/provekit-lsp-protocol-catalog/Cargo.toml
+++ b/implementations/rust/provekit-lsp-protocol-catalog/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "provekit-lsp-protocol-catalog"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Reference CID computation for the shared ProvekIt LSP protocol catalog."
+
+[dependencies]
+provekit-canonicalizer = { path = "../provekit-canonicalizer", features = ["pure-blake3"] }
+serde_json = { workspace = true }

--- a/implementations/rust/provekit-lsp-protocol-catalog/src/lib.rs
+++ b/implementations/rust/provekit-lsp-protocol-catalog/src/lib.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Reference computation for the shared ProvekIt LSP protocol catalog CID.
+//
+// The CID rule mirrors the protocol catalog pattern used by provekit-cli:
+// parse JSON, RFC 8785 JCS-canonicalize it with provekit-canonicalizer, then
+// compute the self-identifying BLAKE3-512 CID.
+
+use std::fmt;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use serde_json::Value as Json;
+
+pub const LSP_PROTOCOL_CATALOG_REPO_PATH: &str =
+    "protocol/catalogs/provekit-lsp-shared-1.catalog.json";
+
+pub const EXPECTED_LSP_PROTOCOL_CATALOG_CID: &str =
+    "blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c";
+
+pub const EMBEDDED_LSP_PROTOCOL_CATALOG_BYTES: &[u8] =
+    include_bytes!("../../../../protocol/catalogs/provekit-lsp-shared-1.catalog.json");
+
+#[derive(Debug)]
+pub enum ProtocolCatalogError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    NonIntegerNumber(String),
+}
+
+impl fmt::Display for ProtocolCatalogError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProtocolCatalogError::Io(err) => write!(f, "I/O error: {err}"),
+            ProtocolCatalogError::Json(err) => write!(f, "JSON error: {err}"),
+            ProtocolCatalogError::NonIntegerNumber(number) => {
+                write!(f, "catalog contains non-i64 JSON number: {number}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProtocolCatalogError {}
+
+impl From<std::io::Error> for ProtocolCatalogError {
+    fn from(err: std::io::Error) -> Self {
+        ProtocolCatalogError::Io(err)
+    }
+}
+
+impl From<serde_json::Error> for ProtocolCatalogError {
+    fn from(err: serde_json::Error) -> Self {
+        ProtocolCatalogError::Json(err)
+    }
+}
+
+pub fn protocol_catalog_cid_from_repo(
+    repo_root: impl AsRef<Path>,
+) -> Result<String, ProtocolCatalogError> {
+    let bytes = fs::read(repo_root.as_ref().join(LSP_PROTOCOL_CATALOG_REPO_PATH))?;
+    protocol_catalog_cid_from_bytes(&bytes)
+}
+
+pub fn embedded_protocol_catalog_cid() -> Result<String, ProtocolCatalogError> {
+    protocol_catalog_cid_from_bytes(EMBEDDED_LSP_PROTOCOL_CATALOG_BYTES)
+}
+
+pub fn protocol_catalog_cid_from_bytes(bytes: &[u8]) -> Result<String, ProtocolCatalogError> {
+    let json: Json = serde_json::from_slice(bytes)?;
+    let canonical = json_to_cvalue(&json)?;
+    let jcs = encode_jcs(&canonical);
+    Ok(blake3_512_of(jcs.as_bytes()))
+}
+
+fn json_to_cvalue(value: &Json) -> Result<Arc<CValue>, ProtocolCatalogError> {
+    Ok(match value {
+        Json::Null => CValue::null(),
+        Json::Bool(value) => CValue::boolean(*value),
+        Json::Number(value) => {
+            let integer = value
+                .as_i64()
+                .ok_or_else(|| ProtocolCatalogError::NonIntegerNumber(value.to_string()))?;
+            CValue::integer(integer)
+        }
+        Json::String(value) => CValue::string(value.clone()),
+        Json::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(json_to_cvalue(item)?);
+            }
+            CValue::array(out)
+        }
+        Json::Object(map) => {
+            let mut out = Vec::with_capacity(map.len());
+            for (key, item) in map {
+                out.push((key.clone(), json_to_cvalue(item)?));
+            }
+            CValue::object(out)
+        }
+    })
+}

--- a/implementations/rust/provekit-lsp-protocol-catalog/tests/protocol_catalog.rs
+++ b/implementations/rust/provekit-lsp-protocol-catalog/tests/protocol_catalog.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::PathBuf;
+
+use provekit_lsp_protocol_catalog::{
+    embedded_protocol_catalog_cid, protocol_catalog_cid_from_repo,
+    EXPECTED_LSP_PROTOCOL_CATALOG_CID, LSP_PROTOCOL_CATALOG_REPO_PATH,
+};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .expect("repo root")
+}
+
+#[test]
+fn lsp_protocol_catalog_cid_is_pinned_and_deterministic() {
+    let repo = repo_root();
+    let first = protocol_catalog_cid_from_repo(&repo).expect("first CID");
+    let second = protocol_catalog_cid_from_repo(&repo).expect("second CID");
+    let embedded = embedded_protocol_catalog_cid().expect("embedded CID");
+
+    println!("protocol_catalog_cid={first}");
+
+    assert_eq!(first, second, "catalog CID must be deterministic");
+    assert_eq!(
+        first, embedded,
+        "embedded catalog bytes and repo catalog file must agree"
+    );
+    assert_eq!(
+        first, EXPECTED_LSP_PROTOCOL_CATALOG_CID,
+        "pinned CID must match the canonical LSP protocol catalog"
+    );
+}
+
+#[test]
+fn lsp_protocol_catalog_declares_shared_surface() {
+    let catalog_path = repo_root().join(LSP_PROTOCOL_CATALOG_REPO_PATH);
+    let bytes = fs::read(&catalog_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", catalog_path.display()));
+    let json: serde_json::Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|err| panic!("parse {}: {err}", catalog_path.display()));
+
+    assert_eq!(json["kind"].as_str(), Some("provekit-lsp-protocol-catalog"));
+    assert_eq!(json["schemaVersion"].as_str(), Some("1"));
+    assert_eq!(
+        json["protocol"]["id"].as_str(),
+        Some("provekit-lsp-shared/1")
+    );
+    assert_eq!(json["protocol"]["version"].as_str(), Some("1"));
+
+    let methods = json["methods"]
+        .as_array()
+        .expect("methods must be an array")
+        .iter()
+        .filter_map(|method| method["name"].as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(methods, ["initialize", "analyzeDocument", "shutdown"]);
+
+    let diagnostic_codes = json["diagnosticCodes"]
+        .as_array()
+        .expect("diagnosticCodes must be an array")
+        .iter()
+        .filter_map(|code| code["code"].as_str())
+        .collect::<Vec<_>>();
+    assert!(diagnostic_codes.contains(&"provekit.lsp.implication_failed"));
+    assert!(diagnostic_codes.contains(&"provekit.lsp.lift_gap"));
+    assert!(diagnostic_codes
+        .iter()
+        .all(|code| code.starts_with("provekit.lsp.")));
+
+    let status_axes = json["statusAxes"]
+        .as_array()
+        .expect("statusAxes must be an array")
+        .iter()
+        .filter_map(|axis| axis.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        status_axes,
+        ["lift", "materialize", "emit", "check", "prove"]
+    );
+
+    let range = &json["analysisResult"]["rangeContract"];
+    assert_eq!(range["lineBase"].as_i64(), Some(1));
+    assert_eq!(range["columnBase"].as_i64(), Some(0));
+    assert_eq!(
+        range["fields"]
+            .as_array()
+            .expect("range fields")
+            .iter()
+            .filter_map(|field| field.as_str())
+            .collect::<Vec<_>>(),
+        ["start_line", "start_col", "end_line", "end_col"]
+    );
+}
+
+#[test]
+fn lsp_protocol_catalog_cid_is_not_the_version_string_hash() {
+    let version_string_cid = provekit_canonicalizer::blake3_512_of(b"provekit-lsp-shared/1");
+    assert_ne!(
+        EXPECTED_LSP_PROTOCOL_CATALOG_CID, version_string_cid,
+        "protocol_catalog_cid must hash the catalog document, not the protocol version string"
+    );
+}

--- a/protocol/catalogs/provekit-lsp-shared-1.catalog.json
+++ b/protocol/catalogs/provekit-lsp-shared-1.catalog.json
@@ -1,0 +1,252 @@
+{
+  "kind": "provekit-lsp-protocol-catalog",
+  "schemaVersion": "1",
+  "catalogName": "provekit-lsp-shared",
+  "catalogVersion": "1",
+  "protocol": {
+    "id": "provekit-lsp-shared/1",
+    "name": "provekit-lsp-shared",
+    "version": "1"
+  },
+  "sourceDocuments": [
+    "protocol/specs/2026-05-25-lsp-shared-protocol.md",
+    "docs/lsp/diagnostic-shape-v1.md",
+    "docs/reference/lsp-plugin-protocol.md"
+  ],
+  "cidRecipe": {
+    "canonicalization": "RFC 8785 JCS",
+    "hash": "blake3-512",
+    "input": "JCS canonical bytes of this JSON catalog document",
+    "outputField": "protocol_catalog_cid"
+  },
+  "transport": {
+    "encoding": "utf-8",
+    "framing": "ndjson-stdio",
+    "rpc": "JSON-RPC 2.0"
+  },
+  "methods": [
+    {
+      "name": "initialize",
+      "required": true,
+      "request": "initialize-request",
+      "result": "initialize-result"
+    },
+    {
+      "name": "analyzeDocument",
+      "required": true,
+      "request": "analyze-document-request",
+      "result": "lsp-document-analysis"
+    },
+    {
+      "name": "shutdown",
+      "required": true,
+      "request": "shutdown-request",
+      "result": "null"
+    }
+  ],
+  "initializeResult": {
+    "requiredFields": [
+      "name",
+      "version",
+      "protocol_version",
+      "kit_id",
+      "protocol_catalog_cid",
+      "capabilities"
+    ],
+    "protocolVersionField": "protocol_version",
+    "protocolCatalogCidField": "protocol_catalog_cid",
+    "capabilityFields": [
+      "source_surfaces",
+      "entry_kinds",
+      "diagnostic_codes",
+      "status_kinds"
+    ]
+  },
+  "analyzeDocumentRequest": {
+    "requiredFields": [
+      "kit_id",
+      "uri",
+      "file",
+      "text",
+      "document_version",
+      "workspace_root"
+    ],
+    "optionalFields": [
+      "accepted_protocol_catalog_cids",
+      "policy_cids"
+    ]
+  },
+  "analysisResult": {
+    "kind": "lsp-document-analysis",
+    "schemaVersion": "1",
+    "requiredFields": [
+      "kind",
+      "schema_version",
+      "kit_id",
+      "uri",
+      "file",
+      "document_cid",
+      "protocol_catalog_cid",
+      "entries",
+      "diagnostics",
+      "statuses",
+      "project"
+    ],
+    "documentCidRecipe": {
+      "canonicalization": "none",
+      "hash": "blake3-512",
+      "input": "exact UTF-8 document bytes from analyzeDocument"
+    },
+    "entryKinds": [
+      "bind-lift-entry",
+      "library-sugar-binding-entry",
+      "call-edge",
+      "concept-site",
+      "proof-site",
+      "extension"
+    ],
+    "rangeContract": {
+      "fields": [
+        "start_line",
+        "start_col",
+        "end_line",
+        "end_col"
+      ],
+      "lineBase": 1,
+      "columnBase": 0,
+      "coordinatorLspLineBase": 0,
+      "coordinatorLspColumnBase": 0,
+      "rule": "producers emit 1-based lines and 0-based columns; the coordinator converts to client-native LSP positions"
+    }
+  },
+  "diagnosticShape": {
+    "source": "provekit",
+    "severityValues": [
+      "error",
+      "warning",
+      "information",
+      "hint"
+    ],
+    "producers": [
+      "kit",
+      "linkerd",
+      "verifier",
+      "materialize",
+      "emit",
+      "check",
+      "lsp-coordinator",
+      "forward-propagation"
+    ],
+    "requiredFields": [
+      "code",
+      "message",
+      "severity",
+      "range",
+      "producer"
+    ],
+    "optionalFields": [
+      "kit_id",
+      "protocol_catalog_cid",
+      "related_cids",
+      "data"
+    ]
+  },
+  "diagnosticCodes": [
+    {
+      "code": "provekit.lsp.parse_error",
+      "producer": "kit",
+      "meaning": "The kit could not parse the live document snapshot."
+    },
+    {
+      "code": "provekit.lsp.lift_gap",
+      "producer": "kit",
+      "meaning": "The kit parsed the source but could not lift a source site into normalized facts."
+    },
+    {
+      "code": "provekit.lsp.catalog_mismatch",
+      "producer": "kit/coordinator",
+      "meaning": "The helper used a protocol catalog CID that does not match project policy."
+    },
+    {
+      "code": "provekit.lsp.materialize_unavailable",
+      "producer": "materialize",
+      "meaning": "The site has no resolvable materialize route for the requested target and library tuple."
+    },
+    {
+      "code": "provekit.lsp.materialize_refused",
+      "producer": "materialize",
+      "meaning": "The route exists but refuses under policy or loss budget."
+    },
+    {
+      "code": "provekit.lsp.emit_unavailable",
+      "producer": "emit",
+      "meaning": "The kit cannot emit the requested test or check artifact for this site."
+    },
+    {
+      "code": "provekit.lsp.check_failed",
+      "producer": "check",
+      "meaning": "A kit-owned host check failed."
+    },
+    {
+      "code": "provekit.lsp.unresolved_symbol",
+      "producer": "linkerd",
+      "meaning": "A call edge target could not be resolved in the project union."
+    },
+    {
+      "code": "provekit.lsp.unprovable_obligation",
+      "producer": "linkerd/verifier",
+      "meaning": "A call-site or bridge obligation could not be discharged."
+    },
+    {
+      "code": "provekit.lsp.implication_failed",
+      "producer": "forward-propagation",
+      "meaning": "Current post facts do not establish the callee precondition."
+    },
+    {
+      "code": "provekit.lsp.vacuous_proof",
+      "producer": "verifier",
+      "meaning": "A proof path reported success without nonzero claims."
+    }
+  ],
+  "statusAxes": [
+    "lift",
+    "materialize",
+    "emit",
+    "check",
+    "prove"
+  ],
+  "statusKinds": [
+    "materialize",
+    "emit",
+    "check",
+    "prove",
+    "concept",
+    "link",
+    "extension"
+  ],
+  "statusStates": [
+    "available",
+    "unavailable",
+    "refused",
+    "unknown",
+    "passed",
+    "failed",
+    "stale"
+  ],
+  "projectPins": [
+    "contractSetCid",
+    "callEdgeSetCid",
+    "bridgeSetCid",
+    "linkBundleCid",
+    "diagnosticsCid"
+  ],
+  "conformanceRules": [
+    "initialize returns protocol_version equal to provekit-lsp-shared/1",
+    "initialize returns protocol_catalog_cid equal to blake3-512 over the JCS canonical bytes of this catalog",
+    "analyzeDocument is deterministic for byte-identical kit_id, file, text, accepted_protocol_catalog_cids, and policy_cids",
+    "returned source ranges point into the submitted document snapshot",
+    "the coordinator does not parse host-language source",
+    "the coordinator preserves stable provekit.lsp.* diagnostic codes",
+    "helpers do not report proof success for a vacuous zero-claim route"
+  ]
+}

--- a/protocol/specs/2026-05-25-lsp-shared-protocol.md
+++ b/protocol/specs/2026-05-25-lsp-shared-protocol.md
@@ -2,7 +2,9 @@
 
 **Version:** v0.1.0
 **Date:** 2026-05-25
-**Status:** design proposal for review. Not cataloged yet.
+**Status:** cataloged by `protocol/catalogs/provekit-lsp-shared-1.catalog.json`
+with `protocol_catalog_cid =
+blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c`.
 **Author:** T Savo
 **Companion specs:** [Linker Daemon Protocol](2026-05-04-linker-daemon-protocol.md), [Bridge Linkage Protocol](2026-05-03-bridge-linkage-protocol.md), [Lift Plugin Protocol](2026-04-30-lift-plugin-protocol.md), [Plugin Extension Protocol](2026-05-12-plugin-protocol.md), [Bind-IR Lift-Result Shape](2026-05-13-bind-ir-lift-result.md), [Body Template Memento](2026-05-13-body-template-memento.md), [Concept Hub Abstraction Layer](2026-05-15-concept-hub-abstraction-layer.md)
 


### PR DESCRIPTION
Shared LSP protocol-catalog (the convergence artifact the four `analyzeDocument` PRs #1504/1505/1506/1507 adopt). `protocol_catalog_cid = blake3-512(JCS(catalog.json))` = `blake3-512:0e3905c2…643c`. Reference crate `provekit-lsp-protocol-catalog` computes it. Ports load+hash the file; no version-string hashing, no per-port reconstruction. CI verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)