### PR TITLE
feat(lift-go): lift leading guard-panics into preconditions

### DIFF
--- a/implementations/go/provekit-lift-go/lift.go
+++ b/implementations/go/provekit-lift-go/lift.go
@@ -316,7 +316,7 @@ func liftFunc(fset *token.FileSet, file *ast.File, pkg *types.Package, info *typ
 	if err != nil {
 		return FunctionContract{}, nil, refuse("unsupported-syntax", errPos(err, fn.Pos()), err.Error())
 	}
-	pre, err := formulaValue(ir.And())
+	pre, err := formulaValue(l.liftLeadingGuardPreconditions(fn.Body.List))
 	if err != nil {
 		return FunctionContract{}, nil, refuse("internal-error", fn.Pos(), err.Error())
 	}
@@ -351,6 +351,66 @@ func liftFunc(fset *token.FileSet, file *ast.File, pkg *types.Package, info *typ
 		SchemaVersion:      "1",
 	}
 	return contract, body.term, nil
+}
+
+// liftLeadingGuardPreconditions lifts a function's leading defensive guards
+// (`if <cond> { panic(...) }`) into a precondition. A guard panics when <cond>
+// holds, so the caller's obligation to avoid the panic is ¬<cond>. This brings
+// the Go production lifter to parity with the Rust (lift_function_precondition)
+// and C# (LiftMethodPrecondition) walkers; without it every function lifted
+// `pre = true`, so a consumer's defensive contract was invisible at call sites.
+// Scans only leading guards and stops at the first non-guard statement, so it
+// never fabricates a precondition from arbitrary control flow.
+func (l *lifter) liftLeadingGuardPreconditions(stmts []ast.Stmt) ir.IrFormula {
+	var atoms []ir.IrFormula
+	for _, stmt := range stmts {
+		ifStmt, ok := stmt.(*ast.IfStmt)
+		if !ok || ifStmt.Init != nil || ifStmt.Else != nil || !isPanicOnlyBlock(ifStmt.Body) {
+			break
+		}
+		atom, ok := l.guardPreconditionAtom(ifStmt.Cond)
+		if !ok {
+			break
+		}
+		atoms = append(atoms, atom)
+	}
+	return ir.And(atoms...)
+}
+
+// guardPreconditionAtom lifts ¬cond as a precondition atom. `if !P { panic }`
+// lifts to the clean `P == true`; a bare `if cond { panic }` lifts to
+// `cond == false`. Returns false when the condition is not liftable, so the
+// caller refuses to invent a precondition rather than emit a wrong one.
+func (l *lifter) guardPreconditionAtom(cond ast.Expr) (ir.IrFormula, bool) {
+	if unary, ok := cond.(*ast.UnaryExpr); ok && unary.Op == token.NOT {
+		inner, err := l.liftExpr(unary.X)
+		if err != nil {
+			return nil, false
+		}
+		return ir.Eq(inner.term, ir.BoolConst(true)), true
+	}
+	lifted, err := l.liftExpr(cond)
+	if err != nil {
+		return nil, false
+	}
+	return ir.Eq(lifted.term, ir.BoolConst(false)), true
+}
+
+// isPanicOnlyBlock reports whether a block is exactly `{ panic(...) }`.
+func isPanicOnlyBlock(b *ast.BlockStmt) bool {
+	if b == nil || len(b.List) != 1 {
+		return false
+	}
+	exprStmt, ok := b.List[0].(*ast.ExprStmt)
+	if !ok {
+		return false
+	}
+	call, ok := exprStmt.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := call.Fun.(*ast.Ident)
+	return ok && ident.Name == "panic"
 }
 
 func extractFormals(info *types.Info, fn *ast.FuncDecl) ([]string, []any, map[types.Object]bool, error) {


### PR DESCRIPTION
The Go production lifter emitted `pre = true` for every function, so a consumer's defensive guard (`if !P(args){panic}`) never became a contract precondition — invisible at call sites. This brings Go to parity with Rust (`lift_function_precondition`) and C# (`LiftMethodPrecondition`).

- Leading `if !P{panic}` → `pre = P == true`; bare `if cond{panic}` → `cond == false`.
- Scans only **leading** guards, stops at the first non-guard, refuses to invent a precondition from an unliftable condition.
- **CID-neutral** for existing kits: the Go self-contracts `contractSetCid` is unchanged (`073e4010…`); no go-kit function uses the guard pattern. Lifter tests pass.

Unblocks **BZ-DETERMINISM-001**: a consumer's `canonical_byte_order` precondition now lifts from idiomatic Go — the first of the lifter features needed to build the determinism reference species honestly (no mock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved safety requirement analysis by deriving preconditions from defensive guards within function bodies rather than using empty default conditions. The system now examines leading conditional statements for panic-triggering patterns and converts them into precise safety constraints, delivering more accurate and comprehensive function safety analysis without inventing unfounded constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->