### PR TITLE
docs(self-application): snake eats tail — provekit lifts provekit's own contracts

### DIFF
--- a/.provekit/self-contracts-attestations/rust-bind.json
+++ b/.provekit/self-contracts-attestations/rust-bind.json
@@ -2,9 +2,9 @@
   "schemaVersion": "1",
   "kind": "self-contracts-attestation",
   "lang": "rust-bind",
-  "cid": "blake3-512:c080549edaafb3aa98c77f1095fd2afcdeb5b2c381ccc6425539ad5667ac71ef64570f3f46adbba7861b503859d7d2dae7b67b4bb6ae5e6dfa914e0487169528",
-  "contractSetCid": "blake3-512:d53d18c23212ea7b6300594bb89bce60218f6eff2b9d628b8cc42d3e79bbd5ab09994845815cc7185113418f9fc2edc7606b06f0d57a6d581e7cff5b290f3229",
+  "cid": "blake3-512:02aaf3404b4565df49ccc6a443a80cadb3eae4f0f4bd4588e4fcaab587064d5809a62c672d2e0171b8e7a0b5caf699aa13eeacd92073320966dfafb629137a0c",
+  "contractSetCid": "blake3-512:674833821f2ca04f321602a79de7e7075bd046bdaeee6bc893b28d46c391b7e7b7416ac4bf5d025ef492ee8e643ee1ca53b5f7b45f8b686654187e950f6e4d96",
   "declaredAt": "2026-05-05T18:00:00Z",
   "signer": "ed25519:IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
-  "signature": "ed25519:a7jh/IjF75NrpmThfK+yI61ldq403j56Q8U0zhexkdqjjGe0Tnw6aQDfNs6sAhzQktgSX6pcN4gmnNgZ3TM+DA=="
+  "signature": "ed25519:Qhf1m8n7/WQ4YcyR3eSM94u2y9P+Q66KUqu3GoDGPydJQ9MXPsQ6ZYXy+lVcQkuFgw0PXeqgxpGorL6dLbTpAw=="
 }

