### PR TITLE
Make Voltron implication proof nonvacuous

### DIFF
--- a/examples/voltron-demo/.provekit/config.toml
+++ b/examples/voltron-demo/.provekit/config.toml
@@ -22,6 +22,11 @@ surface = "rust-contracts"
 emit = "ir-document"
 
 [[plugins]]
+name = "rust-walk-contracts"
+surface = "rust-walk-contracts"
+emit = "ir-document"
+
+[[plugins]]
 name = "rust-implications"
 surface = "rust-implications"
 

--- a/examples/voltron-demo/.provekit/lift/rust-walk-contracts/manifest.toml
+++ b/examples/voltron-demo/.provekit/lift/rust-walk-contracts/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-walk-contracts"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/implementations/rust/provekit-cli/tests/cmd_mint_rust_project_implications.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_rust_project_implications.rs
@@ -158,3 +158,33 @@ fn configured_rust_shims_emit_nonvacuous_implication_claims() {
         let _ = fs::remove_dir_all(out_dir);
     }
 }
+
+#[test]
+fn voltron_demo_emits_nonvacuous_green_implication_claims() {
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Voltron implication proof");
+        return;
+    }
+    build_rust_lifter_bins();
+
+    let repo = repo_root();
+    let project = repo.join("examples/voltron-demo");
+    let out_dir = unique_dir("voltron-demo");
+    run_mint(&project, &out_dir);
+    let (report, code) = run_prove_json(&out_dir);
+    assert_eq!(
+        code, 0,
+        "Voltron should prove cleanly once body contracts and implication bridges align; report: {report}"
+    );
+    let total = report["totalCallsites"].as_u64().unwrap_or(0);
+    assert!(
+        total > 0,
+        "Voltron must not prove vacuously; report: {report}"
+    );
+    assert_eq!(report["violations"], 0, "Voltron report: {report}");
+    assert_eq!(
+        report["discharged"], report["totalCallsites"],
+        "Voltron report: {report}"
+    );
+    let _ = fs::remove_dir_all(out_dir);
+}

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
@@ -86,7 +86,11 @@ pub fn emit_term(term: &Term) -> String {
 /// where reason_code is Some if the sort was opaque.
 fn emit_sort_with_reason(sort: &Sort) -> (String, Option<String>) {
     match sort {
-        Sort::Primitive { name } => (name.clone(), None),
+        Sort::Primitive { name } if is_supported_smt_primitive_sort(name) => (name.clone(), None),
+        Sort::Primitive { name } => (
+            "Int".to_string(),
+            Some(format!("opaque_primitive_sort:{name}")),
+        ),
         Sort::Function { .. } => (
             "Int".to_string(),
             Some("predicate_quantification".to_string()),
@@ -101,6 +105,10 @@ fn emit_sort_with_reason(sort: &Sort) -> (String, Option<String>) {
             Some("other:RegionSort pre-resolved in composition".to_string()),
         ),
     }
+}
+
+fn is_supported_smt_primitive_sort(name: &str) -> bool {
+    matches!(name, "Int" | "Bool" | "Real" | "String")
 }
 
 pub fn emit_sort(sort: &Sort) -> String {
@@ -141,8 +149,8 @@ pub fn emit_formula(formula: &Formula) -> String {
             let (sort_str, reason) = emit_sort_with_reason(sort);
             let body_str = emit_formula(body);
             if let Some(_r) = reason {
-                // Quantifier over opaque sort: assert true as placeholder
-                return "(true)".to_string();
+                // Quantifier over opaque sort: assert SMT-LIB truth as placeholder.
+                return "true".to_string();
             }
             format!("(forall (({} {})) {})", name, sort_str, body_str)
         }
@@ -150,7 +158,7 @@ pub fn emit_formula(formula: &Formula) -> String {
             let (sort_str, reason) = emit_sort_with_reason(sort);
             let body_str = emit_formula(body);
             if let Some(_r) = reason {
-                return "(true)".to_string();
+                return "true".to_string();
             }
             format!("(exists (({} {})) {})", name, sort_str, body_str)
         }
@@ -162,7 +170,7 @@ pub fn emit_formula(formula: &Formula) -> String {
             let (sort_str, reason) = emit_sort_with_reason(sort);
             let body_str = emit_formula(body);
             if let Some(_r) = reason {
-                return "(true)".to_string();
+                return "true".to_string();
             }
             let var_y = format!("{}_y", var_name);
             let body_y = body_str.replace(var_name, &var_y);
@@ -322,7 +330,7 @@ fn emit_formula_with_opacities(formula: &Formula, opacities: &mut Vec<OpacityEnt
                     position_cid: cid,
                     reason_code,
                 });
-                "(true)".to_string()
+                "true".to_string()
             } else {
                 let sort_str = emit_sort(sort);
                 let body_str = emit_formula_with_opacities(body, opacities);
@@ -338,7 +346,7 @@ fn emit_formula_with_opacities(formula: &Formula, opacities: &mut Vec<OpacityEnt
                     position_cid: cid,
                     reason_code,
                 });
-                "(true)".to_string()
+                "true".to_string()
             } else {
                 let sort_str = emit_sort(sort);
                 let body_str = emit_formula_with_opacities(body, opacities);
@@ -358,7 +366,7 @@ fn emit_formula_with_opacities(formula: &Formula, opacities: &mut Vec<OpacityEnt
                     position_cid: cid,
                     reason_code,
                 });
-                "(true)".to_string()
+                "true".to_string()
             } else {
                 let sort_str = emit_sort(sort);
                 let body_str = emit_formula_with_opacities(body, opacities);

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/lib.rs
@@ -202,7 +202,8 @@ mod tests {
             result.opacity_manifest.opacities[0].reason_code,
             "predicate_quantification"
         );
-        assert!(result.body.contains("(true)"));
+        assert!(result.body.contains("(assert (not true))"));
+        assert!(!result.body.contains("(true)"));
     }
 
     #[test]
