### PR TITLE
build(swift): debug not release (swift-syntax release opt was most of the 15min)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,8 +265,16 @@ build-ruby:
 	cd implementations/ruby && $(RUBY) -S bundle exec $(RUBY) -Ilib -e 'require "provekit"; abort unless Provekit::Blake3.hex("provekit").start_with?("blake3-512:")'
 
 .PHONY: build-swift
+# Debug, not release. ~90% of this build is the swift-syntax dependency (the
+# Swift parser the source lifter needs), and compiling it with full release
+# optimization is most of the multi-minute tax. Debug is safe here: minted
+# CIDs are content-addressed (JCS+blake3 over contract data), so binary
+# optimization level cannot change them, and CI fixtures are tiny so lifter
+# runtime perf is irrelevant. Override with `SWIFT_BUILD_CONFIG=release` if a
+# release artifact is ever needed.
+SWIFT_BUILD_CONFIG ?= debug
 build-swift:
-	cd implementations/swift && swift build -c release
+	cd implementations/swift && swift build -c $(SWIFT_BUILD_CONFIG)
 
 # --- Mint targets ------------------------------------------------------------
 


### PR DESCRIPTION
`build-swift` did `swift build -c release` on the whole package every swift job; ~90% of that is **swift-syntax** (the parser the source lifter needs), and release optimization on it is the bulk of the ~15min. Switch to debug (`SWIFT_BUILD_CONFIG ?= debug`, overridable). Safe — minted CIDs are content-addressed (opt level can't change them) and CI fixtures are tiny. Pairs with the `.build` cache (#1526); helps the cold path the cache can't. swift-syntax itself can't be dropped — the swift kit lifts Swift source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)