### PR TITLE
Recognize verb — Go kit foundation (mirrors PR #1577 rust)

### DIFF
--- a/implementations/go/cmd/provekit-lift-go-verify/main.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/main.go
@@ -34,11 +34,9 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
 	"io"
 	"os"
 	"path/filepath"
@@ -277,7 +275,15 @@ func liftWorkspace(root string, mode liftMode) ([]any, []map[string]any, error) 
 				}
 				paramTypes := goParamTypes(fc)
 				returnType := goReturnType(fc)
-				bodyText := extractGoFuncBody(string(src), bareSymbol(fc.FnName))
+				bodySource, ok, bodyErr := liftgo.SugarBodySourceForFunc(rel, src, bareSymbol(fc.FnName))
+				if bodyErr != nil {
+					diagnostics = append(diagnostics, map[string]any{"path": rel, "message": bodyErr.Error()})
+					continue
+				}
+				if !ok {
+					diagnostics = append(diagnostics, map[string]any{"path": rel, "message": fmt.Sprintf("missing body source for %s", fc.FnName)})
+					continue
+				}
 				entry := map[string]any{
 					"kind":                 "library-sugar-binding-entry",
 					"target_language":      "go",
@@ -291,11 +297,7 @@ func liftWorkspace(root string, mode liftMode) ([]any, []map[string]any, error) 
 					"return_type":          returnType,
 					"visibility":           "",
 					"signature_shape_cid":  signatureShapeCID(bareSymbol(fc.FnName), fc.Formals, paramTypes, returnType),
-					"body_source": map[string]any{
-						"file":       rel,
-						"source_cid": cidOf([]byte(bodyText)),
-						"body_text":  bodyText,
-					},
+					"body_source":          bodySource,
 				}
 				if ann.Family != "" {
 					entry["family"] = ann.Family
@@ -441,24 +443,11 @@ func signatureShapeCID(name string, formals, paramTypes []string, returnType str
 // extractGoFuncBody returns the trimmed source text between the parser-owned
 // outer function body braces, mirroring rust's `sugar_body_source` body_text.
 func extractGoFuncBody(src, name string) string {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "", src, parser.ParseComments)
-	if err != nil {
+	body, ok, err := liftgo.GoFuncBodyText([]byte(src), name)
+	if err != nil || !ok {
 		return ""
 	}
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Name.Name != name || fn.Body == nil {
-			continue
-		}
-		open := fset.PositionFor(fn.Body.Lbrace, false).Offset
-		close := fset.PositionFor(fn.Body.Rbrace, false).Offset
-		if open < 0 || close < 0 || open >= close || close > len(src) {
-			return ""
-		}
-		return strings.TrimSpace(src[open+1 : close])
-	}
-	return ""
+	return strings.TrimSpace(body)
 }
 
 func relPath(root, path string) string {
@@ -489,10 +478,15 @@ func idValue(id json.RawMessage) any {
 }
 
 func writeJSON(w io.Writer, v any) {
-	b, err := json.Marshal(v)
-	if err != nil {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
 		fmt.Fprintf(w, `{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":%q}}`+"\n", err.Error())
 		return
 	}
-	fmt.Fprintln(w, string(b))
+	if b := buf.Bytes(); len(b) > 0 && b[len(b)-1] == '\n' {
+		buf.Truncate(len(b) - 1)
+	}
+	fmt.Fprintln(w, buf.String())
 }

--- a/implementations/go/cmd/provekit-lift-go-verify/main_test.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/main_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	liftgo "github.com/tsavo/provekit/go/provekit-lift-go"
 )
 
 func TestExtractGoFuncBodyUsesGoSyntaxPositions(t *testing.T) {
@@ -111,10 +115,11 @@ func Double(x int) int {
 	}
 
 	entry := findBindingEntry(t, ir, "Double")
-	bodySource, ok := entry["body_source"].(map[string]any)
+	bodyStruct, ok := entry["body_source"].(liftgo.SugarBodySource)
 	if !ok {
-		t.Fatalf("body_source = %#v, want object", entry["body_source"])
+		t.Fatalf("body_source = %#v, want liftgo.SugarBodySource", entry["body_source"])
 	}
+	bodySource := objectFromJSON(t, entry["body_source"])
 	bodyText, ok := bodySource["body_text"].(string)
 	if !ok {
 		t.Fatalf("body_text = %#v, want string", bodySource["body_text"])
@@ -128,6 +133,42 @@ func Double(x int) int {
 	if bodySource["source_cid"] != cidOf([]byte(bodyText)) {
 		t.Fatalf("source_cid = %#v, want cid of body_text", bodySource["source_cid"])
 	}
+	if _, ok := bodySource["span"].(map[string]any); !ok {
+		t.Fatalf("span = %#v, want object", bodySource["span"])
+	}
+	template := bodySource["ast_template"]
+	templateObj := objectFromJSON(t, template)
+	if templateObj["kind"] != "block" {
+		t.Fatalf("ast_template.kind = %#v, want block", templateObj["kind"])
+	}
+	paramNames, ok := bodySource["param_names"].([]any)
+	if !ok || len(paramNames) != 1 || paramNames[0] != "x" {
+		t.Fatalf("param_names = %#v, want [x]", bodySource["param_names"])
+	}
+	templateBytes := compactJSONNoHTML(t, bodyStruct.ASTTemplate)
+	if bodySource["template_cid"] != cidOf(templateBytes) {
+		t.Fatalf("template_cid = %#v, want cid of %s", bodySource["template_cid"], templateBytes)
+	}
+}
+
+func objectFromJSON(t *testing.T, v any) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(compactJSONNoHTML(t, v), &out); err != nil {
+		t.Fatalf("unmarshal object from %#v: %v", v, err)
+	}
+	return out
+}
+
+func compactJSONNoHTML(t *testing.T, v any) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n"))
 }
 
 func findBindingEntry(t *testing.T, ir []any, sourceName string) map[string]any {

--- a/implementations/go/provekit-lift-go/ast_template.go
+++ b/implementations/go/provekit-lift-go/ast_template.go
@@ -1,0 +1,530 @@
+package liftgo
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+)
+
+type SourceSpan struct {
+	StartLine int `json:"start_line"`
+	StartCol  int `json:"start_col"`
+	EndLine   int `json:"end_line"`
+	EndCol    int `json:"end_col"`
+}
+
+type SugarBodySource struct {
+	File        string     `json:"file"`
+	Span        SourceSpan `json:"span"`
+	SourceCID   string     `json:"source_cid"`
+	BodyText    string     `json:"body_text"`
+	ASTTemplate any        `json:"ast_template"`
+	TemplateCID string     `json:"template_cid"`
+	ParamNames  []string   `json:"param_names"`
+}
+
+type blockNode struct {
+	Kind  string `json:"kind"`
+	Stmts []any  `json:"stmts"`
+}
+
+type letNode struct {
+	Kind string `json:"kind"`
+	Pat  any    `json:"pat"`
+	Init any    `json:"init"`
+}
+
+type exprStmtNode struct {
+	Kind         string `json:"kind"`
+	Expr         any    `json:"expr"`
+	TrailingSemi bool   `json:"trailing_semi"`
+}
+
+type callNode struct {
+	Kind string `json:"kind"`
+	Func any    `json:"func"`
+	Args []any  `json:"args"`
+}
+
+type methodCallNode struct {
+	Kind     string `json:"kind"`
+	Receiver any    `json:"receiver"`
+	Method   string `json:"method"`
+	Args     []any  `json:"args"`
+}
+
+type identNode struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+type paramRefNode struct {
+	Kind  string `json:"kind"`
+	Index int    `json:"index"`
+}
+
+type pathNode struct {
+	Kind     string   `json:"kind"`
+	Segments []string `json:"segments"`
+}
+
+type litNode struct {
+	Kind  string `json:"kind"`
+	Ty    string `json:"ty"`
+	Value any    `json:"value"`
+}
+
+type refNode struct {
+	Kind       string `json:"kind"`
+	Mutability bool   `json:"mutability"`
+	Expr       any    `json:"expr"`
+}
+
+type returnNode struct {
+	Kind string `json:"kind"`
+	Expr any    `json:"expr"`
+}
+
+type tupleNode struct {
+	Kind  string `json:"kind"`
+	Elems []any  `json:"elems"`
+}
+
+type arrayNode struct {
+	Kind  string `json:"kind"`
+	Elems []any  `json:"elems"`
+}
+
+type binaryNode struct {
+	Kind  string `json:"kind"`
+	Op    string `json:"op"`
+	Left  any    `json:"left"`
+	Right any    `json:"right"`
+}
+
+type bindingNode struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+type wildcardNode struct {
+	Kind string `json:"kind"`
+}
+
+type patTupleNode struct {
+	Kind  string `json:"kind"`
+	Elems []any  `json:"elems"`
+}
+
+type otherNode struct {
+	Kind    string `json:"kind"`
+	Variant string `json:"variant"`
+}
+
+func SugarBodySourceForFunc(sourcePath string, source []byte, fnName string) (SugarBodySource, bool, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, sourcePath, source, parser.ParseComments)
+	if err != nil {
+		return SugarBodySource{}, false, err
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != fnName {
+			continue
+		}
+		if fn.Body == nil {
+			return SugarBodySource{}, false, nil
+		}
+		body, err := sugarBodySourceForDecl(fset, sourcePath, source, fn)
+		return body, true, err
+	}
+	return SugarBodySource{}, false, nil
+}
+
+func GoFuncBodyText(source []byte, fnName string) (string, bool, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", source, parser.ParseComments)
+	if err != nil {
+		return "", false, err
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != fnName || fn.Body == nil {
+			continue
+		}
+		return funcBodyText(fset, source, fn), true, nil
+	}
+	return "", false, nil
+}
+
+func sugarBodySourceForDecl(fset *token.FileSet, sourcePath string, source []byte, fn *ast.FuncDecl) (SugarBodySource, error) {
+	bodyText := funcBodyText(fset, source, fn)
+	paramNames := funcParamNames(fn)
+	template := blockToASTTemplate(fn.Body, paramNames)
+	templateBytes, err := marshalJSONNoHTML(template)
+	if err != nil {
+		return SugarBodySource{}, err
+	}
+	return SugarBodySource{
+		File:        sourcePath,
+		Span:        funcSpan(fset, fn),
+		SourceCID:   canonicalizer.ComputeCID([]byte(bodyText)),
+		BodyText:    bodyText,
+		ASTTemplate: template,
+		TemplateCID: canonicalizer.ComputeCID(templateBytes),
+		ParamNames:  paramNames,
+	}, nil
+}
+
+func funcBodyText(fset *token.FileSet, source []byte, fn *ast.FuncDecl) string {
+	if fn == nil || fn.Body == nil {
+		return ""
+	}
+	open := fset.PositionFor(fn.Body.Lbrace, false).Offset
+	close := fset.PositionFor(fn.Body.Rbrace, false).Offset
+	if open < 0 || close < 0 || open >= close || close > len(source) {
+		return ""
+	}
+	return strings.TrimSpace(string(source[open+1 : close]))
+}
+
+func funcSpan(fset *token.FileSet, fn *ast.FuncDecl) SourceSpan {
+	start := fset.PositionFor(fn.Pos(), false)
+	end := fset.PositionFor(fn.Body.Rbrace, false)
+	startCol := start.Column - 1
+	if startCol < 0 {
+		startCol = 0
+	}
+	endCol := end.Column
+	if endCol < 0 {
+		endCol = 0
+	}
+	return SourceSpan{
+		StartLine: start.Line,
+		StartCol:  startCol,
+		EndLine:   end.Line,
+		EndCol:    endCol,
+	}
+}
+
+func funcParamNames(fn *ast.FuncDecl) []string {
+	var names []string
+	if fn == nil || fn.Type == nil {
+		return names
+	}
+	if fn.Recv != nil {
+		names = append(names, fieldListNames(fn.Recv.List)...)
+	}
+	if fn.Type.Params != nil {
+		names = append(names, fieldListNames(fn.Type.Params.List)...)
+	}
+	return names
+}
+
+func fieldListNames(fields []*ast.Field) []string {
+	var names []string
+	for _, field := range fields {
+		for _, name := range field.Names {
+			names = append(names, name.Name)
+		}
+	}
+	return names
+}
+
+func blockToASTTemplate(block *ast.BlockStmt, params []string) any {
+	stmts := []any{}
+	if block != nil {
+		for _, stmt := range block.List {
+			stmts = append(stmts, stmtToTemplates(stmt, params)...)
+		}
+	}
+	return blockNode{Kind: "block", Stmts: stmts}
+}
+
+func stmtToTemplates(stmt ast.Stmt, params []string) []any {
+	switch s := stmt.(type) {
+	case *ast.AssignStmt:
+		if s.Tok != token.ASSIGN && s.Tok != token.DEFINE {
+			return []any{otherTemplate(s)}
+		}
+		out := make([]any, 0, len(s.Lhs))
+		for i, lhs := range s.Lhs {
+			var init any
+			if i < len(s.Rhs) {
+				init = exprToTemplate(s.Rhs[i], params)
+			}
+			out = append(out, letNode{
+				Kind: "let",
+				Pat:  patToTemplate(lhs, params),
+				Init: init,
+			})
+		}
+		return out
+	case *ast.DeclStmt:
+		return declStmtToTemplates(s, params)
+	case *ast.ExprStmt:
+		return []any{exprStmtNode{Kind: "expr_stmt", Expr: exprToTemplate(s.X, params), TrailingSemi: true}}
+	case *ast.ReturnStmt:
+		return []any{returnNode{Kind: "return", Expr: returnExprTemplate(s.Results, params)}}
+	case *ast.BlockStmt:
+		return []any{blockToASTTemplate(s, params)}
+	default:
+		return []any{otherTemplate(s)}
+	}
+}
+
+func declStmtToTemplates(stmt *ast.DeclStmt, params []string) []any {
+	gen, ok := stmt.Decl.(*ast.GenDecl)
+	if !ok || gen.Tok != token.VAR {
+		return []any{otherTemplate(stmt)}
+	}
+	var out []any
+	for _, spec := range gen.Specs {
+		valueSpec, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			out = append(out, otherTemplate(spec))
+			continue
+		}
+		for i, name := range valueSpec.Names {
+			var init any
+			if i < len(valueSpec.Values) {
+				init = exprToTemplate(valueSpec.Values[i], params)
+			}
+			out = append(out, letNode{
+				Kind: "let",
+				Pat:  patToTemplate(name, params),
+				Init: init,
+			})
+		}
+	}
+	return out
+}
+
+func returnExprTemplate(results []ast.Expr, params []string) any {
+	switch len(results) {
+	case 0:
+		return nil
+	case 1:
+		return exprToTemplate(results[0], params)
+	default:
+		elems := make([]any, 0, len(results))
+		for _, result := range results {
+			elems = append(elems, exprToTemplate(result, params))
+		}
+		return tupleNode{Kind: "tuple", Elems: elems}
+	}
+}
+
+func exprToTemplate(expr ast.Expr, params []string) any {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		return litToTemplate(e)
+	case *ast.Ident:
+		return identToTemplate(e, params)
+	case *ast.BinaryExpr:
+		op, ok := templateBinaryOp(e.Op)
+		if !ok {
+			return otherTemplate(e)
+		}
+		return binaryNode{
+			Kind:  "binary",
+			Op:    op,
+			Left:  exprToTemplate(e.X, params),
+			Right: exprToTemplate(e.Y, params),
+		}
+	case *ast.UnaryExpr:
+		if e.Op == token.AND {
+			return refNode{Kind: "ref", Mutability: false, Expr: exprToTemplate(e.X, params)}
+		}
+		return otherTemplate(e)
+	case *ast.ParenExpr:
+		return exprToTemplate(e.X, params)
+	case *ast.CallExpr:
+		args := exprListToTemplates(e.Args, params)
+		if sel, ok := e.Fun.(*ast.SelectorExpr); ok {
+			return methodCallNode{
+				Kind:     "method_call",
+				Receiver: exprToTemplate(sel.X, params),
+				Method:   sel.Sel.Name,
+				Args:     args,
+			}
+		}
+		return callNode{Kind: "call", Func: exprToTemplate(e.Fun, params), Args: args}
+	case *ast.SelectorExpr:
+		segments, ok := selectorSegments(e)
+		if !ok {
+			return otherTemplate(e)
+		}
+		return pathNode{Kind: "path", Segments: segments}
+	case *ast.CompositeLit:
+		elems := make([]any, 0, len(e.Elts))
+		for _, elt := range e.Elts {
+			elems = append(elems, exprToTemplate(elt, params))
+		}
+		return arrayNode{Kind: "array", Elems: elems}
+	default:
+		return otherTemplate(e)
+	}
+}
+
+func exprListToTemplates(exprs []ast.Expr, params []string) []any {
+	out := make([]any, 0, len(exprs))
+	for _, expr := range exprs {
+		out = append(out, exprToTemplate(expr, params))
+	}
+	return out
+}
+
+func identToTemplate(id *ast.Ident, params []string) any {
+	switch id.Name {
+	case "true":
+		return litNode{Kind: "lit", Ty: "bool", Value: true}
+	case "false":
+		return litNode{Kind: "lit", Ty: "bool", Value: false}
+	case "nil":
+		return litNode{Kind: "lit", Ty: "nil", Value: nil}
+	}
+	if idx := paramIndex(id.Name, params); idx > 0 {
+		return paramRefNode{Kind: "param_ref", Index: idx}
+	}
+	return identNode{Kind: "ident", Name: id.Name}
+}
+
+func litToTemplate(lit *ast.BasicLit) any {
+	switch lit.Kind {
+	case token.STRING:
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return otherTemplate(lit)
+		}
+		return litNode{Kind: "lit", Ty: "str", Value: value}
+	case token.CHAR:
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return otherTemplate(lit)
+		}
+		return litNode{Kind: "lit", Ty: "char", Value: value}
+	case token.INT:
+		value, err := strconv.ParseInt(lit.Value, 0, 64)
+		if err != nil {
+			return otherTemplate(lit)
+		}
+		return litNode{Kind: "lit", Ty: "int", Value: value}
+	case token.FLOAT:
+		value, err := strconv.ParseFloat(lit.Value, 64)
+		if err != nil {
+			return otherTemplate(lit)
+		}
+		return litNode{Kind: "lit", Ty: "float64", Value: value}
+	default:
+		return otherTemplate(lit)
+	}
+}
+
+func patToTemplate(expr ast.Expr, params []string) any {
+	switch p := expr.(type) {
+	case *ast.Ident:
+		if p.Name == "_" {
+			return wildcardNode{Kind: "wildcard"}
+		}
+		if idx := paramIndex(p.Name, params); idx > 0 {
+			return paramRefNode{Kind: "param_ref", Index: idx}
+		}
+		return bindingNode{Kind: "binding", Name: p.Name}
+	case *ast.ParenExpr:
+		return patToTemplate(p.X, params)
+	default:
+		return otherNode{Kind: "pat_other", Variant: astVariantName(p)}
+	}
+}
+
+func paramIndex(name string, params []string) int {
+	for i, param := range params {
+		if param == name {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+func selectorSegments(sel *ast.SelectorExpr) ([]string, bool) {
+	segments := []string{sel.Sel.Name}
+	for {
+		switch x := sel.X.(type) {
+		case *ast.Ident:
+			segments = append([]string{x.Name}, segments...)
+			return segments, true
+		case *ast.SelectorExpr:
+			segments = append([]string{x.Sel.Name}, segments...)
+			sel = x
+		default:
+			return nil, false
+		}
+	}
+}
+
+func templateBinaryOp(tok token.Token) (string, bool) {
+	switch tok {
+	case token.ADD:
+		return "Add", true
+	case token.SUB:
+		return "Sub", true
+	case token.MUL:
+		return "Mul", true
+	case token.QUO:
+		return "Div", true
+	case token.REM:
+		return "Rem", true
+	case token.AND:
+		return "BitAnd", true
+	case token.OR:
+		return "BitOr", true
+	case token.XOR:
+		return "BitXor", true
+	case token.SHL:
+		return "Shl", true
+	case token.SHR:
+		return "Shr", true
+	case token.LAND:
+		return "And", true
+	case token.LOR:
+		return "Or", true
+	case token.EQL:
+		return "Eq", true
+	case token.LSS:
+		return "Lt", true
+	case token.LEQ:
+		return "Le", true
+	case token.NEQ:
+		return "Ne", true
+	case token.GEQ:
+		return "Ge", true
+	case token.GTR:
+		return "Gt", true
+	default:
+		return "", false
+	}
+}
+
+func otherTemplate(v any) any {
+	return otherNode{Kind: "other", Variant: astVariantName(v)}
+}
+
+func astVariantName(v any) string {
+	if v == nil {
+		return "nil"
+	}
+	t := reflect.TypeOf(v)
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Name() == "" {
+		return t.String()
+	}
+	return t.Name()
+}

--- a/implementations/go/provekit-lift-go/recognize.go
+++ b/implementations/go/provekit-lift-go/recognize.go
@@ -1,0 +1,142 @@
+package liftgo
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+)
+
+type RecognizeParams struct {
+	ProjectRoot      string            `json:"project_root"`
+	SourcePaths      []string          `json:"source_paths"`
+	BindingTemplates []BindingTemplate `json:"binding_templates"`
+}
+
+type BindingTemplate struct {
+	ConceptName string          `json:"concept_name"`
+	LibraryTag  string          `json:"library_tag"`
+	Family      any             `json:"family"`
+	ASTTemplate json.RawMessage `json:"ast_template"`
+	TemplateCID string          `json:"template_cid"`
+	ParamNames  []string        `json:"param_names"`
+	ContractCID string          `json:"contract_cid"`
+}
+
+type RecognizeResponse struct {
+	Tags []RecognizeTag `json:"tags"`
+}
+
+type RecognizeTag struct {
+	File          string         `json:"file"`
+	Span          SourceSpan     `json:"span"`
+	FunctionName  string         `json:"function_name"`
+	ConceptName   string         `json:"concept_name"`
+	LibraryTag    string         `json:"library_tag"`
+	Family        any            `json:"family"`
+	TemplateCID   string         `json:"template_cid"`
+	ContractCID   string         `json:"contract_cid"`
+	MatchTier     string         `json:"match_tier"`
+	ParamBindings []ParamBinding `json:"param_bindings"`
+}
+
+type ParamBinding struct {
+	Index      int    `json:"index"`
+	SourceText string `json:"source_text"`
+}
+
+func RecognizeImpl(params RecognizeParams) (RecognizeResponse, error) {
+	if params.ProjectRoot == "" {
+		return RecognizeResponse{}, fmt.Errorf("missing `project_root`")
+	}
+	if params.SourcePaths == nil {
+		return RecognizeResponse{}, fmt.Errorf("missing `source_paths` array")
+	}
+
+	bindingsByCID := map[string]BindingTemplate{}
+	for _, binding := range params.BindingTemplates {
+		if binding.TemplateCID == "" {
+			continue
+		}
+		bindingsByCID[binding.TemplateCID] = binding
+	}
+
+	tags := []RecognizeTag{}
+	for _, relPath := range params.SourcePaths {
+		path := relPath
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(params.ProjectRoot, relPath)
+		}
+		source, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		fileTags, err := recognizeFile(relPath, source, bindingsByCID)
+		if err != nil {
+			continue
+		}
+		tags = append(tags, fileTags...)
+	}
+	return RecognizeResponse{Tags: tags}, nil
+}
+
+func recognizeFile(relPath string, source []byte, bindingsByCID map[string]BindingTemplate) ([]RecognizeTag, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, relPath, source, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	tags := []RecognizeTag{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		tag, ok, err := recognizeFunc(fset, relPath, fn, bindingsByCID)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			tags = append(tags, tag)
+		}
+	}
+	return tags, nil
+}
+
+func recognizeFunc(fset *token.FileSet, relPath string, fn *ast.FuncDecl, bindingsByCID map[string]BindingTemplate) (RecognizeTag, bool, error) {
+	paramNames := funcParamNames(fn)
+	template := blockToASTTemplate(fn.Body, paramNames)
+	templateBytes, err := marshalJSONNoHTML(template)
+	if err != nil {
+		return RecognizeTag{}, false, err
+	}
+	templateCID := canonicalizer.ComputeCID(templateBytes)
+	binding, ok := bindingsByCID[templateCID]
+	if !ok {
+		return RecognizeTag{}, false, nil
+	}
+	paramBindings := make([]ParamBinding, 0, len(paramNames))
+	for i, name := range paramNames {
+		paramBindings = append(paramBindings, ParamBinding{
+			Index:      i + 1,
+			SourceText: name,
+		})
+	}
+	return RecognizeTag{
+		File:          relPath,
+		Span:          funcSpan(fset, fn),
+		FunctionName:  fn.Name.Name,
+		ConceptName:   binding.ConceptName,
+		LibraryTag:    binding.LibraryTag,
+		Family:        binding.Family,
+		TemplateCID:   templateCID,
+		ContractCID:   binding.ContractCID,
+		MatchTier:     "exact",
+		ParamBindings: paramBindings,
+	}, true, nil
+}

