### PR TITLE
Recognize verb — Java kit foundation (mirrors PR #1577 rust)

### DIFF
--- a/implementations/java/provekit-ir/src/main/java/com/provekit/ir/Jcs.java
+++ b/implementations/java/provekit-ir/src/main/java/com/provekit/ir/Jcs.java
@@ -114,12 +114,13 @@ public final class Jcs {
         }
     }
 
-    public sealed interface Json permits Null, Bool, Num, Str, Arr, Obj {}
+    public sealed interface Json permits Null, Bool, Num, Str, Arr, Obj, Raw {}
 
     public record Null() implements Json {}
     public record Bool(boolean value) implements Json {}
     public record Num(long value) implements Json {}
     public record Str(String value) implements Json {}
+    public record Raw(String json, Json parsed) implements Json {}
 
     public record Arr(List<Json> values) implements Json {
         public Arr {
@@ -175,13 +176,13 @@ public final class Jcs {
         }
 
         public Obj objectField(String key) {
-            Json value = get(key);
+            Json value = unwrapRaw(get(key));
             if (value instanceof Obj o) return o;
             throw new IllegalArgumentException("field is not an object: " + key);
         }
 
         public Arr arrayField(String key) {
-            Json value = get(key);
+            Json value = unwrapRaw(get(key));
             if (value instanceof Arr a) return a;
             throw new IllegalArgumentException("field is not an array: " + key);
         }
@@ -201,6 +202,10 @@ public final class Jcs {
 
     public static Str string(String value) {
         return new Str(value);
+    }
+
+    public static Raw raw(String json, Json parsed) {
+        return new Raw(json, parsed);
     }
 
     public static Arr array(Json... values) {
@@ -244,7 +249,9 @@ public final class Jcs {
 
     /** Encode {@code value} to a JCS-canonical UTF-8 string. */
     public static String encode(Json value) {
-        return encode(toValue(value));
+        StringBuilder sb = new StringBuilder();
+        encodeJson(value, sb);
+        return sb.toString();
     }
 
     /** Encode {@code value} to JCS-canonical UTF-8 bytes. */
@@ -328,8 +335,57 @@ public final class Jcs {
                 entries.put(field.key(), toValue(field.value()));
             }
             return Value.object(entries);
+        } else if (value instanceof Raw r && r.parsed() != null) {
+            return toValue(r.parsed());
         }
         throw new IllegalArgumentException("unknown JSON value");
+    }
+
+    private static Json unwrapRaw(Json value) {
+        if (value instanceof Raw r && r.parsed() != null) return r.parsed();
+        return value;
+    }
+
+    private static void encodeJson(Json value, StringBuilder out) {
+        if (value instanceof Raw r) {
+            out.append(r.json());
+        } else if (value instanceof Null) {
+            out.append("null");
+        } else if (value instanceof Bool b) {
+            out.append(b.value() ? "true" : "false");
+        } else if (value instanceof Num n) {
+            out.append(java.lang.Long.toString(n.value()));
+        } else if (value instanceof Str s) {
+            encodeString(s.value(), out);
+        } else if (value instanceof Arr a) {
+            out.append('[');
+            boolean first = true;
+            for (Json item : a.values()) {
+                if (!first) out.append(',');
+                first = false;
+                encodeJson(item, out);
+            }
+            out.append(']');
+        } else if (value instanceof Obj o) {
+            LinkedHashMap<String, Json> entries = new LinkedHashMap<>();
+            for (Field field : o.fields()) {
+                entries.put(field.key(), field.value());
+            }
+            List<String> keys = new ArrayList<>(entries.keySet());
+            Collections.sort(keys, Jcs::compareCodePoints);
+            out.append('{');
+            boolean first = true;
+            for (String key : keys) {
+                if (!first) out.append(',');
+                first = false;
+                encodeString(key, out);
+                out.append(':');
+                encodeJson(entries.get(key), out);
+            }
+            out.append('}');
+        } else {
+            throw new IllegalArgumentException("unknown JSON value");
+        }
     }
 
     private static int compareCodePoints(String a, String b) {
@@ -418,7 +474,16 @@ public final class Jcs {
             if (input.charAt(pos) == '-') pos++;
             while (!isEof() && Character.isDigit(input.charAt(pos))) pos++;
             if (!isEof() && (input.charAt(pos) == '.' || input.charAt(pos) == 'e' || input.charAt(pos) == 'E')) {
-                throw error("JCS helper only accepts integer JSON numbers");
+                if (!isEof() && input.charAt(pos) == '.') {
+                    pos++;
+                    while (!isEof() && Character.isDigit(input.charAt(pos))) pos++;
+                }
+                if (!isEof() && (input.charAt(pos) == 'e' || input.charAt(pos) == 'E')) {
+                    pos++;
+                    if (!isEof() && (input.charAt(pos) == '+' || input.charAt(pos) == '-')) pos++;
+                    while (!isEof() && Character.isDigit(input.charAt(pos))) pos++;
+                }
+                return raw(input.substring(start, pos), null);
             }
             return integer(Long.parseLong(input.substring(start, pos)));
         }

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/JavaAstTemplates.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/JavaAstTemplates.java
@@ -1,0 +1,393 @@
+package com.provekit.lift;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.*;
+import com.provekit.ir.Blake3;
+import com.provekit.ir.Jcs;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public final class JavaAstTemplates {
+    private JavaAstTemplates() {}
+
+    public record TemplateInfo(
+            Jcs.Json astTemplate,
+            String compactJson,
+            String templateCid,
+            List<String> paramNames) {}
+
+    public static TemplateInfo fromMethodSource(String methodSource) {
+        String wrapped = "class __ProveKitTemplate {\n" + methodSource + "\n}\n";
+        ParseResult<CompilationUnit> result = new JavaParser().parse(wrapped);
+        if (!result.isSuccessful() || result.getResult().isEmpty()) {
+            throw new IllegalArgumentException("cannot parse method source: " + result.getProblems());
+        }
+        return result.getResult().get().findFirst(MethodDeclaration.class)
+            .map(JavaAstTemplates::fromMethod)
+            .orElseThrow(() -> new IllegalArgumentException("method source contains no method"));
+    }
+
+    public static TemplateInfo fromMethod(MethodDeclaration method) {
+        List<String> params = paramNames(method);
+        Jcs.Json parsed = method.getBody()
+            .map(body -> blockToTemplate(body, params))
+            .orElseGet(() -> object("kind", Jcs.string("block"), "stmts", Jcs.array()));
+        String compact = compactJson(parsed);
+        return new TemplateInfo(
+            Jcs.raw(compact, parsed),
+            compact,
+            Blake3.blake3_512(compact.getBytes(StandardCharsets.UTF_8)),
+            params
+        );
+    }
+
+    public static List<String> paramNames(MethodDeclaration method) {
+        return method.getParameters().stream()
+            .map(Parameter::getNameAsString)
+            .toList();
+    }
+
+    public static String compactJson(Jcs.Json json) {
+        if (json instanceof Jcs.Raw raw) {
+            return raw.json();
+        }
+        StringBuilder out = new StringBuilder();
+        writeCompact(json, out);
+        return out.toString();
+    }
+
+    private static Jcs.Json blockToTemplate(BlockStmt block, List<String> params) {
+        List<Jcs.Json> stmts = new ArrayList<>();
+        for (Statement stmt : block.getStatements()) {
+            stmts.addAll(stmtToTemplates(stmt, params));
+        }
+        return object("kind", Jcs.string("block"), "stmts", Jcs.array(stmts));
+    }
+
+    private static List<Jcs.Json> stmtToTemplates(Statement stmt, List<String> params) {
+        if (stmt instanceof ExpressionStmt expressionStmt) {
+            Expression expr = unwrap(expressionStmt.getExpression());
+            if (expr instanceof VariableDeclarationExpr declaration) {
+                List<Jcs.Json> lets = new ArrayList<>();
+                for (VariableDeclarator variable : declaration.getVariables()) {
+                    lets.add(object(
+                        "kind", Jcs.string("let"),
+                        "pat", patToTemplate(variable.getNameAsString(), params),
+                        "init", variable.getInitializer()
+                            .map(init -> exprToTemplate(init, params))
+                            .orElseGet(Jcs::nullValue)
+                    ));
+                }
+                return lets;
+            }
+            return List.of(object(
+                "kind", Jcs.string("expr_stmt"),
+                "expr", exprToTemplate(expr, params),
+                "trailing_semi", Jcs.bool(true)
+            ));
+        }
+        if (stmt instanceof ReturnStmt returnStmt) {
+            return List.of(object(
+                "kind", Jcs.string("return"),
+                "expr", returnStmt.getExpression()
+                    .map(expr -> exprToTemplate(expr, params))
+                    .orElseGet(Jcs::nullValue)
+            ));
+        }
+        if (stmt instanceof BlockStmt block) {
+            return List.of(blockToTemplate(block, params));
+        }
+        return List.of(other(stmt));
+    }
+
+    private static Jcs.Json exprToTemplate(Expression expr, List<String> params) {
+        expr = unwrap(expr);
+        if (expr instanceof MethodCallExpr call) {
+            List<Jcs.Json> args = call.getArguments().stream()
+                .map(arg -> exprToTemplate(arg, params))
+                .toList();
+            Optional<Expression> scope = call.getScope();
+            if (scope.isEmpty()) {
+                return object(
+                    "kind", Jcs.string("call"),
+                    "func", object("kind", Jcs.string("ident"), "name", Jcs.string(call.getNameAsString())),
+                    "args", Jcs.array(args)
+                );
+            }
+            return object(
+                "kind", Jcs.string("method_call"),
+                "receiver", scopeToTemplate(scope.get(), params),
+                "method", Jcs.string(call.getNameAsString()),
+                "args", Jcs.array(args)
+            );
+        }
+        if (expr instanceof NameExpr name) {
+            String value = name.getNameAsString();
+            int index = params.indexOf(value);
+            if (index >= 0) {
+                return object("kind", Jcs.string("param_ref"), "index", Jcs.integer(index + 1L));
+            }
+            return object("kind", Jcs.string("ident"), "name", Jcs.string(value));
+        }
+        if (expr instanceof FieldAccessExpr field) {
+            List<String> segments = fieldAccessSegments(field);
+            if (!segments.isEmpty()) {
+                return path(segments);
+            }
+            return other(expr);
+        }
+        if (expr instanceof LiteralExpr literal) {
+            return litToTemplate(literal);
+        }
+        if (expr instanceof BinaryExpr binary) {
+            return object(
+                "kind", Jcs.string("binary"),
+                "op", Jcs.string(binaryOp(binary.getOperator())),
+                "left", exprToTemplate(binary.getLeft(), params),
+                "right", exprToTemplate(binary.getRight(), params)
+            );
+        }
+        if (expr instanceof ArrayInitializerExpr array) {
+            return arrayTemplate(array.getValues(), params);
+        }
+        if (expr instanceof ArrayCreationExpr array) {
+            if (array.getInitializer().isPresent()) {
+                return arrayTemplate(array.getInitializer().get().getValues(), params);
+            }
+            return other(expr);
+        }
+        if (expr instanceof UnaryExpr unary) {
+            return object(
+                "kind", Jcs.string("unary"),
+                "op", Jcs.string(unaryOp(unary.getOperator())),
+                "expr", exprToTemplate(unary.getExpression(), params)
+            );
+        }
+        if (expr instanceof ThisExpr) {
+            return object("kind", Jcs.string("ident"), "name", Jcs.string("this"));
+        }
+        if (expr instanceof SuperExpr) {
+            return object("kind", Jcs.string("ident"), "name", Jcs.string("super"));
+        }
+        return other(expr);
+    }
+
+    private static Jcs.Json scopeToTemplate(Expression scope, List<String> params) {
+        scope = unwrap(scope);
+        if (scope instanceof NameExpr name && looksLikeTypeName(name.getNameAsString())) {
+            return path(List.of(name.getNameAsString()));
+        }
+        return exprToTemplate(scope, params);
+    }
+
+    private static Jcs.Json arrayTemplate(NodeList<Expression> values, List<String> params) {
+        return object(
+            "kind", Jcs.string("array"),
+            "elems", Jcs.array(values.stream().map(value -> exprToTemplate(value, params)).toList())
+        );
+    }
+
+    private static Jcs.Json litToTemplate(LiteralExpr literal) {
+        if (literal instanceof StringLiteralExpr stringLiteral) {
+            return lit("str", Jcs.string(stringLiteral.getValue()));
+        }
+        if (literal instanceof TextBlockLiteralExpr textBlock) {
+            return lit("str", Jcs.string(textBlock.getValue()));
+        }
+        if (literal instanceof IntegerLiteralExpr integerLiteral) {
+            return lit("int", Jcs.integer(integerLiteral.asNumber().longValue()));
+        }
+        if (literal instanceof LongLiteralExpr longLiteral) {
+            return lit("long", Jcs.integer(longLiteral.asNumber().longValue()));
+        }
+        if (literal instanceof BooleanLiteralExpr booleanLiteral) {
+            return lit("bool", Jcs.bool(booleanLiteral.getValue()));
+        }
+        if (literal instanceof CharLiteralExpr charLiteral) {
+            return lit("char", Jcs.string(charLiteral.getValue()));
+        }
+        if (literal instanceof NullLiteralExpr) {
+            return lit("null", Jcs.nullValue());
+        }
+        if (literal instanceof DoubleLiteralExpr doubleLiteral) {
+            String raw = numericLiteralJson(doubleLiteral.getValue());
+            String ty = doubleLiteral.getValue().toLowerCase(java.util.Locale.ROOT).endsWith("f")
+                ? "float"
+                : "double";
+            return lit(ty, Jcs.raw(raw, null));
+        }
+        return other(literal);
+    }
+
+    private static Jcs.Json lit(String ty, Jcs.Json value) {
+        return object("kind", Jcs.string("lit"), "ty", Jcs.string(ty), "value", value);
+    }
+
+    private static Jcs.Json patToTemplate(String name, List<String> params) {
+        int index = params.indexOf(name);
+        if (index >= 0) {
+            return object("kind", Jcs.string("param_ref"), "index", Jcs.integer(index + 1L));
+        }
+        return object("kind", Jcs.string("binding"), "name", Jcs.string(name));
+    }
+
+    private static Jcs.Json path(List<String> segments) {
+        return object(
+            "kind", Jcs.string("path"),
+            "segments", Jcs.array(segments.stream().map(Jcs::string).toList())
+        );
+    }
+
+    private static List<String> fieldAccessSegments(FieldAccessExpr field) {
+        List<String> reversed = new ArrayList<>();
+        Expression current = field;
+        while (current instanceof FieldAccessExpr access) {
+            reversed.add(access.getNameAsString());
+            current = access.getScope();
+        }
+        if (current instanceof NameExpr root) {
+            reversed.add(root.getNameAsString());
+            java.util.Collections.reverse(reversed);
+            return reversed;
+        }
+        return List.of();
+    }
+
+    private static Jcs.Json other(com.github.javaparser.ast.Node node) {
+        return object(
+            "kind", Jcs.string("other"),
+            "variant", Jcs.string(node.getClass().getSimpleName())
+        );
+    }
+
+    private static Expression unwrap(Expression expr) {
+        while (expr instanceof EnclosedExpr enclosed) {
+            expr = enclosed.getInner();
+        }
+        return expr;
+    }
+
+    private static boolean looksLikeTypeName(String name) {
+        return !name.isEmpty() && Character.isUpperCase(name.codePointAt(0));
+    }
+
+    private static String binaryOp(BinaryExpr.Operator op) {
+        return switch (op) {
+            case PLUS -> "Add";
+            case MINUS -> "Sub";
+            case MULTIPLY -> "Mul";
+            case DIVIDE -> "Div";
+            case REMAINDER -> "Rem";
+            case AND -> "And";
+            case OR -> "Or";
+            case XOR -> "BitXor";
+            case BINARY_AND -> "BitAnd";
+            case BINARY_OR -> "BitOr";
+            case LEFT_SHIFT -> "Shl";
+            case SIGNED_RIGHT_SHIFT, UNSIGNED_RIGHT_SHIFT -> "Shr";
+            case EQUALS -> "Eq";
+            case LESS -> "Lt";
+            case LESS_EQUALS -> "Le";
+            case NOT_EQUALS -> "Ne";
+            case GREATER_EQUALS -> "Ge";
+            case GREATER -> "Gt";
+        };
+    }
+
+    private static String unaryOp(UnaryExpr.Operator op) {
+        return switch (op) {
+            case PLUS -> "Plus";
+            case MINUS -> "Neg";
+            case LOGICAL_COMPLEMENT, BITWISE_COMPLEMENT -> "Not";
+            case PREFIX_INCREMENT, POSTFIX_INCREMENT -> "Inc";
+            case PREFIX_DECREMENT, POSTFIX_DECREMENT -> "Dec";
+        };
+    }
+
+    private static String numericLiteralJson(String value) {
+        String normalized = value.replace("_", "");
+        if (normalized.endsWith("f") || normalized.endsWith("F")
+                || normalized.endsWith("d") || normalized.endsWith("D")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private static Jcs.Obj object(Object... keyValues) {
+        return Jcs.object(keyValues);
+    }
+
+    private static void writeCompact(Jcs.Json json, StringBuilder out) {
+        if (json instanceof Jcs.Null) {
+            out.append("null");
+        } else if (json instanceof Jcs.Bool bool) {
+            out.append(bool.value() ? "true" : "false");
+        } else if (json instanceof Jcs.Num number) {
+            out.append(number.value());
+        } else if (json instanceof Jcs.Str string) {
+            writeString(string.value(), out);
+        } else if (json instanceof Jcs.Raw raw) {
+            out.append(raw.json());
+        } else if (json instanceof Jcs.Arr array) {
+            out.append('[');
+            boolean first = true;
+            for (Jcs.Json item : array.values()) {
+                if (!first) out.append(',');
+                first = false;
+                writeCompact(item, out);
+            }
+            out.append(']');
+        } else if (json instanceof Jcs.Obj obj) {
+            out.append('{');
+            boolean first = true;
+            for (Jcs.Field field : obj.fields()) {
+                if (!first) out.append(',');
+                first = false;
+                writeString(field.key(), out);
+                out.append(':');
+                writeCompact(field.value(), out);
+            }
+            out.append('}');
+        } else {
+            throw new IllegalArgumentException("unknown JSON value");
+        }
+    }
+
+    private static void writeString(String value, StringBuilder out) {
+        out.append('"');
+        int i = 0;
+        while (i < value.length()) {
+            int cp = value.codePointAt(i);
+            i += Character.charCount(cp);
+            switch (cp) {
+                case '"' -> out.append("\\\"");
+                case '\\' -> out.append("\\\\");
+                case '\b' -> out.append("\\b");
+                case '\f' -> out.append("\\f");
+                case '\n' -> out.append("\\n");
+                case '\r' -> out.append("\\r");
+                case '\t' -> out.append("\\t");
+                default -> {
+                    if (cp < 0x20) {
+                        out.append("\\u");
+                        String hex = Integer.toHexString(cp);
+                        for (int pad = hex.length(); pad < 4; pad++) out.append('0');
+                        out.append(hex);
+                    } else {
+                        out.appendCodePoint(cp);
+                    }
+                }
+            }
+        }
+        out.append('"');
+    }
+}

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RecognizeHandler.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RecognizeHandler.java
@@ -1,0 +1,131 @@
+package com.provekit.lift;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.provekit.ir.Jcs;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class RecognizeHandler {
+    private RecognizeHandler() {}
+
+    public static Jcs.Obj recognizeImpl(Jcs.Obj params) {
+        String projectRootText = params.stringFieldOrNull("project_root");
+        if (projectRootText == null || projectRootText.isBlank()) {
+            throw new IllegalArgumentException("missing `project_root`");
+        }
+        Path projectRoot = Path.of(projectRootText);
+        List<String> sourcePaths = stringArray(params.get("source_paths"));
+        Map<String, Jcs.Obj> bindingsByCid = new LinkedHashMap<>();
+        if (params.get("binding_templates") instanceof Jcs.Arr bindingTemplates) {
+            for (Jcs.Json value : bindingTemplates.values()) {
+                if (!(value instanceof Jcs.Obj binding)) continue;
+                String cid = binding.stringFieldOrNull("template_cid");
+                if (cid != null && !cid.isBlank()) {
+                    bindingsByCid.put(cid, binding);
+                }
+            }
+        }
+
+        List<Jcs.Json> tags = new ArrayList<>();
+        for (String relPath : sourcePaths) {
+            Path sourcePath = projectRoot.resolve(relPath).normalize();
+            String source;
+            try {
+                source = Files.readString(sourcePath);
+            } catch (IOException e) {
+                System.err.println("recognize: skip unreadable source `" + relPath + "`: " + e.getMessage());
+                continue;
+            }
+            ParseResult<CompilationUnit> result = new JavaParser().parse(source);
+            if (!result.isSuccessful() || result.getResult().isEmpty()) {
+                System.err.println("recognize: skip unparseable source `" + relPath + "`: " + result.getProblems());
+                continue;
+            }
+            for (MethodDeclaration method : result.getResult().get().findAll(MethodDeclaration.class)) {
+                if (method.getBody().isEmpty()) continue;
+                JavaAstTemplates.TemplateInfo candidate = JavaAstTemplates.fromMethod(method);
+                Jcs.Obj binding = bindingsByCid.get(candidate.templateCid());
+                if (binding != null) {
+                    tags.add(tagFor(relPath, method, candidate, binding));
+                }
+            }
+        }
+        return Jcs.object("tags", Jcs.array(tags));
+    }
+
+    private static Jcs.Obj tagFor(
+            String relPath,
+            MethodDeclaration method,
+            JavaAstTemplates.TemplateInfo candidate,
+            Jcs.Obj binding) {
+        List<Jcs.Json> paramBindings = new ArrayList<>();
+        List<String> params = JavaAstTemplates.paramNames(method);
+        for (int i = 0; i < params.size(); i++) {
+            paramBindings.add(Jcs.object(
+                "index", Jcs.integer(i + 1L),
+                "source_text", Jcs.string(params.get(i))
+            ));
+        }
+
+        int startLine = 0;
+        int startCol = 0;
+        int endLine = 0;
+        int endCol = 0;
+        if (method.getRange().isPresent()) {
+            var range = method.getRange().get();
+            startLine = range.begin.line;
+            startCol = Math.max(0, range.begin.column - 1);
+            endLine = range.end.line;
+            endCol = Math.max(0, range.end.column - 1);
+        }
+
+        return Jcs.object(
+            "file", Jcs.string(relPath),
+            "span", Jcs.object(
+                "start_line", Jcs.integer(startLine),
+                "start_col", Jcs.integer(startCol),
+                "end_line", Jcs.integer(endLine),
+                "end_col", Jcs.integer(endCol)
+            ),
+            "function_name", Jcs.string(method.getNameAsString()),
+            "concept_name", valueOrNull(binding, "concept_name"),
+            "library_tag", libraryTag(binding),
+            "family", valueOrNull(binding, "family"),
+            "template_cid", Jcs.string(candidate.templateCid()),
+            "contract_cid", valueOrNull(binding, "contract_cid"),
+            "match_tier", Jcs.string("exact"),
+            "param_bindings", Jcs.array(paramBindings)
+        );
+    }
+
+    private static Jcs.Json libraryTag(Jcs.Obj binding) {
+        Jcs.Json libraryTag = binding.get("library_tag");
+        if (libraryTag != null) return libraryTag;
+        return valueOrNull(binding, "target_library_tag");
+    }
+
+    private static Jcs.Json valueOrNull(Jcs.Obj obj, String key) {
+        Jcs.Json value = obj.get(key);
+        return value == null ? Jcs.nullValue() : value;
+    }
+
+    private static List<String> stringArray(Jcs.Json value) {
+        List<String> out = new ArrayList<>();
+        if (value instanceof Jcs.Arr array) {
+            for (Jcs.Json item : array.values()) {
+                if (item instanceof Jcs.Str string) {
+                    out.add(string.value());
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RpcServer.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RpcServer.java
@@ -45,6 +45,14 @@ public class RpcServer {
                     String emitMode = extractEmitMode(line);
                     sendResponse(id, liftHandler.lift(workspace, surface, emitMode));
                 }
+                case "provekit.plugin.recognize" -> {
+                    Jcs.Json doc = Jcs.parse(line);
+                    if (!(doc instanceof Jcs.Obj obj) || !(obj.get("params") instanceof Jcs.Obj params)) {
+                        sendError(id, -32602, "missing params object");
+                    } else {
+                        sendResponse(id, Jcs.encode(RecognizeHandler.recognizeImpl(params)));
+                    }
+                }
                 case "shutdown" -> {
                     sendResponse(id, "null");
                     System.exit(0);

--- a/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/RecognizeHandlerTest.java
+++ b/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/RecognizeHandlerTest.java
@@ -1,0 +1,195 @@
+package com.provekit.lift;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.provekit.ir.Jcs;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RecognizeHandlerTest {
+    private static final String HTTP_CONTRACT_CID = "blake3-512:" + "a".repeat(128);
+    private static final String SQL_CONTRACT_CID = "blake3-512:" + "b".repeat(128);
+
+    @Test
+    void recognizeEmitsExactTagForAlphaEquivalentUserMethod() throws Exception {
+        JavaAstTemplates.TemplateInfo template = JavaAstTemplates.fromMethodSource("""
+            Object shim(String url, Headers headers) {
+              return client.execute(url, headers);
+            }
+            """);
+        Jcs.Obj binding = binding(
+            "concept:http-request",
+            "provekit-shim-java-okhttp",
+            "concept:family:http",
+            template,
+            HTTP_CONTRACT_CID
+        );
+
+        Path root = Files.createTempDirectory("recognize-java-http");
+        String rel = "src/main/java/com/example/Handlers.java";
+        write(root, rel, """
+            package com.example;
+            class Handlers {
+              Object fetchUrl(String u, Headers h) {
+                return client.execute(u, h);
+              }
+            }
+            """);
+
+        Jcs.Obj response = RecognizeHandler.recognizeImpl(params(root, List.of(rel), List.of(binding)));
+
+        Jcs.Arr tags = response.arrayField("tags");
+        assertEquals(1, tags.values().size(), Jcs.encode(response));
+        Jcs.Obj tag = tags.objectAt(0);
+        assertEquals(rel, tag.stringField("file"));
+        assertEquals("fetchUrl", tag.stringField("function_name"));
+        assertEquals("concept:http-request", tag.stringField("concept_name"));
+        assertEquals("provekit-shim-java-okhttp", tag.stringField("library_tag"));
+        assertEquals("concept:family:http", tag.stringField("family"));
+        assertEquals(template.templateCid(), tag.stringField("template_cid"));
+        assertEquals(HTTP_CONTRACT_CID, tag.stringField("contract_cid"));
+        assertEquals("exact", tag.stringField("match_tier"));
+        assertTrue(numberField(tag.objectField("span"), "start_line") > 0, Jcs.encode(tag));
+
+        Jcs.Arr paramBindings = tag.arrayField("param_bindings");
+        assertEquals(2, paramBindings.values().size());
+        assertEquals(1, numberField(paramBindings.objectAt(0), "index"));
+        assertEquals("u", paramBindings.objectAt(0).stringField("source_text"));
+        assertEquals(2, numberField(paramBindings.objectAt(1), "index"));
+        assertEquals("h", paramBindings.objectAt(1).stringField("source_text"));
+    }
+
+    @Test
+    void recognizeReturnsEmptyTagsForNonMatchingSource() throws Exception {
+        JavaAstTemplates.TemplateInfo template = JavaAstTemplates.fromMethodSource("""
+            Object shim(String url, Headers headers) {
+              return client.execute(url, headers);
+            }
+            """);
+        Jcs.Obj binding = binding(
+            "concept:http-request",
+            "provekit-shim-java-okhttp",
+            null,
+            template,
+            HTTP_CONTRACT_CID
+        );
+
+        Path root = Files.createTempDirectory("recognize-java-negative");
+        String rel = "src/main/java/com/example/Handlers.java";
+        write(root, rel, """
+            package com.example;
+            class Handlers {
+              Object fetchUrl(String u, Headers h) {
+                return client.send(u, h);
+              }
+            }
+            """);
+
+        Jcs.Obj response = RecognizeHandler.recognizeImpl(params(root, List.of(rel), List.of(binding)));
+
+        assertTrue(response.arrayField("tags").isEmpty(), Jcs.encode(response));
+    }
+
+    @Test
+    void recognizeRoutesMultipleBindingsPerCallSitePool() throws Exception {
+        JavaAstTemplates.TemplateInfo httpTemplate = JavaAstTemplates.fromMethodSource("""
+            Object shim(String url, Headers headers) {
+              return client.execute(url, headers);
+            }
+            """);
+        JavaAstTemplates.TemplateInfo sqlTemplate = JavaAstTemplates.fromMethodSource("""
+            Object shim(Connection conn, String sql, Args args) {
+              return conn.query(sql, args);
+            }
+            """);
+        Jcs.Obj httpBinding = binding(
+            "concept:http-request",
+            "provekit-shim-java-okhttp",
+            "concept:family:http",
+            httpTemplate,
+            HTTP_CONTRACT_CID
+        );
+        Jcs.Obj sqlBinding = binding(
+            "concept:sql-query",
+            "provekit-shim-java-jdbc",
+            "concept:family:sql",
+            sqlTemplate,
+            SQL_CONTRACT_CID
+        );
+
+        Path root = Files.createTempDirectory("recognize-java-multi");
+        String rel = "src/main/java/com/example/Handlers.java";
+        write(root, rel, """
+            package com.example;
+            class Handlers {
+              Object fetchUrl(String u, Headers h) {
+                return client.execute(u, h);
+              }
+
+              Object query(Connection c, String q, Args a) {
+                return c.query(q, a);
+              }
+            }
+            """);
+
+        Jcs.Obj response = RecognizeHandler.recognizeImpl(params(root, List.of(rel), List.of(httpBinding, sqlBinding)));
+
+        Jcs.Arr tags = response.arrayField("tags");
+        assertEquals(2, tags.values().size(), Jcs.encode(response));
+        List<String> concepts = tags.values().stream()
+            .map(Jcs.Obj.class::cast)
+            .map(t -> t.stringField("concept_name"))
+            .toList();
+        assertTrue(concepts.contains("concept:http-request"), concepts.toString());
+        assertTrue(concepts.contains("concept:sql-query"), concepts.toString());
+    }
+
+    private static Jcs.Obj binding(
+            String conceptName,
+            String libraryTag,
+            String family,
+            JavaAstTemplates.TemplateInfo template,
+            String contractCid) {
+        List<Object> fields = new java.util.ArrayList<>();
+        fields.add("concept_name");
+        fields.add(Jcs.string(conceptName));
+        fields.add("library_tag");
+        fields.add(Jcs.string(libraryTag));
+        fields.add("ast_template");
+        fields.add(template.astTemplate());
+        fields.add("template_cid");
+        fields.add(Jcs.string(template.templateCid()));
+        fields.add("param_names");
+        fields.add(Jcs.array(template.paramNames().stream().map(Jcs::string).toList()));
+        fields.add("contract_cid");
+        fields.add(Jcs.string(contractCid));
+        if (family != null) {
+            fields.add("family");
+            fields.add(Jcs.string(family));
+        }
+        return Jcs.object(fields.toArray());
+    }
+
+    private static Jcs.Obj params(Path root, List<String> sourcePaths, List<Jcs.Json> bindings) {
+        return Jcs.object(
+            "project_root", Jcs.string(root.toString()),
+            "source_paths", Jcs.array(sourcePaths.stream().map(Jcs::string).toList()),
+            "binding_templates", Jcs.array(bindings)
+        );
+    }
+
+    private static void write(Path root, String rel, String source) throws Exception {
+        Path path = root.resolve(rel);
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, source);
+    }
+
+    private static long numberField(Jcs.Obj obj, String key) {
+        Jcs.Json value = obj.get(key);
+        if (value instanceof Jcs.Num n) return n.value();
+        throw new IllegalArgumentException("field is not a number: " + key);
+    }
+}

--- a/implementations/java/provekit-lift-java-source/pom.xml
+++ b/implementations/java/provekit-lift-java-source/pom.xml
@@ -18,6 +18,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.provekit</groupId>
+            <artifactId>provekit-lift-java-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.0</version>

--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaBindLifter.java
@@ -20,6 +20,7 @@
 package com.provekit.lift.java_source;
 
 import com.provekit.ir.Jcs;
+import com.provekit.lift.JavaAstTemplates;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.BinaryTree;
@@ -413,6 +414,8 @@ public final class JavaBindLifter {
                 // param_types, return_type). body_text carries only the
                 // remaining substance — what the function actually DOES.
                 String bodyOnly = extractMethodBodyStatements(spanText.toString());
+                JavaAstTemplates.TemplateInfo bodyTemplate =
+                    JavaAstTemplates.fromMethodSource(spanText.toString());
 
                 // #41: prepend file-level imports as a comment so the realize
                 // plugin's FQN-extracting regex picks them up. The comment is
@@ -431,15 +434,20 @@ public final class JavaBindLifter {
                 }
 
                 Jcs.Obj bodySource = Jcs.object(
+                    "ast_template", bodyTemplate.astTemplate(),
                     "body_text", Jcs.string(bodyOnly),
                     "file", Jcs.string(rel),
+                    "param_names", Jcs.array(
+                        bodyTemplate.paramNames().stream().map(Jcs::string).toList()
+                    ),
                     "source_cid", Jcs.string(sourceCid),
                     "span", Jcs.object(
                         "end_col", Jcs.integer(methodEndCol),
                         "end_line", Jcs.integer(methodEndLine),
                         "start_col", Jcs.integer(methodStartCol),
                         "start_line", Jcs.integer(methodStartLine)
-                    )
+                    ),
+                    "template_cid", Jcs.string(bodyTemplate.templateCid())
                 );
 
                 // #1369 parametric content-addressing: accumulator for composite

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/JavaSugarBindingLifterTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/JavaSugarBindingLifterTest.java
@@ -5,11 +5,104 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.provekit.ir.Blake3;
 import com.provekit.ir.Jcs;
+import com.provekit.lift.JavaAstTemplates;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class JavaSugarBindingLifterTest {
+    @Test
+    void sugarBodyEmitsAstTemplateAlongsideBodyText() {
+        String source = """
+            package p;
+            class C {
+              @ProveKitSugar(concept = "concept:http-request", library = "java-net-http")
+              Object fetchUrl(String url, Headers headers) {
+                return client.execute(url, headers);
+              }
+            }
+            """;
+
+        JavaBindLifter.Result result = new JavaBindLifter().liftPathsFromSource("C.java", source);
+
+        Jcs.Obj bodySource = ((Jcs.Obj) sugarEntries(result).get(0)).objectField("body_source");
+        assertNotNull(bodySource.get("body_text"), "body_source.body_text must remain present");
+        assertNotNull(bodySource.get("ast_template"), "body_source.ast_template must be present");
+        assertNotNull(bodySource.get("template_cid"), "body_source.template_cid must be present");
+        assertNotNull(bodySource.get("param_names"), "body_source.param_names must be present");
+
+        String expectedTemplate = """
+            {"kind":"block","stmts":[{"kind":"return","expr":{"kind":"method_call","receiver":{"kind":"ident","name":"client"},"method":"execute","args":[{"kind":"param_ref","index":1},{"kind":"param_ref","index":2}]}}]}
+            """.trim();
+        assertEquals(expectedTemplate, JavaAstTemplates.compactJson(bodySource.get("ast_template")));
+        assertEquals(
+            Blake3.blake3_512(expectedTemplate.getBytes(StandardCharsets.UTF_8)),
+            bodySource.stringField("template_cid")
+        );
+        assertEquals("url", bodySource.arrayField("param_names").stringAt(0).value());
+        assertEquals("headers", bodySource.arrayField("param_names").stringAt(1).value());
+
+        String wire = Jcs.encode(result.toJson());
+        assertTrue(
+            wire.contains("\"ast_template\":" + expectedTemplate),
+            "wire JSON must preserve template key order for the hashed ast_template: " + wire
+        );
+    }
+
+    @Test
+    void sugarBodyAlphaEquivalenceCollapsesToSameCid() {
+        String source = """
+            package p;
+            class C {
+              @ProveKitSugar(concept = "concept:http-request", library = "java-net-http")
+              Object fetchA(String url, Headers headers) {
+                return client.execute(url, headers);
+              }
+
+              @ProveKitSugar(concept = "concept:http-request", library = "java-net-http")
+              Object fetchB(String u, Headers h) {
+                return client.execute(u, h);
+              }
+            }
+            """;
+
+        List<Jcs.Json> entries = sugarEntries(new JavaBindLifter().liftPathsFromSource("C.java", source));
+
+        Jcs.Obj bodyA = ((Jcs.Obj) entries.get(0)).objectField("body_source");
+        Jcs.Obj bodyB = ((Jcs.Obj) entries.get(1)).objectField("body_source");
+        assertEquals(bodyA.stringField("template_cid"), bodyB.stringField("template_cid"));
+        assertEquals(
+            JavaAstTemplates.compactJson(bodyA.get("ast_template")),
+            JavaAstTemplates.compactJson(bodyB.get("ast_template"))
+        );
+    }
+
+    @Test
+    void sugarBodyParamNameSwapCanonicalizes() {
+        String source = """
+            package p;
+            class C {
+              @ProveKitSugar(concept = "concept:call-g", library = "test")
+              int f(int a, int b) {
+                return g(a, b);
+              }
+
+              @ProveKitSugar(concept = "concept:call-g", library = "test")
+              int h(int x, int y) {
+                return g(x, y);
+              }
+            }
+            """;
+
+        List<Jcs.Json> entries = sugarEntries(new JavaBindLifter().liftPathsFromSource("C.java", source));
+
+        Jcs.Obj bodyA = ((Jcs.Obj) entries.get(0)).objectField("body_source");
+        Jcs.Obj bodyB = ((Jcs.Obj) entries.get(1)).objectField("body_source");
+        assertEquals(bodyA.stringField("template_cid"), bodyB.stringField("template_cid"));
+    }
+
     @Test
     void annotatedMethodEmitsLibrarySugarBindingEntry() {
         String source = """


### PR DESCRIPTION
Mirrors PR #1577 for Java. Phase A: lifter emits body_source.ast_template + template_cid + param_names via a LinkedHashMap-backed deterministic serializer. Phase B: provekit.plugin.recognize RPC handler with recognizeImpl helper. Tier-1 only (match_tier:exact via template_cid byte equality). 6 JUnit 5 cases mirror the rust recognize suite at implementations/rust/provekit-walk/src/bin/walk_rpc.rs lines 4739-5020. mvn test exit 0.

Co-authored-by: Codex (gpt-5.5 xhigh) <noreply@anthropic.com>