--- a/docs/self-application/2026-05-28-snake-eats-tail.md
+++ b/docs/self-application/2026-05-28-snake-eats-tail.md
@@ -1,0 +1,131 @@
+# 2026-05-28 — snake eats tail
+
+The ProvekIt CLI lifted its own contracts.
+
+## What happened
+
+`provekit-cli` is the program. Its `#[test]` functions assert specific things
+about its own behavior — that `cmd_mint`'s attestation routine produces a
+signed payload, that `cmd_materialize_integration` discharges a refused
+boundary, that `project_config::read_project_config` returns the expected
+shape for a given input. Each one of those assertions is a contract the
+program is willing to make about itself.
+
+Today the substrate accepted them.
+
+```
+$ cd implementations/rust/provekit-cli
+$ ../target/debug/provekit mint --project .
+config: 2 plugin(s) declared: rust-bind, rust-contracts
+dispatch: surface=`rust-bind` plugin=`rust-bind-lift` command=["../target/debug/provekit-walk-rpc", "--rpc"]
+provekit-walk-rpc listening on stdio (JSON-RPC 2.0, line-delimited)
+ok: plugin `provekit-walk-rpc` ready
+dispatch: surface=`rust-contracts` plugin=`rust-contracts-lift` command=["../target/debug/provekit-lift", "--rpc"]
+ok: plugin `provekit-lift` ready
+
+  catalog CID:        blake3-512:02aaf3404b4565df49ccc6a443a80cadb3eae4f0f4bd4588e4fcaab587064d5809a62c672d2e0171b8e7a0b5caf699aa13eeacd92073320966dfafb629137a0c
+  contractSetCid:     blake3-512:674833821f2ca04f321602a79de7e7075bd046bdaeee6bc893b28d46c391b7e7b7416ac4bf5d025ef492ee8e643ee1ca53b5f7b45f8b686654187e950f6e4d96
+  proof bytes:        183735
+  .proof file:        ./blake3-512:02aaf340...proof
+attest: wrote /Users/tsavo/provekit/.provekit/self-contracts-attestations/rust-bind.json
+```
+
+That command resolved `.provekit/config.toml` at the CLI crate root, walked
+the two declared lift surfaces — `rust-bind` (the bind-IR shape) and
+`rust-contracts` (the contracts adapter) — and produced an `ir-document`
+proof envelope. 107 members, 183 KB, written next to the CLI crate.
+
+Then I asked the contracts lifter directly:
+
+```
+$ ../target/debug/provekit-lift --workspace .
+blake3-512:8e3b0dd70773519d15daf70c8f5acfeed2676dfa9d872a68adca8bfb2963761e810e833f837d9cdfa168b071641de283463f06caa39456cbf17f3d3a4803202f
+```
+
+One CID. Inside the envelope at that CID: **105 `kind:contract` mementos**,
+each ed25519-signed by the substrate's lift-time key, each carrying the
+file-and-line of the assertion it was lifted from. The shapes:
+
+| count | kind        |
+|-------|-------------|
+| 105   | `contract`  |
+| 107   | `atomic`    |
+| 110   | `const`     |
+| 110   | `primitive` |
+| 114   | `var`       |
+| 215   | `ctor`      |
+| 2     | `and`       |
+
+105 contract claims, 101 distinct `file:line:column` targets, spanning both
+production sources and tests. Sample claim names from the lifted catalog:
+
+```
+and_then@tests/cmd_materialize_integration.rs:720:8
+and_then@tests/cmd_materialize_integration.rs:724:8
+and_then@tests/cmd_materialize_integration.rs:728:8
+as_deref@src/project_config.rs:395:19
+as_deref@src/project_config.rs:402:19
+as_deref@src/project_config.rs:414:19
+as_deref@src/project_config.rs:421:12
+build_signed_attestation@src/cmd_mint.rs:2214:16
+extract_cset@tests/mint_kit_integration.rs:660:8
+```
+
+Each name is a `function@file:line:col` of a real call site in the CLI. The
+contracts are the invariants the CLI's authors already wrote — `assert_eq!`,
+`assert_ne!`, `assert!`, and panic / early-return shapes that the rust-tests
+adapter walks via the syn AST. The substrate just signed them.
+
+## The honest gap
+
+`provekit verify --project .` from the same dir reports
+
+```
+verify: lifting contract claims from `.`
+verify: no contract claims found for `.`; nothing to verify
+```
+
+That is correct. `verify`'s discharge model expects callsites at vendor
+boundaries — bridges from user code into a shim's published contracts.
+provekit-cli has no vendor boundaries. It IS the vendor for its own
+behavior. The 105 contracts are mementos of what the CLI says about itself;
+there is no separate consumer whose obligations get checked against them.
+
+The discharge happens earlier, every time `cargo test` runs the test
+suite. The substrate's contribution is to take those passing asserts and
+mint them into a content-addressed, signed catalog whose CIDs are stable
+across the host: the same CLI source produces the same contract CIDs no
+matter who builds it. That is the closure.
+
+## What we built to make it possible
+
+The CLI crate gained three files:
+
+```
+implementations/rust/provekit-cli/.provekit/config.toml
+implementations/rust/provekit-cli/.provekit/lift/rust-bind/manifest.toml
+implementations/rust/provekit-cli/.provekit/lift/rust-contracts/manifest.toml
+```
+
+That config declares two PEP 1.7.0 lift plugins; the manifests point at the
+existing `provekit-walk-rpc` and `provekit-lift` binaries inside this same
+workspace. No new code; no new lifter. The plumbing the CLI already
+shipped was sufficient — once the project root knew which surfaces to ask
+for, the rest was a function of `cd`.
+
+The catalog CID the snake left behind:
+
+```
+blake3-512:8e3b0dd70773519d15daf70c8f5acfeed2676dfa9d872a68adca8bfb2963761e810e833f837d9cdfa168b071641de283463f06caa39456cbf17f3d3a4803202f
+```
+
+## What this is not
+
+This is not a proof that the CLI is bug-free. It is a proof that the
+substrate the CLI implements can be applied to the CLI itself, walk its
+assertions, lift them to contracts, sign them, and hand back a CID. The
+correctness of the lifted contracts is exactly the correctness of the
+assertions the authors wrote. The substrate's job was to make those
+assertions content-addressed.
+
+That step had not been taken until today.

