### PR TITLE
feat(python): assemble materialized output in kits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -660,6 +660,7 @@ cross-language-proof-parity-python-env:
 		-e examples/provekit-shim-python-requests \
 		-e implementations/python/provekit-emit-python-pytest \
 		-e implementations/python/provekit-lift-py-tests \
+		-e implementations/python/provekit-realize-python-core \
 		-e implementations/python/provekit-realize-python-requests
 
 .PHONY: cross-language-proof-parity
@@ -846,17 +847,17 @@ test-python: build-python
 	(cd implementations/python/provekit-realize-python-sqlite3 && \
 		python3 -m venv .venv && \
 		. .venv/bin/activate && \
-		python -m pip install --quiet -e ../../../examples/provekit-shim-python-sqlite3 -e . pytest && \
+		python -m pip install --quiet -e ../provekit-realize-python-core -e ../../../examples/provekit-shim-python-sqlite3 -e . pytest && \
 		pytest) || failed="$$failed provekit-realize-python-sqlite3"; \
 	(cd implementations/python/provekit-realize-python-aiosqlite && \
 		python3 -m venv .venv && \
 		. .venv/bin/activate && \
-		python -m pip install --quiet -e ../../../examples/provekit-shim-python-aiosqlite -e . pytest && \
+		python -m pip install --quiet -e ../provekit-realize-python-core -e ../../../examples/provekit-shim-python-aiosqlite -e . pytest && \
 		pytest) || failed="$$failed provekit-realize-python-aiosqlite"; \
 	(cd implementations/python/provekit-realize-python-requests && \
 		python3 -m venv .venv && \
 		. .venv/bin/activate && \
-		python -m pip install --quiet -e ../../../examples/provekit-shim-python-requests -e . pytest && \
+		python -m pip install --quiet -e ../provekit-realize-python-core -e ../../../examples/provekit-shim-python-requests -e . pytest && \
 		pytest) || failed="$$failed provekit-realize-python-requests"; \
 	if [ -n "$$failed" ]; then echo "test-python FAIL:$$failed"; exit 1; fi
 

--- a/implementations/python/provekit-realize-python-aiosqlite/pyproject.toml
+++ b/implementations/python/provekit-realize-python-aiosqlite/pyproject.toml
@@ -7,7 +7,7 @@ name = "provekit-realize-python-aiosqlite"
 version = "0.1.0"
 description = "PEP 1.7.0 Python aiosqlite realize kit for ProvekIt bind canonical output"
 requires-python = ">=3.11"
-dependencies = ["blake3>=1.0.0", "cbor2>=5.4", "provekit-shim-python-aiosqlite"]
+dependencies = ["blake3>=1.0.0", "cbor2>=5.4", "provekit-realize-python-core>=0.1.0", "provekit-shim-python-aiosqlite"]
 
 [project.scripts]
 provekit-realize-python-aiosqlite = "provekit_realize_python_aiosqlite.__main__:main"

--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
@@ -47,6 +47,18 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         except MissingTemplateError as exc:
             return _missing_template_error(msg_id, exc)
         return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    if method == "provekit.plugin.assemble":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        from provekit_realize_python_core.assemble import assemble_response
+
+        try:
+            result = assemble_response(params)
+        except ValueError as exc:
+            return _error(msg_id, -32040, f"ASSEMBLE_FAILED: {exc}")
+        except SyntaxError as exc:
+            return _error(msg_id, -32040, f"ASSEMBLE_FAILED: {exc}")
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
     if method == "provekit.plugin.emit_module":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import json
+import py_compile
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[4]
+CORE_SRC = ROOT / "implementations/python/provekit-realize-python-core/src"
+if str(CORE_SRC) not in sys.path:
+    sys.path.insert(0, str(CORE_SRC))
 PKG_SRC = ROOT / "implementations/python/provekit-realize-python-aiosqlite/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
@@ -31,6 +35,44 @@ SQL_QUERY_ALL_NTT = {
         },
     ],
 }
