### PR TITLE
feat(swift): add XCTest lift production bridge

### DIFF
--- a/implementations/rust/provekit-cli/tests/cmd_verify_swift_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_swift_production_bridge.rs
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Swift production-bridge gauntlet. The Rust CLI is only the generic
+// config/manifest/RPC client here: Swift parsing, XCTest assertion harvesting,
+// and Swift-term-to-ProofIR normalization all live in Swift kit surfaces.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use serde_json::Value as Json;
+
+#[path = "support/contradiction.rs"]
+mod contradiction;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn swift_available() -> bool {
+    Command::new("swift")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-swift-prod-bridge-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir project");
+    p
+}
+
+fn toml_path(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn swift_products() -> (PathBuf, PathBuf) {
+    static PRODUCTS: OnceLock<(PathBuf, PathBuf)> = OnceLock::new();
+    PRODUCTS
+        .get_or_init(|| {
+            let swift_root = repo_root().join("implementations").join("swift");
+            for product in [
+                "provekit-lift-swift-source",
+                "provekit-lift-swift-xctest-tests",
+            ] {
+                let out = Command::new("swift")
+                    .current_dir(&swift_root)
+                    .args(["build", "--product", product])
+                    .output()
+                    .unwrap_or_else(|e| panic!("spawn swift build {product}: {e}"));
+                assert!(
+                    out.status.success(),
+                    "swift build {product} failed\nstdout:\n{}\nstderr:\n{}",
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr)
+                );
+            }
+            (
+                swift_root
+                    .join(".build")
+                    .join("debug")
+                    .join("provekit-lift-swift-source"),
+                swift_root
+                    .join(".build")
+                    .join("debug")
+                    .join("provekit-lift-swift-xctest-tests"),
+            )
+        })
+        .clone()
+}
+
+fn stage_swift_project(suffix: &str, body_factor: i64) -> PathBuf {
+    let (source_bin, tests_bin) = swift_products();
+    let project = unique_dir(suffix);
+    fs::write(
+        project.join("Math.swift"),
+        format!("public func double(_ x: Int) -> Int {{\n    return x * {body_factor}\n}}\n"),
+    )
+    .expect("write Math.swift");
+    fs::write(
+        project.join("MathTests.swift"),
+        r#"import XCTest
+
+final class MathTests: XCTestCase {
+    func testDoubleThreeIsSix() {
+        XCTAssertEqual(double(3), 6)
+    }
+}
+"#,
+    )
+    .expect("write MathTests.swift");
+
+    let provekit = project.join(".provekit");
+    for surface in ["swift-source", "swift-xctest-tests"] {
+        fs::create_dir_all(provekit.join("lift").join(surface))
+            .unwrap_or_else(|_| panic!("mkdir manifest dir {surface}"));
+    }
+    fs::write(
+        provekit.join("config.toml"),
+        "exam_manifest_cid = \"blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"swift-source\"\n\
+         surface = \"swift-source\"\n\
+         layer = \"verify\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"swift-xctest-tests\"\n\
+         surface = \"swift-xctest-tests\"\n\
+         layer = \"tests\"\n",
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("swift-source")
+            .join("manifest.toml"),
+        format!(
+            "name = \"swift-source\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+            toml_path(&source_bin)
+        ),
+    )
+    .expect("write swift-source manifest");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("swift-xctest-tests")
+            .join("manifest.toml"),
+        format!(
+            "name = \"swift-xctest-tests\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+            toml_path(&tests_bin)
+        ),
+    )
+    .expect("write swift-xctest-tests manifest");
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_verify_json_with_code(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .arg("verify")
+        .arg("--project")
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+fn json_contains_str(value: &Json, needle: &str) -> bool {
+    match value {
+        Json::String(s) => s == needle,
+        Json::Array(values) => values.iter().any(|v| json_contains_str(v, needle)),
+        Json::Object(map) => map.values().any(|v| json_contains_str(v, needle)),
+        _ => false,
+    }
+}
+
+#[test]
+fn swift_mint_auto_writes_body_discharge_bridge_from_real_lifters() {
+    if !swift_available() {
+        eprintln!("swift not on PATH: skipping Swift production-bridge bridge-writer test");
+        return;
+    }
+    let project = stage_swift_project("bridge", 2);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "tool-minted bundle must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let bridge = pool.bridges_by_symbol.get("double").unwrap_or_else(|| {
+        panic!(
+            "mint must auto-write + index a bridge with sourceSymbol=double; indexed: {:?}",
+            pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+        )
+    });
+    let target_cid = provekit_verifier::types::memento_body_field(bridge, "targetContractCid")
+        .and_then(|v| v.as_str())
+        .expect("bridge must carry targetContractCid")
+        .to_string();
+    let target = pool.mementos.get(&target_cid).unwrap_or_else(|| {
+        panic!("bridge.targetContractCid {target_cid} must resolve to a member")
+    });
+    assert_eq!(
+        provekit_verifier::types::memento_kind(target),
+        Some("contract"),
+        "bridge target must be a contract memento"
+    );
+    let formals = provekit_verifier::types::memento_body_field(target, "formals")
+        .and_then(|v| v.as_array())
+        .expect("tool-written op-contract must carry formals");
+    assert_eq!(
+        formals.first().and_then(|v| v.as_str()),
+        Some("x"),
+        "op-contract formals must be [x]"
+    );
+    assert!(
+        provekit_verifier::types::memento_body_field(target, "post").is_some(),
+        "op-contract must carry the body-derived post"
+    );
+    assert!(
+        pool.mementos.values().any(|member| {
+            provekit_verifier::types::memento_kind(member) == Some("contract")
+                && provekit_verifier::types::memento_body_field(member, "inv")
+                    .is_some_and(|inv| json_contains_str(inv, "double"))
+        }),
+        "minted bundle must include the Swift XCTest assertion contract mentioning double"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn swift_production_path_double_discharges_and_mints_witness() {
+    if !swift_available() {
+        eprintln!("swift not on PATH: skipping Swift production-bridge positive test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Swift production-bridge positive test");
+        return;
+    }
+    let project = stage_swift_project("pos", 2);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(
+        receipt["kind"], "verification-receipt",
+        "receipt: {receipt}"
+    );
+    assert_eq!(
+        receipt["totalClaims"], 1,
+        "exactly one body-bearing Swift callsite must enumerate; receipt: {receipt}"
+    );
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["pass"], true,
+        "double(3)==6 must discharge through Swift body (* x 2); claim: {claim}"
+    );
+    assert_eq!(claim["status"], "discharged", "claim: {claim}");
+    let solver = claim["dischargingSolver"].as_str().unwrap_or("");
+    assert!(
+        solver.starts_with("z3@"),
+        "discharging solver must be z3; got `{solver}`"
+    );
+    let witness_cid = claim["witnessCid"].as_str().expect("witness minted");
+    assert!(witness_cid.starts_with("blake3-512:"));
+    eprintln!("SWIFT_PRODUCTION_POSITIVE_WITNESS_CID={witness_cid}");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(code, 0, "positive run exits clean; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn swift_production_path_broken_body_fails_unsatisfied_no_witness() {
+    if !swift_available() {
+        eprintln!("swift not on PATH: skipping Swift production-bridge negative test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Swift production-bridge negative test");
+        return;
+    }
+    let project = stage_swift_project("neg", 3);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["status"], "unsatisfied",
+        "broken Swift body x*3 must be UNSATISFIED; claim: {claim}"
+    );
+    assert_eq!(claim["pass"], false, "claim: {claim}");
+    assert!(
+        claim["witnessCid"].is_null(),
+        "no witness for a violated claim; claim: {claim}"
+    );
+    assert_eq!(receipt["ok"], false, "receipt: {receipt}");
+    let witness_files: Vec<_> = fs::read_dir(&witnesses)
+        .map(|rd| rd.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        witness_files.is_empty(),
+        "witness dir must be empty for a violated claim; found {} files",
+        witness_files.len()
+    );
+    assert_eq!(
+        code, 1,
+        "broken-body claim must exit 1 (EXIT_VERIFY_FAIL); got {code}"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn swift_production_path_refuses_planted_contradictory_implication() {
+    if !swift_available() {
+        eprintln!("swift not on PATH: skipping Swift contradictory-implication test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Swift contradictory-implication test");
+        return;
+    }
+    let project = stage_swift_project("contradiction", 2);
+    run_mint(&project);
+
+    let (green, green_code) = contradiction::run_prove_json_with_code(&provekit_bin(), &project);
+    assert_eq!(
+        green_code, 0,
+        "base Swift project must prove before planting contradiction; report: {green}"
+    );
+    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+
+    contradiction::plant_contradictory_implication_proof(
+        &project.join(".provekit"),
+        "swift",
+        "swift-tests",
+        "swift_parity",
+    );
+    let (red, red_code) = contradiction::run_prove_json_with_code(&provekit_bin(), &project);
+    contradiction::assert_prove_refuses_contradiction(
+        &red,
+        red_code,
+        "swift_parity_requires_positive",
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}

--- a/implementations/swift/.provekit/lift/swift-xctest-tests/manifest.toml
+++ b/implementations/swift/.provekit/lift/swift-xctest-tests/manifest.toml
@@ -1,0 +1,11 @@
+name = "swift-xctest-tests"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = [".build/debug/provekit-lift-swift-xctest-tests", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["swift-xctest-tests"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/swift/Package.swift
+++ b/implementations/swift/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .executable(name: "provekit-lsp-swift", targets: ["ProveKitLSPSwift"]),
         .executable(name: "mint-swift-self-contracts", targets: ["MintSwiftSelfContracts"]),
         .executable(name: "provekit-lift-swift-source", targets: ["ProvekitLiftSwiftSourceCLI"]),
+        .executable(name: "provekit-lift-swift-xctest-tests", targets: ["ProvekitLiftSwiftXCTestTests"]),
         .executable(name: "provekit-emit-swift-xctest", targets: ["ProvekitEmitSwiftXCTest"]),
         .executable(name: "test-swift-lsp", targets: ["LSPTests"]),
         .executable(name: "test-swift-crypto", targets: ["CryptoTests"]),
@@ -142,6 +143,14 @@ let package = Package(
         .executableTarget(
             name: "ProvekitLiftSwiftSourceCLI",
             dependencies: ["ProvekitLiftSwiftSource"]
+        ),
+        .executableTarget(
+            name: "ProvekitLiftSwiftXCTestTests",
+            dependencies: [
+                "ProvekitCrypto",
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
+            ]
         ),
         .executableTarget(
             name: "ProvekitEmitSwiftXCTest",

--- a/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceIR.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceIR.swift
@@ -209,6 +209,152 @@ public enum SwiftSourceIR {
         return postArgs[1]
     }
 
+    public static func verifyFacingResult(_ result: SwiftSourceLiftResult) -> SwiftSourceLiftResult {
+        var out = result
+        out.ir = result.ir.compactMap(verifyFacingContract)
+        return out
+    }
+
+    private static func verifyFacingContract(_ contract: JcsCanonical) -> JcsCanonical? {
+        guard field("kind", in: contract).stringValue == "function-contract" else {
+            return contract
+        }
+        let fnName = field("fnName", in: contract).stringValue ?? ""
+        if fnName.hasPrefix("<source-unit:") {
+            return nil
+        }
+
+        guard case .object(let pairs) = contract else {
+            return contract
+        }
+        var rewritten: [(String, JcsCanonical)] = []
+        var sawBridgeSourceSymbol = false
+        for (key, value) in pairs {
+            switch key {
+            case "pre":
+                rewritten.append((key, normalizeFormulaForVerify(value)))
+            case "post":
+                rewritten.append((key, normalizeFormulaForVerify(value)))
+            case "bridgeSourceSymbol":
+                sawBridgeSourceSymbol = true
+                rewritten.append((key, .string(simpleFunctionSymbol(fnName))))
+            default:
+                rewritten.append((key, value))
+            }
+        }
+        if !sawBridgeSourceSymbol {
+            rewritten.append(("bridgeSourceSymbol", .string(simpleFunctionSymbol(fnName))))
+        }
+        return .object(rewritten)
+    }
+
+    private static func normalizeFormulaForVerify(_ formula: JcsCanonical) -> JcsCanonical {
+        guard case .object(let pairs) = formula,
+              let kind = pairs.first(where: { $0.0 == "kind" })?.1.stringValue
+        else {
+            return formula
+        }
+
+        switch kind {
+        case "atomic":
+            return .object(pairs.map { key, value in
+                if key == "name", let name = value.stringValue {
+                    return (key, .string(normalizeAtomicName(name)))
+                }
+                if key == "args", case .array(let args) = value {
+                    return (key, .array(args.map(normalizeTermForVerify)))
+                }
+                return (key, value)
+            })
+        case "and", "or", "not", "implies":
+            return .object(pairs.map { key, value in
+                if key == "operands", case .array(let operands) = value {
+                    return (key, .array(operands.map(normalizeFormulaForVerify)))
+                }
+                return (key, value)
+            })
+        case "forall", "exists":
+            return .object(pairs.map { key, value in
+                if key == "body" {
+                    return (key, normalizeFormulaForVerify(value))
+                }
+                return (key, value)
+            })
+        default:
+            return formula
+        }
+    }
+
+    private static func normalizeTermForVerify(_ term: JcsCanonical) -> JcsCanonical {
+        guard case .object(let pairs) = term,
+              let kind = pairs.first(where: { $0.0 == "kind" })?.1.stringValue
+        else {
+            return term
+        }
+
+        switch kind {
+        case "var":
+            return .object(pairs.map { key, value in
+                if key == "name", value.stringValue == "return_value" {
+                    return (key, .string("result"))
+                }
+                return (key, value)
+            })
+        case "const":
+            return term
+        case "ctor":
+            let name = field("name", in: term).stringValue ?? ""
+            let args = field("args", in: term).arrayValue ?? []
+            if name == "swift:return", args.count == 1 {
+                return normalizeTermForVerify(args[0])
+            }
+            return .object(pairs.map { key, value in
+                if key == "name", let name = value.stringValue {
+                    return (key, .string(normalizeCtorName(name)))
+                }
+                if key == "args", case .array(let args) = value {
+                    return (key, .array(args.map(normalizeTermForVerify)))
+                }
+                return (key, value)
+            })
+        default:
+            return term
+        }
+    }
+
+    private static func normalizeCtorName(_ name: String) -> String {
+        switch name {
+        case "swift:add": return "+"
+        case "swift:sub": return "-"
+        case "swift:mul": return "*"
+        default: return name
+        }
+    }
+
+    private static func normalizeAtomicName(_ name: String) -> String {
+        switch name {
+        case "swift:eq": return "="
+        case "swift:ne": return "≠"
+        case "swift:lt": return "<"
+        case "swift:le": return "≤"
+        case "swift:gt": return ">"
+        case "swift:ge": return "≥"
+        default: return name
+        }
+    }
+
+    private static func simpleFunctionSymbol(_ fnName: String) -> String {
+        let withoutParams = fnName.split(separator: "(", maxSplits: 1).first.map(String.init) ?? fnName
+        return withoutParams.split(separator: ".").last.map(String.init) ?? withoutParams
+    }
+
+    private static func field(_ name: String, in object: JcsCanonical) -> JcsCanonical {
+        guard case .object(let pairs) = object else {
+            return .null
+        }
+        return pairs.first(where: { $0.0 == name })?.1 ?? .null
+    }
+
     public static func canonicalBytes(_ value: JcsCanonical) -> Data {
         JcsCanonicalizer.encode(value)
     }
@@ -274,6 +420,22 @@ public enum SwiftSourceIR {
             ("sort", primitiveSort(sort)),
             ("value", value),
         ])
+    }
+}
+
+private extension JcsCanonical {
+    var stringValue: String? {
+        if case .string(let value) = self {
+            return value
+        }
+        return nil
+    }
+
+    var arrayValue: [JcsCanonical]? {
+        if case .array(let values) = self {
+            return values
+        }
+        return nil
     }
 }
 

--- a/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceRPC.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceRPC.swift
@@ -83,7 +83,10 @@ public enum SwiftSourceRPC {
             return errorResponse(id: id, code: -32602, message: "source_paths must contain strings")
         }
         let workspaceRoot = params["workspace_root"] as? String ?? "."
-        let result = SwiftSourceLifter.liftPaths(workspaceRoot: workspaceRoot, sourcePaths: sourcePaths)
+        var result = SwiftSourceLifter.liftPaths(workspaceRoot: workspaceRoot, sourcePaths: sourcePaths)
+        if requestedVerifyLayer(params) {
+            result = SwiftSourceIR.verifyFacingResult(result)
+        }
 
         return response(id: id, result: [
             "kind": "ir-document",
@@ -93,6 +96,13 @@ public enum SwiftSourceRPC {
             "opacityReport": result.opacityReport.map(SwiftSourceIR.anyValue),
             "refusals": result.refusals.map(SwiftSourceIR.anyValue),
         ])
+    }
+
+    private static func requestedVerifyLayer(_ params: [String: Any]) -> Bool {
+        guard let options = params["options"] as? [String: Any] else {
+            return false
+        }
+        return options["layer"] as? String == "verify"
     }
 
     private static func compile(id: Any, params: [String: Any]) throws -> [String: Any] {
@@ -137,8 +147,7 @@ public enum SwiftSourceRPC {
 
     private static func write(_ object: [String: Any]) {
         guard JSONSerialization.isValidJSONObject(object),
-              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
-              let line = String(data: data, encoding: .utf8)
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
         else {
             FileHandle.standardOutput.write(#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"SERIALIZE_ERROR"}}"#.data(using: .utf8)!)
             FileHandle.standardOutput.write(Data([0x0A]))
@@ -150,6 +159,6 @@ public enum SwiftSourceRPC {
     }
 }
 
-private struct SwiftSourceRPCExit: Error {
+private struct SwiftSourceRPCExit: Error, @unchecked Sendable {
     let response: [String: Any]
 }

--- a/implementations/swift/Sources/ProvekitLiftSwiftXCTestTests/main.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftXCTestTests/main.swift
@@ -1,0 +1,605 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// provekit-lift-swift-xctest-tests: lifts native XCTest assertions into
+// ProofIR contracts over the lift-plugin RPC seam. Swift parsing stays in the
+// Swift kit; the Rust CLI only sees normalized IR data.
+
+import Foundation
+import SwiftParser
+import SwiftSyntax
+import ProvekitCrypto
+
+private let surface = "swift-xctest-tests"
+private let version = "0.1.0"
+
+private struct LiftResult {
+    var ir: [JcsCanonical] = []
+    var diagnostics: [JcsCanonical] = []
+    var refusals: [JcsCanonical] = []
+}
+
+private struct UnsupportedAssertion: Error, CustomStringConvertible {
+    let reason: String
+
+    var description: String { reason }
+}
+
+private enum IR {
+    static func primitiveSort(_ name: String) -> JcsCanonical {
+        .object([
+            ("kind", .string("primitive")),
+            ("name", .string(name)),
+        ])
+    }
+
+    static func varTerm(_ name: String) -> JcsCanonical {
+        .object([
+            ("kind", .string("var")),
+            ("name", .string(name)),
+        ])
+    }
+
+    static func intConst(_ value: Int64) -> JcsCanonical {
+        const(value: .int(value), sort: "Int")
+    }
+
+    static func boolConst(_ value: Bool) -> JcsCanonical {
+        const(value: .bool(value), sort: "Bool")
+    }
+
+    static func stringConst(_ value: String) -> JcsCanonical {
+        const(value: .string(value), sort: "String")
+    }
+
+    static func nilConst() -> JcsCanonical {
+        const(value: .null, sort: "Optional")
+    }
+
+    static func ctor(_ name: String, _ args: [JcsCanonical]) -> JcsCanonical {
+        .object([
+            ("kind", .string("ctor")),
+            ("name", .string(name)),
+            ("args", .array(args)),
+        ])
+    }
+
+    static func atomic(_ name: String, _ args: [JcsCanonical]) -> JcsCanonical {
+        .object([
+            ("kind", .string("atomic")),
+            ("name", .string(name)),
+            ("args", .array(args)),
+        ])
+    }
+
+    static func not(_ formula: JcsCanonical) -> JcsCanonical {
+        .object([
+            ("kind", .string("not")),
+            ("operands", .array([formula])),
+        ])
+    }
+
+    static func contract(name: String, inv: JcsCanonical, path: String, line: Int) -> JcsCanonical {
+        .object([
+            ("schemaVersion", .string("1")),
+            ("kind", .string("contract")),
+            ("name", .string(name)),
+            ("outBinding", .string("out")),
+            ("inv", inv),
+            ("locus", .object([
+                ("file", .string(path)),
+                ("line", .int(Int64(line))),
+                ("col", .int(1)),
+            ])),
+        ])
+    }
+
+    static func diagnostic(severity: String, message: String) -> JcsCanonical {
+        .object([
+            ("severity", .string(severity)),
+            ("message", .string(message)),
+        ])
+    }
+
+    static func refusal(function: String?, path: String, line: Int?, reason: String) -> JcsCanonical {
+        .object([
+            ("kind", .string("xctest-assertion-skip")),
+            ("function", function.map(JcsCanonical.string) ?? .null),
+            ("file", .string(path)),
+            ("line", line.map { .int(Int64($0)) } ?? .null),
+            ("reason", .string(reason)),
+        ])
+    }
+
+    static func anyValue(_ value: JcsCanonical) -> Any {
+        switch value {
+        case .null:
+            return NSNull()
+        case .bool(let b):
+            return b
+        case .int(let n):
+            return n
+        case .string(let s):
+            return s
+        case .array(let values):
+            return values.map(anyValue)
+        case .object(let pairs):
+            var object: [String: Any] = [:]
+            for (key, value) in pairs {
+                object[key] = anyValue(value)
+            }
+            return object
+        }
+    }
+
+    private static func const(value: JcsCanonical, sort: String) -> JcsCanonical {
+        .object([
+            ("kind", .string("const")),
+            ("sort", primitiveSort(sort)),
+            ("value", value),
+        ])
+    }
+}
+
+private final class XCTestAssertionCollector: SyntaxVisitor {
+    private let path: String
+    private let converter: SourceLocationConverter
+    private var functionStack: [String] = []
+    private var assertionIndexByFunction: [String: Int] = [:]
+
+    var contracts: [JcsCanonical] = []
+    var refusals: [JcsCanonical] = []
+
+    init(path: String, converter: SourceLocationConverter) {
+        self.path = path
+        self.converter = converter
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        functionStack.append(node.name.text)
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: FunctionDeclSyntax) {
+        _ = functionStack.popLast()
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        guard let assertion = assertionName(node.calledExpression) else {
+            return .visitChildren
+        }
+
+        let function = functionStack.last ?? "<top-level>"
+        let line = node.startLocation(converter: converter).line
+        do {
+            let inv = try liftAssertion(name: assertion, call: node)
+            let idx = assertionIndexByFunction[function, default: 0]
+            assertionIndexByFunction[function] = idx + 1
+            let contractName = "\(path):\(function)::\(idx)"
+            contracts.append(IR.contract(name: contractName, inv: inv, path: path, line: line))
+        } catch let unsupported as UnsupportedAssertion {
+            refusals.append(IR.refusal(
+                function: function,
+                path: path,
+                line: line,
+                reason: "\(assertion): \(unsupported.reason)"
+            ))
+        } catch {
+            refusals.append(IR.refusal(
+                function: function,
+                path: path,
+                line: line,
+                reason: "\(assertion): \(error)"
+            ))
+        }
+        return .skipChildren
+    }
+}
+
+private func liftPaths(workspaceRoot: String, sourcePaths: [String]) -> LiftResult {
+    var result = LiftResult()
+    let root = URL(fileURLWithPath: workspaceRoot.isEmpty ? "." : workspaceRoot).standardizedFileURL
+    let rootPath = root.path
+    let fileManager = FileManager.default
+
+    for requested in sourcePaths.isEmpty ? ["."] : sourcePaths {
+        let requestedURL = URL(fileURLWithPath: requested, relativeTo: root).standardizedFileURL
+        let fullPath = requestedURL.path
+        guard isPath(fullPath, inside: rootPath) else {
+            result.refusals.append(IR.refusal(
+                function: nil,
+                path: requested,
+                line: nil,
+                reason: "path escapes workspace root"
+            ))
+            continue
+        }
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: fullPath, isDirectory: &isDirectory) else {
+            result.diagnostics.append(IR.diagnostic(
+                severity: "warning",
+                message: "path not found: \(fullPath)"
+            ))
+            continue
+        }
+
+        let files: [String]
+        if isDirectory.boolValue {
+            let enumerator = fileManager.enumerator(atPath: fullPath)
+            files = (enumerator?.compactMap { item -> String? in
+                guard let rel = item as? String, rel.hasSuffix(".swift") else {
+                    return nil
+                }
+                if rel.contains("/.build/") || rel.hasPrefix(".build/") || rel.hasPrefix(".provekit/") {
+                    return nil
+                }
+                return URL(fileURLWithPath: rel, relativeTo: requestedURL).standardizedFileURL.path
+            } ?? []).sorted()
+        } else if fullPath.hasSuffix(".swift") {
+            files = [fullPath]
+        } else {
+            files = []
+        }
+
+        for file in files {
+            do {
+                let source = try String(contentsOfFile: file, encoding: .utf8)
+                let displayPath = relativePath(file, root: rootPath)
+                let sourceFile = Parser.parse(source: source)
+                let converter = SourceLocationConverter(fileName: displayPath, tree: sourceFile)
+                let collector = XCTestAssertionCollector(path: displayPath, converter: converter)
+                collector.walk(sourceFile)
+                result.ir.append(contentsOf: collector.contracts)
+                result.refusals.append(contentsOf: collector.refusals)
+            } catch {
+                result.refusals.append(IR.refusal(
+                    function: nil,
+                    path: file,
+                    line: nil,
+                    reason: "cannot read or parse file: \(error)"
+                ))
+            }
+        }
+    }
+
+    return result
+}
+
+private func liftAssertion(name: String, call: FunctionCallExprSyntax) throws -> JcsCanonical {
+    let args = Array(call.arguments)
+
+    func requireArg(_ index: Int) throws -> ExprSyntax {
+        guard index < args.count else {
+            throw UnsupportedAssertion(reason: "missing argument \(index)")
+        }
+        return args[index].expression
+    }
+
+    switch name {
+    case "XCTAssertEqual":
+        return IR.atomic("=", [
+            try liftTerm(requireArg(0)),
+            try liftTerm(requireArg(1)),
+        ])
+    case "XCTAssertNotEqual":
+        return IR.atomic("≠", [
+            try liftTerm(requireArg(0)),
+            try liftTerm(requireArg(1)),
+        ])
+    case "XCTAssertGreaterThan":
+        return IR.atomic(">", [
+            try liftTerm(requireArg(0)),
+            try liftTerm(requireArg(1)),
+        ])
+    case "XCTAssertGreaterThanOrEqual":
+        return IR.atomic("≥", [
+            try liftTerm(requireArg(0)),
+            try liftTerm(requireArg(1)),
+        ])
+    case "XCTAssertLessThan":
+        return IR.atomic("<", [
+            try liftTerm(requireArg(0)),
+            try liftTerm(requireArg(1)),
+        ])
+    case "XCTAssertLessThanOrEqual":
+        return IR.atomic("≤", [
+            try liftTerm(requireArg(0)),
+            try liftTerm(requireArg(1)),
+        ])
+    case "XCTAssertNil":
+        return IR.atomic("=", [
+            try liftTerm(requireArg(0)),
+            IR.nilConst(),
+        ])
+    case "XCTAssertNotNil":
+        return IR.not(IR.atomic("=", [
+            try liftTerm(requireArg(0)),
+            IR.nilConst(),
+        ]))
+    case "XCTAssertTrue":
+        return try liftBooleanFormula(requireArg(0)) ?? IR.atomic("IsTrue", [try liftTerm(requireArg(0))])
+    case "XCTAssertFalse":
+        if let formula = try liftBooleanFormula(requireArg(0)) {
+            return IR.not(formula)
+        }
+        return IR.atomic("IsFalse", [try liftTerm(requireArg(0))])
+    default:
+        throw UnsupportedAssertion(reason: "not in XCTest assertion whitelist")
+    }
+}
+
+private func liftBooleanFormula(_ expr: ExprSyntax) throws -> JcsCanonical? {
+    if let paren = expr.as(TupleExprSyntax.self),
+       paren.elements.count == 1,
+       let first = paren.elements.first {
+        return try liftBooleanFormula(first.expression)
+    }
+    guard let sequence = expr.as(SequenceExprSyntax.self) else {
+        return nil
+    }
+    let elements = Array(sequence.elements)
+    guard elements.count == 3 else {
+        return nil
+    }
+    let op = elements[1].description.trimmingCharacters(in: .whitespacesAndNewlines)
+    let pred: String
+    switch op {
+    case "==": pred = "="
+    case "!=": pred = "≠"
+    case "<": pred = "<"
+    case "<=": pred = "≤"
+    case ">": pred = ">"
+    case ">=": pred = "≥"
+    default: return nil
+    }
+    return IR.atomic(pred, [
+        try liftTerm(elements[0]),
+        try liftTerm(elements[2]),
+    ])
+}
+
+private func liftTerm(_ expr: ExprSyntax) throws -> JcsCanonical {
+    if let paren = expr.as(TupleExprSyntax.self),
+       paren.elements.count == 1,
+       let first = paren.elements.first {
+        return try liftTerm(first.expression)
+    }
+    if let literal = expr.as(IntegerLiteralExprSyntax.self) {
+        let raw = literal.literal.text.replacingOccurrences(of: "_", with: "")
+        guard let value = Int64(raw) else {
+            throw UnsupportedAssertion(reason: "integer literal is out of Int64 range")
+        }
+        return IR.intConst(value)
+    }
+    if let literal = expr.as(BooleanLiteralExprSyntax.self) {
+        return IR.boolConst(literal.literal.text == "true")
+    }
+    if expr.is(NilLiteralExprSyntax.self) {
+        return IR.nilConst()
+    }
+    if let literal = expr.as(StringLiteralExprSyntax.self) {
+        return try liftStringLiteral(literal)
+    }
+    if let ref = expr.as(DeclReferenceExprSyntax.self) {
+        return IR.varTerm(ref.baseName.text)
+    }
+    if let prefix = expr.as(PrefixOperatorExprSyntax.self) {
+        let op = prefix.operator.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if op == "-",
+           let literal = prefix.expression.as(IntegerLiteralExprSyntax.self),
+           let value = Int64(literal.literal.text.replacingOccurrences(of: "_", with: "")) {
+            return IR.intConst(-value)
+        }
+        return IR.ctor(op, [try liftTerm(prefix.expression)])
+    }
+    if let sequence = expr.as(SequenceExprSyntax.self) {
+        let elements = Array(sequence.elements)
+        guard elements.count == 3 else {
+            throw UnsupportedAssertion(reason: "only single binary expressions are supported")
+        }
+        let op = elements[1].description.trimmingCharacters(in: .whitespacesAndNewlines)
+        let ctor: String
+        switch op {
+        case "+": ctor = "+"
+        case "-": ctor = "-"
+        case "*": ctor = "*"
+        case "/": ctor = "/"
+        case "%": ctor = "mod"
+        default:
+            throw UnsupportedAssertion(reason: "unsupported term operator \(op)")
+        }
+        return IR.ctor(ctor, [
+            try liftTerm(elements[0]),
+            try liftTerm(elements[2]),
+        ])
+    }
+    if let call = expr.as(FunctionCallExprSyntax.self) {
+        guard assertionName(call.calledExpression) == nil else {
+            throw UnsupportedAssertion(reason: "nested XCTest assertion is not an operand")
+        }
+        let callee = calleeName(call.calledExpression)
+        var args: [JcsCanonical] = []
+        for arg in call.arguments {
+            args.append(try liftTerm(arg.expression))
+        }
+        return IR.ctor(callee, args)
+    }
+    if let member = expr.as(MemberAccessExprSyntax.self) {
+        return IR.varTerm(member.description.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    throw UnsupportedAssertion(reason: "unsupported operand \(type(of: expr))")
+}
+
+private func liftStringLiteral(_ node: StringLiteralExprSyntax) throws -> JcsCanonical {
+    let raw = node.description.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard raw.hasPrefix("\""), raw.hasSuffix("\""), !raw.contains("\\(") else {
+        throw UnsupportedAssertion(reason: "only non-interpolated string literals are supported")
+    }
+    let inner = String(raw.dropFirst().dropLast())
+    let decoded = inner
+        .replacingOccurrences(of: "\\n", with: "\n")
+        .replacingOccurrences(of: "\\t", with: "\t")
+        .replacingOccurrences(of: "\\\"", with: "\"")
+        .replacingOccurrences(of: "\\\\", with: "\\")
+    return IR.stringConst(decoded)
+}
+
+private func assertionName(_ expr: ExprSyntax) -> String? {
+    let name = calleeName(expr)
+    return name.hasPrefix("XCTAssert") ? name : nil
+}
+
+private func calleeName(_ expr: ExprSyntax) -> String {
+    if let ref = expr.as(DeclReferenceExprSyntax.self) {
+        return ref.baseName.text
+    }
+    if let member = expr.as(MemberAccessExprSyntax.self) {
+        return member.declName.baseName.text
+    }
+    let rendered = expr.description.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let last = rendered.split(separator: ".").last {
+        return String(last)
+    }
+    return rendered
+}
+
+private func isPath(_ child: String, inside root: String) -> Bool {
+    if child == root {
+        return true
+    }
+    let prefix = root.hasSuffix("/") ? root : root + "/"
+    return child.hasPrefix(prefix)
+}
+
+private func relativePath(_ path: String, root: String) -> String {
+    let prefix = root.hasSuffix("/") ? root : root + "/"
+    if path.hasPrefix(prefix) {
+        return String(path.dropFirst(prefix.count))
+    }
+    return path
+}
+
+private enum RPC {
+    static func initializeResult() -> [String: Any] {
+        [
+            "name": "provekit-lift-swift-xctest-tests",
+            "version": version,
+            "protocol_version": "pep/1.7.0",
+            "dialect": surface,
+            "capabilities": [
+                "authoring_surfaces": [surface],
+                "ir_version": "v1.1.0",
+                "emits_signed_mementos": false,
+            ],
+        ]
+    }
+
+    static func run() {
+        while let line = readLine(strippingNewline: true) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                continue
+            }
+
+            let response: [String: Any]
+            do {
+                guard let data = trimmed.data(using: .utf8),
+                      let request = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+                else {
+                    write(errorResponse(id: nil, code: -32700, message: "PARSE_ERROR"))
+                    continue
+                }
+                response = try dispatch(request)
+            } catch let exit as RPCExit {
+                write(exit.response)
+                return
+            } catch {
+                response = errorResponse(id: nil, code: -32603, message: String(describing: error))
+            }
+            write(response)
+        }
+    }
+
+    private static func dispatch(_ request: [String: Any]) throws -> [String: Any] {
+        let id = request["id"] ?? NSNull()
+        let method = request["method"] as? String ?? ""
+        let params = request["params"] as? [String: Any] ?? [:]
+
+        switch method {
+        case "initialize":
+            return response(id: id, result: initializeResult())
+        case "lift":
+            return lift(id: id, params: params)
+        case "shutdown", "exit":
+            throw RPCExit(response: response(id: id, result: NSNull()))
+        default:
+            return errorResponse(id: id, code: -32601, message: "METHOD_NOT_FOUND: \(method)")
+        }
+    }
+
+    private static func lift(id: Any, params: [String: Any]) -> [String: Any] {
+        let requestedSurface = params["surface"] as? String ?? surface
+        guard requestedSurface == surface else {
+            return errorResponse(id: id, code: 1003, message: "SURFACE_NOT_SUPPORTED: \(requestedSurface)")
+        }
+
+        let sourcePaths = (params["source_paths"] as? [Any])?
+            .compactMap { $0 as? String }
+            .filter { !$0.isEmpty } ?? ["."]
+        let workspaceRoot = params["workspace_root"] as? String ?? "."
+        let result = liftPaths(workspaceRoot: workspaceRoot, sourcePaths: sourcePaths)
+
+        return response(id: id, result: [
+            "kind": "ir-document",
+            "ir": result.ir.map(IR.anyValue),
+            "callEdges": [],
+            "diagnostics": result.diagnostics.map(IR.anyValue),
+            "refusals": result.refusals.map(IR.anyValue),
+        ])
+    }
+
+    private static func response(id: Any, result: Any) -> [String: Any] {
+        [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result,
+        ]
+    }
+
+    private static func errorResponse(id: Any?, code: Int, message: String) -> [String: Any] {
+        [
+            "jsonrpc": "2.0",
+            "id": id ?? NSNull(),
+            "error": [
+                "code": code,
+                "message": message,
+            ],
+        ]
+    }
+
+    private static func write(_ object: [String: Any]) {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        else {
+            FileHandle.standardOutput.write(#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"SERIALIZE_ERROR"}}"#.data(using: .utf8)!)
+            FileHandle.standardOutput.write(Data([0x0A]))
+            return
+        }
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data([0x0A]))
+        fflush(stdout)
+    }
+}
+
+private struct RPCExit: Error, @unchecked Sendable {
+    let response: [String: Any]
+}
+
+if CommandLine.arguments.contains("--rpc") {
+    RPC.run()
+} else {
+    FileHandle.standardError.write("usage: provekit-lift-swift-xctest-tests --rpc\n".data(using: .utf8)!)
+    exit(1)
+}


### PR DESCRIPTION
## Summary
- add a Swift-written XCTest assertion lift surface registered via .provekit manifest
- make swift-source emit verify-facing normalized ProofIR when config requests the verify layer
- add the Swift production-bridge gauntlet: mint bridge, prove positive, prove broken body negative, planted implication refusal

## Verification
- swift build --product provekit-lift-swift-source && swift build --product provekit-lift-swift-xctest-tests && swift build --product provekit-emit-swift-xctest
- cargo test -p provekit-cli --test cmd_verify_swift_production_bridge -- --nocapture
- cargo test -p provekit-cli --test cmd_emit_swift_xctest -- --nocapture
- rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_verify_swift_production_bridge.rs && git diff --check

Note: swift test is blocked on this host by the existing test target importing XCTest under CommandLineTools: no such module 'XCTest'.