### PR TITLE
feat(mint): conjoin lift surfaces

### DIFF
--- a/implementations/rust/libprovekit/src/core/lift_plugin.rs
+++ b/implementations/rust/libprovekit/src/core/lift_plugin.rs
@@ -27,6 +27,7 @@ pub struct LiftPluginKit {
     surface: String,
     command: Vec<String>,
     working_dir: Option<PathBuf>,
+    lift_method: String,
 }
 
 /// Source-shaped Lift Kit adapter over the existing lift-plugin transport.
@@ -47,7 +48,22 @@ impl LiftPluginKit {
             surface: surface.into(),
             command,
             working_dir,
+            lift_method: "lift".to_string(),
         }
+    }
+
+    /// Override the JSON-RPC method used for the lift request. The default
+    /// method remains `lift`; multi-surface kits can expose a second route
+    /// such as `provekit.plugin.lift_implications` while keeping the same
+    /// transport.
+    pub fn with_method(mut self, method: impl Into<String>) -> Self {
+        let method = method.into();
+        self.lift_method = if method.is_empty() {
+            "lift".to_string()
+        } else {
+            method
+        };
+        self
     }
 
     /// Run the plugin transport and retain protocol metadata.
@@ -174,7 +190,7 @@ impl LiftPluginKit {
         let lift_req = json!({
             "jsonrpc": "2.0",
             "id": 2,
-            "method": "lift",
+            "method": self.lift_method,
             "params": lift_params
         });
         writeln!(stdin, "{lift_req}")

--- a/implementations/rust/provekit-cli/.provekit/config.toml
+++ b/implementations/rust/provekit-cli/.provekit/config.toml
@@ -23,6 +23,10 @@ name = "rust-contracts"
 surface = "rust-contracts"
 emit = "ir-document"
 
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
+
 [platform_profile]
 language = "rust"
 family = "concept:family:provekit"

--- a/implementations/rust/provekit-cli/.provekit/lift/rust-implications/manifest.toml
+++ b/implementations/rust/provekit-cli/.provekit/lift/rust-implications/manifest.toml
@@ -13,8 +13,10 @@
 # become enumerable callsites.
 #
 # Same binary as rust-bind / rust-contracts (provekit-walk-rpc owns the
-# syn AST machinery for all three rust lift lanes). The kit dispatches
-# to `provekit.plugin.lift_implications` for this surface.
+# syn AST machinery for all three rust lift lanes). The `method` field
+# tells mint to call the implication lift route instead of the default `lift`.
 name = "rust-implications-lift"
 command = ["../target/debug/provekit-walk-rpc", "--rpc"]
 working_dir = "."
+method = "provekit.plugin.lift_implications"
+phase = "consumer"

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -153,6 +153,20 @@ struct PerPluginDispatch {
     response: Value,
 }
 
+#[derive(Debug, Clone)]
+struct PreparedLiftStep {
+    surface: String,
+    lift_request: Value,
+}
+
+#[derive(Debug, Clone)]
+struct MintedIrDocument {
+    bytes: Vec<u8>,
+    filename_cid: String,
+    contract_set_cid: String,
+    contract_bindings: Vec<Value>,
+}
+
 /// Merge N per-plugin lift responses into one canonical `kind:
 /// "ir-document"` value. The union concatenates each plugin's `ir`
 /// array; diagnostics likewise. Every plugin in a multi-plugin path
@@ -298,64 +312,43 @@ impl MintKit {
             .and_then(Value::as_bool)
             .unwrap_or(false);
 
-        // Per-plugin dispatch. Each lift step contributes its own
-        // lift_request (workspace_root, surface, options) and its own
-        // RPC dispatch. Responses are accumulated and (when N > 1)
-        // merged into a single canonical ir-document before being
-        // minted into ONE envelope by the existing minter.
-        let mut per_plugin: Vec<PerPluginDispatch> = Vec::with_capacity(lift_steps.len());
-        let mut combined_lift_claim: Option<DomainClaim> = None;
+        // Prepare lift steps, then phase them. Producer surfaces emit
+        // contracts/sugars; consumer surfaces, such as rust-implications,
+        // depend on the producers' minted contract CIDs and must run second.
+        let mut producer_steps: Vec<PreparedLiftStep> = Vec::new();
+        let mut consumer_steps: Vec<PreparedLiftStep> = Vec::new();
         let mut surface_for_session: Option<String> = None;
         for lift_step in &lift_steps {
             let lift_request = self.path_step_spec(lift_step, "mint path lift step")?;
             let surface = required_str(&lift_request, "surface", "mint path lift step")
                 .map_err(KitError::Transformation)?
                 .to_string();
-            // Reconstruct the per-plugin LiftPluginOptions from the
-            // lift_request. workspace_override is carried in
-            // `options.workspaceOverride` (set by build_lift_params on
-            // initial construction). Restoring it lets dispatch_lift's
-            // internal build_lift_params re-derive the same
-            // workspace_root the plugin originally received, while
-            // find_manifest correctly uses project_root_for_manifests
-            // for the .provekit/ lookup.
-            let lift_options = LiftPluginOptions {
-                identify_only: lift_request
-                    .get("options")
-                    .and_then(|options| options.get("identifyOnly"))
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false),
-                library_bindings: lift_request
-                    .get("options")
-                    .and_then(|options| options.get("layer"))
-                    .and_then(Value::as_str)
-                    .is_some_and(|layer| layer == "library-bindings"),
-                workspace_override: lift_request
-                    .get("options")
-                    .and_then(|options| options.get("workspaceOverride"))
-                    .and_then(Value::as_str)
-                    .map(|s| s.to_string()),
-                emit: lift_request
-                    .get("options")
-                    .and_then(|options| options.get("emit"))
-                    .and_then(Value::as_str)
-                    .map(|s| s.to_string()),
-                layer: lift_request
-                    .get("options")
-                    .and_then(|options| options.get("layer"))
-                    .and_then(Value::as_str)
-                    .map(|s| s.to_string()),
-            };
-
-            // The first lift step's surface becomes the session's
-            // canonical (used for the self-contracts attestation file).
             if surface_for_session.is_none() {
                 surface_for_session = Some(surface.clone());
             }
+            let prepared = PreparedLiftStep {
+                surface,
+                lift_request,
+            };
+            if lift_plugin::surface_phase(&project_root_for_manifests, &prepared.surface)
+                == "consumer"
+            {
+                consumer_steps.push(prepared);
+            } else {
+                producer_steps.push(prepared);
+            }
+        }
 
+        let mut per_plugin: Vec<PerPluginDispatch> = Vec::with_capacity(lift_steps.len());
+        let mut producer_responses: Vec<PerPluginDispatch> =
+            Vec::with_capacity(producer_steps.len());
+        let mut combined_lift_claim: Option<DomainClaim> = None;
+
+        for step in &producer_steps {
+            let lift_options = lift_options_from_request(&step.lift_request, Vec::new());
             let session = match lift_plugin::dispatch_lift(
                 &project_root_for_manifests,
-                &surface,
+                &step.surface,
                 lift_options,
                 quiet,
             ) {
@@ -384,7 +377,7 @@ impl MintKit {
                     return Ok(MintSession {
                         claim,
                         result,
-                        surface,
+                        surface: step.surface.clone(),
                         out_dir,
                     });
                 }
@@ -404,7 +397,81 @@ impl MintKit {
             if combined_lift_claim.is_none() {
                 combined_lift_claim = Some(session.claim);
             }
-            per_plugin.push(PerPluginDispatch { surface, response });
+            let dispatched = PerPluginDispatch {
+                surface: step.surface.clone(),
+                response,
+            };
+            producer_responses.push(dispatched.clone());
+            per_plugin.push(dispatched);
+        }
+
+        let contract_bindings = if consumer_steps.is_empty() {
+            Vec::new()
+        } else {
+            contract_bindings_from_producer_responses(
+                &producer_responses,
+                &project_root_for_manifests,
+                &out_dir,
+                quiet,
+            )
+            .map_err(KitError::Transformation)?
+        };
+
+        for step in &consumer_steps {
+            let lift_options =
+                lift_options_from_request(&step.lift_request, contract_bindings.clone());
+            let session = match lift_plugin::dispatch_lift(
+                &project_root_for_manifests,
+                &step.surface,
+                lift_options,
+                quiet,
+            ) {
+                Ok(session) => session,
+                Err(LiftPluginError::MissingBinary { binary }) => {
+                    if !quiet {
+                        println!(
+                            "{}: lifter binary `{}` not found: producing empty-set attestation",
+                            "warn".yellow().bold(),
+                            binary
+                        );
+                    }
+                    let empty_cid = compute_contract_set_cid(vec![]);
+                    let result = DispatchResult {
+                        filename_cid: String::new(),
+                        contract_set_cid: empty_cid,
+                        bytes_written: 0,
+                        proof_file: None,
+                        lift_result: json!({
+                            "kind": "empty-set",
+                            "reason": "lifter binary not found",
+                            "binary": binary,
+                        }),
+                    };
+                    let claim = mint_result_claim(input, None, &result)?;
+                    return Ok(MintSession {
+                        claim,
+                        result,
+                        surface: step.surface.clone(),
+                        out_dir,
+                    });
+                }
+                Err(LiftPluginError::Refused(refusal)) => {
+                    return Err(KitError::Transformation(format!(
+                        "{}: {}",
+                        refusal.header.failure_kind, refusal.header.failure_detail
+                    )))
+                }
+                Err(LiftPluginError::Failed(error)) => return Err(KitError::Transformation(error)),
+            };
+
+            let response = session.response().clone();
+            if combined_lift_claim.is_none() {
+                combined_lift_claim = Some(session.claim);
+            }
+            per_plugin.push(PerPluginDispatch {
+                surface: step.surface.clone(),
+                response,
+            });
         }
 
         let merged_lift_response = if per_plugin.len() == 1 {
@@ -454,6 +521,82 @@ impl MintKit {
             }),
         }
     }
+}
+
+fn lift_options_from_request(
+    lift_request: &Value,
+    contract_bindings: Vec<Value>,
+) -> LiftPluginOptions {
+    LiftPluginOptions {
+        identify_only: lift_request
+            .get("options")
+            .and_then(|options| options.get("identifyOnly"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        library_bindings: lift_request
+            .get("options")
+            .and_then(|options| options.get("layer"))
+            .and_then(Value::as_str)
+            .is_some_and(|layer| layer == "library-bindings"),
+        workspace_override: lift_request
+            .get("options")
+            .and_then(|options| options.get("workspaceOverride"))
+            .and_then(Value::as_str)
+            .map(|s| s.to_string()),
+        emit: lift_request
+            .get("options")
+            .and_then(|options| options.get("emit"))
+            .and_then(Value::as_str)
+            .map(|s| s.to_string()),
+        layer: lift_request
+            .get("options")
+            .and_then(|options| options.get("layer"))
+            .and_then(Value::as_str)
+            .map(|s| s.to_string()),
+        contract_bindings,
+    }
+}
+
+fn contract_bindings_from_producer_responses(
+    producer_responses: &[PerPluginDispatch],
+    project_root: &Path,
+    out_dir: &Path,
+    quiet: bool,
+) -> Result<Vec<Value>, String> {
+    if producer_responses.is_empty() {
+        return Ok(Vec::new());
+    }
+    let lift_response = if producer_responses.len() == 1 {
+        producer_responses[0].response.clone()
+    } else {
+        merge_ir_document_responses(producer_responses.to_vec())?
+    };
+    let kind = lift_response
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .ok_or("producer lift response missing `kind` field")?;
+    if kind != "ir-document" {
+        return Err(format!(
+            "consumer lift surfaces require producer ir-documents; producer response kind was `{kind}`"
+        ));
+    }
+    let ir = lift_response
+        .get("ir")
+        .and_then(|v| v.as_array())
+        .ok_or("producer ir-document response missing `ir` array")?;
+    let authorities = lift_response.get("authorities").and_then(|v| v.as_array());
+    let implications = lift_response.get("implications").and_then(|v| v.as_array());
+    let witnesses = lift_response.get("witnesses").and_then(|v| v.as_array());
+    Ok(mint_ir_document(
+        ir,
+        authorities,
+        implications,
+        witnesses,
+        project_root,
+        out_dir,
+        quiet,
+    )?
+    .contract_bindings)
 }
 
 impl Kit for MintKit {
@@ -595,6 +738,7 @@ fn mint_input_multi(
                 workspace_override: plugin.workspace_override.clone(),
                 emit: plugin.emit.clone(),
                 layer: plugin.layer.clone(),
+                contract_bindings: Vec::new(),
             },
         ));
         let lift_input_cid = address(&lift_input);
@@ -713,7 +857,7 @@ fn mint_lift_response(
             let authorities = lift_resp.get("authorities").and_then(|v| v.as_array());
             let implications = lift_resp.get("implications").and_then(|v| v.as_array());
             let witnesses = lift_resp.get("witnesses").and_then(|v| v.as_array());
-            let (bytes, filename_cid, contract_set_cid) = mint_from_ir_document(
+            let minted = mint_ir_document(
                 ir,
                 authorities,
                 implications,
@@ -725,8 +869,8 @@ fn mint_lift_response(
 
             std::fs::create_dir_all(out_dir)
                 .map_err(|e| format!("mkdir {}: {e}", out_dir.display()))?;
-            let out_path = out_dir.join(format!("{filename_cid}.proof"));
-            std::fs::write(&out_path, &bytes)
+            let out_path = out_dir.join(format!("{}.proof", minted.filename_cid));
+            std::fs::write(&out_path, &minted.bytes)
                 .map_err(|e| format!("write {}: {e}", out_path.display()))?;
 
             if !quiet {
@@ -743,9 +887,9 @@ fn mint_lift_response(
             }
 
             Ok(DispatchResult {
-                filename_cid,
-                contract_set_cid,
-                bytes_written: bytes.len(),
+                filename_cid: minted.filename_cid,
+                contract_set_cid: minted.contract_set_cid,
+                bytes_written: minted.bytes.len(),
                 proof_file: Some(out_path),
                 lift_result: lift_resp,
             })
@@ -863,6 +1007,47 @@ pub(crate) fn stamp_platform_profile(
     }
 }
 
+fn mint_bridge_from_decl(
+    decl: &Value,
+    produced_at: &str,
+    signer_seed: Ed25519Seed,
+) -> Result<(String, Vec<u8>), String> {
+    let source_symbol = decl
+        .get("sourceSymbol")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or("bridge ir entry missing `sourceSymbol`")?;
+    let target_contract_cid = decl
+        .get("targetContractCid")
+        .or_else(|| decl.get("sourceContractCid"))
+        .or_else(|| decl.pointer("/target/cid"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or("bridge ir entry missing `targetContractCid`")?;
+    let source_layer = decl
+        .get("sourceLayer")
+        .and_then(|v| v.as_str())
+        .unwrap_or("source");
+    let target_layer = decl
+        .get("targetLayer")
+        .and_then(|v| v.as_str())
+        .unwrap_or("kit");
+    let bridge = mint_bridge(&MintBridgeArgs {
+        produced_by: "provekit-cli".to_string(),
+        produced_at: produced_at.to_string(),
+        source_symbol: source_symbol.to_string(),
+        source_layer: source_layer.to_string(),
+        target_contract_cid: target_contract_cid.to_string(),
+        target_layer: target_layer.to_string(),
+        ir_arg_sorts: vec![],
+        ir_return_sort: String::new(),
+        notes: "implication-lifted callsite bridge".to_string(),
+        signer_seed,
+    });
+    Ok((bridge.cid, bridge.canonical_bytes))
+}
+
+#[cfg(test)]
 fn mint_from_ir_document(
     ir: &[Value],
     authorities: Option<&Vec<Value>>,
@@ -872,6 +1057,27 @@ fn mint_from_ir_document(
     out_dir: &Path,
     quiet: bool,
 ) -> Result<(Vec<u8>, String, String), String> {
+    let minted = mint_ir_document(
+        ir,
+        authorities,
+        implications,
+        witnesses,
+        project_root,
+        out_dir,
+        quiet,
+    )?;
+    Ok((minted.bytes, minted.filename_cid, minted.contract_set_cid))
+}
+
+fn mint_ir_document(
+    ir: &[Value],
+    authorities: Option<&Vec<Value>>,
+    implications: Option<&Vec<Value>>,
+    witnesses: Option<&Vec<Value>>,
+    project_root: &Path,
+    out_dir: &Path,
+    quiet: bool,
+) -> Result<MintedIrDocument, String> {
     use std::collections::BTreeMap;
 
     #[derive(Clone)]
@@ -1157,6 +1363,11 @@ fn mint_from_ir_document(
                     let (cid, bytes) = mint_realization_memento(decl)?;
                     members.entry(cid).or_insert(bytes);
                 }
+                Some("bridge") => {
+                    let (cid, bytes) =
+                        mint_bridge_from_decl(decl, &produced_at, default_signer_seed)?;
+                    members.entry(cid).or_insert(bytes);
+                }
                 _ => {}
             }
         }
@@ -1173,6 +1384,11 @@ fn mint_from_ir_document(
                 }
                 Some("realization-memento") => {
                     let (cid, bytes) = mint_realization_memento(decl)?;
+                    members.entry(cid).or_insert(bytes);
+                }
+                Some("bridge") => {
+                    let (cid, bytes) =
+                        mint_bridge_from_decl(decl, &produced_at, default_signer_seed)?;
                     members.entry(cid).or_insert(bytes);
                 }
                 _ => {}
@@ -1264,6 +1480,15 @@ fn mint_from_ir_document(
     }
 
     let contract_set_cid = compute_contract_set_cid(content_cids);
+    let contract_bindings: Vec<Value> = contracts_by_name
+        .iter()
+        .map(|(name, contract)| {
+            json!({
+                "name": name,
+                "contract_cid": contract.attestation_cid.clone(),
+            })
+        })
+        .collect();
 
     let (proof_signer, proof_signer_seed) = if let Some(authority) = proof_authority {
         (authority.cid, authority.seed)
@@ -1287,7 +1512,12 @@ fn mint_from_ir_document(
 
     let built = build_proof_envelope(&proof_input);
 
-    Ok((built.bytes, built.cid, contract_set_cid))
+    Ok(MintedIrDocument {
+        bytes: built.bytes,
+        filename_cid: built.cid,
+        contract_set_cid,
+        contract_bindings,
+    })
 }
 
 fn mint_library_sugar_binding_entry(decl: &Value) -> Result<(String, Vec<u8>), String> {
@@ -2483,6 +2713,69 @@ mod tests {
 
         assert_eq!(contract_count, 2);
         assert_eq!(implication_count, 1);
+    }
+
+    #[test]
+    fn mint_from_ir_document_mints_explicit_bridge_entries() {
+        let target_cid = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let ir = vec![
+            json!({
+                "kind": "contract",
+                "name": "callee@src/lib.rs:1:1",
+                "outBinding": "out",
+                "post": {"kind": "atomic", "name": "producer_post", "args": []}
+            }),
+            json!({
+                "kind": "bridge",
+                "name": "intra-body:rust:callee@src/lib.rs:2:4",
+                "schemaVersion": "1",
+                "sourceContractCid": target_cid,
+                "sourceLayer": "rust",
+                "sourceSymbol": "callee",
+                "target": {"cid": target_cid, "kind": "contract"},
+                "targetContractCid": target_cid,
+                "targetLayer": "rust-tests"
+            }),
+        ];
+
+        let (bytes, _, _) =
+            mint_from_ir_document(&ir, None, None, None, Path::new("."), Path::new("."), true)
+                .expect("mint contract plus explicit bridge");
+        let catalog = provekit_verifier::cbor_decode::decode(&bytes).expect("decode proof");
+        let members = catalog
+            .as_map()
+            .and_then(|m| m.get("members"))
+            .and_then(|v| v.as_map())
+            .expect("proof members");
+
+        let mut contract_count = 0;
+        let mut bridge_count = 0;
+        for member in members.values() {
+            let bytes = member.as_bstr().expect("member bytes");
+            let envelope: Value = serde_json::from_slice(bytes).expect("member JSON");
+            match envelope.pointer("/header/kind").and_then(|v| v.as_str()) {
+                Some("contract") => contract_count += 1,
+                Some("bridge") => {
+                    bridge_count += 1;
+                    assert_eq!(
+                        envelope
+                            .pointer("/header/targetContractCid")
+                            .and_then(|v| v.as_str()),
+                        Some(target_cid)
+                    );
+                    assert_eq!(
+                        envelope
+                            .pointer("/header/sourceSymbol")
+                            .and_then(|v| v.as_str()),
+                        Some("callee")
+                    );
+                }
+                other => panic!("unexpected member kind {other:?}"),
+            }
+        }
+
+        assert_eq!(contract_count, 1);
+        assert_eq!(bridge_count, 1);
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/src/lift_plugin.rs
+++ b/implementations/rust/provekit-cli/src/lift_plugin.rs
@@ -24,6 +24,14 @@ pub(crate) struct LiftPluginManifest {
     pub name: String,
     pub command: Vec<String>,
     pub working_dir: Option<PathBuf>,
+    /// Optional JSON-RPC method override. Defaults to `lift`.
+    /// Used by a kit binary that owns several lift surfaces, such as
+    /// Rust's `provekit.plugin.lift_implications` consumer surface.
+    pub method: Option<String>,
+    /// Optional lift phase. Defaults to producer. `consumer` surfaces are
+    /// run after producers with producer contract CIDs forwarded as
+    /// top-level `contract_bindings`.
+    pub phase: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -62,6 +70,9 @@ pub struct LiftPluginOptions {
     /// "library-bindings"), so per-plugin config can request the
     /// appropriate layer regardless of the global CLI flag.
     pub layer: Option<String>,
+    /// Contract bindings forwarded to implication consumer surfaces. Each
+    /// entry is `{ "name": <contract name>, "contract_cid": <attestation cid> }`.
+    pub contract_bindings: Vec<Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -124,11 +135,14 @@ pub(crate) fn dispatch_lift(
     }
 
     let lift_params = build_lift_params(project_root, surface, options);
-    let kit = LiftPluginKit::new(
+    let mut kit = LiftPluginKit::new(
         surface,
         manifest.command.clone(),
         resolved_working_dir(project_root, &manifest),
     );
+    if let Some(method) = manifest.method.as_deref() {
+        kit = kit.with_method(method);
+    }
     trace_log(format!("lift kit parse surface={surface}"));
     let core_session = kit.parse_session(&Input::Spec(lift_params.clone()))?;
     trace_log(format!(
@@ -281,6 +295,8 @@ fn parse_manifest(path: &Path) -> Result<LiftPluginManifest, String> {
         name: String::new(),
         command: Vec::new(),
         working_dir: None,
+        method: None,
+        phase: None,
     };
     for line in text.lines() {
         let line = match line.find('#') {
@@ -297,6 +313,18 @@ fn parse_manifest(path: &Path) -> Result<LiftPluginManifest, String> {
         match key {
             "name" => manifest.name = val.trim_matches('"').to_string(),
             "working_dir" => manifest.working_dir = Some(PathBuf::from(val.trim_matches('"'))),
+            "method" => {
+                let method = val.trim_matches('"').to_string();
+                manifest.method = if method.is_empty() {
+                    None
+                } else {
+                    Some(method)
+                };
+            }
+            "phase" => {
+                let phase = val.trim_matches('"').to_string();
+                manifest.phase = if phase.is_empty() { None } else { Some(phase) };
+            }
             "command" => {
                 let inner = val.trim_matches(|c| c == '[' || c == ']');
                 manifest.command = inner
@@ -312,6 +340,14 @@ fn parse_manifest(path: &Path) -> Result<LiftPluginManifest, String> {
         return Err(format!("manifest {} has no `command`", path.display()));
     }
     Ok(manifest)
+}
+
+pub(crate) fn surface_phase(project_root: &Path, surface: &str) -> String {
+    find_manifest(project_root, surface)
+        .ok()
+        .and_then(|manifest| manifest.phase)
+        .filter(|phase| phase == "consumer")
+        .unwrap_or_else(|| "producer".to_string())
 }
 
 fn find_manifest(project_root: &Path, surface: &str) -> Result<LiftPluginManifest, String> {
@@ -392,13 +428,17 @@ pub fn build_lift_params(project_root: &Path, surface: &str, options: LiftPlugin
     if let Some(override_path) = options.workspace_override.as_deref() {
         options_obj["workspaceOverride"] = json!(override_path);
     }
-    json!({
+    let mut params = json!({
         "surface": surface,
         "workspace_root": workspace_root,
         "config_path": ".provekit/config.toml",
         "source_paths": ["."],
         "options": options_obj,
-    })
+    });
+    if !options.contract_bindings.is_empty() {
+        params["contract_bindings"] = Value::Array(options.contract_bindings.clone());
+    }
+    params
 }
 
 fn trace_enabled() -> bool {

--- a/implementations/rust/provekit-cli/tests/cli_surface.rs
+++ b/implementations/rust/provekit-cli/tests/cli_surface.rs
@@ -438,6 +438,155 @@ done
 }
 
 #[test]
+fn mint_conjoins_producer_contracts_and_consumer_bridges_in_one_proof() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let project = dir.path().join("project");
+    let producer_manifest = project.join(".provekit/lift/producer");
+    let consumer_manifest = project.join(".provekit/lift/consumer");
+    let out_dir = dir.path().join("out");
+    fs::create_dir_all(&producer_manifest).expect("create producer manifest dir");
+    fs::create_dir_all(&consumer_manifest).expect("create consumer manifest dir");
+    fs::write(
+        project.join(".provekit/config.toml"),
+        r#"[[plugins]]
+name = "producer"
+surface = "producer"
+emit = "ir-document"
+
+[[plugins]]
+name = "consumer"
+surface = "consumer"
+"#,
+    )
+    .expect("write project config");
+
+    let producer = dir.path().join("producer.sh");
+    write_executable(
+        &producer,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+  if [[ "$line" == *'"method":"initialize"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"producer","protocol_version":"pep/1.7.0","capabilities":{}}}'
+  elif [[ "$line" == *'"method":"lift"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"kind":"ir-document","ir":[{"kind":"contract","name":"callee@src/lib.rs:1:1","outBinding":"out","post":{"kind":"atomic","name":"producer_post","args":[]}}],"diagnostics":[]}}'
+  elif [[ "$line" == *'"method":"shutdown"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+    exit 0
+  fi
+done
+"#,
+    );
+
+    let consumer = dir.path().join("consumer.sh");
+    write_executable(
+        &consumer,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+  if [[ "$line" == *'"method":"initialize"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"consumer","protocol_version":"pep/1.7.0","capabilities":{}}}'
+  elif [[ "$line" == *'"method":"lift"'* ]]; then
+    printf 'consumer must be dispatched via lift_implications, not lift: %s\n' "$line" >&2
+    exit 44
+  elif [[ "$line" == *'"method":"provekit.plugin.lift_implications"'* ]]; then
+    if [[ "$line" != *'"contract_bindings"'* || "$line" != *'"name":"callee@src/lib.rs:1:1"'* ]]; then
+      printf 'consumer did not receive producer contract_bindings: %s\n' "$line" >&2
+      exit 45
+    fi
+    cid="${line#*\"contract_cid\":\"}"
+    cid="${cid%%\"*}"
+    if [[ "$cid" != blake3-512:* ]]; then
+      printf 'consumer received invalid contract cid: %s\n' "$line" >&2
+      exit 46
+    fi
+    printf '{"jsonrpc":"2.0","id":2,"result":{"kind":"ir-document","ir":[{"kind":"bridge","name":"intra-body:rust:callee@src/lib.rs:2:4","schemaVersion":"1","sourceContractCid":"%s","sourceLayer":"rust","sourceSymbol":"callee","target":{"cid":"%s","kind":"contract"},"targetContractCid":"%s","targetLayer":"rust-tests"}],"diagnostics":[]}}\n' "$cid" "$cid" "$cid"
+  elif [[ "$line" == *'"method":"shutdown"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+    exit 0
+  fi
+done
+"#,
+    );
+
+    fs::write(
+        producer_manifest.join("manifest.toml"),
+        format!(
+            "name = \"producer\"\ncommand = [\"{}\"]\n",
+            producer.display()
+        ),
+    )
+    .expect("write producer manifest");
+    fs::write(
+        consumer_manifest.join("manifest.toml"),
+        format!(
+            "name = \"consumer\"\ncommand = [\"{}\"]\nmethod = \"provekit.plugin.lift_implications\"\nphase = \"consumer\"\n",
+            consumer.display()
+        ),
+    )
+    .expect("write consumer manifest");
+
+    let output = output_retrying_etxtbsy(
+        Command::new(provekit_bin())
+            .arg("mint")
+            .arg("--project")
+            .arg(&project)
+            .arg("--out")
+            .arg(&out_dir)
+            .arg("--no-attest")
+            .arg("--json")
+            .arg("--quiet"),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "mint conjoin should run producers, forward contract_bindings to consumers, and emit one proof\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let proof_files: Vec<PathBuf> = fs::read_dir(&out_dir)
+        .expect("read out dir")
+        .filter_map(|entry| {
+            let path = entry.expect("out dir entry").path();
+            (path.extension().and_then(|s| s.to_str()) == Some("proof")).then_some(path)
+        })
+        .collect();
+    assert_eq!(
+        proof_files.len(),
+        1,
+        "producer + consumer conjoin must write one proof, got {proof_files:?}"
+    );
+
+    let pool = provekit_verifier::load_all_proofs::run_with_files(
+        Path::new("/no-such-project"),
+        &proof_files,
+    );
+    assert!(
+        pool.load_errors.is_empty(),
+        "conjoined proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+    let bridge = pool.bridges_by_symbol.get("callee").unwrap_or_else(|| {
+        panic!(
+            "consumer bridge should be indexed by sourceSymbol=callee; got {:?}",
+            pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+        )
+    });
+    let target_cid = provekit_verifier::types::memento_body_field(bridge, "targetContractCid")
+        .and_then(|v| v.as_str())
+        .expect("bridge targetContractCid");
+    let target = pool
+        .mementos
+        .get(target_cid)
+        .unwrap_or_else(|| panic!("bridge target cid {target_cid} must resolve in same proof"));
+    assert_eq!(
+        provekit_verifier::types::memento_kind(target).as_deref(),
+        Some("contract")
+    );
+}
+
+#[test]
 fn mint_uses_path_document_from_project_config() {
     let dir = tempfile::tempdir().expect("create tempdir");
     let project = dir.path().join("project");

--- a/implementations/rust/provekit-cli/tests/dependency_proof_pool_assembly.rs
+++ b/implementations/rust/provekit-cli/tests/dependency_proof_pool_assembly.rs
@@ -158,6 +158,102 @@ fn publish_user_bridge(project_dir: &Path, target_cid: &str, target_bundle_cid: 
     );
 }
 
+fn publish_contradictory_implication_project() -> PathBuf {
+    let project = unique_dir("contradictory-implication");
+    let proof_dir = project.join(".provekit");
+    fs::create_dir_all(&proof_dir).expect("mkdir proof dir");
+
+    let producer_env = json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": "produce_zero",
+                "post": {
+                    "kind": "atomic",
+                    "name": "=",
+                    "args": [var("result"), int_const(0)]
+                }
+            }
+        }
+    });
+    let (producer_cid, producer_bytes) = flat_member(producer_env);
+
+    let consumer_env = json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": "requires_positive",
+                "formals": ["x"],
+                "formalSorts": [int_sort()],
+                "pre": {
+                    "kind": "atomic",
+                    "name": ">",
+                    "args": [var("x"), int_const(0)]
+                }
+            }
+        }
+    });
+    let (consumer_cid, consumer_bytes) = flat_member(consumer_env);
+
+    let source_env = json!({
+        "evidence": {
+            "kind": "contract",
+            "body": {
+                "contractName": "contradictory_callsite",
+                "inv": {
+                    "kind": "atomic",
+                    "name": "observed",
+                    "args": [{
+                        "kind": "ctor",
+                        "name": "requires_positive",
+                        "args": [{
+                            "kind": "ctor",
+                            "name": "produce_zero",
+                            "args": []
+                        }]
+                    }]
+                }
+            }
+        }
+    });
+    let (source_cid, source_bytes) = flat_member(source_env);
+
+    let producer_bridge_env = json!({
+        "evidence": {
+            "kind": "bridge",
+            "body": {
+                "sourceSymbol": "produce_zero",
+                "sourceLayer": "rust",
+                "targetContractCid": producer_cid,
+                "targetLayer": "rust-tests"
+            }
+        }
+    });
+    let (producer_bridge_cid, producer_bridge_bytes) = flat_member(producer_bridge_env);
+
+    let consumer_bridge_env = json!({
+        "evidence": {
+            "kind": "bridge",
+            "body": {
+                "sourceSymbol": "requires_positive",
+                "sourceLayer": "rust",
+                "targetContractCid": consumer_cid,
+                "targetLayer": "rust-tests"
+            }
+        }
+    });
+    let (consumer_bridge_cid, consumer_bridge_bytes) = flat_member(consumer_bridge_env);
+
+    let mut members = BTreeMap::new();
+    members.insert(producer_cid, producer_bytes);
+    members.insert(consumer_cid, consumer_bytes);
+    members.insert(source_cid, source_bytes);
+    members.insert(producer_bridge_cid, producer_bridge_bytes);
+    members.insert(consumer_bridge_cid, consumer_bridge_bytes);
+    write_proof(&proof_dir, "@test/contradictory-implication", members);
+    project
+}
+
 fn install_dependency_proof_stub(project_dir: &Path, proof_path: &Path) {
     let bin = project_dir.join("resolve-deps-stub.sh");
     fs::write(
@@ -247,4 +343,46 @@ fn voltron_pool_refuses_cross_dependency_violation() {
         String::from_utf8_lossy(&output.stderr)
     );
     let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn prove_reports_violation_for_contradictory_implication() {
+    if !z3_available() {
+        eprintln!("SKIP prove_reports_violation_for_contradictory_implication: z3 not on PATH");
+        return;
+    }
+
+    let project = publish_contradictory_implication_project();
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("prove")
+        .arg(&project)
+        .arg("--z3")
+        .arg("z3")
+        .arg("--json")
+        .output()
+        .expect("run provekit prove");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "contradictory implication must be a proof violation\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report: Json =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("parse prove JSON: {e}\n{stdout}"));
+    assert_eq!(report["violations"], 1, "report: {report}");
+    assert!(
+        report["rows"]
+            .as_array()
+            .expect("rows")
+            .iter()
+            .any(|row| row["bridge"] == "requires_positive"
+                && row["status"] == "unsatisfied"
+                && row["reason"].as_str().unwrap_or("").contains("sat")),
+        "requires_positive(produce_zero()) should violate `produce_zero.post -> requires_positive.pre`: {report}"
+    );
+
+    let _ = fs::remove_dir_all(project);
 }

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -472,8 +472,7 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
     let mut entries: Vec<Value> = Vec::new();
     let mut diagnostics: Vec<Value> = Vec::new();
 
-    for rel_path in &source_paths {
-        let full_path = workspace_root.join(rel_path);
+    for (rel_path, full_path) in resolve_rs_source_files(&workspace_root, &source_paths) {
         let src = match std::fs::read_to_string(&full_path) {
             Ok(s) => s,
             Err(_) => continue, // missing files are not lift errors here
@@ -484,7 +483,7 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
         };
 
         let mut callsites: Vec<CallSite> = Vec::new();
-        collect_callsites_in_items(&file.items, rel_path, &mut callsites);
+        collect_callsites_in_items(&file.items, &rel_path, &mut callsites);
 
         for cs in callsites {
             let Some(binding) = contracts_by_callee.get(cs.callee.as_str()) else {
@@ -2526,6 +2525,53 @@ fn ir_term_to_text(term: &IrTerm) -> String {
             format!("let {bindings} in {}", ir_term_to_text(body))
         }
     }
+}
+
+fn resolve_rs_source_files(
+    workspace_root: &Path,
+    source_paths: &[String],
+) -> Vec<(String, PathBuf)> {
+    let mut visited: std::collections::BTreeSet<PathBuf> = Default::default();
+    let scan_roots: Vec<PathBuf> = if source_paths.is_empty() {
+        vec![workspace_root.to_path_buf()]
+    } else {
+        source_paths
+            .iter()
+            .map(|p| workspace_root.join(p))
+            .collect()
+    };
+    for scan_root in &scan_roots {
+        if scan_root.is_file() {
+            if scan_root.extension().map(|x| x == "rs").unwrap_or(false) {
+                visited.insert(scan_root.clone());
+            }
+            continue;
+        }
+        if !scan_root.is_dir() {
+            continue;
+        }
+        let src_dir = scan_root.join("src");
+        let walk_root: &Path = if src_dir.is_dir() {
+            &src_dir
+        } else {
+            scan_root
+        };
+        collect_rs_files(walk_root, &mut visited);
+        if walk_root != scan_root.as_path() {
+            collect_rs_files_shallow(scan_root, &mut visited);
+        }
+    }
+    visited
+        .into_iter()
+        .map(|abs| {
+            let rel = abs
+                .strip_prefix(workspace_root)
+                .unwrap_or(&abs)
+                .to_string_lossy()
+                .to_string();
+            (rel, abs)
+        })
+        .collect()
 }
 
 fn collect_rs_files(dir: &Path, visited: &mut std::collections::BTreeSet<PathBuf>) {
@@ -7325,6 +7371,80 @@ pub fn caller(input: &str) -> i64 {
         assert_eq!(
             norm["targetContractCid"],
             "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_scans_src_when_source_path_is_project_root() {
+        let src = r##"
+pub fn caller(input: &str) -> i64 {
+    parse_input(input)
+}
+"##;
+        let root = temp_workspace("lift_implications_project_root");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(src_dir.join("lib.rs"), src).expect("write source");
+
+        let contract_bindings = json!([
+            { "name": "parse_input@src/lib.rs:5:8",
+              "contract_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+        ]);
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."],
+            "contract_bindings": contract_bindings,
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        assert!(
+            ir.iter()
+                .any(|entry| entry["sourceSymbol"] == "parse_input"),
+            "mint sends source_paths=[\".\"], so implication lift must scan src/: {ir:?}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rpc_dispatches_provekit_plugin_lift_implications_method() {
+        let src = r##"
+pub fn caller(input: &str) -> i64 {
+    parse_input(input)
+}
+"##;
+        let root = temp_workspace("lift_implications_rpc_method");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(src_dir.join("lib.rs"), src).expect("write source");
+
+        let response = handle_line(&json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "provekit.plugin.lift_implications",
+            "params": {
+                "workspace_root": root.to_string_lossy(),
+                "source_paths": ["."],
+                "contract_bindings": [{
+                    "name": "parse_input@src/lib.rs:5:8",
+                    "contract_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                }],
+            }
+        }).to_string());
+
+        assert!(
+            response.get("error").is_none(),
+            "RPC method table must expose provekit.plugin.lift_implications: {response}"
+        );
+        let ir = response["result"]["ir"].as_array().expect("ir array");
+        assert!(
+            ir.iter()
+                .any(|entry| entry["sourceSymbol"] == "parse_input"),
+            "RPC implication route should return bridge IR: {response}"
         );
 
         let _ = fs::remove_dir_all(root);


### PR DESCRIPTION
## Summary
- phase mint-path lift steps by manifest `phase`, so producer surfaces run before consumer surfaces
- dispatch consumer surfaces through configured RPC methods; Rust implications now route to `provekit.plugin.lift_implications`
- forward producer contract CIDs to consumer RPC calls as in-memory `contract_bindings`, with no proof-file roundtrip
- mint explicit bridge IR entries into the same final proof and prove contradictory implications as violations

## Real self-route smoke
From `implementations/rust/provekit-cli`, using the checked-in `.provekit/config.toml` and lift manifests:
- `../target/debug/provekit mint --project . --out /tmp/provekit-real-mint.EkMhil --no-attest --quiet --json`
- minted proof is conformant with 128 members: 110 contracts, 18 bridges
- `../target/debug/provekit prove /tmp/provekit-real-mint.EkMhil --json` => `{"totalCallsites":125,"discharged":125,"violations":0,"loadErrors":[]}`
- prove currently emits back-compat warnings for bridges without `targetProofCid`; target contract CIDs are present and followed

## Tests
- `cargo test -p provekit-cli --test dependency_proof_pool_assembly prove_reports_violation_for_contradictory_implication -- --nocapture`
- `cargo test -p provekit-walk lift_implications -- --nocapture`
- `cargo test -p provekit-cli --test cli_surface mint_conjoins_producer_contracts_and_consumer_bridges_in_one_proof -- --nocapture`
- `cargo test -p provekit-cli cmd_mint::tests::mint_from_ir_document_mints_explicit_bridge_entries -- --nocapture`
- `cargo check -p libprovekit -p provekit-cli -p provekit-walk`
- `rustfmt --check implementations/rust/provekit-cli/tests/dependency_proof_pool_assembly.rs`
- `git diff --check`

Closes #1592