### PR TITLE
Form Voltron: dependency proof pool assembly via kit RPC

### DIFF
--- a/examples/stage4-handshake-demo/stage4_driver.rs
+++ b/examples/stage4-handshake-demo/stage4_driver.rs
@@ -320,6 +320,7 @@ fn run() -> Result<(), String> {
         mint_producer_id: Some("rust-verifier@1.0".into()),
         solvers_config: None,
         extra_projects: Vec::new(),
+        extra_proof_files: Vec::new(),
     };
     let runner = Runner::new(cfg);
     let (report, stats) = runner.run_with_tiers();

--- a/implementations/c/provekit-realize-c-core/src/main.c
+++ b/implementations/c/provekit-realize-c-core/src/main.c
@@ -1898,6 +1898,9 @@ static int run_rpc(const char *argv0) {
             handle_invoke(id, line, end, &catalog);
         } else if (strcmp(method, "provekit.plugin.platform_semantics") == 0) {
             handle_platform_semantics(id);
+        } else if (strcmp(method, "provekit.plugin.resolve_dependency_proofs") == 0) {
+            fprintf(stderr, "provekit-realize-c-core: resolve_dependency_proofs not yet implemented for c; returning empty proof_paths\n");
+            send_result(id, "{\"proof_paths\":[]}");
         } else if (strcmp(method, "shutdown") == 0 ||
                    strcmp(method, "provekit.plugin.shutdown") == 0) {
             send_result(id, "null");

--- a/implementations/go/provekit-realize-go-core/rpc.go
+++ b/implementations/go/provekit-realize-go-core/rpc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 )
 
 type rpcRequest struct {
@@ -33,6 +34,9 @@ func RunRPC(stdin io.Reader, stdout io.Writer) error {
 		switch req.Method {
 		case "provekit.plugin.invoke":
 			writeJSON(stdout, handleInvoke(req.ID, req.Params))
+		case "provekit.plugin.resolve_dependency_proofs":
+			fmt.Fprintln(os.Stderr, "provekit-realize-go-core: resolve_dependency_proofs not yet implemented for go; returning empty proof_paths")
+			writeJSON(stdout, successResponse(req.ID, map[string]any{"proof_paths": []string{}}))
 		case "provekit.plugin.shutdown":
 			writeJSON(stdout, successResponse(req.ID, nil))
 			return nil

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -67,6 +67,10 @@ public final class RpcServer {
                     String resultObj = handleAssemble(line);
                     sendResponse(id, resultObj);
                 }
+                case "provekit.plugin.resolve_dependency_proofs" -> {
+                    System.err.println("provekit-realize-java-core: resolve_dependency_proofs not yet implemented for java; returning empty proof_paths");
+                    sendResponse(id, "{\"proof_paths\":[]}");
+                }
                 case "provekit.plugin.shutdown" -> {
                     sendResponse(id, "null");
                     System.exit(0);

--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
@@ -93,6 +93,12 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
                 "proof_path": str(proof_path),
             },
         }
+    if method == "provekit.plugin.resolve_dependency_proofs":
+        print(
+            "provekit-realize-python-aiosqlite: resolve_dependency_proofs not yet implemented for python; returning empty proof_paths",
+            file=sys.stderr,
+        )
+        return {"jsonrpc": "2.0", "id": msg_id, "result": {"proof_paths": []}}
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
@@ -97,6 +97,12 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
                 "template_authority": realizer.KIT_ID,
             },
         }
+    if method == "provekit.plugin.resolve_dependency_proofs":
+        print(
+            "provekit-realize-python-core: resolve_dependency_proofs not yet implemented for python; returning empty proof_paths",
+            file=sys.stderr,
+        )
+        return {"jsonrpc": "2.0", "id": msg_id, "result": {"proof_paths": []}}
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
@@ -88,6 +88,12 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
                 "proof_path": str(proof_path),
             },
         }
+    if method == "provekit.plugin.resolve_dependency_proofs":
+        print(
+            "provekit-realize-python-requests: resolve_dependency_proofs not yet implemented for python; returning empty proof_paths",
+            file=sys.stderr,
+        )
+        return {"jsonrpc": "2.0", "id": msg_id, "result": {"proof_paths": []}}
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
@@ -93,6 +93,12 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
                 "proof_path": str(proof_path),
             },
         }
+    if method == "provekit.plugin.resolve_dependency_proofs":
+        print(
+            "provekit-realize-python-sqlite3: resolve_dependency_proofs not yet implemented for python; returning empty proof_paths",
+            file=sys.stderr,
+        )
+        return {"jsonrpc": "2.0", "id": msg_id, "result": {"proof_paths": []}}
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")

--- a/implementations/rust/provekit-cli/src/cmd_prove.rs
+++ b/implementations/rust/provekit-cli/src/cmd_prove.rs
@@ -487,7 +487,6 @@ pub fn run(args: ProveArgs) -> u8 {
         return run_target(&args.project, &args.output, target);
     }
 
