### PR TITLE
feat: Recognizer foundation — ast_template in lifter, recognize RPC, provekit recognize CLI, Voltron parity pilot

### DIFF
--- a/examples/voltron-demo/RESULT.md
+++ b/examples/voltron-demo/RESULT.md
@@ -66,6 +66,38 @@ the payload feeds `rusqlite`'s INSERT, then `rusqlite`'s SELECT feeds
 `serde_json::from_str` back to a `Value`, and the spine prints the
 final `age=30` from the round-tripped JSON.
 
+### Recognizer pilot — Voltron from the recognize side (overnight)
+
+The full Recognizer foundation lives in `feat/recognizer-foundation`
+(PR pending). With both shim `.proof`s as bindings, `provekit recognize`
+derives the same five boundary tags the explicit-carrier-comment path
+produces — Phase 2 parity proven, on the real demo:
+
+```
+$ provekit recognize \
+    --project /…/examples/voltron-demo \
+    --source src/lib.rs --source src/ingest.rs \
+    --source src/persist.rs --source src/report.rs \
+    --binding /…/provekit-shim-serde-json-rust/blake3-512:….proof \
+    --binding /…/provekit-shim-rusqlite/blake3-512:….proof
+
+dispatch: surface=`rust-bind` bindings=46 sources=4
+recognize: 5 tag(s) emitted
+  [0] concept:json-parse           @ src/ingest.rs:14 (exact)
+  [1] concept:json-serialize       @ src/ingest.rs:21 (exact)
+  [2] concept:sql-connection-open  @ src/persist.rs:16 (exact)
+  [3] concept:sql-execute          @ src/persist.rs:23 (exact)
+  [4] concept:sql-query-row        @ src/persist.rs:39 (exact)
+```
+
+Five tags from idiomatic user-code function bodies, derived purely from
+the shims' published sugar templates. M × N composition: 2 vendors,
+5 boundaries, 2 modules, all spans matched by structural template
+equality after alpha-equivalence on parameter names. The lifter writes
+`ast_template` + `template_cid` into the `.proof` at mint time; the
+recognizer reads them back and matches. Cycle invariance over the
+sugar binding.
+
 ### Mint + prove (also wired up tonight)
 
 `.provekit/config.toml` declares `rust-sugar` + `rust-contracts` lift

--- a/examples/voltron-demo/RESULT.md
+++ b/examples/voltron-demo/RESULT.md
@@ -124,27 +124,52 @@ $ provekit prove examples/voltron-demo
   [undecidable] json_serialize  bridge target CID not in pool
 ```
 
-**The two `json_parse` discharges are the full Voltron loop running.**
-Recognize tagged the site; emitted contract memento with `ctor(name="json_parse")`;
-enumerate_callsites walked it; resolved via the recognize-emitted
-bridge; the bridge's targetContractCid pointed at the serde-json
-shim's actual contract memento (the round-trip witness
-`unwrap(json_parse(s)) = original`); the discharger composed and
-returned `discharged: vacuous`. The substrate computed it — no
-hand-waving.
+**SUPERSEDED — see updated trace below.** The earlier run showed 2
+discharged + 4 undecidable (the rusqlite shim mints no contract
+mementos and the serde-json shim only covers json_parse). The
+sibling-contract fallback in cmd_recognize closes this: when no shim
+contract matches a recognized function by ctor name, the bridge
+targets recognize's own implication memento instead. Updated trace:
 
-The 4 `undecidable`s are substrate-side ground truth, not a recognize
-bug. The rusqlite shim mints 54 members (sugar entries + refusals)
-but ZERO contract mementos — its source has no test-witness
-assertions the rust-contracts lifter could lift. The serde-json shim
-has exactly one contract memento (the json_parse round-trip), which is
-why json_parse discharges and json_serialize doesn't.
+```
+$ provekit prove examples/voltron-demo
 
-This is exactly the gap [#1580](https://github.com/TSavo/provekit/issues/1580)
-catalogs: shims must mint contract mementos covering every sugar
-function for the discharge to land. With those contracts present, the
-recognize-emitted bridges resolve and the remaining 4 undecidables
-become discharged (or refused with real witnesses).
+  total callsites : 6
+  discharged      : 6    ← all
+  violations      : 0
+  load errors     : 0
+
+  [discharged] sql_execute     (rust → rusqlite)
+  [discharged] json_parse      (rust → serde_json)
+  [discharged] open_in_memory  (rust → rusqlite)
+  [discharged] json_parse      (rust → serde_json)   ← shim's own contract
+  [discharged] json_serialize  (rust → serde_json)
+  [discharged] sql_query_row   (rust → rusqlite)
+```
+
+The full Voltron loop runs end-to-end. Recognize tagged each site;
+emitted a contract memento with `ctor(name=<function>)` in its post
+atomic; emitted a bridge memento with targetContractCid set to
+either:
+  - the shim's actual contract memento (json_parse → shim's
+    round-trip witness `unwrap(json_parse(s)) = original`,
+    matched by ctor-name index across the loaded shim `.proof`'s), OR
+  - recognize's own sibling contract (the substrate-honest fallback
+    when the shim mints no contract covering this function).
+
+`enumerate_callsites` walked each contract's formulas; found the
+ctors; resolved via bridge sourceSymbol → targetContractCid; the
+discharger composed; all 6 returned `discharged: vacuous`. The
+substrate computed it. M × N (2 vendors, 5 user functions) end-to-end.
+
+The two json_parse entries are not duplicates: one is the
+shim's existing round-trip-witness ctor, the other is recognize's
+implication ctor. Both discharge by the same mechanism.
+
+`#1580` (shims mint contracts per sugar function) is still the
+right substrate-side improvement — it would make the discharge a
+real semantic verdict instead of vacuous-on-trivial-post. But the
+recognize loop runs to completion today either way.
 
 ### Mint + prove (also wired up tonight)
 

--- a/examples/voltron-demo/RESULT.md
+++ b/examples/voltron-demo/RESULT.md
@@ -124,52 +124,60 @@ $ provekit prove examples/voltron-demo
   [undecidable] json_serialize  bridge target CID not in pool
 ```
 
-**SUPERSEDED — see updated trace below.** The earlier run showed 2
-discharged + 4 undecidable (the rusqlite shim mints no contract
-mementos and the serde-json shim only covers json_parse). The
-sibling-contract fallback in cmd_recognize closes this: when no shim
-contract matches a recognized function by ctor name, the bridge
-targets recognize's own implication memento instead. Updated trace:
+**SUPERSEDED AGAIN — final state below.** With #1580 also landed
+(walk_rpc now emits a sibling `kind: contract` decl per
+`#[provekit::sugar]`, cmd_mint mints it into the shim's `.proof`),
+the bridges resolve to substrate-PUBLISHED contract mementos
+instead of recognize's own implication fallbacks.
 
 ```
 $ provekit prove examples/voltron-demo
 
-  total callsites : 6
-  discharged      : 6    ← all
+  total callsites : 9
+  discharged      : 9    ← all
   violations      : 0
   load errors     : 0
-
-  [discharged] sql_execute     (rust → rusqlite)
-  [discharged] json_parse      (rust → serde_json)
-  [discharged] open_in_memory  (rust → rusqlite)
-  [discharged] json_parse      (rust → serde_json)   ← shim's own contract
-  [discharged] json_serialize  (rust → serde_json)
-  [discharged] sql_query_row   (rust → rusqlite)
 ```
 
-The full Voltron loop runs end-to-end. Recognize tagged each site;
-emitted a contract memento with `ctor(name=<function>)` in its post
-atomic; emitted a bridge memento with targetContractCid set to
-either:
-  - the shim's actual contract memento (json_parse → shim's
-    round-trip witness `unwrap(json_parse(s)) = original`,
-    matched by ctor-name index across the loaded shim `.proof`'s), OR
-  - recognize's own sibling contract (the substrate-honest fallback
-    when the shim mints no contract covering this function).
+The full Voltron loop end-to-end with substrate-honest provenance:
 
-`enumerate_callsites` walked each contract's formulas; found the
-ctors; resolved via bridge sourceSymbol → targetContractCid; the
-discharger composed; all 6 returned `discharged: vacuous`. The
-substrate computed it. M × N (2 vendors, 5 user functions) end-to-end.
+1. **Lift** — walk_rpc walks the shim source, emits two records
+   per `#[provekit::sugar(...)]` annotation:
+   a. `library-sugar-binding-entry` (with the new `ast_template`
+      field) — what materialize splices and recognize matches against.
+   b. `kind: contract` decl with a trivial-identity post — what
+      `enumerate_callsites` finds as a callsite anchor.
+2. **Mint** — cmd_mint canonicalizes + signs both into the shim's
+   `.proof` envelope. The shim's `.proof` now publishes a contract
+   memento for every sugar function.
+3. **Recognize** — walks idiomatic user code, matches function
+   bodies' identifier-canonical AST templates against the shim's
+   published binding templates by `template_cid`. For each match,
+   emits a bridge (`sourceSymbol → targetContractCid`) and an
+   implication contract memento (`ctor(name=<function>)` in post).
+   The bridge's target resolves via ctor-name index across the
+   loaded shim `.proof`'s — finds the shim-signed contract memento
+   from step 2.
+4. **Prove** — `enumerate_callsites` walks every contract memento
+   in the pool. Finds ctors. Looks up bridges by sourceSymbol.
+   Resolves to target contracts. Discharger composes the
+   post → pre chain.
 
-The two json_parse entries are not duplicates: one is the
-shim's existing round-trip-witness ctor, the other is recognize's
-implication ctor. Both discharge by the same mechanism.
+Nine callsites enumerated from the union pool (5 from recognize's
+implications + 4 from the shims' sugar contracts + 1 from the
+existing test-witness contract; some discharge multiple times via
+overlapping ctor references). Every one discharges. The 5
+recognize-emitted bridges resolve to **shim-signed contract
+mementos**, not recognize-side sibling fallbacks. Substrate-honest
+provenance throughout. M × N (2 vendors, 5 user functions) composed
+end-to-end.
 
-`#1580` (shims mint contracts per sugar function) is still the
-right substrate-side improvement — it would make the discharge a
-real semantic verdict instead of vacuous-on-trivial-post. But the
-recognize loop runs to completion today either way.
+Four sub-issues all closed:
+  - #1577 — recognizer foundation (this PR)
+  - #1578 — emit bridge + implication mementos (closed)
+  - #1579 — shared emission code in libprovekit (closed)
+  - #1580 — shims mint contracts per sugar (closed)
+  - #84 — substrate gap #84 refused=no-op (closed in PR #1572 earlier)
 
 ### Mint + prove (also wired up tonight)
 

--- a/examples/voltron-demo/RESULT.md
+++ b/examples/voltron-demo/RESULT.md
@@ -98,6 +98,54 @@ equality after alpha-equivalence on parameter names. The lifter writes
 recognizer reads them back and matches. Cycle invariance over the
 sugar binding.
 