+
+
+def test_rpc_assemble_returns_compileable_python_module(tmp_path: Path) -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "provekit.plugin.assemble",
+            "params": {
+                "target_lang": "python",
+                "file_basename": "queries",
+                "fragments": [
+                    {
+                        "concept_name": "concept:sql-query-all",
+                        "source": (
+                            "async def select_rows(db, sql, args):\n"
+                            "    async with db.execute(sql, tuple(args)) as cursor:\n"
+                            "        return await cursor.fetchall()\n"
+                        ),
+                        "imports": ["aiosqlite"],
+                        "helpers": ["DEFAULT_LIMIT = 100"],
+                    }
+                ],
+            },
+        }
+    )
+
+    assert "error" not in response
+    file = response["result"]["files"][0]
+    assert file["path"] == "queries.py"
+    content = file["content"]
+    assert "import aiosqlite" in content
+    assert "DEFAULT_LIMIT = 100" in content
+    assert "async def select_rows(db, sql, args):" in content
+
+    module = tmp_path / "queries.py"
+    module.write_text(content, encoding="utf-8")
+    py_compile.compile(str(module), doraise=True)
 
 
 def test_rpc_invoke_renders_aiosqlite_query_all_body(disk_fixture) -> None:

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/assemble.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/assemble.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import ast
+from pathlib import PurePosixPath
+from typing import Any
+
+
+def assemble_response(params: dict[str, Any]) -> dict[str, Any]:
+    target_lang = params.get("target_lang")
+    if target_lang not in (None, "", "python", "py"):
+        raise ValueError(f"python assembler cannot assemble target_lang {target_lang!r}")
+
+    fragments = params.get("fragments")
+    if not isinstance(fragments, list):
+        fragments = []
+
+    content = _assemble_module(fragments)
+    path = _python_file_path(params.get("file_basename"))
+    return {
+        "files": [{"path": path, "content": content}],
+        "compile_classpath": [],
+    }
+
+
+def _assemble_module(fragments: list[Any]) -> str:
+    imports = _collect_imports(fragments)
+    helpers = _collect_blocks(fragments, "helpers")
+    sources = _collect_blocks(fragments, "source")
+
+    blocks: list[str] = []
+    if imports:
+        blocks.append("\n".join(imports))
+    blocks.extend(helpers)
+    blocks.extend(sources)
+    content = "\n\n".join(blocks).rstrip() + "\n"
+    ast.parse(content, filename="<provekit-python-assemble>")
+    return content
+
+
+def _collect_imports(fragments: list[Any]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for fragment in fragments:
+        if not isinstance(fragment, dict):
+            continue
+        imports = fragment.get("imports")
+        if not isinstance(imports, list):
+            continue
+        for value in imports:
+            import_stmt = _normalize_import(value)
+            if not import_stmt or import_stmt in seen:
+                continue
+            seen.add(import_stmt)
+            out.append(import_stmt)
+    return sorted(out)
+
+
+def _normalize_import(value: Any) -> str:
+    raw = str(value).strip()
+    if not raw:
+        return ""
+    if raw.startswith("import ") or raw.startswith("from "):
+        return raw
+    return f"import {raw}"
+
+
+def _collect_blocks(fragments: list[Any], field: str) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for fragment in fragments:
+        if not isinstance(fragment, dict):
+            continue
+        value = fragment.get(field)
+        values = value if isinstance(value, list) else [value]
+        for item in values:
+            if not isinstance(item, str):
+                continue
+            block = item.strip()
+            if not block or block in seen:
+                continue
+            seen.add(block)
+            out.append(block)
+    return out
+
+
+def _python_file_path(value: Any) -> str:
+    base = str(value or "").strip() or "materialized"
+    base = base.replace("\\", "/")
+    base = PurePosixPath(base).name
+    if base.endswith(".py"):
+        base = base[:-3]
+    return _sanitize_file_stem(base) + ".py"
+
+
+def _sanitize_file_stem(stem: str) -> str:
+    chars: list[str] = []
+    for ch in stem:
+        if ch.isascii() and (ch.isalnum() or ch in {"_", "-"}):
+            chars.append(ch)
+        else:
+            chars.append("_")
+    out = "".join(chars).strip("_-.")
+    return out or "materialized"

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
@@ -57,6 +57,18 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         except MissingTemplateError as exc:
             return _missing_template_error(msg_id, exc)
         return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    if method == "provekit.plugin.assemble":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        from .assemble import assemble_response
+
+        try:
+            result = assemble_response(params)
+        except ValueError as exc:
+            return _error(msg_id, -32040, f"ASSEMBLE_FAILED: {exc}")
+        except SyntaxError as exc:
+            return _error(msg_id, -32040, f"ASSEMBLE_FAILED: {exc}")
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
     if method == "provekit.plugin.emit_module":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")

--- a/implementations/python/provekit-realize-python-core/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import py_compile
 import sys
 from pathlib import Path
 
@@ -219,6 +220,47 @@ def test_rpc_body_template_entries_reports_missing_core_resource(monkeypatch) ->
             },
         },
     }
