### PR TITLE
feat(go): add testify emit kit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -675,6 +675,9 @@ cross-language-proof-parity: build-java cross-language-proof-parity-python-env
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_go_testing \
 		emit_go_testing_dispatches_manifest_writes_artifact_and_compile_checks
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_emit_go_testify \
+		emit_go_testify_dispatches_separate_emitter_and_compile_checks
 	PYTHON=$(PARITY_PYTHON) PATH=$(PARITY_PYTHON_BIN):$(PATH) cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_python_pytest \
 		emit_python_pytest_dispatches_real_emitter_and_pytest_checks_output

--- a/implementations/go/provekit-emit-go-testify/cmd/provekit-emit-go-testify/main.go
+++ b/implementations/go/provekit-emit-go-testify/cmd/provekit-emit-go-testify/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	emitgotestify "github.com/tsavo/provekit/go/provekit-emit-go-testify"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--rpc" {
+		if err := emitgotestify.RunRPC(os.Stdin, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "provekit-emit-go-testify rpc: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	fmt.Fprintln(os.Stderr, "usage: provekit-emit-go-testify --rpc")
+	os.Exit(1)
+}

--- a/implementations/go/provekit-emit-go-testify/emitter.go
+++ b/implementations/go/provekit-emit-go-testify/emitter.go
@@ -1,0 +1,458 @@
+package emitgotestify
+
+import (
+	"fmt"
+	"go/token"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+)
+
+type EmitPlan struct {
+	ContractID  string           `json:"contract_id"`
+	PackageName string           `json:"package_name"`
+	Function    string           `json:"function"`
+	Params      []string         `json:"params"`
+	ParamTypes  []string         `json:"param_types"`
+	ReturnType  string           `json:"return_type"`
+	Predicates  []map[string]any `json:"predicates"`
+}
+
+type Emission struct {
+	Kind                  string   `json:"kind"`
+	Source                string   `json:"source"`
+	Path                  string   `json:"path"`
+	Extension             string   `json:"extension"`
+	EmittedArtifactCID    string   `json:"emitted_artifact_cid"`
+	EmittedPredicates     []string `json:"emitted_predicates"`
+	UnsupportedPredicates []string `json:"unsupported_predicates"`
+	IsComplete            bool     `json:"is_complete"`
+}
+
+func EmitPlanFromParams(params map[string]any) EmitPlan {
+	return EmitPlan{
+		ContractID:  firstString(params["contract_id"], params["concept_name"]),
+		PackageName: firstString(params["package_name"], params["package"], params["packageName"]),
+		Function:    firstString(params["function"], params["function_name"], params["functionName"]),
+		Params:      stringList(params["params"]),
+		ParamTypes:  stringList(params["param_types"]),
+		ReturnType:  firstString(params["return_type"], params["returnType"]),
+		Predicates:  mapList(params["predicates"]),
+	}
+}
+
+func Emit(plan EmitPlan) Emission {
+	pkg := sanitizeIdentifier(plan.PackageName, "provekit")
+	var functions []string
+	var emitted []string
+	var unsupported []string
+	needsErrors := false
+
+	for i, predicate := range plan.Predicates {
+		head := headOf(predicate)
+		assertion, ok := renderAssertion(head, predicate)
+		if !ok {
+			unsupported = append(unsupported, unsupportedName(head))
+			continue
+		}
+		vars := freeVars(predicate)
+		decls, declNeedsErrors := declarationsFor(head, vars)
+		if declNeedsErrors {
+			needsErrors = true
+		}
+		functions = append(functions, renderTestFunction(head, i, decls, assertion))
+		emitted = append(emitted, canonicalHead(head))
+	}
+
+	source := renderModule(pkg, functions, needsErrors)
+	return Emission{
+		Kind:                  "go-testify-test-emission",
+		Source:                source,
+		Path:                  "provekit_emitted_test.go",
+		Extension:             "go",
+		EmittedArtifactCID:    canonicalizer.ComputeCID([]byte(source)),
+		EmittedPredicates:     emitted,
+		UnsupportedPredicates: unsupported,
+		IsComplete:            len(unsupported) == 0 && len(emitted) > 0,
+	}
+}
+
+func renderModule(pkg string, functions []string, needsErrors bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "package %s\n", pkg)
+	if len(functions) > 0 {
+		b.WriteString("\nimport (\n")
+		if needsErrors {
+			b.WriteString("\t\"errors\"\n")
+		}
+		b.WriteString("\t\"testing\"\n\n")
+		b.WriteString("\t\"github.com/stretchr/testify/assert\"\n")
+		b.WriteString(")\n")
+	}
+	for _, fn := range functions {
+		b.WriteByte('\n')
+		b.WriteString(fn)
+		if !strings.HasSuffix(fn, "\n") {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func renderTestFunction(head string, index int, decls []string, assertion string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "func TestProvekit%s%d(t *testing.T) {\n", camelHead(head), index)
+	for _, decl := range decls {
+		fmt.Fprintf(&b, "\t%s\n", decl)
+	}
+	fmt.Fprintf(&b, "\t%s\n", assertion)
+	b.WriteString("}\n")
+	return b.String()
+}
+
+func renderAssertion(head string, predicate map[string]any) (string, bool) {
+	args := argsOf(predicate)
+	switch canonicalHead(head) {
+	case "eq":
+		return equalityTestify(args, "assert.Equal")
+	case "ne":
+		return equalityTestify(args, "assert.NotEqual")
+	case "lt":
+		return orderedTestify(args, "assert.Less")
+	case "gt":
+		return orderedTestify(args, "assert.Greater")
+	case "le":
+		return orderedTestify(args, "assert.LessOrEqual")
+	case "ge":
+		return orderedTestify(args, "assert.GreaterOrEqual")
+	case "option-is-some", "not-null":
+		return unaryTestify(args, "assert.NotNil")
+	case "option-is-none":
+		return unaryTestify(args, "assert.Nil")
+	case "fallible-err":
+		return unaryTestify(args, "assert.Error")
+	default:
+		return "", false
+	}
+}
+
+func equalityTestify(args []map[string]any, helper string) (string, bool) {
+	if len(args) != 2 {
+		return "", false
+	}
+	actual, ok := renderTerm(args[0])
+	if !ok {
+		return "", false
+	}
+	expected, ok := renderTerm(args[1])
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%s(t, %s, %s)", helper, expected, actual), true
+}
+
+func orderedTestify(args []map[string]any, helper string) (string, bool) {
+	if len(args) != 2 {
+		return "", false
+	}
+	left, ok := renderTerm(args[0])
+	if !ok {
+		return "", false
+	}
+	right, ok := renderTerm(args[1])
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%s(t, %s, %s)", helper, left, right), true
+}
+
+func unaryTestify(args []map[string]any, helper string) (string, bool) {
+	if len(args) != 1 {
+		return "", false
+	}
+	x, ok := renderTerm(args[0])
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%s(t, %s)", helper, x), true
+}
+
+func declarationsFor(head string, vars []string) ([]string, bool) {
+	decls := make([]string, 0, len(vars))
+	needsErrors := false
+	for i, name := range vars {
+		ident := sanitizeIdentifier(name, fmt.Sprintf("v%d", i))
+		switch canonicalHead(head) {
+		case "option-is-none":
+			decls = append(decls, fmt.Sprintf("var %s any = nil", ident))
+		case "option-is-some", "not-null":
+			decls = append(decls, fmt.Sprintf("%s := any(1)", ident))
+		case "fallible-err":
+			needsErrors = true
+			decls = append(decls, fmt.Sprintf("%s := errors.New(\"contract error\")", ident))
+		default:
+			decls = append(decls, fmt.Sprintf("%s := %s", ident, placeholderValue(head, i)))
+		}
+	}
+	return decls, needsErrors
+}
+
+func placeholderValue(head string, index int) string {
+	switch canonicalHead(head) {
+	case "lt":
+		if index == 0 {
+			return "0"
+		}
+		return "1"
+	case "gt":
+		if index == 0 {
+			return "1"
+		}
+		return "0"
+	case "ne":
+		if index == 0 {
+			return "0"
+		}
+		return "1"
+	default:
+		return "0"
+	}
+}
+
+func renderTerm(term map[string]any) (string, bool) {
+	kind, _ := term["kind"].(string)
+	switch kind {
+	case "var":
+		name, _ := term["name"].(string)
+		ident := sanitizeIdentifier(name, "")
+		if ident == "" {
+			return "", false
+		}
+		return ident, true
+	case "const":
+		return renderConst(term["value"])
+	case "op", "ctor":
+		return renderApplication(term)
+	default:
+		return "", false
+	}
+}
+
+func renderConst(value any) (string, bool) {
+	switch v := value.(type) {
+	case nil:
+		return "nil", true
+	case bool:
+		if v {
+			return "true", true
+		}
+		return "false", true
+	case int:
+		return strconv.Itoa(v), true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case float64:
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10), true
+		}
+		return strconv.FormatFloat(v, 'g', -1, 64), true
+	case string:
+		return strconv.Quote(v), true
+	default:
+		return "", false
+	}
+}
+
+func renderApplication(term map[string]any) (string, bool) {
+	name, _ := term["name"].(string)
+	name = strings.TrimPrefix(name, "concept:")
+	args := argsOf(term)
+	rendered := make([]string, 0, len(args))
+	for _, arg := range args {
+		r, ok := renderTerm(arg)
+		if !ok {
+			return "", false
+		}
+		rendered = append(rendered, r)
+	}
+	if isArithmetic(name) && len(rendered) == 2 {
+		return fmt.Sprintf("(%s %s %s)", rendered[0], name, rendered[1]), true
+	}
+	ident := sanitizeIdentifier(name, "")
+	if ident == "" {
+		return "", false
+	}
+	return fmt.Sprintf("%s(%s)", ident, strings.Join(rendered, ", ")), true
+}
+
+func freeVars(term map[string]any) []string {
+	var out []string
+	seen := map[string]bool{}
+	var walk func(map[string]any)
+	walk = func(node map[string]any) {
+		if node["kind"] == "var" {
+			name, _ := node["name"].(string)
+			if name != "" && !seen[name] {
+				seen[name] = true
+				out = append(out, name)
+			}
+			return
+		}
+		for _, arg := range argsOf(node) {
+			walk(arg)
+		}
+	}
+	walk(term)
+	return out
+}
+
+func headOf(predicate map[string]any) string {
+	name, _ := predicate["name"].(string)
+	return strings.TrimPrefix(name, "concept:")
+}
+
+func canonicalHead(head string) string {
+	switch head {
+	case "neq":
+		return "ne"
+	case "lte":
+		return "le"
+	case "gte":
+		return "ge"
+	default:
+		return head
+	}
+}
+
+func unsupportedName(head string) string {
+	if head == "" {
+		return "<malformed>"
+	}
+	return head
+}
+
+func argsOf(node map[string]any) []map[string]any {
+	switch raw := node["args"].(type) {
+	case []map[string]any:
+		return raw
+	case []any:
+		out := make([]map[string]any, 0, len(raw))
+		for _, item := range raw {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func isArithmetic(name string) bool {
+	switch name {
+	case "+", "-", "*", "/", "%":
+		return true
+	default:
+		return false
+	}
+}
+
+func camelHead(head string) string {
+	head = canonicalHead(head)
+	parts := strings.FieldsFunc(head, func(r rune) bool {
+		return r == '-' || r == '_' || r == ':' || r == '.'
+	})
+	if len(parts) == 0 {
+		return "Predicate"
+	}
+	var b strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		runes := []rune(part)
+		runes[0] = unicode.ToUpper(runes[0])
+		b.WriteString(string(runes))
+	}
+	if b.Len() == 0 {
+		return "Predicate"
+	}
+	return b.String()
+}
+
+func sanitizeIdentifier(name, fallback string) string {
+	if token.IsIdentifier(name) && !isKeyword(name) {
+		return name
+	}
+	if fallback != "" && token.IsIdentifier(fallback) && !isKeyword(fallback) {
+		return fallback
+	}
+	return ""
+}
+
+func isKeyword(name string) bool {
+	return token.Lookup(name).IsKeyword()
+}
+
+func firstString(values ...any) string {
+	for _, value := range values {
+		if s, ok := value.(string); ok && strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func stringList(value any) []string {
+	switch raw := value.(type) {
+	case []string:
+		return append([]string(nil), raw...)
+	case []any:
+		out := make([]string, 0, len(raw))
+		for _, item := range raw {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func mapList(value any) []map[string]any {
+	switch raw := value.(type) {
+	case []map[string]any:
+		return append([]map[string]any(nil), raw...)
+	case []any:
+		out := make([]map[string]any, 0, len(raw))
+		for _, item := range raw {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func supportedPredicates() []string {
+	out := []string{
+		"concept:eq",
+		"concept:ne",
+		"concept:lt",
+		"concept:gt",
+		"concept:le",
+		"concept:ge",
+		"concept:option-is-some",
+		"concept:option-is-none",
+		"concept:not-null",
+		"concept:fallible-err",
+	}
+	sort.Strings(out)
+	return out
+}

--- a/implementations/go/provekit-emit-go-testify/emitter_test.go
+++ b/implementations/go/provekit-emit-go-testify/emitter_test.go
@@ -1,0 +1,105 @@
+package emitgotestify
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func op(name string, args ...map[string]any) map[string]any {
+	return map[string]any{"kind": "op", "name": name, "args": args}
+}
+
+func v(name string) map[string]any {
+	return map[string]any{"kind": "var", "name": name}
+}
+
+func TestEmitUsesTestifyAssertions(t *testing.T) {
+	emission := Emit(EmitPlan{
+		PackageName: "sample",
+		Function:    "clamp",
+		Params:      []string{"x", "lo"},
+		ParamTypes:  []string{"int", "int"},
+		Predicates: []map[string]any{
+			op("concept:ge", v("x"), v("lo")),
+			op("concept:le", v("x"), v("hi")),
+		},
+	})
+
+	if !strings.HasPrefix(emission.Source, "package sample\n") {
+		t.Fatalf("emitted Go test must preserve package name; got:\n%s", emission.Source)
+	}
+	if !strings.Contains(emission.Source, "\"testing\"") {
+		t.Fatalf("emitted Go test must import testing; got:\n%s", emission.Source)
+	}
+	if !strings.Contains(emission.Source, "\"github.com/stretchr/testify/assert\"") {
+		t.Fatalf("testify emitter must import assert; got:\n%s", emission.Source)
+	}
+	if !strings.Contains(emission.Source, "func TestProvekitGe0(t *testing.T)") {
+		t.Fatalf("missing ge test function; got:\n%s", emission.Source)
+	}
+	if !strings.Contains(emission.Source, "assert.GreaterOrEqual(t, x, lo)") {
+		t.Fatalf("missing ge testify assertion; got:\n%s", emission.Source)
+	}
+	if !strings.Contains(emission.Source, "assert.LessOrEqual(t, x, hi)") {
+		t.Fatalf("missing le testify assertion; got:\n%s", emission.Source)
+	}
+	if got, want := emission.EmittedPredicates, []string{"ge", "le"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("emitted predicates = %v, want %v", got, want)
+	}
+	if len(emission.UnsupportedPredicates) != 0 {
+		t.Fatalf("unexpected unsupported predicates: %v", emission.UnsupportedPredicates)
+	}
+	if !emission.IsComplete {
+		t.Fatalf("all supported predicates should make a complete emission")
+	}
+	if !strings.HasPrefix(emission.EmittedArtifactCID, "blake3-512:") {
+		t.Fatalf("missing artifact cid: %q", emission.EmittedArtifactCID)
+	}
+	if emission.Path != "provekit_emitted_test.go" {
+		t.Fatalf("emission path = %q", emission.Path)
+	}
+}
+
+func TestFallibleErrUsesTestifyError(t *testing.T) {
+	emission := Emit(EmitPlan{
+		PackageName: "sample",
+		Function:    "load",
+		Predicates:  []map[string]any{op("concept:fallible-err", v("err"))},
+	})
+
+	if !strings.Contains(emission.Source, "\"errors\"") {
+		t.Fatalf("fallible error placeholder must import errors; got:\n%s", emission.Source)
+	}
+	if !strings.Contains(emission.Source, "err := errors.New(\"contract error\")") {
+		t.Fatalf("fallible error placeholder must be a non-nil error; got:\n%s", emission.Source)
+	}
+	if !strings.Contains(emission.Source, "assert.Error(t, err)") {
+		t.Fatalf("fallible-err must render assert.Error; got:\n%s", emission.Source)
+	}
+}
+
+func TestGeneratedTestifyFileCompilesAndRuns(t *testing.T) {
+	emission := Emit(EmitPlan{
+		PackageName: "sample",
+		Function:    "clamp",
+		Predicates: []map[string]any{
+			op("concept:eq", v("a"), v("b")),
+			op("concept:lt", v("lo"), v("hi")),
+			op("concept:option-is-none", v("maybe")),
+		},
+	})
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module emitted.test\n\ngo 1.22\n\nrequire github.com/stretchr/testify v1.9.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "provekit_emitted_test.go"), []byte(emission.Source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	report := Check(dir)
+	if report["ok"] != true {
+		t.Fatalf("generated Go testify emission must compile and pass: %#v\nsource:\n%s", report, emission.Source)
+	}
+}

--- a/implementations/go/provekit-emit-go-testify/plugin_memento.go
+++ b/implementations/go/provekit-emit-go-testify/plugin_memento.go
@@ -1,0 +1,89 @@
+package emitgotestify
+
+import (
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+)
+
+const (
+	pluginKind       = "emit"
+	pluginVersion    = "0.1.0"
+	provenanceCID    = "blake3-512:provenance-provekit-emit-go-testify-0.1.0"
+	zeroSignature    = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+	zeroSigner       = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	declaredAt       = "2026-05-29T00:00:00.000Z"
+	pluginSourcePath = "implementations/go/provekit-emit-go-testify"
+)
+
+func PluginMemento() map[string]any {
+	return map[string]any{
+		"envelope": map[string]any{
+			"declaredAt": declaredAt,
+			"signature":  zeroSignature,
+			"signer":     zeroSigner,
+		},
+		"header":   pluginHeader(),
+		"metadata": pluginMetadata(),
+	}
+}
+
+func pluginContent() map[string]any {
+	return map[string]any{
+		"name":             "provekit-emit-go-testify",
+		"version":          pluginVersion,
+		"kind":             pluginKind,
+		"target_language":  "go",
+		"target_framework": "testify",
+		"capabilities": map[string]any{
+			"kits":       []any{"go"},
+			"emits":      "go-testify-assertions",
+			"predicates": stringAnyList(supportedPredicates()),
+		},
+	}
+}
+
+func pluginHeader() map[string]any {
+	header := map[string]any{
+		"content":           pluginContent(),
+		"critical":          false,
+		"kind":              pluginKind,
+		"protocol_versions": []any{"pep/1.7.0"},
+		"provenance_cid":    provenanceCID,
+		"schemaVersion":     "1",
+		"version":           pluginVersion,
+	}
+	header["cid"] = computePluginCID(header)
+	return header
+}
+
+func pluginMetadata() map[string]any {
+	return map[string]any{
+		"maintainer": "T Savo <evilgenius@nefariousplan.com>",
+		"note":       "PEP 1.7.0 Go testify emitter: materializes neutral predicates as native testify assertions. Mapping is inline Go package knowledge.",
+		"source_url": pluginSourcePath,
+	}
+}
+
+func computePluginCID(header map[string]any) string {
+	input := map[string]any{
+		"content":           header["content"],
+		"critical":          header["critical"],
+		"kind":              header["kind"],
+		"protocol_versions": header["protocol_versions"],
+		"provenance_cid":    header["provenance_cid"],
+		"schemaVersion":     header["schemaVersion"],
+		"version":           header["version"],
+	}
+	jcs, err := canonicalizer.EncodeJCS(input)
+	if err != nil {
+		panic(err)
+	}
+	return canonicalizer.ComputeCID(jcs)
+}
+
+func stringAnyList(values []string) []any {
+	out := make([]any, len(values))
+	for i, value := range values {
+		out[i] = value
+	}
+	return out
+}

--- a/implementations/go/provekit-emit-go-testify/rpc.go
+++ b/implementations/go/provekit-emit-go-testify/rpc.go
@@ -1,0 +1,144 @@
+package emitgotestify
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+func Dispatch(request map[string]any) map[string]any {
+	id := request["id"]
+	method, _ := request["method"].(string)
+	params := request["params"]
+	if params == nil {
+		params = map[string]any{}
+	}
+
+	switch method {
+	case "provekit.plugin.describe":
+		return success(id, PluginMemento())
+	case "provekit.plugin.invoke":
+		obj, ok := params.(map[string]any)
+		if !ok {
+			return failure(id, -32602, "INVALID_PARAMS: params must be an object")
+		}
+		emission := Emit(EmitPlanFromParams(obj))
+		return success(id, emissionToMap(emission))
+	case "provekit.plugin.check":
+		obj, ok := params.(map[string]any)
+		if !ok {
+			return failure(id, -32602, "INVALID_PARAMS: params must be an object")
+		}
+		outDir := firstString(obj["out_dir"], obj["outDir"])
+		if outDir == "" {
+			return failure(id, -32602, "INVALID_PARAMS: missing out_dir")
+		}
+		return success(id, Check(outDir))
+	case "provekit.plugin.shutdown":
+		return success(id, nil)
+	default:
+		return failure(id, -32601, fmt.Sprintf("METHOD_NOT_FOUND: %s", method))
+	}
+}
+
+func Check(outDir string) map[string]any {
+	{
+		mod := exec.Command("go", "mod", "tidy")
+		mod.Dir = outDir
+		var modStdout bytes.Buffer
+		var modStderr bytes.Buffer
+		mod.Stdout = &modStdout
+		mod.Stderr = &modStderr
+		if err := mod.Run(); err != nil {
+			exitCode := 1
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				exitCode = exitErr.ExitCode()
+			}
+			return map[string]any{
+				"ok":       false,
+				"command":  "go mod tidy",
+				"cwd":      outDir,
+				"stdout":   modStdout.String(),
+				"stderr":   modStderr.String(),
+				"exitCode": exitCode,
+			}
+		}
+	}
+
+	cmd := exec.Command("go", "test", "./...")
+	cmd.Dir = outDir
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitCode = 1
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		}
+	}
+	return map[string]any{
+		"ok":       err == nil,
+		"command":  "go test ./...",
+		"cwd":      outDir,
+		"stdout":   stdout.String(),
+		"stderr":   stderr.String(),
+		"exitCode": exitCode,
+	}
+}
+
+func RunRPC(stdin io.Reader, stdout io.Writer) error {
+	scanner := bufio.NewScanner(stdin)
+	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var request map[string]any
+		if err := json.Unmarshal(line, &request); err != nil {
+			_ = encoder.Encode(failure(nil, -32700, fmt.Sprintf("PARSE_ERROR: %v", err)))
+			continue
+		}
+		response := Dispatch(request)
+		if err := encoder.Encode(response); err != nil {
+			return err
+		}
+		if request["method"] == "provekit.plugin.shutdown" {
+			return nil
+		}
+	}
+	return scanner.Err()
+}
+
+func emissionToMap(emission Emission) map[string]any {
+	return map[string]any{
+		"kind":                   emission.Kind,
+		"source":                 emission.Source,
+		"path":                   emission.Path,
+		"extension":              emission.Extension,
+		"emitted_artifact_cid":   emission.EmittedArtifactCID,
+		"emitted_predicates":     stringAnyList(emission.EmittedPredicates),
+		"unsupported_predicates": stringAnyList(emission.UnsupportedPredicates),
+		"is_complete":            emission.IsComplete,
+	}
+}
+
+func success(id any, result any) map[string]any {
+	return map[string]any{"jsonrpc": "2.0", "id": id, "result": result}
+}
+
+func failure(id any, code int, message string) map[string]any {
+	return map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error":   map[string]any{"code": code, "message": message},
+	}
+}

--- a/implementations/go/provekit-emit-go-testify/rpc_test.go
+++ b/implementations/go/provekit-emit-go-testify/rpc_test.go
@@ -1,0 +1,79 @@
+package emitgotestify
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDescribeReturnsPluginMementoShape(t *testing.T) {
+	response := Dispatch(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      float64(1),
+		"method":  "provekit.plugin.describe",
+	})
+
+	result, ok := response["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("describe result must be object: %#v", response)
+	}
+	for _, key := range []string{"envelope", "header", "metadata"} {
+		if _, ok := result[key]; !ok {
+			t.Fatalf("describe result missing %s: %#v", key, result)
+		}
+	}
+	header := result["header"].(map[string]any)
+	if header["schemaVersion"] != "1" {
+		t.Fatalf("schemaVersion = %#v", header["schemaVersion"])
+	}
+	if !strings.HasPrefix(header["cid"].(string), "blake3-512:") {
+		t.Fatalf("header cid = %#v", header["cid"])
+	}
+	content := header["content"].(map[string]any)
+	if content["kind"] != "emit" {
+		t.Fatalf("plugin kind = %#v", content["kind"])
+	}
+	if content["target_framework"] != "testify" {
+		t.Fatalf("target framework = %#v", content["target_framework"])
+	}
+	if _, err := json.Marshal(response); err != nil {
+		t.Fatalf("response must be json serializable: %v", err)
+	}
+}
+
+func TestInvokeEmitsGoTestifyFile(t *testing.T) {
+	response := Dispatch(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      float64(2),
+		"method":  "provekit.plugin.invoke",
+		"params": map[string]any{
+			"package_name": "sample",
+			"function":     "Id",
+			"predicates":   []any{op("concept:eq", v("x"), v("x"))},
+		},
+	})
+
+	result, ok := response["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("invoke result must be object: %#v", response)
+	}
+	if result["kind"] != "go-testify-test-emission" {
+		t.Fatalf("kind = %#v", result["kind"])
+	}
+	if result["extension"] != "go" {
+		t.Fatalf("extension = %#v", result["extension"])
+	}
+	if result["path"] != "provekit_emitted_test.go" {
+		t.Fatalf("path = %#v", result["path"])
+	}
+	source := result["source"].(string)
+	if !strings.Contains(source, "\"github.com/stretchr/testify/assert\"") {
+		t.Fatalf("source did not import testify assert: %s", source)
+	}
+	if !strings.Contains(source, "assert.Equal(t, x, x)") {
+		t.Fatalf("source did not render assert.Equal: %s", source)
+	}
+	if result["is_complete"] != true {
+		t.Fatalf("is_complete = %#v", result["is_complete"])
+	}
+}

--- a/implementations/rust/provekit-cli/tests/cmd_emit_go_testify.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_go_testify.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn build_go_testify_emitter() -> PathBuf {
+    let go_root = repo_root().join("implementations").join("go");
+    let out = std::env::temp_dir().join(format!("provekit-emit-go-testify-{}", std::process::id()));
+    let built = Command::new("go")
+        .current_dir(&go_root)
+        .args([
+            "build",
+            "-o",
+            out.to_str().expect("utf8 path"),
+            "./provekit-emit-go-testify/cmd/provekit-emit-go-testify",
+        ])
+        .output()
+        .expect("spawn go build");
+    assert!(
+        built.status.success(),
+        "go build provekit-emit-go-testify failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&built.stdout),
+        String::from_utf8_lossy(&built.stderr)
+    );
+    out
+}
+
+fn install_emit_registration(project: &Path, emitter: &Path) {
+    let provekit_dir = project.join(".provekit");
+    fs::create_dir_all(&provekit_dir).expect("mkdir .provekit");
+    fs::write(
+        provekit_dir.join("config.toml"),
+        "exam_manifest_cid = \"blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"go-testify\"\n\
+         surface = \"go-testify\"\n\
+         emit = \"testify\"\n",
+    )
+    .expect("write project config");
+
+    let manifest = project
+        .join(".provekit")
+        .join("emit")
+        .join("go-testify")
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().unwrap()).expect("mkdir manifest");
+    fs::write(
+        manifest,
+        format!(
+            "name = \"go-testify\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\nprotocol_versions = [\"pep/1.7.0\"]\n",
+            emitter
+                .display()
+                .to_string()
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+        ),
+    )
+    .expect("write emit manifest");
+}
+
+#[test]
+fn emit_go_testify_dispatches_separate_emitter_and_compile_checks() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    let out_dir = temp.path().join("out");
+    fs::create_dir_all(&project).expect("mkdir project");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    fs::write(
+        out_dir.join("go.mod"),
+        "module example.com/provekit_emit\n\n\
+         go 1.22\n\n\
+         require github.com/stretchr/testify v1.9.0\n",
+    )
+    .expect("write go.mod");
+
+    let emitter = build_go_testify_emitter();
+    install_emit_registration(&project, &emitter);
+
+    let plan = project.join("plan.json");
+    fs::write(
+        &plan,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "contract_id": "concept:eq",
+            "package_name": "sample",
+            "function": "Id",
+            "params": ["x"],
+            "param_types": ["int"],
+            "return_type": "int",
+            "predicates": [{
+                "kind": "op",
+                "name": "concept:eq",
+                "args": [
+                    {"kind": "var", "name": "x"},
+                    {"kind": "var", "name": "x"}
+                ]
+            }]
+        }))
+        .expect("encode plan"),
+    )
+    .expect("write plan");
+
+    let output = Command::new(provekit_bin())
+        .arg("emit")
+        .arg("--project")
+        .arg(&project)
+        .arg("--target")
+        .arg("go")
+        .arg("--framework")
+        .arg("testify")
+        .arg("--plan")
+        .arg(&plan)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit emit");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "provekit emit failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let receipt: Value = serde_json::from_str(&stdout).expect("emit stdout is JSON");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(receipt["targetLanguage"], "go", "receipt: {receipt}");
+    assert_eq!(receipt["targetFramework"], "testify", "receipt: {receipt}");
+    assert_eq!(receipt["isComplete"], true, "receipt: {receipt}");
+    assert!(
+        receipt["emittedArtifactCid"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("blake3-512:"),
+        "receipt: {receipt}"
+    );
+
+    let emitted_path = out_dir.join("provekit_emitted_test.go");
+    let emitted = fs::read_to_string(&emitted_path)
+        .unwrap_or_else(|_| panic!("read emitted {}", emitted_path.display()));
+    assert!(emitted.contains("package sample"), "emitted:\n{emitted}");
+    assert!(
+        emitted.contains("\"testing\""),
+        "emitted must import testing:\n{emitted}"
+    );
+    assert!(
+        emitted.contains("\"github.com/stretchr/testify/assert\""),
+        "testify emitter must import assert:\n{emitted}"
+    );
+    assert!(
+        emitted.contains("assert.Equal(t, x, x)"),
+        "testify emitter must render assert.Equal:\n{emitted}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `provekit-emit-go-testify` as a separate Go emitter package, not an emitter mode.
- Keep CLI dispatch config/manifest/RPC driven through a project-local `.provekit/emit/go-testify/manifest.toml` registration.
- Emit native Go `testing` tests that use `github.com/stretchr/testify/assert` for testify semantics.
- Add a CLI integration test proving `provekit emit --target go --framework testify --compile-check --json` dispatches to the separate testify kit.
- Add the testify emitter leg to `make cross-language-proof-parity` alongside the existing Go stdlib testing emitter.

## Verification
- `go test ./provekit-emit-go-testify/...`
- `go test ./...` from `implementations/go`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_go_testify -- --nocapture`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_go_testify -- --nocapture`
- `make cross-language-proof-parity`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Go/Testify emitter that generates Go test files with testify assertions, supporting equality, ordering, unary operations, and error predicates.
  * Extended cross-language proof parity testing with Go testify verification step.

* **Tests**
  * Added integration test for Go/Testify emitter validating code generation, compilation, and test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->