### PR TITLE
fix(lsp-go): remove duplicate+wrong hardcoded protocolCatalogCID const (unbreak build-go)

### DIFF
--- a/implementations/go/cmd/provekit-lsp-go/forward_propagator.go
+++ b/implementations/go/cmd/provekit-lsp-go/forward_propagator.go
@@ -9,8 +9,6 @@ import (
 	canonicalizer "github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
 )
 
-const protocolCatalogCID = "blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f"
-
 type Post struct {
 	Constraints []string
 	IsTop       bool


### PR DESCRIPTION
build-go failed: `protocolCatalogCID redeclared`. main.go (#1506) added the computed var; forward_propagator.go still had a hardcoded const = the **CICP** catalog CID (wrong). Delete the stale const → computed `0e3905c2…` used everywhere. Unbreaks build-go + fixes a latent wrong-CID emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)