+
+
+def test_rpc_assemble_returns_compileable_python_module(tmp_path: Path) -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "provekit.plugin.assemble",
+            "params": {
+                "target_lang": "python",
+                "file_basename": "client",
+                "fragments": [
+                    {
+                        "concept_name": "concept:http-request",
+                        "source": (
+                            "def fetch_status(url):\n"
+                            "    return requests.get(url).status_code\n"
+                        ),
+                        "imports": ["requests"],
+                        "helpers": ["DEFAULT_TIMEOUT = 30"],
+                    }
+                ],
+            },
+        }
+    )
+
+    assert "error" not in response
+    result = response["result"]
+    assert result["compile_classpath"] == []
+    assert len(result["files"]) == 1
+    file = result["files"][0]
+    assert file["path"] == "client.py"
+    content = file["content"]
+    assert "import requests" in content
+    assert "DEFAULT_TIMEOUT = 30" in content
+    assert "def fetch_status(url):" in content
+    assert "return requests.get(url).status_code" in content
+
+    module = tmp_path / "client.py"
+    module.write_text(content, encoding="utf-8")
+    py_compile.compile(str(module), doraise=True)
 
 
 def test_emit_module_returns_all_missing_template_errors() -> None:

--- a/implementations/python/provekit-realize-python-requests/pyproject.toml
+++ b/implementations/python/provekit-realize-python-requests/pyproject.toml
@@ -7,7 +7,7 @@ name = "provekit-realize-python-requests"
 version = "0.1.0"
 description = "PEP 1.7.0 Python requests realize kit for ProvekIt bind canonical output"
 requires-python = ">=3.11"
-dependencies = ["cbor2>=5.4", "provekit-shim-python-requests"]
+dependencies = ["cbor2>=5.4", "provekit-realize-python-core>=0.1.0", "provekit-shim-python-requests"]
 
 [project.scripts]
 provekit-realize-python-requests = "provekit_realize_python_requests.__main__:main"

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
@@ -48,6 +48,18 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         except MissingTemplateError as exc:
             return _missing_template_error(msg_id, exc)
         return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    if method == "provekit.plugin.assemble":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        from provekit_realize_python_core.assemble import assemble_response
+
+        try:
+            result = assemble_response(params)
+        except ValueError as exc:
+            return _error(msg_id, -32040, f"ASSEMBLE_FAILED: {exc}")
+        except SyntaxError as exc:
+            return _error(msg_id, -32040, f"ASSEMBLE_FAILED: {exc}")
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
     if method == "provekit.plugin.emit_module":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")

--- a/implementations/python/provekit-realize-python-requests/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-requests/tests/test_rpc.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import json
+import py_compile
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[4]
+CORE_SRC = ROOT / "implementations/python/provekit-realize-python-core/src"
+if str(CORE_SRC) not in sys.path:
+    sys.path.insert(0, str(CORE_SRC))
 PKG_SRC = ROOT / "implementations/python/provekit-realize-python-requests/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
@@ -81,6 +85,47 @@ def test_rpc_body_template_entries_returns_shim_proof_entries() -> None:
     concepts = {entry["concept_name"] for entry in response["result"]["entries"]}
     assert "concept:http-request" in concepts
     assert "concept:http-response" in concepts
+
+
+def test_rpc_assemble_returns_compileable_python_module(tmp_path: Path) -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "provekit.plugin.assemble",
+            "params": {
+                "target_lang": "python",
+                "file_basename": "client",
+                "fragments": [
+                    {
+                        "concept_name": "concept:http-request",
+                        "source": (
+                            "def fetch_status(url):\n"
+                            "    return requests.get(url).status_code\n"
+                        ),
+                        "imports": ["requests"],
+                        "helpers": ["DEFAULT_TIMEOUT = 30"],
+                    }
+                ],
+            },
+        }
+    )
+
+    assert "error" not in response
+    result = response["result"]
+    assert result["compile_classpath"] == []
+    assert len(result["files"]) == 1
+    file = result["files"][0]
+    assert file["path"] == "client.py"
+    content = file["content"]
+    assert "import requests" in content
+    assert "DEFAULT_TIMEOUT = 30" in content
+    assert "def fetch_status(url):" in content
+    assert "return requests.get(url).status_code" in content
+
+    module = tmp_path / "client.py"
+    module.write_text(content, encoding="utf-8")
+    py_compile.compile(str(module), doraise=True)
 
 
 def test_plugin_invoke_returns_structured_missing_template_error() -> None:

--- a/implementations/python/provekit-realize-python-sqlite3/pyproject.toml
+++ b/implementations/python/provekit-realize-python-sqlite3/pyproject.toml
@@ -7,7 +7,7 @@ name = "provekit-realize-python-sqlite3"
 version = "0.1.0"
 description = "PEP 1.7.0 Python sqlite3 realize kit for ProvekIt bind canonical output"
 requires-python = ">=3.11"
-dependencies = ["blake3>=1.0.0", "cbor2>=5.4", "provekit-shim-python-sqlite3"]
+dependencies = ["blake3>=1.0.0", "cbor2>=5.4", "provekit-realize-python-core>=0.1.0", "provekit-shim-python-sqlite3"]
 
 [project.scripts]
 provekit-realize-python-sqlite3 = "provekit_realize_python_sqlite3.__main__:main"

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
@@ -47,6 +47,18 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         except MissingTemplateError as exc:
             return _missing_template_error(msg_id, exc)
         return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    if method == "provekit.plugin.assemble":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        from provekit_realize_python_core.assemble import assemble_response
