### PR TITLE
feat(go): resolve dependency proofs from Go modules

### DIFF
--- a/implementations/go/provekit-realize-go-core/realizer_test.go
+++ b/implementations/go/provekit-realize-go-core/realizer_test.go
@@ -140,6 +140,9 @@ func TestResolveDependencyProofsReturnsProofsFromGoModuleDependencies(t *testing
 	if filepath.Base(got) != proofName {
 		t.Fatalf("proof basename = %q, want %q", filepath.Base(got), proofName)
 	}
+	if got == proofPath {
+		t.Fatalf("resolver must not hand the CLI a Go module-internal proof path: %s", got)
+	}
 	if _, err := os.Stat(got); err != nil {
 		t.Fatalf("proof path must exist: %v", err)
 	}

--- a/implementations/go/provekit-realize-go-core/realizer_test.go
+++ b/implementations/go/provekit-realize-go-core/realizer_test.go
@@ -1,6 +1,7 @@
 package realizego
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -94,4 +95,57 @@ func TestPluginCheckRunsGoTest(t *testing.T) {
 	if result["command"] != "go test ./..." {
 		t.Fatalf("command = %#v", result["command"])
 	}
+}
+
+func TestResolveDependencyProofsReturnsProofsFromGoModuleDependencies(t *testing.T) {
+	project := t.TempDir()
+	dep := filepath.Join(project, "dep")
+	proofName := "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.proof"
+	proofPath := filepath.Join(dep, "META-INF", "provekit", proofName)
+	if err := os.MkdirAll(filepath.Dir(proofPath), 0o755); err != nil {
+		t.Fatalf("mkdir proof dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dep, "go.mod"), []byte("module example.com/proofdep\n\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatalf("write dep go.mod: %v", err)
+	}
+	if err := os.WriteFile(proofPath, []byte("proof bytes"), 0o644); err != nil {
+		t.Fatalf("write proof: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "go.mod"), []byte("module example.com/app\n\ngo 1.22\n\nrequire example.com/proofdep v0.0.0\nreplace example.com/proofdep => ./dep\n"), 0o644); err != nil {
+		t.Fatalf("write project go.mod: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"provekit.plugin.resolve_dependency_proofs","params":{"project_root":` + strconvQuote(project) + `}}` + "\n")
+	if err := RunRPC(stdin, &stdout); err != nil {
+		t.Fatalf("RunRPC: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &response); err != nil {
+		t.Fatalf("parse response %q: %v", stdout.String(), err)
+	}
+	if response["error"] != nil {
+		t.Fatalf("resolve_dependency_proofs returned error: %#v", response["error"])
+	}
+	result := response["result"].(map[string]any)
+	paths := result["proof_paths"].([]any)
+	if len(paths) != 1 {
+		t.Fatalf("proof_paths len = %d, want 1; response=%s", len(paths), stdout.String())
+	}
+	got := paths[0].(string)
+	if !filepath.IsAbs(got) {
+		t.Fatalf("proof path must be absolute: %s", got)
+	}
+	if filepath.Base(got) != proofName {
+		t.Fatalf("proof basename = %q, want %q", filepath.Base(got), proofName)
+	}
+	if _, err := os.Stat(got); err != nil {
+		t.Fatalf("proof path must exist: %v", err)
+	}
+}
+
+func strconvQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
 }

--- a/implementations/go/provekit-realize-go-core/rpc.go
+++ b/implementations/go/provekit-realize-go-core/rpc.go
@@ -2,12 +2,16 @@ package realizego
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
 )
 
 type rpcRequest struct {
@@ -37,8 +41,7 @@ func RunRPC(stdin io.Reader, stdout io.Writer) error {
 		case "provekit.plugin.invoke":
 			writeJSON(stdout, handleInvoke(req.ID, req.Params))
 		case "provekit.plugin.resolve_dependency_proofs":
-			fmt.Fprintln(os.Stderr, "provekit-realize-go-core: resolve_dependency_proofs not yet implemented for go; returning empty proof_paths")
-			writeJSON(stdout, successResponse(req.ID, map[string]any{"proof_paths": []string{}}))
+			writeJSON(stdout, handleResolveDependencyProofs(req.ID, req.Params))
 		case "provekit.plugin.check":
 			writeJSON(stdout, handleCheck(req.ID, req.Params))
 		case "provekit.plugin.shutdown":
@@ -78,6 +81,27 @@ func handleInvoke(id json.RawMessage, raw json.RawMessage) any {
 	return successResponse(id, realized)
 }
 
+func handleResolveDependencyProofs(id json.RawMessage, raw json.RawMessage) any {
+	var params map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return errorResponse(id, -32602, fmt.Sprintf("INVALID_PARAMS: %v", err))
+		}
+	}
+	if params == nil {
+		params = map[string]any{}
+	}
+	projectRoot, _ := params["project_root"].(string)
+	if projectRoot == "" {
+		projectRoot, _ = params["projectRoot"].(string)
+	}
+	paths, err := resolveDependencyProofPaths(projectRoot)
+	if err != nil {
+		return errorResponse(id, -32030, "RESOLVE_DEPENDENCY_PROOFS_FAILED: "+err.Error())
+	}
+	return successResponse(id, map[string]any{"proof_paths": paths})
+}
+
 func handleCheck(id json.RawMessage, raw json.RawMessage) any {
 	var params map[string]any
 	if len(raw) > 0 {
@@ -104,6 +128,126 @@ func handleCheck(id json.RawMessage, raw json.RawMessage) any {
 		report["error"] = err.Error()
 	}
 	return successResponse(id, report)
+}
+
+type listedGoModule struct {
+	Path    string          `json:"Path"`
+	Dir     string          `json:"Dir"`
+	Main    bool            `json:"Main"`
+	Replace *listedGoModule `json:"Replace"`
+}
+
+var dependencyProofName = regexp.MustCompile(`^blake3-512:[0-9a-f]{128}\.proof$`)
+
+func resolveDependencyProofPaths(projectRoot string) ([]string, error) {
+	root := strings.TrimSpace(projectRoot)
+	if root == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		root = wd
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	absRoot = filepath.Clean(absRoot)
+	if _, err := os.Stat(filepath.Join(absRoot, "go.mod")); err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+
+	cmd := exec.Command("go", "list", "-m", "-json", "all")
+	cmd.Dir = absRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail != "" {
+			return nil, fmt.Errorf("go list -m -json all failed: %w: %s", err, detail)
+		}
+		return nil, fmt.Errorf("go list -m -json all failed: %w", err)
+	}
+
+	proofs := map[string]struct{}{}
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	for {
+		var module listedGoModule
+		if err := decoder.Decode(&module); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode go list module: %w", err)
+		}
+		if module.Main {
+			continue
+		}
+		dir := effectiveModuleDir(module)
+		if dir == "" {
+			continue
+		}
+		if !filepath.IsAbs(dir) {
+			dir = filepath.Join(absRoot, dir)
+		}
+		if err := collectProofPaths(filepath.Clean(dir), proofs); err != nil {
+			return nil, err
+		}
+	}
+
+	out := make([]string, 0, len(proofs))
+	for proof := range proofs {
+		out = append(out, proof)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func effectiveModuleDir(module listedGoModule) string {
+	if module.Dir != "" {
+		return module.Dir
+	}
+	if module.Replace != nil {
+		return effectiveModuleDir(*module.Replace)
+	}
+	return ""
+}
+
+func collectProofPaths(root string, proofs map[string]struct{}) error {
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor":
+				if path != root {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if !dependencyProofName.MatchString(entry.Name()) {
+			return nil
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		proofs[filepath.Clean(abs)] = struct{}{}
+		return nil
+	})
 }
 
 func asMissing(err error, target **MissingTemplateError) bool {

--- a/implementations/go/provekit-realize-go-core/rpc.go
+++ b/implementations/go/provekit-realize-go-core/rpc.go
@@ -196,12 +196,12 @@ func resolveDependencyProofPaths(projectRoot string) ([]string, error) {
 		}
 	}
 
-	out := make([]string, 0, len(proofs))
+	originals := make([]string, 0, len(proofs))
 	for proof := range proofs {
-		out = append(out, proof)
+		originals = append(originals, proof)
 	}
-	sort.Strings(out)
-	return out, nil
+	sort.Strings(originals)
+	return copyProofsToTemp(originals)
 }
 
 func effectiveModuleDir(module listedGoModule) string {
@@ -248,6 +248,46 @@ func collectProofPaths(root string, proofs map[string]struct{}) error {
 		proofs[filepath.Clean(abs)] = struct{}{}
 		return nil
 	})
+}
+
+func copyProofsToTemp(paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return []string{}, nil
+	}
+	root, err := os.MkdirTemp("", "provekit-go-dependency-proofs-")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(paths))
+	for i, path := range paths {
+		dir := filepath.Join(root, fmt.Sprintf("%04d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, err
+		}
+		dst := filepath.Join(dir, filepath.Base(path))
+		if err := copyFile(path, dst); err != nil {
+			return nil, err
+		}
+		out = append(out, dst)
+	}
+	return out, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func asMissing(err error, target **MissingTemplateError) bool {

--- a/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
+++ b/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
@@ -24,7 +24,9 @@ use std::process::Command;
 use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
-use provekit_cli::kit_dispatch::{dispatch_realize, RealizeRequest};
+use provekit_cli::kit_dispatch::{
+    dependency_proof_paths_via_rpc, dispatch_realize, RealizeRequest,
+};
 use serde_json::Value as Json;
 
 fn repo_root() -> PathBuf {
@@ -105,6 +107,24 @@ fn install_go_realize_manifest(root: &Path, bin: &Path) {
     fs::write(manifest, text).expect("write manifest");
 }
 
+fn write_go_dependency_with_proof(project: &Path, proof_name: &str) -> PathBuf {
+    let dep = project.join("dep");
+    let proof = dep.join("META-INF").join("provekit").join(proof_name);
+    fs::create_dir_all(proof.parent().unwrap()).expect("mkdir dependency proof dir");
+    fs::write(
+        dep.join("go.mod"),
+        "module example.com/proofdep\n\ngo 1.22\n",
+    )
+    .expect("write dep go.mod");
+    fs::write(&proof, "proof bytes").expect("write dependency proof");
+    fs::write(
+        project.join("go.mod"),
+        "module example.com/app\n\ngo 1.22\n\nrequire example.com/proofdep v0.0.0\nreplace example.com/proofdep => ./dep\n",
+    )
+    .expect("write project go.mod");
+    proof
+}
+
 fn identity_payload_json(function: &str) -> String {
     format!(
         "{{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"identity\",\"function\":\"{function}\",\"params\":[\"x\"],\"param_types\":[\"int\"],\"return_type\":\"int\"}}"
@@ -179,6 +199,28 @@ fn identity_request() -> RealizeRequest {
         function_return_types: std::collections::BTreeMap::new(),
         doc_lines: Vec::new(),
     }
+}
+
+#[test]
+fn go_dependency_proofs_are_resolved_by_configured_go_kit() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping Go dependency proof resolver test");
+        return;
+    }
+    let bin = build_go_realize();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    install_go_realize_manifest(workspace.path(), &bin);
+    let proof_name = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.proof";
+    let expected = write_go_dependency_with_proof(workspace.path(), proof_name);
+
+    let paths = dependency_proof_paths_via_rpc(workspace.path())
+        .expect("CLI must ask the configured Go kit over RPC for dependency proofs");
+
+    assert_eq!(
+        paths,
+        vec![expected],
+        "dependency proof resolution must be kit-owned and config/manifest-driven"
+    );
 }
 
 /// Full CLI path: `provekit materialize` reads Go carrier comments, dispatches

--- a/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
+++ b/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
@@ -217,9 +217,18 @@ fn go_dependency_proofs_are_resolved_by_configured_go_kit() {
         .expect("CLI must ask the configured Go kit over RPC for dependency proofs");
 
     assert_eq!(
-        paths,
-        vec![expected],
+        paths.len(),
+        1,
         "dependency proof resolution must be kit-owned and config/manifest-driven"
+    );
+    assert_eq!(
+        paths[0].file_name(),
+        expected.file_name(),
+        "resolved proof must preserve the content-addressed proof filename"
+    );
+    assert_ne!(
+        paths[0], expected,
+        "the Go kit must not hand the CLI a Go module-internal proof path"
     );
 }
 


### PR DESCRIPTION
## Summary
- implement Go realizer `resolve_dependency_proofs` by asking `go list -m -json all` and scanning non-main module directories for canonical `.proof` files
- copy resolved module proofs into a kit-owned temp proof area before returning RPC paths, so the CLI does not receive Go module-internal paths
- add Go kit and CLI integration coverage proving dependency proof discovery is config/manifest-driven through the Go kit RPC

## Test Plan
- `go test ./...` in `implementations/go/provekit-realize-go-core`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test go_realize_materialize -- --nocapture`
- `make cross-language-proof-parity`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving dependency proofs from Go module dependencies, including handling of local module replacements.

* **Tests**
  * Added integration tests to validate dependency proof discovery and resolution from Go modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->