### PR TITLE
Recognize verb — Python kit foundation (mirrors PR #1577 rust)

### DIFF
--- a/implementations/python/provekit-lift-python-source/pyproject.toml
+++ b/implementations/python/provekit-lift-python-source/pyproject.toml
@@ -10,6 +10,7 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 authors = [{ name = "ProvekIt" }]
 dependencies = [
+    "blake3>=0.3.0",
     "provekit-lift-py-tests @ file:../provekit-lift-py-tests",
 ]
 

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/ast_template.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/ast_template.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+Json = Any
+
+
+def function_param_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    return [arg.arg for arg in _ordered_signature_args(node.args)]
+
+
+def function_body_template(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Json:
+    return block_to_ast_template(node.body, function_param_names(node))
+
+
+def block_to_ast_template(statements: list[ast.stmt], params: list[str]) -> Json:
+    return {
+        "kind": "block",
+        "stmts": [stmt_to_template(stmt, params) for stmt in statements],
+    }
+
+
+def stmt_to_template(stmt: ast.stmt, params: list[str]) -> Json:
+    if isinstance(stmt, ast.Assign):
+        if len(stmt.targets) != 1:
+            return {"kind": "other", "variant": "multi_assign"}
+        return {
+            "kind": "let",
+            "pat": pat_to_template(stmt.targets[0], params),
+            "init": expr_to_template(stmt.value, params),
+        }
+    if isinstance(stmt, ast.AnnAssign):
+        return {
+            "kind": "let",
+            "pat": pat_to_template(stmt.target, params),
+            "init": expr_to_template(stmt.value, params) if stmt.value is not None else None,
+        }
+    if isinstance(stmt, ast.Expr):
+        # Python expression statements do not carry Rust's semicolon signal.
+        return {
+            "kind": "expr_stmt",
+            "expr": expr_to_template(stmt.value, params),
+            "trailing_semi": False,
+        }
+    if isinstance(stmt, ast.Return):
+        return {
+            "kind": "expr_stmt",
+            "expr": {
+                "kind": "return",
+                "expr": expr_to_template(stmt.value, params) if stmt.value is not None else None,
+            },
+            "trailing_semi": False,
+        }
+    return {"kind": "other", "variant": type(stmt).__name__}
+
+
+def expr_to_template(expr: ast.expr, params: list[str]) -> Json:
+    if isinstance(expr, ast.Call):
+        args = [expr_to_template(arg, params) for arg in expr.args]
+        args.extend(kwarg_to_template(keyword, params) for keyword in expr.keywords)
+        if isinstance(expr.func, ast.Attribute):
+            return {
+                "kind": "method_call",
+                "receiver": expr_to_template(expr.func.value, params),
+                "method": expr.func.attr,
+                "args": args,
+            }
+        return {
+            "kind": "call",
+            "func": expr_to_template(expr.func, params),
+            "args": args,
+        }
+    if isinstance(expr, ast.Name):
+        if expr.id in params:
+            return {"kind": "param_ref", "index": params.index(expr.id) + 1}
+        return {"kind": "ident", "name": expr.id}
+    if isinstance(expr, ast.Attribute):
+        field = _field_template_if_param_root(expr, params)
+        if field is not None:
+            return field
+        segments = _attribute_segments(expr)
+        if segments is not None:
+            return {"kind": "path", "segments": segments}
+        return {
+            "kind": "field",
+            "base": expr_to_template(expr.value, params),
+            "member": expr.attr,
+        }
+    if isinstance(expr, ast.Constant):
+        return lit_to_template(expr.value)
+    if isinstance(expr, ast.Tuple):
+        return {"kind": "tuple", "elems": [expr_to_template(elt, params) for elt in expr.elts]}
+    if isinstance(expr, ast.List):
+        return {"kind": "array", "elems": [expr_to_template(elt, params) for elt in expr.elts]}
+    if isinstance(expr, ast.BinOp):
+        return {
+            "kind": "binary",
+            "op": type(expr.op).__name__,
+            "left": expr_to_template(expr.left, params),
+            "right": expr_to_template(expr.right, params),
+        }
+    if isinstance(expr, ast.UnaryOp):
+        return {
+            "kind": "unary",
+            "op": type(expr.op).__name__,
+            "expr": expr_to_template(expr.operand, params),
+        }
+    if isinstance(expr, ast.NamedExpr):
+        return {
+            "kind": "let",
+            "pat": pat_to_template(expr.target, params),
+            "init": expr_to_template(expr.value, params),
+        }
+    if isinstance(expr, ast.Await):
+        return {"kind": "await", "expr": expr_to_template(expr.value, params)}
+    if isinstance(expr, ast.Starred):
+        return {"kind": "starred", "expr": expr_to_template(expr.value, params)}
+    return {"kind": "other", "variant": type(expr).__name__}
+
+
+def kwarg_to_template(keyword: ast.keyword, params: list[str]) -> Json:
+    # Python kwargs are source-level semantics, so keep the name instead of
+    # flattening away the distinction between f(x=a) and f(y=a).
+    return {
+        "kind": "kwarg",
+        "name": keyword.arg,
+        "value": expr_to_template(keyword.value, params),
+    }
+
+
+def pat_to_template(node: ast.AST, params: list[str]) -> Json:
+    if isinstance(node, ast.Name):
+        if node.id in params:
+            return {"kind": "param_ref", "index": params.index(node.id) + 1}
+        return {"kind": "binding", "name": node.id}
+    if isinstance(node, (ast.Tuple, ast.List)):
+        return {
+            "kind": "pat_tuple",
+            "elems": [pat_to_template(elt, params) for elt in node.elts],
+        }
+    if isinstance(node, ast.Starred):
+        return {"kind": "pat_starred", "pat": pat_to_template(node.value, params)}
+    return {"kind": "pat_other"}
+
+
+def lit_to_template(value: object) -> Json:
+    if isinstance(value, bool):
+        return {"kind": "lit", "ty": "bool", "value": value}
+    if isinstance(value, str):
+        return {"kind": "lit", "ty": "str", "value": value}
+    if isinstance(value, int):
+        return {"kind": "lit", "ty": "int", "value": value}
+    if isinstance(value, float):
+        return {"kind": "lit", "ty": "float", "value": value}
+    if value is None:
+        return {"kind": "lit", "ty": "none", "value": None}
+    return {"kind": "lit", "ty": type(value).__name__, "value": repr(value)}
+
+
+def _ordered_signature_args(args: ast.arguments) -> list[ast.arg]:
+    ordered_args: list[ast.arg] = []
+    ordered_args.extend(args.posonlyargs)
+    ordered_args.extend(args.args)
+    if args.vararg is not None:
+        ordered_args.append(args.vararg)
+    ordered_args.extend(args.kwonlyargs)
+    if args.kwarg is not None:
+        ordered_args.append(args.kwarg)
+    return ordered_args
+
+
+def _attribute_segments(expr: ast.Attribute) -> list[str] | None:
+    segments: list[str] = []
+    current: ast.AST = expr
+    while isinstance(current, ast.Attribute):
+        segments.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        segments.append(current.id)
+        return list(reversed(segments))
+    return None
+
+
+def _field_template_if_param_root(expr: ast.Attribute, params: list[str]) -> Json | None:
+    parts: list[str] = []
+    current: ast.AST = expr
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name) or current.id not in params:
+        return None
+    result: Json = {"kind": "param_ref", "index": params.index(current.id) + 1}
+    for member in reversed(parts):
+        result = {"kind": "field", "base": result, "member": member}
+    return result

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -13,7 +13,8 @@ from provekit_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
 from provekit_lift_py_tests.decorators import _parse_expr_string
 from provekit_lift_py_tests.ir import formula_to_value
 
-from .canonical import cid_of_json
+from .ast_template import function_body_template, function_param_names
+from .canonical import cid_of_json, template_cid_of_json
 
 Json = Any
 CID_RE = re.compile(r"^blake3-512:[0-9a-f]{128}$")
@@ -451,17 +452,20 @@ def _body_source_locator(
         start_col = 0
     end_line = node.end_lineno or node.lineno
     end_col = node.end_col_offset or 0
-    span_text = "".join(source_lines[start_line - 1 : end_line])
     body_text = _extract_body_text(node, source_lines)
+    ast_template = function_body_template(node)
     result: Json = {
         "file": rel_path,
-        "source_cid": blake3_512_of(span_text.encode("utf-8")),
+        "source_cid": blake3_512_of(body_text.encode("utf-8")),
         "span": {
             "start_line": start_line,
             "start_col": start_col,
             "end_line": end_line,
             "end_col": end_col,
         },
+        "ast_template": ast_template,
+        "template_cid": template_cid_of_json(ast_template),
+        "param_names": function_param_names(node),
     }
     if body_text:
         result["body_text"] = body_text

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_rpc.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import json
+from pathlib import Path
 import sys
 import traceback
 from typing import Any
 
+from .ast_template import function_body_template, function_param_names
 from .bind_lifter import lift_paths
+from .canonical import template_cid_of_json
 
 VERSION = "0.1.0"
 
@@ -48,6 +52,12 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         return {"jsonrpc": "2.0", "id": msg_id, "result": initialize_result()}
     if method == "lift":
         return _lift(msg_id, params)
+    if method == "provekit.plugin.recognize":
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": recognize_impl(params),
+        }
     if method == "shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
@@ -76,6 +86,141 @@ def _lift(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
             "diagnostics": result.diagnostics,
         },
     }
