### PR TITLE
feat(go): add implication lift RPC surface

### DIFF
--- a/implementations/go/.provekit/lift/go-implications/manifest.toml
+++ b/implementations/go/.provekit/lift/go-implications/manifest.toml
@@ -1,0 +1,13 @@
+name = "go-implications"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["go", "run", "./cmd/provekit-lift-go", "--rpc"]
+working_dir = "provekit-lift-go"
+method = "provekit.plugin.lift_implications"
+phase = "consumer"
+
+[capabilities]
+authoring_surfaces = ["go-implications"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/go/provekit-lift-go/implications.go
+++ b/implementations/go/provekit-lift-go/implications.go
@@ -1,0 +1,214 @@
+package liftgo
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type ContractBinding struct {
+	Name        string `json:"name"`
+	ContractCID string `json:"contract_cid"`
+}
+
+type ImplicationParams struct {
+	WorkspaceRoot    string            `json:"workspace_root"`
+	SourcePaths      []string          `json:"source_paths"`
+	ContractBindings []ContractBinding `json:"contract_bindings"`
+}
+
+type ImplicationResult struct {
+	Kind        string           `json:"kind"`
+	IR          []any            `json:"ir"`
+	Diagnostics []map[string]any `json:"diagnostics"`
+}
+
+type goCallSite struct {
+	Symbol string
+	File   string
+	Line   int
+	Col    int
+}
+
+// LiftImplications is the Go-owned consumer surface for
+// `provekit.plugin.lift_implications`. It walks Go AST call expressions and
+// emits bridge IR for calls whose callee symbol has a producer contract binding.
+func LiftImplications(params ImplicationParams) (ImplicationResult, error) {
+	root := params.WorkspaceRoot
+	if root == "" {
+		cwd, err := os.Getwd()
+		if err == nil {
+			root = cwd
+		} else {
+			root = "."
+		}
+	}
+	if len(params.SourcePaths) == 0 {
+		return ImplicationResult{}, fmt.Errorf("source_paths must be a non-empty array of strings")
+	}
+
+	contractsBySymbol := implicationContractsBySymbol(params.ContractBindings)
+	files, err := implicationSourceFiles(root, params.SourcePaths)
+	if err != nil {
+		return ImplicationResult{}, err
+	}
+
+	result := ImplicationResult{
+		Kind:        "ir-document",
+		IR:          []any{},
+		Diagnostics: []map[string]any{},
+	}
+	for _, path := range files {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		rel := path
+		if r, relErr := filepath.Rel(root, path); relErr == nil {
+			rel = r
+		}
+		callsites, err := collectGoCallsites(rel, src)
+		if err != nil {
+			continue
+		}
+		for _, cs := range callsites {
+			targetCID := contractsBySymbol[cs.Symbol]
+			if targetCID == "" {
+				result.Diagnostics = append(result.Diagnostics, map[string]any{
+					"kind":   "lift-gap",
+					"reason": "no-contract-for-callee",
+					"callee": cs.Symbol,
+					"file":   cs.File,
+					"line":   cs.Line,
+					"col":    cs.Col,
+				})
+				continue
+			}
+			result.IR = append(result.IR, map[string]any{
+				"kind":              "bridge",
+				"name":              fmt.Sprintf("intra-body:go:%s@%s:%d:%d", cs.Symbol, cs.File, cs.Line, cs.Col),
+				"schemaVersion":     "1",
+				"sourceContractCid": targetCID,
+				"sourceLayer":       "go",
+				"sourceSymbol":      cs.Symbol,
+				"target": map[string]any{
+					"cid":  targetCID,
+					"kind": "contract",
+				},
+				"targetContractCid": targetCID,
+				"targetLayer":       "go-contracts",
+				"callsite": map[string]any{
+					"file":       cs.File,
+					"start_line": cs.Line,
+					"start_col":  cs.Col,
+				},
+			})
+		}
+	}
+	return result, nil
+}
+
+func implicationContractsBySymbol(bindings []ContractBinding) map[string]string {
+	out := map[string]string{}
+	for _, binding := range bindings {
+		if binding.ContractCID == "" {
+			continue
+		}
+		for _, key := range implicationBindingKeys(binding.Name) {
+			if key != "" {
+				if _, exists := out[key]; !exists {
+					out[key] = binding.ContractCID
+				}
+			}
+		}
+	}
+	return out
+}
+
+func implicationBindingKeys(name string) []string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return nil
+	}
+	beforeSite := strings.Split(trimmed, "@")[0]
+	beforeParams := strings.Split(beforeSite, "(")[0]
+	simple := beforeParams
+	if i := strings.LastIndex(simple, "."); i >= 0 {
+		simple = simple[i+1:]
+	}
+	return []string{trimmed, beforeSite, beforeParams, simple}
+}
+
+func implicationSourceFiles(root string, sourcePaths []string) ([]string, error) {
+	var files []string
+	for _, sourcePath := range sourcePaths {
+		path := sourcePath
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(root, sourcePath)
+		}
+		expanded, err := goSourceFiles(path)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, expanded...)
+	}
+	return files, nil
+}
+
+func collectGoCallsites(sourcePath string, src []byte) ([]goCallSite, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, sourcePath, src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	var out []goCallSite
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		symbol := implicationSourceSymbol(call.Fun)
+		if symbol == "" || isIgnorableImplicationCallee(symbol) {
+			return true
+		}
+		pos := fset.Position(call.Fun.Pos())
+		out = append(out, goCallSite{
+			Symbol: symbol,
+			File:   sourcePath,
+			Line:   pos.Line,
+			Col:    pos.Column,
+		})
+		return true
+	})
+	return out, nil
+}
+
+func implicationSourceSymbol(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return e.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func isIgnorableImplicationCallee(symbol string) bool {
+	if symbol == "panic" || isPureBuiltin(symbol) {
+		return true
+	}
+	switch symbol {
+	case "bool", "byte", "rune", "string",
+		"int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+		"float32", "float64", "complex64", "complex128":
+		return true
+	default:
+		return false
+	}
+}

--- a/implementations/go/provekit-lift-go/implications_test.go
+++ b/implementations/go/provekit-lift-go/implications_test.go
@@ -1,0 +1,99 @@
+package liftgo
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRPCLiftImplicationsEmitsBridgeForMatchedGoCall(t *testing.T) {
+	root := t.TempDir()
+	src := `package sample
+
+func Caller(x int) int {
+	return Callee(x)
+}
+
+func Callee(x int) int {
+	return x + 1
+}
+`
+	if err := os.WriteFile(filepath.Join(root, "sample.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write sample.go: %v", err)
+	}
+
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"provekit.plugin.lift_implications","params":{"workspace_root":` + strconvQuote(root) + `,"source_paths":["sample.go"],"contract_bindings":[{"name":"example.com/sample.Callee","contract_cid":"blake3-512:abc"}]}}` + "\n")
+	var stdout bytes.Buffer
+	if err := RunRPC(stdin, &stdout); err != nil {
+		t.Fatalf("RunRPC: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &response); err != nil {
+		t.Fatalf("response JSON parses: %v\nstdout: %s", err, stdout.String())
+	}
+	if response["error"] != nil {
+		t.Fatalf("lift_implications RPC returned error: %v", response["error"])
+	}
+	result := response["result"].(map[string]any)
+	ir := result["ir"].([]any)
+	if len(ir) != 1 {
+		t.Fatalf("expected one bridge for Callee call, got %d: %#v", len(ir), ir)
+	}
+	bridge := ir[0].(map[string]any)
+	if bridge["kind"] != "bridge" {
+		t.Fatalf("kind = %#v, want bridge", bridge["kind"])
+	}
+	if bridge["sourceSymbol"] != "Callee" {
+		t.Fatalf("sourceSymbol = %#v, want Callee", bridge["sourceSymbol"])
+	}
+	if bridge["targetContractCid"] != "blake3-512:abc" {
+		t.Fatalf("targetContractCid = %#v", bridge["targetContractCid"])
+	}
+	diagnostics := result["diagnostics"].([]any)
+	if len(diagnostics) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", diagnostics)
+	}
+}
+
+func TestLiftImplicationsReportsGapForUnmatchedGoCall(t *testing.T) {
+	root := t.TempDir()
+	src := `package sample
+
+func Caller(x int) int {
+	return Missing(x)
+}
+`
+	if err := os.WriteFile(filepath.Join(root, "sample.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write sample.go: %v", err)
+	}
+
+	result, err := LiftImplications(ImplicationParams{
+		WorkspaceRoot:    root,
+		SourcePaths:      []string{"sample.go"},
+		ContractBindings: nil,
+	})
+	if err != nil {
+		t.Fatalf("LiftImplications: %v", err)
+	}
+	if len(result.IR) != 0 {
+		t.Fatalf("expected no bridges without binding, got %#v", result.IR)
+	}
+	if len(result.Diagnostics) != 1 {
+		t.Fatalf("expected one lift-gap diagnostic, got %#v", result.Diagnostics)
+	}
+	if result.Diagnostics[0]["kind"] != "lift-gap" || result.Diagnostics[0]["callee"] != "Missing" {
+		t.Fatalf("unexpected diagnostic: %#v", result.Diagnostics[0])
+	}
+}
+
+func strconvQuote(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}

--- a/implementations/go/provekit-lift-go/lift_test.go
+++ b/implementations/go/provekit-lift-go/lift_test.go
@@ -231,7 +231,9 @@ func TestInitializeReportsDraftVersionAndCapabilities(t *testing.T) {
 	if result.Capabilities.EmitsSignedMementos {
 		t.Fatal("source lifter must not claim signed mementos")
 	}
-	if len(result.Capabilities.AuthoringSurfaces) != 1 || result.Capabilities.AuthoringSurfaces[0] != "go-source" {
+	if len(result.Capabilities.AuthoringSurfaces) != 2 ||
+		result.Capabilities.AuthoringSurfaces[0] != "go-source" ||
+		result.Capabilities.AuthoringSurfaces[1] != "go-implications" {
 		t.Fatalf("authoring surfaces = %+v", result.Capabilities.AuthoringSurfaces)
 	}
 }

--- a/implementations/go/provekit-lift-go/rpc.go
+++ b/implementations/go/provekit-lift-go/rpc.go
@@ -64,6 +64,8 @@ func RunRPCWithDefault(stdin io.Reader, stdout io.Writer, defaultOpts LiftOption
 			writeRPC(stdout, successResponse(req.ID, InitializeResult()))
 		case "lift":
 			writeRPC(stdout, handleLift(req.ID, req.Params, defaultOpts))
+		case "provekit.plugin.lift_implications":
+			writeRPC(stdout, handleLiftImplications(req.ID, req.Params))
 		case "compile":
 			writeRPC(stdout, handleCompile(req.ID, req.Params))
 		case "provekit.plugin.recognize":
@@ -76,6 +78,20 @@ func RunRPCWithDefault(stdin io.Reader, stdout io.Writer, defaultOpts LiftOption
 		}
 	}
 	return scanner.Err()
+}
+
+func handleLiftImplications(id json.RawMessage, raw json.RawMessage) any {
+	var params ImplicationParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return errorResponse(id, -32602, "invalid lift_implications params")
+		}
+	}
+	result, err := LiftImplications(params)
+	if err != nil {
+		return errorResponse(id, -32603, fmt.Sprintf("Lift implications failed: %v", err))
+	}
+	return successResponse(id, result)
 }
 
 func handleLift(id json.RawMessage, raw json.RawMessage, defaultOpts LiftOptions) any {

--- a/implementations/go/provekit-lift-go/types.go
+++ b/implementations/go/provekit-lift-go/types.go
@@ -109,7 +109,7 @@ func InitializeResult() InitResult {
 		Version:         Version,
 		ProtocolVersion: "provekit-lift/1",
 		Capabilities: Capabilities{
-			AuthoringSurfaces:   []string{"go-source"},
+			AuthoringSurfaces:   []string{"go-source", "go-implications"},
 			IRVersion:           IRVersion,
 			EmitsSignedMementos: false,
 		},

--- a/implementations/rust/provekit-cli/tests/cmd_mint_go_project_implications.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_go_project_implications.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-go-implications-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn build_go_lift_source() -> PathBuf {
+    let go_module = repo_root()
+        .join("implementations")
+        .join("go")
+        .join("provekit-lift-go");
+    let out = std::env::temp_dir().join(format!("provekit-lift-go-{}", std::process::id()));
+    let built = Command::new("go")
+        .current_dir(&go_module)
+        .args([
+            "build",
+            "-o",
+            out.to_str().unwrap(),
+            "./cmd/provekit-lift-go",
+        ])
+        .output()
+        .expect("spawn go build");
+    assert!(
+        built.status.success(),
+        "go build provekit-lift-go failed\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&built.stdout),
+        String::from_utf8_lossy(&built.stderr)
+    );
+    out
+}
+
+fn stage_go_project(lift_bin: &Path) -> PathBuf {
+    let project = unique_dir("project");
+    fs::write(
+        project.join("go.mod"),
+        "module example.com/sample\n\ngo 1.22\n",
+    )
+    .expect("write go.mod");
+    fs::write(
+        project.join("sample.go"),
+        r#"package sample
+
+func Caller(x int) int {
+	return Callee(x)
+}
+
+func Callee(x int) int {
+	return x + 1
+}
+"#,
+    )
+    .expect("write sample.go");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("go-contracts")).unwrap();
+    fs::create_dir_all(provekit.join("lift").join("go-implications")).unwrap();
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "go-contracts"
+surface = "go-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "go-implications"
+surface = "go-implications"
+"#,
+    )
+    .expect("write config.toml");
+
+    fs::write(
+        provekit
+            .join("lift")
+            .join("go-contracts")
+            .join("manifest.toml"),
+        format!(
+            "name = \"go-contracts\"\ncommand = [\"{}\", \"--rpc\", \"--dialect=core\"]\nworking_dir = \".\"\n",
+            lift_bin.display()
+        ),
+    )
+    .expect("write go-contracts manifest");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("go-implications")
+            .join("manifest.toml"),
+        format!(
+            "name = \"go-implications\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\nmethod = \"provekit.plugin.lift_implications\"\nphase = \"consumer\"\n",
+            lift_bin.display()
+        ),
+    )
+    .expect("write go-implications manifest");
+
+    project
+}
+
+#[test]
+fn go_implication_consumer_mints_bridge_from_manifest_rpc() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping Go implication consumer test");
+        return;
+    }
+    let lift_bin = build_go_lift_source();
+    let project = stage_go_project(&lift_bin);
+    let out_dir = unique_dir("out");
+
+    let output = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(&project)
+        .arg("--out")
+        .arg(&out_dir)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit mint");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "go implication mint should dispatch producer lift then consumer lift_implications\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("no-contract-for-callee"),
+        "matched Callee call should not surface a lift-gap\nstdout:\n{stdout}"
+    );
+
+    let proof_files: Vec<PathBuf> = fs::read_dir(&out_dir)
+        .expect("read out dir")
+        .filter_map(|entry| {
+            let path = entry.expect("out dir entry").path();
+            (path.extension().and_then(|s| s.to_str()) == Some("proof")).then_some(path)
+        })
+        .collect();
+    assert_eq!(
+        proof_files.len(),
+        1,
+        "producer + Go implication consumer should conjoin into one proof"
+    );
+
+    let pool = provekit_verifier::load_all_proofs::run_with_files(
+        Path::new("/no-such-project"),
+        &proof_files,
+    );
+    assert!(
+        pool.load_errors.is_empty(),
+        "conjoined Go proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+    assert!(
+        pool.bridges_by_symbol.contains_key("Callee"),
+        "Go implication consumer must mint a bridge indexed by sourceSymbol=Callee; indexed: {:?}",
+        pool.bridges_by_symbol.keys().collect::<Vec<_>>()
+    );
+    let saw_implication_bridge = pool.mementos.values().any(|env| {
+        provekit_verifier::types::memento_kind(env).as_deref() == Some("bridge")
+            && provekit_verifier::types::memento_body_field(env, "sourceSymbol")
+                .and_then(|v| v.as_str())
+                == Some("Callee")
+            && provekit_verifier::types::memento_body_field(env, "notes").and_then(|v| v.as_str())
+                == Some("implication-lifted callsite bridge")
+    });
+    assert!(
+        saw_implication_bridge,
+        "Go consumer must contribute the implication-lifted callsite bridge, not only rely on producer auto-bridges"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+    let _ = fs::remove_dir_all(&out_dir);
+}


### PR DESCRIPTION
## Summary
- add Go-owned provekit.plugin.lift_implications RPC handling in provekit-lift-go
- add go-implications manifest with consumer phase/method registration
- add Rust CLI mint integration proving producer + Go implication consumer conjoin through config/manifest/RPC

## Verification
- go test ./... -count=1 (in implementations/go/provekit-lift-go)
- cargo test -p provekit-cli --test cmd_mint_go_project_implications --manifest-path implementations/rust/Cargo.toml -- --nocapture

Closes #1601