-
     if args.artifact.is_some() || args.proof.is_some() || args.policy.is_some() {
         return run_admission_gate(&args);
     }
@@ -545,10 +544,23 @@ pub fn run(args: ProveArgs) -> u8 {
         }
     }
 
+    let dependency_proof_files =
+        match crate::kit_dispatch::dependency_proof_paths_via_rpc(&project_root) {
+            Ok(paths) => paths,
+            Err(error) => {
+                eprintln!(
+                    "{}: dependency proof resolution skipped: {error}",
+                    "warning".yellow().bold()
+                );
+                Vec::new()
+            }
+        };
+
     let cfg = RunnerConfig {
         project_root: project_root.clone(),
         z3_path: args.z3,
         extra_projects,
+        extra_proof_files: dependency_proof_files,
         ..Default::default()
     };
     let runner = Runner::new(cfg);

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -473,6 +473,192 @@ pub fn body_template_entries_via_rpc(
     Ok(entries)
 }
 
+/// Ask every configured kit plugin for dependency `.proof` files resolved from
+/// the project's package-manager graph. The substrate stays language-blind:
+/// this function only iterates configured plugin commands, invokes the common
+/// RPC verb, and returns proof file paths for the verifier to content-address.
+pub fn dependency_proof_paths_via_rpc(workspace_root: &Path) -> Result<Vec<PathBuf>, String> {
+    let registry = run_plugin_registry_for_project(workspace_root)?;
+    let mut commands: BTreeMap<String, ResolvedCommand> = BTreeMap::new();
+    for plugin in registry
+        .plugins
+        .iter()
+        .filter(|plugin| registry_authorizes_plugin(&registry, plugin))
+    {
+        let command = resolved_command_from_manifest(workspace_root, &plugin.parsed);
+        if command.argv.is_empty() {
+            continue;
+        }
+        commands
+            .entry(command_key(&command))
+            .or_insert_with(|| command);
+    }
+
+    let mut proof_paths = BTreeSet::new();
+    for command in commands.values() {
+        let Some(paths) = dependency_proof_paths_for_command(workspace_root, command)? else {
+            continue;
+        };
+        for path in paths {
+            proof_paths.insert(path);
+        }
+    }
+    Ok(proof_paths.into_iter().collect())
+}
+
+fn command_key(command: &ResolvedCommand) -> String {
+    format!("{:?}\u{0}{:?}", command.argv, command.working_dir)
+}
+
+fn dependency_proof_paths_for_command(
+    workspace_root: &Path,
+    cmd_spec: &ResolvedCommand,
+) -> Result<Option<Vec<PathBuf>>, String> {
+    let mut command = Command::new(&cmd_spec.argv[0]);
+    if cmd_spec.argv.len() > 1 {
+        command.args(&cmd_spec.argv[1..]);
+    }
+    if !cmd_spec.argv.iter().any(|a| a == "--rpc") {
+        command.arg("--rpc");
+    }
+    if let Some(wd) = &cmd_spec.working_dir {
+        command.current_dir(wd);
+    }
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::inherit());
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            record_dependency_proof_diagnostic(format!(
+                "dependency proof resolver unavailable for {:?}: {error}",
+                cmd_spec.argv
+            ));
+            return Ok(None);
+        }
+    };
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or("dependency proof kit stdin unavailable".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("dependency proof kit stdout unavailable".to_string())?;
+    let mut reader = BufReader::new(stdout);
+
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.resolve_dependency_proofs",
+        "params": {
+            "project_root": workspace_root.display().to_string(),
+        },
+    });
+    writeln!(stdin, "{req}").map_err(|e| format!("write resolve_dependency_proofs: {e}"))?;
+
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .map_err(|e| format!("read resolve_dependency_proofs response: {e}"))?;
+
+    let shutdown = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "provekit.plugin.shutdown",
+    });
+    let _ = writeln!(stdin, "{shutdown}");
+    drop(stdin);
+    let _ = child.wait();
+
+    if line.trim().is_empty() {
+        record_dependency_proof_diagnostic(format!(
+            "dependency proof resolver {:?} closed without a response",
+            cmd_spec.argv
+        ));
+        return Ok(None);
+    }
+
+    let response: Value = serde_json::from_str(line.trim()).map_err(|e| {
+        format!(
+            "resolve_dependency_proofs response not valid JSON: {e}; raw={}",
+            line.trim()
+        )
+    })?;
+    if let Some(error) = response.get("error") {
+        if error.get("code").and_then(Value::as_i64) == Some(-32601) {
+            record_dependency_proof_diagnostic(format!(
+                "dependency proof resolver {:?} does not implement provekit.plugin.resolve_dependency_proofs",
+                cmd_spec.argv
+            ));
+            return Ok(None);
+        }
+        return Err(format!("dependency proof resolver error: {error}"));
+    }
+
+    let paths = response
+        .get("result")
+        .and_then(|result| {
+            result
+                .get("proof_paths")
+                .or_else(|| result.get("proofPaths"))
+                .or_else(|| result.get("paths"))
+        })
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut out = Vec::new();
+    for path in paths {
+        let Some(path) = path.as_str() else {
+            record_dependency_proof_diagnostic(format!(
+                "dependency proof resolver {:?} returned a non-string path: {path}",
+                cmd_spec.argv
+            ));
+            continue;
+        };
+        if let Some(path) = normalize_dependency_proof_path(workspace_root, path) {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out.dedup();
+    Ok(Some(out))
+}
+
+fn normalize_dependency_proof_path(workspace_root: &Path, path: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(path);
+    let resolved = if path.is_absolute() {
+        path
+    } else {
+        workspace_root.join(path)
+    };
+    if resolved.extension().and_then(|s| s.to_str()) != Some("proof") {
+        record_dependency_proof_diagnostic(format!(
+            "dependency proof resolver returned non-.proof path {}; skipping",
+            resolved.display()
+        ));
+        return None;
+    }
+    if !resolved.is_file() {
+        record_dependency_proof_diagnostic(format!(
+            "dependency proof resolver returned missing path {}; skipping",
+            resolved.display()
+        ));
+        return None;
+    }
+    Some(resolved)
+}
+
+fn record_dependency_proof_diagnostic(message: String) {
+    eprintln!("{message}");
+    KIT_DISPATCH_DIAGNOSTICS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .expect("diagnostics lock")
+        .push(message);
+}
+
 /// #1360 / #1355: Return the per-target scope-bringings declared by
 /// the realize manifest matching `(target_lang, library_tag)`. cmd_materialize
 /// collects these across all materialized sites in a consumer file and

--- a/implementations/rust/provekit-cli/tests/dependency_proof_pool_assembly.rs
+++ b/implementations/rust/provekit-cli/tests/dependency_proof_pool_assembly.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Voltron pool assembly: provekit prove must ask configured kits for the
+// dependency .proof files they resolve through their own package managers, then
+// union those files into the verifier pool without teaching the substrate cargo,
+// npm, classpath, sys.path, or any other platform graph.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs};
+use provekit_proof_envelope::{
+    build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
+};
+use provekit_verifier::{Runner, RunnerConfig};
+use serde_json::{json, Value as Json};
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-dep-proof-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn int_sort() -> Json {
+    json!({"kind": "primitive", "name": "Int"})
+}
+
+fn int_const(n: i64) -> Json {
+    json!({"kind": "const", "value": n, "sort": int_sort()})
+}
+
+fn var(name: &str) -> Json {
+    json!({"kind": "var", "name": name})
+}
+
+fn flat_member(mut env: Json) -> (String, Vec<u8>) {
+    if let Json::Object(map) = &mut env {
+        map.remove("cid");
+        map.remove("producerSignature");
+    }
+    let canonical = json_to_canonical_jcs(&env);
+    let cid = blake3_512_of(canonical.as_bytes());
+    (cid, canonical.into_bytes())
+}
+
+fn json_to_canonical_jcs(j: &Json) -> String {
+    fn to_cv(j: &Json) -> std::sync::Arc<provekit_canonicalizer::Value> {
+        use provekit_canonicalizer::Value as CV;
+        match j {
+            Json::Null => CV::null(),
+            Json::Bool(b) => CV::boolean(*b),
+            Json::Number(n) => CV::integer(n.as_i64().unwrap_or(0)),
+            Json::String(s) => CV::string(s.clone()),
+            Json::Array(items) => CV::array(items.iter().map(to_cv).collect()),
+            Json::Object(map) => CV::object(
+                map.iter()
+                    .map(|(k, v)| (k.clone(), to_cv(v)))
+                    .collect::<Vec<_>>(),
+            ),
+        }
+    }
+    encode_jcs(&to_cv(j))
+}
+
+fn write_proof(dir: &Path, name: &str, members: BTreeMap<String, Vec<u8>>) -> String {
+    fs::create_dir_all(dir).expect("mkdir proof dir");
+    let signer_seed: Ed25519Seed = [0x51u8; 32];
+    let signer_pubkey = ed25519_pubkey_string(&signer_seed);
+    let signer_cid = blake3_512_of(signer_pubkey.as_bytes());
+    let built = build_proof_envelope(&ProofEnvelopeInput {
+        name: name.to_string(),
+        version: "1.0.0".into(),
+        binary_cid: None,
+        metadata: None,
+        members,
+        signer_cid,
+        signer_seed,
+        declared_at: "2026-05-27T00:00:00.000Z".into(),
+    });
+    let hex = built.cid.strip_prefix("blake3-512:").unwrap();
+    fs::write(dir.join(format!("{hex}.proof")), &built.bytes).expect("write proof");
+    built.cid
+}
+
+fn publish_vendor_positive_contract(vendor_dir: &Path) -> (String, String, PathBuf) {
+    let target_env = json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": "must_be_positive",
+                "formals": ["x"],
+                "formalSorts": [int_sort()],
+                "pre": {
+                    "kind": "atomic",
+                    "name": ">=",
+                    "args": [var("x"), int_const(0)]
+                }
+            }
+        }
+    });
+    let (target_cid, target_bytes) = flat_member(target_env);
+    let mut members = BTreeMap::new();
+    members.insert(target_cid.clone(), target_bytes);
+    let bundle_cid = write_proof(vendor_dir, "@vendor/must-be-positive", members);
+    let proof_path = fs::read_dir(vendor_dir)
+        .expect("read vendor proofs")
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| path.extension().and_then(|s| s.to_str()) == Some("proof"))
+        .expect("vendor proof exists");
+    (target_cid, bundle_cid, proof_path)
+}
+
+fn publish_user_bridge(project_dir: &Path, target_cid: &str, target_bundle_cid: &str) {
+    let source_env = json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": "user_calls_vendor",
+                "inv": {
+                    "kind": "atomic",
+                    "name": "observed",
+                    "args": [{
+                        "kind": "ctor",
+                        "name": "must_be_positive",
+                        "args": [int_const(-1)]
+                    }]
+                }
+            }
+        }
+    });
+    let (source_cid, source_bytes) = flat_member(source_env);
+    let bridge_env = json!({
+        "evidence": {
+            "kind": "bridge",
+            "body": {
+                "sourceSymbol": "must_be_positive",
+                "sourceLayer": "rust",
+                "targetContractCid": target_cid,
+                "targetProofCid": target_bundle_cid,
+                "targetLayer": "rust-kit"
+            }
+        }
+    });
+    let (bridge_cid, bridge_bytes) = flat_member(bridge_env);
+    let mut members = BTreeMap::new();
+    members.insert(source_cid, source_bytes);
+    members.insert(bridge_cid, bridge_bytes);
+    write_proof(
+        &project_dir.join(".provekit"),
+        "@user/local-bridge",
+        members,
+    );
+}
+
+fn install_dependency_proof_stub(project_dir: &Path, proof_path: &Path) {
+    let bin = project_dir.join("resolve-deps-stub.sh");
+    fs::write(
+        &bin,
+        format!(
+            "#!/bin/sh\nwhile IFS= read -r line; do\n  case \"$line\" in\n    *resolve_dependency_proofs*) echo '{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{\"proof_paths\":[\"{}\"]}}}}' ;;\n    *shutdown*) echo '{{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":null}}'; exit 0 ;;\n    *) echo '{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{}}}}' ;;\n  esac\ndone\n",
+            proof_path.display()
+        ),
+    )
+    .expect("write stub");
+    let manifest_dir = project_dir.join(".provekit").join("realize").join("rust");
+    fs::create_dir_all(&manifest_dir).expect("mkdir manifest");
+    fs::write(
+        manifest_dir.join("manifest.toml"),
+        format!(
+            "name = \"rust-dependency-proof-stub\"\nlibrary_tag = \"test\"\ncommand = [\"/bin/sh\", \"{}\"]\nworking_dir = \".\"\n",
+            bin.display()
+        ),
+    )
+    .expect("write manifest");
+    provekit_cli::kit_dispatch::reset_kit_dispatch_registry_cache_for_tests();
+}
+
+fn z3_available() -> bool {
+    std::process::Command::new("z3")
+        .arg("-version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn dependency_rpc_union_makes_vendor_contract_reachable() {
+    let root = unique_dir("reachable");
+    let project = root.join("user");
+    let vendor = root.join("vendor");
+    fs::create_dir_all(project.join(".provekit")).expect("mkdir project");
+    let (target_cid, bundle_cid, proof_path) = publish_vendor_positive_contract(&vendor);
+    publish_user_bridge(&project, &target_cid, &bundle_cid);
+    install_dependency_proof_stub(&project, &proof_path);
+
+    let dependency_proofs = provekit_cli::kit_dispatch::dependency_proof_paths_via_rpc(&project)
+        .expect("resolve dependency proofs");
+    assert_eq!(dependency_proofs, vec![proof_path.clone()]);
+
+    let runner = Runner::new(RunnerConfig {
+        project_root: project.clone(),
+        extra_proof_files: dependency_proofs,
+        ..Default::default()
+    });
+    let (pool, _callsites) = runner.run_load_and_enumerate();
+    assert!(
+        pool.mementos.get(&target_cid).is_some(),
+        "vendor contract {target_cid} must be present after dependency proof assembly"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn voltron_pool_refuses_cross_dependency_violation() {
+    if !z3_available() {
+        eprintln!("SKIP voltron_pool_refuses_cross_dependency_violation: z3 not on PATH");
+        return;
+    }
+
+    let root = unique_dir("e2e");
+    let project = root.join("user");
+    let vendor = root.join("vendor");
+    fs::create_dir_all(project.join(".provekit")).expect("mkdir project");
+    let (target_cid, bundle_cid, proof_path) = publish_vendor_positive_contract(&vendor);
+    publish_user_bridge(&project, &target_cid, &bundle_cid);
+    install_dependency_proof_stub(&project, &proof_path);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("prove")
+        .arg(&project)
+        .arg("--z3")
+        .arg("z3")
+        .arg("--quiet")
+        .output()
+        .expect("run provekit prove");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "cross-dependency bridge to must_be_positive(-1) must be refused\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let _ = fs::remove_dir_all(root);
+}

--- a/implementations/rust/provekit-realize-rust-core/src/lib.rs
+++ b/implementations/rust/provekit-realize-rust-core/src/lib.rs
@@ -2306,6 +2306,100 @@ fn op_concept_name(op_definition_cid: &str) -> String {
     }
 }
 
+fn resolve_dependency_proof_paths(project_root: &Path) -> Result<Vec<PathBuf>, String> {
+    let manifest_path = project_root.join("Cargo.toml");
+    if !manifest_path.is_file() {
+        return Ok(Vec::new());
+    }
+
+    let output = std::process::Command::new("cargo")
+        .arg("metadata")
+        .arg("--format-version")
+        .arg("1")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .current_dir(project_root)
+        .output()
+        .map_err(|error| format!("spawn cargo metadata: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let metadata: Value = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("parse cargo metadata JSON: {error}"))?;
+
+    let workspace_members = metadata
+        .get("workspace_members")
+        .and_then(Value::as_array)
+        .map(|members| {
+            members
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    let reachable = metadata
+        .get("resolve")
+        .and_then(|resolve| resolve.get("nodes"))
+        .and_then(Value::as_array)
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(|node| node.get("id").and_then(Value::as_str))
+                .map(str::to_string)
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut proof_paths = BTreeSet::new();
+    let Some(packages) = metadata.get("packages").and_then(Value::as_array) else {
+        return Ok(Vec::new());
+    };
+    for package in packages {
+        let Some(package_id) = package.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        if workspace_members.contains(package_id) {
+            continue;
+        }
+        if !reachable.is_empty() && !reachable.contains(package_id) {
+            continue;
+        }
+        let Some(manifest_path) = package.get("manifest_path").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(package_dir) = Path::new(manifest_path).parent() else {
+            continue;
+        };
+        collect_package_proof_files(package_dir, &mut proof_paths);
+    }
+
+    Ok(proof_paths.into_iter().collect())
+}
+
+fn collect_package_proof_files(package_dir: &Path, proof_paths: &mut BTreeSet<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(package_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if file_name == "target" || file_name == ".git" {
+            continue;
+        }
+        if path.is_dir() {
+            collect_package_proof_files(&path, proof_paths);
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) == Some("proof") {
+            proof_paths.insert(path);
+        }
+    }
+}
+
 pub fn dispatch(request: &Value) -> Value {
     let id = request.get("id").cloned().unwrap_or(Value::Null);
     let method = request.get("method").and_then(Value::as_str).unwrap_or("");
@@ -2324,6 +2418,36 @@ pub fn dispatch(request: &Value) -> Value {
                 }
             }
         }),
+        "provekit.plugin.resolve_dependency_proofs" => {
+            let params = request
+                .get("params")
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            let project_root = params
+                .get("project_root")
+                .or_else(|| params.get("projectRoot"))
+                .and_then(Value::as_str)
+                .map(PathBuf::from)
+                .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+            match resolve_dependency_proof_paths(&project_root) {
+                Ok(paths) => serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "proof_paths": paths
+                            .iter()
+                            .map(|path| path.display().to_string())
+                            .collect::<Vec<_>>()
+                    }
+                }),
+                Err(resolve_error) => error(
+                    id,
+                    -32030,
+                    &format!("RESOLVE_DEPENDENCY_PROOFS_FAILED: {resolve_error}"),
+                ),
+            }
+        }
         "provekit.plugin.body_template_entries" => {
             let params = request
                 .get("params")
@@ -4413,6 +4537,7 @@ fn find_repo_file(relative: &Path) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::path::PathBuf;
 
     /// Catalog-driven dispatch (#1391): the realizations catalog at
@@ -4453,6 +4578,69 @@ mod tests {
 
     fn strings(items: &[&str]) -> Vec<String> {
         items.iter().map(|item| item.to_string()).collect()
+    }
+
+    #[test]
+    fn resolve_dependency_proofs_returns_proofs_from_resolved_path_dependencies() {
+        let root = temp_operator_root("rust_dep_proofs");
+        let user = root.join("user");
+        let vendor = root.join("vendor_positive");
+        fs::create_dir_all(user.join("src")).expect("create user src");
+        fs::create_dir_all(vendor.join("src")).expect("create vendor src");
+        fs::write(
+            user.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"user_project\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nvendor_positive = {{ path = \"{}\" }}\n",
+                vendor.display()
+            ),
+        )
+        .expect("write user Cargo.toml");
+        fs::write(
+            user.join("src/lib.rs"),
+            "pub fn call() -> i64 { vendor_positive::id(-1) }\n",
+        )
+        .expect("write user lib");
+        fs::write(
+            vendor.join("Cargo.toml"),
+            "[package]\nname = \"vendor_positive\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .expect("write vendor Cargo.toml");
+        fs::write(
+            vendor.join("src/lib.rs"),
+            "pub fn id(x: i64) -> i64 { x }\n",
+        )
+        .expect("write vendor lib");
+        let proof_path = vendor.join(
+            "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.proof",
+        );
+        fs::write(&proof_path, b"synthetic proof path fixture").expect("write vendor proof");
+
+        let response = dispatch(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "provekit.plugin.resolve_dependency_proofs",
+            "params": {
+                "project_root": user,
+            }
+        }));
+
+        assert!(
+            response.get("error").is_none(),
+            "resolver must be implemented by the Rust kit; got {response}"
+        );
+        let paths = response
+            .pointer("/result/proof_paths")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            paths
+                .iter()
+                .any(|path| path.as_str() == Some(proof_path.to_str().unwrap())),
+            "expected dependency proof path {} in response {response}",
+            proof_path.display()
+        );
+        let _ = fs::remove_dir_all(root);
     }
 
     fn resolved_return_call_new_with_literal_args(args: Vec<Value>) -> Value {

--- a/implementations/rust/provekit-verifier/src/load_all_proofs.rs
+++ b/implementations/rust/provekit-verifier/src/load_all_proofs.rs
@@ -31,15 +31,34 @@ const SIG_TAG_PREFIX: &str = "ed25519:";
 pub fn run(project_root: &Path) -> MementoPool {
     let mut pool = MementoPool::default();
     for path in enumerate_proof_files(project_root) {
-        match load_one(&path, &mut pool) {
-            Ok(()) => {}
-            Err(e) => pool.load_errors.push(LoadError {
-                proof_path: path.display().to_string(),
-                reason: format!("read/decode: {e}"),
-            }),
-        }
+        load_path_into_pool(&path, &mut pool);
     }
     pool
+}
+
+pub fn run_with_files(project_root: &Path, proof_files: &[PathBuf]) -> MementoPool {
+    let mut pool = run(project_root);
+    load_files_into_pool(proof_files, &mut pool);
+    pool
+}
+
+pub fn load_files_into_pool(proof_files: &[PathBuf], pool: &mut MementoPool) {
+    let mut proof_files = proof_files.to_vec();
+    proof_files.sort();
+    proof_files.dedup();
+    for path in proof_files {
+        load_path_into_pool(&path, pool);
+    }
+}
+
+fn load_path_into_pool(path: &Path, pool: &mut MementoPool) {
+    match load_one(path, pool) {
+        Ok(()) => {}
+        Err(e) => pool.load_errors.push(LoadError {
+            proof_path: path.display().to_string(),
+            reason: format!("read/decode: {e}"),
+        }),
+    }
 }
 
 fn enumerate_proof_files(project_root: &Path) -> Vec<PathBuf> {

--- a/implementations/rust/provekit-verifier/src/runner.rs
+++ b/implementations/rust/provekit-verifier/src/runner.rs
@@ -88,6 +88,10 @@ pub struct RunnerConfig {
     /// also be loaded (e.g., OpenAPI spec project for cross-kit
     /// verification).
     pub extra_projects: Vec<PathBuf>,
+    /// Additional individual .proof files resolved by kit-owned package
+    /// managers. These are still loaded by content address; the verifier
+    /// never interprets the package graph that surfaced them.
+    pub extra_proof_files: Vec<PathBuf>,
 }
 
 /// Per-solver telemetry, surfaced in the report alongside the legacy
@@ -182,6 +186,7 @@ impl Runner {
             let extra_pool = load_all_proofs::run(extra);
             pool.merge(extra_pool);
         }
+        load_all_proofs::load_files_into_pool(&self.cfg.extra_proof_files, &mut pool);
         let loaded_cids = sorted_keys(&pool.mementos);
         let load_diagnostics: Vec<Json> = pool
             .load_errors
@@ -386,6 +391,7 @@ impl Runner {
             let extra_pool = load_all_proofs::run(extra);
             pool.merge(extra_pool);
         }
+        load_all_proofs::load_files_into_pool(&self.cfg.extra_proof_files, &mut pool);
 
         // Load and process call edges
         let call_edges = call_edge_loader::load_call_edge_files(&self.cfg.project_root);
@@ -501,7 +507,12 @@ impl Runner {
     }
 
     pub fn run_load_and_enumerate(&self) -> (MementoPool, Vec<CallSite>) {
-        let pool = load_all_proofs::run(&self.cfg.project_root);
+        let mut pool = load_all_proofs::run(&self.cfg.project_root);
+        for extra in &self.cfg.extra_projects {
+            let extra_pool = load_all_proofs::run(extra);
+            pool.merge(extra_pool);
+        }
+        load_all_proofs::load_files_into_pool(&self.cfg.extra_proof_files, &mut pool);
         let cs = enumerate_callsites::run(&pool);
         (pool, cs)
     }
@@ -705,6 +716,9 @@ fn discover_input_artifact_cids(cfg: &RunnerConfig) -> BTreeSet<String> {
     for extra in &cfg.extra_projects {
         collect_proof_file_cids(extra, &mut cids);
     }
+    for proof_file in &cfg.extra_proof_files {
+        collect_one_proof_file_cid(proof_file, &mut cids);
+    }
     cids
 }
 
@@ -726,6 +740,15 @@ fn collect_proof_file_cids(root: &Path, out: &mut BTreeSet<String>) {
         if let Ok(bytes) = std::fs::read(entry.path()) {
             out.insert(provekit_canonicalizer::blake3_512_of(&bytes));
         }
+    }
+}
+
+fn collect_one_proof_file_cid(path: &Path, out: &mut BTreeSet<String>) {
+    if path.extension().and_then(|s| s.to_str()) != Some("proof") {
+        return;
+    }
+    if let Ok(bytes) = std::fs::read(path) {
+        out.insert(provekit_canonicalizer::blake3_512_of(&bytes));
     }
 }
 

--- a/implementations/rust/provekit-verifier/tests/multi_solver_modes.rs
+++ b/implementations/rust/provekit-verifier/tests/multi_solver_modes.rs
@@ -285,6 +285,7 @@ binary = "stub:unsat"
             .unwrap(),
         ),
         extra_projects: Vec::new(),
