### PR TITLE
docs: clarify ProvekIt product vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,325 +1,198 @@
-# ProvekIt: Prove `k(I)=t`
+# ProvekIt
 
-> *Supra omnia, rectum.*
->: T
+ProvekIt is a proof supply chain for software that already exists.
 
-## ProvekIt makes software age backwards.
+It does not ask every team to rewrite code in a proof language. It takes the
+evidence teams already maintain in their native ecosystems, including tests,
+assertions, contracts, schemas, validators, framework annotations, and
+boundary/library sugar, and turns that evidence into portable ProofIR claims.
+Those claims are packaged as signed, content-addressed `.proof` artifacts that
+other packages, tools, and languages can verify without trusting the original
+test runner or re-running the original proof every time.
 
-For 70 years, code has rotted. Every line written makes the next line harder. Every system grows brittle as it grows. Every legacy codebase is a debt that compounds. The industry's working assumption is that software ages forward, toward more debt, more bugs, less certainty.
+The important failure mode is composition. A package can pass its tests, another
+package can pass its tests, and the assembled system can still contain
+contradictory behavioral claims. ProvekIt makes those claims meet in one proof
+graph. The CLI conjoins and composes normalized claims, proves the obligations
+it can prove, and reports proof violations or unresolved residue where the
+assembled claims do not fit together.
 
-ProvekIt inverts the curve.
+## The Shape
 
-Here is the mechanism. ProvekIt lifts your existing codebase, in whatever language it is written in, into a provably correct intermediate representation. It marries that IR with the implications of every concept the code expresses. Then it rewrites the code in a way that proves each concept is well-behaved.
+ProvekIt has two deliberately separate responsibilities.
 
-What ProvekIt finds, it tells you. There are two kinds of finding.
+**Kits own language reality.** A kit knows the language, package manager,
+compiler, test framework, annotation library, and ecosystem conventions. A Rust
+kit can walk Rust tests and contracts. A Java kit can read Bean Validation, JML,
+Spring, JUnit, and Maven-shaped package data. A TypeScript kit can read Zod,
+class-validator, fast-check, and npm-shaped package data. Kits lift native
+evidence into ProofIR or protocol claims, materialize admitted claims back into
+native source when a workflow calls for it, and resolve dependency `.proof`
+artifacts through the package manager and filesystem rules of their ecosystem.
 
-The first is the bug. The substrate proves that a piece of code violates the contract of the concept it claims to implement. Every static analyzer finds bugs. ProvekIt finds them more rigorously, but bug-finding is table stakes.
+**The CLI owns proof computation over normalized data.** The `provekit` CLI is
+language-agnostic. It loads `.proof` artifacts, speaks RPC to configured kits,
+normalizes claims, composes implications, checks proof-file conformance, emits
+proof bundles, and proves obligations. The CLI should not need to know what a
+Maven classifier, npm workspace, Rust proc macro, or Spring annotation means.
+The kit translates those surfaces to proof data; the CLI computes over the
+proof data.
 
-The second is the gap. The substrate identifies regions of your codebase where the *behavior itself is not specified*. Not "this code is wrong" but "this code has no defined notion of right." These are the regions where future bugs live. No test will ever exercise them, because no one has framed what the test should check. Heartbleed was a gap. Log4Shell was a gap. SolarWinds was a gap. CrowdStrike was a gap. Every catastrophic outage in the last decade traces to a gap, not a bug. ProvekIt is the first system that surfaces gaps as a first-class artifact, content-addressed and signed.
+That boundary is the product. ProvekIt is not "a better Rust verifier" or "a
+new test runner." It is the place where language-native evidence becomes a
+portable claim that can survive package boundaries.
 
-Here is the architectural claim. ProvekIt collapses software's quadratic-complexity accident. For 70 years, software has been O(N²) at every scale, because every relationship between languages, libraries, tests, docs, codebases, and tools required bespoke pairwise work. ProvekIt makes it linear. M+N where it was M×N. That is not a productivity improvement, it is a topology change.
+## Why It Matters
 
-The mechanism is one fact: concepts have contracts attached. Once a concept is named and content-addressed in a universal address space, every relationship in software passes through that concept's identity instead of through bespoke pairs. The catalog of named concepts with attached contracts grows as codebases lift through the substrate. The catalog is the moat. It cannot be reimplemented; it can only be accumulated.
+Software supply chains already contain evidence, but the evidence is trapped in
+local tools.
 
-The longer ProvekIt runs against your codebase, the more provable your existing code becomes, without you rewriting a line. New concepts get named. Old code re-lifts under richer contracts. Tomorrow's substrate proves more of yesterday's code.
+- A passing test suite says something true about one package at one time.
+- A contract annotation says something true in one language's syntax.
+- A schema validator says something true at one boundary.
+- A formal verifier says something true in one proof system.
+- A CI run says something true about one input closure.
 
-**Software ages backwards.**
+ProvekIt gives those results a common substrate. Once a kit lifts the evidence
+to canonical ProofIR or a protocol claim, the claim has stable bytes, a CID, a
+signature, and a place in a `.proof` DAG. A downstream verifier can compare the
+claim by CID, check a signed implication, compose it with other claims, or run a
+semantic prover when a new obligation actually needs proof.
 
-The 70-year accident of software's quadratic complexity ends when contracts attach to concepts. That is not hyperbole. That is what the topology says.
+This distinction matters:
 
----
+- Previously minted, unchanged commitments can often be verified cheaply by CID
+  equality, signature checks, and graph walking.
+- Semantic proving still happens when claims are minted, changed, or newly
+  composed in a way the DAG does not already justify.
+- ProvekIt does not make all proving constant-time. It amortizes expensive proof
+  work by making prior commitments content-addressed and reusable.
 
-ProvekIt is the geometry of how lossy abstract interpretations compose
-into a sound joint inference over a content-addressed federated substrate.
+The result is a proof supply chain over existing package ecosystems. Package
+authors keep their normal tools. Consumers get portable claims about the code
+they assemble.
 
-The name is literal: **Prove `k(I)=t`**. ProvekIt is a general-purpose framework
-for proving that a transformation `k`, applied to an input `I` from some domain,
-produces the formal correctness representation `t`.
+## The `.proof` DAG
 
-`k` can be a compiler, lifter, verifier, policy projector, protocol checker,
-CI closure mapper, schema extractor, or repair transform. `I` can be source
-code, annotations, tests, schemas, build inputs, proof files, package metadata,
-or any other domain artifact. `t` is the canonical truth object the artifact is
-supposed to yield: formal, content-addressed, signable, comparable, and
-verifiable.
+A `.proof` artifact is a signed, content-addressed bundle of proof data. It can
+contain contract mementos, implication witnesses, bridge attestations,
+proof-file conformance witnesses, materialization receipts, package inspection
+claims, and policy-relevant metadata.
 
-ProvekIt does not ask you to trust the artifact. It asks for signed,
-content-addressed evidence that applying `k` to `I` produces `t`, then fails
-closed when the graph does not carry the claim.
+The graph is a DAG because every claim names the exact content it depends on:
+contract CIDs, attestation CIDs, contract-set CIDs, proof-bundle CIDs, binary
+CIDs, and protocol catalog CIDs. Old facts remain true about the old bytes that
+minted them. When code or claims change, new CIDs appear. Nothing needs a
+central invalidation service; unchanged commitments remain checkable by content
+identity.
 
