### PR TITLE
feat(rpc): carry dependency proofs as bytes

### DIFF
--- a/implementations/c/provekit-realize-c-core/src/main.c
+++ b/implementations/c/provekit-realize-c-core/src/main.c
@@ -1899,8 +1899,8 @@ static int run_rpc(const char *argv0) {
         } else if (strcmp(method, "provekit.plugin.platform_semantics") == 0) {
             handle_platform_semantics(id);
         } else if (strcmp(method, "provekit.plugin.resolve_dependency_proofs") == 0) {
-            fprintf(stderr, "provekit-realize-c-core: resolve_dependency_proofs not yet implemented for c; returning empty proof_paths\n");
-            send_result(id, "{\"proof_paths\":[]}");
+            fprintf(stderr, "provekit-realize-c-core: resolve_dependency_proofs not yet implemented for c; returning empty proofs\n");
+            send_result(id, "{\"proofs\":[]}");
         } else if (strcmp(method, "shutdown") == 0 ||
                    strcmp(method, "provekit.plugin.shutdown") == 0) {
             send_result(id, "null");

--- a/implementations/go/provekit-realize-go-core/realizer_test.go
+++ b/implementations/go/provekit-realize-go-core/realizer_test.go
@@ -2,6 +2,7 @@ package realizego
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"go/parser"
 	"go/token"
@@ -211,22 +212,19 @@ func TestResolveDependencyProofsReturnsProofsFromGoModuleDependencies(t *testing
 		t.Fatalf("resolve_dependency_proofs returned error: %#v", response["error"])
 	}
 	result := response["result"].(map[string]any)
-	paths := result["proof_paths"].([]any)
-	if len(paths) != 1 {
-		t.Fatalf("proof_paths len = %d, want 1; response=%s", len(paths), stdout.String())
+	proofs := result["proofs"].([]any)
+	if len(proofs) != 1 {
+		t.Fatalf("proofs len = %d, want 1; response=%s", len(proofs), stdout.String())
 	}
-	got := paths[0].(string)
-	if !filepath.IsAbs(got) {
-		t.Fatalf("proof path must be absolute: %s", got)
+	got := proofs[0].(map[string]any)
+	if got["cid"] != strings.TrimSuffix(proofName, ".proof") {
+		t.Fatalf("proof cid = %q, want %q", got["cid"], strings.TrimSuffix(proofName, ".proof"))
 	}
-	if filepath.Base(got) != proofName {
-		t.Fatalf("proof basename = %q, want %q", filepath.Base(got), proofName)
+	if got["bytes_base64"] != base64.StdEncoding.EncodeToString([]byte("proof bytes")) {
+		t.Fatalf("proof bytes_base64 not returned: %#v", got)
 	}
-	if got == proofPath {
-		t.Fatalf("resolver must not hand the CLI a Go module-internal proof path: %s", got)
-	}
-	if _, err := os.Stat(got); err != nil {
-		t.Fatalf("proof path must exist: %v", err)
+	if got["source"] == proofPath {
+		t.Fatalf("resolver must not hand the CLI a Go module-internal proof path: %s", got["source"])
 	}
 }
 

--- a/implementations/go/provekit-realize-go-core/rpc.go
+++ b/implementations/go/provekit-realize-go-core/rpc.go
@@ -3,6 +3,7 @@ package realizego
 import (
 	"bufio"
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -115,11 +116,11 @@ func handleResolveDependencyProofs(id json.RawMessage, raw json.RawMessage) any 
 	if params == nil {
 		params = map[string]any{}
 	}
-	paths, err := resolveDependencyProofPaths(projectRootFromParams(params))
+	proofs, err := resolveDependencyProofs(projectRootFromParams(params))
 	if err != nil {
 		return errorResponse(id, -32030, "RESOLVE_DEPENDENCY_PROOFS_FAILED: "+err.Error())
 	}
-	return successResponse(id, map[string]any{"proof_paths": paths})
+	return successResponse(id, map[string]any{"proofs": proofs})
 }
 
 func handleCheck(id json.RawMessage, raw json.RawMessage) any {
@@ -157,7 +158,33 @@ type listedGoModule struct {
 	Replace *listedGoModule `json:"Replace"`
 }
 
+type dependencyProof struct {
+	CID         string `json:"cid"`
+	BytesBase64 string `json:"bytes_base64"`
+	Source      string `json:"source"`
+}
+
 var dependencyProofName = regexp.MustCompile(`^blake3-512:[0-9a-f]{128}\.proof$`)
+
+func resolveDependencyProofs(projectRoot string) ([]dependencyProof, error) {
+	paths, err := resolveDependencyProofPaths(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	proofs := make([]dependencyProof, 0, len(paths))
+	for _, path := range paths {
+		bytes, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		proofs = append(proofs, dependencyProof{
+			CID:         strings.TrimSuffix(filepath.Base(path), ".proof"),
+			BytesBase64: base64.StdEncoding.EncodeToString(bytes),
+			Source:      "go-module:" + filepath.Base(path),
+		})
+	}
+	return proofs, nil
+}
 
 func resolveDependencyProofPaths(projectRoot string) ([]string, error) {
 	root := strings.TrimSpace(projectRoot)
@@ -221,7 +248,7 @@ func resolveDependencyProofPaths(projectRoot string) ([]string, error) {
 		originals = append(originals, proof)
 	}
 	sort.Strings(originals)
-	return copyProofsToTemp(originals)
+	return originals, nil
 }
 
 func effectiveModuleDir(module listedGoModule) string {
@@ -268,46 +295,6 @@ func collectProofPaths(root string, proofs map[string]struct{}) error {
 		proofs[filepath.Clean(abs)] = struct{}{}
 		return nil
 	})
-}
-
-func copyProofsToTemp(paths []string) ([]string, error) {
-	if len(paths) == 0 {
-		return []string{}, nil
-	}
-	root, err := os.MkdirTemp("", "provekit-go-dependency-proofs-")
-	if err != nil {
-		return nil, err
-	}
-	out := make([]string, 0, len(paths))
-	for i, path := range paths {
-		dir := filepath.Join(root, fmt.Sprintf("%04d", i))
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return nil, err
-		}
-		dst := filepath.Join(dir, filepath.Base(path))
-		if err := copyFile(path, dst); err != nil {
-			return nil, err
-		}
-		out = append(out, dst)
-	}
-	return out, nil
-}
-
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(out, in); err != nil {
-		_ = out.Close()
-		return err
-	}
-	return out.Close()
 }
 
 func asMissing(err error, target **MissingTemplateError) bool {

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -11,9 +11,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.TreeSet;
 import java.util.jar.JarFile;
 import java.util.regex.Pattern;
@@ -124,12 +126,19 @@ public final class RpcServer {
             ? Paths.get("").toAbsolutePath().normalize()
             : Paths.get(projectRootRaw).toAbsolutePath().normalize();
         List<Path> classpath = mavenDependencyClasspath(projectRoot);
-        List<Path> proofs = collectDependencyProofPaths(classpath);
+        List<DependencyProof> proofs = collectDependencyProofs(classpath);
 
-        StringBuilder out = new StringBuilder("{\"proof_paths\":[");
+        StringBuilder out = new StringBuilder("{\"proofs\":[");
         for (int i = 0; i < proofs.size(); i++) {
             if (i > 0) out.append(',');
-            out.append(JsonUtil.quoted(proofs.get(i).toString()));
+            DependencyProof proof = proofs.get(i);
+            out.append("{\"cid\":")
+                .append(JsonUtil.quoted(proof.cid))
+                .append(",\"bytes_base64\":")
+                .append(JsonUtil.quoted(Base64.getEncoder().encodeToString(proof.bytes)))
+                .append(",\"source\":")
+                .append(JsonUtil.quoted(proof.source))
+                .append('}');
         }
         out.append("]}");
         return out.toString();
@@ -186,36 +195,40 @@ public final class RpcServer {
         return List.copyOf(roots);
     }
 
-    private static List<Path> collectDependencyProofPaths(List<Path> classpath) throws IOException {
-        TreeSet<Path> proofs = new TreeSet<>(Comparator.comparing(Path::toString));
-        Path extractedRoot = null;
-        int jarIndex = 0;
+    private static List<DependencyProof> collectDependencyProofs(List<Path> classpath) throws IOException {
+        TreeSet<DependencyProof> proofs = new TreeSet<>(Comparator.comparing(DependencyProof::sortKey));
         for (Path root : classpath) {
             if (Files.isDirectory(root)) {
-                collectDirectoryProofPaths(root, proofs);
+                collectDirectoryProofs(root, proofs);
             } else if (Files.isRegularFile(root) && root.getFileName().toString().endsWith(".jar")) {
-                if (extractedRoot == null) {
-                    extractedRoot = Files.createTempDirectory("provekit-java-dependency-proofs-");
-                }
-                collectJarProofPaths(root, extractedRoot.resolve(Integer.toString(jarIndex++)), proofs);
+                collectJarProofs(root, proofs);
             }
         }
         return List.copyOf(proofs);
     }
 
-    private static void collectDirectoryProofPaths(Path root, TreeSet<Path> proofs) throws IOException {
+    private static void collectDirectoryProofs(Path root, TreeSet<DependencyProof> proofs) throws IOException {
         try (Stream<Path> paths = Files.walk(root)) {
             paths
                 .filter(Files::isRegularFile)
                 .filter(path -> isDependencyProofName(path.getFileName().toString()))
-                .map(path -> path.toAbsolutePath().normalize())
+                .map(path -> {
+                    try {
+                        return DependencyProof.fromBytes(
+                            path.getFileName().toString(),
+                            Files.readAllBytes(path),
+                            "java-classpath:" + path.getFileName()
+                        );
+                    } catch (IOException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
                 .forEach(proofs::add);
         }
     }
 
-    private static void collectJarProofPaths(Path jar, Path extractedRoot, TreeSet<Path> proofs)
-            throws IOException {
-        Files.createDirectories(extractedRoot);
+    private static void collectJarProofs(Path jar, TreeSet<DependencyProof> proofs) throws IOException {
         try (JarFile jarFile = new JarFile(jar.toFile())) {
             var entries = jarFile.entries();
             while (entries.hasMoreElements()) {
@@ -223,11 +236,13 @@ public final class RpcServer {
                 if (entry.isDirectory()) continue;
                 String fileName = jarEntryFileName(entry.getName());
                 if (!isDependencyProofName(fileName)) continue;
-                Path out = extractedRoot.resolve(fileName).toAbsolutePath().normalize();
                 try (var in = jarFile.getInputStream(entry)) {
-                    Files.copy(in, out, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    proofs.add(DependencyProof.fromBytes(
+                        fileName,
+                        in.readAllBytes(),
+                        "java-jar:" + jar.getFileName() + "!/" + entry.getName()
+                    ));
                 }
-                proofs.add(out);
             }
         }
     }
@@ -239,6 +254,16 @@ public final class RpcServer {
 
     private static boolean isDependencyProofName(String fileName) {
         return fileName != null && DEPENDENCY_PROOF_NAME.matcher(fileName).matches();
+    }
+
+    private record DependencyProof(String cid, byte[] bytes, String source) {
+        static DependencyProof fromBytes(String fileName, byte[] bytes, String source) {
+            return new DependencyProof(fileName.substring(0, fileName.length() - ".proof".length()), bytes, source);
+        }
+
+        String sortKey() {
+            return cid + "\u0000" + source;
+        }
     }
 
     /**

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/RpcServerDependencyProofsTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/RpcServerDependencyProofsTest.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -55,18 +56,26 @@ public class RpcServerDependencyProofsTest {
 
         Jcs.Obj doc = (Jcs.Obj) Jcs.parse(response);
         assertNull(doc.get("error"), "resolve_dependency_proofs must not error: " + response);
-        Jcs.Arr paths = doc.objectField("result").arrayField("proof_paths");
-        assertEquals(2, paths.values().size(), "expected both dependency proofs: " + response);
+        Jcs.Arr proofs = doc.objectField("result").arrayField("proofs");
+        assertEquals(2, proofs.values().size(), "expected both dependency proofs: " + response);
 
-        Set<String> names = new HashSet<>();
-        for (Jcs.Json item : paths.values()) {
-            assertInstanceOf(Jcs.Str.class, item, "proof path must be a JSON string");
-            Path path = Path.of(((Jcs.Str) item).value());
-            assertTrue(path.isAbsolute(), "proof path must be absolute: " + path);
-            assertTrue(Files.isRegularFile(path), "proof path must be readable: " + path);
-            names.add(path.getFileName().toString());
+        Set<String> cids = new HashSet<>();
+        Set<String> contents = new HashSet<>();
+        for (Jcs.Json item : proofs.values()) {
+            Jcs.Obj proof = assertInstanceOf(Jcs.Obj.class, item, "proof must be a JSON object");
+            cids.add(proof.stringField("cid"));
+            contents.add(new String(
+                Base64.getDecoder().decode(proof.stringField("bytes_base64")),
+                StandardCharsets.UTF_8
+            ));
+            String source = proof.stringField("source");
+            assertTrue(
+                source.startsWith("java-jar:"),
+                "source must be a diagnostic label, not a filesystem authority: " + source
+            );
         }
-        assertEquals(Set.of(PROOF_A, PROOF_B), names);
+        assertEquals(Set.of(stripProof(PROOF_A), stripProof(PROOF_B)), cids);
+        assertEquals(Set.of("proof-one", "proof-two"), contents);
     }
 
     @Test
@@ -86,8 +95,12 @@ public class RpcServerDependencyProofsTest {
 
         Jcs.Obj doc = (Jcs.Obj) Jcs.parse(response);
         assertNull(doc.get("error"), "resolve_dependency_proofs must not error: " + response);
-        Jcs.Arr paths = doc.objectField("result").arrayField("proof_paths");
-        assertTrue(paths.values().isEmpty(), "expected no dependency proofs: " + response);
+        Jcs.Arr proofs = doc.objectField("result").arrayField("proofs");
+        assertTrue(proofs.values().isEmpty(), "expected no dependency proofs: " + response);
+    }
+
+    private static String stripProof(String name) {
+        return name.substring(0, name.length() - ".proof".length());
     }
 
     private Path writeJar(String name, String entryName, String content) throws Exception {

--- a/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/src/provekit_realize_python_aiosqlite/rpc.py
@@ -106,11 +106,13 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
             },
         }
     if method == "provekit.plugin.resolve_dependency_proofs":
-        print(
-            "provekit-realize-python-aiosqlite: resolve_dependency_proofs not yet implemented for python; returning empty proof_paths",
-            file=sys.stderr,
-        )
-        return {"jsonrpc": "2.0", "id": msg_id, "result": {"proof_paths": []}}
+        from provekit_realize_python_core.rpc import _resolve_dependency_proofs
+
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {"proofs": _resolve_dependency_proofs()},
+        }
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")

--- a/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-aiosqlite/tests/test_rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import py_compile
 import sys
@@ -247,3 +248,64 @@ def test_rpc_error_for_unknown_method_is_json_serializable() -> None:
 
     assert response["error"]["code"] == -32601
     json.dumps(response)
+
+
+def test_resolve_dependency_proofs_returns_distribution_proof_bytes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    proof_path = _install_fake_distribution(site_packages, "aiosqlite_dep", "e")
+    monkeypatch.syspath_prepend(str(site_packages))
+
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "provekit.plugin.resolve_dependency_proofs",
+            "params": {"project_root": str(tmp_path / "project")},
+        }
+    )
+
+    assert "error" not in response, response
+    proof = response["result"]["proofs"][0]
+    assert proof["cid"] == proof_path.name.removesuffix(".proof")
+    assert base64.b64decode(proof["bytes_base64"]) == proof_path.read_bytes()
+    assert proof["source"] == f"python-distribution:{proof_path.name}"
+
+
+def _install_fake_distribution(
+    site_packages: Path,
+    distribution_name: str,
+    proof_digit: str,
+) -> Path:
+    package_name = distribution_name.replace("-", "_")
+    package_dir = site_packages / package_name
+    dist_info = site_packages / f"{distribution_name}-1.0.dist-info"
+    package_dir.mkdir()
+    dist_info.mkdir()
+
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    proof_name = f"blake3-512:{proof_digit * 128}.proof"
+    proof_path = package_dir / proof_name
+    proof_path.write_text(f"synthetic proof for {distribution_name}\n", encoding="utf-8")
+
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {distribution_name}\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (dist_info / "WHEEL").write_text("Wheel-Version: 1.0\n", encoding="utf-8")
+    (dist_info / "RECORD").write_text(
+        "\n".join(
+            [
+                f"{package_name}/__init__.py,,",
+                f"{package_name}/{proof_name},,",
+                f"{distribution_name}-1.0.dist-info/METADATA,,",
+                f"{distribution_name}-1.0.dist-info/WHEEL,,",
+                f"{distribution_name}-1.0.dist-info/RECORD,,",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return proof_path

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from fnmatch import fnmatch
 from importlib import metadata as importlib_metadata
 import json
@@ -125,7 +126,7 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         return {
             "jsonrpc": "2.0",
             "id": msg_id,
-            "result": {"proof_paths": _resolve_dependency_proof_paths()},
+            "result": {"proofs": _resolve_dependency_proofs()},
         }
     if method == "provekit.plugin.check":
         if not isinstance(params, dict):
@@ -195,6 +196,21 @@ def _resolve_dependency_proof_paths() -> list[str]:
             if path.is_file():
                 proof_paths.add(str(path))
     return sorted(proof_paths)
+
+
+def _resolve_dependency_proofs() -> list[dict[str, str]]:
+    proofs: list[dict[str, str]] = []
+    for path_text in _resolve_dependency_proof_paths():
+        path = Path(path_text)
+        proof_bytes = path.read_bytes()
+        proofs.append(
+            {
+                "cid": path.name.removesuffix(".proof"),
+                "bytes_base64": base64.b64encode(proof_bytes).decode("ascii"),
+                "source": f"python-distribution:{path.name}",
+            }
+        )
+    return proofs
 
 
 def _check_materialized(params: dict[str, Any]) -> dict[str, Any]:

--- a/implementations/python/provekit-realize-python-core/tests/test_dependency_proof_resolution.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_dependency_proof_resolution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 import subprocess
@@ -31,13 +32,14 @@ def test_resolve_dependency_proofs_returns_installed_distribution_proofs(tmp_pat
     )
 
     assert "error" not in response, response
-    proof_paths = response["result"]["proof_paths"]
-    assert set(proof_paths) == {str(first_proof), str(second_proof)}
-    for proof_path in proof_paths:
-        path = Path(proof_path)
-        assert path.is_absolute()
-        assert path.is_file()
-        assert path.read_text(encoding="utf-8").startswith("synthetic proof for")
+    proofs = response["result"]["proofs"]
+    got_by_cid = {proof["cid"]: proof for proof in proofs}
+    for path in [first_proof, second_proof]:
+        assert path is not None
+        cid = path.name.removesuffix(".proof")
+        proof = got_by_cid[cid]
+        assert base64.b64decode(proof["bytes_base64"]) == path.read_bytes()
+        assert proof["source"] == f"python-distribution:{path.name}"
 
 
 def test_resolve_dependency_proofs_returns_empty_array_without_distribution_proofs(
@@ -62,7 +64,7 @@ def test_resolve_dependency_proofs_returns_empty_array_without_distribution_proo
     assert response == {
         "jsonrpc": "2.0",
         "id": 4,
-        "result": {"proof_paths": []},
+        "result": {"proofs": []},
     }
 
 

--- a/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
+++ b/implementations/python/provekit-realize-python-requests/src/provekit_realize_python_requests/rpc.py
@@ -103,11 +103,13 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
             },
         }
     if method == "provekit.plugin.resolve_dependency_proofs":
-        print(
-            "provekit-realize-python-requests: resolve_dependency_proofs not yet implemented for python; returning empty proof_paths",
-            file=sys.stderr,
-        )
-        return {"jsonrpc": "2.0", "id": msg_id, "result": {"proof_paths": []}}
+        from provekit_realize_python_core.rpc import _resolve_dependency_proofs
+
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {"proofs": _resolve_dependency_proofs()},
+        }
     if method == "provekit.plugin.check":
         if not isinstance(params, dict):
             return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")

--- a/implementations/python/provekit-realize-python-requests/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-requests/tests/test_rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import py_compile
 import sys
@@ -258,3 +259,64 @@ def test_rpc_error_for_unknown_method_is_json_serializable() -> None:
 
     assert response["error"]["code"] == -32601
     json.dumps(response)
+
+
+def test_resolve_dependency_proofs_returns_distribution_proof_bytes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    proof_path = _install_fake_distribution(site_packages, "requests_dep", "c")
+    monkeypatch.syspath_prepend(str(site_packages))
+
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "provekit.plugin.resolve_dependency_proofs",
+            "params": {"project_root": str(tmp_path / "project")},
+        }
+    )
+
+    assert "error" not in response, response
+    proof = response["result"]["proofs"][0]
+    assert proof["cid"] == proof_path.name.removesuffix(".proof")
+    assert base64.b64decode(proof["bytes_base64"]) == proof_path.read_bytes()
+    assert proof["source"] == f"python-distribution:{proof_path.name}"
+
+
+def _install_fake_distribution(
+    site_packages: Path,
+    distribution_name: str,
+    proof_digit: str,
+) -> Path:
+    package_name = distribution_name.replace("-", "_")
+    package_dir = site_packages / package_name
+    dist_info = site_packages / f"{distribution_name}-1.0.dist-info"
+    package_dir.mkdir()
+    dist_info.mkdir()
+
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    proof_name = f"blake3-512:{proof_digit * 128}.proof"
+    proof_path = package_dir / proof_name
+    proof_path.write_text(f"synthetic proof for {distribution_name}\n", encoding="utf-8")
+
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {distribution_name}\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (dist_info / "WHEEL").write_text("Wheel-Version: 1.0\n", encoding="utf-8")
+    (dist_info / "RECORD").write_text(
+        "\n".join(
+            [
+                f"{package_name}/__init__.py,,",
+                f"{package_name}/{proof_name},,",
+                f"{distribution_name}-1.0.dist-info/METADATA,,",
+                f"{distribution_name}-1.0.dist-info/WHEEL,,",
+                f"{distribution_name}-1.0.dist-info/RECORD,,",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return proof_path

--- a/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/src/provekit_realize_python_sqlite3/rpc.py
@@ -106,11 +106,13 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
             },
         }
     if method == "provekit.plugin.resolve_dependency_proofs":
-        print(
-            "provekit-realize-python-sqlite3: resolve_dependency_proofs not yet implemented for python; returning empty proof_paths",
-            file=sys.stderr,
-        )
-        return {"jsonrpc": "2.0", "id": msg_id, "result": {"proof_paths": []}}
+        from provekit_realize_python_core.rpc import _resolve_dependency_proofs
+
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {"proofs": _resolve_dependency_proofs()},
+        }
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")

--- a/implementations/python/provekit-realize-python-sqlite3/tests/test_rpc.py
+++ b/implementations/python/provekit-realize-python-sqlite3/tests/test_rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import py_compile
 import sys
@@ -298,3 +299,64 @@ def test_rpc_error_for_unknown_method_is_json_serializable() -> None:
 
     assert response["error"]["code"] == -32601
     json.dumps(response)
+
+
+def test_resolve_dependency_proofs_returns_distribution_proof_bytes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    proof_path = _install_fake_distribution(site_packages, "sqlite_dep", "d")
+    monkeypatch.syspath_prepend(str(site_packages))
+
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "provekit.plugin.resolve_dependency_proofs",
+            "params": {"project_root": str(tmp_path / "project")},
+        }
+    )
+
+    assert "error" not in response, response
+    proof = response["result"]["proofs"][0]
+    assert proof["cid"] == proof_path.name.removesuffix(".proof")
+    assert base64.b64decode(proof["bytes_base64"]) == proof_path.read_bytes()
+    assert proof["source"] == f"python-distribution:{proof_path.name}"
+
+
+def _install_fake_distribution(
+    site_packages: Path,
+    distribution_name: str,
+    proof_digit: str,
+) -> Path:
+    package_name = distribution_name.replace("-", "_")
+    package_dir = site_packages / package_name
+    dist_info = site_packages / f"{distribution_name}-1.0.dist-info"
+    package_dir.mkdir()
+    dist_info.mkdir()
+
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    proof_name = f"blake3-512:{proof_digit * 128}.proof"
+    proof_path = package_dir / proof_name
+    proof_path.write_text(f"synthetic proof for {distribution_name}\n", encoding="utf-8")
+
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {distribution_name}\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (dist_info / "WHEEL").write_text("Wheel-Version: 1.0\n", encoding="utf-8")
+    (dist_info / "RECORD").write_text(
+        "\n".join(
+            [
+                f"{package_name}/__init__.py,,",
+                f"{package_name}/{proof_name},,",
+                f"{distribution_name}-1.0.dist-info/METADATA,,",
+                f"{distribution_name}-1.0.dist-info/WHEEL,,",
+                f"{distribution_name}-1.0.dist-info/RECORD,,",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return proof_path

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1913,6 +1913,7 @@ dependencies = [
 name = "provekit-realize-rust-core"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "provekit-canonicalizer",
  "provekit-ir-types",
  "provekit-proof-envelope",

--- a/implementations/rust/provekit-cli/src/cmd_prove.rs
+++ b/implementations/rust/provekit-cli/src/cmd_prove.rs
@@ -544,23 +544,22 @@ pub fn run(args: ProveArgs) -> u8 {
         }
     }
 
-    let dependency_proof_files =
-        match crate::kit_dispatch::dependency_proof_paths_via_rpc(&project_root) {
-            Ok(paths) => paths,
-            Err(error) => {
-                eprintln!(
-                    "{}: dependency proof resolution skipped: {error}",
-                    "warning".yellow().bold()
-                );
-                Vec::new()
-            }
-        };
+    let dependency_proofs = match crate::kit_dispatch::dependency_proofs_via_rpc(&project_root) {
+        Ok(proofs) => proofs,
+        Err(error) => {
+            eprintln!(
+                "{}: dependency proof resolution skipped: {error}",
+                "warning".yellow().bold()
+            );
+            Vec::new()
+        }
+    };
 
     let cfg = RunnerConfig {
         project_root: project_root.clone(),
         z3_path: args.z3,
         extra_projects,
-        extra_proof_files: dependency_proof_files,
+        extra_proofs: dependency_proofs,
         ..Default::default()
     };
     let runner = Runner::new(cfg);

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -34,6 +34,7 @@
 // Per Supra omnia, rectum the dispatcher refuses loudly with a gap record
 // the caller turns into a `GapRecord` and propagates downstream.
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{BufRead, BufReader, Write};
@@ -52,6 +53,7 @@ use provekit_plugin_loader::{
     cid::compute_plugin_cid, write_plugin_registry_memento, PluginEnvelope, PluginHeader,
     PluginMemento, PluginMetadata, PluginRegistry, PluginRegistryMemento,
 };
+use provekit_verifier::load_all_proofs::ProofBytes;
 
 use crate::project_config::read_project_config;
 
@@ -351,11 +353,11 @@ fn read_provides_concepts_from_manifest_source(workspace_root: &Path, source: &s
     }
 }
 
-/// Ask every configured kit plugin for dependency `.proof` files resolved from
+/// Ask every configured kit plugin for dependency proof catalogs resolved from
 /// the project's package-manager graph. The substrate stays language-blind:
-/// this function only iterates configured plugin commands, invokes the common
-/// RPC verb, and returns proof file paths for the verifier to content-address.
-pub fn dependency_proof_paths_via_rpc(workspace_root: &Path) -> Result<Vec<PathBuf>, String> {
+/// this function only iterates configured plugin commands and consumes proof
+/// bytes over RPC. The CLI never follows package-system `.proof` paths.
+pub fn dependency_proofs_via_rpc(workspace_root: &Path) -> Result<Vec<ProofBytes>, String> {
     let registry = run_plugin_registry_for_project(workspace_root)?;
     let mut commands: BTreeMap<String, ResolvedCommand> = BTreeMap::new();
     for plugin in registry
@@ -372,26 +374,29 @@ pub fn dependency_proof_paths_via_rpc(workspace_root: &Path) -> Result<Vec<PathB
             .or_insert_with(|| command);
     }
 
-    let mut proof_paths = BTreeSet::new();
+    let mut proofs = Vec::new();
     for command in commands.values() {
-        let Some(paths) = dependency_proof_paths_for_command(workspace_root, command)? else {
+        let Some(mut resolved) = dependency_proofs_for_command(workspace_root, command)? else {
             continue;
         };
-        for path in paths {
-            proof_paths.insert(path);
-        }
+        proofs.append(&mut resolved);
     }
-    Ok(proof_paths.into_iter().collect())
+    proofs.sort_by(|a, b| {
+        (a.expected_cid.as_deref(), a.label.as_str())
+            .cmp(&(b.expected_cid.as_deref(), b.label.as_str()))
+    });
+    proofs.dedup_by(|a, b| a.expected_cid == b.expected_cid && a.bytes == b.bytes);
+    Ok(proofs)
 }
 
 fn command_key(command: &ResolvedCommand) -> String {
     format!("{:?}\u{0}{:?}", command.argv, command.working_dir)
 }
 
-fn dependency_proof_paths_for_command(
+fn dependency_proofs_for_command(
     workspace_root: &Path,
     cmd_spec: &ResolvedCommand,
-) -> Result<Option<Vec<PathBuf>>, String> {
+) -> Result<Option<Vec<ProofBytes>>, String> {
     let mut command = Command::new(&cmd_spec.argv[0]);
     if cmd_spec.argv.len() > 1 {
         command.args(&cmd_spec.argv[1..]);
@@ -475,57 +480,95 @@ fn dependency_proof_paths_for_command(
         return Err(format!("dependency proof resolver error: {error}"));
     }
 
-    let paths = response
-        .get("result")
-        .and_then(|result| {
-            result
-                .get("proof_paths")
-                .or_else(|| result.get("proofPaths"))
-                .or_else(|| result.get("paths"))
-        })
+    let result = response.get("result").cloned().unwrap_or(Value::Null);
+    let proofs = result
+        .get("proofs")
+        .or_else(|| result.get("proofs_base64"))
+        .or_else(|| result.get("proofBytes"))
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default();
     let mut out = Vec::new();
-    for path in paths {
-        let Some(path) = path.as_str() else {
-            record_dependency_proof_diagnostic(format!(
-                "dependency proof resolver {:?} returned a non-string path: {path}",
-                cmd_spec.argv
-            ));
-            continue;
-        };
-        if let Some(path) = normalize_dependency_proof_path(workspace_root, path) {
-            out.push(path);
+    for proof in proofs {
+        match decode_dependency_proof_entry(cmd_spec, &proof) {
+            Some(decoded) => out.push(decoded),
+            None => continue,
         }
     }
-    out.sort();
-    out.dedup();
+
+    let legacy_paths = result
+        .get("proof_paths")
+        .or_else(|| result.get("proofPaths"))
+        .or_else(|| result.get("paths"))
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    if legacy_paths > 0 {
+        record_dependency_proof_diagnostic(format!(
+            "dependency proof resolver {:?} returned legacy proof_paths; ignoring paths because package proof bytes must cross RPC",
+            cmd_spec.argv
+        ));
+    }
+
+    out.sort_by(|a, b| {
+        (a.expected_cid.as_deref(), a.label.as_str())
+            .cmp(&(b.expected_cid.as_deref(), b.label.as_str()))
+    });
+    out.dedup_by(|a, b| a.expected_cid == b.expected_cid && a.bytes == b.bytes);
     Ok(Some(out))
 }
 
-fn normalize_dependency_proof_path(workspace_root: &Path, path: &str) -> Option<PathBuf> {
-    let path = PathBuf::from(path);
-    let resolved = if path.is_absolute() {
-        path
-    } else {
-        workspace_root.join(path)
+fn decode_dependency_proof_entry(cmd_spec: &ResolvedCommand, proof: &Value) -> Option<ProofBytes> {
+    let Some(object) = proof.as_object() else {
+        record_dependency_proof_diagnostic(format!(
+            "dependency proof resolver {:?} returned a non-object proof entry: {proof}",
+            cmd_spec.argv
+        ));
+        return None;
     };
-    if resolved.extension().and_then(|s| s.to_str()) != Some("proof") {
+    let expected_cid = object
+        .get("cid")
+        .or_else(|| object.get("proof_cid"))
+        .or_else(|| object.get("proofCid"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let Some(bytes_base64) = object
+        .get("bytes_base64")
+        .or_else(|| object.get("bytesBase64"))
+        .and_then(Value::as_str)
+    else {
         record_dependency_proof_diagnostic(format!(
-            "dependency proof resolver returned non-.proof path {}; skipping",
-            resolved.display()
+            "dependency proof resolver {:?} returned a proof entry without bytes_base64: {proof}",
+            cmd_spec.argv
         ));
         return None;
-    }
-    if !resolved.is_file() {
-        record_dependency_proof_diagnostic(format!(
-            "dependency proof resolver returned missing path {}; skipping",
-            resolved.display()
-        ));
-        return None;
-    }
-    Some(resolved)
+    };
+    let bytes = match BASE64.decode(bytes_base64) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            record_dependency_proof_diagnostic(format!(
+                "dependency proof resolver {:?} returned invalid bytes_base64: {error}",
+                cmd_spec.argv
+            ));
+            return None;
+        }
+    };
+    let derived_cid = blake3_512_of(&bytes);
+    let label = object
+        .get("source")
+        .or_else(|| object.get("label"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| expected_cid.clone())
+        .unwrap_or(derived_cid);
+
+    Some(ProofBytes {
+        label,
+        expected_cid,
+        bytes,
+    })
 }
 
 fn record_dependency_proof_diagnostic(message: String) {

--- a/implementations/rust/provekit-cli/tests/dependency_proof_pool_assembly.rs
+++ b/implementations/rust/provekit-cli/tests/dependency_proof_pool_assembly.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use provekit_canonicalizer::{blake3_512_of, encode_jcs};
 use provekit_proof_envelope::{
     build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
@@ -87,7 +88,7 @@ fn write_proof(dir: &Path, name: &str, members: BTreeMap<String, Vec<u8>>) -> St
     built.cid
 }
 
-fn publish_vendor_positive_contract(vendor_dir: &Path) -> (String, String, PathBuf) {
+fn publish_vendor_positive_contract(vendor_dir: &Path) -> (String, String, PathBuf, Vec<u8>) {
     let target_env = json!({
         "evidence": {
             "kind": "contract",
@@ -113,7 +114,8 @@ fn publish_vendor_positive_contract(vendor_dir: &Path) -> (String, String, PathB
         .map(|entry| entry.path())
         .find(|path| path.extension().and_then(|s| s.to_str()) == Some("proof"))
         .expect("vendor proof exists");
-    (target_cid, bundle_cid, proof_path)
+    let proof_bytes = fs::read(&proof_path).expect("read vendor proof bytes");
+    (target_cid, bundle_cid, proof_path, proof_bytes)
 }
 
 fn publish_user_bridge(project_dir: &Path, target_cid: &str, target_bundle_cid: &str) {
@@ -254,13 +256,14 @@ fn publish_contradictory_implication_project() -> PathBuf {
     project
 }
 
-fn install_dependency_proof_stub(project_dir: &Path, proof_path: &Path) {
+fn install_dependency_proof_stub(project_dir: &Path, proof_cid: &str, proof_bytes: &[u8]) {
     let bin = project_dir.join("resolve-deps-stub.sh");
+    let proof_bytes_base64 = BASE64.encode(proof_bytes);
     fs::write(
         &bin,
         format!(
-            "#!/bin/sh\nwhile IFS= read -r line; do\n  case \"$line\" in\n    *resolve_dependency_proofs*) echo '{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{\"proof_paths\":[\"{}\"]}}}}' ;;\n    *shutdown*) echo '{{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":null}}'; exit 0 ;;\n    *) echo '{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{}}}}' ;;\n  esac\ndone\n",
-            proof_path.display()
+            "#!/bin/sh\nwhile IFS= read -r line; do\n  case \"$line\" in\n    *resolve_dependency_proofs*) echo '{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{\"proofs\":[{{\"cid\":\"{}\",\"bytes_base64\":\"{}\",\"source\":\"stub-package-proof\"}}]}}}}' ;;\n    *shutdown*) echo '{{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":null}}'; exit 0 ;;\n    *) echo '{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{}}}}' ;;\n  esac\ndone\n",
+            proof_cid, proof_bytes_base64
         ),
     )
     .expect("write stub");
@@ -291,17 +294,23 @@ fn dependency_rpc_union_makes_vendor_contract_reachable() {
     let project = root.join("user");
     let vendor = root.join("vendor");
     fs::create_dir_all(project.join(".provekit")).expect("mkdir project");
-    let (target_cid, bundle_cid, proof_path) = publish_vendor_positive_contract(&vendor);
+    let (target_cid, bundle_cid, proof_path, proof_bytes) =
+        publish_vendor_positive_contract(&vendor);
     publish_user_bridge(&project, &target_cid, &bundle_cid);
-    install_dependency_proof_stub(&project, &proof_path);
+    install_dependency_proof_stub(&project, &bundle_cid, &proof_bytes);
+    fs::remove_file(&proof_path).expect("remove dependency proof path after kit reads it");
 
-    let dependency_proofs = provekit_cli::kit_dispatch::dependency_proof_paths_via_rpc(&project)
+    let dependency_proofs = provekit_cli::kit_dispatch::dependency_proofs_via_rpc(&project)
         .expect("resolve dependency proofs");
-    assert_eq!(dependency_proofs, vec![proof_path.clone()]);
+    assert_eq!(dependency_proofs.len(), 1);
+    assert_eq!(
+        dependency_proofs[0].expected_cid.as_deref(),
+        Some(bundle_cid.as_str())
+    );
 
     let runner = Runner::new(RunnerConfig {
         project_root: project.clone(),
-        extra_proof_files: dependency_proofs,
+        extra_proofs: dependency_proofs,
         ..Default::default()
     });
     let (pool, _callsites) = runner.run_load_and_enumerate();
@@ -323,9 +332,11 @@ fn voltron_pool_refuses_cross_dependency_violation() {
     let project = root.join("user");
     let vendor = root.join("vendor");
     fs::create_dir_all(project.join(".provekit")).expect("mkdir project");
-    let (target_cid, bundle_cid, proof_path) = publish_vendor_positive_contract(&vendor);
+    let (target_cid, bundle_cid, proof_path, proof_bytes) =
+        publish_vendor_positive_contract(&vendor);
     publish_user_bridge(&project, &target_cid, &bundle_cid);
-    install_dependency_proof_stub(&project, &proof_path);
+    install_dependency_proof_stub(&project, &bundle_cid, &proof_bytes);
+    fs::remove_file(&proof_path).expect("remove dependency proof path after kit reads it");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_provekit"))
         .arg("prove")

--- a/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
+++ b/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
@@ -25,9 +25,7 @@ use std::process::Command;
 use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
-use provekit_cli::kit_dispatch::{
-    dependency_proof_paths_via_rpc, dispatch_realize, RealizeRequest,
-};
+use provekit_cli::kit_dispatch::{dependency_proofs_via_rpc, dispatch_realize, RealizeRequest};
 use provekit_proof_envelope::{
     build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
 };
@@ -373,21 +371,22 @@ fn go_dependency_proofs_are_resolved_by_configured_go_kit() {
     let proof_name = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.proof";
     let expected = write_go_dependency_with_proof(workspace.path(), proof_name);
 
-    let paths = dependency_proof_paths_via_rpc(workspace.path())
+    let proofs = dependency_proofs_via_rpc(workspace.path())
         .expect("CLI must ask the configured Go kit over RPC for dependency proofs");
 
     assert_eq!(
-        paths.len(),
+        proofs.len(),
         1,
         "dependency proof resolution must be kit-owned and config/manifest-driven"
     );
+    let expected_bytes = fs::read(&expected).expect("read expected dependency proof");
     assert_eq!(
-        paths[0].file_name(),
-        expected.file_name(),
-        "resolved proof must preserve the content-addressed proof filename"
+        blake3_512_of(&proofs[0].bytes),
+        blake3_512_of(&expected_bytes),
+        "resolved proof must preserve content-addressed proof bytes"
     );
-    assert_ne!(
-        paths[0], expected,
+    assert!(
+        proofs[0].label != expected.display().to_string(),
         "the Go kit must not hand the CLI a Go module-internal proof path"
     );
 }

--- a/implementations/rust/provekit-realize-rust-core/Cargo.toml
+++ b/implementations/rust/provekit-realize-rust-core/Cargo.toml
@@ -15,6 +15,7 @@ name = "provekit-realize-rust"
 path = "src/main.rs"
 
 [dependencies]
+base64 = { workspace = true }
 provekit-canonicalizer = { path = "../provekit-canonicalizer" }
 provekit-ir-types = { path = "../provekit-ir-types" }
 provekit-proof-envelope = { path = "../provekit-proof-envelope" }

--- a/implementations/rust/provekit-realize-rust-core/src/lib.rs
+++ b/implementations/rust/provekit-realize-rust-core/src/lib.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_ir_types::realization_tags::tag_sugar_carrier;
 use serde_json::{json, Value};
@@ -2372,6 +2373,15 @@ fn collect_package_proof_files(package_dir: &Path, proof_paths: &mut BTreeSet<Pa
     }
 }
 
+fn dependency_proof_json(path: &Path) -> Option<Value> {
+    let bytes = std::fs::read(path).ok()?;
+    Some(json!({
+        "cid": blake3_512_of(&bytes),
+        "bytes_base64": BASE64.encode(bytes),
+        "source": path.display().to_string()
+    }))
+}
+
 pub fn dispatch(request: &Value) -> Value {
     let id = request.get("id").cloned().unwrap_or(Value::Null);
     let method = request.get("method").and_then(Value::as_str).unwrap_or("");
@@ -2407,9 +2417,9 @@ pub fn dispatch(request: &Value) -> Value {
                     "jsonrpc": "2.0",
                     "id": id,
                     "result": {
-                        "proof_paths": paths
+                        "proofs": paths
                             .iter()
-                            .map(|path| path.display().to_string())
+                            .filter_map(|path| dependency_proof_json(path))
                             .collect::<Vec<_>>()
                     }
                 }),
@@ -4715,16 +4725,18 @@ mod tests {
             response.get("error").is_none(),
             "resolver must be implemented by the Rust kit; got {response}"
         );
-        let paths = response
-            .pointer("/result/proof_paths")
+        let proofs = response
+            .pointer("/result/proofs")
             .and_then(Value::as_array)
             .cloned()
             .unwrap_or_default();
         assert!(
-            paths
+            proofs
                 .iter()
-                .any(|path| path.as_str() == Some(proof_path.to_str().unwrap())),
-            "expected dependency proof path {} in response {response}",
+                .any(|proof| proof.get("source").and_then(Value::as_str)
+                    == Some(proof_path.to_str().unwrap())
+                    && proof.get("bytes_base64").and_then(Value::as_str).is_some()),
+            "expected dependency proof bytes sourced from {} in response {response}",
             proof_path.display()
         );
         let _ = fs::remove_dir_all(root);

--- a/implementations/rust/provekit-verifier/src/load_all_proofs.rs
+++ b/implementations/rust/provekit-verifier/src/load_all_proofs.rs
@@ -28,6 +28,13 @@ use crate::types::{LoadError, MementoPool};
 const HASH_TAG_PREFIX: &str = "blake3-512:";
 const SIG_TAG_PREFIX: &str = "ed25519:";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofBytes {
+    pub label: String,
+    pub expected_cid: Option<String>,
+    pub bytes: Vec<u8>,
+}
+
 pub fn run(project_root: &Path) -> MementoPool {
     let mut pool = MementoPool::default();
     for path in enumerate_proof_files(project_root) {
@@ -48,6 +55,23 @@ pub fn load_files_into_pool(proof_files: &[PathBuf], pool: &mut MementoPool) {
     proof_files.dedup();
     for path in proof_files {
         load_path_into_pool(&path, pool);
+    }
+}
+
+pub fn load_proof_bytes_into_pool(proofs: &[ProofBytes], pool: &mut MementoPool) {
+    let mut proofs = proofs.to_vec();
+    proofs.sort_by(|a, b| {
+        (a.expected_cid.as_deref(), a.label.as_str())
+            .cmp(&(b.expected_cid.as_deref(), b.label.as_str()))
+    });
+    proofs.dedup_by(|a, b| a.expected_cid == b.expected_cid && a.bytes == b.bytes);
+    for proof in proofs {
+        load_bytes_into_pool(
+            &proof.label,
+            proof.expected_cid.as_deref(),
+            &proof.bytes,
+            pool,
+        );
     }
 }
 
@@ -84,6 +108,7 @@ fn enumerate_proof_files(project_root: &Path) -> Vec<PathBuf> {
 
 fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::error::Error>> {
     let bytes = std::fs::read(path)?;
+    let source_label = path.display().to_string();
 
     // Rule 1: filename CID matches content (trust root).
     let filename = path
@@ -100,7 +125,7 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
     let hex_only = filename_hex.chars().all(|c| c.is_ascii_hexdigit());
     if hex_only && filename_hex.len() == 128 && filename_hex != derived_hex {
         pool.load_errors.push(LoadError {
-            proof_path: path.display().to_string(),
+            proof_path: source_label,
             reason: format!(
                 "rule 1 (trust root): filename CID {filename_hex} != content hash {derived_hex}"
             ),
@@ -113,7 +138,7 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
     // it must be blake3-512.)
     if !hex_only && !filename_hex.is_empty() {
         pool.load_errors.push(LoadError {
-            proof_path: path.display().to_string(),
+            proof_path: source_label,
             reason: format!(
                 "rule 1: filename '{filename}' has non-hex stem; v1.1.0 requires `blake3-512:`"
             ),
@@ -121,7 +146,43 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
         return Ok(());
     }
 
-    let catalog = decode(&bytes)?;
+    load_catalog_bytes(path.display().to_string(), None, &bytes, pool)
+}
+
+fn load_bytes_into_pool(
+    source_label: &str,
+    expected_cid: Option<&str>,
+    bytes: &[u8],
+    pool: &mut MementoPool,
+) {
+    if let Err(e) = load_catalog_bytes(source_label.to_string(), expected_cid, bytes, pool) {
+        pool.load_errors.push(LoadError {
+            proof_path: source_label.to_string(),
+            reason: format!("read/decode: {e}"),
+        });
+    }
+}
+
+fn load_catalog_bytes(
+    source_label: String,
+    expected_cid: Option<&str>,
+    bytes: &[u8],
+    pool: &mut MementoPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let derived_full = blake3_512_of(bytes);
+    if let Some(expected_cid) = expected_cid {
+        if expected_cid != derived_full {
+            pool.load_errors.push(LoadError {
+                proof_path: source_label,
+                reason: format!(
+                    "rule 1 (trust root): expected proof CID {expected_cid} != content hash {derived_full}"
+                ),
+            });
+            return Ok(());
+        }
+    }
+
+    let catalog = decode(bytes)?;
     let m_root = catalog.as_map().ok_or("catalog is not a map")?.clone();
 
     let members = m_root
@@ -132,7 +193,7 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
     for (cid, val) in members_map {
         if !cid.starts_with(HASH_TAG_PREFIX) {
             pool.load_errors.push(LoadError {
-                proof_path: path.display().to_string(),
+                proof_path: source_label.clone(),
                 reason: format!(
                     "member {cid}: unsupported hash tag; v1.1.0 requires `{HASH_TAG_PREFIX}`"
                 ),
@@ -143,7 +204,7 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
             Some(b) => b,
             None => {
                 pool.load_errors.push(LoadError {
-                    proof_path: path.display().to_string(),
+                    proof_path: source_label.clone(),
                     reason: format!("member {cid}: value is not bstr"),
                 });
                 continue;
@@ -154,7 +215,7 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
             Ok(v) => v,
             Err(e) => {
                 pool.load_errors.push(LoadError {
-                    proof_path: path.display().to_string(),
+                    proof_path: source_label.clone(),
                     reason: format!("member {cid}: JSON parse: {e}"),
                 });
                 continue;
@@ -170,7 +231,7 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
         if let Some(sig) = sig_str_opt {
             if !sig.starts_with(SIG_TAG_PREFIX) {
                 pool.load_errors.push(LoadError {
-                    proof_path: path.display().to_string(),
+                    proof_path: source_label.clone(),
                     reason: format!(
                         "member {cid}: unsupported signature tag; v1.1.0 requires `{SIG_TAG_PREFIX}`"
                     ),
@@ -184,7 +245,7 @@ fn load_one(path: &Path, pool: &mut MementoPool) -> Result<(), Box<dyn std::erro
         let derived = compute_member_cid(&env);
         if derived != *cid {
             pool.load_errors.push(LoadError {
-                proof_path: path.display().to_string(),
+                proof_path: source_label.clone(),
                 reason: format!("rule 2: member {cid} derives to {derived}"),
             });
             continue;

--- a/implementations/rust/provekit-verifier/src/runner.rs
+++ b/implementations/rust/provekit-verifier/src/runner.rs
@@ -33,7 +33,8 @@ use crate::solvers::{
 };
 use crate::types::{CallSite, MementoPool, ObligationVerdict, Report};
 use crate::{
-    body_discharge, call_edge_loader, enumerate_callsites, instantiate, load_all_proofs,
+    body_discharge, call_edge_loader, enumerate_callsites, instantiate,
+    load_all_proofs::{self, ProofBytes},
     report as report_stage, resolve_target, smt_emitter,
 };
 
@@ -92,6 +93,9 @@ pub struct RunnerConfig {
     /// managers. These are still loaded by content address; the verifier
     /// never interprets the package graph that surfaced them.
     pub extra_proof_files: Vec<PathBuf>,
+    /// Additional proof catalogs carried over kit RPC. Package managers and
+    /// archive layouts stay kit-owned; the verifier consumes bytes only.
+    pub extra_proofs: Vec<ProofBytes>,
 }
 
 /// Per-solver telemetry, surfaced in the report alongside the legacy
@@ -187,6 +191,7 @@ impl Runner {
             pool.merge(extra_pool);
         }
         load_all_proofs::load_files_into_pool(&self.cfg.extra_proof_files, &mut pool);
+        load_all_proofs::load_proof_bytes_into_pool(&self.cfg.extra_proofs, &mut pool);
         let loaded_cids = sorted_keys(&pool.mementos);
         let load_diagnostics: Vec<Json> = pool
             .load_errors
@@ -392,6 +397,7 @@ impl Runner {
             pool.merge(extra_pool);
         }
         load_all_proofs::load_files_into_pool(&self.cfg.extra_proof_files, &mut pool);
+        load_all_proofs::load_proof_bytes_into_pool(&self.cfg.extra_proofs, &mut pool);
 
         // Load and process call edges
         let call_edges = call_edge_loader::load_call_edge_files(&self.cfg.project_root);
@@ -513,6 +519,7 @@ impl Runner {
             pool.merge(extra_pool);
         }
         load_all_proofs::load_files_into_pool(&self.cfg.extra_proof_files, &mut pool);
+        load_all_proofs::load_proof_bytes_into_pool(&self.cfg.extra_proofs, &mut pool);
         let cs = enumerate_callsites::run(&pool);
         (pool, cs)
     }
@@ -718,6 +725,9 @@ fn discover_input_artifact_cids(cfg: &RunnerConfig) -> BTreeSet<String> {
     }
     for proof_file in &cfg.extra_proof_files {
         collect_one_proof_file_cid(proof_file, &mut cids);
+    }
+    for proof in &cfg.extra_proofs {
+        cids.insert(provekit_canonicalizer::blake3_512_of(&proof.bytes));
     }
     cids
 }

--- a/implementations/rust/provekit-verifier/tests/multi_solver_modes.rs
+++ b/implementations/rust/provekit-verifier/tests/multi_solver_modes.rs
@@ -286,6 +286,7 @@ binary = "stub:unsat"
         ),
         extra_projects: Vec::new(),
         extra_proof_files: Vec::new(),
+        extra_proofs: Vec::new(),
     };
     let runner = Runner::new(cfg);
     let (report, stats) = runner.run_with_tiers();

--- a/implementations/typescript/provekit-realize-typescript-better-sqlite3/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-better-sqlite3/src/rpc.js
@@ -3,6 +3,7 @@ const readline = require("node:readline");
 const realizer = require("./realizer");
 const { emitStub } = realizer;
 const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
+const { resolveDependencyProofs } = require("../../provekit-realize-typescript-core/src/dependency_proofs");
 
 function runRpc() {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
@@ -60,8 +61,7 @@ function dispatch(request) {
     return { jsonrpc: "2.0", id: msgId, result: { entries, proof_path: proofPath } };
   }
   if (method === "provekit.plugin.resolve_dependency_proofs") {
-    console.error("provekit-realize-typescript-better-sqlite3: resolve_dependency_proofs not yet implemented for typescript; returning empty proof_paths");
-    return { jsonrpc: "2.0", id: msgId, result: { proof_paths: [] } };
+    return { jsonrpc: "2.0", id: msgId, result: { proofs: resolveDependencyProofs(params.project_root) } };
   }
   if (method === "provekit.plugin.shutdown") {
     return { jsonrpc: "2.0", id: msgId, result: null };

--- a/implementations/typescript/provekit-realize-typescript-better-sqlite3/tests/rpc.test.js
+++ b/implementations/typescript/provekit-realize-typescript-better-sqlite3/tests/rpc.test.js
@@ -1,0 +1,61 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { dispatch } = require("../src/rpc");
+
+function makeProject() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "provekit-ts-sqlite-dep-proofs-"));
+  fs.writeFileSync(path.join(root, "package.json"), "{\"private\":true}\n");
+  fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+  return root;
+}
+
+function writePackage(root, packageName) {
+  const packageRoot = packageName.startsWith("@")
+    ? path.join(root, "node_modules", ...packageName.split("/"))
+    : path.join(root, "node_modules", packageName);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify({ name: packageName, version: "1.0.0" })}\n`,
+  );
+  return packageRoot;
+}
+
+function writeProof(packageRoot, hex) {
+  const proofPath = path.join(packageRoot, `blake3-512:${hex}.proof`);
+  fs.writeFileSync(proofPath, "synthetic better-sqlite3 dependency proof\n");
+  return proofPath;
+}
+
+test("resolve_dependency_proofs returns node_modules proof bytes", () => {
+  const projectRoot = makeProject();
+  try {
+    const proofPath = writeProof(writePackage(projectRoot, "sqlite-dep"), "d".repeat(128));
+
+    const response = dispatch({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "provekit.plugin.resolve_dependency_proofs",
+      params: { project_root: projectRoot },
+    });
+
+    assert.equal(response.jsonrpc, "2.0");
+    assert.equal(response.id, 7);
+    assert.equal(response.error, undefined);
+    const proof = response.result.proofs[0];
+    assert.equal(proof.cid, path.basename(proofPath, ".proof"));
+    assert.equal(
+      Buffer.from(proof.bytes_base64, "base64").toString("utf8"),
+      "synthetic better-sqlite3 dependency proof\n",
+    );
+    assert.equal(proof.source, `typescript-package:${path.basename(proofPath)}`);
+  } finally {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});

--- a/implementations/typescript/provekit-realize-typescript-core/src/dependency_proofs.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/dependency_proofs.js
@@ -22,6 +22,17 @@ function resolveDependencyProofPaths(projectRoot) {
   return Array.from(proofPaths).sort();
 }
 
+function resolveDependencyProofs(projectRoot) {
+  return resolveDependencyProofPaths(projectRoot).map((proofPath) => {
+    const fileName = path.basename(proofPath);
+    return {
+      cid: fileName.replace(/\.proof$/, ""),
+      bytes_base64: fs.readFileSync(proofPath).toString("base64"),
+      source: `typescript-package:${fileName}`,
+    };
+  });
+}
+
 function walkNodeModules(nodeModulesDir, state) {
   const realNodeModules = realDirectoryPath(nodeModulesDir);
   if (realNodeModules === null || state.visitedNodeModules.has(realNodeModules)) return;
@@ -103,5 +114,6 @@ function realDirectoryPath(candidate) {
 }
 
 module.exports = {
+  resolveDependencyProofs,
   resolveDependencyProofPaths,
 };

--- a/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
@@ -1,6 +1,6 @@
 const readline = require("node:readline");
 
-const { resolveDependencyProofPaths } = require("./dependency_proofs");
+const { resolveDependencyProofs } = require("./dependency_proofs");
 const { emitStub } = require("./realizer");
 const { answers: literalEncodingAnswers } = require("./literal_encoding");
 const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
@@ -61,7 +61,7 @@ function dispatch(request) {
       return {
         jsonrpc: "2.0",
         id: msgId,
-        result: { proof_paths: resolveDependencyProofPaths(projectRoot) },
+        result: { proofs: resolveDependencyProofs(projectRoot) },
       };
     } catch (error) {
       return errorResponse(msgId, -32030, `RESOLVE_DEPENDENCY_PROOFS_FAILED: ${error.message}`);

--- a/implementations/typescript/provekit-realize-typescript-core/tests/dependency_proofs.test.js
+++ b/implementations/typescript/provekit-realize-typescript-core/tests/dependency_proofs.test.js
@@ -85,11 +85,16 @@ test("resolve_dependency_proofs returns absolute readable proofs from node_modul
     assert.equal(response.jsonrpc, "2.0");
     assert.equal(response.id, 7);
     assert.equal(response.error, undefined);
-    const proofPaths = response.result.proof_paths.toSorted();
-    assert.deepEqual(proofPaths, [proofOne, proofTwo].toSorted());
-    for (const proofPath of proofPaths) {
-      assert.equal(path.isAbsolute(proofPath), true);
-      assert.equal(fs.statSync(proofPath).isFile(), true);
+    const proofs = response.result.proofs.toSorted((a, b) => a.cid.localeCompare(b.cid));
+    assert.deepEqual(
+      proofs.map((proof) => proof.cid),
+      [`blake3-512:${"a".repeat(128)}`, `blake3-512:${"b".repeat(128)}`],
+    );
+    for (const proof of proofs) {
+      assert.equal(Buffer.from(proof.bytes_base64, "base64").toString("utf8"), "synthetic dependency proof\n");
+      assert.equal(proof.source.startsWith("typescript-package:"), true);
+      assert.notEqual(proof.source, proofOne);
+      assert.notEqual(proof.source, proofTwo);
     }
   } finally {
     fs.rmSync(projectRoot, { recursive: true, force: true });
@@ -106,7 +111,7 @@ test("resolve_dependency_proofs returns an empty array when dependencies have no
     assert.equal(response.jsonrpc, "2.0");
     assert.equal(response.id, 7);
     assert.equal(response.error, undefined);
-    assert.deepEqual(response.result.proof_paths, []);
+    assert.deepEqual(response.result.proofs, []);
   } finally {
     fs.rmSync(projectRoot, { recursive: true, force: true });
   }

--- a/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
@@ -3,6 +3,7 @@ const readline = require("node:readline");
 const realizer = require("./realizer");
 const { emitStub } = realizer;
 const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
+const { resolveDependencyProofs } = require("../../provekit-realize-typescript-core/src/dependency_proofs");
 
 function runRpc() {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
@@ -60,8 +61,7 @@ function dispatch(request) {
     return { jsonrpc: "2.0", id: msgId, result: { entries, proof_path: proofPath } };
   }
   if (method === "provekit.plugin.resolve_dependency_proofs") {
-    console.error("provekit-realize-typescript-pg: resolve_dependency_proofs not yet implemented for typescript; returning empty proof_paths");
-    return { jsonrpc: "2.0", id: msgId, result: { proof_paths: [] } };
+    return { jsonrpc: "2.0", id: msgId, result: { proofs: resolveDependencyProofs(params.project_root) } };
   }
   if (method === "provekit.plugin.shutdown") {
     return { jsonrpc: "2.0", id: msgId, result: null };

--- a/implementations/typescript/provekit-realize-typescript-pg/tests/rpc.test.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/tests/rpc.test.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { dispatch } = require("../src/rpc");
+
+function makeProject() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "provekit-ts-pg-dep-proofs-"));
+  fs.writeFileSync(path.join(root, "package.json"), "{\"private\":true}\n");
+  fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+  return root;
+}
+
+function writePackage(root, packageName) {
+  const packageRoot = packageName.startsWith("@")
+    ? path.join(root, "node_modules", ...packageName.split("/"))
+    : path.join(root, "node_modules", packageName);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify({ name: packageName, version: "1.0.0" })}\n`,
+  );
+  return packageRoot;
+}
+
+function writeProof(packageRoot, hex) {
+  const proofPath = path.join(packageRoot, `blake3-512:${hex}.proof`);
+  fs.writeFileSync(proofPath, "synthetic pg dependency proof\n");
+  return proofPath;
+}
+
+test("resolve_dependency_proofs returns node_modules proof bytes", () => {
+  const projectRoot = makeProject();
+  try {
+    const proofPath = writeProof(writePackage(projectRoot, "pg-dep"), "c".repeat(128));
+
+    const response = dispatch({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "provekit.plugin.resolve_dependency_proofs",
+      params: { project_root: projectRoot },
+    });
+
+    assert.equal(response.jsonrpc, "2.0");
+    assert.equal(response.id, 7);
+    assert.equal(response.error, undefined);
+    const proof = response.result.proofs[0];
+    assert.equal(proof.cid, path.basename(proofPath, ".proof"));
+    assert.equal(Buffer.from(proof.bytes_base64, "base64").toString("utf8"), "synthetic pg dependency proof\n");
+    assert.equal(proof.source, `typescript-package:${path.basename(proofPath)}`);
+  } finally {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});

--- a/protocol/specs/2026-05-12-plugin-protocol.md
+++ b/protocol/specs/2026-05-12-plugin-protocol.md
@@ -262,7 +262,7 @@ Kit-owned package-manager proof resolution. The runtime calls this method before
 verification pool assembly. The substrate MUST NOT inspect cargo metadata,
 classpath entries, node_modules, sys.path, or any other platform dependency
 graph directly; it passes the project root to configured kits and unions the
-returned `.proof` bundles by CID.
+returned proof catalog bytes by CID.
 
 Request:
 ```json
@@ -282,17 +282,25 @@ Response (success):
   "jsonrpc": "2.0",
   "id": 3,
   "result": {
-    "proof_paths": ["/absolute/vendor/package/blake3-512:<hex>.proof"]
+    "proofs": [
+      {
+        "cid": "blake3-512:<hex>",
+        "bytes_base64": "<standard-base64-proof-catalog-bytes>",
+        "source": "diagnostic-kit-owned-label"
+      }
+    ]
   }
 }
 ```
 
-`proof_paths` entries MUST name `.proof` bundle files. Implementations MAY
-return an empty array when the language kit has no implementation yet, but MUST
-log that language-specific dependency proof resolution is not implemented. The
-runtime MUST treat the returned bundles as opaque content-addressed proof files:
-load by bytes, recompute bundle and member CIDs, and union members. It MUST NOT
-extract formulas for rewriting or reinterpret package-manager metadata.
+`proofs` entries MUST carry opaque `.proof` catalog bytes in `bytes_base64`.
+`cid`, when present, MUST match the content CID of those bytes. `source` is a
+diagnostic label only and MUST NOT be treated as filesystem or package-manager
+authority. Implementations MAY return an empty array when the language kit has
+no implementation yet, but MUST log that language-specific dependency proof
+resolution is not implemented. The runtime MUST load by bytes, recompute bundle
+and member CIDs, and union members. It MUST NOT extract formulas for rewriting,
+follow kit-supplied `.proof` paths, or reinterpret package-manager metadata.
 
 #### §4.2.4 `provekit.plugin.shutdown`
 


### PR DESCRIPTION
## Summary
- Change `provekit.plugin.resolve_dependency_proofs` from kit-returned `.proof` paths to plural proof-byte payloads: `{ proofs: [{ cid, bytes_base64, source }] }`.
- Teach the Rust CLI/verifier to consume in-memory proof catalogs from kit RPC, content-address the bytes, verify optional expected CIDs, and ignore legacy `proof_paths` instead of following them.
- Update Java, Go, Python, Rust, TypeScript, and C kit RPC surfaces to return proof data, with kit-local package resolution remaining inside each kit.
- Include Python and TypeScript library-specific wrapper kits, not only their core kits, so project-registered package emitters/realizers also return proof bytes over RPC.
- Update the plugin protocol spec so the RPC seam is proof data over RPC, not path authority.

## Verification
- `make cross-language-proof-parity` PASS for Java/Go/Python/Rust emit, materialize, prove, and contradiction parity.
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test dependency_proof_pool_assembly -- --nocapture`
- `PYTHON=$(command -v python3) cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture`
- `go test ./...` in `implementations/go/provekit-realize-go-core`
- `python3 -m pytest implementations/python/provekit-realize-python-core/tests implementations/python/provekit-realize-python-requests/tests implementations/python/provekit-realize-python-sqlite3/tests implementations/python/provekit-realize-python-aiosqlite/tests -q`
- `mvn -q -f implementations/java/pom.xml -pl provekit-realize-java-core -am -Dtest=RpcServerDependencyProofsTest test`
- `node --test tests/dependency_proofs.test.js` in `implementations/typescript/provekit-realize-typescript-core`
- `npm install --ignore-scripts && npm test` in `implementations/typescript/provekit-realize-typescript-pg`
- `npm install --ignore-scripts && npm test` in `implementations/typescript/provekit-realize-typescript-better-sqlite3`
- `node --check` for touched TypeScript RPC files
- `make -C implementations/c/provekit-realize-c-core test`
- repo-root `npm test` PASS: 41 files, 864 passed, 4 todo
- `git diff --check`

## Existing Drift Observed
- `npm test` inside `implementations/typescript/provekit-realize-typescript-core` still fails on `origin/main` for the existing pg body-template tests; the dependency-proof RPC test added/updated here passes on both the branch and main.
