### PR TITLE
ci(swift): cache SwiftPM .build on the macOS jobs (was cold ~15min/run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # The macOS swift jobs were cold-compiling SwiftPM from scratch every
+      # run (~15 min) because NOTHING cached `.build` — only cargo was cached
+      # (wrong language). Restore the SwiftPM build dir always (incl. PRs) so
+      # source-only changes recompile incrementally off a warm `.build`; save
+      # only on push so a PR's post-job upload can't time the job out (same
+      # discipline as the cargo cache above).
+      - name: Restore SwiftPM build
+        uses: actions/cache/restore@v4
+        with:
+          path: implementations/swift/.build
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-
+
+      - name: Save SwiftPM build
+        if: github.event_name != 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: implementations/swift/.build
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
+
       - name: Verify swift toolchain
         # macOS GitHub-hosted runners ship the swift toolchain
         # pre-installed (Xcode command-line tools). No setup-swift action
@@ -735,6 +756,24 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+
+      # Cache SwiftPM `.build` (restore always, save on push) — see the
+      # conformance-macos-swift job for the rationale; cold SwiftPM compile
+      # was the ~15-min tax on this job.
+      - name: Restore SwiftPM build
+        uses: actions/cache/restore@v4
+        with:
+          path: implementations/swift/.build
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-
+
+      - name: Save SwiftPM build
+        if: github.event_name != 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: implementations/swift/.build
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
 
       - name: CICP shadow blast radius (swift)
         run: |


### PR DESCRIPTION
macOS swift jobs cached the rust target (keyed on Cargo.lock) but never the SwiftPM `.build` — so every run cold-compiled swift from scratch (~15 min). Add restore-always/save-on-push cache for `implementations/swift/.build` keyed on `Package.resolved` (prefix restore-key fallback → incremental on source-only changes), mirroring the cargo two-step. Swift kits pass already; this kills the cold-compile tax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI build performance by implementing build caching for macOS Swift jobs, reducing compilation time during continuous integration runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->