### PR TITLE
feat(parity): extend materialize emit prove lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@
 #   make help: print this help
 #   make ci: Linux-profile gate (catalog + protocol + live mints + tests)
 #   make conformance: catalog + protocol + live mint CIDs + self-contract tests
-#   make cross-language-proof-parity: Java/Go/Python/Rust emit + materialize + prove gate
+#   make cross-language-proof-parity: Java/Go/Python/Rust emit + materialize + prove gate,
+#                                      plus TypeScript kit-owned materialize coverage
 #   make all-mint: run all 11 Linux-profile mint commands; print CIDs
 #   make bootstrap-self-contracts: re-sign attestations from live artifacts
 #   make test-all: run the Linux native test aggregate
@@ -87,6 +88,7 @@ help:
 	@echo "  make conformance    catalog + protocol + 11 mint CIDs + self-contract tests"
 	@echo "  make cross-language-proof-parity"
 	@echo "                       Java/Go/Python/Rust emit + materialize + prove gate"
+	@echo "                       plus TypeScript kit-owned materialize coverage"
 	@echo "  make all-mint       11 mint commands (Swift excluded: macOS-only, use mint-swift)"
 	@echo "  make bug-zoo        replay executable bug specimens through source-routed CLI"
 	@echo "  make bootstrap-self-contracts"
@@ -217,6 +219,7 @@ build-ts:
 	# deps (the kits are npm package-lock.json based, outside the pnpm root),
 	# so install each kit explicitly. Without this the kit RPC returns
 	# SHIM_NOT_FOUND and SQL/migrate materialize tests refuse.
+	npm --prefix implementations/typescript/provekit-emit-typescript-vitest ci
 	npm --prefix implementations/typescript/provekit-realize-typescript-core ci
 	npm --prefix implementations/typescript/provekit-realize-typescript-better-sqlite3 ci
 	npm --prefix implementations/typescript/provekit-realize-typescript-pg ci
@@ -664,8 +667,8 @@ cross-language-proof-parity-python-env:
 		-e implementations/python/provekit-realize-python-requests
 
 .PHONY: cross-language-proof-parity
-cross-language-proof-parity: build-java cross-language-proof-parity-python-env
-	@echo "=== Cross-language proof parity: emit/materialize/prove for Java, Go, Python, Rust ==="
+cross-language-proof-parity: build-java build-ts build-zig cross-language-proof-parity-python-env
+	@echo "=== Cross-language proof parity: emit/materialize/prove for Java, Go, Python, Rust, TypeScript, Zig ==="
 	cargo build --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-realize-rust-core --bin provekit-realize-rust
 	@echo "--- emit parity ---"
@@ -684,6 +687,9 @@ cross-language-proof-parity: build-java cross-language-proof-parity-python-env
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_rust_cargo_test \
 		emit_rust_cargo_test_dispatches_real_emitter_and_cargo_checks_output
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_emit_typescript_vitest \
+		emit_typescript_vitest_dispatches_real_emitter_and_vitest_checks_output
 	@echo "--- materialize parity ---"
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_materialize_proof_load \
@@ -694,6 +700,9 @@ cross-language-proof-parity: build-java cross-language-proof-parity-python-env
 	PATH=$(PARITY_PYTHON_BIN):$(PATH) cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_materialize_integration \
 		compile_check_passes_for_valid_python_materialized_output
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_materialize_integration \
+		materialize_out_dir_writes_materialized_copy_and_leaves_source_unchanged
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_materialize_integration \
 		materialize_rust_reqwest_example_uses_rust_library_shim
@@ -710,6 +719,12 @@ cross-language-proof-parity: build-java cross-language-proof-parity-python-env
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_verify_rust_production_bridge \
 		rust_production_path_double_discharges_and_mints_witness
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_verify_typescript_production_bridge \
+		typescript_production_path_double_discharges_and_mints_witness
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_verify_zig_production_bridge \
+		zig_production_path_double_discharges_and_mints_witness
 	@echo "--- contradiction parity ---"
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_verify_java_production_bridge \
@@ -723,6 +738,12 @@ cross-language-proof-parity: build-java cross-language-proof-parity-python-env
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_verify_rust_production_bridge \
 		rust_production_path_refuses_planted_contradictory_implication
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_verify_typescript_production_bridge \
+		typescript_production_path_refuses_planted_contradictory_implication
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_verify_zig_production_bridge \
+		zig_production_path_refuses_planted_contradictory_implication
 	@echo "==== cross-language-proof-parity: PASS ===="
 
 .PHONY: bootstrap-self-contracts
@@ -893,11 +914,11 @@ test-zig:
 	cd implementations/zig/provekit-ir && zig build test
 	cd implementations/zig/provekit-self-contracts && zig build test
 	@echo "test-zig: native substrate (jcs + cbor + ed25519 + envelopes) verified"
-	cd implementations/zig/provekit-lift-zig && zig build test
-	cd implementations/zig/provekit-lift-zig && zig build
+	cd implementations/zig/provekit-lift-zig-tests && zig build test
+	cd implementations/zig/provekit-lift-zig-tests && zig build
 	cd implementations/zig/provekit-lift-zig-source && zig build test
 	cd implementations/zig/provekit-lift-zig-source && zig build
-	@echo "test-zig: lift-zig and lift-zig-source binary builds verified"
+	@echo "test-zig: lift-zig-tests and lift-zig-source binary builds verified"
 	cd implementations/zig/provekit-lsp-zig && zig build test
 	cd implementations/zig/provekit-lsp-zig && zig build
 	@echo "test-zig: LSP lifecycle integration test"
@@ -907,7 +928,7 @@ test-zig:
 build-zig:
 	cd implementations/zig/provekit-ir && zig build
 	cd implementations/zig/provekit-self-contracts && zig build
-	cd implementations/zig/provekit-lift-zig && zig build
+	cd implementations/zig/provekit-lift-zig-tests && zig build
 	cd implementations/zig/provekit-lift-zig-source && zig build
 	cd implementations/zig/provekit-lsp-zig && zig build
 	cd implementations/zig/provekit-proof-envelope-zig && zig build

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -219,10 +219,9 @@ pub fn run(args: MaterializeArgs) -> u8 {
         // job; the substrate holds no language syntax). When the kit supports
         // the assemble RPC, route every file's fragments through it and write
         // back what the kit returns, then ask the kit to run any native
-        // compile/test check with the kit-declared metadata. When the kit does
-        // NOT implement assemble, fall back to
-        // writing the in-place-rewritten content (kits not yet on the assemble
-        // protocol keep working unchanged).
+        // compile/test check with the kit-declared metadata. If the selected
+        // kit does not implement assemble, fail closed: target-language source
+        // assembly is kit-owned, not a CLI fallback surface.
         match emit_out_dir_via_kit_assemble(
             &project_root,
             &target_lang,
@@ -234,24 +233,6 @@ pub fn run(args: MaterializeArgs) -> u8 {
             EmitOutcome::Assembled(code) => {
                 if code != EXIT_OK {
                     return code;
-                }
-            }
-            EmitOutcome::KitDoesNotAssemble => {
-                if let Err(error) = write_out_dir(out_dir, &files) {
-                    eprintln!("{}: {error}", "error".red().bold());
-                    return EXIT_USER_ERROR;
-                }
-                if args.compile_check {
-                    let check_result = run_materialize_check(
-                        &project_root,
-                        &target_lang,
-                        library_tag.as_deref(),
-                        out_dir,
-                        &[],
-                    );
-                    if check_result != EXIT_OK {
-                        return check_result;
-                    }
                 }
             }
         }
@@ -329,84 +310,12 @@ struct EmittedFile {
     /// Each entry is the realize-fragment JSON shape (source + imports +
     /// helpers + dependencies + diagnostics + compile_unit_requirements +
     /// concept_name) that the target kit's assembler consumes to produce
-    /// a compilation unit. Substrate keeps these alongside the legacy
-    /// bodies+imports so it can fall back to concatenation if the kit
-    /// doesn't implement the assemble RPC.
+    /// a compilation unit. Substrate keeps these so the selected kit owns
+    /// target-source assembly.
     fragments: Vec<serde_json::Value>,
     /// Target manifest used for this file's emission (kept so the
     /// substrate knows which kit to call for assemble).
     target_manifest: Option<String>,
-}
-
-/// Map a target language to a file extension. Substrate-honest fallback
-/// "txt" for unknown languages (no per-lang knowledge encoded beyond the
-/// declared extension; the kit could declare this in its manifest in a
-/// follow-up substrate-mint).
-fn target_lang_file_extension(target_lang: &str) -> &'static str {
-    match target_lang {
-        "rust" => "rs",
-        "python" => "py",
-        "typescript" => "ts",
-        "java" => "java",
-        "c" => "c",
-        "csharp" => "cs",
-        "go" => "go",
-        "php" => "php",
-        "ruby" => "rb",
-        "zig" => "zig",
-        _ => "txt",
-    }
-}
-
-/// #1374: wrap fragment-declared FQN imports as the target language's
-/// import-statement syntax. Stops here on substrate-side idiom — the rest
-/// (package declaration, class wrapping, helper placement) is Milestone C
-/// (target-owned assembly). Languages without a standard import-block
-/// syntax (or unsupported) get a comment-listing of the FQNs so the
-/// information isn't lost.
-fn format_imports_for(target_lang: &str, imports: &std::collections::BTreeSet<String>) -> String {
-    if imports.is_empty() {
-        return String::new();
-    }
-    let lines: Vec<String> = match target_lang {
-        "java" => imports.iter().map(|fqn| format!("import {fqn};")).collect(),
-        "python" => imports
-            .iter()
-            .map(|fqn| {
-                // Python convention: `import pkg.mod` for module-paths,
-                // `from pkg.mod import Name` when the FQN ends in a Class.
-                // Substrate-honest minimum: if the last segment starts with
-                // an uppercase letter, emit `from ... import Name`; else
-                // emit `import ...`.
-                let mut parts: Vec<&str> = fqn.split('.').collect();
-                if let Some(last) = parts.last().copied() {
-                    if last.chars().next().is_some_and(|c| c.is_ascii_uppercase())
-                        && parts.len() > 1
-                    {
-                        parts.pop();
-                        return format!("from {} import {}", parts.join("."), last);
-                    }
-                }
-                format!("import {}", fqn)
-            })
-            .collect(),
-        "rust" => imports.iter().map(|fqn| format!("use {fqn};")).collect(),
-        "typescript" => imports
-            .iter()
-            .map(|fqn| {
-                // TS imports require explicit named-bindings + module specifier;
-                // a bare FQN can't unambiguously become either ESM or CJS.
-                // Surface as a TODO comment until Milestone C's target-kit
-                // assembler decides.
-                format!("// TODO(#1375 assembly): import binding for `{}`", fqn)
-            })
-            .collect(),
-        _ => imports
-            .iter()
-            .map(|fqn| format!("// fragment import: {}", fqn))
-            .collect(),
-    };
-    lines.join("\n")
 }
 
 /// Discrimated outcome of a cross-language discovery realize-probe.
@@ -1054,7 +963,6 @@ fn run_cross_language_discovery(
             );
             return EXIT_USER_ERROR;
         }
-        let ext = target_lang_file_extension(target_lang);
         let mut files_written = 0usize;
         // #1388: aggregate kit-declared compile metadata across all files so
         // --compile-check can pass it back to the same kit over RPC.