--- a/implementations/go/provekit-lift-go/recognize_test.go
+++ b/implementations/go/provekit-lift-go/recognize_test.go
@@ -1,0 +1,311 @@
+package liftgo
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+)
+
+func TestSugarBodyEmitsAstTemplateAlongsideBodyText(t *testing.T) {
+	src := []byte(`package shim
+
+func Fetch(url string, headers Header) Response {
+	return http.Get(url, headers)
+}
+`)
+	body := mustSugarBodySource(t, "shim.go", src, "Fetch")
+	if body.BodyText != "return http.Get(url, headers)" {
+		t.Fatalf("body_text = %q", body.BodyText)
+	}
+	if body.SourceCID != canonicalizer.ComputeCID([]byte(body.BodyText)) {
+		t.Fatalf("source_cid = %q, want cid of body_text", body.SourceCID)
+	}
+	if !equalStrings(body.ParamNames, []string{"url", "headers"}) {
+		t.Fatalf("param_names = %#v", body.ParamNames)
+	}
+	templateBytes := compactJSON(t, body.ASTTemplate)
+	if body.TemplateCID != canonicalizer.ComputeCID(templateBytes) {
+		t.Fatalf("template_cid = %q, want cid of %s", body.TemplateCID, templateBytes)
+	}
+
+	template := jsonObject(t, body.ASTTemplate)
+	if template["kind"] != "block" {
+		t.Fatalf("template kind = %#v", template["kind"])
+	}
+	stmts := jsonArray(t, template["stmts"])
+	if len(stmts) != 1 {
+		t.Fatalf("stmts = %#v, want one", stmts)
+	}
+	ret := jsonObject(t, stmts[0])
+	if ret["kind"] != "return" {
+		t.Fatalf("stmt kind = %#v, want return", ret["kind"])
+	}
+	call := jsonObject(t, ret["expr"])
+	if call["kind"] != "method_call" {
+		t.Fatalf("expr kind = %#v, want method_call", call["kind"])
+	}
+	if call["method"] != "Get" {
+		t.Fatalf("method = %#v, want Get", call["method"])
+	}
+	args := jsonArray(t, call["args"])
+	if got := jsonObject(t, args[0]); got["kind"] != "param_ref" || got["index"] != float64(1) {
+		t.Fatalf("first arg = %#v, want param_ref 1", got)
+	}
+	if got := jsonObject(t, args[1]); got["kind"] != "param_ref" || got["index"] != float64(2) {
+		t.Fatalf("second arg = %#v, want param_ref 2", got)
+	}
+}
+
+func TestSugarBodyAlphaEquivalenceCollapsesToSameCid(t *testing.T) {
+	srcA := []byte(`package shim
+
+func Fetch(url string, headers Header) Response {
+	return http.Get(url, headers)
+}
+`)
+	srcB := []byte(`package shim
+
+func Fetch(addr string, hdrs Header) Response {
+	return http.Get(addr, hdrs)
+}
+`)
+	bodyA := mustSugarBodySource(t, "a.go", srcA, "Fetch")
+	bodyB := mustSugarBodySource(t, "b.go", srcB, "Fetch")
+	if !bytes.Equal(compactJSON(t, bodyA.ASTTemplate), compactJSON(t, bodyB.ASTTemplate)) {
+		t.Fatalf("alpha-equivalent templates diverged:\nA: %s\nB: %s", compactJSON(t, bodyA.ASTTemplate), compactJSON(t, bodyB.ASTTemplate))
+	}
+	if bodyA.TemplateCID != bodyB.TemplateCID {
+		t.Fatalf("template_cid mismatch: %s vs %s", bodyA.TemplateCID, bodyB.TemplateCID)
+	}
+	if bodyA.SourceCID == bodyB.SourceCID {
+		t.Fatalf("source_cid must preserve original body text spelling")
+	}
+}
+
+func TestSugarBodyParamNameSwapCanonicalizes(t *testing.T) {
+	srcA := []byte(`package shim
+
+func F(a, b int) int {
+	return g(a, b)
+}
+`)
+	srcB := []byte(`package shim
+
+func F(x, y int) int {
+	return g(x, y)
+}
+`)
+	bodyA := mustSugarBodySource(t, "a.go", srcA, "F")
+	bodyB := mustSugarBodySource(t, "b.go", srcB, "F")
+	if bodyA.TemplateCID != bodyB.TemplateCID {
+		t.Fatalf("template_cid mismatch under param rename: %s vs %s", bodyA.TemplateCID, bodyB.TemplateCID)
+	}
+}
+
+func TestRecognizeEmitsExactTagForAlphaEquivalentUserFunction(t *testing.T) {
+	binding := mustBindingTemplate(t, "concept:http-request", "provekit-shim-go-stdlib-http", "concept:family:http", `package shim
+
+func Fetch(url string, headers Header) Response {
+	return http.Get(url, headers)
+}
+`, "Fetch")
+	root := t.TempDir()
+	rel := filepath.Join("pkg", "handlers", "fetch.go")
+	writeFile(t, filepath.Join(root, rel), `package handlers
+
+func FetchURL(u string, h Header) Response {
+	return http.Get(u, h)
+}
+`)
+
+	resp, err := RecognizeImpl(RecognizeParams{
+		ProjectRoot:      root,
+		SourcePaths:      []string{rel},
+		BindingTemplates: []BindingTemplate{binding},
+	})
+	if err != nil {
+		t.Fatalf("RecognizeImpl: %v", err)
+	}
+	if len(resp.Tags) != 1 {
+		t.Fatalf("tags = %#v, want one", resp.Tags)
+	}
+	tag := resp.Tags[0]
+	if tag.MatchTier != "exact" {
+		t.Fatalf("match_tier = %q, want exact", tag.MatchTier)
+	}
+	if tag.File != rel || tag.FunctionName != "FetchURL" {
+		t.Fatalf("tag route = %#v", tag)
+	}
+	if tag.ConceptName != "concept:http-request" || tag.LibraryTag != "provekit-shim-go-stdlib-http" || tag.Family != "concept:family:http" {
+		t.Fatalf("binding axes not preserved: %#v", tag)
+	}
+	if tag.TemplateCID != binding.TemplateCID || tag.ContractCID != binding.ContractCID {
+		t.Fatalf("cid fields not preserved: %#v", tag)
+	}
+	if len(tag.ParamBindings) != 2 || tag.ParamBindings[0].SourceText != "u" || tag.ParamBindings[1].SourceText != "h" {
+		t.Fatalf("param_bindings = %#v", tag.ParamBindings)
+	}
+}
+
+func TestRecognizeReturnsEmptyTagsForNonMatchingSource(t *testing.T) {
+	binding := mustBindingTemplate(t, "concept:http-request", "provekit-shim-go-stdlib-http", "", `package shim
+
+func Fetch(url string, headers Header) Response {
+	return http.Get(url, headers)
+}
+`, "Fetch")
+	root := t.TempDir()
+	rel := "fetch.go"
+	writeFile(t, filepath.Join(root, rel), `package handlers
+
+func FetchURL(u string, h Header) Response {
+	return completelyDifferent(u, h)
+}
+`)
+
+	resp, err := RecognizeImpl(RecognizeParams{
+		ProjectRoot:      root,
+		SourcePaths:      []string{rel},
+		BindingTemplates: []BindingTemplate{binding},
+	})
+	if err != nil {
+		t.Fatalf("RecognizeImpl: %v", err)
+	}
+	if len(resp.Tags) != 0 {
+		t.Fatalf("tags = %#v, want empty", resp.Tags)
+	}
+}
+
+func TestRecognizeRoutesMultipleBindingsPerCallSitePool(t *testing.T) {
+	httpBinding := mustBindingTemplate(t, "concept:http-request", "http-lib", "concept:family:http", `package shim
+
+func Fetch(url string, headers Header) Response {
+	return http.Get(url, headers)
+}
+`, "Fetch")
+	sqlBinding := mustBindingTemplate(t, "concept:sql-execute", "sql-lib", "concept:family:sql", `package shim
+
+func Exec(conn DB, sql string, args Args) Result {
+	return conn.Execute(sql, args)
+}
+`, "Exec")
+	root := t.TempDir()
+	rel := "calls.go"
+	writeFile(t, filepath.Join(root, rel), `package app
+
+func FetchURL(u string, h Header) Response {
+	return http.Get(u, h)
+}
+
+func RunQuery(db DB, query string, params Args) Result {
+	return db.Execute(query, params)
+}
+`)
+
+	resp, err := RecognizeImpl(RecognizeParams{
+		ProjectRoot:      root,
+		SourcePaths:      []string{rel},
+		BindingTemplates: []BindingTemplate{httpBinding, sqlBinding},
+	})
+	if err != nil {
+		t.Fatalf("RecognizeImpl: %v", err)
+	}
+	if len(resp.Tags) != 2 {
+		t.Fatalf("tags = %#v, want two", resp.Tags)
+	}
+	seen := map[string]string{}
+	for _, tag := range resp.Tags {
+		seen[tag.ConceptName] = tag.FunctionName
+		if tag.MatchTier != "exact" {
+			t.Fatalf("match_tier = %q, want exact", tag.MatchTier)
+		}
+	}
+	if seen["concept:http-request"] != "FetchURL" {
+		t.Fatalf("http binding routed to %#v", seen["concept:http-request"])
+	}
+	if seen["concept:sql-execute"] != "RunQuery" {
+		t.Fatalf("sql binding routed to %#v", seen["concept:sql-execute"])
+	}
+}
+
+func mustSugarBodySource(t *testing.T, path string, src []byte, fn string) SugarBodySource {
+	t.Helper()
+	body, ok, err := SugarBodySourceForFunc(path, src, fn)
+	if err != nil {
+		t.Fatalf("SugarBodySourceForFunc: %v", err)
+	}
+	if !ok {
+		t.Fatalf("missing function %s", fn)
+	}
+	return body
+}
+
+func mustBindingTemplate(t *testing.T, concept, library, family, src, fn string) BindingTemplate {
+	t.Helper()
+	body := mustSugarBodySource(t, "shim.go", []byte(src), fn)
+	astTemplate := json.RawMessage(compactJSON(t, body.ASTTemplate))
+	return BindingTemplate{
+		ConceptName: concept,
+		LibraryTag:  library,
+		Family:      family,
+		ASTTemplate: astTemplate,
+		TemplateCID: body.TemplateCID,
+		ParamNames:  body.ParamNames,
+		ContractCID: "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+	}
+}
+
+func compactJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := marshalJSONNoHTML(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func jsonObject(t *testing.T, v any) map[string]any {
+	t.Helper()
+	b := compactJSON(t, v)
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal object from %s: %v", b, err)
+	}
+	return out
+}
+
+func jsonArray(t *testing.T, v any) []any {
+	t.Helper()
+	b := compactJSON(t, v)
+	var out []any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal array from %s: %v", b, err)
+	}
+	return out
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func writeFile(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/implementations/go/provekit-lift-go/rpc.go
+++ b/implementations/go/provekit-lift-go/rpc.go
@@ -66,6 +66,8 @@ func RunRPCWithDefault(stdin io.Reader, stdout io.Writer, defaultOpts LiftOption
 			writeRPC(stdout, handleLift(req.ID, req.Params, defaultOpts))
 		case "compile":
 			writeRPC(stdout, handleCompile(req.ID, req.Params))
+		case "provekit.plugin.recognize":
+			writeRPC(stdout, handleRecognize(req.ID, req.Params))
 		case "shutdown":
 			writeRPC(stdout, successResponse(req.ID, nil))
 			return nil
@@ -110,6 +112,20 @@ func handleLift(id json.RawMessage, raw json.RawMessage, defaultOpts LiftOptions
 		"opacityReport": []any{},
 		"refusals":      result.Refusals,
 	})
+}
+
+func handleRecognize(id json.RawMessage, raw json.RawMessage) any {
+	var params RecognizeParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return errorResponse(id, -32602, "invalid recognize params")
+		}
+	}
+	result, err := RecognizeImpl(params)
+	if err != nil {
+		return errorResponse(id, -32602, err.Error())
+	}
+	return successResponse(id, result)
 }
 
 func handleCompile(id json.RawMessage, raw json.RawMessage) any {


### PR DESCRIPTION
Mirrors PR #1577 for Go. Phase A: lifter emits body_source.ast_template + template_cid + param_names via typed structs in declared field order matching rust serde insertion order (SetEscapeHTML(false) for parity). Phase B: provekit.plugin.recognize case in rpc.go with RecognizeImpl helper. Tier-1 only (match_tier:exact via template_cid byte equality). 6 Go testing cases mirror the rust recognize suite at implementations/rust/provekit-walk/src/bin/walk_rpc.rs lines 4739-5020. go test ./... passes in both implementations/go/provekit-lift-go and implementations/go.

Co-authored-by: Codex (gpt-5.5 xhigh) <noreply@anthropic.com>