### PR TITLE
fix(swift): point lift manifests at .build/debug to match build-swift (#1535)

### DIFF
--- a/implementations/swift/.provekit/lift/swift-self-contracts/manifest.toml
+++ b/implementations/swift/.provekit/lift/swift-self-contracts/manifest.toml
@@ -2,7 +2,7 @@ name = "swift-self-contracts"
 version = "1.0.0"
 protocol_version = "pep/1.7.0"
 kind = "lift"
-command = [".build/release/mint-swift-self-contracts"]
+command = [".build/debug/mint-swift-self-contracts"]
 working_dir = "."
 
 [capabilities]

--- a/implementations/swift/.provekit/lift/swift-source/manifest.toml
+++ b/implementations/swift/.provekit/lift/swift-source/manifest.toml
@@ -2,7 +2,7 @@ name = "swift-source"
 version = "0.1.0-draft"
 protocol_version = "pep/1.7.0"
 kind = "lift"
-command = [".build/release/provekit-lift-swift-source", "--rpc"]
+command = [".build/debug/provekit-lift-swift-source", "--rpc"]
 working_dir = "."
 
 [capabilities]


### PR DESCRIPTION
## Root cause of the standing macOS-swift gate failure (#1535)

`provekit mint --kit=swift` collapses to the empty-set contractSetCid (`swift_kit_pins_expected_contract_set_cid` → "swift kit collapsed to the empty-set CID — routing or lifter regression"), failing the macOS-swift conformance gate **and** prove-swift on every main run.

**Why:** the swift lift manifests spawn `.build/release/<bin>`, but #1527's swift-build speedup made `make build-swift` default to **debug** (`SWIFT_BUILD_CONFIG ?= debug`). CI never builds the release binary → ENOENT on spawn → mint emits the empty-set attestation ("lifter binary not found"). #1527 changed the build config without updating its consumers; this PR completes it.

## Fix
Repoint both manifests `.build/release/` → `.build/debug/`:
- `swift-self-contracts/manifest.toml` (`mint-swift-self-contracts`) — used by `mint --kit=swift`
- `swift-source/manifest.toml` (`provekit-lift-swift-source`) — used by prove-swift

Minting uses debug by design (runtime perf irrelevant; the comment at Makefile:288 says so); release builds stay available via `SWIFT_BUILD_CONFIG=release`.

## Verified on macOS (the affected platform)
Before: `mint --kit=swift` → `blake3-512:d53d18c2…` (empty-set).
After: `mint --kit=swift` → `blake3-512:272543ef…742c56` (non-empty), **byte-identical to the pinned `.provekit/self-contracts-attestations/swift.json`** — so both `swift_kit_pins` (non-empty guard) and `verify-self-contracts` (pin match) pass.

Closes #1535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Swift Lift build configurations to use debug binaries instead of release binaries for swift-self-contracts and swift-source modules, optimizing development and testing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->