### PR TITLE
Form Voltron in TypeScript: resolve_dependency_proofs over node_modules

### DIFF
--- a/implementations/typescript/provekit-realize-typescript-core/src/dependency_proofs.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/dependency_proofs.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const PROOF_FILE_RE = /^blake3-512:[0-9a-fA-F]+\.proof$/;
+
+function resolveDependencyProofPaths(projectRoot) {
+  const root = path.resolve(
+    typeof projectRoot === "string" && projectRoot !== "" ? projectRoot : process.cwd(),
+  );
+  const proofPaths = new Set();
+  const visitedNodeModules = new Set();
+  const visitedPackages = new Set();
+
+  walkNodeModules(path.join(root, "node_modules"), {
+    proofPaths,
+    visitedNodeModules,
+    visitedPackages,
+  });
+
+  return Array.from(proofPaths).sort();
+}
+
+function walkNodeModules(nodeModulesDir, state) {
+  const realNodeModules = realDirectoryPath(nodeModulesDir);
+  if (realNodeModules === null || state.visitedNodeModules.has(realNodeModules)) return;
+  state.visitedNodeModules.add(realNodeModules);
+
+  let entries;
+  try {
+    entries = fs.readdirSync(realNodeModules, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) continue;
+
+    const entryPath = path.join(realNodeModules, entry.name);
+    if (entry.name.startsWith("@")) {
+      walkScopedPackages(entryPath, state);
+      continue;
+    }
+
+    collectPackage(entryPath, state);
+  }
+}
+
+function walkScopedPackages(scopeDir, state) {
+  const realScopeDir = realDirectoryPath(scopeDir);
+  if (realScopeDir === null) return;
+
+  let entries;
+  try {
+    entries = fs.readdirSync(realScopeDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    collectPackage(path.join(realScopeDir, entry.name), state);
+  }
+}
+
+function collectPackage(packageDir, state) {
+  const realPackageDir = realDirectoryPath(packageDir);
+  if (realPackageDir === null || state.visitedPackages.has(realPackageDir)) return;
+  state.visitedPackages.add(realPackageDir);
+
+  collectPackageProofFiles(realPackageDir, state.proofPaths);
+  walkNodeModules(path.join(realPackageDir, "node_modules"), state);
+}
+
+function collectPackageProofFiles(packageDir, proofPaths) {
+  let entries;
+  try {
+    entries = fs.readdirSync(packageDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(packageDir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      collectPackageProofFiles(entryPath, proofPaths);
+      continue;
+    }
+    if (entry.isFile() && PROOF_FILE_RE.test(entry.name)) {
+      proofPaths.add(entryPath);
+    }
+  }
+}
+
+function realDirectoryPath(candidate) {
+  try {
+    const realPath = fs.realpathSync(candidate);
+    return fs.statSync(realPath).isDirectory() ? realPath : null;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  resolveDependencyProofPaths,
+};

--- a/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
@@ -1,5 +1,6 @@
 const readline = require("node:readline");
 
+const { resolveDependencyProofPaths } = require("./dependency_proofs");
 const { emitStub } = require("./realizer");
 const { answers: literalEncodingAnswers } = require("./literal_encoding");
 const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
@@ -50,8 +51,21 @@ function dispatch(request) {
     return { jsonrpc: "2.0", id: msgId, result: { answers: literalEncodingAnswers() } };
   }
   if (method === "provekit.plugin.resolve_dependency_proofs") {
-    console.error("provekit-realize-typescript-core: resolve_dependency_proofs not yet implemented for typescript; returning empty proof_paths");
-    return { jsonrpc: "2.0", id: msgId, result: { proof_paths: [] } };
+    let projectRoot = process.cwd();
+    if (typeof params.project_root === "string") {
+      projectRoot = params.project_root;
+    } else if (typeof params.projectRoot === "string") {
+      projectRoot = params.projectRoot;
+    }
+    try {
+      return {
+        jsonrpc: "2.0",
+        id: msgId,
+        result: { proof_paths: resolveDependencyProofPaths(projectRoot) },
+      };
+    } catch (error) {
+      return errorResponse(msgId, -32030, `RESOLVE_DEPENDENCY_PROOFS_FAILED: ${error.message}`);
+    }
   }
   if (method === "provekit.plugin.shutdown") {
     return { jsonrpc: "2.0", id: msgId, result: null };

--- a/implementations/typescript/provekit-realize-typescript-core/tests/dependency_proofs.test.js
+++ b/implementations/typescript/provekit-realize-typescript-core/tests/dependency_proofs.test.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const KIT_ROOT = path.join(__dirname, "..");
+const RPC_MAIN = path.join(KIT_ROOT, "src", "main.js");
+
+function makeProject() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "provekit-ts-dep-proofs-"));
+  fs.writeFileSync(path.join(root, "package.json"), "{\"private\":true}\n");
+  fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+  return root;
+}
+
+function writePackage(root, packageName) {
+  const packageRoot = packageName.startsWith("@")
+    ? path.join(root, "node_modules", ...packageName.split("/"))
+    : path.join(root, "node_modules", packageName);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify({ name: packageName, version: "1.0.0" })}\n`,
+  );
+  return packageRoot;
+}
+
+function writeProof(packageRoot, hex) {
+  const proofPath = path.join(packageRoot, `blake3-512:${hex}.proof`);
+  fs.writeFileSync(proofPath, "synthetic dependency proof\n");
+  return proofPath;
+}
+
+function invokeResolveDependencyProofs(projectRoot) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [RPC_MAIN, "--rpc"], {
+      cwd: KIT_ROOT,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`rpc exited with code ${code}: ${stderr}`));
+        return;
+      }
+      const line = stdout.trim().split("\n").filter(Boolean)[0];
+      if (!line) {
+        reject(new Error(`rpc returned no response; stderr: ${stderr}`));
+        return;
+      }
+      resolve(JSON.parse(line));
+    });
+    child.stdin.end(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "provekit.plugin.resolve_dependency_proofs",
+      params: { project_root: projectRoot },
+    })}\n`);
+  });
+}
+
+test("resolve_dependency_proofs returns absolute readable proofs from node_modules packages", async () => {
+  const projectRoot = makeProject();
+  try {
+    const depOne = writePackage(projectRoot, "dep-one");
+    const depTwo = writePackage(projectRoot, "@scope/dep-two");
+    const proofOne = fs.realpathSync(writeProof(depOne, "a".repeat(128)));
+    const proofTwo = fs.realpathSync(writeProof(depTwo, "b".repeat(128)));
+    fs.symlinkSync(depOne, path.join(projectRoot, "node_modules", "dep-one-alias"), "dir");
+
+    const response = await invokeResolveDependencyProofs(projectRoot);
+
+    assert.equal(response.jsonrpc, "2.0");
+    assert.equal(response.id, 7);
+    assert.equal(response.error, undefined);
+    const proofPaths = response.result.proof_paths.toSorted();
+    assert.deepEqual(proofPaths, [proofOne, proofTwo].toSorted());
+    for (const proofPath of proofPaths) {
+      assert.equal(path.isAbsolute(proofPath), true);
+      assert.equal(fs.statSync(proofPath).isFile(), true);
+    }
+  } finally {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolve_dependency_proofs returns an empty array when dependencies have no proofs", async () => {
+  const projectRoot = makeProject();
+  try {
+    writePackage(projectRoot, "dep-without-proof");
+
+    const response = await invokeResolveDependencyProofs(projectRoot);
+
+    assert.equal(response.jsonrpc, "2.0");
+    assert.equal(response.id, 7);
+    assert.equal(response.error, undefined);
+    assert.deepEqual(response.result.proof_paths, []);
+  } finally {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Mirrors PR #1568 for the rust kit. The TypeScript realize kit's JSON-RPC server now handles `provekit.plugin.resolve_dependency_proofs` per protocol spec §4.2.3.

## What changes
- `src/dependency_proofs.js`: walks `project_root/node_modules` recursively (scoped packages + nested deps), scans for files matching `blake3-512:<hex>.proof`, returns absolute canonical paths deduped by package real-path.
- `src/rpc.js`: dispatch wired in.
- `tests/dependency_proofs.test.js`: RPC-level acceptance + negative case.

## Verification
- `node --test tests/dependency_proofs.test.js`: 2/2 pass
- `node --check` on both new files: pass

## Voltron context
This is the **TypeScript lion** in Voltron pool assembly. With this PR + #1568 (rust) + the upcoming Java/Go/Python resolvers, `provekit prove` can union vendor `.proof` envelopes across any combination of these languages. The substrate stays language-blind; each kit owns its package-manager walk.