@@ -1064,107 +972,75 @@ fn run_cross_language_discovery(
             if file.bodies.is_empty() {
                 continue;
             }
-            // Preserve source-relative directory structure so two source
-            // files with the same basename in different directories (e.g.
-            // src/lib.rs vs tests/lib.rs, or pkg_a/foo.rs vs pkg_b/foo.rs)
-            // don't silently overwrite each other in --out-dir.
             let rel = source_path.strip_prefix(source_dir).unwrap_or(source_path);
-            let rel_with_ext = rel.with_extension(ext);
-            let out_path = out_dir_path.join(&rel_with_ext);
-            if let Some(parent) = out_path.parent() {
-                if let Err(err) = std::fs::create_dir_all(parent) {
-                    eprintln!(
-                        "{}: failed to create out-dir subpath {}: {err}",
-                        "error".red().bold(),
-                        parent.display()
-                    );
-                    return EXIT_USER_ERROR;
-                }
-            }
             // #1375 Milestone C: route compilation-unit assembly to the
             // target kit. The kit decides file layout, package, imports,
-            // class wrapping. Fall back to substrate-side legacy concat
-            // when the kit doesn't implement assemble (method-not-found).
+            // and class/module wrapping. Missing assembly is a boundary
+            // failure, not permission for the CLI to bake target syntax.
             let file_basename = rel.file_stem().and_then(|s| s.to_str()).unwrap_or("lib");
             let fragments_json =
                 serde_json::to_string(&file.fragments).unwrap_or_else(|_| "[]".to_string());
-            let mut wrote_assembled = false;
-            if let Some(manifest) = file.target_manifest.as_deref() {
-                use crate::kit_dispatch::{dispatch_assemble, AssembleError};
-                match dispatch_assemble(
-                    project_root,
-                    target_lang,
-                    Some(manifest),
-                    &fragments_json,
-                    file_basename,
-                    None,
-                ) {
-                    Ok(assembled_result) => {
-                        for af in &assembled_result.files {
-                            let assembled_path = out_dir_path.join(&af.path);
-                            if let Some(parent) = assembled_path.parent() {
-                                let _ = std::fs::create_dir_all(parent);
-                            }
-                            if let Err(err) = std::fs::write(&assembled_path, &af.content) {
-                                eprintln!(
-                                    "{}: failed to write {}: {err}",
-                                    "error".red().bold(),
-                                    assembled_path.display()
-                                );
-                                return EXIT_USER_ERROR;
-                            }
+            let Some(manifest) = file.target_manifest.as_deref() else {
+                eprintln!(
+                    "{}: no target manifest available to assemble {} via kit RPC",
+                    "error".red().bold(),
+                    rel.display()
+                );
+                return EXIT_VERIFY_FAIL;
+            };
+            use crate::kit_dispatch::{dispatch_assemble, AssembleError};
+            match dispatch_assemble(
+                project_root,
+                target_lang,
+                Some(manifest),
+                &fragments_json,
+                file_basename,
+                None,
+            ) {
+                Ok(assembled_result) => {
+                    for af in &assembled_result.files {
+                        let assembled_path = out_dir_path.join(&af.path);
+                        if let Some(parent) = assembled_path.parent() {
+                            let _ = std::fs::create_dir_all(parent);
+                        }
+                        if let Err(err) = std::fs::write(&assembled_path, &af.content) {
                             eprintln!(
-                                "  {} wrote {} (target-owned assembly via {} kit)",
-                                "EMIT".green().bold(),
-                                assembled_path.display(),
-                                target_lang,
+                                "{}: failed to write {}: {err}",
+                                "error".red().bold(),
+                                assembled_path.display()
                             );
-                            files_written += 1;
+                            return EXIT_USER_ERROR;
                         }
-                        // #1388: collect kit-declared classpath entries.
-                        for cp in &assembled_result.compile_classpath {
-                            aggregated_classpath.insert(cp.clone());
-                        }
-                        wrote_assembled = true;
-                    }
-                    Err(AssembleError::MethodNotSupported) => {
-                        // Legacy kit — fall through to substrate concat.
-                    }
-                    Err(AssembleError::Failed(err)) => {
                         eprintln!(
-                            "  {}: target-kit assemble failed (falling back to legacy concat): {err}",
-                            "WARN".yellow().bold(),
+                            "  {} wrote {} (target-owned assembly via {} kit)",
+                            "EMIT".green().bold(),
+                            assembled_path.display(),
+                            target_lang,
                         );
+                        files_written += 1;
+                    }
+                    // #1388: collect kit-declared classpath entries.
+                    for cp in &assembled_result.compile_classpath {
+                        aggregated_classpath.insert(cp.clone());
                     }
                 }
+                Err(AssembleError::MethodNotSupported) => {
+                    eprintln!(
+                        "{}: selected {target_lang} kit must implement assemble RPC for --out-dir materialize; refusing CLI-side target assembly for {}",
+                        "error".red().bold(),
+                        rel.display()
+                    );
+                    return EXIT_VERIFY_FAIL;
+                }
+                Err(AssembleError::Failed(err)) => {
+                    eprintln!(
+                        "{}: target-kit assemble failed for {}: {err}",
+                        "error".red().bold(),
+                        rel.display()
+                    );
+                    return EXIT_VERIFY_FAIL;
+                }
             }
-            if wrote_assembled {
-                continue;
-            }
-            // Legacy concat path (substrate bakes language syntax).
-            let imports_block = format_imports_for(target_lang, &file.imports);
-            let bodies_block = file.bodies.join("\n\n");
-            let content = if imports_block.is_empty() {
-                format!("{bodies_block}\n")
-            } else {
-                format!("{imports_block}\n\n{bodies_block}\n")
-            };
-            if let Err(err) = std::fs::write(&out_path, content) {
-                eprintln!(
-                    "{}: failed to write {}: {err}",
-                    "error".red().bold(),
-                    out_path.display()
-                );
-                return EXIT_USER_ERROR;
-            }
-            eprintln!(
-                "  {} wrote {} ({} bodies, {} imports)",
-                "EMIT".green().bold(),
-                out_path.display(),
-                file.bodies.len(),
-                file.imports.len()
-            );
-            files_written += 1;
         }
         eprintln!(
             "{} cross-language emission: {files_written} file(s) written to {}",
@@ -1875,9 +1751,6 @@ enum EmitOutcome {
     /// The kit assembled (one or more files); inner is the compile-check exit
     /// code (EXIT_OK when --compile-check is off or the kit check passed).
     Assembled(u8),
-    /// The kit does not implement the assemble RPC; caller falls back to the
-    /// legacy in-place-rewrite write path (back-compat for not-yet-migrated kits).
-    KitDoesNotAssemble,
 }
 
 /// Route each materialized file's fragments through the LANGUAGE KIT's
@@ -1887,9 +1760,6 @@ enum EmitOutcome {
 /// compiler semantics. Same-language and cross-language both land here;
 /// source-lang == target-lang changes the lift, not who assembles/checks.
 ///
-/// Returns `KitDoesNotAssemble` when the kit replies method-not-found on the
-/// FIRST file with fragments, so the caller can fall back to the legacy
-/// carrier-rewrite write path for kits not yet on the assemble protocol.
 fn emit_out_dir_via_kit_assemble(
     project_root: &Path,
     target_lang: &str,
@@ -1911,8 +1781,6 @@ fn emit_out_dir_via_kit_assemble(
 
     let mut aggregated_classpath: std::collections::BTreeSet<String> =
         std::collections::BTreeSet::new();
-    let mut wrote_any = false;
-
     for file in files {
         // Files with no realizable fragments (refuse-only) have nothing for
         // the kit to assemble; preserve the in-place-rewritten content so the
@@ -1975,22 +1843,14 @@ fn emit_out_dir_via_kit_assemble(
                         out_path.display(),
                         target_lang,
                     );
-                    wrote_any = true;
                 }
                 for cp in &assembled.compile_classpath {
                     aggregated_classpath.insert(cp.clone());
                 }
             }
             Err(AssembleError::MethodNotSupported) => {
-                // Kit predates the assemble protocol. If we haven't written
-                // anything yet, signal fallback to the legacy write path.
-                if !wrote_any {
-                    return EmitOutcome::KitDoesNotAssemble;
-                }
-                // Mixed-capability shouldn't happen within one (lang, library);
-                // surface it loudly rather than silently dropping the file.
                 eprintln!(
-                    "{}: kit for {target_lang} stopped supporting assemble mid-run for {}",
+                    "{}: selected {target_lang} kit must implement assemble RPC for --out-dir materialize; refusing CLI-side target assembly for {}",
                     "error".red().bold(),
                     file.relative_path.display()
                 );
@@ -2014,19 +1874,6 @@ fn emit_out_dir_via_kit_assemble(
         return EmitOutcome::Assembled(code);
     }
     EmitOutcome::Assembled(EXIT_OK)
-}
-
-fn write_out_dir(out_dir: &Path, files: &[MaterializedFile]) -> Result<(), String> {
-    for file in files {
-        let target = out_dir.join(&file.relative_path);
-        if let Some(parent) = target.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|error| format!("create {}: {error}", parent.display()))?;
-        }
-        std::fs::write(&target, &file.content)
-            .map_err(|error| format!("write {}: {error}", target.display()))?;
-    }
-    Ok(())
 }
 
 fn sync_materialize_bridge_proof(

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -182,7 +182,12 @@ struct MintedIrDocument {
 fn merge_ir_document_responses(per_plugin: Vec<PerPluginDispatch>) -> Result<Value, String> {
     let mut merged_ir: Vec<Value> = Vec::new();
     let mut merged_diagnostics: Vec<Value> = Vec::new();
+    let mut merged_implications: Vec<Value> = Vec::new();
+    let mut merged_authorities: Vec<Value> = Vec::new();
+    let mut merged_witnesses: Vec<Value> = Vec::new();
     let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut seen_implications: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut seen_authorities: std::collections::HashSet<String> = std::collections::HashSet::new();
     for entry in per_plugin {
         let kind = entry
             .response
@@ -219,12 +224,53 @@ fn merge_ir_document_responses(per_plugin: Vec<PerPluginDispatch>) -> Result<Val
         if let Some(arr) = entry.response.get("diagnostics").and_then(|v| v.as_array()) {
             merged_diagnostics.extend(arr.iter().cloned());
         }
+        if let Some(arr) = entry
+            .response
+            .get("implications")
+            .and_then(|v| v.as_array())
+        {
+            for item in arr {
+                let key = item
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if key.is_empty() || seen_implications.insert(key) {
+                    merged_implications.push(item.clone());
+                }
+            }
+        }
+        if let Some(arr) = entry.response.get("authorities").and_then(|v| v.as_array()) {
+            for item in arr {
+                let key = item
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if key.is_empty() || seen_authorities.insert(key) {
+                    merged_authorities.push(item.clone());
+                }
+            }
+        }
+        if let Some(arr) = entry.response.get("witnesses").and_then(|v| v.as_array()) {
+            merged_witnesses.extend(arr.iter().cloned());
+        }
     }
-    Ok(json!({
+    let mut merged = json!({
         "kind": "ir-document",
         "ir": merged_ir,
         "diagnostics": merged_diagnostics,
-    }))
+    });
+    if !merged_implications.is_empty() {
+        merged["implications"] = Value::Array(merged_implications);
+    }
+    if !merged_authorities.is_empty() {
+        merged["authorities"] = Value::Array(merged_authorities);
+    }
+    if !merged_witnesses.is_empty() {
+        merged["witnesses"] = Value::Array(merged_witnesses);
+    }
+    Ok(merged)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -2524,6 +2570,50 @@ mod tests {
 
         assert_eq!(contract_count, 2);
         assert_eq!(implication_count, 1);
+    }
+
+    #[test]
+    fn merge_ir_document_responses_preserves_implications_from_lifters() {
+        let merged = merge_ir_document_responses(vec![
+            PerPluginDispatch {
+                surface: "zig-tests".to_string(),
+                response: json!({
+                    "kind": "ir-document",
+                    "ir": [{
+                        "kind": "contract",
+                        "name": "zig.assertion",
+                        "inv": {"kind": "atomic", "name": "=", "args": []}
+                    }],
+                    "diagnostics": []
+                }),
+            },
+            PerPluginDispatch {
+                surface: "zig-implications".to_string(),
+                response: json!({
+                    "kind": "ir-document",
+                    "ir": [],
+                    "implications": [{
+                        "name": "zig.assertion.scope",
+                        "antecedent": "zig.assertion",
+                        "consequent": "zig.assertion",
+                        "antecedentSlot": "inv",
+                        "consequentSlot": "inv"
+                    }],
+                    "diagnostics": []
+                }),
+            },
+        ])
+        .expect("merge ir-documents");
+
+        assert_eq!(merged["ir"].as_array().expect("ir").len(), 1);
+        assert_eq!(
+            merged["implications"]
+                .as_array()
+                .expect("implications")
+                .len(),
+            1,
+            "merged ir-document must keep implication-lifter output: {merged}"
+        );
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/tests/cli_surface.rs
+++ b/implementations/rust/provekit-cli/tests/cli_surface.rs
@@ -1198,24 +1198,24 @@ test "checked does not return 42" {
     fs::write(
         project.path().join(".provekit/config.toml"),
         r#"[authoring.lift]
-surface = "zig"
+surface = "zig-tests"
 "#,
     )
     .expect("write config");
-    let shim = project.path().join("zig-lift.sh");
+    let shim = project.path().join("zig-tests-lift.sh");
     write_executable(
         &shim,
         &format!(
             "#!/usr/bin/env sh\nmkdir -p '{0}/.zig-global-cache' '{0}/.zig-local-cache'\nexport ZIG_GLOBAL_CACHE_DIR='{0}/.zig-global-cache'\nexport ZIG_LOCAL_CACHE_DIR='{0}/.zig-local-cache'\ncd '{1}'\nexec zig build run -- \"$@\"\n",
             project.path().display(),
-            root.join("implementations/zig/provekit-lift-zig").display()
+            root.join("implementations/zig/provekit-lift-zig-tests").display()
         ),
     );
-    let manifest_dir = project.path().join(".provekit/lift/zig");
+    let manifest_dir = project.path().join(".provekit/lift/zig-tests");
     fs::create_dir_all(&manifest_dir).expect("create manifest dir");
     fs::write(
         manifest_dir.join("manifest.toml"),
-        "name = \"zig-lift\"\ncommand = [\"./zig-lift.sh\", \"--rpc\"]\nworking_dir = \".\"\n",
+        "name = \"zig-tests\"\ncommand = [\"./zig-tests-lift.sh\", \"--rpc\"]\nworking_dir = \".\"\n",
     )
     .expect("write manifest");
 

--- a/implementations/rust/provekit-cli/tests/cmd_emit_swift_xctest.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_swift_xctest.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn swift_available() -> bool {
+    Command::new("swift")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn build_swift_xctest_emitter() -> PathBuf {
+    let swift_root = repo_root().join("implementations").join("swift");
+    let built = Command::new("swift")
+        .current_dir(&swift_root)
+        .args(["build", "--product", "provekit-emit-swift-xctest"])
+        .output()
+        .expect("spawn swift build provekit-emit-swift-xctest");
+    assert!(
+        built.status.success(),
+        "swift build provekit-emit-swift-xctest failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&built.stdout),
+        String::from_utf8_lossy(&built.stderr)
+    );
+    let emitter = swift_root
+        .join(".build")
+        .join("debug")
+        .join("provekit-emit-swift-xctest");
+    assert!(emitter.exists(), "missing emitter {}", emitter.display());
+    emitter
+}
+
+fn install_emit_registration(project: &Path, emitter: &Path) {
+    let provekit_dir = project.join(".provekit");
+    fs::create_dir_all(&provekit_dir).expect("mkdir .provekit");
+    fs::write(
+        provekit_dir.join("config.toml"),
+        "exam_manifest_cid = \"blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"swift-xctest\"\n\
+         surface = \"swift-xctest\"\n\
+         emit = \"xctest\"\n",
+    )
+    .expect("write project config");
+
+    let manifest = project
+        .join(".provekit")
+        .join("emit")
+        .join("swift-xctest")
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().unwrap()).expect("mkdir manifest");
+    fs::write(
+        manifest,
+        format!(
+            "name = \"swift-xctest\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\nprotocol_versions = [\"pep/1.7.0\"]\n",
+            emitter
+                .display()
+                .to_string()
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+        ),
+    )
+    .expect("write emit manifest");
+}
+
+fn write_swift_package(root: &Path) {
+    fs::create_dir_all(root.join("Sources/ProvekitSwiftEmitCheck")).expect("mkdir Sources");
+    fs::write(
+        root.join("Package.swift"),
+        r#"// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "ProvekitSwiftEmitCheck",
+    products: [
+        .library(name: "ProvekitSwiftEmitCheck", targets: ["ProvekitSwiftEmitCheck"]),
+    ],
+    targets: [
+        .target(name: "ProvekitSwiftEmitCheck"),
+        .testTarget(
+            name: "ProvekitEmittedTests",
+            dependencies: ["ProvekitSwiftEmitCheck"]
+        ),
+    ]
+)
+"#,
+    )
+    .expect("write Package.swift");
+    fs::write(
+        root.join("Sources/ProvekitSwiftEmitCheck/Stub.swift"),
+        "public enum ProvekitSwiftEmitCheck { public static let ok = true }\n",
+    )
+    .expect("write source stub");
+}
+
+#[test]
+fn emit_swift_xctest_dispatches_real_emitter_and_swift_parse_checks_output() {
+    if !swift_available() {
+        eprintln!("skipping: swift not on PATH");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    let out_dir = temp.path().join("swift-package");
+    fs::create_dir_all(&project).expect("mkdir project");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    write_swift_package(&out_dir);
+
+    let emitter = build_swift_xctest_emitter();
+    install_emit_registration(&project, &emitter);
+
+    let plan = project.join("plan.json");
+    fs::write(
+        &plan,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "contract_id": "concept:eq",
+            "function": "identity",
+            "params": ["a", "b"],
+            "param_types": ["Int", "Int"],
+            "predicates": [{
+                "kind": "op",
+                "name": "concept:eq",
+                "args": [
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}},
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}}
+                ]
+            }]
+        }))
+        .expect("encode plan"),
+    )
+    .expect("write plan");
+
+    let output = Command::new(provekit_bin())
+        .arg("emit")
+        .arg("--project")
+        .arg(&project)
+        .arg("--target")
+        .arg("swift")
+        .arg("--framework")
+        .arg("xctest")
+        .arg("--plan")
+        .arg(&plan)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit emit swift");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "provekit emit swift failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let receipt: Value = serde_json::from_str(&stdout).expect("emit stdout is JSON");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(receipt["targetLanguage"], "swift", "receipt: {receipt}");
+    assert_eq!(receipt["targetFramework"], "xctest", "receipt: {receipt}");
+    assert_eq!(receipt["isComplete"], true, "receipt: {receipt}");
+    assert!(
+        receipt["emittedArtifactCid"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("blake3-512:"),
+        "receipt: {receipt}"
+    );
+
+    let emitted_path = out_dir.join("Tests/ProvekitEmittedTests/ProvekitEmittedTests.swift");
+    let emitted = fs::read_to_string(&emitted_path)
+        .unwrap_or_else(|_| panic!("read emitted {}", emitted_path.display()));
+    assert!(emitted.contains("import XCTest"), "emitted:\n{emitted}");
+    assert!(
+        emitted.contains("XCTAssertEqual(2, 2)"),
+        "emitted:\n{emitted}"
+    );
+}

--- a/implementations/rust/provekit-cli/tests/cmd_emit_typescript_vitest.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_typescript_vitest.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn typescript_vitest_emitter_available() -> bool {
+    let emitter = repo_root()
+        .join("implementations")
+        .join("typescript")
+        .join("provekit-emit-typescript-vitest");
+    Command::new("node")
+        .current_dir(&emitter)
+        .args([
+            "-e",
+            "require('./src/emitter'); process.exit(require('fs').existsSync('./node_modules/vitest/vitest.mjs') ? 0 : 1);",
+        ])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn install_emit_registration(project: &Path) {
+    let emitter_main = repo_root()
+        .join("implementations")
+        .join("typescript")
+        .join("provekit-emit-typescript-vitest")
+        .join("src")
+        .join("main.js");
+
+    let provekit_dir = project.join(".provekit");
+    fs::create_dir_all(&provekit_dir).expect("mkdir .provekit");
+    fs::write(
+        provekit_dir.join("config.toml"),
+        "exam_manifest_cid = \"blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"typescript-vitest\"\n\
+         surface = \"typescript-vitest\"\n\
+         emit = \"vitest\"\n",
+    )
+    .expect("write project config");
+
+    let manifest = project
+        .join(".provekit")
+        .join("emit")
+        .join("typescript-vitest")
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().unwrap()).expect("mkdir manifest");
+    fs::write(
+        manifest,
+        format!(
+            "name = \"typescript-vitest\"\ncommand = [\"node\", \"{}\", \"--rpc\"]\nworking_dir = \".\"\nprotocol_versions = [\"pep/1.7.0\"]\n",
+            emitter_main
+                .display()
+                .to_string()
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+        ),
+    )
+    .expect("write emit manifest");
+}
+
+#[test]
+fn emit_typescript_vitest_dispatches_real_emitter_and_vitest_checks_output() {
+    if !node_available() {
+        eprintln!("skipping: node not on PATH");
+        return;
+    }
+    if !typescript_vitest_emitter_available() {
+        eprintln!(
+            "skipping: TypeScript Vitest emitter deps unavailable; run `make build-ts` first"
+        );
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    let out_dir = temp.path().join("out");
+    fs::create_dir_all(&project).expect("mkdir project");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    install_emit_registration(&project);
+
+    let plan = project.join("plan.json");
+    fs::write(
+        &plan,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "contract_id": "concept:eq",
+            "function": "identity",
+            "params": ["x"],
+            "param_types": ["number"],
+            "return_type": "number",
+            "predicates": [{
+                "kind": "op",
+                "name": "concept:eq",
+                "args": [
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}},
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}}
+                ]
+            }]
+        }))
+        .expect("encode plan"),
+    )
+    .expect("write plan");
+
+    let output = Command::new(provekit_bin())
+        .arg("emit")
+        .arg("--project")
+        .arg(&project)
+        .arg("--target")
+        .arg("typescript")
+        .arg("--framework")
+        .arg("vitest")
+        .arg("--plan")
+        .arg(&plan)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit emit typescript");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "provekit emit typescript failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let receipt: Value = serde_json::from_str(&stdout).expect("emit stdout is JSON");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(
+        receipt["targetLanguage"], "typescript",
+        "receipt: {receipt}"
+    );
+    assert_eq!(receipt["targetFramework"], "vitest", "receipt: {receipt}");
+    assert_eq!(receipt["isComplete"], true, "receipt: {receipt}");
+    assert_eq!(receipt["compileCheck"]["ok"], true, "receipt: {receipt}");
+    assert!(
+        receipt["emittedArtifactCid"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("blake3-512:"),
+        "receipt: {receipt}"
+    );
+
+    let emitted_path = out_dir.join("provekit_identity.test.ts");
+    let emitted = fs::read_to_string(&emitted_path)
+        .unwrap_or_else(|_| panic!("read emitted {}", emitted_path.display()));
+    assert!(
+        emitted.contains("describe(\"provekit contract identity\""),
+        "emitted:\n{emitted}"
+    );
+    assert!(
+        emitted.contains("expect(2).toEqual(2);"),
+        "emitted:\n{emitted}"
+    );
+}

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -618,6 +618,42 @@ for line in sys.stdin:
     .expect("write fake materialize check kit");
 }
 
+fn write_materialize_no_assemble_rpc_kit(path: &Path) {
+    fs::write(
+        path,
+        r#"import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    msg_id = request.get("id")
+    method = request.get("method")
+    if method == "provekit.plugin.invoke":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {
+                "source": "def fetch_status(url):\n    return 200\n",
+                "is_stub": False,
+                "extension": "py",
+                "imports": [],
+                "emitted_artifact_cid": "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            }
+        }), flush=True)
+    elif method == "provekit.plugin.shutdown":
+        print(json.dumps({"jsonrpc": "2.0", "id": msg_id, "result": None}), flush=True)
+        break
+    else:
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": {"code": -32601, "message": "METHOD_NOT_FOUND: " + str(method)}
+        }), flush=True)
+"#,
+    )
+    .expect("write fake no-assemble materialize kit");
+}
+
 fn write_rust_http_request_source(src_dir: &Path) -> PathBuf {
     let source_path = src_dir.join("lib.rs");
     let payload = http_payload_json("fetch_status", "&str", "i64");
@@ -1286,6 +1322,93 @@ for line in sys.stdin:
     );
 }
 
+#[test]
+fn cross_language_out_dir_refuses_target_kit_without_assemble_rpc() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let repo = repo_root();
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+    write_rust_family_sql_carrier_source(&src_dir);
+    fs::write(
+        workspace.path().join("Cargo.toml"),
+        "[package]\nname = \"cross-language-no-assemble\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write source project marker");
+
+    let fake_realize = workspace.path().join("fake_cross_language_no_assemble.py");
+    fs::write(
+        &fake_realize,
+        r#"import json, sys
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request.get("method")
+    if method == "provekit.plugin.invoke":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request.get("id"),
+            "result": {
+                "source": "const rows = db.prepare(sql).all(args);",
+                "is_stub": False,
+                "extension": "ts"
+            }
+        }), flush=True)
+    elif method == "provekit.plugin.shutdown":
+        print(json.dumps({"jsonrpc": "2.0", "id": request.get("id"), "result": None}), flush=True)
+        break
+    else:
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request.get("id"),
+            "error": {"code": -32601, "message": "METHOD_NOT_FOUND: " + str(method)}
+        }), flush=True)
+"#,
+    )
+    .expect("write fake realize script");
+
+    install_python_script_manifest_with_metadata(
+        workspace.path(),
+        "typescript-better-sqlite3",
+        &fake_realize,
+        "better-sqlite3",
+        Some("concept:family:sql"),
+        &["concept:sql-query-all"],
+    );
+
+    let out_dir = workspace.path().join("materialized");
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .env("PROVEKIT_REPO_ROOT", repo)
+        .arg("materialize")
+        .arg("--source-lang")
+        .arg("rust")
+        .arg("--target")
+        .arg("typescript")
+        .arg("--library")
+        .arg("typescript-better-sqlite3")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .output()
+        .expect("spawn cross-language materialize with no-assemble target kit");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "cross-language materialize must fail closed when the target kit cannot assemble source\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("assemble RPC"),
+        "failure should name the missing target-kit assembly boundary\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !out_dir.join("lib.ts").exists(),
+        "CLI must not write cross-language target source through legacy concat fallback"
+    );
+}
+
 // --- compile-check tests (#1376) ---
 
 /// --compile-check without --out-dir must be rejected by clap (requires = "out_dir").
@@ -1425,5 +1548,60 @@ fn materialize_compile_check_dispatches_to_realize_kit() {
     assert!(
         marker_body.contains("kit-owned-classpath"),
         "compile-check RPC must receive kit-owned assemble metadata: {marker_body}"
+    );
+}
+
+#[test]
+fn materialize_out_dir_refuses_selected_kit_without_assemble_rpc() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+    fs::write(
+        workspace.path().join("pyproject.toml"),
+        "[project]\nname = \"materialize-no-assemble\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("write project marker");
+    write_python_http_request_source(&src_dir);
+
+    let fake_kit = workspace.path().join("fake_materialize_no_assemble_kit.py");
+    write_materialize_no_assemble_rpc_kit(&fake_kit);
+    install_python_script_manifest_with_metadata(
+        workspace.path(),
+        "python-no-assemble",
+        &fake_kit,
+        "no-assemble",
+        None,
+        &["concept:http-request"],
+    );
+
+    let out_dir = workspace.path().join("materialized");
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--target")
+        .arg("python")
+        .arg("--library")
+        .arg("no-assemble")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .output()
+        .expect("spawn provekit materialize with no-assemble kit");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "materialize must fail closed when the selected kit cannot assemble target source\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("assemble RPC"),
+        "failure should name the missing kit assembly boundary\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !out_dir.join("client.py").exists(),
+        "CLI must not write target source through legacy fallback when kit assembly is missing"
     );
 }

