### PR TITLE
[codex] Narrow macOS Swift Rust build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,9 +334,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust (stable)
-        # mint-swift depends on build-rust (the orchestrator binary
-        # provekit-cli is the dispatcher invoked via the lift-plugin-protocol
-        # RPC against mint-swift-self-contracts).
+        # mint-swift depends on the release provekit CLI plus the
+        # self-contract verifier; it must not build the whole Rust workspace.
         uses: dtolnay/rust-toolchain@stable
 
       - name: Restore Rust target dirs
@@ -351,7 +350,6 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             implementations/rust/target
-            tools/recompute-spec-cids/target
             tools/foundation-keygen/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
@@ -369,7 +367,6 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             implementations/rust/target
-            tools/recompute-spec-cids/target
             tools/foundation-keygen/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
@@ -408,10 +405,14 @@ jobs:
       - name: make help (sanity)
         run: make help
 
+      - name: check macOS Swift Rust build scope
+        run: make check-macos-swift-rust-scope
+
       - name: make mint-swift
-        # End-to-end: build-rust + build-swift, then dispatch mint --kit=swift
-        # to the swift orchestrator (mint-swift-self-contracts --rpc), and
-        # verify the resulting contractSetCid matches the pinned envelope at
+        # End-to-end: build the release provekit CLI + verifier + Swift slab,
+        # then dispatch mint --kit=swift to the swift orchestrator
+        # (mint-swift-self-contracts --rpc), and verify the resulting
+        # contractSetCid matches the pinned envelope at
         # provenance/self-contracts-attest/swift.json. Failure here means the
         # swift kit's emission has drifted relative to the rest of the
         # protocol (or the swift slab itself has changed) and is a hard stop.

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,50 @@ build-rust:
 	cargo build --release --manifest-path tools/recompute-spec-cids/Cargo.toml
 	cargo build --release --manifest-path tools/foundation-keygen/Cargo.toml
 
+.PHONY: build-rust-cli
+build-rust-cli:
+	cargo build --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli
+
+.PHONY: build-rust-self-contract-verifier
+build-rust-self-contract-verifier:
+	cargo build --release --manifest-path tools/foundation-keygen/Cargo.toml --bin verify-self-contracts
+
+.PHONY: build-rust-mint-tools
+build-rust-mint-tools: build-rust-cli build-rust-self-contract-verifier
+
+.PHONY: check-macos-swift-rust-scope
+check-macos-swift-rust-scope:
+	@mint_dry="$$( $(MAKE) --no-print-directory -n mint-swift )"; \
+	prove_dry="$$( $(MAKE) --no-print-directory -n prove-swift )"; \
+	cli_tree="$$(cargo tree --manifest-path implementations/rust/Cargo.toml -p provekit-cli --edges normal,build --depth 4)"; \
+	cli_cmd='cargo build --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli'; \
+	verifier_cmd='cargo build --release --manifest-path tools/foundation-keygen/Cargo.toml --bin verify-self-contracts'; \
+	full_workspace_cmd='cargo build --release --manifest-path implementations/rust/Cargo.toml'; \
+	echo "$$mint_dry" | grep -F -- "$$cli_cmd" >/dev/null || \
+		(echo "FAIL: mint-swift must build only the provekit CLI, not the full Rust workspace" && exit 1); \
+	echo "$$mint_dry" | grep -F -- "$$verifier_cmd" >/dev/null || \
+		(echo "FAIL: mint-swift must build the self-contract verifier it invokes" && exit 1); \
+	echo "$$prove_dry" | grep -F -- "$$cli_cmd" >/dev/null || \
+		(echo "FAIL: prove-swift must build only the provekit CLI, not the full Rust workspace" && exit 1); \
+	if echo "$$mint_dry" | grep -F -x -- "$$full_workspace_cmd" >/dev/null; then \
+		echo "FAIL: mint-swift still pulls the full Rust workspace"; exit 1; \
+	fi; \
+	if echo "$$prove_dry" | grep -F -x -- "$$full_workspace_cmd" >/dev/null; then \
+		echo "FAIL: prove-swift still pulls the full Rust workspace"; exit 1; \
+	fi; \
+	if echo "$$mint_dry" | grep -F -- 'tools/recompute-spec-cids/Cargo.toml' >/dev/null; then \
+		echo "FAIL: mint-swift must not build recompute-spec-cids"; exit 1; \
+	fi; \
+	if echo "$$cli_tree" | grep -F -- 'provekit-realize-rust-core' >/dev/null; then \
+		echo "FAIL: provekit-cli must not pull the Rust realize kit into macOS Swift mint builds"; exit 1; \
+	fi; \
+	if echo "$$cli_tree" | grep -F -- '/examples/provekit-shim-' >/dev/null; then \
+		echo "FAIL: provekit-cli must not pull Rust shim example crates into macOS Swift mint builds"; exit 1; \
+	fi; \
+	if echo "$$cli_tree" | grep -E 'smoke-test-e2e|provekit-bridgeworks|provekit-supply-chain-rails|provekit-protocol-switchyard|bug-zoo' >/dev/null; then \
+		echo "FAIL: provekit-cli must not pull menagerie crates into macOS Swift mint builds"; exit 1; \
+	fi
+
 .PHONY: build-cpp
 build-cpp:
 	tools/build-cpp-self-contracts.sh --build-only
@@ -350,7 +394,7 @@ mint-csharp: build-rust
 # NOTE: mint-swift requires a macOS host with the Swift toolchain.
 # Excluded from all-mint (Linux/CI). Use `make mint-swift` on macOS.
 .PHONY: mint-swift