-That linked evidence object is a **proofchain**: a locally verifiable chain of
-signed, content-addressed evidence for logically true claims. A blockchain
-carries state transitions; a proofchain carries formal proofs. Proof validity
-does not need a global ledger because the object of verification is the
-evidence itself.
-
-Modern software already depends on `k(I)=t` claims everywhere. A compiler says
-source becomes a binary. A type checker says a program inhabits a type. A CI run
-says a precise closure of inputs produced a result. A schema says a payload has a
-shape. A repair tool says a patch closes a defect.
-
-Most of those claims are trusted because a tool said so, a log existed, a check
-passed once, or a convention held locally. They do not travel cleanly across
-languages, repositories, build systems, package ecosystems, generated code, and
-time. The claim falls out of the place where it was made, and the next domain
-has to trust it again from scratch.
-
-Every test you have ever written is already a contribution to such a substrate.
-Every type annotation, every assertion, every kernel-doc comment, every
-OpenAPI schema, every Coq proof, every static-analyzer rule, every property
-test: each one is a `k_i` that projects some lossy view of the same code into
-its domain's expressible facts. They had nowhere to settle but their own
-isolated checker. ProvekIt is the place where they conjoin. The substrate is
-their joint inference: strictly more constraining than any single `k_i`,
-content-addressed, federated across languages, monotonic under addition.
-
-That is the thing software has never had: **a place where claims about behavior
-settle once and apply everywhere.**
-
-ProvekIt makes those claims first-class. The input, transformation, formal
-truth object, evidence, and proof edge become content-addressed artifacts. They
-can be signed, compared, composed, replayed, rejected, and carried across domain
-boundaries without asking the next tool to inherit the previous tool's trust.
-
-## The Correctness Stack
-
-ProvekIt has three layers:
-
-1. **Projection.** Native adapters apply `k` to domain artifacts `I`: source,
-   annotations, tests, schemas, CI inputs, protocol files, package metadata, or
-   generated repairs.
-2. **Truth.** The result `t` is canonicalized into a formal claim object with
-   stable bytes, stable CIDs, and explicit provenance.
-3. **Proof.** The verifier decides whether the graph carries the required edge:
-   an obligation is discharged, a missing implication is exposed, or a claimed
-   closure is rejected.
-
-That is the substrate. Software correctness stops being a local tool result and
-becomes a portable, checkable relationship between domain evidence and formal
-truth.
-
-**Artifacts become accountable.** Code is one implementation of a claim, not the
-claim itself. Refactoring, generated code, and AI-produced repairs can be judged
-by the formal truth they preserve or fail to preserve.
-
-**Domains compose.** A language contract, package policy, protocol conformance
-claim, CI result, proof file, and repair witness can all live in the same graph
-when they reduce to content-addressed truth objects.
-
-**Correctness fails closed.** If the graph cannot prove the edge, the claim does
-not travel. That is how bug classes become missing obligations instead of local
-runtime surprises.
-
-## Canonical Truth
-
-Different domains need different projections, but the output of a projection
-has to become something the rest of the graph can reason about. In this repo,
-the central truth format is ProofIR.
-
-ProofIR is not a universal language for re-expressing every implementation
-detail of every programming language. It is a canonical language for claim
-boundaries: preconditions, postconditions, invariants, protocol obligations,
-value predicates, resource states, signer claims, CI blast radii, grammar
-conformance claims, realizer outputs, and the implication edges that connect
-them.
-
-That is why a Spring annotation, a Zod validator, an OpenAPI schema, a Rust type
-invariant, and a ProvekIt-native contract can all collapse to the same canonical
-predicate when they assert the same boundary fact. The host-language texture can
-be discarded; the obligation survives.
-
-Once projected into ProofIR, a boundary is comparable, solvable, translatable,
-content-addressable, and signable. It has canonical bytes and a CID. It can be
-carried across languages, repositories, package ecosystems, commits, and time.
-The contracts were often already in your code; ProvekIt turns them into
-accountable edges the rest of the graph must satisfy.
-
-## Federation by Construction
-
-A substrate that promises portable correctness has to answer how it scales
-without drowning. Every prior framework that tried to cover many languages,
-many checkers, many proof obligations, and many target runtimes ran into the
-same wall: each new dimension multiplied the surface that had to be built,
-audited, and trusted. M sources times N targets times K checkers times L
-sugars is unbounded. ProvekIt is structured so that wall is never met.
-
-Each semantic axis collapses through the same hub topology. Languages do not
-translate to each other; they translate to and from canonical operation CIDs.
-Lifters do not bind to specific provers; they emit ProofIR and the discharge
-portfolio chooses. Loss functions do not bind to specific transports; they
-rank candidate transformations by content-addressed loss records. The cost of
-extending the substrate is linear in the number of plugged-in components, not
-quadratic in the number of pairs they could connect.
-
-| Axis | What plugs in |
-| --- | --- |
-| Source languages | Lifters that emit terms over canonical operation CIDs |
-| Target runtimes | Realizers that consume terms and emit per-target source |
-| Sugar dictionaries | JSON files or JSON-RPC plugins per host idiom (Spring, JML, JUnit, ...) |
-| Loss functions | JSON files or JSON-RPC plugins that rank candidate transformations |
-| Discharge backends | Solver portfolios that close obligations into signed receipts |
-| Effect signatures | Catalogs that name the side effects an op is permitted to admit |
-| Concept catalogs | Federated stores of canonical operation and abstraction CIDs |
-
-Every plug is content-addressed. Every plug is byte-deterministic. The
-`provekit` binary is the protocol implementation; the protocol is the set of
-plugins currently loaded; the loaded set is itself a content-addressed object
-any audit can replay. Two installations that load the same plugin set produce
-the same receipts. Two installations that load different plugin sets disagree
-by exactly the loss records their plugins emit, and the disagreement is itself
-addressable.
-
-The substrate grows by being used. A new sugar dictionary published as a JSON
-file becomes a citable artifact the moment something runs against it. A new
-lifter for an unsupported language extends coverage the moment it discharges
-its first obligation cleanly. A new loss function published with a fidelity
-receipt becomes a lens any caller can adopt. The hub is the public good and
-the spokes are the contributions; use is publication.
-
-That externalization is tracked end to end in [#732](https://github.com/TSavo/provekit/issues/732),
-which enumerates the surfaces being moved out of the binary and into
-content-addressed federable mementos.
-
-## I want to...
-
-| | |
-| --- | --- |
-| **Use the CLI** | [docs/quickstart-end-user.md](docs/quickstart-end-user.md) to install and run `provekit`; [docs/reference/protocol-extensions.md#tool-surfaces](docs/reference/protocol-extensions.md#tool-surfaces) for the command surface |
-| **See a bug class map to an addressable shape CID across languages** | [docs/explanation/bug-zoo.md](docs/explanation/bug-zoo.md); run `cargo run --manifest-path menagerie/bug-zoo/Cargo.toml -- --all` |
-| **See supported languages and kit coverage** | [docs/reference/per-language-status.md](docs/reference/per-language-status.md) |
-| **Understand the move** | [docs/papers/](docs/papers/): recommended order: paper 03 → 06 → 02 |
-| **Understand proofchains** | [docs/explanation/proofchain.md](docs/explanation/proofchain.md) |
-| **Extend it / build a kit** | [docs/contributing/](docs/contributing/) |
-| **Read the spec** | [docs/papers/02-bluepaper.md](docs/papers/02-bluepaper.md) |
-| **Understand the new protocol/tooling surface** | [docs/reference/protocol-extensions.md](docs/reference/protocol-extensions.md) |
-| **Compare to other tools** | [docs/explanation/compared-to/](docs/explanation/compared-to/) |
-
-For more entry points (per-language tutorials, IDE integration, publishing a `.proof`, Bug Zoo, protocol extensions, threat model, and spec CIDs), see [docs/index.md](docs/index.md).
-
-## Status
-
-- **Protocol catalog**: v1.6.2
-- **Catalog CID**: `blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f`
-- **Canonical implementation**: Rust, built from this repository with `cargo install --path implementations/rust/provekit-cli`
-- **Conforming implementations**: Rust, TypeScript, Python, Java, C#, Ruby, Zig, Go, C++, Swift, C, PHP. Coverage varies; see [docs/reference/per-language-status.md](docs/reference/per-language-status.md).
-- **Protocol evolution**: PEP dogfoods catalog transitions as signed, content-addressed body-claims under `protocol/evolution/v1.6.1/` and `protocol/evolution/v1.6.2/`.
-- **Bug Zoo**: the self-contained `menagerie/bug-zoo/` runner checks lab, exhibit, fixed, link, equivalence, and composition receipts for checked-in specimens. Wild sightings are metadata only until real upstream specimens are pinned and wired into the runner.
-- **Menagerie**: [menagerie/](menagerie/) is the executable map of proof workflows. Bug Zoo is the runnable destination today; Hashbound Mainline, Supply Chain Rails, Bridgeworks, Protocol Switchyard, and Change Station name the next routes.
-- **Conformance gate**: catalog CIDs, proof-protocol fixtures, self-contract attestations, and per-kit tests must agree before CI is green.
-
-The protocol is content-addressed end to end. Each version's canonical name is its own catalog hash. Anyone with the spec bytes can verify that label locally. No central party decides what a version means; the bytes do.
-
-## Bug Zoo
-
-Bug Zoo is the executable lab for the claim above. Each specimen runs in an
-isolated host-language environment, uses that language's own compiler/kit to
-map source to canonical truth, then checks that the expected shape CID or
-boundary receipt CID is addressable from that projection. The normal proof gate
-for projects is `provekit prove`; Bug Zoo owns the fixture orchestration under
-`menagerie/bug-zoo/` and routes lift, link, and proof work through the Rust CLI.
-It is the first runnable destination in the broader [Menagerie](menagerie/),
-where workflows like Hashbound Mainline, Supply Chain Rails, Bridgeworks,
-Protocol Switchyard, and Change Station can share the same proof-carrying
-shape.
-
-The zoo is organized by species, not by language. A species directory owns a
-`specimen.yaml` manifest, then each language under that species carries the same
-lifecycle:
-
-- `lab/`: ordinary host code that passes native checks while the bug class is
-  still latent. It has no ProvekIt workflow.
-- `exhibit/<surface>/`: a native contract surface that lifts or links to the
-  missing edge and yields the red `provekit prove` or `provekit link` signal.
-- `fixed/<surface>/`: the paired source with that boundary closed, re-run
-  through the same surface to yield the green `provekit prove` or
-  `provekit link` signal.
-- `wild/`: optional real upstream sightings pinned by advisory, commit, path,
-  and evidence. No checked-in wild specimens are executed today; current
-  `wildSightings` entries are reported as metadata.
-
-In shorthand:
+That is the supply-chain move:
 
 ```text
-k_lang(I) = t
+native evidence -> kit lift/materialize -> ProofIR or protocol claim
+               -> signed memento -> .proof DAG -> provekit proof computation
 ```
 
-`k_lang` is the language compiler as a ProvekIt kit/lifter, `I` is the source,
-and `t` is the canonical truth object: a ProofIR shape CID for claim
-boundaries, or a LinkBundle receipt CID for cross-kit bridge derivations.
-Different languages can disagree in syntax, runtime behavior, and exception
-type while their native evidence maps homomorphically to the same addressable
-shape.
+## What The CLI Does
 
-Each native surface maps through a structure-preserving homomorphism into the
-correctness object; the proof layer checks whether the mapped obligation
-commutes with equivalent surfaces or closes under the fixed witness.
+The canonical CLI is the Rust `provekit` binary. Current subcommands include
+proof and protocol surfaces such as:
 
-The current null-boundary receipts show Java, TypeScript, and C# lifting the same
-missing edge:
+- `provekit mint`: dispatch configured lift plugins and write `.proof`
+  artifacts.
+- `provekit prove`: load `.proof` artifacts, resolve dependency proofs through
+  kits, enumerate obligations, compose/conjoin claims, and report discharge
+  status.
+- `provekit verify`: verify a kit end to end by lifting contract claims,
+  discharging each claim, and emitting per-claim receipts.
+- `provekit proof`: hash, inspect, check, and witness `.proof` conformance.
+- `provekit protocol`: work with protocol catalog evolution artifacts.
+- `provekit materialize`: route concept or boundary carriers through native
+  realize kits and emit admitted source plus proof receipts.
+- `provekit link` and `provekit compose`: derive and compose cross-contract
+  bridges.
+- `provekit verify-protocol`: confirm the local binary conforms to its embedded
+  protocol catalog CID.
 
-```text
-maybe_null(name) => non_null(name)
-```
-
-to the same ProofIR CID:
-
-```text
-blake3-512:0d611d8478a205ff040e7d0bcf6c21b12051340ecc5f00c3953af632b23fc01e069b4ad8a8699869163e135b9fde85792eba6acc54cd75cb3d3cc6a40a99ded4
-```
-
-They also run the red/green proof obligations through the Rust CLI: lab null is
-rejected against each lifted non-null requirement, and each fixed surface
-discharges the paired non-null implication with `provekit prove --formula`.
-
-Bug Zoo also carries value-scope escape as `BZ-SHAPE-006`: Java JUnit and Spring
-exhibits both witness a point value, and the runner invokes
-`provekit prove --formula` to produce the red signal when 42 fails a `>= 43`
-requirement and the green signal when the fixed surface witnesses 43.
-
-`BZ-SHAPE-007` carries the polyglot link-obligation specimen: a Go cgo caller
-invokes a Rust callee whose native contract requires a stricter input. The zoo
-routes the fixture through `provekit link`; the exhibit produces an
-`unprovable-obligation` link-bundle receipt, and the fixed pair links clean.
-
-Read [docs/explanation/bug-zoo.md](docs/explanation/bug-zoo.md), or run:
-
-```sh
-cargo run --manifest-path menagerie/bug-zoo/Cargo.toml -- --all
-```
-
-| Kit | Self-contracts | Lift-plugin-protocol bridges | LSP plugin |
-|---|---|---|---|
-| Rust | full conformance | full (source of truth) | shipping |
-| Go | full conformance | in progress | planned |
-| C# | full conformance | not started | shipping |
-| Ruby | in progress | not started | shipping |
-| Zig | in progress | not started | shipping |
-| Python | full conformance | in progress | shipping |
-| TypeScript | full conformance | in progress | planned |
-| C++ | full conformance | not started | planned |
-| Java | full conformance | not started | planned |
-| Swift | full conformance | not started | planned |
-| C | full conformance | not started | planned |
-| PHP | in progress | not started | planned |
+The command surface keeps moving as protocol work lands. Use `provekit --help`
+and [docs/reference/per-language-status.md](docs/reference/per-language-status.md)
+for the current matrix.
 
 ## Install
 
-This project is **build-from-source only**. Crates.io publishing is on the roadmap; until then see [docs/quickstart-end-user.md](docs/quickstart-end-user.md) for build instructions.
-
-The core binary is:
+This repository is build-from-source today. Crates.io publishing is still future
+work. The current install path is:
 
 ```sh
 cargo install --path implementations/rust/provekit-cli
 ```
 
-`provekit verify-protocol` confirms the local install conforms to the expected protocol catalog CID. `cargo provekit-lift` walks the workspace, runs every registered lift adapter, and emits a `.proof` catalog of signed contract mementos. `provekit prove` runs the three-tier handshake and reports the discharge breakdown. `provekit proof` and `provekit protocol` cover proof-file conformance and PEP transitions. Bug Zoo specimens are checked by the repo-owned runner under `menagerie/bug-zoo/`. Any of these can fail closed; none requires the network.
+Verify the installed CLI's embedded protocol catalog:
 
-For other host languages, see the polyglot-stack tutorial above. The Rust CLI is the canonical implementation; non-Rust kits use it for verification today.
+```sh
+provekit verify-protocol
+```
 
-## Building from source
+For project setup and first runs, start with
+[docs/quickstart-end-user.md](docs/quickstart-end-user.md). If you are working
+on ProvekIt itself, see [docs/contributing/build.md](docs/contributing/build.md)
+for the polyglot Make targets, system dependencies, and per-implementation build
+commands.
 
-If you are working on ProvekIt itself (kit, lift adapter, prover backend, spec change), see [docs/contributing/build.md](docs/contributing/build.md) for the polyglot Make targets, system dependencies, and per-implementation build commands. The default `make ci` gate covers the Linux conformance profile plus the Linux native test aggregate; the full GitHub workflow adds macOS Swift and per-kit verifier jobs.
+## Current Status
+
+- **Canonical implementation:** the Rust CLI in
+  `implementations/rust/provekit-cli`.
+- **Current CLI protocol catalog:** v1.6.6, embedded in the CLI and verified by
+  `provekit verify-protocol`.
+- **Supported ecosystem surface:** Rust, TypeScript, Python, Java, C#, Ruby,
+  Zig, Go, C++, Swift, C, and PHP have varying kit, library, lift-adapter,
+  embedded-verifier, and LSP coverage. See
+  [docs/reference/per-language-status.md](docs/reference/per-language-status.md).
+- **Proof artifacts:** `.proof` envelopes, signed mementos, contract CIDs,
+  attestation CIDs, contract-set CIDs, and protocol catalog CIDs are the durable
+  units.
+- **Executable exhibits:** [menagerie/bug-zoo/](menagerie/bug-zoo/) runs checked
+  specimens that show native checks passing while lifted cross-package or
+  cross-language obligations fail until the missing edge is closed.
+- **Self-application:** the CLI can mint proof data from its own assertions and
+  tests; see
+  [docs/self-application/2026-05-28-snake-eats-tail.md](docs/self-application/2026-05-28-snake-eats-tail.md).
+
+## Start Here
+
+| Goal | Read |
+|---|---|
+| Install and run the CLI | [docs/quickstart-end-user.md](docs/quickstart-end-user.md) |
+| Understand the product surface | [docs/explanation/product.md](docs/explanation/product.md) |
+| Understand the architecture | [docs/explanation/architecture.md](docs/explanation/architecture.md) |
+| Understand `.proof` and proofchains | [docs/explanation/proofchain.md](docs/explanation/proofchain.md) |
+| See kit and language coverage | [docs/reference/per-language-status.md](docs/reference/per-language-status.md) |
+| Publish a `.proof` artifact | [docs/how-to/publishing-a-proof.md](docs/how-to/publishing-a-proof.md) |
+| Build or extend a kit | [docs/quickstart-extender.md](docs/quickstart-extender.md) |
+| Compare to other tools | [docs/explanation/compared-to/](docs/explanation/compared-to/) |
+| Read the paper ladder | [docs/papers/README.md](docs/papers/README.md) |
+
+For the full docs map, see [docs/index.md](docs/index.md).
+
+## What ProvekIt Is Not
+
+ProvekIt is not a replacement for tests. Tests remain the source of much of the
+evidence that kits lift.
+
+ProvekIt is not a replacement for Kani, Prusti, Coq, Lean, F*, Dafny, TLA+, Z3,
+or other verification tools. Those tools can produce evidence; ProvekIt gives
+that evidence a portable content-addressed supply chain.
+
+ProvekIt is not a central registry. `.proof` artifacts verify from their bytes,
+CIDs, signatures, witnesses, and local policy. A server may index proof data for
+convenience, but it is not the authority.
+
+ProvekIt is not a promise that any current kit sees every useful contract in a
+codebase. Adapter coverage is empirical. Unknown, unsupported, or lossy
+surfaces must be reported honestly as residue, loss, or refusal.
 
 ## License
 
-Source files use SPDX headers where present. A repository-level license file has not been added yet.
+Source files use SPDX headers where present. A repository-level license file has
+not been added yet.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,204 +1,147 @@
 # ProvekIt Architecture
 
-A walk-through of the protocol's mechanics in roughly fifteen minutes. This document describes the v1.6.2 protocol catalog at CID `blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f`. Every spec referenced here is itself content-addressed; CIDs are quoted where authoritativeness matters.
+ProvekIt is a pipeline for turning native software evidence into portable proof
+data, then computing over that proof data without keeping language-specific
+logic in the core CLI.
 
-> **v1.4 architectural cut:** every memento now has three layers: envelope (signed wrapper), header (substrate-verified data), body (tooling-interpreted metadata). The substrate verifies envelope + header. Body is opaque to the substrate but signed under the envelope, so tooling reads body fields with cryptographic provenance for free. New protocols add body conventions, never substrate primitives. See [`../papers/03-substrate-not-blockchain.md`](../papers/03-substrate-not-blockchain.md) §11 through §12 for the multi-dimensional address-space framing this operationalizes, and [`docs/reference/cids.md`](../reference/cids.md) for the v1.4 spec list.
+The short version:
 
-## The architecture is a claim pipeline
-
-ProvekIt is not only a library you call. It is a pipeline for proving content-addressed claims. Data flows in one direction: grammar or source surface -> canonical claim -> CID -> signed evidence -> proof bundle or extension witness -> verification.
-
-For application correctness, the source surface is a host-language contract idiom. For protocol evolution, the source surface is a catalog diff and policy. For Bug Zoo droppers, it is a proof plan, language projection, transformed artifact, post-lift ProofIR, and fix receipt.
-
-### Stage 1: CDDL (the single source of truth)
-
-`protocol/provekit-ir.cddl` is the root of the entire protocol. It defines:
-
-- `IrTerm`: variables, constants, constructors, lambdas, let-bindings
-- `IrFormula`: atomic predicates, connectives (and/or/not/implies), quantifiers (forall/exists), choice
-- `Sort`: primitive types (Int, String, Bool)
-- `Declaration`: contracts, bridges, evidence
-- `ProofBundle`: the catalog format (name, version, binaryCid, metadata, members)
-
-The grammar is machine-readable by the `cddl` crate. The spec is human-readable in `protocol/specs/2026-04-30-ir-formal-grammar.md`. Both are content-addressed.
-
-### Stage 2: Codegen (types and compilers from the grammar)
-
-`provekit-ir-codegen` reads the CDDL and emits:
-
-1. **`provekit-ir-types/src/lib.rs`**: serde types matching the spec exactly. `Term`, `Formula`, `Sort`, `Declaration`, `BridgeDeclaration`, `EvidenceTerm`.
-2. **`provekit-ir-compiler-smt-lib/src/generated.rs`**: SMT-LIB emitter: `emit_term`, `emit_formula`, `emit_sort`.
-3. **`provekit-ir-compiler-coq/src/generated.rs`**: Coq emitter: `emit_term`, `emit_formula`, `sort_to_coq`.
-
-The generated code is never hand-edited. Change the CDDL, run `cargo run -p provekit-ir-codegen`, all three files update automatically. The compilers use the generated types, so they always match the spec.
-
-### Stage 3: Authoring (the developer's surface)
-
-`provekit-ir-symbolic` provides the authoring kit: `forall`, `exists`, `atomic`, `gte`, `eq`, etc. It also provides conversions to/from the generated types, so a developer can:
-
-```rust
-use provekit_ir_symbolic::{forall, atomic, gte, var, const_};
-
-let f = forall("n", "Int", atomic("parseInt", vec![var("s")], gte(const_(0))));
+```text
+host evidence -> kit lift -> ProofIR/protocol claim -> signed memento
+             -> .proof DAG -> provekit compose/conjoin/prove/report
 ```
 
-The `#[provekit::contract]` and `#[provekit::verify]` macros lift source-level annotations to IR formulas.
+## The boundary
 
-The `#[provekit::implement(target = "bafy...")]` macro binds a function to a contract by CID:
+The architecture is organized around one boundary.
 
-```rust
-#[provekit::implement(target = "bafy...js-parseInt-v24")]
-fn my_parse_int(s: &str) -> i64 {
-    s.parse().unwrap_or(0)
-}
-```
+**Kits own native meaning.** A kit may know a language grammar, an AST library,
+a compiler or bytecode format, a package manager, a test framework, an
+annotation library, a validation library, or an IDE surface. Kits are allowed to
+understand Cargo, Maven, npm, Spring, JML, JUnit, Zod, Pydantic, Rust contracts,
+or any other host-specific surface. They lift those surfaces into normalized
+claims, materialize admitted claims back into native source when asked, and
+resolve dependency `.proof` artifacts in the way their ecosystem actually
+ships packages.
 
-This registers: "`my_parse_int` is an implementation of contract `bafy...js-parseInt-v24`." The lifter resolves the function call to that contract CID.
+**The CLI owns normalized proof computation.** The Rust `provekit` CLI loads
+`.proof` artifacts, speaks JSON-RPC style plugin protocols to configured kits,
+checks proof-file and protocol conformance, composes and conjoins claims,
+dispatches prover work, emits proof bundles, and reports the result. It should
+not need to understand every package manager or annotation library. It computes
+over ProofIR, protocol claims, CIDs, signatures, witnesses, and policy.
 
-### Stage 4: Proof bundle (the distribution artifact)
+This keeps the system extensible. Adding a language or package ecosystem should
+add a kit, not a new proof engine.
 
-The `.proof` file IS the package. It replaces `package.json`, `Cargo.toml`, `go.mod` as the primary distribution artifact for verified software.
+## Claims
 
-```cddl
-ProofBundle = {
-  kind: "catalog",
-  name: "@types/node-v24",
-  version: "24.3.0",
-  ? binaryCid: "bafy...node-v24-v8-snapshot",
-  metadata: {
-    "bytecode-cid": "bafy...evm-module",
-    "vm": "evm-cancun",
-    "entry-point": "parseInt"
-  },
-  members: {
-    "bafy...contract-1": <contract memento bytes>,
-    "bafy...bridge-1": <bridge memento bytes>,
-    "bafy...evidence-1": <evidence memento bytes>
-  },
-  signature: <ed25519 signature>
-}
-```
+The central normalized claim format is ProofIR. ProofIR is not a universal
+language for re-expressing every implementation detail of every programming
+language. It is a canonical language for claim boundaries: preconditions,
+postconditions, invariants, value predicates, protocol obligations, bridge
+edges, materialization receipts, and the implication edges that connect them.
 
-Key fields:
-- `binaryCid`: pins the compiled artifact. Change any bit, the CID changes, the proof fails.
-- `metadata`: freeform, decorative, signed but non-normative. For tooling, diagnostics, human review.
-- `members`: map from CID to canonical bytes. Every memento is content-addressed and recursively verifiable.
+Host-language texture can be discarded when it is not part of the obligation.
+The obligation survives as canonical bytes. Those bytes can be hashed, signed,
+compared, solved, transported, and packaged.
 
-### Stage 5: Verification (the build-time gate)
+Protocol claims use the same substrate pattern. A proof-file conformance claim,
+a protocol-catalog evolution claim, a package inspection claim, and a
+materialization receipt are not all ordinary function contracts, but they still
+become content-addressed claims with witnesses and policy.
 
-The build script (or `provekit prove`) walks the DAG:
+## `.proof` DAGs
 
-1. Load all `.proof` bundles from dependencies
-2. Index contracts by CID, bridges by source symbol
-3. For each call site, resolve the function to its contract CID
-4. Walk bridges transitively: `my_fn → js-parseInt-v24 → ref-parseInt-v1`
-5. At each hop, verify the implication: does source contract imply target contract?
-6. If all hops verify, the call site is discharged
-7. Mint a witnessed proof memento: "body of `my_fn` implies contract X, here's the Z3 model"
+A `.proof` artifact is the transport container for signed proof data. It is not
+a replacement for `Cargo.toml`, `package.json`, `pom.xml`, or other native
+manifests. Those ecosystems still own package distribution. A `.proof` artifact
+travels with or beside those packages and carries the claims the package is
+willing to make.
 
-Three tiers, in order:
+Inside a `.proof` artifact, members are content-addressed. The DAG can include:
 
-**Tier 1: hash equality.** The publisher's post-hash equals the consumer's pre-hash. `memcmp` returns zero. Discharged for free.
+- contract mementos;
+- implication witnesses;
+- bridge attestations;
+- proof-file conformance witnesses;
+- package inspection claims;
+- materialization or emit receipts;
+- binary, contract-set, attestation, and protocol catalog CIDs.
 
-**Tier 2: cached implication.** A signed implication memento exists. Check Ed25519 signature once. Discharge every call site sharing this pair.
+The verifier walks this DAG under policy. If a node or edge names bytes that are
+not present, malformed, unsigned, signed by an untrusted key, or semantically
+insufficient, the claim does not travel.
 
-**Tier 3: solver fallback.** Z3 invoked once per genuinely-novel pair. On `unsat`, mint a fresh implication memento. Next verifier hits Tier 2.
+## Proof computation
 
-## The handshake is DAG walking
+For a composed obligation, the CLI uses the cheapest honest route available.
 
-Traditional verification asks: "does post imply pre?"
+1. **CID equality.** If two canonical claims are byte-identical, their CIDs
+   match. This discharges identity cases without theorem proving.
+2. **Cached implication.** If a signed implication memento already proves that
+   one claim implies another, the verifier can check the memento and reuse that
+   result.
+3. **Semantic proving.** If the graph does not already carry the edge, a prover
+   has to prove or reject the new obligation. If accepted, the result can be
+   minted as a new memento for future reuse.
 
-ProvekIt asks: "is there a path in the DAG from this contract to that contract where every edge is a verified implication?"
+This is an amortization model, not a claim that all proof is constant-time.
+Previously minted and unchanged commitments are cheap to recheck. Newly minted,
+changed, or newly composed semantic claims still require semantic work.
 
-The DAG is the proof. Every node is a contract. Every edge is a bridge. The path from `my_fn` to `ref-parseInt-v1` is:
+## Composition
 
-```
-my_fn (CID A)
-  → bridge A → js-parseInt-v24 (CID B)
-    → bridge B → ref-parseInt-v1 (CID C)
-```
+Traditional local verification asks whether one artifact satisfies one local
+contract. ProvekIt asks whether the assembled claim graph carries the edges the
+consumer needs.
 
-The verifier checks:
-1. Bridge A is valid (signed, source contract matches, target contract resolves)
-2. Bridge B is valid (same)
-3. The transitive composition holds (A implies B implies C)
+That matters because local success can compose into global contradiction. A
+test suite can pass while a dependency publishes a weaker guarantee than the
+consumer assumes. A bridge can type-check while dropping a boundary condition. A
+generated artifact can compile while failing to re-lift to the claim it was
+supposed to realize.
 
-If all checks pass, the proof transfers. The JavaScript claim about `parseInt` is now a Rust claim about `parse`. Cross-domain verification is free because the bridges are hash-bounded.
+ProvekIt handles this by conjoining and composing normalized claims. If the
+assembled graph cannot satisfy the obligation, the result is a proof violation,
+unresolved residue, explicit bounded loss, or refusal, not a silent pass.
 
-## The `.proof` file as the package format
+## Kit RPC
 
-Traditional:
-```
-package.json → describes package
-node_modules/ → contains code
-(no verification included)
-```
+Kit interaction is explicit. Current CLI paths dispatch configured plugins for
+lift, emit, materialize, package inspection, dependency proof resolution, and
+related surfaces. The plugin protocol uses request/response methods such as
+`provekit.plugin.invoke`, `provekit.plugin.assemble`,
+`provekit.plugin.resolve_dependency_proofs`, and shutdown handshakes over the
+configured subprocess transport.
 
-ProvekIt:
-```
-<cid>.proof → IS the package
-  ├── contracts: what the code guarantees
-  ├── bridges: how it relates to other packages
-  ├── binaryCid: the exact compiled artifact
-  ├── metadata: bytecode references, build flags, etc.
-  └── signature: developer-signed, tamper-evident
-```
-
-The `.proof` file is self-contained. It needs no network. It needs no registry. It needs no central authority. It is a signed, content-addressed bill of materials for the entire verified artifact.
-
-## Supply chain security
-
-The `binaryCid` field is the supply chain anchor:
-
-- **Compiler backdoor:** Different binary → different CID → proof fails
-- **Runtime patch:** JIT override changes binary hash → proof fails
-- **Dependency injection:** Wrong package → wrong CID → proof fails
-- **Monkey-patch:** User redefined `parseInt` → contract CID doesn't match → proof fails
-
-The alarm is not a security scan. It is a **mathematical contradiction.** The proof was minted for bytes with CID X. The running binary has CID Y. X ≠ Y. The proof is invalid for this binary.
-
-## Cross-domain conformance
-
-The IR is language-agnostic. A Rust kit, a TypeScript kit, and a Go kit all emit the same canonical bytes for the same canonical formula. A contract memento minted by the Rust kit and a contract memento minted by the TypeScript kit, expressing the same proposition, share a CID.
-
-The handshake at Tier 1 sees them as identical. A TypeScript consumer of a Rust library has the same Tier-1 discharge fraction as a Rust consumer would. Cross-domain verification works because all kits bridge to the same reference contracts.
-
-The same principle applies beyond language boundaries. PEP bridges protocol
-catalog versions. GCP witnesses extension body grammar conformance. ORP and Bug Zoo droppers accept
-generated host artifacts only after re-lift proves closure. These are all
-domain crossings over the same signed CID graph.
-
-Bug Zoo is the executable version of this claim for bug classes. Each language
-uses its own compiler/kit to map source to a witnessed bug output, then the
-self-contained Bug Zoo runner verifies that the lifted ProofIR bytes are
-identical. The current null-boundary specimens show Java, TypeScript, and C#
-converging on the same missing edge, `maybe_null(name) => non_null(name)`, and
-the same ProofIR CID. See [`bug-zoo.md`](bug-zoo.md).
+The design goal is simple: native knowledge stays in the kit, proof computation
+stays in the CLI, and the exchange between them is normalized, content-addressed
+proof data.
 
 ## Fail-closed posture
 
-Every gate is fail-closed:
+Every public proof surface should fail closed:
 
-- A memento whose recomputed CID does not match the embedded CID is rejected.
-- A memento whose signature does not verify is rejected.
-- A `.proof` file with malformed CBOR is rejected.
-- A `binaryCid` that does not match the running binary is rejected.
-- A bridge whose `targetProofCid` does not resolve is rejected.
-- A handshake at Tier 3 that times out returns `REQUIRES_PER_CALLSITE`, never a false positive.
-- A protocol catalog whose CID does not match the implementation's declared conformance is rejected.
+- malformed `.proof` bytes are rejected;
+- recomputed CIDs must match the claimed CIDs;
+- signatures must verify under local policy;
+- dependency proof paths returned by kits must exist and be `.proof` artifacts;
+- materialized output must carry receipts or explicit refusal/loss;
+- unknown or unsupported native surfaces remain residue instead of becoming
+  invented claims;
+- prover timeout or absence is not a proof.
 
-There is no "best effort" mode. There is no "soft fail" mode. The verifier either has a discharge witness or it does not.
-
-## What this architecture does NOT include
-
-ProvekIt does not author specifications. The kit emits IR; the lift adapter reads existing source-language annotations; the developer keeps writing `proptest!`, `#[contracts::ensures]`, `pydantic.BaseModel`, `zod.object`, or whatever idiom their codebase already uses. The protocol's job is to canonicalize, hash, sign, and check. The act of describing what should be true belongs to the libraries the codebase already trusts.
-
-This is the lift-not-author posture. ProvekIt sits beneath every annotation library; it does not compete with any of them. The architecture's surface area is small: CDDL grammar, codegen pipeline, authoring kit, proof bundle, verifier. The rest is implementation.
+This posture is what makes the supply-chain story honest. The graph either
+carries the claim under policy or it does not.
 
 ## Read further
 
-- [README.md](../../README.md) for the install path.
-- [thesis.md](thesis.md) for the deeper architectural claim: hash-bounded verification.
-- [product.md](product.md) for what ProvekIt replaces and complements.
-- [docs/reference/per-language-status.md](../reference/per-language-status.md) for kit and adapter coverage.
-- [protocol/specs/](../../protocol/specs/) for the canonical spec set, addressed by CID.
+- [product.md](product.md) for the product framing.
+- [proofchain.md](proofchain.md) for the linked evidence object.
+- [lift-not-author.md](lift-not-author.md) for the adoption posture.
+- [cross-language-equivalence.md](cross-language-equivalence.md) for the
+  concept-hub and morphism model.
+- [../reference/per-language-status.md](../reference/per-language-status.md) for
+  current kit and adapter coverage.
+- [../../protocol/specs/](../../protocol/specs/) for the canonical specs.

--- a/docs/explanation/cold-start.md
+++ b/docs/explanation/cold-start.md
@@ -51,7 +51,8 @@ discharged by cache:      6    (13%)
 discharged by solver:     1    (2%)
 ```
 
-The protocol's promise, "one CPU instruction per call site for the common case", manifests at this stage. Tier 1 is the hot path; Tier 3 is rare.
+The protocol's amortization goal manifests at this stage. Tier 1 CID equality
+is the hot path; Tier 3 semantic proving is rare.
 
 ## The bootstrap challenge
 

--- a/docs/explanation/cross-domain-verification.md
+++ b/docs/explanation/cross-domain-verification.md
@@ -113,7 +113,7 @@ A consumer in JavaScript imports a Python ML library that calls `int(input_strin
 
 The JavaScript consumer's verifier sees the call site (Python's `int(...)`) and does the handshake:
 
-1. **Tier 1**: does the JavaScript consumer's pre-condition (whatever it is, at the call site) match the canonical IR for `ref-parseInt-v1`? If yes, hash equality discharges. Free.
+1. **Tier 1**: does the JavaScript consumer's pre-condition (whatever it is, at the call site) match the canonical IR for `ref-parseInt-v1`? If yes, hash equality discharges without theorem proving.
 2. **Tier 2**: if no exact hash match, is there a cached implication memento for `(consumer-pre, ref-parseInt-v1)`? If yes, signature check discharges.
 3. **Tier 3**: solver fallback. Z3 invoked once per genuinely-novel pair.
 
@@ -121,7 +121,10 @@ Most consumers' pre-conditions for `parseInt`-style calls match `ref-parseInt-v1
 
 The protocol walks: consumer's pre-condition → ref-parseInt-v1 ← Python's source contract. The Python bridge's evidence (showing Python's contract implies the reference) was minted once, by the Python kit author, and is cached forever. The JavaScript consumer doesn't re-derive it.
 
-The JavaScript consumer's verification is one CPU instruction: `memcmp` of the consumer's pre-CID against the reference contract's CID. The Python implementation's correctness, verified once by the Python kit author against `ref-parseInt-v1`, is now JavaScript consumers' verification result for free.
+The JavaScript consumer's Tier 1 identity check is just CID equality. The Python
+implementation's bridge to `ref-parseInt-v1`, verified once by the Python kit
+author and admitted by local policy, can now be reused by JavaScript consumers
+without re-deriving the Python proof.
 
 ## Why this works
 

--- a/docs/explanation/landing.md
+++ b/docs/explanation/landing.md
@@ -1,6 +1,7 @@
-# ProvekIt: prove software correctness across domains by comparing 64 bytes
+# ProvekIt: a proof supply chain for existing software
 
-Modern dependency stacks, protocol stacks, and CI supply chains are deep. ProvekIt collapses their load-bearing claims to content-addressed evidence.
+Modern dependency stacks, protocol stacks, and CI supply chains are deep.
+ProvekIt turns their load-bearing claims into content-addressed proof data.
 
 ```bash
 cargo install --path implementations/rust/provekit-cli
@@ -10,45 +11,73 @@ cargo provekit-lift
 provekit prove
 ```
 
-Install once; then three commands. Sixty-four bytes of comparison per call site. One CPU instruction per discharge.
+Install once; then start lifting native evidence into `.proof` artifacts and
+proving assembled obligations.
 
 ## What it does
 
-A library publishes signed contract mementos along with its bytes. A consumer's verifier loads the mementos, walks every call site in the consumer's code, and runs a three-tier handshake: hash equality (free), cached implication memento (one signature verification), Z3 fallback (once per novel pair, mints the result for everyone else).
+A library publishes signed contract mementos along with its bytes. A consumer's
+verifier loads the mementos, asks kits to resolve dependency `.proof` artifacts,
+walks the consumer obligations, and runs a tiered proof path: CID equality,
+cached implication memento, then semantic proving for genuinely new or changed
+obligations.
 
 The same graph carries non-callsite claims too: a protocol catalog transition admitted by PEP, a proof-file consumer admitted by proof-protocol fixtures, or a generated dropper transform accepted only after re-lift.
 
-`memcmp(local, expected, 64) == 0` is the protocol. The whole stack of human-published verified knowledge, at the average case, collapses to one CPU instruction.
+CID equality is the cheapest path, not the whole protocol. The point is
+amortization: proof work that was already minted can be reused by content
+identity; new semantic obligations still need proof.
 
 ## Why it works
 
 Verification at supply-chain scale has the same shape as currency, source history, content distribution, and the addressable web. Each was once thought to need a central authority. Each turned out to admit a content-addressed protocol with no central party. Bitcoin proved you can mint trust without a mint. Git proved a content-addressed graph holds a software project's full history. BitTorrent proved a swarm can distribute petabytes without a server. IPFS proved that "the address is the content" generalizes.
 
-ProvekIt is one more application of the same primitive. The "registry" is the BLAKE3-512 hashspace. There is no master copy. There is no service that mediates membership. There is no party whose downtime stops the protocol. The protocol asks no one's permission to publish; it provides bytes that verify themselves.
+ProvekIt is one more application of the same primitive. The "registry" is the
+BLAKE3-512 hashspace plus local policy over signed proof data. There is no
+master copy. There is no service that mediates membership. There is no party
+whose downtime stops the protocol. The protocol asks no one's permission to
+publish; it provides bytes that verify themselves.
 
 ## Lift, don't author
 
 Every annotation library in wide deployment already contains specifications. `proptest` invariants. `contracts` pre/post-conditions. `kani` proofs. `prusti` annotations. `pydantic` schemas. `zod` validators. `class-validator` decorators. `bean-validation` annotations. JML predicates. `go-playground/validator` tags. Each is a spec the codebase already maintains.
 
-ProvekIt does not compete with these libraries. It sits beneath them. Whatever annotation library a codebase already uses, the lift adapter promotes those annotations to content-addressed signed contract mementos, with no rewrites and no parallel spec to maintain. Authoring stays where the developer already is. Verification moves underneath.
+ProvekIt does not compete with these libraries. It sits beneath them. Whatever
+annotation library a codebase already uses, the lift adapter promotes the
+recognized annotations to content-addressed signed contract mementos, with no
+rewrites and no parallel spec to maintain. Authoring stays where the developer
+already is. Verification moves underneath.
 
-The adapter surface covers Rust, TypeScript, Python, Java, Go, C#, Ruby, Zig, C++, C, Swift, and PHP at different depths. The pattern is uniform: walk the idiom, emit canonical IR or an extension body, mint a signed memento, and verify the claim by CID.
+The adapter surface covers Rust, TypeScript, Python, Java, Go, C#, Ruby, Zig,
+C++, C, Swift, and PHP at different depths. The pattern is uniform: walk the
+idiom, emit canonical IR or an extension body, mint a signed memento, and verify
+or compose the claim by CID and proof evidence.
 
-## The protocol is its hash
+## The protocol is content-addressed
 
-v1.6.2 is shorthand. The canonical name of v1.6.2 is
+The CLI declares conformance to an embedded protocol catalog CID. Current
+binaries verify that embedded catalog with:
 
+```bash
+provekit verify-protocol
 ```
-blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f
+
+The repository also ships a reference CID checker at `tools/recompute-spec-cids/`:
+
+```bash
+cargo run --release --manifest-path tools/recompute-spec-cids/Cargo.toml -- --verify
 ```
 
-the BLAKE3-512 hash of the JCS-canonical form of the protocol catalog. Anyone with the spec bytes can re-derive the CID locally. The repository ships a reference implementation at `tools/recompute-spec-cids/`; `cargo run --release --manifest-path tools/recompute-spec-cids/Cargo.toml -- --verify` re-derives every CID and fails on any drift.
+That command re-derives catalog and spec CIDs and fails on drift.
 
 There is no central authority that decides what a protocol version means. The bytes do.
 
 ## What ships
 
-- A canonical Rust CLI: `provekit`. Subcommands include `prove`, `verify-protocol`, `proof`, `protocol`, `mint`, `dump`, `hash`, `ask`, `search`, `implicate`. Bug Zoo is checked by the self-contained runner under `menagerie/bug-zoo/`.
+- A canonical Rust CLI: `provekit`. Subcommands include `prove`,
+  `verify-protocol`, `proof`, `protocol`, `mint`, `dump`, `hash`, `implicate`,
+  `link`, `compose`, `emit`, `materialize`, and kit-oriented gates. Bug Zoo is
+  checked by the self-contained runner under `menagerie/bug-zoo/`.
 - A Rust workspace of libraries: `provekit-canonicalizer`, `provekit-claim-envelope`, `provekit-proof-envelope`, `provekit-ir-symbolic`, `provekit-verifier`, `provekit-macros`, `provekit-lift`, `provekit-lift-proptest`, `provekit-lift-contracts`.
 - Per-language kits, verifier libs, lift adapters, and self-contract attestations.
 - A protocol catalog at `protocol/specs/2026-04-30-protocol-catalog.json`, protocol extension specs, proof-protocol fixtures, and PEP evolution witnesses.

--- a/docs/explanation/monotonic-provability.md
+++ b/docs/explanation/monotonic-provability.md
@@ -118,7 +118,8 @@ What it means concretely:
 
 Tomorrow's lattice has all of today's pairs plus new ones. A codebase running tomorrow's verifier hits Tier 1 on more pairs than today's verifier.
 
-Verification cost decreases over time, asymptotically approaching the structural minimum (one CPU instruction per call site, the Tier 1 hot path).
+Verification cost can decrease over time as more obligations hit prior CIDs or
+cached implication mementos instead of requiring new semantic proof.
 
 This is the inverse of conventional software, where dependencies get harder to reason about as the dependency tree grows. With ProvekIt, the dependency tree's verification cost decreases as the lattice grows. The codebase ages "backwards" in the sense that older codebases are harder to verify (less lattice support) than newer ones.
 

--- a/docs/explanation/pitch.md
+++ b/docs/explanation/pitch.md
@@ -1,18 +1,35 @@
-# ProvekIt: prove software correctness across domains by comparing 64 bytes
+# ProvekIt: a proof supply chain for existing software
 
 A modern Rust workspace pulls in a few hundred crates. A modern npm project pulls in tens of thousands. A modern Go service drags in transitive C dependencies through cgo. Behind every `cargo build`, `npm install`, and `go mod tidy`, a developer is implicitly trusting a graph of code they have never read, written by people they have never met, doing things they cannot easily verify.
 
 The conventional answer is "run more tests." Tests are good. Tests are not the answer to behavioral verification at supply-chain scale. Tests verify a finite point set; properties hold over the whole input domain. The tools that do verify properties (Kani, Prusti, F\*, Dafny, TLA+) are heavyweight, language-bound, and demand specifications written and maintained alongside the code. They do not federate. They do not compose across packages. They do not survive a `cargo update`.
 
-ProvekIt is a toolchain for proving content-addressed claims. Behavioral contracts are the first surface, but the same machinery proves claims about protocol evolution, proof-file conformance, CI supply-chain input closure, and generated repair closure. It does not compete with the verification tools above. It sits beneath them and turns their output into proofchains: portable, signed, content-addressed evidence structures that compose across the dependency graph.
+ProvekIt is a toolchain for proving content-addressed claims. Behavioral
+contracts are the first surface, but the same machinery proves claims about
+protocol evolution, proof-file conformance, CI supply-chain input closure,
+generated repair closure, package inspection, and materialization receipts. It
+does not compete with the verification tools above. It sits beneath them and
+turns their output into proofchains: portable, signed, content-addressed
+evidence structures that compose across the dependency graph.
 
-## The petabyte-to-64-bytes ratio
+## The amortization move
 
-A library publishes signed contract mementos along with its bytes. A consumer's verifier loads the mementos, walks the call sites in the consumer's own code, and asks one question per call site: does the publisher's post-condition imply the consumer's pre-condition? After canonicalization to a deterministic IR, the answer reduces to comparing two BLAKE3-512 hashes. Sixty-four bytes versus sixty-four bytes. One CPU instruction.
+A library publishes signed contract mementos along with its bytes. A consumer's
+verifier loads the mementos, asks kits to resolve dependency `.proof` artifacts,
+walks the obligations in the assembled system, and asks whether the graph
+carries the needed implication.
 
-When the hashes match, the call site is discharged. The verifier did not parse the dependency. It did not run the dependency. It did not invoke a solver. It compared 64 bytes.
+When two canonical claims are byte-identical, their BLAKE3-512 CIDs match and
+the obligation can discharge by equality. The verifier did not parse the
+dependency, run the dependency, or invoke a solver for that identity case.
 
-This is the protocol's headline arithmetic. Verification of an arbitrarily-deep dependency stack reduces to hash comparison; the verifier's cost is decoupled from the size of the stack. The lattice tractability theorem (CID `blake3-512:b6d7c2772c2929294d7f516f79559bd292e44f51805a6bd6ea0ca7fe365b82ec96b86c434f53dfb003f5acd306533831dc0257e46ead4c7d71081f9f56ec6d07`) makes the claim formal: honest verifier cost is a function of grammar parameters and decision-procedure complexity, not of the populated cardinality of the address space and not of the cryptographic security parameter. The 2^512 hashspace is a property of the address space, not the search space.
+That is the cheap path, not the whole protocol. If a signed implication memento
+already exists, the verifier can reuse that proof edge. If the graph does not
+already carry the obligation, semantic proving still happens and the result can
+be minted for future reuse. The lattice tractability theorem (CID
+`blake3-512:b6d7c2772c2929294d7f516f79559bd292e44f51805a6bd6ea0ca7fe365b82ec96b86c434f53dfb003f5acd306533831dc0257e46ead4c7d71081f9f56ec6d07`)
+is about this amortized content-addressed graph, not a promise that every new
+proof is one comparison.
 
 This is why the high-level primitive is a proofchain. The payload of a blockchain is a series of state transitions. The payload of a proofchain is a series of formal proofs. The implication is slight, but fundamental: the chain is carrying why a claim is logically true.
 
@@ -22,7 +39,10 @@ The fundamental problem of formal verification has always been "how do we get th
 
 ProvekIt's answer is different: every annotation library in wide deployment already contains specifications. `proptest` invariants, `contracts` pre/post-conditions, `kani` proofs, `prusti` annotations, `pydantic` schemas, `zod` validators, `class-validator` decorators, `bean-validation` annotations, JML predicates, `go-playground/validator` tags. Each is an informal or semi-formal specification the codebase already maintains as part of normal development.
 
-The lift adapter is the bridge. Per source library, an adapter walks the AST, recognizes the library's idiom, and emits a canonical IR. The IR is canonicalized, hashed, and wrapped in a contract memento envelope. The envelope is signed. The signed memento is a content-addressed unit of behavioral specification.
+The lift adapter is the bridge. Per source library, an adapter walks the AST,
+recognizes the library's idiom, and emits ProofIR or a protocol claim. The claim
+is canonicalized, hashed, and wrapped in a signed memento. The signed memento is
+a content-addressed unit of behavioral specification.
 
 The codebase keeps its existing annotations. The author keeps their existing workflow. ProvekIt does not ask the author to learn a new spec language, write a parallel specification, or migrate to a different annotation library. The lift adapter promotes whatever the codebase already uses.
 
@@ -32,7 +52,10 @@ Bitcoin demonstrated that a global ledger can exist with no central party. Git d
 
 ProvekIt is one more application of the same primitive, applied to behavioral verification. The "registry" is the BLAKE3-512 hashspace. Populated points are sparse: only the canonical-IR formulas that some kit has emitted exist as addresses. The protocol asks no central party's permission to mint new contracts, publish implications, or discover new mementos. The bytes verify themselves.
 
-Cache invalidation is structurally absent. When a contract's bytes change, its CID changes; old mementos remain cryptographically valid against the old bytes; nothing is poisoned, nothing is stale, nothing requires a service call to refresh. Provability is monotonic. A fact, once minted, is a hash lookup forever.
+Cache invalidation is structurally absent. When a contract's bytes change, its
+CID changes; old mementos remain cryptographically valid against the old bytes.
+They do not silently apply to the new bytes. Provability is monotonic in that
+old facts stay true about the content they named.
 
 Search is grep. "Find a library function whose post-condition implies my pre-condition" is the npm-by-behavior query. The hashspace is a searchable substrate; the search reduces to walking `.proof` files and comparing CIDs.
 
@@ -40,9 +63,15 @@ Search is grep. "Find a library function whose post-condition implies my pre-con
 
 Verification at scale is a cost-amortization problem. Naive per-call-site solver invocation does not scale. ProvekIt's handshake (CID `blake3-512:acbf67dda9373c648e591d8ad74b8f8d56f4c92ba9c82bdc6690dc521e6f17012dd195e98a96b099090eeeb5a424312d90ff441c882d0e317a190561aa1a6925`) breaks the cost model into three tiers, in increasing order of work:
 
-1. **Hash equality.** The publisher's post-formula and the consumer's pre-formula canonicalize to identical bytes. `memcmp` is zero. The call site is discharged for free. This is the librarian, not the expert: the verifier is doing content-addressed lookup, not theorem proving.
-2. **Cached implication.** A signed implication memento exists asserting `post → pre`, witnessed by Z3, signed by some prover. The verifier checks the signature once per `(post, pre)` pair. Constant time, branch-free, network-free.
-3. **Solver fallback.** Z3 is invoked once per genuinely-novel `(post, pre)` pair. On `unsat`, the result is minted as a new signed implication memento and published per the verifier's policy. Every future verifier in the ecosystem hits Tier 2 instead.
+1. **Hash equality.** The publisher's post-formula and the consumer's
+   pre-formula canonicalize to identical bytes. The verifier is doing
+   content-addressed lookup, not theorem proving.
+2. **Cached implication.** A signed implication memento exists asserting
+   `post -> pre`, witnessed by a prover and signed by a producer the verifier's
+   policy admits. The verifier checks and reuses that edge.
+3. **Solver fallback.** A prover is invoked for a genuinely novel `(post, pre)`
+   pair. On success, the result can be minted as a new signed implication
+   memento so future verifiers can reuse it.
 
 The headline metric is the hash-discharge fraction: the share of call sites discharged by Tier 1 alone. A high fraction means contracts are composing well across the ecosystem. The implication server (a passive indexer, not an authority) reports observed coverage.
 
@@ -62,13 +91,20 @@ cargo provekit-lift
 provekit prove
 ```
 
-The Rust CLI is the canonical shipping implementation for v1.6.3. Per-language libs embed the verifier; per-language kits emit canonical IR and extension bodies; per-language lift adapters bridge from existing annotation libraries. See [docs/reference/per-language-status.md](../reference/per-language-status.md) for the matrix.
+The Rust CLI is the canonical shipping implementation. Per-language libs embed
+or call the verifier; per-language kits emit canonical IR and extension bodies;
+per-language lift adapters bridge from existing annotation libraries. See
+[docs/reference/per-language-status.md](../reference/per-language-status.md) for
+the matrix.
 
 ## What's not in the box
 
 ProvekIt is honest about scope. It is not a soundness-certified compliance tool; if a regulator requires Coq, Isabelle, or F\* output, those tools remain the right choice. It is not a substitute for runtime testing; properties hold over the input domain only insofar as the lifted IR faithfully encodes the source library's idiom, and per-library adapter coverage is empirical. It is not a substitute for human review; signed mementos document who claimed what, but the trust decision belongs to the verifier.
 
-What ProvekIt is, is the load-bearing primitive missing from the verification ecosystem: proofchains over which the existing tools can publish their findings in a portable, signed, composable form. The petabyte/64-byte ratio is the headline. The lift-not-author posture is the adoption story. The Bitcoin/Git/BitTorrent adjacency is the reason it scales.
+What ProvekIt is, is the load-bearing primitive missing from the verification
+ecosystem: proofchains over which existing tools can publish their findings in a
+portable, signed, composable form. The lift-not-author posture is the adoption
+story. Content-addressed reuse is the scaling story.
 
 ## Read further
 

--- a/docs/explanation/product.md
+++ b/docs/explanation/product.md
@@ -2,143 +2,158 @@
 
 ## What ProvekIt is
 
-ProvekIt is a toolchain for proving content-addressed claims. It defines four core things: a canonical IR for claim boundaries, a signed memento envelope wrapping claims with provenance, a published `.proof` catalog of mementos addressed by CID, and a handshake algorithm that verifies a consumer's obligations against a publisher's evidence in time decoupled from the size of the dependency graph.
+ProvekIt is a proof supply chain for code and packages that already exist.
 
-Those pieces compose into proofchains: portable, locally verifiable chains of signed, content-addressed evidence for logically true claims. A blockchain carries state transitions; a proofchain carries formal proofs. The chain exists so a verifier can re-check why a claim is true under explicit policy.
+Most projects already contain evidence about behavior: tests, assertions,
+contracts, schemas, validators, type annotations, framework annotations, package
+metadata, CI results, and proof-tool output. Today that evidence usually stays
+inside one language, one test runner, one repository, or one build. ProvekIt
+promotes it into portable ProofIR or protocol claims, wraps those claims in
+signed mementos, and distributes them as content-addressed `.proof` artifacts.
 
-Software correctness across domains is the center use case: language to language, package to package, protocol version to protocol version, and generated repair to re-lifted proof. Cross-platform contract correctness is one expression of that larger pattern.
+The product has two main actors:
 
-Verification reduces to hash comparison. When the publisher's post-condition and the consumer's pre-condition canonicalize to identical bytes, the call site is discharged for free. When they don't, a signed implication memento may exist that bridges them; the verifier checks the signature once and discharges every call site that shares the same `(post, pre)` pair. When neither path applies, Z3 runs once per novel pair, mints the result as a fresh implication memento, and every future verifier hits the cached path.
+- **Kits** know native ecosystems. They lift language-native evidence into
+  ProofIR or protocol claims, materialize admitted claims back into native
+  source when needed, and resolve dependency `.proof` artifacts through the
+  package manager and filesystem rules of their ecosystem.
+- **The CLI** computes over normalized proof data. It loads `.proof` artifacts,
+  speaks RPC to kits, conjoins and composes claims, checks conformance, emits
+  proof bundles, and proves obligations. It should not need to know Maven, npm,
+  Cargo, Spring, Zod, JML, or Rust proc-macro semantics directly.
 
-ProvekIt is shipped as a canonical Rust CLI (`provekit`) plus per-language libraries and kits. The protocol version is itself a CID: v1.6.2 is shorthand for `blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f`. Anyone with the spec bytes can verify that label locally.
+That is the important boundary. ProvekIt is not a verifier for one language and
+not another test runner. It is a substrate where claims from many local tools
+can be compared, composed, signed, and rejected when they contradict.
 
-## Who it's for
+## The game changer
 
-Four audiences, in order of immediate fit:
+Local success does not imply assembled success.
 
-**Library authors who want their behavioral guarantees to ship.** Today, a Rust crate that uses `proptest` invariants or `contracts` pre/post-conditions communicates those guarantees to whoever reads the crate's source. ProvekIt's lift adapter promotes the existing annotations to signed contract mementos that ship in a `.proof` catalog alongside the crate's bytes. Downstream consumers verify against the mementos without ever running the original test suite or invoking the original solver. The author's annotations stay where they are; the verification is now portable.
+A library can pass its tests. A consumer can pass its tests. A shim can pass its
+smoke suite. The system assembled from those parts can still make inconsistent
+claims: a callee publishes a weaker postcondition than the caller requires, two
+packages disagree about a boundary value, a generated bridge drops a condition,
+or a dependency update changes a contract set while the application still
+expects the old one.
 
-**Application teams that depend on libraries they did not write.** A consumer's verifier walks the dependency tree, loads every `.proof` it finds, and discharges call sites against the cached contract mementos. The Tier-1 hash-discharge fraction is the headline metric: a high fraction means the consumer's expectations and the library's guarantees agree on shape. A low fraction means there is real work to do, and the work is the residue, not the average case. The verifier's cost is decoupled from the depth of the dependency tree.
+ProvekIt makes the claims fight together. It lifts the local evidence into a
+shared proof graph, composes the claims, and reports proof violations or
+unresolved residue when the graph cannot justify the assembled system.
 
-**Build-tool maintainers and language teams.** Per-language kits emit canonical IR. Per-language libs verify. The Rust CLI is one shipping implementation; alternative CLIs in any language are conforming as long as they accept the v1.6.2 catalog CID. The protocol is the contract; implementations are interchangeable.
+That makes ProvekIt a supply-chain tool as much as a verification tool. The
+question is not only "did this package pass its own checks?" The question is
+"do the claims this package ships still hold when combined with the claims its
+consumers, dependencies, bridges, and generated artifacts rely on?"
 
-**Protocol and tooling authors.** PEP, GCP, TDP, ORP, CBP, and proof-protocol conformance let ProvekIt prove protocol/tooling claims with the same content-addressed graph used for application contracts.
+## `.proof` artifacts
+
+A `.proof` artifact is a signed, content-addressed bundle of proof data. It can
+contain contract mementos, implication witnesses, bridge attestations,
+proof-file conformance witnesses, materialization receipts, package inspection
+claims, and policy-relevant metadata.
+
+Those artifacts form a DAG. Nodes and edges are named by content: contract CIDs,
+attestation CIDs, contract-set CIDs, proof-bundle CIDs, binary CIDs, and protocol
+catalog CIDs. If bytes change, the CID changes. Old mementos remain true about
+the old bytes, but they do not silently apply to the new bytes.
+
+This is where the cost model comes from:
+
+- If a prior commitment is unchanged, a verifier may discharge work by CID
+  equality, signature verification, and graph walking.
+- If a signed implication already exists for a pair of claims, the verifier can
+  reuse that implication instead of re-solving it.
+- If a claim is new, changed, or newly composed in a way the DAG does not
+  already justify, semantic proving still has to happen.
+
+So the honest statement is not "all proving is O(1)." Expensive proof work can
+be done once and then reused by content identity. New semantic work still costs
+what it costs.
+
+## Who it is for
+
+**Library authors** can publish behavioral claims alongside package bytes. Their
+tests, assertions, validators, contracts, and proof-tool outputs stay in the
+native source. A kit lifts those surfaces and emits `.proof` artifacts.
+
+**Application teams** can verify the claims that dependencies ship instead of
+trusting a package because its upstream CI was green once. The verifier reports
+which obligations discharged by equality, which used cached implications, which
+needed proving, and which failed or remained unsupported.
+
+**Kit authors** build the ecosystem-specific side: native syntax walking,
+package proof resolution, framework sugar, diagnostic translation, and
+materialization into the host language.
+
+**Protocol and tooling authors** use the same substrate for claims that are not
+ordinary function contracts: proof-file conformance, protocol catalog evolution,
+CI input closure, generated repair closure, package inspection, and
+materialization receipts.
 
 ## What ProvekIt replaces
 
-Nothing. ProvekIt does not replace `cargo test`, `npm test`, `go test`, or any other test runner. It does not replace `clippy`, `eslint`, `golangci-lint`, or any other linter. It does not replace Kani, Prusti, F\*, Dafny, TLA+, or any other formal verifier.
+ProvekIt replaces the missing portable layer under existing tools.
 
-ProvekIt replaces the absence of a portable, signed, composable substrate underneath those tools. Today, when `proptest` finds an invariant, that invariant lives in the test runner's output; nothing else can use it. When Kani proves a property, that property lives in Kani's output; nothing downstream can carry it forward. ProvekIt is the missing layer: lift the existing tool's output into a signed memento, address it by content, publish it in a `.proof` or extension witness, and the next tool in the pipeline sees a cached fact instead of a fresh problem.
-
-## What ProvekIt complements
-
-This list is comprehensive on purpose. ProvekIt sits beneath every annotation library; it does not compete with any of them. Adoption pattern is uniform: the lift adapter walks the source library's annotations, emits canonical IR, mints a signed contract memento, and publishes.
-
-**Rust:**
-- `proptest` (lift adapter shipping in v1.1)
-- `contracts` (lift adapter shipping in v1.1)
-- `kani`, `prusti`
-- `creusot`, `flux` (lift adapters under evaluation)
-- `quickcheck` (idiom maps to `proptest` adapter shape)
-
-**TypeScript / JavaScript:**
-- `zod`, `class-validator`, `fast-check`
-- `io-ts`, `runtypes`, `valibot`, `ajv` schemas (planned)
-- TypeScript's own type system (the `ts-types-proof` lib lifts type annotations)
-
-**Python:**
-- `pydantic`, `attrs`, `dataclasses-json` schemas
-- `deal`, `hypothesis`, `icontract` (planned)
-- `mypy` and `pyright` annotations (planned)
-
-**Java / JVM:**
-- Bean Validation (`jakarta.validation`, `javax.validation`)
-- JML, Cofoja (planned)
-- KeY-style annotations, OpenJML (planned)
-
-**Go:**
-- `go-playground/validator`
-- `ozzo-validation`, `validator.v9` (planned)
-- Build-tag-based assertions (planned)
-
-**C++:**
-- C++26 contract attributes `[[expects:]]`, `[[ensures:]]` (kit shipping; lift adapter planned)
-- `assert.h` patterns (planned)
-- Boost.Hana and Boost.Contract (under evaluation)
-
-The pattern is uniform across host languages. Whatever annotation library a codebase already uses, ProvekIt promotes those annotations to content-addressed signed contracts, with no rewrites and no parallel spec to maintain.
+It does not replace `cargo test`, `npm test`, `go test`, JUnit, pytest, Kani,
+Prusti, Coq, Lean, F*, Dafny, TLA+, Z3, schema validators, or static analyzers.
+Those tools remain the source of evidence. ProvekIt gives their claims stable
+bytes, CIDs, signatures, and a proof graph where downstream consumers can reuse
+or reject them.
 
 ## What ProvekIt is not
 
-ProvekIt is not a soundness-certified compliance tool. If a regulator requires output from Coq, Isabelle, F\*, or another tool whose own correctness is itself certified, those tools remain the right choice. ProvekIt's correctness rests on (a) BLAKE3-512 collision resistance, (b) Ed25519 unforgeability, (c) the underlying solver's correctness on the IR fragment used, and (d) the per-language lift adapter's faithful translation of the source library's idiom. Each of these is an honest assumption; none of them produces a regulator-accepted certificate.
+ProvekIt is not a soundness-certified compliance product. If a deployment
+requires a regulator-recognized proof artifact from Coq, Isabelle, F*, or a
+specific certified toolchain, that toolchain remains the authority.
 
-ProvekIt is not a replacement for runtime testing. Tests cover concrete inputs; contracts cover the input domain. A high Tier-1 hash-discharge fraction is a strong signal that contracts compose, but adapter coverage is empirical; the per-language lift adapter only sees what it knows how to walk. Anything outside the adapter's idiom remains as untouched as it was before ProvekIt arrived.
+ProvekIt is not a substitute for runtime testing. Tests are often the evidence
+that gets lifted. Adapter coverage is empirical, and each kit only sees the
+idioms it knows how to walk.
 
-ProvekIt is not a database. There is no central registry, no service to call, no party that decides what counts as a valid contract. The protocol asks no one's permission to publish; it provides bytes that verify themselves. The implication server, if one exists, is a passive indexer over published `.proof` files, not an authority.
+ProvekIt is not a central registry. A `.proof` artifact verifies from its bytes,
+CIDs, signatures, witnesses, and local policy. A server can index proof data for
+discovery, but the server is not the source of truth.
 
-ProvekIt is not a coding-agent guardrail or an LLM proof harness. The protocol does not invoke an LLM at any step. The Rust CLI invokes Z3 at Tier 3 of the handshake, and only there. Cache hits at Tier 1 and Tier 2 are network-free, solver-free, and constant-time per call site.
+ProvekIt is not a promise that every boundary can be materialized exactly.
+Materialization can produce exact output, bounded lossy output with an explicit
+loss record, or refusal. Silent loss is the forbidden case.
 
 ## Adoption surfaces
 
-ProvekIt has three adoption paths.
-
-**1. Library author publishes a `.proof` alongside their crate.**
+The current source-built CLI is:
 
 ```bash
 cargo install --path implementations/rust/provekit-cli
-cd my-crate
-cargo provekit-lift   # walks proptest! and #[contracts::ensures] annotations
-                      # emits target/.proof
-provekit prove        # local verification of the catalog
+provekit verify-protocol
 ```
 
-The `.proof` is a signed catalog of contract mementos. Ship it alongside the crate's bytes (in `target/release/` or in the published crate, depending on the publisher's policy). Consumers find it during their own verifier walk.
-
-**2. Application team verifies a dependency tree at build time.**
+A project that declares lift plugins can mint proof data:
 
 ```bash
-cd my-app
-provekit prove
+provekit mint --project .
 ```
 
-The verifier walks `<projectRoot>` and the dependency tree's `.proof` files, indexes the memento pool, runs the handshake at every call site, and reports the discharge breakdown. Exit code is 0 (everything discharged), 1 (violations or unresolved residue), 2 (user error), or 3 (solver unavailable / timeout).
+A consumer can run the proof gate over local and dependency `.proof` artifacts:
 
-**3. Build-script integration (planned).**
-
-```rust
-// build.rs
-fn main() {
-    provekit_build::verify_or_fail();
-}
+```bash
+provekit prove .
 ```
 
-Contract violations become compile-time errors in the same stream as type errors. ProvekIt is the proof gate, enforced at the same boundary as the type system.
-
-## Configuration
-
-A repository declares its conformance via a `provekit.config.yaml` at the project root:
-
-```yaml
-protocol:
-  cid: blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f
-  version: v1.6.2
-
-publish:
-  implications:
-    target: project    # one of: local, project, registry
-```
-
-The conformance CID is the protocol version. An implementation that declares a different CID is a different protocol; implementations may declare multiple CIDs to support cross-version operation.
+The exact plugin manifests, kit coverage, and package-manager proof resolution
+depend on the host ecosystem. Start with
+[../quickstart-end-user.md](../quickstart-end-user.md) to run the CLI and
+[../quickstart-extender.md](../quickstart-extender.md) to build or extend a kit.
 
 ## What you actually get
 
-You don't get "mathematical certainty that your code is correct." You get:
-
-- A signed `.proof` catalog of contract mementos that ships with your library.
-- A proofchain that carries the claims, witnesses, attestations, and policy context needed to verify the result locally.
-- A verifier that walks consumer call sites and reports the hash-discharge fraction.
-- A growing lattice of cached implication mementos that amortize solver cost across the ecosystem.
-- A per-call-site report identifying the residue that genuinely needs your attention.
-- A protocol that does not require permission, does not need invalidation, does not call home, and does not depend on any party but the bytes you and your peers published.
-
-The proof gate fits underneath the tools your team already runs. The compounding value comes from adoption: every published `.proof` raises the Tier-1 discharge fraction for everyone who consumes the library. Software ages backwards.
+- A way to turn existing native evidence into portable ProofIR or protocol
+  claims.
+- Signed `.proof` artifacts that carry those claims by content identity.
+- A language-agnostic CLI that composes and proves normalized proof data.
+- Kit-owned integration with language syntax, libraries, package managers, and
+  materialization surfaces.
+- Reports that distinguish proved obligations, cached commitments, violations,
+  unsupported residue, bounded loss, and refusal.
+- A proof supply chain that runs over existing ecosystems instead of replacing
+  them.

--- a/docs/explanation/thesis.md
+++ b/docs/explanation/thesis.md
@@ -6,21 +6,38 @@ Z3, Coq, Lean, F\*, Isabelle, Kani, Prusti, Creusot, Dafny, TLA+, CBMC: those ar
 
 This is the same shape as Bitcoin (content-addressed currency, no central mint), Git (content-addressed source history, no master copy), BitTorrent (content-addressed content distribution, no central server), IPFS (content-addressed web, no registry). Each of those took a domain that was thought to require a central authority and showed it admits a content-addressed protocol with no central party. ProvekIt applies the same primitive to behavioral verification.
 
-ProvekIt's central claim is operational, not philosophical: a content-addressed protocol can carry behavioral verification across an arbitrarily-deep dependency graph at a cost that does not depend on the depth of the graph or the cardinality of the address space. The verifier compares 64 bytes per call site. The 64 bytes summarize a chain of arguments whose total length is irrelevant to the comparison.
+ProvekIt's central claim is operational, not philosophical: a content-addressed
+protocol can carry behavioral verification across a dependency graph without
+making every consumer redo all prior semantic work. When a prior commitment is
+unchanged, the verifier can compare CIDs, check signatures, and walk proof
+edges instead of re-running the original tests or solvers.
 
-But the deeper claim is **cross-domain verification for free**. A proof about JavaScript's `parseInt` transfers to Rust's `str::parse` because both bridge to the same reference contract. The bridge is a hash-bounded claim: "contract A (CID X) implies contract B (CID Y)." The implication is verified once, cached forever, and every verifier in every language hits the cache.
+But the deeper claim is **cross-domain proof reuse**. A proof about
+JavaScript's `parseInt` can transfer to Rust's `str::parse` when both bridge to
+the same reference contract. The bridge is a hash-bounded claim: "contract A
+(CID X) implies contract B (CID Y)." The implication is verified once against
+those bytes and can be reused by verifiers whose policy admits that memento.
 
 The thesis breaks into two core claims, each precise, each independently checkable.
 
-## 1. Verify a petabyte of correctness with a hash
+## 1. Reuse prior correctness by content identity
 
-Modern dependency graphs span tens of thousands of packages. The total bytes a verifier could trace through transitive dependencies is, plausibly, a petabyte. ProvekIt verifies arbitrarily-deep stacks via 64-byte hash comparison.
+Modern dependency graphs span many packages and tools. A consumer should not
+need to re-run every upstream test, solver, and package inspection if the
+upstream claim was already minted and the bytes have not changed.
 
-The mechanism is straightforward. A library publishes a contract memento whose `post` formula canonicalizes to a CID. A consumer's call site has a `pre` formula whose canonicalization yields some CID. The handshake question is: does post imply pre? Tier 1 of the handshake answers yes when the CIDs are equal, by `memcmp(local, expected, 64) == 0`. One CPU instruction. Branch-free. Constant-time.
+The mechanism is straightforward. A library publishes a contract memento whose
+`post` formula canonicalizes to a CID. A consumer's obligation has a `pre`
+formula whose canonicalization yields another CID. The handshake question is:
+does `post` imply `pre`? Tier 1 answers yes when the CIDs are equal. Tier 2
+answers yes when an admitted signed implication memento already carries that
+edge. Tier 3 proves or rejects genuinely new edges.
 
-The protocol's headline arithmetic is the ratio of these two numbers: petabytes of behavior verified, 64 bytes of comparison per discharge. The ratio is unbounded above; it grows with the size of the dependency graph the consumer chose to verify.
+The thesis is amortization. Expensive semantic work can be minted once and then
+reused by content identity. New, changed, or newly composed obligations still
+require semantic proof.
 
-## 2. Prove correctness across domains for free
+## 2. Reuse correctness across domains
 
 The bridge mechanism makes cross-domain transfer automatic. When the JavaScript kit emits:
 
@@ -50,19 +67,30 @@ Both implementations bridge to the **same reference contract** (CID `bafy...ref-
 js-parseInt-v24 → ref-parseInt-v1 ← rust-parse-v1
 ```
 
-The transfer is free because the implication `js-parseInt-v24 → ref-parseInt-v1` was verified once (by the JS kit's producer) and cached. The implication `rust-parse-v1 → ref-parseInt-v1` was verified once (by the Rust kit's producer) and cached. The framework composes them transitively without re-running Z3.
+The transfer is cheap after the implications `js-parseInt-v24 ->
+ref-parseInt-v1` and `rust-parse-v1 -> ref-parseInt-v1` have been verified and
+minted. The framework composes those edges transitively without re-running the
+same solver work for every consumer.
 
 **The hash is the boundary.** Above the hash is math: the lattice of populated formulas, the implications between them, the signatures that anchor non-repudiation. Below the hash is physics: the byte sequence that hashes to it. The verifier does not look below the hash. When the consumer's pre-hash equals the publisher's post-hash, the verifier has a proof of equality up to canonicalization, and that proof is the comparison itself.
 
 ## 3. Hash-bounded verification: the mechanism
 
-The term "hash-bounded" means: the verification of a claim is bounded by the size of the hash, not by the size of the claim. A petabyte dependency graph reduces to 64 bytes per call site because the hash summarizes everything below it.
+The term "hash-bounded" means: a minted claim is referenced by the hash of its
+canonical bytes, not by a tool log, package name, or mutable registry entry.
+When the verifier is checking identity or a previously minted edge, the work is
+bounded by content identity and the memento's verification rules, not by the
+size of the original dependency graph.
 
-More importantly, **cross-domain claims are hash-bounded too.** The bridge `A → B` is not a symbolic name lookup ("`parseInt` probably means this"). It is a **content-addressed claim about content-addressed contracts.** The bridge says: "the contract at CID X implies the contract at CID Y." The verifier checks this by comparing hashes, not by interpreting names.
+More importantly, **cross-domain claims are hash-bounded too.** The bridge `A ->
+B` is not a symbolic name lookup ("`parseInt` probably means this"). It is a
+**content-addressed claim about content-addressed contracts.** The bridge says:
+"the contract at CID X implies the contract at CID Y." The verifier checks the
+edge by verifying the memento and local policy, not by interpreting names.
 
 This is what makes supply chain attacks detectable. If an attacker injects malicious code into `lodash`, the binary CID changes, the `.proof` bundle's CID changes, the bridge's `sourceContractCid` no longer resolves, and the **build fails at compile time.** Not because someone audited the code. Because the **mathematical proof is for different bytes.**
 
-## 4. The proof bundle IS the package
+## 4. The proof bundle travels with the package
 
 Traditional software distribution:
 ```
@@ -72,9 +100,9 @@ node_modules/ → contains dependencies
  audits? → manual, optional, slow
 ```
 
-ProvekIt distribution:
+ProvekIt proof distribution:
 ```
-<cid>.proof → IS the package
+<cid>.proof -> travels with or beside the package
   ├── contracts: what the code guarantees
   ├── bridges: how it relates to other packages
   ├── binaryCid: the exact compiled artifact
@@ -82,7 +110,10 @@ ProvekIt distribution:
   └── signature: developer-signed, tamper-evident
 ```
 
-The `.proof` file replaces the package manifest, the lockfile, the audit report, and the SBOM. It is all of them in one content-addressed artifact. Change any bit, the CID changes, the old proof is still valid, the new one must be re-verified.
+The `.proof` file does not replace native manifests or package managers. It
+adds a content-addressed proof artifact beside them. Change any claimed bytes
+and the CID changes; the old proof remains valid for the old bytes, while the
+new bytes need new proof data.
 
 ## 5. The DAG of proofs is a verifiable execution trace
 
@@ -92,7 +123,10 @@ At every node in the DAG:
 - `evidence` = the Z3/Coq/Kani proof (why it's correct)
 - `inputCids` = dependencies on prior state (what this transition requires)
 
-Walking the DAG in topological order is **executing a program where every instruction is formally verified.** The call stack IS a proof tree. The DAG tells you the exact order in which to verify theorems so that the composition is guaranteed correct.
+Walking the DAG in topological order gives the verifier the order in which to
+check claims, witnesses, signatures, policies, and implication edges. It is a
+proof execution trace, not a claim that every runtime instruction in every
+package has been formally verified.
 
 ## 6. No database; computable hashspace
 
@@ -114,11 +148,14 @@ ProvekIt does not compete with these libraries. It sits beneath them. Whatever a
 
 This is the lift-not-author posture. It is the answer to "how do we get the specifications?" that fifty years of formal methods could not solve. The specifications already exist; we just need to lift them.
 
-## 9. The 64-byte verification is one CPU instruction
+## 9. CID equality is the hot path
 
-`memcmp(local, expected, 64) == 0`. Constant-time. Branch-free. The whole stack of human-published verified knowledge, at Tier 1 of the handshake, collapses to a single CPU instruction.
+At Tier 1 of the handshake, the verifier compares canonical claim CIDs. If they
+match, identity discharges without theorem proving.
 
-This is not metaphor. This is the actual wire-level instruction the verifier executes when the publisher's post-hash and the consumer's pre-hash agree. The hash is 64 bytes; the comparison is one instruction; the call site is discharged. The protocol's promise is that this is the hot path, the average case, the place where most call sites land in a healthy ecosystem.
+This is the desired hot path in a healthy ecosystem. It is not the whole proof
+story. Tier 2 reuses admitted implication mementos, and Tier 3 performs
+semantic proving for obligations the graph does not already carry.
 
 The hash-discharge fraction (the share of call sites discharged at Tier 1 alone) is the headline metric. A high fraction means the ecosystem's contracts are composing well: publishers and consumers are agreeing on shape, and the verifier's work is amortized to near-zero.
 
@@ -140,4 +177,5 @@ This is not a claim of zero adoption cost. The lift adapter is per source librar
 
 What the thesis is, is a structural claim: the verification problem at supply-chain scale has the same shape as currency, source history, content distribution, and the addressable web. Each of those problems was once thought to require a central authority. Each turned out to admit a content-addressed protocol with no central party. ProvekIt applies the same primitive to behavioral verification, and the primitive carries the load.
 
-The proof is in the bytes. The bytes are at the CID above. The verifier is one CPU instruction.
+The proof is in the bytes. The bytes are named by CID, signed by producers, and
+accepted or rejected under local verifier policy.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,28 @@
 # ProvekIt documentation
 
-ProvekIt is a toolchain for proving content-addressed claims.
+ProvekIt is a proof supply chain for existing software ecosystems.
 
-The center use case is software correctness across domains: language to language, package to package, protocol version to protocol version, and generated repair to re-lifted proof. Cross-platform contract correctness is one expression of that. The common shape is simple: canonicalize a proposition, name it by CID, name the evidence by CID, sign the edge, and fail closed when the graph does not carry the claim.
+It turns language-native evidence, including tests, assertions, contracts,
+schemas, validators, framework annotations, and boundary/library sugar, into
+portable ProofIR or protocol claims. Kits own the language and package-manager
+details. The CLI stays language-agnostic: it loads `.proof` artifacts, speaks
+RPC to kits, composes normalized claims, emits proof bundles, and proves the
+assembled obligations.
 
-That linked evidence object is a proofchain: a locally verifiable chain of signed, content-addressed evidence for logically true claims.
+The center use case is assembled correctness. Two packages can each pass their
+own checks and still make contradictory claims when used together. ProvekIt
+makes those claims meet in one content-addressed `.proof` DAG and fails closed
+when the graph cannot carry the composed claim.
 
-Current protocol catalog: **v1.6.3**
+A proofchain is the linked evidence object formed by that DAG: canonical claims,
+CIDs, signatures, witnesses, attestations, and verifier policy. Previously
+minted commitments can often be rechecked cheaply by CID equality and signature
+verification, while semantic proving still happens when a claim is minted,
+changed, or newly composed.
 
-Current catalog CID: `blake3-512:dd0cc79889ee67d2594f5cfa20a191bafed15196fb2c5036f85deced7cd976055ae93825edebc10812b6fcf3c6ccf274fbc1137f32705aa0dc5938dc5825e31d`
+The canonical CLI embeds its current protocol catalog. Verify your local binary
+with `provekit verify-protocol`; see [reference/cids.md](reference/cids.md) for
+spec CID background.
 
 ## References
 
@@ -28,6 +42,7 @@ Current catalog CID: `blake3-512:dd0cc79889ee67d2594f5cfa20a191bafed15196fb2c503
 | Install and run the verifier | [quickstart-end-user.md](quickstart-end-user.md) |
 | Build or extend a kit | [quickstart-extender.md](quickstart-extender.md) |
 | Understand the broad use cases | [explanation/use-cases.md](explanation/use-cases.md) |
+| Understand the product surface | [explanation/product.md](explanation/product.md) |
 | Understand the architecture | [explanation/architecture.md](explanation/architecture.md) |
 | Read the protocol/tooling extension map | [reference/protocol-extensions.md](reference/protocol-extensions.md) |
 | Look up current CIDs | [reference/cids.md](reference/cids.md) |
@@ -87,6 +102,7 @@ See [reference/per-language-status.md](reference/per-language-status.md) for the
 | Why lift, do not author? | [explanation/lift-not-author.md](explanation/lift-not-author.md) |
 | Why is provability monotonic? | [explanation/monotonic-provability.md](explanation/monotonic-provability.md) |
 | How do we know two `if`s in different languages are the same construct? | [explanation/cross-language-equivalence.md](explanation/cross-language-equivalence.md) |
+| How do kits and the CLI divide responsibility? | [explanation/architecture.md](explanation/architecture.md) |
 | What is out of scope? | [explanation/boundaries.md](explanation/boundaries.md) |
 | What is the product surface? | [explanation/product.md](explanation/product.md) |
 | What is the short pitch? | [explanation/pitch.md](explanation/pitch.md) |

--- a/docs/papers/README.md
+++ b/docs/papers/README.md
@@ -4,13 +4,25 @@ This directory contains paper-grade arguments. These are not docs (how to use th
 
 Each paper is intended to be cite-able in academic and industry contexts.
 
+Read the papers as arguments, not as a promise that every described route is
+fully shipped in the current tree. The current product surface is narrower and
+more concrete: kits lift existing language-native evidence into ProofIR or
+protocol claims, the CLI computes over normalized `.proof` data, and the
+content-addressed DAG lets prior contracts and proofs be reused by CID when the
+same commitments appear again. Semantic proving still happens when claims are
+minted, changed, or newly composed.
+
+For the current operator-facing map, start with
+[../explanation/product.md](../explanation/product.md) and
+[../explanation/architecture.md](../explanation/architecture.md).
+
 ## Index
 
 The papers are an inductive ladder. Paper 1 is the pitch, paper 2 is the formal spec, and papers 3 through 23 are the After-X rungs: given what the prior paper established, here is what changes. Read them in order, because later rungs assume the framing earlier ones built.
 
 1. **[The Whitepaper](01-whitepaper.md)**: Executive summary. What ProvekIt is, why it matters, who it is for, the trojan horse, the cypherpunk lineage. The trust-depth knob; the three-CLI surface; the install path. The shortest path from "I have heard of this" to "I understand the move."
 
-2. **[The Bluepaper](02-bluepaper.md)**: Formal protocol specification. Theorem statements with proofs; the canonical IR grammar in EBNF; the constant-size verification theorem with hypotheses H1-H5; the `memcmp` line shown verbatim; the cryptographic-minimum claim; every spec referenced by content hash. Closes with a runnable verification: compute the catalog CID locally, and the bluepaper has just verified its own authority. The paper is a formal baseline; the current v1.6.3 catalog and extension CIDs live in [../reference/cids.md](../reference/cids.md) and [../reference/protocol-extensions.md](../reference/protocol-extensions.md).
+2. **[The Bluepaper](02-bluepaper.md)**: Formal protocol specification. Theorem statements with proofs; the canonical IR grammar in EBNF; the constant-size verification theorem with hypotheses H1-H5; the `memcmp` line shown verbatim; the cryptographic-minimum claim; every spec referenced by content hash. Closes with a runnable verification: compute the catalog CID locally, and the bluepaper has just verified its own authority. The paper is a formal baseline; the current CLI catalog and extension CIDs live in [../reference/cids.md](../reference/cids.md) and [../reference/protocol-extensions.md](../reference/protocol-extensions.md).
 
 3. **[After Bluepapers: Substrate, Not Blockchain](03-substrate-not-blockchain.md)**: The proofchain/blockchain adjacency argument. Contains the formal lemma that proof validity does not require distributed consensus, while distributed timestamp-server claims do. Also covers §10 closure-by-composition, §11 the address as multi-dimensional, and §12 the pin as a tuple. The four pinning dimensions (`contractCid` / `contractSetCid` / `attestationCid` / bundle file CID), each a different content projection. The rank-N tuple discipline: a pin must match the rank of the assertion it attests; collapsing a rank-2 relation into rank-1 leaks the discarded axis as drift. This is the architectural foundation the v1.4 specs operationalize.
 

--- a/docs/reference/cids.md
+++ b/docs/reference/cids.md
@@ -1,6 +1,8 @@
-# Spec CIDs at HEAD
+# Spec CIDs
 
-Every spec in ProvekIt is content-addressed by BLAKE3-512. This page lists the canonical CIDs at HEAD (protocol v1.6.3). Verify the local install conforms via `provekit verify-protocol`.
+Every spec in ProvekIt is content-addressed by BLAKE3-512. Verify the local
+install conforms to the protocol catalog embedded in the CLI via
+`provekit verify-protocol`.
 
 ## Two hashing rules
 
@@ -16,11 +18,14 @@ cargo run --release --manifest-path tools/recompute-spec-cids/Cargo.toml -- --ve
 
 `--verify` reads every spec in raw bytes, hashes each, then reads the catalog, JCS-canonicalizes it, hashes that, and compares all values. Exit 0 iff every value matches.
 
-## Pinned CIDs (v1.6.3)
+## Pinned CIDs
 
 | Document | CID |
 |---|---|
-| **Protocol catalog (v1.6.3)** | `blake3-512:dd0cc79889ee67d2594f5cfa20a191bafed15196fb2c5036f85deced7cd976055ae93825edebc10812b6fcf3c6ccf274fbc1137f32705aa0dc5938dc5825e31d` |
+| **Protocol catalog (v1.6.6, current CLI)** | `blake3-512:809ed1ebd538f206beb9df6de712f502fbcd310ee52d76c34afecec6455259d49cd7d288eb761d5aac9ebbd3643ae4dfe09bc9c7f2aea23e57720df6085c6640` |
+| Protocol catalog (v1.6.5, historical) | `blake3-512:42ab046d530993a039cb6f78d8edb20b9e5f001f96182e57890379ccf9dbc9233430159724422ba4b91f783953f3e0ef3f8d56d4c112085904e8b08fbfce02d0` |
+| Protocol catalog (v1.6.4, historical) | `blake3-512:09ccf7b1464622eceb4ac0e9bae3b435ba92d87c19e89f93724e6be75f4afce9eb3dedb7b8ebe2536de054143efefcb3cb622e6e5b4140bb26e6156a9bc9adf3` |
+| Protocol catalog (v1.6.3, historical) | `blake3-512:dd0cc79889ee67d2594f5cfa20a191bafed15196fb2c5036f85deced7cd976055ae93825edebc10812b6fcf3c6ccf274fbc1137f32705aa0dc5938dc5825e31d` |
 | Protocol catalog (v1.6.2, historical) | `blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f` |
 | Protocol catalog (v1.6.1, historical) | `blake3-512:fa1fbf90b7f092b732cd2b088d12210befe304065acbe0f9640785a911dd917f1c49fb90d1ff4dcd1861310cf739350ef60b46f1b54be0ea54ccb09d0c1b76f0` |
 | Protocol catalog (v1.6.0, historical) | `blake3-512:ce04a40534986a95362d5f130fd3a1a667b7a157f0554f262af11ec7a2ac8e8b80f56c36cca93d7a180535eedc99949d760fce6ab63c405de8837fa20f00e781` |
@@ -41,6 +46,11 @@ cargo run --release --manifest-path tools/recompute-spec-cids/Cargo.toml -- --ve
 | Version chains pinning | `blake3-512:281bf014f6f0ebc9a5d455329ee033ff8b7ee85e001bcbdcb45a62c14e43855892c46462789ccb74961859e708eae70829fdf736798c17f59f0239ef78dd7e45` |
 | Protocol Evolution Protocol (PEP) | `blake3-512:d8827f89df20e5be38c4d5de851fe4e55420dcd6cacfd9b98f458c53e64e6ba07349e29f8da2fbab6cb7195b297c3704a70f489c020e3f55c96ef702c4a09949` |
 | Lift Plugin Protocol | `blake3-512:f2b856a8010b0f95cdd9961e0c367b003b1de7be39b6668db7f96cfe884a99f153609a846be39ad4a4f40a3bb778fecf2b0e24908b94411f32be165473045055` |
+
+The detailed property list below was originally written for v1.6.3 and still
+records the stable core CIDs used by the current catalog. The current CLI's
+authoritative answer is the embedded catalog checked by `provekit verify-protocol`;
+historical signatures live under `.provekit/catalog-signatures/`.
 
 ## v1.6.3 changes (patch over v1.6.2)
 
@@ -100,7 +110,7 @@ The v1.4.0 bump is additive over v1.3.1. New specs published with v1.4.0:
 - `bundle-attestation-protocol` (`2026-05-02-bundle-attestation-protocol.md`)
 - `opacity-manifest-grammar` (`2026-05-02-opacity-manifest-grammar.md`)
 
-The full list of v1.6.3 spec CIDs is in `protocol/specs/2026-04-30-protocol-catalog.json`. Recompute locally to verify.
+The full list of current spec CIDs is in `protocol/specs/2026-04-30-protocol-catalog.json`. Recompute locally to verify.
 
 ## Per-kit self-contract attestations
 
@@ -116,7 +126,13 @@ Two runs producing the same CID is the framework verifying its own canonicalizat
 
 ## Bluepaper recursive-verification
 
-The protocol catalog's CID is the protocol version. Verifying the catalog is the act of running the protocol; running the protocol verifies the catalog. There is no external authority. The bluepaper at [`../papers/02-bluepaper.md`](../papers/02-bluepaper.md) closes with this recursive verification recipe. Run `--verify`. If the computed catalog CID matches `dd0cc798...825e31d` (v1.6.3), `52bdb2be...719a0f` (v1.6.2), `fa1fbf90...1b76f0` (v1.6.1), `ce04a405...00e781` (v1.6.0), `540e8c1f...ee1843` (v1.5.0), `dc2f42ff...1dc641` (v1.4.1), or `b0f2030d...60f52f` (v1.4.0, historical), the bluepaper has just verified its own authority over the bytes you have.
+The protocol catalog's CID is the protocol version. Verifying the catalog is the
+act of running the protocol; running the protocol verifies the catalog. There is
+no external authority. The bluepaper at
+[`../papers/02-bluepaper.md`](../papers/02-bluepaper.md) closes with this
+recursive verification recipe. Run `--verify`. If the computed catalog CID
+matches one of the current or historical catalog CIDs listed above, the
+bluepaper has just verified its own authority over the bytes you have.
 
 ## Read next
 


### PR DESCRIPTION
## Summary
- Reframe the root README around ProvekIt as a proof supply chain over existing ecosystems
- Clarify the kit-owned native surface vs language-agnostic CLI proof-computation boundary
- Tighten `.proof` DAG and CID reuse language so prior commitments are cheap to verify without claiming all proving is constant-time
- Update public docs entry points and related explanation pages to remove stale 64-byte/one-instruction shorthand where it obscured the semantic proving path

## Verification
- `git diff --check`
- Looked for an obvious markdown/link lint script in `package.json` and `Makefile`; none was present