### PR TITLE
Form Voltron in Python: resolve_dependency_proofs over importlib.metadata

### DIFF
--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
+from fnmatch import fnmatch
+from importlib import metadata as importlib_metadata
 import json
+from pathlib import Path
 import sys
 import traceback
 from typing import Any
-
-from .literal_encoding import answers as _literal_encoding_answers
-from .platform_semantics import declaration as _platform_semantics_declaration
-from . import realizer
-from .realizer import BodyTemplateResourceError, MissingTemplateError, emit_stub
 
 
 def run_rpc() -> None:
@@ -41,12 +39,18 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         params = {}
 
     if method == "provekit.plugin.platform_semantics":
+        from .platform_semantics import declaration as _platform_semantics_declaration
+
         return {"jsonrpc": "2.0", "id": msg_id, "result": _platform_semantics_declaration()}
     if method == "provekit.plugin.literal_encoding_answers":
+        from .literal_encoding import answers as _literal_encoding_answers
+
         return {"jsonrpc": "2.0", "id": msg_id, "result": {"answers": _literal_encoding_answers()}}
     if method == "provekit.plugin.invoke":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        from .realizer import MissingTemplateError
+
         try:
             result = _emit_one(params)
         except MissingTemplateError as exc:
@@ -58,6 +62,8 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         functions = params.get("functions")
         if not isinstance(functions, list):
             return _error(msg_id, -32602, "INVALID_PARAMS: functions must be an array")
+        from .realizer import MissingTemplateError
+
         results: list[dict[str, Any]] = []
         missing = []
         for item in functions:
@@ -85,6 +91,9 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         target_library_tag = params.get("target_library_tag")
         if not isinstance(target_library_tag, str):
             target_library_tag = None
+        from . import realizer
+        from .realizer import BodyTemplateResourceError
+
         try:
             entries = realizer.body_template_entries_for_library_tag(target_library_tag)
         except BodyTemplateResourceError as exc:
@@ -98,17 +107,21 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
             },
         }
     if method == "provekit.plugin.resolve_dependency_proofs":
-        print(
-            "provekit-realize-python-core: resolve_dependency_proofs not yet implemented for python; returning empty proof_paths",
-            file=sys.stderr,
-        )
-        return {"jsonrpc": "2.0", "id": msg_id, "result": {"proof_paths": []}}
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {"proof_paths": _resolve_dependency_proof_paths()},
+        }
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
 
 
 def _emit_one(params: dict[str, Any]) -> dict[str, Any]:
+    from .realizer import emit_stub
+
     return emit_stub(
         function=str(params.get("function", "")),
         params=_string_list(params.get("params")),
@@ -155,7 +168,19 @@ def _annotation_enabled(params: dict[str, Any]) -> bool:
     return params.get("annotate") is True
 
 
-def _body_template_entry_json(entry: realizer.BodyTemplateEntry) -> dict[str, Any]:
+def _resolve_dependency_proof_paths() -> list[str]:
+    proof_paths: set[str] = set()
+    for dist in importlib_metadata.distributions():
+        for file in dist.files or ():
+            if not fnmatch(Path(str(file)).name, "blake3-512:*.proof"):
+                continue
+            path = Path(dist.locate_file(file)).resolve()
+            if path.is_file():
+                proof_paths.add(str(path))
+    return sorted(proof_paths)
+
+
+def _body_template_entry_json(entry: Any) -> dict[str, Any]:
     guard: dict[str, Any] = {}
     if entry.min_params is not None:
         guard["min_params"] = entry.min_params
@@ -204,6 +229,8 @@ def _body_template_resource_error(
     msg_id: Any,
     exc: BodyTemplateResourceError,
 ) -> dict[str, Any]:
+    from . import realizer
+
     return {
         "jsonrpc": "2.0",
         "id": msg_id,

--- a/implementations/python/provekit-realize-python-core/tests/test_dependency_proof_resolution.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_dependency_proof_resolution.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-realize-python-core/src"
+
+
+def test_resolve_dependency_proofs_returns_installed_distribution_proofs(tmp_path: Path) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    first_proof = _install_fake_distribution(site_packages, "voltron_dep_alpha", "a")
+    second_proof = _install_fake_distribution(site_packages, "voltron_dep_beta", "b")
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    response = _rpc_call(
+        site_packages,
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "provekit.plugin.resolve_dependency_proofs",
+            "params": {"project_root": str(project_root)},
+        },
+    )
+
+    assert "error" not in response, response
+    proof_paths = response["result"]["proof_paths"]
+    assert set(proof_paths) == {str(first_proof), str(second_proof)}
+    for proof_path in proof_paths:
+        path = Path(proof_path)
+        assert path.is_absolute()
+        assert path.is_file()
+        assert path.read_text(encoding="utf-8").startswith("synthetic proof for")
+
+
+def test_resolve_dependency_proofs_returns_empty_array_without_distribution_proofs(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    _install_fake_distribution(site_packages, "plain_dep", None)
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    response = _rpc_call(
+        site_packages,
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "provekit.plugin.resolve_dependency_proofs",
+            "params": {"project_root": str(project_root)},
+        },
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "result": {"proof_paths": []},
+    }
+
+
+def _install_fake_distribution(
+    site_packages: Path,
+    distribution_name: str,
+    proof_digit: str | None,
+) -> Path | None:
+    package_name = distribution_name.replace("-", "_")
+    package_dir = site_packages / package_name
+    dist_info = site_packages / f"{distribution_name}-1.0.dist-info"
+    package_dir.mkdir()
+    dist_info.mkdir()
+
+    init_path = package_dir / "__init__.py"
+    init_path.write_text("", encoding="utf-8")
+    resource_path = package_dir / "not-a-proof.txt"
+    resource_path.write_text("ordinary package data\n", encoding="utf-8")
+
+    record_entries = [
+        f"{package_name}/__init__.py,,",
+        f"{package_name}/not-a-proof.txt,,",
+        f"{distribution_name}-1.0.dist-info/METADATA,,",
+        f"{distribution_name}-1.0.dist-info/WHEEL,,",
+        f"{distribution_name}-1.0.dist-info/RECORD,,",
+    ]
+
+    proof_path = None
+    if proof_digit is not None:
+        proof_name = f"blake3-512:{proof_digit * 128}.proof"
+        proof_path = package_dir / proof_name
+        proof_path.write_text(f"synthetic proof for {distribution_name}\n", encoding="utf-8")
+        record_entries.append(f"{package_name}/{proof_name},,")
+
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {distribution_name}\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (dist_info / "WHEEL").write_text("Wheel-Version: 1.0\n", encoding="utf-8")
+    (dist_info / "RECORD").write_text("\n".join(record_entries) + "\n", encoding="utf-8")
+    return proof_path
+
+
+def _rpc_call(site_packages: Path, request: dict[str, Any]) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join([str(PKG_SRC), str(site_packages)])
+    env["PYTHONNOUSERSITE"] = "1"
+    shutdown = {"jsonrpc": "2.0", "id": "shutdown", "method": "provekit.plugin.shutdown"}
+    proc = subprocess.run(
+        [sys.executable, "-S", "-m", "provekit_realize_python_core", "--rpc"],
+        input=json.dumps(request) + "\n" + json.dumps(shutdown) + "\n",
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    lines = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+    assert lines, proc.stderr
+    return lines[0]


### PR DESCRIPTION
Mirrors PR #1568 for the rust kit. The Python realize kit's JSON-RPC server now handles `provekit.plugin.resolve_dependency_proofs` per protocol spec §4.2.3.

## What changes
- `rpc.py`: dispatch for `resolve_dependency_proofs`. Enumerates installed distributions via `importlib.metadata.distributions()`, scans each distribution's RECORD for `blake3-512:*.proof` entries, resolves via `dist.locate_file()`, returns existing absolute paths.
- `tests/test_dependency_proof_resolution.py`: RPC subprocess test with two fake installed distributions containing `.proof` resources + an empty-result case.

## Verification
- Focused resolver test: 2/2 pass
- Full Python-core suite: 104/104 pass

## Voltron context
This is the **Python lion** in Voltron pool assembly. With this PR + #1568 (rust) + the upcoming Java/TS/Go resolvers, `provekit prove` can union vendor `.proof` envelopes across any combination of these languages. The substrate stays language-blind; each kit owns its package-manager walk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented dependency proof resolution for installed Python distributions
* **Refactor**
  * Optimized module initialization with lazy imports for improved performance
* **Tests**
  * Added comprehensive test coverage for dependency proof resolution with multiple scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->