### PR TITLE
feat(go): load materialize bodies from module proofs

### DIFF
--- a/implementations/go/provekit-realize-go-core/go.mod
+++ b/implementations/go/provekit-realize-go-core/go.mod
@@ -1,3 +1,12 @@
 module github.com/tsavo/provekit/go/provekit-realize-go-core
 
 go 1.22
+
+require github.com/tsavo/provekit/go/provekit-ir-symbolic v0.0.0
+
+require (
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	lukechampine.com/blake3 v1.4.1 // indirect
+)
+
+replace github.com/tsavo/provekit/go/provekit-ir-symbolic => ../provekit-ir-symbolic

--- a/implementations/go/provekit-realize-go-core/go.sum
+++ b/implementations/go/provekit-realize-go-core/go.sum
@@ -1,0 +1,4 @@
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+lukechampine.com/blake3 v1.4.1 h1:I3Smz7gso8w4/TunLKec6K2fn+kyKtDxr/xcQEN84Wg=
+lukechampine.com/blake3 v1.4.1/go.mod h1:QFosUxmjB8mnrWFSNwKmvxHpfY72bmD2tQ0kBMM3kwo=

--- a/implementations/go/provekit-realize-go-core/proof_templates.go
+++ b/implementations/go/provekit-realize-go-core/proof_templates.go
@@ -1,0 +1,213 @@
+package realizego
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/proof_envelope"
+)
+
+var goIdentRE = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_]*`)
+
+func loadBodyTemplateEntriesForProject(projectRoot, libraryTag string) ([]map[string]any, error) {
+	paths, err := resolveDependencyProofPaths(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]map[string]any, 0)
+	for _, path := range paths {
+		proofEntries, err := entriesFromShimProof(path, libraryTag)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, proofEntries...)
+	}
+	return entries, nil
+}
+
+func loadBodyTemplatesForProject(projectRoot, libraryTag string) ([]bodyTemplate, error) {
+	entries, err := loadBodyTemplateEntriesForProject(projectRoot, libraryTag)
+	if err != nil {
+		return nil, err
+	}
+	templates := make([]bodyTemplate, 0, len(entries))
+	for _, entry := range entries {
+		template, ok := bodyTemplateFromEntry(entry)
+		if ok {
+			templates = append(templates, template)
+		}
+	}
+	return templates, nil
+}
+
+func entriesFromShimProof(path, libraryTag string) ([]map[string]any, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read Go shim proof %s: %w", path, err)
+	}
+	catalog, err := proof_envelope.NewCBORDecoder(bytes).DecodeCatalog()
+	if err != nil {
+		return nil, fmt.Errorf("decode Go shim proof %s: %w", path, err)
+	}
+	rawMembers, ok := catalog["members"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("decode Go shim proof %s: missing members map", path)
+	}
+	entries := make([]map[string]any, 0)
+	for _, rawMember := range rawMembers {
+		memberBytes, ok := rawMember.([]byte)
+		if !ok {
+			continue
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal(memberBytes, &parsed); err != nil {
+			continue
+		}
+		body := parsed
+		if rawBody, ok := parsed["body"].(map[string]any); ok {
+			body = rawBody
+		}
+		if body["kind"] != "library-sugar-binding-entry" {
+			continue
+		}
+		if libraryTag != "" && body["target_library_tag"] != libraryTag {
+			continue
+		}
+		entry, ok := bindingEntryToTemplateEntry(body)
+		if ok {
+			entries = append(entries, entry)
+		}
+	}
+	return entries, nil
+}
+
+func bindingEntryToTemplateEntry(decl map[string]any) (map[string]any, bool) {
+	conceptName, ok := decl["concept_name"].(string)
+	if !ok || conceptName == "" {
+		return nil, false
+	}
+	paramNames := stringSlice(decl["param_names"])
+	bodySource, _ := decl["body_source"].(map[string]any)
+	bodyText, _ := bodySource["body_text"].(string)
+	if bodyText == "" {
+		return nil, false
+	}
+	libraryTag, _ := decl["target_library_tag"].(string)
+	arity := len(paramNames)
+	entry := map[string]any{
+		"concept_name": conceptName,
+		"emission_template": map[string]any{
+			"kind":     "verbatim",
+			"template": substituteShimParamsWithPlaceholders(bodyText, paramNames),
+		},
+		"loss_record_contribution": map[string]any{
+			"form": "literal",
+			"value": map[string]any{
+				"entries": []any{},
+			},
+		},
+		"signature_guard": map[string]any{
+			"min_params": arity,
+			"max_params": arity,
+		},
+		"target_library_tag": libraryTag,
+	}
+	if loss, ok := decl["loss_record_contribution"]; ok {
+		entry["loss_record_contribution"] = loss
+	}
+	if observed, ok := decl["observed_dimension"].(string); ok {
+		entry["observed_dimension"] = observed
+	}
+	if helpers, ok := decl["file_helpers"]; ok {
+		entry["file_helpers"] = helpers
+	}
+	return entry, true
+}
+
+func bodyTemplateFromEntry(entry map[string]any) (bodyTemplate, bool) {
+	conceptName, ok := entry["concept_name"].(string)
+	if !ok || conceptName == "" {
+		return bodyTemplate{}, false
+	}
+	emission, _ := entry["emission_template"].(map[string]any)
+	template, ok := emission["template"].(string)
+	if !ok || template == "" {
+		return bodyTemplate{}, false
+	}
+	guard, _ := entry["signature_guard"].(map[string]any)
+	minParams, okMin := intValue(guard["min_params"])
+	maxParams, okMax := intValue(guard["max_params"])
+	if !okMin || !okMax {
+		return bodyTemplate{}, false
+	}
+	return bodyTemplate{
+		conceptName: conceptName,
+		template:    template,
+		minParams:   minParams,
+		maxParams:   maxParams,
+	}, true
+}
+
+func substituteShimParamsWithPlaceholders(bodyText string, paramNames []string) string {
+	return goIdentRE.ReplaceAllStringFunc(bodyText, func(ident string) string {
+		for i, name := range paramNames {
+			if ident == name {
+				return fmt.Sprintf("${param%d}", i)
+			}
+		}
+		return ident
+	})
+}
+
+func stringSlice(raw any) []string {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if value, ok := item.(string); ok {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func intValue(raw any) (int, bool) {
+	switch value := raw.(type) {
+	case int:
+		return value, true
+	case float64:
+		return int(value), true
+	case json.Number:
+		i, err := value.Int64()
+		return int(i), err == nil
+	default:
+		return 0, false
+	}
+}
+
+func projectRootFromParams(params map[string]any) string {
+	projectRoot, _ := params["project_root"].(string)
+	if projectRoot == "" {
+		projectRoot, _ = params["projectRoot"].(string)
+	}
+	return strings.TrimSpace(projectRoot)
+}
+
+func libraryTagFromParams(params map[string]any) string {
+	libraryTag, _ := params["target_library_tag"].(string)
+	if libraryTag == "" {
+		libraryTag, _ = params["targetLibraryTag"].(string)
+	}
+	if libraryTag == "" {
+		libraryTag, _ = params["library_tag"].(string)
+	}
+	if libraryTag == "" {
+		libraryTag, _ = params["libraryTag"].(string)
+	}
+	return strings.TrimSpace(libraryTag)
+}

--- a/implementations/go/provekit-realize-go-core/realizer.go
+++ b/implementations/go/provekit-realize-go-core/realizer.go
@@ -7,13 +7,9 @@
 // cross-language `concept_name` plus the function signature; this kit returns
 // REAL Go source realizing that concept. Contract in -> Go sugar out.
 //
-// Minimal mirror (this session): ONE concept, `identity`, with its body
-// template inlined here. The PRODUCTION shape (Python pattern) loads templates
-// from a sealed JSON artifact under
-// `menagerie/go-language-signature/specs/body-templates/...`; that, plus the
-// broader concept set (addition, etc.), is deferred follow-up. The emitted
-// source is real Go that `go build`s -- never a stub for the supported
-// concept. Supra omnia, rectum.
+// Body templates come from Go-module-resolved `.proof` catalogs owned by this
+// kit. The Rust CLI dispatches over RPC and never reads Go module proof files
+// or Go package internals directly.
 package realizego
 
 import (
@@ -24,9 +20,9 @@ import (
 // KitID identifies this realize kit in emitted provenance.
 const KitID = "provekit-realize-go-core@0.1.0"
 
-// bodyTemplate is the inline analog of one entry in Python's
-// `python-canonical-bodies.json`: a concept name, a `${paramN}`-placeholder
-// body template, and a signature guard (param-count bounds).
+// bodyTemplate is the kit-internal rendering shape loaded from
+// `library-sugar-binding-entry` proof members: a concept name, a
+// `${paramN}`-placeholder body template, and a signature guard.
 type bodyTemplate struct {
 	conceptName string
 	template    string // Go statement(s); `${paramN}` substituted by argument names.
@@ -34,30 +30,20 @@ type bodyTemplate struct {
 	maxParams   int
 }
 
-// templates is the kit's supported-concept set. One concept for the minimal
-// mirror; adding rows (or loading a sealed JSON template file) is additive.
-var templates = []bodyTemplate{
-	{
-		// `identity`: a cross-language concept (also in Python's
-		// canonical-bodies). Go realization `return x` -- the same shape as
-		// Python's `return ${param0}`.
-		conceptName: "identity",
-		template:    "return ${param0}",
-		minParams:   1,
-		maxParams:   1,
-	},
-}
-
 // RealizeRequest mirrors the fields of the dispatcher's PEP 1.7.0 realize
 // request (libprovekit core::RealizeRequest) this kit consumes. Unused fields
 // are tolerated (the dispatcher serializes the full request).
 type RealizeRequest struct {
-	Function    string   `json:"function"`
-	Params      []string `json:"params"`
-	ParamTypes  []string `json:"param_types"`
-	ReturnType  string   `json:"return_type"`
-	ConceptName string   `json:"concept_name"`
-	Visibility  string   `json:"visibility"`
+	Function              string   `json:"function"`
+	Params                []string `json:"params"`
+	ParamTypes            []string `json:"param_types"`
+	ReturnType            string   `json:"return_type"`
+	ConceptName           string   `json:"concept_name"`
+	Visibility            string   `json:"visibility"`
+	TargetLibraryTag      string   `json:"target_library_tag"`
+	TargetLibraryTagCamel string   `json:"targetLibraryTag"`
+	ProjectRoot           string   `json:"project_root"`
+	ProjectRootCamel      string   `json:"projectRoot"`
 }
 
 // RealizedSource is the `result` of a realize invoke: the native Go sugar.
@@ -86,7 +72,11 @@ func (e *MissingTemplateError) Error() string {
 // function signature. Returns *MissingTemplateError when the concept/signature
 // is uncovered.
 func Realize(req RealizeRequest) (RealizedSource, error) {
-	tpl, ok := lookupTemplate(req.ConceptName, len(req.Params))
+	templates, err := loadBodyTemplatesForProject(req.projectRoot(), req.targetLibraryTag())
+	if err != nil {
+		return RealizedSource{}, err
+	}
+	tpl, ok := lookupTemplate(templates, req.ConceptName, len(req.Params))
 	if !ok {
 		return RealizedSource{}, &MissingTemplateError{
 			ConceptName: req.ConceptName,
@@ -107,7 +97,21 @@ func Realize(req RealizeRequest) (RealizedSource, error) {
 	}, nil
 }
 
-func lookupTemplate(concept string, numParams int) (bodyTemplate, bool) {
+func (r RealizeRequest) targetLibraryTag() string {
+	if r.TargetLibraryTag != "" {
+		return r.TargetLibraryTag
+	}
+	return r.TargetLibraryTagCamel
+}
+
+func (r RealizeRequest) projectRoot() string {
+	if r.ProjectRoot != "" {
+		return r.ProjectRoot
+	}
+	return r.ProjectRootCamel
+}
+
+func lookupTemplate(templates []bodyTemplate, concept string, numParams int) (bodyTemplate, bool) {
 	for _, t := range templates {
 		if t.conceptName != concept {
 			continue

--- a/implementations/go/provekit-realize-go-core/realizer_test.go
+++ b/implementations/go/provekit-realize-go-core/realizer_test.go
@@ -7,60 +7,77 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/proof_envelope"
 )
 
 func TestRealizeIdentityEmitsCompilableSignature(t *testing.T) {
-	got, err := Realize(RealizeRequest{
-		Function:    "Id",
-		Params:      []string{"x"},
-		ParamTypes:  []string{"int"},
-		ReturnType:  "int",
-		ConceptName: "identity",
+	project := t.TempDir()
+	writeProofBackedGoDependency(t, project, "go", "identity", "x", "return x")
+	withWorkingDir(t, project, func() {
+		got, err := Realize(RealizeRequest{
+			Function:         "Id",
+			Params:           []string{"x"},
+			ParamTypes:       []string{"int"},
+			ReturnType:       "int",
+			ConceptName:      "identity",
+			TargetLibraryTag: "go",
+		})
+		if err != nil {
+			t.Fatalf("Realize identity: %v", err)
+		}
+		if got.IsStub {
+			t.Fatal("identity must not be a stub")
+		}
+		if got.Extension != "go" {
+			t.Fatalf("extension = %q, want go", got.Extension)
+		}
+		if !strings.Contains(got.Source, "func Id(x int) int") {
+			t.Fatalf("source missing signature: %s", got.Source)
+		}
+		if !strings.Contains(got.Source, "return x") {
+			t.Fatalf("identity body must be `return x`: %s", got.Source)
+		}
 	})
-	if err != nil {
-		t.Fatalf("Realize identity: %v", err)
-	}
-	if got.IsStub {
-		t.Fatal("identity must not be a stub")
-	}
-	if got.Extension != "go" {
-		t.Fatalf("extension = %q, want go", got.Extension)
-	}
-	if !strings.Contains(got.Source, "func Id(x int) int") {
-		t.Fatalf("source missing signature: %s", got.Source)
-	}
-	if !strings.Contains(got.Source, "return x") {
-		t.Fatalf("identity body must be `return x`: %s", got.Source)
-	}
 }
 
 // Discrimination: an unsupported concept is refused with MissingTemplateError,
 // never silently stubbed.
 func TestRealizeUnsupportedConceptRefuses(t *testing.T) {
-	_, err := Realize(RealizeRequest{
-		Function:    "F",
-		Params:      []string{"x"},
-		ConceptName: "concept:not-supported",
+	project := t.TempDir()
+	writeProofBackedGoDependency(t, project, "go", "identity", "x", "return x")
+	withWorkingDir(t, project, func() {
+		_, err := Realize(RealizeRequest{
+			Function:         "F",
+			Params:           []string{"x"},
+			ConceptName:      "concept:not-supported",
+			TargetLibraryTag: "go",
+		})
+		if err == nil {
+			t.Fatal("unsupported concept must be refused")
+		}
+		if _, ok := err.(*MissingTemplateError); !ok {
+			t.Fatalf("want *MissingTemplateError, got %T: %v", err, err)
+		}
 	})
-	if err == nil {
-		t.Fatal("unsupported concept must be refused")
-	}
-	if _, ok := err.(*MissingTemplateError); !ok {
-		t.Fatalf("want *MissingTemplateError, got %T: %v", err, err)
-	}
 }
 
 // Discrimination: identity's signature guard rejects a wrong param count
 // (2 params) rather than emitting a malformed body.
 func TestRealizeIdentityRejectsWrongArity(t *testing.T) {
-	_, err := Realize(RealizeRequest{
-		Function:    "Id2",
-		Params:      []string{"x", "y"},
-		ConceptName: "identity",
+	project := t.TempDir()
+	writeProofBackedGoDependency(t, project, "go", "identity", "x", "return x")
+	withWorkingDir(t, project, func() {
+		_, err := Realize(RealizeRequest{
+			Function:         "Id2",
+			Params:           []string{"x", "y"},
+			ConceptName:      "identity",
+			TargetLibraryTag: "go",
+		})
+		if err == nil {
+			t.Fatal("identity with 2 params must be refused (max_params=1)")
+		}
 	})
-	if err == nil {
-		t.Fatal("identity with 2 params must be refused (max_params=1)")
-	}
 }
 
 // Structural: substitute fills ${paramN} placeholders positionally.
@@ -146,6 +163,187 @@ func TestResolveDependencyProofsReturnsProofsFromGoModuleDependencies(t *testing
 	if _, err := os.Stat(got); err != nil {
 		t.Fatalf("proof path must exist: %v", err)
 	}
+}
+
+func TestBodyTemplateEntriesReturnProofBackedGoModuleBindings(t *testing.T) {
+	project := t.TempDir()
+	writeProofBackedGoDependency(t, project, "go", "concept:go-proof-backed", "value", "return value + 41")
+
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":8,"method":"provekit.plugin.body_template_entries","params":{"project_root":` + strconvQuote(project) + `,"target_library_tag":"go"}}` + "\n")
+	if err := RunRPC(stdin, &stdout); err != nil {
+		t.Fatalf("RunRPC: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &response); err != nil {
+		t.Fatalf("parse response %q: %v", stdout.String(), err)
+	}
+	if response["error"] != nil {
+		t.Fatalf("body_template_entries returned error: %#v", response["error"])
+	}
+	result := response["result"].(map[string]any)
+	entries := result["entries"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("entries len = %d, want 1; response=%s", len(entries), stdout.String())
+	}
+	entry := entries[0].(map[string]any)
+	if entry["concept_name"] != "concept:go-proof-backed" {
+		t.Fatalf("concept_name = %#v", entry["concept_name"])
+	}
+	template := entry["emission_template"].(map[string]any)
+	if template["template"] != "return ${param0} + 41" {
+		t.Fatalf("template = %#v, want proof-backed placeholder template", template["template"])
+	}
+	if entry["target_library_tag"] != "go" {
+		t.Fatalf("target_library_tag = %#v, want go", entry["target_library_tag"])
+	}
+}
+
+func TestBodyTemplateEntriesReportsMalformedProof(t *testing.T) {
+	project := t.TempDir()
+	proofName := "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd.proof"
+	writeGoDependencyWithProofBytes(t, project, proofName, []byte("not deterministic cbor"))
+
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":10,"method":"provekit.plugin.body_template_entries","params":{"project_root":` + strconvQuote(project) + `,"target_library_tag":"go"}}` + "\n")
+	if err := RunRPC(stdin, &stdout); err != nil {
+		t.Fatalf("RunRPC: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &response); err != nil {
+		t.Fatalf("parse response %q: %v", stdout.String(), err)
+	}
+	errObj, ok := response["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("malformed proof must produce an explicit kit error: %s", stdout.String())
+	}
+	message, _ := errObj["message"].(string)
+	if !strings.Contains(message, "BODY_TEMPLATE_ENTRIES_FAILED") ||
+		!strings.Contains(message, "decode Go shim proof") {
+		t.Fatalf("malformed proof diagnostic is not explicit enough: %q", message)
+	}
+}
+
+func TestInvokeUsesProofBackedTemplateFromGoModuleDependency(t *testing.T) {
+	project := t.TempDir()
+	writeProofBackedGoDependency(t, project, "go", "concept:go-proof-backed", "value", "return value + 41")
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir project: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":9,"method":"provekit.plugin.invoke","params":{"function":"AddFortyOne","params":["x"],"param_types":["int"],"return_type":"int","concept_name":"concept:go-proof-backed","target_library_tag":"go"}}` + "\n")
+	if err := RunRPC(stdin, &stdout); err != nil {
+		t.Fatalf("RunRPC: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &response); err != nil {
+		t.Fatalf("parse response %q: %v", stdout.String(), err)
+	}
+	if response["error"] != nil {
+		t.Fatalf("invoke returned error: %#v", response["error"])
+	}
+	result := response["result"].(map[string]any)
+	source := result["source"].(string)
+	if !strings.Contains(source, "func AddFortyOne(x int) int") {
+		t.Fatalf("source missing signature: %s", source)
+	}
+	if !strings.Contains(source, "return x + 41") {
+		t.Fatalf("source must come from the proof-backed body, not inline identity: %s", source)
+	}
+}
+
+func writeProofBackedGoDependency(t *testing.T, project, libraryTag, conceptName, paramName, bodyText string) string {
+	t.Helper()
+	member := map[string]any{
+		"body": map[string]any{
+			"kind":                 "library-sugar-binding-entry",
+			"concept_name":         conceptName,
+			"source_function_name": "ProofBacked",
+			"target_language":      "go",
+			"target_library_tag":   libraryTag,
+			"param_names":          []string{paramName},
+			"param_types":          []string{"int"},
+			"return_type":          "int",
+			"body_source": map[string]any{
+				"body_text": bodyText,
+			},
+			"loss_record_contribution": map[string]any{
+				"form": "literal",
+				"value": map[string]any{
+					"entries": []any{},
+				},
+			},
+		},
+	}
+	memberBytes, err := json.Marshal(member)
+	if err != nil {
+		t.Fatalf("marshal member: %v", err)
+	}
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = 0x42
+	}
+	out, err := proof_envelope.NewBuilder().Build(&proof_envelope.Input{
+		Name:       "@test/go-proof-backed",
+		Version:    "0.0.0",
+		Members:    map[string][]byte{"blake3-512:" + strings.Repeat("b", 128): memberBytes},
+		SignerCID:  "blake3-512:" + strings.Repeat("c", 128),
+		SignerSeed: seed,
+		DeclaredAt: "2026-05-29T00:00:00.000Z",
+	})
+	if err != nil {
+		t.Fatalf("build proof envelope: %v", err)
+	}
+	return writeGoDependencyWithProofBytes(t, project, out.FilenameCID+".proof", out.Bytes)
+}
+
+func writeGoDependencyWithProofBytes(t *testing.T, project, proofName string, proofBytes []byte) string {
+	t.Helper()
+	dep := filepath.Join(project, "dep")
+	proofPath := filepath.Join(dep, "META-INF", "provekit", proofName)
+	if err := os.MkdirAll(filepath.Dir(proofPath), 0o755); err != nil {
+		t.Fatalf("mkdir dependency proof dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dep, "go.mod"), []byte("module example.com/proofdep\n\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatalf("write dep go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "go.mod"), []byte("module example.com/app\n\ngo 1.22\n\nrequire example.com/proofdep v0.0.0\nreplace example.com/proofdep => ./dep\n"), 0o644); err != nil {
+		t.Fatalf("write project go.mod: %v", err)
+	}
+	if err := os.WriteFile(proofPath, proofBytes, 0o644); err != nil {
+		t.Fatalf("write proof: %v", err)
+	}
+	return proofPath
+}
+
+func withWorkingDir(t *testing.T, dir string, fn func()) {
+	t.Helper()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	defer func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+	fn()
 }
 
 func strconvQuote(s string) string {

--- a/implementations/go/provekit-realize-go-core/rpc.go
+++ b/implementations/go/provekit-realize-go-core/rpc.go
@@ -42,6 +42,8 @@ func RunRPC(stdin io.Reader, stdout io.Writer) error {
 			writeJSON(stdout, handleInvoke(req.ID, req.Params))
 		case "provekit.plugin.resolve_dependency_proofs":
 			writeJSON(stdout, handleResolveDependencyProofs(req.ID, req.Params))
+		case "provekit.plugin.body_template_entries":
+			writeJSON(stdout, handleBodyTemplateEntries(req.ID, req.Params))
 		case "provekit.plugin.check":
 			writeJSON(stdout, handleCheck(req.ID, req.Params))
 		case "provekit.plugin.shutdown":
@@ -81,6 +83,26 @@ func handleInvoke(id json.RawMessage, raw json.RawMessage) any {
 	return successResponse(id, realized)
 }
 
+func handleBodyTemplateEntries(id json.RawMessage, raw json.RawMessage) any {
+	var params map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return errorResponse(id, -32602, fmt.Sprintf("INVALID_PARAMS: %v", err))
+		}
+	}
+	if params == nil {
+		params = map[string]any{}
+	}
+	entries, err := loadBodyTemplateEntriesForProject(
+		projectRootFromParams(params),
+		libraryTagFromParams(params),
+	)
+	if err != nil {
+		return errorResponse(id, -32031, "BODY_TEMPLATE_ENTRIES_FAILED: "+err.Error())
+	}
+	return successResponse(id, map[string]any{"entries": entries})
+}
+
 func handleResolveDependencyProofs(id json.RawMessage, raw json.RawMessage) any {
 	var params map[string]any
 	if len(raw) > 0 {
@@ -91,11 +113,7 @@ func handleResolveDependencyProofs(id json.RawMessage, raw json.RawMessage) any 
 	if params == nil {
 		params = map[string]any{}
 	}
-	projectRoot, _ := params["project_root"].(string)
-	if projectRoot == "" {
-		projectRoot, _ = params["projectRoot"].(string)
-	}
-	paths, err := resolveDependencyProofPaths(projectRoot)
+	paths, err := resolveDependencyProofPaths(projectRootFromParams(params))
 	if err != nil {
 		return errorResponse(id, -32030, "RESOLVE_DEPENDENCY_PROOFS_FAILED: "+err.Error())
 	}

--- a/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
+++ b/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
@@ -18,6 +18,7 @@
 // The concept is `identity` -- a real cross-language concept (also in Python's
 // canonical-bodies), realized in Go as `return x`. Requires `go` on PATH.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -26,6 +27,9 @@ use std::sync::Arc;
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
 use provekit_cli::kit_dispatch::{
     dependency_proof_paths_via_rpc, dispatch_realize, RealizeRequest,
+};
+use provekit_proof_envelope::{
+    build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
 };
 use serde_json::Value as Json;
 
@@ -131,6 +135,12 @@ fn identity_payload_json(function: &str) -> String {
     )
 }
 
+fn proof_backed_payload_json(function: &str) -> String {
+    format!(
+        "{{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"concept:go-proof-backed\",\"function\":\"{function}\",\"params\":[\"x\"],\"param_types\":[\"int\"],\"return_type\":\"int\"}}"
+    )
+}
+
 fn payload_cid(payload: &str) -> String {
     let json: Json = serde_json::from_str(payload).expect("payload json parses");
     let canonical = canonical_value_from_json(&json);
@@ -170,6 +180,95 @@ fn write_go_identity_carrier(src_dir: &Path) -> PathBuf {
     source
 }
 
+fn write_go_proof_backed_carrier(src_dir: &Path) -> PathBuf {
+    let payload = proof_backed_payload_json("AddFortyOne");
+    let source = src_dir.join("add_forty_one.go");
+    fs::write(
+        &source,
+        format!(
+            "package sample\n\n// provekit-concept: {payload}\n// provekit-concept-payload-cid: {}\n",
+            payload_cid(&payload)
+        ),
+    )
+    .expect("write go proof-backed carrier source");
+    source
+}
+
+fn write_external_go_dependency_with_proof_backed_body(project: &Path) -> PathBuf {
+    write_external_go_dependency_with_body(
+        project,
+        "concept:go-proof-backed",
+        "value",
+        "return value + 41",
+    )
+}
+
+fn write_external_go_dependency_with_identity_body(project: &Path) -> PathBuf {
+    write_external_go_dependency_with_body(project, "identity", "x", "return x")
+}
+
+fn write_external_go_dependency_with_body(
+    project: &Path,
+    concept_name: &str,
+    param_name: &str,
+    body_text: &str,
+) -> PathBuf {
+    let dep = unique_dir("go-proof-backed-dep");
+    let proof_dir = dep.join("META-INF").join("provekit");
+    fs::create_dir_all(&proof_dir).expect("mkdir dependency proof dir");
+    fs::write(
+        dep.join("go.mod"),
+        "module example.com/proofdep\n\ngo 1.22\n",
+    )
+    .expect("write dep go.mod");
+
+    let member = serde_json::json!({
+        "body": {
+            "kind": "library-sugar-binding-entry",
+            "concept_name": concept_name,
+            "source_function_name": "ProofBacked",
+            "target_language": "go",
+            "target_library_tag": "go",
+            "param_names": [param_name],
+            "param_types": ["int"],
+            "return_type": "int",
+            "body_source": {
+                "body_text": body_text
+            },
+            "loss_record_contribution": {
+                "form": "literal",
+                "value": {"entries": []}
+            }
+        }
+    });
+    let member_bytes = serde_json::to_vec(&member).expect("member json");
+    let mut members = BTreeMap::new();
+    members.insert(format!("blake3-512:{}", "b".repeat(128)), member_bytes);
+    let signer_seed: Ed25519Seed = [0x42; 32];
+    let proof = build_proof_envelope(&ProofEnvelopeInput {
+        name: "@test/go-proof-backed".to_string(),
+        version: "0.0.0".to_string(),
+        binary_cid: None,
+        metadata: None,
+        members,
+        signer_cid: ed25519_pubkey_string(&signer_seed),
+        signer_seed,
+        declared_at: "2026-05-29T00:00:00.000Z".to_string(),
+    });
+    let proof_path = proof_dir.join(format!("{}.proof", proof.cid));
+    fs::write(&proof_path, proof.bytes).expect("write proof-backed Go proof");
+
+    fs::write(
+        project.join("go.mod"),
+        format!(
+            "module example.com/app\n\ngo 1.22\n\nrequire example.com/proofdep v0.0.0\nreplace example.com/proofdep => {}\n",
+            dep.display()
+        ),
+    )
+    .expect("write project go.mod");
+    proof_path
+}
+
 fn identity_request() -> RealizeRequest {
     RealizeRequest {
         function: "Id".to_string(),
@@ -199,6 +298,67 @@ fn identity_request() -> RealizeRequest {
         function_return_types: std::collections::BTreeMap::new(),
         doc_lines: Vec::new(),
     }
+}
+
+#[test]
+fn go_materialize_uses_body_template_from_go_module_proof() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go proof-backed materialize CLI test");
+        return;
+    }
+    let bin = build_go_realize();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    install_go_realize_manifest(workspace.path(), &bin);
+    let proof_path = write_external_go_dependency_with_proof_backed_body(workspace.path());
+    assert!(
+        !proof_path.starts_with(workspace.path()),
+        "fixture must keep the shim .proof outside the CLI project root"
+    );
+
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    write_go_proof_backed_carrier(&src_dir);
+
+    let out_dir = workspace.path().join("materialized");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    fs::write(
+        out_dir.join("go.mod"),
+        "module example.com/provekit_go_materialized\n\ngo 1.22\n",
+    )
+    .expect("write output go.mod");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--target")
+        .arg("go")
+        .arg("--library")
+        .arg("go")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .output()
+        .expect("spawn provekit materialize for proof-backed Go");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Go materialize must load body templates through the Go kit's module proof resolver\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let emitted = fs::read_to_string(out_dir.join("add_forty_one.go"))
+        .expect("read materialized proof-backed Go");
+    assert!(
+        emitted.contains("func AddFortyOne(x int) int"),
+        "materialized Go should contain realized function signature:\n{emitted}"
+    );
+    assert!(
+        emitted.contains("return x + 41"),
+        "materialized Go body must come from the dependency .proof, not the inline identity table:\n{emitted}"
+    );
 }
 
 #[test]
@@ -244,6 +404,7 @@ fn go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check() {
     let bin = build_go_realize();
     let workspace = tempfile::tempdir().expect("tempdir");
     install_go_realize_manifest(workspace.path(), &bin);
+    write_external_go_dependency_with_identity_body(workspace.path());
     let src_dir = workspace.path().join("src");
     fs::create_dir_all(&src_dir).expect("mkdir src");
     write_go_identity_carrier(&src_dir);
@@ -309,6 +470,7 @@ fn go_realize_shim_materializes_compilable_go_for_identity() {
     let bin = build_go_realize();
     let workspace = unique_dir("ws");
     install_go_realize_manifest(&workspace, &bin);
+    write_external_go_dependency_with_identity_body(&workspace);
 
     let realized = dispatch_realize(&workspace, "go", None, &identity_request())
         .expect("go realize shim must materialize the identity concept");
@@ -369,6 +531,7 @@ fn go_realize_shim_refuses_unsupported_concept() {
     let bin = build_go_realize();
     let workspace = unique_dir("refuse");
     install_go_realize_manifest(&workspace, &bin);
+    write_external_go_dependency_with_identity_body(&workspace);
 
     let mut req = identity_request();
     req.concept_name = "concept:unsupported-go-thing".to_string();


### PR DESCRIPTION
## Summary
- Teach the Go realize kit to decode Go-module-resolved `.proof` catalogs and expose `library-sugar-binding-entry` bodies through `provekit.plugin.body_template_entries`.
- Remove the production inline identity template path; `provekit.plugin.invoke` now renders from proof-backed body templates resolved by the Go kit.
- Add Go unit coverage plus Rust CLI materialize coverage proving the CLI uses config/manifest/RPC while the shim proof lives outside the project root.

Closes #1481.

## Test Plan
- `go test ./...` in `implementations/go/provekit-realize-go-core`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test go_realize_materialize -- --nocapture`
- `make cross-language-proof-parity`
- `git diff --check`