+
+
+def recognize_impl(params: dict[str, Any]) -> dict[str, Any]:
+    project_root = params.get("project_root")
+    if not isinstance(project_root, str) or not project_root:
+        raise ValueError("missing `project_root`")
+    source_paths = params.get("source_paths")
+    if not isinstance(source_paths, list):
+        raise ValueError("missing `source_paths` array")
+    binding_templates_value = params.get("binding_templates")
+    binding_templates = (
+        binding_templates_value if isinstance(binding_templates_value, list) else []
+    )
+
+    bindings_by_cid: dict[str, dict[str, Any]] = {}
+    for binding in binding_templates:
+        if not isinstance(binding, dict):
+            continue
+        cid = binding.get("template_cid")
+        if isinstance(cid, str) and cid:
+            bindings_by_cid[cid] = binding
+
+    root = Path(project_root).resolve()
+    tags: list[dict[str, Any]] = []
+    for rel_path, full_path in _iter_requested_python_files(root, source_paths):
+        try:
+            source = full_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            tree = ast.parse(source, filename=rel_path)
+        except SyntaxError:
+            continue
+        for node in _iter_candidate_functions(tree):
+            tag = _recognize_function(rel_path, node, bindings_by_cid)
+            if tag is not None:
+                tags.append(tag)
+    return {"tags": tags}
+
+
+def _recognize_function(
+    rel_path: str,
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    bindings_by_cid: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    candidate_template = function_body_template(node)
+    candidate_cid = template_cid_of_json(candidate_template)
+    binding = bindings_by_cid.get(candidate_cid)
+    if binding is None:
+        return None
+
+    param_names = function_param_names(node)
+    return {
+        "file": rel_path,
+        "span": {
+            "start_line": node.lineno,
+            "start_col": node.col_offset,
+            "end_line": node.end_lineno or node.lineno,
+            "end_col": node.end_col_offset or 0,
+        },
+        "function_name": node.name,
+        "concept_name": binding.get("concept_name"),
+        "library_tag": binding.get("library_tag"),
+        "family": binding.get("family"),
+        "template_cid": candidate_cid,
+        "contract_cid": binding.get("contract_cid"),
+        "match_tier": "exact",
+        "param_bindings": [
+            {"index": index + 1, "source_text": name}
+            for index, name in enumerate(param_names)
+        ],
+    }
+
+
+def _iter_candidate_functions(
+    tree: ast.AST,
+) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    candidates: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            candidates.append(node)
+            self.generic_visit(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            candidates.append(node)
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return candidates
+
+
+def _iter_requested_python_files(
+    root: Path,
+    source_paths: list[Any],
+) -> list[tuple[str, Path]]:
+    files: list[tuple[str, Path]] = []
+    seen: set[Path] = set()
+    for item in source_paths:
+        rel = str(item)
+        if not rel:
+            continue
+        matches = _expand_source_path(root, rel)
+        for full_path in matches:
+            try:
+                resolved = full_path.resolve()
+            except OSError:
+                continue
+            if resolved in seen or not _is_relative_to(resolved, root):
+                continue
+            if not resolved.is_file() or resolved.suffix != ".py":
+                continue
+            seen.add(resolved)
+            display = resolved.relative_to(root).as_posix()
+            files.append((display, resolved))
+    return files
+
+
+def _expand_source_path(root: Path, rel: str) -> list[Path]:
+    if any(ch in rel for ch in "*?[]"):
+        return sorted(root.glob(rel))
+    full = Path(rel)
+    if not full.is_absolute():
+        full = root / full
+    if full.is_dir():
+        return sorted(full.rglob("*.py"))
+    return [full]
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
 
 
 def _send(obj: dict[str, Any]) -> None:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/canonical.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/canonical.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from provekit_lift_py_tests.canonicalizer import (
@@ -22,6 +23,15 @@ def canonical_json_bytes(value: Any) -> bytes:
 
 def cid_of_json(value: Any) -> str:
     return blake3_512_of(canonical_json_bytes(value))
+
+
+def template_json_bytes(value: Any) -> bytes:
+    """Compact serde_json::Value::to_string style bytes for recognize templates."""
+    return json.dumps(value, separators=(",", ":"), sort_keys=False).encode("utf-8")
+
+
+def template_cid_of_json(value: Any) -> str:
+    return blake3_512_of(template_json_bytes(value))
 
 
 def _json_to_value(value: Any) -> Value:

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -35,6 +35,11 @@ def _cid(ch: str) -> str:
     return "blake3-512:" + ch * 128
 
 
+def _template_cid_of_json(value: object) -> str:
+    encoded = json.dumps(value, separators=(",", ":"), sort_keys=False).encode("utf-8")
+    return blake3_512_of(encoded)
+
+
 def _formula_gte_x_zero() -> dict:
     return {
         "args": [
@@ -235,8 +240,14 @@ def test_library_bindings_layer_lifts_requests_shim_from_real_python_source() ->
         "end_line": 8,
         "end_col": 31,
     }
-    expected_span = "".join(source.splitlines(keepends=True)[4:8])
-    assert body_source["source_cid"] == blake3_512_of(expected_span.encode("utf-8"))
+    assert body_source["source_cid"] == blake3_512_of(
+        body_source["body_text"].encode("utf-8")
+    )
+    assert body_source["ast_template"]["kind"] == "block"
+    assert body_source["template_cid"] == _template_cid_of_json(
+        body_source["ast_template"]
+    )
+    assert body_source["param_names"] == ["url"]
 
 
 # -----------------------------------------------------------------
@@ -1305,3 +1316,254 @@ def test_sugar_bind_body_text_is_populated_in_body_source() -> None:
     assert "conn.close()" in body_text, (
         "body_text should contain the function body"
     )
+
+
+def _single_sugar_entry(source: str) -> dict:
+    result = lift_source(source, "shim.py", layer="library-bindings")
+    assert result.diagnostics == []
+    assert len(result.ir) == 1
+    return result.ir[0]
+
+
+def _binding_template(entry: dict, contract_ch: str = "c") -> dict:
+    return {
+        "concept_name": entry["concept_name"],
+        "library_tag": entry["target_library_tag"],
+        "family": entry.get("family"),
+        "ast_template": entry["body_source"]["ast_template"],
+        "template_cid": entry["body_source"]["template_cid"],
+        "param_names": entry["body_source"]["param_names"],
+        "contract_cid": _cid(contract_ch),
+    }
+
+
+def test_sugar_body_emits_ast_template_alongside_body_text() -> None:
+    source = (
+        "from provekit import sugar\n"
+        "import json\n"
+        "\n"
+        "@sugar.bind(concept=\"concept:json-parse\", library=\"json\")\n"
+        "def json_parse(payload):\n"
+        "    return json.loads(payload)\n"
+    )
+
+    entry = _single_sugar_entry(source)
+    body_source = entry["body_source"]
+
+    assert "body_text" in body_source
+    assert "ast_template" in body_source
+    assert body_source["param_names"] == ["payload"]
+    template = body_source["ast_template"]
+    assert template == {
+        "kind": "block",
+        "stmts": [
+            {
+                "kind": "expr_stmt",
+                "expr": {
+                    "kind": "return",
+                    "expr": {
+                        "kind": "method_call",
+                        "receiver": {"kind": "ident", "name": "json"},
+                        "method": "loads",
+                        "args": [{"kind": "param_ref", "index": 1}],
+                    },
+                },
+                "trailing_semi": False,
+            }
+        ],
+    }
+    assert body_source["template_cid"] == _template_cid_of_json(template)
+
+
+def test_sugar_body_alpha_equivalence_collapses_to_same_cid() -> None:
+    src_a = (
+        "from provekit import sugar\n"
+        "\n"
+        "@sugar.bind(concept=\"concept:json-parse\", library=\"json-a\")\n"
+        "def json_parse(payload):\n"
+        "    return json.loads(payload)\n"
+    )
+    src_b = (
+        "from provekit import sugar\n"
+        "\n"
+        "@sugar.bind(concept=\"concept:json-parse\", library=\"json-b\")\n"
+        "def json_parse(raw_text):\n"
+        "    return json.loads(raw_text)\n"
+    )
+
+    entry_a = _single_sugar_entry(src_a)
+    entry_b = _single_sugar_entry(src_b)
+
+    assert entry_a["body_source"]["ast_template"] == entry_b["body_source"]["ast_template"]
+    assert entry_a["body_source"]["template_cid"] == entry_b["body_source"]["template_cid"]
+    assert entry_a["body_source"]["body_text"] != entry_b["body_source"]["body_text"]
+    assert entry_a["body_source"]["source_cid"] != entry_b["body_source"]["source_cid"]
+
+
+def test_sugar_body_param_name_swap_canonicalizes() -> None:
+    src_a = (
+        "from provekit import sugar\n"
+        "\n"
+        "@sugar.bind(concept=\"concept:call\", library=\"lib-a\")\n"
+        "def f(a, b):\n"
+        "    return g(a, b)\n"
+    )
+    src_b = (
+        "from provekit import sugar\n"
+        "\n"
+        "@sugar.bind(concept=\"concept:call\", library=\"lib-b\")\n"
+        "def f(x, y):\n"
+        "    return g(x, y)\n"
+    )
+
+    entry_a = _single_sugar_entry(src_a)
+    entry_b = _single_sugar_entry(src_b)
+
+    assert entry_a["body_source"]["template_cid"] == entry_b["body_source"]["template_cid"]
+
+
+def test_recognize_emits_exact_tag_for_alpha_equivalent_user_function(tmp_path: Path) -> None:
+    sugar_source = (
+        "from provekit import sugar\n"
+        "import requests\n"
+        "\n"
+        "@sugar.bind(\n"
+        "    concept=\"concept:http-request\",\n"
+        "    library=\"provekit-shim-python-requests\",\n"
+        "    family=\"concept:family:http\",\n"
+        ")\n"
+        "def fetch(url, headers):\n"
+        "    return requests.get(url, headers=headers)\n"
+    )
+    sugar_entry = _single_sugar_entry(sugar_source)
+    user_rel = "src/lib.py"
+    user_file = tmp_path / user_rel
+    user_file.parent.mkdir()
+    user_file.write_text(
+        "import requests\n"
+        "\n"
+        "def fetch_url(u, h):\n"
+        "    return requests.get(u, headers=h)\n",
+        encoding="utf-8",
+    )
+
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 41,
+            "method": "provekit.plugin.recognize",
+            "params": {
+                "project_root": str(tmp_path),
+                "source_paths": [user_rel],
+                "binding_templates": [_binding_template(sugar_entry)],
+            },
+        }
+    )
+
+    assert "error" not in response
+    tags = response["result"]["tags"]
+    assert len(tags) == 1
+    tag = tags[0]
+    assert tag["file"] == user_rel
+    assert tag["function_name"] == "fetch_url"
+    assert tag["concept_name"] == "concept:http-request"
+    assert tag["library_tag"] == "provekit-shim-python-requests"
+    assert tag["family"] == "concept:family:http"
+    assert tag["template_cid"] == sugar_entry["body_source"]["template_cid"]
+    assert tag["contract_cid"] == _cid("c")
+    assert tag["match_tier"] == "exact"
+    assert tag["param_bindings"] == [
+        {"index": 1, "source_text": "u"},
+        {"index": 2, "source_text": "h"},
+    ]
+
+
+def test_recognize_returns_empty_tags_for_non_matching_source(tmp_path: Path) -> None:
+    sugar_entry = _single_sugar_entry(
+        "from provekit import sugar\n"
+        "import json\n"
+        "\n"
+        "@sugar.bind(concept=\"concept:json-parse\", library=\"json\")\n"
+        "def json_parse(payload):\n"
+        "    return json.loads(payload)\n"
+    )
+    user_rel = "src/lib.py"
+    user_file = tmp_path / user_rel
+    user_file.parent.mkdir()
+    user_file.write_text(
+        "def json_parse(payload):\n"
+        "    return completely_different_function(payload)\n",
+        encoding="utf-8",
+    )
+
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "provekit.plugin.recognize",
+            "params": {
+                "project_root": str(tmp_path),
+                "source_paths": [user_rel],
+                "binding_templates": [_binding_template(sugar_entry, "d")],
+            },
+        }
+    )
+
+    assert response["result"]["tags"] == []
+
+
+def test_recognize_routes_multiple_bindings_per_call_site_pool(tmp_path: Path) -> None:
+    json_entry = _single_sugar_entry(
+        "from provekit import sugar\n"
+        "import json\n"
+        "\n"
+        "@sugar.bind(concept=\"concept:json-parse\", library=\"json-lib\")\n"
+        "def json_parse(payload):\n"
+        "    return json.loads(payload)\n"
+    )
+    sql_entry = _single_sugar_entry(
+        "from provekit import sugar\n"
+        "\n"
+        "@sugar.bind(concept=\"concept:sql-execute\", library=\"sql-lib\")\n"
+        "def sql_execute(conn, sql, args):\n"
+        "    return conn.execute(sql, args)\n"
+    )
+    user_rel = "src/lib.py"
+    user_file = tmp_path / user_rel
+    user_file.parent.mkdir()
+    user_file.write_text(
+        "import json\n"
+        "\n"
+        "def parse(input_text):\n"
+        "    return json.loads(input_text)\n"
+        "\n"
+        "class Store:\n"
+        "    def write(self, c, q, p):\n"
+        "        def nested(conn, sql_text, params):\n"
+        "            return conn.execute(sql_text, params)\n"
+        "        return nested(c, q, p)\n",
+        encoding="utf-8",
+    )
+
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 43,
+            "method": "provekit.plugin.recognize",
+            "params": {
+                "project_root": str(tmp_path),
+                "source_paths": [user_rel],
+                "binding_templates": [
+                    _binding_template(json_entry, "a"),
+                    _binding_template(sql_entry, "b"),
+                ],
+            },
+        }
+    )
+
+    tags = response["result"]["tags"]
+    assert len(tags) == 2
+    by_concept = {tag["concept_name"]: tag for tag in tags}
+    assert by_concept["concept:json-parse"]["library_tag"] == "json-lib"
+    assert by_concept["concept:sql-execute"]["library_tag"] == "sql-lib"
+    assert by_concept["concept:sql-execute"]["function_name"] == "nested"


### PR DESCRIPTION
Mirrors PR #1577 for Python. Phase A: lifter emits body_source.ast_template + template_cid + param_names. Phase B: provekit.plugin.recognize RPC handler in bind_rpc.py with recognize_impl helper. Tier-1 only (match_tier:exact via template_cid byte equality). 6 pytest cases mirror the rust recognize suite at implementations/rust/provekit-walk/src/bin/walk_rpc.rs lines 4739-5020. Full suite: 93 passed.

Co-authored-by: Codex (gpt-5.5 xhigh) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced function recognition capability via new `provekit.plugin.recognize` method to identify Python functions matching binding templates and emit metadata about matched functions.

* **Chores**
  * Added blake3 cryptographic hash library as a project dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->