@@ -220,7 +221,8 @@ mod tests {
             result.opacity_manifest.opacities[0].reason_code,
             "dependent_type"
         );
-        assert!(result.body.contains("(true)"));
+        assert!(result.body.contains("(assert (not true))"));
+        assert!(!result.body.contains("(true)"));
     }
 
     #[test]
@@ -238,6 +240,32 @@ mod tests {
         let result = compile_to_parts(&ir).expect("compile succeeds");
         assert!(result.opacity_manifest.opacities.is_empty());
         assert!(result.body.contains("(forall ((x Int))"));
+    }
+
+    #[test]
+    fn opaque_primitive_sort_quantifier_emits_opacity_entry() {
+        // Rust source sorts such as `Ref<Connection>` are valid IR
+        // primitive-sort labels for identity, but not SMT-LIB builtin sorts.
+        // The SMT backend must not emit them raw.
+        let ir = serde_json::json!({
+            "kind": "forall",
+            "name": "conn",
+            "sort": { "kind": "primitive", "name": "Ref<Connection>" },
+            "body": { "kind": "atomic", "name": "true", "args": [] }
+        });
+        let result = compile_to_parts(&ir).expect("compile succeeds");
+        assert_eq!(result.opacity_manifest.opacities.len(), 1);
+        assert_eq!(
+            result.opacity_manifest.opacities[0].reason_code,
+            "opaque_primitive_sort:Ref<Connection>"
+        );
+        assert!(
+            !result.body.contains("Ref<Connection>"),
+            "opaque Rust source sort must not be emitted as raw SMT-LIB: {}",
+            result.body
+        );
+        assert!(result.body.contains("(assert (not true))"));
+        assert!(!result.body.contains("(true)"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- register the Voltron rust-walk-contracts lift surface so body contracts join implication bridges
- make SMT-LIB treat non-native primitive sort labels like `Ref<Connection>` as opaque, with valid `true` placeholders instead of raw source sorts or `(true)`
- add a Voltron integration test that requires a nonzero callsite count, zero violations, and full discharge

Closes #1606.

## Verification
- `cargo test -p provekit-ir-compiler-smt-lib -- --nocapture`
- `cargo test -p provekit-cli --test cmd_mint_rust_project_implications -- --nocapture`
- `cargo test -p provekit-cli --test cmd_verify_rust_production_bridge -- --nocapture`
- `cargo check -p provekit-cli -p provekit-walk -p provekit-lift -p provekit-ir-compiler-smt-lib`
- `rustfmt --edition 2021 --check implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs implementations/rust/provekit-ir-compiler-smt-lib/src/lib.rs implementations/rust/provekit-cli/tests/cmd_mint_rust_project_implications.rs`
- `git diff --check`

Note: workspace-wide `cargo fmt --all -- --check` still reports pre-existing formatting drift in unrelated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the Voltron demo project with contract verification capabilities.

* **Tests**
  * Added verification test for the Voltron demo to ensure correct contract discharge results.

* **Chores**
  * Improved internal handling of primitive type compilation in the verification engine.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->