### PR TITLE
feat(go): assemble materialized output in kit

### DIFF
--- a/implementations/go/provekit-realize-go-core/assemble.go
+++ b/implementations/go/provekit-realize-go-core/assemble.go
@@ -1,0 +1,243 @@
+package realizego
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/format"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type AssembleRequest struct {
+	TargetLang   string             `json:"target_lang"`
+	FileBasename string             `json:"file_basename"`
+	PackageHint  string             `json:"package_hint"`
+	Fragments    []AssembleFragment `json:"fragments"`
+}
+
+type AssembleFragment struct {
+	ConceptName string   `json:"concept_name"`
+	Source      string   `json:"source"`
+	Imports     []string `json:"imports"`
+	Helpers     []string `json:"helpers"`
+}
+
+type AssembleResponse struct {
+	Files            []AssembledFile `json:"files"`
+	CompileClasspath []string        `json:"compile_classpath"`
+}
+
+type AssembledFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func handleAssemble(id json.RawMessage, raw json.RawMessage) any {
+	var req AssembleRequest
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &req); err != nil {
+			return errorResponse(id, -32602, fmt.Sprintf("INVALID_PARAMS: %v", err))
+		}
+	}
+	response, err := Assemble(req)
+	if err != nil {
+		return errorResponse(id, -32040, "ASSEMBLE_FAILED: "+err.Error())
+	}
+	return successResponse(id, response)
+}
+
+func Assemble(req AssembleRequest) (AssembleResponse, error) {
+	if req.TargetLang != "" && req.TargetLang != "go" {
+		return AssembleResponse{}, fmt.Errorf("go assembler cannot assemble target_lang %q", req.TargetLang)
+	}
+	path := goFilePath(req.FileBasename)
+	content, err := assembleGoContent(req)
+	if err != nil {
+		return AssembleResponse{}, err
+	}
+	return AssembleResponse{
+		Files: []AssembledFile{{
+			Path:    path,
+			Content: content,
+		}},
+		CompileClasspath: []string{},
+	}, nil
+}
+
+func assembleGoContent(req AssembleRequest) (string, error) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "package %s\n\n", goPackageName(req.PackageHint))
+
+	imports := collectGoImports(req.Fragments)
+	if len(imports) == 1 {
+		fmt.Fprintf(&b, "import %s\n\n", strconv.Quote(imports[0]))
+	} else if len(imports) > 1 {
+		b.WriteString("import (\n")
+		for _, importPath := range imports {
+			fmt.Fprintf(&b, "\t%s\n", strconv.Quote(importPath))
+		}
+		b.WriteString(")\n\n")
+	}
+
+	for _, helper := range collectGoHelpers(req.Fragments) {
+		b.WriteString(helper)
+		b.WriteString("\n\n")
+	}
+	for _, fragment := range req.Fragments {
+		source := strings.TrimSpace(fragment.Source)
+		if source == "" {
+			continue
+		}
+		b.WriteString(source)
+		b.WriteString("\n\n")
+	}
+
+	formatted, err := format.Source([]byte(b.String()))
+	if err != nil {
+		return "", fmt.Errorf("format assembled Go: %w", err)
+	}
+	return string(formatted), nil
+}
+
+func collectGoImports(fragments []AssembleFragment) []string {
+	seen := map[string]struct{}{}
+	for _, fragment := range fragments {
+		for _, importPath := range fragment.Imports {
+			importPath = normalizeImportPath(importPath)
+			if importPath == "" {
+				continue
+			}
+			seen[importPath] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for importPath := range seen {
+		out = append(out, importPath)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func collectGoHelpers(fragments []AssembleFragment) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, fragment := range fragments {
+		for _, helper := range fragment.Helpers {
+			helper = strings.TrimSpace(helper)
+			if helper == "" {
+				continue
+			}
+			if _, ok := seen[helper]; ok {
+				continue
+			}
+			seen[helper] = struct{}{}
+			out = append(out, helper)
+		}
+	}
+	return out
+}
+
+func normalizeImportPath(importPath string) string {
+	importPath = strings.TrimSpace(importPath)
+	if importPath == "" {
+		return ""
+	}
+	if unquoted, err := strconv.Unquote(importPath); err == nil {
+		return unquoted
+	}
+	return importPath
+}
+
+func goFilePath(base string) string {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "materialized"
+	}
+	base = strings.ReplaceAll(base, "\\", "/")
+	base = filepath.Base(base)
+	base = strings.TrimSuffix(base, ".go")
+	return sanitizeFileStem(base) + ".go"
+}
+
+func sanitizeFileStem(stem string) string {
+	var b strings.Builder
+	for _, r := range stem {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '_' || r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := strings.Trim(b.String(), "_-.")
+	if out == "" {
+		return "materialized"
+	}
+	return out
+}
+
+func goPackageName(hint string) string {
+	hint = strings.TrimSpace(hint)
+	if hint == "" {
+		return "main"
+	}
+	hint = strings.ReplaceAll(hint, "\\", "/")
+	hint = filepath.Base(hint)
+
+	var b strings.Builder
+	for i, r := range hint {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || (i > 0 && r >= '0' && r <= '9')
+		if valid {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "main"
+	}
+	if out[0] >= '0' && out[0] <= '9' {
+		out = "pkg_" + out
+	}
+	if goKeywords[out] {
+		out += "_pkg"
+	}
+	return out
+}
+
+var goKeywords = map[string]bool{
+	"break":       true,
+	"default":     true,
+	"func":        true,
+	"interface":   true,
+	"select":      true,
+	"case":        true,
+	"defer":       true,
+	"go":          true,
+	"map":         true,
+	"struct":      true,
+	"chan":        true,
+	"else":        true,
+	"goto":        true,
+	"package":     true,
+	"switch":      true,
+	"const":       true,
+	"fallthrough": true,
+	"if":          true,
+	"range":       true,
+	"type":        true,
+	"continue":    true,
+	"for":         true,
+	"import":      true,
+	"return":      true,
+	"var":         true,
+}

--- a/implementations/go/provekit-realize-go-core/realizer_test.go
+++ b/implementations/go/provekit-realize-go-core/realizer_test.go
@@ -3,6 +3,8 @@ package realizego
 import (
 	"bytes"
 	"encoding/json"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,6 +113,69 @@ func TestPluginCheckRunsGoTest(t *testing.T) {
 	}
 	if result["command"] != "go test ./..." {
 		t.Fatalf("command = %#v", result["command"])
+	}
+}
+
+func TestPluginAssembleReturnsFormattedGoFiles(t *testing.T) {
+	params := map[string]any{
+		"target_lang":   "go",
+		"file_basename": "id",
+		"package_hint":  "sample",
+		"fragments": []map[string]any{
+			{
+				"concept_name": "identity",
+				"source":       "func Label(x int) string {\nreturn fmt.Sprint(x)\n}",
+				"imports":      []string{"fmt"},
+				"helpers":      []string{"const helperValue = 1"},
+			},
+		},
+	}
+	req := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      17,
+		"method":  "provekit.plugin.assemble",
+		"params":  params,
+	}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal assemble request: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := RunRPC(bytes.NewReader(append(raw, '\n')), &stdout); err != nil {
+		t.Fatalf("RunRPC: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &response); err != nil {
+		t.Fatalf("parse response %q: %v", stdout.String(), err)
+	}
+	if response["error"] != nil {
+		t.Fatalf("assemble returned error: %#v", response["error"])
+	}
+	result := response["result"].(map[string]any)
+	files := result["files"].([]any)
+	if len(files) != 1 {
+		t.Fatalf("files len = %d, want 1; response=%s", len(files), stdout.String())
+	}
+	file := files[0].(map[string]any)
+	if file["path"] != "id.go" {
+		t.Fatalf("assembled path = %#v, want id.go", file["path"])
+	}
+	content := file["content"].(string)
+	if _, err := parser.ParseFile(token.NewFileSet(), "id.go", content, parser.AllErrors); err != nil {
+		t.Fatalf("assembled content must parse as Go: %v\n%s", err, content)
+	}
+	for _, want := range []string{
+		"package sample",
+		"import \"fmt\"",
+		"const helperValue = 1",
+		"func Label(x int) string",
+		"return fmt.Sprint(x)",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("assembled content missing %q:\n%s", want, content)
+		}
 	}
 }
 

--- a/implementations/go/provekit-realize-go-core/rpc.go
+++ b/implementations/go/provekit-realize-go-core/rpc.go
@@ -40,6 +40,8 @@ func RunRPC(stdin io.Reader, stdout io.Writer) error {
 		switch req.Method {
 		case "provekit.plugin.invoke":
 			writeJSON(stdout, handleInvoke(req.ID, req.Params))
+		case "provekit.plugin.assemble":
+			writeJSON(stdout, handleAssemble(req.ID, req.Params))
 		case "provekit.plugin.resolve_dependency_proofs":
 			writeJSON(stdout, handleResolveDependencyProofs(req.ID, req.Params))
 		case "provekit.plugin.body_template_entries":

--- a/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
+++ b/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
@@ -443,6 +443,10 @@ fn go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check() {
         stderr.contains("compile-check: go test ./... passed"),
         "Go materialize must ask the Go kit to run its native check\nstderr:\n{stderr}"
     );
+    assert!(
+        stderr.contains("assembled by go kit via RPC"),
+        "Go materialize must use the configured Go kit for assembly, not legacy concat fallback\nstderr:\n{stderr}"
+    );
 
     let emitted = fs::read_to_string(out_dir.join("id.go")).expect("read materialized Go");
     assert!(


### PR DESCRIPTION
## Summary
- implement `provekit.plugin.assemble` in `provekit-realize-go-core`
- assemble package declarations, imports, helpers, and realized fragments inside the Go kit using Go formatting
- assert `provekit materialize --target go --out-dir ...` uses kit assembly instead of legacy concat fallback

Closes #1483

## Verification
- `go test ./...` in `implementations/go/provekit-realize-go-core`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test go_realize_materialize go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check -- --nocapture`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test go_realize_materialize -- --nocapture`
- `make cross-language-proof-parity`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Go code assembly functionality to generate formatted Go source files with automatic package naming and import deduplication.

* **Tests**
  * Added comprehensive test coverage for code assembly output, validating proper formatting and RPC integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->