### PR TITLE
fix(solvers): quote/sanitize special-char symbols across smt-lib, coq, and lean backends

### DIFF
--- a/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-coq/src/generated.rs
@@ -27,12 +27,12 @@ pub fn emit_term(term: &Term) -> String {
         }
         Term::Ctor { name, args, .. } => {
             if args.is_empty() {
-                return name.clone();
+                return coq_ident(name);
             };
             let args_str = args.iter();
             let args_str = args_str.map(emit_term);
             let args_str: Vec<String> = args_str.collect();
-            format!("({} {})", name, args_str.join(" "))
+            format!("({} {})", coq_ident(name), args_str.join(" "))
         }
         Term::Lambda {
             param_name,
@@ -54,12 +54,12 @@ pub fn emit_term(term: &Term) -> String {
         }
         Term::Ctor { name, args } => {
             if args.is_empty() {
-                return name.clone();
+                return coq_ident(name);
             };
             let args_str = args.iter();
             let args_str = args_str.map(emit_term);
             let args_str: Vec<String> = args_str.collect();
-            format!("({} {})", name, args_str.join(" "))
+            format!("({} {})", coq_ident(name), args_str.join(" "))
         }
         Term::Lambda {
             param_name,
@@ -95,7 +95,7 @@ pub fn emit_formula(formula: &Formula) -> String {
                 "\u{2260}" => format!("({} <> {})", args_str[0].clone(), args_str[1].clone()),
                 "true" => "True".to_string(),
                 "false" => "False".to_string(),
-                _ => format!("{} {}", name, args_str.join(" ")),
+                _ => format!("{} {}", coq_ident(name), args_str.join(" ")),
             }
         }
         Formula::And { operands } => {
@@ -256,6 +256,23 @@ fn sort_to_coq_paren(sort: &Sort) -> String {
         Sort::Primitive { .. } | Sort::Float { .. } | Sort::Region { .. } => sort_to_coq(sort),
     }
 }
+// coq_ident sanitizes a name into a valid Coq identifier: Coq identifiers
+// allow letters, digits, '_' and '\''; lifted ctor names like `go:call` /
+// `go:slice-literal` contain ':' and '-', which Coq rejects. Replacing them
+// with '_' is applied consistently at both the `Parameter` declaration and
+// every use, so the symbol still matches.
+fn coq_ident(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '\'' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 fn emit_const_value(value: &serde_json::Value, _sort_name: &str) -> String {
     match value {
         serde_json::Value::Number(n) => {
@@ -290,7 +307,7 @@ pub fn compile_formula(formula: &Formula) -> (String, String, Vec<FreeVar>) {
             "Bool" => "bool",
             _ => "Z",
         };
-        body.push_str(&format!("Parameter {} : {}.\n", name, coq_sort));
+        body.push_str(&format!("Parameter {} : {}.\n", coq_ident(name), coq_sort));
     }
     body.push_str("\nGoal ");
     body.push_str(&emit_formula(formula));

--- a/implementations/rust/provekit-ir-compiler-lean/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-lean/src/lib.rs
@@ -115,16 +115,16 @@ pub fn compile_to_parts(ir: &Json) -> Result<CompiledFormula, CompileError> {
 
     let mut binders = Vec::new();
     for (name, ty) in &ctx.type_params {
-        binders.push(format!("({name} : {ty})"));
+        binders.push(format!("({} : {ty})", lean_ident(name)));
     }
     for (name, sig) in &ctx.functions {
-        binders.push(format!("({name} : {})", sig.as_lean_type()));
+        binders.push(format!("({} : {})", lean_ident(name), sig.as_lean_type()));
     }
     for (name, sig) in &ctx.predicates {
-        binders.push(format!("({name} : {})", sig.as_lean_type()));
+        binders.push(format!("({} : {})", lean_ident(name), sig.as_lean_type()));
     }
     for (name, sort) in &ctx.free_vars {
-        binders.push(format!("({name} : {sort})"));
+        binders.push(format!("({} : {sort})", lean_ident(name)));
     }
 
     let theorem_head = if binders.is_empty() {

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
@@ -28,12 +28,12 @@ pub fn emit_term(term: &Term) -> String {
         }
         Term::Ctor { name, args, .. } => {
             if args.is_empty() {
-                return name.clone();
+                return smt_quote(name);
             };
             let args_str = args.iter();
             let args_str = args_str.map(emit_term);
             let args_str: Vec<String> = args_str.collect();
-            format!("({} {})", name, args_str.join(" "))
+            format!("({} {})", smt_quote(name), args_str.join(" "))
         }
         Term::Lambda {
             param_name,
@@ -55,12 +55,12 @@ pub fn emit_term(term: &Term) -> String {
         }
         Term::Ctor { name, args } => {
             if args.is_empty() {
-                return name.clone();
+                return smt_quote(name);
             };
             let args_str = args.iter();
             let args_str = args_str.map(emit_term);
             let args_str: Vec<String> = args_str.collect();
-            format!("({} {})", name, args_str.join(" "))
+            format!("({} {})", smt_quote(name), args_str.join(" "))
         }
         Term::Lambda {
             param_name,
@@ -212,6 +212,24 @@ fn emit_const_value(value: &serde_json::Value, _sort_name: &str) -> String {
         }
         serde_json::Value::String(s) => format!("\"{}\"", s),
         _ => "0".to_string(),
+    }
+}
+
+// smt_quote renders a name as an SMT-LIB symbol, quoting with |...| when it is
+// not a valid simple symbol (e.g. lifted ctor names like `go:call`, which
+// contain ':' -- an unquoted ':' is a syntax error z3 rejects). Applied
+// consistently at ctor applications and their declare-fun, so the symbol
+// matches. NOTE: mirror this in tools/generate-from-cddl.py on regeneration.
+fn smt_quote(name: &str) -> String {
+    let simple = !name.is_empty()
+        && !name.chars().next().is_some_and(|c| c.is_ascii_digit())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || "~!@$%^&*_-+=<>.?/".contains(c));
+    if simple {
+        name.to_string()
+    } else {
+        format!("|{}|", name)
     }
 }
 
@@ -714,7 +732,7 @@ pub fn compile_asserted_formula(formula: &Formula) -> CompiledFormula {
     for (name, signature) in ctor_decls.iter() {
         preamble.push_str(&format!(
             "(declare-fun {} ({}) {})\n",
-            name,
+            smt_quote(name),
             signature.args.join(" "),
             signature.ret
         ));


### PR DESCRIPTION
Lifted ctor names like `go:call` / `go:slice-literal` contain `:`, which is illegal in an SMT-LIB *simple symbol* — z3 rejected them ("invalid expression, unexpected keyword"), which surfaced as a spurious `undecidable`. They now emit as quoted symbols (`|go:call|`) at both the ctor application and its `declare-fun`, so z3 parses and reasons about them as uninterpreted functions.

Verified: the byte-order composition obligation `post(serialize) ⟹ canonical(out)` now parses and z3 returns `sat` on its negation — the obligation is genuinely *not valid* (a real seam, not a syntax error). smt-lib compiler tests green.

`generated.rs` is CDDL-generated; mirror in `tools/generate-from-cddl.py` on regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Compiler backends now properly handle special characters in identifiers across Coq, Lean, and SMT-LIB targets
- Improved symbol compatibility to ensure correct translation to each target verification system

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->