### PR TITLE
Lift Rust stdlib algebra from unit tests

### DIFF
--- a/examples/provekit-shim-rust-std/.provekit/lift/rust-contracts/manifest.toml
+++ b/examples/provekit-shim-rust-std/.provekit/lift/rust-contracts/manifest.toml
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Rust std algebra is expressed as ordinary Rust unit tests in this shim.
+# The contracts surface must therefore dispatch to the Rust test/assertion
+# lifter. The separate rust-bind surface owns #[provekit::sugar] binding
+# material; do not route unit-test lifting through the sugar/bind lifter.
 name = "rust-contracts-lift"
-command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+command = ["../../implementations/rust/target/debug/provekit-lift", "--rpc"]
 working_dir = "."

--- a/examples/provekit-shim-rust-std/src/lib.rs
+++ b/examples/provekit-shim-rust-std/src/lib.rs
@@ -48,10 +48,67 @@ pub fn Err<T, E>(error: E) -> Result<T, E> {
 mod tests {
     use super::*;
 
+    fn plus_one(value: i32) -> i32 {
+        value + 1
+    }
+
+    fn some_plus_one(value: i32) -> Option<i32> {
+        Option::Some(value + 1)
+    }
+
+    fn tag_error(_: &'static str) -> &'static str {
+        "tagged"
+    }
+
     #[test]
     fn option_and_result_constructors_match_std() {
         assert_eq!(Some(1), Option::Some(1));
         assert_eq!(Ok::<i32, &str>(2), Result::Ok(2));
         assert_eq!(Err::<i32, &str>("no"), Result::Err("no"));
+    }
+
+    #[test]
+    fn option_constructor_tag_and_projection_algebra() {
+        assert!(Some(1).is_some());
+        assert!(!Some(1).is_none());
+        assert_ne!(Some(1), Option::None);
+        assert_eq!(Some(1).unwrap(), 1);
+        assert_eq!(Some(1).unwrap_or(9), 1);
+        assert_eq!(Option::<i32>::None.unwrap_or(9), 9);
+    }
+
+    #[test]
+    fn option_functor_and_result_conversion_algebra() {
+        assert_eq!(Some(1).map(plus_one), Option::Some(2));
+        assert_eq!(Some(1).and_then(some_plus_one), Option::Some(2));
+        assert_eq!(Some(1).ok_or("missing"), Result::Ok(1));
+        assert_eq!(Option::<i32>::None.ok_or("missing"), Result::Err("missing"));
+    }
+
+    #[test]
+    fn result_constructor_tag_and_projection_algebra() {
+        assert!(Ok::<i32, &str>(2).is_ok());
+        assert!(!Ok::<i32, &str>(2).is_err());
+        assert!(Err::<i32, &str>("no").is_err());
+        assert!(!Err::<i32, &str>("no").is_ok());
+        assert_eq!(Ok::<i32, &str>(2).unwrap(), 2);
+        assert_eq!(Err::<i32, &str>("no").unwrap_err(), "no");
+        assert_eq!(Ok::<i32, &str>(2).unwrap_or(9), 2);
+        assert_eq!(Err::<i32, &str>("no").unwrap_or(9), 9);
+    }
+
+    #[test]
+    fn result_functor_and_option_conversion_algebra() {
+        assert_eq!(Ok::<i32, &str>(2).map(plus_one), Result::Ok(3));
+        assert_eq!(Err::<i32, &str>("no").map(plus_one), Result::Err("no"));
+        assert_eq!(Ok::<i32, &str>(2).map_err(tag_error), Result::Ok(2));
+        assert_eq!(
+            Err::<i32, &str>("no").map_err(tag_error),
+            Result::Err("tagged")
+        );
+        assert_eq!(Ok::<i32, &str>(2).ok(), Option::Some(2));
+        assert_eq!(Err::<i32, &str>("no").ok(), Option::None);
+        assert_eq!(Ok::<i32, &str>(2).err(), Option::None);
+        assert_eq!(Err::<i32, &str>("no").err(), Option::Some("no"));
     }
 }

--- a/implementations/rust/provekit-cli/tests/cmd_mint_rust_project_implications.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_rust_project_implications.rs
@@ -47,13 +47,22 @@ fn build_rust_lifter_bins() {
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
         let workspace = rust_workspace_root();
+        let bin_dir = provekit_bin()
+            .parent()
+            .expect("provekit bin parent")
+            .to_path_buf();
+        let build_release = bin_dir.file_name().and_then(|name| name.to_str()) == Some("release");
         for (package, bin) in [
             ("provekit-walk", "provekit-walk-rpc"),
             ("provekit-lift", "provekit-lift"),
         ] {
+            let mut args = vec!["build", "-p", package, "--bin", bin];
+            if build_release {
+                args.push("--release");
+            }
             let output = Command::new("cargo")
                 .current_dir(&workspace)
-                .args(["build", "-p", package, "--bin", bin])
+                .args(args)
                 .output()
                 .unwrap_or_else(|e| panic!("spawn cargo build -p {package} --bin {bin}: {e}"));
             assert!(
@@ -64,10 +73,6 @@ fn build_rust_lifter_bins() {
             );
         }
 
-        let bin_dir = provekit_bin()
-            .parent()
-            .expect("provekit bin parent")
-            .to_path_buf();
         let walk_rpc = bin_dir.join("provekit-walk-rpc");
         let lift = bin_dir.join("provekit-lift");
         assert!(
@@ -110,6 +115,22 @@ fn run_mint(project: &Path, out_dir: &Path) {
     );
 }
 
+fn load_proof_pool_from_out_dir(out_dir: &Path) -> provekit_verifier::types::MementoPool {
+    let proof_files: Vec<PathBuf> = fs::read_dir(out_dir)
+        .expect("read out dir")
+        .filter_map(|entry| {
+            let path = entry.expect("out dir entry").path();
+            (path.extension().and_then(|s| s.to_str()) == Some("proof")).then_some(path)
+        })
+        .collect();
+    assert!(
+        !proof_files.is_empty(),
+        "mint should write at least one .proof into {}",
+        out_dir.display()
+    );
+    provekit_verifier::load_all_proofs::run_with_files(Path::new("/no-such-project"), &proof_files)
+}
+
 fn run_prove_json(out_dir: &Path) -> (Json, i32) {
     let output = Command::new(provekit_bin())
         .arg("prove")
@@ -130,6 +151,33 @@ fn json_contains_str(value: &Json, needle: &str) -> bool {
         Json::Object(map) => map.values().any(|v| json_contains_str(v, needle)),
         _ => false,
     }
+}
+
+fn pool_contains_contract_inv(
+    pool: &provekit_verifier::types::MementoPool,
+    name_prefix: &str,
+    needle: &str,
+) -> bool {
+    pool.name_to_cid.iter().any(|(name, cid)| {
+        name.starts_with(name_prefix)
+            && pool
+                .mementos
+                .get(cid)
+                .and_then(|memento| provekit_verifier::types::memento_body_field(memento, "inv"))
+                .is_some_and(|inv| json_contains_str(inv, needle))
+    })
+}
+
+fn assert_pool_contains_contract_inv(
+    pool: &provekit_verifier::types::MementoPool,
+    name_prefix: &str,
+    needle: &str,
+) {
+    assert!(
+        pool_contains_contract_inv(pool, name_prefix, needle),
+        "missing contract `{name_prefix}...` with invariant mentioning `{needle}`; indexed contracts: {:?}",
+        pool.name_to_cid.keys().collect::<Vec<_>>()
+    );
 }
 
 fn int_sort() -> Json {
@@ -374,6 +422,53 @@ fn voltron_demo_surfaces_nonvacuous_implication_refusals() {
 }
 
 #[test]
+fn rust_stdlib_checked_config_lifts_constructor_algebra_from_unit_tests() {
+    build_rust_lifter_bins();
+
+    let repo = repo_root();
+    let project = repo.join("examples/provekit-shim-rust-std");
+    let out_dir = unique_dir("rust-std-shim");
+    run_mint(&project, &out_dir);
+
+    let pool = load_proof_pool_from_out_dir(&out_dir);
+    assert!(
+        pool.load_errors.is_empty(),
+        "stdlib shim proof bundle must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    for (name_prefix, expected_ctor) in [
+        ("Some@src/lib.rs:", "Option::Some"),
+        ("Ok@src/lib.rs:", "Result::Ok"),
+        ("Err@src/lib.rs:", "Result::Err"),
+        ("is_some@src/lib.rs:", "True"),
+        ("is_none@src/lib.rs:", "False"),
+        ("unwrap@src/lib.rs:", "Some"),
+        ("unwrap@src/lib.rs:", "Ok"),
+        ("unwrap_err@src/lib.rs:", "Err"),
+        ("unwrap_or@src/lib.rs:", "Option::None"),
+        ("unwrap_or@src/lib.rs:", "Err"),
+        ("map@src/lib.rs:", "plus_one"),
+        ("and_then@src/lib.rs:", "some_plus_one"),
+        ("ok_or@src/lib.rs:", "Result::Ok"),
+        ("ok_or@src/lib.rs:", "Result::Err"),
+        ("is_ok@src/lib.rs:", "True"),
+        ("is_ok@src/lib.rs:", "False"),
+        ("is_err@src/lib.rs:", "True"),
+        ("is_err@src/lib.rs:", "False"),
+        ("map_err@src/lib.rs:", "tag_error"),
+        ("ok@src/lib.rs:", "Option::Some"),
+        ("ok@src/lib.rs:", "Option::None"),
+        ("err@src/lib.rs:", "Option::Some"),
+        ("err@src/lib.rs:", "Option::None"),
+    ] {
+        assert_pool_contains_contract_inv(&pool, name_prefix, expected_ctor);
+    }
+
+    let _ = fs::remove_dir_all(out_dir);
+}
+
+#[test]
 fn rust_stdlib_shim_closes_option_result_constructor_lift_gaps() {
     build_rust_lifter_bins();
 
@@ -421,6 +516,7 @@ edition = "2021"
         .expect("provekit bin parent")
         .to_path_buf();
     let walk_rpc = bin_dir.join("provekit-walk-rpc");
+    let lift = bin_dir.join("provekit-lift");
     fs::write(
         provekit.join("config.toml"),
         format!(
@@ -445,7 +541,7 @@ surface = "rust-implications"
             .join("manifest.toml"),
         format!(
             "name = \"rust-stdlib-contracts\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
-            walk_rpc.display()
+            lift.display()
         ),
     )
     .expect("write rust-stdlib-contracts manifest");
@@ -486,17 +582,7 @@ surface = "rust-implications"
         "stdlib shim should close constructor lift-gaps, not report them: {report}"
     );
 
-    let proof_files: Vec<PathBuf> = fs::read_dir(&out_dir)
-        .expect("read out dir")
-        .filter_map(|entry| {
-            let path = entry.expect("out dir entry").path();
-            (path.extension().and_then(|s| s.to_str()) == Some("proof")).then_some(path)
-        })
-        .collect();
-    let pool = provekit_verifier::load_all_proofs::run_with_files(
-        Path::new("/no-such-project"),
-        &proof_files,
-    );
+    let pool = load_proof_pool_from_out_dir(&out_dir);
     assert!(
         pool.load_errors.is_empty(),
         "stdlib shim proof bundle must load cleanly: {:?}",
@@ -520,6 +606,18 @@ surface = "rust-implications"
             provekit_verifier::types::memento_kind(target).as_deref(),
             Some("contract"),
             "bridge target for `{symbol}` must be a contract"
+        );
+        let expected_ctor = match symbol {
+            "Some" => "Option::Some",
+            "Ok" => "Result::Ok",
+            "Err" => "Result::Err",
+            other => panic!("unexpected stdlib constructor symbol `{other}`"),
+        };
+        let inv = provekit_verifier::types::memento_body_field(target, "inv")
+            .unwrap_or_else(|| panic!("bridge target for `{symbol}` must carry a test-lifted inv"));
+        assert!(
+            json_contains_str(inv, expected_ctor),
+            "bridge target for `{symbol}` must come from the std shim unit-test algebra and mention `{expected_ctor}`; target: {target}"
         );
     }
 

--- a/implementations/rust/provekit-cli/tests/cmd_mint_rust_project_implications.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_rust_project_implications.rs
@@ -52,35 +52,45 @@ fn build_rust_lifter_bins() {
             .expect("provekit bin parent")
             .to_path_buf();
         let build_release = bin_dir.file_name().and_then(|name| name.to_str()) == Some("release");
-        for (package, bin) in [
-            ("provekit-walk", "provekit-walk-rpc"),
-            ("provekit-lift", "provekit-lift"),
-        ] {
-            let mut args = vec!["build", "-p", package, "--bin", bin];
-            if build_release {
-                args.push("--release");
+        let mut profiles = vec![false];
+        if build_release {
+            profiles.push(true);
+        }
+        for release in profiles {
+            for (package, bin) in [
+                ("provekit-walk", "provekit-walk-rpc"),
+                ("provekit-lift", "provekit-lift"),
+            ] {
+                let mut args = vec!["build", "-p", package, "--bin", bin];
+                if release {
+                    args.push("--release");
+                }
+                let output = Command::new("cargo")
+                    .current_dir(&workspace)
+                    .args(args)
+                    .output()
+                    .unwrap_or_else(|e| panic!("spawn cargo build -p {package} --bin {bin}: {e}"));
+                assert!(
+                    output.status.success(),
+                    "cargo build -p {package} --bin {bin}{} failed\n  stdout: {}\n  stderr: {}",
+                    if release { " --release" } else { "" },
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
             }
-            let output = Command::new("cargo")
-                .current_dir(&workspace)
-                .args(args)
-                .output()
-                .unwrap_or_else(|e| panic!("spawn cargo build -p {package} --bin {bin}: {e}"));
-            assert!(
-                output.status.success(),
-                "cargo build -p {package} --bin {bin} failed\n  stdout: {}\n  stderr: {}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
         }
 
-        let walk_rpc = bin_dir.join("provekit-walk-rpc");
-        let lift = bin_dir.join("provekit-lift");
-        assert!(
-            walk_rpc.exists(),
-            "cargo build produced no {}",
-            walk_rpc.display()
-        );
-        assert!(lift.exists(), "cargo build produced no {}", lift.display());
+        let debug_bin_dir = workspace.join("target").join("debug");
+        for bin_dir in [debug_bin_dir, bin_dir] {
+            let walk_rpc = bin_dir.join("provekit-walk-rpc");
+            let lift = bin_dir.join("provekit-lift");
+            assert!(
+                walk_rpc.exists(),
+                "cargo build produced no {}",
+                walk_rpc.display()
+            );
+            assert!(lift.exists(), "cargo build produced no {}", lift.display());
+        }
     });
 }
 

--- a/implementations/rust/provekit-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/lib.rs
@@ -22,6 +22,8 @@
 //   assert_eq!(<lhs>, <rhs>)         -> atomic eq
 //   assert_ne!(<lhs>, <rhs>)         -> atomic ne
 //   assert!(<lhs> <binop> <rhs>)     -> atomic comparison
+//   assert!(<bool-expr>)             -> atomic eq against True
+//   assert!(!<bool-expr>)            -> atomic eq against False
 //   assert_matches!(<lhs>, <pat>)    -> atomic eq against ctor-of-lit
 //                                       (only the trivial `Ok(42)` /
 //                                       `Err(_)` shape; deeper patterns
@@ -731,6 +733,7 @@ fn collect_expr_callsites(
             collect_expr_callsites(&b.left, bindings, out, substitutions);
             collect_expr_callsites(&b.right, bindings, out, substitutions);
         }
+        syn::Expr::Unary(u) => collect_expr_callsites(&u.expr, bindings, out, substitutions),
         syn::Expr::Paren(p) => collect_expr_callsites(&p.expr, bindings, out, substitutions),
         syn::Expr::Reference(r) => collect_expr_callsites(&r.expr, bindings, out, substitutions),
         syn::Expr::Cast(c) => collect_expr_callsites(&c.expr, bindings, out, substitutions),
@@ -1149,8 +1152,22 @@ fn translate_bool_expr(expr: &syn::Expr) -> Result<Rc<Formula>, String> {
             }
         }
         syn::Expr::Paren(p) => translate_bool_expr(&p.expr),
-        _ => Err("assert! body must be a comparison expression".into()),
+        syn::Expr::Unary(u) if matches!(u.op, syn::UnOp::Not(_)) => {
+            let term = translate_term(&u.expr)?;
+            Ok(eq(term, bool_ctor(false)))
+        }
+        _ => {
+            let term = translate_term(expr)?;
+            Ok(eq(term, bool_ctor(true)))
+        }
     }
+}
+
+fn bool_ctor(value: bool) -> Rc<Term> {
+    Rc::new(Term::Ctor {
+        name: if value { "True" } else { "False" }.into(),
+        args: vec![],
+    })
 }
 
 /// Term translation. Whitelist (v0.5):
@@ -1217,11 +1234,7 @@ fn translate_term(expr: &syn::Expr) -> Result<Rc<Term>, String> {
                 }))
             }
             syn::Lit::Bool(lb) => {
-                let name = if lb.value { "True" } else { "False" };
-                Ok(Rc::new(Term::Ctor {
-                    name: name.into(),
-                    args: vec![],
-                }))
+                Ok(bool_ctor(lb.value))
             }
             _ => Err(
                 "only integer, string, byte-string, and bool literals are liftable in v0.5".into(),
@@ -1525,6 +1538,56 @@ mod tests {
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
         assert_callsite_name(&out.decls[0].name, "some_value");
+    }
+
+    #[test]
+    fn lifts_assert_bool_method_call_as_true() {
+        let src = r#"
+            #[test]
+            fn option_is_some() {
+                assert!(Some(1).is_some());
+            }
+        "#;
+        let f = parse(src);
+        let out = lift_file(&f, "t.rs");
+        assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+        assert_callsite_name(&out.decls[0].name, "is_some");
+        let inv = out.decls[0].inv.as_ref().expect("inv");
+        match &**inv {
+            Formula::Atomic { name, args } if name == "=" && args.len() == 2 => match &*args[1] {
+                Term::Ctor { name, args } => {
+                    assert_eq!(name, "True");
+                    assert!(args.is_empty());
+                }
+                other => panic!("expected True ctor, got {other:?}"),
+            },
+            other => panic!("expected atomic =, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lifts_negated_assert_bool_method_call_as_false() {
+        let src = r#"
+            #[test]
+            fn option_not_none() {
+                assert!(!Some(1).is_none());
+            }
+        "#;
+        let f = parse(src);
+        let out = lift_file(&f, "t.rs");
+        assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+        assert_callsite_name(&out.decls[0].name, "is_none");
+        let inv = out.decls[0].inv.as_ref().expect("inv");
+        match &**inv {
+            Formula::Atomic { name, args } if name == "=" && args.len() == 2 => match &*args[1] {
+                Term::Ctor { name, args } => {
+                    assert_eq!(name, "False");
+                    assert!(args.is_empty());
+                }
+                other => panic!("expected False ctor, got {other:?}"),
+            },
+            other => panic!("expected atomic =, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- routes the Rust std shim `rust-contracts` surface to `provekit-lift --rpc`, keeping sugar/bind on `provekit-walk-rpc`
- expands the std shim with ordinary Rust unit tests for Option/Result constructor, tag, projection, conversion, and functor algebra
- widens the existing Rust test/assertion lifter for idiomatic `assert!(expr)` and `assert!(!expr)` boolean assertions
- tightens mint tests so consumer lift-gap closure uses test-derived std shim contracts, not sugar placeholder contracts

## Test Plan
- [x] `cargo test --release --manifest-path examples/provekit-shim-rust-std/Cargo.toml -- --nocapture`
- [x] `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-lift-rust-tests --lib -- --nocapture`
- [x] `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_mint_rust_project_implications -- --nocapture`
- [x] `make cross-language-proof-parity`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Rust standard library support with improved handling of `Option` and `Result` constructor algebra.
  * Improved boolean assertion recognition in proof verification, including negated assertions.

* **Tests**
  * Added comprehensive test coverage for Rust constructor behavior and functor operations (`map`, `and_then`, `ok_or`, etc.).
  * New validation tests for stdlib configuration lifting and constructor invariant verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->