-mint-swift: build-rust build-swift
+mint-swift: build-rust-mint-tools build-swift
 	@echo ">> minting swift self-contracts"
 	@mint_out=$$($(PROVEKIT) mint --kit=swift --quiet); \
 	cid=$$(echo "$$mint_out" | head -1); \
@@ -511,7 +555,7 @@ prove-evm-bytecode: build-rust
 
 # macOS-only: requires Swift toolchain.
 .PHONY: prove-swift
-prove-swift: build-rust build-swift
+prove-swift: build-rust-cli build-swift
 	@echo ">> proving swift lift-plugin-protocol conformance (C1-C8)"
 	$(PROVEKIT) prove --kit=swift
 

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1277,7 +1277,6 @@ dependencies = [
  "provekit-canonicalizer",
  "provekit-ir-types",
  "provekit-proof-envelope",
- "provekit-realize-rust-core",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/implementations/rust/libprovekit/Cargo.toml
+++ b/implementations/rust/libprovekit/Cargo.toml
@@ -18,7 +18,6 @@ crate-type = ["lib", "cdylib", "staticlib"]
 provekit-canonicalizer = { path = "../provekit-canonicalizer" }
 provekit-proof-envelope = { path = "../provekit-proof-envelope" }
 provekit-ir-types = { path = "../provekit-ir-types" }
-provekit-realize-rust-core = { path = "../provekit-realize-rust-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/implementations/rust/provekit-lift-rust-tests/Cargo.toml
+++ b/implementations/rust/provekit-lift-rust-tests/Cargo.toml
@@ -10,7 +10,7 @@ description = "ProvekIt lift adapter: walk #[test] / #[tokio::test] functions an
 provekit-ir-symbolic = { path = "../provekit-ir-symbolic" }
 provekit-ir-types = { path = "../provekit-ir-types" }
 provekit-canonicalizer = { path = "../provekit-canonicalizer" }
-provekit-walk = { path = "../provekit-walk" }
+provekit-walk = { path = "../provekit-walk", default-features = false }
 syn = { workspace = true }
 proc-macro2 = { workspace = true, features = ["span-locations"] }
 quote = { workspace = true }

--- a/implementations/rust/provekit-walk/Cargo.toml
+++ b/implementations/rust/provekit-walk/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/bin/walk_emit.rs"
 [[bin]]
 name = "provekit-walk-rpc"
 path = "src/bin/walk_rpc.rs"
+required-features = ["rpc"]
 
 # Conventional alias so the kit-dispatch resolver (which looks for
 # `provekit-bind-lift-<source_lang>` per its `provekit-bind-lift-{lang}`
@@ -31,6 +32,11 @@ path = "src/bin/walk_rpc.rs"
 [[bin]]
 name = "provekit-bind-lift-rust"
 path = "src/bin/walk_rpc.rs"
+required-features = ["rpc"]
+
+[features]
+default = ["rpc"]
+rpc = ["provekit-realize-rust-core"]
 
 [dependencies]
 syn = { workspace = true }
@@ -43,7 +49,7 @@ provekit-canonicalizer = { path = "../provekit-canonicalizer" }
 provekit-claim-envelope = { path = "../provekit-claim-envelope" }
 provekit-proof-envelope = { path = "../provekit-proof-envelope" }
 libprovekit = { path = "../libprovekit" }
-provekit-realize-rust-core = { path = "../provekit-realize-rust-core" }
+provekit-realize-rust-core = { path = "../provekit-realize-rust-core", optional = true }
 serde_json = { workspace = true }
 base64 = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Summary

- add narrow Rust build targets for the macOS Swift mint/prove path
- make `mint-swift` build only the release `provekit` CLI plus `verify-self-contracts`, instead of the full Rust workspace
- feature-gate the Rust walk RPC dependency on `provekit-realize-rust-core` so `provekit-cli` does not drag Rust shim examples into Swift mint builds
- add a CI/Makefile regression check that fails if the Swift path reintroduces the full workspace, menagerie crates, Rust realize kit, or shim examples

## Root Cause

The macOS Swift CI job ran `make mint-swift`, which depended on `build-rust`. `build-rust` performs a full release build of `implementations/rust/Cargo.toml`, pulling menagerie fixtures, smoke-test crates, and shim examples into a Swift-only gate. The CLI package path also indirectly pulled `provekit-realize-rust-core` through the Rust walk stack, which brought the Rust shim example crates back even after targeting `-p provekit-cli`.

There was also a separate runner-host incident during diagnosis: macOS `syspolicyd`/`trustd` wedged executable launch for newly built Mach-O binaries. Restarting those daemons restored local binary execution. This PR reduces the CI blast radius, but the host daemon wedge was machine state, not repo logic.

## Validation

- `make check-macos-swift-rust-scope`
- `git diff --check`
- `cargo tree --manifest-path implementations/rust/Cargo.toml -p provekit-cli --edges normal,build --depth 4 | rg 'provekit-realize-rust-core|/examples/provekit-shim-|smoke-test-e2e|provekit-bridgeworks|provekit-supply-chain-rails|provekit-protocol-switchyard|bug-zoo' || true`
- `CARGO_BUILD_JOBS=2 cargo check --manifest-path implementations/rust/Cargo.toml -p provekit-cli`
- `CARGO_BUILD_JOBS=2 cargo check --manifest-path implementations/rust/Cargo.toml -p provekit-walk --bin provekit-walk-rpc`
