### PR TITLE
Materialize carries the vendor's contract to the boundary (as a bridge)

### DIFF
--- a/docs/plans/2026-05-27-materialize-carries-contract-bridge.md
+++ b/docs/plans/2026-05-27-materialize-carries-contract-bridge.md
@@ -1,0 +1,87 @@
+# Materialize carries the vendor's contract to the boundary (as a bridge)
+
+**Branch:** `feat/materialize-carries-contract-bridge` (stacked on `chore/catalog-starts-empty` / PR #1565, which holds the hardened bridge-discharge machinery this relies on).
+
+## The thesis (why this is the capstone)
+
+`materialize` writes a vendor's **sugar** (body) into a **boundary** in the user's
+source. The vendor ships a `.proof` carrying the sugar **and the contract you
+incur by using it**. The act of materializing **creates new implications** where
+none existed: a stub is a signature around a hole (a leaf, no edges); splicing
+the body in gives it a call structure (a subgraph of `post → pre` edges).
+
+Those new implications must carry the vendor's **real** contract, or adoption is
+all cost and no ratchet. When they do, every contract a user adopts **shrinks
+their valid-program space** — more wrong programs rejected, change gets cheaper,
+**software ages backwards**. Cross-platform falls out because the contract is
+platform-evacuated (canonical `Int`, see PR #1565): one `.proof`, every language's
+`materialize`, the same obligation.
+
+## The gap (grounded, exact locations)
+
+The vendor's contract pointer is **in hand and dropped**:
+
+- **Origin:** `RealizeRequest.contract: Option<RealizeContractPayload>`
+  (`lower_plugin.rs:61`), parsed from the carrier payload at
+  `lower_plugin.rs:1331` (`non_null_field(spec, &["contract"])`).
+  `RealizeContractPayload.local_contract_cid` (`:494`) is the CID of the vendor's
+  contract memento — a **pointer**, never inlined formulas (confirmed: the struct
+  is all CIDs + verdict + witnesses). Carrying a *copy* of the obligation would
+  fork its content-addressed identity — death in a content-addressed system.
+
+- **Drop site 1:** `claim_from_realized` (`lower_plugin.rs:1437`) mints the
+  lower-realize claim contract via `memento_from_parts(..., formula_true(),
+  formula_true(), ...)` — vacuous — with `invocation.request.contract` ignored
+  in scope.
+
+- **Drop site 2:** `claim_from_receipt` (`source_transform_kit.rs:219`) mints the
+  source-transform claim contract `true → true` likewise ("trivial pre/post").
+
+- **Why it can't carry today:** `RealizedSource` (`lower_plugin.rs:519`) has no
+  contract field, so even though `MaterializeKit::transform_site`
+  (`cmd_materialize.rs:1834`) has the realized source, the pointer is already
+  gone by then. `binding_cid` it records = `emitted_artifact_cid` (the *body's*
+  CID), not the contract.
+
+## The fix (the bridge — "you get the rest for free")
+
+Emit a **bridge** at the boundary write. The materialized boundary becomes a
+callsite the verifier already chews: `enumerate_callsites` finds the bridged
+symbol, `resolve_target` resolves the vendor contract **by CID**, and the
+hardened discharge from PR #1565 runs — **zero new enforcement code**. Producer
+callsites and library boundaries collapse into one mechanism.
+
+Touch-points:
+
+1. **`RealizedSource`** (`lower_plugin.rs:519`): add
+   `#[serde(default, skip_serializing_if = "Option::is_none")] pub contract_cid: Option<String>`.
+2. **`claim_from_realized`** (`:1398`): `mut realized`; set
+   `realized.contract_cid = invocation.request.contract.as_ref().map(|c| c.local_contract_cid.clone())`
+   before `realized_source_term(&realized)`, so it round-trips through the claim
+   payload and `realized_source_from_claim` (`:613`) deserializes it back.
+3. **`SiteOutcome::Materialize` / `LoudlyLossy`** (`source_transform_kit.rs`):
+   carry the contract CID alongside `binding_cid`.
+4. **The boundary write** (`MaterializeKit::transform_site` /
+   `claim_from_receipt`): when `contract_cid` is `Some`, emit a
+   `BridgeHeaderV14` (`sourceSymbol` = boundary site, `sourceContractCid` =
+   `local_contract_cid`, target = vendor contract memento) **instead of** the
+   `true → true` mint. `None` (vendor declared no contract) legitimately carries
+   nothing.
+5. **verify**: free — the bridge flows through the existing discharge.
+
+## Done = (grounding + e2e)
+
+- **Grounding (Task #75):** materializing a boundary emits a bridge whose
+  `sourceContractCid` = the vendor's `local_contract_cid`, NOT a fresh
+  `true → true`. Red on current code, green after.
+- **E2E (Task #78), the boundary-side analog of `rust-missing-edge`:** a vendor
+  sugar with a real contract, materialized into a user boundary whose surrounding
+  use violates it → `provekit verify`/`prove` **refuses** (the squiggly). Today it
+  false-greens. This is "software ages backwards," demonstrated.
+
+## Invariants (do not violate)
+
+- Carry the **CID**, never the formulas. Inlining forks identity = death.
+- The verifier stays language-blind; the bridge references a canonical contract
+  CID. No platform intrinsic enters the substrate (see
+  `project_provekit_platform_in_sidecar`).

--- a/implementations/rust/libprovekit/src/core/lower_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lower_plugin.rs
@@ -521,6 +521,8 @@ pub struct RealizedSource {
     pub source: String,
     pub is_stub: bool,
     pub emitted_artifact_cid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contract_cid: Option<String>,
     pub observed_loss_record: Value,
     pub used_sugars: Vec<Value>,
     pub observation_wrapper_emission_record: Option<Value>,
@@ -1395,7 +1397,12 @@ pub fn request_from_spec(spec: &Value) -> Result<RealizeRequest, String> {
     })
 }
 
-fn claim_from_realized(invocation: RealizeInvocation, realized: RealizedSource) -> DomainClaim {
+fn claim_from_realized(invocation: RealizeInvocation, mut realized: RealizedSource) -> DomainClaim {
+    realized.contract_cid = invocation
+        .request
+        .contract
+        .as_ref()
+        .map(|contract| contract.local_contract_cid.clone());
     let response_term = realized_source_term(&realized);
     let response_cid = address(&response_term);
     let to = realized
@@ -1420,6 +1427,13 @@ fn claim_from_realized(invocation: RealizeInvocation, realized: RealizedSource) 
             .filter_map(|cid| Cid::parse(cid.as_str()).ok()),
     );
     artifacts.extend(realized.used_sugars.iter().filter_map(cid_from_used_sugar));
+    if let Some(contract_cid) = realized
+        .contract_cid
+        .as_deref()
+        .and_then(|cid| Cid::parse(cid).ok())
+    {
+        artifacts.push(contract_cid);
+    }
     if let Some(loss_cid) = loss_record_cid(&realized.observed_loss_record) {
         artifacts.push(loss_cid);
     }

--- a/implementations/rust/libprovekit/src/core/source_transform.rs
+++ b/implementations/rust/libprovekit/src/core/source_transform.rs
@@ -320,6 +320,7 @@ pub enum SiteOutcome {
     Materialize {
         body: String,
         binding_cid: String,
+        contract_cid: Option<String>,
         loss_record: Json,
     },
 
@@ -329,6 +330,7 @@ pub enum SiteOutcome {
     LoudlyLossy {
         body: String,
         binding_cid: String,
+        contract_cid: Option<String>,
         declared_loss: Vec<String>,
     },
 
@@ -850,6 +852,8 @@ pub struct AggregateSummary {
 pub struct SiteWitness {
     pub source_binding_cid: Option<String>,
     pub target_binding_cid: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contract_cid: Option<String>,
     pub concept_name: String,
     pub function_name: String,
     pub outcome_kind: OutcomeKind,
@@ -901,11 +905,16 @@ pub fn build_receipt(
             .clone()
             .unwrap_or_else(|| site.carrier.function.clone());
         match outcome {
-            SiteOutcome::Materialize { binding_cid, .. } => {
+            SiteOutcome::Materialize {
+                binding_cid,
+                contract_cid,
+                ..
+            } => {
                 aggregate_summary.exact += 1;
                 site_witnesses.push(SiteWitness {
                     source_binding_cid: source_lib.map(|_| String::new()),
                     target_binding_cid: binding_cid.clone(),
+                    contract_cid: contract_cid.clone(),
                     concept_name,
                     function_name,
                     outcome_kind: OutcomeKind::Exact,
@@ -913,6 +922,7 @@ pub fn build_receipt(
             }
             SiteOutcome::LoudlyLossy {
                 binding_cid,
+                contract_cid,
                 declared_loss,
                 ..
             } => {
@@ -924,6 +934,7 @@ pub fn build_receipt(
                 site_witnesses.push(SiteWitness {
                     source_binding_cid: source_lib.map(|_| String::new()),
                     target_binding_cid: binding_cid.clone(),
+                    contract_cid: contract_cid.clone(),
                     concept_name,
                     function_name,
                     outcome_kind: OutcomeKind::LoudlyLossy,
@@ -942,6 +953,7 @@ pub fn build_receipt(
                 site_witnesses.push(SiteWitness {
                     source_binding_cid: source_lib.map(|_| String::new()),
                     target_binding_cid: String::new(),
+                    contract_cid: None,
                     concept_name,
                     function_name,
                     outcome_kind: OutcomeKind::Refused,
@@ -1677,6 +1689,7 @@ pub fn h(_bytes: &[u8]) -> i64 {
             Ok(SiteOutcome::Materialize {
                 body: self.body.clone(),
                 binding_cid: self.binding_cid.clone(),
+                contract_cid: None,
                 loss_record: json!([]),
             })
         }
@@ -1772,6 +1785,7 @@ fn after() {}\n";
                     carrier.function, carrier.concept_name
                 ),
                 binding_cid: "cid:mock".to_string(),
+                contract_cid: None,
                 loss_record: json!([]),
             })
         }
@@ -1830,6 +1844,7 @@ fn after() {}\n";
             Ok(SiteOutcome::Materialize {
                 body: format!("fn {}() {{}}", carrier.function),
                 binding_cid: "cid:divergent".to_string(),
+                contract_cid: None,
                 loss_record: json!([]),
             })
         }
@@ -1915,6 +1930,7 @@ fn after() {}\n";
                 Ok(SiteOutcome::Materialize {
                     body: "fn do_thing(x: u32) -> u32 {\n    x\n}".to_string(),
                     binding_cid: "cid:mock".to_string(),
+                    contract_cid: None,
                     loss_record: json!([]),
                 })
             }
@@ -1942,11 +1958,13 @@ fn after() {}\n";
                     "exact" => Ok(SiteOutcome::Materialize {
                         body: "fn exact() {}".to_string(),
                         binding_cid: "cid:exact".to_string(),
+                        contract_cid: None,
                         loss_record: json!([]),
                     }),
                     "lossy" => Ok(SiteOutcome::LoudlyLossy {
                         body: "fn lossy() {}".to_string(),
                         binding_cid: "cid:lossy".to_string(),
+                        contract_cid: None,
                         declared_loss: vec!["dim:overflow".to_string()],
                     }),
                     _ => Ok(SiteOutcome::Refuse {

--- a/implementations/rust/libprovekit/src/core/source_transform_kit.rs
+++ b/implementations/rust/libprovekit/src/core/source_transform_kit.rs
@@ -24,7 +24,7 @@
 //! Every substrate operation is a kit. Every kit is a path step. Every
 //! transformation is a chain. The CLI is N projections over one engine.
 
-use provekit_ir_types::Sort;
+use provekit_ir_types::{BridgeHeaderV14, BridgeTarget, Sort};
 use serde_json::{json, Value};
 
 use super::primitives::address;
@@ -34,8 +34,8 @@ use super::source_transform::{
 };
 use super::traits::{Kit, KitError};
 use super::types::{
-    any_sort, formula_true, memento_from_parts, Cid, Dialect, DomainClaim, DomainKind, Input, Term,
-    Verdict,
+    any_sort, formula_true, memento_from_parts, Cid, Contract, Dialect, DomainClaim, DomainKind,
+    Input, Term, Verdict,
 };
 
 /// Wire-stable schema name advertised in the [`Term::Const`] payload's
@@ -207,7 +207,7 @@ fn claim_from_receipt<K: SiteTransformKit>(
 ) -> DomainClaim {
     let payload_value = json!({
         "rewritten": rewritten,
-        "receipt": receipt,
+        "receipt": &receipt,
     });
     let payload = Term::Const {
         value: payload_value,
@@ -216,22 +216,43 @@ fn claim_from_receipt<K: SiteTransformKit>(
         },
     };
     let to = address(&payload);
-    let contract = memento_from_parts(
-        format!(
-            "source_transform:{source_lang}->{}:{target_library}",
-            kit.target_language()
-        ),
-        Vec::new(),
-        Vec::new(),
-        any_sort(),
-        formula_true(),
-        formula_true(),
-        Some(to.to_string()),
+    let contract_name = format!(
+        "source_transform:{source_lang}->{}:{target_library}",
+        kit.target_language()
     );
+    let contract = bridge_contract_from_receipt(
+        &receipt,
+        source_lang,
+        &contract_name,
+        kit.target_language(),
+        target_library,
+    )
+    .unwrap_or_else(|| {
+        memento_from_parts(
+            contract_name,
+            Vec::new(),
+            Vec::new(),
+            any_sort(),
+            formula_true(),
+            formula_true(),
+            Some(to.to_string()),
+        )
+    });
+    let mut artifacts = vec![to.clone()];
+    if let Ok(contract_cid) = Cid::parse(contract.cid.clone()) {
+        artifacts.push(contract_cid);
+    }
+    artifacts.extend(receipt.site_witnesses.iter().filter_map(|site| {
+        site.contract_cid
+            .as_deref()
+            .and_then(|contract_cid| Cid::parse(contract_cid).ok())
+    }));
+    artifacts.sort();
+    artifacts.dedup();
     DomainClaim {
         domain: DomainKind::Other("source-transform".to_string()),
         contract,
-        artifacts: vec![to.clone()],
+        artifacts,
         from: vec![from_cid],
         premises: Vec::new(),
         to,
@@ -240,6 +261,63 @@ fn claim_from_receipt<K: SiteTransformKit>(
         verdict: Verdict::Unresolved,
         attestation: None,
     }
+}
+
+fn bridge_contract_from_receipt(
+    receipt: &SourceTransformReceipt,
+    source_layer: &str,
+    contract_name: &str,
+    target_language: &str,
+    target_library: &str,
+) -> Option<Contract> {
+    let site = receipt
+        .site_witnesses
+        .iter()
+        .find(|site| site.contract_cid.is_some())?;
+    let source_contract_cid = site.contract_cid.as_ref()?.clone();
+    let header = BridgeHeaderV14 {
+        schema_version: "1".to_string(),
+        kind: "bridge".to_string(),
+        name: format!(
+            "{contract_name}:{}",
+            if site.function_name.is_empty() {
+                "boundary"
+            } else {
+                site.function_name.as_str()
+            }
+        ),
+        source_symbol: site.function_name.clone(),
+        source_layer: source_layer.to_string(),
+        source_contract_cid: source_contract_cid.clone(),
+        target: BridgeTarget::Contract {
+            cid: source_contract_cid.clone(),
+        },
+    };
+    let mut value = serde_json::to_value(&header).expect("bridge header serializes");
+    if let Value::Object(map) = &mut value {
+        map.insert(
+            "targetContractCid".to_string(),
+            Value::String(source_contract_cid.clone()),
+        );
+        map.insert(
+            "targetLayer".to_string(),
+            Value::String(target_library.to_string()),
+        );
+    }
+    let canonical = crate::canonical::json_jcs(&value).expect("bridge header canonicalizes");
+    let cid = crate::canonical::json_cid(&value).expect("bridge header CIDs");
+    let mut contract = memento_from_parts(
+        format!("{contract_name}:{target_language}:{target_library}"),
+        Vec::new(),
+        Vec::new(),
+        any_sort(),
+        formula_true(),
+        formula_true(),
+        None,
+    );
+    contract.canonical_bytes = canonical.into_bytes();
+    contract.cid = cid;
+    Some(contract)
 }
 
 /// Decode the structured payload from a source-transform claim. Companion
@@ -300,6 +378,7 @@ mod tests {
     struct MockKit {
         target_language: String,
         call_count: AtomicUsize,
+        contract_cid: Option<String>,
     }
 
     impl MockKit {
@@ -307,6 +386,15 @@ mod tests {
             Self {
                 target_language: "rust".to_string(),
                 call_count: AtomicUsize::new(0),
+                contract_cid: None,
+            }
+        }
+
+        fn with_contract_cid(contract_cid: impl Into<String>) -> Self {
+            Self {
+                target_language: "rust".to_string(),
+                call_count: AtomicUsize::new(0),
+                contract_cid: Some(contract_cid.into()),
             }
         }
     }
@@ -321,6 +409,7 @@ mod tests {
             Ok(SiteOutcome::Materialize {
                 body: format!("fn {}() {{ /* mocked */ }}", carrier.function),
                 binding_cid: "blake3:mock-binding".to_string(),
+                contract_cid: self.contract_cid.clone(),
                 loss_record: Value::Null,
             })
         }
@@ -359,6 +448,43 @@ mod tests {
         assert_eq!(receipt.target_language, "rust");
         assert_eq!(receipt.target_library, "rusqlite");
         assert!(receipt.source_library.is_none());
+    }
+
+    #[test]
+    fn adapter_transform_emits_bridge_for_materialized_vendor_contract() {
+        let vendor_contract_cid = format!("blake3-512:{}", "a".repeat(128));
+        let kit = MockKit::with_contract_cid(vendor_contract_cid.clone());
+        let adapter = SourceTransformAdapter::new(kit, "rust", None, "vendor-lib");
+        let input = Input::Spec(json!({ "source": one_carrier_source() }));
+
+        let claim = adapter
+            .transform(&input)
+            .expect("adapter transform succeeds on a contract-bearing materialize site");
+        let contract_value: Value = serde_json::from_slice(&claim.contract.canonical_bytes)
+            .expect("source-transform contract slot carries bridge JSON");
+
+        assert_eq!(contract_value["schemaVersion"], "1");
+        assert_eq!(contract_value["kind"], "bridge");
+        assert_eq!(contract_value["sourceSymbol"], "phase_h_demo");
+        assert_eq!(
+            contract_value["sourceContractCid"],
+            Value::String(vendor_contract_cid.clone())
+        );
+        assert_eq!(
+            contract_value["target"],
+            json!({
+                "kind": "contract",
+                "cid": vendor_contract_cid,
+            })
+        );
+        assert_eq!(
+            contract_value["targetContractCid"],
+            Value::String(vendor_contract_cid.clone())
+        );
+        assert!(
+            contract_value.get("pre").is_none() && contract_value.get("post").is_none(),
+            "contract-bearing materialize must emit a bridge, not mint a true->true memento: {contract_value}"
+        );
     }
 
     #[test]

--- a/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
+++ b/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
@@ -9,8 +9,8 @@ use libprovekit::compose::{
 use libprovekit::core::lower_plugin::realize_spec_from_named_term;
 use libprovekit::core::{
     address, concept_bind_result_cid, named_term_document_from_bind_payload, BindKit, BindOptions,
-    Cid, DomainClaim, DomainKind, Input, Kit, LowerKit, RealizeRequest, RealizeTransport,
-    RealizedSource, Term, Verdict,
+    Cid, DomainClaim, DomainKind, Input, Kit, LowerKit, RealizeContractPayload, RealizeRequest,
+    RealizeTransport, RealizedSource, Term, Verdict,
 };
 use provekit_ir_types::{IrFormula, Sort};
 use serde_json::{json, Value};
@@ -316,6 +316,53 @@ fn term_const_claim_fast_path_is_preserved() {
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].function, "const_path");
     assert_eq!(requests[0].concept_name, "concept:const-path");
+}
+
+#[test]
+fn lower_realize_claim_payload_carries_request_contract_cid() {
+    let contract_cid = valid_cid('f');
+    let spec = json!({
+        "kind": "RealizeRequest",
+        "function": "contract_path",
+        "params": ["x"],
+        "paramTypes": ["int"],
+        "returnType": "int",
+        "conceptName": "concept:contract-path",
+        "termShapeCid": parse_cid('c'),
+        "contract": RealizeContractPayload {
+            concept_site_cid: valid_cid('1'),
+            object_fcm_cid: valid_cid('2'),
+            local_contract_cid: contract_cid.clone(),
+            origin: "test".to_string(),
+            discharge_verdict: "accepted".to_string(),
+            witnesses: vec![],
+        }
+    });
+    let transport = CapturingTransport::default();
+    let lower = LowerKit::new(
+        PathBuf::from("/tmp/provekit-lower-contract-cid-test"),
+        "python".to_string(),
+        None,
+        transport.clone(),
+    );
+
+    let claim = lower
+        .transform(&Input::Spec(spec))
+        .expect("lower claim succeeds");
+    let realized = LowerKit::<CapturingTransport>::realized_source_from_claim(&claim)
+        .expect("realized payload decodes");
+
+    assert_eq!(
+        realized.contract_cid.as_deref(),
+        Some(contract_cid.as_str())
+    );
+    assert!(
+        claim
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.to_string() == contract_cid),
+        "lower claim artifacts must retain the carried contract CID"
+    );
 }
 
 #[test]

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -2150,19 +2150,18 @@ fn sync_materialize_bridge_proof(
     files: &[MaterializedFile],
 ) -> Result<Option<PathBuf>, String> {
     let proof_dir = project_root.join(".provekit").join("materialize");
-    if proof_dir.exists() {
-        for entry in std::fs::read_dir(&proof_dir)
-            .map_err(|error| format!("read {}: {error}", proof_dir.display()))?
-        {
-            let entry = entry.map_err(|error| format!("read {}: {error}", proof_dir.display()))?;
-            let path = entry.path();
-            if path.extension().and_then(|ext| ext.to_str()) == Some("proof") {
-                std::fs::remove_file(&path)
-                    .map_err(|error| format!("remove stale {}: {error}", path.display()))?;
-            }
-        }
-    }
 
+    // NO global cleanup. The prior behavior wiped EVERY existing `.proof` in
+    // this dir before rebuilding from just THIS invocation's files — which
+    // silently deleted bridges emitted by earlier (or wider-scope) materialize
+    // runs, so `prove` stopped enforcing already-adopted vendor contracts
+    // after any partial scan (Codex P1 on #1566). Now: leave existing
+    // envelopes in place and just write THIS invocation's envelope. The
+    // verifier walks `.provekit/` and unions all bridge members across
+    // envelopes; the filename stays content-addressed (`<cid>.proof`) so
+    // idempotent re-runs overwrite themselves in place. Stale orphan
+    // envelopes (whose members no longer correspond to any live source) are
+    // a hygiene concern for a future garbage-collect verb, not data loss.
     let mut members = BTreeMap::new();
     for file in files {
         for site in &file.receipt.site_witnesses {

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -18,6 +18,11 @@ use libprovekit::core::{
 // `transform_source_text` + the `SiteTransformKit` trait (#1337).
 pub(crate) use libprovekit::core::source_transform::*;
 use owo_colors::OwoColorize;
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
+use provekit_ir_types::{BridgeHeaderV14, BridgeTarget};
+use provekit_proof_envelope::{
+    build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
+};
 use serde_json::Value as Json;
 use walkdir::WalkDir;
 
@@ -25,6 +30,9 @@ use crate::kit_dispatch::{
     provides_concepts_for_realize, scope_bringings_for_realize, DispatchRealizeTransport,
 };
 use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
+
+const MATERIALIZE_BRIDGE_DECLARED_AT: &str = "2026-05-27T00:00:00.000Z";
+const MATERIALIZE_BRIDGE_SIGNER_SEED: Ed25519Seed = [0x6d; 32];
 
 /// #1361 follow-up: `family=library` pair from --family-library clap arg.
 #[derive(Debug, Clone)]
@@ -249,6 +257,13 @@ pub fn run(args: MaterializeArgs) -> u8 {
     } else if let Err(error) = print_dry_run(&files) {
         eprintln!("{}: {error}", "error".red().bold());
         return EXIT_USER_ERROR;
+    }
+
+    if args.write || args.out_dir.is_some() {
+        if let Err(error) = sync_materialize_bridge_proof(&project_root, &files) {
+            eprintln!("{}: {error}", "error".red().bold());
+            return EXIT_USER_ERROR;
+        }
     }
 
     // Phase E (`#1339`): emit a per-file SourceTransformReceipt summary so
@@ -1908,12 +1923,14 @@ impl SiteTransformKit for MaterializeKit<'_> {
             Ok(SiteOutcome::LoudlyLossy {
                 body: realized.source,
                 binding_cid,
+                contract_cid: realized.contract_cid,
                 declared_loss: extract_loss_dims(&realized.observed_loss_record),
             })
         } else {
             Ok(SiteOutcome::Materialize {
                 body: realized.source,
                 binding_cid,
+                contract_cid: realized.contract_cid,
                 loss_record: realized.observed_loss_record,
             })
         }
@@ -2126,4 +2143,133 @@ fn write_out_dir(out_dir: &Path, files: &[MaterializedFile]) -> Result<(), Strin
             .map_err(|error| format!("write {}: {error}", target.display()))?;
     }
     Ok(())
+}
+
+fn sync_materialize_bridge_proof(
+    project_root: &Path,
+    files: &[MaterializedFile],
+) -> Result<Option<PathBuf>, String> {
+    let proof_dir = project_root.join(".provekit").join("materialize");
+    if proof_dir.exists() {
+        for entry in std::fs::read_dir(&proof_dir)
+            .map_err(|error| format!("read {}: {error}", proof_dir.display()))?
+        {
+            let entry = entry.map_err(|error| format!("read {}: {error}", proof_dir.display()))?;
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) == Some("proof") {
+                std::fs::remove_file(&path)
+                    .map_err(|error| format!("remove stale {}: {error}", path.display()))?;
+            }
+        }
+    }
+
+    let mut members = BTreeMap::new();
+    for file in files {
+        for site in &file.receipt.site_witnesses {
+            let Some(contract_cid) = site.contract_cid.as_deref() else {
+                continue;
+            };
+            let body = materialize_bridge_body(&file.receipt, site, contract_cid);
+            let envelope = serde_json::json!({
+                "evidence": {
+                    "kind": "bridge",
+                    "body": body,
+                }
+            });
+            let (cid, bytes) = flat_member(&envelope)?;
+            members.entry(cid).or_insert(bytes);
+        }
+    }
+
+    if members.is_empty() {
+        return Ok(None);
+    }
+
+    std::fs::create_dir_all(&proof_dir)
+        .map_err(|error| format!("create {}: {error}", proof_dir.display()))?;
+    let signer = ed25519_pubkey_string(&MATERIALIZE_BRIDGE_SIGNER_SEED);
+    let proof = build_proof_envelope(&ProofEnvelopeInput {
+        name: "@provekit/materialize-bridges".to_string(),
+        version: "0.1.0".to_string(),
+        binary_cid: None,
+        metadata: None,
+        members,
+        signer_cid: signer,
+        signer_seed: MATERIALIZE_BRIDGE_SIGNER_SEED,
+        declared_at: MATERIALIZE_BRIDGE_DECLARED_AT.to_string(),
+    });
+    let path = proof_dir.join(format!("{}.proof", proof.cid));
+    std::fs::write(&path, &proof.bytes)
+        .map_err(|error| format!("write {}: {error}", path.display()))?;
+    Ok(Some(path))
+}
+
+fn materialize_bridge_body(
+    receipt: &SourceTransformReceipt,
+    site: &SiteWitness,
+    contract_cid: &str,
+) -> Json {
+    let target_layer = if receipt.target_library.is_empty() {
+        receipt.target_language.as_str()
+    } else {
+        receipt.target_library.as_str()
+    };
+    let header = BridgeHeaderV14 {
+        schema_version: "1".to_string(),
+        kind: "bridge".to_string(),
+        name: format!(
+            "materialize:{}:{}",
+            receipt.target_language, site.function_name
+        ),
+        source_symbol: site.function_name.clone(),
+        source_layer: receipt.source_language.clone(),
+        source_contract_cid: contract_cid.to_string(),
+        target: BridgeTarget::Contract {
+            cid: contract_cid.to_string(),
+        },
+    };
+    let mut value = serde_json::to_value(header).expect("BridgeHeaderV14 serializes");
+    if let Json::Object(map) = &mut value {
+        map.insert(
+            "targetContractCid".to_string(),
+            Json::String(contract_cid.to_string()),
+        );
+        map.insert(
+            "targetLayer".to_string(),
+            Json::String(target_layer.to_string()),
+        );
+    }
+    value
+}
+
+fn flat_member(envelope: &Json) -> Result<(String, Vec<u8>), String> {
+    let canonical = canonical_json(envelope)?;
+    let cid = blake3_512_of(canonical.as_bytes());
+    Ok((cid, canonical.into_bytes()))
+}
+
+fn canonical_json(value: &Json) -> Result<String, String> {
+    let canonical = canonical_value(value)?;
+    Ok(encode_jcs(canonical.as_ref()))
+}
+
+fn canonical_value(value: &Json) -> Result<std::sync::Arc<CanonicalValue>, String> {
+    match value {
+        Json::Null => Ok(CanonicalValue::null()),
+        Json::Bool(value) => Ok(CanonicalValue::boolean(*value)),
+        Json::Number(value) => value.as_i64().map(CanonicalValue::integer).ok_or_else(|| {
+            format!("materialize bridge proof contains non-integer number `{value}`")
+        }),
+        Json::String(value) => Ok(CanonicalValue::string(value)),
+        Json::Array(values) => values
+            .iter()
+            .map(canonical_value)
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::array),
+        Json::Object(entries) => entries
+            .iter()
+            .map(|(key, value)| canonical_value(value).map(|value| (key.clone(), value)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::object),
+    }
 }

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -1668,6 +1668,7 @@ fn invoke_realize(
         source,
         is_stub,
         emitted_artifact_cid,
+        contract_cid: None,
         observed_loss_record,
         used_sugars,
         observation_wrapper_emission_record,

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
+use provekit_proof_envelope::{
+    build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
+};
 use serde_json::Value as Json;
 
 fn repo_root() -> PathBuf {
@@ -230,6 +234,139 @@ fn payload_cid(payload: &str) -> String {
     let json: Json = serde_json::from_str(payload).expect("payload json parses");
     let canonical = canonical_value_from_json(&json);
     blake3_512_of(encode_jcs(canonical.as_ref()).as_bytes())
+}
+
+fn flat_member(mut env: Json) -> (String, Vec<u8>) {
+    if let Json::Object(map) = &mut env {
+        map.remove("cid");
+        map.remove("producerSignature");
+    }
+    let canonical = encode_jcs(canonical_value_from_json(&env).as_ref());
+    let cid = blake3_512_of(canonical.as_bytes());
+    (cid, canonical.into_bytes())
+}
+
+fn int_const(value: i64) -> Json {
+    serde_json::json!({
+        "kind": "const",
+        "value": value,
+        "sort": {"kind": "primitive", "name": "Int"},
+    })
+}
+
+fn publish_materialize_contract_fixture(project: &Path, boundary_fn: &str) -> String {
+    let proof_dir = project.join(".provekit");
+    fs::create_dir_all(&proof_dir).expect("create .provekit");
+    let mut members = BTreeMap::new();
+
+    let target_env = serde_json::json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": format!("{boundary_fn}_vendor_contract"),
+                "pre": {
+                    "kind": "forall",
+                    "name": "x",
+                    "sort": {"kind": "primitive", "name": "Int"},
+                    "body": {
+                        "kind": "atomic",
+                        "name": ">",
+                        "args": [
+                            {"kind": "var", "name": "x"},
+                            int_const(0),
+                        ],
+                    },
+                },
+            },
+        },
+    });
+    let (target_cid, target_bytes) = flat_member(target_env);
+    members.insert(target_cid.clone(), target_bytes);
+
+    let source_env = serde_json::json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": "materialized_boundary_consumer",
+                "post": {
+                    "kind": "atomic",
+                    "name": "=",
+                    "args": [
+                        {"kind": "var", "name": "out"},
+                        {"kind": "ctor", "name": boundary_fn, "args": [int_const(0)]},
+                    ],
+                },
+            },
+        },
+    });
+    let (source_cid, source_bytes) = flat_member(source_env);
+    members.insert(source_cid, source_bytes);
+
+    let signer_seed: Ed25519Seed = [0x42; 32];
+    let proof = build_proof_envelope(&ProofEnvelopeInput {
+        name: "@test/materialize-contract-fixture".to_string(),
+        version: "1.0.0".to_string(),
+        binary_cid: None,
+        metadata: None,
+        members,
+        signer_cid: ed25519_pubkey_string(&signer_seed),
+        signer_seed,
+        declared_at: "2026-05-27T00:00:00.000Z".to_string(),
+    });
+    fs::write(proof_dir.join(format!("{}.proof", proof.cid)), &proof.bytes).expect("write proof");
+    target_cid
+}
+
+fn write_contract_materialize_source(src_dir: &Path, contract_cid: &str) -> PathBuf {
+    let source_path = src_dir.join("lib.rs");
+    let payload = serde_json::json!({
+        "artifact_kind": "provekit-concept-citation-comment-sugar",
+        "concept_name": "concept:must-be-positive",
+        "function": "must_be_positive",
+        "params": ["x"],
+        "param_types": ["i64"],
+        "return_type": "i64",
+        "contract": {
+            "concept_site_cid": format!("blake3-512:{}", "1".repeat(128)),
+            "object_fcm_cid": format!("blake3-512:{}", "2".repeat(128)),
+            "local_contract_cid": contract_cid,
+            "origin": "vendor-fixture",
+            "discharge_verdict": "accepted",
+            "witnesses": [],
+        },
+    });
+    let payload = serde_json::to_string(&payload).expect("payload serializes");
+    fs::write(
+        &source_path,
+        format!(
+            "{}pub fn must_be_positive(x: i64) -> i64 {{\n    0\n}}\n",
+            carrier_lines("//", "", &payload)
+        ),
+    )
+    .expect("write contract materialize source");
+    source_path
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn run_verify_json_with_code(project: &Path) -> (Json, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("verify")
+        .arg("--project")
+        .arg(project)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("verify JSON parse failed: {error}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
 }
 
 fn http_payload_json(function: &str, param_type: &str, return_type: &str) -> String {
@@ -477,6 +614,134 @@ fn materialize_write_rewrites_source_file_in_place_and_reports_summary() {
         !rewritten.contains("provekit-concept-payload-cid:"),
         "write mode should remove payload CID carrier comments:\n{rewritten}"
     );
+}
+
+#[test]
+fn materialize_write_emits_contract_bridge_that_verify_refuses_on_violation() {
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping materialize contract bridge e2e");
+        return;
+    }
+
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+    fs::write(
+        workspace.path().join("Cargo.toml"),
+        "[package]\nname = \"materialize-contract-bridge\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write cargo marker");
+
+    let vendor_contract_cid =
+        publish_materialize_contract_fixture(workspace.path(), "must_be_positive");
+    let source_path = write_contract_materialize_source(&src_dir, &vendor_contract_cid);
+
+    let fake_realize = workspace.path().join("fake_realize_contract.py");
+    fs::write(
+        &fake_realize,
+        r#"import json, sys
+for line in sys.stdin:
+    request = json.loads(line)
+    print(json.dumps({
+        "jsonrpc": "2.0",
+        "id": request.get("id"),
+        "result": {
+            "source": "fn must_be_positive(x: i64) -> i64 { x }",
+            "is_stub": False,
+            "extension": "rs",
+            "emitted_artifact_cid": "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+    }), flush=True)
+"#,
+    )
+    .expect("write fake realize contract script");
+    install_python_script_manifest_with_metadata(
+        workspace.path(),
+        "rust-vendor",
+        &fake_realize,
+        "vendor",
+        None,
+        &["concept:must-be-positive"],
+    );
+
+    let (before, before_code) = run_verify_json_with_code(workspace.path());
+    assert_eq!(
+        before_code, 0,
+        "pre-materialize verify should be empty: {before}"
+    );
+    assert_eq!(
+        before["totalClaims"], 0,
+        "without the materialize bridge the boundary call should not enumerate: {before}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--target")
+        .arg("rust")
+        .arg("--library")
+        .arg("vendor")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--write")
+        .output()
+        .expect("spawn provekit materialize --write");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "materialize --write should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let rewritten = fs::read_to_string(&source_path).expect("read rewritten source");
+    assert!(
+        rewritten.contains("pub fn must_be_positive(x: i64) -> i64"),
+        "materialize should preserve the boundary signature:\n{rewritten}"
+    );
+
+    let pool = provekit_verifier::load_all_proofs::run(workspace.path());
+    assert!(
+        pool.load_errors.is_empty(),
+        "materialize bridge proof should load cleanly: {:?}",
+        pool.load_errors
+    );
+    let bridge = pool
+        .bridges_by_symbol
+        .get("must_be_positive")
+        .unwrap_or_else(|| {
+            panic!(
+                "materialize must write a bridge for the boundary; indexed symbols: {:?}",
+                pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+            )
+        });
+    let body = provekit_verifier::types::memento_body(bridge).expect("bridge body");
+    assert_eq!(
+        body.get("sourceContractCid").and_then(Json::as_str),
+        Some(vendor_contract_cid.as_str())
+    );
+    assert_eq!(
+        body.get("targetContractCid").and_then(Json::as_str),
+        Some(vendor_contract_cid.as_str())
+    );
+    assert_eq!(
+        body.pointer("/target/cid").and_then(Json::as_str),
+        Some(vendor_contract_cid.as_str())
+    );
+    assert!(
+        pool.mementos.contains_key(&vendor_contract_cid),
+        "bridge target must resolve to the vendor contract memento"
+    );
+
+    let (after, after_code) = run_verify_json_with_code(workspace.path());
+    assert_eq!(
+        after_code, 1,
+        "violating materialized boundary must be refused\nreceipt: {after}"
+    );
+    assert_eq!(after["totalClaims"], 1, "receipt: {after}");
+    let claim = &after["claims"].as_array().expect("claims")[0];
+    assert_eq!(claim["status"], "unsatisfied", "claim: {claim}");
+    assert_eq!(claim["pass"], false, "claim: {claim}");
 }
 
 #[test]


### PR DESCRIPTION
The capstone of this substrate arc. \`provekit materialize\` writes a vendor's sugar (an implementation body) into a user's boundary (a stub site), and the act of materializing **creates new implications where none existed** — a stub is a hole with no edges, and splicing the body in gives it a call structure. Those new implications must carry the vendor's real contract, or adoption is all cost and no safety. With it, each adopted contract shrinks the user's valid-program space → cost of change falls → **software ages backwards**. This is the flagship behavior; it was broken and is now fixed.

## The gap (was)
The vendor's contract pointer was in hand and dropped at two sites:

- \`lower_plugin.rs:1437\` — \`claim_from_realized\` minted the lower-realize claim contract via \`memento_from_parts(..., formula_true(), formula_true(), ...)\`, ignoring \`invocation.request.contract.local_contract_cid\` in scope.
- \`source_transform_kit.rs:219\` — \`claim_from_receipt\` minted the source-transform claim contract \`true → true\` likewise.

\`RealizedSource\` had no contract field, so even though \`MaterializeKit::transform_site\` had the realized source, the pointer was already gone — \`binding_cid\` recorded which body, never which contract.

## The fix (the bridge)
- \`RealizedSource\` gains \`contract_cid: Option<String>\`.
- \`claim_from_realized\` populates it from \`invocation.request.contract.local_contract_cid\`, round-tripping through the claim payload to \`realized_source_from_claim\`.
- \`SiteOutcome::Materialize\`/\`LoudlyLossy\` carry the CID alongside \`binding_cid\`.
- The boundary write emits a \`BridgeHeaderV14\` (\`sourceSymbol\` = boundary, \`sourceContractCid\` = the carried CID, \`target\` = the vendor contract memento) instead of \`true → true\`. \`None\` (vendor declared no contract) carries nothing.
- **Verifier discharge: UNCHANGED.** The bridge flows through \`enumerate_callsites\` → \`resolve_target\` → discharge for free — producer callsites and library boundaries collapse into one mechanism.

## Invariants held
- Carries the **CID**, never inlines pre/post formulas (content-address-honest; inlining would fork identity — fatal in a content-addressed system).
- Verifier stays language-blind: the bridge references a canonical contract CID; no platform intrinsic enters the substrate.

## Verified
- **Grounding**: a materialized boundary's bridge \`sourceContractCid\` == the vendor's \`local_contract_cid\` (not a fresh \`true→true\` memento).
- **E2E catch**: \`materialize_write_emits_contract_bridge_that_verify_refuses_on_violation\` — a vendor sugar with a real contract, materialized into a user boundary whose surrounding use violates it → \`provekit prove\` returns sat on the unsatisfied callsite (today it would false-green).
- \`cargo test -p libprovekit -p provekit-verifier -p provekit-walk\` — independently re-run, all green.

## Stack
Stacked on #1565 — depends on its hardened bridge-discharge (\`enumerate_callsites\`/\`resolve_target\`, Holes 1–3), canonical-\`Int\` sorts, and the missing-edge catch. Auto-rebases to \`main\` when #1565 merges.

See \`docs/plans/2026-05-27-materialize-carries-contract-bridge.md\` (in this PR) for the grounded spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)