+
+        try:
+            result = assemble_response(params)
+        except ValueError as exc:
+            return _error(msg_id, -32040, f"ASSEMBLE_FAILED: {exc}")
+        except SyntaxError as exc:
+            return _error(msg_id, -32040, f"ASSEMBLE_FAILED: {exc}")
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
     if method == "provekit.plugin.emit_module":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")

--- a/implementations/python/provekit-realize-python-sqlite3/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/tests/test_rpc.py
@@ -1,15 +1,57 @@
 from __future__ import annotations
 
 import json
+import py_compile
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[4]
+CORE_SRC = ROOT / "implementations/python/provekit-realize-python-core/src"
+if str(CORE_SRC) not in sys.path:
+    sys.path.insert(0, str(CORE_SRC))
 PKG_SRC = ROOT / "implementations/python/provekit-realize-python-sqlite3/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
 from provekit_realize_python_sqlite3.rpc import dispatch
+
+
+def test_rpc_assemble_returns_compileable_python_module(tmp_path: Path) -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "provekit.plugin.assemble",
+            "params": {
+                "target_lang": "python",
+                "file_basename": "queries",
+                "fragments": [
+                    {
+                        "concept_name": "concept:sql-query-all",
+                        "source": (
+                            "def select_rows(db, sql, args):\n"
+                            "    cursor = db.execute(sql, tuple(args))\n"
+                            "    return cursor.fetchall()\n"
+                        ),
+                        "imports": ["sqlite3"],
+                        "helpers": ["DEFAULT_LIMIT = 100"],
+                    }
+                ],
+            },
+        }
+    )
+
+    assert "error" not in response
+    file = response["result"]["files"][0]
+    assert file["path"] == "queries.py"
+    content = file["content"]
+    assert "import sqlite3" in content
+    assert "DEFAULT_LIMIT = 100" in content
+    assert "def select_rows(db, sql, args):" in content
+
+    module = tmp_path / "queries.py"
+    module.write_text(content, encoding="utf-8")
+    py_compile.compile(str(module), doraise=True)
 
 
 def test_rpc_invoke_renders_sqlite3_query_all_body(disk_fixture) -> None:

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -198,15 +198,20 @@ fn write_python_requests_project_fixture(workspace: &Path) -> Option<PathBuf> {
         .join("python")
         .join("provekit-realize-python-requests")
         .join("src");
+    let core_src = repo
+        .join("implementations")
+        .join("python")
+        .join("provekit-realize-python-core")
+        .join("src");
     let shim_src = repo.join("examples").join("provekit-shim-python-requests");
-    if !package_src.is_dir() || !shim_src.is_dir() {
+    if !package_src.is_dir() || !core_src.is_dir() || !shim_src.is_dir() {
         return None;
     }
     install_python_module_manifest(
         workspace,
         "python-requests",
         "provekit_realize_python_requests",
-        &[package_src, shim_src],
+        &[core_src, package_src, shim_src],
         "python-realize-requests",
         "requests",
     );
@@ -1353,6 +1358,10 @@ fn compile_check_passes_for_valid_python_materialized_output() {
     assert!(
         stderr.contains("compile-check: python -m py_compile passed"),
         "stderr should confirm the python kit check passed\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("assembled by python kit via RPC"),
+        "Python materialize must use the configured Python kit for assembly, not legacy concat fallback\nstderr:\n{stderr}"
     );
     let emitted = fs::read_to_string(out_dir.join("client.py")).expect("read emitted python");
     assert!(


### PR DESCRIPTION
## Summary
- add shared Python module assembly helper in `provekit-realize-python-core`
- wire `provekit.plugin.assemble` into core, requests, sqlite3, and aiosqlite realize kits
- require Python materialize to use kit assembly instead of the legacy concat fallback
- install the shared core assembler in Python parity/test environments

Closes #1489

## Verification
- `python3 -m pytest tests -q` in `implementations/python/provekit-realize-python-core`
- `python3 -m pytest tests -q` in `implementations/python/provekit-realize-python-requests`
- `python3 -m pytest tests -q` in `implementations/python/provekit-realize-python-sqlite3`
- `python3 -m pytest tests -q` in `implementations/python/provekit-realize-python-aiosqlite`
- `python3 -m py_compile implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/assemble.py implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_materialize_integration compile_check_passes_for_valid_python_materialized_output -- --nocapture`
- `make cross-language-proof-parity`
- `make test-python PYTHON=/tmp/provekit-python-assemble-test/bin/python`
- `git diff --check`