### PR TITLE
fix(ci): remove broken provekit-verify step (red gate exit-127 since 2026-05-07)

### DIFF
--- a/.github/workflows/provekit.yml
+++ b/.github/workflows/provekit.yml
@@ -22,5 +22,11 @@ jobs:
         run: pnpm install
       - name: Run tests
         run: pnpm test
-      - name: ProvekIt verify
-        run: npx provekit verify --ci
+      # `ProvekIt verify` removed 2026-05-28: this package's package.json
+      # declares only `provekit-lsp-ts` as a bin, no `provekit` bin, so
+      # `npx provekit verify --ci` resolved to a published version that
+      # then spawned `provekit-lsp-ts` from PATH (where no symlink exists
+      # in CI). Net: exit 127 every run since 2026-05-07. A red gate is
+      # not a gate. The cross-language conformance gate carries the
+      # actual self-prove signal; re-add a working step when there's
+      # a real verify command that doesn't shell out via npx-into-registry.


### PR DESCRIPTION
Drops the `ProvekIt verify` step from `.github/workflows/provekit.yml`.

**Why:** Step has been failing every run since 2026-05-07 with `sh: 1: provekit-lsp-ts: not found` (exit 127). package.json declares only `provekit-lsp-ts` as a bin (no `provekit` bin), so `npx provekit verify --ci` falls through to npm registry, fetches a published version, and the published verifier spawns `provekit-lsp-ts` from PATH — where no symlink exists on the CI runner. Every PR has carried the failure marker for weeks. A red gate is not a gate.

**Impact:** unblocks #1582 / #1583 / #1584 (recognize-* PRs, all green on Cross-language conformance gate) plus every other open PR. The Cross-language conformance gate continues to carry the actual self-prove signal.

**Re-adding later:** when there is a verify command that does not shell out via npx-into-registry (e.g. a workspace-local `bin/provekit` symlink or a `pnpm exec` invocation that resolves to a workspace bin), the step can come back as a fresh PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)