--- a/implementations/rust/provekit-cli/tests/cmd_verify_typescript_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_typescript_production_bridge.rs
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// TypeScript production-bridge gauntlet. The Rust CLI is only the generic
+// config/manifest/RPC client here: TypeScript parsing, Vitest assertion
+// harvesting, and TS-term-to-ProofIR normalization all live in the TS kit.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value as Json;
+
+#[path = "support/contradiction.rs"]
+mod contradiction;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn tsx_cli() -> Option<PathBuf> {
+    let path = repo_root()
+        .join("node_modules")
+        .join("tsx")
+        .join("dist")
+        .join("cli.mjs");
+    path.exists().then_some(path)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-ts-prod-bridge-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir project");
+    p
+}
+
+fn stage_typescript_project(suffix: &str, body_factor: i64) -> PathBuf {
+    let tsx = tsx_cli().expect("tsx CLI must exist; run make build-ts first");
+    let project = unique_dir(suffix);
+    fs::create_dir_all(project.join("src")).expect("mkdir src");
+    fs::write(
+        project.join("src").join("double.ts"),
+        format!("export function double(x: number): number {{\n  return x * {body_factor};\n}}\n"),
+    )
+    .expect("write src/double.ts");
+    fs::write(
+        project.join("double.test.ts"),
+        r#"import { expect, it } from "vitest";
+import { double } from "./src/double";
+
+it("double three is six", () => {
+  expect(double(3)).toBe(6);
+});
+"#,
+    )
+    .expect("write double.test.ts");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("typescript-source"))
+        .expect("mkdir typescript-source manifest dir");
+    fs::create_dir_all(provekit.join("lift").join("typescript-vitest-tests"))
+        .expect("mkdir typescript-vitest-tests manifest dir");
+    fs::write(
+        provekit.join("config.toml"),
+        "exam_manifest_cid = \"blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"typescript-source\"\n\
+         surface = \"typescript-source\"\n\
+         layer = \"verify\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"typescript-vitest-tests\"\n\
+         surface = \"typescript-vitest-tests\"\n",
+    )
+    .expect("write config.toml");
+
+    let ts_source_bin = repo_root()
+        .join("implementations")
+        .join("typescript")
+        .join("src")
+        .join("lift")
+        .join("typescript-source")
+        .join("bin.ts");
+    let vitest_bin = repo_root()
+        .join("implementations")
+        .join("typescript")
+        .join("src")
+        .join("lift")
+        .join("vitest-tests-bin.ts");
+
+    fs::write(
+        provekit
+            .join("lift")
+            .join("typescript-source")
+            .join("manifest.toml"),
+        format!(
+            "name = \"typescript-source\"\ncommand = [\"node\", \"{}\", \"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+            tsx.display(),
+            ts_source_bin.display()
+        ),
+    )
+    .expect("write typescript-source manifest");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("typescript-vitest-tests")
+            .join("manifest.toml"),
+        format!(
+            "name = \"typescript-vitest-tests\"\ncommand = [\"node\", \"{}\", \"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+            tsx.display(),
+            vitest_bin.display()
+        ),
+    )
+    .expect("write typescript-vitest-tests manifest");
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_verify_json_with_code(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .arg("verify")
+        .arg("--project")
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+fn json_contains_str(value: &Json, needle: &str) -> bool {
+    match value {
+        Json::String(s) => s == needle,
+        Json::Array(values) => values.iter().any(|v| json_contains_str(v, needle)),
+        Json::Object(map) => map.values().any(|v| json_contains_str(v, needle)),
+        _ => false,
+    }
+}
+
+#[test]
+fn typescript_mint_auto_writes_body_discharge_bridge_from_real_lifters() {
+    if !node_available() {
+        eprintln!("node not on PATH: skipping TypeScript production-bridge bridge-writer test");
+        return;
+    }
+    if tsx_cli().is_none() {
+        eprintln!("tsx not installed at repo root: skipping; run make build-ts first");
+        return;
+    }
+    let project = stage_typescript_project("bridge", 2);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "tool-minted bundle must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let bridge = pool.bridges_by_symbol.get("double").unwrap_or_else(|| {
+        panic!(
+            "mint must auto-write + index a bridge with sourceSymbol=double; indexed: {:?}",
+            pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+        )
+    });
+    let target_cid = provekit_verifier::types::memento_body_field(bridge, "targetContractCid")
+        .and_then(|v| v.as_str())
+        .expect("bridge must carry targetContractCid")
+        .to_string();
+    let target = pool.mementos.get(&target_cid).unwrap_or_else(|| {
+        panic!("bridge.targetContractCid {target_cid} must resolve to a member")
+    });
+    assert_eq!(
+        provekit_verifier::types::memento_kind(target),
+        Some("contract"),
+        "bridge target must be a contract memento"
+    );
+    let formals = provekit_verifier::types::memento_body_field(target, "formals")
+        .and_then(|v| v.as_array())
+        .expect("tool-written op-contract must carry formals");
+    assert_eq!(
+        formals.first().and_then(|v| v.as_str()),
+        Some("x"),
+        "op-contract formals must be [x]"
+    );
+    assert!(
+        provekit_verifier::types::memento_body_field(target, "post").is_some(),
+        "op-contract must carry the body-derived post"
+    );
+
+    let saw_callsite_contract = pool.mementos.values().any(|member| {
+        provekit_verifier::types::memento_kind(member) == Some("contract")
+            && provekit_verifier::types::memento_body_field(member, "inv")
+                .is_some_and(|inv| json_contains_str(inv, "double"))
+    });
+    assert!(
+        saw_callsite_contract,
+        "minted bundle must include the TypeScript Vitest assertion contract mentioning double"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn typescript_production_path_double_discharges_and_mints_witness() {
+    if !node_available() {
+        eprintln!("node not on PATH: skipping TypeScript production-bridge positive test");
+        return;
+    }
+    if tsx_cli().is_none() {
+        eprintln!("tsx not installed at repo root: skipping; run make build-ts first");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping TypeScript production-bridge positive test");
+        return;
+    }
+    let project = stage_typescript_project("pos", 2);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(
+        receipt["kind"], "verification-receipt",
+        "receipt: {receipt}"
+    );
+    assert_eq!(
+        receipt["totalClaims"], 1,
+        "exactly one body-bearing TypeScript callsite must enumerate; receipt: {receipt}"
+    );
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["pass"], true,
+        "double(3)==6 must discharge through body (* x 2); claim: {claim}"
+    );
+    assert_eq!(claim["status"], "discharged", "claim: {claim}");
+    let solver = claim["dischargingSolver"].as_str().unwrap_or("");
+    assert!(
+        solver.starts_with("z3@"),
+        "discharging solver must be z3; got `{solver}`"
+    );
+    let witness_cid = claim["witnessCid"].as_str().expect("witness minted");
+    assert!(witness_cid.starts_with("blake3-512:"));
+    eprintln!("TYPESCRIPT_PRODUCTION_POSITIVE_WITNESS_CID={witness_cid}");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(code, 0, "positive run exits clean; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn typescript_production_path_broken_body_fails_unsatisfied_no_witness() {
+    if !node_available() {
+        eprintln!("node not on PATH: skipping TypeScript production-bridge negative test");
+        return;
+    }
+    if tsx_cli().is_none() {
+        eprintln!("tsx not installed at repo root: skipping; run make build-ts first");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping TypeScript production-bridge negative test");
+        return;
+    }
+    let project = stage_typescript_project("neg", 3);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["status"], "unsatisfied",
+        "broken TypeScript body x*3 must be UNSATISFIED; claim: {claim}"
+    );
+    assert_eq!(claim["pass"], false, "claim: {claim}");
+    assert!(
+        claim["witnessCid"].is_null(),
+        "no witness for a violated claim; claim: {claim}"
+    );
+    assert_eq!(receipt["ok"], false, "receipt: {receipt}");
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a violated claim; found {} files",
+        witness_files.len()
+    );
+    assert_eq!(
+        code, 1,
+        "broken-body claim must exit 1 (EXIT_VERIFY_FAIL); got {code}"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn typescript_production_path_refuses_planted_contradictory_implication() {
+    if !node_available() {
+        eprintln!("node not on PATH: skipping TypeScript contradictory-implication test");
+        return;
+    }
+    if tsx_cli().is_none() {
+        eprintln!("tsx not installed at repo root: skipping; run make build-ts first");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping TypeScript contradictory-implication test");
+        return;
+    }
+    let project = stage_typescript_project("contradiction", 2);
+    run_mint(&project);
+
+    let (green, green_code) = contradiction::run_prove_json_with_code(&provekit_bin(), &project);
+    assert_eq!(
+        green_code, 0,
+        "base TypeScript project must prove before planting contradiction; report: {green}"
+    );
+    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+
+    contradiction::plant_contradictory_implication_proof(
+        &project.join(".provekit"),
+        "typescript",
+        "typescript-tests",
+        "typescript_parity",
+    );
+    let (red, red_code) = contradiction::run_prove_json_with_code(&provekit_bin(), &project);
+    contradiction::assert_prove_refuses_contradiction(
+        &red,
+        red_code,
+        "typescript_parity_requires_positive",
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}

--- a/implementations/rust/provekit-cli/tests/cmd_verify_zig_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_zig_production_bridge.rs
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Zig production-bridge gauntlet. The Rust CLI is only the generic
+// config/manifest/RPC client here: Zig parsing, std.testing assertion
+// harvesting, implication lifting, and Zig-term-to-ProofIR normalization all
+// live in Zig lifter surfaces.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value as Json;
+
+#[path = "support/contradiction.rs"]
+mod contradiction;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn zig_available() -> bool {
+    Command::new("zig")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-zig-prod-bridge-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir project");
+    p
+}
+
+fn toml_path(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn zig_command(cache_root: &Path) -> String {
+    format!(
+        "[\"env\", \"ZIG_GLOBAL_CACHE_DIR={}\", \"ZIG_LOCAL_CACHE_DIR={}\", \"zig\", \"build\", \"run\", \"--\", \"--rpc\"]",
+        toml_path(&cache_root.join("zig-global-cache")),
+        toml_path(&cache_root.join("zig-local-cache")),
+    )
+}
+
+fn stage_zig_project(suffix: &str, body_factor: i64) -> PathBuf {
+    let root = repo_root();
+    let project = unique_dir(suffix);
+    fs::write(
+        project.join("math.zig"),
+        format!(
+            r#"const std = @import("std");
+
+pub fn double(x: i64) i64 {{
+    return x * {body_factor};
+}}
+
+test "double three is six" {{
+    const actual = double(3);
+    try std.testing.expectEqual(@as(i64, 6), actual);
+}}
+"#
+        ),
+    )
+    .expect("write math.zig");
+
+    let provekit = project.join(".provekit");
+    for surface in ["zig-source", "zig-tests", "zig-implications"] {
+        fs::create_dir_all(provekit.join("lift").join(surface))
+            .unwrap_or_else(|_| panic!("mkdir manifest dir {surface}"));
+    }
+    fs::write(
+        provekit.join("config.toml"),
+        "exam_manifest_cid = \"blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"zig-source\"\n\
+         surface = \"zig-source\"\n\
+         layer = \"verify\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"zig-tests\"\n\
+         surface = \"zig-tests\"\n\
+         layer = \"tests\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"zig-implications\"\n\
+         surface = \"zig-implications\"\n\
+         layer = \"implications\"\n",
+    )
+    .expect("write config.toml");
+
+    let source_dir = root
+        .join("implementations")
+        .join("zig")
+        .join("provekit-lift-zig-source");
+    let tests_dir = root
+        .join("implementations")
+        .join("zig")
+        .join("provekit-lift-zig-tests");
+    let cache_root = project.join(".provekit").join("zig-cache");
+    fs::create_dir_all(&cache_root).expect("mkdir zig cache");
+    let command = zig_command(&cache_root);
+
+    fs::write(
+        provekit
+            .join("lift")
+            .join("zig-source")
+            .join("manifest.toml"),
+        format!(
+            "name = \"zig-source\"\ncommand = {command}\nworking_dir = \"{}\"\n",
+            toml_path(&source_dir)
+        ),
+    )
+    .expect("write zig-source manifest");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("zig-tests")
+            .join("manifest.toml"),
+        format!(
+            "name = \"zig-tests\"\ncommand = {command}\nworking_dir = \"{}\"\n",
+            toml_path(&tests_dir)
+        ),
+    )
+    .expect("write zig-tests manifest");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("zig-implications")
+            .join("manifest.toml"),
+        format!(
+            "name = \"zig-implications\"\ncommand = {command}\nworking_dir = \"{}\"\nmethod = \"provekit.plugin.lift_implications\"\nphase = \"consumer\"\n",
+            toml_path(&tests_dir)
+        ),
+    )
+    .expect("write zig-implications manifest");
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_verify_json_with_code(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .arg("verify")
+        .arg("--project")
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+fn json_contains_str(value: &Json, needle: &str) -> bool {
+    match value {
+        Json::String(s) => s == needle,
+        Json::Array(values) => values.iter().any(|v| json_contains_str(v, needle)),
+        Json::Object(map) => map.values().any(|v| json_contains_str(v, needle)),
+        _ => false,
+    }
+}
+
+#[test]
+fn zig_mint_auto_writes_body_discharge_bridge_and_implications_from_real_lifters() {
+    if !zig_available() {
+        eprintln!("zig not on PATH: skipping Zig production-bridge bridge-writer test");
+        return;
+    }
+    let project = stage_zig_project("bridge", 2);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "tool-minted bundle must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let bridge = pool.bridges_by_symbol.get("double").unwrap_or_else(|| {
+        panic!(
+            "mint must auto-write + index a bridge with sourceSymbol=double; indexed: {:?}",
+            pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+        )
+    });
+    let target_cid = provekit_verifier::types::memento_body_field(bridge, "targetContractCid")
+        .and_then(|v| v.as_str())
+        .expect("bridge must carry targetContractCid")
+        .to_string();
+    let target = pool.mementos.get(&target_cid).unwrap_or_else(|| {
+        panic!("bridge.targetContractCid {target_cid} must resolve to a member")
+    });
+    assert_eq!(
+        provekit_verifier::types::memento_kind(target),
+        Some("contract"),
+        "bridge target must be a contract memento"
+    );
+    assert!(
+        pool.mementos.values().any(|member| {
+            provekit_verifier::types::memento_kind(member) == Some("contract")
+                && provekit_verifier::types::memento_body_field(member, "inv")
+                    .is_some_and(|inv| json_contains_str(inv, "double"))
+        }),
+        "minted bundle must include the Zig std.testing assertion contract mentioning double"
+    );
+    assert!(
+        pool.mementos
+            .values()
+            .any(|member| provekit_verifier::types::memento_kind(member) == Some("implication")),
+        "zig-implications lifter output must be minted into implication mementos"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn zig_production_path_double_discharges_and_mints_witness() {
+    if !zig_available() {
+        eprintln!("zig not on PATH: skipping Zig production-bridge positive test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Zig production-bridge positive test");
+        return;
+    }
+    let project = stage_zig_project("pos", 2);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["pass"], true,
+        "double(3)==6 must discharge through Zig body (* x 2); claim: {claim}"
+    );
+    assert_eq!(claim["status"], "discharged", "claim: {claim}");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(code, 0, "positive run exits clean; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn zig_production_path_broken_body_fails_unsatisfied_no_witness() {
+    if !zig_available() {
+        eprintln!("zig not on PATH: skipping Zig production-bridge negative test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Zig production-bridge negative test");
+        return;
+    }
+    let project = stage_zig_project("neg", 3);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["status"], "unsatisfied",
+        "broken Zig body x*3 must be UNSATISFIED; claim: {claim}"
+    );
+    assert_eq!(claim["pass"], false, "claim: {claim}");
+    assert!(claim["witnessCid"].is_null(), "claim: {claim}");
+    assert_eq!(receipt["ok"], false, "receipt: {receipt}");
+    assert_eq!(code, 1, "broken-body claim must exit 1; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn zig_production_path_refuses_planted_contradictory_implication() {
+    if !zig_available() {
+        eprintln!("zig not on PATH: skipping Zig contradictory-implication test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Zig contradictory-implication test");
+        return;
+    }
+    let project = stage_zig_project("contradiction", 2);
+    run_mint(&project);
+
+    let (green, green_code) = contradiction::run_prove_json_with_code(&provekit_bin(), &project);
+    assert_eq!(
+        green_code, 0,
+        "base Zig project must prove before planting contradiction; report: {green}"
+    );
+    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+
+    contradiction::plant_contradictory_implication_proof(
+        &project.join(".provekit"),
+        "zig",
+        "zig-tests",
+        "zig_parity",
+    );
+    let (red, red_code) = contradiction::run_prove_json_with_code(&provekit_bin(), &project);
+    contradiction::assert_prove_refuses_contradiction(
+        &red,
+        red_code,
+        "zig_parity_requires_positive",
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}

--- a/implementations/swift/.provekit/emit/swift-xctest/manifest.toml
+++ b/implementations/swift/.provekit/emit/swift-xctest/manifest.toml
@@ -1,0 +1,6 @@
+name = "swift-xctest"
+version = "0.1.0"
+protocol_versions = ["pep/1.7.0"]
+kind = "emit"
+command = [".build/debug/provekit-emit-swift-xctest", "--rpc"]
+working_dir = "."

--- a/implementations/swift/Package.swift
+++ b/implementations/swift/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .executable(name: "provekit-lsp-swift", targets: ["ProveKitLSPSwift"]),
         .executable(name: "mint-swift-self-contracts", targets: ["MintSwiftSelfContracts"]),
         .executable(name: "provekit-lift-swift-source", targets: ["ProvekitLiftSwiftSourceCLI"]),
+        .executable(name: "provekit-emit-swift-xctest", targets: ["ProvekitEmitSwiftXCTest"]),
         .executable(name: "test-swift-lsp", targets: ["LSPTests"]),
         .executable(name: "test-swift-crypto", targets: ["CryptoTests"]),
     ],
@@ -141,6 +142,10 @@ let package = Package(
         .executableTarget(
             name: "ProvekitLiftSwiftSourceCLI",
             dependencies: ["ProvekitLiftSwiftSource"]
+        ),
+        .executableTarget(
+            name: "ProvekitEmitSwiftXCTest",
+            dependencies: ["ProvekitCrypto"]
         ),
         // LSPTests: standalone integration test runner (no XCTest/Testing dep needed).
         // `swift run test-swift-lsp` returns exit 0 on pass, non-zero on fail.

--- a/implementations/swift/Sources/ProvekitEmitSwiftXCTest/main.swift
+++ b/implementations/swift/Sources/ProvekitEmitSwiftXCTest/main.swift
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-emit-swift-xctest: PEP 1.7.0 emit plugin for Swift XCTest.
+//
+// The Rust CLI sends a neutral EmitPlan over JSON-RPC. This kit owns the
+// Swift/XCTest syntax and a native Swift parser check.
+
+import Foundation
+import ProvekitCrypto
+
+private struct EmitPlan {
+    let contractID: String
+    let function: String
+    let params: [String]
+    let paramTypes: [String]
+    let predicates: [[String: Any]]
+
+    static func from(_ params: [String: Any]) -> EmitPlan {
+        EmitPlan(
+            contractID: firstString(params["contract_id"], params["concept_name"]) ?? "",
+            function: firstString(params["function"], params["function_name"], params["functionName"]) ?? "contract",
+            params: stringList(params["params"]),
+            paramTypes: stringList(params["param_types"]),
+            predicates: mapList(params["predicates"])
+        )
+    }
+}
+
+private struct Emission {
+    let source: String
+    let path: String
+    let artifactCID: String
+    let emittedPredicates: [String]
+    let unsupportedPredicates: [String]
+
+    var isComplete: Bool {
+        unsupportedPredicates.isEmpty && !emittedPredicates.isEmpty
+    }
+
+    func toJSON() -> [String: Any] {
+        [
+            "kind": "swift-xctest-test-emission",
+            "source": source,
+            "path": path,
+            "extension": "swift",
+            "emitted_artifact_cid": artifactCID,
+            "emitted_predicates": emittedPredicates,
+            "unsupported_predicates": unsupportedPredicates,
+            "is_complete": isComplete,
+        ]
+    }
+}
+
+private func emit(_ plan: EmitPlan) -> Emission {
+    var functions: [String] = []
+    var emitted: [String] = []
+    var unsupported: [String] = []
+
+    for (idx, predicate) in plan.predicates.enumerated() {
+        let head = predicateHead(predicate)
+        guard let assertion = renderAssertion(head: head, predicate: predicate) else {
+            unsupported.append(head ?? "<malformed>")
+            continue
+        }
+        let declarations = variableDeclarations(for: predicate, head: head)
+        functions.append(renderTestFunction(name: testFunctionName(head: head, index: idx), declarations: declarations, assertion: assertion))
+        emitted.append(head ?? "predicate")
+    }
+
+    let source = renderModule(className: testClassName(plan.function), functions: functions)
+    return Emission(
+        source: source,
+        path: "Tests/ProvekitEmittedTests/ProvekitEmittedTests.swift",
+        artifactCID: Blake3.hex(Data(source.utf8)),
+        emittedPredicates: emitted,
+        unsupportedPredicates: unsupported
+    )
+}
+
+private func renderModule(className: String, functions: [String]) -> String {
+    var lines: [String] = [
+        "import XCTest",
+        "",
+        "final class \(className): XCTestCase {",
+    ]
+    if functions.isEmpty {
+        lines.append("}")
+        lines.append("")
+        return lines.joined(separator: "\n")
+    }
+    for (index, function) in functions.enumerated() {
+        if index > 0 {
+            lines.append("")
+        }
+        lines.append(contentsOf: function.split(separator: "\n", omittingEmptySubsequences: false).map(String.init))
+    }
+    lines.append("}")
+    lines.append("")
+    return lines.joined(separator: "\n")
+}
+
+private func renderTestFunction(name: String, declarations: [String], assertion: String) -> String {
+    var lines: [String] = ["    func \(name)() {"]
+    for declaration in declarations {
+        lines.append("        \(declaration)")
+    }
+    for line in assertion.split(separator: "\n", omittingEmptySubsequences: false) {
+        lines.append("        \(line)")
+    }
+    lines.append("    }")
+    return lines.joined(separator: "\n")
+}
+
+private func renderAssertion(head: String?, predicate: [String: Any]) -> String? {
+    guard let head else {
+        return nil
+    }
+    let args = argumentMaps(predicate)
+    switch head {
+    case "eq":
+        guard let pair = renderPair(args) else { return nil }
+        return "XCTAssertEqual(\(pair.0), \(pair.1))"
+    case "ne":
+        guard let pair = renderPair(args) else { return nil }
+        return "XCTAssertNotEqual(\(pair.0), \(pair.1))"
+    case "lt":
+        guard let pair = renderPair(args) else { return nil }
+        return "XCTAssertTrue(\(pair.0) < \(pair.1))"
+    case "le":
+        guard let pair = renderPair(args) else { return nil }
+        return "XCTAssertTrue(\(pair.0) <= \(pair.1))"
+    case "gt":
+        guard let pair = renderPair(args) else { return nil }
+        return "XCTAssertTrue(\(pair.0) > \(pair.1))"
+    case "ge":
+        guard let pair = renderPair(args) else { return nil }
+        return "XCTAssertTrue(\(pair.0) >= \(pair.1))"
+    case "not-null", "option-is-some":
+        guard args.count == 1, let expr = renderTerm(args[0]) else { return nil }
+        return "XCTAssertNotNil(\(expr))"
+    case "option-is-none":
+        guard args.count == 1, let expr = renderTerm(args[0]) else { return nil }
+        return "XCTAssertNil(\(expr))"
+    default:
+        return nil
+    }
+}
+
+private func renderPair(_ args: [[String: Any]]) -> (String, String)? {
+    guard args.count == 2,
+          let left = renderTerm(args[0]),
+          let right = renderTerm(args[1])
+    else {
+        return nil
+    }
+    return (left, right)
+}
+
+private func renderTerm(_ term: [String: Any]) -> String? {
+    let kind = term["kind"] as? String
+    switch kind {
+    case "const":
+        return constExpression(term["value"])
+    case "var":
+        return sanitizeIdentifier(term["name"] as? String, fallback: "value")
+    case "op":
+        let head = predicateHead(term)
+        let args = argumentMaps(term)
+        switch head {
+        case "add": return renderBinaryExpression(args, "+")
+        case "sub": return renderBinaryExpression(args, "-")
+        case "mul": return renderBinaryExpression(args, "*")
+        case "div": return renderBinaryExpression(args, "/")
+        default: return nil
+        }
+    default:
+        return nil
+    }
+}
+
+private func renderBinaryExpression(_ args: [[String: Any]], _ op: String) -> String? {
+    guard let pair = renderPair(args) else {
+        return nil
+    }
+    return "(\(pair.0) \(op) \(pair.1))"
+}
+
+private func constExpression(_ value: Any?) -> String? {
+    if value == nil || value is NSNull {
+        return "nil"
+    }
+    if let bool = value as? Bool {
+        return bool ? "true" : "false"
+    }
+    if let number = value as? NSNumber {
+        return number.stringValue
+    }
+    if let string = value as? String {
+        return "\"\(escapeSwiftString(string))\""
+    }
+    return nil
+}
+
+private func variableDeclarations(for predicate: [String: Any], head: String?) -> [String] {
+    var ordered: [String] = []
+    var seen = Set<String>()
+    collectVars(predicate, into: &ordered, seen: &seen)
+    return ordered.enumerated().map { index, raw in
+        "\(sanitizeIdentifier(raw, fallback: "v\(index)")) = \(placeholderValue(for: head, index: index))"
+    }
+}
+
+private func collectVars(_ term: [String: Any], into ordered: inout [String], seen: inout Set<String>) {
+    if term["kind"] as? String == "var", let name = term["name"] as? String {
+        if seen.insert(name).inserted {
+            ordered.append(name)
+        }
+    }
+    for arg in argumentMaps(term) {
+        collectVars(arg, into: &ordered, seen: &seen)
+    }
+}
+
+private func placeholderValue(for head: String?, index: Int) -> String {
+    switch head {
+    case "lt", "le":
+        return index == 0 ? "0" : "1"
+    case "gt", "ge":
+        return index == 0 ? "1" : "0"
+    case "ne":
+        return index == 0 ? "0" : "1"
+    case "not-null", "option-is-some":
+        return "Optional(1)"
+    case "option-is-none":
+        return "Optional<Int>.none"
+    default:
+        return "0"
+    }
+}
+
+private func predicateHead(_ predicate: [String: Any]) -> String? {
+    guard let raw = firstString(predicate["name"], predicate["op"], predicate["head"])?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    else {
+        return nil
+    }
+    if raw.isEmpty {
+        return nil
+    }
+    let suffix = raw.split(separator: ":").last.map(String.init) ?? raw
+    return suffix
+        .replacingOccurrences(of: "_", with: "-")
+        .lowercased()
+}
+
+private func argumentMaps(_ predicate: [String: Any]) -> [[String: Any]] {
+    guard let args = predicate["args"] as? [Any] else {
+        return []
+    }
+    return args.compactMap { $0 as? [String: Any] }
+}
+
+private func testClassName(_ function: String) -> String {
+    "\(upperCamel(function, fallback: "Contract"))ContractTests"
+}
+
+private func testFunctionName(head: String?, index: Int) -> String {
+    "testVerifies\(upperCamel(head ?? "predicate", fallback: "Predicate"))\(index)"
+}
+
+private func upperCamel(_ raw: String, fallback: String) -> String {
+    let parts = raw
+        .split { !$0.isLetter && !$0.isNumber }
+        .map(String.init)
+        .filter { !$0.isEmpty }
+    let joined = parts.map { part in
+        part.prefix(1).uppercased() + part.dropFirst()
+    }.joined()
+    let candidate = joined.isEmpty ? fallback : joined
+    if candidate.first?.isNumber == true {
+        return "\(fallback)\(candidate)"
+    }
+    return candidate
+}
+
+private func sanitizeIdentifier(_ raw: String?, fallback: String) -> String {
+    let source = (raw ?? "").isEmpty ? fallback : raw!
+    var scalars: [UnicodeScalar] = []
+    for scalar in source.unicodeScalars {
+        if CharacterSet.alphanumerics.contains(scalar) || scalar == "_" {
+            scalars.append(scalar)
+        } else {
+            scalars.append("_")
+        }
+    }
+    var out = String(String.UnicodeScalarView(scalars)).trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+    if out.isEmpty {
+        out = fallback
+    }
+    if out.unicodeScalars.first.map(CharacterSet.decimalDigits.contains) == true {
+        out = "_\(out)"
+    }
+    switch out {
+    case "class", "struct", "enum", "func", "let", "var", "return", "nil", "true", "false":
+        return "`\(out)`"
+    default:
+        return out
+    }
+}
+
+private func escapeSwiftString(_ raw: String) -> String {
+    raw
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+        .replacingOccurrences(of: "\n", with: "\\n")
+        .replacingOccurrences(of: "\t", with: "\\t")
+}
+
+private func firstString(_ values: Any?...) -> String? {
+    for value in values {
+        if let string = value as? String {
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+    }
+    return nil
+}
+
+private func stringList(_ value: Any?) -> [String] {
+    guard let array = value as? [Any] else {
+        return []
+    }
+    return array.compactMap { $0 as? String }
+}
+
+private func mapList(_ value: Any?) -> [[String: Any]] {
+    guard let array = value as? [Any] else {
+        return []
+    }
+    return array.compactMap { $0 as? [String: Any] }
+}
+
+private func runCheck(outDir: String, artifactPath: String?) -> [String: Any] {
+    let path = artifactPath ?? "\(outDir)/Tests/ProvekitEmittedTests/ProvekitEmittedTests.swift"
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["swiftc", "-parse", path]
+    process.currentDirectoryURL = URL(fileURLWithPath: outDir)
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {
+        return [
+            "ok": false,
+            "command": "swiftc -parse \(path)",
+            "cwd": outDir,
+            "stdout": "",
+            "stderr": String(describing: error),
+            "exitCode": -1,
+        ]
+    }
+    let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    return [
+        "ok": process.terminationStatus == 0,
+        "command": "swiftc -parse \(path)",
+        "cwd": outDir,
+        "stdout": stdoutText,
+        "stderr": stderrText,
+        "exitCode": Int(process.terminationStatus),
+    ]
+}
+
+private func dispatch(_ request: [String: Any]) -> [String: Any] {
+    let id = request["id"] ?? NSNull()
+    let method = request["method"] as? String ?? ""
+    let params = request["params"] as? [String: Any] ?? [:]
+
+    switch method {
+    case "provekit.plugin.describe":
+        return success(id: id, result: [
+            "name": "swift-xctest",
+            "kind": "emit",
+            "protocol_versions": ["pep/1.7.0"],
+            "target_language": "swift",
+            "framework": "xctest",
+            "supported_predicates": ["eq", "ne", "lt", "le", "gt", "ge", "not-null", "option-is-some", "option-is-none"],
+        ])
+    case "provekit.plugin.invoke":
+        let emission = emit(EmitPlan.from(params))
+        return success(id: id, result: emission.toJSON())
+    case "provekit.plugin.check":
+        guard let outDir = firstString(params["out_dir"], params["outDir"]) else {
+            return failure(id: id, code: -32602, message: "INVALID_PARAMS: missing out_dir")
+        }
+        return success(
+            id: id,
+            result: runCheck(
+                outDir: outDir,
+                artifactPath: firstString(params["artifact_path"], params["artifactPath"])
+            )
+        )
+    case "provekit.plugin.shutdown":
+        return success(id: id, result: NSNull())
+    default:
+        return failure(id: id, code: -32601, message: "METHOD_NOT_FOUND: \(method)")
+    }
+}
+
+private func success(id: Any, result: Any) -> [String: Any] {
+    [
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    ]
+}
+
+private func failure(id: Any, code: Int, message: String) -> [String: Any] {
+    [
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": [
+            "code": code,
+            "message": message,
+        ],
+    ]
+}
+
+private func writeJSONLine(_ object: [String: Any]) {
+    guard JSONSerialization.isValidJSONObject(object),
+          let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    else {
+        FileHandle.standardOutput.write(#"{"error":{"code":-32603,"message":"SERIALIZE_ERROR"},"id":null,"jsonrpc":"2.0"}"#.data(using: .utf8)!)
+        FileHandle.standardOutput.write(Data([0x0A]))
+        return
+    }
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data([0x0A]))
+    fflush(stdout)
+}
+
+private func runRPC() {
+    while let line = readLine(strippingNewline: true) {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            continue
+        }
+        let response: [String: Any]
+        if let data = trimmed.data(using: .utf8),
+           let request = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            response = dispatch(request)
+            writeJSONLine(response)
+            if request["method"] as? String == "provekit.plugin.shutdown" {
+                return
+            }
+        } else {
+            writeJSONLine(failure(id: NSNull(), code: -32700, message: "PARSE_ERROR"))
+        }
+    }
+}
+
+if CommandLine.arguments.contains("--rpc") {
+    runRPC()
+} else {
+    let emission = emit(EmitPlan(
+        contractID: "concept:eq",
+        function: "contract",
+        params: [],
+        paramTypes: [],
+        predicates: [[
+            "kind": "op",
+            "name": "concept:eq",
+            "args": [
+                ["kind": "const", "value": 1],
+                ["kind": "const", "value": 1],
+            ],
+        ]]
+    ))
+    print(emission.source)
+}

--- a/implementations/typescript/provekit-emit-typescript-vitest/package-lock.json
+++ b/implementations/typescript/provekit-emit-typescript-vitest/package-lock.json
@@ -1,0 +1,1232 @@
+{
+  "name": "provekit-emit-typescript-vitest",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "provekit-emit-typescript-vitest",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noble/hashes": "^2.2.0",
+        "vitest": "^4.1.5"
+      },
+      "bin": {
+        "provekit-emit-typescript-vitest": "src/main.js"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.3.tgz",
+      "integrity": "sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/implementations/typescript/provekit-emit-typescript-vitest/package.json
+++ b/implementations/typescript/provekit-emit-typescript-vitest/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "provekit-emit-typescript-vitest",
+  "version": "0.1.0",
+  "description": "PEP 1.7.0 TypeScript Vitest emitter kit for ProvekIt contracts",
+  "type": "commonjs",
+  "main": "src/main.js",
+  "bin": {
+    "provekit-emit-typescript-vitest": "src/main.js"
+  },
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  },
+  "dependencies": {
+    "@noble/hashes": "^2.2.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/implementations/typescript/provekit-emit-typescript-vitest/src/emitter.js
+++ b/implementations/typescript/provekit-emit-typescript-vitest/src/emitter.js
@@ -1,0 +1,266 @@
+"use strict";
+
+const { blake3 } = require("@noble/hashes/blake3.js");
+
+function emit(plan) {
+  const normalized = normalizePlan(plan);
+  const emittedPredicates = [];
+  const unsupportedPredicates = [];
+  const tests = [];
+
+  normalized.predicates.forEach((predicate, index) => {
+    const head = headOf(predicate);
+    const assertion = renderAssertion(head, predicate);
+    if (assertion === null) {
+      unsupportedPredicates.push(head || "<malformed>");
+      return;
+    }
+    emittedPredicates.push(canonicalHead(head));
+    tests.push(renderTest(head, index, declarationsFor(head, freeVars(predicate)), assertion));
+  });
+
+  const source = renderModule(normalized.functionName, tests);
+  return {
+    kind: "typescript-vitest-test-emission",
+    source,
+    path: modulePath(normalized.functionName),
+    extension: "ts",
+    emitted_artifact_cid: blake3Cid(source),
+    emitted_predicates: emittedPredicates,
+    unsupported_predicates: unsupportedPredicates,
+    is_complete: unsupportedPredicates.length === 0 && emittedPredicates.length > 0,
+  };
+}
+
+function normalizePlan(plan) {
+  const params = isObject(plan) ? plan : {};
+  return {
+    contractId: firstString(params.contract_id, params.concept_name),
+    functionName: firstString(params.function, params.function_name, params.functionName) || "contract",
+    predicates: array(params.predicates).filter(isObject),
+  };
+}
+
+function renderModule(functionName, tests) {
+  const suite = stringLiteral(`provekit contract ${functionName || "contract"}`);
+  const body = tests.length > 0 ? tests.join("\n\n") : "  it(\"has no emitted predicates\", () => {});";
+  return `describe(${suite}, () => {\n${body}\n});\n`;
+}
+
+function renderTest(head, index, declarations, assertion) {
+  const testName = stringLiteral(`verifies ${canonicalHead(head)} ${index}`);
+  const lines = [`  it(${testName}, () => {`];
+  declarations.forEach((decl) => lines.push(`    ${decl}`));
+  assertion.split("\n").forEach((line) => lines.push(`    ${line}`));
+  lines.push("  });");
+  return lines.join("\n");
+}
+
+function renderAssertion(head, predicate) {
+  const args = array(predicate.args).filter(isObject);
+  switch (canonicalHead(head)) {
+    case "eq":
+      return binaryAssertion(args, "toEqual");
+    case "ne":
+      return binaryAssertion(args, "not.toEqual");
+    case "lt":
+      return binaryComparator(args, "<");
+    case "gt":
+      return binaryComparator(args, ">");
+    case "le":
+      return binaryComparator(args, "<=");
+    case "ge":
+      return binaryComparator(args, ">=");
+    case "option-is-some":
+    case "not-null":
+      return unaryNotNull(args);
+    case "option-is-none":
+      return unaryNull(args);
+    default:
+      return null;
+  }
+}
+
+function binaryAssertion(args, matcher) {
+  if (args.length !== 2) return null;
+  const left = renderTerm(args[0]);
+  const right = renderTerm(args[1]);
+  if (left === null || right === null) return null;
+  return `expect(${left}).${matcher}(${right});`;
+}
+
+function binaryComparator(args, op) {
+  if (args.length !== 2) return null;
+  const left = renderTerm(args[0]);
+  const right = renderTerm(args[1]);
+  if (left === null || right === null) return null;
+  return `expect(${left} ${op} ${right}).toBe(true);`;
+}
+
+function unaryNotNull(args) {
+  if (args.length !== 1) return null;
+  const value = renderTerm(args[0]);
+  if (value === null) return null;
+  return `expect(${value}).not.toBeNull();`;
+}
+
+function unaryNull(args) {
+  if (args.length !== 1) return null;
+  const value = renderTerm(args[0]);
+  if (value === null) return null;
+  return `expect(${value}).toBeNull();`;
+}
+
+function declarationsFor(head, vars) {
+  return vars.map((name, index) => {
+    const ident = sanitizeIdentifier(name, `v${index}`);
+    return `const ${ident} = ${placeholderValue(head, index)};`;
+  });
+}
+
+function placeholderValue(head, index) {
+  switch (canonicalHead(head)) {
+    case "lt":
+      return index === 0 ? "0" : "1";
+    case "gt":
+      return index === 0 ? "1" : "0";
+    case "le":
+    case "ge":
+    case "eq":
+      return "0";
+    case "ne":
+      return index === 0 ? "0" : "1";
+    case "option-is-none":
+      return "null";
+    case "option-is-some":
+    case "not-null":
+      return "1";
+    default:
+      return "0";
+  }
+}
+
+function renderTerm(term) {
+  if (!isObject(term)) return null;
+  const kind = firstString(term.kind);
+  if (kind === "var") {
+    return sanitizeIdentifier(firstString(term.name), "");
+  }
+  if (kind === "const") {
+    return renderConst(term.value);
+  }
+  if (kind === "op" || kind === "ctor") {
+    return renderApplication(term);
+  }
+  return null;
+}
+
+function renderConst(value) {
+  if (value === null) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number" && Number.isFinite(value)) return JSON.stringify(value);
+  if (typeof value === "string") return JSON.stringify(value);
+  return null;
+}
+
+function renderApplication(term) {
+  const name = firstString(term.name, term.conceptName, term.concept_name);
+  const args = array(term.args).filter(isObject);
+  const rendered = args.map(renderTerm);
+  if (rendered.some((value) => value === null)) return null;
+  if (["+", "-", "*", "/", "%"].includes(name) && rendered.length === 2) {
+    return `(${rendered[0]} ${name} ${rendered[1]})`;
+  }
+  if (name === "array") return `[${rendered.join(", ")}]`;
+  if (name === "tuple") return `[${rendered.join(", ")}]`;
+  const callee = sanitizeIdentifier(name.replace(/^concept:/, ""), "");
+  if (callee === "") return null;
+  return `${callee}(${rendered.join(", ")})`;
+}
+
+function freeVars(predicate) {
+  const out = [];
+  collectFreeVars(predicate, out);
+  return out;
+}
+
+function collectFreeVars(value, out) {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectFreeVars(item, out));
+    return;
+  }
+  if (!isObject(value)) return;
+  if (value.kind === "var") {
+    const name = firstString(value.name);
+    if (name !== "" && !out.includes(name)) out.push(name);
+  }
+  collectFreeVars(value.args, out);
+}
+
+function headOf(predicate) {
+  if (!isObject(predicate)) return "";
+  return firstString(predicate.name, predicate.concept_name, predicate.conceptName);
+}
+
+function canonicalHead(head) {
+  const normalized = firstString(head).replace(/^concept:/, "").replace(/_/g, "-");
+  switch (normalized) {
+    case "=":
+      return "eq";
+    case "!=":
+    case "\u2260":
+      return "ne";
+    case "<":
+      return "lt";
+    case ">":
+      return "gt";
+    case "<=":
+    case "\u2264":
+      return "le";
+    case ">=":
+    case "\u2265":
+      return "ge";
+    default:
+      return normalized;
+  }
+}
+
+function modulePath(functionName) {
+  const safe = firstString(functionName).replace(/[^0-9A-Za-z_]+/g, "_").replace(/^_+|_+$/g, "").toLowerCase();
+  return `provekit_${safe || "contract"}.test.ts`;
+}
+
+function sanitizeIdentifier(value, fallback) {
+  const raw = firstString(value).replace(/-/g, "_").replace(/[^0-9A-Za-z_$]/g, "_");
+  const candidate = raw.replace(/^[^A-Za-z_$]+/, "");
+  return /^[A-Za-z_$][0-9A-Za-z_$]*$/.test(candidate) ? candidate : fallback;
+}
+
+function stringLiteral(value) {
+  return JSON.stringify(String(value));
+}
+
+function blake3Cid(source) {
+  const digest = blake3(Buffer.from(source, "utf8"), { dkLen: 64 });
+  return `blake3-512:${Buffer.from(digest).toString("hex")}`;
+}
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim() !== "") return value.trim();
+  }
+  return "";
+}
+
+function array(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+module.exports = {
+  emit,
+  normalizePlan,
+};

--- a/implementations/typescript/provekit-emit-typescript-vitest/src/main.js
+++ b/implementations/typescript/provekit-emit-typescript-vitest/src/main.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+"use strict";
+
+const { runRpc } = require("./rpc");
+
+if (process.argv.includes("--rpc")) {
+  runRpc();
+} else {
+  process.stderr.write("usage: provekit-emit-typescript-vitest --rpc\n");
+  process.exit(2);
+}

--- a/implementations/typescript/provekit-emit-typescript-vitest/src/rpc.js
+++ b/implementations/typescript/provekit-emit-typescript-vitest/src/rpc.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const path = require("node:path");
+const readline = require("node:readline");
+const { spawnSync } = require("node:child_process");
+
+const { emit } = require("./emitter");
+
+function runRpc() {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
+  rl.on("line", (line) => {
+    if (line.trim() === "") return;
+    let method = "";
+    try {
+      const request = JSON.parse(line);
+      method = String(request.method ?? "");
+      send(dispatch(request));
+      if (method === "provekit.plugin.shutdown") rl.close();
+    } catch (error) {
+      send(errorResponse(null, -32700, `PARSE_ERROR: ${error.message}`));
+    }
+  });
+}
+
+function dispatch(request) {
+  const msgId = request.id ?? null;
+  const method = String(request.method ?? "");
+  const params = request.params ?? {};
+  if (method === "provekit.plugin.invoke") {
+    if (!isObject(params)) return errorResponse(msgId, -32602, "INVALID_PARAMS: params must be an object");
+    return { jsonrpc: "2.0", id: msgId, result: emit(params) };
+  }
+  if (method === "provekit.plugin.check") {
+    if (!isObject(params)) return errorResponse(msgId, -32602, "INVALID_PARAMS: params must be an object");
+    const outDir = stringField(params, "out_dir") || stringField(params, "outDir");
+    const artifactPath = stringField(params, "artifact_path") || stringField(params, "artifactPath");
+    if (outDir === "") return errorResponse(msgId, -32602, "INVALID_PARAMS: missing out_dir");
+    if (artifactPath === "") return errorResponse(msgId, -32602, "INVALID_PARAMS: missing artifact_path");
+    return { jsonrpc: "2.0", id: msgId, result: checkVitest(outDir, artifactPath) };
+  }
+  if (method === "provekit.plugin.shutdown") {
+    return { jsonrpc: "2.0", id: msgId, result: null };
+  }
+  return errorResponse(msgId, -32601, `METHOD_NOT_FOUND: ${method}`);
+}
+
+function checkVitest(outDir, artifactPath) {
+  const vitestBin = path.join(__dirname, "..", "node_modules", "vitest", "vitest.mjs");
+  const target = path.isAbsolute(artifactPath) ? artifactPath : path.resolve(outDir, artifactPath);
+  const filter = path.relative(outDir, target);
+  const completed = spawnSync(process.execPath, [vitestBin, "run", "--globals", filter], {
+    cwd: outDir,
+    encoding: "utf8",
+  });
+  return {
+    ok: completed.status === 0,
+    command: `${process.execPath} ${vitestBin} run --globals ${filter}`,
+    cwd: outDir,
+    stdout: completed.stdout || "",
+    stderr: completed.stderr || "",
+    exitCode: completed.status === null ? 1 : completed.status,
+  };
+}
+
+function send(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function errorResponse(id, code, message) {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+function stringField(value, field) {
+  return typeof value[field] === "string" ? value[field] : "";
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+module.exports = {
+  checkVitest,
+  dispatch,
+  runRpc,
+};

--- a/implementations/typescript/provekit-emit-typescript-vitest/tests/emitter.test.js
+++ b/implementations/typescript/provekit-emit-typescript-vitest/tests/emitter.test.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { emit } = require("../src/emitter");
+
+test("emit renders a passing Vitest module from neutral predicates", () => {
+  const result = emit({
+    contract_id: "concept:eq",
+    function: "identity",
+    predicates: [
+      {
+        kind: "op",
+        name: "concept:eq",
+        args: [
+          { kind: "const", value: 2 },
+          { kind: "const", value: 2 },
+        ],
+      },
+      {
+        kind: "op",
+        name: "concept:lt",
+        args: [
+          { kind: "var", name: "lo" },
+          { kind: "var", name: "hi" },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.kind, "typescript-vitest-test-emission");
+  assert.equal(result.path, "provekit_identity.test.ts");
+  assert.equal(result.extension, "ts");
+  assert.match(result.emitted_artifact_cid, /^blake3-512:[0-9a-f]{128}$/);
+  assert.deepEqual(result.emitted_predicates, ["eq", "lt"]);
+  assert.deepEqual(result.unsupported_predicates, []);
+  assert.equal(result.is_complete, true);
+  assert.match(result.source, /describe\("provekit contract identity"/);
+  assert.match(result.source, /expect\(2\)\.toEqual\(2\);/);
+  assert.match(result.source, /const lo = 0;/);
+  assert.match(result.source, /const hi = 1;/);
+  assert.match(result.source, /expect\(lo < hi\)\.toBe\(true\);/);
+});
+
+test("emit reports unsupported predicates instead of emitting vacuous tests", () => {
+  const result = emit({
+    function: "unsupported",
+    predicates: [{ kind: "op", name: "concept:unknown", args: [] }],
+  });
+
+  assert.equal(result.is_complete, false);
+  assert.deepEqual(result.emitted_predicates, []);
+  assert.deepEqual(result.unsupported_predicates, ["concept:unknown"]);
+});

--- a/implementations/typescript/provekit-emit-typescript-vitest/tests/rpc.test.js
+++ b/implementations/typescript/provekit-emit-typescript-vitest/tests/rpc.test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { dispatch } = require("../src/rpc");
+
+test("rpc invoke emits TypeScript Vitest source", () => {
+  const response = dispatch({
+    id: 1,
+    method: "provekit.plugin.invoke",
+    params: {
+      function: "identity",
+      predicates: [
+        {
+          kind: "op",
+          name: "concept:eq",
+          args: [
+            { kind: "const", value: 2 },
+            { kind: "const", value: 2 },
+          ],
+        },
+      ],
+    },
+  });
+
+  assert.equal(response.jsonrpc, "2.0");
+  assert.equal(response.id, 1);
+  assert.ok(!response.error, `unexpected error: ${JSON.stringify(response.error)}`);
+  assert.equal(response.result.path, "provekit_identity.test.ts");
+  assert.match(response.result.source, /expect\(2\)\.toEqual\(2\);/);
+});
+
+test("rpc check runs Vitest on emitted artifact", () => {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "provekit-ts-vitest-check-"));
+  const artifactPath = path.join(outDir, "provekit_identity.test.ts");
+  fs.writeFileSync(
+    artifactPath,
+    'describe("provekit", () => {\n  it("passes", () => {\n    expect(2).toEqual(2);\n  });\n});\n',
+  );
+
+  const response = dispatch({
+    id: 2,
+    method: "provekit.plugin.check",
+    params: { out_dir: outDir, artifact_path: artifactPath },
+  });
+
+  assert.equal(response.jsonrpc, "2.0");
+  assert.equal(response.id, 2);
+  assert.equal(response.result.ok, true, `stdout:\n${response.result.stdout}\nstderr:\n${response.result.stderr}`);
+});

--- a/implementations/typescript/provekit-realize-typescript-better-sqlite3/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-better-sqlite3/src/rpc.js
@@ -4,6 +4,7 @@ const realizer = require("./realizer");
 const { emitStub } = realizer;
 const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
 const { resolveDependencyProofs } = require("../../provekit-realize-typescript-core/src/dependency_proofs");
+const { assembleResponse } = require("../../provekit-realize-typescript-core/src/assemble");
 
 function runRpc() {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
@@ -59,6 +60,13 @@ function dispatch(request) {
     }
     const entries = realizer.shimProofEntries ? realizer.shimProofEntries() : [];
     return { jsonrpc: "2.0", id: msgId, result: { entries, proof_path: proofPath } };
+  }
+  if (method === "provekit.plugin.assemble") {
+    try {
+      return { jsonrpc: "2.0", id: msgId, result: assembleResponse(params) };
+    } catch (error) {
+      return errorResponse(msgId, -32040, `ASSEMBLE_FAILED: ${error.message}`);
+    }
   }
   if (method === "provekit.plugin.resolve_dependency_proofs") {
     return { jsonrpc: "2.0", id: msgId, result: { proofs: resolveDependencyProofs(params.project_root) } };

--- a/implementations/typescript/provekit-realize-typescript-better-sqlite3/tests/realizer.test.js
+++ b/implementations/typescript/provekit-realize-typescript-better-sqlite3/tests/realizer.test.js
@@ -65,6 +65,29 @@ test("rpc body_template_entries returns shim-resolved entries", () => {
   assert.ok(resp.result.proof_path.includes("node_modules"), "proof_path must be in node_modules");
 });
 
+test("rpc assemble returns TypeScript compilation unit", () => {
+  const resp = dispatch({
+    id: 2,
+    method: "provekit.plugin.assemble",
+    params: {
+      file_basename: "queries",
+      fragments: [
+        {
+          source: "function selectRows(db, sql, args) {\n  return db.prepare(sql).all(args);\n}\n",
+          helpers: ["const DEFAULT_LIMIT = 100;"],
+        },
+      ],
+    },
+  });
+
+  assert.ok(!resp.error, `unexpected error: ${JSON.stringify(resp.error)}`);
+  assert.deepEqual(resp.result.compile_classpath, []);
+  assert.equal(resp.result.files.length, 1);
+  assert.equal(resp.result.files[0].path, "queries.ts");
+  assert.match(resp.result.files[0].content, /const DEFAULT_LIMIT = 100;/);
+  assert.match(resp.result.files[0].content, /function selectRows/);
+});
+
 // NTT source substitution: 2-param NTT picks stmt-based binding from shim
 test("rpc forwards named term tree sources to better-sqlite3 template substitution", () => {
   const response = dispatch({
@@ -104,4 +127,3 @@ test("rpc forwards named term tree sources to better-sqlite3 template substituti
   // The NTT source for the sql arg is inlined as the statement.
   assert.match(response.result.source, /"SELECT id FROM users WHERE id = \?"/);
 });
-

--- a/implementations/typescript/provekit-realize-typescript-core/src/assemble.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/assemble.js
@@ -1,0 +1,68 @@
+"use strict";
+
+function assembleResponse(params) {
+  if (params === null || typeof params !== "object" || Array.isArray(params)) {
+    throw new Error("params must be an object");
+  }
+  const fileBasename = safeBasename(
+    typeof params.file_basename === "string" && params.file_basename !== ""
+      ? params.file_basename
+      : "module",
+  );
+  const fragments = Array.isArray(params.fragments) ? params.fragments : [];
+  const imports = new Set();
+  const helpers = [];
+  const sources = [];
+
+  for (const fragment of fragments) {
+    if (fragment === null || typeof fragment !== "object" || Array.isArray(fragment)) continue;
+    for (const item of stringArray(fragment.imports)) imports.add(item);
+    for (const item of stringArray(fragment.helpers)) helpers.push(item);
+    if (typeof fragment.source === "string" && fragment.source.trim() !== "") {
+      sources.push(fragment.source.trimEnd());
+    }
+  }
+
+  const sections = [];
+  const importBlock = renderImports(imports);
+  if (importBlock !== "") sections.push(importBlock);
+  if (helpers.length > 0) sections.push(dedupe(helpers).join("\n"));
+  if (sources.length > 0) sections.push(sources.join("\n\n"));
+
+  return {
+    files: [
+      {
+        path: `${fileBasename}.ts`,
+        content: `${sections.join("\n\n")}${sections.length > 0 ? "\n" : ""}`,
+      },
+    ],
+    compile_classpath: [],
+  };
+}
+
+function renderImports(imports) {
+  return Array.from(imports)
+    .sort()
+    .map((item) => {
+      if (item.startsWith("import ")) return item.endsWith(";") ? item : `${item};`;
+      return `import ${JSON.stringify(item)};`;
+    })
+    .join("\n");
+}
+
+function safeBasename(value) {
+  return value.replace(/[^A-Za-z0-9_.-]/g, "_").replace(/^\.+/, "") || "module";
+}
+
+function stringArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item) => typeof item === "string" && item !== "");
+}
+
+function dedupe(values) {
+  return Array.from(new Set(values));
+}
+
+module.exports = {
+  assembleResponse,
+};

--- a/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-core/src/rpc.js
@@ -1,6 +1,7 @@
 const readline = require("node:readline");
 
 const { resolveDependencyProofs } = require("./dependency_proofs");
+const { assembleResponse } = require("./assemble");
 const { emitStub } = require("./realizer");
 const { answers: literalEncodingAnswers } = require("./literal_encoding");
 const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
@@ -49,6 +50,13 @@ function dispatch(request) {
   }
   if (method === "provekit.plugin.literal_encoding_answers") {
     return { jsonrpc: "2.0", id: msgId, result: { answers: literalEncodingAnswers() } };
+  }
+  if (method === "provekit.plugin.assemble") {
+    try {
+      return { jsonrpc: "2.0", id: msgId, result: assembleResponse(params) };
+    } catch (error) {
+      return errorResponse(msgId, -32040, `ASSEMBLE_FAILED: ${error.message}`);
+    }
   }
   if (method === "provekit.plugin.resolve_dependency_proofs") {
     let projectRoot = process.cwd();

--- a/implementations/typescript/provekit-realize-typescript-core/tests/assemble.test.js
+++ b/implementations/typescript/provekit-realize-typescript-core/tests/assemble.test.js
@@ -1,0 +1,34 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { assembleResponse } = require("../src/assemble");
+
+test("assembleResponse renders a TypeScript compilation unit from fragments", () => {
+  const result = assembleResponse({
+    file_basename: "users module",
+    fragments: [
+      {
+        imports: ['import { Pool } from "pg"'],
+        helpers: ["const TABLE = \"users\";"],
+        source: "async function getUser(pool, id) {\n  return pool.query(\"select * from users where id = $1\", [id]);\n}\n",
+      },
+      {
+        imports: ['import { Pool } from "pg"'],
+        helpers: ["const TABLE = \"users\";"],
+        source: "function rowCount(rows) {\n  return rows.length;\n}\n",
+      },
+    ],
+  });
+
+  assert.deepEqual(result.compile_classpath, []);
+  assert.equal(result.files.length, 1);
+  assert.equal(result.files[0].path, "users_module.ts");
+  assert.equal(
+    result.files[0].content,
+    'import { Pool } from "pg";\n\nconst TABLE = "users";\n\nasync function getUser(pool, id) {\n  return pool.query("select * from users where id = $1", [id]);\n}\n\nfunction rowCount(rows) {\n  return rows.length;\n}\n',
+  );
+});
+
+test("assembleResponse rejects non-object params", () => {
+  assert.throws(() => assembleResponse(null), /params must be an object/);
+});

--- a/implementations/typescript/provekit-realize-typescript-core/tests/realizer.test.js
+++ b/implementations/typescript/provekit-realize-typescript-core/tests/realizer.test.js
@@ -10,19 +10,6 @@ const SQL_GUARD_TEMPLATE = path.join(
   "body-templates",
   "ntt-sql-guard.json",
 );
-const PG_BODY_TEMPLATE = path.join(
-  __dirname,
-  "..",
-  "..",
-  "..",
-  "..",
-  "menagerie",
-  "typescript-language-signature",
-  "specs",
-  "body-templates",
-  "typescript-canonical-bodies-pg.json",
-);
-
 function namedTermTree(conceptName, args = []) {
   return {
     args,
@@ -112,50 +99,6 @@ test("named term tree shape satisfies a canonical sql body template guard", () =
 
   assert.equal(result.is_stub, false);
   assert.match(result.source, /pool\.query\(sql, args\)/);
-});
-
-test("named term tree request resolves the existing pg sql query body template", () => {
-  const realizer = createRealizer(PG_BODY_TEMPLATE);
-  const result = realizer.emitStub({
-    functionName: "getUserById",
-    params: ["sql", "args"],
-    paramTypes: ["number"],
-    returnType: "User",
-    conceptName: "concept:sql-query",
-    namedTermTree: namedTermTree("concept:sql-query", [
-      namedTermTree("concept:sql-literal"),
-      namedTermTree("concept:sql-args"),
-    ]),
-  });
-
-  assert.equal(result.is_stub, false);
-  assert.match(result.source, /await pool\.query\(sql, args\)/);
-});
-
-test("named term tree source values drive pg sql query template substitution", () => {
-  const realizer = createRealizer(PG_BODY_TEMPLATE);
-  const result = realizer.emitStub({
-    functionName: "getUserById",
-    params: ["id"],
-    paramTypes: ["number"],
-    returnType: "User",
-    conceptName: "concept:sql-query",
-    namedTermTree: namedTermTree("concept:sql-query", [
-      {
-        ...namedTermTree("Sql"),
-        source: "\"SELECT id, name, email FROM users WHERE id = $1\"",
-        sort: "Sql",
-      },
-      {
-        ...namedTermTree("SqlArgs"),
-        source: "[id]",
-        sort: "SqlArgs",
-      },
-    ]),
-  });
-
-  assert.equal(result.is_stub, false);
-  assert.match(result.source, /await pool\.query\("SELECT id, name, email FROM users WHERE id = \$1", \[id\]\)/);
 });
 
 test("bare signature request still uses mapped param types without named term tree", () => {

--- a/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/src/rpc.js
@@ -4,6 +4,7 @@ const realizer = require("./realizer");
 const { emitStub } = realizer;
 const { declaration: platformSemanticsDeclaration } = require("./platform_semantics");
 const { resolveDependencyProofs } = require("../../provekit-realize-typescript-core/src/dependency_proofs");
+const { assembleResponse } = require("../../provekit-realize-typescript-core/src/assemble");
 
 function runRpc() {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
@@ -59,6 +60,13 @@ function dispatch(request) {
     }
     const entries = realizer.shimProofEntries ? realizer.shimProofEntries() : [];
     return { jsonrpc: "2.0", id: msgId, result: { entries, proof_path: proofPath } };
+  }
+  if (method === "provekit.plugin.assemble") {
+    try {
+      return { jsonrpc: "2.0", id: msgId, result: assembleResponse(params) };
+    } catch (error) {
+      return errorResponse(msgId, -32040, `ASSEMBLE_FAILED: ${error.message}`);
+    }
   }
   if (method === "provekit.plugin.resolve_dependency_proofs") {
     return { jsonrpc: "2.0", id: msgId, result: { proofs: resolveDependencyProofs(params.project_root) } };

--- a/implementations/typescript/provekit-realize-typescript-pg/tests/realizer.test.js
+++ b/implementations/typescript/provekit-realize-typescript-pg/tests/realizer.test.js
@@ -80,6 +80,29 @@ test("rpc body_template_entries returns shim-resolved entries", () => {
   assert.ok(resp.result.proof_path.includes("node_modules"), "proof_path must be in node_modules");
 });
 
+test("rpc assemble returns TypeScript compilation unit", () => {
+  const resp = dispatch({
+    id: 2,
+    method: "provekit.plugin.assemble",
+    params: {
+      file_basename: "queries",
+      fragments: [
+        {
+          source: "async function selectRows(pool, sql, args) {\n  return await pool.query(sql, args);\n}\n",
+          helpers: ["const DEFAULT_LIMIT = 100;"],
+        },
+      ],
+    },
+  });
+
+  assert.ok(!resp.error, `unexpected error: ${JSON.stringify(resp.error)}`);
+  assert.deepEqual(resp.result.compile_classpath, []);
+  assert.equal(resp.result.files.length, 1);
+  assert.equal(resp.result.files[0].path, "queries.ts");
+  assert.match(resp.result.files[0].content, /const DEFAULT_LIMIT = 100;/);
+  assert.match(resp.result.files[0].content, /async function selectRows/);
+});
+
 // NTT source substitution: 2-param NTT picks the migrate sql-query-all binding
 test("rpc forwards named term tree sources to pg template substitution", () => {
   const response = dispatch({

--- a/implementations/typescript/src/lift/typescript-source/verify.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/verify.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { liftTypeScriptSourceText } from "./index.js";
+import { normalizeTypeScriptSourceVerifyDocument } from "./verify.js";
+
+describe("typescript-source verify projection", () => {
+  it("projects TypeScript body contracts into solver-facing ProofIR without source-unit noise", () => {
+    const lifted = liftTypeScriptSourceText(
+      "export function double(x: number): number { return x * 2; }\n",
+      "src/double.ts",
+    );
+
+    const doc = normalizeTypeScriptSourceVerifyDocument(lifted);
+
+    expect(doc.kind).toBe("ir-document");
+    expect(doc.ir).toHaveLength(1);
+    const contract = doc.ir[0] as any;
+    expect(contract.kind).toBe("function-contract");
+    expect(contract.fnName).toBe("src/double.ts:double");
+    expect(contract.bridgeSourceSymbol).toBe("double");
+    expect(contract.formals).toEqual(["x"]);
+    expect(contract.post.args[0]).toEqual({ kind: "var", name: "result" });
+    expect(contract.post.args[1]).toMatchObject({ kind: "ctor", name: "*" });
+    expect(contract.post.args[1].args[1]).toEqual({
+      kind: "const",
+      value: 2,
+      sort: { kind: "primitive", name: "Int" },
+    });
+    expect(JSON.stringify(doc.ir)).not.toContain("<source-unit>");
+  });
+});

--- a/implementations/typescript/src/lift/typescript-source/verify.ts
+++ b/implementations/typescript/src/lift/typescript-source/verify.ts
@@ -1,0 +1,191 @@
+import type { IrFormula, IrTerm, Sort } from "../../ir/formulas.js";
+import type {
+  FunctionContractMemento,
+  TypeScriptSourceDiagnostic,
+  TypeScriptSourceLiftResult,
+  TypeScriptSourceRefusal,
+} from "./index.js";
+
+export interface TypeScriptSourceVerifyContract extends FunctionContractMemento {
+  bridgeSourceSymbol: string;
+}
+
+export interface TypeScriptSourceVerifyIrDocument {
+  kind: "ir-document";
+  ir: TypeScriptSourceVerifyContract[];
+  callEdges: [];
+  diagnostics: TypeScriptSourceDiagnostic[];
+  opacityReport: unknown[];
+  refusals: TypeScriptSourceRefusal[];
+}
+
+export function normalizeTypeScriptSourceVerifyDocument(
+  result: TypeScriptSourceLiftResult,
+): TypeScriptSourceVerifyIrDocument {
+  return {
+    kind: "ir-document",
+    ir: result.declarations
+      .filter((decl) => !decl.fnName.endsWith(":<source-unit>"))
+      .map(normalizeFunctionContractForVerify),
+    callEdges: [],
+    diagnostics: result.diagnostics,
+    opacityReport: result.opacityReport,
+    refusals: result.refusals,
+  };
+}
+
+export function normalizeFunctionContractForVerify(
+  contract: FunctionContractMemento,
+): TypeScriptSourceVerifyContract {
+  return {
+    ...contract,
+    bridgeSourceSymbol: bridgeSourceSymbol(contract.fnName),
+    formalSorts: contract.formalSorts.map(normalizeSortForVerify),
+    returnSort: normalizeSortForVerify(contract.returnSort),
+    pre: normalizeFormulaForVerify(contract.pre),
+    post: normalizeFormulaForVerify(contract.post),
+  };
+}
+
+function normalizeFormulaForVerify(formula: IrFormula): IrFormula {
+  switch (formula.kind) {
+    case "atomic":
+      return {
+        ...formula,
+        name: normalizeAtomicName(formula.name),
+        args: formula.args.map(normalizeTermForVerify),
+      };
+    case "and":
+    case "or":
+    case "not":
+    case "implies":
+      return { ...formula, operands: formula.operands.map(normalizeFormulaForVerify) };
+    case "forall":
+    case "exists":
+      return {
+        ...formula,
+        sort: normalizeSortForVerify(formula.sort),
+        body: normalizeFormulaForVerify(formula.body),
+      };
+    case "choice":
+      return {
+        ...formula,
+        sort: normalizeSortForVerify(formula.sort),
+        body: normalizeFormulaForVerify(formula.body),
+      };
+  }
+}
+
+function normalizeTermForVerify(term: IrTerm): IrTerm {
+  switch (term.kind) {
+    case "var":
+      return {
+        ...term,
+        name: term.name === "return_value" ? "result" : term.name,
+      };
+    case "const":
+      return {
+        ...term,
+        sort: normalizeConstSortForVerify(term.value, term.sort),
+      };
+    case "ctor":
+      return {
+        ...term,
+        name: normalizeCtorName(term.name),
+        args: term.args.map(normalizeTermForVerify),
+      };
+    case "lambda":
+      return {
+        ...term,
+        paramSort: normalizeSortForVerify(term.paramSort),
+        body: normalizeTermForVerify(term.body),
+      };
+    case "let":
+      return {
+        ...term,
+        bindings: term.bindings.map((binding) => ({
+          ...binding,
+          boundTerm: normalizeTermForVerify(binding.boundTerm),
+        })),
+        body: normalizeTermForVerify(term.body),
+      };
+  }
+}
+
+function normalizeSortForVerify(sort: Sort): Sort {
+  switch (sort.kind) {
+    case "primitive":
+      if (sort.name === "Number") return { kind: "primitive", name: "Real" };
+      if (sort.name === "Boolean") return { kind: "primitive", name: "Bool" };
+      if (sort.name === "Unit") return { kind: "primitive", name: "Int" };
+      if (sort.name === "Any" || sort.name === "Unknown" || sort.name === "Null") {
+        return { kind: "primitive", name: "Int" };
+      }
+      return sort;
+    case "set":
+      return { ...sort, element: normalizeSortForVerify(sort.element) };
+    case "tuple":
+      return { ...sort, elements: sort.elements.map(normalizeSortForVerify) };
+    case "function":
+      return {
+        ...sort,
+        args: sort.args.map(normalizeSortForVerify),
+        return: normalizeSortForVerify(sort.return),
+      };
+    case "dependent":
+      return { ...sort, indexSort: normalizeSortForVerify(sort.indexSort) };
+    default:
+      return sort;
+  }
+}
+
+function normalizeConstSortForVerify(value: unknown, sort: Sort): Sort {
+  if (sort.kind === "primitive" && sort.name === "Number") {
+    return Number.isInteger(value) ? { kind: "primitive", name: "Int" } : { kind: "primitive", name: "Real" };
+  }
+  return normalizeSortForVerify(sort);
+}
+
+function normalizeCtorName(name: string): string {
+  switch (name) {
+    case "ts:add":
+      return "+";
+    case "ts:sub":
+      return "-";
+    case "ts:mul":
+      return "*";
+    case "ts:div":
+      return "/";
+    case "ts:mod":
+      return "mod";
+    default:
+      return name;
+  }
+}
+
+function normalizeAtomicName(name: string): string {
+  switch (name) {
+    case "ts:eq":
+      return "=";
+    case "ts:ne":
+      return "≠";
+    case "ts:lt":
+      return "<";
+    case "ts:le":
+      return "≤";
+    case "ts:gt":
+      return ">";
+    case "ts:ge":
+      return "≥";
+    default:
+      return name;
+  }
+}
+
+function bridgeSourceSymbol(fnName: string): string {
+  const withoutParams = fnName.split("(")[0] ?? fnName;
+  const afterModule = withoutParams.includes(":")
+    ? withoutParams.slice(withoutParams.lastIndexOf(":") + 1)
+    : withoutParams;
+  return afterModule.split(".").pop() || afterModule;
+}

--- a/implementations/typescript/src/lift/vitest-tests-bin.ts
+++ b/implementations/typescript/src/lift/vitest-tests-bin.ts
@@ -1,16 +1,9 @@
 #!/usr/bin/env node
 import readline from "node:readline";
 
-import {
-  compileTypeScriptSourceIr,
-  liftTypeScriptLibraryBindingsPaths,
-  liftTypeScriptSourcePaths,
-  type FunctionContractMemento,
-} from "./index.js";
-import { normalizeTypeScriptSourceVerifyDocument } from "./verify.js";
+import { liftVitestTestsIrDocument } from "./vitest-tests-rpc.js";
 
-const DIALECT = "typescript-source";
-const SURFACE_ALIASES = new Set([DIALECT, "typescript-bind"]);
+const DIALECT = "typescript-vitest-tests";
 const VERSION = "0.1.0-draft";
 
 interface JsonRpcRequest {
@@ -22,7 +15,7 @@ interface JsonRpcRequest {
 
 export function main(argv: string[] = process.argv.slice(2)): void {
   if (!argv.includes("--rpc")) {
-    process.stderr.write("usage: provekit-lift-typescript-source --rpc\n");
+    process.stderr.write("usage: provekit-lift-typescript-vitest-tests --rpc\n");
     process.exit(1);
   }
   runRpcMode();
@@ -52,19 +45,17 @@ function dispatch(request: JsonRpcRequest): Record<string, unknown> | null {
   switch (request.method) {
     case "initialize":
       return success(request.id, {
-        name: "provekit-lift-typescript-source",
+        name: "provekit-lift-typescript-vitest-tests",
         version: VERSION,
         protocol_version: "pep/1.7.0",
         capabilities: {
-          authoring_surfaces: [...SURFACE_ALIASES],
+          authoring_surfaces: [DIALECT],
           ir_version: "v1.1.0",
           emits_signed_mementos: false,
         },
       });
     case "lift":
       return liftRpc(request);
-    case "compile":
-      return compileRpc(request);
     case "shutdown":
       return success(request.id, null);
     default:
@@ -75,7 +66,7 @@ function dispatch(request: JsonRpcRequest): Record<string, unknown> | null {
 function liftRpc(request: JsonRpcRequest): Record<string, unknown> {
   const params = request.params ?? {};
   const surface = typeof params.surface === "string" ? params.surface : DIALECT;
-  if (!SURFACE_ALIASES.has(surface)) {
+  if (surface !== DIALECT) {
     return errorResponse(request.id ?? null, 1003, `SURFACE_NOT_SUPPORTED: ${surface}`);
   }
   const sourcePaths = Array.isArray(params.source_paths)
@@ -85,41 +76,7 @@ function liftRpc(request: JsonRpcRequest): Record<string, unknown> {
     return errorResponse(request.id ?? null, -32602, "source_paths must be a non-empty array of strings");
   }
   const workspaceRoot = typeof params.workspace_root === "string" ? params.workspace_root : ".";
-  const options = params.options && typeof params.options === "object" ? (params.options as Record<string, unknown>) : {};
-  const layer = typeof options.layer === "string" ? options.layer : "all";
-  if (layer === "library-bindings") {
-    const result = liftTypeScriptLibraryBindingsPaths(workspaceRoot, sourcePaths);
-    return success(request.id, {
-      kind: "ir-document",
-      ir: [...result.libraryBindings, ...result.libraryRefusals],
-      callEdges: [],
-      diagnostics: result.diagnostics,
-      opacityReport: result.opacityReport,
-      refusals: result.refusals,
-    });
-  }
-  const result = liftTypeScriptSourcePaths(workspaceRoot, sourcePaths);
-  if (layer === "verify") {
-    return success(request.id, normalizeTypeScriptSourceVerifyDocument(result));
-  }
-  return success(request.id, {
-    kind: "ir-document",
-    ir: result.declarations,
-    callEdges: [],
-    diagnostics: result.diagnostics,
-    opacityReport: result.opacityReport,
-    refusals: result.refusals,
-  });
-}
-
-function compileRpc(request: JsonRpcRequest): Record<string, unknown> {
-  const params = request.params ?? {};
-  const ir = params.ir;
-  if (!Array.isArray(ir)) {
-    return errorResponse(request.id ?? null, -32602, "ir must be an array of function-contract mementos");
-  }
-  const body = compileTypeScriptSourceIr(ir as FunctionContractMemento[]);
-  return success(request.id, { kind: "compiled-formula", body });
+  return success(request.id, liftVitestTestsIrDocument(workspaceRoot, sourcePaths));
 }
 
 function success(id: unknown, result: unknown): Record<string, unknown> {

--- a/implementations/typescript/src/lift/vitest-tests-rpc.test.ts
+++ b/implementations/typescript/src/lift/vitest-tests-rpc.test.ts
@@ -1,0 +1,47 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { liftVitestTestsIrDocument } from "./vitest-tests-rpc.js";
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "provekit-ts-vitest-rpc-"));
+}
+
+describe("typescript vitest lift RPC projection", () => {
+  it("exposes existing Vitest assertion lifting as ir-document contract entries", () => {
+    const root = tempDir();
+    mkdirSync(join(root, "src"));
+    writeFileSync(
+      join(root, "double.test.ts"),
+      `
+import { expect, it } from "vitest";
+import { double } from "./src/double";
+
+it("double three is six", () => {
+  expect(double(3)).toBe(6);
+});
+`,
+      "utf8",
+    );
+
+    const doc = liftVitestTestsIrDocument(root, ["."]);
+
+    expect(doc.kind).toBe("ir-document");
+    expect(doc.ir).toHaveLength(1);
+    const contract = doc.ir[0] as any;
+    expect(contract.kind).toBe("contract");
+    expect(contract.name).toBe("double three is six::0");
+    expect(contract.outBinding).toBe("out");
+    expect(contract.inv).toMatchObject({
+      kind: "atomic",
+      name: "=",
+      args: [
+        { kind: "ctor", name: "double" },
+        { kind: "const", value: 6, sort: { kind: "primitive", name: "Int" } },
+      ],
+    });
+    expect(contract.inv.args[0].args).toHaveLength(1);
+  });
+});

--- a/implementations/typescript/src/lift/vitest-tests-rpc.ts
+++ b/implementations/typescript/src/lift/vitest-tests-rpc.ts
@@ -1,0 +1,64 @@
+import { resolve } from "node:path";
+
+import { liftPath } from "./index.js";
+import type { ContractDecl, AdapterWarning } from "./types.js";
+
+export interface VitestTestsIrDocument {
+  kind: "ir-document";
+  ir: Record<string, unknown>[];
+  callEdges: [];
+  diagnostics: Array<{ severity: "warning" | "error"; message: string }>;
+}
+
+export function liftVitestTestsIrDocument(
+  workspaceRoot: string,
+  sourcePaths: readonly string[],
+): VitestTestsIrDocument {
+  const paths = sourcePaths.length > 0 ? sourcePaths : ["."];
+  const ir: Record<string, unknown>[] = [];
+  const diagnostics: VitestTestsIrDocument["diagnostics"] = [];
+  const seen = new Set<string>();
+
+  for (const sourcePath of paths) {
+    const report = liftPath(resolve(workspaceRoot, sourcePath));
+    diagnostics.push(
+      ...report.parseErrors.map((error) => ({
+        severity: "error" as const,
+        message: `${error.path}: ${error.message}`,
+      })),
+    );
+    const vitestReport = report.adapterReports.find((entry) => entry.adapter === "vitest-tests");
+    if (vitestReport) {
+      diagnostics.push(...vitestReport.warnings.map(warningToDiagnostic));
+    }
+    for (const decl of report.decls.filter((entry) => entry.adapter === "vitest-tests")) {
+      const item = contractDeclToIrEntry(decl);
+      const key = String(item.name ?? "");
+      if (key && seen.has(key)) continue;
+      if (key) seen.add(key);
+      ir.push(item);
+    }
+  }
+
+  return { kind: "ir-document", ir, callEdges: [], diagnostics };
+}
+
+function contractDeclToIrEntry(decl: ContractDecl): Record<string, unknown> {
+  const entry: Record<string, unknown> = {
+    schemaVersion: "1",
+    kind: "contract",
+    name: decl.name,
+    outBinding: decl.outBinding,
+  };
+  if (decl.pre !== undefined) entry.pre = decl.pre;
+  if (decl.post !== undefined) entry.post = decl.post;
+  if (decl.inv !== undefined) entry.inv = decl.inv;
+  return entry;
+}
+
+function warningToDiagnostic(warning: AdapterWarning): { severity: "warning"; message: string } {
+  return {
+    severity: "warning",
+    message: `${warning.sourcePath}:${warning.itemName}: ${warning.reason}`,
+  };
+}

--- a/implementations/zig/.provekit/lift/zig-implications/manifest.toml
+++ b/implementations/zig/.provekit/lift/zig-implications/manifest.toml
@@ -1,0 +1,13 @@
+name = "zig-implications"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["zig", "build", "run", "--", "--rpc"]
+working_dir = "provekit-lift-zig-tests"
+method = "provekit.plugin.lift_implications"
+phase = "consumer"
+
+[capabilities]
+authoring_surfaces = ["zig-implications"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/zig/.provekit/lift/zig-tests/manifest.toml
+++ b/implementations/zig/.provekit/lift/zig-tests/manifest.toml
@@ -1,0 +1,11 @@
+name = "zig-tests"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["zig", "build", "run", "--", "--rpc"]
+working_dir = "provekit-lift-zig-tests"
+
+[capabilities]
+authoring_surfaces = ["zig-tests"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/zig/.provekit/lift/zig/manifest.toml
+++ b/implementations/zig/.provekit/lift/zig/manifest.toml
@@ -1,3 +1,0 @@
-name = "zig-lift"
-command = ["provekit-lift-zig", "--rpc"]
-working_dir = "."

--- a/implementations/zig/provekit-lift-zig-source/src/lift.zig
+++ b/implementations/zig/provekit-lift-zig-source/src/lift.zig
@@ -139,6 +139,7 @@ pub const Effect = union(enum) {
 
 pub const FunctionContract = struct {
     fn_name: []const u8,
+    bridge_source_symbol: ?[]const u8 = null,
     formals: []const []const u8,
     formal_sorts: []const provekit.Sort,
     return_sort: provekit.Sort,
@@ -160,6 +161,10 @@ pub const FunctionContract = struct {
         try jws.endArray();
         try jws.objectField("bodyCid");
         if (self.body_cid) |cid| try jws.write(cid) else try jws.write(null);
+        if (self.bridge_source_symbol) |symbol| {
+            try jws.objectField("bridgeSourceSymbol");
+            try jws.write(symbol);
+        }
         try jws.objectField("effects");
         try jws.write(self.effects);
         try jws.objectField("fnName");
@@ -806,6 +811,117 @@ pub fn liftSource(alloc: std.mem.Allocator, source: []const u8, path: []const u8
     return lifter.lift();
 }
 
+pub fn verifyContracts(alloc: std.mem.Allocator, declarations: []const FunctionContract) ![]FunctionContract {
+    var out: std.ArrayList(FunctionContract) = .empty;
+    for (declarations) |decl| {
+        if (std.mem.startsWith(u8, decl.fn_name, "<source-unit:")) continue;
+        try out.append(alloc, try verifyContract(alloc, decl));
+    }
+    return out.toOwnedSlice(alloc);
+}
+
+fn verifyContract(alloc: std.mem.Allocator, decl: FunctionContract) !FunctionContract {
+    var out = decl;
+    out.bridge_source_symbol = try bareSymbol(alloc, decl.fn_name);
+    out.pre = try normalizeFormulaForVerify(alloc, decl.pre);
+    out.post = try normalizePostForVerify(alloc, decl.post);
+    out.body_term = try normalizeTermForVerify(alloc, decl.body_term);
+    return out;
+}
+
+fn normalizePostForVerify(alloc: std.mem.Allocator, formula: provekit.Formula) !provekit.Formula {
+    return switch (formula) {
+        .atomic => |a| blk: {
+            if (std.mem.eql(u8, a.name, "=") and a.args.len == 2) {
+                const args = try termArgs(alloc, .{
+                    provekit.Var("result"),
+                    try normalizeTermForVerify(alloc, unwrapReturn(a.args[1])),
+                });
+                break :blk provekit.Atomic("=", args);
+            }
+            break :blk try normalizeFormulaForVerify(alloc, formula);
+        },
+        else => try normalizeFormulaForVerify(alloc, formula),
+    };
+}
+
+fn normalizeFormulaForVerify(alloc: std.mem.Allocator, formula: provekit.Formula) anyerror!provekit.Formula {
+    return switch (formula) {
+        .atomic => |a| provekit.Atomic(normalizeAtomicName(a.name), try normalizeTermSliceForVerify(alloc, a.args)),
+        .connective => |c| .{ .connective = .{
+            .kind = c.kind,
+            .operands = try normalizeFormulaSliceForVerify(alloc, c.operands),
+        } },
+        .quantifier => |q| blk: {
+            const body = try alloc.create(provekit.Formula);
+            body.* = try normalizeFormulaForVerify(alloc, q.body.*);
+            break :blk .{ .quantifier = .{
+                .kind = q.kind,
+                .name = q.name,
+                .sort = q.sort,
+                .body = body,
+            } };
+        },
+    };
+}
+
+fn normalizeFormulaSliceForVerify(alloc: std.mem.Allocator, formulas: []const provekit.Formula) ![]const provekit.Formula {
+    var out = try alloc.alloc(provekit.Formula, formulas.len);
+    for (formulas, 0..) |formula, i| out[i] = try normalizeFormulaForVerify(alloc, formula);
+    return out;
+}
+
+fn normalizeTermSliceForVerify(alloc: std.mem.Allocator, terms: []const provekit.Term) ![]const provekit.Term {
+    var out = try alloc.alloc(provekit.Term, terms.len);
+    for (terms, 0..) |term, i| out[i] = try normalizeTermForVerify(alloc, term);
+    return out;
+}
+
+fn normalizeTermForVerify(alloc: std.mem.Allocator, term: provekit.Term) anyerror!provekit.Term {
+    return switch (term) {
+        .var_term => |v| if (std.mem.eql(u8, v.name, "return_value")) provekit.Var("result") else term,
+        .const_term => term,
+        .ctor_term => |c| blk: {
+            if (std.mem.eql(u8, c.name, "zig:return")) {
+                break :blk try normalizeTermForVerify(alloc, unwrapReturn(term));
+            }
+            break :blk provekit.Ctor(normalizeCtorName(c.name), try normalizeTermSliceForVerify(alloc, c.args));
+        },
+    };
+}
+
+fn unwrapReturn(term: provekit.Term) provekit.Term {
+    return switch (term) {
+        .ctor_term => |c| if (std.mem.eql(u8, c.name, "zig:return") and c.args.len == 1) c.args[0] else term,
+        else => term,
+    };
+}
+
+fn normalizeCtorName(name: []const u8) []const u8 {
+    if (std.mem.eql(u8, name, "zig:add")) return "+";
+    if (std.mem.eql(u8, name, "zig:sub")) return "-";
+    if (std.mem.eql(u8, name, "zig:mul")) return "*";
+    if (std.mem.eql(u8, name, "zig:div")) return "/";
+    if (std.mem.eql(u8, name, "zig:mod")) return "mod";
+    return name;
+}
+
+fn normalizeAtomicName(name: []const u8) []const u8 {
+    if (std.mem.eql(u8, name, "zig:eq")) return "=";
+    if (std.mem.eql(u8, name, "zig:ne")) return "!=";
+    if (std.mem.eql(u8, name, "zig:lt")) return "<";
+    if (std.mem.eql(u8, name, "zig:le")) return "<=";
+    if (std.mem.eql(u8, name, "zig:gt")) return ">";
+    if (std.mem.eql(u8, name, "zig:ge")) return ">=";
+    return name;
+}
+
+fn bareSymbol(alloc: std.mem.Allocator, fn_name: []const u8) ![]const u8 {
+    const without_params = if (std.mem.indexOfScalar(u8, fn_name, '(')) |idx| fn_name[0..idx] else fn_name;
+    const after_dot = if (std.mem.lastIndexOfScalar(u8, without_params, '.')) |idx| without_params[idx + 1 ..] else without_params;
+    return try alloc.dupe(u8, after_dot);
+}
+
 pub fn canonicalTermBytes(alloc: std.mem.Allocator, term: provekit.Term) ![]u8 {
     return provekit.jcsStringify(alloc, term);
 }
@@ -1109,6 +1225,30 @@ test "lifts primitive add function into zig-prefixed source unit and contract" {
     const source_unit_json = try provekit.jcsStringify(alloc, out.declarations[0]);
     try std.testing.expect(std.mem.indexOf(u8, source_unit_json, "\"name\":\"zig:source-unit\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, source_unit_json, "\"name\":\"zig:add\"") != null);
+}
+
+test "verify contracts normalize result variable return wrapper arithmetic op and bridge symbol" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const src =
+        \\pub fn double(x: i64) i64 {
+        \\    return x * 2;
+        \\}
+        \\
+    ;
+
+    const out = try liftSource(alloc, src, "math.zig");
+    const verify = try verifyContracts(alloc, out.declarations);
+    try std.testing.expectEqual(@as(usize, 1), verify.len);
+    try std.testing.expectEqualStrings("double", verify[0].bridge_source_symbol.?);
+
+    const json = try provekit.jcsStringify(alloc, verify[0]);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"result\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"*\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"zig:return\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"bridgeSourceSymbol\":\"double\"") != null);
 }
 
 test "refuses unhandled switch without emitting unknown operation" {

--- a/implementations/zig/provekit-lift-zig-source/src/main.zig
+++ b/implementations/zig/provekit-lift-zig-source/src/main.zig
@@ -78,6 +78,7 @@ fn handleLift(alloc: std.mem.Allocator, io: Io, line: []const u8, id: []const u8
 
     var declarations: std.ArrayList(lift.FunctionContract) = .empty;
     var refusals: std.ArrayList(lift.Refusal) = .empty;
+    const verify_layer = std.mem.indexOf(u8, line, "\"layer\":\"verify\"") != null;
 
     if (extractJsonStringField(line, "source")) |source_raw| {
         const source = try unescapeJsonString(arena_alloc, source_raw);
@@ -96,15 +97,13 @@ fn handleLift(alloc: std.mem.Allocator, io: Io, line: []const u8, id: []const u8
         }
         var dir = try Io.Dir.openDir(Io.Dir.cwd(), io, workspace, .{ .iterate = true });
         defer dir.close(io);
-        for (paths) |rel| {
-            const file_text = Io.Dir.readFileAlloc(dir, io, rel, arena_alloc, .unlimited) catch |err| {
-                try refusals.append(arena_alloc, .{ .kind = "io-error", .function = null, .line = 0, .reason = try std.fmt.allocPrint(arena_alloc, "read {s}: {t}", .{ rel, err }) });
-                continue;
-            };
-            const out = try lift.liftSource(arena_alloc, file_text, rel);
-            for (out.declarations) |decl| try declarations.append(arena_alloc, decl);
-            for (out.refusals) |refusal| try refusals.append(arena_alloc, refusal);
-        }
+        for (paths) |rel| try liftPath(arena_alloc, io, dir, rel, &declarations, &refusals);
+    }
+
+    if (verify_layer) {
+        const verify_declarations = try lift.verifyContracts(arena_alloc, declarations.items);
+        declarations.clearRetainingCapacity();
+        for (verify_declarations) |decl| try declarations.append(arena_alloc, decl);
     }
 
     const decls_json = try std.json.Stringify.valueAlloc(alloc, declarations.items, .{ .whitespace = .minified });
@@ -112,6 +111,47 @@ fn handleLift(alloc: std.mem.Allocator, io: Io, line: []const u8, id: []const u8
     const refusals_json = try std.json.Stringify.valueAlloc(alloc, refusals.items, .{ .whitespace = .minified });
     defer alloc.free(refusals_json);
     try writer.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"kind\":\"ir-document\",\"ir\":{s},\"callEdges\":[],\"diagnostics\":[],\"opacityReport\":[],\"refusals\":{s}}}}}\n", .{ id, decls_json, refusals_json });
+}
+
+fn liftPath(
+    alloc: std.mem.Allocator,
+    io: Io,
+    root: Io.Dir,
+    rel: []const u8,
+    declarations: *std.ArrayList(lift.FunctionContract),
+    refusals: *std.ArrayList(lift.Refusal),
+) !void {
+    const file_text = Io.Dir.readFileAlloc(root, io, rel, alloc, .unlimited) catch |err| switch (err) {
+        error.IsDir => {
+            var subdir = Io.Dir.openDir(root, io, rel, .{ .iterate = true }) catch |open_err| {
+                try refusals.append(alloc, .{ .kind = "io-error", .function = null, .line = 0, .reason = try std.fmt.allocPrint(alloc, "open {s}: {t}", .{ rel, open_err }) });
+                return;
+            };
+            defer subdir.close(io);
+            var walker = try subdir.walk(alloc);
+            defer walker.deinit();
+            while (try walker.next(io)) |entry| {
+                if (entry.kind != .file) continue;
+                if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
+                const text = Io.Dir.readFileAlloc(entry.dir, io, entry.basename, alloc, .unlimited) catch |read_err| {
+                    try refusals.append(alloc, .{ .kind = "io-error", .function = null, .line = 0, .reason = try std.fmt.allocPrint(alloc, "read {s}: {t}", .{ entry.path, read_err }) });
+                    continue;
+                };
+                const path = if (std.mem.eql(u8, rel, ".")) entry.path else try std.fmt.allocPrint(alloc, "{s}/{s}", .{ rel, entry.path });
+                const out = try lift.liftSource(alloc, text, path);
+                for (out.declarations) |decl| try declarations.append(alloc, decl);
+                for (out.refusals) |refusal| try refusals.append(alloc, refusal);
+            }
+            return;
+        },
+        else => {
+            try refusals.append(alloc, .{ .kind = "io-error", .function = null, .line = 0, .reason = try std.fmt.allocPrint(alloc, "read {s}: {t}", .{ rel, err }) });
+            return;
+        },
+    };
+    const out = try lift.liftSource(alloc, file_text, rel);
+    for (out.declarations) |decl| try declarations.append(alloc, decl);
+    for (out.refusals) |refusal| try refusals.append(alloc, refusal);
 }
 
 fn extractId(line: []const u8) []const u8 {

--- a/implementations/zig/provekit-lift-zig-tests/build.zig
+++ b/implementations/zig/provekit-lift-zig-tests/build.zig
@@ -10,9 +10,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    // lift module: pure parse logic, no IO.
-    // Registered as a public module so provekit-lsp-zig can depend on it.
-    const lift_mod = b.addModule("provekit-lift-zig", .{
+    const lift_mod = b.addModule("provekit-lift-zig-tests", .{
         .root_source_file = b.path("src/lift.zig"),
         .target = target,
         .optimize = optimize,
@@ -27,12 +25,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "provekit-ir", .module = provekit_ir },
-            .{ .name = "provekit-lift-zig", .module = lift_mod },
+            .{ .name = "provekit-lift-zig-tests", .module = lift_mod },
         },
     });
 
     const exe = b.addExecutable(.{
-        .name = "provekit-lift-zig",
+        .name = "provekit-lift-zig-tests",
         .root_module = exe_mod,
     });
     b.installArtifact(exe);

--- a/implementations/zig/provekit-lift-zig-tests/build.zig.zon
+++ b/implementations/zig/provekit-lift-zig-tests/build.zig.zon
@@ -1,6 +1,6 @@
 .{
-    .name = .provekit_lift_zig,
-    .fingerprint = 0x243eb567a3bcd8ec,
+    .name = .provekit_lift_zig_tests,
+    .fingerprint = 0x7a3ec9ea8f0e0f30,
     .version = "0.1.0",
     .paths = .{
         "build.zig",

--- a/implementations/zig/provekit-lift-zig-tests/src/lift.zig
+++ b/implementations/zig/provekit-lift-zig-tests/src/lift.zig
@@ -1,23 +1,10 @@
-// provekit-lift-zig/src/lift.zig
+// provekit-lift-zig-tests/src/lift.zig
 //
-// Pure parsing logic: no IO.  Imported by provekit-lift-zig (the CLI binary)
-// and by provekit-lsp-zig (the LSP plugin).
+// Pure parsing logic for native Zig unit tests and callsite implications.
+// It does not lift provekit comment annotations or expose direct IR authoring.
 
 const std = @import("std");
 const provekit = @import("provekit-ir");
-
-pub const Annotation = struct {
-    function_name: []const u8,
-    kind: Kind,
-    target_cid: ?[]const u8 = null,
-    line: usize,
-
-    pub const Kind = enum {
-        contract,
-        implement,
-        verify,
-    };
-};
 
 pub const ImplicationDecl = struct {
     name: []const u8,
@@ -53,138 +40,9 @@ pub const LiftOutput = struct {
     implications: []ImplicationDecl,
 };
 
-/// Parse provekit annotations from Zig source text.
-/// Caller owns the returned slice; call `alloc.free(slice)` when done.
-pub fn parseAnnotations(alloc: std.mem.Allocator, text: []const u8) ![]Annotation {
-    var annotations: std.ArrayList(Annotation) = .empty;
-    errdefer annotations.deinit(alloc);
-
-    var lines = std.mem.splitScalar(u8, text, '\n');
-    var line_num: usize = 0;
-    while (lines.next()) |line| : (line_num += 1) {
-        const trimmed = std.mem.trim(u8, line, " \t");
-
-        if (std.mem.startsWith(u8, trimmed, "//provekit:implement ")) {
-            const cid = std.mem.trim(u8, trimmed[20..], " \t");
-            const fn_name = findAheadFnName(text, line_num);
-            try annotations.append(alloc, .{
-                .function_name = fn_name,
-                .kind = .implement,
-                .target_cid = cid,
-                .line = line_num,
-            });
-        } else if (std.mem.startsWith(u8, trimmed, "//provekit:contract")) {
-            const fn_name = findAheadFnName(text, line_num);
-            try annotations.append(alloc, .{
-                .function_name = fn_name,
-                .kind = .contract,
-                .line = line_num,
-            });
-        } else if (std.mem.startsWith(u8, trimmed, "//provekit:verify")) {
-            const fn_name = findAheadFnName(text, line_num);
-            try annotations.append(alloc, .{
-                .function_name = fn_name,
-                .kind = .verify,
-                .line = line_num,
-            });
-        }
-    }
-
-    return annotations.toOwnedSlice(alloc);
-}
-
-fn findAheadFnName(text: []const u8, start_line: usize) []const u8 {
-    var lines = std.mem.splitScalar(u8, text, '\n');
-    var current: usize = 0;
-    // Recognize Zig function prefixes (review feedback: PR #165 / CodeRabbit):
-    // bare `fn`, `pub fn`, `export fn`, `extern fn`, `inline fn`, plus
-    // combinations such as `pub export fn`, `pub extern fn`, `pub inline fn`.
-    // Strip leading visibility/linkage qualifiers until we find `fn `.
-    const qualifiers = [_][]const u8{ "pub", "export", "extern", "inline", "noinline", "comptime" };
-    while (lines.next()) |line| : (current += 1) {
-        if (current <= start_line) continue;
-        if (current > start_line + 10) break;
-
-        var trimmed = std.mem.trim(u8, line, " \t");
-        // Strip qualifiers iteratively. Each pass strips one qualifier (or an
-        // `extern "C"`-style calling-convention quoted string) so combinations
-        // like `pub extern "C" fn` are handled.
-        var stripped = true;
-        while (stripped) {
-            stripped = false;
-            for (qualifiers) |q| {
-                if (trimmed.len > q.len and
-                    std.mem.startsWith(u8, trimmed, q) and
-                    (trimmed[q.len] == ' ' or trimmed[q.len] == '\t'))
-                {
-                    trimmed = std.mem.trimStart(u8, trimmed[q.len..], " \t");
-                    stripped = true;
-                    break;
-                }
-            }
-            // Tolerate `extern "C"` calling-convention spec.
-            if (trimmed.len > 0 and trimmed[0] == '"') {
-                if (std.mem.indexOfScalar(u8, trimmed[1..], '"')) |close_idx| {
-                    const after = trimmed[1 + close_idx + 1 ..];
-                    trimmed = std.mem.trimStart(u8, after, " \t");
-                    stripped = true;
-                }
-            }
-        }
-        if (std.mem.startsWith(u8, trimmed, "fn ")) {
-            const after = trimmed[3..];
-            const end = std.mem.indexOfAny(u8, after, " (\n") orelse after.len;
-            return after[0..end];
-        }
-    }
-    return "unknown";
-}
-
-/// Lift annotations from source text into a slice of provekit IR declarations.
-/// Caller owns the returned slice.
-pub fn liftToDecls(alloc: std.mem.Allocator, text: []const u8) ![]provekit.Decl {
-    const anns = try parseAnnotations(alloc, text);
-    defer alloc.free(anns);
-
-    var decls: std.ArrayList(provekit.Decl) = .empty;
-    errdefer decls.deinit(alloc);
-
-    for (anns) |ann| {
-        switch (ann.kind) {
-            .contract => {
-                const post_args = [_]provekit.Term{};
-                const post = provekit.Atomic("true", &post_args);
-                try decls.append(alloc, .{ .contract = .{
-                    .name = ann.function_name,
-                    .post = post,
-                } });
-            },
-            .implement => {
-                if (ann.target_cid) |cid| {
-                    try decls.append(alloc, .{ .bridge = .{
-                        .name = ann.function_name,
-                        .source_symbol = ann.function_name,
-                        .source_layer = "zig",
-                        .source_contract_cid = "",
-                        .target_contract_cid = cid,
-                        .target_proof_cid = "",
-                        .target_layer = "rust",
-                    } });
-                }
-            },
-            .verify => {},
-        }
-    }
-
-    return decls.toOwnedSlice(alloc);
-}
-
 pub fn liftSource(alloc: std.mem.Allocator, text: []const u8, source_file: []const u8) !LiftOutput {
     var declarations: std.ArrayList(provekit.Decl) = .empty;
     var implications: std.ArrayList(ImplicationDecl) = .empty;
-
-    const annotation_decls = try liftToDecls(alloc, text);
-    for (annotation_decls) |decl| try declarations.append(alloc, decl);
 
     var functions: std.ArrayList(FunctionDef) = .empty;
     var tests: std.ArrayList(TestBlock) = .empty;
@@ -630,8 +488,11 @@ fn appendTestValueScope(
 ) !void {
     const facts_name = try uniqueName(alloc, used_names, try std.fmt.allocPrint(alloc, "{s}::facts", .{call.base}));
     const assertion_name = try uniqueName(alloc, used_names, try std.fmt.allocPrint(alloc, "{s}::assertion", .{call.base}));
-    const fact_args = try termArgs(alloc, .{ provekit.Var(call.local), call.term });
-    const facts = provekit.Atomic("=", fact_args);
+    // The value-scope antecedent is implication evidence, not a separate
+    // body-discharge obligation. Keep the actual function call in the
+    // assertion contract; otherwise verify enumerates both `actual = f(x)`
+    // and `f(x) = expected`, and the former is a false universal claim.
+    const facts = provekit.Atomic("true", &.{});
     try declarations.append(alloc, .{ .contract = .{ .name = facts_name, .inv = facts } });
     try declarations.append(alloc, .{ .contract = .{ .name = assertion_name, .inv = assertion } });
     try implications.append(alloc, .{
@@ -914,71 +775,6 @@ fn containsName(names: []const []const u8, needle: []const u8) bool {
     return false;
 }
 
-test "parseAnnotations finds contract" {
-    const alloc = std.testing.allocator;
-    const src =
-        \\//provekit:contract
-        \\fn myFn(x: i32) void {
-        \\    _ = x;
-        \\}
-    ;
-    const anns = try parseAnnotations(alloc, src);
-    defer alloc.free(anns);
-    try std.testing.expectEqual(@as(usize, 1), anns.len);
-    try std.testing.expectEqual(Annotation.Kind.contract, anns[0].kind);
-    try std.testing.expectEqualStrings("myFn", anns[0].function_name);
-}
-
-test "parseAnnotations finds implement" {
-    const alloc = std.testing.allocator;
-    const src =
-        \\//provekit:implement blake3-512:abc123
-        \\fn bridge(x: i32) void {
-        \\    _ = x;
-        \\}
-    ;
-    const anns = try parseAnnotations(alloc, src);
-    defer alloc.free(anns);
-    try std.testing.expectEqual(@as(usize, 1), anns.len);
-    try std.testing.expectEqual(Annotation.Kind.implement, anns[0].kind);
-    try std.testing.expectEqualStrings("blake3-512:abc123", anns[0].target_cid.?);
-}
-
-test "parseAnnotations finds verify" {
-    const alloc = std.testing.allocator;
-    const src =
-        \\//provekit:verify
-        \\fn checkFn() void {}
-    ;
-    const anns = try parseAnnotations(alloc, src);
-    defer alloc.free(anns);
-    try std.testing.expectEqual(@as(usize, 1), anns.len);
-    try std.testing.expectEqual(Annotation.Kind.verify, anns[0].kind);
-    try std.testing.expectEqualStrings("checkFn", anns[0].function_name);
-}
-
-test "parseAnnotations empty source" {
-    const alloc = std.testing.allocator;
-    const anns = try parseAnnotations(alloc, "");
-    defer alloc.free(anns);
-    try std.testing.expectEqual(@as(usize, 0), anns.len);
-}
-
-test "liftToDecls contract produces IR" {
-    const alloc = std.testing.allocator;
-    const src =
-        \\//provekit:contract
-        \\fn myFn() void {}
-    ;
-    const decls = try liftToDecls(alloc, src);
-    defer alloc.free(decls);
-    try std.testing.expectEqual(@as(usize, 1), decls.len);
-    switch (decls[0]) {
-        .contract => |c| try std.testing.expectEqualStrings("myFn", c.name),
-        else => return error.WrongKind,
-    }
-}
-
 test "liftSource walks production callsite preconditions back to entry" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -1081,6 +877,10 @@ test "liftSource shows production composes while Zig unit tests conflict" {
     try std.testing.expectEqual(@as(usize, 2), assertion_count);
     try std.testing.expectEqual(@as(usize, 1), eq_count);
     try std.testing.expectEqual(@as(usize, 1), neq_count);
+    const facts = findContractWithSuffix(out.declarations, "::facts") orelse return error.MissingFactsContract;
+    const facts_json = try provekit.jcsStringify(alloc, facts.inv.?);
+    try std.testing.expect(std.mem.indexOf(u8, facts_json, "\"name\":\"checked\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, facts_json, "\"name\":\"true\"") != null);
 
     try std.testing.expectEqual(@as(usize, 3), countImplicationsByProver(out.implications, "zig-wp-walk"));
     try std.testing.expectEqual(@as(usize, 2), countImplicationsByProver(out.implications, "zig-test-value-scope"));
@@ -1117,69 +917,4 @@ fn countImplicationsByProver(implications: []const ImplicationDecl, prover: []co
         if (std.mem.eql(u8, imp.prover, prover)) count += 1;
     }
     return count;
-}
-
-// Zig function-prefix coverage (review feedback: PR #165 / CodeRabbit).
-// findAheadFnName must handle visibility/linkage qualifiers preceding `fn`.
-
-test "parseAnnotations finds pub fn" {
-    const alloc = std.testing.allocator;
-    const src =
-        \\//provekit:contract
-        \\pub fn pubFn(x: i32) void {
-        \\    _ = x;
-        \\}
-    ;
-    const anns = try parseAnnotations(alloc, src);
-    defer alloc.free(anns);
-    try std.testing.expectEqual(@as(usize, 1), anns.len);
-    try std.testing.expectEqualStrings("pubFn", anns[0].function_name);
-}
-
-test "parseAnnotations finds export fn" {
-    const alloc = std.testing.allocator;
-    const src =
-        \\//provekit:contract
-        \\export fn exportedFn() void {}
-    ;
-    const anns = try parseAnnotations(alloc, src);
-    defer alloc.free(anns);
-    try std.testing.expectEqual(@as(usize, 1), anns.len);
-    try std.testing.expectEqualStrings("exportedFn", anns[0].function_name);
-}
-
-test "parseAnnotations finds extern fn" {
-    const alloc = std.testing.allocator;
-    const src =
-        \\//provekit:contract
-        \\extern fn externFn() void;
-    ;
-    const anns = try parseAnnotations(alloc, src);
-    defer alloc.free(anns);
-    try std.testing.expectEqual(@as(usize, 1), anns.len);
-    try std.testing.expectEqualStrings("externFn", anns[0].function_name);
-}
-
-test "parseAnnotations finds inline fn" {
-    const alloc = std.testing.allocator;
-    const src =
-        \\//provekit:contract
-        \\inline fn inlinedFn() void {}
-    ;
-    const anns = try parseAnnotations(alloc, src);
-    defer alloc.free(anns);
-    try std.testing.expectEqual(@as(usize, 1), anns.len);
-    try std.testing.expectEqualStrings("inlinedFn", anns[0].function_name);
-}
-
-test "parseAnnotations finds pub extern \"C\" fn" {
-    const alloc = std.testing.allocator;
-    const src =
-        \\//provekit:contract
-        \\pub extern "C" fn cAbiFn() void;
-    ;
-    const anns = try parseAnnotations(alloc, src);
-    defer alloc.free(anns);
-    try std.testing.expectEqual(@as(usize, 1), anns.len);
-    try std.testing.expectEqualStrings("cAbiFn", anns[0].function_name);
 }

--- a/implementations/zig/provekit-lift-zig-tests/src/main.zig
+++ b/implementations/zig/provekit-lift-zig-tests/src/main.zig
@@ -1,14 +1,12 @@
 const std = @import("std");
-const lift = @import("provekit-lift-zig");
+const lift = @import("provekit-lift-zig-tests");
 const provekit = @import("provekit-ir");
 
-// ProvekIt Lift Tool for Zig
+// ProvekIt Zig test/implication lifter.
 //
-// Scans Zig source files for provekit annotations and emits JCS canonical IR.
-//
-// Usage:
-//   provekit-lift-zig --workspace ./src --output ./target/provekit/
-//   provekit-lift-zig --rpc              (NDJSON JSON-RPC plugin mode)
+// Scans native `std.testing` unit tests and production callsites and emits
+// canonical IR over the lift-plugin RPC seam. It intentionally does not expose
+// a standalone IR-authoring mode.
 
 const Io = std.Io;
 const Dir = std.Io.Dir;
@@ -55,18 +53,13 @@ fn handleLine(
 
     if (std.mem.indexOf(u8, line, "\"initialize\"") != null) {
         try writer.print(
-            "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"name\":\"provekit-lift-zig\",\"version\":\"0.1.0\",\"capabilities\":[\"parse\",\"lift\"]}}}}\n",
+            "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"name\":\"provekit-lift-zig-tests\",\"version\":\"0.1.0\",\"protocol_version\":\"pep/1.7.0\",\"capabilities\":{{\"authoring_surfaces\":[\"zig-tests\",\"zig-implications\"],\"emits_signed_mementos\":false,\"ir_version\":\"v1.1.0\"}}}}}}\n",
             .{id},
         );
         return true;
     }
 
-    if (std.mem.indexOf(u8, line, "\"parse\"") != null) {
-        try handleParse(alloc, line, id, writer);
-        return true;
-    }
-
-    if (std.mem.indexOf(u8, line, "\"lift\"") != null) {
+    if (std.mem.indexOf(u8, line, "\"lift\"") != null or std.mem.indexOf(u8, line, "\"provekit.plugin.lift_implications\"") != null) {
         try handleLift(alloc, io, line, id, writer);
         return true;
     }
@@ -87,40 +80,6 @@ fn handleLine(
     return true;
 }
 
-fn handleParse(
-    alloc: std.mem.Allocator,
-    line: []const u8,
-    id: []const u8,
-    writer: *Io.Writer,
-) !void {
-    // Extract "source" field value: naive string extraction.
-    const source_raw = extractJsonStringField(line, "source") orelse "";
-    const source = try unescapeJsonString(alloc, source_raw);
-    defer alloc.free(source);
-    const path_raw = extractJsonStringField(line, "path") orelse "input.zig";
-    const path = try unescapeJsonString(alloc, path_raw);
-    defer alloc.free(path);
-
-    var arena = std.heap.ArenaAllocator.init(alloc);
-    defer arena.deinit();
-    const arena_alloc = arena.allocator();
-
-    const lifted = try lift.liftSource(arena_alloc, source, sourceFileName(path));
-
-    // Serialize declarations as a JSON array.
-    const decls_json = try std.json.Stringify.valueAlloc(alloc, lifted.declarations, .{ .whitespace = .minified });
-    defer alloc.free(decls_json);
-    const implications_json = try std.json.Stringify.valueAlloc(alloc, lifted.implications, .{ .whitespace = .minified });
-    defer alloc.free(implications_json);
-
-    // callEdges: zig kit emits empty array (no cross-kit call tracking yet).
-    // warnings: empty.
-    try writer.print(
-        "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"declarations\":{s},\"callEdges\":[],\"implications\":{s},\"warnings\":[]}}}}\n",
-        .{ id, decls_json, implications_json },
-    );
-}
-
 fn handleLift(
     alloc: std.mem.Allocator,
     io: Io,
@@ -138,6 +97,10 @@ fn handleLift(
 
     var declarations: std.ArrayList(provekit.Decl) = .empty;
     var implications: std.ArrayList(lift.ImplicationDecl) = .empty;
+    const implications_only =
+        std.mem.indexOf(u8, line, "\"provekit.plugin.lift_implications\"") != null or
+        std.mem.indexOf(u8, line, "\"surface\":\"zig-implications\"") != null or
+        std.mem.indexOf(u8, line, "\"layer\":\"implications\"") != null;
 
     var dir = try Dir.openDir(Dir.cwd(), io, workspace, .{ .iterate = true });
     defer dir.close(io);
@@ -151,7 +114,9 @@ fn handleLift(
 
         const file_text = try Dir.readFileAlloc(entry.dir, io, entry.basename, arena_alloc, .unlimited);
         const lifted = try lift.liftSource(arena_alloc, file_text, entry.basename);
-        for (lifted.declarations) |decl| try declarations.append(arena_alloc, decl);
+        if (!implications_only) {
+            for (lifted.declarations) |decl| try declarations.append(arena_alloc, decl);
+        }
         for (lifted.implications) |implication| try implications.append(arena_alloc, implication);
     }
 
@@ -166,54 +131,6 @@ fn handleLift(
         "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"kind\":\"ir-document\",\"ir\":{s},\"implications\":{s},\"diagnostics\":[]}}}}\n",
         .{ id, decls_json, implications_json },
     );
-}
-
-fn sourceFileName(path: []const u8) []const u8 {
-    if (std.mem.lastIndexOfAny(u8, path, "/\\")) |idx| {
-        return path[idx + 1 ..];
-    }
-    return path;
-}
-
-fn runStandaloneMode(alloc: std.mem.Allocator, io: Io, workspace_path: []const u8, output_path: []const u8) !void {
-    var decls: std.ArrayList(provekit.Decl) = .empty;
-    defer decls.deinit(alloc);
-
-    var dir = try Dir.openDir(Dir.cwd(), io, workspace_path, .{ .iterate = true });
-    defer dir.close(io);
-
-    var walker = try dir.walk(alloc);
-    defer walker.deinit();
-
-    while (try walker.next(io)) |entry| {
-        if (entry.kind != .file) continue;
-        if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
-
-        const file_text = try Dir.readFileAlloc(entry.dir, io, entry.basename, alloc, .unlimited);
-        defer alloc.free(file_text);
-
-        const file_decls = try lift.liftToDecls(alloc, file_text);
-        defer alloc.free(file_decls);
-
-        for (file_decls) |decl| {
-            try decls.append(alloc, decl);
-        }
-    }
-
-    const decls_slice = try decls.toOwnedSlice(alloc);
-    defer alloc.free(decls_slice);
-
-    const jcs = try provekit.jcsStringify(alloc, decls_slice);
-    defer alloc.free(jcs);
-
-    try Dir.createDirPath(Dir.cwd(), io, output_path);
-    const out_path = try std.fs.path.join(alloc, &.{ output_path, "lifted.json" });
-    defer alloc.free(out_path);
-    const out_file = try Dir.createFile(Dir.cwd(), io, out_path, .{});
-    defer out_file.close(io);
-    try Io.File.writeStreamingAll(out_file, io, jcs);
-
-    std.debug.print("Wrote {d} declarations to {s}\n", .{ decls_slice.len, out_path });
 }
 
 /// Extract the raw JSON "id" value token from a NDJSON line.
@@ -280,26 +197,19 @@ pub fn main(init: std.process.Init) !void {
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     var rpc_mode = false;
-    var workspace: ?[]const u8 = null;
-    var output: ?[]const u8 = null;
 
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         const arg = args[i];
         if (std.mem.eql(u8, arg, "--rpc")) {
             rpc_mode = true;
-        } else if (std.mem.eql(u8, arg, "--workspace")) {
-            i += 1;
-            if (i < args.len) workspace = args[i];
-        } else if (std.mem.eql(u8, arg, "--output")) {
-            i += 1;
-            if (i < args.len) output = args[i];
         }
     }
 
     if (rpc_mode) {
         try runRpcMode(alloc, io);
     } else {
-        try runStandaloneMode(alloc, io, workspace orelse ".", output orelse "./target/provekit");
+        std.debug.print("usage: provekit-lift-zig-tests --rpc\n", .{});
+        std.process.exit(1);
     }
 }

--- a/implementations/zig/provekit-lsp-zig/build.zig
+++ b/implementations/zig/provekit-lsp-zig/build.zig
@@ -10,9 +10,8 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    // Reuse the pure parse module from provekit-lift-zig.
     const lift_mod = b.createModule(.{
-        .root_source_file = b.path("../provekit-lift-zig/src/lift.zig"),
+        .root_source_file = b.path("../provekit-lift-zig-source/src/lift.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
@@ -26,7 +25,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "provekit-ir", .module = provekit_ir },
-            .{ .name = "provekit-lift-zig", .module = lift_mod },
+            .{ .name = "provekit-lift-zig-source", .module = lift_mod },
         },
     });
 
@@ -51,7 +50,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "provekit-ir", .module = provekit_ir },
-            .{ .name = "provekit-lift-zig", .module = lift_mod },
+            .{ .name = "provekit-lift-zig-source", .module = lift_mod },
         },
     });
 

--- a/implementations/zig/provekit-lsp-zig/src/main.zig
+++ b/implementations/zig/provekit-lsp-zig/src/main.zig
@@ -14,8 +14,7 @@
 // Binary name expected by consumers: provekit-lsp-zig
 
 const std = @import("std");
-const lift = @import("provekit-lift-zig");
-const provekit = @import("provekit-ir");
+const lift = @import("provekit-lift-zig-source");
 
 const Io = std.Io;
 
@@ -101,19 +100,18 @@ fn handleParse(
     id: []const u8,
     writer: *Io.Writer,
 ) !void {
-    // Extract "source" field value: naive string extraction.
-    // The source is a JSON string with escape sequences.  We unescape only the
-    // common cases (\n, \t, \\, \") since we only need to scan for annotations.
     const source_raw = extractJsonStringField(line, "source") orelse "";
     const source = try unescapeJsonString(alloc, source_raw);
     defer alloc.free(source);
+    const path_raw = extractJsonStringField(line, "path") orelse "input.zig";
+    const path = try unescapeJsonString(alloc, path_raw);
+    defer alloc.free(path);
 
-    // Lift to IR declarations via the lift module.
-    const decls = try lift.liftToDecls(alloc, source);
-    defer alloc.free(decls);
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const lifted = try lift.liftSource(arena.allocator(), source, path);
 
-    // Serialize declarations as a JSON array.
-    const decls_json = try std.json.Stringify.valueAlloc(alloc, decls, .{ .whitespace = .minified });
+    const decls_json = try std.json.Stringify.valueAlloc(alloc, lifted.declarations, .{ .whitespace = .minified });
     defer alloc.free(decls_json);
 
     // callEdges: zig kit emits empty array (no cross-kit call tracking yet).

--- a/implementations/zig/provekit-lsp-zig/src/test_lsp.zig
+++ b/implementations/zig/provekit-lsp-zig/src/test_lsp.zig
@@ -4,7 +4,7 @@
 // by calling the same parsing helpers used in main.zig.
 
 const std = @import("std");
-const lift = @import("provekit-lift-zig");
+const lift = @import("provekit-lift-zig-source");
 
 // ---------------------------------------------------------------------------
 // Helpers re-exported from main.zig logic (duplicated for test isolation).
@@ -132,16 +132,16 @@ test "initialize response shape" {
 }
 
 test "parse response includes declarations callEdges warnings" {
-    // Simulate parse of a fixture .zig file with a contract annotation.
     const alloc = std.testing.allocator;
-    const fixture_source = "//provekit:contract\nfn myFn(x: i32) void { _ = x; }";
+    const fixture_source = "pub fn myFn(x: i64) i64 { return x; }";
 
-    const decls = try lift.liftToDecls(alloc, fixture_source);
-    defer alloc.free(decls);
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const lifted = try lift.liftSource(arena.allocator(), fixture_source, "fixture.zig");
 
-    try std.testing.expect(decls.len == 1);
+    try std.testing.expect(lifted.declarations.len >= 1);
 
-    const decls_json = try std.json.Stringify.valueAlloc(alloc, decls, .{ .whitespace = .minified });
+    const decls_json = try std.json.Stringify.valueAlloc(alloc, lifted.declarations, .{ .whitespace = .minified });
     defer alloc.free(decls_json);
 
     const response = try std.fmt.allocPrint(
@@ -154,44 +154,38 @@ test "parse response includes declarations callEdges warnings" {
     try std.testing.expect(std.mem.indexOf(u8, response, "\"declarations\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, response, "\"callEdges\":[]") != null);
     try std.testing.expect(std.mem.indexOf(u8, response, "\"warnings\":[]") != null);
-    try std.testing.expect(std.mem.indexOf(u8, response, "\"kind\":\"contract\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"kind\":\"function-contract\"") != null);
 }
 
 test "parse empty source returns empty declarations" {
     const alloc = std.testing.allocator;
 
-    const decls = try lift.liftToDecls(alloc, "");
-    defer alloc.free(decls);
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const lifted = try lift.liftSource(arena.allocator(), "", "empty.zig");
 
-    try std.testing.expectEqual(@as(usize, 0), decls.len);
+    try std.testing.expectEqual(@as(usize, 0), lifted.declarations.len);
 
-    const decls_json = try std.json.Stringify.valueAlloc(alloc, decls, .{ .whitespace = .minified });
+    const decls_json = try std.json.Stringify.valueAlloc(alloc, lifted.declarations, .{ .whitespace = .minified });
     defer alloc.free(decls_json);
 
     try std.testing.expectEqualStrings("[]", decls_json);
 }
 
-test "parse fixture zig file with implement annotation" {
+test "parse fixture zig file with function body" {
     const alloc = std.testing.allocator;
     const fixture =
-        \\//provekit:implement blake3-512:deadbeef
-        \\fn bridgeFn(x: i32) i32 {
-        \\    return x;
+        \\pub fn bridgeFn(x: i32) i32 {
+        \\    return x + 1;
         \\}
     ;
 
-    const decls = try lift.liftToDecls(alloc, fixture);
-    defer alloc.free(decls);
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const lifted = try lift.liftSource(arena.allocator(), fixture, "fixture.zig");
 
-    try std.testing.expectEqual(@as(usize, 1), decls.len);
-    switch (decls[0]) {
-        .bridge => |b| {
-            try std.testing.expectEqualStrings("bridgeFn", b.name);
-            try std.testing.expectEqualStrings("blake3-512:deadbeef", b.target_contract_cid);
-            try std.testing.expectEqualStrings("zig", b.source_layer);
-        },
-        else => return error.WrongKind,
-    }
+    try std.testing.expectEqual(@as(usize, 2), lifted.declarations.len);
+    try std.testing.expectEqualStrings("fixture.zig.bridgeFn", lifted.declarations[1].fn_name);
 }
 
 test "shutdown response is null result" {

--- a/implementations/zig/provekit-lsp-zig/test_lsp.sh
+++ b/implementations/zig/provekit-lsp-zig/test_lsp.sh
@@ -55,9 +55,9 @@ assert_not_contains() {
     fi
 }
 
-# Fixture: a tiny Zig source with one //provekit:contract annotation.
+# Fixture: a tiny Zig source with one native function body.
 INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
-PARSE='{"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"fixture.zig","source":"//provekit:contract\nfn myFn(x: i32) void { _ = x; }"}}'
+PARSE='{"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"fixture.zig","source":"pub fn myFn(x: i64) i64 { return x; }"}}'
 SHUTDOWN='{"jsonrpc":"2.0","id":3,"method":"shutdown","params":{}}'
 
 INPUT="$(printf '%s\n%s\n%s\n' "$INIT" "$PARSE" "$SHUTDOWN")"
@@ -78,8 +78,8 @@ echo "=== parse ==="
 assert_contains "declarations field"  "$PARSE_RESP"    '"declarations":'
 assert_contains "callEdges field"     "$PARSE_RESP"    '"callEdges":[]'
 assert_contains "warnings field"      "$PARSE_RESP"    '"warnings":[]'
-assert_contains "at least one decl"   "$PARSE_RESP"    '"kind":"contract"'
-assert_contains "contract name"       "$PARSE_RESP"    '"name":"myFn"'
+assert_contains "at least one decl"   "$PARSE_RESP"    '"kind":"function-contract"'
+assert_contains "contract name"       "$PARSE_RESP"    '"fnName":"fixture.zig.myFn"'
 assert_not_contains "no error"        "$PARSE_RESP"    '"error"'
 
 echo "=== shutdown ==="


### PR DESCRIPTION
## Summary
- removes the remaining CLI-side source assembly fallback so materialize out-dir requires kit-owned assemble RPC
- adds TypeScript Vitest emit, TypeScript assemble/verify/test lifter wiring, and TS prove parity coverage
- retires Zig direct IR authoring into Zig test/implication lifters, adds Zig verify production bridge coverage, and adds Swift XCTest emit dispatch

## Test Plan
- rustfmt --edition 2021 --check implementations/rust/provekit-cli/src/cmd_materialize.rs implementations/rust/provekit-cli/src/cmd_mint.rs implementations/rust/provekit-cli/tests/cli_surface.rs implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs implementations/rust/provekit-cli/tests/cmd_emit_swift_xctest.rs implementations/rust/provekit-cli/tests/cmd_emit_typescript_vitest.rs implementations/rust/provekit-cli/tests/cmd_verify_typescript_production_bridge.rs implementations/rust/provekit-cli/tests/cmd_verify_zig_production_bridge.rs
- zig build test (provekit-lift-zig-source)
- zig build test (provekit-lift-zig-tests)
- zig build test (provekit-lsp-zig)
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_materialize_integration -- --nocapture
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_swift_xctest -- --nocapture
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_typescript_vitest -- --nocapture
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_typescript_production_bridge -- --nocapture
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_zig_production_bridge -- --nocapture
- pnpm exec vitest run implementations/typescript/src/lift/typescript-source/verify.test.ts implementations/typescript/src/lift/vitest-tests-rpc.test.ts
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli merge_ir_document_responses_preserves_implications_from_lifters

## Notes
Scala is intentionally not included here: a proposed Python-backed Scala emitter was rejected because Scala kits must be written in Scala/JVM code and registered through config/manifest/RPC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Swift/XCTest test emission support for proof generation.
  * Added TypeScript/Vitest test emission support for proof generation.
  * Extended cross-language verification coverage to include TypeScript and Zig.
  * New test lifting and implications analysis for Zig.

* **Bug Fixes**
  * Materialize command now enforces stricter validation; exits with error when target kit cannot assemble, preventing incomplete output.

* **Tests**
  * Added comprehensive integration tests for Swift and TypeScript emitters, plus production-bridge verification workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->