### PR TITLE
fix: ETXTBSY race + bundle SQLite (greens main; CICP removal lands next)

### DIFF
--- a/examples/provekit-shim-rusqlite/Cargo.toml
+++ b/examples/provekit-shim-rusqlite/Cargo.toml
@@ -9,7 +9,12 @@ keywords = ["sqlite", "rusqlite", "provekit", "proofchain", "boundary-realizatio
 categories = ["database"]
 
 [dependencies]
-rusqlite = "0.39"
+# `bundled`: compile SQLite from the amalgamation and link it statically, so
+# the build never depends on a system `libsqlite3.so` being discoverable by the
+# linker. The self-hosted runner fleet is heterogeneous (lld doesn't always get
+# `/usr/lib/x86_64-linux-gnu` on its search path), which intermittently broke
+# `-lsqlite3` resolution in build-rust. Bundled makes the build runner-independent.
+rusqlite = { version = "0.39", features = ["bundled"] }
 provekit = { package = "provekit-sugar", path = "../../implementations/rust/provekit-sugar" }
 
 [dev-dependencies]

--- a/examples/rusqlite-demo-consumer/Cargo.toml
+++ b/examples/rusqlite-demo-consumer/Cargo.toml
@@ -10,4 +10,5 @@ name = "rusqlite-demo"
 path = "src/main.rs"
 
 [dependencies]
-rusqlite = "0.39"
+# bundled: static SQLite, no system libsqlite3.so link dependency (runner-independent).
+rusqlite = { version = "0.39", features = ["bundled"] }

--- a/implementations/rust/provekit-cli/tests/cmd_verify_python_division_unsound.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_python_division_unsound.rs
@@ -83,17 +83,29 @@ fn unique_dir(suffix: &str) -> PathBuf {
 }
 
 fn build_python_lift_verify() -> PathBuf {
+    use std::io::Write as _;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    // Unique per call: parallel tests in this binary share one process id, so a
+    // pid-keyed path collides (ETXTBSY when one execs while another writes).
+    static SEQ: AtomicU64 = AtomicU64::new(0);
     let src = python_lift_src();
     let script = std::env::temp_dir().join(format!(
-        "provekit-lift-python-verify-div-{}.sh",
-        std::process::id()
+        "provekit-lift-python-verify-div-{}-{}.sh",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
     ));
     let body = format!(
         "#!/bin/sh\nexec python3 -c \"import sys; sys.path.insert(0, '{}'); \
          from provekit_lift_python_source.verify_rpc import run_rpc; run_rpc()\"\n",
         src.display()
     );
-    fs::write(&script, body).expect("write python lift wrapper");
+    // sync_all + drop writer fd before chmod/spawn so exec never sees an open writer.
+    {
+        let mut f = fs::File::create(&script).expect("create python lift wrapper");
+        f.write_all(body.as_bytes())
+            .expect("write python lift wrapper");
+        f.sync_all().expect("sync python lift wrapper");
+    }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
@@ -96,17 +96,32 @@ fn unique_dir(suffix: &str) -> PathBuf {
 /// Go test compiles a Go binary; Python is interpreted, so the analog is a
 /// stable wrapper invoking `python3 -c "...; run_rpc()"`.
 fn build_python_lift_verify() -> PathBuf {
+    use std::io::Write as _;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    // Unique per call: cargo runs the tests in this binary as parallel threads
+    // of ONE process, so a `process::id()`-keyed path is SHARED across them.
+    // One test exec'ing the wrapper while another truncates it for write =>
+    // ETXTBSY (os error 26). An atomic counter gives each call its own path.
+    static SEQ: AtomicU64 = AtomicU64::new(0);
     let src = python_lift_src();
     let script = std::env::temp_dir().join(format!(
-        "provekit-lift-python-verify-{}.sh",
-        std::process::id()
+        "provekit-lift-python-verify-{}-{}.sh",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
     ));
     let body = format!(
         "#!/bin/sh\nexec python3 -c \"import sys; sys.path.insert(0, '{}'); \
          from provekit_lift_python_source.verify_rpc import run_rpc; run_rpc()\"\n",
         src.display()
     );
-    fs::write(&script, body).expect("write python lift wrapper");
+    // sync_all + drop the writer fd BEFORE chmod/spawn so `exec` never sees an
+    // open writer (the second half of the ETXTBSY guard; see cli_surface.rs).
+    {
+        let mut f = fs::File::create(&script).expect("create python lift wrapper");
+        f.write_all(body.as_bytes())
+            .expect("write python lift wrapper");
+        f.sync_all().expect("sync python lift wrapper");
+    }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
## Why main is red

The revert (#1530) backed out the LSP ports cleanly, but main's conformance gate stayed **red** on a single failure:

```
test python_mint_auto_writes_body_discharge_bridge ... FAILED
  stderr: kit transform failed: spawn ["/tmp/provekit-lift-python-verify-43642.sh", "--rpc"]: Text file busy (os error 26)
==== test-all FAIL: test-rust ====
```

`make conformance` (C1-C8) is **green**; java/ts/ruby/C all green. Only this one test fails, intermittently.

## Root cause

`cmd_verify_python_production_bridge.rs` (3 tests) and `cmd_verify_python_division_unsound.rs` (2 tests) each run as parallel threads of **one** process. `build_python_lift_verify()` keyed the wrapper-script path on `process::id()` alone — so all parallel tests wrote and exec'd the **same** `/tmp/provekit-lift-python-verify-<pid>.sh`. One test exec'ing it while another truncates it for write => **ETXTBSY**.

## Fix

- Append a process-wide `AtomicU64` counter to the path → unique per call, no cross-test collision.
- Adopt the `sync_all`+drop-before-chmod write already proven in `cli_surface.rs::write_executable` → closes the open-writer-fd half of the race.

Test-only; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for Python lift verification by enhancing temporary script generation to prevent collisions during concurrent test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->