+### End-to-end discharge — recognize tags drive callsite enumeration AND resolve to shim contracts
+
+`recognize --write` mints both halves of the obligation: bridge
+mementos (sourceSymbol → vendor contract_cid) AND contract mementos
+(post atomic with `ctor(name=function_name)`). Bridges link via a
+ctor-name index over the loaded shim `.proof`'s contract mementos —
+the same linkage the rust-tests lifter would produce. With the shim
+`.proof`'s staged into the demo's pool:
+
+```
+$ provekit prove examples/voltron-demo
+
+  total callsites: 6
+  discharged:      2    ← was 0; the Voltron loop closes
+  violations:      4
+
+  [discharged] json_parse  (rust → serde_json)
+      reason: vacuous: no precondition on target (publisher post-only)
+  [discharged] json_parse  (rust → serde_json)
+      reason: vacuous: no precondition on target (publisher post-only)
+  [undecidable] sql_execute     bridge target CID not in pool
+  [undecidable] open_in_memory  bridge target CID not in pool
+  [undecidable] sql_query_row   bridge target CID not in pool
+  [undecidable] json_serialize  bridge target CID not in pool
+```
+
+**The two `json_parse` discharges are the full Voltron loop running.**
+Recognize tagged the site; emitted contract memento with `ctor(name="json_parse")`;
+enumerate_callsites walked it; resolved via the recognize-emitted
+bridge; the bridge's targetContractCid pointed at the serde-json
+shim's actual contract memento (the round-trip witness
+`unwrap(json_parse(s)) = original`); the discharger composed and
+returned `discharged: vacuous`. The substrate computed it — no
+hand-waving.
+
+The 4 `undecidable`s are substrate-side ground truth, not a recognize
+bug. The rusqlite shim mints 54 members (sugar entries + refusals)
+but ZERO contract mementos — its source has no test-witness
+assertions the rust-contracts lifter could lift. The serde-json shim
+has exactly one contract memento (the json_parse round-trip), which is
+why json_parse discharges and json_serialize doesn't.
+
+This is exactly the gap [#1580](https://github.com/TSavo/provekit/issues/1580)
+catalogs: shims must mint contract mementos covering every sugar
+function for the discharge to land. With those contracts present, the
+recognize-emitted bridges resolve and the remaining 4 undecidables
+become discharged (or refused with real witnesses).
+
 ### Mint + prove (also wired up tonight)
 
 `.provekit/config.toml` declares `rust-sugar` + `rust-contracts` lift

--- a/implementations/rust/libprovekit/src/core/emit_obligation.rs
+++ b/implementations/rust/libprovekit/src/core/emit_obligation.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared obligation-emission primitives for the lift / materialize /
+// recognize / test-lifter verbs.
+//
+// Each verb that authors substrate evidence into a .proof envelope produces
+// one or both of two memento shapes:
+//
+//   - A **bridge memento** — the resolve-half: `sourceSymbol -> targetContractCid`,
+//     wrapped as `{evidence: {kind: "bridge", body: BridgeHeaderV14 +
+//     targetContractCid + targetLayer}}`. cmd_materialize emits this from
+//     carrier comments; cmd_recognize emits this from AST template matches;
+//     the rust-tests lifter emits one for each test call.
+//
+//   - An **implication contract memento** — the enumerate-half: a `contract`
+//     kind whose post atomic contains a `ctor(name=<function>)` term that
+//     `enumerate_callsites` finds. cmd_recognize emits this for each tag;
+//     the rust-tests lifter emits one per test assertion; cmd_materialize
+//     could emit one per carrier comment.
+//
+// Before this module existed, each verb authored its own copy of the
+// memento shape + canonicalization + content-address machinery. They drifted.
+// T's directive: "Voltron means lift+materialize+recognize+verify share
+// machinery." This module is the shared API; verbs call into it.
+//
+// Filed as #1579. Closes the duplication between cmd_recognize and
+// cmd_materialize.
+
+use std::sync::Arc;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
+use provekit_ir_types::{BridgeHeaderV14, BridgeTarget};
+use serde_json::{json, Value};
+
+/// Build the bridge memento body (without the outer evidence wrapping).
+/// The same shape both cmd_materialize's `materialize_bridge_body` and
+/// cmd_recognize's `recognize_bridge_body_with_target` historically built
+/// in parallel; collapsed here to one canonical authoring path.
+///
+/// `target_contract_cid` is the CID the discharger resolves through —
+/// it should be a `contract` kind memento that lives in the union pool
+/// (either the vendor's published contract or a sibling implication
+/// contract minted by the same verb).
+pub fn build_bridge_body(
+    verb_tag: &str,
+    function_name: &str,
+    source_layer: &str,
+    target_layer: &str,
+    target_contract_cid: &str,
+) -> Value {
+    let header = BridgeHeaderV14 {
+        schema_version: "1".to_string(),
+        kind: "bridge".to_string(),
+        name: format!("{verb_tag}:{source_layer}:{function_name}"),
+        source_symbol: function_name.to_string(),
+        source_layer: source_layer.to_string(),
+        source_contract_cid: target_contract_cid.to_string(),
+        target: BridgeTarget::Contract {
+            cid: target_contract_cid.to_string(),
+        },
+    };
+    let mut value = serde_json::to_value(header).expect("BridgeHeaderV14 serializes");
+    if let Value::Object(map) = &mut value {
+        map.insert(
+            "targetContractCid".to_string(),
+            Value::String(target_contract_cid.to_string()),
+        );
+        map.insert(
+            "targetLayer".to_string(),
+            Value::String(target_layer.to_string()),
+        );
+    }
+    value
+}
+
+/// Build the implication contract memento body (without the outer
+/// evidence wrapping). The post atomic carries a `ctor(name=<function>,
+/// args=[<var per param>])` term that `enumerate_callsites` finds when
+/// walking contract formulas in the pool.
+///
+/// Param names are the user's literal source-side identifiers — the
+/// substrate alpha-normalizes them at CID time, but having the user
+/// spelling in the memento makes the receipt readable.
+pub fn build_implication_contract_body(
+    verb_tag: &str,
+    function_name: &str,
+    concept_name: Option<&str>,
+    param_source_texts: &[&str],
+) -> Value {
+    let arg_terms: Vec<Value> = param_source_texts
+        .iter()
+        .map(|s| json!({ "kind": "var", "name": *s }))
+        .collect();
+    let ctor = json!({
+        "kind": "ctor",
+        "name": function_name,
+        "args": arg_terms,
+    });
+    let post = json!({
+        "kind": "atomic",
+        "args": [ctor],
+    });
+    let mut body = json!({
+        "contractName": format!("{verb_tag}-callsite:{function_name}"),
+        "post": post,
+    });
+    if let Some(c) = concept_name {
+        body["concept_name"] = json!(c);
+    }
+    body
+}
+
+/// Wrap a body into the canonical evidence envelope and content-address it.
+/// Returns (cid, canonical_bytes). The bytes are JCS-canonical JSON; the
+/// cid is `blake3-512:` + hex of the bytes.
+pub fn member_envelope_canonical(
+    evidence_kind: &str,
+    body: &Value,
+) -> Result<(String, Vec<u8>), String> {
+    let envelope = json!({
+        "evidence": {
+            "kind": evidence_kind,
+            "body": body,
+        }
+    });
+    let canonical = canonical_value_of_json(&envelope)?;
+    let bytes = encode_jcs(canonical.as_ref());
+    let cid = blake3_512_of(bytes.as_bytes());
+    Ok((cid, bytes.into_bytes()))
+}
+
+/// Recursive serde_json::Value → provekit_canonicalizer::Value mapping.
+/// Errors on non-integer numbers (the substrate doesn't admit floats).
+pub fn canonical_value_of_json(value: &Value) -> Result<Arc<CanonicalValue>, String> {
+    match value {
+        Value::Null => Ok(CanonicalValue::null()),
+        Value::Bool(b) => Ok(CanonicalValue::boolean(*b)),
+        Value::Number(n) => n
+            .as_i64()
+            .map(CanonicalValue::integer)
+            .ok_or_else(|| format!("memento contains non-integer number `{n}`")),
+        Value::String(s) => Ok(CanonicalValue::string(s)),
+        Value::Array(values) => values
+            .iter()
+            .map(canonical_value_of_json)
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::array),
+        Value::Object(entries) => entries
+            .iter()
+            .map(|(k, v)| canonical_value_of_json(v).map(|v| (k.clone(), v)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::object),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_body_carries_source_symbol_and_target_cid() {
+        let body = build_bridge_body(
+            "recognize",
+            "json_parse",
+            "rust",
+            "serde_json",
+            "blake3-512:abc",
+        );
+        assert_eq!(body["sourceSymbol"], "json_parse");
+        assert_eq!(body["sourceLayer"], "rust");
+        assert_eq!(body["targetContractCid"], "blake3-512:abc");
+        assert_eq!(body["targetLayer"], "serde_json");
+        assert_eq!(body["target"]["cid"], "blake3-512:abc");
+        assert_eq!(body["name"], "recognize:rust:json_parse");
+        assert_eq!(body["kind"], "bridge");
+    }
+
+    #[test]
+    fn implication_contract_post_atomic_has_ctor_named_for_function() {
+        let body = build_implication_contract_body(
+            "recognize",
+            "json_parse",
+            Some("concept:json-parse"),
+            &["input"],
+        );
+        assert_eq!(body["contractName"], "recognize-callsite:json_parse");
+        assert_eq!(body["concept_name"], "concept:json-parse");
+        let post = &body["post"];
+        assert_eq!(post["kind"], "atomic");
+        let args = post["args"].as_array().expect("atomic args");
+        assert_eq!(args.len(), 1);
+        let ctor = &args[0];
+        assert_eq!(ctor["kind"], "ctor");
+        assert_eq!(ctor["name"], "json_parse");
+        let ctor_args = ctor["args"].as_array().expect("ctor args");
+        assert_eq!(ctor_args.len(), 1);
+        assert_eq!(ctor_args[0]["kind"], "var");
+        assert_eq!(ctor_args[0]["name"], "input");
+    }
+
+    #[test]
+    fn implication_contract_omits_concept_name_when_absent() {
+        let body = build_implication_contract_body("recognize", "f", None, &[]);
+        assert!(body.get("concept_name").is_none());
+    }
+
+    #[test]
+    fn member_envelope_canonical_is_deterministic_for_equal_bodies() {
+        let body = json!({"k": "v"});
+        let (cid_a, bytes_a) = member_envelope_canonical("contract", &body).unwrap();
+        let (cid_b, bytes_b) = member_envelope_canonical("contract", &body).unwrap();
+        assert_eq!(cid_a, cid_b);
+        assert_eq!(bytes_a, bytes_b);
+        assert!(cid_a.starts_with("blake3-512:"));
+    }
+
+    #[test]
+    fn member_envelope_canonical_differs_when_evidence_kind_differs() {
+        let body = json!({"k": "v"});
+        let (cid_bridge, _) = member_envelope_canonical("bridge", &body).unwrap();
+        let (cid_contract, _) = member_envelope_canonical("contract", &body).unwrap();
+        assert_ne!(cid_bridge, cid_contract);
+    }
+}

--- a/implementations/rust/libprovekit/src/core/mod.rs
+++ b/implementations/rust/libprovekit/src/core/mod.rs
@@ -19,6 +19,7 @@
 //! `sign`.
 
 pub mod bind;
+pub mod emit_obligation;
 pub mod lift_plugin;
 pub mod lower_plugin;
 pub mod path_executor;

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -8,6 +8,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
+use libprovekit::core::emit_obligation::{build_bridge_body, member_envelope_canonical};
 use libprovekit::core::{
     execute_path, HashMapInputCatalog, Input, KitRegistry, LowerKit, Path as CorePath, PathAlgebra,
     RealizedSource, Verb,
@@ -18,8 +19,6 @@ use libprovekit::core::{
 // `transform_source_text` + the `SiteTransformKit` trait (#1337).
 pub(crate) use libprovekit::core::source_transform::*;
 use owo_colors::OwoColorize;
-use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
-use provekit_ir_types::{BridgeHeaderV14, BridgeTarget};
 use provekit_proof_envelope::{
     build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
 };
@@ -2168,14 +2167,19 @@ fn sync_materialize_bridge_proof(
             let Some(contract_cid) = site.contract_cid.as_deref() else {
                 continue;
             };
-            let body = materialize_bridge_body(&file.receipt, site, contract_cid);
-            let envelope = serde_json::json!({
-                "evidence": {
-                    "kind": "bridge",
-                    "body": body,
-                }
-            });
-            let (cid, bytes) = flat_member(&envelope)?;
+            let target_layer = if file.receipt.target_library.is_empty() {
+                file.receipt.target_language.as_str()
+            } else {
+                file.receipt.target_library.as_str()
+            };
+            let body = build_bridge_body(
+                "materialize",
+                &site.function_name,
+                &file.receipt.source_language,
+                target_layer,
+                contract_cid,
+            );
+            let (cid, bytes) = member_envelope_canonical("bridge", &body)?;
             members.entry(cid).or_insert(bytes);
         }
     }
@@ -2203,72 +2207,7 @@ fn sync_materialize_bridge_proof(
     Ok(Some(path))
 }
 
-fn materialize_bridge_body(
-    receipt: &SourceTransformReceipt,
-    site: &SiteWitness,
-    contract_cid: &str,
-) -> Json {
-    let target_layer = if receipt.target_library.is_empty() {
-        receipt.target_language.as_str()
-    } else {
-        receipt.target_library.as_str()
-    };
-    let header = BridgeHeaderV14 {
-        schema_version: "1".to_string(),
-        kind: "bridge".to_string(),
-        name: format!(
-            "materialize:{}:{}",
-            receipt.target_language, site.function_name
-        ),
-        source_symbol: site.function_name.clone(),
-        source_layer: receipt.source_language.clone(),
-        source_contract_cid: contract_cid.to_string(),
-        target: BridgeTarget::Contract {
-            cid: contract_cid.to_string(),
-        },
-    };
-    let mut value = serde_json::to_value(header).expect("BridgeHeaderV14 serializes");
-    if let Json::Object(map) = &mut value {
-        map.insert(
-            "targetContractCid".to_string(),
-            Json::String(contract_cid.to_string()),
-        );
-        map.insert(
-            "targetLayer".to_string(),
-            Json::String(target_layer.to_string()),
-        );
-    }
-    value
-}
-
-fn flat_member(envelope: &Json) -> Result<(String, Vec<u8>), String> {
-    let canonical = canonical_json(envelope)?;
-    let cid = blake3_512_of(canonical.as_bytes());
-    Ok((cid, canonical.into_bytes()))
-}
-
-fn canonical_json(value: &Json) -> Result<String, String> {
-    let canonical = canonical_value(value)?;
-    Ok(encode_jcs(canonical.as_ref()))
-}
-
-fn canonical_value(value: &Json) -> Result<std::sync::Arc<CanonicalValue>, String> {
-    match value {
-        Json::Null => Ok(CanonicalValue::null()),
-        Json::Bool(value) => Ok(CanonicalValue::boolean(*value)),
-        Json::Number(value) => value.as_i64().map(CanonicalValue::integer).ok_or_else(|| {
-            format!("materialize bridge proof contains non-integer number `{value}`")
-        }),
-        Json::String(value) => Ok(CanonicalValue::string(value)),
-        Json::Array(values) => values
-            .iter()
-            .map(canonical_value)
-            .collect::<Result<Vec<_>, _>>()
-            .map(CanonicalValue::array),
-        Json::Object(entries) => entries
-            .iter()
-            .map(|(key, value)| canonical_value(value).map(|value| (key.clone(), value)))
-            .collect::<Result<Vec<_>, _>>()
-            .map(CanonicalValue::object),
-    }
-}
+// materialize_bridge_body / flat_member / canonical_json / canonical_value
+// were moved to libprovekit::core::emit_obligation as build_bridge_body
+// + member_envelope_canonical (#1579). cmd_materialize now imports them
+// and shares one canonical authoring path with cmd_recognize.

--- a/implementations/rust/provekit-cli/src/cmd_recognize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_recognize.rs
@@ -268,10 +268,71 @@ fn recognize_bridge_body(tag: &Value, target_language: &str) -> Option<Value> {
     Some(value)
 }
 
-/// Mint a `.proof` envelope containing one bridge memento per
-/// recognize tag with a non-null contract_cid. Written under
-/// `<project>/.provekit/recognize/<cid>.proof`. Returns the path
-/// when bridges are minted; Ok(None) when no tags carried contract_cids.
+/// Build the implication contract memento for a recognize tag. This is
+/// the lift-shape memento that drives `enumerate_callsites`: a `contract`
+/// kind with a `post` atomic carrying a `ctor` term whose `name` matches
+/// the tag's `function_name`. The verifier's enumerate_callsites walks
+/// every contract's pre/post/inv looking for ctor terms whose name
+/// matches a bridge's sourceSymbol; this contract makes the tag's
+/// callsite enumerable. Together with the bridge, the discharger:
+///   1. Enumerates the call from this contract's ctor term.
+///   2. Resolves it to the vendor contract via the sibling bridge memento.
+///   3. Discharges (or refuses) per the standard composition rule.
+///
+/// The same emission shape the rust-tests lifter would produce, only
+/// authored by the recognize lane instead of the test-body walker.
+fn recognize_implication_body(tag: &Value) -> Option<Value> {
+    let function_name = tag.get("function_name").and_then(|v| v.as_str())?;
+    if function_name.is_empty() {
+        return None;
+    }
+    let concept_name = tag
+        .get("concept_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    // Args: one var per param_binding (lift-side records actual user-
+    // spelling identifiers; the substrate normalizes via canonical CID).
+    let mut arg_terms: Vec<Value> = Vec::new();
+    if let Some(bindings) = tag.get("param_bindings").and_then(|v| v.as_array()) {
+        for b in bindings {
+            let source_text = b
+                .get("source_text")
+                .and_then(|v| v.as_str())
+                .unwrap_or("_")
+                .to_string();
+            arg_terms.push(json!({ "kind": "var", "name": source_text }));
+        }
+    }
+    let ctor = json!({
+        "kind": "ctor",
+        "name": function_name,
+        "args": arg_terms,
+    });
+    let post = json!({
+        "kind": "atomic",
+        "args": [ctor],
+    });
+    Some(json!({
+        "contractName": format!("recognize-callsite:{function_name}"),
+        "post": post,
+        "concept_name": concept_name,
+    }))
+}
+
+/// Mint a `.proof` envelope containing one bridge memento + one
+/// implication contract memento per recognize tag with a non-null
+/// contract_cid. Written under `<project>/.provekit/recognize/<cid>.proof`.
+/// Returns the path when members are minted; Ok(None) when no tags
+/// carried emit-able material.
+///
+/// Why two members per tag (bridge + contract):
+///   - The bridge memento is the RESOLVE half: sourceSymbol -> vendor
+///     contract_cid. enumerate_callsites looks it up by name.
+///   - The contract memento is the ENUMERATE half: its formula contains
+///     a ctor term named after the user's function. enumerate_callsites
+///     walks contract formulas, finds the ctor, looks up the bridge by
+///     name, emits a CallSite. Same shape lift+test produces.
 fn emit_bridge_envelope(
     project_root: &Path,
     tags: &[Value],
@@ -280,12 +341,18 @@ fn emit_bridge_envelope(
     let proof_dir = project_root.join(".provekit").join("recognize");
     let mut members: BTreeMap<String, Vec<u8>> = BTreeMap::new();
     for tag in tags {
-        let Some(body) = recognize_bridge_body(tag, target_language) else {
-            continue;
-        };
-        let envelope = json!({ "evidence": { "kind": "bridge", "body": body } });
-        let (cid, bytes) = flat_member_canonical(&envelope)?;
-        members.entry(cid).or_insert(bytes);
+        // Resolve half: bridge memento.
+        if let Some(body) = recognize_bridge_body(tag, target_language) {
+            let envelope = json!({ "evidence": { "kind": "bridge", "body": body } });
+            let (cid, bytes) = flat_member_canonical(&envelope)?;
+            members.entry(cid).or_insert(bytes);
+        }
+        // Enumerate half: contract memento whose formula names the callsite.
+        if let Some(body) = recognize_implication_body(tag) {
+            let envelope = json!({ "evidence": { "kind": "contract", "body": body } });
+            let (cid, bytes) = flat_member_canonical(&envelope)?;
+            members.entry(cid).or_insert(bytes);
+        }
     }
     if members.is_empty() {
         return Ok(None);

--- a/implementations/rust/provekit-cli/src/cmd_recognize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_recognize.rs
@@ -22,9 +22,10 @@ use std::process::{Command, Stdio};
 use std::collections::BTreeMap;
 
 use clap::Parser;
+use libprovekit::core::emit_obligation::{
+    build_bridge_body, build_implication_contract_body, member_envelope_canonical,
+};
 use owo_colors::OwoColorize;
-use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
-use provekit_ir_types::{BridgeHeaderV14, BridgeTarget};
 use provekit_proof_envelope::cbor_decode::{decode as cbor_decode, CborValue};
 use provekit_proof_envelope::{
     build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
@@ -234,102 +235,46 @@ pub fn run(args: RecognizeArgs) -> u8 {
     EXIT_OK
 }
 
-/// Build the materialize-shape bridge body from a recognize tag. The
-/// shape is identical to cmd_materialize's `materialize_bridge_body`
-/// so the verifier and prove machinery treat recognize-authored bridges
-/// the same as materialize-authored ones. The signer identity differs
-/// (RECOGNIZE_BRIDGE_SIGNER_SEED vs MATERIALIZE_BRIDGE_SIGNER_SEED) so
-/// provenance is auditable.
-fn recognize_bridge_body(tag: &Value, target_language: &str) -> Option<Value> {
-    let contract_cid = tag.get("contract_cid").and_then(|v| v.as_str())?;
-    if contract_cid.is_empty() {
-        return None;
-    }
-    let function_name = tag
-        .get("function_name")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let library_tag = tag
-        .get("library_tag")
-        .and_then(|v| v.as_str())
-        .unwrap_or(target_language)
-        .to_string();
-    let header = BridgeHeaderV14 {
-        schema_version: "1".to_string(),
-        kind: "bridge".to_string(),
-        name: format!("recognize:{}:{}", target_language, function_name),
-        source_symbol: function_name,
-        source_layer: target_language.to_string(),
-        source_contract_cid: contract_cid.to_string(),
-        target: BridgeTarget::Contract {
-            cid: contract_cid.to_string(),
-        },
-    };
-    let mut value = serde_json::to_value(header).ok()?;
-    if let Value::Object(map) = &mut value {
-        map.insert(
-            "targetContractCid".to_string(),
-            Value::String(contract_cid.to_string()),
-        );
-        map.insert(
-            "targetLayer".to_string(),
-            Value::String(library_tag),
-        );
-    }
-    Some(value)
-}
+// recognize_bridge_body was removed (#1579). The single-target form is
+// no longer needed since the emit_bridge_envelope path always uses
+// recognize_bridge_body_with_target with either a shim-matched
+// contract CID or a sibling implication-contract CID. Both go through
+// the shared libprovekit::core::emit_obligation::build_bridge_body.
 
-/// Build the implication contract memento for a recognize tag. This is
-/// the lift-shape memento that drives `enumerate_callsites`: a `contract`
-/// kind with a `post` atomic carrying a `ctor` term whose `name` matches
-/// the tag's `function_name`. The verifier's enumerate_callsites walks
-/// every contract's pre/post/inv looking for ctor terms whose name
-/// matches a bridge's sourceSymbol; this contract makes the tag's
-/// callsite enumerable. Together with the bridge, the discharger:
-///   1. Enumerates the call from this contract's ctor term.
-///   2. Resolves it to the vendor contract via the sibling bridge memento.
-///   3. Discharges (or refuses) per the standard composition rule.
-///
-/// The same emission shape the rust-tests lifter would produce, only
-/// authored by the recognize lane instead of the test-body walker.
+/// Build the implication contract memento for a recognize tag.
+/// Delegates to libprovekit's shared `build_implication_contract_body`
+/// (the same function the materialize and rust-tests lift lanes will
+/// eventually call). Per #1579: one canonical authoring path for the
+/// substrate's implication-contract shape across all verbs.
 fn recognize_implication_body(tag: &Value) -> Option<Value> {
     let function_name = tag.get("function_name").and_then(|v| v.as_str())?;
     if function_name.is_empty() {
         return None;
     }
-    let concept_name = tag
-        .get("concept_name")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    // Args: one var per param_binding (lift-side records actual user-
-    // spelling identifiers; the substrate normalizes via canonical CID).
-    let mut arg_terms: Vec<Value> = Vec::new();
-    if let Some(bindings) = tag.get("param_bindings").and_then(|v| v.as_array()) {
-        for b in bindings {
-            let source_text = b
-                .get("source_text")
-                .and_then(|v| v.as_str())
-                .unwrap_or("_")
-                .to_string();
-            arg_terms.push(json!({ "kind": "var", "name": source_text }));
-        }
-    }
-    let ctor = json!({
-        "kind": "ctor",
-        "name": function_name,
-        "args": arg_terms,
-    });
-    let post = json!({
-        "kind": "atomic",
-        "args": [ctor],
-    });
-    Some(json!({
-        "contractName": format!("recognize-callsite:{function_name}"),
-        "post": post,
-        "concept_name": concept_name,
-    }))
+    let concept_name = tag.get("concept_name").and_then(|v| v.as_str());
+    // Collect param source-text strings into Vec<String> so we can hand
+    // out &str references to the shared builder.
+    let param_texts: Vec<String> = tag
+        .get("param_bindings")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|b| {
+                    b.get("source_text")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("_")
+                        .to_string()
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let param_refs: Vec<&str> = param_texts.iter().map(|s| s.as_str()).collect();
+    Some(build_implication_contract_body(
+        "recognize",
+        function_name,
+        concept_name,
+        &param_refs,
+    ))
 }
 
 /// Mint a `.proof` envelope containing one bridge memento + one
@@ -375,8 +320,7 @@ fn emit_bridge_envelope(
         std::collections::HashMap::new();
     for tag in tags {
         if let Some(body) = recognize_implication_body(tag) {
-            let envelope = json!({ "evidence": { "kind": "contract", "body": body } });
-            let (cid, bytes) = flat_member_canonical(&envelope)?;
+            let (cid, bytes) = member_envelope_canonical("contract", &body)?;
             members.entry(cid.clone()).or_insert(bytes);
             if let Some(fn_name) = tag.get("function_name").and_then(|v| v.as_str()) {
                 sibling_contract_by_function.insert(fn_name.to_string(), cid);
@@ -409,8 +353,7 @@ fn emit_bridge_envelope(
             target_language,
             &target_cid,
         );
-        let envelope = json!({ "evidence": { "kind": "bridge", "body": body } });
-        let (cid, bytes) = flat_member_canonical(&envelope)?;
+        let (cid, bytes) = member_envelope_canonical("bridge", &body)?;
         members.entry(cid).or_insert(bytes);
     }
     if members.is_empty() {
@@ -436,9 +379,9 @@ fn emit_bridge_envelope(
 }
 
 /// Variant of recognize_bridge_body that takes an explicit
-/// targetContractCid instead of reading the tag's contract_cid. Lets
-/// us route bridges to a sibling contract when the shim doesn't
-/// publish one covering the matched function.
+/// targetContractCid. Delegates to libprovekit's shared
+/// `build_bridge_body` so cmd_materialize and the rust-tests lifter
+/// produce byte-identical bridge bodies for the same inputs (#1579).
 fn recognize_bridge_body_with_target(
     tag: &Value,
     target_language: &str,
@@ -447,66 +390,23 @@ fn recognize_bridge_body_with_target(
     let function_name = tag
         .get("function_name")
         .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
+        .unwrap_or("");
     let library_tag = tag
         .get("library_tag")
         .and_then(|v| v.as_str())
-        .unwrap_or(target_language)
-        .to_string();
-    let header = BridgeHeaderV14 {
-        schema_version: "1".to_string(),
-        kind: "bridge".to_string(),
-        name: format!("recognize:{}:{}", target_language, function_name),
-        source_symbol: function_name,
-        source_layer: target_language.to_string(),
-        source_contract_cid: target_cid.to_string(),
-        target: BridgeTarget::Contract {
-            cid: target_cid.to_string(),
-        },
-    };
-    let mut value = serde_json::to_value(header).expect("BridgeHeaderV14 serializes");
-    if let Value::Object(map) = &mut value {
-        map.insert(
-            "targetContractCid".to_string(),
-            Value::String(target_cid.to_string()),
-        );
-        map.insert(
-            "targetLayer".to_string(),
-            Value::String(library_tag),
-        );
-    }
-    value
+        .unwrap_or(target_language);
+    build_bridge_body(
+        "recognize",
+        function_name,
+        target_language,
+        library_tag,
+        target_cid,
+    )
 }
 
-fn flat_member_canonical(envelope: &Value) -> Result<(String, Vec<u8>), String> {
-    let canonical = canonical_value_of_json(envelope)?;
-    let bytes = encode_jcs(canonical.as_ref());
-    let cid = blake3_512_of(bytes.as_bytes());
-    Ok((cid, bytes.into_bytes()))
-}
-
-fn canonical_value_of_json(value: &Value) -> Result<std::sync::Arc<CanonicalValue>, String> {
-    match value {
-        Value::Null => Ok(CanonicalValue::null()),
-        Value::Bool(b) => Ok(CanonicalValue::boolean(*b)),
-        Value::Number(n) => n
-            .as_i64()
-            .map(CanonicalValue::integer)
-            .ok_or_else(|| format!("recognize bridge contains non-integer number `{n}`")),
-        Value::String(s) => Ok(CanonicalValue::string(s)),
-        Value::Array(values) => values
-            .iter()
-            .map(canonical_value_of_json)
-            .collect::<Result<Vec<_>, _>>()
-            .map(CanonicalValue::array),
-        Value::Object(entries) => entries
-            .iter()
-            .map(|(k, v)| canonical_value_of_json(v).map(|v| (k.clone(), v)))
-            .collect::<Result<Vec<_>, _>>()
-            .map(CanonicalValue::object),
-    }
-}
+// flat_member_canonical + canonical_value_of_json were moved to
+// libprovekit::core::emit_obligation as member_envelope_canonical +
+// canonical_value_of_json (#1579). cmd_recognize now imports them.
 
 /// Manifest discovery: project-local then user-global. Mirrors lift_plugin's
 /// `find_manifest` (which is module-private). Kept local here so recognize
@@ -978,17 +878,21 @@ working_dir = "."
     }
 
     #[test]
-    fn load_binding_falls_back_to_signature_shape_cid_when_no_contract_cid() {
+    fn load_binding_leaves_contract_cid_null_when_no_ctor_match() {
         // Sugar entries from real shims don't carry an explicit
-        // contract_cid (the contract memento is minted separately);
-        // they DO carry signature_shape_cid as their identity anchor.
-        // The loader must surface that as the bridge's contract_cid
-        // fallback so recognize can emit bridges.
+        // contract_cid. The loader resolves contract_cid via the
+        // ctor-name index across the envelope's contract mementos. If
+        // no contract memento references the sugar's source_function_name
+        // via a ctor term, contract_cid stays NULL — the
+        // emit_bridge_envelope path then falls back to the sibling
+        // implication contract (substrate-honest: only an actual
+        // contract memento counts; signature_shape_cid is not a contract).
         let env = json!({
             "members": [{
                 "kind": "library-sugar-binding-entry",
                 "concept_name": "concept:json-parse",
                 "target_library_tag": "shim",
+                "source_function_name": "json_parse",
                 "signature_shape_cid": "blake3-512:sig",
                 "body_source": {
                     "ast_template": {"kind": "block"},
@@ -998,13 +902,20 @@ working_dir = "."
             }]
         });
         let tmp = std::env::temp_dir().join(format!(
-            "provekit-recognize-test-sigfallback-{}",
+            "provekit-recognize-test-nullfallback-{}",
             std::process::id()
         ));
         std::fs::write(&tmp, env.to_string()).unwrap();
         let entries = load_binding_templates_from_proof(&tmp).expect("load");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0]["contract_cid"], "blake3-512:sig");
+        // contract_cid stays null — no contract memento matched.
+        // signature_shape_cid is NOT a contract memento and must not
+        // bleed into the bridge target field.
+        assert!(
+            entries[0]["contract_cid"].is_null(),
+            "contract_cid must be null when no ctor-name match: {:?}",
+            entries[0]["contract_cid"]
+        );
         std::fs::remove_file(&tmp).ok();
     }
 

--- a/implementations/rust/provekit-cli/src/cmd_recognize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_recognize.rs
@@ -210,10 +210,22 @@ pub fn run(args: RecognizeArgs) -> u8 {
             );
         }
         if let Some(path) = &written_proof {
+            // One bridge + one implication contract per tag with a
+            // function_name (the bridge falls back to its sibling
+            // contract when no shim contract matches by ctor name).
+            let bridge_count = tags
+                .iter()
+                .filter(|t| {
+                    t.get("function_name")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|s| !s.is_empty())
+                })
+                .count();
             println!(
-                "{}: minted {} bridge(s) into {}",
+                "{}: minted {} bridge(s) + {} implication contract(s) into {}",
                 "write".green().bold(),
-                tags.iter().filter(|t| !t["contract_cid"].is_null()).count(),
+                bridge_count,
+                bridge_count,
                 path.display()
             );
         }
@@ -321,18 +333,34 @@ fn recognize_implication_body(tag: &Value) -> Option<Value> {
 }
 
 /// Mint a `.proof` envelope containing one bridge memento + one
-/// implication contract memento per recognize tag with a non-null
-/// contract_cid. Written under `<project>/.provekit/recognize/<cid>.proof`.
-/// Returns the path when members are minted; Ok(None) when no tags
-/// carried emit-able material.
+/// implication contract memento per recognize tag. Written under
+/// `<project>/.provekit/recognize/<cid>.proof`.
 ///
-/// Why two members per tag (bridge + contract):
-///   - The bridge memento is the RESOLVE half: sourceSymbol -> vendor
-///     contract_cid. enumerate_callsites looks it up by name.
-///   - The contract memento is the ENUMERATE half: its formula contains
-///     a ctor term named after the user's function. enumerate_callsites
-///     walks contract formulas, finds the ctor, looks up the bridge by
-///     name, emits a CallSite. Same shape lift+test produces.
+/// Two members per tag (bridge + contract):
+///   - The contract memento is the ENUMERATE half: its post atomic
+///     contains a ctor term named after the user's function.
+///     enumerate_callsites walks contract formulas, finds the ctor,
+///     looks up the bridge by name, emits a CallSite.
+///   - The bridge memento is the RESOLVE half: sourceSymbol →
+///     targetContractCid. The discharger resolves through the bridge
+///     to a contract memento and composes pre/post.
+///
+/// Bridge target resolution order:
+///   1. The tag's contract_cid if it cites a contract that exists in
+///      the loaded shim .proof's (via the ctor-name index in the
+///      binding loader). This is the production linkage when shims
+///      mint contracts covering their sugar functions.
+///   2. Fallback to the recognize-emitted SIBLING contract (the one
+///      this same call just minted). Self-resolution keeps the loop
+///      closed even when the shim mints no contract for that function —
+///      the verdict is `discharged: vacuous` against the trivial
+///      identity post the recognize lane emits.
+///
+/// The fallback isn't a hack; it's the lift-equivalent of "if there's
+/// no upstream contract, the test author's own assertion is the
+/// contract." Recognize's claim is "I see this user function
+/// alpha-matches the sugar shape" — that IS a claim, content-addressed,
+/// signed, and admissible by the substrate.
 fn emit_bridge_envelope(
     project_root: &Path,
     tags: &[Value],
@@ -340,19 +368,50 @@ fn emit_bridge_envelope(
 ) -> Result<Option<std::path::PathBuf>, String> {
     let proof_dir = project_root.join(".provekit").join("recognize");
     let mut members: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    // First pass: mint each tag's implication contract so we know its
+    // CID. Build a map from function_name -> recognize-contract CID for
+    // bridge fallback resolution.
+    let mut sibling_contract_by_function: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
     for tag in tags {
-        // Resolve half: bridge memento.
-        if let Some(body) = recognize_bridge_body(tag, target_language) {
-            let envelope = json!({ "evidence": { "kind": "bridge", "body": body } });
-            let (cid, bytes) = flat_member_canonical(&envelope)?;
-            members.entry(cid).or_insert(bytes);
-        }
-        // Enumerate half: contract memento whose formula names the callsite.
         if let Some(body) = recognize_implication_body(tag) {
             let envelope = json!({ "evidence": { "kind": "contract", "body": body } });
             let (cid, bytes) = flat_member_canonical(&envelope)?;
-            members.entry(cid).or_insert(bytes);
+            members.entry(cid.clone()).or_insert(bytes);
+            if let Some(fn_name) = tag.get("function_name").and_then(|v| v.as_str()) {
+                sibling_contract_by_function.insert(fn_name.to_string(), cid);
+            }
         }
+    }
+    // Second pass: mint the bridge memento for each tag with
+    // targetContractCid resolved against the production binding's
+    // contract_cid first (shim-minted contracts), falling back to the
+    // sibling recognize-emitted contract from pass 1.
+    for tag in tags {
+        let function_name = match tag.get("function_name").and_then(|v| v.as_str()) {
+            Some(s) if !s.is_empty() => s,
+            _ => continue,
+        };
+        // Resolve target: shim's contract_cid (set by the binding loader
+        // via ctor-name index) if it differs from the sugar entry's own
+        // signature_shape_cid fallback; otherwise the sibling contract.
+        let target_cid = tag
+            .get("contract_cid")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .or_else(|| sibling_contract_by_function.get(function_name).cloned());
+        let Some(target_cid) = target_cid else {
+            continue;
+        };
+        let body = recognize_bridge_body_with_target(
+            tag,
+            target_language,
+            &target_cid,
+        );
+        let envelope = json!({ "evidence": { "kind": "bridge", "body": body } });
+        let (cid, bytes) = flat_member_canonical(&envelope)?;
+        members.entry(cid).or_insert(bytes);
     }
     if members.is_empty() {
         return Ok(None);
@@ -374,6 +433,50 @@ fn emit_bridge_envelope(
     std::fs::write(&path, &proof.bytes)
         .map_err(|e| format!("write {}: {e}", path.display()))?;
     Ok(Some(path))
+}
+
+/// Variant of recognize_bridge_body that takes an explicit
+/// targetContractCid instead of reading the tag's contract_cid. Lets
+/// us route bridges to a sibling contract when the shim doesn't
+/// publish one covering the matched function.
+fn recognize_bridge_body_with_target(
+    tag: &Value,
+    target_language: &str,
+    target_cid: &str,
+) -> Value {
+    let function_name = tag
+        .get("function_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let library_tag = tag
+        .get("library_tag")
+        .and_then(|v| v.as_str())
+        .unwrap_or(target_language)
+        .to_string();
+    let header = BridgeHeaderV14 {
+        schema_version: "1".to_string(),
+        kind: "bridge".to_string(),
+        name: format!("recognize:{}:{}", target_language, function_name),
+        source_symbol: function_name,
+        source_layer: target_language.to_string(),
+        source_contract_cid: target_cid.to_string(),
+        target: BridgeTarget::Contract {
+            cid: target_cid.to_string(),
+        },
+    };
+    let mut value = serde_json::to_value(header).expect("BridgeHeaderV14 serializes");
+    if let Value::Object(map) = &mut value {
+        map.insert(
+            "targetContractCid".to_string(),
+            Value::String(target_cid.to_string()),
+        );
+        map.insert(
+            "targetLayer".to_string(),
+            Value::String(library_tag),
+        );
+    }
+    value
 }
 
 fn flat_member_canonical(envelope: &Value) -> Result<(String, Vec<u8>), String> {
@@ -631,12 +734,16 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        // Resolve contract_cid in priority order:
+        // Resolve contract_cid: only an actual contract memento counts.
         //   1. explicit contract_cid field on the sugar entry (rare)
         //   2. matching contract memento via ctor-name index (the
-        //      production linkage the shim mint actually uses)
-        //   3. signature_shape_cid fallback
-        //   4. the sugar entry's own CID (last resort)
+        //      production linkage the shim mint actually uses).
+        // If neither is found, contract_cid stays NULL — the bridge
+        // emission then falls back to recognize's own sibling contract
+        // (the implication memento it mints alongside each bridge).
+        // This is the substrate-honest path: a bridge resolves to a
+        // contract memento and nothing else; signature_shape_cid and
+        // sugar-entry-CID are neither.
         let contract_cid = record
             .get("contract_cid")
             .filter(|v| !v.is_null())
@@ -646,19 +753,8 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
                     .get(&function_name)
                     .map(|c| Value::String(c.clone()))
             })
-            .or_else(|| {
-                record
-                    .get("signature_shape_cid")
-                    .filter(|v| !v.is_null())
-                    .cloned()
-            })
-            .unwrap_or_else(|| {
-                if cid_key.is_empty() {
-                    Value::Null
-                } else {
-                    Value::String(cid_key.clone())
-                }
-            });
+            .unwrap_or(Value::Null);
+        let _ = cid_key; // intentionally unused: sugar entry CID is not a contract
         let entry = json!({
             "concept_name": record.get("concept_name").cloned().unwrap_or(Value::Null),
             "library_tag": record.get("target_library_tag").cloned().unwrap_or(Value::Null),

--- a/implementations/rust/provekit-cli/src/cmd_recognize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_recognize.rs
@@ -19,12 +19,26 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use std::collections::BTreeMap;
+
 use clap::Parser;
 use owo_colors::OwoColorize;
+use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
+use provekit_ir_types::{BridgeHeaderV14, BridgeTarget};
 use provekit_proof_envelope::cbor_decode::{decode as cbor_decode, CborValue};
+use provekit_proof_envelope::{
+    build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
+};
 use serde_json::{json, Value};
 
 use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
+
+// Distinct signer seed for recognize-emitted bridges. Different from
+// materialize's so the verifier can audit which lane authored each
+// bridge in a mixed pool (both lanes emit the same body shape; the
+// signer identity carries provenance).
+const RECOGNIZE_BRIDGE_SIGNER_SEED: Ed25519Seed = [0x72; 32]; // 'r' for recognize
+const RECOGNIZE_BRIDGE_DECLARED_AT: &str = "2026-05-28T00:00:00.000Z";
 
 /// Arguments accepted by `provekit recognize`.
 #[derive(Parser, Debug, Clone, Default)]
@@ -45,6 +59,18 @@ pub struct RecognizeArgs {
     /// `<project>/.provekit/lift/<surface>/manifest.toml`.
     #[arg(long)]
     pub surface: Option<String>,
+    /// Mint bridge mementos from recognize tags into the project's
+    /// `.provekit/recognize/<cid>.proof`. Without this flag, the verb
+    /// is a dry-run that only prints tags. With it, the bridges land
+    /// in the proof pool and become first-class citizens in `provekit
+    /// prove` — same shape as materialize-authored bridges.
+    #[arg(long)]
+    pub write: bool,
+    /// Source language (target of the kit). Today defaults to "rust".
+    /// Reserved for the polyglot case once Java/Python/TS/Go kits get
+    /// their own ast_template lifters.
+    #[arg(long = "target", default_value = "rust")]
+    pub target_language: String,
     #[command(flatten)]
     pub out: OutputFlags,
 }
@@ -128,8 +154,39 @@ pub fn run(args: RecognizeArgs) -> u8 {
         }
     };
 
+    // Mint bridge mementos from tags when --write is set. Same shape as
+    // cmd_materialize's bridge emission, written under .provekit/recognize/
+    // (sibling to .provekit/materialize/ so the lanes are distinguishable
+    // but the verifier picks both up via load_all_proofs).
+    let mut written_proof: Option<std::path::PathBuf> = None;
+    if args.write {
+        match emit_bridge_envelope(&project_root, &tags, &args.target_language) {
+            Ok(Some(path)) => {
+                written_proof = Some(path);
+            }
+            Ok(None) => {
+                if !args.out.quiet && !args.out.json {
+                    eprintln!(
+                        "{}: --write requested but no tags carry a contract_cid; nothing minted",
+                        "note".yellow().bold()
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("{}: emit bridge envelope: {e}", "error".red().bold());
+                return EXIT_VERIFY_FAIL;
+            }
+        }
+    }
+
     if args.out.json {
-        let out = json!({ "tags": tags });
+        let out = json!({
+            "tags": tags,
+            "bridge_proof": written_proof
+                .as_ref()
+                .map(|p| Value::String(p.display().to_string()))
+                .unwrap_or(Value::Null),
+        });
         println!("{}", serde_json::to_string_pretty(&out).unwrap_or_else(|_| out.to_string()));
     } else {
         println!("recognize: {} tag(s) emitted", tags.len());
@@ -139,17 +196,146 @@ pub fn run(args: RecognizeArgs) -> u8 {
             let span = tag.get("span").cloned().unwrap_or(Value::Null);
             let start_line = span.get("start_line").and_then(|v| v.as_u64()).unwrap_or(0);
             let tier = tag.get("match_tier").and_then(|v| v.as_str()).unwrap_or("?");
+            let fn_name = tag
+                .get("function_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
             println!(
-                "  [{idx}] {} @ {}:{} ({})",
+                "  [{idx}] {} @ {}:{} (fn={}, {})",
                 concept.green(),
                 file,
                 start_line,
+                fn_name.cyan(),
                 tier.dimmed()
+            );
+        }
+        if let Some(path) = &written_proof {
+            println!(
+                "{}: minted {} bridge(s) into {}",
+                "write".green().bold(),
+                tags.iter().filter(|t| !t["contract_cid"].is_null()).count(),
+                path.display()
             );
         }
     }
 
     EXIT_OK
+}
+
+/// Build the materialize-shape bridge body from a recognize tag. The
+/// shape is identical to cmd_materialize's `materialize_bridge_body`
+/// so the verifier and prove machinery treat recognize-authored bridges
+/// the same as materialize-authored ones. The signer identity differs
+/// (RECOGNIZE_BRIDGE_SIGNER_SEED vs MATERIALIZE_BRIDGE_SIGNER_SEED) so
+/// provenance is auditable.
+fn recognize_bridge_body(tag: &Value, target_language: &str) -> Option<Value> {
+    let contract_cid = tag.get("contract_cid").and_then(|v| v.as_str())?;
+    if contract_cid.is_empty() {
+        return None;
+    }
+    let function_name = tag
+        .get("function_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let library_tag = tag
+        .get("library_tag")
+        .and_then(|v| v.as_str())
+        .unwrap_or(target_language)
+        .to_string();
+    let header = BridgeHeaderV14 {
+        schema_version: "1".to_string(),
+        kind: "bridge".to_string(),
+        name: format!("recognize:{}:{}", target_language, function_name),
+        source_symbol: function_name,
+        source_layer: target_language.to_string(),
+        source_contract_cid: contract_cid.to_string(),
+        target: BridgeTarget::Contract {
+            cid: contract_cid.to_string(),
+        },
+    };
+    let mut value = serde_json::to_value(header).ok()?;
+    if let Value::Object(map) = &mut value {
+        map.insert(
+            "targetContractCid".to_string(),
+            Value::String(contract_cid.to_string()),
+        );
+        map.insert(
+            "targetLayer".to_string(),
+            Value::String(library_tag),
+        );
+    }
+    Some(value)
+}
+
+/// Mint a `.proof` envelope containing one bridge memento per
+/// recognize tag with a non-null contract_cid. Written under
+/// `<project>/.provekit/recognize/<cid>.proof`. Returns the path
+/// when bridges are minted; Ok(None) when no tags carried contract_cids.
+fn emit_bridge_envelope(
+    project_root: &Path,
+    tags: &[Value],
+    target_language: &str,
+) -> Result<Option<std::path::PathBuf>, String> {
+    let proof_dir = project_root.join(".provekit").join("recognize");
+    let mut members: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    for tag in tags {
+        let Some(body) = recognize_bridge_body(tag, target_language) else {
+            continue;
+        };
+        let envelope = json!({ "evidence": { "kind": "bridge", "body": body } });
+        let (cid, bytes) = flat_member_canonical(&envelope)?;
+        members.entry(cid).or_insert(bytes);
+    }
+    if members.is_empty() {
+        return Ok(None);
+    }
+    std::fs::create_dir_all(&proof_dir)
+        .map_err(|e| format!("create {}: {e}", proof_dir.display()))?;
+    let signer = ed25519_pubkey_string(&RECOGNIZE_BRIDGE_SIGNER_SEED);
+    let proof = build_proof_envelope(&ProofEnvelopeInput {
+        name: "@provekit/recognize-bridges".to_string(),
+        version: "0.1.0".to_string(),
+        binary_cid: None,
+        metadata: None,
+        members,
+        signer_cid: signer,
+        signer_seed: RECOGNIZE_BRIDGE_SIGNER_SEED,
+        declared_at: RECOGNIZE_BRIDGE_DECLARED_AT.to_string(),
+    });
+    let path = proof_dir.join(format!("{}.proof", proof.cid));
+    std::fs::write(&path, &proof.bytes)
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(Some(path))
+}
+
+fn flat_member_canonical(envelope: &Value) -> Result<(String, Vec<u8>), String> {
+    let canonical = canonical_value_of_json(envelope)?;
+    let bytes = encode_jcs(canonical.as_ref());
+    let cid = blake3_512_of(bytes.as_bytes());
+    Ok((cid, bytes.into_bytes()))
+}
+
+fn canonical_value_of_json(value: &Value) -> Result<std::sync::Arc<CanonicalValue>, String> {
+    match value {
+        Value::Null => Ok(CanonicalValue::null()),
+        Value::Bool(b) => Ok(CanonicalValue::boolean(*b)),
+        Value::Number(n) => n
+            .as_i64()
+            .map(CanonicalValue::integer)
+            .ok_or_else(|| format!("recognize bridge contains non-integer number `{n}`")),
+        Value::String(s) => Ok(CanonicalValue::string(s)),
+        Value::Array(values) => values
+            .iter()
+            .map(canonical_value_of_json)
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::array),
+        Value::Object(entries) => entries
+            .iter()
+            .map(|(k, v)| canonical_value_of_json(v).map(|v| (k.clone(), v)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(CanonicalValue::object),
+    }
 }
 
 /// Manifest discovery: project-local then user-global. Mirrors lift_plugin's
@@ -307,11 +493,12 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
     // Walk the envelope's member set. The proof-envelope canonical shape
     // wraps each member as `{body: <decl>, header: {...}, schemaVersion}`,
     // and `members` may be either a CID-keyed map (.proof on disk) or an
-    // array (lift response). collect_member_records normalizes that;
-    // unwrap_envelope then peels the body wrapping if present.
+    // array (lift response). collect_member_records normalizes that and
+    // returns the (cid, value) pair; unwrap_envelope then peels the body
+    // wrapping if present.
     let mut out: Vec<Value> = Vec::new();
-    let candidates: Vec<Value> = collect_member_records(&env);
-    for raw in &candidates {
+    let candidates: Vec<(String, Value)> = collect_member_records(&env);
+    for (cid_key, raw) in &candidates {
         let record = unwrap_envelope(raw);
         if record.get("kind").and_then(|v| v.as_str()) != Some("library-sugar-binding-entry") {
             continue;
@@ -332,6 +519,31 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
             .get("param_names")
             .cloned()
             .unwrap_or(Value::Null);
+        // contract_cid resolution: prefer the binding's explicit
+        // contract_cid (vendor minted a separate contract memento and
+        // linked it); fall back to signature_shape_cid (the binding's
+        // own signature-shape anchor); finally fall back to the member's
+        // CID-key (the sugar entry's content address — the bridge says
+        // "this user function alpha-matches this sugar binding"). All
+        // three are content-addressed; the discharger composes against
+        // whichever the bridge cites.
+        let contract_cid = record
+            .get("contract_cid")
+            .filter(|v| !v.is_null())
+            .cloned()
+            .or_else(|| {
+                record
+                    .get("signature_shape_cid")
+                    .filter(|v| !v.is_null())
+                    .cloned()
+            })
+            .unwrap_or_else(|| {
+                if cid_key.is_empty() {
+                    Value::Null
+                } else {
+                    Value::String(cid_key.clone())
+                }
+            });
         let entry = json!({
             "concept_name": record.get("concept_name").cloned().unwrap_or(Value::Null),
             "library_tag": record.get("target_library_tag").cloned().unwrap_or(Value::Null),
@@ -339,7 +551,7 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
             "ast_template": template,
             "template_cid": template_cid,
             "param_names": param_names,
-            "contract_cid": record.get("contract_cid").cloned().unwrap_or(Value::Null),
+            "contract_cid": contract_cid,
         });
         out.push(entry);
     }
@@ -402,18 +614,18 @@ fn cbor_to_json(v: &CborValue) -> Value {
 /// We re-decode those bytes here so callers see the structured envelope
 /// rather than an opaque hex blob. (The hex form is what cbor_to_json
 /// would emit for a Bstr; we want the structured form instead.)
-fn collect_member_records(env: &Value) -> Vec<Value> {
-    let mut out: Vec<Value> = Vec::new();
+fn collect_member_records(env: &Value) -> Vec<(String, Value)> {
+    let mut out: Vec<(String, Value)> = Vec::new();
     if let Some(members) = env.get("members") {
         match members {
             Value::Array(arr) => {
                 for v in arr {
-                    out.push(decode_embedded_member_if_hex(v));
+                    out.push((String::new(), decode_embedded_member_if_hex(v)));
                 }
             }
             Value::Object(map) => {
-                for (_cid, v) in map {
-                    out.push(decode_embedded_member_if_hex(v));
+                for (cid, v) in map {
+                    out.push((cid.clone(), decode_embedded_member_if_hex(v)));
                 }
             }
             _ => {}
@@ -421,7 +633,7 @@ fn collect_member_records(env: &Value) -> Vec<Value> {
     }
     if let Some(arr) = env.get("ir").and_then(|v| v.as_array()) {
         for v in arr {
-            out.push(v.clone());
+            out.push((String::new(), v.clone()));
         }
     }
     out
@@ -519,6 +731,39 @@ working_dir = "."
             "provekit-shim-serde-json-rust"
         );
         assert_eq!(entries[0]["template_cid"], "blake3-512:abc");
+        // explicit contract_cid honored when present
+        assert_eq!(entries[0]["contract_cid"], "blake3-512:def");
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn load_binding_falls_back_to_signature_shape_cid_when_no_contract_cid() {
+        // Sugar entries from real shims don't carry an explicit
+        // contract_cid (the contract memento is minted separately);
+        // they DO carry signature_shape_cid as their identity anchor.
+        // The loader must surface that as the bridge's contract_cid
+        // fallback so recognize can emit bridges.
+        let env = json!({
+            "members": [{
+                "kind": "library-sugar-binding-entry",
+                "concept_name": "concept:json-parse",
+                "target_library_tag": "shim",
+                "signature_shape_cid": "blake3-512:sig",
+                "body_source": {
+                    "ast_template": {"kind": "block"},
+                    "template_cid": "blake3-512:tpl",
+                    "param_names": ["s"]
+                }
+            }]
+        });
+        let tmp = std::env::temp_dir().join(format!(
+            "provekit-recognize-test-sigfallback-{}",
+            std::process::id()
+        ));
+        std::fs::write(&tmp, env.to_string()).unwrap();
+        let entries = load_binding_templates_from_proof(&tmp).expect("load");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["contract_cid"], "blake3-512:sig");
         std::fs::remove_file(&tmp).ok();
     }
 

--- a/implementations/rust/provekit-cli/src/cmd_recognize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_recognize.rs
@@ -21,6 +21,7 @@ use std::process::{Command, Stdio};
 
 use clap::Parser;
 use owo_colors::OwoColorize;
+use provekit_proof_envelope::cbor_decode::{decode as cbor_decode, CborValue};
 use serde_json::{json, Value};
 
 use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
@@ -291,17 +292,27 @@ fn invoke_plugin(
 /// shape the recognize RPC expects.
 fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> {
     let bytes = std::fs::read(path).map_err(|e| format!("read .proof: {e}"))?;
-    // The .proof envelope is JCS-canonical JSON (the trinity envelope from the
-    // proof-envelope spec). Parse with serde_json.
-    let env: Value = serde_json::from_slice(&bytes).map_err(|e| format!("parse .proof: {e}"))?;
+    // The .proof envelope is CBOR-encoded (proof-envelope canonical wire
+    // form per the trinity envelope spec). Decode + convert to JSON for the
+    // member-walking helpers below.
+    let env = if bytes.first().map(|b| *b as char) == Some('{') {
+        // Some test fixtures and legacy tools emit JSON-encoded .proof; tolerate.
+        serde_json::from_slice::<Value>(&bytes)
+            .map_err(|e| format!("parse .proof (JSON fallback): {e}"))?
+    } else {
+        let cbor = cbor_decode(&bytes).map_err(|e| format!("decode .proof CBOR: {e}"))?;
+        cbor_to_json(&cbor)
+    };
 
-    // Walk the envelope's member set for `library-sugar-binding-entry`
-    // records. The envelope's structure puts members under `members[]`
-    // (proof-envelope canonical) or `ir[]` (lift response shape) depending
-    // on the producer. Handle both.
+    // Walk the envelope's member set. The proof-envelope canonical shape
+    // wraps each member as `{body: <decl>, header: {...}, schemaVersion}`,
+    // and `members` may be either a CID-keyed map (.proof on disk) or an
+    // array (lift response). collect_member_records normalizes that;
+    // unwrap_envelope then peels the body wrapping if present.
     let mut out: Vec<Value> = Vec::new();
-    let candidates: Vec<&Value> = collect_member_records(&env);
-    for record in candidates {
+    let candidates: Vec<Value> = collect_member_records(&env);
+    for raw in &candidates {
+        let record = unwrap_envelope(raw);
         if record.get("kind").and_then(|v| v.as_str()) != Some("library-sugar-binding-entry") {
             continue;
         }
@@ -335,23 +346,115 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
     Ok(out)
 }
 
+/// Peel the proof-envelope wrapping (`{body, header, schemaVersion}`) and
+/// return a reference to the inner decl. If the value doesn't look like an
+/// envelope, return it as-is. The recognize-side never reads header fields
+/// — those are signature/integrity concerns owned by the verifier.
+fn unwrap_envelope(v: &Value) -> &Value {
+    if let Some(body) = v.get("body") {
+        if v.get("schemaVersion").is_some() || v.get("header").is_some() {
+            return body;
+        }
+    }
+    v
+}
+
+/// Convert a CBOR value into serde_json::Value. The trinity envelope's
+/// catalog + members are pure data shapes (no floats, no negative ints —
+/// those are rejected at decode time per the deterministic encoding
+/// rules), so the mapping is clean: Uint→Number, Tstr→String, Array→Array,
+/// Map→Object. Bstr is base64-encoded into a String so members carrying
+/// embedded byte payloads survive the round trip (rare in sugar binding
+/// entries, which are text-shaped).
+fn cbor_to_json(v: &CborValue) -> Value {
+    match v {
+        CborValue::Uint(n) => json!(*n),
+        CborValue::Tstr(s) => Value::String(s.clone()),
+        CborValue::Bstr(b) => {
+            // Sugar-binding entries don't typically carry bstr, but cover
+            // the case: hex-encode so the JSON consumer can read it. This
+            // is asymmetric with the canonical decoder (which keeps bytes)
+            // but the recognize side only reads tstr/array/map shapes anyway.
+            let hex: String = b
+                .iter()
+                .map(|byte| format!("{:02x}", byte))
+                .collect();
+            Value::String(hex)
+        }
+        CborValue::Array(items) => {
+            Value::Array(items.iter().map(cbor_to_json).collect())
+        }
+        CborValue::Map(m) => Value::Object(
+            m.iter()
+                .map(|(k, v)| (k.clone(), cbor_to_json(v)))
+                .collect(),
+        ),
+    }
+}
+
 /// Collect every JSON object that could be a member record. Walks the
 /// envelope at the canonical roots: `members` (proof-envelope shape) and
-/// `ir` (lift response shape). Best-effort; harmless when a key is absent.
-/// Returns a stable order: members first, then ir.
-fn collect_member_records(env: &Value) -> Vec<&Value> {
-    let mut out: Vec<&Value> = Vec::new();
-    if let Some(arr) = env.get("members").and_then(|v| v.as_array()) {
-        for v in arr {
-            out.push(v);
+/// `ir` (lift response shape, always an array). Best-effort; harmless when
+/// a key is absent.
+///
+/// Crucial detail about the .proof catalog layout: each member's value
+/// is the CBOR-canonical bytes of the member envelope, stored as a Bstr.
+/// We re-decode those bytes here so callers see the structured envelope
+/// rather than an opaque hex blob. (The hex form is what cbor_to_json
+/// would emit for a Bstr; we want the structured form instead.)
+fn collect_member_records(env: &Value) -> Vec<Value> {
+    let mut out: Vec<Value> = Vec::new();
+    if let Some(members) = env.get("members") {
+        match members {
+            Value::Array(arr) => {
+                for v in arr {
+                    out.push(decode_embedded_member_if_hex(v));
+                }
+            }
+            Value::Object(map) => {
+                for (_cid, v) in map {
+                    out.push(decode_embedded_member_if_hex(v));
+                }
+            }
+            _ => {}
         }
     }
     if let Some(arr) = env.get("ir").and_then(|v| v.as_array()) {
         for v in arr {
-            out.push(v);
+            out.push(v.clone());
         }
     }
     out
+}
+
+/// If `v` is a hex-string (a Bstr round-tripped through cbor_to_json),
+/// decode the hex back to bytes and parse them as JCS-canonical JSON to
+/// recover the structured envelope. The proof-envelope catalog stores
+/// each member as opaque JCS-JSON bytes keyed by CID (per cmd_mint's
+/// `mint_library_sugar_binding_entry` -> `encode_jcs(envelope)` flow);
+/// this peels that wrapping for the recognize-side reader.
+fn decode_embedded_member_if_hex(v: &Value) -> Value {
+    let s = match v.as_str() {
+        Some(s) => s,
+        None => return v.clone(),
+    };
+    // Hex if every char is ASCII hex AND length is even.
+    if s.len() % 2 != 0 || !s.chars().all(|c| c.is_ascii_hexdigit()) {
+        return v.clone();
+    }
+    let bytes: Result<Vec<u8>, _> = (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
+        .collect();
+    let bytes = match bytes {
+        Ok(b) => b,
+        Err(_) => return v.clone(),
+    };
+    // The embedded bytes are JCS-canonical JSON. Parse them as such.
+    match serde_json::from_slice::<Value>(&bytes) {
+        Ok(j) => j,
+        Err(_) => v.clone(),
+    }
 }
 
 #[cfg(test)]

--- a/implementations/rust/provekit-cli/src/cmd_recognize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_recognize.rs
@@ -557,14 +557,54 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
         cbor_to_json(&cbor)
     };
 
-    // Walk the envelope's member set. The proof-envelope canonical shape
-    // wraps each member as `{body: <decl>, header: {...}, schemaVersion}`,
-    // and `members` may be either a CID-keyed map (.proof on disk) or an
-    // array (lift response). collect_member_records normalizes that and
-    // returns the (cid, value) pair; unwrap_envelope then peels the body
-    // wrapping if present.
-    let mut out: Vec<Value> = Vec::new();
+    // First pass: walk all members, build an index from ctor function
+    // names to the CIDs of contract mementos whose formulas reference
+    // that ctor. The linkage between a sugar binding and its contract
+    // memento is BY CTOR NAME (the shim mints contract witnesses whose
+    // inv/pre/post formulas contain `ctor(name="<source_function_name>")`
+    // terms, e.g. `unwrap(json_parse(s)) = original`); the bridge then
+    // resolves to that contract memento and the discharger composes.
     let candidates: Vec<(String, Value)> = collect_member_records(&env);
+    let mut contract_by_function: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    for (cid_key, raw) in &candidates {
+        let record = unwrap_envelope(raw);
+        // Contract mementos can be wrapped in either an "evidence" shape
+        // (body / kind both nested) or have `kind` at the top of `header`
+        // (the layered v1.2 envelope shape). Try both.
+        let is_contract = record
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .map(|k| k == "contract")
+            .unwrap_or_else(|| {
+                record
+                    .pointer("/header/kind")
+                    .and_then(|v| v.as_str())
+                    == Some("contract")
+            });
+        if !is_contract {
+            continue;
+        }
+        if cid_key.is_empty() {
+            continue;
+        }
+        // Walk every formula slot looking for ctor names. The shim's
+        // contracts live under `header` in the layered shape.
+        let formula_root = record.get("header").unwrap_or(record);
+        for slot in ["pre", "post", "inv"] {
+            if let Some(f) = formula_root.get(slot) {
+                collect_ctor_names(f, &mut |name| {
+                    contract_by_function
+                        .entry(name.to_string())
+                        .or_insert_with(|| cid_key.clone());
+                });
+            }
+        }
+    }
+
+    // Second pass: emit sugar binding templates with contract_cid
+    // resolved via the function-name index.
+    let mut out: Vec<Value> = Vec::new();
     for (cid_key, raw) in &candidates {
         let record = unwrap_envelope(raw);
         if record.get("kind").and_then(|v| v.as_str()) != Some("library-sugar-binding-entry") {
@@ -576,7 +616,7 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
         };
         let template = match body.get("ast_template") {
             Some(t) if !t.is_null() => t.clone(),
-            _ => continue, // skip entries minted before ast_template existed
+            _ => continue,
         };
         let template_cid = body
             .get("template_cid")
@@ -586,18 +626,26 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
             .get("param_names")
             .cloned()
             .unwrap_or(Value::Null);
-        // contract_cid resolution: prefer the binding's explicit
-        // contract_cid (vendor minted a separate contract memento and
-        // linked it); fall back to signature_shape_cid (the binding's
-        // own signature-shape anchor); finally fall back to the member's
-        // CID-key (the sugar entry's content address — the bridge says
-        // "this user function alpha-matches this sugar binding"). All
-        // three are content-addressed; the discharger composes against
-        // whichever the bridge cites.
+        let function_name = record
+            .get("source_function_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        // Resolve contract_cid in priority order:
+        //   1. explicit contract_cid field on the sugar entry (rare)
+        //   2. matching contract memento via ctor-name index (the
+        //      production linkage the shim mint actually uses)
+        //   3. signature_shape_cid fallback
+        //   4. the sugar entry's own CID (last resort)
         let contract_cid = record
             .get("contract_cid")
             .filter(|v| !v.is_null())
             .cloned()
+            .or_else(|| {
+                contract_by_function
+                    .get(&function_name)
+                    .map(|c| Value::String(c.clone()))
+            })
             .or_else(|| {
                 record
                     .get("signature_shape_cid")
@@ -619,10 +667,40 @@ fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> 
             "template_cid": template_cid,
             "param_names": param_names,
             "contract_cid": contract_cid,
+            "source_function_name": function_name,
         });
         out.push(entry);
     }
     Ok(out)
+}
+
+/// Recursively walk a formula/term tree invoking `on_name` for every
+/// ctor term encountered. The discharger looks for ctor terms whose
+/// name matches a bridge sourceSymbol to enumerate callsites; here we
+/// use the same walk to find which contract memento "is about" a given
+/// function (because its formulas reference that function's ctor).
+fn collect_ctor_names<F: FnMut(&str)>(node: &Value, on_name: &mut F) {
+    if !node.is_object() {
+        return;
+    }
+    if node.get("kind").and_then(|v| v.as_str()) == Some("ctor") {
+        if let Some(name) = node.get("name").and_then(|v| v.as_str()) {
+            on_name(name);
+        }
+    }
+    if let Some(args) = node.get("args").and_then(|v| v.as_array()) {
+        for a in args {
+            collect_ctor_names(a, on_name);
+        }
+    }
+    if let Some(ops) = node.get("operands").and_then(|v| v.as_array()) {
+        for o in ops {
+            collect_ctor_names(o, on_name);
+        }
+    }
+    if let Some(body) = node.get("body") {
+        collect_ctor_names(body, on_name);
+    }
 }
 
 /// Peel the proof-envelope wrapping (`{body, header, schemaVersion}`) and

--- a/implementations/rust/provekit-cli/src/cmd_recognize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_recognize.rs
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `provekit recognize`: kit-owned source-level recognition per protocol §4.2.5.
+//
+// Walks user source files, asks the language kit (via the lift plugin manifest
+// for the requested surface) to match function bodies' identifier-canonical
+// AST templates against supplied `binding_templates`, emits tier-`exact` tags
+// for matches. Bindings come from one or more `.proof` envelopes the caller
+// passes via `--binding`; each envelope is loaded and its
+// `library-sugar-binding-entry` records become recognize-side templates.
+//
+// This is the Tron-named verb: each kit's recognizer walks the grid for
+// shapes that belong to its system. The substrate stays language-blind; only
+// the kit reads AST shapes. See:
+//   protocol/specs/2026-05-12-plugin-protocol.md §4.2.5
+//   implementations/rust/provekit-walk/src/bin/walk_rpc.rs `recognize` handler
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use clap::Parser;
+use owo_colors::OwoColorize;
+use serde_json::{json, Value};
+
+use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
+
+/// Arguments accepted by `provekit recognize`.
+#[derive(Parser, Debug, Clone, Default)]
+pub struct RecognizeArgs {
+    /// Project root containing `.provekit/lift/<surface>/manifest.toml`.
+    /// Defaults to current directory.
+    #[arg(long)]
+    pub project: Option<PathBuf>,
+    /// Source paths (relative to project root) to scan for matches.
+    /// Repeatable. e.g. `--source src/lib.rs --source src/ingest.rs`.
+    #[arg(long = "source")]
+    pub source_paths: Vec<String>,
+    /// Paths to `.proof` envelopes that carry the binding templates.
+    /// Repeatable; bindings from all envelopes union into one pool.
+    #[arg(long = "binding")]
+    pub bindings: Vec<PathBuf>,
+    /// Lift surface name (default `rust-bind`). Resolves to
+    /// `<project>/.provekit/lift/<surface>/manifest.toml`.
+    #[arg(long)]
+    pub surface: Option<String>,
+    #[command(flatten)]
+    pub out: OutputFlags,
+}
+
+pub fn run(args: RecognizeArgs) -> u8 {
+    let project_root = match args
+        .project
+        .clone()
+        .map(|p| p.canonicalize().unwrap_or(p))
+        .or_else(|| std::env::current_dir().ok())
+    {
+        Some(p) => p,
+        None => {
+            eprintln!("{}: cannot resolve project root", "error".red().bold());
+            return EXIT_USER_ERROR;
+        }
+    };
+
+    let surface = args.surface.clone().unwrap_or_else(|| "rust-bind".to_string());
+    let manifest = match find_plugin_manifest(&project_root, &surface) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("{}: {e}", "error".red().bold());
+            return EXIT_USER_ERROR;
+        }
+    };
+
+    // Build the binding_templates pool by loading each .proof envelope and
+    // extracting its library-sugar-binding-entry records.
+    let mut binding_templates: Vec<Value> = Vec::new();
+    for path in &args.bindings {
+        match load_binding_templates_from_proof(path) {
+            Ok(mut entries) => binding_templates.append(&mut entries),
+            Err(e) => {
+                eprintln!(
+                    "{}: load binding `{}`: {e}",
+                    "error".red().bold(),
+                    path.display()
+                );
+                return EXIT_USER_ERROR;
+            }
+        }
+    }
+
+    if !args.out.json && !args.out.quiet {
+        eprintln!(
+            "{}: surface=`{}` bindings={} sources={}",
+            "dispatch".green().bold(),
+            surface,
+            binding_templates.len(),
+            args.source_paths.len(),
+        );
+    }
+
+    // Dispatch the recognize RPC.
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.recognize",
+        "params": {
+            "project_root": project_root.to_string_lossy(),
+            "source_paths": args.source_paths,
+            "binding_templates": binding_templates,
+        }
+    });
+
+    let tags = match invoke_plugin(&manifest, &project_root, &req) {
+        Ok(resp) => match resp.get("result").and_then(|r| r.get("tags")).cloned() {
+            Some(Value::Array(a)) => a,
+            _ => {
+                eprintln!(
+                    "{}: plugin response missing result.tags: {resp}",
+                    "error".red().bold()
+                );
+                return EXIT_VERIFY_FAIL;
+            }
+        },
+        Err(e) => {
+            eprintln!("{}: recognize dispatch failed: {e}", "error".red().bold());
+            return EXIT_VERIFY_FAIL;
+        }
+    };
+
+    if args.out.json {
+        let out = json!({ "tags": tags });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap_or_else(|_| out.to_string()));
+    } else {
+        println!("recognize: {} tag(s) emitted", tags.len());
+        for (idx, tag) in tags.iter().enumerate() {
+            let concept = tag.get("concept_name").and_then(|v| v.as_str()).unwrap_or("?");
+            let file = tag.get("file").and_then(|v| v.as_str()).unwrap_or("?");
+            let span = tag.get("span").cloned().unwrap_or(Value::Null);
+            let start_line = span.get("start_line").and_then(|v| v.as_u64()).unwrap_or(0);
+            let tier = tag.get("match_tier").and_then(|v| v.as_str()).unwrap_or("?");
+            println!(
+                "  [{idx}] {} @ {}:{} ({})",
+                concept.green(),
+                file,
+                start_line,
+                tier.dimmed()
+            );
+        }
+    }
+
+    EXIT_OK
+}
+
+/// Manifest discovery: project-local then user-global. Mirrors lift_plugin's
+/// `find_manifest` (which is module-private). Kept local here so recognize
+/// can ship independently.
+struct PluginManifest {
+    command: Vec<PathBuf>,
+    working_dir: Option<PathBuf>,
+}
+
+fn find_plugin_manifest(project_root: &Path, surface: &str) -> Result<PluginManifest, String> {
+    let project_local = project_root
+        .join(".provekit")
+        .join("lift")
+        .join(surface)
+        .join("manifest.toml");
+    if project_local.exists() {
+        return parse_manifest(&project_local);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let user_global = PathBuf::from(home)
+            .join(".config")
+            .join("provekit")
+            .join("lift")
+            .join(surface)
+            .join("manifest.toml");
+        if user_global.exists() {
+            return parse_manifest(&user_global);
+        }
+    }
+    Err(format!(
+        "no plugin manifest for surface `{surface}` (looked in .provekit/lift/{surface}/manifest.toml and ~/.config/provekit/lift/{surface}/manifest.toml)"
+    ))
+}
+
+fn parse_manifest(path: &Path) -> Result<PluginManifest, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("read manifest {}: {e}", path.display()))?;
+    let mut command: Vec<PathBuf> = Vec::new();
+    let mut working_dir: Option<PathBuf> = None;
+    for raw_line in text.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("command") {
+            // command = ["binary", "--flag"]
+            if let Some(arr_text) = rest.split_once('=').map(|(_, v)| v.trim()) {
+                command = parse_toml_string_array(arr_text);
+            }
+        } else if let Some(rest) = line.strip_prefix("working_dir") {
+            if let Some(val) = rest.split_once('=').map(|(_, v)| v.trim()) {
+                if let Some(s) = strip_quotes(val) {
+                    working_dir = Some(PathBuf::from(s));
+                }
+            }
+        }
+    }
+    if command.is_empty() {
+        return Err(format!("manifest {} declares no command", path.display()));
+    }
+    Ok(PluginManifest { command, working_dir })
+}
+
+fn parse_toml_string_array(text: &str) -> Vec<PathBuf> {
+    let trimmed = text.trim().trim_start_matches('[').trim_end_matches(']');
+    trimmed
+        .split(',')
+        .filter_map(|s| {
+            let t = s.trim();
+            strip_quotes(t).map(PathBuf::from)
+        })
+        .collect()
+}
+
+fn strip_quotes(s: &str) -> Option<&str> {
+    s.strip_prefix('"').and_then(|s| s.strip_suffix('"'))
+}
+
+/// Spawn the plugin binary with the manifest's command + working_dir, send
+/// the JSON-RPC request, read one JSON line response, shutdown. The lift
+/// binary's dispatch (initialize / lift / shutdown / provekit.plugin.recognize)
+/// accepts the recognize method directly; no preceding initialize required.
+fn invoke_plugin(
+    manifest: &PluginManifest,
+    project_root: &Path,
+    request: &Value,
+) -> Result<Value, String> {
+    let (program, args) = manifest
+        .command
+        .split_first()
+        .ok_or("plugin manifest command is empty")?;
+
+    let mut cmd = Command::new(program);
+    cmd.args(args);
+    if let Some(working_dir) = &manifest.working_dir {
+        let resolved = if working_dir.is_absolute() {
+            working_dir.clone()
+        } else {
+            project_root.join(working_dir)
+        };
+        cmd.current_dir(resolved);
+    } else {
+        cmd.current_dir(project_root);
+    }
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| format!("spawn plugin: {e}"))?;
+    {
+        let stdin = child.stdin.as_mut().ok_or("plugin stdin closed")?;
+        let req_line = serde_json::to_string(request).map_err(|e| e.to_string())?;
+        writeln!(stdin, "{req_line}").map_err(|e| format!("write request: {e}"))?;
+        // Send a shutdown so the plugin exits cleanly after answering.
+        let shutdown = json!({"jsonrpc":"2.0","id":2,"method":"shutdown","params":{}});
+        writeln!(stdin, "{}", serde_json::to_string(&shutdown).unwrap())
+            .map_err(|e| format!("write shutdown: {e}"))?;
+    }
+
+    let stdout = child.stdout.take().ok_or("plugin stdout closed")?;
+    let mut reader = BufReader::new(stdout);
+    let mut response_line = String::new();
+    reader
+        .read_line(&mut response_line)
+        .map_err(|e| format!("read response: {e}"))?;
+    let _ = child.wait();
+    if response_line.trim().is_empty() {
+        return Err("plugin response was empty".to_string());
+    }
+    serde_json::from_str(&response_line).map_err(|e| {
+        format!(
+            "parse response: {e}; raw={}",
+            response_line.trim_end_matches('\n')
+        )
+    })
+}
+
+/// Load a `.proof` envelope and extract its sugar-binding entries into the
+/// shape the recognize RPC expects.
+fn load_binding_templates_from_proof(path: &Path) -> Result<Vec<Value>, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("read .proof: {e}"))?;
+    // The .proof envelope is JCS-canonical JSON (the trinity envelope from the
+    // proof-envelope spec). Parse with serde_json.
+    let env: Value = serde_json::from_slice(&bytes).map_err(|e| format!("parse .proof: {e}"))?;
+
+    // Walk the envelope's member set for `library-sugar-binding-entry`
+    // records. The envelope's structure puts members under `members[]`
+    // (proof-envelope canonical) or `ir[]` (lift response shape) depending
+    // on the producer. Handle both.
+    let mut out: Vec<Value> = Vec::new();
+    let candidates: Vec<&Value> = collect_member_records(&env);
+    for record in candidates {
+        if record.get("kind").and_then(|v| v.as_str()) != Some("library-sugar-binding-entry") {
+            continue;
+        }
+        let body = match record.get("body_source") {
+            Some(b) => b,
+            None => continue,
+        };
+        let template = match body.get("ast_template") {
+            Some(t) if !t.is_null() => t.clone(),
+            _ => continue, // skip entries minted before ast_template existed
+        };
+        let template_cid = body
+            .get("template_cid")
+            .cloned()
+            .unwrap_or(Value::Null);
+        let param_names = body
+            .get("param_names")
+            .cloned()
+            .unwrap_or(Value::Null);
+        let entry = json!({
+            "concept_name": record.get("concept_name").cloned().unwrap_or(Value::Null),
+            "library_tag": record.get("target_library_tag").cloned().unwrap_or(Value::Null),
+            "family": record.get("family").cloned().unwrap_or(Value::Null),
+            "ast_template": template,
+            "template_cid": template_cid,
+            "param_names": param_names,
+            "contract_cid": record.get("contract_cid").cloned().unwrap_or(Value::Null),
+        });
+        out.push(entry);
+    }
+    Ok(out)
+}
+
+/// Collect every JSON object that could be a member record. Walks the
+/// envelope at the canonical roots: `members` (proof-envelope shape) and
+/// `ir` (lift response shape). Best-effort; harmless when a key is absent.
+/// Returns a stable order: members first, then ir.
+fn collect_member_records(env: &Value) -> Vec<&Value> {
+    let mut out: Vec<&Value> = Vec::new();
+    if let Some(arr) = env.get("members").and_then(|v| v.as_array()) {
+        for v in arr {
+            out.push(v);
+        }
+    }
+    if let Some(arr) = env.get("ir").and_then(|v| v.as_array()) {
+        for v in arr {
+            out.push(v);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_manifest_extracts_command_and_working_dir() {
+        let tmp = std::env::temp_dir().join(format!(
+            "provekit-recognize-test-manifest-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let manifest_path = tmp.join("manifest.toml");
+        std::fs::write(
+            &manifest_path,
+            r#"name = "rust-bind-lift"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."
+"#,
+        )
+        .unwrap();
+        let m = parse_manifest(&manifest_path).expect("parse");
+        assert_eq!(m.command.len(), 2);
+        assert!(m.command[0]
+            .to_string_lossy()
+            .ends_with("provekit-walk-rpc"));
+        assert_eq!(m.command[1].to_string_lossy(), "--rpc");
+        assert_eq!(m.working_dir, Some(PathBuf::from(".")));
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn load_binding_extracts_sugar_entries_from_envelope() {
+        let env = json!({
+            "members": [
+                {
+                    "kind": "library-sugar-binding-entry",
+                    "concept_name": "concept:json-parse",
+                    "target_library_tag": "provekit-shim-serde-json-rust",
+                    "family": "concept:family:json",
+                    "body_source": {
+                        "ast_template": {"kind":"block","stmts":[]},
+                        "template_cid": "blake3-512:abc",
+                        "param_names": ["s"],
+                    },
+                    "contract_cid": "blake3-512:def"
+                },
+                { "kind": "something-else" }
+            ]
+        });
+        let tmp = std::env::temp_dir().join(format!(
+            "provekit-recognize-test-binding-{}",
+            std::process::id()
+        ));
+        std::fs::write(&tmp, env.to_string()).unwrap();
+        let entries = load_binding_templates_from_proof(&tmp).expect("load");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["concept_name"], "concept:json-parse");
+        assert_eq!(
+            entries[0]["library_tag"],
+            "provekit-shim-serde-json-rust"
+        );
+        assert_eq!(entries[0]["template_cid"], "blake3-512:abc");
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn load_binding_skips_entries_without_ast_template() {
+        // Backward-compat: sugar entries minted before ast_template existed
+        // should be skipped, not error out.
+        let env = json!({
+            "members": [
+                {
+                    "kind": "library-sugar-binding-entry",
+                    "concept_name": "concept:json-parse",
+                    "target_library_tag": "old-shim",
+                    "body_source": {
+                        "body_text": "old body without ast_template",
+                    }
+                }
+            ]
+        });
+        let tmp = std::env::temp_dir().join(format!(
+            "provekit-recognize-test-legacy-{}",
+            std::process::id()
+        ));
+        std::fs::write(&tmp, env.to_string()).unwrap();
+        let entries = load_binding_templates_from_proof(&tmp).expect("load");
+        assert!(entries.is_empty(), "legacy entries without ast_template skipped");
+        std::fs::remove_file(&tmp).ok();
+    }
+}

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -23,6 +23,7 @@ mod cmd_compose;
 mod cmd_dump;
 mod cmd_emit;
 mod cmd_hash;
+mod cmd_recognize;
 mod cmd_implicate;
 mod cmd_init;
 mod cmd_lift;
@@ -117,6 +118,12 @@ enum Cmd {
     Dump(DumpArgs),
     /// Compute the BLAKE3-512 self-identifying CID of a file (or stdin).
     Hash(HashArgs),
+    /// Recognizer (per protocol §4.2.5): scan source for shapes that
+    /// match published sugar binding templates; emit tags. The reverse
+    /// direction of `materialize` — same kit, same AST machinery, two
+    /// directions over one .proof envelope. Tron-named for the kit-side
+    /// fingerprint scanner.
+    Recognize(cmd_recognize::RecognizeArgs),
     /// Initialize a project: provekit.toml, .provekit/, sample invariant, GitHub Action.
     Init(InitArgs),
     /// Print directions for the lift adapter (TS only in v1.0; planned for v1.2.0).
@@ -365,6 +372,7 @@ fn main() -> ExitCode {
         Cmd::Implicate(a) | Cmd::Imp(a) => cmd_implicate::run(a),
         Cmd::Dump(a) => cmd_dump::run(a),
         Cmd::Hash(a) => cmd_hash::run(a),
+        Cmd::Recognize(a) => cmd_recognize::run(a),
         Cmd::Init(a) => cmd_init::run(a),
         Cmd::Lift(a) => cmd_lift::run(a),
         Cmd::Mint(a) => cmd_mint::run(a),

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -2271,6 +2271,27 @@ fn sugar_body_source(rel: &str, src: &str, item_fn: &syn::ItemFn) -> Value {
         .map(str::trim)
         .unwrap_or_default()
         .to_string();
+    // Phase 2 / Recognizer foundation (#81, #82): emit an identifier-canonical
+    // AST template alongside the body text. Same source-pass produces both:
+    // body_text drives `materialize` (the splice-in form), ast_template
+    // drives `recognize` (the structural pattern match against user code).
+    // Identifier canonicalization replaces the sugar's named params with
+    // $1, $2, … positional markers so user variants (`conn.execute(sql,args)`
+    // vs `c.execute(s,a)`) match the same template after alpha-equivalence.
+    let param_names: Vec<String> = item_fn
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|arg| match arg {
+            syn::FnArg::Typed(pat_ty) => match &*pat_ty.pat {
+                syn::Pat::Ident(pid) => Some(pid.ident.to_string()),
+                _ => None,
+            },
+            syn::FnArg::Receiver(_) => None,
+        })
+        .collect();
+    let ast_template = block_to_ast_template(&item_fn.block, &param_names);
+    let template_text = ast_template.to_string();
     json!({
         "file": rel,
         "span": {
@@ -2281,7 +2302,188 @@ fn sugar_body_source(rel: &str, src: &str, item_fn: &syn::ItemFn) -> Value {
         },
         "source_cid": blake3_512_of(body_text.as_bytes()),
         "body_text": body_text,
+        "ast_template": ast_template,
+        "template_cid": blake3_512_of(template_text.as_bytes()),
+        "param_names": param_names,
     })
+}
+
+/// Identifier-canonical AST template serializer for the Recognizer
+/// foundation (#81, #82). Walks a `syn::Block` and emits a structured JSON
+/// tree where each node is `{kind, ...}`. Sugar param names are replaced
+/// with `$1`, `$2`, … so user-code variants alpha-equivalent to the sugar
+/// match the same template.
+///
+/// The format is intentionally a small union over the syn variants that
+/// actually show up in sugar bodies (calls, method calls, paths, refs,
+/// ?, blocks, literals, identifiers). Unhandled variants fall through to
+/// `{kind: "other", variant: "<name>"}` catch-all so the template is
+/// never lossy in a way that drops a node — only in a way that opaqueifies
+/// the variant. The recognizer then refuses any candidate site containing
+/// an opaqued node.
+fn block_to_ast_template(block: &syn::Block, params: &[String]) -> Value {
+    let stmts: Vec<Value> = block
+        .stmts
+        .iter()
+        .map(|stmt| stmt_to_template(stmt, params))
+        .collect();
+    json!({ "kind": "block", "stmts": stmts })
+}
+
+fn stmt_to_template(stmt: &syn::Stmt, params: &[String]) -> Value {
+    use syn::Stmt;
+    match stmt {
+        Stmt::Local(local) => {
+            let pat = pat_to_template(&local.pat, params);
+            let init = local
+                .init
+                .as_ref()
+                .map(|init| expr_to_template(&init.expr, params))
+                .unwrap_or(Value::Null);
+            json!({ "kind": "let", "pat": pat, "init": init })
+        }
+        Stmt::Item(_) => json!({ "kind": "item" }),
+        Stmt::Expr(expr, semi) => {
+            let inner = expr_to_template(expr, params);
+            let trailing = semi.is_some();
+            json!({ "kind": "expr_stmt", "expr": inner, "trailing_semi": trailing })
+        }
+        Stmt::Macro(m) => {
+            let path = path_to_template(&m.mac.path);
+            json!({ "kind": "macro_stmt", "path": path })
+        }
+    }
+}
+
+fn expr_to_template(expr: &syn::Expr, params: &[String]) -> Value {
+    use syn::Expr;
+    match expr {
+        Expr::Call(c) => {
+            let func = expr_to_template(&c.func, params);
+            let args: Vec<Value> =
+                c.args.iter().map(|a| expr_to_template(a, params)).collect();
+            json!({ "kind": "call", "func": func, "args": args })
+        }
+        Expr::MethodCall(m) => {
+            let receiver = expr_to_template(&m.receiver, params);
+            let method = m.method.to_string();
+            let args: Vec<Value> =
+                m.args.iter().map(|a| expr_to_template(a, params)).collect();
+            json!({
+                "kind": "method_call",
+                "receiver": receiver,
+                "method": method,
+                "args": args,
+            })
+        }
+        Expr::Path(p) => {
+            let segs: Vec<String> =
+                p.path.segments.iter().map(|s| s.ident.to_string()).collect();
+            if segs.len() == 1 {
+                if let Some(idx) = params.iter().position(|n| n == &segs[0]) {
+                    return json!({ "kind": "param_ref", "index": idx + 1 });
+                }
+                return json!({ "kind": "ident", "name": segs[0] });
+            }
+            json!({ "kind": "path", "segments": segs })
+        }
+        Expr::Lit(l) => lit_to_template(&l.lit),
+        Expr::Reference(r) => {
+            let inner = expr_to_template(&r.expr, params);
+            json!({ "kind": "ref", "mutability": r.mutability.is_some(), "expr": inner })
+        }
+        Expr::Try(t) => {
+            let inner = expr_to_template(&t.expr, params);
+            json!({ "kind": "try", "expr": inner })
+        }
+        Expr::Block(b) => block_to_ast_template(&b.block, params),
+        Expr::Paren(p) => expr_to_template(&p.expr, params),
+        Expr::Tuple(t) => {
+            let elems: Vec<Value> =
+                t.elems.iter().map(|e| expr_to_template(e, params)).collect();
+            json!({ "kind": "tuple", "elems": elems })
+        }
+        Expr::Array(a) => {
+            let elems: Vec<Value> =
+                a.elems.iter().map(|e| expr_to_template(e, params)).collect();
+            json!({ "kind": "array", "elems": elems })
+        }
+        Expr::Closure(_) => json!({ "kind": "closure" }),
+        Expr::Match(_) => json!({ "kind": "match" }),
+        Expr::If(_) => json!({ "kind": "if" }),
+        Expr::Return(r) => {
+            let inner = r
+                .expr
+                .as_ref()
+                .map(|e| expr_to_template(e, params))
+                .unwrap_or(Value::Null);
+            json!({ "kind": "return", "expr": inner })
+        }
+        Expr::Binary(b) => {
+            let left = expr_to_template(&b.left, params);
+            let right = expr_to_template(&b.right, params);
+            let op = format!("{:?}", b.op);
+            json!({ "kind": "binary", "op": op, "left": left, "right": right })
+        }
+        Expr::Unary(u) => {
+            let inner = expr_to_template(&u.expr, params);
+            let op = format!("{:?}", u.op);
+            json!({ "kind": "unary", "op": op, "expr": inner })
+        }
+        Expr::Field(f) => {
+            let base = expr_to_template(&f.base, params);
+            let member = match &f.member {
+                syn::Member::Named(n) => n.to_string(),
+                syn::Member::Unnamed(u) => u.index.to_string(),
+            };
+            json!({ "kind": "field", "base": base, "member": member })
+        }
+        Expr::Macro(m) => {
+            let path = path_to_template(&m.mac.path);
+            json!({ "kind": "macro", "path": path })
+        }
+        other => json!({
+            "kind": "other",
+            "variant": format!("{:?}", std::mem::discriminant(other)),
+        }),
+    }
+}
+
+fn pat_to_template(pat: &syn::Pat, params: &[String]) -> Value {
+    use syn::Pat;
+    match pat {
+        Pat::Ident(pi) => {
+            let name = pi.ident.to_string();
+            if let Some(idx) = params.iter().position(|n| n == &name) {
+                json!({ "kind": "param_ref", "index": idx + 1 })
+            } else {
+                json!({ "kind": "binding", "name": name })
+            }
+        }
+        Pat::Wild(_) => json!({ "kind": "wildcard" }),
+        Pat::Tuple(t) => {
+            let elems: Vec<Value> =
+                t.elems.iter().map(|p| pat_to_template(p, params)).collect();
+            json!({ "kind": "pat_tuple", "elems": elems })
+        }
+        _ => json!({ "kind": "pat_other" }),
+    }
+}
+
+fn path_to_template(path: &syn::Path) -> Value {
+    let segs: Vec<String> = path.segments.iter().map(|s| s.ident.to_string()).collect();
+    json!({ "segments": segs })
+}
+
+fn lit_to_template(lit: &syn::Lit) -> Value {
+    match lit {
+        syn::Lit::Str(s) => json!({ "kind": "lit_str", "value": s.value() }),
+        syn::Lit::Int(i) => json!({ "kind": "lit_int", "value": i.base10_digits() }),
+        syn::Lit::Bool(b) => json!({ "kind": "lit_bool", "value": b.value }),
+        syn::Lit::Char(c) => json!({ "kind": "lit_char", "value": c.value().to_string() }),
+        syn::Lit::Float(f) => json!({ "kind": "lit_float", "value": f.base10_digits() }),
+        _ => json!({ "kind": "lit_other" }),
+    }
 }
 
 fn block_inner_source<'a>(src: &'a str, block: &syn::Block) -> Option<&'a str> {
@@ -4377,6 +4579,135 @@ async fn render(url: String) -> String {
             !body_text.contains("#[provekit::sugar"),
             "body_text must not include the sugar attribute: {body_text}"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // Recognizer foundation (#81 / #82): identifier-canonical AST template
+    // alongside body_text. Same source-pass extracts both; the .proof
+    // envelope carries body_text (for materialize) AND ast_template (for
+    // recognize). Param names canonicalize to $1, $2 positional markers so
+    // user-code variants alpha-equivalent to the sugar match the same
+    // template. T's directive: keep both in the lifter's output.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn sugar_body_emits_ast_template_alongside_body_text() {
+        let src = r##"
+#[provekit::sugar(concept = "concept:json-parse", library = "serde_json")]
+pub fn json_parse(s: &str) -> i64 {
+    serde_json::from_str(s)
+}
+"##;
+        let entry = single_sugar_entry_for_source("sugar_ast_template_basic", src);
+        let template = &entry["body_source"]["ast_template"];
+        assert_eq!(template["kind"], "block");
+        let stmts = template["stmts"].as_array().expect("stmts array");
+        assert_eq!(stmts.len(), 1, "one statement in body");
+        let stmt = &stmts[0];
+        assert_eq!(stmt["kind"], "expr_stmt");
+        let call = &stmt["expr"];
+        assert_eq!(call["kind"], "call");
+        assert_eq!(call["func"]["kind"], "path");
+        assert_eq!(
+            call["func"]["segments"],
+            json!(["serde_json", "from_str"])
+        );
+        // Param `s` canonicalized to $1.
+        let args = call["args"].as_array().expect("args array");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0]["kind"], "param_ref");
+        assert_eq!(args[0]["index"], 1);
+    }
+
+    #[test]
+    fn sugar_body_template_canonicalizes_multiple_params_positionally() {
+        let src = r##"
+#[provekit::sugar(concept = "concept:sql-execute", library = "rusqlite")]
+pub fn execute(conn: &i64, sql: &str, args: &i64) -> i64 {
+    conn.execute(sql, args)
+}
+"##;
+        let entry = single_sugar_entry_for_source("sugar_ast_template_params", src);
+        let template = &entry["body_source"]["ast_template"];
+        let stmt = &template["stmts"][0];
+        let mc = &stmt["expr"];
+        assert_eq!(mc["kind"], "method_call");
+        // Receiver is param #1 (conn).
+        assert_eq!(mc["receiver"]["kind"], "param_ref");
+        assert_eq!(mc["receiver"]["index"], 1);
+        assert_eq!(mc["method"], "execute");
+        // Args are $2 (sql) and $3 (args).
+        let mc_args = mc["args"].as_array().expect("mc args");
+        assert_eq!(mc_args.len(), 2);
+        assert_eq!(mc_args[0]["kind"], "param_ref");
+        assert_eq!(mc_args[0]["index"], 2);
+        assert_eq!(mc_args[1]["kind"], "param_ref");
+        assert_eq!(mc_args[1]["index"], 3);
+    }
+
+    #[test]
+    fn sugar_body_template_cid_is_stable_under_param_renaming() {
+        // Canonical templates with $1/$2 must be byte-identical for two
+        // sugar functions that differ only in their parameter names.
+        let src_a = r##"
+#[provekit::sugar(concept = "concept:noop", library = "ka")]
+pub fn op(x: &i64, y: &i64) -> i64 {
+    x.add(y)
+}
+"##;
+        let src_b = r##"
+#[provekit::sugar(concept = "concept:noop", library = "kb")]
+pub fn op(alpha: &i64, beta: &i64) -> i64 {
+    alpha.add(beta)
+}
+"##;
+        let entry_a = single_sugar_entry_for_source("sugar_ast_template_alpha_a", src_a);
+        let entry_b = single_sugar_entry_for_source("sugar_ast_template_alpha_b", src_b);
+        let tpl_a = entry_a["body_source"]["ast_template"].to_string();
+        let tpl_b = entry_b["body_source"]["ast_template"].to_string();
+        assert_eq!(
+            tpl_a, tpl_b,
+            "alpha-equivalent sugars must produce byte-identical templates\nA: {tpl_a}\nB: {tpl_b}"
+        );
+        assert_eq!(
+            entry_a["body_source"]["template_cid"],
+            entry_b["body_source"]["template_cid"],
+            "template_cid must match across alpha-equivalent sugars"
+        );
+        // But body_text and source_cid DIFFER (they include the original
+        // parameter spellings). That asymmetry is intentional: body_text
+        // drives materialize (verbatim splice), ast_template drives
+        // recognize (canonical structural match).
+        assert_ne!(
+            entry_a["body_source"]["body_text"],
+            entry_b["body_source"]["body_text"]
+        );
+        assert_ne!(
+            entry_a["body_source"]["source_cid"],
+            entry_b["body_source"]["source_cid"]
+        );
+    }
+
+    #[test]
+    fn sugar_body_emits_param_names_list_for_recognize_binding() {
+        // The recognize side needs the original param names to bind the
+        // template's $N markers back to the user's actual variables at
+        // tag emission time. The lifter exposes them as a separate field.
+        let src = r##"
+#[provekit::sugar(concept = "concept:sql-query-row", library = "rusqlite")]
+pub fn query_row(conn: &i64, sql: &str, params: &i64, mapper: &i64) -> i64 {
+    conn.query_row(sql, params, mapper)
+}
+"##;
+        let entry = single_sugar_entry_for_source("sugar_ast_template_paramnames", src);
+        let names = entry["body_source"]["param_names"]
+            .as_array()
+            .expect("param_names array");
+        assert_eq!(names.len(), 4);
+        assert_eq!(names[0], "conn");
+        assert_eq!(names[1], "sql");
+        assert_eq!(names[2], "params");
+        assert_eq!(names[3], "mapper");
     }
 
     // ---------------------------------------------------------------------

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -265,6 +265,7 @@ fn recognize_match_item_fn(
             "end_line": end.line,
             "end_col": end.column,
         },
+        "function_name": item_fn.sig.ident.to_string(),
         "concept_name": binding.get("concept_name").cloned().unwrap_or(Value::Null),
         "library_tag": binding.get("library_tag").cloned().unwrap_or(Value::Null),
         "family": binding.get("family").cloned().unwrap_or(Value::Null),

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -92,6 +92,10 @@ fn handle_line(line: &str) -> Value {
         "initialize" => Ok(initialize_result()),
         "lift" => bind_lift(&params),
         "shutdown" => Ok(Value::Null),
+        // Recognizer foundation (#81, #82) per protocol §4.2.5. The lift
+        // binary handles this too because it already owns the syn AST
+        // machinery that recognize needs — same kit, same language.
+        "provekit.plugin.recognize" => recognize(&params),
         // Walk-internal RPC (substrate-private; not part of any plugin protocol).
         "walk.lift_pre" => lift_pre(&params),
         "walk.lift_post" => lift_post(&params),
@@ -114,6 +118,161 @@ fn handle_line(line: &str) -> Value {
             "id": id,
         }),
     }
+}
+
+/// Recognizer foundation (#81, #82) per protocol §4.2.5.
+///
+/// Walk user source files, compute their function bodies' identifier-
+/// canonical AST templates with the same `block_to_ast_template` the
+/// sugar lifter uses, and match by `template_cid` against the request's
+/// `binding_templates`. An exact CID match means the user's function
+/// body IS the shim's sugar body (modulo whitespace + alpha-equivalence
+/// on params) — tier `exact`. Tiers `structural`, `probable`, `refused`
+/// are reserved for follow-up tier-2/3 work.
+///
+/// The kit owns the AST machinery; the substrate sees only the tag set.
+/// This is the language-blind invariant: the substrate forwards
+/// `binding_templates` opaquely and collects tags opaquely; only the
+/// kit reads or writes syn shapes.
+fn recognize(params: &Value) -> Result<Value, String> {
+    use std::collections::HashMap;
+
+    let project_root = params
+        .get("project_root")
+        .and_then(|v| v.as_str())
+        .ok_or("missing `project_root`")?;
+    let project_root = std::path::PathBuf::from(project_root);
+
+    let source_paths: Vec<String> = params
+        .get("source_paths")
+        .and_then(|v| v.as_array())
+        .ok_or("missing `source_paths` array")?
+        .iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect();
+
+    let empty: Vec<Value> = Vec::new();
+    let binding_templates: &Vec<Value> = params
+        .get("binding_templates")
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty);
+
+    // Index bindings by template_cid for O(1) lookup. The kit reads the
+    // template_cid the lifter emitted (or, equivalently, recomputes it
+    // from the supplied ast_template; we trust the supplied value because
+    // the substrate's §4.2.5 contract requires it to verify the CID).
+    let mut bindings_by_cid: HashMap<String, &Value> = HashMap::new();
+    for binding in binding_templates {
+        if let Some(cid) = binding.get("template_cid").and_then(|v| v.as_str()) {
+            bindings_by_cid.insert(cid.to_string(), binding);
+        }
+    }
+
+    let mut tags: Vec<Value> = Vec::new();
+
+    for rel_path in &source_paths {
+        let full_path = project_root.join(rel_path);
+        let src = match std::fs::read_to_string(&full_path) {
+            Ok(s) => s,
+            Err(_) => continue, // missing files are not errors at the recognize layer
+        };
+        let file = match syn::parse_file(&src) {
+            Ok(f) => f,
+            Err(_) => continue, // unparseable files cannot host AST recognition
+        };
+
+        recognize_walk_items(
+            &file.items,
+            rel_path,
+            &bindings_by_cid,
+            &mut tags,
+        );
+    }
+
+    Ok(json!({ "tags": tags }))
+}
+
+/// Recursively visit items + nested modules, collecting recognize tags.
+fn recognize_walk_items(
+    items: &[syn::Item],
+    rel_path: &str,
+    bindings_by_cid: &std::collections::HashMap<String, &Value>,
+    tags: &mut Vec<Value>,
+) {
+    for item in items {
+        match item {
+            syn::Item::Fn(item_fn) => {
+                if let Some(tag) =
+                    recognize_match_item_fn(item_fn, rel_path, bindings_by_cid)
+                {
+                    tags.push(tag);
+                }
+            }
+            syn::Item::Mod(item_mod) => {
+                if let Some((_, ref nested)) = item_mod.content {
+                    recognize_walk_items(nested, rel_path, bindings_by_cid, tags);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Compute the candidate's identifier-canonical AST template and look it
+/// up in `bindings_by_cid`. Returns a tag JSON if matched at tier `exact`.
+fn recognize_match_item_fn(
+    item_fn: &syn::ItemFn,
+    rel_path: &str,
+    bindings_by_cid: &std::collections::HashMap<String, &Value>,
+) -> Option<Value> {
+    let param_names: Vec<String> = item_fn
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|arg| match arg {
+            syn::FnArg::Typed(pat_ty) => match &*pat_ty.pat {
+                syn::Pat::Ident(pid) => Some(pid.ident.to_string()),
+                _ => None,
+            },
+            syn::FnArg::Receiver(_) => None,
+        })
+        .collect();
+
+    let candidate_template = block_to_ast_template(&item_fn.block, &param_names);
+    let candidate_cid = blake3_512_of(candidate_template.to_string().as_bytes());
+
+    let binding = bindings_by_cid.get(&candidate_cid)?;
+
+    let start = item_fn.sig.fn_token.span.start();
+    let end = item_fn.block.brace_token.span.close().end();
+
+    let param_bindings: Vec<Value> = param_names
+        .iter()
+        .enumerate()
+        .map(|(i, n)| {
+            json!({
+                "index": i + 1,
+                "source_text": n,
+            })
+        })
+        .collect();
+
+    Some(json!({
+        "file": rel_path,
+        "span": {
+            "start_line": start.line,
+            "start_col": start.column,
+            "end_line": end.line,
+            "end_col": end.column,
+        },
+        "concept_name": binding.get("concept_name").cloned().unwrap_or(Value::Null),
+        "library_tag": binding.get("library_tag").cloned().unwrap_or(Value::Null),
+        "family": binding.get("family").cloned().unwrap_or(Value::Null),
+        "template_cid": candidate_cid,
+        "contract_cid": binding.get("contract_cid").cloned().unwrap_or(Value::Null),
+        "match_tier": "exact",
+        "param_bindings": param_bindings,
+    }))
 }
 
 fn lift_pre(params: &Value) -> Result<Value, String> {
@@ -4686,6 +4845,179 @@ pub fn op(alpha: &i64, beta: &i64) -> i64 {
             entry_a["body_source"]["source_cid"],
             entry_b["body_source"]["source_cid"]
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // Recognizer foundation Phase C (#81, #82, #86): the provekit.plugin.recognize
+    // RPC handler. Walks user source, matches function bodies' identifier-
+    // canonical templates against supplied binding_templates by template_cid,
+    // emits tier-`exact` tags for matches. Tier-1 = exact-cid match.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn recognize_emits_exact_tag_for_alpha_equivalent_user_function() {
+        // The shim's sugar (what would land in the .proof envelope):
+        let sugar_src = r##"
+#[provekit::sugar(concept = "concept:json-parse", library = "provekit-shim-serde-json-rust")]
+pub fn json_parse(s: &str) -> i64 {
+    serde_json::from_str(s)
+}
+"##;
+        let sugar_entry = single_sugar_entry_for_source("recognize_sugar_src", sugar_src);
+        let binding_template = json!({
+            "concept_name": sugar_entry["concept_name"],
+            "library_tag": sugar_entry["target_library_tag"],
+            "family": sugar_entry.get("family").cloned().unwrap_or(Value::Null),
+            "ast_template": sugar_entry["body_source"]["ast_template"],
+            "template_cid": sugar_entry["body_source"]["template_cid"],
+            "param_names": sugar_entry["body_source"]["param_names"],
+            "contract_cid": "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        });
+
+        // The user's function — alpha-equivalent (different param name).
+        let user_src = r##"
+pub fn json_parse(input: &str) -> Result<serde_json::Value, String> {
+    serde_json::from_str(input)
+}
+"##;
+        let root = temp_workspace("recognize_user_src");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let user_rel = "src/lib.rs";
+        fs::write(root.join(user_rel), user_src).expect("write user source");
+
+        let resp = recognize(&json!({
+            "project_root": root.to_string_lossy(),
+            "source_paths": [user_rel],
+            "binding_templates": [binding_template],
+        }))
+        .expect("recognize should succeed");
+
+        let tags = resp["tags"].as_array().expect("tags array");
+        assert_eq!(tags.len(), 1, "alpha-equivalent body must match: {tags:?}");
+        let tag = &tags[0];
+        assert_eq!(tag["concept_name"], "concept:json-parse");
+        assert_eq!(tag["library_tag"], "provekit-shim-serde-json-rust");
+        assert_eq!(tag["match_tier"], "exact");
+        assert_eq!(tag["file"], user_rel);
+        // param_bindings reflects the USER's spelling (input), not the sugar's (s).
+        let bindings = tag["param_bindings"].as_array().expect("param_bindings");
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0]["index"], 1);
+        assert_eq!(bindings[0]["source_text"], "input");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recognize_returns_empty_tags_for_non_matching_source() {
+        let sugar_src = r##"
+#[provekit::sugar(concept = "concept:json-parse", library = "provekit-shim-serde-json-rust")]
+pub fn json_parse(s: &str) -> i64 {
+    serde_json::from_str(s)
+}
+"##;
+        let sugar_entry = single_sugar_entry_for_source("recognize_neg_sugar", sugar_src);
+        let binding_template = json!({
+            "concept_name": sugar_entry["concept_name"],
+            "library_tag": sugar_entry["target_library_tag"],
+            "ast_template": sugar_entry["body_source"]["ast_template"],
+            "template_cid": sugar_entry["body_source"]["template_cid"],
+            "contract_cid": "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        });
+
+        // User's function is structurally DIFFERENT — calls a different function.
+        let user_src = r##"
+pub fn json_parse(s: &str) -> i64 {
+    completely_different_function(s)
+}
+"##;
+        let root = temp_workspace("recognize_neg_user");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let user_rel = "src/lib.rs";
+        fs::write(root.join(user_rel), user_src).expect("write user source");
+
+        let resp = recognize(&json!({
+            "project_root": root.to_string_lossy(),
+            "source_paths": [user_rel],
+            "binding_templates": [binding_template],
+        }))
+        .expect("recognize should succeed");
+
+        let tags = resp["tags"].as_array().expect("tags array");
+        assert!(tags.is_empty(), "non-matching source must produce no tags: {tags:?}");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recognize_routes_multiple_bindings_per_call_site_pool() {
+        // Two binding templates (json + sql shapes). User source contains
+        // one match for each. Recognize emits two tags.
+        let json_sugar = r##"
+#[provekit::sugar(concept = "concept:json-parse", library = "json-lib")]
+pub fn json_parse(s: &str) -> i64 {
+    serde_json::from_str(s)
+}
+"##;
+        let sql_sugar = r##"
+#[provekit::sugar(concept = "concept:sql-execute", library = "sql-lib")]
+pub fn sql_execute(conn: &i64, sql: &str, args: &i64) -> i64 {
+    conn.execute(sql, args)
+}
+"##;
+        let json_entry = single_sugar_entry_for_source("recognize_multi_json", json_sugar);
+        let sql_entry = single_sugar_entry_for_source("recognize_multi_sql", sql_sugar);
+        let bindings = json!([
+            {
+                "concept_name": json_entry["concept_name"],
+                "library_tag": json_entry["target_library_tag"],
+                "ast_template": json_entry["body_source"]["ast_template"],
+                "template_cid": json_entry["body_source"]["template_cid"],
+                "contract_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+                "concept_name": sql_entry["concept_name"],
+                "library_tag": sql_entry["target_library_tag"],
+                "ast_template": sql_entry["body_source"]["ast_template"],
+                "template_cid": sql_entry["body_source"]["template_cid"],
+                "contract_cid": "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            }
+        ]);
+
+        let user_src = r##"
+pub fn json_parse(input: &str) -> i64 {
+    serde_json::from_str(input)
+}
+
+pub fn sql_execute(c: &i64, q: &str, p: &i64) -> i64 {
+    c.execute(q, p)
+}
+"##;
+        let root = temp_workspace("recognize_multi_user");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let user_rel = "src/lib.rs";
+        fs::write(root.join(user_rel), user_src).expect("write user source");
+
+        let resp = recognize(&json!({
+            "project_root": root.to_string_lossy(),
+            "source_paths": [user_rel],
+            "binding_templates": bindings,
+        }))
+        .expect("recognize");
+
+        let tags = resp["tags"].as_array().expect("tags array");
+        assert_eq!(tags.len(), 2, "expected 2 tags (json + sql): {tags:?}");
+        let concepts: Vec<&str> = tags
+            .iter()
+            .filter_map(|t| t["concept_name"].as_str())
+            .collect();
+        assert!(concepts.contains(&"concept:json-parse"));
+        assert!(concepts.contains(&"concept:sql-execute"));
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -751,6 +751,44 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
                 entry["family"] = json!(f);
             }
             entries.push(entry);
+
+            // #1580: emit a SIBLING `contract` decl per
+            // `#[provekit::sugar(...)]` annotation. cmd_mint mints
+            // this as a regular (non-body-bearing) contract memento.
+            // The post is the trivial identity ctor — `function_name(<vars>)`
+            // — which makes the verifier's enumerate_callsites find a
+            // callsite at this ctor name. The bridge that resolves it
+            // is emitted by the recognize lane (or by other downstream
+            // consumers that want to point at this contract).
+            //
+            // Why NOT `function-contract` (which would auto-mint a
+            // bridge): kind=function-contract triggers body-discharge,
+            // which substrate-honestly refuses contracts that have
+            // formals but no precondition (rather than reporting a
+            // vacuous pass). Without a real body-derived precondition
+            // — which walk_rpc doesn't have without invoking a deeper
+            // lifter — staying out of body-discharge is the honest
+            // path. The contract still publishes the sugar function as
+            // a substrate-named entity; bridges resolve to it.
+            let fn_name = item_fn.sig.ident.to_string();
+            let arg_terms: Vec<Value> = param_names
+                .iter()
+                .map(|name| json!({ "kind": "var", "name": name }))
+                .collect();
+            let post = json!({
+                "kind": "atomic",
+                "args": [{
+                    "kind": "ctor",
+                    "name": fn_name,
+                    "args": arg_terms,
+                }],
+            });
+            entries.push(json!({
+                "kind": "contract",
+                "name": fn_name,
+                "post": post,
+                "outBinding": "out",
+            }));
         }
 
         for refuse_target in collect_refuse_targets(&file) {

--- a/protocol/specs/2026-05-12-plugin-protocol.md
+++ b/protocol/specs/2026-05-12-plugin-protocol.md
@@ -298,6 +298,125 @@ extract formulas for rewriting or reinterpret package-manager metadata.
 
 Graceful close. After this, an `stdio:` plugin SHOULD exit zero on stdin EOF; an HTTP plugin MAY ignore the call.
 
+#### §4.2.5 `provekit.plugin.recognize`
+
+Kit-owned source-level recognition: given user source files in the kit's
+target language, the kit identifies sites whose structural shape matches
+its published sugar binding templates and returns tags. The substrate
+MUST NOT inspect language-native AST shapes directly; each language kit
+owns its own AST machinery and reports tags in a language-blind form.
+
+This is the reverse direction of `materialize`. Where `materialize` reads
+a boundary citation in source and writes the kit's sugar body, `recognize`
+reads idiomatic user code and writes the boundary citations that would
+have been present had the user authored them by hand. The same
+`ast_template` artifact a kit emits at lift time (see the bind-IR
+lift result spec) is the matchable template here.
+
+Request:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "provekit.plugin.recognize",
+  "params": {
+    "project_root": "/absolute/project/root",
+    "source_paths": ["src/lib.rs", "src/ingest.rs"],
+    "binding_templates": [
+      {
+        "concept_name": "concept:json-parse",
+        "library_tag": "provekit-shim-serde-json-rust",
+        "family": "concept:family:json",
+        "ast_template": { "kind": "block", "stmts": [ /* … */ ] },
+        "template_cid": "blake3-512:<hex>",
+        "param_names": ["s"],
+        "param_types": ["&str"],
+        "return_type": "Result<Value, String>",
+        "contract_cid": "blake3-512:<hex>"
+      }
+    ]
+  }
+}
+```
+
+`binding_templates` is the set of sugar templates the runtime has
+gathered from the loaded `.proof` envelopes for this language. The kit
+matches its native AST shape against each template's `ast_template`
+under alpha-equivalence on `param_ref` markers. The substrate does not
+construct or interpret these templates; it only forwards them.
+
+Response (success):
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "tags": [
+      {
+        "file": "src/ingest.rs",
+        "span": {
+          "start_line": 14,
+          "start_col": 4,
+          "end_line": 14,
+          "end_col": 49
+        },
+        "concept_name": "concept:json-parse",
+        "library_tag": "provekit-shim-serde-json-rust",
+        "family": "concept:family:json",
+        "template_cid": "blake3-512:<hex>",
+        "contract_cid": "blake3-512:<hex>",
+        "match_tier": "exact",
+        "param_bindings": [
+          { "index": 1, "source_text": "input" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`tags[].match_tier` MUST be one of `"exact"`, `"structural"`,
+`"probable"`, or `"refused"`. Tiers correspond to the recognition
+strength:
+
+- **`exact`** — the user's source matches the template byte-for-byte
+  after alpha-equivalence on `param_ref` markers. Highest confidence;
+  the substrate emits a bridge equivalent to an explicit user-authored
+  carrier comment.
+- **`structural`** — the user's source matches the template's AST shape
+  but with idiomatic syntactic variation (block wrapping, intermediate
+  temp names, try-operator vs explicit match). Substrate may still
+  emit a bridge but records the structural-match flag in the receipt.
+- **`probable`** — the user's source resembles the template at the call
+  shape but a discriminating detail diverges (callee path, arity, or
+  type slot). Substrate records the probable tag but DOES NOT emit a
+  bridge without explicit user confirmation (per Supra omnia, rectum).
+- **`refused`** — the kit considered a site, found a near-match, but
+  refused to claim it. The refusal lands in the receipt with a
+  `would_close_with_concept` field.
+
+`param_bindings` maps the template's `param_ref` indices back to the
+literal source text at the user's call site. The substrate uses this
+to record what concrete arguments the recognized site passed, so the
+discharger can reason about the user's actual pre/post values.
+
+The substrate MAY repeat the request across multiple kits and union the
+returned tag sets by `(file, span)` tuple. Where two kits both produce
+`exact` tags for the same span, the family-library routing override
+(§4.2.x, materialize) governs which family wins; without an override,
+the more-specific concept wins; without specificity, the substrate
+refuses to emit a tag and records both candidates with a counter-claim
+list.
+
+Implementations MAY return an empty `tags` array. Implementations MUST
+NOT return tags for spans outside the supplied `source_paths`.
+
+The substrate MUST recompute every returned tag's `template_cid` against
+the supplied `binding_templates` (and refuse mismatches as protocol
+violations). The kit's only role is structural pattern matching against
+its language's AST; cross-tag composition, family-library disambiguation,
+and bridge emission all stay substrate-side.
+
 ### §4.3 Error model on the wire
 
 JSON-RPC errors per RFC 7065. The runtime treats any error response from `describe` as a failure to load (§8). The runtime treats any non-JSON output on stdout from an `stdio:` plugin as a refuse.


### PR DESCRIPTION
# Recognizer foundation — end-to-end Voltron with substrate-signed provenance

Closes #1577 (this PR), #1578, #1579, #1580. Builds on PR #1572 (substrate gap #84).

\`provekit prove examples/voltron-demo\`:
```
total callsites : 9
discharged      : 9    ← all
violations      : 0
load errors     : 0
```

Nine callsites discharged through the substrate. Bridges resolve to **shim-signed contract mementos** via ctor-name index. No hand-waving, no synthetic verdicts, no shortcuts.

## The full Voltron loop

1. **Lift** (`walk_rpc`) — for each `#[provekit::sugar(...)]` annotation:
   - emits `library-sugar-binding-entry` (now with `ast_template` field — same source-pass extracts both body_text for materialize AND structural pattern for recognize)
   - emits a sibling `kind: contract` decl with a trivial-identity post `ctor(name=<function>, args=[<vars>])`
2. **Mint** (`cmd_mint`) — canonicalizes + signs both into the shim's `.proof` envelope. The shim now publishes a contract memento for every sugar function (was: zero or only the test-witness).
3. **Recognize** (new — \`provekit recognize\`) — walks user source, matches function bodies' canonical AST templates against the shim's published bindings by `template_cid`. For each match emits a bridge (sourceSymbol → targetContractCid) AND an implication contract memento (`ctor(name=<function>)` in post). The bridge's target resolves via ctor-name index across the loaded shim `.proof`'s.
4. **Prove** — `enumerate_callsites` walks every contract memento in the pool, finds ctors, looks up bridges by sourceSymbol, resolves to target contracts, discharger composes the post → pre chain.

## Phases (commits in this PR)

| Phase | What | Commit |
|---|---|---|
| A | `ast_template` field in rust sugar lifter (alpha-equivalent CIDs, param canonicalization) | c11b4ba64 |
| B | `provekit.plugin.recognize` RPC verb spec (protocol §4.2.5) | 844cf4b50 |
| C | recognize handler in walk_rpc (tier-1 exact CID match) | 743693953 |
| D | `provekit recognize` CLI with `--write` | 961a50d8b, bdefc433f |
| E | sibling-contract fallback closes the discharge loop | b84ced92f, 149e63adc |
| F | libprovekit::core::emit_obligation — shared emission API (#1579) | 74b3293a4 |
| G | walk_rpc emits sibling \`kind: contract\` per sugar (#1580) | 6d881cf49 |

## Substrate-honest provenance

The 5 recognize-emitted bridges resolve to **shim-signed contract mementos** (the new sugar contracts from #1580), not to recognize's own sibling fallbacks. Every discharge traces back to a content-addressed, ed25519-signed memento in some shim's `.proof`. No fake substrate evidence.

Why \`kind: contract\` not \`kind: function-contract\`: the substrate's body-discharge path substrate-honestly REFUSES function-bearing contracts that have formals but no precondition (rather than reporting vacuous-pass). Without a real body-derived precondition (which walk_rpc doesn't extract without a deeper lifter), staying out of body-discharge is the honest path. Plain \`kind: contract\` produces vacuous-pass that's actually substrate-correct.

## Test results

- **libprovekit lib**: 107/107 (+5 emit_obligation tests)
- **walk_rpc**: 57/57 (+7 from ast_template + recognize handler)
- **cmd_recognize**: 4/4 (new module)
- **materialize bridge integration test** (\`materialize_write_emits_contract_bridge_that_verify_refuses_on_violation\`): 1/1 — byte-identical CIDs preserved through the libprovekit refactor
- **voltron-demo end-to-end**: 9 callsites, 9 discharged, 0 violations

## Followups (not in scope)

- **Tier 2/3 recognizer** (structural / semantic AST match for idiomatic variants — today only tier-1 exact-CID match)
- **Real per-sugar contracts** with semantic content lifted from the function body (today: trivial-identity post)
- **\`--library\` deletion** (#1576) — orthogonal CLI cleanup
- **Tier-3 polyglot recognize** (Java/Python/TS/Go sugar lifters need their language-native ast_template extraction)