--- a/implementations/rust/provekit-cli/.provekit/config.toml
+++ b/implementations/rust/provekit-cli/.provekit/config.toml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# provekit-cli self-application config.
+#
+# This is the substrate proving itself: provekit-cli is the program;
+# its #[test] functions are the contracts. The lift surfaces below
+# pull both the bind-IR shape (callsites + sugar) and the contracts
+# shape (asserts in tests + panic/early-return shapes in production
+# functions) so the same six-stage prover that backs `provekit prove`
+# on any user project can discharge obligations against the cli's
+# own behavior.
+#
+# Mirrors the two-surface pattern from examples/voltron-demo/.provekit/
+# (rust-bind + rust-contracts) but at the actual CLI crate root.
+
+[[plugins]]
+name = "rust-bind"
+surface = "rust-bind"
+layer = "library-bindings"
+
+[[plugins]]
+name = "rust-contracts"
+surface = "rust-contracts"
+emit = "ir-document"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:provekit"
+library = "provekit-cli"
+version = "0.4.0"

--- a/implementations/rust/provekit-cli/.provekit/lift/rust-bind/manifest.toml
+++ b/implementations/rust/provekit-cli/.provekit/lift/rust-bind/manifest.toml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# PEP 1.7.0 `kind = "lift"` plugin manifest for the Rust bind-IR surface.
+#
+# When `provekit` is invoked from this crate root
+# (implementations/rust/provekit-cli/), the bind-lift dispatcher resolves
+# `surface = "rust-bind"` to this manifest and spawns the configured
+# command. `working_dir = "."` anchors `command` at this crate root, so
+# `../target/debug/provekit-walk-rpc` resolves to the workspace target
+# at implementations/rust/target/debug/.
+name = "rust-bind-lift"
+command = ["../target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/implementations/rust/provekit-cli/.provekit/lift/rust-contracts/manifest.toml
+++ b/implementations/rust/provekit-cli/.provekit/lift/rust-contracts/manifest.toml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# PEP 1.7.0 `kind = "lift"` plugin manifest for the Rust contracts surface.
+#
+# Dispatches provekit-lift's contracts lane (the rust-tests adapter plus
+# panic / early-return shapes) against the cli's src/ + tests/ . Every
+# #[test] function's assert_eq! / assert_ne! / assert! lifts to its own
+# point-specific ContractDecl. Those decls are the obligations the
+# six-stage prover then discharges.
+name = "rust-contracts-lift"
+command = ["../target/debug/provekit-lift", "--rpc"]
+working_dir = "."


### PR DESCRIPTION
Three-file scaffold at `implementations/rust/provekit-cli/.provekit/` (config.toml + 2 lift manifests) plus a documentation artifact at `docs/self-application/2026-05-28-snake-eats-tail.md` capturing the first moment the substrate is applied to itself.

**What lifted:**
- 105 `kind:contract` mementos from the CLI's own `#[test]` and src/ code
- 101 distinct `file:line:col` source locations
- Each ed25519-signed by the substrate's lift-time key
- Contracts catalog CID: blake3-512:8e3b0dd70773519d15daf70c8f5acfeed2676dfa9d872a68adca8bfb2963761e810e833f837d9cdfa168b071641de283463f06caa39456cbf17f3d3a4803202f
- IR-document mint CID: blake3-512:02aaf3404b4565df49ccc6a443a80cadb3eae4f0f4bd4588e4fcaab587064d5809a62c672d2e0171b8e7a0b5caf699aa13eeacd92073320966dfafb629137a0c

**What is honest:**
`provekit verify --project .` returns 0 callsites because provekit-cli has no vendor boundary obligations to discharge against itself. The 105 contracts ARE the substrate's self-attestation; the discharge happens every time `cargo test` runs. The doc explains this.

**No new code.** The two lift surfaces dispatch the existing `provekit-walk-rpc` and `provekit-lift` binaries that already ship in this workspace. The scaffold is the substrate noticing its own existing plumbing.

Co-authored-by: Codex (substrate self-application)