+        extra_proof_files: Vec::new(),
     };
     let runner = Runner::new(cfg);
     let (report, stats) = runner.run_with_tiers();

--- a/implementations/typescript/provekit-realize-typescript-better-sqlite3/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-better-sqlite3/src/rpc.js
@@ -59,6 +59,10 @@ function dispatch(request) {
     const entries = realizer.shimProofEntries ? realizer.shimProofEntries() : [];
     return { jsonrpc: "2.0", id: msgId, result: { entries, proof_path: proofPath } };
   }
+  if (method === "provekit.plugin.resolve_dependency_proofs") {
+    console.error("provekit-realize-typescript-better-sqlite3: resolve_dependency_proofs not yet implemented for typescript; returning empty proof_paths");
+    return { jsonrpc: "2.0", id: msgId, result: { proof_paths: [] } };
+  }
   if (method === "provekit.plugin.shutdown") {
     return { jsonrpc: "2.0", id: msgId, result: null };
   }

--- a/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
@@ -49,6 +49,10 @@ function dispatch(request) {
   if (method === "provekit.plugin.literal_encoding_answers") {
     return { jsonrpc: "2.0", id: msgId, result: { answers: literalEncodingAnswers() } };
   }
+  if (method === "provekit.plugin.resolve_dependency_proofs") {
+    console.error("provekit-realize-typescript-core: resolve_dependency_proofs not yet implemented for typescript; returning empty proof_paths");
+    return { jsonrpc: "2.0", id: msgId, result: { proof_paths: [] } };
+  }
   if (method === "provekit.plugin.shutdown") {
     return { jsonrpc: "2.0", id: msgId, result: null };
   }

--- a/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
@@ -59,6 +59,10 @@ function dispatch(request) {
     const entries = realizer.shimProofEntries ? realizer.shimProofEntries() : [];
     return { jsonrpc: "2.0", id: msgId, result: { entries, proof_path: proofPath } };
   }
+  if (method === "provekit.plugin.resolve_dependency_proofs") {
+    console.error("provekit-realize-typescript-pg: resolve_dependency_proofs not yet implemented for typescript; returning empty proof_paths");
+    return { jsonrpc: "2.0", id: msgId, result: { proof_paths: [] } };
+  }
   if (method === "provekit.plugin.shutdown") {
     return { jsonrpc: "2.0", id: msgId, result: null };
   }

--- a/protocol/specs/2026-05-12-plugin-protocol.md
+++ b/protocol/specs/2026-05-12-plugin-protocol.md
@@ -256,7 +256,45 @@ Request:
 }
 ```
 
-#### §4.2.3 `provekit.plugin.shutdown`
+#### §4.2.3 `provekit.plugin.resolve_dependency_proofs`
+
+Kit-owned package-manager proof resolution. The runtime calls this method before
+verification pool assembly. The substrate MUST NOT inspect cargo metadata,
+classpath entries, node_modules, sys.path, or any other platform dependency
+graph directly; it passes the project root to configured kits and unions the
+returned `.proof` bundles by CID.
+
+Request:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "provekit.plugin.resolve_dependency_proofs",
+  "params": {
+    "project_root": "/absolute/project/root"
+  }
+}
+```
+
+Response (success):
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "proof_paths": ["/absolute/vendor/package/blake3-512:<hex>.proof"]
+  }
+}
+```
+
+`proof_paths` entries MUST name `.proof` bundle files. Implementations MAY
+return an empty array when the language kit has no implementation yet, but MUST
+log that language-specific dependency proof resolution is not implemented. The
+runtime MUST treat the returned bundles as opaque content-addressed proof files:
+load by bytes, recompute bundle and member CIDs, and union members. It MUST NOT
+extract formulas for rewriting or reinterpret package-manager metadata.
+
+#### §4.2.4 `provekit.plugin.shutdown`
 
 Graceful close. After this, an `stdio:` plugin SHOULD exit zero on stdin EOF; an HTTP plugin MAY ignore the call.
 


### PR DESCRIPTION
The final piece of the substrate arc. Each \`.proof\` is a content-addressed bundle (a lion). The user's program lift is the spine (PR #1565 + the head: \`provekit mint --project\`). PR #1566 made the user's bridges *point at* vendor contract CIDs. This PR is what makes those bridges actually *resolve* — by bringing the vendor \`.proof\`s into the prove pool.

## What's missing without this
\`load_all_proofs::run\` walks one project's local \`.provekit/\`. So when a user's bridge references a vendor's \`local_contract_cid\`, \`resolve_target\` does \`pool.mementos.get(target_cid)\`, doesn't find it (the vendor's \`.proof\` is in the cargo registry / classpath / \`node_modules\` — not in the project's local catalog), and the cross-vendor edge falls through. The lions are pointing at each other and missing.

## The mechanism: one new RPC verb, behind an existing boundary
**The substrate stays language-blind.** The verifier/CLI \*never\* learn cargo, classpath, sys.path, or \`node_modules\` — that's the prohibition (\`project_provekit_platform_in_sidecar\`). Instead: each kit already speaks an RPC at \`lift\`/\`realize\`; we add one more verb, \`provekit.plugin.resolve_dependency_proofs\`, and the substrate's role is one shape: ask the kit, union the answer.

- \`protocol/specs/2026-05-12-plugin-protocol.md\` — defines the verb.
- \`provekit-realize-rust-core/src/lib.rs\` — Rust kit implementation via \`cargo metadata\` (the cargo knowledge lives **only** here, behind the RPC boundary).
- \`provekit-cli/src/kit_dispatch.rs\` — language-blind fan-out: iterate configured kits, call each, collect returned \`.proof\` paths.
- \`provekit-verifier/src/load_all_proofs.rs\` + \`runner.rs\` — pool-construction extension (\`load_files_into_pool\` / \`extra_proof_files\`/\`extra_projects\` config fields). Doc-comment on the change: *"these are still loaded by content address; the verifier never interprets the package graph that surfaced them."*
- Java / Python / TypeScript / Go / C kits stubbed (return empty + clear stderr log). Per-language implementations of the verb are deliberate follow-ups; the substrate is ready the moment each kit fills in its own.

## Verified
- **Grounding**: \`resolve_dependency_proofs_returns_proofs_from_resolved_path_dependencies\` (rust kit returns \`.proof\` paths via cargo metadata).
- **Substrate-side**: \`dependency_proof_pool_assembly\` — vendor contract memento reachable in \`pool.mementos\` after fan-out, even though absent from the project's local \`.provekit/\`.
- **E2E (Voltron forming)**: \`voltron_pool_refuses_cross_dependency_violation\` — a rust user project depends on a vendor crate shipping \`must_be_positive\` (pre: \`x >= 0\`); the user materializes the vendor sugar; user's bridge resolves into the vendor's \`.proof\` via the new RPC; \`provekit prove\` **refuses** the violating callsite. Today (single-project pool) this would silently green-up; with this fix it returns sat on the unsatisfied callsite. **Software ages backwards across the ecosystem — demonstrated.**
- \`cargo test -p libprovekit -p provekit-verifier -p provekit-walk\` — independently re-run, all green.

## Invariants held (audited)
- ✅ No \`cargo_metadata\`/classpath/\`sys.path\`/\`node_modules\` code in the substrate (cli/libprovekit/verifier source). All three \`cargo metadata\` spawns live in the Rust kit; substrate is blind.
- ✅ Verifier discharge files untouched (\`enumerate_callsites\`/\`resolve_target\`/\`handshake\`/\`types\`/\`instantiate\`/\`smt_emitter\`). \`runner.rs\` changes are pool-plumbing only — no tier-discharge logic touched.
- ✅ \`.proof\` filenames stay content-addressed; the pool just gets bigger via CID-keyed dedup.

Follows #1565 and #1566 (now both on \`main\`). Filed follow-up: #1567 (handshake \`wrap_post_forall\` return-sort plumbing, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kit plugins can now provide proof file paths for dependency packages via the new dependency proof resolution capability
  * Verifier automatically discovers and loads dependency proofs alongside project proofs for comprehensive verification coverage

* **Documentation**
  * Added protocol specification for the new dependency proof resolution method

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->