### PR TITLE
ci(swift): per-runner SwiftPM cache key — fix cross-runner prove-swift failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,16 +382,23 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: implementations/swift/.build
-          key: ${{ runner.os }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.name }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-swiftpm-
+            ${{ runner.os }}-${{ runner.name }}-swiftpm-
 
       - name: Save SwiftPM build
-        if: github.event_name != 'pull_request'
+        # Per-runner key (includes runner.name): a runner only ever restores a
+        # .build it built itself, so clang's ModuleCache .pcm files — which
+        # embed the absolute build path — never get restored onto a runner with
+        # a different _work path (the prove-swift cross-runner failure). Save on
+        # PRs too (not just push): main-push dispatches to one runner per event,
+        # so without PR-save the other runner would be permanently cold. With
+        # the per-runner key, only the first PR on each runner pays the upload;
+        # the rest cache-hit and skip.
         uses: actions/cache@v5
         with:
           path: implementations/swift/.build
-          key: ${{ runner.os }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.name }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
 
       - name: Verify swift toolchain
         # macOS GitHub-hosted runners ship the swift toolchain
@@ -610,7 +617,11 @@ jobs:
     name: "prove-swift (C1-C8 conformance, macOS)"
     # Self-hosted Mac runner (issue #305).
     runs-on: [self-hosted, macOS, X64]
-    timeout-minutes: 20
+    # 35 (was 20): the per-runner SwiftPM cache key means the first PR on each
+    # runner cold-compiles swift-syntax (~15 min) on top of the rust CLI build
+    # before there's a warm .build to restore. Headroom so that first cold run
+    # reports green instead of clipping at the deadline.
+    timeout-minutes: 35
     needs: conformance
 
     steps:
@@ -655,16 +666,23 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: implementations/swift/.build
-          key: ${{ runner.os }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.name }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-swiftpm-
+            ${{ runner.os }}-${{ runner.name }}-swiftpm-
 
       - name: Save SwiftPM build
-        if: github.event_name != 'pull_request'
+        # Per-runner key (includes runner.name): a runner only ever restores a
+        # .build it built itself, so clang's ModuleCache .pcm files — which
+        # embed the absolute build path — never get restored onto a runner with
+        # a different _work path (the prove-swift cross-runner failure). Save on
+        # PRs too (not just push): main-push dispatches to one runner per event,
+        # so without PR-save the other runner would be permanently cold. With
+        # the per-runner key, only the first PR on each runner pays the upload;
+        # the rest cache-hit and skip.
         uses: actions/cache@v5
         with:
           path: implementations/swift/.build
-          key: ${{ runner.os }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.name }}-swiftpm-${{ hashFiles('implementations/swift/Package.resolved') }}
 
       - name: prove-swift
         run: make prove-swift


### PR DESCRIPTION
## Root cause (from the failure log, not hypothesis)

The two self-hosted macOS runners — `tsavo-mac-x64` and `tsavo-mac-x64-2`, both under user `tsavo` on one host — share **one** GitHub Actions cache key (`macOS-swiftpm-<hash>`). Clang's precompiled modules in `.build/.../ModuleCache` embed the **absolute** build path:

```
error: precompiled file '.../ModuleCache/..._Builtin_stdbool-....pcm' was
compiled with module cache path '/Users/tsavo/actions-runner/_work/...',
but the path is currently '/Users/tsavo/actions-runner-2/_work2/...'
```

When one runner restores a `.build` the *other* runner saved, clang rejects every module and `build-swift` dies. It's **cross-runner cache poisoning**, not a live race:
- #1539's swift rerun **passed** — it landed on the runner that built the cache.
- #1537's swift rerun **failed** — it landed on the other runner.
- #1536 passed originally because it ran before the other runner had saved a competing cache.

## Fix
- Add `${{ runner.name }}` to the SwiftPM `.build` cache **key and restore-keys** on both macOS jobs → a runner only ever restores a `.build` it built itself, so no foreign absolute paths reach clang.
- **Enable PR-save** (drop the push-only guard): main-push dispatches to one runner per event, so without PR-save the other runner stays permanently cold. With the per-runner key, only the *first* PR on each runner pays the upload; the rest cache-hit and skip.
- Bump `prove-swift` timeout **20 → 35** for the first cold swift compile per runner.
- `cargo` cache keys untouched — rust artifacts are relocatable; the proven failure is swift-only.

## Note
This supersedes the earlier `--cache-path` approach (which targeted the wrong cache — the live global SwiftPM cache, a race I never actually confirmed). The failure log proved it's the `.build` ModuleCache restored cross-runner. Per-runner key is bulletproof: clang dying on the first `.pcm` means there's no evidence other artifacts are path-clean, so excluding ModuleCache would be a gamble — keying the whole cache per runner isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)